### PR TITLE
Web API: implement Blob.textStream()

### DIFF
--- a/Jint.Tests/Runtime/WebApi/BlobTests.cs
+++ b/Jint.Tests/Runtime/WebApi/BlobTests.cs
@@ -430,6 +430,271 @@ public class BlobTests
             .UnwrapIfPromise().AsString().Should().Be("ab");
     }
 
+    /// <summary>
+    /// An engine that can read a stream to the end and record what came out of it, so a test can pin both
+    /// the decoded text and the number of chunks it arrived in.
+    /// </summary>
+    private static Engine TextStreamEngine()
+    {
+        var engine = WebEngine();
+        engine.Execute("""
+            var log = [];
+            async function collect(stream, label) {
+              const reader = stream.getReader();
+              for (;;) {
+                let result;
+                try { result = await reader.read(); }
+                catch (e) { log.push(label + ':error:' + e.name); return; }
+                if (result.done) { log.push(label + ':done'); return; }
+                log.push(label + ':' + typeof result.value + ':' + result.value);
+              }
+            }
+            function bytes() { return new Uint8Array(Array.prototype.slice.call(arguments)); }
+            """);
+        return engine;
+    }
+
+    private static string Log(Engine engine) => engine.Evaluate("log.join(',')").AsString();
+
+    /// <summary>
+    /// https://w3c.github.io/FileAPI/#dom-blob-textstream: the blob's stream piped through a UTF-8
+    /// <c>TextDecoderStream</c>, so the chunks are strings rather than bytes.
+    /// </summary>
+    [Fact]
+    public void TextStreamDecodesTheBytesAsUtf8Strings()
+    {
+        var engine = TextStreamEngine();
+        engine.Execute("collect(new Blob(['hello world']).textStream(), 'out');");
+
+        // One chunk, because the source is Blob.stream() and that hands over its bytes in one — the decoder
+        // adds no boundaries of its own. WPT only asserts that there is at least one; this is the reduction
+        // Blob.stream() documents, pinned where it is observable as text.
+        Log(engine).Should().Be("out:string:hello world,out:done");
+    }
+
+    [Fact]
+    public void TextStreamOfAnEmptyBlobClosesWithNoChunks()
+    {
+        // The flush produces the empty string, and "if outputChunk is not the empty string" means nothing is
+        // enqueued for it — https://encoding.spec.whatwg.org/#flush-and-enqueue.
+        var engine = TextStreamEngine();
+        engine.Execute("collect(new Blob().textStream(), 'out');");
+
+        Log(engine).Should().Be("out:done");
+    }
+
+    /// <summary>
+    /// A code point split across two blob parts still decodes to that code point: the parts are concatenated
+    /// into one byte sequence before anything reads it.
+    /// </summary>
+    /// <remarks>
+    /// It is worth being honest about what this does and does not exercise. Jint's blob stream hands its
+    /// bytes over as a single chunk, so the split here is a split between blob <i>parts</i> and not a chunk
+    /// boundary the decoder ever sees — the streaming-decode path that carries an incomplete sequence from
+    /// one chunk to the next is pinned by <c>TextDecoderStreamTests.JoinsASequenceSplitAcrossChunks</c>
+    /// instead. What this pins is that the composition cannot decode part-wise, which is exactly what would
+    /// break if <c>textStream()</c> ever decoded each part on its own or if the source were later chunked.
+    /// </remarks>
+    [Fact]
+    public void TextStreamJoinsAMultiByteSequenceSplitAcrossParts()
+    {
+        var engine = TextStreamEngine();
+
+        // U+20AC EURO SIGN is E2 82 AC, split after the second byte; U+1D306 is F0 9D 8C 86, split after the
+        // first, so the second part opens mid sequence *and* mid surrogate pair.
+        engine.Execute("""
+            var b = new Blob([bytes(0xE2, 0x82), bytes(0xAC), bytes(0xF0), bytes(0x9D, 0x8C, 0x86)]);
+            collect(b.textStream(), 'out');
+            """);
+
+        Log(engine).Should().Be("out:string:€𝌆,out:done");
+    }
+
+    /// <summary>
+    /// The decoder is an ordinary UTF-8 <c>TextDecoderStream</c>, so "serialize I/O queue" step 2.3 drops a
+    /// single leading U+FEFF — https://encoding.spec.whatwg.org/#concept-td-serialize.
+    /// </summary>
+    /// <remarks>
+    /// The vendored corpus asserts nothing about a BOM, so this is Jint's own pin rather than a WPT row. It
+    /// deliberately asserts the same three answers <c>text()</c> gives, since both are "UTF-8 decode" and the
+    /// two must not drift.
+    /// </remarks>
+    [Fact]
+    public void TextStreamStripsOneLeadingByteOrderMark()
+    {
+        // One drain per Execute, so the log is this stream's chunks rather than three pipes interleaved.
+        var engine = TextStreamEngine();
+        engine.Execute("collect(new Blob([bytes(0xEF, 0xBB, 0xBF, 0x41)]).textStream(), 'one');");
+        engine.Execute("collect(new Blob([bytes(0xEF, 0xBB, 0xBF, 0xEF, 0xBB, 0xBF)]).textStream(), 'two');");
+        engine.Execute("collect(new Blob([bytes(0x41, 0xEF, 0xBB, 0xBF)]).textStream(), 'mid');");
+
+        // Exactly one BOM goes, and only when it leads: the second of two survives as U+FEFF, and one after
+        // a character was never the start of the stream at all.
+        Log(engine).Should().Be("one:string:A,one:done,two:string:﻿,two:done,mid:string:A﻿,mid:done");
+
+        // The same bytes through text(), which is the other spelling of UTF-8 decode.
+        Eval("new Blob([new Uint8Array([0xEF, 0xBB, 0xBF, 0x41])]).text()").UnwrapIfPromise().AsString().Should().Be("A");
+    }
+
+    [Fact]
+    public void TextStreamSubstitutesU00FFFDRatherThanFailing()
+    {
+        // The error mode is "replacement", not "fatal" — "set up a text decoder stream" defaults it that
+        // way and textStream() overrides nothing. So an ill-formed sequence is a chunk, never an error.
+        var engine = TextStreamEngine();
+        engine.Execute("collect(new Blob([bytes(0x41, 0xFF, 0x42)]).textStream(), 'out');");
+
+        Log(engine).Should().Be("out:string:A�B,out:done");
+    }
+
+    /// <summary>
+    /// "This differs from <c>readAsText()</c> in that it always uses the UTF-8 encoding" — the blob's
+    /// <c>type</c> is never consulted, whatever charset it names.
+    /// </summary>
+    [Fact]
+    public void TextStreamIgnoresTheCharsetOfTheBlobType()
+    {
+        var engine = TextStreamEngine();
+        engine.Execute("""
+            var utf16 = new Blob([bytes(0x68, 0x00, 0x69, 0x00)], { type: 'text/plain; charset=utf-16le' });
+            var latin1 = new Blob([bytes(0xC3, 0xA9)], { type: 'text/plain; charset=iso-8859-1' });
+            var nonsense = new Blob(['hi'], { type: 'text/plain; charset=invalid-charset' });
+            """);
+
+        // One drain per Execute, so the log is not three pipes interleaved.
+        engine.Execute("collect(utf16.textStream(), 'utf16');");
+        engine.Execute("collect(latin1.textStream(), 'latin1');");
+        engine.Execute("collect(nonsense.textStream(), 'nonsense');");
+
+        // An invalid charset is not a RangeError either: no label is ever resolved, so there is nothing to
+        // reject. All three decode as UTF-8.
+        Log(engine).Should().Be(
+            "utf16:string:h\0i\0,utf16:done,latin1:string:é,latin1:done,nonsense:string:hi,nonsense:done");
+    }
+
+    /// <summary>
+    /// <c>[NewObject]</c>: every call builds a fresh source, a fresh decoder and a fresh result, so reading
+    /// one cannot disturb another.
+    /// </summary>
+    [Fact]
+    public void TextStreamHandsEachCallItsOwnStream()
+    {
+        var engine = TextStreamEngine();
+        engine.Execute("var b = new Blob(['hello']); var s1 = b.textStream(); var s2 = b.textStream();");
+
+        engine.Evaluate("s1 === s2").AsBoolean().Should().BeFalse();
+        engine.Evaluate("s1.locked || s2.locked").AsBoolean().Should().BeFalse();
+
+        // Draining one leaves the other untouched — including its lock, which is what a shared source or a
+        // shared decoder would have taken.
+        engine.Execute("collect(s1, 'first');");
+        engine.Evaluate("s2.locked").AsBoolean().Should().BeFalse();
+        engine.Execute("collect(s2, 'second');");
+
+        Log(engine).Should().Be("first:string:hello,first:done,second:string:hello,second:done");
+    }
+
+    /// <summary>
+    /// A <c>stream()</c> and a <c>textStream()</c> taken from one blob are two streams over two sources,
+    /// not one source read twice — so either can be drained without the other noticing, in either order.
+    /// </summary>
+    [Fact]
+    public void TextStreamAndStreamOfOneBlobAreIndependent()
+    {
+        var engine = TextStreamEngine();
+        engine.Execute("var b = new Blob(['hello']); var raw = b.stream(); var txt = b.textStream();");
+
+        // Neither is locked by the other's existence, although textStream() has locked the *source* it made
+        // for itself — which is a different stream from the one stream() handed over.
+        engine.Evaluate("raw.locked || txt.locked").AsBoolean().Should().BeFalse();
+
+        engine.Execute("collect(txt, 'txt');");
+        engine.Execute("""
+            (async function () {
+              const reader = raw.getReader();
+              const chunk = await reader.read();
+              log.push('raw:' + chunk.value.constructor.name + ':' + chunk.value.length);
+              log.push('raw:' + (await reader.read()).done);
+            })();
+            """);
+
+        // The byte stream still yields bytes and the text stream still yields the string they decode to.
+        Log(engine).Should().Be("txt:string:hello,txt:done,raw:Uint8Array:5,raw:true");
+    }
+
+    /// <summary>
+    /// Cancelling the returned stream. The pipe is built with every option defaulted — nothing prevented —
+    /// so cancelling the readable side errors the transform's writable side and the pipe cancels the source
+    /// behind it, which is what <c>preventCancel</c> being false means.
+    /// </summary>
+    /// <remarks>
+    /// What that backward cancellation does to the source is not observable from script here, because the
+    /// source is a blob's bytes in memory and its cancel steps have nothing to release. What is observable,
+    /// and is what this pins, is that the cancellation settles cleanly rather than erroring the stream: the
+    /// promise fulfils with <c>undefined</c>, the next read is done, and <c>closed</c> fulfils.
+    /// </remarks>
+    [Fact]
+    public void TextStreamCanBeCancelled()
+    {
+        var engine = TextStreamEngine();
+        engine.Execute("""
+            var s = new Blob(['hello world']).textStream();
+            (async function () {
+              const reader = s.getReader();
+              log.push('cancel:' + String(await reader.cancel('no thanks')));
+              const after = await reader.read();
+              log.push('after:' + after.done + ':' + String(after.value));
+              try { await reader.closed; log.push('closed:fulfilled'); }
+              catch (e) { log.push('closed:rejected:' + e.name); }
+            })();
+            """);
+
+        Log(engine).Should().Be("cancel:undefined,after:true:undefined,closed:fulfilled");
+
+        // And through the stream itself, with no reader ever acquired — cancel() acquires and releases one.
+        var direct = TextStreamEngine();
+        direct.Execute("""
+            var s = new Blob(['hello world']).textStream();
+            s.cancel('no thanks').then(v => log.push('cancel:' + String(v)), e => log.push('cancel:error:' + e.name));
+            """);
+
+        Log(direct).Should().Be("cancel:undefined");
+    }
+
+    /// <summary>
+    /// The result is an ordinary <c>ReadableStream</c> of strings: the byte-stream machinery is the
+    /// <i>source</i>, and what a transform's readable side hands out is not a byte stream.
+    /// </summary>
+    [Fact]
+    public void TextStreamIsNotAByteStream()
+    {
+        var engine = WebEngine();
+
+        // Files and nothing else, so ReadableStream is not a global — but the object is the real interface,
+        // reached through its prototype, exactly as stream()'s is.
+        engine.Evaluate("typeof ReadableStream").AsString().Should().Be("undefined");
+        engine.Evaluate("Object.prototype.toString.call(new Blob(['x']).textStream())").AsString()
+            .Should().Be("[object ReadableStream]");
+        engine.Evaluate("Object.getPrototypeOf(new Blob(['x']).stream()) === Object.getPrototypeOf(new Blob(['x']).textStream())")
+            .AsBoolean().Should().BeTrue();
+
+        // stream() serves a BYOB reader; textStream() cannot, because its chunks are strings.
+        engine.Execute("var byob = new Blob(['x']).stream().getReader({ mode: 'byob' });");
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new Blob(['x']).textStream().getReader({ mode: 'byob' })"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void TextStreamBrandChecksItsReceiver()
+    {
+        var engine = WebEngine();
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("Blob.prototype.textStream()"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("Blob.prototype.textStream.call({})"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+    }
+
     [Fact]
     public void DeclaresTheArityTheIdlDoes()
     {
@@ -440,6 +705,8 @@ public class BlobTests
         engine.Evaluate("Blob.prototype.arrayBuffer.length").AsNumber().Should().Be(0);
         engine.Evaluate("Blob.prototype.bytes.length").AsNumber().Should().Be(0);
         engine.Evaluate("Blob.prototype.stream.length").AsNumber().Should().Be(0);
+        engine.Evaluate("Blob.prototype.textStream.length").AsNumber().Should().Be(0);
+        engine.Evaluate("Blob.prototype.textStream.name").AsString().Should().Be("textStream");
     }
 }
 #endif

--- a/Jint.Tests/Runtime/WebApi/FileTests.cs
+++ b/Jint.Tests/Runtime/WebApi/FileTests.cs
@@ -44,6 +44,39 @@ public class FileTests
         engine.Evaluate("Object.prototype.toString.call(new File([], 'a'))").AsString().Should().Be("[object File]");
     }
 
+    /// <summary>
+    /// <c>File</c> declares no read methods of its own, so every one of <c>Blob</c>'s is reached through the
+    /// prototype chain above — including <c>textStream()</c>, https://w3c.github.io/FileAPI/#dom-blob-textstream,
+    /// which brand-checks for a <c>Blob</c> and a <c>File</c> is one.
+    /// </summary>
+    [Fact]
+    public void InheritsEveryBlobReadMethodIncludingTextStream()
+    {
+        var engine = WebEngine();
+        engine.Execute("""
+            var log = [];
+            var f = new File(['héllo'], 'note.txt');
+            (async function () {
+              const reader = f.textStream().getReader();
+              for (;;) {
+                const r = await reader.read();
+                if (r.done) { log.push('done'); return; }
+                log.push(r.value);
+              }
+            })();
+            """);
+
+        engine.Evaluate("log.join(',')").AsString().Should().Be("héllo,done");
+
+        // The method itself is Blob's, not a copy — nothing here re-declares it.
+        engine.Evaluate("File.prototype.hasOwnProperty('textStream')").AsBoolean().Should().BeFalse();
+        engine.Evaluate("f.textStream === Blob.prototype.textStream").AsBoolean().Should().BeTrue();
+
+        engine.Evaluate("f.text()").UnwrapIfPromise().AsString().Should().Be("héllo");
+        engine.Evaluate("f.bytes()").UnwrapIfPromise().AsObject().Get("length").AsNumber().Should().Be(6);
+        engine.Evaluate("Object.prototype.toString.call(f.stream())").AsString().Should().Be("[object ReadableStream]");
+    }
+
     [Fact]
     public void SlicingAFileProducesAPlainBlob()
     {

--- a/Jint.Tests/Wpt/Vendor/README.md
+++ b/Jint.Tests/Wpt/Vendor/README.md
@@ -290,15 +290,16 @@ assertion this change added to the shim.
 
 ## What the File API corpus says about this engine
 
-342 assertions across 14 files (11 in `blob/`, 2 in `file/`, 1 in the root), of which **11 do not pass**.
+342 assertions across 14 files (11 in `blob/`, 2 in `file/`, 1 in the root), of which **3 do not pass**.
 
-**8 are `Blob.textStream()`** (`NeedsBlobTextStream`), which
-[the File API added](https://w3c.github.io/FileAPI/#dom-blob-textstream) after this `Blob` was written. It is
-normative rather than optional, and its algorithm is three steps over pieces the engine already has — get the
-blob's stream, set up a `TextDecoderStream` with UTF-8, pipe one through the other — so `Blob-textStream.any.js`
-is 8-for-8 red purely because the method is absent.
+The eight that used to be red were the whole of `Blob-textStream.any.js`, under a `NeedsBlobTextStream`
+category, because [the File API added](https://w3c.github.io/FileAPI/#dom-blob-textstream) `textStream()`
+after this `Blob` was written. They pass since
+[#3211](https://github.com/sebastienros/jint/issues/3211) implemented it — the blob's stream piped through a
+UTF-8 `TextDecoderStream`, which is four steps over pieces the engine already had — and the two entries and
+the category are gone with them.
 
-**The other 3 are `NeedsTriage`, and the defect is not in `Blob` at all.** All three rows of
+**The 3 that remain are `NeedsTriage`, and the defect is not in `Blob` at all.** All three rows of
 `Blob-constructor.any.js` fail with `TypeError: cannot construct iterator`, thrown by
 `Array.prototype.values`:
 

--- a/Jint.Tests/Wpt/WptExclusions.cs
+++ b/Jint.Tests/Wpt/WptExclusions.cs
@@ -254,15 +254,6 @@ internal enum WptDivergence
     NeedsIncrementalInflater,
 
     /// <summary>
-    /// The test calls <c>Blob.textStream()</c> — https://w3c.github.io/FileAPI/#dom-blob-textstream, which
-    /// the File API added after Jint's <c>Blob</c> was written and which is normative rather than optional.
-    /// Its algorithm is three steps over pieces this engine already has (get the blob's stream, set up a
-    /// <c>TextDecoderStream</c> with UTF-8, pipe one through the other), so this is a gap to close and not a
-    /// decision; the whole of <c>Blob-textStream.any.js</c> is red for the method simply being absent.
-    /// </summary>
-    NeedsBlobTextStream,
-
-    /// <summary>
     /// A genuine failure that is not attributable to a feature Jint has decided not to have. Every entry
     /// here is a bug or a specification detail to chase, and the phase of the harness work that stood the
     /// suites up deliberately recorded them rather than fixing them: the point was to find out what they

--- a/Jint.Tests/Wpt/WptTestRunner.cs
+++ b/Jint.Tests/Wpt/WptTestRunner.cs
@@ -817,13 +817,6 @@ public class WptTestRunner
         new("compression/decompression-corrupt-input.any.js", "trailing junk for 'brotli' should give an error", WptDivergence.NeedsBrotli),
 
         // ---------------------------------------------------------------- FileAPI
-        // Blob.textStream(), which https://w3c.github.io/FileAPI/#dom-blob-textstream added and this Blob
-        // does not have. Two entries rather than one `*` over the file: the existence row and the seven that
-        // call the method say different things, and the file is 8-for-8 red today only because the method is
-        // wholly absent.
-        new("FileAPI/blob/Blob-textStream.any.js", "textStream method existence", WptDivergence.NeedsBlobTextStream),
-        new("FileAPI/blob/Blob-textStream.any.js", "Blob.textStream() *", WptDivergence.NeedsBlobTextStream),
-
         // Three rows of Blob-constructor.any.js, and they are one engine defect rather than three Blob ones
         // — see WptDivergence.NeedsTriage and Vendor/README.md. Recorded rather than fixed, because the
         // change that first runs a suite is not the change that moves the engine.

--- a/Jint/Options.WebApi.cs
+++ b/Jint/Options.WebApi.cs
@@ -722,7 +722,9 @@ public enum WebApiFeatures
     /// <remarks>
     /// <c>Blob.stream()</c> answers a real <c>ReadableStream</c> whether or not <see cref="Streams"/> is also
     /// enabled — the interface is always there, and the flag only decides whether <c>ReadableStream</c> is a
-    /// global a script can name. <see cref="Default"/> has both.
+    /// global a script can name. The same goes for <c>Blob.textStream()</c>, which is that byte stream piped
+    /// through a UTF-8 <c>TextDecoderStream</c> and so needs neither <see cref="Streams"/> nor
+    /// <see cref="Encoding"/> to work. <see cref="Default"/> has all three.
     /// </remarks>
     Files = 1 << 9,
 

--- a/Jint/WebApi/Encoding/EncodingLabels.cs
+++ b/Jint/WebApi/Encoding/EncodingLabels.cs
@@ -30,6 +30,14 @@ internal static class EncodingLabels
     /// <summary>The name https://encoding.spec.whatwg.org/#utf-8 gives the encoding, already ASCII-lowercase.</summary>
     internal const string Utf8 = "utf-8";
 
+    /// <summary>
+    /// https://encoding.spec.whatwg.org/#utf-8 itself, for an algorithm that names the encoding rather than
+    /// resolving a label — "set up decoder with UTF-8", https://w3c.github.io/FileAPI/#dom-blob-textstream
+    /// step 3, is the one that does. Written out rather than looked up because UTF-8 is the generated
+    /// table's one fixed point: it is not a single-byte encoding, so it carries no index.
+    /// </summary>
+    internal static readonly EncodingEntry Utf8Encoding = new(Utf8, EncodingKind.Utf8, SingleByteIndex.None);
+
     /// <summary>The name https://encoding.spec.whatwg.org/#utf-16le gives the encoding.</summary>
     internal const string Utf16Le = "utf-16le";
 

--- a/Jint/WebApi/Encoding/JsTextDecoderStream.cs
+++ b/Jint/WebApi/Encoding/JsTextDecoderStream.cs
@@ -29,6 +29,33 @@ internal sealed class JsTextDecoderStream : JsGenericTransformStream
     internal TextDecoderCommon Common { get; }
 
     /// <summary>
+    /// "Set up a text decoder stream" — https://encoding.spec.whatwg.org/#set-up-a-text-decoder-stream —
+    /// with every one of its optional arguments defaulted, which is UTF-8 and nothing else. This is
+    /// https://w3c.github.io/FileAPI/#dom-blob-textstream steps 2 and 3, whose decoder is a platform object
+    /// no script ever names: it is created here rather than through the constructor because the algorithm
+    /// says "a new <c>TextDecoderStream</c>", not "the result of calling the constructor" — so no label is
+    /// converted and a script cannot reach it by subclassing.
+    /// </summary>
+    internal static JsTextDecoderStream SetUpUtf8(Engine engine, Realm realm)
+    {
+        var stream = new JsTextDecoderStream(engine, realm, TextDecoderCommon.Utf8())
+        {
+            _prototype = realm.Intrinsics.TextDecoderStream.PrototypeObject,
+        };
+
+        stream.SetUpTransform();
+        return stream;
+    }
+
+    /// <summary>
+    /// The half of "set up a text decoder stream" that needs the instance: the transform whose algorithms
+    /// close over it. It is a separate step for exactly that reason — the object has to exist first, which
+    /// is why the specification's operation takes the stream as an argument.
+    /// </summary>
+    internal void SetUpTransform()
+        => Transform = TransformStreamOperations.SetUp(Engine, Realm, DecodeAndEnqueue, FlushAndEnqueue);
+
+    /// <summary>
     /// "Decode and enqueue a chunk" — https://encoding.spec.whatwg.org/#decode-and-enqueue-a-chunk.
     /// </summary>
     /// <remarks>

--- a/Jint/WebApi/Encoding/TextDecoderCommon.cs
+++ b/Jint/WebApi/Encoding/TextDecoderCommon.cs
@@ -69,6 +69,19 @@ internal sealed class TextDecoderCommon
     internal bool IgnoreBom { get; }
 
     /// <summary>
+    /// The decoder "set up a text decoder stream"
+    /// (https://encoding.spec.whatwg.org/#set-up-a-text-decoder-stream) builds when every one of its
+    /// optional arguments is left at its default: UTF-8, the "replacement" error mode, and
+    /// <c>ignoreBOM</c> false. That is the state <c>new TextDecoderStream()</c> produces, and it is what
+    /// https://w3c.github.io/FileAPI/#dom-blob-textstream step 3 — "set up decoder with UTF-8" — asks for.
+    /// </summary>
+    /// <remarks>
+    /// No label is resolved: the caller names the encoding, so there is nothing here that could fail and no
+    /// <c>RangeError</c> to raise.
+    /// </remarks>
+    internal static TextDecoderCommon Utf8() => new(in EncodingLabels.Utf8Encoding, fatal: false, ignoreBom: false);
+
+    /// <summary>
     /// The <c>(label, options)</c> pair both constructors take:
     /// <c>constructor(optional DOMString label = "utf-8", optional TextDecoderOptions options = {})</c>.
     /// </summary>

--- a/Jint/WebApi/Encoding/TextDecoderStreamConstructor.cs
+++ b/Jint/WebApi/Encoding/TextDecoderStreamConstructor.cs
@@ -4,7 +4,6 @@ using Jint.Native.Function;
 using Jint.Native.Object;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.WebApi.Streams;
 
 namespace Jint.WebApi.Encoding;
 
@@ -55,11 +54,7 @@ internal sealed class TextDecoderStreamConstructor : Constructor
 
         // The algorithms close over the instance, so the transform can only be set up once it exists —
         // which is why the specification's "set up" operation takes the stream as an argument.
-        stream.Transform = TransformStreamOperations.SetUp(
-            _engine,
-            _realm,
-            stream.DecodeAndEnqueue,
-            stream.FlushAndEnqueue);
+        stream.SetUpTransform();
 
         return stream;
     }

--- a/Jint/WebApi/Files/BlobPrototype.cs
+++ b/Jint/WebApi/Files/BlobPrototype.cs
@@ -25,8 +25,9 @@ namespace Jint.WebApi.Files;
 /// <c>text()</c>, <c>arrayBuffer()</c> and <c>bytes()</c> each answer an already-resolved promise — the
 /// bytes are in memory, so there is nothing for an event-loop turn to wait for. They are still real
 /// promises: <c>await blob.text()</c> works exactly as it does in a browser, and the value arrives on the
-/// microtask turn a <c>then</c> would give it. <c>stream()</c> is the fourth, and answers a
-/// <c>ReadableStream</c> over those same bytes.
+/// microtask turn a <c>then</c> would give it. The other two read methods answer a <c>ReadableStream</c>
+/// over those same bytes instead of a promise: <c>stream()</c> a byte stream, and <c>textStream()</c> that
+/// byte stream piped through a UTF-8 <c>TextDecoderStream</c>, so its chunks are strings.
 /// </para>
 /// <para>
 /// One documented simplification against WebIDL: the operations are non-enumerable, where a WebIDL
@@ -184,6 +185,42 @@ internal sealed partial class BlobPrototype : Prototype
     private Streams.JsReadableStream Stream(JsValue thisObject)
     {
         return Streams.ByteStreams.CreateFromBytes(_engine, _realm, Brand(thisObject).Data);
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/FileAPI/#dom-blob-textstream — four steps over pieces that already exist: get
+    /// the blob's stream, make a <c>TextDecoderStream</c> in this realm, set it up with UTF-8, and return
+    /// the source piped through it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Always UTF-8.</b> The interface takes no encoding argument and the blob's own <c>type</c> is never
+    /// consulted, so a <c>charset</c> parameter on it — valid, invalid, or contradicting the bytes — changes
+    /// nothing. That is the specification's own note, and the difference from <c>FileReader.readAsText()</c>,
+    /// which does read the charset. Being an ordinary UTF-8 <c>TextDecoderStream</c> also fixes the rest of
+    /// the behaviour: one leading BOM is dropped, an ill-formed sequence becomes U+FFFD rather than failing,
+    /// and a sequence split across two chunks decodes to what the whole byte sequence would have.
+    /// </para>
+    /// <para>
+    /// <b>What comes back is an ordinary <c>ReadableStream</c> of strings.</b> The byte-stream machinery
+    /// behind <see cref="Stream"/> is only the <i>source</i> here — the transform's readable side is a
+    /// default-controller stream whose chunks are strings, so <c>getReader({ mode: "byob" })</c> on it is
+    /// the <c>TypeError</c> it is on any non-byte stream. And <c>[NewObject]</c>: every call builds a fresh
+    /// source, a fresh decoder and a fresh result, so reading one cannot disturb another.
+    /// </para>
+    /// </remarks>
+    [JsFunction(Name = "textStream", Length = 0)]
+    private Streams.JsReadableStream TextStream(JsValue thisObject)
+    {
+        // Step 1, which is "get stream" on this — the same algorithm stream() is, so the two cannot drift.
+        var stream = Stream(thisObject);
+
+        // Steps 2 and 3: a new TextDecoderStream in this's relevant realm, set up with UTF-8. The decoder
+        // itself never reaches script; only the readable side of its transform does.
+        var decoder = Encoding.JsTextDecoderStream.SetUpUtf8(_engine, _realm);
+
+        // Step 4.
+        return Streams.ReadableStreamPipe.PipeThrough(stream, decoder.Transform);
     }
 
     /// <summary>

--- a/Jint/WebApi/Streams/ReadableStreamPipe.cs
+++ b/Jint/WebApi/Streams/ReadableStreamPipe.cs
@@ -93,6 +93,46 @@ internal sealed class ReadableStreamPipe
         return StreamPromises.PromiseOf(pipe._capability);
     }
 
+    /// <summary>
+    /// "Pipe <paramref name="readable"/> through <paramref name="transform"/>" —
+    /// https://streams.spec.whatwg.org/#readablestream-pipe-through, the abstract operation another
+    /// standard's algorithm reaches for when it composes two streams the engine owns.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is deliberately <i>not</i> <c>ReadableStream.prototype.pipeThrough</c>. That method exists to
+    /// convert a <c>ReadableWritablePair</c> a script supplied — reading <c>readable</c> and
+    /// <c>writable</c> off an arbitrary object, and <c>signal</c>/<c>preventClose</c>/… off a
+    /// <c>StreamPipeOptions</c> — and every one of those reads is a property access a script can intercept.
+    /// A composition inside the engine has neither an untrusted pair nor options to read: both streams came
+    /// from a transform this code just built, so the operation is what it reduces to once those conversions
+    /// are done. It is the same choice the piping algorithm itself is written against — "public API must not
+    /// be used" — carried one level out.
+    /// </para>
+    /// <para>
+    /// The operation's two assertions (neither side is locked) hold by construction for every caller here,
+    /// since both streams are fresh. Its every option is defaulted: no signal, and nothing prevented.
+    /// </para>
+    /// <para>
+    /// The pipe's own promise is not handed back — the readable side is — so it is marked handled and a
+    /// failure surfaces through that stream instead of as an unhandled rejection.
+    /// </para>
+    /// </remarks>
+    internal static JsReadableStream PipeThrough(JsReadableStream readable, JsTransformStream transform)
+    {
+        var promise = PipeTo(
+            readable,
+            transform.Writable,
+            preventClose: false,
+            preventAbort: false,
+            preventCancel: false,
+            signal: null);
+
+        StreamPromises.MarkHandled(promise);
+
+        return transform.Readable;
+    }
+
     private void Start()
     {
         if (_signal is { } signal)

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ its own `console` (or any other name in the table below), enabling the feature l
 | `performance.now` / `timeOrigin` / `mark` / `measure` / `getEntries*` / `clearMarks` / `clearMeasures` | `WebApiFeatures.Performance` | ✔ shipped |
 | `Event` / `EventTarget` / `CustomEvent` / `AbortController` / `AbortSignal` | `Events` | ✔ shipped |
 | `URL` / `URLSearchParams` / `URLPattern` | `Url` | ✔ shipped |
-| `Blob` (incl. `stream()`) / `File` / `FormData` | `Files` | ✔ shipped |
+| `Blob` (incl. `stream()` and `textStream()`) / `File` / `FormData` | `Files` | ✔ shipped |
 | `navigator.userAgent` | `Navigator` | ✔ shipped |
 | `ReadableStream` / `WritableStream` / `TransformStream` (all three transferable) / `ByteLengthQueuingStrategy` / `CountQueuingStrategy` | `Streams` | ✔ shipped |
 | `TextEncoderStream` / `TextDecoderStream` | `Encoding` **and** `Streams` | ✔ shipped |
@@ -1261,6 +1261,11 @@ network response, on a buffered body and on a blob — and `tee()` on any of the
 `Engine.Advanced.CreateReadableStream(Stream)` is the one that is still an ordinary stream: it wraps a host
 `Stream` you already own, whose reads go into a buffer the bridge owns rather than into one a script
 supplied.
+
+[`Blob.textStream()`](https://w3c.github.io/FileAPI/#dom-blob-textstream) is the composition of the two: the
+blob's byte stream piped through a UTF-8 `TextDecoderStream`, so what comes back is an *ordinary* stream
+whose chunks are strings. It always decodes as UTF-8 — the blob's `type` is never consulted, whatever
+`charset` it names, which is the specification's own difference from `FileReader.readAsText()`.
 
 One deliberate reduction: **only the five interfaces a script constructs by name are globals.**
 `ReadableStreamDefaultReader`, `ReadableStreamBYOBReader`, `WritableStreamDefaultWriter`, the four


### PR DESCRIPTION
Closes #3211.

`Blob.textStream()` — https://w3c.github.io/FileAPI/#dom-blob-textstream, `[NewObject] ReadableStream textStream();` — is a normative member of the `Blob` interface added after Jint's `Blob` was written. Its algorithm is four steps over pieces the engine already ships: get the blob's stream, create a `TextDecoderStream` in this's relevant realm, set it up with UTF-8, return the source piped through it.

`FileAPI/blob/Blob-textStream.any.js` was 8-for-8 red purely because the method was absent. It is now 8-for-8 green, and the corpus file is the conformance suite: the `NeedsBlobTextStream` category and its rows are deleted, which the driver enforces.

### Always UTF-8, and an ordinary stream of strings

The interface takes no encoding argument and the blob's own `type` is never consulted, so a `charset` parameter on it — valid, invalid, or contradicting the bytes — changes nothing. That is the specification's own note and the difference from `FileReader.readAsText()`. Being an ordinary UTF-8 `TextDecoderStream` settles the rest of the behaviour for free: one leading BOM dropped, ill-formed sequences to U+FFFD rather than a throw, and a sequence split across chunks decoding to what the whole byte sequence would.

The issue asked us to decide the returned stream's identity. It is the transform's readable side — an ordinary default-controller `ReadableStream` whose chunks are strings, so `getReader({ mode: "byob" })` on it is the `TypeError` it is on any non-byte stream. `Blob.stream()`'s byte machinery is only the *source*. The decoder is built directly rather than through the constructor, so no label is converted and a subclass cannot reach it — which is what "a new `TextDecoderStream`" plus a separate "set up" step mean.

### Two internal entry points, and why they are not a bypass

`ReadableStreamPipe.PipeThrough` is the streams standard's [pipe-through abstract operation](https://streams.spec.whatwg.org/#readablestream-pipe-through), which is deliberately *not* `ReadableStream.prototype.pipeThrough`. That method exists to convert a `ReadableWritablePair` a script supplied — reading `readable`/`writable` off an arbitrary object and the options off a `StreamPipeOptions`, every one of them a property access a script can intercept. A composition inside the engine has neither an untrusted pair nor options to read, so the operation is what the method reduces to once those conversions are done. It is the piping algorithm's own "public API must not be used", carried one level out. **All four options are passed explicitly rather than skipped**, and the script-visible `pipeThrough` is untouched — it keeps its dictionary conversions and both lock checks.

`JsTextDecoderStream.SetUpUtf8` and its `SetUpTransform` are the same shape for the decoder. The one edit to a shipped code path is `TextDecoderStreamConstructor` calling the extracted `SetUpTransform()`; it is provably equivalent, since `OrdinaryCreateFromConstructor` builds the instance from the *constructor's* engine and realm unconditionally and only the prototype comes from `newTarget`. No shipped API gained, lost or altered a member.

### Verification

Solution builds Release across all five TFMs, so the whole-file `#if NET8_0_OR_GREATER` gate holds. `Jint.Tests` 10064 net10.0 / 7102 net472, `Jint.Tests.PublicInterface` 2379 / 1865, WPT 322 files green.

The before/after on the FileAPI corpus is measured rather than inferred (base restored, re-run): `Blob-textStream.any.js` 8 failing → 8 passing, corpus 11 not-passing → 3, exclusion rows 5 → 3. The 3 that remain are the `Array.prototype.values` engine defect, which is #3209.

Behaviour checked by probe beyond the corpus: BOM handling (leading one dropped, second survives, mid-stream untouched), invalid bytes, charset ignored in three variants, `[NewObject]` independence, `stream()` and `textStream()` from one blob independent in either drain order, cancellation via reader and via stream, an abandoned stream, `tee()`, `slice().textStream()`, `class extends Blob`, 200 KB, two concurrent drains, `File.textStream()`, brand check, `length`/`name`, and a descriptor shape identical to `stream`/`text`/`bytes`.

### One pre-existing finding, not fixed here

A *successful* drain fires three `PromiseRejectionTracker` `Reject` events. It is not this method's: `blob.stream().pipeThrough(new TransformStream())` and a script-built stream's `pipeThrough` produce the identical count and reasons, and a plain `blob.stream()` drain produces none. It originates in `ReadableStreamPipe`'s shutdown, where the reject precedes the `MarkHandled` and `RejectPromise` fires the TC39 hook while `[[PromiseIsHandled]]` is still false — which is what ECMA-262 prescribes; a browser suppresses it at HTML's deferred checkpoint, which AGENTS.md already documents Jint as not implementing. Filed separately rather than changing shipped `pipeTo`/`pipeThrough` behaviour in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
