### PR TITLE
Workers: the error channels, and a restore or dispose on either side

### DIFF
--- a/Jint.Tests.PublicInterface/WebApiWorkerTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiWorkerTests.cs
@@ -344,6 +344,138 @@ public class WebApiWorkerTests
     }
 
     /// <summary>
+    /// A startup failure reaches the host through the connection alone — no sink, no listener, nothing wired.
+    /// </summary>
+    /// <remarks>
+    /// The two channels carry different things and this pin is about the one a host gets for free: the reason
+    /// says <i>what</i> happened rather than blaming a <c>terminate()</c> nobody called, and the failure is a
+    /// CLR exception rather than a worker-realm value that could not have crossed the thread anyway. The
+    /// script-facing half — a plain <c>Event</c> named <c>error</c> at the <c>Worker</c> object — is asserted
+    /// beside it, because a host that does wire a listener gets both.
+    /// </remarks>
+    [Fact]
+    public void AHostSeesAStartupFailureWithoutWiringAnySink()
+    {
+        var host = new PumpOnDemandWorkerHost(new Dictionary<string, string>());
+
+        var parent = new Engine(options => options.UseWebApis().UseWorkers(host));
+        parent.Execute("""
+            var seen = [];
+            var w = new Worker('./missing.js', { type: 'module' });
+            w.onerror = e => seen.push(e.type + '|' + (e instanceof ErrorEvent));
+            """);
+
+        var connection = host.Connections.Should().ContainSingle().Subject;
+        connection.IsEnded.Should().BeFalse("nothing has pumped the worker yet");
+
+        host.Drain(parent);
+
+        connection.IsEnded.Should().BeTrue();
+        connection.EndReason.Should().Be(WorkerEndReason.StartupFailed);
+        connection.IsFaulted.Should().BeTrue();
+        connection.Error.Should().BeOfType<ModuleResolutionException>();
+        connection.TerminationToken.IsCancellationRequested.Should().BeTrue();
+
+        parent.Evaluate("seen.join(',')").AsString().Should().Be(
+            "error|false",
+            "the standard's step for a script that failed to fetch names no interface");
+    }
+
+    /// <summary>
+    /// A provider that chains its own <see cref="DiagnosticsSink"/> onto the worker's options still sees every
+    /// worker error, whatever the parent's script does about it — the sink's contract is that a script may not
+    /// switch it off, and the parent-side relay deliberately sits beside it rather than on it.
+    /// </summary>
+    /// <remarks>
+    /// Both directions are asserted from one run: the worker's own sink hears the failure as an
+    /// <c>UncaughtCallbackError</c> even though the parent cancelled the propagation, and the parent's sink
+    /// stays silent because cancelling is exactly what HTML's <i>notHandled</i> gate is for.
+    /// </remarks>
+    [Fact]
+    public void ADiagnosticsSinkChainedByTheProviderStillSeesWorkerErrors()
+    {
+        var workerSink = new CollectingSink();
+        var parentSink = new CollectingSink();
+
+        var host = new PumpOnDemandWorkerHost(new Dictionary<string, string>
+        {
+            ["./worker.js"] = "addEventListener('message', () => { throw new TypeError('boom'); });",
+        })
+        {
+            Tune = options => options.WebApi.Diagnostics.Sink = workerSink,
+        };
+
+        var parent = new Engine(options =>
+        {
+            options.UseWebApis().UseWorkers(host);
+            options.WebApi.Diagnostics.Sink = parentSink;
+        });
+
+        parent.Execute("""
+            var seen = [];
+            var w = new Worker('./worker.js', { type: 'module' });
+            w.onerror = e => { seen.push(e.message + '|' + (e.error === null)); e.preventDefault(); };
+            w.postMessage('go');
+            """);
+
+        host.Drain(parent);
+
+        parent.Evaluate("seen.join(',')").AsString().Should().Be("boom|true", "error is null for every worker error");
+
+        workerSink.Kinds.Should().Equal(DiagnosticEventKind.UncaughtCallbackError);
+        workerSink.Messages.Should().ContainSingle().Which.Should().Contain("boom");
+
+        parentSink.Kinds.Should().BeEmpty("the Worker object's listener cancelled, which is HTML's gate");
+    }
+
+    /// <summary>
+    /// The same failure with nothing cancelling it reaches the parent's sink as its own kind, so a host that
+    /// wires one sink for a parent and its workers can still tell the two reports apart.
+    /// </summary>
+    [Fact]
+    public void AnUnhandledWorkerErrorReachesTheParentsSinkAsItsOwnKind()
+    {
+        var sink = new CollectingSink();
+
+        var host = new PumpOnDemandWorkerHost(new Dictionary<string, string>
+        {
+            ["./worker.js"] = "addEventListener('message', () => { throw new TypeError('boom'); });",
+        })
+        {
+            Tune = options => options.WebApi.Diagnostics.Sink = sink,
+        };
+
+        var parent = new Engine(options =>
+        {
+            options.UseWebApis().UseWorkers(host);
+            options.WebApi.Diagnostics.Sink = sink;
+        });
+
+        parent.Execute("var w = new Worker('./worker.js', { type: 'module' }); w.postMessage('go');");
+        host.Drain(parent);
+
+        sink.Kinds.Should().Equal(DiagnosticEventKind.UncaughtCallbackError, DiagnosticEventKind.WorkerError);
+        sink.Messages.Should().AllSatisfy(message => message.Should().Contain("boom"));
+    }
+
+    /// <summary>
+    /// A sink that keeps kinds and messages as CLR values, which is what the remarks on
+    /// <see cref="DiagnosticsSink"/> say to do with a report rather than stashing its <c>JsValue</c>s.
+    /// </summary>
+    private sealed class CollectingSink : DiagnosticsSink
+    {
+        public List<DiagnosticEventKind> Kinds { get; } = new();
+
+        public List<string> Messages { get; } = new();
+
+        public override void Report(DiagnosticEvent report)
+        {
+            Kinds.Add(report.Kind);
+            Messages.Add(report.Exception?.Message ?? report.Value.ToString());
+        }
+    }
+
+    /// <summary>
     /// A provider the test drives itself: it builds the worker engine over an in-memory module map, starts no
     /// thread, and lets the test decide when each worker gets a turn.
     /// </summary>
@@ -358,6 +490,9 @@ public class WebApiWorkerTests
 
         public Action<WorkerConnection>? OnStarted { get; set; }
 
+        /// <summary>Runs on the worker's options, after <c>CreateDefaultOptions</c> and before the engine.</summary>
+        public Action<Options>? Tune { get; set; }
+
         public List<WorkerConnection> Connections { get; } = new();
 
         public string Log => string.Join(",", _log);
@@ -368,6 +503,7 @@ public class WebApiWorkerTests
 
             var options = request.CreateDefaultOptions();
             options.Modules.ModuleLoader = new MapModuleLoader(_modules);
+            Tune?.Invoke(options);
 
             var engine = new Engine(options);
             engine.SetValue("report", new Action<string>(_log.Add));

--- a/Jint.Tests/Runtime/WebApi/WorkerMechanismTests.cs
+++ b/Jint.Tests/Runtime/WebApi/WorkerMechanismTests.cs
@@ -1231,9 +1231,17 @@ public class WorkerMechanismTests
     /// than fired at listeners that are closures over globals the restore has just replaced.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// The listener records through a CLR delegate it closed over, not through a global, so the assertion
-    /// survives the very restore it is about — which is what makes the pin about the fence rather than about
-    /// the binding.
+    /// survives the very restore it is about — which is what makes the pin about the mechanism rather than
+    /// about the binding.
+    /// </para>
+    /// <para>
+    /// Two things cover this and the pin holds them together. The parent-side event is a <b>job on the
+    /// parent's loop</b> rather than a dispatch on the worker's thread — the first assertion, which is what a
+    /// synchronous fire would break — and it carries the <b>generation</b> of the cycle that queued it, which
+    /// is what covers a failure landing after the loop has already been cleared.
+    /// </para>
     /// </remarks>
     [Fact]
     public void AParentRestoreDropsAQueuedErrorEvent()

--- a/Jint.Tests/Runtime/WebApi/WorkerMechanismTests.cs
+++ b/Jint.Tests/Runtime/WebApi/WorkerMechanismTests.cs
@@ -725,6 +725,282 @@ public class WorkerMechanismTests
     }
 
     // -------------------------------------------------------------------------------------------------------
