### PR TITLE
Tests: turn the WebApi transport waits into wedge ceilings off the pool

### DIFF
--- a/Jint.Tests.PublicInterface/WebApiCacheTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiCacheTests.cs
@@ -134,6 +134,21 @@ public class WebApiCacheTests
     private static string Run(Engine engine, string body)
         => engine.Evaluate("(async () => {" + body + "})()").UnwrapIfPromise().AsString();
 
+    /// <summary>
+    /// <see cref="Run(Engine, string)"/> for a cache filled over the network. Separate because the promise it
+    /// waits for settles only once <c>FetchBodyStream</c>'s <c>Task.Run</c> read loop has delivered each body,
+    /// so the wait needs a thread-pool worker where every other test here settles on the engine's own queue.
+    /// The bound is therefore a ceiling only a genuine failure to deliver can reach rather than a ten-second
+    /// interval a loaded runner can lose, and its caller hands its body to
+    /// <see cref="DedicatedThread.RunAsync"/> so the wait is not holding the worker the read loop needs
+    /// (sebastienros/jint#3213).
+    /// </summary>
+    private static string RunFetching(Engine engine, string body)
+        => engine.Evaluate("(async () => {" + body + "})()").UnwrapIfPromise(TransportSignalCeiling).AsString();
+
+    /// <summary>How long a network-backed cache operation may take to settle. Not a measurement.</summary>
+    private static readonly TimeSpan TransportSignalCeiling = TimeSpan.FromMinutes(2);
+
     [Fact]
     public void ADefaultEngineHasNoCaches()
     {
@@ -414,7 +429,7 @@ public class WebApiCacheTests
     }
 
     [Fact]
-    public void AddAllCommitsTheWholeBatchAsOneWrite()
+    public Task AddAllCommitsTheWholeBatchAsOneWrite() => DedicatedThread.RunAsync(() =>
     {
         var provider = new RecordingProvider();
         var handler = new StubHandler();
@@ -423,7 +438,7 @@ public class WebApiCacheTests
             .UseCacheApi(cache => cache.Provider = provider)
             .UseFetch(fetch => fetch.HttpClient = new HttpClient(handler)));
 
-        Run(engine, """
+        RunFetching(engine, """
             const cache = await caches.open('v1');
             await cache.addAll(['https://example.org/a', 'https://example.org/b']);
             return 'done';
@@ -437,7 +452,7 @@ public class WebApiCacheTests
         store.Writes.Should().ContainSingle();
         store.Writes[0].Added.Should().HaveCount(2);
         store.Entries.Should().HaveCount(2);
-    }
+    });
 
     [Fact]
     public void AFailedAddAllNeverReachesTheProvider()

--- a/Jint.Tests.PublicInterface/WebApiEventSourceTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiEventSourceTests.cs
@@ -15,14 +15,33 @@ namespace Jint.Tests.PublicInterface;
 /// on, and what a restore does to a connection that is still open.
 /// </summary>
 /// <remarks>
+/// <para>
 /// This project has no <c>InternalsVisibleTo</c>, so everything here is reachable by a third party — the stub
 /// transport goes in through <c>Options.WebApi.Fetch.HttpClient</c>, the same door a host uses for a
 /// <c>DelegatingHandler</c> or an <c>IHttpClientFactory</c> client, and it is the same group <c>fetch</c>
 /// reads because server-sent events deliberately share it.
+/// </para>
+/// <para>
+/// <b>The three tests that wait for a hanging handler's token run on
+/// <see cref="DedicatedThread.RunAsync"/>.</b> A handler that hangs is parked in <c>Task.Delay</c>, so the
+/// <c>catch</c> that sets <see cref="StubHandler.Cancelled"/> is a thread-pool continuation — and blocking an
+/// xUnit pool worker to wait for one is the resource inversion described on
+/// <see cref="DedicatedThread.RunAsync"/>, which is exactly the claim and exactly the treatment
+/// sebastienros/jint#3207 gave the in-assembly sibling of these tests. Every other test here drives a handler
+/// that answers synchronously, so its connection loop runs inline on the thread that started it and there is
+/// nothing to wait for.
+/// </para>
 /// </remarks>
 public class WebApiEventSourceTests
 {
     private const string StreamUrl = "https://example.org/stream";
+
+    /// <summary>
+    /// How long a test will wait for a signal the transport raises. The claim is that the signal happens at
+    /// all, never how quickly, so this is a ceiling only a genuine failure to propagate can reach — never an
+    /// interval a loaded runner can lose (sebastienros/jint#3213).
+    /// </summary>
+    private static readonly TimeSpan TransportSignalCeiling = TimeSpan.FromMinutes(2);
 
     /// <summary>
     /// A clock that only moves when a test moves it, so the reconnect delay is exact and instant.
@@ -152,9 +171,13 @@ public class WebApiEventSourceTests
     /// Pumps the engine from the host's own thread, which is the only way anything an event source produces
     /// is delivered at all.
     /// </summary>
+    /// <remarks>
+    /// The bound is <see cref="TransportSignalCeiling"/> rather than an interval the engine is expected to
+    /// beat: what is being waited for is a hand-over, so only a hand-over that never happens can reach it.
+    /// </remarks>
     private static void Pump(Engine engine, Func<bool> until, string expectation)
     {
-        var deadline = DateTime.UtcNow.AddSeconds(15);
+        var deadline = DateTime.UtcNow + TransportSignalCeiling;
         while (DateTime.UtcNow < deadline)
         {
             engine.Advanced.ProcessTasks();
@@ -293,7 +316,7 @@ public class WebApiEventSourceTests
     }
 
     [Fact]
-    public void CloseCancelsTheRequestInFlight()
+    public Task CloseCancelsTheRequestInFlight() => DedicatedThread.RunAsync(() =>
     {
         var handler = new StubHandler { Hang = true };
         var (engine, _, records) = SseEngine(handler);
@@ -304,17 +327,17 @@ public class WebApiEventSourceTests
         engine.Execute("es.close();");
 
         // The abort reached the socket, not just the object.
-        handler.Cancelled.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
+        handler.Cancelled.Wait(TransportSignalCeiling).Should().BeTrue("closing an EventSource must cancel the request in flight, not merely mark the object CLOSED");
 
         engine.Evaluate("es.readyState").AsNumber().Should().Be(2);
 
         // And closing fires nothing: it is not a failure, so there is no error event.
         Idle(engine);
         Joined(records).Should().BeEmpty();
-    }
+    });
 
     [Fact]
-    public void ARestoreCancelsTheConnectionAndDeliversNothingIntoTheRestoredEngine()
+    public Task ARestoreCancelsTheConnectionAndDeliversNothingIntoTheRestoredEngine() => DedicatedThread.RunAsync(() =>
     {
         var handler = new StubHandler { Hang = true };
         var (engine, _, records) = SseEngine(handler);
@@ -326,7 +349,7 @@ public class WebApiEventSourceTests
         engine.Advanced.RestoreGlobalSnapshot(snapshot);
 
         // The socket is let go at once ...
-        handler.Cancelled.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
+        handler.Cancelled.Wait(TransportSignalCeiling).Should().BeTrue("a restore must cancel the connection rather than leave the socket held");
 
         // ... and nothing from the ended cycle ever reaches the restored engine.
         Idle(engine);
@@ -335,7 +358,7 @@ public class WebApiEventSourceTests
         // The engine is perfectly usable afterwards.
         engine.Evaluate("typeof EventSource").AsString().Should().Be("function");
         engine.Evaluate("typeof es").AsString().Should().Be("undefined");
-    }
+    });
 
     [Fact]
     public void ARestoreAlsoTakesTheReconnectDelayWithIt()
@@ -362,7 +385,7 @@ public class WebApiEventSourceTests
     }
 
     [Fact]
-    public void AnEngineCancellationEndsTheConnectionSilently()
+    public Task AnEngineCancellationEndsTheConnectionSilently() => DedicatedThread.RunAsync(() =>
     {
         // A constraint that became an error event would let the script carry on — and reconnect — which is
         // precisely what the constraint exists to stop.
@@ -375,14 +398,14 @@ public class WebApiEventSourceTests
         Pump(engine, () => handler.RequestCount == 1, "the request to reach the transport");
 
         cancellation.Cancel();
-        handler.Cancelled.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
+        handler.Cancelled.Wait(TransportSignalCeiling).Should().BeTrue("an engine cancellation must reach the connection in flight");
 
         clock.Advance(60_000);
         Idle(engine);
 
         Count(records).Should().Be(0);
         handler.RequestCount.Should().Be(1);
-    }
+    });
 
     [Fact]
     public void BoundsHowManyStreamsOneEngineMayHaveOpen()

--- a/Jint.Tests.PublicInterface/WebApiFetchStreamTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiFetchStreamTests.cs
@@ -26,9 +26,22 @@ namespace Jint.Tests.PublicInterface;
 /// is how many of them happened and in which order; the waits on a <see cref="ManualResetEventSlim"/> are
 /// waits for an event at a deliberately generous bound, not measurements.
 /// </para>
+/// <para>
+/// <b>Every test that reaches the transport runs on <see cref="DedicatedThread.RunAsync"/>.</b> A network
+/// response body is pumped by a <c>Task.Run</c> loop inside <c>FetchBodyStream</c>, so each chunk and each
+/// cancellation arrives on a thread-pool worker; a body that blocked an xUnit pool worker to wait for one
+/// would be the resource inversion described on <see cref="DedicatedThread.RunAsync"/>, and the bound would
+/// stop being a check and start being a race (sebastienros/jint#3213).
+/// </para>
 /// </remarks>
 public class WebApiFetchStreamTests
 {
+    /// <summary>
+    /// How long a test will wait for the transport. A ceiling only a genuine failure to deliver can reach,
+    /// never a budget the pool has to beat: what is asserted is that the read, or the cancel, happens at all.
+    /// </summary>
+    private static readonly TimeSpan TransportSignalCeiling = TimeSpan.FromMinutes(2);
+
     /// <summary>
     /// A response body whose reads are served from a channel the test fills, so a read blocks until the test
     /// has said what it should answer with.
@@ -117,7 +130,7 @@ public class WebApiFetchStreamTests
     }
 
     [Fact]
-    public void AHostScriptDrainsTheResponseBodyChunkByChunk()
+    public Task AHostScriptDrainsTheResponseBodyChunkByChunk() => DedicatedThread.RunAsync(() =>
     {
         var handler = new GatedHandler();
         handler.Body.Emit("first ");
@@ -136,14 +149,14 @@ public class WebApiFetchStreamTests
                     seen.push(dec(value));
                 }
                 return seen.join('|');
-            })()").UnwrapIfPromise().AsString().Should().Be("first |second");
+            })()").UnwrapIfPromise(TransportSignalCeiling).AsString().Should().Be("first |second");
 
         // One read per chunk, plus the one that saw the end of the body.
         handler.Body.ReadCount.Should().Be(3);
-    }
+    });
 
     [Fact]
