### PR TITLE
Workers: the Worker constructor, the two façades and the connection lifecycle

### DIFF
--- a/Jint.Tests.PublicInterface/WebApiWorkerTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiWorkerTests.cs
@@ -1,7 +1,10 @@
 #if NET8_0_OR_GREATER
 #nullable enable
 
+using System.Threading;
 using Jint;
+using Jint.Runtime;
+using Jint.Runtime.Modules;
 using Jint.WebApi;
 
 namespace Jint.Tests.PublicInterface;
@@ -19,9 +22,11 @@ namespace Jint.Tests.PublicInterface;
 /// over rather than things a host builds.
 /// </para>
 /// <para>
-/// <see cref="TypeofWorkerIsUndefinedEvenWithTheFlagAndProvider"/> is the pin that keeps this change from
-/// being the one that also moves the engine: the constructor, the worker global and the error channels land
-/// in their own changes, and until they do a script cannot tell that any of this exists.
+/// <see cref="TypeofWorkerAnswersOnlyWithBothTheFlagAndAProvider"/> replaced the foundation's
+/// no-script-surface pin, deliberately: that one asserted <c>typeof Worker === 'undefined'</c> even with the
+/// flag <i>and</i> a provider, which was true exactly while the constructor did not exist. Now that it does,
+/// the same question has a three-way answer and the pin asserts it — the absent-with-flag-alone and
+/// absent-with-provider-alone halves are the ones that survived unchanged.
 /// </para>
 /// </remarks>
 public class WebApiWorkerTests
@@ -108,28 +113,347 @@ public class WebApiWorkerTests
         (WebApiFeatures.Default & WebApiFeatures.Workers).Should().Be(WebApiFeatures.None);
     }
 
-    [Theory]
-    [InlineData(false)]
-    [InlineData(true)]
-    public void TypeofWorkerIsUndefinedEvenWithTheFlagAndProvider(bool enableWorkers)
+    /// <summary>
+    /// The <c>Worker</c> global needs the flag <b>and</b> a provider, and there is deliberately no way to get a
+    /// constructor that can only throw: a worker needs a thread and a pump, and Jint never starts either.
+    /// </summary>
+    [Fact]
+    public void TypeofWorkerAnswersOnlyWithBothTheFlagAndAProvider()
     {
         var provider = new RecordingWorkerProvider();
-        var engine = new Engine(options =>
+
+        var neither = new Engine(options => options.UseWebApis());
+        neither.Evaluate("typeof Worker").AsString().Should().Be("undefined");
+
+        var flagOnly = new Engine(options => options.UseWebApis(WebApiFeatures.Default | WebApiFeatures.Workers));
+        flagOnly.Evaluate("typeof Worker").AsString().Should().Be("undefined", "with no provider there is no thread");
+
+        var providerOnly = new Engine(options =>
         {
             options.UseWebApis();
-            if (enableWorkers)
-            {
-                options.UseWorkers(provider);
-            }
+            options.WebApi.Workers.Provider = provider;
+        });
+        providerOnly.Evaluate("typeof Worker").AsString().Should().Be("undefined", "the flag is still the grant");
+
+        var both = new Engine(options => options.UseWebApis().UseWorkers(provider));
+        both.Evaluate("typeof Worker").AsString().Should().Be("function");
+
+        // The interface objects that would make `self instanceof WorkerGlobalScope` lie stay absent whatever
+        // was enabled — the ruling this feature shares with the interface-globals decision.
+        both.Evaluate("typeof WorkerGlobalScope").AsString().Should().Be("undefined");
+        both.Evaluate("typeof DedicatedWorkerGlobalScope").AsString().Should().Be("undefined");
+
+        provider.Requests.Should().Be(0, "building an engine consults no provider");
+    }
+
+    /// <summary>
+    /// A provider that refuses everything is still reachable, and its refusal is what the script sees.
+    /// </summary>
+    [Fact]
+    public void AProviderRefusalIsReachableFromScript()
+    {
+        var provider = new RecordingWorkerProvider();
+        var engine = new Engine(options => options.UseWebApis().UseWorkers(provider));
+
+        var exception = Assert.Throws<JavaScriptException>(
+            () => engine.Execute("new Worker('./worker.js', { type: 'module' })"));
+
+        exception.Error.Get("name").AsString().Should().Be("SecurityError");
+        provider.Requests.Should().Be(1);
+    }
+
+    /// <summary>
+    /// A worker gets strictly fewer capabilities than its creator, and the one that matters most is the
+    /// network. Reachable through the real constructor now, rather than through a hand-built request.
+    /// </summary>
+    [Fact]
+    public void AWorkerDoesNotInheritNetworkAccess()
+    {
+        var host = new PumpOnDemandWorkerHost(new Dictionary<string, string>
+        {
+            ["./worker.js"] = """
+                report('fetch:' + typeof fetch);
+                report('WebSocket:' + typeof WebSocket);
+                report('EventSource:' + typeof EventSource);
+                report('localStorage:' + typeof localStorage);
+                report('caches:' + typeof caches);
+                report('Worker:' + typeof Worker);
+                report('postMessage:' + typeof postMessage);
+                """,
         });
 
-        engine.Evaluate("typeof Worker").AsString().Should().Be(
-            "undefined",
-            "the constructor lands in its own change; nothing about this one is observable to a script");
+        var parent = new Engine(options =>
+        {
+            options.UseWebApis(WebApiFeatures.Default | WebApiFeatures.Fetch | WebApiFeatures.WebSocket | WebApiFeatures.Storage | WebApiFeatures.CacheApi);
+            options.UseWorkers(host);
+        });
 
-        engine.Evaluate("typeof WorkerGlobalScope").AsString().Should().Be("undefined");
-        engine.Evaluate("typeof DedicatedWorkerGlobalScope").AsString().Should().Be("undefined");
-        provider.Requests.Should().Be(0);
+        parent.Evaluate("typeof fetch").AsString().Should().Be("function", "the parent really was granted it");
+
+        parent.Execute("var w = new Worker('./worker.js', { type: 'module' });");
+        host.Drain(parent);
+
+        host.Log.Should().Be(
+            "fetch:undefined,WebSocket:undefined,EventSource:undefined,localStorage:undefined,caches:undefined,Worker:undefined,postMessage:function");
+    }
+
+    /// <summary>
+    /// One provider serving a pool of engines reaches per-request policy through
+    /// <c>request.Parent.Advanced.HostDefined</c>, which is per engine and which the engine never reads.
+    /// </summary>
+    [Fact]
+    public void TheProviderCanReachPerRequestStateThroughHostDefined()
+    {
+        var seen = new List<string>();
+        var host = new PumpOnDemandWorkerHost(new Dictionary<string, string> { ["./worker.js"] = "" })
+        {
+            Inspect = request => seen.Add((string) request.Parent.Advanced.HostDefined!),
+        };
+
+        var shared = new Options().UseWebApis().UseWorkers(host);
+
+        var tenantA = new Engine(shared);
+        tenantA.Advanced.HostDefined = "tenant-a";
+        var tenantB = new Engine(shared);
+        tenantB.Advanced.HostDefined = "tenant-b";
+
+        tenantA.Execute("new Worker('./worker.js', { type: 'module' });");
+        tenantB.Execute("new Worker('./worker.js', { type: 'module' });");
+
+        seen.Should().Equal("tenant-a", "tenant-b");
+    }
+
+    /// <summary>
+    /// <c>OnWorkerStarted</c> is where a host starts pumping, so the engine it is handed has to be one the host
+    /// can pump on its own thread — which means the engine wiring must have let go of it first.
+    /// </summary>
+    [Fact]
+    public void OnWorkerStartedSeesAPumpableEngine()
+    {
+        var pumpedInsideCallback = false;
+        var host = new PumpOnDemandWorkerHost(new Dictionary<string, string> { ["./worker.js"] = "report('ran');" })
+        {
+            OnStarted = connection =>
+            {
+                // The host's very first act, on the parent's thread, exactly as a thread-per-worker provider's
+                // Thread.Start would be — and it has to be allowed.
+                connection.Worker.Advanced.ProcessTasks();
+                pumpedInsideCallback = true;
+            },
+        };
+
+        var parent = new Engine(options => options.UseWebApis().UseWorkers(host));
+        parent.Execute("new Worker('./worker.js', { type: 'module' });");
+
+        pumpedInsideCallback.Should().BeTrue();
+        host.Log.Should().Be("ran", "the worker's module runs on the first pump the host gives it");
+    }
+
+    /// <summary>
+    /// Several workers cooperating on one host loop — the game-frame shape — each make progress, and neither
+    /// starves the other.
+    /// </summary>
+    [Fact]
+    public void TwoWorkersPumpedFromOneLoopBothMakeProgress()
+    {
+        var host = new PumpOnDemandWorkerHost(new Dictionary<string, string>
+        {
+            ["./a.js"] = "addEventListener('message', e => postMessage('a:' + e.data));",
+            ["./b.js"] = "addEventListener('message', e => postMessage('b:' + e.data));",
+        });
+
+        var parent = new Engine(options => options.UseWebApis().UseWorkers(host));
+        parent.Execute("""
+            var got = [];
+            var a = new Worker('./a.js', { type: 'module' });
+            var b = new Worker('./b.js', { type: 'module' });
+            a.onmessage = e => got.push(e.data);
+            b.onmessage = e => got.push(e.data);
+            a.postMessage(1);
+            b.postMessage(2);
+            """);
+
+        host.Connections.Should().HaveCount(2);
+        host.Drain(parent);
+
+        var got = parent.Evaluate("got.slice().sort().join(',')").AsString();
+        got.Should().Be("a:1,b:2");
+    }
+
+    /// <summary>
+    /// The shape the feature exists for: the host gives each worker a thread of its own, and a full
+    /// <c>postMessage</c> round trip crosses it.
+    /// </summary>
+    /// <remarks>
+    /// Event-driven throughout, with a ten-second ceiling on every wait so that a loaded machine makes this
+    /// slower rather than redder. The worker's thread parks on its own reset event, which the parent's pump
+    /// wakes — the engine's own wait primitive is a separate change and this deliberately does not depend on
+    /// it.
+    /// </remarks>
+    [Fact]
+    public void AHostProviderThreadPerWorkerRoundTrips()
+    {
+        using var host = new ThreadPerWorkerHost();
+
+        var parent = new Engine(options => options.UseWebApis().UseWorkers(host));
+        parent.Execute("""
+            var got = null;
+            var w = new Worker('./worker.js', { type: 'module' });
+            w.onmessage = e => { got = e.data; };
+            w.postMessage('ping');
+            """);
+
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
+        while (DateTime.UtcNow < deadline && parent.Evaluate("got").IsNull())
+        {
+            parent.Advanced.ProcessTasks();
+            host.Answered.Wait(TimeSpan.FromMilliseconds(50));
+        }
+
+        parent.Evaluate("got").AsString().Should().Be("pong:ping");
+
+        parent.Execute("w.terminate();");
+        host.WaitForPumpToLeave();
+    }
+
+    /// <summary>
+    /// A provider the test drives itself: it builds the worker engine over an in-memory module map, starts no
+    /// thread, and lets the test decide when each worker gets a turn.
+    /// </summary>
+    private sealed class PumpOnDemandWorkerHost : WorkerProvider
+    {
+        private readonly Dictionary<string, string> _modules;
+        private readonly List<string> _log = new();
+
+        public PumpOnDemandWorkerHost(Dictionary<string, string> modules) => _modules = modules;
+
+        public Action<WorkerRequest>? Inspect { get; set; }
+
+        public Action<WorkerConnection>? OnStarted { get; set; }
+
+        public List<WorkerConnection> Connections { get; } = new();
+
+        public string Log => string.Join(",", _log);
+
+        public override Engine? CreateWorkerEngine(WorkerRequest request)
+        {
+            Inspect?.Invoke(request);
+
+            var options = request.CreateDefaultOptions();
+            options.Modules.ModuleLoader = new MapModuleLoader(_modules);
+
+            var engine = new Engine(options);
+            engine.SetValue("report", new Action<string>(_log.Add));
+            return engine;
+        }
+
+        public override void OnWorkerStarted(WorkerConnection connection)
+        {
+            Connections.Add(connection);
+            OnStarted?.Invoke(connection);
+        }
+
+        public void Drain(Engine parent, int rounds = 50)
+        {
+            for (var i = 0; i < rounds; i++)
+            {
+                foreach (var connection in Connections)
+                {
+                    connection.Worker.Advanced.ProcessTasks();
+                }
+
+                parent.Advanced.ProcessTasks();
+            }
+        }
+    }
+
+    /// <summary>
+    /// The thread-per-worker shape, written the way <see cref="WorkerProvider"/> documents it: the connection
+    /// is registered before the pump starts, the loop watches <see cref="WorkerConnection.IsEnded"/>, and the
+    /// engine is disposed on the thread that was pumping it.
+    /// </summary>
+    private sealed class ThreadPerWorkerHost : WorkerProvider, IDisposable
+    {
+        private readonly ManualResetEventSlim _left = new(false);
+        private Thread? _thread;
+
+        public ManualResetEventSlim Answered { get; } = new(false);
+
+        public override Engine? CreateWorkerEngine(WorkerRequest request)
+        {
+            var options = request.CreateDefaultOptions();
+            options.Modules.ModuleLoader = new MapModuleLoader(new Dictionary<string, string>
+            {
+                ["./worker.js"] = "addEventListener('message', e => { postMessage('pong:' + e.data); answered(); });",
+            });
+
+            var engine = new Engine(options);
+            engine.SetValue("answered", new Action(() => Answered.Set()));
+            return engine;
+        }
+
+        public override void OnWorkerStarted(WorkerConnection connection)
+        {
+            _thread = new Thread(() =>
+            {
+                try
+                {
+                    while (!connection.IsEnded)
+                    {
+                        connection.Worker.Advanced.ProcessTasks();
+                        connection.TerminationToken.WaitHandle.WaitOne(TimeSpan.FromMilliseconds(5));
+                    }
+                }
+                catch (ExecutionCanceledException)
+                {
+                    // terminate()'s cooperative half, observed on this thread. Leaving is what it asks for.
+                }
+                finally
+                {
+                    // On the pumping thread, after the loop — never from OnWorkerEnded.
+                    connection.Worker.Dispose();
+                    _left.Set();
+                }
+            })
+            {
+                IsBackground = true,
+                Name = "worker pump",
+            };
+
+            _thread.Start();
+        }
+
+        public void WaitForPumpToLeave()
+            => _left.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue("the loop observes IsEnded and leaves");
+
+        public void Dispose()
+        {
+            _left.Dispose();
+            Answered.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// A module loader over a dictionary, built out of the public module API alone.
+    /// </summary>
+    private sealed class MapModuleLoader : IModuleLoader
+    {
+        private readonly Dictionary<string, string> _sources;
+
+        public MapModuleLoader(Dictionary<string, string> sources) => _sources = sources;
+
+        public ResolvedSpecifier Resolve(string? referencingModuleLocation, ModuleRequest moduleRequest)
+        {
+            if (!_sources.ContainsKey(moduleRequest.Specifier))
+            {
+                throw new ModuleResolutionException("Module not found", moduleRequest.Specifier, referencingModuleLocation, filePath: null);
+            }
+
+            return new ResolvedSpecifier(moduleRequest, moduleRequest.Specifier, Uri: null, SpecifierType.RelativeOrAbsolute);
+        }
+
+        public Jint.Runtime.Modules.Module LoadModule(Engine engine, ResolvedSpecifier resolved)
+            => ModuleFactory.BuildSourceTextModule(engine, resolved, _sources[resolved.Key]);
     }
 }
 #endif

--- a/Jint.Tests.PublicInterface/WebApiWorkerTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiWorkerTests.cs
@@ -224,28 +224,55 @@ public class WebApiWorkerTests
     }
 
     /// <summary>
-    /// <c>OnWorkerStarted</c> is where a host starts pumping, so the engine it is handed has to be one the host
-    /// can pump on its own thread — which means the engine wiring must have let go of it first.
+    /// <c>OnWorkerStarted</c> is where a host starts pumping, and a thread-per-worker provider starts that
+    /// thread from inside it — so the engine wiring has to have let go of the worker engine before the call.
     /// </summary>
+    /// <remarks>
+    /// The callback waits for that thread's first pump before returning, which is what makes the pin
+    /// deterministic: the engine is <i>provably</i> still inside <c>OnWorkerStarted</c> while another thread
+    /// enters it. Holding the construction's ownership across the callback makes that pump the engine's own
+    /// concurrent-use exception. Pumping from the callback's own thread would prove nothing — same-thread
+    /// re-entry is always allowed.
+    /// </remarks>
     [Fact]
     public void OnWorkerStartedSeesAPumpableEngine()
     {
-        var pumpedInsideCallback = false;
+        Exception? pumpFailure = null;
         var host = new PumpOnDemandWorkerHost(new Dictionary<string, string> { ["./worker.js"] = "report('ran');" })
         {
             OnStarted = connection =>
             {
-                // The host's very first act, on the parent's thread, exactly as a thread-per-worker provider's
-                // Thread.Start would be — and it has to be allowed.
-                connection.Worker.Advanced.ProcessTasks();
-                pumpedInsideCallback = true;
+                using var pumped = new ManualResetEventSlim(false);
+                var pump = new Thread(() =>
+                {
+                    try
+                    {
+                        connection.Worker.Advanced.ProcessTasks();
+                    }
+                    catch (Exception ex)
+                    {
+                        pumpFailure = ex;
+                    }
+                    finally
+                    {
+                        pumped.Set();
+                    }
+                })
+                {
+                    IsBackground = true,
+                    Name = "worker pump",
+                };
+
+                pump.Start();
+                pumped.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
+                pump.Join(TimeSpan.FromSeconds(10)).Should().BeTrue();
             },
         };
 
         var parent = new Engine(options => options.UseWebApis().UseWorkers(host));
         parent.Execute("new Worker('./worker.js', { type: 'module' });");
 
-        pumpedInsideCallback.Should().BeTrue();
+        pumpFailure.Should().BeNull("the worker engine is the host's from the moment this callback runs");
         host.Log.Should().Be("ran", "the worker's module runs on the first pump the host gives it");
     }
 

--- a/Jint.Tests/Runtime/WebApi/MessagingTests.cs
+++ b/Jint.Tests/Runtime/WebApi/MessagingTests.cs
@@ -252,6 +252,65 @@ public class MessagingTests
         Log(engine).Should().Be("microtask,message");
     }
 