+    // The error channels
+    // -------------------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// A load or parse failure fires <b>a plain <c>Event</c></b> at the <c>Worker</c> object. The standard's
+    /// step names no interface, and libraries branch on exactly that to tell "the script never loaded" from
+    /// "the script threw".
+    /// </summary>
+    /// <remarks>
+    /// Firing an <c>ErrorEvent</c> here instead would make every assertion below but the first still pass,
+    /// which is why the shape is asserted rather than the arrival.
+    /// </remarks>
+    [Fact]
+    public void ALoadFailureFiresAPlainEventNotAnErrorEvent()
+    {
+        var host = new TestWorkerHost();
+        var parent = Parent(host);
+
+        parent.Execute("""
+            var seen = [];
+            var w = new Worker('./missing.js', { type: 'module' });
+            w.onerror = e => seen.push([
+                e.type,
+                e instanceof ErrorEvent,
+                e.isTrusted,
+                'message' in e,
+                e.target === w].join('|'));
+            """);
+
+        Drain(parent, host.Connection);
+
+        parent.Evaluate("seen.join(',')").AsString().Should().Be(
+            "error|false|true|false|true",
+            "the onComplete step for a script that failed to fetch names no interface, so it is an Event");
+    }
+
+    /// <summary>
+    /// An uncaught runtime error inside a worker reaches the parent as an <c>ErrorEvent</c> carrying the
+    /// message and the location — and <c>error: null</c>, which is the specification's own value and not a
+    /// limitation dressed up as one.
+    /// </summary>
+    [Fact]
+    public void AWorkerErrorReachesTheParentWithNullError()
+    {
+        var host = new TestWorkerHost(Module("""
+            addEventListener('message', () => { throw new TypeError('boom'); });
+            """));
+
+        var parent = Parent(host);
+        parent.Execute("""
+            var seen = [];
+            var w = new Worker('./worker.js', { type: 'module' });
+            w.onerror = e => seen.push([
+                e.type,
+                e instanceof ErrorEvent,
+                e.isTrusted,
+                e.error === null,
+                e.message,
+                e.target === w].join('|'));
+            w.postMessage('go');
+            """);
+
+        Drain(parent, host.Connection);
+
+        parent.Evaluate("seen.length").AsNumber().Should().Be(1);
+        parent.Evaluate("seen[0]").AsString().Should().StartWith("error|true|true|true|boom|");
+        parent.Evaluate("seen[0]").AsString().Should().EndWith("|true");
+
+        host.Connection.IsEnded.Should().BeFalse("a runtime error is not the end of the connection");
+    }
+
+    /// <summary>
+    /// Step 5.2.3: the <c>ErrorEvent</c> at the <c>Worker</c> object was not cancelled either, so the failure is
+    /// reported one level further up — at the parent's own global scope, and to the parent's sink.
+    /// </summary>
+    [Fact]
+    public void AnUnhandledWorkerErrorReachesTheParentsGlobalErrorEvent()
+    {
+        var host = new TestWorkerHost(Module("""
+            addEventListener('message', () => { throw new TypeError('boom'); });
+            """));
+
+        var sink = new RecordingSink();
+        var parent = Parent(host, parentSink: sink);
+        parent.Execute("""
+            var seen = [];
+            var w = new Worker('./worker.js', { type: 'module' });
+            addEventListener('error', e => seen.push(e.message + '|' + (e.error === null)));
+            w.postMessage('go');
+            """);
+
+        Drain(parent, host.Connection);
+
+        parent.Evaluate("seen.join(',')").AsString().Should().Be(
+            "boom|true",
+            "nothing handled it on the worker's side or on the Worker object's, so it is reported here");
+
+        sink.Reports.Should().ContainSingle().Which.Should().Be($"{DiagnosticEventKind.WorkerError}:boom");
+    }
+
+    /// <summary>
+    /// The relay is gated on HTML's <i>notHandled</i>, which is what a worker-side <c>preventDefault()</c> sets
+    /// to false — and it is deliberately not the <see cref="DiagnosticsSink"/>, whose contract is that a script
+    /// may not switch it off.
+    /// </summary>
+    [Fact]
+    public void AWorkerSidePreventDefaultStopsPropagationToTheParent()
+    {
+        var host = new TestWorkerHost(Module("""
+            addEventListener('error', e => { record('worker-saw:' + e.message); e.preventDefault(); });
+            addEventListener('message', () => { throw new TypeError('boom'); });
+            """));
+
+        var workerSink = new RecordingSink();
+        var parentSink = new RecordingSink();
+        var parent = Parent(host, parentSink: parentSink);
+        host.Tune = options => options.WebApi.Diagnostics.Sink = workerSink;
+
+        parent.Execute("""
+            var seen = [];
+            var w = new Worker('./worker.js', { type: 'module' });
+            w.onerror = () => seen.push('parent-saw');
+            addEventListener('error', () => seen.push('parent-global'));
+            w.postMessage('go');
+            """);
+
+        Drain(parent, host.Connection);
+
+        host.Log.Should().Be("worker-saw:boom");
+        parent.Evaluate("seen.join(',')").AsString().Should().BeEmpty("preventDefault() on the worker's side is HTML's gate");
+
+        workerSink.Reports.Should().ContainSingle().Which.Should().StartWith(DiagnosticEventKind.UncaughtCallbackError.ToString());
+        parentSink.Reports.Should().BeEmpty("the parent was never told, so its sink has nothing to say either");
+    }
+
+    /// <summary>
+    /// The worker global's <c>onerror</c> is HTML's legacy shape — «message, filename, lineno, colno, error»,
+    /// and returning <see langword="true"/> cancels. That is what decides <i>notHandled</i> on the worker side.
+    /// </summary>
+    [Fact]
+    public void TheWorkerGlobalOnErrorTakesFiveArgumentsAndCancelsByReturningTrue()
+    {
+        var host = new TestWorkerHost(Module("""
+            onerror = function (message, filename, lineno, colno, error) {
+                record('args:' + arguments.length);
+                record('message:' + message);
+                record('lineno>0:' + (lineno > 0));
+                record('error:' + (error instanceof TypeError));
+                return true;
+            };
+            addEventListener('message', () => { throw new TypeError('boom'); });
+            """));
+
+        var parent = Parent(host);
+        parent.Execute("""
+            var seen = [];
+            var w = new Worker('./worker.js', { type: 'module' });
+            w.onerror = () => seen.push('parent-saw');
+            w.postMessage('go');
+            """);
+
+        Drain(parent, host.Connection);
+
+        host.Log.Should().Be(
+            "args:5,message:boom,lineno>0:true,error:true",
+            "an ErrorEvent named error at a global scope gets the five-argument invocation");
+        parent.Evaluate("seen.join(',')").AsString().Should().BeEmpty("returning true is the worker cancelling it");
+    }
+
+    /// <summary>
+    /// <c>Worker.onerror</c> is <c>AbstractWorker</c>'s <i>plain</i> <c>EventHandler</c> instead: invoked with
+    /// the event, and cancelled by <c>preventDefault()</c> or by returning <see langword="false"/> — the
+    /// opposite boolean from the global's.
+    /// </summary>
+    [Fact]
+    public void TheWorkerObjectOnErrorTakesTheEventAndCancelsByReturningFalse()
+    {
+        var host = new TestWorkerHost(Module("""
+            addEventListener('message', () => { throw new TypeError('boom'); });
+            """));
+
+        var sink = new RecordingSink();
+        var parent = Parent(host, parentSink: sink);
+        parent.Execute("""
+            var seen = [];
+            var w = new Worker('./worker.js', { type: 'module' });
+            w.onerror = function () { seen.push('args:' + arguments.length + ':' + arguments[0].message); return false; };
+            addEventListener('error', () => seen.push('parent-global'));
+            w.postMessage('go');
+            """);
+
+        Drain(parent, host.Connection);
+
+        parent.Evaluate("seen.join(',')").AsString().Should().Be(
+            "args:1:boom",
+            "the plain shape takes the event, and returning false is what cancels it");
+        sink.Reports.Should().BeEmpty("a cancelled ErrorEvent is not reported one level up");
+    }
+
+    /// <summary>
+    /// An unhandled rejection fires at the worker's own global and reaches the parent through nothing at all.
+    /// The sink wiring makes the opposite easy to fall into, which is why it is pinned.
+    /// </summary>
+    [Fact]
+    public void AnUnhandledRejectionInAWorkerDoesNotReachTheParent()
+    {
+        var host = new TestWorkerHost(Module("""
+            onunhandledrejection = e => record('worker-rejection:' + e.reason.message);
+            addEventListener('message', () => { Promise.reject(new TypeError('nope')); });
+            """));
+
+        var sink = new RecordingSink();
+        var parent = Parent(host, parentSink: sink);
+        parent.Execute("""
+            var seen = [];
+            var w = new Worker('./worker.js', { type: 'module' });
+            w.onerror = () => seen.push('parent-error');
+            addEventListener('error', () => seen.push('parent-global'));
+            addEventListener('unhandledrejection', () => seen.push('parent-rejection'));
+            w.postMessage('go');
+            """);
+
+        Drain(parent, host.Connection);
+
+        host.Log.Should().Be("worker-rejection:nope", "the event really did fire, on the worker's own global");
+        parent.Evaluate("seen.join(',')").AsString().Should().BeEmpty("the relay carries error reports and nothing else");
+        sink.Reports.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// A constraint failure is never an error event. It is a <c>JintException</c> and not a
+    /// <c>JavaScriptException</c>, so nothing catches it: the worker's budget is the <b>host's</b> to observe,
+    /// on whichever thread was pumping, and the parent's script never learns of it.
+    /// </summary>
+    /// <remarks>
+    /// The constraint is a tripwire rather than a clock or a statement count, so the pin turns on the
+    /// classification and not on how much work a module happens to do. It is registered as a <i>factory</i> on
+    /// the parent, which is what the request replays — each engine gets its own instance over one shared
+    /// switch.
+    /// </remarks>
+    [Fact]
+    public void AWorkerConstraintFailureEruptsFromTheHostsPump()
+    {
+        var tripwire = new Tripwire();
+        var host = new TestWorkerHost(Module("""
+            addEventListener('error', () => record('worker-error-event'));
+            addEventListener('message', () => { var n = 0; for (var i = 0; i < 5000; i++) { n += i; } record('finished'); });
+            """));
+
+        var parent = Parent(host, tune: options => options.Constraint(() => new TripwireConstraint(tripwire)));
+        parent.Execute("""
+            var seen = [];
+            var w = new Worker('./worker.js', { type: 'module' });
+            w.onerror = () => seen.push('parent-error');
+            """);
+
+        // The module evaluates and the message is queued with the tripwire still down, so what trips is the
+        // listener — the very callback a sink would otherwise turn into a report.
+        Drain(parent, host.Connection);
+        parent.Execute("w.postMessage('go');");
+        host.Connection.IsEnded.Should().BeFalse();
+
+        tripwire.Tripped = true;
+
+        var escaped = Record.Exception(() => DrainWorker(host.Connection));
+
+        escaped.Should().BeOfType<MemoryLimitExceededException>("a constraint bounds the host's pump, it does not become an event");
+        host.Log.Should().NotContain("worker-error-event");
+        host.Log.Should().NotContain("finished");
+
+        tripwire.Tripped = false;
+        parent.Advanced.ProcessTasks();
+        parent.Evaluate("seen.join(',')").AsString().Should().BeEmpty("the parent's script never learns of a budget");
+    }
+
+    // -------------------------------------------------------------------------------------------------------
     // The worker global scope
     // -------------------------------------------------------------------------------------------------------
 
@@ -926,7 +1202,9 @@ public class WorkerMechanismTests
         TestWorkerHost host,
         int maxWorkers = 16,
         int maxQueuedMessages = 16384,
-        string workerName = "")
+        string workerName = "",
+        DiagnosticsSink? parentSink = null,
+        Action<Options>? tune = null)
     {
         _ = workerName;
 
@@ -935,7 +1213,65 @@ public class WorkerMechanismTests
             options.UseWebApis().UseWorkers(host);
             options.WebApi.Workers.MaxWorkers = maxWorkers;
             options.WebApi.Workers.MaxQueuedMessages = maxQueuedMessages;
+
+            if (parentSink is not null)
+            {
+                options.WebApi.Diagnostics.Sink = parentSink;
+            }
+
+            tune?.Invoke(options);
         });
+    }
+
+    /// <summary>
+    /// A sink that keeps what it was told as strings, so an assertion can name the kind and the message without
+    /// holding a <c>JsValue</c> past the call.
+    /// </summary>
+    private sealed class RecordingSink : DiagnosticsSink
+    {
+        private readonly ConcurrentQueue<string> _reports = new();
+
+        public List<string> Reports => _reports.ToList();
+
+        public override void Report(DiagnosticEvent report)
+            => _reports.Enqueue($"{report.Kind}:{report.Exception?.Message ?? report.Value.ToString()}");
+    }
+
+    /// <summary>A switch two engines' constraint instances share, so a pin can decide exactly when one fails.</summary>
+    private sealed class Tripwire
+    {
+        private volatile bool _tripped;
+
+        public bool Tripped
+        {
+            get => _tripped;
+            set => _tripped = value;
+        }
+    }
+
+    /// <summary>
+    /// A constraint that observes external state and nothing else — the shape the request replays as a factory,
+    /// and one whose failure is a <c>JintException</c> that is not a <c>JavaScriptException</c>.
+    /// </summary>
+    private sealed class TripwireConstraint : Constraint
+    {
+        private readonly Tripwire _tripwire;
+
+        public TripwireConstraint(Tripwire tripwire) => _tripwire = tripwire;
+
+        public override void Check()
+        {
+            if (_tripwire.Tripped)
+            {
+                // A JintException that is not a JavaScriptException, which is exactly the class every built-in
+                // budget throws and exactly the discrimination the two report sites make.
+                throw new MemoryLimitExceededException("the tripwire is up");
+            }
+        }
+
+        public override void Reset()
+        {
+        }
     }
 
     /// <summary>
@@ -1000,6 +1336,9 @@ public class WorkerMechanismTests
         /// <summary>Runs on the freshly built engine, before it is handed back.</summary>
         public Action<Engine>? Configure { get; set; }
 
+        /// <summary>Runs on the worker's options, after <c>CreateDefaultOptions</c> and before the engine.</summary>
+        public Action<Options>? Tune { get; set; }
+
         public int Requests { get; private set; }
 
         public List<WorkerConnection> Started { get; } = [];
@@ -1031,6 +1370,7 @@ public class WorkerMechanismTests
 
             var options = request.CreateDefaultOptions();
             options.Modules.ModuleLoader = new MapModuleLoader(Modules);
+            Tune?.Invoke(options);
 
             var engine = new Engine(options);
             engine.SetValue("record", new Action<string>(_log.Enqueue));

--- a/Jint.Tests/Runtime/WebApi/WorkerMechanismTests.cs
+++ b/Jint.Tests/Runtime/WebApi/WorkerMechanismTests.cs
@@ -1138,6 +1138,209 @@ public class WorkerMechanismTests
         host.Ended.Should().ContainSingle();
     }
 
