### PR TITLE
Wpt: vendor and run the workers corpus, in a real worker

### DIFF
--- a/Jint.Tests/Wpt/Prelude/testharness-shim.js
+++ b/Jint.Tests/Wpt/Prelude/testharness-shim.js
@@ -16,7 +16,13 @@
 //
 // Deliberate divergences from upstream testharness.js, all of them recorded in Jint.Tests/Wpt/Vendor/README.md:
 //   * `self.GLOBAL` reports neither window nor worker nor shadow realm, so the DOM-only branches of a
-//     `.any.js` file skip themselves the way they do in a global they were not written for.
+//     `.any.js` file skip themselves the way they do in a global they were not written for. Note that this
+//     stays true in the driver's *worker* lane, where the file really is running inside one: `isWorker()`
+//     answers false there as well, because the shim has no way to tell the lanes apart and nothing in the
+//     corpus asks — only `isWindow()` is ever called, by `url/historical.any.js` and by
+//     `workers/semantics/multiple-workers/exposure.any.js`, and false is the right answer for both. A file
+//     that guards a worker-specific branch on `isWorker()` would skip it silently, so vendoring one means
+//     giving the shim a way to know first.
 //   * `fetch` is a *resource loader* over the vendored tree, not the Fetch API. It is what
 //     `fetch("resources/urltestdata.json")` needs and nothing more.
 //   * Timers are the engine's own: this file installs no `setTimeout`, and its `step_timeout` is a thin
@@ -820,7 +826,13 @@
 
     // ---------------------------------------------------------------- environment
 
-    global.self = global;
+    // Only when the engine has not already got one. Every engine the driver builds enables GlobalEvents and so
+    // installs `self` itself, and in the worker lane HTML makes `WorkerGlobalScope.self` a *read-only*
+    // attribute — so an unconditional assignment here would both overwrite what is under test and, the day the
+    // engine makes it read-only, throw out of this strict-mode function and take every suite with it.
+    if (global.self !== global) {
+        global.self = global;
+    }
 
     // A `.any.js` file is served into a global that tells it what it is. Jint's is none of the three, and
     // saying so is what makes the DOM-only branches (`document.createElement`, `location.searchParams`)

--- a/Jint.Tests/Wpt/Vendor/README.md
+++ b/Jint.Tests/Wpt/Vendor/README.md
@@ -29,12 +29,60 @@ because one unsharded run is the union of every variant, and why the object mode
 (`url/urlencoded-parser.any.js` runs each of its 35 inputs through `URLSearchParams`, `Request.formData()`
 and `Response.formData()`, one algorithm reached three ways).
 
-Seven standards are vendored: `url/`, `encoding/`, `compression/` and `urlpattern/` as one suite each,
-`FileAPI/` as **three** (its root, `blob/` and `file/`), `WebCryptoAPI/` as **eight** and `streams/` as
-**seven** — their root files plus one suite per sub-directory, because `WptCorpus.TestFiles` lists a
-directory's own files and never descends. That is 184 theory cases: 48 of them the WebCryptoAPI corpus's
-24,136 assertions, 65 the streams corpus's 1,154, 15 the compression corpus's 297, 3 the URL Pattern
-corpus's 373 and 14 the File API's 342; the whole driver runs in about a minute.
+Eight standards are vendored: `url/`, `encoding/`, `compression/` and `urlpattern/` as one suite each,
+`FileAPI/` as **three** (its root, `blob/` and `file/`), `workers/` as **three**, `WebCryptoAPI/` as **eight**
+and `streams/` as **seven** — their root files plus one suite per sub-directory, because
+`WptCorpus.TestFiles` lists a directory's own files and never descends. That is 195 theory cases: 48 of them
+the WebCryptoAPI corpus's 24,136 assertions, 65 the streams corpus's 1,154, 15 the compression corpus's 297,
+3 the URL Pattern corpus's 373, 14 the File API's 342 and 11 the workers corpus's 15; the whole driver runs
+in about a minute.
+
+## Two lanes: the top-level engine, and a real worker
+
+Every suite but one runs its file in the driver's own engine. The `workers/` corpus does not, and cannot:
+every `.any.js` file in it that is reachable at all carries `// META: global=worker` or
+`global=dedicatedworker`, because the file's whole subject *is* the worker global. Run in the driver's
+top-level engine, `workers/Worker-custom-event.any.js` would test that engine's own `addEventListener`, pass,
+and prove nothing — the same emptiness that keeps `urlpattern.https.any.js` out of the tree.
+
+So the driver has a second lane. `WptWorkerProvider` is a `WorkerProvider` — the shipped host extension point
+— and the file becomes the body of a **real module worker**, constructed by a real `new Worker(…, { type:
+'module' })` from a parent engine, with the parent and the worker pumped cooperatively on the test's own
+thread. Nothing here starts a thread: `OnWorkerStarted` starts nothing and the drive loop calls
+`ProcessTasks` on the parent and on each live worker in turn, so a suite's outcome cannot depend on how two
+schedulers interleaved. Results are read straight off the worker engine between turns rather than posted back,
+so a defect in the serializer would present as a failing assertion rather than as every worker suite reporting
+nothing.
+
+Three consequences worth knowing:
+
+* **`WptHarness.RunsInAWorker` picks the lane from the directory *and* the `// META: global=` key**, and needs
+  both. The directory alone would force the lane on a `workers/` file that is really about a window creating a
+  worker — which most of upstream's `workers/` tree is. The key alone would let a corpus bump move a settled
+  suite by editing one comment, and would move the wrong ones: `global=window,worker` is true of both lanes and
+  says nothing about which is worth running. `EveryWorkerLaneFileIsAWorkersFile` pins both directions.
+* **The file is a module, where a browser's `.any.js` for a worker is a classic script.** Jint runs module
+  workers only, so there is no classic script to evaluate and no `importScripts` to pull the harness in with;
+  the loader serves one module whose source is the shim, then the file's `// META: script=` helpers, then the
+  file — the same three-step composition the top-level lane performs with three `Execute` calls, and sound
+  because the shim assigns everything it exports onto `globalThis` explicitly. The one behavioural difference
+  is that module code is strict. No vendored file depends on sloppy mode; the nearest thing,
+  `interfaces/WorkerGlobalScope/self.any.js`'s `self = 1`, assigns to a property that is writable either way —
+  which is itself the one triage entry below.
+* **The worker gets the same environment the top-level engine gets**: `WebApiFeatures.Default` minus the
+  grants a worker never inherits, plus the fetch object model, plus the shim's resource reader. A file's
+  outcome therefore does not depend on which lane ran it.
+
+The shim changed in one place for this. It used to install `self` unconditionally; it now does so only when
+the engine has not, because `WorkerGlobalScope.self` is read-only in HTML and an unconditional assignment
+would both overwrite what is under test and — the day the engine makes it read-only — throw out of a
+strict-mode function and take every suite with it.
+
+One thing deliberately did **not** change: `GLOBAL.isWorker()` still answers `false` in the worker lane. The
+shim cannot tell the lanes apart and nothing in the corpus asks — `isWindow()` is the only one of the three
+ever called, and `false` is the right answer for it in both lanes. A file that guards a worker-specific branch
+on `isWorker()` would skip it silently, so vendoring one means giving the shim a way to know first. That is
+recorded rather than fixed because an unused mechanism is one nothing proves right.
 
 Tests that do not pass are named in the driver's exclusion table with the category they belong to. An entry
 there must match at least one failing test and no passing one, so a fix, a rename or a corpus bump cannot
@@ -68,6 +116,12 @@ without revisiting the reason fails rather than quietly adding a red suite.
 | `urlpattern/*.tentative.any.js`, `urlpattern/*.tentative.https.any.js` | Upstream's `.tentative` marker: `compare()` and `generate()` are proposals the URL Pattern Standard has not adopted. Covered by the two existing `*.tentative.*` rows. |
 | `FileAPI/file/send-file-formdata*.any.js` | All four POST a `FormData` to wptserve's `/fetch/api/resources/echo-content.py` and assert on the multipart body that comes back, so they need the fetch object model, an outbound request and the server's own Python handler. Serializing a `FormData` as `multipart/form-data` is a fetch body's job and arrives with that feature, which `WebApiFeatures.Default` never includes. |
 | `FileAPI/fileReader.any.js` | Jint has no `FileReader` — a `Blob` is read here through `text()`, `arrayBuffer()`, `bytes()` and `stream()` — and this file is about that reader's state machine (`readyState`, `abort()`, the progress events) rather than about a `Blob`. It is the only `.any.js` in the File API's root that is not vendored; its sibling `unicode.any.js` needs no reader and is. |