+    /// <summary>
+    /// The other half of the rule above, and the one a single message cannot show: a message is a task, so
+    /// everything one listener queues runs before the <i>next</i> message is even looked at — the same
+    /// checkpoint per message that each timer callback gets.
+    /// </summary>
+    /// <remarks>
+    /// The mechanism is the order of the two lines at the end of <c>JsMessagePort.DrainOne</c>: the next
+    /// delivery job is armed <i>after</i> the dispatch, in a finally, so a listener's reactions are queued
+    /// ahead of it. Arming it first — which is what the code used to do, for a throw-resilience reason the
+    /// finally keeps — put the second message ahead of the first message's microtasks and made this read
+    /// <c>m1,m2,p1,p2</c>.
+    /// </remarks>
+    [Fact]
+    public void EachMessageGetsItsOwnMicrotaskCheckpoint()
+    {
+        var engine = MessagingEngine();
+
+        engine.Execute("""
+            var ch = new MessageChannel();
+            ch.port1.onmessage = function (e) {
+                log.push('m' + e.data);
+                Promise.resolve().then(function () { log.push('p' + e.data); });
+            };
+            ch.port2.postMessage(1);
+            ch.port2.postMessage(2);
+            """);
+
+        Log(engine).Should().Be("m1,p1,m2,p2");
+    }
+
+    /// <summary>
+    /// The property the arm-before-dispatch order was written for, kept: a listener that throws erupts from
+    /// the pump, and the message behind it is still delivered on the next turn.
+    /// </summary>
+    [Fact]
+    public void AThrowingListenerDoesNotStrandTheMessagesBehindIt()
+    {
+        var engine = MessagingEngine();
+
+        engine.Execute("""
+            var ch = new MessageChannel();
+            ch.port1.onmessage = function (e) {
+                log.push('m' + e.data);
+                if (e.data === 1) { throw new Error('boom'); }
+            };
+            """);
+
+        // The throw erupts from whatever is draining the loop, which for a script-driven post is Execute.
+        Assert.Throws<Jint.Runtime.JavaScriptException>(() => engine.Execute("""
+            ch.port2.postMessage(1);
+            ch.port2.postMessage(2);
+            """));
+
+        Log(engine).Should().Be("m1");
+
+        engine.Advanced.ProcessTasks();
+        Log(engine).Should().Be("m1,m2");
+    }
+
     [Fact]
     public void FiresATrustedMessageEventWithTheSpecifiedDefaults()
     {

--- a/Jint.Tests/Runtime/WebApi/WorkerMechanismTests.cs
+++ b/Jint.Tests/Runtime/WebApi/WorkerMechanismTests.cs
@@ -789,17 +789,30 @@ public class WorkerMechanismTests
     // -------------------------------------------------------------------------------------------------------
 
     /// <summary>
-    /// The host ending a connection while the worker's own thread is inside <c>ProcessTasks</c> is the ordinary
-    /// thread-per-worker shape, and it must touch nothing but endpoints, a token and interlocked bookkeeping.
+    /// The host ending a connection while the worker's own thread is <b>provably inside</b> the worker engine
+    /// is the ordinary thread-per-worker shape, and it must touch nothing but endpoints, a token and
+    /// interlocked bookkeeping.
     /// </summary>
+    /// <remarks>
+    /// The rendezvous is the point, and is what makes the pin deterministic rather than lucky: the worker's
+    /// listener parks in a host callback, so its thread owns the engine for as long as the test wants. Anything
+    /// in the end sequence that reached into the worker engine — a <c>ProcessTasks</c>, a <c>Dispose</c>, a
+    /// <c>Constraints.Reset</c> — is then the engine's own concurrent-use exception, thrown out of
+    /// <c>End()</c> on the caller's thread. No wall-clock assertion anywhere; the ceilings only stop a
+    /// deadlock from hanging the run.
+    /// </remarks>
     [Fact]
     public void EndingTheConnectionFromTheParentWhileTheWorkerPumpsDoesNotThrow()
     {
-        using var pumping = new ManualResetEventSlim(false);
-        using var stop = new ManualResetEventSlim(false);
+        using var inside = new ManualResetEventSlim(false);
+        using var release = new ManualResetEventSlim(false);
 
-        var host = new TestWorkerHost(Module("addEventListener('message', () => postMessage('pong'));"));
-        host.Configure = engine => engine.SetValue("noop", new Action(() => { }));
+        var host = new TestWorkerHost(Module("addEventListener('message', () => hold());"));
+        host.Configure = engine => engine.SetValue("hold", new Action(() =>
+        {
+            inside.Set();
+            release.Wait(Ceiling);
+        }));
 
         var parent = Parent(host);
         parent.Execute("var w = new Worker('./worker.js', { type: 'module' });");
@@ -810,10 +823,9 @@ public class WorkerMechanismTests
         {
             try
             {
-                while (!connection.IsEnded && !stop.IsSet)
+                while (!connection.IsEnded)
                 {
                     connection.Worker.Advanced.ProcessTasks();
-                    pumping.Set();
                 }
             }
             catch (ExecutionCanceledException)
@@ -831,12 +843,18 @@ public class WorkerMechanismTests
         };
 
         pump.Start();
-        pumping.Wait(Ceiling).Should().BeTrue();
 
-        // From the parent's thread, while the worker's thread is inside its pump.
-        connection.End();
+        // The message that parks the worker's thread inside the engine. Posted from the parent's thread, which
+        // is allowed: a port's queue is the one part of another engine any thread may touch.
+        parent.Execute("w.postMessage('park');");
 
-        stop.Set();
+        inside.Wait(Ceiling).Should().BeTrue("the worker's thread has to own its engine before End() means anything");
+
+        // From the parent's thread, with the worker's thread demonstrably inside the worker engine.
+        var end = Record.Exception(connection.End);
+        end.Should().BeNull("ending a connection touches only endpoints, a token and interlocked bookkeeping");
+
+        release.Set();
         pump.Join(Ceiling).Should().BeTrue("the pump loop observes IsEnded and leaves");
         escaped.Should().BeNull();
 

--- a/Jint.Tests/Runtime/WebApi/WorkerMechanismTests.cs
+++ b/Jint.Tests/Runtime/WebApi/WorkerMechanismTests.cs
@@ -1,0 +1,1053 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using System.Collections.Concurrent;
+using System.Threading;
+using Jint.Runtime;
+using Jint.Runtime.Modules;
+using Jint.WebApi;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// The <c>Worker</c> constructor, the two façades, the message paths, and the two ways a connection ends.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The worker engine is pumped by the test's own thread</b> wherever determinism matters, which is nearly
+/// everywhere: <see cref="TestWorkerHost"/> builds the engine and hands it back, and the test calls
+/// <c>ProcessTasks</c> on the two engines in turn. Nothing here waits on a clock. The three pins that are
+/// genuinely about threads say so and use a real one, with an event-driven wait and a ceiling generous enough
+/// that a slow machine makes them slower rather than redder.
+/// </para>
+/// <para>
+/// The sibling file <c>WorkerTests</c> holds the host-facing foundation — <c>CreateDefaultOptions</c> and the
+/// connection object — which needs no constructor to exercise.
+/// </para>
+/// </remarks>
+public class WorkerMechanismTests
+{
+    private const string Specifier = "./worker.js";
+
+    /// <summary>Ten seconds: long enough that a loaded machine is slow rather than red.</summary>
+    private static readonly TimeSpan Ceiling = TimeSpan.FromSeconds(10);
+
+    // -------------------------------------------------------------------------------------------------------
+    // Construction and refusals
+    // -------------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void NoProviderMeansNoWorkerGlobal()
+    {
+        var withFlagOnly = new Engine(options => options.UseWebApis(WebApiFeatures.Default | WebApiFeatures.Workers));
+        withFlagOnly.Evaluate("typeof Worker").AsString().Should().Be(
+            "undefined",
+            "a worker needs a thread and a pump, and with no provider there is neither");
+
+        var withProviderOnly = new Engine(options =>
+        {
+            options.UseWebApis();
+            options.WebApi.Workers.Provider = new TestWorkerHost();
+        });
+        withProviderOnly.Evaluate("typeof Worker").AsString().Should().Be("undefined", "the flag is still the grant");
+
+        var withBoth = new Engine(options => options.UseWebApis().UseWorkers(new TestWorkerHost()));
+        withBoth.Evaluate("typeof Worker").AsString().Should().Be("function");
+    }
+
+    [Theory]
+    [InlineData("new Worker('./worker.js')", "type: 'module'")]
+    [InlineData("new Worker('./worker.js', { type: 'classic' })", "type: 'module'")]
+    [InlineData("new Worker('./worker.js', { type: 'nope' })", "WorkerType")]
+    public void AClassicWorkerRequestIsATypeError(string source, string expectedInMessage)
+    {
+        var host = new TestWorkerHost();
+        var parent = Parent(host);
+
+        var exception = Assert.Throws<JavaScriptException>(() => parent.Execute(source));
+
+        exception.Error.Get("name").AsString().Should().Be("TypeError");
+        exception.Message.Should().Contain(expectedInMessage);
+        host.Requests.Should().Be(0, "WebIDL runs before the host is ever consulted");
+    }
+
+    [Fact]
+    public void AProviderRefusalIsASecurityError()
+    {
+        var host = new TestWorkerHost { Refuse = true };
+        var parent = Parent(host);
+
+        var exception = Assert.Throws<JavaScriptException>(
+            () => parent.Execute("new Worker('./worker.js', { type: 'module' })"));
+
+        exception.Error.Get("name").AsString().Should().Be(
+            "SecurityError",
+            "a refusal is a policy decision, not a fetch failure");
+        host.Requests.Should().Be(1);
+        host.Started.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AProviderExceptionPropagatesUnchanged()
+    {
+        var failure = new InvalidTimeZoneException("the tenant has no worker budget");
+        var host = new TestWorkerHost { Throw = failure };
+        var parent = Parent(host);
+
+        var thrown = Assert.Throws<InvalidTimeZoneException>(
+            () => parent.Execute("new Worker('./worker.js', { type: 'module' })"));
+
+        thrown.Should().BeSameAs(failure, "nothing a provider throws is translated");
+    }
+
+    [Fact]
+    public void MoreThanMaxWorkersIsAQuotaExceededError()
+    {
+        var host = new TestWorkerHost(Module("")) ;
+        var parent = Parent(host, maxWorkers: 2);
+
+        parent.Execute("var a = new Worker('./worker.js', { type: 'module' });");
+        parent.Execute("var b = new Worker('./worker.js', { type: 'module' });");
+
+        var exception = Assert.Throws<JavaScriptException>(
+            () => parent.Execute("var c = new Worker('./worker.js', { type: 'module' });"));
+
+        exception.Error.Get("name").AsString().Should().Be("QuotaExceededError");
+        exception.Error.Get("quota").AsNumber().Should().Be(2);
+        exception.Error.Get("requested").AsNumber().Should().Be(3);
+        host.Requests.Should().Be(2, "the cap is checked before the host is consulted");
+
+        // And the slot comes back when a connection ends.
+        parent.Execute("a.terminate();");
+        parent.Execute("var d = new Worker('./worker.js', { type: 'module' });");
+    }
+
+    [Fact]
+    public void AnEngineWithoutTheTerminationTokenIsRefused()
+    {
+        var host = new TestWorkerHost
+        {
+            Build = _ => new Engine(options => options.UseWebApis(WebApiFeatures.Messaging | WebApiFeatures.GlobalEvents)),
+        };
+        var parent = Parent(host);
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => parent.Execute("new Worker('./worker.js', { type: 'module' })"));
+
+        exception.Message.Should().Contain("request.TerminationToken");
+        exception.Message.Should().Contain("options.CancellationToken", "the message names the one-line fix");
+    }
+
+    [Fact]
+    public void AnEngineWithoutMessagingIsRefused()
+    {
+        var host = new TestWorkerHost
+        {
+            Build = request => new Engine(options => options.CancellationToken(request.TerminationToken)),
+        };
+        var parent = Parent(host);
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => parent.Execute("new Worker('./worker.js', { type: 'module' })"));
+
+        exception.Message.Should().Contain("WebApiFeatures.Messaging");
+    }
+
+    [Fact]
+    public void TheParentEngineItselfIsRefused()
+    {
+        var host = new TestWorkerHost();
+        Engine? parent = null;
+        host.Build = _ => parent!;
+        parent = Parent(host);
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => parent.Execute("new Worker('./worker.js', { type: 'module' })"));
+
+        exception.Message.Should().Contain("returned the parent engine");
+    }
+
+    /// <summary>
+    /// A pre-warmed engine another thread is already inside is the bug this validates against, and the answer
+    /// is the engine's own admission error at <c>new Worker()</c> rather than silent corruption later.
+    /// </summary>
+    [Fact]
+    public void AnUnQuiescentWorkerEngineIsRefused()
+    {
+        using var owned = new ManualResetEventSlim(false);
+        using var release = new ManualResetEventSlim(false);
+
+        var busy = new Engine(options => options.UseWebApis(WebApiFeatures.Messaging | WebApiFeatures.GlobalEvents));
+        var host = new TestWorkerHost { Build = _ => busy };
+        var parent = Parent(host);
+
+        var holder = new Thread(() =>
+        {
+            using (busy.EnterHostCall())
+            {
+                owned.Set();
+                release.Wait(Ceiling);
+            }
+        })
+        {
+            IsBackground = true,
+            Name = "worker engine holder",
+        };
+
+        holder.Start();
+        owned.Wait(Ceiling).Should().BeTrue("the holder thread has to have the engine before the constructor runs");
+
+        try
+        {
+            var exception = Assert.Throws<InvalidOperationException>(
+                () => parent.Execute("new Worker('./worker.js', { type: 'module' })"));
+
+            exception.Message.Should().Contain("already in use by another thread");
+        }
+        finally
+        {
+            release.Set();
+            holder.Join(Ceiling).Should().BeTrue();
+        }
+    }
+
+    /// <summary>
+    /// Nothing of the worker's script runs during <c>new Worker()</c>, and what runs it is whichever thread
+    /// pumps the worker engine — never the parent's.
+    /// </summary>
+    [Fact]
+    public void TheWorkerScriptDoesNotRunOnTheParentsThread()
+    {
+        using var evaluated = new ManualResetEventSlim(false);
+
+        var recorded = 0;
+        var host = new TestWorkerHost(Module("record('evaluated');"));
+        host.Configure = engine => engine.SetValue("noteThread", new Action(() =>
+        {
+            Volatile.Write(ref recorded, Environment.CurrentManagedThreadId);
+            evaluated.Set();
+        }));
+        host.Modules[Specifier] = "noteThread();";
+
+        var parent = Parent(host);
+        var parentThread = Environment.CurrentManagedThreadId;
+
+        parent.Execute("var w = new Worker('./worker.js', { type: 'module' });");
+
+        evaluated.IsSet.Should().BeFalse("new Worker() runs none of the worker's script");
+        Volatile.Read(ref recorded).Should().Be(0);
+
+        var connection = host.Connection;
+        var pump = new Thread(() =>
+        {
+            for (var i = 0; i < 200 && !evaluated.IsSet; i++)
+            {
+                connection.Worker.Advanced.ProcessTasks();
+            }
+        })
+        {
+            IsBackground = true,
+            Name = "worker pump",
+        };
+
+        pump.Start();
+        evaluated.Wait(Ceiling).Should().BeTrue("the worker's module runs on the thread that pumps it");
+        pump.Join(Ceiling).Should().BeTrue();
+
+        Volatile.Read(ref recorded).Should().NotBe(parentThread);
+    }
+
+    // -------------------------------------------------------------------------------------------------------
+    // Messaging and ordering
+    // -------------------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// The worker's own queue is not enabled until its module has evaluated, so a message posted before then
+    /// waits rather than being dispatched at a global that has not registered a listener yet.
+    /// </summary>
+    /// <remarks>
+    /// The worker's module suspends on a timer, which is what makes the pin bite: with the inner queue enabled
+    /// at construction the delivery job would run during that suspension and the first message would be
+    /// dropped on the floor.
+    /// </remarks>
+    [Fact]
+    public void AMessagePostedBeforeTheWorkerEvaluatesIsBuffered()
+    {
+        var host = new TestWorkerHost(Module("""
+            record('evaluating');
+            await new Promise(resolve => setTimeout(resolve, 0));
+            addEventListener('message', e => record('msg:' + e.data));
+            record('ready');
+            """));
+
+        var parent = Parent(host);
+        parent.Execute("""
+            var w = new Worker('./worker.js', { type: 'module' });
+            w.postMessage(1);
+            w.postMessage(2);
+            """);
+
+        Drain(parent, host.Connection);
+
+        host.Log.Should().Be("evaluating,ready,msg:1,msg:2");
+    }
+
+    [Fact]
+    public void MessagesArriveInPostOrder()
+    {
+        var host = new TestWorkerHost(Module("addEventListener('message', e => record(e.data));"));
+        var parent = Parent(host);
+
+        parent.Execute("""
+            var w = new Worker('./worker.js', { type: 'module' });
+            for (var i = 0; i < 8; i++) { w.postMessage('m' + i); }
+            """);
+
+        Drain(parent, host.Connection);
+
+        host.Log.Should().Be("m0,m1,m2,m3,m4,m5,m6,m7");
+    }
+
+    /// <summary>
+    /// A message is a task, so everything a listener queues runs before the next message is even looked at —
+    /// the timers' rule, inherited whole.
+    /// </summary>
+    [Fact]
+    public void EachMessageGetsItsOwnMicrotaskCheckpoint()
+    {
+        var host = new TestWorkerHost(Module("""
+            addEventListener('message', e => {
+                record('m' + e.data);
+                Promise.resolve().then(() => record('p' + e.data));
+            });
+            """));
+
+        var parent = Parent(host);
+        parent.Execute("""
+            var w = new Worker('./worker.js', { type: 'module' });
+            w.postMessage(1);
+            w.postMessage(2);
+            """);
+
+        Drain(parent, host.Connection);
+
+        host.Log.Should().Be("m1,p1,m2,p2", "not m1,m2,p1,p2");
+    }
+
+    /// <summary>
+    /// The parent half is enabled by the engine at construction, so a message the worker posts during its own
+    /// evaluation waits on the parent's queue until the parent is pumped — whenever the handler was assigned.
+    /// </summary>
+    [Fact]
+    public void AMessageSentBeforeTheParentAssignsOnmessageIsNotLost()
+    {
+        var host = new TestWorkerHost(Module("postMessage('hello');"));
+        var parent = Parent(host);
+
+        parent.Execute("var got = []; var w = new Worker('./worker.js', { type: 'module' });");
+
+        // The worker runs and posts while the parent has no handler at all.
+        DrainWorker(host.Connection);
+
+        parent.Execute("w.onmessage = e => got.push(e.data);");
+        Drain(parent, host.Connection);
+
+        parent.Evaluate("got.join(',')").AsString().Should().Be("hello");
+    }
+
+    /// <summary>
+    /// <c>addEventListener('message', …)</c> alone receives on both façades. The <c>onmessage</c>-implies-
+    /// <c>start()</c> rule is scoped to the <c>MessagePort</c> interface and must not be reused here.
+    /// </summary>
+    [Fact]
+    public void AWorkerDeliversToAddEventListenerWithoutStart()
+    {
+        var host = new TestWorkerHost(Module("""
+            addEventListener('message', e => { record('in:' + e.data); postMessage('out:' + e.data); });
+            """));
+
+        var parent = Parent(host);
+        parent.Execute("""
+            var got = [];
+            var w = new Worker('./worker.js', { type: 'module' });
+            w.addEventListener('message', e => got.push(e.data));
+            w.postMessage('x');
+            """);
+
+        Drain(parent, host.Connection);
+
+        host.Log.Should().Be("in:x");
+        parent.Evaluate("got.join(',')").AsString().Should().Be("out:x");
+    }
+
+    [Fact]
+    public void ATransferredArrayBufferIsMovedNotCopied()
+    {
+        var host = new TestWorkerHost(Module("""
+            addEventListener('message', e => record('bytes:' + new Uint8Array(e.data).join('-')));
+            """));
+
+        var parent = Parent(host);
+        parent.Execute("""
+            var w = new Worker('./worker.js', { type: 'module' });
+            var view = new Uint8Array([7, 8, 9]);
+            var detachedBefore = view.buffer.byteLength;
+            w.postMessage(view.buffer, [view.buffer]);
+            var detachedAfter = view.buffer.byteLength;
+            """);
+
+        parent.Evaluate("detachedBefore").AsNumber().Should().Be(3);
+        parent.Evaluate("detachedAfter").AsNumber().Should().Be(0, "the sender's buffer is detached, not copied");
+
+        Drain(parent, host.Connection);
+
+        host.Log.Should().Be("bytes:7-8-9");
+    }
+
+    [Fact]
+    public void ASharedArrayBufferIsADataCloneError()
+    {
+        var host = new TestWorkerHost(Module(""));
+        var parent = Parent(host);
+
+        var exception = Assert.Throws<JavaScriptException>(() => parent.Execute("""
+            var w = new Worker('./worker.js', { type: 'module' });
+            w.postMessage(new SharedArrayBuffer(8));
+            """));
+
+        exception.Error.Get("name").AsString().Should().Be("DataCloneError");
+    }
+
+    [Fact]
+    public void APortTransferredToAWorkerIsReEntangledOnTheWorkerSide()
+    {
+        var host = new TestWorkerHost(Module("""
+            addEventListener('message', e => {
+                const port = e.ports[0];
+                port.onmessage = m => record('private:' + m.data);
+                port.postMessage('pong');
+            });
+            """));
+
+        var parent = Parent(host);
+        parent.Execute("""
+            var got = [];
+            var w = new Worker('./worker.js', { type: 'module' });
+            var channel = new MessageChannel();
+            channel.port1.onmessage = e => { got.push(e.data); channel.port1.postMessage('ping'); };
+            w.postMessage('take it', [channel.port2]);
+            """);
+
+        Drain(parent, host.Connection);
+
+        parent.Evaluate("got.join(',')").AsString().Should().Be("pong");
+        host.Log.Should().Be("private:ping");
+    }
+
+    [Fact]
+    public void MoreThanMaxQueuedMessagesIsAQuotaExceededError()
+    {
+        var host = new TestWorkerHost(Module("addEventListener('message', e => record(e.data));"));
+        var parent = Parent(host, maxQueuedMessages: 2);
+
+        // The worker is never pumped, so nothing leaves the queue.
+        var exception = Assert.Throws<JavaScriptException>(() => parent.Execute("""
+            var w = new Worker('./worker.js', { type: 'module' });
+            w.postMessage('a');
+            w.postMessage('b');
+            w.postMessage('c');
+            """));
+
+        exception.Error.Get("name").AsString().Should().Be("QuotaExceededError");
+        exception.Error.Get("quota").AsNumber().Should().Be(2);
+        exception.Error.Get("requested").AsNumber().Should().Be(3);
+
+        // Draining the queue makes room again: the cap is a backstop against a stuck receiver, not a budget.
+        Drain(parent, host.Connection);
+        host.Log.Should().Be("a,b");
+
+        parent.Execute("w.postMessage('d');");
+        Drain(parent, host.Connection);
+        host.Log.Should().Be("a,b,d");
+    }
+
+    // -------------------------------------------------------------------------------------------------------
+    // terminate()
+    // -------------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void APostMessageAfterTerminateIsNeverDelivered()
+    {
+        var host = new TestWorkerHost(Module("addEventListener('message', e => record(e.data));"));
+        var parent = Parent(host);
+
+        parent.Execute("var w = new Worker('./worker.js', { type: 'module' }); w.postMessage('before');");
+        Drain(parent, host.Connection);
+        host.Log.Should().Be("before");
+
+        parent.Execute("w.terminate(); w.postMessage('after');");
+        Drain(parent, host.Connection);
+
+        host.Log.Should().Be("before", "terminate is an immediate parent-to-worker fence");
+    }
+
+    /// <summary>
+    /// "Silent no-op" is true only for serializable values: HTML's step 5 runs before step 6, so the message is
+    /// serialized — and any transfer performed — before there turns out to be nowhere to deliver it.
+    /// </summary>
+    [Fact]
+    public void APostMessageAfterTerminateStillThrowsDataCloneError()
+    {
+        var host = new TestWorkerHost(Module(""));
+        var parent = Parent(host);
+
+        parent.Execute("var w = new Worker('./worker.js', { type: 'module' }); w.terminate();");
+
+        var exception = Assert.Throws<JavaScriptException>(() => parent.Execute("w.postMessage(function () {})"));
+        exception.Error.Get("name").AsString().Should().Be("DataCloneError");
+
+        parent.Execute("""
+            var view = new Uint8Array([1, 2, 3]);
+            w.postMessage(view.buffer, [view.buffer]);
+            var lengthAfter = view.buffer.byteLength;
+            """);
+
+        parent.Evaluate("lengthAfter").AsNumber().Should().Be(0, "a transfer-listed buffer is still detached");
+    }
+
+    [Fact]
+    public void TerminateIsIdempotent()
+    {
+        var host = new TestWorkerHost(Module(""));
+        var parent = Parent(host);
+
+        parent.Execute("""
+            var w = new Worker('./worker.js', { type: 'module' });
+            w.terminate();
+            w.terminate();
+            w.terminate();
+            """);
+
+        host.Ended.Should().ContainSingle().Which.Reason.Should().Be(WorkerEndReason.Terminated);
+        host.Connection.IsEnded.Should().BeTrue();
+        host.Connection.EndReason.Should().Be(WorkerEndReason.Terminated);
+        host.Connection.IsFaulted.Should().BeFalse();
+
+        // The host's own terminate is the same thing, and is equally idempotent.
+        host.Connection.End();
+        host.Ended.Should().ContainSingle();
+    }
+
+    /// <summary>
+    /// Termination is cooperative and bounded by the engine's amortized check interval on the <i>worker's</i>
+    /// thread: a running worker stops, and the cancellation erupts from whatever is pumping it.
+    /// </summary>
+    [Fact]
+    public void TerminateStopsARunningWorkerWithinTheAmortizedInterval()
+    {
+        using var running = new ManualResetEventSlim(false);
+
+        var host = new TestWorkerHost();
+        host.Modules[Specifier] = "started(); while (true) { }";
+        host.Configure = engine => engine.SetValue("started", new Action(() => running.Set()));
+
+        var parent = Parent(host);
+        parent.Execute("var w = new Worker('./worker.js', { type: 'module' });");
+
+        var connection = host.Connection;
+        Exception? escaped = null;
+        var pump = new Thread(() =>
+        {
+            try
+            {
+                connection.Worker.Advanced.ProcessTasks();
+            }
+            catch (Exception ex)
+            {
+                escaped = ex;
+            }
+        })
+        {
+            IsBackground = true,
+            Name = "worker pump",
+        };
+
+        pump.Start();
+        running.Wait(Ceiling).Should().BeTrue("the worker has to be inside its loop before terminate() means anything");
+
+        parent.Execute("w.terminate();");
+
+        pump.Join(Ceiling).Should().BeTrue("a terminated worker stops rather than spinning forever");
+        escaped.Should().BeOfType<ExecutionCanceledException>(
+            "the worker's budget is the host's to observe, not the parent script's");
+    }
+
+    /// <summary>
+    /// Terminate's fourth step — "empty the port message queue of the port entangled with the worker's" — is
+    /// the specification's own licence for discarding what the worker had already posted.
+    /// </summary>
+    [Fact]
+    public void TerminateDiscardsAMessageTheWorkerAlreadyPosted()
+    {
+        var host = new TestWorkerHost(Module("addEventListener('message', () => postMessage('from-worker'));"));
+        var parent = Parent(host);
+
+        parent.Execute("""
+            var got = [];
+            var w = new Worker('./worker.js', { type: 'module' });
+            w.onmessage = e => got.push(e.data);
+            w.postMessage('go');
+            """);
+
+        // The worker answers; the parent has not been pumped, so the answer is sitting on its queue.
+        DrainWorker(host.Connection);
+
+        parent.Execute("w.terminate();");
+        Drain(parent, host.Connection);
+
+        parent.Evaluate("got.join(',')").AsString().Should().BeEmpty("terminate empties the parent-side queue");
+    }
+
+    // -------------------------------------------------------------------------------------------------------
+    // close()
+    // -------------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void CloseFromTheWorkerEndsTheConnection()
+    {
+        var host = new TestWorkerHost(Module("record('before'); close(); record('after');"));
+        var parent = Parent(host);
+
+        parent.Execute("var w = new Worker('./worker.js', { type: 'module' });");
+        host.Connection.IsEnded.Should().BeFalse();
+
+        Drain(parent, host.Connection);
+
+        host.Connection.IsEnded.Should().BeTrue();
+        host.Connection.EndReason.Should().Be(WorkerEndReason.ClosedByWorker);
+        host.Connection.IsFaulted.Should().BeFalse();
+        host.Connection.TerminationToken.IsCancellationRequested.Should().BeFalse(
+            "close() lets the current turn finish; only terminate cancels");
+        host.Ended.Should().ContainSingle().Which.Reason.Should().Be(WorkerEndReason.ClosedByWorker);
+    }
+
+    /// <summary>
+    /// <i>Close a worker</i> discards the worker's queued tasks and sets the closing flag. It does not abort
+    /// the running script, which is what makes <c>close(); flushMetrics();</c> work.
+    /// </summary>
+    [Fact]
+    public void CloseDoesNotAbortTheCurrentlyRunningScript()
+    {
+        var host = new TestWorkerHost(Module("""
+            addEventListener('message', () => {
+                close();
+                var total = 0;
+                for (var i = 0; i < 500; i++) { total += i; }
+                record('after-close:' + total);
+            });
+            """));
+
+        var parent = Parent(host);
+        parent.Execute("var w = new Worker('./worker.js', { type: 'module' }); w.postMessage('go');");
+
+        Drain(parent, host.Connection);
+
+        host.Log.Should().Be("after-close:124750", "five hundred statements is far past the 64-statement check interval");
+        host.Connection.EndReason.Should().Be(WorkerEndReason.ClosedByWorker);
+    }
+
+    /// <summary>
+    /// The parent-side queue drains rather than being discarded, so <c>postMessage(result); close();</c> — the
+    /// commonest <c>close()</c> idiom there is — reaches the parent whether or not it had pumped in between.
+    /// </summary>
+    [Fact]
+    public void AFinalPostMessageBeforeCloseIsDelivered()
+    {
+        var host = new TestWorkerHost(Module("""
+            addEventListener('message', () => { postMessage('result'); close(); });
+            """));
+
+        var parent = Parent(host);
+        parent.Execute("""
+            var got = [];
+            var w = new Worker('./worker.js', { type: 'module' });
+            w.onmessage = e => got.push(e.data);
+            w.postMessage('go');
+            """);
+
+        // The worker answers and closes with the parent never having been pumped.
+        DrainWorker(host.Connection);
+        host.Connection.IsEnded.Should().BeTrue();
+
+        Drain(parent, host.Connection);
+
+        parent.Evaluate("got.join(',')").AsString().Should().Be("result");
+    }
+
+    // -------------------------------------------------------------------------------------------------------
+    // Startup failure
+    // -------------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void ALoadFailureEndsTheConnectionAsStartupFailedWithACLRError()
+    {
+        var host = new TestWorkerHost();
+        var parent = Parent(host);
+
+        parent.Execute("var w = new Worker('./missing.js', { type: 'module' });");
+        Drain(parent, host.Connection);
+
+        var connection = host.Connection;
+        connection.IsEnded.Should().BeTrue();
+        connection.EndReason.Should().Be(
+            WorkerEndReason.StartupFailed,
+            "'the specifier was wrong' reported as 'somebody called terminate()' is the worst log line this could ship");
+        connection.IsFaulted.Should().BeTrue();
+        connection.Error.Should().BeOfType<ModuleResolutionException>(
+            "the connection surface is a CLR channel, never a worker-realm JsValue");
+        host.Ended.Should().ContainSingle().Which.Reason.Should().Be(WorkerEndReason.StartupFailed);
+    }
+
+    [Fact]
+    public void AModuleThatThrowsEndsTheConnectionAsStartupFailedWithASummaryException()
+    {
+        var host = new TestWorkerHost(Module("throw new RangeError('boom');"));
+        var parent = Parent(host);
+
+        parent.Execute("var w = new Worker('./worker.js', { type: 'module' });");
+        Drain(parent, host.Connection);
+
+        var connection = host.Connection;
+        connection.EndReason.Should().Be(WorkerEndReason.StartupFailed);
+        connection.IsFaulted.Should().BeTrue();
+        connection.Error.Should().NotBeNull();
+        connection.Error!.Message.Should().Contain("boom");
+    }
+
+    // -------------------------------------------------------------------------------------------------------
+    // The worker global scope
+    // -------------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void ImportScriptsThrowsTypeError()
+    {
+        var host = new TestWorkerHost(Module("""
+            record('typeof:' + typeof importScripts);
+            try { importScripts('./other.js'); record('no-throw'); }
+            catch (e) { record('caught:' + (e instanceof TypeError)); }
+            """));
+
+        var parent = Parent(host);
+        parent.Execute("var w = new Worker('./worker.js', { type: 'module' });");
+        Drain(parent, host.Connection);
+
+        host.Log.Should().Be(
+            "typeof:function,caught:true",
+            "the specification's own step 1 for a module worker prescribes the throw, so the function is present");
+    }
+
+    [Fact]
+    public void TheWorkerGlobalHasNoWorkerGlobalScopeInterfaceObject()
+    {
+        var host = new TestWorkerHost(Module("""
+            record('WorkerGlobalScope:' + typeof WorkerGlobalScope);
+            record('DedicatedWorkerGlobalScope:' + typeof DedicatedWorkerGlobalScope);
+            record('self:' + (self === globalThis));
+            record('postMessage:' + typeof postMessage);
+            record('close:' + typeof close);
+            record('name:' + name);
+            record('onmessage:' + onmessage);
+            """));
+
+        var parent = Parent(host, workerName: "crunch");
+        parent.Execute("var w = new Worker('./worker.js', { type: 'module', name: 'crunch' });");
+        Drain(parent, host.Connection);
+
+        host.Log.Should().Be(
+            "WorkerGlobalScope:undefined,DedicatedWorkerGlobalScope:undefined,self:true,postMessage:function,close:function,name:crunch,onmessage:null");
+    }
+
+    [Fact]
+    public void TheWorkerObjectCarriesTheEventHandlerAttributes()
+    {
+        var host = new TestWorkerHost(Module(""));
+        var parent = Parent(host);
+
+        parent.Execute("var w = new Worker('./worker.js', { type: 'module' });");
+
+        parent.Evaluate("typeof w.postMessage").AsString().Should().Be("function");
+        parent.Evaluate("typeof w.terminate").AsString().Should().Be("function");
+        parent.Evaluate("w.onmessage").IsNull().Should().BeTrue();
+        parent.Evaluate("w.onmessageerror").IsNull().Should().BeTrue();
+        parent.Evaluate("w.onerror").IsNull().Should().BeTrue();
+        parent.Evaluate("w instanceof EventTarget").AsBoolean().Should().BeTrue();
+        parent.Evaluate("Object.prototype.toString.call(w)").AsString().Should().Be("[object Worker]");
+    }
+
+    // -------------------------------------------------------------------------------------------------------
+    // Threading and the transferable-stream interaction
+    // -------------------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// The host ending a connection while the worker's own thread is inside <c>ProcessTasks</c> is the ordinary
+    /// thread-per-worker shape, and it must touch nothing but endpoints, a token and interlocked bookkeeping.
+    /// </summary>
+    [Fact]
+    public void EndingTheConnectionFromTheParentWhileTheWorkerPumpsDoesNotThrow()
+    {
+        using var pumping = new ManualResetEventSlim(false);
+        using var stop = new ManualResetEventSlim(false);
+
+        var host = new TestWorkerHost(Module("addEventListener('message', () => postMessage('pong'));"));
+        host.Configure = engine => engine.SetValue("noop", new Action(() => { }));
+
+        var parent = Parent(host);
+        parent.Execute("var w = new Worker('./worker.js', { type: 'module' });");
+
+        var connection = host.Connection;
+        Exception? escaped = null;
+        var pump = new Thread(() =>
+        {
+            try
+            {
+                while (!connection.IsEnded && !stop.IsSet)
+                {
+                    connection.Worker.Advanced.ProcessTasks();
+                    pumping.Set();
+                }
+            }
+            catch (ExecutionCanceledException)
+            {
+                // The cooperative half of terminate; the loop is leaving anyway.
+            }
+            catch (Exception ex)
+            {
+                escaped = ex;
+            }
+        })
+        {
+            IsBackground = true,
+            Name = "worker pump",
+        };
+
+        pump.Start();
+        pumping.Wait(Ceiling).Should().BeTrue();
+
+        // From the parent's thread, while the worker's thread is inside its pump.
+        connection.End();
+
+        stop.Set();
+        pump.Join(Ceiling).Should().BeTrue("the pump loop observes IsEnded and leaves");
+        escaped.Should().BeNull();
+
+        connection.EndReason.Should().Be(WorkerEndReason.Terminated);
+        host.Ended.Should().ContainSingle();
+    }
+
+    /// <summary>
+    /// The drain-then-close endpoint state and the transferable-stream predicate meet here: a stream the worker
+    /// transferred, and then <c>close()</c>d behind, still reaches the parent and still ends cleanly.
+    /// </summary>
+    /// <remarks>
+    /// Closing the parent-side endpoint outright — terminate's treatment — strands the transferred stream's own
+    /// channel side in the discarded record, and the parent's <c>read()</c> then never completes.
+    /// </remarks>
+    [Fact]
+    public void ATransferredStreamStillClosesCleanlyAcrossAWorkerClose()
+    {
+        var host = new TestWorkerHost(Module("""
+            const stream = new ReadableStream({
+                start(controller) {
+                    controller.enqueue('a');
+                    controller.enqueue('b');
+                    controller.close();
+                }
+            });
+            postMessage(stream, [stream]);
+            close();
+            """));
+
+        var parent = Parent(host);
+        parent.Execute("""
+            var chunks = [];
+            var done = false;
+            var failed = null;
+            var w = new Worker('./worker.js', { type: 'module' });
+            w.onmessage = async e => {
+                try {
+                    const reader = e.data.getReader();
+                    for (;;) {
+                        const r = await reader.read();
+                        if (r.done) { break; }
+                        chunks.push(r.value);
+                    }
+                    done = true;
+                } catch (err) { failed = String(err); }
+            };
+            """);
+
+        // The worker posts the stream and closes with the parent never having been pumped, which is exactly the
+        // case drain-then-close exists for.
+        DrainWorker(host.Connection);
+        host.Connection.EndReason.Should().Be(WorkerEndReason.ClosedByWorker);
+
+        Drain(parent, host.Connection, rounds: 200);
+
+        parent.Evaluate("failed").IsNull().Should().BeTrue();
+        parent.Evaluate("chunks.join(',')").AsString().Should().Be("a,b");
+        parent.Evaluate("done").AsBoolean().Should().BeTrue("the stream ends rather than hanging");
+    }
+
+    // -------------------------------------------------------------------------------------------------------
+    // Harness
+    // -------------------------------------------------------------------------------------------------------
+
+    private static Dictionary<string, string> Module(string source) => new() { [Specifier] = source };
+
+    private static Engine Parent(
+        TestWorkerHost host,
+        int maxWorkers = 16,
+        int maxQueuedMessages = 16384,
+        string workerName = "")
+    {
+        _ = workerName;
+
+        return new Engine(options =>
+        {
+            options.UseWebApis().UseWorkers(host);
+            options.WebApi.Workers.MaxWorkers = maxWorkers;
+            options.WebApi.Workers.MaxQueuedMessages = maxQueuedMessages;
+        });
+    }
+
+    /// <summary>
+    /// Alternates the two engines' pumps a fixed number of times. Deliberately a count rather than a clock: a
+    /// slow machine makes nothing here flaky, and a mechanism that stopped working fails on the assertion
+    /// rather than on a timeout.
+    /// </summary>
+    private static void Drain(Engine parent, WorkerConnection connection, int rounds = 50)
+    {
+        for (var i = 0; i < rounds; i++)
+        {
+            PumpWorker(connection);
+            parent.Advanced.ProcessTasks();
+        }
+    }
+
+    private static void DrainWorker(WorkerConnection connection, int rounds = 50)
+    {
+        for (var i = 0; i < rounds; i++)
+        {
+            PumpWorker(connection);
+        }
+    }
+
+    private static void PumpWorker(WorkerConnection connection)
+    {
+        try
+        {
+            connection.Worker.Advanced.ProcessTasks();
+        }
+        catch (ExecutionCanceledException)
+        {
+            // A terminated worker's cooperative stop erupts from whatever is pumping, which here is the test.
+        }
+    }
+
+    /// <summary>
+    /// A worker host the test drives itself: it builds the worker engine over an in-memory module map and does
+    /// not start a thread, so the test decides exactly when the worker gets a turn.
+    /// </summary>
+    private sealed class TestWorkerHost : WorkerProvider
+    {
+        private readonly ConcurrentQueue<string> _log = new();
+
+        public TestWorkerHost() : this(new Dictionary<string, string>())
+        {
+        }
+
+        public TestWorkerHost(Dictionary<string, string> modules) => Modules = modules;
+
+        public Dictionary<string, string> Modules { get; }
+
+        /// <summary>Returns null from <c>CreateWorkerEngine</c>, which is the host's policy refusal.</summary>
+        public bool Refuse { get; set; }
+
+        /// <summary>Thrown from <c>CreateWorkerEngine</c>, to pin that nothing translates it.</summary>
+        public Exception? Throw { get; set; }
+
+        /// <summary>Replaces the whole engine-building step, for the validation pins.</summary>
+        public Func<WorkerRequest, Engine>? Build { get; set; }
+
+        /// <summary>Runs on the freshly built engine, before it is handed back.</summary>
+        public Action<Engine>? Configure { get; set; }
+
+        public int Requests { get; private set; }
+
+        public List<WorkerConnection> Started { get; } = [];
+
+        public List<(WorkerConnection Connection, WorkerEndReason Reason)> Ended { get; } = [];
+
+        public WorkerConnection Connection => Started[^1];
+
+        public string Log => string.Join(",", _log);
+
+        public override Engine? CreateWorkerEngine(WorkerRequest request)
+        {
+            Requests++;
+
+            if (Throw is { } failure)
+            {
+                throw failure;
+            }
+
+            if (Refuse)
+            {
+                return null;
+            }
+
+            if (Build is { } build)
+            {
+                return build(request);
+            }
+
+            var options = request.CreateDefaultOptions();
+            options.Modules.ModuleLoader = new MapModuleLoader(Modules);
+
+            var engine = new Engine(options);
+            engine.SetValue("record", new Action<string>(_log.Enqueue));
+            Configure?.Invoke(engine);
+            return engine;
+        }
+
+        public override void OnWorkerStarted(WorkerConnection connection) => Started.Add(connection);
+
+        public override void OnWorkerEnded(WorkerConnection connection, WorkerEndReason reason)
+            => Ended.Add((connection, reason));
+    }
+
+    /// <summary>
+    /// A module loader over a dictionary, so a test can say exactly what a specifier resolves to — and what it
+    /// does not, which is what the startup-failure pin needs.
+    /// </summary>
+    private sealed class MapModuleLoader : IModuleLoader
+    {
+        private readonly Dictionary<string, string> _sources;
+
+        internal MapModuleLoader(Dictionary<string, string> sources) => _sources = sources;
+
+        public ResolvedSpecifier Resolve(string? referencingModuleLocation, ModuleRequest moduleRequest)
+        {
+            if (!_sources.ContainsKey(moduleRequest.Specifier))
+            {
+                throw new ModuleResolutionException("Module not found", moduleRequest.Specifier, referencingModuleLocation, filePath: null);
+            }
+
+            return new ResolvedSpecifier(moduleRequest, moduleRequest.Specifier, Uri: null, SpecifierType.RelativeOrAbsolute);
+        }
+
+        public Jint.Runtime.Modules.Module LoadModule(Engine engine, ResolvedSpecifier resolved)
+            => ModuleFactory.BuildSourceTextModule(engine, resolved, _sources[resolved.Key]);
+    }
+}
+#endif