-    public void TheTransportIsOnlyReadWhenTheScriptAsks()
+    public Task TheTransportIsOnlyReadWhenTheScriptAsks() => DedicatedThread.RunAsync(() =>
     {
         // Backpressure, from the host's side: a script that takes the response and never reads its body
         // leaves the transport untouched however hard the engine is pumped.
@@ -169,12 +182,12 @@ public class WebApiFetchStreamTests
         handler.Body.ReadCount.Should().Be(0);
 
         // The first read is what reaches the socket.
-        engine.Evaluate("r.body.getReader().read().then(x => dec(x.value))").UnwrapIfPromise().AsString().Should().Be("ignored");
+        engine.Evaluate("r.body.getReader().read().then(x => dec(x.value))").UnwrapIfPromise(TransportSignalCeiling).AsString().Should().Be("ignored");
         handler.Body.ReadCount.Should().Be(1);
-    }
+    });
 
     [Fact]
-    public void CancellingTheBodyLetsGoOfTheConnection()
+    public Task CancellingTheBodyLetsGoOfTheConnection() => DedicatedThread.RunAsync(() =>
     {
         // Nothing is emitted, so the transport is parked in a read and only its token can end it.
         var handler = new GatedHandler();
@@ -186,16 +199,16 @@ public class WebApiFetchStreamTests
         engine.Execute("var reader = r.body.getReader(); reader.read();");
         engine.Advanced.ProcessTasks();
 
-        handler.Body.ReadStarted.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue("the read should have reached the transport");
+        handler.Body.ReadStarted.Wait(TransportSignalCeiling).Should().BeTrue("the read should have reached the transport");
 
         engine.Execute("reader.cancel();");
         engine.Advanced.ProcessTasks();
 
-        handler.Body.Cancelled.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
-    }
+        handler.Body.Cancelled.Wait(TransportSignalCeiling).Should().BeTrue("cancelling the body must cancel the read in flight, not merely close the stream");
+    });
 
     [Fact]
-    public void ARestoreLetsGoOfAStreamingBodyMidFlight()
+    public Task ARestoreLetsGoOfAStreamingBodyMidFlight() => DedicatedThread.RunAsync(() =>
     {
         var handler = new GatedHandler();
         var engine = WebEngine(handler);
@@ -207,20 +220,20 @@ public class WebApiFetchStreamTests
         engine.Execute("var reader = r.body.getReader(); reader.read();");
         engine.Advanced.ProcessTasks();
 
-        handler.Body.ReadStarted.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
+        handler.Body.ReadStarted.Wait(TransportSignalCeiling).Should().BeTrue("the read should have reached the transport");
 
         engine.Advanced.RestoreGlobalSnapshot(snapshot);
 
         // The socket goes with the cycle that opened it: a body still arriving is not something the restored
         // engine can finish reading, so it is cancelled rather than left holding a connection.
-        handler.Body.Cancelled.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
+        handler.Body.Cancelled.Wait(TransportSignalCeiling).Should().BeTrue("a restore must cancel the read in flight rather than leave the connection held");
 
         engine.Evaluate("typeof r").AsString().Should().Be("undefined");
         engine.Evaluate("typeof fetch").AsString().Should().Be("function");
-    }
+    });
 
     [Fact]
-    public void AResponseBodyCanBePipedThroughATransformStream()
+    public Task AResponseBodyCanBePipedThroughATransformStream() => DedicatedThread.RunAsync(() =>
     {
         // The two features meeting: a streaming body driving a TransformStream, all on the engine's own job
         // queue and with nothing but the host's transport off it.
@@ -240,7 +253,7 @@ public class WebApiFetchStreamTests
                 let out = '';
                 for await (const piece of r.body.pipeThrough(upper)) { out += piece; }
                 return out;
-            })()").UnwrapIfPromise().AsString().Should().Be("ABCD");
-    }
+            })()").UnwrapIfPromise(TransportSignalCeiling).AsString().Should().Be("ABCD");
+    });
 }
 #endif

--- a/Jint.Tests.PublicInterface/WebApiFetchTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiFetchTests.cs
@@ -16,12 +16,31 @@ namespace Jint.Tests.PublicInterface;
 /// threads its promise settles on.
 /// </summary>
 /// <remarks>
+/// <para>
 /// This project has no <c>InternalsVisibleTo</c>, so everything here is reachable by a third party — the
 /// stub transport goes in through <c>Options.WebApi.Fetch.HttpClient</c>, which is the same door a host uses
 /// for a <c>DelegatingHandler</c> or an <c>IHttpClientFactory</c> client.
+/// </para>
+/// <para>
+/// <b>A test that waits for the transport runs on <see cref="DedicatedThread.RunAsync"/>.</b> Two things here
+/// only finish on a thread-pool worker: a hanging handler resuming from <c>Task.Delay</c> when its token
+/// fires, and a response body, which the engine pumps from the <c>Task.Run</c> loop inside
+/// <c>FetchBodyStream</c>. Blocking an xUnit pool worker to wait for one is the resource inversion described
+/// on <see cref="DedicatedThread.RunAsync"/> — a saturated pool injects workers at roughly one per 500 ms —
+/// and it is why every window in this class is now <see cref="TransportSignalCeiling"/>, a bound only a
+/// genuine failure can reach, rather than the five and ten second intervals a loaded runner could lose
+/// (sebastienros/jint#3213). Tests whose promise settles at the response headers wait for nothing and stay
+/// where they are.
+/// </para>
 /// </remarks>
 public class WebApiFetchTests
 {
+    /// <summary>
+    /// How long a test will wait for the transport: a request settling, a body arriving, a cancelled request
+    /// seeing its token. The claim is always that it happens at all, never how quickly.
+    /// </summary>
+    private static readonly TimeSpan TransportSignalCeiling = TimeSpan.FromMinutes(2);
+
     /// <summary>
     /// A handler that answers immediately or hangs until its token is cancelled, and remembers which.
     /// </summary>
@@ -114,13 +133,13 @@ public class WebApiFetchTests
         var engine = WebEngine(handler, f => f.AllowedSchemes.Remove("http"));
 
         engine.Evaluate("fetch('http://example.org/').then(() => 'resolved', e => e.constructor.name + ': ' + e.message)")
-            .UnwrapIfPromise().AsString().Should().Be("TypeError: Failed to fetch");
+            .UnwrapIfPromise(TransportSignalCeiling).AsString().Should().Be("TypeError: Failed to fetch");
 
         // Refused before a socket was opened.
         handler.Urls.Should().BeEmpty();
 
         // https is still allowed.
-        engine.Evaluate("fetch('https://example.org/').then(r => r.status)").UnwrapIfPromise().AsNumber().Should().Be(200);
+        engine.Evaluate("fetch('https://example.org/').then(r => r.status)").UnwrapIfPromise(TransportSignalCeiling).AsNumber().Should().Be(200);
     }
 
     [Fact]
@@ -130,11 +149,11 @@ public class WebApiFetchTests
         var engine = WebEngine(handler, f => f.UrlFilter = uri => uri.Host.EndsWith(".example.org", StringComparison.OrdinalIgnoreCase));
 
         engine.Evaluate("fetch('https://169.254.169.254/latest/meta-data/').then(() => 'resolved', e => e.message)")
-            .UnwrapIfPromise().AsString().Should().Be("Failed to fetch");
+            .UnwrapIfPromise(TransportSignalCeiling).AsString().Should().Be("Failed to fetch");
 
         handler.Urls.Should().BeEmpty();
 
-        engine.Evaluate("fetch('https://api.example.org/').then(r => r.status)").UnwrapIfPromise().AsNumber().Should().Be(200);
+        engine.Evaluate("fetch('https://api.example.org/').then(r => r.status)").UnwrapIfPromise(TransportSignalCeiling).AsNumber().Should().Be(200);
     }
 
     [Fact]
@@ -164,7 +183,7 @@ public class WebApiFetchTests
         });
 
         engine.Evaluate("fetch('https://api.example.org/a').then(() => 'resolved', e => e.constructor.name + ': ' + e.message)")
-            .UnwrapIfPromise().AsString().Should().Be("TypeError: Failed to fetch");
+            .UnwrapIfPromise(TransportSignalCeiling).AsString().Should().Be("TypeError: Failed to fetch");
 
         // The filter saw both hops, and only the first reached the transport.
         seen.Should().Equal("https://api.example.org/a", "http://169.254.169.254/latest/meta-data/");
@@ -182,12 +201,12 @@ public class WebApiFetchTests
         var engine = WebEngine(handler, f => f.MaxResponseBytes = 1024);
 
         engine.Evaluate("fetch('https://example.org/').then(() => 'resolved', e => e.constructor.name + '|' + e.message)")
-            .UnwrapIfPromise().AsString().Should()
+            .UnwrapIfPromise(TransportSignalCeiling).AsString().Should()
             .Be("TypeError|Failed to fetch: The response body exceeded the 1024 byte limit set by Options.WebApi.Fetch.MaxResponseBytes.");
     }
 
     [Fact]
-    public void CapsTheResponseBodyWithoutAContentLengthWhileItStreams()
+    public Task CapsTheResponseBodyWithoutAContentLengthWhileItStreams() => DedicatedThread.RunAsync(() =>
     {
         // A server that lies about the length, or uses chunked encoding, is caught by the running total
         // rather than by the declared one.
@@ -205,11 +224,11 @@ public class WebApiFetchTests
         var engine = WebEngine(handler, f => f.MaxResponseBytes = 1024);
 
         engine.Evaluate("fetch('https://example.org/').then(r => r.text()).then(() => 'resolved', e => e.constructor.name + '|' + e.message)")
-            .UnwrapIfPromise().AsString().Should().Be("TypeError|Failed to fetch: The response body exceeded the 1024 byte limit set by Options.WebApi.Fetch.MaxResponseBytes.");
-    }
+            .UnwrapIfPromise(TransportSignalCeiling).AsString().Should().Be("TypeError|Failed to fetch: The response body exceeded the 1024 byte limit set by Options.WebApi.Fetch.MaxResponseBytes.");
+    });
 
     [Fact]
-    public void TheCapReachesAConsumerThatReadsTheStreamItself()
+    public Task TheCapReachesAConsumerThatReadsTheStreamItself() => DedicatedThread.RunAsync(() =>
     {
         // The same failure through the other door: a script draining response.body chunk by chunk sees the
         // reader's promise reject rather than a body mixin method's.
@@ -236,8 +255,8 @@ public class WebApiFetchTests
             })()")
             // How many bytes arrived first depends on how the transport chunked them; that the read ends in
             // a TypeError rather than in a close is the pin.
-            .UnwrapIfPromise().AsString().Should().StartWith("TypeError after ");
-    }
+            .UnwrapIfPromise(TransportSignalCeiling).AsString().Should().StartWith("TypeError after ");
+    });
 
     /// <summary>
     /// Content that streams its bytes and refuses to say how many there are, which is what a chunked
@@ -260,7 +279,7 @@ public class WebApiFetchTests
     }
 
     [Fact]
