### PR TITLE
Stop the security-stack budget tests asserting a timing coincidence

### DIFF
--- a/Jint.Tests.PublicInterface/HostCallLoopConstraintTests.cs
+++ b/Jint.Tests.PublicInterface/HostCallLoopConstraintTests.cs
@@ -93,18 +93,22 @@ public class HostCallLoopConstraintTests
 
     /// <summary>
     /// What each host call spends of that budget. Deliberately a small fraction of
-    /// <see cref="HostCallTimeout"/>: the remainder is the headroom an entry has for a scheduling stall
-    /// before the engine is entitled to fail it, and the smaller the fraction the more calls it takes for
-    /// a deadline that failed to re-arm to accumulate past the timeout — four, with these numbers, which
-    /// is well inside the loop.
+    /// <see cref="HostCallTimeout"/>: the remainder — 500 ms here — is the headroom an entry has for a
+    /// scheduling stall before the engine is entitled to fail it, and the smaller the fraction the more
+    /// calls it takes for a deadline that failed to re-arm to accumulate past the timeout — six, with
+    /// these numbers, which is half of the loop.
     /// </summary>
-    private static readonly TimeSpan PausePerCall = TimeSpan.FromMilliseconds(150);
+    private static readonly TimeSpan PausePerCall = TimeSpan.FromMilliseconds(100);
 
     /// <summary>
     /// Enough calls that the loop's engine-resident time (<see cref="TimedLoopCalls"/> ×
-    /// <see cref="PausePerCall"/> = 900 ms) comfortably outlives <see cref="HostCallTimeout"/>.
+    /// <see cref="PausePerCall"/> = 1200 ms) is twice <see cref="HostCallTimeout"/>, so that half of the
+    /// iterations begin only once the interval has already passed. Those six are the sample the two
+    /// accumulation tests observe the engine on, and every one of them has to be stalled past the whole
+    /// interval before a run has nothing left to report. The previous six-call, 150 ms shape offered a
+    /// sample of two.
     /// </summary>
-    private const int TimedLoopCalls = 6;
+    private const int TimedLoopCalls = 12;
 
     /// <summary>
     /// Absorbs the constraint's conversion of the configured interval into <see cref="Stopwatch"/> ticks,
@@ -158,26 +162,21 @@ public class HostCallLoopConstraintTests
         var engine = CreatePausingEngine(PausePerCall);
         var work = engine.GetValue("pausingWork");
 
-        var engineTime = TimeSpan.Zero;
-        var completed = 0;
-
-        for (var i = 0; i < TimedLoopCalls; i++)
-        {
-            var iteration = RunOneHostLoopIteration(() => work.Call(i));
-            engineTime += iteration.Elapsed;
-            if (iteration.Completed)
-            {
-                completed++;
-            }
-        }
+        var outcome = RunHostLoop(i => work.Call(i));
 
         // premise: the engine really was resident for longer than one entry's budget, over several
         // separate entries — deterministically so, because each call sleeps for at least PausePerCall
-        engineTime.Should().BeGreaterThan(HostCallTimeout);
-        completed.Should().BeGreaterThan(
-            1,
-            "a deadline that carried over would leave only the calls before it expired, and every "
-            + "iteration here spends a quarter of the interval");
+        outcome.EngineTime.Should().BeGreaterThan(HostCallTimeout);
+
+        // A deadline that carried over would have expired before any of these iterations began, so every
+        // one of them would have failed rather than completed — but it would have failed them after an
+        // iteration of PausePerCall, which RunOneHostLoopIteration has already refused above. Seeing none
+        // of them therefore means the runner stalled every late iteration past the whole interval, which
+        // is a machine this run cannot learn anything from. See RunHostLoop.
+        Assert.SkipWhen(
+            outcome.CompletionsAfterTheIntervalHadPassed == 0,
+            "the runner stalled every iteration past the whole interval, so this run observed no entry "
+            + "completing after the loop had outlived it");
     }
 
     [Fact]