+    [Fact]
+    public void TerminateIsObservableOnTheConnection()
+    {
+        var host = new TestWorkerHost(Module(""));
+        var parent = Parent(host);
+
+        parent.Execute("var w = new Worker('./worker.js', { type: 'module' });");
+
+        var connection = host.Connection;
+        connection.IsEnded.Should().BeFalse();
+        connection.EndReason.Should().BeNull();
+        connection.TerminationToken.IsCancellationRequested.Should().BeFalse();
+
+        parent.Execute("w.terminate();");
+
+        connection.IsEnded.Should().BeTrue("the flag a pump loop keys on");
+        connection.EndReason.Should().Be(WorkerEndReason.Terminated);
+        connection.IsFaulted.Should().BeFalse();
+        connection.TerminationToken.IsCancellationRequested.Should().BeTrue(
+            "the token is what wakes a pump thread parked on it, from whichever thread ended the connection");
+        host.Ended.Should().ContainSingle().Which.Reason.Should().Be(WorkerEndReason.Terminated);
+    }
+
+    // -------------------------------------------------------------------------------------------------------
+    // Restore and dispose
+    // -------------------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// A <c>RestoreGlobalSnapshot</c> on the parent ends every connection it is a party to — both endpoints,
+    /// the token, and the host told with a reason of its own.
+    /// </summary>
+    [Fact]
+    public void AParentRestoreEndsTheConnection()
+    {
+        var host = new TestWorkerHost(Module("addEventListener('message', e => record(e.data));"));
+        var parent = Parent(host);
+
+        var snapshot = parent.Advanced.CaptureGlobalSnapshot();
+        parent.Execute("var w = new Worker('./worker.js', { type: 'module' });");
+        Drain(parent, host.Connection);
+
+        var connection = host.Connection;
+        connection.IsEnded.Should().BeFalse();
+
+        parent.Advanced.RestoreGlobalSnapshot(snapshot);
+
+        connection.IsEnded.Should().BeTrue();
+        connection.EndReason.Should().Be(WorkerEndReason.ParentRestored);
+        connection.IsFaulted.Should().BeFalse();
+        connection.TerminationToken.IsCancellationRequested.Should().BeTrue();
+        host.Ended.Should().ContainSingle().Which.Reason.Should().Be(WorkerEndReason.ParentRestored);
+        parent.Evaluate("typeof w").AsString().Should().Be("undefined", "the binding went back with the globals");
+    }
+
+    /// <summary>
+    /// The <c>Worker</c> object outlives the restore and is <b>inert</b>: <c>postMessage</c> is a no-op after
+    /// the serialization the standard's step order still prescribes, and <c>terminate()</c> does nothing.
+    /// </summary>
+    /// <remarks>
+    /// The snapshot is captured <i>after</i> the worker exists, which is the pooled-engine shape — the setup a
+    /// host wants every cycle to start from — and is also what keeps the binding pointing at the same
+    /// <c>Worker</c> object afterwards, so the pin can ask it questions.
+    /// </remarks>
+    [Fact]
+    public void APostMessageAfterAParentRestoreIsASilentNoOp()
+    {
+        var host = new TestWorkerHost(Module("addEventListener('message', e => record(e.data));"));
+        var parent = Parent(host);
+
+        parent.Execute("var w = new Worker('./worker.js', { type: 'module' });");
+        var snapshot = parent.Advanced.CaptureGlobalSnapshot();
+        Drain(parent, host.Connection);
+
+        parent.Advanced.RestoreGlobalSnapshot(snapshot);
+
+        parent.Execute("w.postMessage('after'); w.terminate(); w.terminate();");
+        Drain(parent, host.Connection);
+
+        host.Log.Should().BeEmpty("both endpoints closed with the connection");
+        host.Ended.Should().ContainSingle().Which.Reason.Should().Be(
+            WorkerEndReason.ParentRestored,
+            "terminate() on an ended connection is idempotent, not a second end");
+
+        // Still post-serialization, which is HTML's own step order: step 5 runs before step 6.
+        var exception = Assert.Throws<JavaScriptException>(() => parent.Execute("w.postMessage(function () {})"));
+        exception.Error.Get("name").AsString().Should().Be("DataCloneError");
+    }
+
+    /// <summary>
+    /// An error event queued on the parent's loop before a restore is dropped by the generation fence rather
+    /// than fired at listeners that are closures over globals the restore has just replaced.
+    /// </summary>
+    /// <remarks>
+    /// The listener records through a CLR delegate it closed over, not through a global, so the assertion
+    /// survives the very restore it is about — which is what makes the pin about the fence rather than about
+    /// the binding.
+    /// </remarks>
+    [Fact]
+    public void AParentRestoreDropsAQueuedErrorEvent()
+    {
+        var fired = 0;
+        var host = new TestWorkerHost();
+        var parent = Parent(host);
+        parent.SetValue("noteError", new Action(() => fired++));
+
+        var snapshot = parent.Advanced.CaptureGlobalSnapshot();
+        parent.Execute("""
+            var w = new Worker('./missing.js', { type: 'module' });
+            (function () { var note = noteError; w.onerror = function () { note(); }; })();
+            """);
+
+        // The worker's module fails to resolve, which queues the plain `error` event on the parent's loop. The
+        // parent is deliberately not pumped.
+        DrainWorker(host.Connection);
+        host.Connection.EndReason.Should().Be(WorkerEndReason.StartupFailed);
+        fired.Should().Be(0, "nothing has pumped the parent yet");
+
+        parent.Advanced.RestoreGlobalSnapshot(snapshot);
+        parent.Advanced.ProcessTasks();
+
+        fired.Should().Be(0, "the job carries the generation of the cycle that queued it");
+    }
+
+    /// <summary>
+    /// A <c>RestoreGlobalSnapshot</c> on the <i>worker</i> ends the connection too, and from the other side:
+    /// the reason says which engine it was.
+    /// </summary>
+    [Fact]
+    public void AWorkerRestoreEndsTheConnection()
+    {
+        var host = new TestWorkerHost(Module("addEventListener('message', e => record(e.data));"));
+        var parent = Parent(host);
+
+        parent.Execute("var w = new Worker('./worker.js', { type: 'module' }); w.postMessage('before');");
+        Drain(parent, host.Connection);
+        host.Log.Should().Be("before");
+
+        var connection = host.Connection;
+        var snapshot = connection.Worker.Advanced.CaptureGlobalSnapshot();
+        connection.Worker.Advanced.RestoreGlobalSnapshot(snapshot);
+
+        connection.IsEnded.Should().BeTrue();
+        connection.EndReason.Should().Be(WorkerEndReason.WorkerRestored);
+        connection.TerminationToken.IsCancellationRequested.Should().BeTrue();
+        host.Ended.Should().ContainSingle().Which.Reason.Should().Be(WorkerEndReason.WorkerRestored);
+
+        parent.Execute("w.postMessage('after');");
+        Drain(parent, host.Connection);
+        host.Log.Should().Be("before", "the parent's half closed with the connection");
+    }
+
+    [Fact]
+    public void ParentDisposeEndsEveryConnection()
+    {
+        var host = new TestWorkerHost(new Dictionary<string, string> { ["./a.js"] = "", ["./b.js"] = "" });
+        var parent = Parent(host);
+
+        parent.Execute("""
+            var a = new Worker('./a.js', { type: 'module' });
+            var b = new Worker('./b.js', { type: 'module' });
+            """);
+
+        host.Started.Should().HaveCount(2);
+
+        parent.Dispose();
+
+        host.Ended.Should().HaveCount(2);
+        host.Ended.Should().AllSatisfy(entry => entry.Reason.Should().Be(WorkerEndReason.ParentDisposed));
+        host.Started.Should().AllSatisfy(connection =>
+        {
+            connection.IsEnded.Should().BeTrue();
+            connection.TerminationToken.IsCancellationRequested.Should().BeTrue();
+        });
+    }
+
+    /// <summary>
+    /// The host disposing the engine it built ends the connection from the worker's side, so the far side does
+    /// not stay a <c>Worker</c> object that looks alive while every <c>postMessage</c> pays a full
+    /// serialization into a queue nothing will ever drain.
+    /// </summary>
+    [Fact]
+    public void DisposingTheWorkerEngineEndsTheConnectionAsWorkerDisposed()
+    {
+        var host = new TestWorkerHost(Module("addEventListener('message', e => record(e.data));"));
+        var parent = Parent(host);
+
+        parent.Execute("var w = new Worker('./worker.js', { type: 'module' }); w.postMessage('before');");
+        Drain(parent, host.Connection);
+        host.Log.Should().Be("before");
+
+        var connection = host.Connection;
+        connection.Worker.Dispose();
+
+        connection.IsEnded.Should().BeTrue();
+        connection.EndReason.Should().Be(WorkerEndReason.WorkerDisposed);
+        connection.TerminationToken.IsCancellationRequested.Should().BeTrue();
+        host.Ended.Should().ContainSingle().Which.Reason.Should().Be(WorkerEndReason.WorkerDisposed);
+
+        parent.Execute("w.postMessage('after');");
+        parent.Advanced.ProcessTasks();
+        host.Log.Should().Be("before");
+    }
+
     /// <summary>
     /// The drain-then-close endpoint state and the transferable-stream predicate meet here: a stream the worker
     /// transferred, and then <c>close()</c>d behind, still reaches the parent and still ends cleanly.

--- a/Jint.Tests/Runtime/WebApi/WorkerTests.cs
+++ b/Jint.Tests/Runtime/WebApi/WorkerTests.cs
@@ -392,7 +392,7 @@ public class WorkerTests
                 new Engine(),
                 new Engine(),
                 "w",
-                reason =>
+                (reason, _) =>
                 {
                     Interlocked.Increment(ref callbacks[index]);
                     reasons[index].Add(reason);

--- a/Jint/Engine.GlobalSnapshot.cs
+++ b/Jint/Engine.GlobalSnapshot.cs
@@ -288,7 +288,12 @@ public partial class Engine
         // A timer registered by the cycle that is ending must never fire into the globals just restored. The
         // queue is the engine's, not the event loop's, so clearing the loop above does not reach it; the
         // generation each entry carries is the second line of defence for one already promoted into a job.
-        _webApi?.ResetTransientState();
+        //
+        // This also ends every worker connection this engine is a party to — in both directions, since a
+        // worker connection is one object spanning two engines rather than two independent peers. Only the
+        // thread-safe half happens there: the host's OnWorkerEnded callbacks come back as a list and are run
+        // at the bottom of this method, so a provider that throws cannot leave the engine half-reset.
+        var endedWorkers = _webApi?.ResetTransientState();
 
         // A bridge to a host System.IO.Stream holds an operating-system handle, so the cycle ending has to
         // close it rather than merely stop delivering its chunks: the generation fence already does the
@@ -308,6 +313,12 @@ public partial class Engine
         // would resurface the next time the same CLR object is wrapped.
         _recentObjectWrapperCache?.Clear();
         _objectWrapperCache = null;
+
+#if NET8_0_OR_GREATER
+        // Last of all, with the engine whole again: the host is told about the worker connections this restore
+        // ended. It is host code, so it runs outside everything above it rather than in the middle of it.
+        WebApiEngineState.NotifyWorkerHosts(endedWorkers);
+#endif
     }
 }
 

--- a/Jint/Engine.WebApi.cs
+++ b/Jint/Engine.WebApi.cs
@@ -285,9 +285,17 @@ internal sealed class WebApiEngineState
     /// nobody's worker. Written once, on the parent's thread, while this engine is owned and quiescent.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// It is what makes "not already connected" a construction-time refusal rather than a second connection
-    /// that would give one global two parents, and it is the seam a worker-side <c>RestoreGlobalSnapshot</c>
-    /// and <c>Dispose</c> will end the connection through — those hooks land in their own change (wave 3).
+    /// that would give one global two parents, and it is what a worker-side <c>RestoreGlobalSnapshot</c> or
+    /// <c>Dispose</c> ends the connection through — see <see cref="EndWorkerConnections"/>.
+    /// </para>
+    /// <para>
+    /// It is deliberately <b>not</b> cleared when the connection ends, so an engine that has been somebody's
+    /// worker can never become somebody else's. Reusing one would be a trap rather than a saving: the worker
+    /// global scope is installed non-clobbering, so a second connection's <c>postMessage</c> would be declined
+    /// in favour of the first connection's dead one, and the difference is invisible from script.
+    /// </para>
     /// </remarks>
     internal WorkerLink? OwningWorkerLink { get; set; }
 
@@ -823,8 +831,13 @@ internal sealed class WebApiEngineState
     /// The peer is deliberately <i>not</i> closed: disentangling is one-sided, and a peer on another engine is
     /// in a cycle of its own that this restore has no business ending.
     /// </remarks>