--- a/Jint.Tests/Runtime/WebApi/WorkerTests.cs
+++ b/Jint.Tests/Runtime/WebApi/WorkerTests.cs
@@ -15,17 +15,16 @@ namespace Jint.Tests.Runtime.WebApi;
 /// </summary>
 /// <remarks>
 /// <para>
-/// There is no script surface yet — <c>typeof Worker</c> is <c>undefined</c> on every engine, which
-/// <c>Jint.Tests.PublicInterface.WebApiWorkerTests</c> pins from outside the assembly. What exists is the
-/// host-facing contract: <see cref="WorkerRequest.CreateDefaultOptions"/>, whose whole job is that a worker
-/// inherits its creator's <i>restrictions</i> and none of its <i>grants</i>, and
-/// <see cref="WorkerConnection"/>, which is thread-safe from the day it exists because the machinery that
-/// will end it from two threads lands later.
+/// This file is the host-facing contract alone: <see cref="WorkerRequest.CreateDefaultOptions"/>, whose whole
+/// job is that a worker inherits its creator's <i>restrictions</i> and none of its <i>grants</i>, and
+/// <see cref="WorkerConnection"/>, which is thread-safe because two threads really do end it. The script
+/// surface — the constructor, the two façades, the message paths and the two ways a connection ends — is
+/// <c>WorkerMechanismTests</c>.
 /// </para>
 /// <para>
 /// The request is built directly through its internal constructor, which is what this project's