@@ -356,38 +355,21 @@ public class HostCallLoopConstraintTests
         var engine = CreatePausingEngine(PausePerCall);
         var work = engine.GetValue("pausingWork");
 
-        var engineTime = TimeSpan.Zero;
-        var completed = 0;
-
-        for (var i = 0; i < TimedLoopCalls; i++)
+        var outcome = RunHostLoop(i =>
         {
-            var iteration = RunOneHostLoopIteration(() =>
-            {
-                work.Call(i);
-                engine.Constraints.Check();
-            });
+            work.Call(i);
+            engine.Constraints.Check();
+        });
 
-            engineTime += iteration.Elapsed;
-            if (iteration.Completed)
-            {
-                completed++;
-            }
-        }
+        outcome.EngineTime.Should().BeGreaterThan(HostCallTimeout);
 
-        engineTime.Should().BeGreaterThan(HostCallTimeout);
-
-        // A loaded CI runner can stall one call past the whole timeout, which makes a single completion
-        // indistinguishable from the accumulation bug this test exists to refute. The stall is detectable —
-        // the loop then spent far longer than its healthy total — and a detected stall is a skip, not a
-        // verdict either way.
+        // The host-loop check measures the time since the last entry returned and re-armed the deadline,
+        // not the age of the loop, so entries keep completing however long the loop has been running.
+        // Observing none of them is a stalled runner rather than a verdict; see the sibling above.
         Assert.SkipWhen(
-            completed <= 1 && engineTime > HostCallTimeout + HostCallTimeout,
-            "the runner stalled a single call past the whole timeout, so this run cannot distinguish the behaviours");
-
-        completed.Should().BeGreaterThan(
-            1,
-            "the host-loop check measures the time since the last entry returned and re-armed the "
-            + "deadline, not the age of the loop");
+            outcome.CompletionsAfterTheIntervalHadPassed == 0,
+            "the runner stalled every iteration past the whole interval, so this run observed no entry "
+            + "completing after the loop had outlived it");
     }
 
     [Fact]
@@ -506,22 +488,54 @@ public class HostCallLoopConstraintTests
             OperationBudget - AttributionSlack,
             "the deadline may only fire once the budget has actually elapsed");
 
-        // A loaded CI runner can stall the very first call past the whole budget, which makes one call
-        // exhausting it correct behaviour rather than mis-arming. The stall is detectable — the elapsed
-        // wall time then dwarfs the budget one healthy call would have spent — and a detected stall is a
-        // skip, not a verdict either way.
-        Assert.SkipWhen(
-            calls <= 1 && stopwatch.Elapsed > OperationBudget + OperationBudget,
-            "the runner stalled the first call past the whole budget, so this run cannot distinguish the behaviours");
-
-        calls.Should().BeGreaterThan(
-            1,
-            "each call spends a tenth of the budget, so exhausting it takes several of them — a throw "
-            + "inside the first call would mean the budget was mis-armed rather than accumulated");
+        // Deliberately NOT asserted here: that more than one call fitted inside the budget. Given the
+        // assertion above, `calls == 1` says only that the runner stalled the first call past the whole
+        // budget — a statement about the machine, not about the engine — and asserting it failed CI legs
+        // on changes that touched nothing here (#3221, #3139 before it). Every way of mis-arming the
+        // budget is caught without it: one refunded per entry could never fire for calls this short, so
+        // the loop would run to completion and the Throw above would fail; one armed in the past fires
+        // inside the first call, and the stopwatch above would fail. That the budget survives an entry
+        // boundary at all is pinned without any clock at all by the test below.
 
         // A generous upper bound only: Thread.Sleep never returns early, so the budget is gone within a
         // dozen calls, and a loaded machine only makes that number smaller.
         calls.Should().BeLessThanOrEqualTo(60, "the deadline must be noticed promptly, not eventually");