-    internal void ResetTransientState()
+    internal List<Action>? ResetTransientState()
     {
+        // First, and before the general port sweep below: a worker connection is two endpoints plus a token
+        // plus a reason, and CloseMessagePorts would otherwise close this engine's half of it as an anonymous
+        // port — stopping delivery while leaving the connection reading as live.
+        var endedWorkers = EndWorkerConnections(WorkerEndReason.ParentRestored, WorkerEndReason.WorkerRestored);
+
         Timers?.Clear();
         Scheduler?.Clear();
         AbandonFetches();
@@ -844,6 +857,90 @@ internal sealed class WebApiEngineState
         // cycle's generation and would be dropped at dequeue anyway, so keeping the registration alive could
         // only accumulate one per cycle on a pooled engine.
         ReleaseHostAbortBridges();
+
+        return endedWorkers;
+    }
+
+    /// <summary>
+    /// Ends every worker connection this engine is a party to — the ones it created, and the one it <i>is</i>
+    /// the worker of.
+    /// </summary>
+    /// <param name="asParent">The reason for a connection this engine created.</param>
+    /// <param name="asWorker">The reason for the connection this engine is the worker of.</param>
+    /// <returns>
+    /// The host callbacks to run once the teardown is over, or <see langword="null"/> when there was nothing to
+    /// end. See <see cref="NotifyWorkerHosts"/>.
+    /// </returns>
+    /// <remarks>
+    /// <para>
+    /// <b>Both endpoints are closed, which is a worker-specific rule rather than the port rule.</b> A
+    /// <c>MessagePort</c> deliberately does not close its peer — disentangling is one-sided, and a peer on
+    /// another engine is in a cycle of its own. A worker connection is not two independent peers: it is one
+    /// object the engine created spanning two engines, and a one-sided close would stop <i>delivery</i> while
+    /// leaving the survivor paying a full structured clone per <c>postMessage</c>, detaching its own
+    /// transfer-listed buffers and throwing <c>DataCloneError</c> for unserializable values, forever. Closing
+    /// both is what stops the survivor's work.
+    /// </para>
+    /// <para>
+    /// The <c>Worker</c> object itself stays alive and becomes <b>inert</b> — <c>postMessage</c> a no-op after
+    /// the serialization the standard's step order still prescribes, <c>terminate()</c> idempotent, no further
+    /// events, since every job this cycle queued on either loop carries a generation the restore has moved
+    /// past. That is not a concession: the disentangled-port clause of HTML's own error propagation describes
+    /// exactly this state.
+    /// </para>
+    /// <para>
+    /// Everything here is the thread-safe part of ending — endpoints, a token, interlocked bookkeeping — which
+    /// is what makes it callable from a teardown at all. The host callback is <i>collected</i> rather than
+    /// invoked, so a provider that throws from <c>OnWorkerEnded</c> cannot erupt out of the middle of a
+    /// half-finished restore.
+    /// </para>
+    /// </remarks>
+    private List<Action>? EndWorkerConnections(WorkerEndReason asParent, WorkerEndReason asWorker)
+    {
+        var registry = Workers;
+        if (registry is not { LiveCount: > 0 } && OwningWorkerLink is null)
+        {
+            return null;
+        }
+
+        var deferred = new List<Action>();
+
+        if (registry is not null)
+        {
+            // Copied out under the registry's own lock before the walk, because ending one removes it from
+            // that very list.
+            foreach (var link in registry.Snapshot())
+            {
+                link.Connection.TryEnd(asParent, error: null, deferred);
+            }
+        }
+
+        OwningWorkerLink?.Connection.TryEnd(asWorker, error: null, deferred);
+
+        return deferred.Count == 0 ? null : deferred;
+    }
+
+    /// <summary>
+    /// Runs the <see cref="WorkerProvider.OnWorkerEnded"/> callbacks a teardown deferred, once that teardown
+    /// has finished and the engine is whole again.
+    /// </summary>
+    /// <remarks>
+    /// A host exception propagates from here, which is the right place for it: the caller asked for the restore
+    /// or the dispose, the engine has completed it, and swallowing a provider's failure would hide it. Ending
+    /// the remaining connections first is deliberate — the engine's own work is done for all of them before any
+    /// host code runs.
+    /// </remarks>
+    internal static void NotifyWorkerHosts(List<Action>? deferred)
+    {
+        if (deferred is null)
+        {
+            return;
+        }
+
+        foreach (var notification in deferred)
+        {
+            notification();
+        }
     }
 
     private void AbandonFetches()
@@ -943,16 +1040,28 @@ internal sealed class WebApiEngineState
     /// <summary>
     /// Called from <see cref="Engine.Dispose"/>: releases the state that reaches outside the engine, which is
     /// the host token registrations, the subscriptions in a <see cref="BroadcastChannelBroker"/> the host may
-    /// share with engines that outlive this one, and the <c>MessagePort</c> sides entangled with ports of
-    /// another engine — each of which is a live reference to this disposed one, and each of which would go on
-    /// accepting messages into a queue nothing will ever drain. The queues need nothing — they hold no
-    /// unmanaged resource and no timer, and die with the engine.
+    /// share with engines that outlive this one, the worker connections spanning two engines, and the
+    /// <c>MessagePort</c> sides entangled with ports of another engine — each of which is a live reference to
+    /// this disposed one, and each of which would go on accepting messages into a queue nothing will ever
+    /// drain. The queues need nothing — they hold no unmanaged resource and no timer, and die with the engine.
     /// </summary>
-    internal void Dispose()
+    /// <returns>The host callbacks for the connections this ended; see <see cref="NotifyWorkerHosts"/>.</returns>
+    /// <remarks>
+    /// A worker engine's own dispose ends its connection too, and that is the half worth naming: the far side
+    /// would otherwise stay a <c>Worker</c> object that looks alive while every <c>postMessage</c> pays a full
+    /// serialization into a queue nothing will ever drain. The host that built the engine is the host that
+    /// disposes it, so <see cref="WorkerEndReason.WorkerDisposed"/> is a fact it can act on rather than a
+    /// surprise.
+    /// </remarks>
+    internal List<Action>? Dispose()
     {
+        var endedWorkers = EndWorkerConnections(WorkerEndReason.ParentDisposed, WorkerEndReason.WorkerDisposed);
+
         ReleaseHostAbortBridges();
         CloseBroadcastChannels();
         CloseMessagePorts();
+
+        return endedWorkers;
     }
 }
 #endif

--- a/Jint/Engine.WebApi.cs
+++ b/Jint/Engine.WebApi.cs
@@ -667,16 +667,18 @@ internal sealed class WebApiEngineState
     /// a listener for it; step 6 hands the value to the sink. <b>The two are additive rather than
     /// alternative:</b> HTML lets a listener's <c>preventDefault()</c> set <i>notHandled</i> false and so
     /// suppress the console report, and Jint deliberately reports either way — a host's diagnostics channel is
-    /// not something the script it is running may switch off.
+    /// not something the script it is running may switch off. The <i>parent</i> of a worker is told only when
+    /// <i>notHandled</i> is true, which is the half of the algorithm a script legitimately controls; see
+    /// <see cref="FireErrorAndPropagate"/>.
     /// </remarks>
     internal void ReportError(JsValue value)
     {
-        if (_globalEventTarget is { } target)
+        if (HasSomewhereToReportAnError)
         {
             // The location the engine last saw, which for a call from script is the reportError call site —
             // the same fallback every web API that has to place a failure uses.
             var location = _engine._lastSyntaxElement?.Location ?? default;
-            target.FireError(ErrorEventDetails.FromReportedValue(value, in location));
+            FireErrorAndPropagate(ErrorEventDetails.FromReportedValue(value, in location));
         }
 
         Diagnostics?.Report(DiagnosticEvent.ForReportedError(value));
@@ -688,12 +690,74 @@ internal sealed class WebApiEngineState
     /// sink report they make carries the exception itself and not merely its value.
     /// </summary>
     /// <remarks>
-    /// A no-op on an engine that has no global listener, which is every engine until a script registers one.
-    /// It declines to recurse: an exception thrown by a listener <i>while</i> a report is being dispatched
-    /// reaches the sink alone — see <see cref="GlobalEventTarget"/>.
+    /// A no-op on an engine that has no global listener and is nobody's worker, which is every engine until a
+    /// script registers one. It declines to recurse: an exception thrown by a listener <i>while</i> a report is
+    /// being dispatched reaches the sink alone — see <see cref="GlobalEventTarget"/>.
     /// </remarks>
     internal void FireGlobalErrorEvent(JavaScriptException exception)
-        => _globalEventTarget?.FireError(ErrorEventDetails.FromException(exception));
+    {
+        if (HasSomewhereToReportAnError)
+        {
+            FireErrorAndPropagate(ErrorEventDetails.FromException(exception));
+        }
+    }
+
+    /// <summary>
+    /// Step 5.2.3 of <i>report an exception</i>: the <c>error</c> event this engine's own <c>Worker</c> object
+    /// raised was not cancelled either, so the failure is reported one level further up — at <i>this</i>
+    /// engine's global scope and to <i>this</i> engine's sink.
+    /// </summary>
+    /// <remarks>
+    /// It is the recursive step, so it propagates again when this engine is itself a worker, which is what
+    /// produces HTML's up-the-chain propagation for the nested workers a provider deliberately enabled.
+    /// </remarks>
+    internal void ReportWorkerError(in ErrorEventDetails details)
+    {
+        FireErrorAndPropagate(in details);
+        Diagnostics?.Report(DiagnosticEvent.ForWorkerError(details.Message));
+    }
+
+    /// <summary>
+    /// Whether a failure reported here could reach anything at all: a global <c>error</c> listener, or the
+    /// parent of a worker. Two field reads, which is what every report site costs on an engine that has
+    /// neither.
+    /// </summary>
+    private bool HasSomewhereToReportAnError => _globalEventTarget is not null || OwningWorkerLink is not null;
+
+    /// <summary>
+    /// <i>Report an exception</i> step 5: fire <c>error</c> at this global scope, and — <b>only</b> when the
+    /// result is HTML's <i>notHandled</i> — hand the failure to the <c>Worker</c> object one engine up.
+    /// <para>
+    /// https://html.spec.whatwg.org/multipage/webappapis.html#report-an-exception
+    /// </para>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>The <i>notHandled</i> gate is the whole reason this is not the <see cref="DiagnosticsSink"/>.</b> The
+    /// sink is deliberately unsuppressible by script and is told whatever a listener did; HTML's propagation to
+    /// the parent is gated on exactly the bool a worker-side <c>preventDefault()</c> — or a global
+    /// <c>onerror</c> returning <see langword="true"/> — sets to false. So the relay sits beside the sink and
+    /// reads that bool, and the host's own channel is untouched.
+    /// </para>
+    /// <para>
+    /// Reading <see cref="GlobalEventTarget.IsReporting"/> <i>before</i> the dispatch is the in-error-reporting
+    /// mode guard: a failure raised while a previous one was being reported fires nothing (the dispatch itself
+    /// declines) and must not be propagated either, or the recursion the guard exists to stop would simply move
+    /// one engine up. After the call the flag would answer for the outer report's frame instead, which is the
+    /// same answer for the wrong reason.
+    /// </para>
+    /// </remarks>
+    private void FireErrorAndPropagate(in ErrorEventDetails details)
+    {
+        var target = _globalEventTarget;
+        var reporting = target is { IsReporting: true };
+        var notHandled = target is null || target.FireError(in details);
+
+        if (notHandled && !reporting)
+        {
+            OwningWorkerLink?.ReportErrorToParent(in details);
+        }
+    }
 
     /// <summary>
     /// The sink's half of <c>HostPromiseRejectionTracker</c>. Additive to

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -3754,23 +3754,26 @@ public sealed partial class Engine : IDisposable
 #if NET8_0_OR_GREATER
         // A host CancellationToken bridged to an AbortSignal holds a registration that reaches this engine, and
         // the token may well outlive it — an application-lifetime token would otherwise keep every engine it
-        // was ever handed to reachable.
-        _webApi?.Dispose();
+        // was ever handed to reachable. The same call ends every worker connection this engine is a party to,
+        // in both directions; the host's OnWorkerEnded callbacks come back as a list and are run at the very
+        // bottom of this method, once the engine has finished letting go of everything else.
+        var endedWorkers = _webApi?.Dispose();
 #endif
 
-        if (_objectWrapperCache is null)
+        if (_objectWrapperCache is not null)
         {
-            return;
+#if SUPPORTS_WEAK_TABLE_CLEAR
+            _objectWrapperCache.Clear();
+#else
+            // we can expect that reflection is OK as we've been generating object wrappers already
+            var clearMethod = _objectWrapperCache.GetType().GetMethod("Clear", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            clearMethod?.Invoke(_objectWrapperCache, []);
+#endif
         }
 
-#if SUPPORTS_WEAK_TABLE_CLEAR
-        _objectWrapperCache.Clear();
-#else
-        // we can expect that reflection is OK as we've been generating object wrappers already
-        var clearMethod = _objectWrapperCache.GetType().GetMethod("Clear", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
-        clearMethod?.Invoke(_objectWrapperCache, []);
+#if NET8_0_OR_GREATER
+        WebApiEngineState.NotifyWorkerHosts(endedWorkers);
 #endif
-
     }
 
     [DebuggerDisplay("Engine")]

--- a/Jint/WebApi/DiagnosticsSink.cs
+++ b/Jint/WebApi/DiagnosticsSink.cs
@@ -200,6 +200,13 @@ public sealed class DiagnosticEvent
         => new(DiagnosticEventKind.UncaughtCallbackError, exception.Error, exception, source);
 
     /// <summary>
+    /// A failure inside a worker that neither the worker nor the parent's <c>Worker</c> object handled, which
+    /// HTML's <i>report an exception</i> reports one level up — at the parent.
+    /// </summary>
+    internal static DiagnosticEvent ForWorkerError(string message)
+        => new(DiagnosticEventKind.WorkerError, JsString.Create(message));
+
+    /// <summary>
     /// The two <c>HostPromiseRejectionTracker</c> operations, which are also what
     /// <see cref="Engine.AdvancedOperations.PromiseRejectionTracker"/> raises.
     /// </summary>
@@ -241,6 +248,29 @@ public enum DiagnosticEventKind
     /// <see cref="DiagnosticEvent.RejectionHandled"/>.
     /// </summary>
     UnhandledPromiseRejection,
+
+    /// <summary>
+    /// A failure inside a <c>Worker</c> this engine created that nothing handled — neither the worker's own
+    /// <c>error</c> listeners nor the <c>Worker</c> object's. It is HTML's <i>report an exception</i> reaching
+    /// its last step one engine up
+    /// (https://html.spec.whatwg.org/multipage/webappapis.html#report-an-exception).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="DiagnosticEvent.Value"/> is the failure's <b>message, as a string</b>, and that is not a
+    /// simplification: the thrown value belongs to the worker's realm and to the worker's thread, so it may not
+    /// cross — which is the same reason the <c>ErrorEvent</c> the parent's script sees carries
+    /// <c>error: null</c>, exactly as the standard prescribes. A worker that wants its parent to have the real
+    /// failure catches it and <c>postMessage</c>s it.
+    /// </para>
+    /// <para>
+    /// A worker's own sink — the one a provider installed on the worker engine — has already seen the same
+    /// failure as an <see cref="UncaughtCallbackError"/> or a <see cref="ReportedError"/>, because that channel
+    /// is unsuppressible. So a host that wires <i>one</i> sink for a parent and its workers sees the failure
+    /// twice, once from each side; this kind is what tells the two apart.
+    /// </para>
+    /// </remarks>
+    WorkerError,
 }
 
 /// <summary>

--- a/Jint/WebApi/Events/JsEventTarget.cs
+++ b/Jint/WebApi/Events/JsEventTarget.cs
@@ -3,6 +3,7 @@ using Jint.Native;
 using Jint.Native.Object;
 using Jint.Runtime;
 using Jint.WebApi.Abort;
+using Jint.WebApi.GlobalEvents;
 
 namespace Jint.WebApi.Events;
 
@@ -90,6 +91,18 @@ internal class JsEventTarget : ObjectInstance
     /// way to name.
     /// </remarks>
     internal virtual JsValue EventTargetValue => this;
+
+    /// <summary>
+    /// Whether this target is the engine's global scope — WebIDL's <c>WindowOrWorkerGlobalScope</c>, which in
+    /// Jint is the synthetic global target and nothing else.
+    /// </summary>
+    /// <remarks>
+    /// Read by exactly one rule: HTML's <i>special error event handling</i>, which is what makes a global
+    /// <c>onerror</c> take five arguments and cancel by returning <see langword="true"/> where every other
+    /// event handler takes the event and cancels by returning <see langword="false"/>. See
+    /// <see cref="InvokeCallback"/>.
+    /// </remarks>
+    internal virtual bool IsGlobalScope => false;
 
     /// <summary>
     /// Whether one dispatch of <paramref name="type"/> could invoke anything at all. The engine asks before
@@ -349,9 +362,19 @@ internal class JsEventTarget : ObjectInstance
     /// <c>this</c>, and anything else has <c>handleEvent</c> looked up on it afresh — the lookup is per
     /// invocation, so a script may swap the method between two dispatches.
     /// </summary>
+    /// <remarks>
+    /// An <b>event-handler</b> registration is a different algorithm and takes the branch below:
+    /// https://html.spec.whatwg.org/multipage/webappapis.html#the-event-handler-processing-algorithm.
+    /// </remarks>
     private void InvokeCallback(EventListenerRegistration listener, JsEvent ev)
     {
         var callback = listener.Callback;
+
+        if (listener.IsEventHandler)
+        {
+            InvokeEventHandler(callback, ev);
+            return;
+        }
 
         if (callback is ICallable directly)
         {
@@ -359,10 +382,8 @@ internal class JsEventTarget : ObjectInstance
             return;
         }
 
-        // HTML's event handler processing algorithm invokes the assigned value as a function and knows
-        // nothing about handleEvent, so a non-callable onabort is simply never called. addEventListener's
-        // callback is a WebIDL callback *interface* and does get the lookup.
-        if (listener.IsEventHandler || callback is not ObjectInstance handler)
+        // addEventListener's callback is a WebIDL callback *interface* and does get the lookup.
+        if (callback is not ObjectInstance handler)
         {
             return;
         }
@@ -374,6 +395,71 @@ internal class JsEventTarget : ObjectInstance
         }
 
         operation.Call(handler, ev);
+    }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/webappapis.html#the-event-handler-processing-algorithm — what an
+    /// event handler IDL attribute (<c>onmessage</c>, <c>onerror</c>, …) does that an <c>addEventListener</c>
+    /// callback does not.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Two things. It knows nothing about <c>handleEvent</c>, so a non-callable value assigned to the attribute
+    /// is simply never called (step 2). And its <b>return value is read</b> (step 5), which is the half that
+    /// makes the two <c>onerror</c> shapes different:
+    /// </para>
+    /// <list type="bullet">
+    /// <item><description>
+    /// <b>Special error event handling</b> (step 3) — an <c>ErrorEvent</c> named <c>error</c> at a global scope
+    /// — invokes the handler with «<c>message</c>, <c>filename</c>, <c>lineno</c>, <c>colno</c>, <c>error</c>»
+    /// and cancels the event when it returns <see langword="true"/>. That is the legacy shape a worker's own
+    /// <c>onerror</c> has, and it is what decides HTML's <i>notHandled</i> on the worker side.
+    /// </description></item>
+    /// <item><description>
+    /// Every other handler — including <c>Worker.onerror</c>, which is <c>AbstractWorker</c>'s plain
+    /// <c>EventHandler</c> — is invoked with the event and cancels when it returns <see langword="false"/>.
+    /// </description></item>
+    /// </list>
+    /// <para>
+    /// Both tests are for the boolean value itself rather than for truthiness, which is what the algorithm
+    /// says: a handler returning <c>0</c> or <c>""</c> cancels nothing. Cancelling goes through
+    /// <see cref="JsEvent.SetCanceledFlag"/>, so a non-cancelable event is unaffected either way.
+    /// </para>
+    /// </remarks>
+    private void InvokeEventHandler(JsValue callback, JsEvent ev)
+    {
+        if (callback is not ICallable handler)
+        {
+            return;
+        }
+
+        // Step 3: an ErrorEvent named `error` fired at a global scope, and nothing else.
+        if (ev is JsErrorEvent errorEvent
+            && IsGlobalScope
+            && string.Equals(ev.TypeName, GlobalEventNames.ErrorName, StringComparison.Ordinal))
+        {
+            var legacy = handler.Call(
+                ev.CurrentTarget,
+                JsString.Create(errorEvent.Message),
+                JsString.Create(errorEvent.Filename),
+                JsNumber.Create(errorEvent.Lineno),
+                JsNumber.Create(errorEvent.Colno),
+                errorEvent.Error);
+
+            if (legacy is JsBoolean && legacy.AsBoolean())
+            {
+                ev.SetCanceledFlag();
+            }
+
+            return;
+        }
+
+        var result = handler.Call(ev.CurrentTarget, ev);
+
+        if (result is JsBoolean && !result.AsBoolean())
+        {
+            ev.SetCanceledFlag();
+        }
     }
 
     /// <summary>