-    public void ABodyUnderTheCapIsReadInFull()
+    public Task ABodyUnderTheCapIsReadInFull() => DedicatedThread.RunAsync(() =>
     {
         var handler = new StubHandler
         {
@@ -269,11 +288,11 @@ public class WebApiFetchTests
 
         var engine = WebEngine(handler, f => f.MaxResponseBytes = 1024);
         engine.Evaluate("fetch('https://example.org/').then(r => r.text()).then(t => t.length)")
-            .UnwrapIfPromise().AsNumber().Should().Be(1024);
-    }
+            .UnwrapIfPromise(TransportSignalCeiling).AsNumber().Should().Be(1024);
+    });
 
     [Fact]
-    public void AnAbortMidFlightRejectsWithTheReasonAndCancelsTheRequest()
+    public Task AnAbortMidFlightRejectsWithTheReasonAndCancelsTheRequest() => DedicatedThread.RunAsync(() =>
     {
         var handler = new StubHandler { Hang = true };
         var engine = WebEngine(handler);
@@ -282,25 +301,25 @@ public class WebApiFetchTests
                 const c = new AbortController();
                 setTimeout(() => c.abort('stop'), 0);
                 return fetch('https://example.org/', { signal: c.signal }).then(() => 'resolved', e => e);
-            })()").UnwrapIfPromise();
+            })()").UnwrapIfPromise(TransportSignalCeiling);
 
         outcome.AsString().Should().Be("stop");
 
         // The abort reached the socket, not just the promise.
-        handler.Cancelled.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
-    }
+        handler.Cancelled.Wait(TransportSignalCeiling).Should().BeTrue("aborting a fetch must cancel the request in flight, not merely reject the promise");
+    });
 
     [Fact]
-    public void ADeadlineRejectsWithATimeoutErrorDomException()
+    public Task ADeadlineRejectsWithATimeoutErrorDomException() => DedicatedThread.RunAsync(() =>
     {
         var handler = new StubHandler { Hang = true };
         var engine = WebEngine(handler, f => f.Timeout = TimeSpan.FromMilliseconds(50));
 
         engine.Evaluate("fetch('https://example.org/').then(() => 'resolved', e => e.name + '|' + (e instanceof Error))")
-            .UnwrapIfPromise().AsString().Should().Be("TimeoutError|true");
+            .UnwrapIfPromise(TransportSignalCeiling).AsString().Should().Be("TimeoutError|true");
 
-        handler.Cancelled.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
-    }
+        handler.Cancelled.Wait(TransportSignalCeiling).Should().BeTrue("the deadline must reach the request in flight, not merely reject the promise");
+    });
 
     [Fact]
     public void RefusesMoreConcurrentRequestsThanTheHostAllows()
@@ -333,14 +352,14 @@ public class WebApiFetchTests
 
         for (var i = 0; i < 3; i++)
         {
-            engine.Evaluate($"fetch('https://example.org/{i}').then(r => r.status)").UnwrapIfPromise().AsNumber().Should().Be(200);
+            engine.Evaluate($"fetch('https://example.org/{i}').then(r => r.status)").UnwrapIfPromise(TransportSignalCeiling).AsNumber().Should().Be(200);
         }
 
         handler.Urls.Should().HaveCount(3);
     }
 
     [Fact]
-    public void ARestoreCancelsTheRequestAndTheOldPromiseNeverSettles()
+    public Task ARestoreCancelsTheRequestAndTheOldPromiseNeverSettles() => DedicatedThread.RunAsync(() =>
     {
         var handler = new StubHandler { Hang = true };
         var settled = 0;
@@ -354,7 +373,7 @@ public class WebApiFetchTests
         engine.Advanced.RestoreGlobalSnapshot(snapshot);
 
         // The socket is let go at once...
-        handler.Cancelled.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
+        handler.Cancelled.Wait(TransportSignalCeiling).Should().BeTrue("a restore must cancel the request in flight rather than leave the socket held");
 
         // ... and nothing from the ended cycle ever settles into the restored engine.
         for (var i = 0; i < 20; i++)
@@ -367,10 +386,10 @@ public class WebApiFetchTests
 
         // The engine is perfectly usable afterwards.
         engine.Evaluate("typeof fetch").AsString().Should().Be("function");
-    }
+    });
 
     [Fact]
-    public void AnEngineCancellationSettlesNothingAtAll()
+    public Task AnEngineCancellationSettlesNothingAtAll() => DedicatedThread.RunAsync(() =>
     {
         // A constraint that became a promise rejection would no longer bound anything: script would observe
         // an ordinary failed fetch and carry on.
@@ -387,7 +406,7 @@ public class WebApiFetchTests
         engine.Execute("fetch('https://example.org/').then(record, record);");
 
         cancellation.Cancel();
-        handler.Cancelled.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
+        handler.Cancelled.Wait(TransportSignalCeiling).Should().BeTrue("an engine cancellation must reach the request in flight");
 
         for (var i = 0; i < 20; i++)
         {
@@ -396,17 +415,17 @@ public class WebApiFetchTests
         }
 
         Volatile.Read(ref settled).Should().Be(0);
-    }
+    });
 
     [Fact]
-    public void CompletesUnderABlockingUnwrap()
+    public Task CompletesUnderABlockingUnwrap() => DedicatedThread.RunAsync(() =>
     {
         var handler = new StubHandler();
         var engine = WebEngine(handler);
 
         engine.Evaluate("(async () => { const r = await fetch('https://example.org/'); return await r.text(); })()")
-            .UnwrapIfPromise().AsString().Should().Be("ok");
-    }
+            .UnwrapIfPromise(TransportSignalCeiling).AsString().Should().Be("ok");
+    });
 
     [Fact]
     public async Task CompletesUnderEvaluateAsync()
@@ -419,7 +438,7 @@ public class WebApiFetchTests
     }
 
     [Fact]
-    public void CompletesUnderAHostProcessTasksLoop()
+    public Task CompletesUnderAHostProcessTasksLoop() => DedicatedThread.RunAsync(() =>
     {
         // The shape a game loop or a message pump uses: every turn provably runs on the host's own thread,
         // and nothing here ever blocks on the engine.
@@ -428,7 +447,10 @@ public class WebApiFetchTests
 
         engine.Execute("var text, done = false; fetch('https://example.org/').then(r => r.text()).then(t => { text = t; done = true; });");
 
-        var deadline = DateTime.UtcNow.AddSeconds(10);
+        // The loop turns until the body has arrived. Its bound is a ceiling rather than a budget: the body is
+        // delivered by a pool worker, so how many turns that takes is the runner's business and not the
+        // claim — which is that a host driving nothing but ProcessTasks eventually sees the text.
+        var deadline = DateTime.UtcNow + TransportSignalCeiling;
         while (DateTime.UtcNow < deadline && !engine.Evaluate("done").AsBoolean())
         {
             engine.Advanced.ProcessTasks();
@@ -436,7 +458,7 @@ public class WebApiFetchTests
         }
 
         engine.Evaluate("text").AsString().Should().Be("ok");
-    }
+    });
 
     [Fact]
     public void TheHostReadsTheClrExceptionBehindAFailure()
@@ -481,7 +503,7 @@ public class WebApiFetchTests
             }));
 
         engine.Advanced.HostDefined = "tenant-a";
-        engine.Evaluate("fetch('https://example.org/').then(r => r.status)").UnwrapIfPromise().AsNumber().Should().Be(202);
+        engine.Evaluate("fetch('https://example.org/').then(r => r.status)").UnwrapIfPromise(TransportSignalCeiling).AsNumber().Should().Be(202);
 
         seen.Should().Equal("tenant-a");
         byProperty.Urls.Should().BeEmpty();