+    }
+
+    [Fact]
+    public void AnEntryEnteredAfterTheOperationsBudgetHasElapsedInheritsItRatherThanAFreshOne()
+    {
+        // The spanning claim of the test above, pinned without a race. Every top-level entry invites its
+        // registered constraints to rewind — before the callback and again after it — and this one
+        // declines, so an entry beginning after the operation's budget is gone must fail on its first
+        // check instead of being handed the window again.
+        //
+        // Spending the budget on the host's own clock is what makes the run deterministic. The budget is
+        // wall clock from Begin, so host time is part of the operation exactly as engine time is, and
+        // Thread.Sleep only ever overshoots: there is no machine slow enough to leave time on the budget,
+        // and none fast enough for the entry to beat it. Nothing here divides a budget into slices that a
+        // contended runner could overspend.
+        var deadline = new OperationDeadlineConstraint();
+        var engine = CreateDeadlineEngine(deadline);
+        var work = engine.GetValue("work");
+
+        deadline.Begin(OperationBudget);
+        try
+        {
+            Thread.Sleep(OperationBudget + OperationBudget);
+
+            Invoking(() => work.Call(1)).Should().Throw<TimeoutException>(
+                "the entry inherits what is left of the operation's budget, which is nothing — a Reset() "
+                + "that re-armed it would hand this entry the whole window again");
+        }
+        finally
+        {
+            deadline.End();
+        }
+
+        // ...and closing the operation really does release the engine, so the throw above was an elapsed
+        // budget rather than a constraint left permanently tripped.
+        Invoking(() => work.Call(1)).Should().NotThrow("End() disarmed the constraint");
     }
 
     [Fact]
@@ -765,6 +779,47 @@ public class HostCallLoopConstraintTests
     }
 
     /// <summary>
+    /// Runs <see cref="TimedLoopCalls"/> iterations of a host loop and reports the two aggregates the
+    /// accumulation tests read.
+    /// <para>
+    /// The load-bearing assertion is not here but in <see cref="RunOneHostLoopIteration"/>: a throw may
+    /// only come from an iteration that itself outlived the interval. No amount of runner contention can
+    /// falsify that, and a deadline carried over from an earlier host call falsifies it on the first
+    /// iteration that begins past the interval — before either aggregate below is so much as computed.
+    /// </para>
+    /// <para>
+    /// The aggregates therefore assert nothing about the engine; they establish that the run <em>saw</em>
+    /// the scenario. A count of zero means the runner stalled every late iteration past the whole
+    /// interval, which is correct behaviour the engine is entitled to and a run with nothing to report,
+    /// so the callers skip on it rather than fail. Widening the loop is not an alternative: the stall
+    /// that produces a zero is systemic — every wake-up delayed — so it takes the extra iterations with
+    /// it. What the extra iterations do buy is a bigger sample, and so a rarer skip.
+    /// </para>
+    /// </summary>
+    private static HostLoopOutcome RunHostLoop(Action<int> iteration)
+    {
+        var engineTime = TimeSpan.Zero;
+        var completionsAfterTheIntervalHadPassed = 0;
+
+        for (var i = 0; i < TimedLoopCalls; i++)
+        {
+            // Engine-resident time only, which under-counts the wall clock a carried-over deadline would
+            // have been measuring. The comparison can therefore only err towards ignoring an iteration,
+            // never towards counting one that in fact began before the interval had passed.
+            var engineTimeBeforeThisIteration = engineTime;
+            var result = RunOneHostLoopIteration(() => iteration(i));
+            engineTime += result.Elapsed;
+
+            if (result.Completed && engineTimeBeforeThisIteration >= HostCallTimeout)
+            {
+                completionsAfterTheIntervalHadPassed++;
+            }
+        }
+
+        return new HostLoopOutcome(engineTime, completionsAfterTheIntervalHadPassed);
+    }
+
+    /// <summary>
     /// Runs one iteration of a host loop under <see cref="HostCallTimeout"/> and reports whether it
     /// completed, converting the one <see cref="TimeoutException"/> the engine is entitled to throw into
     /// an observation instead of a failure.