--- a/Jint/WebApi/GlobalEvents/GlobalEventTarget.cs
+++ b/Jint/WebApi/GlobalEvents/GlobalEventTarget.cs
@@ -47,6 +47,26 @@ internal sealed class GlobalEventTarget : JsEventTarget
     /// <inheritdoc />
     internal override JsValue EventTargetValue => _realm.GlobalObject;
 
+    /// <inheritdoc />
+    /// <remarks>
+    /// True here and nowhere else, which is what scopes HTML's <i>special error event handling</i> — the
+    /// five-argument <c>onerror</c> that cancels by returning <see langword="true"/> — to the global scope. A
+    /// <c>Worker</c> object's <c>onerror</c> is <c>AbstractWorker</c>'s plain <c>EventHandler</c> and takes the
+    /// other branch.
+    /// </remarks>
+    internal override bool IsGlobalScope => true;
+
+    /// <summary>
+    /// Whether a report is being dispatched at this target right now — HTML's <i>in error reporting mode</i>,
+    /// and the reason <see cref="FireReport"/> declines a second one.
+    /// </summary>
+    /// <remarks>
+    /// Read by the worker error relay, which must decline for the same reason the dispatch does: an error
+    /// raised <i>while</i> a previous one was being reported is not a second failure to tell a parent about,
+    /// and propagating it would be the unbounded recursion the guard exists to stop, one engine further up.
+    /// </remarks>
+    internal bool IsReporting => _reporting;
+
     /// <summary>
     /// Fires one trusted event at the global scope, unless nothing is listening for it or a report is already
     /// in flight.

--- a/Jint/WebApi/Workers/WorkerConnection.cs
+++ b/Jint/WebApi/Workers/WorkerConnection.cs
@@ -34,9 +34,10 @@ public sealed class WorkerConnection
 
     /// <summary>
     /// What the engine does when the connection ends: close the endpoints, cancel the termination source, tell
-    /// the provider. Supplied by the engine wiring, and invoked at most once, outside <see cref="_lock"/>.
+    /// the provider. Supplied by the engine wiring, and invoked at most once, outside <see cref="_lock"/>. The
+    /// second argument is the deferral list an engine teardown passes; see <see cref="TryEnd"/>.
     /// </summary>
-    private readonly Action<WorkerEndReason>? _onEnded;
+    private readonly Action<WorkerEndReason, List<Action>?>? _onEnded;
 
     /// <summary>
     /// Written last inside <see cref="_lock"/>, so a thread that reads <see langword="true"/> — from any
@@ -58,7 +59,7 @@ public sealed class WorkerConnection
         Engine parent,
         Engine worker,
         string name,