-/// <c>InternalsVisibleTo</c> is for: it is the same object the constructor will hand a provider, without a
-/// constructor to run it through yet.
+/// <c>InternalsVisibleTo</c> is for: it is the same object the constructor hands a provider, without having to
+/// run a constructor to get one.
 /// </para>
 /// </remarks>
 public class WorkerTests

--- a/Jint/Engine.WebApi.cs
+++ b/Jint/Engine.WebApi.cs
@@ -14,6 +14,7 @@ using Jint.WebApi.ServerSentEvents;
 using Jint.WebApi.Streams;
 using Jint.WebApi.Timers;
 using Jint.WebApi.WebSockets;
+using Jint.WebApi.Workers;
 
 namespace Jint;
 
@@ -268,6 +269,29 @@ internal sealed class WebApiEngineState
     internal TimerQueue? Timers { get; private set; }
 
     /// <summary>
+    /// This engine's worker provider, its two caps and its live connections, or <see langword="null"/> — which
+    /// is what every engine carries unless it enabled <see cref="WebApiFeatures.Workers"/> <i>and</i> named a
+    /// provider. That null is also what leaves the <c>Worker</c> global uninstalled, so
+    /// <c>typeof Worker === 'undefined'</c>: the family's absent-rather-than-throwing convention.
+    /// </summary>
+    /// <remarks>
+    /// The one member of this state whose contents are touched from more than one thread; see
+    /// <see cref="WorkerRegistry"/> for why, and for the lock that makes it safe.
+    /// </remarks>
+    internal WorkerRegistry? Workers { get; private set; }
+
+    /// <summary>
+    /// The connection this engine is the <i>worker</i> of, or <see langword="null"/> for an engine that is
+    /// nobody's worker. Written once, on the parent's thread, while this engine is owned and quiescent.
+    /// </summary>
+    /// <remarks>
+    /// It is what makes "not already connected" a construction-time refusal rather than a second connection
+    /// that would give one global two parents, and it is the seam a worker-side <c>RestoreGlobalSnapshot</c>
+    /// and <c>Dispose</c> will end the connection through — those hooks land in their own change (wave 3).
+    /// </remarks>
+    internal WorkerLink? OwningWorkerLink { get; set; }
+
+    /// <summary>
     /// The host's fetch settings, or <see langword="null"/> when the feature is off. Read once — when the
     /// engine is built, or when <c>Engine.Advanced.EnableWebApis</c> turned the feature on — so that no
     /// background thread ever reaches into <see cref="Options"/>.
@@ -488,6 +512,13 @@ internal sealed class WebApiEngineState
     {
         Debug.Assert(Timers is null, "the timer queue must never be replaced on a live engine");
         Timers = timers;
+    }
+
+    /// <inheritdoc cref="AttachTimers" />
+    internal void AttachWorkers(WorkerRegistry workers)
+    {
+        Debug.Assert(Workers is null, "the worker registry must never be replaced on a live engine");
+        Workers = workers;
     }
 
     /// <inheritdoc cref="AttachTimers" />

--- a/Jint/Runtime/Intrinsics.WebApi.cs
+++ b/Jint/Runtime/Intrinsics.WebApi.cs
@@ -26,6 +26,7 @@ using Jint.WebApi.Timers;
 using Jint.WebApi.Url;
 using Jint.WebApi.Url.Pattern;
 using Jint.WebApi.WebSockets;
+using Jint.WebApi.Workers;
 
 namespace Jint.Runtime;
 
@@ -395,6 +396,12 @@ public sealed partial class Intrinsics
     /// </summary>
     internal GlobalEventFunctions GlobalEventFunctions =>
         _globalEventFunctions ??= Jint.WebApi.GlobalEvents.GlobalEventFunctions.Create(_engine, _realm);
+
+    private WorkerConstructor? _worker;
+
+    /// <summary><c>Worker</c> inherits from <c>EventTarget</c>.</summary>
+    internal WorkerConstructor Worker =>
+        _worker ??= new WorkerConstructor(_engine, _realm, EventTarget);
 
     private FetchEventConstructor? _fetchEvent;
 

--- a/Jint/WebApi/Messaging/JsMessagePort.cs
+++ b/Jint/WebApi/Messaging/JsMessagePort.cs
@@ -119,6 +119,29 @@ internal sealed class JsMessagePort : JsEventTarget
     /// </remarks>
     internal Action<JsValue>? InternalMessageHandler { get; set; }
 
+    /// <summary>
+    /// The target a <c>message</c> event is dispatched at instead of this port — HTML's "all messages received
+    /// by that port must immediately be retargeted at the <c>Worker</c> object". Null for every port a script
+    /// can reach, which is every port but a worker connection's two.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The sibling of <see cref="InternalMessageHandler"/> and deliberately a separate hook: that one is the
+    /// engine consuming a message with <i>no</i> event at all (a transferred stream's chunks), while this one
+    /// still builds the trusted <c>MessageEvent</c> and runs the whole dispatch algorithm — it only changes
+    /// <i>where</i>. A worker needs the event, because the listener list it has to reach is the one
+    /// <c>worker.onmessage</c> and <c>addEventListener('message', …)</c> write to, and neither of the
+    /// connection's two ports is reachable by script to carry it.
+    /// </para>
+    /// <para>
+    /// The retarget also decides what <c>event.target</c> answers, because a dispatch reports the target it
+    /// ran on: the <c>Worker</c> object on the parent's side, and — through
+    /// <c>GlobalEventTarget.EventTargetValue</c> — the global object on the worker's, which is what a browser
+    /// reports for a <c>DedicatedWorkerGlobalScope</c>.
+    /// </para>
+    /// </remarks>
+    internal JsEventTarget? RetargetTo { get; set; }
+
     internal JsMessagePort(Engine engine, Realm realm) : this(engine, realm, endpoint: null)
     {
     }
@@ -239,8 +262,10 @@ internal sealed class JsMessagePort : JsEventTarget
         var record = new StructuredSerializer(_engine, _realm).Serialize(message, transferList);
 
         // Step 6: "If targetPort is null, or if doomed is true, then return." A closed or detached port is
-        // disentangled, which is the same thing as having no target.
-        if (doomed || endpoint is null || endpoint.Closed || target is null || target.Closed)
+        // disentangled, which is the same thing as having no target. The target is asked whether it still
+        // accepts rather than whether it is closed, because a worker's close() leaves the parent-side queue
+        // draining — deliverable but no longer joinable — which is a state an ordinary port never enters.
+        if (doomed || endpoint is null || endpoint.Closed || target is null || !target.AcceptsPosts)
         {
             // Whatever the message was carrying is now unreachable, so a side transferred into it would sit
             // unbound forever while its own peer went on posting. Ending it here is what "causing the
@@ -369,11 +394,19 @@ internal sealed class JsMessagePort : JsEventTarget
             return;
         }
 
-        // The next message is armed BEFORE this one is dispatched, so a listener that throws — which erupts
-        // from the pump, per JsEventTarget's contract — does not strand everything behind it.
-        ScheduleDrain();
-
-        Dispatch(record);
+        try
+        {
+            Dispatch(record);
+        }
+        finally
+        {
+            // AFTER the dispatch, and in a finally so that a listener which throws — which erupts from the
+            // pump, per JsEventTarget's contract — still does not strand everything behind it. The order is
+            // observable and is HTML's: a message is a task, so everything the listener queued (its promise
+            // reactions) runs before the next message is even looked at. Arming it first put the next drain
+            // job ahead of those reactions and delivered two messages back to back.
+            ScheduleDrain();
+        }
     }
 
     /// <summary>
@@ -392,7 +425,7 @@ internal sealed class JsMessagePort : JsEventTarget
         }
 
         var messageEvent = _realm.Intrinsics.MessageEvent.CreateTrustedMessageEvent(_messageEventName, message.Value, message.Ports);
-        DispatchEvent(messageEvent);
+        (RetargetTo ?? this).DispatchEvent(messageEvent);
     }
 }
 #endif

--- a/Jint/WebApi/Messaging/MessagePortBridge.cs
+++ b/Jint/WebApi/Messaging/MessagePortBridge.cs
@@ -141,6 +141,23 @@ internal sealed class MessagePortEndpoint
     private volatile bool _closed;
 
     /// <summary>
+    /// Whether this side has been half-closed: it takes no further message, but what its queue already holds
+    /// is still deliverable, and it closes for real once that queue runs dry. <b>Only a worker's
+    /// <c>close()</c> produces this state</b> — HTML's <i>close a worker</i> discards the worker's own queued
+    /// tasks and pointedly does not empty the queue of the port entangled with it, which <i>terminate a
+    /// worker</i> does as its fourth step. So <c>postMessage(result); close();</c> — the commonest idiom there
+    /// is — must still deliver, whether or not the parent had pumped in between.
+    /// </summary>
+    /// <remarks>
+    /// It is deliberately <b>not</b> expressed as <see cref="Closed"/>. That flag is read by
+    /// <c>JsMessagePort.IsChannelExhausted</c>, which a transferred stream consults to decide that its channel
+    /// can never carry anything again — and a draining side whose queue still holds the stream's own
+    /// <c>close</c> message is exactly the case where that answer would be wrong, and would error a stream
+    /// that was about to end cleanly. Refusing new posts is <see cref="AcceptsPosts"/>'s job instead.
+    /// </remarks>
+    private volatile bool _draining;
+
+    /// <summary>
     /// The side this one is entangled with, or <see langword="null"/> for a side that was never entangled.
     /// Assigned once, by <see cref="Entangle"/>, before either port can be reached by any script, and
     /// deliberately never reassigned: a transfer moves a <i>side</i>, so the other end goes on talking to the
@@ -164,6 +181,13 @@ internal sealed class MessagePortEndpoint
     /// </summary>
     internal bool Closed => _closed;
 
