### PR TITLE
Web API: add the brotli CompressionFormat to CompressionStream/DecompressionStream

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -492,7 +492,7 @@ exclusion table. Two files are there for that today, and they are opposite ends 
 `streams/readable-byte-streams/construct-byob-request.any.js` throws before registering a case, and
 `compression/decompression-extra-input.any.js` registers four and then waits forever on a stream that a
 conforming implementation would have errored. Prefer a sibling file that asserts the same property by
-*comparing a result* — `decompression-corrupt-input.any.js` does, in four rows — and say in the not-vendored
+*comparing a result* — `decompression-corrupt-input.any.js` does, in six rows — and say in the not-vendored
 row which one it is, so the divergence is still pinned somewhere.
 
 ## Modules

--- a/Jint.Tests/Runtime/WebApi/CompressionStreamTests.cs
+++ b/Jint.Tests/Runtime/WebApi/CompressionStreamTests.cs
@@ -12,7 +12,8 @@ namespace Jint.Tests.Runtime.WebApi;
 /// The pin that matters most is <see cref="DeflateIsTheZlibWrapperNotRawDeflate"/>: the standard's
 /// <c>"deflate"</c> is RFC 1950's ZLIB container, and only <c>"deflate-raw"</c> is RFC 1951's bare bit
 /// stream. The vectors the tests decompress were produced by CPython's <c>zlib</c> module, so they are an