@@ -780,7 +835,7 @@ public class HostCallLoopConstraintTests
     /// What the engine does promise is the implication: a throw can only come from an entry that itself
     /// ran past the interval. That is what is asserted here, and it cannot be falsified by a stall, only
     /// by the regression the tests exist for — a deadline carried over from an earlier host call fires
-    /// after an iteration costing <see cref="PausePerCall"/>, a quarter of the interval. The stopwatch
+    /// after an iteration costing <see cref="PausePerCall"/>, a sixth of the interval. The stopwatch
     /// starts before the entry arms its deadline and stops after it throws, so the window it measures is
     /// always a superset of the one the constraint measured; the comparison can only err towards
     /// tolerating a throw, never towards inventing one.
@@ -807,6 +862,15 @@ public class HostCallLoopConstraintTests
 
     [StructLayout(LayoutKind.Auto)]
     private readonly record struct HostLoopIteration(bool Completed, TimeSpan Elapsed);
+
+    /// <param name="EngineTime">How long the engine was resident across the whole loop.</param>
+    /// <param name="CompletionsAfterTheIntervalHadPassed">
+    /// How many iterations completed although the loop had already spent more than
+    /// <see cref="HostCallTimeout"/> inside the engine before they began. A deadline that spanned host
+    /// calls would have expired before every one of them.
+    /// </param>
+    [StructLayout(LayoutKind.Auto)]
+    private readonly record struct HostLoopOutcome(TimeSpan EngineTime, int CompletionsAfterTheIntervalHadPassed);
 
     /// <summary>
     /// Pays the JIT cost of the whole call path — the interpreter, the constraint plumbing and the

--- a/Jint.Tests.PublicInterface/HostMemoryLimitTests.cs
+++ b/Jint.Tests.PublicInterface/HostMemoryLimitTests.cs
@@ -19,6 +19,22 @@ public class HostMemoryLimitTests
     private const int AllocationSize = 2_000_000;
     private const int SingleAllocationBudget = 3_500_000;
 
+    /// <summary>
+    /// How long <see cref="PromiseContinuationRetainsItsOriginatingBudgetWhenPumpedOnAnotherThread"/>
+    /// keeps pumping before giving up. A ceiling only a genuine hang can reach rather than a budget the
+    /// continuation has to beat: a healthy run exits on the first pump that observes the settled
+    /// continuation, so widening this costs nothing except on a failure.
+    /// </summary>
+    private static readonly TimeSpan PumpCeiling = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// How long the asynchronous loader keeps
+    /// <see cref="SynchronousImportDoesNotChargeAsyncLoaderWaitToExecutionTimeout"/> waiting. Deliberately
+    /// longer than that test's 200 ms execution timeout, since the whole claim is that the wait is not
+    /// charged to it.
+    /// </summary>
+    private static readonly TimeSpan LoaderWait = TimeSpan.FromMilliseconds(500);
+
     [Fact]
     public async Task EvaluateAsyncCarriesAllocationBudgetAcrossAThreadHop()
     {
@@ -177,7 +193,7 @@ public class HostMemoryLimitTests
     }
 
     [Fact]