--- a/Jint.Tests.PublicInterface/WebApiMultipartTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiMultipartTests.cs
@@ -26,6 +26,16 @@ public class WebApiMultipartTests
 {
     private const string TypePrefix = "multipart/form-data; boundary=";
 
+    /// <summary>
+    /// How long the two tests that read a <i>response</i> back will wait for it. Their promise settles only
+    /// once <c>FetchBodyStream</c>'s <c>Task.Run</c> read loop has delivered the body, so it is a thread-pool
+    /// continuation they are waiting for; the bound is a ceiling only a genuine failure to deliver can reach,
+    /// and both hand their bodies to <see cref="DedicatedThread.RunAsync"/> so the wait is not itself holding
+    /// the worker that loop needs (sebastienros/jint#3213). The request-side tests assert what the handler was
+    /// sent and wait for nothing.
+    /// </summary>
+    private static readonly TimeSpan TransportSignalCeiling = TimeSpan.FromMinutes(2);
+
     /// <summary>A handler that answers immediately and keeps what it was sent.</summary>
     private sealed class CapturingHandler : HttpMessageHandler
     {
@@ -118,7 +128,7 @@ public class WebApiMultipartTests
     }
 
     [Fact]
-    public void ReadsAMultipartResponseBackAsFormData()
+    public Task ReadsAMultipartResponseBackAsFormData() => DedicatedThread.RunAsync(() =>
     {
         var handler = new CapturingHandler
         {
@@ -150,11 +160,11 @@ public class WebApiMultipartTests
         engine.Evaluate(@"fetch('https://api.example.org/')
                 .then(r => r.formData())
                 .then(fd => fd.get('status') + '|' + fd.get('receipt').name + '|' + fd.get('receipt').type)")
-            .UnwrapIfPromise().AsString().Should().Be("done|r.txt|text/plain");
-    }
+            .UnwrapIfPromise(TransportSignalCeiling).AsString().Should().Be("done|r.txt|text/plain");
+    });
 
     [Fact]
-    public void RejectsAMalformedMultipartResponseWithATypeError()
+    public Task RejectsAMalformedMultipartResponseWithATypeError() => DedicatedThread.RunAsync(() =>
     {
         var handler = new CapturingHandler
         {
@@ -175,7 +185,7 @@ public class WebApiMultipartTests
         engine.Evaluate(@"fetch('https://api.example.org/')
                 .then(r => r.formData())
                 .then(() => 'resolved', e => e.constructor.name)")
-            .UnwrapIfPromise().AsString().Should().Be("TypeError");
-    }
+            .UnwrapIfPromise(TransportSignalCeiling).AsString().Should().Be("TypeError");
+    });
 }
 #endif

--- a/Jint.Tests.PublicInterface/WebApiSchedulingSurfaceTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiSchedulingSurfaceTests.cs
@@ -20,6 +20,15 @@ namespace Jint.Tests.PublicInterface;
 /// </remarks>
 public class WebApiSchedulingSurfaceTests
 {
+    /// <summary>
+    /// The one wall-clock bound in this class, and it is reached only by a wedge: the thread it waits for is
+    /// one the test started itself, doing nothing but <c>Cancel()</c>, so no amount of runner load can lose
+    /// the race and only a cancellation that blocks forever — the very thing being ruled out — can spend two
+    /// minutes here. Deliberately not the thirty-second interval it replaced (sebastienros/jint#3213): a
+    /// bound that a slow machine can plausibly reach is a flake, and one it cannot is a check.
+    /// </summary>
+    private static readonly TimeSpan HandoffCeiling = TimeSpan.FromMinutes(2);
+
     /// <summary>A host-supplied clock, so that a suite exercising timed work need not sleep.</summary>
     private sealed class ManualClock : TimeProvider
     {
@@ -218,7 +227,7 @@ public class WebApiSchedulingSurfaceTests
         };
 
         canceller.Start();
-        canceller.Join(TimeSpan.FromSeconds(30)).Should().BeTrue("the cancelling thread must not block");
+        canceller.Join(HandoffCeiling).Should().BeTrue("the cancelling thread must not block");
 
         // Cancel() has returned, so every registration it runs has run. Nothing observed the abort, because
         // the registration only enqueued.

--- a/Jint.Tests/Runtime/WebApi/CacheTests.cs
+++ b/Jint.Tests/Runtime/WebApi/CacheTests.cs
@@ -22,6 +22,33 @@ public class CacheTests
     private static JsValue Run(string source) => Run(CacheEngine(), source);
 
     /// <summary>
+    /// <see cref="Run(Engine, string)"/> for a cache that is filled over the network. It is a separate helper
+    /// because the promise it waits for settles only once <c>FetchBodyStream</c>'s <c>Task.Run</c> read loop
+    /// has delivered the whole body, so the wait depends on a thread-pool continuation where every other test
+    /// in this class settles on the engine's own queue.
+    /// </summary>
+    /// <remarks>
+    /// Hence <see cref="TransportSignalCeiling"/> rather than the ten-second default: what is asserted is what
+    /// the cache ended up holding, never how long the transport took, so the bound must be one only a genuine
+    /// failure to deliver can reach. Every test that reaches the transport also hands its body to
+    /// <see cref="DedicatedThread.RunAsync"/>, so this wait is not holding the worker the read loop needs —
+    /// which is the inversion that dropped <see cref="AddAllRefusesTwoRequestsThatMatchEachOther"/> on a
+    /// loaded machine (sebastienros/jint#3213).
+    /// <para>
+    /// It is what every test built on <see cref="FetchingCacheEngine"/> uses, including the several that
+    /// refuse before a socket is opened and pin that with <c>Requests.Should().BeEmpty()</c>: which of them
+    /// reaches the transport is a property of the case, not of the harness, and one helper for the group
+    /// keeps a test that starts fetching from silently inheriting the ten-second default.
+    /// </para>
+    /// </remarks>
+    private static JsValue RunFetching(Engine engine, string source) => engine.Evaluate(source).UnwrapIfPromise(TransportSignalCeiling);
+
+    /// <summary>
+    /// How long a network-backed cache operation may take to settle. Not a measurement and not a budget.
+    /// </summary>
+    private static readonly TimeSpan TransportSignalCeiling = TimeSpan.FromMinutes(2);
+
+    /// <summary>
     /// Wraps a body in an immediately-invoked async function, which is how every one of these tests reads the
     /// promises the whole interface is made of.
     /// </summary>
@@ -638,11 +665,11 @@ public class CacheTests
     }
 
     [Fact]
-    public void AddAllFetchesEveryRequestAndStoresThemAll()
+    public Task AddAllFetchesEveryRequestAndStoresThemAll() => DedicatedThread.RunAsync(() =>
     {
         var handler = new StubHandler();
 
-        Run(FetchingCacheEngine(handler), Async("""
+        RunFetching(FetchingCacheEngine(handler), Async("""
             const cache = await caches.open('v1');
             const result = await cache.addAll(['https://example.org/a', 'https://example.org/b']);
 
@@ -652,22 +679,22 @@ public class CacheTests
             """)).AsString().Should().Be("undefined|https://example.org/a,https://example.org/b|body of https://example.org/a");
 
         handler.Requests.Should().BeEquivalentTo(["https://example.org/a", "https://example.org/b"]);
-    }
+    });
 
     [Fact]
-    public void AddStoresTheOneResponseItFetched()
+    public Task AddStoresTheOneResponseItFetched() => DedicatedThread.RunAsync(() =>
     {
         var handler = new StubHandler();
 
-        Run(FetchingCacheEngine(handler), Async("""
+        RunFetching(FetchingCacheEngine(handler), Async("""
             const cache = await caches.open('v1');
             await cache.add('https://example.org/a');
             return await (await cache.match('https://example.org/a')).text();
             """)).AsString().Should().Be("body of https://example.org/a");
-    }
+    });
 
     [Fact]
-    public void AddAllStoresNothingWhenAnyResponseIsNotOk()
+    public Task AddAllStoresNothingWhenAnyResponseIsNotOk() => DedicatedThread.RunAsync(() =>
     {
         var handler = new StubHandler
         {
@@ -678,7 +705,7 @@ public class CacheTests
 
         // "If response's … status is not an ok status … reject responsePromise with a TypeError" — and
         // because nothing is committed until every response has passed, the first one is not stored either.
-        Run(FetchingCacheEngine(handler), Async("""
+        RunFetching(FetchingCacheEngine(handler), Async("""
             const cache = await caches.open('v1');
             let outcome = 'stored';
             try { await cache.addAll(['https://example.org/a', 'https://example.org/b']); }
@@ -686,10 +713,10 @@ public class CacheTests
 
             return outcome + ':' + (await cache.keys()).length;
             """)).AsString().Should().Be("TypeError:0");
-    }
+    });
 
     [Fact]
-    public void AddAllStoresNothingWhenAResponseVariesByEverything()
+    public Task AddAllStoresNothingWhenAResponseVariesByEverything() => DedicatedThread.RunAsync(() =>
     {
         var handler = new StubHandler
         {
@@ -701,7 +728,7 @@ public class CacheTests
             },
         };
 
-        Run(FetchingCacheEngine(handler), Async("""
+        RunFetching(FetchingCacheEngine(handler), Async("""
             const cache = await caches.open('v1');
             let outcome = 'stored';
             try { await cache.addAll(['https://example.org/a']); }
@@ -709,16 +736,16 @@ public class CacheTests
 
             return outcome + ':' + (await cache.keys()).length;
             """)).AsString().Should().Be("TypeError:0");
-    }
+    });
 
     [Fact]
-    public void AddAllRefusesTwoRequestsThatMatchEachOther()
+    public Task AddAllRefusesTwoRequestsThatMatchEachOther() => DedicatedThread.RunAsync(() =>
     {
         var handler = new StubHandler();
 
         // Batch Cache Operations step 4.3: "if the result of running Query Cache with operation's request …
         // and addedItems is not empty, throw an InvalidStateError" — and the rollback leaves nothing behind.
-        Run(FetchingCacheEngine(handler), Async("""
+        RunFetching(FetchingCacheEngine(handler), Async("""
             const cache = await caches.open('v1');
             let outcome = 'stored';
             try { await cache.addAll(['https://example.org/a', 'https://example.org/a']); }
@@ -726,14 +753,14 @@ public class CacheTests
 
             return outcome + ':' + (await cache.keys()).length;
             """)).AsString().Should().Be("InvalidStateError:0");
-    }
+    });
 
     [Fact]
     public void AddAllRefusesANonHttpSchemeBeforeFetchingAnything()
     {
         var handler = new StubHandler();
 
-        Run(FetchingCacheEngine(handler), Async("""
+        RunFetching(FetchingCacheEngine(handler), Async("""
             const cache = await caches.open('v1');
             let outcome = 'stored';
             try { await cache.addAll(['https://example.org/a', 'data:,hello']); }
@@ -751,7 +778,7 @@ public class CacheTests
     {
         var handler = new StubHandler();
 
-        Run(FetchingCacheEngine(handler), Async("""
+        RunFetching(FetchingCacheEngine(handler), Async("""
             const cache = await caches.open('v1');
             try { await cache.addAll([new Request('https://example.org/a', { method: 'POST', body: 'x' })]); return 'stored'; }
             catch (e) { return e.constructor.name; }
@@ -769,7 +796,7 @@ public class CacheTests
         // list, size cap and deadline bound them exactly as they bound a fetch the script wrote itself.
         var engine = FetchingCacheEngine(handler, fetch => fetch.UrlFilter = uri => uri.Host.Equals("allowed.example", StringComparison.Ordinal));
 
-        Run(engine, Async("""
+        RunFetching(engine, Async("""
             const cache = await caches.open('v1');
             let outcome = 'stored';
             try { await cache.add('https://denied.example/a'); }
@@ -786,7 +813,7 @@ public class CacheTests
     {
         var handler = new StubHandler();
 
-        Run(FetchingCacheEngine(handler), Async("""
+        RunFetching(FetchingCacheEngine(handler), Async("""
             const cache = await caches.open('v1');
             const result = await cache.addAll([]);
             return typeof result + ':' + (await cache.keys()).length;
@@ -802,7 +829,7 @@ public class CacheTests
 
         // The sequence<RequestInfo> conversion is an argument conversion, so its failure is a rejection like
         // every other — https://webidl.spec.whatwg.org/#es-sequence.
-        Run(FetchingCacheEngine(handler), Async("""
+        RunFetching(FetchingCacheEngine(handler), Async("""
             const cache = await caches.open('v1');
             try { await cache.addAll(5); return 'accepted'; }
             catch (e) { return e.constructor.name; }

--- a/Jint.Tests/Runtime/WebApi/EventSourceTests.cs
+++ b/Jint.Tests/Runtime/WebApi/EventSourceTests.cs
@@ -217,9 +217,16 @@ public class EventSourceTests
     /// Pumps the engine until <paramref name="until"/> holds, which is what a host's own loop does. Nothing
     /// an event source produces is delivered any other way.
     /// </summary>
+    /// <remarks>
+    /// The bound is <see cref="TransportSignalCeiling"/> for the reason stated on it: what this turns the
+    /// engine over waiting for is a job queued from the transport's own thread-pool continuation, so a
+    /// fifteen-second window was the same fixed clock over the same hand-over that
+    /// <see cref="CloseStopsEverythingAndDispatchesNothingFurther"/>'s wait already gave up
+    /// (sebastienros/jint#3213). Only a hand-over that never happens can reach a ceiling this far out.
+    /// </remarks>
     private static void Pump(Engine engine, Func<bool> until, string expectation)
     {
-        var deadline = DateTime.UtcNow.AddSeconds(15);
+        var deadline = DateTime.UtcNow + TransportSignalCeiling;
         while (DateTime.UtcNow < deadline)
         {
             engine.Advanced.ProcessTasks();

--- a/Jint.Tests/Runtime/WebApi/FetchStreamTests.cs
+++ b/Jint.Tests/Runtime/WebApi/FetchStreamTests.cs
@@ -1,6 +1,7 @@
 #if NET8_0_OR_GREATER
 #nullable enable
 
+using System.Diagnostics;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
@@ -17,13 +18,34 @@ namespace Jint.Tests.Runtime.WebApi;
 /// clock.
 /// </summary>
 /// <remarks>
+/// <para>
 /// <b>No assertion in this file races a wall clock.</b> What is asserted is structural: how many times the
-/// transport was read, in which order the chunks arrived, and what state a stream ended in. The two waits on
-/// a <see cref="ManualResetEventSlim"/> are waits for an event that either happens or fails the test at a
-/// deliberately generous bound, not measurements of how long anything took.
+/// transport was read, in which order the chunks arrived, and what state a stream ended in. The waits on a
+/// <see cref="ManualResetEventSlim"/> are waits for an event that either happens or fails the test, not
+/// measurements of how long anything took.
+/// </para>
+/// <para>
+/// <b>Every test that reaches the transport runs on <see cref="DedicatedThread.RunAsync"/>.</b> A network
+/// response body is pumped by a <c>Task.Run</c> loop inside <c>FetchBodyStream</c>, and every chunk it
+/// delivers — and every cancellation it observes — is a thread-pool continuation. A test body that waited
+/// for one while itself occupying an xUnit pool worker is the resource inversion described on
+/// <see cref="DedicatedThread.RunAsync"/>: a saturated pool injects workers at roughly one per 500 ms, so a
+/// ten-second budget stops being a check and becomes a race. That is what
+/// <see cref="TheBodyIsReadOneChunkPerReadAndNotBefore"/> lost on the windows leg of a PR that touches
+/// neither this class nor the engine (sebastienros/jint#3213), and it is the same mechanism
+/// sebastienros/jint#3201 was diagnosed as. Off the pool, the wait costs the pool nothing.
+/// </para>
 /// </remarks>
 public class FetchStreamTests
 {
+    /// <summary>
+    /// How long a test will wait for a signal the transport raises: a chunk arriving, a read seeing its token
+    /// fire, a request reaching the handler. The claim being made is always that the signal happens at all,
+    /// never how quickly, so this is a ceiling only a genuine failure to deliver can reach — never a budget
+    /// the transport has to beat. It is deliberately far past any plausible scheduling delay.
+    /// </summary>
+    private static readonly TimeSpan TransportSignalCeiling = TimeSpan.FromMinutes(2);
+
     /// <summary>
     /// A response body stream whose reads are served from a channel the test fills, so a read only completes
     /// when the test has said what it should answer with — and blocks until then.
@@ -180,17 +202,18 @@ public class FetchStreamTests
     }
 
     /// <summary>
-    /// Runs event-loop turns until <paramref name="condition"/> holds, or fails the test at a deliberately
-    /// generous bound. The bound is not a measurement: what is being waited for is a hand-over between the
-    /// engine's thread and the transport's, which either happens or means the test has found a bug.
+    /// Runs event-loop turns until <paramref name="condition"/> holds, or fails the test at
+    /// <see cref="TransportSignalCeiling"/>. The bound is not a measurement: what is being waited for is a
+    /// hand-over between the engine's thread and the transport's, which either happens or means the test has
+    /// found a bug.
     /// </summary>
     private static void PumpUntil(Engine engine, Func<bool> condition, string what)
     {
-        var deadline = Environment.TickCount64 + 15_000;
+        var elapsed = Stopwatch.StartNew();
 
         while (!condition())
         {
-            if (Environment.TickCount64 > deadline)
+            if (elapsed.Elapsed > TransportSignalCeiling)
             {
                 Assert.Fail("Timed out waiting for " + what);
             }
@@ -210,7 +233,7 @@ public class FetchStreamTests
     }
 
     [Fact]
-    public void TheBodyIsReadOneChunkPerReadAndNotBefore()
+    public Task TheBodyIsReadOneChunkPerReadAndNotBefore() => DedicatedThread.RunAsync(() =>
     {
         var handler = new GatedHandler();
         handler.Body.Emit("he");
@@ -233,21 +256,21 @@ public class FetchStreamTests
         engine.Execute("var reader = r.body.getReader();");
         handler.Body.ReadCount.Should().Be(0);
 
-        engine.Evaluate("reader.read().then(x => x.done + ':' + dec(x.value))").UnwrapIfPromise().AsString().Should().Be("false:he");
+        engine.Evaluate("reader.read().then(x => x.done + ':' + dec(x.value))").UnwrapIfPromise(TransportSignalCeiling).AsString().Should().Be("false:he");
         handler.Body.ReadCount.Should().Be(1);
 
-        engine.Evaluate("reader.read().then(x => x.done + ':' + dec(x.value))").UnwrapIfPromise().AsString().Should().Be("false:llo");
+        engine.Evaluate("reader.read().then(x => x.done + ':' + dec(x.value))").UnwrapIfPromise(TransportSignalCeiling).AsString().Should().Be("false:llo");
         handler.Body.ReadCount.Should().Be(2);
 
         // The read that sees the end of the body closes the stream.
-        engine.Evaluate("reader.read().then(x => x.done + ':' + (x.value === undefined))").UnwrapIfPromise().AsString().Should().Be("true:true");
+        engine.Evaluate("reader.read().then(x => x.done + ':' + (x.value === undefined))").UnwrapIfPromise(TransportSignalCeiling).AsString().Should().Be("true:true");
         handler.Body.ReadCount.Should().Be(3);
 
         engine.Evaluate("r.bodyUsed").AsBoolean().Should().BeTrue();
-    }
+    });
 
     [Fact]
-    public void ForAwaitOfDrainsAStreamingBody()
+    public Task ForAwaitOfDrainsAStreamingBody() => DedicatedThread.RunAsync(() =>
     {
         var handler = new GatedHandler();
         handler.Body.Emit("a");
@@ -262,14 +285,14 @@ public class FetchStreamTests
                 let out = '';
                 for await (const chunk of r.body) { out += dec(chunk) + '|'; }
                 return out;
-            })()").UnwrapIfPromise().AsString().Should().Be("a|b|c|");
+            })()").UnwrapIfPromise(TransportSignalCeiling).AsString().Should().Be("a|b|c|");
 
         // One read per chunk plus the one that saw the end.
         handler.Body.ReadCount.Should().Be(4);
-    }
+    });
 
     [Fact]
-    public void TextOverAStreamingBodyEqualsTheBufferedAnswer()
+    public Task TextOverAStreamingBodyEqualsTheBufferedAnswer() => DedicatedThread.RunAsync(() =>
     {
         var handler = new GatedHandler();
         handler.Body.Emit("{\"a\":");
@@ -280,14 +303,14 @@ public class FetchStreamTests
 
         // The mixin's consumers run the standard's fully-read steps over the stream and reassemble the bytes,
         // so a body split across chunks is indistinguishable from one that arrived whole.
-        var streamed = engine.Evaluate("fetch('https://example.org/').then(r => r.text())").UnwrapIfPromise().AsString();
+        var streamed = engine.Evaluate("fetch('https://example.org/').then(r => r.text())").UnwrapIfPromise(TransportSignalCeiling).AsString();
         var buffered = engine.Evaluate("new Response('{\"a\":1}').text()").UnwrapIfPromise().AsString();
 
         streamed.Should().Be(buffered).And.Be("{\"a\":1}");
-    }
+    });
 
     [Fact]
-    public void JsonOverAStreamingBodyParsesAcrossChunkBoundaries()
+    public Task JsonOverAStreamingBodyParsesAcrossChunkBoundaries() => DedicatedThread.RunAsync(() =>
     {
         var handler = new GatedHandler();
         handler.Body.Emit("{\"a\":");
@@ -298,11 +321,11 @@ public class FetchStreamTests
         var engine = WebEngine(handler);
 
         engine.Evaluate("fetch('https://example.org/').then(r => r.json()).then(v => v.a.join('-'))")
-            .UnwrapIfPromise().AsString().Should().Be("1-2-3");
-    }
+            .UnwrapIfPromise(TransportSignalCeiling).AsString().Should().Be("1-2-3");
+    });
 
     [Fact]
-    public void CloneTeesTheStreamAndBothHalvesAreReadable()
+    public Task CloneTeesTheStreamAndBothHalvesAreReadable() => DedicatedThread.RunAsync(() =>
     {
         var handler = new GatedHandler();
         handler.Body.Emit("hel");
@@ -319,20 +342,20 @@ public class FetchStreamTests
         engine.Evaluate("r.body === before").AsBoolean().Should().BeFalse();
         engine.Evaluate("copy.body === r.body").AsBoolean().Should().BeFalse();
 
-        engine.Evaluate("r.text()").UnwrapIfPromise().AsString().Should().Be("hello");
+        engine.Evaluate("r.text()").UnwrapIfPromise(TransportSignalCeiling).AsString().Should().Be("hello");
         engine.Evaluate("r.bodyUsed").AsBoolean().Should().BeTrue();
 
         // The clone carries its own flag over its own branch, and the branch buffered everything the shared
         // reader pulled.
         engine.Evaluate("copy.bodyUsed").AsBoolean().Should().BeFalse();
-        engine.Evaluate("copy.text()").UnwrapIfPromise().AsString().Should().Be("hello");
+        engine.Evaluate("copy.text()").UnwrapIfPromise(TransportSignalCeiling).AsString().Should().Be("hello");
 
         // One reader over the original, so the transport is still read exactly once per chunk.
         handler.Body.ReadCount.Should().Be(3);
-    }
+    });
 
     [Fact]
-    public void CancellingTheBodyStreamCancelsTheTransport()
+    public Task CancellingTheBodyStreamCancelsTheTransport() => DedicatedThread.RunAsync(() =>
     {
         // Nothing is emitted, so the pump parks inside a read and the only way out is the token.
         var handler = new GatedHandler();
@@ -344,19 +367,26 @@ public class FetchStreamTests
         engine.Execute("var state = 'pending'; var reader = r.body.getReader(); reader.read().then(x => state = x.done ? 'done' : 'chunk', () => state = 'error');");
         engine.Advanced.ProcessTasks();
 
-        handler.Body.ReadStarted.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue("the pull should have reached the transport");
+        handler.Body.ReadStarted.Wait(TransportSignalCeiling).Should().BeTrue("the pull should have reached the transport");
 
         engine.Execute("reader.cancel('stop');");
         engine.Advanced.ProcessTasks();
 
         // The cancel reached the socket, not just the stream.
-        handler.Body.Cancelled.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
+        handler.Body.Cancelled.Wait(TransportSignalCeiling).Should().BeTrue(
+            "cancelling the body must cancel the read in flight, not merely close the stream");
 
         // Cancelling closes the stream, so the outstanding read resolves as done rather than hanging.
         engine.Evaluate("state").AsString().Should().Be("done");
         engine.Evaluate("r.bodyUsed").AsBoolean().Should().BeTrue();
-    }
+    });
 
+    /// <remarks>
+    /// One of the two tests in this class that stays on the xUnit worker, because nothing here waits for the
+    /// transport: no consumer ever pulls, so the read loop never leaves its demand wait, and every assertion
+    /// below — including the two negative ones — is decided on the engine thread by the time
+    /// <c>RestoreGlobalSnapshot</c> returns.
+    /// </remarks>
     [Fact]
     public void ARestoreErrorsALiveBodyStreamAndCancelsTheTransport()
     {
@@ -387,7 +417,7 @@ public class FetchStreamTests
     }
 
     [Fact]
-    public void ARestoreCancelsATransportThatWasAlreadyReading()
+    public Task ARestoreCancelsATransportThatWasAlreadyReading() => DedicatedThread.RunAsync(() =>
     {
         var handler = new GatedHandler();
         var engine = WebEngine(handler);
@@ -399,13 +429,19 @@ public class FetchStreamTests
         engine.Execute("var reader = r.body.getReader(); reader.read();");
         engine.Advanced.ProcessTasks();
 
-        handler.Body.ReadStarted.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
+        handler.Body.ReadStarted.Wait(TransportSignalCeiling).Should().BeTrue(
+            "the read should have reached the transport");
 
         engine.Advanced.RestoreGlobalSnapshot(snapshot);
 
-        handler.Body.Cancelled.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
-    }
+        handler.Body.Cancelled.Wait(TransportSignalCeiling).Should().BeTrue(
+            "a restore must cancel the read in flight rather than leave the connection held");
+    });
 
+    /// <remarks>
+    /// The other one, and for a stronger reason: a null body status has no <c>FetchBodyStream</c> at all, so
+    /// there is no transport loop to wait for and <c>r.text()</c> settles on the engine's own queue.
+    /// </remarks>
     [Fact]
     public void ANullBodyStatusStillHasNoStreamAtAll()
     {
@@ -437,7 +473,7 @@ public class FetchStreamTests
     /// </para>
     /// </summary>
     [Fact]
-    public void AStreamingRequestBodyReachesTheTransportAsTheScriptProducesIt()
+    public Task AStreamingRequestBodyReachesTheTransportAsTheScriptProducesIt() => DedicatedThread.RunAsync(() =>
     {
         var handler = new UploadHandler();
         var engine = WebEngine(handler);
@@ -475,7 +511,7 @@ public class FetchStreamTests
 
         // The body's stream is disturbed and locked, as a body consumed by a fetch always is.
         engine.Evaluate("t.readable.locked").AsBoolean().Should().BeTrue();
-    }
+    });
 
     /// <summary>
     /// A streaming upload is cross-cycle state like any other in-flight request, so
@@ -484,7 +520,7 @@ public class FetchStreamTests
     /// deadline.
     /// </summary>
     [Fact]
-    public void ARestoreEndsAStreamingRequestBody()
+    public Task ARestoreEndsAStreamingRequestBody() => DedicatedThread.RunAsync(() =>
     {
         var handler = new UploadHandler();
         var engine = WebEngine(handler);
@@ -500,8 +536,9 @@ public class FetchStreamTests
 
         engine.Advanced.RestoreGlobalSnapshot(snapshot);
 
-        handler.Cancelled.Wait(TimeSpan.FromSeconds(15)).Should().BeTrue();
-    }
+        handler.Cancelled.Wait(TransportSignalCeiling).Should().BeTrue(
+            "a restore must end the upload in flight, not leave the request holding the socket");
+    });
 
     /// <summary>
     /// A network response body is a byte stream — https://fetch.spec.whatwg.org/#concept-body — so it can be
@@ -509,7 +546,7 @@ public class FetchStreamTests
     /// transport's: one BYOB read takes one transport read, however much room the caller offered.
     /// </summary>
     [Fact]
-    public void ANetworkResponseBodyCanBeReadByob()
+    public Task ANetworkResponseBodyCanBeReadByob() => DedicatedThread.RunAsync(() =>
     {
         var handler = new GatedHandler();
         handler.Body.Emit("he");
@@ -525,16 +562,16 @@ public class FetchStreamTests
         handler.Body.ReadCount.Should().Be(0);
 
         engine.Evaluate("reader.read(new Uint8Array(8)).then(x => x.done + ':' + dec(x.value))")
-            .UnwrapIfPromise().AsString().Should().Be("false:he");
+            .UnwrapIfPromise(TransportSignalCeiling).AsString().Should().Be("false:he");
         handler.Body.ReadCount.Should().Be(1);
 
         engine.Evaluate("reader.read(new Uint8Array(8)).then(x => x.done + ':' + dec(x.value))")
-            .UnwrapIfPromise().AsString().Should().Be("false:llo");
+            .UnwrapIfPromise(TransportSignalCeiling).AsString().Should().Be("false:llo");
         handler.Body.ReadCount.Should().Be(2);
 
         engine.Evaluate("reader.read(new Uint8Array(8)).then(x => x.done + ':' + x.value.byteLength)")
-            .UnwrapIfPromise().AsString().Should().Be("true:0");
+            .UnwrapIfPromise(TransportSignalCeiling).AsString().Should().Be("true:0");
         handler.Body.ReadCount.Should().Be(3);
-    }
+    });
 }
 #endif

--- a/Jint.Tests/Runtime/WebApi/FetchTests.cs
+++ b/Jint.Tests/Runtime/WebApi/FetchTests.cs
@@ -13,8 +13,24 @@ namespace Jint.Tests.Runtime.WebApi;
 /// <c>fetch</c> as the Fetch Standard specifies it — https://fetch.spec.whatwg.org/#fetch-method — driven
 /// against a stub <see cref="HttpMessageHandler"/> so that nothing here touches a network.
 /// </summary>
+/// <remarks>
+/// Most of these tests never wait for anything: the handler answers synchronously, so the promise has settled
+/// by the time the drain looks. The two that stream a request body and the two that read a response body do
+/// wait, because both of those cross to a thread-pool worker — <c>FetchRequestBodyStream</c> and
+/// <c>FetchBodyStream</c> are both channel-driven — and those hand their bodies to
+/// <see cref="DedicatedThread.RunAsync"/> so that the wait is not itself holding the worker the transport
+/// needs (sebastienros/jint#3213). Every wall-clock window in the class is
+/// <see cref="TransportSignalCeiling"/>, a bound only a genuine failure to settle can reach, rather than an
+/// interval a loaded runner can lose.
+/// </remarks>
 public class FetchTests
 {
+    /// <summary>
+    /// How long the helpers below will wait for a fetch to settle. Not a measurement and not a budget: what is
+    /// asserted is always what the fetch produced, never how long it took.
+    /// </summary>
+    private static readonly TimeSpan TransportSignalCeiling = TimeSpan.FromMinutes(2);
+
     /// <summary>
     /// What one request looked like when the transport sent it.
     /// </summary>
@@ -89,11 +105,11 @@ public class FetchTests
 
     private static JsValue Fetch(HttpMessageHandler handler, string source, Action<Options.FetchOptions>? configure = null)
     {
-        return WebEngine(handler, configure).Evaluate(source).UnwrapIfPromise();
+        return WebEngine(handler, configure).Evaluate(source).UnwrapIfPromise(TransportSignalCeiling);
     }
 
     [Fact]
-    public void ResolvesWithAResponseCarryingTheStatusAndBody()
+    public Task ResolvesWithAResponseCarryingTheStatusAndBody() => DedicatedThread.RunAsync(() =>
     {
         var handler = new StubHandler
         {
@@ -105,10 +121,10 @@ public class FetchTests
 
         var engine = WebEngine(handler);
         engine.Evaluate("fetch('https://example.org/a').then(r => r.status + ':' + r.ok + ':' + r.type + ':' + r.url + ':' + r.redirected)")
-            .UnwrapIfPromise().AsString().Should().Be("201:true:basic:https://example.org/a:false");
+            .UnwrapIfPromise(TransportSignalCeiling).AsString().Should().Be("201:true:basic:https://example.org/a:false");
 
-        engine.Evaluate("fetch('https://example.org/a').then(r => r.text())").UnwrapIfPromise().AsString().Should().Be("hello");
-    }
+        engine.Evaluate("fetch('https://example.org/a').then(r => r.text())").UnwrapIfPromise(TransportSignalCeiling).AsString().Should().Be("hello");
+    });
 
     [Fact]
     public void SendsTheMethodHeadersAndBodyTheRequestDescribes()
@@ -133,7 +149,7 @@ public class FetchTests
     /// arrives as the bytes the stream produced, chunked because nothing can compute its length in advance.
     /// </summary>
     [Fact]
-    public void AStreamRequestBodyReachesTheTransport()
+    public Task AStreamRequestBodyReachesTheTransport() => DedicatedThread.RunAsync(() =>
     {
         var handler = new StubHandler();
 
@@ -154,7 +170,7 @@ public class FetchTests
 
         // https://fetch.spec.whatwg.org/#concept-bodyinit-extract — the ReadableStream arm implies no type.
         request.Header("content-type").Should().BeNull();
-    }
+    });
 
     /// <summary>
     /// https://fetch.spec.whatwg.org/#dom-request step 41: a <c>ReadableStream</c> body without
@@ -182,7 +198,7 @@ public class FetchTests
     /// error, which a buffered upload would have propagated verbatim.
     /// </summary>
     [Fact]
-    public void AStreamRequestBodyThatErrorsFailsTheFetch()
+    public Task AStreamRequestBodyThatErrorsFailsTheFetch() => DedicatedThread.RunAsync(() =>
     {
         var handler = new StubHandler();
 
@@ -192,7 +208,7 @@ public class FetchTests
             body: new ReadableStream({ start(c) { c.error(new TypeError('boom')); } }),
         }).then(() => 'resolved', e => e.constructor.name + ': ' + e.message)")
             .AsString().Should().Be("TypeError: Failed to fetch");
-    }
+    });
 
     /// <summary>
     /// https://fetch.spec.whatwg.org/#http-redirect-fetch step 12: "If internalResponse's status is not 303,
@@ -200,7 +216,7 @@ public class FetchTests
     /// bytes have gone down the first hop's socket and cannot go down a second one.
     /// </summary>
     [Fact]
-    public void AStreamRequestBodyCannotSurviveABodyPreservingRedirect()
+    public Task AStreamRequestBodyCannotSurviveABodyPreservingRedirect() => DedicatedThread.RunAsync(() =>
     {
         var handler = new StubHandler
         {
@@ -226,14 +242,14 @@ public class FetchTests
 
         // The first hop was sent; the second never was.
         handler.Requests.Should().ContainSingle().Which.Url.Should().Be("https://example.org/a");
-    }
+    });
 
     /// <summary>
     /// A 303 is the exemption the step above carves out: it drops the body along with the method, so there
     /// is nothing left to re-send and the redirect is followed as it would be for any other body.
     /// </summary>
     [Fact]
-    public void AStreamRequestBodyFollowsA303ThatDropsIt()
+    public Task AStreamRequestBodyFollowsA303ThatDropsIt() => DedicatedThread.RunAsync(() =>
     {
         var handler = new StubHandler
         {
@@ -260,7 +276,7 @@ public class FetchTests
         handler.Requests.Should().HaveCount(2);
         handler.Requests[1].Method.Should().Be("GET");
         handler.Requests[1].Body.Should().BeNull();
-    }
+    });
 
     [Fact]
     public void MapsEveryResponseHeaderIncludingRepeatedOnes()
@@ -326,7 +342,7 @@ public class FetchTests
 
         var engine = WebEngine(handler);
         engine.Evaluate("fetch('https://example.org/a').then(r => r.url + ':' + r.redirected + ':' + r.status)")
-            .UnwrapIfPromise().AsString().Should().Be("https://example.org/b:true:200");
+            .UnwrapIfPromise(TransportSignalCeiling).AsString().Should().Be("https://example.org/b:true:200");
 
         handler.Requests.Should().HaveCount(2);
         handler.Requests[1].Url.Should().Be("https://example.org/b");
@@ -462,7 +478,7 @@ public class FetchTests
     }
 
     [Fact]
-    public void TheResponseBodyObeysTheUsualConsumeRules()
+    public Task TheResponseBodyObeysTheUsualConsumeRules() => DedicatedThread.RunAsync(() =>
     {
         var handler = new StubHandler
         {
@@ -482,14 +498,14 @@ public class FetchTests
         engine.Execute("var copy = r.clone();");
         engine.Evaluate("r.body === copy.body").AsBoolean().Should().BeFalse();
 
-        engine.Evaluate("r.json()").UnwrapIfPromise().AsObject().Get("a").AsNumber().Should().Be(1);
+        engine.Evaluate("r.json()").UnwrapIfPromise(TransportSignalCeiling).AsObject().Get("a").AsNumber().Should().Be(1);
         engine.Evaluate("r.bodyUsed").AsBoolean().Should().BeTrue();
-        engine.Evaluate("r.text().then(() => 'resolved', e => e.constructor.name)").UnwrapIfPromise().AsString().Should().Be("TypeError");
+        engine.Evaluate("r.text().then(() => 'resolved', e => e.constructor.name)").UnwrapIfPromise(TransportSignalCeiling).AsString().Should().Be("TypeError");
 
         // The clone carries its own flag over the same bytes.
         engine.Evaluate("copy.bodyUsed").AsBoolean().Should().BeFalse();
-        engine.Evaluate("copy.text()").UnwrapIfPromise().AsString().Should().Be("{\"a\":1}");
-    }
+        engine.Evaluate("copy.text()").UnwrapIfPromise(TransportSignalCeiling).AsString().Should().Be("{\"a\":1}");
+    });
 
     [Fact]
     public void ANetworkFailureRejectsWithAnUninformativeTypeError()

--- a/Jint.Tests/Runtime/WebApi/WebSocketTests.cs
+++ b/Jint.Tests/Runtime/WebApi/WebSocketTests.cs
@@ -25,9 +25,27 @@ namespace Jint.Tests.Runtime.WebApi;
 /// until the state a test is waiting for arrives, and its deadline exists only so that a hang fails the run
 /// instead of hanging it.
 /// </para>
+/// <para>
+/// <b>A test that waits for the send loop runs on <see cref="DedicatedThread.RunAsync"/>.</b> The operation's
+/// outgoing queue is a <c>Channel</c>, which does not allow synchronous continuations, so everything past a
+/// <c>send()</c> or a <c>close()</c> — the write itself, the <c>bufferedAmount</c> release, the Close frame,
+/// and the <c>await sender</c> that has to finish before a <c>close</c> event is dispatched — resumes on a
+/// thread-pool worker. Waiting for one from a body that is itself occupying an xUnit pool worker is the
+/// resource inversion <see cref="DedicatedThread.RunAsync"/> exists for, and it is what turned fixed windows
+/// elsewhere in this suite into flakes (sebastienros/jint#3201, #3213). Tests driven only by the test
+/// thread's own hand-offs — a delivered message, a completed handshake, a refused URL — stay where they are,
+/// because their continuations run inline on the thread that raised them.
+/// </para>
 /// </remarks>
 public class WebSocketTests
 {
+    /// <summary>
+    /// How long a test will wait for something the socket's own loops must produce. The claim is always that
+    /// the write, or the event, happens at all — never how quickly — so this is a ceiling only a genuine
+    /// failure can reach rather than a budget the pool has to beat.
+    /// </summary>
+    private static readonly TimeSpan TransportSignalCeiling = TimeSpan.FromMinutes(2);
+
     /// <summary>
     /// A socket the test drives by hand. Its <see cref="ConnectAsync"/> answers a gate the test opens, its
     /// <see cref="ReceiveAsync"/> answers whatever the test has delivered, and everything it was asked to
@@ -180,11 +198,17 @@ public class WebSocketTests
         /// Waits for the send loop — which runs on a thread pool thread, deliberately, so that a socket write
         /// never blocks the engine — to have written <paramref name="count"/> things.
         /// </summary>
+        /// <remarks>
+        /// The bound is <see cref="TransportSignalCeiling"/>, not an interval the send loop is expected to
+        /// beat: every caller of this hands its body to <see cref="DedicatedThread.RunAsync"/>, so the pool
+        /// worker the loop needs is not the one this wait is holding, and only a write that never happens can
+        /// reach the ceiling.
+        /// </remarks>
         internal void WaitForWrites(int count)
         {
             for (var i = 0; i < count; i++)
             {
-                _written.Wait(TimeSpan.FromSeconds(30)).Should().BeTrue("the send loop should have written {0} time(s)", count);
+                _written.Wait(TransportSignalCeiling).Should().BeTrue("the send loop should have written {0} time(s)", count);
             }
         }
     }
@@ -229,7 +253,7 @@ public class WebSocketTests
                 return;
             }
 
-            if (stopwatch.Elapsed > TimeSpan.FromSeconds(30))
+            if (stopwatch.Elapsed > TransportSignalCeiling)
             {
                 Assert.Fail("the engine never reached the state the test was waiting for");
             }
@@ -440,7 +464,7 @@ public class WebSocketTests
     /// message has been received".
     /// </summary>
     [Fact]
-    public void AMessageThatArrivesAfterTheCloseIsDropped()
+    public Task AMessageThatArrivesAfterTheCloseIsDropped() => DedicatedThread.RunAsync(() =>
     {
         var (engine, sockets) = OpenSocket("""
             ws.onmessage = e => log.push('message:' + e.data);
@@ -462,10 +486,10 @@ public class WebSocketTests
         PumpUntilLogged(engine, 2);
 
         Log(engine).Should().Be("open:1:|close:1000");
-    }
+    });
 
     [Fact]
-    public void SendMarshalsOnTheEngineThreadAndBufferedAmountFallsWhenTheBytesGoOut()
+    public Task SendMarshalsOnTheEngineThreadAndBufferedAmountFallsWhenTheBytesGoOut() => DedicatedThread.RunAsync(() =>
     {
         var (engine, sockets) = OpenSocket();
         var socket = sockets.Last;
@@ -493,10 +517,10 @@ public class WebSocketTests
 
         socket.Sent[1].IsText.Should().BeFalse();
         socket.Sent[1].Payload.Should().Equal([7, 8, 9], "the bytes were copied when send() was called, not when they were written");
-    }
+    });
 
     [Fact]
-    public void SendAcceptsEveryArmOfTheUnion()
+    public Task SendAcceptsEveryArmOfTheUnion() => DedicatedThread.RunAsync(() =>
     {
         var (engine, sockets) = OpenSocket();
         var socket = sockets.Last;
@@ -516,7 +540,7 @@ public class WebSocketTests
         socket.Sent[2].Payload.Should().Equal([3, 4, 5]);
         socket.Sent[3].Payload.Should().Equal("ab"u8.ToArray());
         socket.Sent[4].Payload.Should().Equal("42"u8.ToArray());
-    }
+    });
 
     /// <summary>
     /// https://websockets.spec.whatwg.org/#dom-websocket-send step 1.
@@ -542,7 +566,7 @@ public class WebSocketTests
     /// send() method" — https://websockets.spec.whatwg.org/#dom-websocket-bufferedamount.
     /// </summary>
     [Fact]
-    public void SendAfterTheCloseOnlyCountsBytesAndWritesNothing()
+    public Task SendAfterTheCloseOnlyCountsBytesAndWritesNothing() => DedicatedThread.RunAsync(() =>
     {
         var (engine, sockets) = OpenSocket();
         var socket = sockets.Last;
@@ -560,13 +584,13 @@ public class WebSocketTests
         // ... and it never comes down again, because nothing will ever write those bytes.
         engine.Advanced.ProcessTasks();
         engine.Evaluate("ws.bufferedAmount").AsNumber().Should().Be(4);
-    }
+    });
 
     /// <summary>
     /// https://websockets.spec.whatwg.org/#dom-websocket-close step 3.3, then the peer's answer.
     /// </summary>
     [Fact]
-    public void CloseStartsTheHandshakeAndStaysClosingUntilThePeerAnswers()
+    public Task CloseStartsTheHandshakeAndStaysClosingUntilThePeerAnswers() => DedicatedThread.RunAsync(() =>
     {
         var (engine, sockets) = OpenSocket("""
             ws.onclose = e => log.push(['close', e.code, e.reason, e.wasClean, e.isTrusted, e instanceof CloseEvent].join(','));
@@ -587,10 +611,10 @@ public class WebSocketTests
 
         Log(engine).Should().Be("open:1:|close,3000,bye,true,true,true");
         engine.Evaluate("ws.readyState").AsNumber().Should().Be(3);
-    }
+    });
 
     [Fact]
-    public void CloseWithNoArgumentsSendsAFrameWithNoBody()
+    public Task CloseWithNoArgumentsSendsAFrameWithNoBody() => DedicatedThread.RunAsync(() =>
     {
         var (engine, sockets) = OpenSocket();
 
@@ -598,10 +622,10 @@ public class WebSocketTests
         sockets.Last.WaitForWrites(1);
 
         sockets.Last.CloseFrames.Should().Equal((null, string.Empty));
-    }
+    });
 
     [Fact]
-    public void QueuedMessagesAreWrittenBeforeTheCloseFrame()
+    public Task QueuedMessagesAreWrittenBeforeTheCloseFrame() => DedicatedThread.RunAsync(() =>
     {
         var (engine, sockets) = OpenSocket();
         var socket = sockets.Last;
@@ -612,14 +636,14 @@ public class WebSocketTests
         // The Close frame goes out last, which is what lets a script send and then close without losing the
         // message it just sent.
         socket.Writes.Should().Equal("text:first", "text:second", "close:1000");
-    }
+    });
 
     /// <summary>
     /// The peer's Close frame: "when the WebSocket closing handshake is started" moves the ready state, and
     /// this endpoint answers with a Close frame of its own before the connection ends.
     /// </summary>
     [Fact]
-    public void APeerInitiatedCloseIsEchoedAndReportedAsClean()
+    public Task APeerInitiatedCloseIsEchoedAndReportedAsClean() => DedicatedThread.RunAsync(() =>
     {
         var (engine, sockets) = OpenSocket("""
             ws.onclose = e => log.push(['close', e.code, e.reason, e.wasClean].join(','));
@@ -633,14 +657,14 @@ public class WebSocketTests
 
         Log(engine).Should().Be("open:1:|close,1001,going away,true");
         socket.CloseFrames.Should().Equal((1001, string.Empty));
-    }
+    });
 
     /// <summary>
     /// A Close frame with no status code is 1005, "no status received" —
     /// https://www.rfc-editor.org/rfc/rfc6455#section-7.4.1 — and is answered with a body-less frame.
     /// </summary>
     [Fact]
-    public void APeerCloseWithNoCodeIsReportedAs1005()
+    public Task APeerCloseWithNoCodeIsReportedAs1005() => DedicatedThread.RunAsync(() =>
     {
         var (engine, sockets) = OpenSocket("ws.onclose = e => log.push('close:' + e.code + ':' + e.wasClean);");
 
@@ -649,7 +673,7 @@ public class WebSocketTests
 
         Log(engine).Should().Be("open:1:|close:1005:true");
         sockets.Last.CloseFrames.Should().Equal((null, string.Empty));
-    }
+    });
 
     /// <summary>
     /// https://websockets.spec.whatwg.org/#dom-websocket-close step 3.2: closing before the connection is
@@ -684,7 +708,7 @@ public class WebSocketTests
     /// queued — and must not be dispatched into a socket the script has since closed.
     /// </summary>
     [Fact]
-    public void AnOpenThatWasAlreadyQueuedIsSuppressedByAClose()
+    public Task AnOpenThatWasAlreadyQueuedIsSuppressedByAClose() => DedicatedThread.RunAsync(() =>
     {
         var (engine, sockets) = SocketEngine();
 
@@ -704,7 +728,7 @@ public class WebSocketTests
 
         Log(engine).Should().Be("error|close:1006");
         engine.Evaluate("ws.readyState").AsNumber().Should().Be(3);
-    }
+    });
 
     /// <summary>
     /// A handshake that never succeeds ends in the same pair, which is what
@@ -730,7 +754,7 @@ public class WebSocketTests
     }
 
     [Fact]
-    public void ADroppedConnectionFiresErrorThenClose()
+    public Task ADroppedConnectionFiresErrorThenClose() => DedicatedThread.RunAsync(() =>
     {
         var (engine, sockets) = OpenSocket("""
             ws.onerror = () => log.push('error');
@@ -741,14 +765,14 @@ public class WebSocketTests
         PumpUntilLogged(engine, 3);
 
         Log(engine).Should().Be("open:1:|error|close,1006,false");
-    }
+    });
 
     /// <summary>
     /// A message larger than <c>Options.WebApi.Fetch.MaxResponseBytes</c> is the host's own limit rather than
     /// the network's, so unlike every other failure it names itself with RFC 6455's 1009.
     /// </summary>
     [Fact]
-    public void AMessageOverTheCeilingClosesWith1009()
+    public Task AMessageOverTheCeilingClosesWith1009() => DedicatedThread.RunAsync(() =>
     {
         var (engine, sockets) = OpenSocket("""
             ws.onerror = () => log.push('error');
@@ -761,7 +785,7 @@ public class WebSocketTests
 
         Log(engine).Should().Be("open:1:|error|close,1009,false");
         sockets.Last.Aborts.Should().Be(1);
-    }
+    });
 
     /// <summary>
     /// https://websockets.spec.whatwg.org/#dom-websocket-close steps 1 and 2.
@@ -789,7 +813,7 @@ public class WebSocketTests
     [InlineData("1000")]
     [InlineData("3000")]
     [InlineData("4999")]
-    public void CloseAcceptsTheCodesAnApplicationMaySend(string code)
+    public Task CloseAcceptsTheCodesAnApplicationMaySend(string code) => DedicatedThread.RunAsync(() =>
     {
         var (engine, sockets) = OpenSocket();
 
@@ -797,7 +821,7 @@ public class WebSocketTests
         sockets.Last.WaitForWrites(1);
 
         sockets.Last.CloseFrames.Should().Equal((int.Parse(code, System.Globalization.CultureInfo.InvariantCulture), string.Empty));
-    }
+    });
 
     [Fact]
     public void CloseRefusesAReasonLongerThan123Utf8Bytes()
@@ -833,7 +857,7 @@ public class WebSocketTests
     }
 
     [Fact]
-    public void CloseIsIdempotentAndSendsOneFrame()
+    public Task CloseIsIdempotentAndSendsOneFrame() => DedicatedThread.RunAsync(() =>
     {
         var (engine, sockets) = OpenSocket();
 
@@ -841,14 +865,14 @@ public class WebSocketTests
         sockets.Last.WaitForWrites(1);
 
         sockets.Last.CloseFrames.Should().Equal((1000, "first"));
-    }
+    });
 
     /// <summary>
     /// A reason with no code has nowhere to live in the protocol's Close frame, so it travels behind a normal
     /// closure rather than being dropped.
     /// </summary>
     [Fact]
-    public void AReasonWithNoCodeTravelsAsANormalClosure()
+    public Task AReasonWithNoCodeTravelsAsANormalClosure() => DedicatedThread.RunAsync(() =>
     {
         var (engine, sockets) = OpenSocket();
 
@@ -856,7 +880,7 @@ public class WebSocketTests
         sockets.Last.WaitForWrites(1);
 
         sockets.Last.CloseFrames.Should().Equal((1000, "bye"));
-    }
+    });
 
     /// <summary>
     /// The policy refuses the URL, and the script cannot tell that from a refused connection — which
@@ -927,7 +951,7 @@ public class WebSocketTests
     /// flight, since a socket is meant to be long-lived.
     /// </summary>
     [Fact]
-    public void TooManyOpenSocketsIsAQuotaExceededError()
+    public Task TooManyOpenSocketsIsAQuotaExceededError() => DedicatedThread.RunAsync(() =>
     {
         var (engine, sockets) = SocketEngine(net => net.MaxConcurrentRequests = 2);
 
@@ -958,7 +982,7 @@ public class WebSocketTests
 
         engine.Execute("new WebSocket('wss://example.org/4');");
         sockets.Created.Should().HaveCount(3);
-    }
+    });
 
     /// <summary>
     /// A restore ends the evaluation cycle, so the socket is dropped rather than left delivering into globals


### PR DESCRIPTION
Closes #3213.

The ledger from the #3207 diagnosis: WebApi tests waiting on a thread-pool continuation behind a fixed wall-clock window, which a saturated runner can lose. Treatment is the established #3207 pattern — move the blocking side onto `DedicatedThread`, replace the clock with a signal-driven wait whose only clock is a wedge ceiling, keep every assertion's substance. Tests only; **no engine code**, and every file is `#if NET8_0_OR_GREATER`.

### The ledger under-described the defect

The issue names 18 `.Wait(...)` line numbers. The larger hole is the *implicit* ten-second budget inside `UnwrapIfPromise()`, which no line number names — a test with no `.Wait` at all still waits on a pool continuation, it just does it through the promise unwrap. That is why this PR touches four files the ledger does not list (`CacheTests`, `FetchTests`, `WebApiCacheTests`, `WebApiMultipartTests`), and the issue's own parenthetical is the evidence: the three tests it mentions dropping together on a loaded machine are `CacheTests.AddAllRefusesTwoRequestsThatMatchEachOther`, `FetchStreamTests.ANetworkResponseBodyCanBeReadByob` and `FetchTests.ResolvesWithAResponseCarryingTheStatusAndBody` — and **two of those are in files the line list does not cover**.

All 18 ledger entries are addressed. Beyond them, 57 test methods moved to `DedicatedThread.RunAsync`.

### Reproduction, before and after

Under a starved pool (`DOTNET_ThreadPool_ForceMinWorkerThreads=1` plus 26 CPU burners on a 32-thread box, CPU pegged):

| | result |
| --- | --- |
| pre-fix | **0 pass / 5 runs**, 9 distinct tests failing |
| post-fix | **12 pass / 12 runs**, zero individual failures |
| post-fix, whole WebApi surface (2,885 tests per iteration) | **3 pass / 3 runs** |

Failure modes were the predicted ones — `Expected handler.Body.ReadStarted.Wait(TimeSpan.FromSeconds(10)) … but found False` and `PromiseRejectedException : Timeout of 00:00:10 reached`. Every one of the 9 baseline failures is in the set of 57 tests the fix converted; nothing failed that the fix left alone. Run duration is itself evidence the ceiling is a wedge guard rather than a budget being spent: failing baseline runs took 16–27 s burning their windows, post-fix runs take 2–5 s.

### Substance preservation, checked mechanically

Assertion counts and `[Fact]`/`[Theory]` counts are identical file by file. Normalising every changed assertion line gives 52 removed and 52 added, each removed one having an added counterpart with the same subject and the same verdict. No assertion became a tautology; several *gained* because-text naming the claim. No test lost its timeout — every blocking call is `Wait(TransportSignalCeiling)`, `Join(HandoffCeiling)` or `UnwrapIfPromise(TransportSignalCeiling)`, so a genuinely wedged test still fails rather than hangs.

Which tests stay on the pool is deliberate and justified per site: `WebApiSchedulingSurfaceTests`' `Join` waits on a thread the *test* created (not a pool thread) that only calls `Cancel()`, so there is no inversion to remove — it takes the ceiling and nothing else. The WebSocket hand-off tests likewise rely on `FetchConnection.Handshake` being a plain `TaskCompletionSource` with inline continuations.

### Two small changes beyond the inherited work

- `EventSourceTests.Pump` still used `DateTime.UtcNow.AddSeconds(15)` while **this same change** hardened the identical `Pump` in its `Jint.Tests.PublicInterface` twin. That inconsistency would have been introduced by the fix itself; it now takes the ceiling.
- `CacheTests.RunFetching`'s doc said "for a cache that is filled over the network", but the helper is also applied to five tests asserting `handler.Requests.Should().BeEmpty()`. Doc-only clarification; the call sites were deliberately not churned back.

### Two findings left for separate issues

**`HostResultLimitsTests.OperationDeadlineSpansEvaluationAndConversion` is flaky on `main` today**, reproduced twice. It gives an `OperationDeadlineConstraint` a 400 ms budget over a `Thread.Sleep(250)` — 150 ms of headroom — and asserts the `TimeoutException` erupts from the *conversion*; under load the *evaluation* phase blows the budget first. It fails on net472 too, where nothing in this PR exists (`#if NET8_0_OR_GREATER`), and `HostResultLimitsTests.cs` is byte-identical between this branch and `main`. Different mechanism from #3213 — a budget the test wants to expire with too little headroom, not a pool-continuation wait — so it belongs with the #3221 sweep rather than here.

**One unidentified single-test failure** in the first full `Jint.Tests` net10.0 run after rebuild; the name was not captured. Five subsequent full runs (one under 20 burners), the net472 leg, and 15 starved runs of the whole WebApi surface were all clean, so it is unlikely to be in this file set — recorded rather than guessed at.

### Verification

Solution builds Release, 0 errors. `Jint.Tests` net472 7102 / net10.0 10052; `Jint.Tests.PublicInterface` net10.0 2379 / net472 1865. Both suites also on the `JINT_HOST_CONTRACT_VERIFICATION=1` leg, where the skip count drops 9 → 5, which is the proof the switch reached the test host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