-/// independent implementation's idea of each format rather than a round trip against ourselves.
+/// independent implementation's idea of each format rather than a round trip against ourselves — with the
+/// exception of <see cref="BclBrotliVector"/>, whose provenance is stated on it.
 /// </remarks>
 public class CompressionStreamTests
 {
@@ -29,6 +30,25 @@ public class CompressionStreamTests
     /// <summary>The same payload as gzip — <c>gzip.GzipFile(mtime=0, compresslevel=6)</c>.</summary>
     private const string GzipVector =
         "31,139,8,0,0,0,0,0,0,255,243,72,205,201,201,215,81,240,202,204,43,81,4,0,123,253,209,10,12,0,0,0";
+
+    /// <summary>
+    /// The same payload as brotli, and <b>this one was produced by the BCL</b> —
+    /// <c>new BrotliStream(output, CompressionMode.Compress)</c> at its default level, which emitted these
+    /// same bytes on .NET 8 and on .NET 10. It is therefore not an interop vector; it is a fixed blob to
+    /// decode, so the tests that read it do not depend on this engine's encoder at all. Nothing asserts that
+    /// the encoder still produces it — that would pin a platform's framing choice, which no part of the
+    /// standard fixes. <see cref="ForeignBrotliVector"/> is the independent one.
+    /// </summary>
+    private const string BclBrotliVector = "139,5,128,72,101,108,108,111,44,32,74,105,110,116,33,3";
+
+    /// <summary>
+    /// <c>"expected output"</c> as brotli, taken from web-platform-tests'
+    /// <c>compression/resources/decompression-input.js</c> and therefore produced by a brotli encoder that is
+    /// not .NET's. It is a genuinely independent vector, and it exercises a shape .NET's own encoder never
+    /// emits for this input: the payload is stored literally (readable as ASCII in the bytes below) in an
+    /// uncompressed meta-block, where <see cref="BclBrotliVector"/> is Huffman-coded.
+    /// </summary>
+    private const string ForeignBrotliVector = "33,56,0,4,101,120,112,101,99,116,101,100,32,111,117,116,112,117,116,3";
 
     private const string Payload = "Hello, Jint!";
 
@@ -103,6 +123,7 @@ public class CompressionStreamTests
     [InlineData("gzip")]
     [InlineData("deflate")]
     [InlineData("deflate-raw")]
+    [InlineData("brotli")]
     public void RoundTripsThroughItsOwnCompressor(string format)
     {
         var engine = StreamEngine();
@@ -173,6 +194,7 @@ public class CompressionStreamTests
     [InlineData("gzip", GzipVector)]
     [InlineData("deflate", ZlibVector)]
     [InlineData("deflate-raw", RawDeflateVector)]
+    [InlineData("brotli", BclBrotliVector)]
     public void DecompressesInputSplitOneByteAtATime(string format, string bytes)
     {
         var engine = StreamEngine();
@@ -256,7 +278,8 @@ public class CompressionStreamTests
 
         // Compressing nothing is not an error — it is a valid, tiny member that decompresses to nothing.
         // The lengths are each format's empty member: a gzip header and trailer, a zlib header and
-        // ADLER32, and one final empty DEFLATE block.
+        // ADLER32, and one final empty DEFLATE block. They are exact because CompressionCodec emits them
+        // from constants of its own, the BCL's deflate-family encoders writing nothing at all for no input.
         var text = engine.Evaluate("""
             (async () => {
               const lengths = [];
@@ -271,6 +294,130 @@ public class CompressionStreamTests
 
         text.AsString().Should().Be("gzip:20:empty deflate:8:empty deflate-raw:2:empty");
         Log(engine).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ClosingABrotliCompressionStreamThatReceivedNothingProducesAnEmptyStream()
+    {
+        var engine = StreamEngine();
+
+        // Brotli is the one format with no constant behind it: BrotliStream writes the empty stream itself
+        // when it is closed, so these bytes are the encoder's. The assertion is therefore the property that
+        // matters — some bytes, and they decode to nothing — rather than a length, which would pin an
+        // encoder's framing choice the standard leaves free.
+        var text = engine.Evaluate("""
+            (async () => {
+              const compressed = await compress('brotli', '');
+              const back = await decompress('brotli', compressed);
+              return (compressed.length > 0) + ':' + (back === '' ? 'empty' : back);
+            })()
+            """).UnwrapIfPromise();
+
+        text.AsString().Should().Be("true:empty");
+        Log(engine).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void DecompressesBrotliBytesItDidNotProduce()
+    {
+        var engine = StreamEngine();
+
+        // The independent vector first — a stored meta-block this engine's encoder would never emit for that
+        // input — and then the fixed BCL blob, whole and split one byte at a time.
+        engine.Evaluate($"decompress('brotli', vector('{ForeignBrotliVector}'))")
+            .UnwrapIfPromise().AsString().Should().Be("expected output");
+        engine.Evaluate($"decompress('brotli', vector('{BclBrotliVector}'))")
+            .UnwrapIfPromise().AsString().Should().Be(Payload);
+
+        // https://compression.spec.whatwg.org/#decompressionstream: an empty payload is still a stream, and
+        // this is the two-byte one web-platform-tests uses. It decodes to no chunks at all, not an error.
+        engine.Evaluate("decompress('brotli', [0xa1, 0x01])").UnwrapIfPromise().AsString().Should().BeEmpty();
+
+        Log(engine).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void RoundTripsBrotliOneByteAtATimeOnBothSides()
+    {
+        var engine = StreamEngine();
+
+        // A payload longer than one chunk of anything, written one byte at a time and read back one byte at
+        // a time: the compression context is per stream, not per chunk, on both sides.
+        var text = engine.Evaluate("""
+            (async () => {
+              const original = 'brotli '.repeat(500) + 'é€😀';
+              const compressed = await compress('brotli', original);
+              const back = await decompress('brotli', compressed, 1);
+              return (back === original) + ':' + (compressed.length < original.length);
+            })()
+            """).UnwrapIfPromise();
+
+        text.AsString().Should().Be("true:true");
+        Log(engine).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void RefusesBytesTheBrotliDecoderCannotParse()
+    {
+        var engine = StreamEngine();
+
+        // BrotliStream reports data it cannot parse as InvalidOperationException where the deflate family
+        // raises InvalidDataException — a BCL naming inconsistency DecompressionCodec translates. What is
+        // pinned here is only what script sees: the standard's TypeError on both sides, exactly as for the
+        // other three formats. If the translation is dropped, the CLR exception escapes Evaluate instead.
+        engine.Execute($"var gzip = vector('{GzipVector}');");
+
+        engine.Evaluate("decompress('brotli', gzip)").UnwrapIfPromise().IsNull().Should().BeTrue();
+        Log(engine).Should().Contain("brotli:error:TypeError");
+
+        engine.Execute("log.length = 0;");
+        engine.Execute("""
+            var ds = new DecompressionStream('brotli');
+            drain(ds.readable, 'out');
+            var writer = ds.writable.getWriter();
+            writer.write(new Uint8Array([255, 255, 255, 255, 255, 255, 255, 255])).catch(e => log.push('write:' + e.name));
+            writer.closed.catch(e => log.push('writable:' + e.name));
+            """);
+
+        Log(engine).Should().StartWith("out:error:TypeError:");
+        Log(engine).Should().Contain("write:TypeError").And.Contain("writable:TypeError");
+
+        // And the format names itself in the message, so a script's console says which one refused.
+        Log(engine).Should().Contain("not valid brotli data");
+    }
+
+    [Fact]
+    public void BrotliSharesTheLenientTruncationDivergence()
+    {
+        var engine = StreamEngine();
+
+        // The divergence DecompressionCodec documents on itself, asserted rather than assumed: .NET exposes
+        // no decoder that reports how many bytes it consumed, so a stream that ends mid-member closes
+        // cleanly and bytes after a complete stream are ignored. BrotliStream is no different from the
+        // deflate family here, which is what puts brotli's two rows of
+        // compression/decompression-corrupt-input.any.js under WptDivergence.NeedsIncrementalInflater
+        // alongside them. https://compression.spec.whatwg.org/#decompressionstream calls both an error.
+        engine.Execute($"var full = vector('{BclBrotliVector}');");
+
+        var text = engine.Evaluate("""
+            (async () => {
+              const truncated = await decompress('brotli', full.slice(0, -1));
+              const extended = await decompress('brotli', full.concat([0]));
+              return 'truncated:' + JSON.stringify(truncated) + ' trailing:' + JSON.stringify(extended);
+            })()
+            """).UnwrapIfPromise();
+
+        // Both are what the standard would have errored, and neither loses the payload that did decode.
+        text.AsString().Should().Be($"truncated:\"{Payload}\" trailing:\"{Payload}\"");
+        Log(engine).Should().BeEmpty();
+
+        // The one truncation that is caught stays caught for brotli too: no compressed bytes at all.
+        engine.Execute("""
+            var ds = new DecompressionStream('brotli');
+            drain(ds.readable, 'nothing');
+            ds.writable.getWriter().close().catch(e => log.push('close:' + e.name));
+            """);
+        Log(engine).Should().StartWith("nothing:error:TypeError:").And.Contain("close:TypeError");
     }
 
     [Fact]
@@ -310,22 +457,39 @@ public class CompressionStreamTests
     }
 
     [Theory]
-    [InlineData("brotli")]
     [InlineData("GZIP")]
     [InlineData("Deflate")]
+    [InlineData("Brotli")]
     [InlineData("deflate_raw")]
+    [InlineData("br")]
     [InlineData("")]
     public void RefusesAFormatItDoesNotSupport(string format)
     {
         var engine = StreamEngine();
         engine.SetValue("format", format);
 
-        // The WebIDL enumeration is matched exactly; "brotli" is in it but unsupported here, which the
-        // standard also spells as a TypeError.
+        // https://webidl.spec.whatwg.org/#es-enumeration matches the identifier exactly and
+        // case-sensitively, so none of these is the enumeration value it resembles. "br" in particular is
+        // the HTTP Content-Encoding token for brotli and is not what CompressionFormat calls it.
         Assert.Throws<JavaScriptException>(() => engine.Evaluate("new CompressionStream(format)"))
             .Error.Get("name").AsString().Should().Be("TypeError");
         Assert.Throws<JavaScriptException>(() => engine.Evaluate("new DecompressionStream(format)"))
             .Error.Get("name").AsString().Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void AcceptsEveryFormatTheEnumerationNames()
+    {
+        var engine = StreamEngine();
+
+        // https://compression.spec.whatwg.org/#supported-formats declares four values, and the constructors'
+        // step 1 — "if format is unsupported in CompressionStream, then throw a TypeError" — now has nothing
+        // left to refuse. This is the test that fails when a format arm is removed from the validation.
+        engine.Evaluate("""
+            ['deflate', 'deflate-raw', 'gzip', 'brotli']
+              .map(f => f + ':' + (new CompressionStream(f) && new DecompressionStream(f) ? 'ok' : 'no'))
+              .join(' ')
+            """).AsString().Should().Be("deflate:ok deflate-raw:ok gzip:ok brotli:ok");
     }
 
     [Fact]

--- a/Jint.Tests/Wpt/Vendor/README.md
+++ b/Jint.Tests/Wpt/Vendor/README.md
@@ -251,30 +251,40 @@ runs them without `--expose-gc`.
 
 ## What the compression corpus says about this engine
 
-297 assertions across 15 files, of which **84 do not pass** — and 68 of those are one word.
+297 assertions across 15 files, of which **22 do not pass**.
 
-**`brotli` is 68 of the 84** (`NeedsBrotli`). The Compression Standard's `CompressionFormat` enumeration
+**It was 84, and 68 of those were one word.** The Compression Standard's `CompressionFormat` enumeration
 lists `brotli` alongside `deflate`, `deflate-raw` and `gzip`, and the corpus's `resources/formats.js` loops
-over all four, so every per-format family in every file has a brotli row. Refusing it is *conforming* —
-`new CompressionStream(format)` step 1 is "if *format* is unsupported in `CompressionStream`, then throw a
-`TypeError`", which is exactly what this engine answers — but the corpus does not ask that question, it
-assumes support. This is nevertheless the one exclusion category in this directory that is neither a platform
-limit nor a deliberate reduction: **.NET ships `BrotliStream`**, on the same pull-stream shape
-`CompressionCodec`/`DecompressionCodec` already drive for the other three formats, so it is a feature to add.
+over all four, so every per-format family in every file has a brotli row. Refusing the format was
+*conforming* — `new CompressionStream(format)` step 1 is "if *format* is unsupported in `CompressionStream`,
+then throw a `TypeError`" — but the corpus does not ask that question, it assumes support, and this was the
+one exclusion category in this directory that was neither a platform limit nor a deliberate reduction: .NET
+ships `BrotliStream`, on the same pull-stream shape `CompressionCodec`/`DecompressionCodec` already drove for
+the other three formats. https://github.com/sebastienros/jint/issues/3210 wired it in, and **62 of the 68
+rows went green with it**. The other six did not vanish, they moved: four to `NeedsWebAssembly` and two to
+`NeedsIncrementalInflater`, joining their deflate and gzip siblings for reasons that have nothing to do with
+brotli.
 
-**12 are `NeedsWebAssembly`**: the `SharedArrayBuffer` and shared-`Uint8Array` rows of the two bad-chunk
-files, which build their SAB through `WebAssembly.Memory` inline rather than through `common/sab.js`.
+**16 are `NeedsWebAssembly`**: the `SharedArrayBuffer` and shared-`Uint8Array` rows of the two bad-chunk
+files, which build their SAB through `WebAssembly.Memory` inline rather than through `common/sab.js`. All
+four formats, both files, both chunk types — eight rows per file, and now one glob per chunk type rather than
+one entry per format, which is a shape the table could not have while brotli's row of each pair failed for a
+different reason.
 
-**The remaining 4 are the two lenient-decompression divergences, and they are the reason this corpus was
+**The remaining 6 are the two lenient-decompression divergences, and they are the reason this corpus was
 worth running.** `DecompressionCodec` documents both on itself: the standard makes it an error for a stream
 to end before its member is complete and an error for anything to follow the member, and detecting either
 needs to know how many of the bytes handed over the decompressor actually *consumed* — which .NET's pull
-streams do not report. `decompression-corrupt-input.any.js` is the only file in the corpus that asserts them,
-in four rows (`truncating the input` and `trailing junk`, for `deflate` and for `gzip`), and they are excluded
-under `NeedsIncrementalInflater` with that citation. Everything else that file checks passes: a bad CMF or
-gzip ID, a bad FCHECK, an FHCRC flag, a corrupted last data byte, a wrong ADLER32, CRC32 or ISIZE, a
-dictionary-compressed stream, and every field the formats say may hold anything. So the divergence is exactly
-"a corrupt member is still rejected; an *incomplete* or *over-long* one is not", which is what the class says.
+streams do not report, `BrotliStream` no more than the deflate family.
+`decompression-corrupt-input.any.js` is the only file in the corpus that asserts them, in six rows
+(`truncating the input` and `trailing junk`, for each of that file's three formats — `deflate`, `gzip` and
+`brotli`), and they are excluded under `NeedsIncrementalInflater` with that citation. Everything else that
+file checks passes: a bad CMF or gzip ID, a bad FCHECK, an FHCRC flag, a corrupted last data byte, a wrong
+ADLER32, CRC32 or ISIZE, a dictionary-compressed stream, every field the formats say may hold anything, and
+all three unchanged inputs. So the divergence is exactly "a corrupt member is still rejected; an *incomplete*
+or *over-long* one is not", which is what the class says — and adding a fourth format did not widen it,
+because a brotli stream that cannot be parsed is still an error and the two that pass through are still only
+these two.
 
 A fifth file, `decompression-extra-input.any.js`, asserts the trailing-byte half by *waiting* for the error
 rather than by comparing a result, and therefore stalls instead of failing — see the not-vendored table.

--- a/Jint.Tests/Wpt/WptExclusions.cs
+++ b/Jint.Tests/Wpt/WptExclusions.cs
@@ -214,40 +214,29 @@ internal enum WptDivergence
 
     /// <summary>
     /// <para>
-    /// The test asks for the <c>brotli</c> <c>CompressionFormat</c>, which
-    /// https://compression.spec.whatwg.org/#compressionstream lists in the enumeration and which this engine
-    /// answers with the <c>TypeError</c> the constructor's own step 1 asks for — "if <i>format</i> is
-    /// unsupported in <c>CompressionStream</c>, then throw a <c>TypeError</c>". Refusing it is therefore
-    /// conforming; the corpus loops over the whole enumeration and assumes support, so every one of its
-    /// per-format families has a brotli row that fails on the constructor before reaching what the file is
-    /// actually about.
-    /// </para>
-    /// <para>
-    /// <b>This is the one category here that is neither a platform limit nor a deliberate reduction.</b>
-    /// .NET ships <c>BrotliStream</c> in <c>System.IO.Compression</c>, on exactly the pull-stream shape
-    /// <c>CompressionCodec</c>/<c>DecompressionCodec</c> already drive for the other three formats, so
-    /// closing it is a feature to add rather than something the BCL forbids. It stays out of this change
-    /// because a corpus that first runs a suite must not also be the change that moves the engine.
-    /// </para>
-    /// </summary>
-    NeedsBrotli,
-
-    /// <summary>
-    /// <para>
     /// The test asserts one of the two lenient-decompression divergences <c>DecompressionCodec</c> documents
     /// on itself: https://compression.spec.whatwg.org/#decompressionstream makes it an error for a stream to
     /// end before its member is complete, and an error for anything to follow the member. Detecting either
     /// needs to know how many of the bytes handed over the decompressor actually consumed, and .NET exposes
-    /// no incremental inflater — only <c>GZipStream</c>, <c>ZLibStream</c> and <c>DeflateStream</c>, which
-    /// pull from a source stream, buffer input internally and report neither figure. So a truncated stream
-    /// ends its readable side cleanly and trailing bytes are ignored.
+    /// no incremental inflater or decoder — only <c>GZipStream</c>, <c>ZLibStream</c>, <c>DeflateStream</c>
+    /// and <c>BrotliStream</c>, which pull from a source stream, buffer input internally and report neither
+    /// figure. So a truncated stream ends its readable side cleanly and trailing bytes are ignored.
     /// </para>
     /// <para>
-    /// Four rows of <c>decompression-corrupt-input.any.js</c> are the whole of it, and everything the
-    /// decompressor itself rejects — a bad header, a failed CRC32/ADLER32, a malformed DEFLATE block, a
-    /// dictionary-compressed stream, an empty input — is still an error and still passes, which is the case
-    /// that matters for telling corrupt input from good. The one file that asserts the same divergence by
-    /// <i>waiting</i> for the error rather than by comparing a result,
+    /// <b><c>brotli</c> shares the divergence rather than escaping it.</b> Its rows were parked under a
+    /// category of their own while the format was refused outright, on the reasoning that they never reached
+    /// the point where this divergence could decide them;
+    /// https://github.com/sebastienros/jint/issues/3210 implemented the format and they landed here, because
+    /// <c>BrotliStream</c> answers a dropped last byte and an appended junk byte exactly as the deflate
+    /// family does — it hands over the payload it decoded and then reports "no more input for now".
+    /// </para>
+    /// <para>
+    /// Six rows of <c>decompression-corrupt-input.any.js</c> are the whole of it — <c>truncating the input</c>
+    /// and <c>trailing junk</c>, for each of that file's three formats — and everything the decompressor
+    /// itself rejects — a bad header, a failed CRC32/ADLER32, a malformed DEFLATE block, a brotli stream the
+    /// decoder cannot parse, a dictionary-compressed stream, an empty input — is still an error and still
+    /// passes, which is the case that matters for telling corrupt input from good. The one file that asserts
+    /// the same divergence by <i>waiting</i> for the error rather than by comparing a result,
     /// <c>compression/decompression-extra-input.any.js</c>, is not vendored: it stalls rather than fails.
     /// </para>
     /// </summary>

--- a/Jint.Tests/Wpt/WptTestRunner.cs
+++ b/Jint.Tests/Wpt/WptTestRunner.cs
@@ -152,7 +152,7 @@ public class WptTestRunner
         // — so the read waits for input that cannot arrive and the *file* stalls rather than any test failing.
         // A stalled run is a harness error for the whole file, which no per-test exclusion can name, exactly
         // as streams/readable-byte-streams/construct-byob-request.any.js is. The divergence itself is still
-        // asserted, by decompression-corrupt-input.any.js's four excluded rows.
+        // asserted, by decompression-corrupt-input.any.js's six excluded rows.
         ("compression/decompression-extra-input.any.js",
             "hangs on the trailing-byte divergence rather than failing a test"),
 
@@ -770,51 +770,26 @@ public class WptTestRunner
             "enqueue() must not synchronously call write algorithm", WptDivergence.NeedsTriage),
 
         // ---------------------------------------------------------------- compression
-        // Every "brotli" row of every file. The Compression Standard's CompressionFormat enumeration lists
-        // brotli, and its constructor step 1 — "if format is unsupported in CompressionStream, then throw a
-        // TypeError" — is what makes refusing it conforming rather than wrong; the corpus loops over the
-        // enumeration and assumes support. See WptDivergence.NeedsBrotli, which records that .NET does ship
-        // BrotliStream, so this is a gap to close rather than a platform limit.
-        new("compression/compression-bad-chunks.any.js", "chunk of type * should error the stream for brotli", WptDivergence.NeedsBrotli),
-        new("compression/compression-including-empty-chunk.any.js", "the result of compressing * with brotli should be 'HelloHello'", WptDivergence.NeedsBrotli),
-        new("compression/compression-large-flush-output.any.js", "brotli compression with large flush output", WptDivergence.NeedsBrotli),
-        new("compression/compression-multiple-chunks.any.js", "compressing * chunks with brotli should work", WptDivergence.NeedsBrotli),
-        new("compression/decompression-bad-chunks.any.js", "chunk of type * should error the stream for brotli", WptDivergence.NeedsBrotli),
-        new("compression/decompression-buffersource.any.js", "chunk of type * should work for brotli", WptDivergence.NeedsBrotli),
-        new("compression/decompression-correct-input.any.js", "decompressing brotli input should work", WptDivergence.NeedsBrotli),
-        new("compression/decompression-empty-input.any.js", "decompressing brotli empty input should work", WptDivergence.NeedsBrotli),
-        new("compression/decompression-split-chunk.any.js", "decompressing splitted chunk into pieces of size * should work in brotli", WptDivergence.NeedsBrotli),
-        new("compression/decompression-uint8array-output.any.js", "decompressing brotli output should give Uint8Array chunks", WptDivergence.NeedsBrotli),
-
         // The SharedArrayBuffer rows of the two bad-chunk files, which take their SAB constructor from
-        // WebAssembly.Memory through their own inline helper rather than through common/sab.js. Named one
-        // format at a time, because the brotli row of each pair is above under a different reason and an
-        // exclusion has to say which one applies.
-        new("compression/compression-bad-chunks.any.js", "chunk of type SharedArrayBuffer should error the stream for deflate", WptDivergence.NeedsWebAssembly),
-        new("compression/compression-bad-chunks.any.js", "chunk of type SharedArrayBuffer should error the stream for deflate-raw", WptDivergence.NeedsWebAssembly),
-        new("compression/compression-bad-chunks.any.js", "chunk of type SharedArrayBuffer should error the stream for gzip", WptDivergence.NeedsWebAssembly),
-        new("compression/compression-bad-chunks.any.js", "chunk of type shared Uint8Array should error the stream for deflate", WptDivergence.NeedsWebAssembly),
-        new("compression/compression-bad-chunks.any.js", "chunk of type shared Uint8Array should error the stream for deflate-raw", WptDivergence.NeedsWebAssembly),
-        new("compression/compression-bad-chunks.any.js", "chunk of type shared Uint8Array should error the stream for gzip", WptDivergence.NeedsWebAssembly),
-        new("compression/decompression-bad-chunks.any.js", "chunk of type SharedArrayBuffer should error the stream for deflate", WptDivergence.NeedsWebAssembly),
-        new("compression/decompression-bad-chunks.any.js", "chunk of type SharedArrayBuffer should error the stream for deflate-raw", WptDivergence.NeedsWebAssembly),
-        new("compression/decompression-bad-chunks.any.js", "chunk of type SharedArrayBuffer should error the stream for gzip", WptDivergence.NeedsWebAssembly),
-        new("compression/decompression-bad-chunks.any.js", "chunk of type shared Uint8Array should error the stream for deflate", WptDivergence.NeedsWebAssembly),
-        new("compression/decompression-bad-chunks.any.js", "chunk of type shared Uint8Array should error the stream for deflate-raw", WptDivergence.NeedsWebAssembly),
-        new("compression/decompression-bad-chunks.any.js", "chunk of type shared Uint8Array should error the stream for gzip", WptDivergence.NeedsWebAssembly),
+        // WebAssembly.Memory through their own inline helper rather than through common/sab.js. One glob per
+        // chunk type covers all four formats, which it could not do while brotli's rows of the same families
+        // failed for a different reason — https://github.com/sebastienros/jint/issues/3210 removed that
+        // reason, so the entry can now say the one thing that is actually true of every row it names.
+        new("compression/compression-bad-chunks.any.js", "chunk of type SharedArrayBuffer should error the stream for *", WptDivergence.NeedsWebAssembly),
+        new("compression/compression-bad-chunks.any.js", "chunk of type shared Uint8Array should error the stream for *", WptDivergence.NeedsWebAssembly),
+        new("compression/decompression-bad-chunks.any.js", "chunk of type SharedArrayBuffer should error the stream for *", WptDivergence.NeedsWebAssembly),
+        new("compression/decompression-bad-chunks.any.js", "chunk of type shared Uint8Array should error the stream for *", WptDivergence.NeedsWebAssembly),
 
-        // The two lenient-decompression divergences DecompressionCodec documents, and the only four rows in
+        // The two lenient-decompression divergences DecompressionCodec documents, and the only six rows in
         // the whole corpus that assert them: a member that ends early and a member with something after it.
-        // Spelled out per format rather than globbed over the quoted name, because the brotli rows of the
-        // same two families are above under NeedsBrotli — they never reach the point where this divergence
-        // could decide them — and deflate-raw is not one of this file's three formats at all.
-        new("compression/decompression-corrupt-input.any.js", "truncating the input for 'deflate' should give an error", WptDivergence.NeedsIncrementalInflater),
-        new("compression/decompression-corrupt-input.any.js", "truncating the input for 'gzip' should give an error", WptDivergence.NeedsIncrementalInflater),
-        new("compression/decompression-corrupt-input.any.js", "trailing junk for 'deflate' should give an error", WptDivergence.NeedsIncrementalInflater),
-        new("compression/decompression-corrupt-input.any.js", "trailing junk for 'gzip' should give an error", WptDivergence.NeedsIncrementalInflater),
-        new("compression/decompression-corrupt-input.any.js", "the unchanged input for 'brotli' should decompress successfully", WptDivergence.NeedsBrotli),
-        new("compression/decompression-corrupt-input.any.js", "truncating the input for 'brotli' should give an error", WptDivergence.NeedsBrotli),
-        new("compression/decompression-corrupt-input.any.js", "trailing junk for 'brotli' should give an error", WptDivergence.NeedsBrotli),
+        // Globbed over the format now, because all three of the formats this file carries — deflate, gzip and
+        // brotli, the fourth value deflate-raw not being one of them — diverge in exactly the same way and for
+        // exactly the same reason: BrotliStream reports how many bytes it consumed no more than the deflate
+        // family does, so the last byte of a brotli stream can be dropped, or a junk byte appended, and the
+        // decoder still hands over the payload rather than erroring. The unchanged-input row of all three
+        // passes, which is what the driver's no-passing-test rule holds these two globs to.
+        new("compression/decompression-corrupt-input.any.js", "truncating the input for * should give an error", WptDivergence.NeedsIncrementalInflater),
+        new("compression/decompression-corrupt-input.any.js", "trailing junk for * should give an error", WptDivergence.NeedsIncrementalInflater),
 
         // ---------------------------------------------------------------- FileAPI
         // Blob.textStream(), which https://w3c.github.io/FileAPI/#dom-blob-textstream added and this Blob

--- a/Jint/Options.WebApi.cs
+++ b/Jint/Options.WebApi.cs
@@ -896,10 +896,9 @@ public enum WebApiFeatures
 
     /// <summary>
     /// <c>CompressionStream</c> and <c>DecompressionStream</c> — https://compression.spec.whatwg.org/ — for
-    /// the three formats the standard's <c>CompressionFormat</c> names and this implementation supports:
-    /// <c>gzip</c> (RFC 1952), <c>deflate</c> (the ZLIB wrapper of RFC 1950, as the standard defines that
-    /// name) and <c>deflate-raw</c> (RFC 1951). <c>brotli</c> is not implemented and, like any other
-    /// unsupported value, is a <c>TypeError</c>.
+    /// all four formats the standard's <c>CompressionFormat</c> names: <c>gzip</c> (RFC 1952),
+    /// <c>deflate</c> (the ZLIB wrapper of RFC 1950, as the standard defines that name), <c>deflate-raw</c>
+    /// (RFC 1951) and <c>brotli</c> (RFC 7932). A value outside the enumeration is a <c>TypeError</c>.
     /// </summary>
     /// <remarks>
     /// <b>Requires <see cref="Streams"/> as well</b>: both are transform streams, so naming this flag on

--- a/Jint/WebApi/Compression/CompressionCodec.cs
+++ b/Jint/WebApi/Compression/CompressionCodec.cs
@@ -60,11 +60,13 @@ internal sealed class CompressionCodec : IDisposable
         _format = format;
 
         // See CompressionFormat: "deflate" is the ZLIB wrapper of RFC 1950, and only "deflate-raw" is the
-        // bare RFC 1951 bit stream.
+        // bare RFC 1951 bit stream. CompressionMode.Compress is CompressionLevel.Optimal for all four, which
+        // is the BCL's default and what the standard leaves free.
         _compressor = format switch
         {
             CompressionFormat.Gzip => new GZipStream(_output, CompressionMode.Compress, leaveOpen: true),
             CompressionFormat.Deflate => new ZLibStream(_output, CompressionMode.Compress, leaveOpen: true),
+            CompressionFormat.Brotli => new BrotliStream(_output, CompressionMode.Compress, leaveOpen: true),
             _ => new DeflateStream(_output, CompressionMode.Compress, leaveOpen: true),
         };
     }
@@ -93,13 +95,22 @@ internal sealed class CompressionCodec : IDisposable
     /// final DEFLATE block — and then everything left is taken out.
     /// </summary>
     /// <remarks>
-    /// The empty case is the constant above rather than the compressor's own output, because the BCL will
-    /// not produce one: a compressing <see cref="DeflateStream"/> that was never handed a byte writes
-    /// <i>nothing at all</i> when it is closed — deliberately, because <c>ZipArchiveEntry</c> depends on
-    /// zero output for zero input. On .NET 8 a zero-length write was enough to arm it and on .NET 10 it is
-    /// not, so relying on that would make the same source produce different bytes per target framework.
-    /// Zero bytes is not a valid stream in any of the three formats — our own <c>DecompressionStream</c>
-    /// rejects it, and so does every other implementation — so the empty member is emitted explicitly.
+    /// <para>
+    /// For the deflate family the empty case is one of the constants above rather than the compressor's own
+    /// output, because the BCL will not produce one: a compressing <see cref="DeflateStream"/> that was never
+    /// handed a byte writes <i>nothing at all</i> when it is closed — deliberately, because
+    /// <c>ZipArchiveEntry</c> depends on zero output for zero input. On .NET 8 a zero-length write was enough
+    /// to arm it and on .NET 10 it is not, so relying on that would make the same source produce different
+    /// bytes per target framework. Zero bytes is not a valid stream in any of those three formats — our own
+    /// <c>DecompressionStream</c> rejects it, and so does every other implementation — so the empty member is
+    /// emitted explicitly.
+    /// </para>
+    /// <para>
+    /// <b><see cref="BrotliStream"/> needs no such constant</b> and deliberately does not get one: closing an
+    /// encoder that was never written to emits the one-byte empty brotli stream on its own (verified on .NET 8
+    /// and .NET 10), so brotli takes the ordinary close path below and the bytes are the encoder's rather than
+    /// ours. Writing a fourth constant would pin an encoder's framing choice that nothing here needs pinned.
+    /// </para>
     /// </remarks>
     internal byte[]? Finish()
     {
@@ -108,15 +119,10 @@ internal sealed class CompressionCodec : IDisposable
             return null;
         }
 
-        if (!_wroteBytes)
+        if (!_wroteBytes && EmptyMember(_format) is { } empty)
         {
             Dispose();
-            return _format switch
-            {
-                CompressionFormat.Gzip => EmptyGzipMember.ToArray(),
-                CompressionFormat.Deflate => EmptyZlibStream.ToArray(),
-                _ => EmptyDeflateBlock.ToArray(),
-            };
+            return empty;
         }
 
         _compressor.Dispose();
@@ -124,6 +130,18 @@ internal sealed class CompressionCodec : IDisposable
         _disposed = true;
         return output;
     }
+
+    /// <summary>
+    /// The format's whole compressed stream for an empty payload, or <see langword="null"/> for a format
+    /// whose own encoder produces one when it is closed.
+    /// </summary>
+    private static byte[]? EmptyMember(CompressionFormat format) => format switch
+    {
+        CompressionFormat.Gzip => EmptyGzipMember.ToArray(),
+        CompressionFormat.Deflate => EmptyZlibStream.ToArray(),
+        CompressionFormat.DeflateRaw => EmptyDeflateBlock.ToArray(),
+        _ => null,
+    };
 
     private byte[]? TakeOutput()
     {

--- a/Jint/WebApi/Compression/CompressionFormat.cs
+++ b/Jint/WebApi/Compression/CompressionFormat.cs
@@ -17,10 +17,11 @@ namespace Jint.WebApi.Compression;
 /// here, and it produces bytes no other implementation can read.
 /// </para>
 /// <para>
-/// The standard's fourth value, <c>"brotli"</c> ([RFC7932]), is not implemented. A value the standard
-/// names but an implementation does not support is a <c>TypeError</c> ("If format is unsupported in
-/// CompressionStream, then throw a TypeError"), which is the same failure a value outside the enumeration
-/// gets from the WebIDL conversion — so a script sees one answer either way.
+/// <b>The standard fixes no compression quality.</b> Its compress step is "compress <i>chunk</i> with
+/// <i>format</i> and <i>context</i>" and nothing anywhere names a level, so every value the enumeration
+/// carries is driven at the BCL's own default — <see cref="System.IO.Compression.CompressionMode.Compress"/>,
+/// which is <see cref="System.IO.Compression.CompressionLevel.Optimal"/>. Implementations differ here and
+/// are entitled to: only the bytes' decodability is normative, not their density.
 /// </para>
 /// </remarks>
 internal enum CompressionFormat
@@ -33,6 +34,13 @@ internal enum CompressionFormat
 
     /// <summary>"The DEFLATE algorithm" [RFC1951] — <see cref="System.IO.Compression.DeflateStream"/>.</summary>
     DeflateRaw,
+
+    /// <summary>
+    /// "Brotli Compressed Data Format" [RFC7932] — <see cref="System.IO.Compression.BrotliStream"/>. It is
+    /// the enumeration's fourth value and the one that needs no wrapper argument at all: the format is a
+    /// single self-delimiting stream, so unlike the deflate family there is no container to choose.
+    /// </summary>
+    Brotli,
 }
 
 /// <summary>
@@ -41,9 +49,10 @@ internal enum CompressionFormat
 internal static class CompressionFormats
 {
     /// <summary>
-    /// The <c>format</c> argument both constructors take: a required <c>CompressionFormat</c>, so a
-    /// missing argument and an unrecognized one are both a <c>TypeError</c> — and so is
-    /// <c>"brotli"</c>, which the enumeration names but this implementation does not support.
+    /// The <c>format</c> argument both constructors take: a required <c>CompressionFormat</c>, so a missing
+    /// argument and an unrecognized one are both a <c>TypeError</c>. All four values the enumeration names
+    /// are supported, which leaves the constructors' own step 1 — "if <i>format</i> is unsupported in
+    /// <c>CompressionStream</c>, then throw a <c>TypeError</c>" — with nothing left to refuse.
     /// </summary>
     internal static CompressionFormat ReadFormat(Realm realm, JsCallArguments arguments, string interfaceName)
     {
@@ -58,14 +67,14 @@ internal static class CompressionFormats
             Throw.TypeError(
                 realm,
                 "Failed to construct '" + interfaceName + "': the provided value '" + value +
-                "' is not a supported CompressionFormat; use 'gzip', 'deflate' or 'deflate-raw'");
+                "' is not a supported CompressionFormat; use 'gzip', 'deflate', 'deflate-raw' or 'brotli'");
         }
 
         return format;
     }
 
     /// <summary>
-    /// Matches one of the three identifiers the standard defines, exactly and case-sensitively, as
+    /// Matches one of the four identifiers the standard defines, exactly and case-sensitively, as
     /// https://webidl.spec.whatwg.org/#es-enumeration requires.
     /// </summary>
     private static bool TryParse(string value, out CompressionFormat format)
@@ -80,6 +89,9 @@ internal static class CompressionFormats
                 return true;
             case "deflate-raw":
                 format = CompressionFormat.DeflateRaw;
+                return true;
+            case "brotli":
+                format = CompressionFormat.Brotli;
                 return true;
             default:
                 format = default;

--- a/Jint/WebApi/Compression/DecompressionCodec.cs
+++ b/Jint/WebApi/Compression/DecompressionCodec.cs
@@ -22,16 +22,20 @@ namespace Jint.WebApi.Compression;
 /// caller's <c>ArrayBuffer</c> cannot be observed.
 /// </para>
 /// <para>
-/// <b>Two documented divergences, both in the lenient direction.</b> The standard makes it an error for a
-/// stream to end before its member is complete, and an error for anything to follow the member (a second
-/// gzip "member" included). Detecting either needs to know how many of the bytes handed over the
-/// decompressor actually consumed, and .NET exposes no incremental inflater — only these pull streams,
-/// which buffer input internally and report neither figure. So a truncated stream ends its readable side
-/// cleanly rather than erroring it, trailing bytes after a member are ignored, and a multi-member gzip
-/// stream decodes every member. Everything the decompressor itself rejects — a bad header, a failed
-/// CRC32/ADLER32, a malformed DEFLATE block — is still an error, which is the case that matters for
-/// telling corrupt input from good. The one truncation that <i>is</i> caught here is the empty stream: no
-/// compressed bytes at all cannot be a complete member in any of the three formats.
+/// <b>Two documented divergences, both in the lenient direction, and they apply to every format.</b> The
+/// standard makes it an error for a stream to end before its member is complete, and an error for anything
+/// to follow the member (a second gzip "member" included). Detecting either needs to know how many of the
+/// bytes handed over the decompressor actually consumed, and .NET exposes no incremental inflater or
+/// decoder — only these pull streams, which buffer input internally and report neither figure. So a
+/// truncated stream ends its readable side cleanly rather than erroring it, trailing bytes after a member
+/// are ignored, and a multi-member gzip stream decodes every member. <see cref="BrotliStream"/> behaves
+/// exactly the same way on both counts, so brotli shares the divergence rather than escaping it: the last
+/// byte of a brotli stream may be dropped, or a junk byte appended, and the decoder still hands over the
+/// payload it decoded and then reports "no more input for now". Everything the decompressor itself rejects
+/// — a bad header, a failed CRC32/ADLER32, a malformed DEFLATE block, a brotli stream the decoder cannot
+/// parse — is still an error, which is the case that matters for telling corrupt input from good. The one
+/// truncation that <i>is</i> caught here is the empty stream: no compressed bytes at all cannot be a
+/// complete member in any of the four formats.
 /// </para>
 /// </remarks>
 internal sealed class DecompressionCodec : IDisposable
@@ -39,17 +43,21 @@ internal sealed class DecompressionCodec : IDisposable
     private readonly PushSource _source = new();
     private readonly Stream _decompressor;
     private readonly byte[] _buffer = new byte[8192];
+    private readonly bool _isBrotli;
     private long _inputBytes;
     private bool _disposed;
 
     internal DecompressionCodec(CompressionFormat format)
     {
+        _isBrotli = format == CompressionFormat.Brotli;
+
         // See CompressionFormat: "deflate" is the ZLIB wrapper of RFC 1950, and only "deflate-raw" is the
         // bare RFC 1951 bit stream.
         _decompressor = format switch
         {
             CompressionFormat.Gzip => new GZipStream(_source, CompressionMode.Decompress, leaveOpen: true),
             CompressionFormat.Deflate => new ZLibStream(_source, CompressionMode.Decompress, leaveOpen: true),
+            CompressionFormat.Brotli => new BrotliStream(_source, CompressionMode.Decompress, leaveOpen: true),
             _ => new DeflateStream(_source, CompressionMode.Decompress, leaveOpen: true),
         };
     }
@@ -98,14 +106,36 @@ internal sealed class DecompressionCodec : IDisposable
     /// Reads the decompressor until it has produced everything the input so far allows. A read of 0 means
     /// it asked the push source for input that has not arrived, not that the stream ended.
     /// </summary>
+    /// <remarks>
+    /// The <see cref="InvalidOperationException"/> clause is <see cref="BrotliStream"/> alone, and it is a
+    /// naming inconsistency in the BCL rather than a different condition: the deflate family reports data it
+    /// cannot parse as <see cref="InvalidDataException"/>, while <c>BrotliStream</c> raises
+    /// <c>InvalidOperationException("Decoder ran into invalid data.")</c> for the decoder's
+    /// <c>OperationStatus.InvalidData</c>. Translating it here keeps this class's one promise to its caller —
+    /// input the format rejects arrives as <see cref="InvalidDataException"/> or <see cref="IOException"/> —
+    /// true for all four formats, so the two call sites in <c>JsDecompressionStream</c> stay a single
+    /// <c>catch</c>. It is scoped to brotli deliberately: an <see cref="InvalidOperationException"/> out of
+    /// the deflate family would be a defect on our side and must not be reported to script as bad input —
+    /// and <see cref="ObjectDisposedException"/> is excluded for the same reason, being a derived type of it
+    /// that <c>BrotliStream</c> raises for a use-after-dispose rather than for anything about the bytes.
+    /// Both callers return early when this codec is disposed, so it cannot be reached today; leaving it in
+    /// the clause would mean a future one arriving as the standard's "not valid brotli data" instead.
+    /// </remarks>
     private byte[]? Drain()
     {
         MemoryStream? output = null;
 
-        int read;
-        while ((read = _decompressor.Read(_buffer, 0, _buffer.Length)) > 0)
+        try
         {
-            (output ??= new MemoryStream()).Write(_buffer, 0, read);
+            int read;
+            while ((read = _decompressor.Read(_buffer, 0, _buffer.Length)) > 0)
+            {
+                (output ??= new MemoryStream()).Write(_buffer, 0, read);
+            }
+        }
+        catch (InvalidOperationException e) when (_isBrotli && e is not ObjectDisposedException)
+        {
+            throw new InvalidDataException(e.Message, e);
         }
 
         return output?.ToArray();

--- a/Jint/WebApi/Compression/JsDecompressionStream.cs
+++ b/Jint/WebApi/Compression/JsDecompressionStream.cs
@@ -89,6 +89,7 @@ internal sealed class JsDecompressionStream : JsGenericTransformStream, IDisposa
     {
         CompressionFormat.Gzip => "gzip",
         CompressionFormat.Deflate => "deflate",
+        CompressionFormat.Brotli => "brotli",
         _ => "deflate-raw",
     };
 }

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ its own `console` (or any other name in the table below), enabling the feature l
 | `navigator.userAgent` | `Navigator` | ✔ shipped |
 | `ReadableStream` / `WritableStream` / `TransformStream` (all three transferable) / `ByteLengthQueuingStrategy` / `CountQueuingStrategy` | `Streams` | ✔ shipped |
 | `TextEncoderStream` / `TextDecoderStream` | `Encoding` **and** `Streams` | ✔ shipped |
-| `CompressionStream` / `DecompressionStream` (`gzip`, `deflate`, `deflate-raw`) | `Compression` **and** `Streams` | ✔ shipped |
+| `CompressionStream` / `DecompressionStream` (`gzip`, `deflate`, `deflate-raw`, `brotli`) | `Compression` **and** `Streams` | ✔ shipped |
 | `scheduler.postTask` / `scheduler.yield` / `TaskController` / `TaskSignal` | `Scheduler` | ✔ shipped |
 | `requestIdleCallback` / `cancelIdleCallback` / `IdleDeadline` | `IdleCallback` | ✔ shipped |
 | `MessageChannel` / `MessagePort` / `MessageEvent` (incl. cross-engine ports and port transfer) / `BroadcastChannel` | `Messaging` | ✔ shipped |
@@ -1792,15 +1792,18 @@ chunks is reassembled into the one scalar value it denotes rather than becoming 
 code unit or a byte order mark split across chunks all decode as if the bytes had arrived in one piece. A
 `fatal` decoder errors *both* sides with a `TypeError`, as the standard prescribes.
 
-For compression, note that the standard's `deflate` is **RFC 1950's ZLIB container**, named that way for
-consistency with HTTP `Content-Encoding`; raw RFC 1951 DEFLATE is the separate `deflate-raw`. Jint maps them
-onto `ZLibStream` and `DeflateStream` accordingly (and `gzip` onto `GZipStream`), so bytes produced here are
-the bytes every other implementation expects. `brotli`, which the standard's enumeration also names, is not
-implemented and — like any unsupported value — raises a `TypeError`. Input a format rejects (a bad header, a
-failed CRC32 or ADLER32, a malformed block) errors both sides with a `TypeError`; two truncation cases the
-standard also calls errors are the documented exception, because .NET exposes no incremental inflater that
-could report them: a stream that ends mid-member closes cleanly instead, and bytes following a complete
-member are ignored. A stream that ends with no compressed bytes at all *is* refused.
+All four formats the standard's `CompressionFormat` enumeration names are supported — `gzip`, `deflate`,
+`deflate-raw` and `brotli` — so the constructors' own "if *format* is unsupported, then throw a `TypeError`"
+step has nothing left to refuse and only a value outside the enumeration is rejected. Note that the standard's
+`deflate` is **RFC 1950's ZLIB container**, named that way for consistency with HTTP `Content-Encoding`; raw
+RFC 1951 DEFLATE is the separate `deflate-raw`. Jint maps the four onto `GZipStream`, `ZLibStream`,
+`DeflateStream` and `BrotliStream` respectively, so bytes produced here are the bytes every other
+implementation expects. Nothing in the standard fixes a compression *quality*, so each format runs at the
+BCL's own default. Input a format rejects (a bad header, a failed CRC32 or ADLER32, a malformed block, a
+brotli stream the decoder cannot parse) errors both sides with a `TypeError`; two truncation cases the
+standard also calls errors are the documented exception, because .NET exposes no incremental inflater or
+decoder that could report them: a stream that ends mid-member closes cleanly instead, and bytes following
+a complete member are ignored. A stream that ends with no compressed bytes at all *is* refused.
 
 ### Bridging a stream to `System.IO.Stream`
 


### PR DESCRIPTION
Closes #3210.

The Compression Standard's `CompressionFormat` enumeration has four values and Jint supported three. Refusing `brotli` was *conforming* — constructor step 1 is "if format is unsupported in CompressionStream, then throw a TypeError" — but it was the one WPT exclusion category in that corpus that was neither a platform limit nor a deliberate reduction: .NET ships `BrotliStream`, on exactly the pull-stream shape `CompressionCodec`/`DecompressionCodec` already drive.

`brotli` is now the fourth format, and the constructors' step 1 has nothing left to refuse.

### Three things the deflate arms did not prepare us for

**`BrotliStream` emits its empty stream on its own.** The other three formats get an explicit `EmptyMember` constant because a compressing `DeflateStream` that was never handed a byte writes *nothing at all* on close (deliberately — `ZipArchiveEntry` depends on it), and the .NET 8 / .NET 10 behaviour differs enough that relying on it would make one source produce different bytes per target framework. A `BrotliStream` closed unwritten emits the one-byte empty stream itself, verified on both, so brotli deliberately gets **no** fourth constant and takes the ordinary close path — pinning an encoder's framing choice nothing needs pinned would be the worse option.

**Bad data arrives under a different exception type.** The deflate family raises `InvalidDataException`; `BrotliStream` raises `InvalidOperationException("Decoder ran into invalid data.")` for the decoder's `OperationStatus.InvalidData`. That is translated at the drain so this class's promise to its caller stays true for all four formats and the two `catch` sites in `JsDecompressionStream` stay single. The clause is scoped to brotli on purpose — an `InvalidOperationException` out of the deflate family would be a defect on our side and must not reach script as "the input is not valid brotli data" — and it also excludes `ObjectDisposedException`, which derives from it and which `BrotliStream` raises for use-after-dispose rather than for anything about the bytes.

**The lenient-decompression divergence is shared, not escaped.** The two documented divergences (a member that ends early, anything following a member) exist because .NET exposes no incremental inflater that reports how many bytes it consumed. `BrotliStream` reports that no better, so brotli's truncation and trailing-junk rows moved to `NeedsIncrementalInflater` rather than passing — which is what #3210 asked us to check, and it is where they landed.

### Exclusion table

68 `NeedsBrotli` rows, and the category, are gone. 62 rows went green across 11 files; the remaining 6 are the truncation/trailing-junk pairs now under `NeedsIncrementalInflater`. Measured at both the base commit and HEAD with the row-level dump: 15 files / 297 assertions, **84 not passing → 22**, zero unexcluded failures and zero stale exclusions on both sides.

Two groups of entries could also stop being spelled out per format. They were only spelled out because brotli's rows of the same families failed for a *different* reason and an exclusion has to say which one applies; that reason is gone, so `chunk of type SharedArrayBuffer should error the stream for *` and `truncating the input for * should give an error` now say the one thing true of every row they name. The driver's rule that an entry must match at least one failing test and no passing one is what keeps those globs honest — the unchanged-input row of all three formats passes.

### Verification

Solution builds Release across all five TFMs (`net462`/`netstandard2.0`/`netstandard2.1`/`net8.0`/`net10.0`), so the whole-file `#if NET8_0_OR_GREATER` gate holds. `Jint.Tests` 10061 net10.0 / 7102 net472, `Jint.Tests.PublicInterface` 2379 / 1865, all green.

Beyond the corpus, a round-trip interop probe on net8.0 and net10.0 — 25 checks, all passing — confirms we emit genuinely valid brotli rather than merely self-consistent bytes: Jint compresses → raw BCL `BrotliStream` decompresses identically, and the reverse, for empty / 1 byte / 12 bytes / 108 KB compressible / 256 KB incompressible (the stored-block path) / astral UTF-8, each also with 1-byte chunking; our empty member decodes in the raw BCL; a wpt vector using a stored meta-block .NET never emits decodes correctly; and bad data reaches script as a `TypeError`, never a CLR exception escaping `Evaluate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