-    public void PromiseContinuationRetainsItsOriginatingBudgetWhenPumpedOnAnotherThread()
+    public async Task PromiseContinuationRetainsItsOriginatingBudgetWhenPumpedOnAnotherThread()
     {
         var allocations = new List<byte[]>();
         var gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -193,12 +209,25 @@ public class HostMemoryLimitTests
 
         gate.SetResult(true);
 
-        var failure = RunOnNewThread(() =>
+        // The pump waits for the gate's continuation, which itself needs a thread-pool worker, so it must
+        // not hold one while it waits — a saturated pool would otherwise decide the outcome rather than
+        // the engine. See DedicatedThread.RunAsync.
+        Exception? failure = null;
+        await DedicatedThread.RunAsync(() =>
         {
-            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+            var deadline = DateTime.UtcNow + PumpCeiling;
             while (DateTime.UtcNow < deadline)
             {
-                engine.Advanced.ProcessTasks();
+                try
+                {
+                    engine.Advanced.ProcessTasks();
+                }
+                catch (Exception exception)
+                {
+                    failure = exception;
+                    return;
+                }
+
                 Thread.Sleep(1);
             }
         });
@@ -369,24 +398,33 @@ public class HostMemoryLimitTests
     }
 
     [Fact]
-    public void SynchronousImportDoesNotChargeAsyncLoaderWaitToExecutionTimeout()
+    public async Task SynchronousImportDoesNotChargeAsyncLoaderWaitToExecutionTimeout()
     {
         var loader = new DelayedModuleLoader(() => { });
         var engine = new Engine(options =>
         {
             options.LimitMemory(SingleAllocationBudget);
             options.TimeoutInterval(TimeSpan.FromMilliseconds(200));
-            options.Constraints.PromiseTimeout = TimeSpan.FromSeconds(5);
+
+            // A ceiling only a genuine hang can reach, rather than a budget racing the loader wait: the
+            // wait resumes on a thread-pool worker, and on a saturated runner the pool's injection rate
+            // would otherwise decide the outcome. Same treatment as #3123 and #3154.
+            options.Constraints.PromiseTimeout = TimeSpan.FromMinutes(2);
             options.EnableModules(loader);
         });
 
-        _ = Task.Run(async () =>
-        {
-            await Task.Delay(500);
-            loader.Complete("export const value = 42;");
-        });
+        // The blocking Import waits for a completion that arrives from another thread, so it must not
+        // hold a pool worker while it does. See DedicatedThread.RunAsync.
+        var import = DedicatedThread.RunAsync(
+            () => engine.Modules.Import("module").Get("value").AsNumber().Should().Be(42));
 
-        engine.Modules.Import("module").Get("value").AsNumber().Should().Be(42);
+        // The completion only exists once the engine has actually asked the loader for the module; the
+        // wait that follows is what has to stay off the execution timeout.
+        loader.WaitUntilStarted();
+        await Task.Delay(LoaderWait);
+        loader.Complete("export const value = 42;");
+
+        await import;
     }
 
     [Fact]
@@ -600,7 +638,10 @@ public class HostMemoryLimitTests
             release.Wait();
         }));
         var constraint = engine.Constraints.Find<MemoryLimitConstraint>()!;
-        var running = Task.Run(() => engine.Execute("block()"));
+        // A dedicated thread rather than Task.Run: the script blocks until this test releases it, and
+        // the test blocks until the script has entered, so putting either on the thread pool makes the
+        // pool's injection rate part of the outcome. See DedicatedThread.RunAsync.
+        var running = DedicatedThread.RunAsync(() => engine.Execute("block()"));
 
         entered.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
         try
@@ -679,7 +720,10 @@ public class HostMemoryLimitTests
         }));
         var constraint = engine.Constraints.Find<MemoryLimitConstraint>()!;
         constraint.Begin();
-        var running = Task.Run(() => engine.Execute("block()"));
+        // A dedicated thread rather than Task.Run: the script blocks until this test releases it, and
+        // the test blocks until the script has entered, so putting either on the thread pool makes the
+        // pool's injection rate part of the outcome. See DedicatedThread.RunAsync.
+        var running = DedicatedThread.RunAsync(() => engine.Execute("block()"));
 
         entered.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
         try
@@ -900,6 +944,7 @@ public class HostMemoryLimitTests
     private sealed class DelayedModuleLoader : IAsyncModuleLoader
     {
         private readonly Action _onLoad;
+        private readonly ManualResetEventSlim _started = new();
         private ModuleLoadCompletion? _completion;
 
         public DelayedModuleLoader(Action onLoad) => _onLoad = onLoad;
@@ -917,7 +962,18 @@ public class HostMemoryLimitTests
             Started = true;
             _onLoad();
             _completion = completion;
+
+            // Set last, so that a thread woken by this has a completion to settle.
+            _started.Set();
         }