-        Action<WorkerEndReason>? onEnded,
+        Action<WorkerEndReason, List<Action>?>? onEnded,
         CancellationToken terminationToken)
     {
         Parent = parent;
@@ -168,11 +169,20 @@ public sealed class WorkerConnection
     /// The engine-side entry: ends the connection with a reason of its own and, for a failure, the CLR
     /// exception behind it.
     /// </summary>
+    /// <param name="reason">Why it is ending.</param>
+    /// <param name="error">The failure behind it, for <see cref="WorkerEndReason.StartupFailed"/>.</param>
+    /// <param name="deferredHostNotifications">
+    /// Where to collect <see cref="WorkerProvider.OnWorkerEnded"/> instead of calling it, or
+    /// <see langword="null"/> to call it here. An engine teardown — a <c>RestoreGlobalSnapshot</c> or a
+    /// <c>Dispose</c> ending every connection at once — passes a list and runs it once the teardown is over, so
+    /// that a host throwing from the callback cannot leave the engine half-reset. Everything else passes
+    /// nothing.
+    /// </param>
     /// <returns>
     /// <see langword="true"/> when this call is the one that ended it — the caller is then the only thread
     /// running the end sequence — and <see langword="false"/> when it had already ended.
     /// </returns>
-    internal bool TryEnd(WorkerEndReason reason, Exception? error)
+    internal bool TryEnd(WorkerEndReason reason, Exception? error, List<Action>? deferredHostNotifications = null)
     {
         lock (_lock)
         {
@@ -191,7 +201,7 @@ public sealed class WorkerConnection
 
         // Outside the lock, always: this closes endpoints and calls into the host's OnWorkerEnded, and nothing
         // that can run host code may run while a lock of this feature's is held.
-        _onEnded?.Invoke(reason);
+        _onEnded?.Invoke(reason, deferredHostNotifications);
         return true;
     }
 }

--- a/Jint/WebApi/Workers/WorkerGlobalScope.cs
+++ b/Jint/WebApi/Workers/WorkerGlobalScope.cs
@@ -90,9 +90,14 @@ internal sealed class WorkerGlobalScope
 
         // WinterTC §5.3's three. The events already fire at this same target under
         // WebApiFeatures.GlobalEvents; what these add is the attribute form of registering for them.
-        // `onerror`'s legacy five-argument invocation — «message, filename, lineno, colno, error», where
-        // returning true cancels — lands with the parent-side error channels in their own change; until then
-        // it is the ordinary event-handler shape and the dispatch is the ordinary one.
+        //
+        // `onerror` is the legacy shape, and it is legacy because the target is a global scope rather than
+        // because of anything this feature does: HTML's event handler processing algorithm gives an ErrorEvent
+        // named `error` fired at a WindowOrWorkerGlobalScope its own invocation — «message, filename, lineno,
+        // colno, error», where returning TRUE cancels — and JsEventTarget implements exactly that, keyed on
+        // JsEventTarget.IsGlobalScope. This attribute is therefore what decides notHandled on the worker side,
+        // which is the bool the parent-side relay is gated on: an onerror returning true is a worker saying it
+        // has dealt with its own failure, and the parent is not told.
         scope.InstallEventHandler(global, "onerror", GlobalEventNames.ErrorName);
         scope.InstallEventHandler(global, "onunhandledrejection", GlobalEventNames.UnhandledRejectionName);
         scope.InstallEventHandler(global, "onrejectionhandled", GlobalEventNames.RejectionHandledName);

--- a/Jint/WebApi/Workers/WorkerGlobalScope.cs
+++ b/Jint/WebApi/Workers/WorkerGlobalScope.cs
@@ -177,9 +177,9 @@ internal sealed class WorkerGlobalScope
     /// </summary>
     /// <remarks>
     /// Read per call rather than captured, because <c>ResetTransientEvaluationState</c> replaces the target
-    /// when an evaluation cycle ends. A restore on the worker also ends the connection, which lands with the
-    /// restore and dispose hooks in their own change (wave 3); reading it fresh is what keeps this correct
-    /// either way.
+    /// when an evaluation cycle ends. A restore on the worker also ends the connection, so what these
+    /// attributes write to afterwards is a listener list nothing will ever dispatch at; reading it fresh is
+    /// what keeps that a dead end rather than a stale reference to the previous cycle's list.
     /// </remarks>
     private GlobalEventTarget Target => _engine._webApi!.GlobalEventTarget;
 

--- a/Jint/WebApi/Workers/WorkerLink.cs
+++ b/Jint/WebApi/Workers/WorkerLink.cs
@@ -8,6 +8,7 @@ using Jint.Runtime;
 using Jint.Runtime.Descriptors;
 using Jint.Runtime.Interop;
 using Jint.Runtime.Modules;
+using Jint.WebApi.GlobalEvents;
 using Jint.WebApi.Messaging;
 
 namespace Jint.WebApi.Workers;
@@ -63,11 +64,22 @@ internal sealed class WorkerLink
     /// </summary>
     private readonly int _workerGeneration;
 
+    /// <summary>
+    /// The same, for the parent: the cycle it was in when the connection was made. Every job this class queues
+    /// on the <i>parent's</i> loop — both error events — carries it, so a <c>RestoreGlobalSnapshot</c> on the
+    /// parent drops an error that was already queued rather than firing it at a <c>Worker</c> object whose
+    /// listeners are closures over globals that no longer exist.
+    /// </summary>
+    private readonly int _parentGeneration;
+
     private readonly string _specifier;
     private readonly string? _referencingLocation;
 
     /// <summary>The job <c>close()</c> queues, built once so a script calling it in a loop allocates nothing.</summary>
     private readonly Action _closeJob;
+
+    /// <summary>The parent-side job a startup failure queues; it carries nothing, so it is built once too.</summary>
+    private readonly Action _startupErrorJob;
 
     internal WorkerLink(
         Engine parent,
@@ -86,7 +98,9 @@ internal sealed class WorkerLink
         _specifier = specifier;
         _referencingLocation = referencingLocation;
         _workerGeneration = worker.EventLoopGeneration;
+        _parentGeneration = parent.EventLoopGeneration;
         _closeJob = EndAsClosedByWorker;
+        _startupErrorJob = FireStartupErrorEvent;
 
         WorkerObject = workerObject;
 
@@ -197,12 +211,32 @@ internal sealed class WorkerLink
     /// The token is cancelled for every reason but <see cref="WorkerEndReason.ClosedByWorker"/>: cancelling it
     /// there would abort the very turn the worker asked to be allowed to finish.
     /// </para>
+    /// <para>
+    /// <paramref name="deferredHostNotifications"/> is what an engine <i>teardown</i> passes — a
+    /// <c>RestoreGlobalSnapshot</c> or a <c>Dispose</c> ending every connection at once. Everything above it in
+    /// this method is the thread-safe part and runs now; the host callback is collected instead, so a host that
+    /// throws from it cannot erupt out of the middle of a half-finished teardown. Passing the list through the
+    /// call rather than setting a flag is what makes it race-free: the thread that <i>wins</i>
+    /// <see cref="WorkerConnection.TryEnd"/> is the thread carrying the list, so a <c>terminate()</c> landing on
+    /// another thread at the same instant still calls the host itself.
+    /// </para>
     /// </remarks>
-    private void OnEnded(WorkerEndReason reason)
+    private void OnEnded(WorkerEndReason reason, List<Action>? deferredHostNotifications)
     {
         var closedByWorker = reason == WorkerEndReason.ClosedByWorker;
 
         _innerPort.Endpoint?.Close();
+
+        // §6.3's order for a startup failure: the inner endpoint is closed first — so the records the parent
+        // posted are discarded and the sides they carried stranded — then the parent-side event is queued, and
+        // only then is the outer endpoint closed. The event rides the parent's event loop rather than the port,
+        // so closing the port neither carries it nor cancels it; the order is kept because the specification
+        // states one and a queue that outlives its channel is exactly the kind of thing that stops being true
+        // silently.
+        if (reason == WorkerEndReason.StartupFailed)
+        {
+            _parent.AddToEventLoop(_startupErrorJob, _parentGeneration);
+        }
 
         if (closedByWorker)
         {
@@ -222,7 +256,14 @@ internal sealed class WorkerLink
 
         // Last, and outside everything: it is host code, and the host is documented as being allowed to do
         // nothing here but signal its own pump.
-        _registry.Provider.OnWorkerEnded(Connection, reason);
+        if (deferredHostNotifications is null)
+        {
+            _registry.Provider.OnWorkerEnded(Connection, reason);
+        }
+        else
+        {
+            deferredHostNotifications.Add(() => _registry.Provider.OnWorkerEnded(Connection, reason));
+        }
     }
 
     private void EndAsClosedByWorker() => Connection.TryEnd(WorkerEndReason.ClosedByWorker, error: null);
@@ -297,20 +338,92 @@ internal sealed class WorkerLink
     }
 
     /// <summary>
-    /// The module never ran. §6.3's order: the inner endpoint first — so the records the parent posted are
-    /// discarded and the sides they carried are stranded rather than left waiting for a deserialization that
-    /// can never happen — then the outer one, then the host is told.
+    /// The module never ran: the specifier did not resolve, the fetch failed, or the graph did not
+    /// instantiate. The end sequence does the rest — see <see cref="OnEnded"/> for the order.
     /// </summary>
     /// <remarks>
-    /// The parent-side <c>error</c> event HTML fires at the <c>Worker</c> object lands in its own change
-    /// (wave 3); what this wave gives a host is the connection surface, which needs no sink wired at all:
+    /// Two channels, and they carry different things on purpose. The <b>host</b> gets
     /// <see cref="WorkerConnection.IsFaulted"/>, <see cref="WorkerConnection.Error"/> and an
     /// <see cref="WorkerEndReason.StartupFailed"/> that says what happened rather than blaming a
-    /// <c>terminate()</c> nobody called.
+    /// <c>terminate()</c> nobody called — with no sink wired at all. The parent's <b>script</b> gets
+    /// <see cref="FireStartupErrorEvent"/>'s plain <c>Event</c>, which carries nothing, because that is what
+    /// the standard fires.
     /// </remarks>
     private void OnModuleFailed(JsValue error) => FailStartup(ToClrFailure(error));
 
     private void FailStartup(Exception error) => Connection.TryEnd(WorkerEndReason.StartupFailed, error);
+
+    /// <summary>
+    /// The load-failure event, on the parent's own thread: <b>a plain <c>Event</c> named <c>error</c></b> at
+    /// the <c>Worker</c> object, and emphatically not an <c>ErrorEvent</c>.
+    /// <para>
+    /// https://html.spec.whatwg.org/multipage/workers.html#run-a-worker (the <i>onComplete</i> step for a
+    /// script that failed to fetch or parse: "queue a global task … to fire an event named <c>error</c> at
+    /// worker").
+    /// </para>
+    /// </summary>
+    /// <remarks>
+    /// The step names no interface, so the event is an <c>Event</c> — no <c>message</c>, no <c>filename</c>, no
+    /// <c>error</c> — and libraries branch on exactly that to tell "the worker's script never loaded" from "the
+    /// worker's script threw". Anything a host wants to <i>know</i> about the failure is on the connection,
+    /// where it can be a CLR exception rather than a value that may not cross a realm.
+    /// </remarks>
+    private void FireStartupErrorEvent() => WorkerObject.FireEvent(GlobalEventNames.Error);
+
+    /// <summary>
+    /// The runtime-error relay: HTML's <i>report an exception</i> reaching its worker branch. Called on the
+    /// <b>worker's</b> thread, from the worker engine's own report sites, and <i>only</i> when they answered
+    /// <i>notHandled</i>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// What crosses is four CLR values and nothing else. The thrown value stays in the worker's realm on the
+    /// worker's thread — which is why the event the parent sees carries <c>error: null</c>, and why that is the
+    /// standard's own answer rather than a limitation being dressed up as one.
+    /// </para>
+    /// <para>
+    /// The connection is tested here and not again in the job. A <c>terminate()</c> that lands after the job
+    /// was queued does not unqueue it: HTML puts errors and messages on different task sources and orders
+    /// neither, so an error arriving just after a terminate is one interleaving of a race the standard leaves
+    /// open, where firing at a <c>Worker</c> object whose connection had <i>already</i> ended when the failure
+    /// happened would not be.
+    /// </para>
+    /// </remarks>
+    internal void ReportErrorToParent(in ErrorEventDetails details)
+    {
+        if (Connection.IsEnded)
+        {
+            return;
+        }
+
+        var report = new WorkerErrorReport(details.Message, details.Filename, details.Lineno, details.Colno);
+        _parent.AddToEventLoop(() => DeliverErrorToParent(report), _parentGeneration);
+    }
+
+    /// <summary>
+    /// The relayed error, on the parent's thread: fire a trusted <c>ErrorEvent</c> at the <c>Worker</c> object
+    /// with <c>error: null</c>, and — when that is not cancelled either — report it one level further up.
+    /// </summary>
+    /// <remarks>
+    /// <c>error</c> is null for <b>every</b> worker error, same-origin included: <i>report an exception</i>
+    /// step 5.1 initializes it that way before the <c>Worker</c> object ever sees the event. Node deliberately
+    /// ships the opposite, cloning the error through an allowlist of constructors; Jint implements HTML's
+    /// <c>Worker</c>, and a worker that wants its parent to have the real failure catches it and
+    /// <c>postMessage</c>s it — where the serializer's <c>Error</c> support is intentional.
+    /// </remarks>
+    private void DeliverErrorToParent(WorkerErrorReport report)
+    {
+        var details = new ErrorEventDetails(report.Message, report.Filename, report.Lineno, report.Colno, JsValue.Null);
+
+        var ev = WorkerObject._realm.Intrinsics.ErrorEvent.CreateTrustedError(GlobalEventNames.Error, in details);
+
+        // DispatchEvent answers false exactly when a listener cancelled, which is HTML's notHandled. Step
+        // 5.2.3: still unhandled, so report it for the Worker object's own global — this engine's.
+        if (WorkerObject.DispatchEvent(ev))
+        {
+            _parent._webApi?.ReportWorkerError(in details);
+        }
+    }
 
     /// <summary>
     /// Reduces the worker realm's rejection value to a CLR exception, because
@@ -387,6 +500,19 @@ internal sealed class WorkerLink
             requested: (double) queued + 1);
     }
 }
+
+/// <summary>
+/// One relayed worker error, reduced to what may cross a thread and a realm: four CLR values, and no
+/// <c>JsValue</c> at all.
+/// </summary>
+/// <remarks>
+/// It exists as a type rather than as an <c>ErrorEventDetails</c> handed straight across so that the rule is
+/// structural instead of a comment: there is nowhere here to put the thrown value even by accident. The
+/// parent rebuilds the details on its own thread, with <c>error</c> null, which is what the standard says the
+/// <c>Worker</c> object's event carries anyway.
+/// </remarks>
+[System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Auto)]
+internal readonly record struct WorkerErrorReport(string Message, string Filename, uint Lineno, uint Colno);
 
 /// <summary>
 /// The failure a worker's startup is reported as when there is no CLR exception behind it — a module whose

--- a/Jint/WebApi/Workers/WorkerPrototype.cs
+++ b/Jint/WebApi/Workers/WorkerPrototype.cs
@@ -133,10 +133,26 @@ internal sealed partial class WorkerPrototype : Prototype
     /// global's <c>onerror</c> is the legacy five-argument one instead.)
     /// </summary>
     /// <remarks>