+| `workers/*.worker.js` | Twenty-one files that look like the most runnable thing in the directory and are the least: **every one opens with `importScripts("/resources/testharness.js")` at file scope.** A `.worker.js` is a *classic* worker's top-level script, and Jint runs module workers only — `importScripts` is present and throws a `TypeError`, which is the module-worker step [the standard itself prescribes](https://html.spec.whatwg.org/multipage/workers.html#dom-workerglobalscope-importscripts). So the file throws before registering a test, and a harness error is for the whole file rather than anything a per-test exclusion can name. What they assert about the worker global is asserted instead by the `.any.js` files beside them and by `Jint.Tests/Runtime/WebApi/WorkerMechanismTests.cs`. |
+| `workers/modules/*` | **The one row here that is a finding rather than a decision.** `dedicated-worker-import.any.js` is the flagship of the directory — nine `promise_test`s over static, nested and dynamic `import` in a module worker, exactly the feature Jint has. It cannot run, and the reason is in the *fixture*: every one of the nine worker scripts `import-test-cases.js` drives opens with `if ('DedicatedWorkerGlobalScope' in self && self instanceof DedicatedWorkerGlobalScope)` and installs its `onmessage` handler **inside** that branch. Jint ships no `DedicatedWorkerGlobalScope` interface object — the design's divergence #5, ruled together with [#3195](https://github.com/sebastienros/jint/issues/3195), because an interface object without the prototype chain would make `instanceof` lie — so no branch is taken, no handler is installed, the worker never answers, and all nine tests hang. A stall is a harness error for the whole file and no per-test exclusion can express a sniff that never reached an assertion. The `blob-url` and `data-url` siblings need `URL.createObjectURL` and a `data:` module loader on top of that. The module loading itself is covered by `WorkerMechanismTests`. |
+| `workers/SharedWorker-*.any.js`, `workers/semantics/interface-objects/*` | `SharedWorker` and `SharedWorkerGlobalScope`, which Jint does not have — the design records it as still open, needing a cross-engine name registry of the shape `BroadcastChannelBroker` has. A `global=sharedworker` file cannot even be run in the worker lane: there is no shared worker to be the global of. |
+| `workers/examples/*` | Upstream's own tutorial for writing worker tests, and it teaches wpt rather than testing an engine: `general.any.js` is two tests, the second asserting `location.pathname === "/workers/examples/general.any.worker.js"` — the path of the glue script the wpt server generates for a `.any.js` file. There is no server here to generate one. `onconnect.any.js` beside it is `global=sharedworker`. |
+| `workers/Worker-location.sub.any.js`, `workers/interfaces/WorkerUtils/importScripts/*`, `workers/importscripts_mime*.any.js` | `.sub.` is wptserve's server-side substitution: it rewrites `{{host}}` and `{{ports[…]}}` into a real origin before serving the file, so a vendored copy carries the placeholders verbatim. The `importScripts` families are classic-worker script loading on top of that, over server-chosen MIME types and cross-origin redirects. `Worker-location.sub.any.js` additionally asserts every member of a `WorkerLocation`, which is declined below. |
+| `workers/interfaces/WorkerGlobalScope/location/*` | The whole assertion of `returns-same-object.any.js` is `location === location`. The harness shim installs a stub `location` of its own — `/common/subset-tests.js` reads `location.search` to pick a shard — so a vendored copy would pass **against the shim** while Jint deliberately has no `WorkerLocation` at all. A test that can only assert the harness is worse than no test, which is why this is a row here and not an exclusion. |
 
 Nothing was left out for being slow. Every vendored file was timed at the pin; the slowest is
 `derive_bits_keys/pbkdf2.https.any.js` at ~20 s for 8,632 cases (it is `// META: timeout=long` and sharded
@@ -82,12 +136,16 @@ The three corpora added last measure 2.6 s (compression, 15 files), 3.1 s (urlpa
 (FileAPI, 14 files), run one after another on one thread. Two files carry almost all of that: `urlpattern.any.js`
 at ~2.9 s, which is 369 patterns each compiled and then matched, and `compression/compression-large-flush-output.any.js`
 at ~1.5 s, which compresses half a megabyte and inflates it again with pako. Both are `// META: timeout=long`
-upstream. Everything else in the three is under 120 ms.
+upstream. Everything else in the three is under 120 ms. The workers corpus added after them measures 0.46 s
+for its 11 files — a whole engine is constructed, entangled and pumped per file, and that is still what it
+costs.
 
 Everything else upstream that is not a `.any.js` file is out of scope by construction: `.window.js`, `.html`,
 `.worker.js` and `.xhtml` tests are for a browsing context or a worker — which is what excludes
 `WebCryptoAPI/algorithm-discards-context.https.window.js`, `FileAPI/blob/Blob-constructor-dom.window.js`,
-`FileAPI/blob/Blob-in-worker.worker.js` and `FileAPI/file/Worker-read-file-constructor.worker.js`.
+`FileAPI/blob/Blob-in-worker.worker.js` and `FileAPI/file/Worker-read-file-constructor.worker.js`. Jint now
+*has* a worker, so `.worker.js` needed its own row above rather than resting on that sentence: those files are
+out for what they are — classic-worker scripts — and not for want of somewhere to run them.
 
 ## Two copies of `urltestdata.json`
 
@@ -128,15 +186,9 @@ prose where a browser answers `InvalidAccessError`.
 
 ## What the streams corpus says about this engine
 
-<<<<<<< HEAD
-1,150 assertions across 64 files, of which **16 do not pass** — 98.6%, which is what one expects of an
+1,154 assertions across 65 files, of which **16 do not pass** — 98.6%, which is what one expects of an
 implementation written operation by operation against the standard, and also why the sixteen are worth naming
 individually. (Only the URL Pattern corpus below beats it, at 100%.)
-=======
-1,154 assertions across 65 files, of which **16 do not pass** — the highest-passing corpus vendored so far,
-which is what one expects of an implementation written operation by operation against the standard, and also
-why the sixteen are worth naming individually.
->>>>>>> 2bcb07e4f (Web streams: transfer a ReadableStream, a WritableStream or a TransformStream)
 
 `transferable/transform-stream-members.any.js` is the newest of the 65 and all four of its assertions pass.
 It is the whole `.any.js` surface of transferable streams, and it asks one thing four ways: naming a
@@ -282,6 +334,54 @@ working *across* a point where a collection may have happened — the same terms
 `--expose-gc`. `Blob-constructor-detached-buffer.any.js` passes on the strength of
 `Engine.Advanced`'s message ports: it detaches its buffer with
 `new MessageChannel().port1.postMessage(buffer, [buffer])`.
+
+## What the workers corpus says about this engine
+
+**15 assertions across 11 files, of which 8 pass and 7 do not** — and the interesting figure is not the ratio
+but that **six of the seven were decided in writing before a line of this corpus was run**, in the divergence
+ledger of [issue #3167](https://github.com/sebastienros/jint/issues/3167). This is the smallest corpus here
+and the one that most nearly assays a *design* rather than an implementation.
+
+What passes is the worker global doing its job. `Worker-custom-event.any.js` adds a listener for a custom
+event on `self` and dispatches one, so the worker global really is an event target.
+`Worker-replace-event-handler.any.js` assigns `onmessage` eight times over.
+`Worker-replace-global-constructor.any.js` replaces `self.MessageEvent`. `Worker-base64.any.js` finds `atob`
+and `btoa`. `Worker-formdata.any.js` is the best of them: it builds a `FormData`, appends a `Blob` to it, and
+then asserts that `postMessage(formData)` is a `DataCloneError` — so the worker global's `postMessage` is the
+port's, running the real serializer, refusing the right value. The second row of
+`semantics/multiple-workers/exposure.any.js` asserts `SharedWorker` is absent outside a window, and two of the
+four rows of `interfaces/WorkerGlobalScope/self.any.js` pass on `self === self` and `'self' in self`.
+
+**Five of the seven failures are one decision family** (`NeedsDeclinedWorkerGlobals`): the worker global is
+the global the engine already builds plus the worker names, and there are three names it deliberately does not
+add. `WorkerGlobalScope`/`DedicatedWorkerGlobalScope` (divergence #5) — an interface object with no such
+prototype chain would make `self instanceof WorkerGlobalScope` answer false while the constructor was
+nevertheless reachable, an `instanceof` that lies, and absence is the coherent half of that pair.
+`WorkerLocation` (#6) — a worker's script name is its `Module.Location`, and there is no URL for the other
+eight members to be parts of. `WorkerNavigator`, and `hardwareConcurrency` in particular (#7) — in Jint the
+*host* owns every thread, so an engine answering a number would be guessing at a resource it does not
+allocate. **The sixth** is `exposure.any.js`'s "Worker exposure" (`NeedsWorkerNesting`): nesting is off by
+default, so `Worker` is `undefined` inside a worker until a provider grants it — a grant withheld rather than
+a name declined, which is why it is a category of its own.
+
+**The seventh is `NeedsTriage`, and the defect is not in the worker code.**
+`interfaces/WorkerGlobalScope/self.any.js`, "self = 1", assigns to `self` and asserts it did not change.
+`WebApiRegistration` installs `self` once, for every global, as an ordinary writable data property, and its
+own comment says which definition that was written against: "HTML exposes `self` through a `[Replaceable]`
+accessor pair on **Window**" — which was the only global there was at the time.
+[`WorkerGlobalScope`'s](https://html.spec.whatwg.org/multipage/workers.html#dom-workerglobalscope-self) is a
+plain `readonly attribute` with no `[Replaceable]`, so the worker inherited the window's semantics along with
+the property. The install predates `Worker` and is shared with the top-level lane, so it is recorded rather
+than fixed here, on the standing rule that the change which first runs a suite is not the change that moves
+the engine. Fixing it means installing `self` per global rather than once; `DedicatedWorkerGlobalScope.name`
+is the same shape and the same question.
+
+**And the divergence the corpus made expensive rather than merely visible** is #5 again, from the other side:
+it is why `workers/modules/` is not vendored at all. The canonical "am I in a dedicated worker" sniff —
+`'DedicatedWorkerGlobalScope' in self && self instanceof DedicatedWorkerGlobalScope` — is how every one of
+wpt's module-worker fixtures decides where to install its `onmessage` handler, so in Jint none of them
+installs one and the whole flagship file hangs. The design named that wrinkle when it took the decision; this
+is what it costs, and it is a cost paid by real third-party worker code and not only by a conformance suite.
 
 ## Updating the pin
 

--- a/Jint.Tests/Wpt/Vendor/workers/Worker-base64.any.js
+++ b/Jint.Tests/Wpt/Vendor/workers/Worker-base64.any.js
@@ -1,0 +1,5 @@
+// META: global=worker
+test(() => {
+  assert_equals(typeof atob, 'function');
+  assert_equals(typeof btoa, 'function');
+}, 'Tests that atob() / btoa() functions are exposed to workers');

--- a/Jint.Tests/Wpt/Vendor/workers/Worker-constructor-proto.any.js
+++ b/Jint.Tests/Wpt/Vendor/workers/Worker-constructor-proto.any.js
@@ -1,0 +1,7 @@
+//META: global=worker
+test(() => {
+  const proto = {};
+  assert_equals(String(Object.getPrototypeOf(WorkerLocation)).replace(/\n/g, " ").replace(/\s\s+/g, " "), "function () { [native code] }");
+  Object.setPrototypeOf(WorkerLocation, proto);
+  assert_equals(Object.getPrototypeOf(WorkerLocation), proto);
+}, 'Tests that setting the proto of a built in constructor is not reset.');

--- a/Jint.Tests/Wpt/Vendor/workers/Worker-custom-event.any.js
+++ b/Jint.Tests/Wpt/Vendor/workers/Worker-custom-event.any.js
@@ -1,0 +1,8 @@
+// META: global=worker
+async_test(t => {
+  var target = self;
+  target.addEventListener('custom-event', t.step_func_done());
+
+  var event = new Event('custom-event');
+  target.dispatchEvent(event);
+}, 'Test CustomEvents on workers.');

--- a/Jint.Tests/Wpt/Vendor/workers/Worker-formdata.any.js
+++ b/Jint.Tests/Wpt/Vendor/workers/Worker-formdata.any.js
@@ -1,0 +1,19 @@
+// META: global=dedicatedworker
+test(() => {
+  assert_own_property(self, 'FormData');
+  assert_equals(FormData.length, 0);
+
+  var formData = new FormData();
+  assert_not_equals(formData, null);
+  assert_own_property(FormData.prototype, 'append');
+  formData.append('key', 'value');
+
+  var blob = new Blob([]);
+  assert_not_equals(blob, null);
+  formData.append('key', blob);
+  formData.append('key', blob, 'filename');
+
+  assert_throws_dom("DataCloneError",
+                    function() { postMessage(formData) },
+                    "Trying to clone formdata inside a postMessage results in an exception." );
+},'Test FormData interface object');

--- a/Jint.Tests/Wpt/Vendor/workers/Worker-replace-event-handler.any.js
+++ b/Jint.Tests/Wpt/Vendor/workers/Worker-replace-event-handler.any.js
@@ -1,0 +1,11 @@
+// META: global=worker
+// This is a regression test for a crash bug in Chrome: http://crbug.com/239669
+function update() {
+  onmessage = undefined;
+}
+
+test(() => {
+  for (var i = 0; i < 8; ++i) {
+    update();
+  }
+}, "Tests that repeatedly setting 'onmessage' within a worker doesn't crash.");

--- a/Jint.Tests/Wpt/Vendor/workers/Worker-replace-global-constructor.any.js
+++ b/Jint.Tests/Wpt/Vendor/workers/Worker-replace-global-constructor.any.js
@@ -1,0 +1,9 @@
+// META: global=worker
+test(() => {
+  try {
+    self.MessageEvent = 'PASS';
+    assert_equals(self.MessageEvent, 'PASS');
+  } catch (ex) {
+    assert_unreached("FAIL: unexpected exception (" + ex + ") received while replacing global constructor MessageEvent.");
+  }
+}, 'Test replacing global constructors in a worker context.');

--- a/Jint.Tests/Wpt/Vendor/workers/Worker-replace-self.any.js
+++ b/Jint.Tests/Wpt/Vendor/workers/Worker-replace-self.any.js
@@ -1,0 +1,9 @@
+// META: global=worker
+test(() => {
+  try {
+    self = 'PASS';
+    assert_true(self instanceof WorkerGlobalScope);
+  } catch (ex) {
+    assert_unreached("FAIL: unexpected exception (" + ex + ") received while replacing self.");
+  }
+}, 'Test that self is not replaceable.');

--- a/Jint.Tests/Wpt/Vendor/workers/WorkerNavigator-hardware-concurrency.any.js
+++ b/Jint.Tests/Wpt/Vendor/workers/WorkerNavigator-hardware-concurrency.any.js
@@ -1,0 +1,4 @@
+// META: global=worker
+test(() => {
+  assert_true(navigator.hardwareConcurrency > 0);
+}, 'Test worker navigator hardware concurrency.');

--- a/Jint.Tests/Wpt/Vendor/workers/WorkerNavigator.any.js
+++ b/Jint.Tests/Wpt/Vendor/workers/WorkerNavigator.any.js
@@ -1,0 +1,12 @@
+// META: global=worker
+test(() => {
+  assert_equals(typeof navigator, "object");
+  assert_true(navigator instanceof WorkerNavigator);
+  assert_equals(navigator.appName, "Netscape");
+  assert_true(navigator.appVersion.indexOf('WebKit') != 0);
+  assert_equals(typeof navigator.platform, "string");
+  assert_true(navigator.userAgent.indexOf('WebKit') != 0);
+  assert_equals(typeof navigator.onLine, "boolean");
+  assert_equals(navigator.appCodeName, 'Mozilla');
+  assert_equals(navigator.product, 'Gecko');
+}, "Testing Navigator properties on workers.");

--- a/Jint.Tests/Wpt/Vendor/workers/interfaces/WorkerGlobalScope/self.any.js
+++ b/Jint.Tests/Wpt/Vendor/workers/interfaces/WorkerGlobalScope/self.any.js
@@ -1,0 +1,19 @@
+// META: global=worker
+
+test(function() {
+  assert_equals(self, self);
+}, 'self === self');
+
+test(function() {
+  assert_true(self instanceof WorkerGlobalScope);
+}, 'self instanceof WorkerGlobalScope');
+
+test(function() {
+  assert_true('self' in self);
+}, '\'self\' in self');
+
+test(function() {
+  var x = self;
+  self = 1;
+  assert_equals(self, x);
+}, 'self = 1');

--- a/Jint.Tests/Wpt/Vendor/workers/semantics/multiple-workers/exposure.any.js
+++ b/Jint.Tests/Wpt/Vendor/workers/semantics/multiple-workers/exposure.any.js
@@ -1,0 +1,11 @@
+// META: global=window,worker
+
+test(() => {
+  const assert = "ServiceWorkerGlobalScope" in globalThis ? assert_equals : assert_not_equals;
+  assert(globalThis.Worker, undefined);
+}, "Worker exposure");
+
+test(() => {
+  const assert = globalThis.GLOBAL.isWindow() ? assert_not_equals : assert_equals;
+  assert(globalThis.SharedWorker, undefined);
+}, "SharedWorker exposure");

--- a/Jint.Tests/Wpt/WptExclusions.cs
+++ b/Jint.Tests/Wpt/WptExclusions.cs
@@ -40,11 +40,85 @@ internal enum WptDivergence
     NeedsWebAssembly,
 
     /// <summary>
-    /// The test detaches a buffer by posting it through a <c>MessageChannel</c>. Message ports are a worker
-    /// primitive and Jint has no worker story, so this is the corpus meeting an environment it was not
-    /// written for rather than a gap to close.
+    /// The test needs a <c>MessageChannel</c> — historically to detach a buffer by posting it through one.
+    /// <para>
+    /// <b>No entry uses this today, and the reason it once gave is no longer true.</b> It used to read "message
+    /// ports are a worker primitive and Jint has no worker story", which stopped being the case in stages:
+    /// <c>MessageChannel</c> and <c>MessagePort</c> arrived with <see cref="Jint.WebApi.WebApiFeatures"/>'s
+    /// messaging feature, transferring a port between engines arrived with
+    /// https://github.com/sebastienros/jint/issues/3197, and <c>Worker</c> itself with
+    /// https://github.com/sebastienros/jint/issues/3167. The corpus reports the change rather than the prose
+    /// doing it: <c>FileAPI/blob/Blob-constructor-detached-buffer.any.js</c> detaches its buffer with
+    /// <c>new MessageChannel().port1.postMessage(buffer, [buffer])</c> and passes on exactly that mechanism,
+    /// which is why its rows are not here.
+    /// </para>
+    /// <para>
+    /// The category is kept because the driver's engine enables
+    /// <see cref="Jint.WebApi.WebApiFeatures.Default"/> and not everything, so a future suite may still meet a
+    /// channel it was not granted. What it must never again mean is "workers do not exist here".
+    /// </para>
     /// </summary>
     NeedsMessageChannel,
+
+    /// <summary>
+    /// <para>
+    /// The test names one of the three globals HTML gives a worker and Jint's worker global scope
+    /// <b>deliberately does not add</b>. They are one decision, taken together and for one reason — the worker
+    /// global is the global the engine already builds plus the worker names, and a name it cannot back with the
+    /// object HTML says is behind it is not faked:
+    /// </para>
+    /// <list type="bullet">
+    /// <item><description>
+    /// <b><c>WorkerGlobalScope</c> and <c>DedicatedWorkerGlobalScope</c></b>
+    /// (https://html.spec.whatwg.org/multipage/workers.html#the-workerglobalscope-common-interface). The worker
+    /// global is not an <c>EventTarget</c> and has no such prototype chain, so an interface object would make
+    /// <c>self instanceof WorkerGlobalScope</c> answer <see langword="false"/> while the constructor was
+    /// nevertheless reachable — an <c>instanceof</c> that lies. Absence is the coherent half of that pair, and
+    /// it is the same ruling as https://github.com/sebastienros/jint/issues/3195 took for <c>Crypto</c>,
+    /// <c>SubtleCrypto</c> and <c>Performance</c>.
+    /// </description></item>
+    /// <item><description>
+    /// <b><c>location</c> and <c>WorkerLocation</c></b>
+    /// (https://html.spec.whatwg.org/multipage/workers.html#dom-workerglobalscope-location). A worker's script
+    /// name is its <c>Module.Location</c>, which a host exposes through <c>import.meta</c>; there is no URL for
+    /// the other eight members of a <c>WorkerLocation</c> to be parts of. Declined for v1 and cheap to add if
+    /// porting pressure appears.
+    /// </description></item>
+    /// <item><description>
+    /// <b><c>WorkerNavigator</c>, and <c>hardwareConcurrency</c> in particular</b>
+    /// (https://html.spec.whatwg.org/multipage/workers.html#the-workernavigator-object). A worker gets whatever
+    /// <c>navigator</c> its parent's <c>Navigator</c> flag gave it and no separate worker interface;
+    /// <c>hardwareConcurrency</c> is absent on purpose, because in Jint the <i>host</i> owns every thread and an
+    /// engine that answered a number would be guessing at a resource it does not allocate.
+    /// </description></item>
+    /// </list>
+    /// <para>
+    /// All three are numbered divergences (5, 6 and 7) in the ledger of
+    /// https://github.com/sebastienros/jint/issues/3167, so these entries are that ledger asserted rather than
+    /// merely written down.
+    /// </para>
+    /// </summary>
+    NeedsDeclinedWorkerGlobals,
+
+    /// <summary>
+    /// <para>
+    /// The test expects a worker to be able to create a worker. Jint's default is the opposite:
+    /// <c>WorkerRequest.CreateDefaultOptions()</c> subtracts <c>WebApiFeatures.Workers</c> and does not copy the
+    /// provider, so <c>Worker</c> is <c>undefined</c> inside a worker until a provider sets both — one visible
+    /// line, by which the host accepts the accounting.
+    /// </para>
+    /// <para>
+    /// This is the opposite kind of decision from <see cref="NeedsDeclinedWorkerGlobals"/>: not a name declined
+    /// but a <i>grant</i> withheld, on the feature's rule that grants never travel by implication. A per-engine
+    /// worker cap bounds the branching factor of a tree, never its depth, so inheriting the capability that
+    /// manufactures engines would make a three-line self-spawning module an unbounded fork bomb on the shipped
+    /// defaults. QuickJS refuses nesting outright, browsers bound the tree only with a global cap, and Deno
+    /// answers with monotone capability; off-by-default is the shape all three agree on for a library.
+    /// <c>WorkerRequest.Depth</c> and <c>LiveWorkerCount</c> exist to let a provider that opts in bound the
+    /// tree itself.
+    /// </para>
+    /// </summary>
+    NeedsWorkerNesting,
 
     /// <summary>
     /// <para>
@@ -241,6 +315,22 @@ internal enum WptDivergence
     /// <c>[...Array.prototype.values.call({})]</c> is a <c>TypeError</c> where the specification says
     /// <c>[]</c>. Reproduces with no web API involved at all; see <c>Vendor/README.md</c> for the six shapes
     /// and what each one should answer.
+    /// </description></item>
+    /// <item><description>
+    /// <b><c>self</c> is writable in a worker, where <c>WorkerGlobalScope.self</c> is read-only.</b>
+    /// <c>workers/interfaces/WorkerGlobalScope/self.any.js</c>, "self = 1": the file assigns to <c>self</c> and
+    /// asserts it did not change. <c>WebApiRegistration</c> installs <c>self</c> once, for every global, as an
+    /// ordinary writable data property, and its own comment says which definition that was written against —
+    /// "HTML exposes <c>self</c> through a <c>[Replaceable]</c> accessor pair on <b>Window</b>"
+    /// (https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-self), which was the only global there
+    /// was at the time. <c>WorkerGlobalScope</c>'s is a plain
+    /// <c>readonly attribute WorkerGlobalScope self</c>
+    /// (https://html.spec.whatwg.org/multipage/workers.html#dom-workerglobalscope-self) with no
+    /// <c>[Replaceable]</c>, so the worker inherited the window's semantics along with the property. It is
+    /// <i>not</i> new worker code — the install predates <c>Worker</c> and is shared with the top-level lane —
+    /// which is why it is triaged here rather than fixed alongside the corpus that found it. Fixing it means
+    /// installing <c>self</c> per-global rather than once, and the sibling
+    /// <c>DedicatedWorkerGlobalScope.name</c> is the same shape and the same question.
     /// </description></item>
     /// </list>
     /// </summary>

--- a/Jint.Tests/Wpt/WptHarness.cs
+++ b/Jint.Tests/Wpt/WptHarness.cs
@@ -2,6 +2,7 @@
 #nullable enable
 
 using System.Diagnostics;
+using System.Text;
 using Jint.Native;
 using Jint.Native.Object;
 using Jint.Runtime;
@@ -81,7 +82,239 @@ internal static class WptHarness
     internal static WptRunOutcome Run(string testFilePath)
     {
         var directory = WptCorpus.DirectoryOf(testFilePath);
-        return Execute(directory, MetaScripts(testFilePath, directory), WptCorpus.Read(testFilePath), testFilePath);
+        return RunsInAWorker(testFilePath)
+            ? RunInWorker(testFilePath, directory)
+            : Execute(directory, MetaScripts(testFilePath, directory), WptCorpus.Read(testFilePath), testFilePath);
+    }
+
+    /// <summary>
+    /// Whether a file is run <b>inside a worker</b>: it is in the <c>workers/</c> corpus, and its own
+    /// <c>// META: global=</c> line says it can be.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>The directory decides the scope and the META key decides the suitability</b>, and neither half does
+    /// the job alone. The directory alone would force a lane on a <c>workers/</c> file that is really about a
+    /// <i>window</i> creating a worker — which is what most of upstream's <c>workers/</c> tree is, and what the
+    /// not-vendored table is mostly full of. The META key alone would let a corpus bump move a settled suite
+    /// into a worker by editing one comment, and would move exactly the wrong files: it is a list of the
+    /// globals a file <i>supports</i>, so <c>global=window,worker</c> is true of both lanes and says nothing
+    /// about which one is worth running.
+    /// </para>
+    /// <para>
+    /// What the key genuinely rules out is a file that names no worker global at all: running such a file in a
+    /// worker would be asserting window semantics against a global that is not one. And what the directory
+    /// rules out is the opposite mistake — running <c>workers/Worker-custom-event.any.js</c> in the driver's
+    /// top-level engine, where it would test that engine's own <c>addEventListener</c>, pass, and prove nothing
+    /// about a worker. <c>WptTestRunner.EveryWorkerLaneFileIsAWorkersFile</c> pins both directions.
+    /// </para>
+    /// <para>
+    /// Negated entries — upstream's <c>global=worker,!serviceworker</c> form — are subtractions from a group
+    /// and can never add a global, so they are skipped rather than parsed.
+    /// </para>
+    /// </remarks>
+    internal static bool RunsInAWorker(string testFilePath)
+    {
+        if (!testFilePath.StartsWith("workers/", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        foreach (var value in MetaValues(WptCorpus.Read(testFilePath), "global="))
+        {
+            foreach (var entry in value.Split(','))
+            {
+                var name = entry.Trim();
+                if (name.Length == 0 || name[0] == '!')
+                {
+                    continue;
+                }
+
+                if (name is "worker" or "dedicatedworker")
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// The values of one <c>// META:</c> key, in declaration order.
+    /// </summary>
+    /// <remarks>
+    /// The META block is a run of leading comment lines; the first line of code ends it. Both spellings
+    /// upstream uses are accepted — <c>// META: global=worker</c> and the space-less <c>//META: global=worker</c>,
+    /// which <c>workers/Worker-constructor-proto.any.js</c> is written with. Reading only the first spelling
+    /// would drop a <c>script=</c> line silently, which presents as a suite failing on a missing helper rather
+    /// than as a parsing bug.
+    /// </remarks>
+    private static IEnumerable<string> MetaValues(string source, string key)
+    {
+        foreach (var rawLine in source.Split('\n'))
+        {
+            var line = rawLine.TrimEnd('\r');
+
+            var payload =
+                line.StartsWith("// META:", StringComparison.Ordinal) ? line.Substring("// META:".Length)
+                : line.StartsWith("//META:", StringComparison.Ordinal) ? line.Substring("//META:".Length)
+                : null;
+
+            if (payload is null)
+            {
+                if (line.Length == 0 || line.StartsWith("//", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                yield break;
+            }
+
+            payload = payload.TrimStart();
+            if (payload.StartsWith(key, StringComparison.Ordinal))
+            {
+                yield return payload.Substring(key.Length).Trim();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Runs one worker-scoped file by making it the body of a real module worker, then pumping the parent and
+    /// the worker cooperatively on this thread until the shim reports every test settled.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The results are read straight off the <b>worker</b> engine rather than posted back to the parent. That
+    /// is not a shortcut past the message path: the driver holds <c>connection.Worker</c>, pumps it on its own
+    /// thread and reads it between turns, so the values are as settled as the parent's would be — and routing
+    /// them through <c>postMessage</c> would make every file's outcome depend on the serializer, so a defect in
+    /// it would present as every worker suite reporting nothing rather than as a failing assertion.
+    /// </para>
+    /// <para>
+    /// A worker whose module never evaluated ends as <c>StartupFailed</c> carrying the CLR reason, and that is
+    /// reported as a harness error for the whole file — which is what it is: no test was registered, so there
+    /// is nothing a per-test exclusion could name.
+    /// </para>
+    /// </remarks>
+    private static WptRunOutcome RunInWorker(string testFilePath, string directory)
+    {
+        // The same three-step composition a top-level suite gets from three Execute calls: the shim, then the
+        // file's META helpers, then the file. It is one module because a module worker has one entry script.
+        var body = new StringBuilder(WptCorpus.Prelude).Append('\n');
+        foreach (var script in MetaScripts(testFilePath, directory))
+        {
+            body.Append(WptCorpus.Read(script)).Append('\n');
+        }
+
+        body.Append(WptCorpus.Read(testFilePath));
+
+        var provider = new WptWorkerProvider(body.ToString(), directory);
+        var parent = BuildEngine(directory, provider);
+
+        Engine? worker = null;
+        try
+        {
+            parent.SetValue("__wptWorkerSpecifier", testFilePath);
+            parent.Execute("globalThis.__wptWorker = new Worker(__wptWorkerSpecifier, { type: 'module' });");
+
+            var stalled = PumpWorker(parent, provider, out worker);
+            return new WptRunOutcome(worker is null ? [] : ReadResults(worker), stalled);
+        }
+        catch (Exception ex)
+        {
+            List<WptTestResult> partial;
+            try
+            {
+                partial = worker is null ? [] : ReadResults(worker);
+            }
+            catch
+            {
+                partial = [];
+            }
+
+            return new WptRunOutcome(partial, Describe(ex));
+        }
+    }
+
+    /// <summary>
+    /// Drives the parent and every live worker in turn until the worker's shim reports itself complete.
+    /// </summary>
+    /// <remarks>
+    /// One thread, no waiting on another: <c>ProcessTasks</c> drains an engine's queue, and a message crossing
+    /// between the two only <i>enqueues</i> on the receiver, so a round of the loop that changed anything is
+    /// followed by another round that sees it. The idle rule is the top-level loop's, widened over both
+    /// engines: when no engine has queued work and none has scheduled any, no amount of pumping can change the
+    /// answer.
+    /// </remarks>
+    private static string? PumpWorker(Engine parent, WptWorkerProvider provider, out Engine? worker)
+    {
+        var started = Stopwatch.GetTimestamp();
+        worker = provider.Started.Count > 0 ? provider.Started[0].Worker : null;
+
+        while (true)
+        {
+            parent.Advanced.ProcessTasks();
+
+            // A copy, because a worker that ends while being pumped removes itself from the live list.
+            foreach (var connection in provider.Live.ToArray())
+            {
+                connection.Worker.Advanced.ProcessTasks();
+            }
+
+            worker ??= provider.Started.Count > 0 ? provider.Started[0].Worker : null;
+
+            if (provider.Started.Count > 0 && provider.Started[0] is { IsFaulted: true } faulted)
+            {
+                return $"the worker did not start ({faulted.EndReason}): {Describe(faulted.Error!)}";
+            }
+
+            // Null until the worker's module has evaluated, which is what the first rounds are waiting for.
+            var outstanding = worker is null ? null : Outstanding(worker);
+            if (outstanding is not null && IsComplete(outstanding))
+            {
+                return null;
+            }
+
+            if (NextDue(parent, provider) is not { } untilDue)
+            {
+                return outstanding is null
+                    ? "nothing is left to pump and the worker never installed the harness shim"
+                    : Stalled(outstanding, "nothing is left to pump");
+            }
+
+            if (Stopwatch.GetElapsedTime(started) >= _harnessDeadline)
+            {
+                return outstanding is null
+                    ? $"the worker did not install the harness shim within {_harnessDeadline}"
+                    : Stalled(outstanding, $"the harness did not complete within {_harnessDeadline}");
+            }
+
+            if (untilDue > TimeSpan.Zero)
+            {
+                Thread.Sleep(untilDue < TimeSpan.FromMilliseconds(10) ? untilDue : TimeSpan.FromMilliseconds(10));
+            }
+        }
+    }
+
+    /// <summary>
+    /// The soonest any of the engines has work, or <see langword="null"/> when none of them has any.
+    /// </summary>
+    private static TimeSpan? NextDue(Engine parent, WptWorkerProvider provider)
+    {
+        var soonest = parent.TimeUntilNextPumpScheduledWork();
+
+        foreach (var connection in provider.Live.ToArray())
+        {
+            if (connection.Worker.TimeUntilNextPumpScheduledWork() is not { } due)
+            {
+                continue;
+            }
+
+            soonest = soonest is { } best && best <= due ? best : due;
+        }
+
+        return soonest;
     }
 
     /// <summary>
@@ -141,44 +374,37 @@ internal static class WptHarness
     /// The <c>// META: script=</c> lines, in the order they are declared, resolved against the tree.
     /// </summary>
     /// <remarks>
-    /// The other keys are read and deliberately ignored: <c>global=</c> names the browser globals the file
-    /// supports (this one is none of them — see the shim's <c>GLOBAL</c>), <c>title=</c> and <c>timeout=</c>
-    /// are for the browser reporter, and <c>variant=</c> is sharding.
+    /// <c>global=</c> is the one other key that is acted on — see <see cref="RunsInAWorker"/>, which is what
+    /// keeps a file about the worker global out of the driver's top-level engine. The rest are read and
+    /// deliberately ignored: <c>title=</c> and <c>timeout=</c> are for the browser reporter, and
+    /// <c>variant=</c> is sharding.
     /// </remarks>
     private static List<string> MetaScripts(string testFilePath, string directory)
     {
-        const string ScriptKey = "// META: script=";
         var scripts = new List<string>();
 
-        foreach (var rawLine in WptCorpus.Read(testFilePath).Split('\n'))
+        foreach (var reference in MetaValues(WptCorpus.Read(testFilePath), "script="))
         {
-            var line = rawLine.TrimEnd('\r');
-            if (!line.StartsWith("// META:", StringComparison.Ordinal))
-            {
-                // The META block is a run of leading comment lines; the first line of code ends it.
-                if (line.Length == 0 || line.StartsWith("//", StringComparison.Ordinal))
-                {
-                    continue;
-                }
-
-                break;
-            }
-
-            if (line.StartsWith(ScriptKey, StringComparison.Ordinal))
-            {
-                scripts.Add(WptCorpus.ResolveReference(directory, line.Substring(ScriptKey.Length).Trim()));
-            }
+            scripts.Add(WptCorpus.ResolveReference(directory, reference));
         }
 
         return scripts;
     }
 
-    private static Engine BuildEngine(string directory)
+    private static Engine BuildEngine(string directory, WptWorkerProvider? workers = null)
     {
         var engine = new Engine(options =>
         {
             // Everything except outbound network access, which is what a suite under test is allowed to see.
             options.UseWebApis(WebApiFeatures.Default);
+
+            // Only for the worker lane, and only then: an engine that no vendored file asks to create a worker
+            // from is byte-for-byte the engine every other suite has always run on. `Worker` is absent without
+            // both the flag and a provider, which UseWorkers sets together.
+            if (workers is not null)
+            {
+                options.UseWorkers(workers);
+            }
 
             // A guard on a hung script rather than a budget anything is measured against; see the field.
             options.TimeoutInterval(_harnessDeadline);
@@ -186,19 +412,27 @@ internal static class WptHarness
 
         // Headers, Request and Response, which no feature flag names on their own — see the class remarks.
         WebApiRegistration.InstallFetchModel(engine);
+        InstallResourceReader(engine, directory);
 
-        // The shim's `fetch` is this and nothing else: a reader over the vendored tree, so that a suite's
-        // `fetch("resources/urltestdata.json")` finds its corpus. A path the corpus does not hold is a
-        // vendoring bug rather than a test failure, so it erupts as a CLR exception and is reported as a
-        // harness error for the whole file instead of becoming a rejected promise a test could mask.
-        engine.SetValue("__wptReadResource", new ClrFunction(engine, "__wptReadResource", (_, args) =>
+        return engine;
+    }
+
+    /// <summary>
+    /// Installs the shim's <c>fetch</c> back-end: a reader over the vendored tree, so that a suite's
+    /// <c>fetch("resources/urltestdata.json")</c> finds its corpus.
+    /// </summary>
+    /// <remarks>
+    /// A path the corpus does not hold is a vendoring bug rather than a test failure, so it erupts as a CLR
+    /// exception and is reported as a harness error for the whole file instead of becoming a rejected promise a
+    /// test could mask. The worker lane installs the same reader on the worker engine, so a file's environment
+    /// does not depend on which lane ran it.
+    /// </remarks>
+    internal static void InstallResourceReader(Engine engine, string directory)
+        => engine.SetValue("__wptReadResource", new ClrFunction(engine, "__wptReadResource", (_, args) =>
         {
             var reference = TypeConverter.ToString(args.At(0));
             return WptCorpus.Read(WptCorpus.ResolveReference(directory, reference));
         }));
-
-        return engine;
-    }
 
     /// <summary>
     /// Drives the engine until the shim reports every async test and promise test settled. Returns

--- a/Jint.Tests/Wpt/WptTestRunner.cs
+++ b/Jint.Tests/Wpt/WptTestRunner.cs
@@ -8,8 +8,8 @@ namespace Jint.Tests.Wpt;
 
 /// <summary>
 /// Runs the vendored web-platform-tests suites for the URL, URL Pattern, Encoding, Web Cryptography,
-/// Streams, Compression and File API standards, one theory case per <c>.any.js</c> file, under the harness
-/// shim in <c>Prelude/testharness-shim.js</c>.
+/// Streams, Compression, File API and Workers standards, one theory case per <c>.any.js</c> file, under the
+/// harness shim in <c>Prelude/testharness-shim.js</c>.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -27,16 +27,25 @@ namespace Jint.Tests.Wpt;
 /// by https://github.com/sebastienros/jint/issues/3121, and both the WebCryptoAPI corpus found are fixed too:
 /// the point at which <c>SubtleCrypto</c> copies its caller's bytes by
 /// https://github.com/sebastienros/jint/issues/3179, and ECDH's mismatched-curve error by
-/// https://github.com/sebastienros/jint/issues/3180. The category holds the five the streams corpus filed
-/// and the one the File API corpus did — an <c>Array.prototype.values</c> defect with no web API in it at
-/// all; <c>Vendor/README.md</c> analyses each.
+/// https://github.com/sebastienros/jint/issues/3180. The category holds the five the streams corpus filed,
+/// the one the File API corpus did — an <c>Array.prototype.values</c> defect with no web API in it at all —
+/// and the one the workers corpus did, which is a <c>self</c> installed against <c>Window</c>'s definition
+/// for every global including a worker's. <c>Vendor/README.md</c> analyses each.
 /// </para>
 /// <para>
-/// <b>The WebCryptoAPI, streams and FileAPI corpora are one suite per directory</b> rather than one for the
-/// lot, because <see cref="WptCorpus.TestFiles"/> lists a directory's own files and never descends. That is
-/// deliberate: a suite is a theory, a theory is a line in a test report, and seventeen of them tell a reader
-/// which operation went red where three would not. <c>compression/</c> and <c>urlpattern/</c> have a single
-/// directory apiece and are therefore one suite apiece.
+/// <b>The WebCryptoAPI, streams, FileAPI and workers corpora are one suite per directory</b> rather than one
+/// for the lot, because <see cref="WptCorpus.TestFiles"/> lists a directory's own files and never descends.
+/// That is deliberate: a suite is a theory, a theory is a line in a test report, and twenty of them tell a
+/// reader which operation went red where four would not. <c>compression/</c> and <c>urlpattern/</c> have a
+/// single directory apiece and are therefore one suite apiece.
+/// </para>
+/// <para>
+/// <b>The <c>workers/</c> corpus runs in a lane of its own</b>: its files are the body of a real module
+/// worker rather than a script in the driver's engine, because every one of them carries
+/// <c>// META: global=worker</c> and would otherwise assert nothing about a worker. See
+/// <see cref="WptHarness.RunsInAWorker"/> for how the lane is chosen, <see cref="WptWorkerProvider"/> for the
+/// provider and the cooperative pump, and <c>Vendor/README.md</c> for the twenty upstream files the lane
+/// still cannot reach.
 /// </para>
 /// </remarks>
 public class WptTestRunner
@@ -165,6 +174,57 @@ public class WptTestRunner
         // about the reader's state machine (readyState, abort, the progress events) rather than about a Blob.
         // Its sibling unicode.any.js needs no reader at all and *is* vendored.
         ("FileAPI/fileReader.any.js", "FileReader is not implemented"),
+
+        // ---------------------------------------------------------------- workers
+        // Twenty-one files that look like the most runnable thing in the directory and are the least: every
+        // single one opens with `importScripts("/resources/testharness.js")` at file scope. A .worker.js is a
+        // *classic* worker's top-level script, and Jint runs module workers only — importScripts is present and
+        // throws a TypeError, which is the module-worker step the specification itself prescribes. So the file
+        // throws before registering a test, and a harness error is for the whole file rather than something a
+        // per-test exclusion can name. What they assert about the worker global is asserted instead by the
+        // vendored `.any.js` files beside them and by Jint.Tests/Runtime/WebApi/WorkerMechanismTests.cs.
+        ("workers/*.worker.js", "a classic worker's top-level script: importScripts at file scope"),
+
+        // SharedWorker and its global, which Jint does not have — the design records it as still open, needing
+        // a cross-engine name registry. `global=sharedworker` files cannot even be run in the worker lane:
+        // there is no shared worker to be the global of.
+        ("workers/SharedWorker-*.any.js", "SharedWorker is not implemented"),
+        ("workers/semantics/interface-objects/*", "global=sharedworker, and the .worker.js pair above"),
+
+        // Upstream's own tutorial directory, and it teaches wpt rather than testing an engine: general.any.js
+        // is two tests, the second of which asserts
+        // `location.pathname === "/workers/examples/general.any.worker.js"` — the path of the glue script the
+        // wpt server generates for a `.any.js` file. There is no server here to generate one. onconnect.any.js
+        // beside it is global=sharedworker.
+        ("workers/examples/*", "upstream's tutorial: asserts the wpt server's own generated glue, and a SharedWorker"),
+
+        // `.sub.` is server-side substitution: wptserve rewrites {{host}}/{{ports[…]}} into a real origin
+        // before serving the file. Nothing here serves anything, so a vendored copy would carry the
+        // placeholders verbatim. Worker-location.sub.any.js additionally asserts every member of a
+        // WorkerLocation, which is the declined feature below.
+        ("workers/Worker-location.sub.any.js", "needs wptserve substitution and a WorkerLocation"),
+        ("workers/interfaces/WorkerUtils/importScripts/*", "classic-worker importScripts, most of it .sub. as well"),
+        ("workers/importscripts_mime*.any.js", "classic-worker importScripts, over server-chosen MIME types"),
+
+        // The only file in the directory whose whole assertion is `location === location`. The harness shim
+        // installs a stub `location` of its own — `/common/subset-tests.js` reads `location.search` to pick a
+        // shard — so a vendored copy would pass against the shim while Jint deliberately has no WorkerLocation
+        // at all (the worker's script name is its Module.Location). A test that can only assert the harness is
+        // worse than no test, which is why this is a not-vendored row and not an exclusion.
+        ("workers/interfaces/WorkerGlobalScope/location/*", "would assert the shim's own stub location"),
+
+        // The module-worker corpus, and the one row here that is a finding rather than a decision. Every one of
+        // the nine worker scripts import-test-cases.js drives opens with
+        // `if ('DedicatedWorkerGlobalScope' in self && self instanceof DedicatedWorkerGlobalScope)` and installs
+        // its onmessage handler *inside* that branch. Jint ships no DedicatedWorkerGlobalScope interface object
+        // (the design's divergence #5, ruled together with #3195 — an interface object without the prototype
+        // chain would make `instanceof` lie), so no branch is taken, no handler is installed, the worker never
+        // answers, and all nine promise_tests hang: a harness error for the whole file with no test to name.
+        // The sniff is in the fixture rather than in an assertion, which is exactly why no per-test exclusion
+        // can express it. What the file would have proved about module loading in a worker — static, nested,
+        // dynamic, and the two orders of the pair — is proved instead by WorkerMechanismTests' module pins.
+        // The blob-url and data-url siblings need URL.createObjectURL and a data: module loader on top of that.
+        ("workers/modules/*", "the fixtures sniff DedicatedWorkerGlobalScope, which Jint deliberately does not expose"),
     ];
 
     /// <summary>
@@ -382,6 +442,21 @@ public class WptTestRunner
         ["FileAPI/file/File-constructor.any.js"] = 49,
 
         ["FileAPI/unicode.any.js"] = 4,
+
+        // Small numbers, because these files are small: the worker corpus asks one question per file about the
+        // global it is running in, and the floor is what proves the file reached a worker at all rather than
+        // failing to start one.
+        ["workers/Worker-base64.any.js"] = 1,
+        ["workers/Worker-constructor-proto.any.js"] = 1,
+        ["workers/Worker-custom-event.any.js"] = 1,
+        ["workers/Worker-formdata.any.js"] = 1,
+        ["workers/Worker-replace-event-handler.any.js"] = 1,
+        ["workers/Worker-replace-global-constructor.any.js"] = 1,
+        ["workers/Worker-replace-self.any.js"] = 1,
+        ["workers/WorkerNavigator-hardware-concurrency.any.js"] = 1,
+        ["workers/WorkerNavigator.any.js"] = 1,
+        ["workers/interfaces/WorkerGlobalScope/self.any.js"] = 4,
+        ["workers/semantics/multiple-workers/exposure.any.js"] = 2,
     };
 
     /// <summary>
@@ -758,6 +833,35 @@ public class WptTestRunner
             "ToUint32 should be applied to the length and any exceptions should be propagated.", WptDivergence.NeedsTriage),
         new("FileAPI/blob/Blob-constructor.any.js",
             "Getters and value conversions should happen in order until an exception is thrown.", WptDivergence.NeedsTriage),
+
+        // ---------------------------------------------------------------- workers
+        // Six rows, five of them one decision family and none of them a surprise: the worker global is the
+        // global the engine already builds plus the worker names, and these are the names it deliberately does
+        // not add. Each is a numbered divergence in the design — see WptDivergence.NeedsDeclinedWorkerGlobals
+        // for the three citations. That is the whole of what this corpus found to be missing, which is the
+        // useful figure: everything else it asks of a worker global passes.
+        new("workers/Worker-replace-self.any.js",
+            "Test that self is not replaceable.", WptDivergence.NeedsDeclinedWorkerGlobals),
+        new("workers/interfaces/WorkerGlobalScope/self.any.js",
+            "self instanceof WorkerGlobalScope", WptDivergence.NeedsDeclinedWorkerGlobals),
+        new("workers/Worker-constructor-proto.any.js",
+            "Tests that setting the proto of a built in constructor is not reset.", WptDivergence.NeedsDeclinedWorkerGlobals),
+        new("workers/WorkerNavigator.any.js",
+            "Testing Navigator properties on workers.", WptDivergence.NeedsDeclinedWorkerGlobals),
+        new("workers/WorkerNavigator-hardware-concurrency.any.js",
+            "Test worker navigator hardware concurrency.", WptDivergence.NeedsDeclinedWorkerGlobals),
+
+        // Nesting is off by default, so `Worker` is undefined inside a worker — a grant withheld rather than a
+        // name declined, which is why it is its own category. The file's other row asserts that SharedWorker is
+        // absent outside a window and passes.
+        new("workers/semantics/multiple-workers/exposure.any.js", "Worker exposure", WptDivergence.NeedsWorkerNesting),
+
+        // The one genuine defect this corpus found, and it is not in the worker code: `self` is installed once
+        // for every global as a writable data property, against Window's [Replaceable] definition, and
+        // WorkerGlobalScope's is read-only. Recorded rather than fixed — the install predates Worker and is
+        // shared with the top-level lane, so moving it is not a change this corpus gets to make. See
+        // WptDivergence.NeedsTriage.
+        new("workers/interfaces/WorkerGlobalScope/self.any.js", "self = 1", WptDivergence.NeedsTriage),
     ];
 
     public static IEnumerable<object[]> UrlSuiteFiles() => Cases("url");
@@ -853,6 +957,24 @@ public class WptTestRunner
 
     public static IEnumerable<object[]> FileApiFileSuiteFiles() => Cases("FileAPI/file");
 
+    /// <summary>
+    /// The three vendored <c>workers/</c> directories. Every file in them runs <b>inside a real module
+    /// worker</b> — see <see cref="WptHarness.RunsInAWorker"/> for the rule and <c>Vendor/README.md</c> for the
+    /// twenty upstream files that cannot be reached at all.
+    /// </summary>
+    private static readonly string[] _workersSuites =
+    [
+        "workers",
+        "workers/interfaces/WorkerGlobalScope",
+        "workers/semantics/multiple-workers",
+    ];
+
+    public static IEnumerable<object[]> WorkersSuiteFiles() => Cases("workers");
+
+    public static IEnumerable<object[]> WorkerGlobalScopeSuiteFiles() => Cases("workers/interfaces/WorkerGlobalScope");
+
+    public static IEnumerable<object[]> MultipleWorkersSuiteFiles() => Cases("workers/semantics/multiple-workers");
+
     [Theory]
     [MemberData(nameof(UrlSuiteFiles))]
     public void RunsTheUrlSuite(string file) => RunSuiteFile(file);
@@ -941,6 +1063,18 @@ public class WptTestRunner
     [MemberData(nameof(FileApiFileSuiteFiles))]
     public void RunsTheFileApiFileSuite(string file) => RunSuiteFile(file);
 
+    [Theory]
+    [MemberData(nameof(WorkersSuiteFiles))]
+    public void RunsTheWorkersSuite(string file) => RunSuiteFile(file);
+
+    [Theory]
+    [MemberData(nameof(WorkerGlobalScopeSuiteFiles))]
+    public void RunsTheWorkerGlobalScopeSuite(string file) => RunSuiteFile(file);
+
+    [Theory]
+    [MemberData(nameof(MultipleWorkersSuiteFiles))]
+    public void RunsTheMultipleWorkersSuite(string file) => RunSuiteFile(file);
+
     /// <summary>
     /// The inventory check: what is vendored, what is run, and what is deliberately absent must all agree.
     /// </summary>
@@ -1002,6 +1136,7 @@ public class WptTestRunner
         CheckSuiteGroup("WebCryptoAPI/", _webCryptoSuites);
         CheckSuiteGroup("streams/", _streamsSuites);
         CheckSuiteGroup("FileAPI/", _fileApiSuites);
+        CheckSuiteGroup("workers/", _workersSuites);
 
         string.Join(Environment.NewLine, problems).Should().BeEmpty();
 
@@ -1103,6 +1238,62 @@ public class WptTestRunner
 
         reachedBy.Keys.Should().BeEquivalentTo(vendored,
             "every vendored .any.js must be reached by a theory, and a theory must reach nothing else");
+    }
+
+    /// <summary>
+    /// The worker lane holds exactly the <c>workers/</c> corpus, and holds all of it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="WptHarness.RunsInAWorker"/> asks two questions, and a corpus bump can break either. A
+    /// <c>workers/</c> file whose <c>// META: global=</c> line stopped naming a worker global would quietly
+    /// fall back to the top-level engine, where it would assert nothing about a worker and stay green — the
+    /// most expensive kind of silence a conformance driver can have. And a file vendored into
+    /// <c>workers/</c> that is really about a <i>window</i> creating a worker would be run as a worker's own
+    /// body, which is not what it is for.
+    /// </para>
+    /// <para>
+    /// So both directions are pinned here rather than left to the rule. Everything outside <c>workers/</c> is
+    /// covered by the same walk, which is what says the lane cannot widen: the directory clause is the reason
+    /// no previously vendored suite can move, and this is the check that it stays the reason.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void EveryWorkerLaneFileIsAWorkersFile()
+    {
+        var problems = new List<string>();
+        var inTheWorkerLane = 0;
+
+        foreach (var path in WptCorpus.Paths)
+        {
+            if (!path.EndsWith(".any.js", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var inWorkersDirectory = path.StartsWith("workers/", StringComparison.Ordinal);
+            var runsInAWorker = WptHarness.RunsInAWorker(path);
+
+            if (runsInAWorker)
+            {
+                inTheWorkerLane++;
+            }
+
+            if (runsInAWorker && !inWorkersDirectory)
+            {
+                problems.Add($"{path} would run inside a worker, but only the workers/ corpus is meant to");
+            }
+            else if (inWorkersDirectory && !runsInAWorker)
+            {
+                problems.Add($"{path} is a workers/ file that would run in the top-level engine, where it "
+                    + "would assert nothing about a worker");
+            }
+        }
+
+        string.Join(Environment.NewLine, problems).Should().BeEmpty();
+
+        // And the lane is not empty, which the two rules above would both be satisfied by.
+        inTheWorkerLane.Should().BeGreaterThanOrEqualTo(10, "the workers/ corpus runs inside real workers");
     }
 
     [Fact]

--- a/Jint.Tests/Wpt/WptWorkerProvider.cs
+++ b/Jint.Tests/Wpt/WptWorkerProvider.cs
@@ -1,0 +1,141 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using System.Threading;
+using Jint.Runtime.Modules;
+using Jint.WebApi;
+
+namespace Jint.Tests.Wpt;
+
+/// <summary>
+/// The driver's <see cref="WorkerProvider"/>: it builds the engine that runs one worker-scoped
+/// <c>.any.js</c> file, and hands the driver a live list of the connections to pump.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>This is test infrastructure, not shipped code.</b> It is the simplest provider that can be correct for
+/// a single-threaded driver, and it is deliberately the <i>cooperative</i> shape rather than the
+/// thread-per-worker one: <see cref="OnWorkerStarted"/> starts nothing, and the driver's own pump loop calls
+/// <c>ProcessTasks</c> on the parent and on every live worker in turn. That keeps the whole run on one thread,
+/// so a suite's outcome cannot depend on how two schedulers happened to interleave — which is what a
+/// conformance corpus needs and what <c>Advanced.WaitForScheduledWork</c> would only obscure here, since
+/// nothing in this driver blocks waiting for a worker.
+/// </para>
+/// <para>
+/// <b>Why the file runs inside a worker at all.</b> Every <c>.any.js</c> in wpt's <c>workers/</c> directory
+/// that this corpus can reach carries <c>// META: global=worker</c> or <c>global=dedicatedworker</c> — there
+/// is no window variant, because the file's whole subject is the worker global. Running such a file in the
+/// driver's top-level engine, the way every other vendored suite is run, would assert nothing about workers:
+/// <c>Worker-custom-event.any.js</c> would test the driver engine's own <c>addEventListener</c> and pass
+/// without a worker existing. <see cref="WptHarness"/> therefore reads the <c>global=</c> key it otherwise
+/// ignores and routes those files here — see its class remarks for the rule and for why no previously
+/// vendored file changes lane.
+/// </para>
+/// <para>
+/// <b>The file becomes the worker's module body.</b> Jint runs module workers only (the design's divergence
+/// #2), so there is no classic script to evaluate and no <c>importScripts</c> to pull the harness in with.
+/// The loader below serves one module whose source is the shim, then the file's <c>// META: script=</c>
+/// helpers, then the file itself — the same three-step composition
+/// <see cref="WptHarness"/> performs with three <c>Execute</c> calls for a top-level suite, and legitimate
+/// because the shim installs everything it exports onto <c>globalThis</c> explicitly rather than relying on a
+/// script's own <c>var</c> bindings. The one behavioural difference from a browser's classic worker is that
+/// module code is strict, which is recorded in <c>Vendor/README.md</c>; no vendored file depends on sloppy
+/// mode today.
+/// </para>
+/// </remarks>
+internal sealed class WptWorkerProvider : WorkerProvider
+{
+    private readonly string _moduleSource;
+    private readonly string _directory;
+    private readonly List<WorkerConnection> _live = [];
+
+    /// <param name="moduleSource">The shim, the META helpers and the test file, already concatenated.</param>
+    /// <param name="directory">The directory a worker-side <c>fetch()</c> resolves a corpus file against.</param>
+    internal WptWorkerProvider(string moduleSource, string directory)
+    {
+        _moduleSource = moduleSource;
+        _directory = directory;
+    }
+
+    /// <summary>
+    /// The connections that have started and not ended, in start order. Single-threaded by construction —
+    /// every callback on this provider runs on the driver's own thread, because nothing else ever pumps.
+    /// </summary>
+    internal IReadOnlyList<WorkerConnection> Live => _live;
+
+    /// <summary>
+    /// Every connection that has started, live or not. The driver reads a file's results off the worker
+    /// engine <i>after</i> the run, and a file that ends its own connection with <c>close()</c> would
+    /// otherwise take the engine holding those results out of <see cref="Live"/> with it.
+    /// </summary>
+    internal List<WorkerConnection> Started { get; } = [];
+
+    /// <summary>Every connection that has ended, with the reason, so a suite's teardown can be asserted.</summary>
+    internal List<(string Name, WorkerEndReason Reason)> Ended { get; } = [];
+
+    public override Engine? CreateWorkerEngine(WorkerRequest request)
+    {
+        var options = request.CreateDefaultOptions();
+        options.Modules.ModuleLoader = new WptWorkerModuleLoader(request.Specifier, _moduleSource);
+
+        var engine = new Engine(options);
+
+        // The same two things the driver gives its top-level engine, so a file's environment does not depend
+        // on which lane it ran in: the fetch object model (Headers/Request/Response/FormData, which no feature
+        // flag names on its own — see WptHarness) and the shim's resource reader.
+        WebApiRegistration.InstallFetchModel(engine);
+        WptHarness.InstallResourceReader(engine, _directory);
+
+        return engine;
+    }
+
+    public override void OnWorkerStarted(WorkerConnection connection)
+    {
+        Started.Add(connection);
+        _live.Add(connection);
+    }
+
+    public override void OnWorkerEnded(WorkerConnection connection, WorkerEndReason reason)
+    {
+        _live.Remove(connection);
+        Ended.Add((connection.Name, reason));
+    }
+
+    /// <summary>
+    /// Serves the one module the worker loads, and refuses everything else.
+    /// </summary>
+    /// <remarks>
+    /// A specifier this loader does not know is a vendoring bug rather than a test result — no vendored
+    /// worker-scoped file imports anything — so it raises <see cref="ModuleResolutionException"/>, which the
+    /// worker reports as a startup failure and the driver turns into a harness error naming the specifier.
+    /// </remarks>
+    private sealed class WptWorkerModuleLoader : IModuleLoader
+    {
+        private readonly string _specifier;
+        private readonly string _source;
+
+        internal WptWorkerModuleLoader(string specifier, string source)
+        {
+            _specifier = specifier;
+            _source = source;
+        }
+
+        public ResolvedSpecifier Resolve(string? referencingModuleLocation, ModuleRequest moduleRequest)
+        {
+            if (!string.Equals(moduleRequest.Specifier, _specifier, StringComparison.Ordinal))
+            {
+                throw new ModuleResolutionException(
+                    "The vendored web-platform-tests corpus has no such worker module",
+                    moduleRequest.Specifier,
+                    referencingModuleLocation,
+                    filePath: null);
+            }
+
+            return new ResolvedSpecifier(moduleRequest, moduleRequest.Specifier, Uri: null, SpecifierType.RelativeOrAbsolute);
+        }
+
+        public Jint.Runtime.Modules.Module LoadModule(Engine engine, ResolvedSpecifier resolved)
+            => ModuleFactory.BuildSourceTextModule(engine, resolved, _source);
+    }
+}
+#endif


### PR DESCRIPTION
The capstone of #3167: the reachable subset of web-platform-tests' `workers/` directory, vendored at the existing pin and run against the shipped implementation — **inside a real worker**. Every reachable `.any.js` there is `// META: global=worker`, so running them in the driver's top-level engine would prove nothing; the driver instead grew a worker lane that makes the file the body of a genuine `new Worker(…, { type: 'module' })`, with parent and worker pumped cooperatively on the test's own thread through a thread-free `WptWorkerProvider`. Results are read off the worker engine between turns rather than posted back, so a serializer defect fails an assertion instead of silencing every worker suite. A lane-classification pin (`EveryWorkerLaneFileIsAWorkersFile`) holds both directions of the routing rule.

11 of 31 upstream files vendored (the rest named in the not-vendored table with reasons — browsing-context, classic-worker and `SharedWorker` material), 15 assertions, 0.46 s. Seven exclusion rows in three categories: `NeedsDeclinedWorkerGlobals` (the interface objects, `location` and `WorkerNavigator` the design declines by name), `NeedsWorkerNesting` (off by default, by design), and one genuine `NeedsTriage` — `self` is installed writable everywhere while `WorkerGlobalScope.self` is `readonly`, now tracked as #3224. `NeedsMessageChannel`'s stale "Jint has no worker story" wording is rewritten to what remains true.

Two findings beyond the table: the flagship `modules/dedicated-worker-import.any.js` suite (nine tests of the feature Jint ships) stalls on the canonical `self instanceof DedicatedWorkerGlobalScope` sniff and had to be not-vendored — posted to #3195 as a concrete cost datum for the exposure ruling — and `Vendor/README.md` on main carried live merge-conflict markers from #3215, fixed here since the file was being edited anyway.

Closes the implementation plan of #3167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PnghUC3EKrYa12xQ2LaYyd