+
+        /// <summary>
+        /// Blocks until the engine has asked for the module, so that a host driving the load from another
+        /// thread cannot reach <see cref="Complete"/> before there is a completion to settle.
+        /// </summary>
+        public void WaitUntilStarted() => _started
+            .Wait(TimeSpan.FromSeconds(30))
+            .Should().BeTrue("the engine never asked the loader for the module");
 
         public void Complete(string source) => _completion!.SetSource(source);
     }

--- a/Jint.Tests.PublicInterface/HostResultLimitsTests.cs
+++ b/Jint.Tests.PublicInterface/HostResultLimitsTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Jint.Constraints;
 using Jint.Native;
 using Jint.Native.Json;
@@ -9,6 +10,38 @@ namespace Jint.Tests.PublicInterface;
 public class HostResultLimitsTests
 {
     private const string ConcurrentUseMessage = "*already in use by another thread or has an asynchronous operation in progress*";
+
+    /// <summary>
+    /// The budget one host operation gets in <see cref="OperationDeadlineSpansEvaluationAndConversion"/>.
+    /// Nothing has to fit inside a <em>slice</em> of it: the only entry that must complete is a warm
+    /// four-hundred-statement evaluation, and the whole budget is its headroom.
+    /// </summary>
+    private static readonly TimeSpan OperationBudget = TimeSpan.FromMilliseconds(400);
+
+    /// <summary>
+    /// How far past <see cref="OperationBudget"/> the host sleeps, so that no timer granularity anywhere
+    /// can leave time on a budget the test needs gone.
+    /// </summary>
+    private static readonly TimeSpan BudgetOverspend = TimeSpan.FromMilliseconds(100);
+
+    /// <summary>
+    /// Absorbs the constraint's truncation of the budget into <see cref="Stopwatch"/> ticks when deciding
+    /// whether a throw out of the evaluation entry means the runner stalled or the budget was armed in
+    /// the past.
+    /// </summary>
+    private static readonly TimeSpan AttributionSlack = TimeSpan.FromMilliseconds(1);
+
+    /// <summary>
+    /// A script whose evaluation <em>and</em> whose getter each run well past the interpreter's amortized
+    /// check interval (64 statements), so that both the evaluation entry and the conversion entry provably
+    /// reach a constraint check rather than merely probably. Without the leading loop the evaluation of a
+    /// bare object literal is short enough to slip between two checks, and the entry would then sit inside
+    /// the operation without ever consulting its budget.
+    /// </summary>
+    private const string CheckedEvaluationSource = """
+        for (var w = 0; w < 200; w++) {}
+        ({ get value() { for (var i = 0; i < 200; i++) {} return 42; } })
+        """;
 
     [Fact]
     public void DefaultConversionRemainsUnlimitedAndCompatible()
@@ -315,7 +348,10 @@ public class HostResultLimitsTests
             entered.Set();
             release.Wait();
         }));
-        var running = Task.Run(() => engine.Execute("block()"));
+        // A dedicated thread rather than Task.Run: the script blocks until this test releases it, and the
+        // test blocks until the script has entered, so putting either on the thread pool makes the pool's
+        // injection rate part of the outcome. See DedicatedThread.RunAsync.
+        var running = DedicatedThread.RunAsync(() => engine.Execute("block()"));
 
         entered.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
         try