-    /// The attribute exists from this change; what fires at it — a plain <c>Event</c> for a load failure and
-    /// an <c>ErrorEvent</c> with <c>error: null</c> for a runtime error — lands with the parent-side error
-    /// channels in their own change. Until then a load failure is reported to the <i>host</i> instead, through
-    /// <see cref="WorkerConnection.IsFaulted"/> and <see cref="WorkerConnection.Error"/>.
+    /// <para>
+    /// Two different events reach it, and telling them apart is the point. A <b>load or parse failure</b> fires
+    /// a plain <c>Event</c> — no <c>message</c>, no <c>error</c> — which is what the standard's own step names,
+    /// and which libraries branch on to mean "the worker's script never ran". A <b>runtime error</b> the worker
+    /// did not handle itself fires an <c>ErrorEvent</c> carrying <c>message</c>, <c>filename</c>,
+    /// <c>lineno</c>, <c>colno</c> and <c>error: null</c> — null for every worker error, because the thrown
+    /// value belongs to the worker's realm and its thread.
+    /// </para>
+    /// <para>
+    /// This is <c>AbstractWorker</c>'s plain <c>EventHandler</c>: the handler is invoked with the event, and
+    /// cancels with <c>preventDefault()</c> or by returning <see langword="false"/> — which stops the failure
+    /// being reported at this engine's own global scope and to its <c>DiagnosticsSink</c>. The worker global's
+    /// own <c>onerror</c> is the legacy five-argument shape instead, and cancels by returning
+    /// <see langword="true"/>.
+    /// </para>
+    /// <para>
+    /// A host that wants to know without wiring any script is served by the connection instead:
+    /// <see cref="WorkerConnection.IsFaulted"/> and <see cref="WorkerConnection.Error"/>, which carry a CLR
+    /// exception rather than a value that may not cross a realm.
+    /// </para>
     /// </remarks>
     [JsAccessor("onerror", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
     private JsValue OnErrorGet(JsValue thisObject)

--- a/Jint/WebApi/Workers/WorkerRegistry.cs
+++ b/Jint/WebApi/Workers/WorkerRegistry.cs
@@ -84,9 +84,9 @@ internal sealed class WorkerRegistry
     /// one calls back into <see cref="Remove"/>, and into host code.
     /// </summary>
     /// <remarks>
-    /// The seam a parent-side <c>RestoreGlobalSnapshot</c> and <c>Dispose</c> will end every connection
-    /// through; those hooks land in their own change (wave 3), which is also where the reasons
-    /// <c>ParentRestored</c> and <c>ParentDisposed</c> start being used.
+    /// What a parent-side <c>RestoreGlobalSnapshot</c> and <c>Dispose</c> end every connection through — see
+    /// <c>WebApiEngineState.EndWorkerConnections</c>, which is where <c>ParentRestored</c> and
+    /// <c>ParentDisposed</c> come from.
     /// </remarks>
     internal WorkerLink[] Snapshot()
     {

--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ its own `console` (or any other name in the table below), enabling the feature l
 | `scheduler.postTask` / `scheduler.yield` / `TaskController` / `TaskSignal` | `Scheduler` | ✔ shipped |
 | `requestIdleCallback` / `cancelIdleCallback` / `IdleDeadline` | `IdleCallback` | ✔ shipped |
 | `MessageChannel` / `MessagePort` / `MessageEvent` (incl. cross-engine ports and port transfer) / `BroadcastChannel` | `Messaging` | ✔ shipped |
+| `Worker` (module workers only, over a host-supplied `WorkerProvider`) | `Workers` — **opt-in on its own, and does nothing without a provider** | ✔ shipped |
 | `reportError` (and the `DiagnosticsSink` behind it) | `Reporting` | ✔ shipped |
 | `addEventListener` / `removeEventListener` / `dispatchEvent` / `self` on the global scope, with `ErrorEvent` / `PromiseRejectionEvent` and the `error` / `unhandledrejection` / `rejectionhandled` events | `GlobalEvents` | ✔ shipped |
 | `localStorage` / `sessionStorage` / `Storage` | `Storage` *(not in `Default` — see below)* | ✔ shipped |
@@ -246,7 +247,8 @@ grows as the table fills in, and it will never include `fetch`: network egress i
 `Storage` is one standing exception, for the reason in its own section below; `CacheApi` is another, for the
 neighbouring one — a cache outlives the evaluation that filled it, so where its data goes, and what bounds it,
 is a decision you make rather than inherit; and `FetchEvents` is the third, because a script that can register
-a `fetch` listener can take over every request you route into the engine.
+a `fetch` listener can take over every request you route into the engine. `Workers` is outside `Default` for a
+different reason again: it needs a thread, and Jint never starts one — see its own section below.
 
 `crypto.subtle` carries **all twelve operations** — `digest`, `sign`, `verify`, `encrypt`, `decrypt`,
 `generateKey`, `importKey`, `exportKey`, `deriveBits`, `deriveKey`, `wrapKey` and `unwrapKey` — over
@@ -405,9 +407,11 @@ Five entries need more than a flag name, stated here rather than left to be disc
   for the reason the whole section opens with: network egress is a grant a host makes rather than inherits.
   The three interfaces come with `Fetch`, `CacheApi` or `FetchEvents`; the function comes with `Fetch` alone.
 
-§5.3 *Web workers* asks for `onerror`, `onunhandledrejection`, `onrejectionhandled` and `self` on any global
-that maps to a `WorkerGlobalScope`. Jint's does not map to one, so only `self` applies, and the three
-handlers are the §6 case above.
+§5.3 *Web workers* does not require a runtime to support them at all, and asks for `onerror`,
+`onunhandledrejection`, `onrejectionhandled` and `self` on any global that *does* map to a
+`WorkerGlobalScope`. An ordinary Jint global does not map to one, so only `self` applies there and the three
+handlers are the §6 case above; a **worker's** global (`WebApiFeatures.Workers`, above) maps to one and
+carries all four, with `onerror` in HTML's legacy five-argument shape.
 
 **§5.1 Common interfaces**
 
@@ -766,6 +770,167 @@ subscribers strongly, exactly as a browser keeps a channel alive until it is clo
 long-lived and short-lived engines wants the short-lived ones closed, restored or `Dispose()`d — a
 `RestoreGlobalSnapshot` and an `Engine.Dispose` each end every channel that engine created.
 
+### `new Worker()`, with the thread supplied by you
+
+`WebApiFeatures.Workers` gives a script the `Worker` constructor. Everything a worker needs already exists —
+a second isolated global is a second `Engine`, the channel between them is the cross-engine port pair above,
+delivery on the receiver's own thread is its event loop — except the one thing that must not: **the thread**.
+*Jint never starts a thread to run script*, so `new Worker()` is only implementable if you supply the
+execution resource. That is what `WorkerProvider` is. The engine owns the specification-shaped parts — port
+entanglement, the worker global, message and error plumbing, ordering, `terminate()` semantics — and you own
+every thread, every pump, and the worker engine's configuration.
+
+This is the ordinary layering rather than a Jint improvisation: a browser *is* a host-supplied worker factory,
+with Chromium in the provider's role, and Deno, QuickJS, Moddable and GraalJS all draw the line in the same
+place. What is new here is that the boundary is a public extension point, which is the right consequence of
+Jint being a library and not a runtime.
+
+```csharp
+var engine = new Engine(options => options.UseWebApis().UseWorkers(new ThreadPerWorker(workerRoot)));
+
+engine.Execute("""
+    const w = new Worker('./crunch.js', { type: 'module' });
+    w.onmessage = e => log(e.data);
+    w.postMessage({ rows: 10000 });
+    """);
+```
+
+`UseWorkers` sets the flag and the provider together so the two cannot get out of step. **With no provider the
+global is not installed at all**, so `typeof Worker === 'undefined'` and a script can feature-detect —
+the family's absent-rather-than-throwing convention, and better than a constructor that could only throw.
+
+A provider decides three things: whether a worker may exist, what engine runs it, and which thread pumps it.
+
+```csharp
+sealed class ThreadPerWorker(string root) : WorkerProvider
+{
+    // On the PARENT's thread, with the parent's script suspended mid-statement. Read the request; do not
+    // run script, do not block, and do not fetch the worker's script — that is the worker's own
+    // IModuleLoader's job, on the worker's own pump. Return null to refuse (the script gets a SecurityError).
+    public override Engine? CreateWorkerEngine(WorkerRequest request)
+        => new Engine(request.CreateDefaultOptions().EnableModules(root));
+
+    // Still the parent's thread, ports entangled and the start job queued. This is where you start pumping.
+    public override void OnWorkerStarted(WorkerConnection c)
+        => new Thread(() =>
+        {
+            while (!c.IsEnded)
+            {
+                c.Worker.Advanced.ProcessTasks();
+                try { c.Worker.Advanced.WaitForScheduledWork(TimeSpan.FromSeconds(1), c.TerminationToken); }
+                catch (OperationCanceledException) { }   // terminate() — fall out via IsEnded
+            }
+
+            c.Worker.Dispose();                          // on the pumping thread, after the loop
+        }) { IsBackground = true }.Start();
+
+    // OnWorkerEnded is a SIGNAL ONLY, on whichever thread ended the connection — frequently not the
+    // worker's. Never Dispose() or ProcessTasks() the worker engine from it: a terminate() ends the
+    // connection on the parent's thread while the worker thread sits inside ProcessTasks, and either call
+    // would be the engine's concurrent-use exception thrown out of the middle of the parent's script. The
+    // loop above needs nothing here — it observes IsEnded and wakes on the token.
+}
+```
+
+`WaitForScheduledWork` is what keeps an idle worker cheap *and* responsive: it parks until a job arrives from
+any thread or the worker's own next timer comes due, so a `postMessage` from the parent is picked up
+immediately rather than at the end of a polling interval. It does not pump — you call `ProcessTasks()`
+yourself, which is the same division every other host-driven API in Jint keeps.
+
+**N workers on one existing loop** — a game frame, say — works too, with one thing to get right:
+`ProcessTasks` drains until empty, so an unbounded worker handler would eat the frame. Give each worker a
+slice, which is exactly what `OperationDeadlineConstraint` is for (no-op `Reset()`, so it survives the
+per-entry constraint reset, and it erupts as a `TimeoutException` from `ProcessTasks`):
+
+```csharp
+foreach (var c in live)
+{
+    var slice = (OperationDeadlineConstraint) c.HostState!;   // registered in CreateWorkerEngine
+    slice.Begin(TimeSpan.FromMilliseconds(2), c.TerminationToken);
+    try { c.Worker.Advanced.ProcessTasks(); }
+    catch (TimeoutException) { /* overran its slice; resumes next frame */ }
+    finally { slice.End(); }
+}
+```
+
+**What a worker inherits: restrictions yes, grants no.** `request.CreateDefaultOptions()` gives you a fresh
+`Options` — never the parent's instance — carrying the parent's whole *restrictive* posture: the seven
+`Options.Constraints` values, `Host.StringCompilationAllowed`, `AgentCanSuspend`, `Json.MaxParseDepth`, the
+parser bounds, the module-graph limits and `ResultLimits`, plus a replay of every constraint **factory** the
+parent registered, so each engine gets its own constraint instances. Otherwise `new Worker()` would be an
+`eval` escape hatch out of a hardened parent. What it does *not* carry is anything that grants a capability:
+`fetch`, `EventSource`, `WebSocket`, `Storage`, `CacheApi` and `FetchEvents` are subtracted whatever the
+parent has, CLR interop and the module loader are yours to give deliberately, and **nesting is off** — a
+worker gets neither the `Workers` flag nor the provider, because a worker that can spawn workers is a grant,
+by implication, of the thing that manufactures engines. Turning nesting on is two visible lines, by which you
+accept the accounting; `request.Depth` and `request.LiveWorkerCount` are there to bound the tree. It is a
+convenience and not a security boundary: if you built the parent's `Options` from a hardening helper, build
+the worker's from the same one.
+
+Two per-engine backstops sit under all of that, neither of them the policy — the provider is the policy:
+`Options.WebApi.Workers.MaxWorkers` (default 16) and `MaxQueuedMessages` (default 16384) each refuse with a
+`QuotaExceededError` rather than letting a script manufacture engines, or fill a queue nobody drains, faster
+than any host policy was written to notice.
+
+**`terminate()` and `close()` are not the same mechanism with a flag.** `terminate()` closes both ends at
+once, discards what the parent had already posted, and cancels the connection's token — after which the
+worker's script stops within the engine's amortized check interval (64 statements) on its own thread, and not
+at all while it is inside one of your CLR calls. That published bound is stronger than the field's: V8's
+`TerminateExecution` is frame-bounded in the same way. Cancellation skips JavaScript `finally` blocks, which
+is exactly what the standard's *abort a running script* prescribes. `close()` from inside the worker is the
+opposite in every respect the standard makes it so: the turn that called it **runs to completion**, and the
+parent-side queue **drains** rather than being discarded — so `postMessage(result); close();`, the commonest
+idiom there is, still delivers whether or not the parent had pumped in between.
+
+**Errors reach you by three routes.** A load or parse failure fires a plain `Event` named `error` at the
+`Worker` object — no `message`, no `ErrorEvent`, which is what the standard's own step says and what libraries
+branch on — and ends the connection as `StartupFailed` with `IsFaulted` and a CLR `Error` on it, so **a host
+sees a startup failure without wiring anything at all**. An uncaught runtime error fires an `ErrorEvent` at
+the `Worker` object carrying `message`, `filename`, `lineno`, `colno` and **`error: null`** — null for every
+worker error, because the thrown value belongs to the worker's realm and its thread, and because the standard
+says so; a worker that wants its parent to have the real failure catches it and `postMessage`s it, where the
+serializer's `Error` support is deliberate. Whether the parent is told at all is gated on the standard's
+*notHandled*, so a worker-side `preventDefault()`, or a worker global `onerror` returning `true`, stops the
+propagation — and your `DiagnosticsSink` still sees every report either way, because a host's diagnostics
+channel is not something the script it is running may switch off. Unhandled promise rejections stay on the
+worker's own global and reach the parent through nothing at all, and a constraint failure is never an event:
+it erupts from whatever is pumping, because a worker's budget is yours to observe and not the parent script's.
+
+**Restore and dispose end connections, on either side.** A `RestoreGlobalSnapshot` or an `Engine.Dispose` on
+the parent ends every connection it created (`ParentRestored` / `ParentDisposed`), and the same on a worker
+engine ends its own (`WorkerRestored` / `WorkerDisposed`) — both endpoints, in both directions, because a
+worker connection is one object spanning two engines rather than two independent peers, and a one-sided close
+would leave the survivor paying a full structured clone per `postMessage` forever. The `Worker` object stays
+alive and becomes inert: `postMessage` a no-op, `terminate()` idempotent, no further events.
+
+Two smaller truths worth knowing before you rely on them. `type: 'module'` is required — the standard's own
+default is `'classic'` and Jint refuses it with a `TypeError` that names the fix, for the reasons every
+non-browser runtime refuses it. And on an engine that is *only* ever pumped, `ProcessTasks` runs jobs raw, so
+a replayed `TimeoutInterval` **never fires** and `MaxStatements` becomes a lifetime budget; the worker budget
+that does work is the pair built for it — `OperationDeadlineConstraint` for wall-clock and
+`MemoryLimitConstraint` for allocations, both armed once with `Begin`/`End` — plus the termination token for
+stopping.
+
+#### Sharing state between a parent and a worker
+
+No modern JavaScript runtime lets two threads share one JS heap, and Jint enforces that rather than hoping:
+a second thread entering an engine gets an `InvalidOperationException`, because the engine's speed *is* its
+unsynchronized state. What you have instead, in order of how much is shared:
+
+1. **Move a buffer** — `postMessage(v, { transfer: [buf] })` is genuinely zero-copy and genuinely one-way.
+2. **Move a channel** — `MessagePort` transfer, which is the shape Comlink-style RPC is built from; a
+   transferable stream rides the same way.
+3. **Share a CLR object.** Hand the *same* .NET object to both engines with `SetValue`: each builds its own
+   `ObjectWrapper`, so no `JsValue` crosses, while the object underneath is one instance whose mutations both
+   sides see. It is strictly more than `SharedArrayBuffer` offers, with three obligations — the object's
+   thread-safety is entirely yours, there is no reactivity (that is what the port in (2) is for), and it must
+   be *data* rather than a bridge, since calling into an engine another thread is inside is the admission
+   exception. It only works inward: a JS-born object *is* an engine-affine C# instance, so it crosses by clone
+   or by transfer and no other way.
+4. **`SharedArrayBuffer`** — refused with a `DataCloneError`, exactly as `postMessage` refuses one in a page
+   that is not cross-origin isolated. `Atomics.waitAsync`, which Jint already runs on the pump, is the
+   sanctioned replacement.
+
 ### Uncaught script errors go to a `DiagnosticsSink`
 
 A script's failures are not all catchable by the host: a promise rejects with nobody listening, a `setTimeout`
@@ -782,11 +947,14 @@ sealed class LogSink : DiagnosticsSink
 var engine = new Engine(options => options.UseWebApis().UseDiagnostics(new LogSink()));
 ```
 
-There are three kinds of report. `ReportedError` is what a script handed `reportError(e)`.
+There are four kinds of report. `ReportedError` is what a script handed `reportError(e)`.
 `UnhandledPromiseRejection` is `HostPromiseRejectionTracker`'s two operations, told apart by
 `RejectionHandled` — and it is *additive*: the long-standing `engine.Advanced.PromiseRejectionTracker` event
 still fires exactly as it did, first. `UncaughtCallbackError` is an exception that escaped a callback the
-engine invoked for you.
+engine invoked for you. `WorkerError` is a failure inside a `Worker` that neither the worker nor the `Worker`
+object handled; its `Value` is the message as a string, because the thrown value belongs to the worker's realm
+and cannot cross, and it is its own kind so that one sink wired for a parent *and* its workers can tell the
+report it already heard from the worker's side apart from this one.
 
 **That last one is the reason a sink changes behaviour, so install one deliberately.** With no sink a timer
 callback or an event listener that throws erupts out of whatever was running it, because the alternative

--- a/docs/design/web-workers.md
+++ b/docs/design/web-workers.md
@@ -414,7 +414,13 @@ points:
   bool, so a worker-side `preventDefault()` (or a global `onerror` returning `true`) must stop the parent from
   being told. The two consumption sites therefore keep the bool and hand it to an internal per-connection hook
   that sits **beside** the sink: the host's own sink still sees every report, its documented contract, while
-  parent propagation honours *notHandled*.
+  parent propagation honours *notHandled*. Two details settled at implementation. The relay reads the
+  in-error-reporting-mode flag `GlobalEventTarget` already keeps, *before* the dispatch: a failure raised while
+  a previous one was being reported propagates nowhere, or the recursion that guard exists to stop would simply
+  move one engine up. And the re-report at the parent reaches its sink as its own kind,
+  `DiagnosticEventKind.WorkerError`, carrying the **message as a string** — the value cannot cross, for the
+  same reason the event carries `error: null` — so a host wiring one sink for a parent *and* its workers can
+  tell that report apart from the one it already heard from the worker's side.
 - **Unhandled promise rejections never propagate.** `unhandledrejection` fires at the worker's own global and
   reaches the parent through nothing at all; the relay filters kinds. Pinned, because the sink wiring makes the
   opposite easy to fall into.
@@ -690,9 +696,14 @@ a worker is different, and it is about *cost rather than delivery*: a one-sided 
 surviving side still pays a full structured clone per `postMessage`, still detaches its own transfer-listed
 buffers, still throws `DataCloneError` for unserializable values — forever. A worker connection is one object
 the engine created spanning two engines, not two independent host peers, so closing both is what stops the
-survivor's work. The restore-path hook does only the thread-safe part (endpoints, token, flags);
-`OnWorkerEnded` is invoked after `ResetTransientEvaluationState` finishes, so a host exception cannot erupt from
-the middle of a half-finished restore.
+survivor's work. The restore-path hook does only the thread-safe part (endpoints, token, flags); the host
+callback is *collected* into a list carried through `WorkerConnection.TryEnd` and run as the last act of
+`ResetTransientEvaluationState` — and of `Engine.Dispose` — with the engine whole again, so a host exception
+cannot erupt from the middle of a half-finished teardown. Passing the list through the call rather than setting
+a flag is what keeps it race-free: the thread that *wins* `TryEnd` is the thread carrying the list, so a
+`terminate()` landing at the same instant still calls the host itself. The connections are ended *before* the
+general port sweep in the same method, or `CloseMessagePorts` would close an engine's half of one as an
+anonymous port — stopping delivery while leaving the connection reading as live.
 
 A parent restore leaves the `Worker` object alive but **inert** — `postMessage` a no-op (post-serialization),
 `terminate()` idempotent, no further events — which is not a concession but conformance: the spec's


### PR DESCRIPTION
Steps 4–6 of the Web Workers plan (#3167 §14), completing the feature: the error channels, restore and
dispose on both sides, and the README section.

**Three error channels, three different shapes** (issue §6.3):

- A **load or parse failure** fires a plain `Event` named `error` at the `Worker` object — not an
  `ErrorEvent`, because HTML's *run a worker* names no interface for it and libraries branch on exactly
  that. Queued on the parent's loop with the parent generation captured at connection creation, in §6.3's
  order, after the connection has already ended as `StartupFailed` with a CLR exception on
  `WorkerConnection.Error`.
- A **runtime error** runs *report an exception* faithfully. The worker-parent relay is an internal hook
  **beside** the `DiagnosticsSink`, not the sink itself: the sink stays unsuppressible by script (its
  documented contract), while the relay reads the *notHandled* bool the two `FireError` consumption sites
  used to discard — so a worker-side `preventDefault()`, or a global `onerror` returning `true`, stops the
  parent from being told, exactly as the spec gates step 5. What crosses the thread is a
  `WorkerErrorReport` record of four CLR values, making the no-`JsValue`-crosses rule structural; the
  parent's job builds a trusted `ErrorEvent` with **`error: null`** (spec-mandated — *report an exception*
  step 5.1 sets it before the `Worker` object ever sees it), and an unhandled one re-reports one level up
  (step 5.2.3), which recurses naturally for the nested workers a provider deliberately enabled. The
  in-error-reporting-mode guard is honored on the relay too — read *before* the dispatch, so a failure
  raised while one is being reported doesn't move the recursion one engine up.
- **Unhandled rejections propagate to nothing**, and constraint failures stay eruptions from the host's
  pump — both pinned.

**`JsEventTarget` now implements HTML's event handler processing algorithm** — the return value of an
`on*` attribute handler is read (it never was before), scoped strictly to event-handler registrations and
never `addEventListener` callbacks: *special error event handling* (an `ErrorEvent` named `error` at a
global scope, and nothing else) invokes the worker global's `onerror` with «message, filename, lineno,
colno, error» and cancels on `true`, while every other handler — `Worker.onerror` included, per
`AbstractWorker` — gets the event and cancels on `false`. Boolean identity, not truthiness, per the
algorithm; cancellation goes through the canceled flag, so non-cancelable events are unaffected.

One public addition: **`DiagnosticEventKind.WorkerError`**, carrying the failure's message as a string. A
worker's own sink has already seen the failure (that channel is unsuppressible), so a host wiring one sink
for a parent and its workers hears it twice — this kind is what tells the parent-side re-report apart.

**Restore and dispose end the connection from either side** (issue §10's table): `ParentRestored` /
`WorkerRestored` via `ResetTransientState` (before the general port sweep, so a connection never decays
into an anonymous closed port), `ParentDisposed` / `WorkerDisposed` via `Engine.Dispose` — a disposed
worker engine no longer leaves the far side a `Worker` object that looks alive while every `postMessage`
pays a full serialization into a dead queue. Ending closes **both** endpoints — a worker-specific rule
argued on its own merits, since the port rule is deliberately one-sided — and the `Worker` object goes
inert exactly as HTML's disentangled-port clause describes. The provider's `OnWorkerEnded` callbacks are
**collected, not invoked**, during a teardown, and run only once the restore or dispose has finished — a
provider that throws cannot leave an engine half-reset — threaded through `TryEnd` itself so the deferral
is race-free against a concurrent `terminate()`.

README gains the Workers section: the provider shape with the corrected thread-per-worker sample
(`WaitForScheduledWork`, dispose after the loop), the cooperative-loop budget slice, what a worker inherits
and never inherits, close-vs-terminate, the error channels, and the state-sharing tiers.

Tests: 18 new pins across both projects, 12 mutations applied to shipped code with every named pin
verified to fail; two pins were strengthened when a first-form mutation did not bite. Full matrix green on
both TFMs plus both `JINT_HOST_CONTRACT_VERIFICATION=1` legs.

With this, #3167's implementation plan is complete through §14 step 6. The remaining item is vendoring the
WPT `workers/` corpus as its own PR.

Part of #3167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PnghUC3EKrYa12xQ2LaYyd