+    /// <summary>
+    /// Whether a sender may still join this side's queue. False once it is closed, and once it is draining —
+    /// see <see cref="_draining"/>. Read by the peer's engine from its own thread; the authoritative test is
+    /// the one <see cref="Post"/> makes under the lock.
+    /// </summary>
+    internal bool AcceptsPosts => !_closed && !_draining;
+
     /// <summary>Whether anything is waiting to be taken off this side's queue. Bound engine's thread.</summary>
     internal bool HasQueuedMessages
     {
@@ -172,6 +196,22 @@ internal sealed class MessagePortEndpoint
             lock (_gate)
             {
                 return _queue.Count > 0;
+            }
+        }
+    }
+
+    /// <summary>
+    /// How many messages are waiting to be taken off this side's queue. What
+    /// <c>Options.WebApi.Workers.MaxQueuedMessages</c> bounds, read by the sending engine's thread before it
+    /// serializes anything.
+    /// </summary>
+    internal int QueuedMessageCount
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _queue.Count;
             }
         }
     }
@@ -292,7 +332,7 @@ internal sealed class MessagePortEndpoint
         lock (_gate)
         {
             // The authoritative closed test. The volatile read callers make first is only an early-out.
-            if (_closed)
+            if (_closed || _draining)
             {
                 return;
             }
@@ -321,6 +361,8 @@ internal sealed class MessagePortEndpoint
     /// </remarks>
     internal bool TryDequeue(JsMessagePort caller, out SerializationRecord record)
     {
+        bool drained;
+
         lock (_gate)
         {
             if (_closed || !ReferenceEquals(_boundPort, caller) || _queue.Count == 0)
@@ -330,7 +372,48 @@ internal sealed class MessagePortEndpoint
             }
 
             record = _queue.Dequeue();
-            return true;
+
+            // A draining side that has just handed over its last message has done what it was kept open for.
+            drained = _draining && _queue.Count == 0;
+        }
+
+        if (drained)
+        {
+            // Outside the lock: Close walks a work list of stranded sides and takes each of their gates.
+            Close();
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Half-closes this side: it accepts nothing further, what it already holds stays deliverable, and it
+    /// closes for real when that queue runs dry — or when a teardown closes it outright. See
+    /// <see cref="_draining"/> for why this is not simply <see cref="Close"/>.
+    /// </summary>
+    /// <remarks>
+    /// Any thread, like <see cref="Close"/>: a worker's <c>close()</c> runs on the worker's thread and this is
+    /// the <i>parent's</i> side. An empty queue is closed on the spot rather than left in a state nothing
+    /// would ever leave, since only a dequeue ends it and there is nothing left to dequeue.
+    /// </remarks>
+    internal void BeginDrainThenClose()
+    {
+        bool alreadyEmpty;
+
+        lock (_gate)
+        {
+            if (_closed || _draining)
+            {
+                return;
+            }
+
+            _draining = true;
+            alreadyEmpty = _queue.Count == 0;
+        }
+
+        if (alreadyEmpty)
+        {
+            Close();
         }
     }
 }

--- a/Jint/WebApi/WebApiRegistration.cs
+++ b/Jint/WebApi/WebApiRegistration.cs
@@ -6,6 +6,7 @@ using Jint.Runtime.Descriptors.Specialized;
 using Jint.WebApi.Idle;
 using Jint.WebApi.Scheduling;
 using Jint.WebApi.Timers;
+using Jint.WebApi.Workers;
 
 namespace Jint.WebApi;
 
@@ -312,6 +313,15 @@ internal static class WebApiRegistration
             Install(global, engine, "BroadcastChannel", static e => e.Realm.Intrinsics.BroadcastChannel, PropertyFlag.NonEnumerable);
         }
 
+        if ((features & WebApiFeatures.Workers) != WebApiFeatures.None && engine._webApi?.Workers is not null)
+        {
+            // The one global in this file conditioned on something other than a flag, and deliberately: with
+            // the feature on and no provider there is no execution resource for a worker to run on, so the
+            // constructor could do nothing but throw. Absent rather than throwing is this family's convention,
+            // and it is what lets a script feature-detect with `typeof Worker`.
+            Install(global, engine, "Worker", static e => e.Realm.Intrinsics.Worker, PropertyFlag.NonEnumerable);
+        }
+
         if ((features & WebApiFeatures.Reporting) != WebApiFeatures.None)
         {
             // A WebIDL operation on the global — https://webidl.spec.whatwg.org/#es-operations. Installed
@@ -461,6 +471,16 @@ internal static class WebApiRegistration
             features |= WebApiFeatures.GlobalEvents | WebApiFeatures.Url | WebApiFeatures.Files;
         }
 
+        // A worker connection IS a MessagePort pair — the Worker object and the worker's global scope are its
+        // two unexposed ends — and the worker global's self, addEventListener and error events are what the
+        // global-events feature installs. Deliberately BEFORE the GlobalEvents rule below, which is what turns
+        // the flag added here into WebApiFeatures.Events as well. It applies to the PARENT: a worker engine's
+        // own set is the provider's to decide, and WorkerRequest.CreateDefaultOptions forces the same two.
+        if ((features & WebApiFeatures.Workers) != WebApiFeatures.None)
+        {
+            features |= WebApiFeatures.Messaging | WebApiFeatures.GlobalEvents;
+        }
+
         // The three global operations register listeners on an EventTarget and dispatch an Event, and the two
         // interface objects the feature adds are Event subclasses — so without the events feature it would
         // install operations with nothing to use them on.
@@ -507,7 +527,7 @@ internal static class WebApiRegistration
     /// both of which live here, and a closure is not a reason to depend on one.
     /// </summary>
     private const WebApiFeatures NeedsEngineState =
-        WebApiFeatures.Timers | WebApiFeatures.Events | WebApiFeatures.Performance | WebApiFeatures.Fetch | WebApiFeatures.Scheduler | WebApiFeatures.Messaging | WebApiFeatures.Storage | WebApiFeatures.WebSocket | WebApiFeatures.CacheApi | WebApiFeatures.IdleCallback | WebApiFeatures.GlobalEvents | WebApiFeatures.FetchEvents;
+        WebApiFeatures.Timers | WebApiFeatures.Events | WebApiFeatures.Performance | WebApiFeatures.Fetch | WebApiFeatures.Scheduler | WebApiFeatures.Messaging | WebApiFeatures.Storage | WebApiFeatures.WebSocket | WebApiFeatures.CacheApi | WebApiFeatures.IdleCallback | WebApiFeatures.GlobalEvents | WebApiFeatures.FetchEvents | WebApiFeatures.Workers;
 
     /// <summary>
     /// The queue exists for the timer globals, for AbortSignal.timeout() and for a delayed
@@ -583,6 +603,35 @@ internal static class WebApiRegistration
         var messaging = (features & WebApiFeatures.Messaging) != WebApiFeatures.None ? options.WebApi.Messaging : null;
 
         engine._webApi = new WebApiEngineState(engine, timeProvider, timers, fetch, scheduler, diagnostics, storage, cache, idleCallbacks, messaging);
+
+        AttachWorkers(options, engine._webApi, features);
+    }
+
+    /// <summary>
+    /// Gives the state its worker registry, when the flag is on <b>and</b> the host named a provider. Without
+    /// a provider there is nothing to attach and, deliberately, no <c>Worker</c> global either: a worker needs
+    /// a thread and a pump, and Jint never starts either, so an engine that asked for the feature and supplied
+    /// no execution resource has to answer <c>typeof Worker === 'undefined'</c> rather than hand a script a
+    /// constructor that can only throw.
+    /// </summary>
+    /// <remarks>
+    /// The provider and the two caps are read here, once, exactly as the clock and the timer cap are — so a
+    /// host mutating <c>Options.WebApi.Workers</c> afterwards does not change an engine that already exists.
+    /// </remarks>
+    private static void AttachWorkers(Options options, WebApiEngineState state, WebApiFeatures features)
+    {
+        if ((features & WebApiFeatures.Workers) == WebApiFeatures.None || state.Workers is not null)
+        {
+            return;
+        }
+
+        var workers = options.WebApi.Workers;
+        if (workers.Provider is not { } provider)
+        {
+            return;
+        }
+
+        state.AttachWorkers(new WorkerRegistry(provider, workers.MaxWorkers, workers.MaxQueuedMessages));
     }
 
     /// <summary>
@@ -633,6 +682,8 @@ internal static class WebApiRegistration
         {
             state.AttachMessaging(options.WebApi.Messaging);
         }