@@ -361,24 +397,47 @@ public class HostResultLimitsTests
     [Fact]
     public void OperationDeadlineSpansEvaluationAndConversion()
     {
+        // Evaluating a script and converting its result are two separate top-level entries, and the
+        // engine rewinds every ordinary constraint at each of those boundaries. This one declines, so
+        // what the evaluation entry left of the operation's budget is what the conversion entry gets —
+        // here, nothing.
+        //
+        // The budget is spent on the host's own clock rather than by a pause inside the script, and that
+        // is the whole point of the shape. A script pause long enough to exhaust the budget would fail
+        // the entry that ran it, so exhausting it from inside the engine means splitting the budget into
+        // slices and requiring the evaluation to fit in one — which is a claim about the runner, and is
+        // exactly how this row failed a macOS leg of a workers-only change (#3221). The budget is wall
+        // clock from Begin, host time counts against it just as engine time does, and Thread.Sleep only
+        // ever overshoots: no machine is slow enough to leave time on it.
         var deadline = new OperationDeadlineConstraint();
         using var engine = new Engine(options => options.Constraint(deadline));
-        engine.SetValue("pause", new Action(() => Thread.Sleep(250)));
-        engine.SetValue("noop", new Action(() => { }));
 
-        // Warm parsing, the interop call path and ConvertResult before the clock starts. The budget
-        // leaves only 150ms of headroom over the first pause, and on .NET Framework a cold first
-        // evaluation costs more than that often enough to make the Evaluate below throw the
-        // TimeoutException this test means to observe from the conversion instead.
-        engine.Advanced.ConvertResult(engine.Evaluate("noop(); ({ get value() { noop(); return 42; } })"));
+        // Warm parsing, the getter's call path and ConvertResult before the clock starts.
+        engine.Advanced.ConvertResult(engine.Evaluate(CheckedEvaluationSource));
 
-        deadline.Begin(TimeSpan.FromMilliseconds(400));
+        var stopwatch = Stopwatch.StartNew();
+        deadline.Begin(OperationBudget);
         try
         {
-            var value = engine.Evaluate("pause(); ({ get value() { pause(); return 42; } })");
+            JsValue value = null;
+            var evaluationFailure = Record.Exception(() => value = engine.Evaluate(CheckedEvaluationSource));
+
+            // A stall long enough to fail this entry is the runner's doing, and failing it is what the
+            // engine promises, but it leaves the run with nothing to say about the conversion. A budget
+            // armed in the past fails the same entry with the stopwatch reading nearly zero, and that is
+            // a defect — hence the elapsed-time condition rather than a bare "did it throw", and hence
+            // the assertion that follows for every other failure.
+            Assert.SkipWhen(
+                evaluationFailure is TimeoutException && stopwatch.Elapsed >= OperationBudget - AttributionSlack,
+                "the runner stalled the evaluation entry past the whole operation budget");
+            evaluationFailure.Should().BeNull("the evaluation entry runs inside a budget it cannot have spent");
+
+            Thread.Sleep(OperationBudget + BudgetOverspend);
 
             Invoking(() => engine.Advanced.ConvertResult(value))
-                .Should().ThrowExactly<TimeoutException>();
+                .Should().ThrowExactly<TimeoutException>(
+                    "the conversion is a fresh top-level entry, and the engine's per-entry reset must not "
+                    + "refund it the operation's budget");
         }
         finally
         {


### PR DESCRIPTION
Closes #3221.

The security-stack budget tests conflate two different things: **the property they mean to prove** — a bracketed budget accumulates across host entries instead of re-arming per call — and **an incidental timing coincidence** — "and therefore it takes more than one call to exhaust it", which is only true when no single call is slow enough to blow the whole budget by itself. A contended runner breaks the second without touching the first, and `calls == 1` then reads as a mis-armed budget when nothing is mis-armed.

Per the issue's comment this is a sweep of the whole family — `HostCallLoopConstraintTests`, `HostResultLimitsTests`, `HostMemoryLimitTests` — not a patch of the one line the first sighting named. 81 timing-, allocation- or count-dependent assertions were inventoried and classified; most are safe as they stand, and the ones that are not are fixed by asserting the property directly rather than by widening a window.

### What changed, and why each is not a weakening

The bar for every edit was: **would this still fail if the constraint were mis-armed?** Each is answered by mutation, not by argument — the mutations were applied to the engine locally, the tests observed failing, and the mutations reverted.

- **`calls > 1` in `ADeadlineSpansAHostLoop…` is removed outright.** The test already asserts `Should().Throw<TimeoutException>()` *and* that the stopwatch reached the budget. Given those two, `calls == 1` says only that the runner stalled the first call past the entire budget — it carries no information the other assertions do not already carry. *Mutation:* refunded-per-entry ⇒ no throw ⇒ fails; armed-in-the-past ⇒ throw at stopwatch ≈ 0 ⇒ fails.
- **The two `completed > 1` rows become a precise observation plus a precise skip.** `TimeoutIsRearmed…` had **no skip guard at all** and is the row that actually failed under load. The loop went 6×150 ms → 12×100 ms so the sample of post-interval iterations grows 2 → 6, and the claim is now "an entry completed after the loop had already outlived the interval" — which is the re-arming property stated directly. A zero now *skips* rather than fails. The old skip on the sibling row (`elapsed > 2 × timeout`) was arbitrary and did not even cover `calls == 1, elapsed == 1.5 ×`. *Mutation:* `TimeConstraint.Reset` arming once ⇒ both rows fail through the assertion, not the skip.
- **A new test carries the property with zero timing tolerance:** `AnEntryEnteredAfterTheOperationsBudgetHasElapsedInheritsItRatherThanAFreshOne` arms the budget, has the host sleep twice it, and requires a *fresh* entry to throw immediately. A `Reset()` that re-arms hands that entry a whole new window and it completes. This is the row that cannot be argued about, and it is why deleting `calls > 1` costs nothing.
- **`OperationDeadlineSpansEvaluationAndConversion`** — the site named in this PR's sibling finding from #3230, flaky on `main` today on **both** net10.0 and net472. It gave a 400 ms budget over a `Thread.Sleep(250)`, 150 ms of headroom, and asserted the throw comes from the *conversion*; under load the *evaluation* blows it first. Restructured to elapse the budget host-side, with a `CheckedEvaluationSource` making both entries provably reach a check, and a skip that cannot mask the mutation: with the budget armed in the past the evaluation fails at stopwatch ≈ 0, the skip does not fire, and `evaluationFailure.Should().BeNull()` fails.
- **Four pool-scheduling races moved off the thread pool** (`Task.Run` → `DedicatedThread.RunAsync`), which is the #3207 treatment. A test that blocks an xUnit pool worker while waiting for a continuation that needs a pool worker is not a budget problem at all. Two ceilings widened alongside, both on failure paths only. `DelayedModuleLoader.WaitUntilStarted()` closes a latent `_completion!` null race found on the way.

### Evidence

**With the fix: 64 runs of the three classes, 0 failures, 0 skips** — 32 idle (16 net10.0 + 16 net472) and 32 under deliberate CPU load (64–160 spinning processes on 32 logical cores, CPU pinned at 100%, individual runs stretching to 30 s).

**Against unmodified `main` under the same load: 5 failures in 16 runs (31%)** — every one on `calls > 1` or `completed > 1`, i.e. exactly the assertions the issue names, plus 3 of the old skips firing.

Post-rebase, serial, one pass each: `Jint.Tests.PublicInterface` 2396 (net10.0) + 1875 (net472); with `JINT_HOST_CONTRACT_VERIFICATION=1`, 2400 + 1879. `Jint.Tests` 10073 + 7102, identical on both legs. All green.

### Left alone, deliberately

`NestedTransferredCallbacksKeepTheOuterMemoryOperation` (new in #3216) blocks the xUnit pool worker on `Task.Run(...).GetAwaiter().GetResult()`. It is a real resource inversion, but it carries no timeout, so it can only ever be *slow* — never spuriously red. Inventoried, not touched.

The three `entered.Wait(10 s)` gates stay at 10 s: with the script now on a dedicated thread they no longer depend on pool injection at all.

**No fake clock for the constraints themselves.** `OperationDeadlineConstraint` and `TimeConstraint` read `Stopwatch.GetTimestamp()` directly and have no `TimeProvider` seam — unlike `TimerQueue`, which #3216's new tests drive with a `ManualClock`. Adding one is engine work and out of scope here; filed separately, since it is what would let the remaining wall-clock rows become fully deterministic instead of merely one-sided.

Tests only — `git diff --name-only` is exactly the three files. No engine defect surfaced by the audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