+
+        AttachWorkers(options, state, added);
 
         if ((added & WebApiFeatures.CacheApi) != WebApiFeatures.None && state.CacheProvider is null)
         {

--- a/Jint/WebApi/Workers/JsWorker.cs
+++ b/Jint/WebApi/Workers/JsWorker.cs
@@ -1,0 +1,50 @@
+#if NET8_0_OR_GREATER
+using Jint.Runtime;
+using Jint.WebApi.Events;
+
+namespace Jint.WebApi.Workers;
+
+/// <summary>
+/// A <c>Worker</c> instance: the parent's handle on one worker, and the <see cref="JsEventTarget"/> its
+/// <c>message</c> events are retargeted at.
+/// <para>
+/// https://html.spec.whatwg.org/multipage/workers.html#dedicated-workers-and-the-worker-interface
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>There is no <c>worker.port</c>, and that is HTML's shape rather than a simplification.</b> A dedicated
+/// worker's two ports are unexposed: <c>Worker</c> includes the <c>MessageEventTarget</c> mixin, so this
+/// object <i>is</i> the parent end of the channel — "all messages received by that port must immediately be
+/// retargeted at the <c>Worker</c> object". A port a script could reach belongs to <c>SharedWorker</c>.
+/// </para>
+/// <para>
+/// The object outlives the connection. A terminated, closed or failed worker leaves it alive and inert:
+/// <c>postMessage</c> still serializes and then goes nowhere, <c>terminate()</c> does nothing, and no further
+/// event fires — which is the state HTML's disentangled-port clause describes rather than a concession.
+/// </para>
+/// </remarks>
+internal sealed class JsWorker : JsEventTarget
+{
+    /// <summary>https://html.spec.whatwg.org/multipage/indices.html#event-message.</summary>
+    internal const string MessageEventType = "message";
+
+    /// <summary>https://html.spec.whatwg.org/multipage/indices.html#event-messageerror.</summary>
+    internal const string MessageErrorEventType = "messageerror";
+
+    /// <summary>https://html.spec.whatwg.org/multipage/indices.html#event-error.</summary>
+    internal const string ErrorEventType = "error";
+
+    internal JsWorker(Engine engine, Realm realm) : base(engine, realm)
+    {
+        _prototype = realm.Intrinsics.Worker.PrototypeObject;
+    }
+
+    /// <summary>
+    /// The connection this object is the parent end of. Assigned once, by the constructor, immediately after
+    /// the object is created — it is a property rather than a constructor argument only because the link needs
+    /// the object it retargets at.
+    /// </summary>
+    internal WorkerLink? Link { get; set; }
+}
+#endif

--- a/Jint/WebApi/Workers/WorkerConnection.cs
+++ b/Jint/WebApi/Workers/WorkerConnection.cs
@@ -85,11 +85,15 @@ public sealed class WorkerConnection
     public string Name { get; }
 
     /// <summary>
-    /// Cancelled when the connection ends. Safe to read and to wait on from any thread.
+    /// Cancelled when anything but the worker itself ends the connection. Safe to read and to wait on from
+    /// any thread.
     /// </summary>
     /// <remarks>
-    /// This is what a pump loop parks on, so that ending the connection from another thread wakes it rather
-    /// than leaving it asleep until its own ceiling elapses.
+    /// This is what a pump loop parks on, so that ending the connection from <i>another</i> thread — a
+    /// <c>terminate()</c>, a restore, <see cref="End"/> — wakes it rather than leaving it asleep until its
+    /// own ceiling elapses. The one end that does not cancel is the worker's own <c>close()</c>: its teardown
+    /// runs on the pumping thread itself, which therefore observes <see cref="IsEnded"/> on its very next
+    /// loop iteration with nothing to be woken from.
     /// </remarks>
     public CancellationToken TerminationToken { get; }
 

--- a/Jint/WebApi/Workers/WorkerConstructor.cs
+++ b/Jint/WebApi/Workers/WorkerConstructor.cs
@@ -1,0 +1,336 @@
+#if NET8_0_OR_GREATER
+using System.Threading;
+using Jint.Constraints;
+using Jint.Native;
+using Jint.Native.Function;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.Runtime.Modules;
+using Jint.WebApi.DomException;
+using Jint.WebApi.Events;
+
+namespace Jint.WebApi.Workers;
+
+/// <summary>
+/// The <c>Worker</c> interface object.
+/// <para>
+/// https://html.spec.whatwg.org/multipage/workers.html#dedicated-workers-and-the-worker-interface
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>Worker</c> inherits from <c>EventTarget</c>, so its <c>[[Prototype]]</c> is the <c>EventTarget</c>
+/// interface object — https://webidl.spec.whatwg.org/#interface-object.
+/// </para>
+/// <para>
+/// <b>The constructor runs entirely on the parent's thread and runs none of the worker's script.</b> What it
+/// does is build the request, ask the host's <see cref="WorkerProvider"/> for an engine, validate that engine,
+/// entangle a port pair with it, install its global scope, and queue the module import as a job on the
+/// <i>worker's</i> event loop. The first pump the host gives that engine is what runs any of it.
+/// </para>
+/// </remarks>
+[JsObject(UseShape = true)]
+internal sealed partial class WorkerConstructor : Constructor
+{
+    private static readonly JsString _functionName = new("Worker");
+
+    /// <summary>The <c>WorkerType</c> enumeration, https://html.spec.whatwg.org/multipage/workers.html#workertype.</summary>
+    private const string ClassicType = "classic";
+
+    private const string ModuleType = "module";
+
+    internal WorkerConstructor(Engine engine, Realm realm, EventTargetConstructor eventTargetConstructor)
+        : base(engine, realm, _functionName)
+    {
+        _prototype = eventTargetConstructor;
+        PrototypeObject = new WorkerPrototype(engine, realm, this, eventTargetConstructor.PrototypeObject);
+        _length = new PropertyDescriptor(JsNumber.PositiveOne, PropertyFlag.Configurable);
+        _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
+    }
+
+    internal WorkerPrototype PrototypeObject { get; }
+
+    protected override void Initialize() => CreateProperties_Generated();
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/workers.html#dom-worker — the constructor steps, in the design's
+    /// order: WebIDL, quota, token, provider, validation, entanglement, global scope, start job, hand-off.
+    /// </summary>
+    public override ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget)
+    {
+        if (arguments.Length == 0)
+        {
+            Throw.TypeError(_realm, "Failed to construct 'Worker': 1 argument required, but only 0 present.");
+        }
+
+        // Step 1: WebIDL first, and before anything with a side effect — a badly typed call must not have cost
+        // a quota slot or reached the host at all. Jint does not URL-parse the specifier, so the
+        // specification's SyntaxError for an unparseable URL becomes whatever the worker's own loader reports
+        // later, as a startup failure.
+        var specifier = TypeConverter.ToString(arguments[0]);
+        var options = ReadOptions(arguments.At(1));
+
+        var registry = _engine._webApi?.Workers;
+        if (registry is null)
+        {
+            // Unreachable: the global that reaches this constructor is installed only where the registry was
+            // created, in the same block of WebApiRegistration.
+            Throw.InvalidOperationException("The Worker global was reached on an engine that has no worker provider.");
+            return null!;
+        }
+
+        // Step 2: the per-engine backstop. The provider is the policy — this only stops a script manufacturing
+        // engines faster than any host policy was written to notice.
+        var live = registry.LiveCount;
+        if (live >= registry.MaxWorkers)
+        {
+            WorkerErrors.ThrowQuotaExceededError(
+                _engine,
+                _realm,
+                $"Failed to construct 'Worker': this engine already has {live} live workers, which is its Options.WebApi.Workers.MaxWorkers limit.",
+                quota: Math.Max(0, registry.MaxWorkers),
+                requested: (double) live + 1);
+        }
+
+        // Step 3: minted before the provider is called, so that CreateDefaultOptions can register it on
+        // options the provider has not built yet.
+        var termination = new CancellationTokenSource();
+
+        var request = new WorkerRequest(
+            _engine,
+            specifier,
+            ReferencingLocation(),
+            WorkerType.Module,
+            options.Name,
+            registry.Depth,
+            live,
+            termination.Token);
+
+        // Step 4: the host's decision. Anything it throws propagates unchanged — nothing here is translated,
+        // because a provider's exception is host code failing and not a script's error.
+        var workerEngine = registry.Provider.CreateWorkerEngine(request);
+        if (workerEngine is null)
+        {
+            WorkerErrors.ThrowDomException(
+                _engine,
+                _realm,
+                DomExceptionNames.Security,
+                $"Failed to construct 'Worker': the host's worker provider refused to create a worker for '{specifier}'.");
+        }
+
+        return CreateWorker(registry, request, workerEngine!, termination, newTarget);
+    }
+
+    /// <summary>
+    /// Steps 5 to 10, with the worker engine <b>owned</b> throughout.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Everything from here on mutates the worker engine — entangling a port materializes its
+    /// <c>MessagePort</c> intrinsics, installing its global scope writes to its global object — so the engine
+    /// has to be quiescent, and that is validated rather than trusted: a provider that hands back a pre-warmed
+    /// engine another thread is already pumping gets the engine's own concurrent-use exception here, at
+    /// <c>new Worker()</c>, instead of silent corruption later.
+    /// </para>
+    /// <para>
+    /// The ownership is released before <see cref="WorkerProvider.OnWorkerStarted"/>, which is where the host
+    /// starts pumping: holding it across that call would make the host's very first <c>ProcessTasks</c> on its
+    /// own thread the concurrent-use exception.
+    /// </para>
+    /// </remarks>
+    private JsWorker CreateWorker(
+        WorkerRegistry registry,
+        WorkerRequest request,
+        Engine workerEngine,
+        CancellationTokenSource termination,
+        JsValue newTarget)
+    {
+        var worker = OrdinaryCreateFromConstructor(
+            newTarget,
+            static intrinsics => intrinsics.Worker.PrototypeObject,
+            static (Engine engine, Realm realm, object? _) => new JsWorker(engine, realm),
+            (object?) null);
+
+        WorkerLink link;
+
+        using (workerEngine.EnterHostCall())
+        {
+            // Step 5.
+            Validate(workerEngine, request);
+
+            // Steps 6 to 8.
+            link = new WorkerLink(
+                _engine,
+                workerEngine,
+                registry,
+                worker,
+                request.Name,
+                request.Specifier,
+                request.ReferencingLocation,
+                termination);
+
+            worker.Link = link;
+            workerEngine._webApi!.OwningWorkerLink = link;
+
+            // The child's own depth, so that a provider which deliberately granted this worker the ability to
+            // create workers of its own sees a Depth that says how deep the tree already is.
+            if (workerEngine._webApi.Workers is { } childRegistry)
+            {
+                childRegistry.Depth = registry.Depth + 1;
+            }
+
+            link.EnableParentHalf();
+            WorkerGlobalScope.Install(link, request.Name);
+
+            // Step 9.
+            link.QueueStartJob();
+        }
+
+        // Registered before the host is told, so that a connection which ends on the worker's thread the
+        // instant the host starts pumping is removed from a list it is already in.
+        registry.Add(link);
+
+        // Step 10.
+        registry.Provider.OnWorkerStarted(link.Connection);
+
+        return worker;
+    }
+
+    /// <summary>
+    /// Step 5: what the engine a provider handed back has to be. Every failure is an
+    /// <see cref="InvalidOperationException"/> whose message names the fix, because each of them is host code
+    /// having made a mistake rather than a script having done anything.
+    /// </summary>
+    private void Validate(Engine workerEngine, WorkerRequest request)
+    {
+        if (ReferenceEquals(workerEngine, _engine))
+        {
+            Throw.InvalidOperationException(
+                "WorkerProvider.CreateWorkerEngine returned the parent engine. A worker is a second engine with a global of its own; build one with new Engine(request.CreateDefaultOptions()).");
+        }
+
+        if ((workerEngine._webApiFeatures & WebApiFeatures.Messaging) == WebApiFeatures.None
+            || workerEngine._webApi is null)
+        {
+            Throw.InvalidOperationException(
+                "WorkerProvider.CreateWorkerEngine returned an engine without WebApiFeatures.Messaging, which the worker's own postMessage is built out of. Start from request.CreateDefaultOptions(), which sets it.");
+        }
+
+        if (workerEngine._webApi!.OwningWorkerLink is not null)
+        {
+            Throw.InvalidOperationException(
+                "WorkerProvider.CreateWorkerEngine returned an engine that is already running a worker. Each worker needs an engine of its own — a second connection would give one global two parents.");
+        }
+
+        if (!ObservesTerminationToken(workerEngine, request.TerminationToken))
+        {
+            Throw.InvalidOperationException(
+                "WorkerProvider.CreateWorkerEngine returned an engine that does not observe request.TerminationToken, so terminate() could close its ports but never stop its script — a worker that is deaf and mute while still burning a thread. Register it with options.CancellationToken(request.TerminationToken), which request.CreateDefaultOptions() already does.");
+        }
+    }
+
+    /// <summary>
+    /// Whether the engine carries a <see cref="CancellationConstraint"/> for this request's token.
+    /// </summary>
+    /// <remarks>
+    /// Every registration is looked at rather than only the first, because a worker whose parent registered a
+    /// cancellation token of its own has two of them and the replay puts the parent's beside ours.
+    /// </remarks>
+    private static bool ObservesTerminationToken(Engine workerEngine, CancellationToken terminationToken)
+    {
+        foreach (var constraint in workerEngine._constraints)
+        {
+            if (constraint is CancellationConstraint cancellation && cancellation.Token == terminationToken)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// <c>Module.Location</c> of the module the constructor was reached from, so a provider can resolve a
+    /// relative specifier the way <c>import()</c> would have; null when the call came from a script.
+    /// </summary>
+    private string? ReferencingLocation()
+        => _engine.GetActiveScriptOrModule() is Jint.Runtime.Modules.Module module ? module.Location : null;
+
+    /// <summary>
+    /// The <c>WorkerOptions</c> dictionary, https://html.spec.whatwg.org/multipage/workers.html#workeroptions.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// WebIDL converts a dictionary's members in <b>lexicographical order of their identifiers</b>
+    /// (https://webidl.spec.whatwg.org/#es-dictionary), which is <c>credentials</c>, <c>name</c>, <c>type</c> —
+    /// so an invalid <c>credentials</c> is the failure a script sees even when <c>type</c> is wrong too.
+    /// </para>
+    /// <para>
+    /// <c>credentials</c> is validated and then <b>ignored</b>: it only parameterizes the fetch, and the fetch
+    /// belongs to the worker engine's own <c>IModuleLoader</c>. Validating it anyway is what keeps a typo a
+    /// <c>TypeError</c> here rather than a silently different policy later.
+    /// </para>
+    /// </remarks>
+    private WorkerOptionsValues ReadOptions(JsValue options)
+    {
+        if (options.IsNullOrUndefined())
+        {
+            // The dictionary's own defaults, which means type 'classic' — refused below, exactly as an
+            // explicit one is.
+            ThrowClassicRefusal();
+        }
+
+        if (options is not ObjectInstance dictionary)
+        {
+            Throw.TypeError(_realm, "Failed to construct 'Worker': The provided value is not of type 'WorkerOptions'.");
+            return default;
+        }
+
+        var credentials = dictionary.Get("credentials");
+        if (!credentials.IsUndefined())
+        {
+            var value = TypeConverter.ToString(credentials);
+            if (value is not ("omit" or "same-origin" or "include"))
+            {
+                Throw.TypeError(_realm, $"Failed to construct 'Worker': Failed to read the 'credentials' property from 'WorkerOptions': The provided value '{value}' is not a valid enum value of type RequestCredentials.");
+            }
+        }
+
+        var name = dictionary.Get("name");
+        var workerName = name.IsUndefined() ? string.Empty : TypeConverter.ToString(name);
+
+        var type = dictionary.Get("type");
+        var typeValue = type.IsUndefined() ? ClassicType : TypeConverter.ToString(type);
+
+        if (typeValue is not (ClassicType or ModuleType))
+        {
+            // The WebIDL enumeration conversion, https://webidl.spec.whatwg.org/#es-enumeration.
+            Throw.TypeError(_realm, $"Failed to construct 'Worker': Failed to read the 'type' property from 'WorkerOptions': The provided value '{typeValue}' is not a valid enum value of type WorkerType.");
+        }
+
+        if (string.Equals(typeValue, ClassicType, StringComparison.Ordinal))
+        {
+            ThrowClassicRefusal();
+        }
+
+        return new WorkerOptionsValues(workerName);
+    }
+
+    /// <summary>
+    /// Jint's own refusal of the specification's own default, and the one message here that names a fix:
+    /// there is no classic-script loader to run one with, and a synchronous fetch-and-execute inside a
+    /// statement is the one thing this feature family refuses. Every non-browser runtime that ships workers
+    /// has converged on module workers for the same reasons.
+    /// </summary>
+    private void ThrowClassicRefusal()
+        => Throw.TypeError(_realm, "Failed to construct 'Worker': Jint runs module workers only. Pass { type: 'module' } — the HTML Standard's default is 'classic', which Jint does not implement.");
+
+    /// <summary>
+    /// What the constructor keeps from <c>WorkerOptions</c>. <c>type</c> has already decided whether there is
+    /// a worker at all, and <c>credentials</c> is validated and discarded.
+    /// </summary>
+    [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Auto)]
+    private readonly record struct WorkerOptionsValues(string Name);
+}
+#endif

--- a/Jint/WebApi/Workers/WorkerErrors.cs
+++ b/Jint/WebApi/Workers/WorkerErrors.cs
@@ -1,0 +1,85 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.WebApi.DomException;
+using Jint.WebApi.Events;
+
+namespace Jint.WebApi.Workers;
+
+/// <summary>
+/// The two refusals this feature raises at script, and the one-line event-handler attribute plumbing its two
+/// façades share.
+/// </summary>
+internal static class WorkerErrors
+{
+    /// <summary>
+    /// https://webidl.spec.whatwg.org/#quotaexceedederror, with the ceiling and the count the refused
+    /// operation would have reached — the same shape the timer queue and the socket ceiling already refuse
+    /// with, so <c>e.constructor === QuotaExceededError</c> and <c>e.quota</c> answer as a script expects.
+    /// </summary>
+    internal static void ThrowQuotaExceededError(Engine engine, Realm realm, string message, double quota, double requested)
+    {
+        var exception = realm.Intrinsics.QuotaExceededError.CreateException(message, quota, requested);
+        var location = engine._lastSyntaxElement?.Location ?? default;
+        Throw.JavaScriptException(engine, exception, in location);
+    }
+
+    /// <summary>
+    /// A <c>DOMException</c> of the named kind. <c>SecurityError</c> is what a provider's refusal reaches the
+    /// script as: it is a policy decision rather than a fetch failure, and it is the shape a browser already
+    /// throws synchronously from <c>new Worker()</c> for a script it will not run.
+    /// </summary>
+    internal static void ThrowDomException(Engine engine, Realm realm, string name, string message)
+    {
+        var exception = realm.Intrinsics.DomException.CreateException(name, message);
+        var location = engine._lastSyntaxElement?.Location ?? default;
+        Throw.JavaScriptException(engine, exception, in location);
+    }
+
+    /// <summary>
+    /// The getter half of an event handler IDL attribute,
+    /// https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes.
+    /// </summary>
+    internal static JsValue GetEventHandler(JsEventTarget target, string type)
+        => target.FindEventHandler(type)?.Callback ?? JsValue.Null;
+
+    /// <summary>
+    /// HTML's "set the current value of the event handler". <c>EventHandler</c> is a nullable callback
+    /// function annotated <c>[LegacyTreatNonObjectAsNull]</c>, so assigning anything that is not an object
+    /// clears the handler rather than raising a <c>TypeError</c>; reassigning replaces the value in place, so
+    /// the listener keeps the position it was first given among the <c>addEventListener</c> ones.
+    /// </summary>
+    /// <remarks>
+    /// <b>It deliberately does not start anything.</b> <c>MessagePort</c>'s <c>onmessage</c> setter enables
+    /// that port's queue, because the specification scopes that rule to the <c>MessagePort</c> interface; the
+    /// <c>MessageEventTarget</c> mixin a <c>Worker</c> and a worker's global scope include carries no such
+    /// rule, so on those two <c>addEventListener('message', …)</c> alone has to receive — the exact opposite
+    /// of a <c>MessageChannel</c>, where <c>start()</c> is required. Both façades are therefore enabled by the
+    /// engine rather than by an assignment.
+    /// </remarks>
+    internal static void SetEventHandler(JsEventTarget target, string type, JsValue value)
+    {
+        var existing = target.FindEventHandler(type);
+
+        if (value is not ObjectInstance)
+        {
+            // "Deactivate an event handler": the listener goes away entirely.
+            if (existing is not null)
+            {
+                target.RemoveListener(existing);
+            }
+
+            return;
+        }
+
+        if (existing is not null)
+        {
+            existing.Callback = value;
+            return;
+        }
+
+        target.AddListener(new EventListenerRegistration(type, value) { IsEventHandler = true });
+    }
+}
+#endif

--- a/Jint/WebApi/Workers/WorkerGlobalScope.cs
+++ b/Jint/WebApi/Workers/WorkerGlobalScope.cs
@@ -1,0 +1,196 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Native.Symbol;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.Runtime.Interop;
+using Jint.WebApi.GlobalEvents;
+using Jint.WebApi.Messaging;
+using Jint.WebApi.StructuredClone;
+
+namespace Jint.WebApi.Workers;
+
+/// <summary>
+/// The names a dedicated worker's global scope carries, installed on the worker engine's global object when
+/// the connection is made.
+/// <para>
+/// https://html.spec.whatwg.org/multipage/workers.html#dedicated-workers-and-the-dedicatedworkerglobalscope-interface
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>There is no <c>WorkerGlobalScope</c> or <c>DedicatedWorkerGlobalScope</c> interface object</b>, and that
+/// is the coherent half rather than a missing one: Jint's global object is not an <c>EventTarget</c> and has
+/// no such prototype chain, so an interface object would make <c>self instanceof WorkerGlobalScope</c> lie
+/// about a relationship that does not exist. WinterTC's Minimum Common API §6 blesses the mechanism used
+/// instead — firing the events "through a suitable alternative mechanism available at the global scope" —
+/// and §5.3 names exactly what such a global must expose: <c>onerror</c>, <c>onunhandledrejection</c>,
+/// <c>onrejectionhandled</c> and <c>self</c>.
+/// </para>
+/// <para>
+/// <b>Every event-handler attribute here is one entry of the engine's synthetic global listener list</b>
+/// (<see cref="GlobalEventTarget"/>), which is the same list <c>addEventListener</c> writes to and the list
+/// the worker's hidden port retargets its <c>message</c> events at. That is what makes
+/// <c>self.onmessage = f</c> and <c>addEventListener('message', f)</c> equivalent, as they are on a
+/// <c>DedicatedWorkerGlobalScope</c> — and it is deliberately unlike <c>MessagePort</c>, whose
+/// <c>onmessage</c> setter also starts the port, a rule the specification scopes to that interface alone.
+/// </para>
+/// <para>
+/// Everything is installed <b>non-clobbering</b>, exactly as <c>WebApiRegistration</c> installs a global: a
+/// name the host already put on the worker's global object is left as the host left it.
+/// </para>
+/// </remarks>
+internal sealed class WorkerGlobalScope
+{
+    private readonly WorkerLink _link;
+    private readonly Engine _engine;
+    private readonly Realm _realm;
+
+    private WorkerGlobalScope(WorkerLink link, Engine engine, Realm realm)
+    {
+        _link = link;
+        _engine = engine;
+        _realm = realm;
+    }
+
+    /// <summary>
+    /// Step 8 of the construction: installs the worker names on <paramref name="link"/>'s worker engine.
+    /// Called on the parent's thread, with that engine owned and quiescent.
+    /// </summary>
+    internal static void Install(WorkerLink link, string name)
+    {
+        var engine = link.Worker;
+
+        // The PRINCIPAL realm, deliberately, and for WebApiRegistration's reason: these globals belong to the
+        // engine's own realm and to no other, and a ShadowRealm carries none of them.
+        var realm = engine._mainRealm;
+        var global = realm.GlobalObject;
+
+        var scope = new WorkerGlobalScope(link, engine, realm);
+
+        // WebIDL operations on the global are writable, enumerable and configurable —
+        // https://webidl.spec.whatwg.org/#es-operations.
+        InstallValue(global, "postMessage", scope.CreateFunction("postMessage", 1, scope.PostMessage));
+        InstallValue(global, "close", scope.CreateFunction("close", 0, scope.Close));
+
+        // https://html.spec.whatwg.org/multipage/workers.html#import-scripts-into-worker-global-scope, whose
+        // step 1 is "If worker global scope's type is 'module', throw a TypeError exception." So the function
+        // is PRESENT and throws, and `typeof importScripts === 'function'` answers true exactly as it does in
+        // a browser — the one place this family's absent-rather-than-throwing convention and the standard
+        // disagree, and the standard wins because it is prescribing the throw itself.
+        InstallValue(global, "importScripts", scope.CreateFunction("importScripts", 0, scope.ImportScripts));
+
+        // https://html.spec.whatwg.org/multipage/workers.html#dom-dedicatedworkerglobalscope-name. A plain
+        // writable data property is the [Replaceable] simplification `self` is already installed with.
+        InstallValue(global, "name", JsString.Create(name));
+
+        scope.InstallEventHandler(global, "onmessage", JsMessagePort.MessageEventType);
+        scope.InstallEventHandler(global, "onmessageerror", JsMessagePort.MessageErrorEventType);
+
+        // WinterTC §5.3's three. The events already fire at this same target under
+        // WebApiFeatures.GlobalEvents; what these add is the attribute form of registering for them.
+        // `onerror`'s legacy five-argument invocation — «message, filename, lineno, colno, error», where
+        // returning true cancels — lands with the parent-side error channels in their own change; until then
+        // it is the ordinary event-handler shape and the dispatch is the ordinary one.
+        scope.InstallEventHandler(global, "onerror", GlobalEventNames.ErrorName);
+        scope.InstallEventHandler(global, "onunhandledrejection", GlobalEventNames.UnhandledRejectionName);
+        scope.InstallEventHandler(global, "onrejectionhandled", GlobalEventNames.RejectionHandledName);
+    }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/workers.html#dom-dedicatedworkerglobalscope-postmessage — the
+    /// worker half of the connection's port pair.
+    /// </summary>
+    /// <remarks>
+    /// Both WebIDL overloads, resolved the way <c>MessagePort.postMessage</c> resolves them: an iterable
+    /// second argument is the <c>sequence&lt;object&gt;</c> arm and anything else is the
+    /// <c>StructuredSerializeOptions</c> dictionary. The list travels verbatim, which is what lets a
+    /// <c>MessagePort</c> and a transferable stream ride back to the parent untouched.
+    /// </remarks>
+    private JsValue PostMessage(JsValue thisObject, JsCallArguments arguments)
+    {
+        if (arguments.Length == 0)
+        {
+            Throw.TypeError(_realm, "Failed to execute 'postMessage' on 'DedicatedWorkerGlobalScope': 1 argument required, but only 0 present.");
+        }
+
+        const string Operation = "postMessage' on 'DedicatedWorkerGlobalScope";
+        var argument = arguments.At(1);
+
+        var transferList = argument is ObjectInstance && JsValue.GetMethod(_realm, argument, GlobalSymbolRegistry.Iterator) is not null
+            ? StructuredSerializeOptions.ReadTransferSequence(_realm, argument, Operation)
+            : StructuredSerializeOptions.ReadTransferOption(_realm, argument, Operation);
+
+        _link.PostFromWorker(_realm, arguments[0], transferList);
+        return JsValue.Undefined;
+    }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/workers.html#dom-dedicatedworkerglobalscope-close — <i>close a
+    /// worker</i>: discard the tasks on the worker's own queues and set the closing flag. It pointedly does
+    /// <b>not</b> abort the running script, and pointedly does not empty the parent-side queue.
+    /// </summary>
+    private JsValue Close(JsValue thisObject, JsCallArguments arguments)
+    {
+        _link.CloseFromWorker();
+        return JsValue.Undefined;
+    }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/workers.html#import-scripts-into-worker-global-scope, step 1.
+    /// </summary>
+    private JsValue ImportScripts(JsValue thisObject, JsCallArguments arguments)
+    {
+        Throw.TypeError(_realm, "Failed to execute 'importScripts' on 'DedicatedWorkerGlobalScope': Module scripts don't support importScripts(). Use a static or dynamic import instead.");
+        return JsValue.Undefined;
+    }
+
+    private ClrFunction CreateFunction(string name, int length, JsCallDelegate body)
+        => new(_engine, _realm, name, body, length, PropertyFlag.Configurable);
+
+    /// <summary>
+    /// An event handler IDL attribute over the engine's synthetic global listener list —
+    /// https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes, whose accessor
+    /// pair is configurable and enumerable.
+    /// </summary>
+    private void InstallEventHandler(ObjectInstance global, string attribute, string eventType)
+    {
+        var getter = CreateFunction(attribute, 0, (_, _) => WorkerErrors.GetEventHandler(Target, eventType));
+        var setter = CreateFunction(attribute, 1, (_, arguments) =>
+        {
+            WorkerErrors.SetEventHandler(Target, eventType, arguments.At(0));
+            return JsValue.Undefined;
+        });
+
+        InstallDescriptor(global, attribute, new GetSetPropertyDescriptor(getter, setter, PropertyFlag.Configurable | PropertyFlag.Enumerable));
+    }
+
+    /// <summary>
+    /// The listener list every one of these attributes writes to, and the one the worker's hidden port
+    /// dispatches at.
+    /// </summary>
+    /// <remarks>
+    /// Read per call rather than captured, because <c>ResetTransientEvaluationState</c> replaces the target
+    /// when an evaluation cycle ends. A restore on the worker also ends the connection, which lands with the
+    /// restore and dispose hooks in their own change (wave 3); reading it fresh is what keeps this correct
+    /// either way.
+    /// </remarks>
+    private GlobalEventTarget Target => _engine._webApi!.GlobalEventTarget;
+
+    private static void InstallValue(ObjectInstance global, string name, JsValue value)
+        => InstallDescriptor(global, name, new PropertyDescriptor(value, PropertyFlag.ConfigurableEnumerableWritable));
+
+    private static void InstallDescriptor(ObjectInstance global, string name, PropertyDescriptor descriptor)
+    {
+        // Non-clobbering, and probing rather than reading, so that a host's own lazy global is not forced into
+        // existence merely by our looking — WebApiRegistration.Install's reasoning, unchanged.
+        if (global.HasOwnProperty(JsString.Create(name)))
+        {
+            return;
+        }
+
+        global.SetProperty(name, descriptor);
+    }
+}
+#endif

--- a/Jint/WebApi/Workers/WorkerLink.cs
+++ b/Jint/WebApi/Workers/WorkerLink.cs
@@ -1,0 +1,407 @@
+#if NET8_0_OR_GREATER
+using System.Threading;
+using Jint.Native;
+using Jint.Native.Error;
+using Jint.Native.Object;
+using Jint.Native.Promise;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.Runtime.Interop;
+using Jint.Runtime.Modules;
+using Jint.WebApi.Messaging;
+
+namespace Jint.WebApi.Workers;
+
+/// <summary>
+/// The engine-side half of one worker: the two entangled ports neither side ever sees, the start job, the
+/// message paths in both directions, and the two ways a connection ends.
+/// <para>
+/// https://html.spec.whatwg.org/multipage/workers.html#dedicated-workers-and-the-worker-interface
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Neither port is handed to script</b>, which is HTML's own shape: <c>Worker</c> and
+/// <c>DedicatedWorkerGlobalScope</c> both include <c>MessageEventTarget</c> and there is no <c>worker.port</c>
+/// — that belongs to <c>SharedWorker</c>. So the <c>Worker</c> object <i>is</i> the parent half's façade and
+/// the worker's global scope <i>is</i> the worker half's, and each hidden port carries a
+/// <see cref="JsMessagePort.RetargetTo"/> pointing at the listener list its façade owns.
+/// </para>
+/// <para>
+/// <b>Which thread runs what.</b> This object is created on the parent's thread, with the worker engine
+/// quiescent and owned for the duration. After that, everything that touches the worker engine's state is an
+/// event-loop job carrying the worker's own generation, and everything that ends the connection touches only
+/// endpoints, a <see cref="CancellationTokenSource"/> and interlocked bookkeeping — which is what makes
+/// <see cref="WorkerConnection.End"/> callable from any thread.
+/// </para>
+/// </remarks>
+internal sealed class WorkerLink
+{
+    private readonly Engine _parent;
+    private readonly Engine _worker;
+    private readonly WorkerRegistry _registry;
+
+    /// <summary>The parent's hidden port: its side is the parent's inbox, and the worker posts into it.</summary>
+    private readonly JsMessagePort _outerPort;
+
+    /// <summary>The worker's hidden port: its side is the worker's inbox, and the parent posts into it.</summary>
+    private readonly JsMessagePort _innerPort;
+
+    /// <summary>
+    /// Cancelled when the connection ends, <b>except</b> for a worker's own <c>close()</c> — see
+    /// <see cref="OnEnded"/>. Deliberately never disposed: a host pump loop is documented as waiting on
+    /// <see cref="WorkerConnection.TerminationToken"/>, and a disposed source turns that wait into an
+    /// <see cref="ObjectDisposedException"/> on the host's thread. It holds no timer and no registration of
+    /// the engine's own, so it is ordinary garbage once the host lets go of the connection.
+    /// </summary>
+    private readonly CancellationTokenSource _termination;
+
+    /// <summary>
+    /// The evaluation cycle the worker engine was in when the connection was made. Every job this class queues
+    /// on the worker's loop carries it, so a <c>RestoreGlobalSnapshot</c> on the worker discards them rather
+    /// than running the ended cycle's work against the restored globals.
+    /// </summary>
+    private readonly int _workerGeneration;
+
+    private readonly string _specifier;
+    private readonly string? _referencingLocation;
+
+    /// <summary>The job <c>close()</c> queues, built once so a script calling it in a loop allocates nothing.</summary>
+    private readonly Action _closeJob;
+
+    internal WorkerLink(
+        Engine parent,
+        Engine worker,
+        WorkerRegistry registry,
+        JsWorker workerObject,
+        string name,
+        string specifier,
+        string? referencingLocation,
+        CancellationTokenSource termination)
+    {
+        _parent = parent;
+        _worker = worker;
+        _registry = registry;
+        _termination = termination;
+        _specifier = specifier;
+        _referencingLocation = referencingLocation;
+        _workerGeneration = worker.EventLoopGeneration;
+        _closeJob = EndAsClosedByWorker;
+
+        WorkerObject = workerObject;
+
+        // Step 6: entangle. Both ports are built here, on the parent's thread, with the worker engine owned —
+        // which is what constructing a port on it amounts to, since it materializes that realm's MessagePort
+        // intrinsics.
+        var (outer, inner) = MessagePortBridge.CreatePair(parent, parent._mainRealm, worker, worker._mainRealm);
+        _outerPort = outer;
+        _innerPort = inner;
+
+        // The retarget hook: a message that arrives on the parent's hidden port fires at the Worker object,
+        // and one that arrives on the worker's fires at the worker's global scope.
+        _outerPort.RetargetTo = workerObject;
+        _innerPort.RetargetTo = worker._webApi!.GlobalEventTarget;
+
+        Connection = new WorkerConnection(parent, worker, name, OnEnded, termination.Token);
+    }
+
+    /// <summary>The host's view of this link.</summary>
+    internal WorkerConnection Connection { get; }
+
+    /// <summary>The <c>Worker</c> object the parent's script holds.</summary>
+    internal JsWorker WorkerObject { get; }
+
+    /// <summary>The engine that runs the worker — what <c>close()</c> and the start job are queued on.</summary>
+    internal Engine Worker => _worker;
+
+    /// <summary>
+    /// Step 7: the parent half is enabled now, so a message the worker posts during its own evaluation is
+    /// delivered on the parent's next pump. <b>A documented divergence</b> — HTML enables both queues only
+    /// after the worker's initial script has run — and the reason the <i>inner</i> queue stays disabled until
+    /// <see cref="OnModuleEvaluated"/>, which is what makes
+    /// <c>const w = new Worker(u); w.postMessage(1)</c> buffer in order rather than being lost.
+    /// </summary>
+    internal void EnableParentHalf() => _outerPort.Start();
+
+    /// <summary>
+    /// Step 9: the start job, queued on the <b>worker's</b> loop with the worker's own generation. Nothing of
+    /// the worker's script has run when <c>new Worker(...)</c> returns; the first pump the host gives it is
+    /// what runs this.
+    /// </summary>
+    internal void QueueStartJob() => _worker.AddToEventLoop(RunStartJob, _workerGeneration);
+
+    /// <summary>
+    /// <c>worker.postMessage(message, transfer)</c> — the parent half. Runs on the parent's thread.
+    /// </summary>
+    internal void PostFromParent(Realm realm, JsValue message, List<JsValue>? transferList)
+    {
+        EnforceQueueBound(_parent, realm, _outerPort, "postMessage' on 'Worker");
+        _outerPort.PostMessage(message, transferList);
+    }
+
+    /// <summary>
+    /// The worker global's <c>postMessage(message, transfer)</c>. Runs on the worker's thread.
+    /// </summary>
+    internal void PostFromWorker(Realm realm, JsValue message, List<JsValue>? transferList)
+    {
+        EnforceQueueBound(_worker, realm, _innerPort, "postMessage' on 'DedicatedWorkerGlobalScope");
+        _innerPort.PostMessage(message, transferList);
+    }
+
+    /// <summary>
+    /// <c>worker.terminate()</c>, https://html.spec.whatwg.org/multipage/workers.html#dom-worker-terminate —
+    /// and <see cref="WorkerConnection.End"/>, which is the same thing from the host's side. Idempotent, and
+    /// safe from any thread.
+    /// </summary>
+    internal void Terminate() => Connection.TryEnd(WorkerEndReason.Terminated, error: null);
+
+    /// <summary>
+    /// The worker global's <c>close()</c>,
+    /// https://html.spec.whatwg.org/multipage/workers.html#dom-dedicatedworkerglobalscope-close — <i>close a
+    /// worker</i>, which is emphatically not <i>terminate a worker</i>.
+    /// </summary>
+    /// <remarks>
+    /// Two halves, and the split is the whole point. The worker's own side is disentangled <b>now</b>, so it
+    /// receives nothing further and posts nothing further. The connection itself ends on a job queued on the
+    /// worker's own loop, so the turn that called <c>close()</c> runs to completion first — which is what
+    /// keeps <c>close(); flushMetrics();</c> working, where terminate's cancellation would have killed it
+    /// within 64 statements.
+    /// </remarks>
+    internal void CloseFromWorker()
+    {
+        if (Connection.IsEnded)
+        {
+            return;
+        }
+
+        // Always the endpoint, never JsMessagePort.Close(): the port object's fields are engine-thread-only,
+        // and doing it uniformly here keeps this method's shape identical to the end sequence's.
+        _innerPort.Endpoint?.Close();
+
+        _worker.AddToEventLoop(_closeJob, _workerGeneration);
+    }
+
+    /// <summary>
+    /// The end sequence, run exactly once, on whichever thread ended the connection, and outside every lock
+    /// this feature holds.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The endpoint treatment is §6.1/§6.2 of the design, which is the specification split: <i>terminate a
+    /// worker</i>'s fourth step empties the queue of the port entangled with the worker's, and <i>close a
+    /// worker</i> has no counterpart to it at all. So a terminate closes both sides and discards what the
+    /// parent had already posted, while a <c>close()</c> leaves the parent's side draining — deliverable, but
+    /// joinable no longer.
+    /// </para>
+    /// <para>
+    /// The token is cancelled for every reason but <see cref="WorkerEndReason.ClosedByWorker"/>: cancelling it
+    /// there would abort the very turn the worker asked to be allowed to finish.
+    /// </para>
+    /// </remarks>
+    private void OnEnded(WorkerEndReason reason)
+    {
+        var closedByWorker = reason == WorkerEndReason.ClosedByWorker;
+
+        _innerPort.Endpoint?.Close();
+
+        if (closedByWorker)
+        {
+            _outerPort.Endpoint?.BeginDrainThenClose();
+        }
+        else
+        {
+            _outerPort.Endpoint?.Close();
+        }
+
+        if (!closedByWorker)
+        {
+            _termination.Cancel();
+        }
+
+        _registry.Remove(this);
+
+        // Last, and outside everything: it is host code, and the host is documented as being allowed to do
+        // nothing here but signal its own pump.
+        _registry.Provider.OnWorkerEnded(Connection, reason);
+    }
+
+    private void EndAsClosedByWorker() => Connection.TryEnd(WorkerEndReason.ClosedByWorker, error: null);
+
+    /// <summary>
+    /// The start job's body: begin the import, and settle the connection from what it answers.
+    /// </summary>
+    /// <remarks>
+    /// <c>StartImport</c> rather than <c>Import</c> or <c>ImportAsync</c>, and the operation's promise rather
+    /// than its <c>IsCompleted</c>: polling would need a pump the connection may no longer get, and every
+    /// getter on the operation is admission-guarded, so a poll from anywhere but the worker's own thread is an
+    /// exception rather than an answer. It is legal from inside a job — a blocking import is what
+    /// <c>ThrowIfBlockedInsideJob</c> refuses, and this one never blocks.
+    /// </remarks>
+    private void RunStartJob()
+    {
+        if (Connection.IsEnded)
+        {
+            return;
+        }
+
+        ModuleImportOperation operation;
+        try
+        {
+            operation = _worker.Modules.StartImport(_specifier, _referencingLocation);
+        }
+        catch (Exception ex) when (!Throw.MustPropagateHostException(ex))
+        {
+            // StartImport turns almost everything into a rejection itself; this is the backstop for what it
+            // does not, so that a failure to even begin still reaches the host as StartupFailed rather than
+            // erupting from whatever was pumping.
+            FailStartup(ex);
+            return;
+        }
+
+        if (operation.Promise is not JsPromise promise)
+        {
+            // Unreachable: StartImport always hands back a promise capability's promise.
+            FailStartup(new WorkerStartupException($"The worker's module '{_specifier}' could not be started."));
+            return;
+        }
+
+        var onFulfilled = new ClrFunction(_worker, "", (_, _) =>
+        {
+            OnModuleEvaluated();
+            return JsValue.Undefined;
+        }, 1, PropertyFlag.Configurable);
+
+        var onRejected = new ClrFunction(_worker, "", (_, arguments) =>
+        {
+            OnModuleFailed(arguments.At(0));
+            return JsValue.Undefined;
+        }, 1, PropertyFlag.Configurable);
+
+        // Reactions rather than a poll — and this also marks the rejection handled, so a worker whose module
+        // fails to load does not additionally read as an unhandled promise rejection.
+        PromiseOperations.PerformPromiseThen(_worker, promise, onFulfilled, onRejected, resultCapability: null!);
+    }
+
+    /// <summary>
+    /// The module evaluated: enable the worker's own queue, which delivers everything the parent posted while
+    /// it was loading, in order.
+    /// </summary>
+    private void OnModuleEvaluated()
+    {
+        if (Connection.IsEnded)
+        {
+            return;
+        }
+
+        _innerPort.Start();
+    }
+
+    /// <summary>
+    /// The module never ran. §6.3's order: the inner endpoint first — so the records the parent posted are
+    /// discarded and the sides they carried are stranded rather than left waiting for a deserialization that
+    /// can never happen — then the outer one, then the host is told.
+    /// </summary>
+    /// <remarks>
+    /// The parent-side <c>error</c> event HTML fires at the <c>Worker</c> object lands in its own change
+    /// (wave 3); what this wave gives a host is the connection surface, which needs no sink wired at all:
+    /// <see cref="WorkerConnection.IsFaulted"/>, <see cref="WorkerConnection.Error"/> and an
+    /// <see cref="WorkerEndReason.StartupFailed"/> that says what happened rather than blaming a
+    /// <c>terminate()</c> nobody called.
+    /// </remarks>
+    private void OnModuleFailed(JsValue error) => FailStartup(ToClrFailure(error));
+
+    private void FailStartup(Exception error) => Connection.TryEnd(WorkerEndReason.StartupFailed, error);
+
+    /// <summary>
+    /// Reduces the worker realm's rejection value to a CLR exception, because
+    /// <see cref="WorkerConnection.Error"/> is read by a host on some other thread and a <c>JsValue</c>
+    /// belongs to the engine that made it.
+    /// </summary>
+    /// <remarks>
+    /// The CLR exception behind the failure is preferred whenever there is one — a
+    /// <c>ModuleResolutionException</c>, or whatever a host loader threw, which the module machinery records
+    /// on the error value it built. Failing that, the message and location are copied out as <i>strings</i>,
+    /// through own data properties only: reading them with <c>Get</c> would run a script getter while the
+    /// connection is being torn down.
+    /// </remarks>
+    private Exception ToClrFailure(JsValue error)
+    {
+        if (error is ErrorInstance instance && instance.ClrException is { } clrException)
+        {
+            return clrException;
+        }
+
+        return new WorkerStartupException($"The worker's module '{_specifier}' failed to start: {Describe(error)}");
+    }
+
+    /// <summary>
+    /// A one-line description of a rejection value, built without running any script.
+    /// </summary>
+    private static string Describe(JsValue error)
+    {
+        if (error is not ObjectInstance instance)
+        {
+            return Throw.SafeToDisplayString(error);
+        }
+
+        var name = ReadOwnString(instance, "name") ?? "Error";
+        var message = ReadOwnString(instance, "message");
+        var text = message is null ? name : $"{name}: {message}";
+
+        return ReadOwnString(instance, "stack") is { } stack ? stack : text;
+    }
+
+    private static string? ReadOwnString(ObjectInstance instance, string property)
+    {
+        var descriptor = instance.GetOwnProperty(JsString.Create(property));
+        return descriptor.IsDataDescriptor() && descriptor.Value is JsString value ? value.ToString() : null;
+    }
+
+    /// <summary>
+    /// <c>Options.WebApi.Workers.MaxQueuedMessages</c>, per direction: the sender is refused before it
+    /// serializes anything, so a receiver nobody pumps cannot grow the sender's live set without bound.
+    /// </summary>
+    /// <remarks>
+    /// Before the serialization rather than after it, unlike the specification's own step order for a
+    /// disentangled port: this is a resource refusal rather than a delivery outcome, and there is nothing to
+    /// be gained by detaching a transfer list for a message that is not going to be taken.
+    /// </remarks>
+    private void EnforceQueueBound(Engine engine, Realm realm, JsMessagePort source, string operation)
+    {
+        if (source.Endpoint?.Peer is not { } target)
+        {
+            return;
+        }
+
+        var queued = target.QueuedMessageCount;
+        if (queued < _registry.MaxQueuedMessages)
+        {
+            return;
+        }
+
+        WorkerErrors.ThrowQuotaExceededError(
+            engine,
+            realm,
+            $"Failed to execute '{operation}': the connection already has {queued} messages waiting to be delivered, which is its Options.WebApi.Workers.MaxQueuedMessages limit.",
+            quota: Math.Max(0, _registry.MaxQueuedMessages),
+            requested: (double) queued + 1);
+    }
+}
+
+/// <summary>
+/// The failure a worker's startup is reported as when there is no CLR exception behind it — a module whose
+/// evaluation threw a JavaScript error, which cannot cross to the host as a value.
+/// </summary>
+/// <remarks>
+/// Internal deliberately: a host reads it through <see cref="WorkerConnection.Error"/>, which is typed
+/// <see cref="Exception"/>, and what it carries is a message. Making the type public would promise a shape
+/// that is a summary by construction — the real failure is a value in another engine's realm, and the whole
+/// reason this exists is that such a value may not travel.
+/// </remarks>
+internal sealed class WorkerStartupException : Exception
+{
+    internal WorkerStartupException(string message) : base(message)
+    {
+    }
+}
+#endif

--- a/Jint/WebApi/Workers/WorkerPrototype.cs
+++ b/Jint/WebApi/Workers/WorkerPrototype.cs
@@ -1,0 +1,180 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Native.Symbol;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.WebApi.StructuredClone;
+
+namespace Jint.WebApi.Workers;
+
+/// <summary>
+/// <c>Worker.prototype</c> — the interface prototype object.
+/// <para>
+/// https://html.spec.whatwg.org/multipage/workers.html#dedicated-workers-and-the-worker-interface
+/// </para>
+/// </summary>
+/// <remarks>
+/// Its <c>[[Prototype]]</c> is <c>EventTarget.prototype</c>, so a worker has <c>addEventListener</c> and the
+/// rest and <c>worker instanceof EventTarget</c> holds. The three event-handler attributes are the ones the
+/// IDL declares — <c>onmessage</c> and <c>onmessageerror</c> from <c>MessageEventTarget</c>, <c>onerror</c>
+/// from <c>AbstractWorker</c>; <c>messageerror</c> exists and can never fire, for the reason
+/// <c>JsMessagePort</c> records.
+/// </remarks>
+[JsObject(UseShape = true)]
+internal sealed partial class WorkerPrototype : Prototype
+{
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
+    private readonly WorkerConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString WorkerToStringTag = new("Worker");
+
+    internal WorkerPrototype(
+        Engine engine,
+        Realm realm,
+        WorkerConstructor constructor,
+        ObjectInstance eventTargetPrototype) : base(engine, realm)
+    {
+        _prototype = eventTargetPrototype;
+        _constructor = constructor;
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/workers.html#dom-worker-postmessage — "the <i>message port post
+    /// message steps</i> ... with the worker's port".
+    /// </summary>
+    /// <remarks>
+    /// Two overloads share one name, and WebIDL's overload resolution picks between them by asking whether the
+    /// second argument is iterable (https://webidl.spec.whatwg.org/#es-overloads step 12.3), exactly as
+    /// <c>MessagePort.postMessage</c> does — so both <c>postMessage(x, [buf])</c> and
+    /// <c>postMessage(x, { transfer: [buf] })</c> work, and the list travels verbatim, which is what lets a
+    /// <c>MessagePort</c> and a transferable stream ride through untouched.
+    /// </remarks>
+    [JsFunction(Name = "postMessage", Length = 1)]
+    private JsValue PostMessage(JsValue thisObject, JsCallArguments arguments)
+    {
+        var worker = Brand(thisObject);
+
+        if (arguments.Length == 0)
+        {
+            Throw.TypeError(_realm, "Failed to execute 'postMessage' on 'Worker': 1 argument required, but only 0 present.");
+        }
+
+        var transferList = ReadTransferArgument(arguments.At(1));
+        worker.Link?.PostFromParent(_realm, arguments[0], transferList);
+        return Undefined;
+    }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/workers.html#dom-worker-terminate — <i>terminate a worker</i>.
+    /// </summary>
+    /// <remarks>
+    /// Idempotent, and an immediate parent→worker fence the instant it returns: both endpoints are closed, so
+    /// nothing can be enqueued in either direction any more. Stopping the worker's <i>script</i> is
+    /// cooperative — the cancellation the token carries is observed within the engine's amortized check
+    /// interval on the worker's own thread, and not at all while it is inside a host CLR call. That bound is
+    /// stronger than the field's: V8's <c>TerminateExecution</c> is frame-bounded in exactly the same way and
+    /// does not unwind an embedder's native call either.
+    /// </remarks>
+    [JsFunction(Name = "terminate", Length = 0)]
+    private JsValue Terminate(JsValue thisObject)
+    {
+        Brand(thisObject).Link?.Terminate();
+        return Undefined;
+    }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/workers.html#handler-worker-onmessage.
+    /// </summary>
+    /// <remarks>
+    /// The handler is one entry of this object's own event listener list, so it takes its turn in registration
+    /// order among the <c>addEventListener('message', …)</c> listeners. <b>Assigning it starts nothing</b> —
+    /// the parent's queue is enabled by the engine when the worker is created, so a listener registered either
+    /// way receives; see <c>WorkerErrors.SetEventHandler</c>.
+    /// </remarks>
+    [JsAccessor("onmessage", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsValue OnMessageGet(JsValue thisObject)
+        => WorkerErrors.GetEventHandler(Brand(thisObject), JsWorker.MessageEventType);
+
+    /// <inheritdoc cref="OnMessageGet" />
+    [JsAccessor("onmessage", AccessorKind.Set, Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsValue OnMessageSet(JsValue thisObject, JsValue value)
+    {
+        WorkerErrors.SetEventHandler(Brand(thisObject), JsWorker.MessageEventType, value);
+        return Undefined;
+    }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/workers.html#handler-worker-onmessageerror. Present because the
+    /// interface has it; nothing in Jint ever fires one.
+    /// </summary>
+    [JsAccessor("onmessageerror", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsValue OnMessageErrorGet(JsValue thisObject)
+        => WorkerErrors.GetEventHandler(Brand(thisObject), JsWorker.MessageErrorEventType);
+
+    /// <inheritdoc cref="OnMessageErrorGet" />
+    [JsAccessor("onmessageerror", AccessorKind.Set, Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsValue OnMessageErrorSet(JsValue thisObject, JsValue value)
+    {
+        WorkerErrors.SetEventHandler(Brand(thisObject), JsWorker.MessageErrorEventType, value);
+        return Undefined;
+    }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/workers.html#handler-abstractworker-onerror — the <i>plain</i>
+    /// <c>EventHandler</c> shape: invoked with the event, cancelled with <c>preventDefault()</c>. (The worker
+    /// global's <c>onerror</c> is the legacy five-argument one instead.)
+    /// </summary>
+    /// <remarks>
+    /// The attribute exists from this change; what fires at it — a plain <c>Event</c> for a load failure and
+    /// an <c>ErrorEvent</c> with <c>error: null</c> for a runtime error — lands with the parent-side error
+    /// channels in their own change. Until then a load failure is reported to the <i>host</i> instead, through
+    /// <see cref="WorkerConnection.IsFaulted"/> and <see cref="WorkerConnection.Error"/>.
+    /// </remarks>
+    [JsAccessor("onerror", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsValue OnErrorGet(JsValue thisObject)
+        => WorkerErrors.GetEventHandler(Brand(thisObject), JsWorker.ErrorEventType);
+
+    /// <inheritdoc cref="OnErrorGet" />
+    [JsAccessor("onerror", AccessorKind.Set, Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsValue OnErrorSet(JsValue thisObject, JsValue value)
+    {
+        WorkerErrors.SetEventHandler(Brand(thisObject), JsWorker.ErrorEventType, value);
+        return Undefined;
+    }
+
+    /// <summary>
+    /// Resolves <c>postMessage</c>'s second argument to a transfer list. See the operation's remarks for the
+    /// overload rule.
+    /// </summary>
+    private List<JsValue>? ReadTransferArgument(JsValue argument)
+    {
+        const string Operation = "postMessage' on 'Worker";
+
+        if (argument is ObjectInstance && JsValue.GetMethod(_realm, argument, GlobalSymbolRegistry.Iterator) is not null)
+        {
+            return StructuredSerializeOptions.ReadTransferSequence(_realm, argument, Operation);
+        }
+
+        return StructuredSerializeOptions.ReadTransferOption(_realm, argument, Operation);
+    }
+
+    private JsWorker Brand(JsValue thisObject)
+    {
+        if (thisObject is JsWorker worker)
+        {
+            return worker;
+        }
+
+        Throw.TypeError(_realm, "Illegal invocation: receiver is not a Worker");
+        return null!;
+    }
+}
+#endif

--- a/Jint/WebApi/Workers/WorkerRegistry.cs
+++ b/Jint/WebApi/Workers/WorkerRegistry.cs
@@ -1,0 +1,99 @@
+#if NET8_0_OR_GREATER
+using System.Threading;
+
+namespace Jint.WebApi.Workers;
+
+/// <summary>
+/// One engine's worker configuration and its live connections: the provider, the two per-engine caps, and the
+/// list <c>MaxWorkers</c> is counted against.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>This is an explicit, deliberate carve-out from <c>WebApiEngineState</c>'s engine-thread-only rule</b>,
+/// and the same carve-out <c>MessagePortEndpoint</c> documents. Every other list on that state — the fetches
+/// in flight, the sockets, the broadcast channels — is added to and removed from by the engine's own thread
+/// alone. A worker connection is not: it is created on the parent's thread and can end on the <i>worker's</i>,
+/// from a <c>close()</c> that runs while the parent is inside an unrelated statement. So the list is guarded
+/// by a lock and the count is a separate interlocked field, which is what lets
+/// <see cref="LiveCount"/> be read from the parent's thread without taking it.
+/// </para>
+/// <para>
+/// The three configuration values are read once, when the engine is built — the promise every setting in this
+/// options subtree makes — so a host mutating <c>Options.WebApi.Workers</c> afterwards does not change an
+/// engine that already exists.
+/// </para>
+/// </remarks>
+internal sealed class WorkerRegistry
+{
+    private readonly Lock _gate = new();
+    private readonly List<WorkerLink> _live = new();
+
+    /// <summary>
+    /// The same count as <c>_live.Count</c>, kept beside it so that the constructor's quota check — which runs
+    /// on the parent's thread, in the middle of a statement — costs one interlocked read rather than a lock
+    /// that a worker's <c>close()</c> on another thread may be holding.
+    /// </summary>
+    private int _liveCount;
+
+    internal WorkerRegistry(WorkerProvider provider, int maxWorkers, int maxQueuedMessages)
+    {
+        Provider = provider;
+        MaxWorkers = maxWorkers;
+        MaxQueuedMessages = maxQueuedMessages;
+    }
+
+    /// <summary>The host's answer to <c>new Worker(...)</c>; never null, or this registry would not exist.</summary>
+    internal WorkerProvider Provider { get; }
+
+    /// <summary><c>Options.WebApi.Workers.MaxWorkers</c>, read once.</summary>
+    internal int MaxWorkers { get; }
+
+    /// <summary><c>Options.WebApi.Workers.MaxQueuedMessages</c>, read once.</summary>
+    internal int MaxQueuedMessages { get; }
+
+    /// <summary>
+    /// How deep in a worker tree the engine owning this registry sits: 0 for a top-level engine, and greater
+    /// only for one a provider deliberately granted the ability to create workers of its own. What
+    /// <see cref="WorkerRequest.Depth"/> reports, plus one.
+    /// </summary>
+    internal int Depth { get; set; }
+
+    /// <summary>How many connections this engine has live. Any thread.</summary>
+    internal int LiveCount => Volatile.Read(ref _liveCount);
+
+    internal void Add(WorkerLink link)
+    {
+        lock (_gate)
+        {
+            _live.Add(link);
+            Volatile.Write(ref _liveCount, _live.Count);
+        }
+    }
+
+    internal void Remove(WorkerLink link)
+    {
+        lock (_gate)
+        {
+            _live.Remove(link);
+            Volatile.Write(ref _liveCount, _live.Count);
+        }
+    }
+
+    /// <summary>
+    /// The live connections, copied out under the lock so the caller can end them without holding it — ending
+    /// one calls back into <see cref="Remove"/>, and into host code.
+    /// </summary>
+    /// <remarks>
+    /// The seam a parent-side <c>RestoreGlobalSnapshot</c> and <c>Dispose</c> will end every connection
+    /// through; those hooks land in their own change (wave 3), which is also where the reasons
+    /// <c>ParentRestored</c> and <c>ParentDisposed</c> start being used.
+    /// </remarks>
+    internal WorkerLink[] Snapshot()
+    {
+        lock (_gate)
+        {
+            return _live.ToArray();
+        }
+    }
+}
+#endif

--- a/Jint/WebApi/Workers/WorkerRequest.cs
+++ b/Jint/WebApi/Workers/WorkerRequest.cs
@@ -120,9 +120,13 @@ public sealed class WorkerRequest
     public int LiveWorkerCount { get; }
 
     /// <summary>
-    /// Cancelled when the connection ends — by <c>terminate()</c>, by the teardown a worker's <c>close()</c>
-    /// runs, by a <c>RestoreGlobalSnapshot</c> or <c>Dispose</c> on either side, or by
-    /// <see cref="WorkerConnection.End"/>.
+    /// Cancelled when anything but the worker itself ends the connection — <c>terminate()</c>,
+    /// <see cref="WorkerConnection.End"/>, a <c>RestoreGlobalSnapshot</c> or <c>Dispose</c> on either side. A
+    /// worker's own <c>close()</c> ends the connection <i>without</i> cancelling it: its teardown runs as a
+    /// job on the worker's own loop — the very thread that pumps — so the pump loop observes
+    /// <see cref="WorkerConnection.IsEnded"/> on its next iteration anyway, and cancelling would make any
+    /// straggler job a host pumps afterwards erupt as <c>ExecutionCanceledException</c> from a close that
+    /// deserved a quiet end.
     /// </summary>
     /// <remarks>
     /// <para>


### PR DESCRIPTION
Step 2–3 of the Web Workers plan (#3167 §14): `new Worker(specifier, { type: 'module' })` now runs a real
worker — a second `Engine` the host's `WorkerProvider` built, pumped on whichever thread the host chose,
entangled with its parent by a `MessagePort` pair neither side ever sees.

**The constructor** (issue §5, ten steps in order): WebIDL first and in the dictionary's lexicographic
member order (`credentials` validated as `RequestCredentials` then ignored; `'classic'` — the spec's own
default — refused with a `TypeError` whose message names the fix; an unknown `type` is the enum-conversion
`TypeError`); the per-engine `MaxWorkers` backstop as a `QuotaExceededError` with `quota`/`requested`; the
termination source minted before the provider is called; `null` from the provider a synchronous
`SecurityError`, a throw propagated unchanged; then validation of the returned engine —
`InvalidOperationException` naming the fix for the parent-engine mistake, missing `Messaging`, an engine
already running a worker, and **an engine that does not observe `request.TerminationToken`** (the
deaf-but-running worker becomes a construction-time error). Steps 6–10 run under `EnterHostCall` on the
worker engine, so a pre-warmed engine another thread is already pumping is refused with the engine's own
admission error instead of being corrupted; ownership is released before `OnWorkerStarted`, and the
connection is registered before the host is told to pump.

**Three messaging primitives** carry the façades, and one is a deliberate shipped-behavior change:

- `JsMessagePort.RetargetTo` — the event-creating sibling of #3215's `InternalMessageHandler`: the hidden
  ports dispatch their `message` events at the `Worker` object and at the worker's global scope (HTML's
  "immediately retargeted"), with `event.target` answering what a browser answers. Both façades enable
  eagerly — the `onmessage`-implies-`start()` rule is scoped to the `MessagePort` interface, and on a
  worker `addEventListener('message', …)` alone must receive.
- A **draining** endpoint state that is deliberately not `Closed`: a worker's `close()` leaves the
  parent-side queue deliverable-but-unjoinable (HTML's *close a worker* has no counterpart to terminate's
  empty-the-queue step), so `postMessage(result); close()` still delivers — while `IsChannelExhausted`
  stays truthful for a transferred stream whose own `close` message is still queued, which is exactly the
  case that predicate exists for.
- `DrainOne` now arms the next delivery **after** the dispatch, in a `finally`. Arming first put the next
  drain job ahead of the reactions the listener queued, delivering two messages back to back — the order is
  observable and is HTML's (a message is a task; everything it queued runs before the next message is
  looked at). This changes shipped `MessagePort` behavior and is pinned for a plain `MessageChannel` too.

**The start job** runs on the worker's own loop with the worker's generation — no part of the worker's
script ever runs on the parent's thread, pinned. It calls `Modules.StartImport` and attaches reactions:
fulfil enables the inner queue (messages posted before the module evaluated arrive buffered, in order);
reject ends the connection as **`StartupFailed`** with a CLR exception on `WorkerConnection.Error` — the
CLR exception behind the failure when there is one, otherwise a summary built from own data properties
only, so no getter runs during teardown and no worker-realm `JsValue` crosses a thread. The parent-side
`error` event is wave 3; the connection surface needs no sink at all.

**`terminate()` and `close()` split exactly as the spec splits them** (§6.1/§6.2): terminate closes both
endpoints immediately (still serializing afterwards, so `DataCloneError` still throws and transfers still
detach — pinned), cancels the token, reports `Terminated`; `close()` disentangles the worker's side now,
lets the current turn finish (the teardown is a job on the worker's own loop — which is also why it alone
does not cancel the token: the teardown runs on the pumping thread, which sees `IsEnded` on its next
iteration, and cancelling would make straggler jobs erupt from the host's pump after a clean close), and
drains-then-closes the parent side. `MaxQueuedMessages` is enforced per direction before serialization.

The worker global scope carries §8's table — `postMessage` (both overloads, transfer list verbatim, so a
`MessagePort` or a transferred stream rides back untouched), `close`, `name`, the `onmessage`/
`onmessageerror`/`onerror`/`onunhandledrejection`/`onrejectionhandled` attributes over the synthetic global
listener list (WinterTC §5.3's exact set), and **`importScripts` present-and-throwing `TypeError`** — the
spec's own step 1 for a module worker, the one place the family's absent-rather-than-throwing convention
loses to the standard prescribing the throw. No `WorkerGlobalScope` interface object. The wave-1 pin that
asserted no script surface at all is replaced by the three-way `typeof Worker` pin (flag and provider
together, and only together).

Tests: 36 mechanism pins + 6 PublicInterface + 2 `MessagingTests` (the drain-order change on a plain
channel), **27 mutations applied to shipped code with every named pin verified to fail**, threading pins
rendezvousing on events (no wall-clock assertions), mechanism and PublicInterface worker suites run ×5
green. Full matrix green on both TFMs plus both `JINT_HOST_CONTRACT_VERIFICATION=1` legs.

Wave 3 (the parent-side error channels with `error: null` and the *notHandled* relay, restore/dispose on
both sides) follows on the seams left for it: `WorkerRegistry.Snapshot()`, `WebApiEngineState.OwningWorkerLink`,
and the notes on `WorkerLink.OnModuleFailed`/`WorkerPrototype`.

Part of #3167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PnghUC3EKrYa12xQ2LaYyd
