### PR TITLE
Array.prototype.values/keys/entries: no array-like gate on the receiver

### DIFF
--- a/Jint.Tests/Runtime/ArrayIteratorReceiverTests.cs
+++ b/Jint.Tests/Runtime/ArrayIteratorReceiverTests.cs
@@ -1,0 +1,489 @@
+#nullable enable
+
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// <see href="https://tc39.es/ecma262/#sec-array.prototype.values">Array.prototype.values</see> — and
+/// <c>keys</c> and <c>entries</c> with it — is two steps: <i>ToObject(this)</i> and
+/// <i>CreateArrayIterator(O, kind)</i>. Neither reads <c>length</c>, and there is no array-like
+/// precondition the receiver can fail. The <c>length</c> read belongs to the iterator's own closure,
+/// whose step 1.b is <i>LengthOfArrayLike</i> — a <c>Get</c> plus a <c>ToLength</c> — performed afresh on
+/// <em>every</em> <c>next()</c>.
+/// <para>
+/// Jint gated all three on <c>ObjectInstance.IsArrayLike</c>, which demands a <c>length</c> that is
+/// present, is <em>already</em> a <c>JsNumber</c>, and is non-negative, and threw
+/// <c>TypeError: cannot construct iterator</c> otherwise. That was wrong in six ways at once: absent means
+/// zero, a string or a boolean coerces, a negative clamps to zero, and the read — with any throw from a
+/// <c>length</c> getter — belongs to the first <c>next()</c> rather than to <c>values()</c>. Found by the
+/// FileAPI web-platform-tests corpus, where <c>new Blob({[Symbol.iterator]: Array.prototype[Symbol.iterator]})</c>
+/// is exactly this shape, and reproducible with no web API enabled at all.
+/// </para>
+/// </summary>
+public class ArrayIteratorReceiverTests
+{
+    private readonly Engine _engine = new();
+
+    /// <summary>
+    /// The seven shapes named in the issue, each with what the specification requires of it.
+    /// </summary>
+    [Theory]
+    // No `length` at all: LengthOfArrayLike is ToLength(undefined), which is 0, so the closure returns
+    // on its very first step.
+    [InlineData("[...Array.prototype.values.call({})]", "")]
+    // A string `length` coerces: ToLength('3') is 3.
+    [InlineData("[...Array.prototype.values.call({length: '3', 0: 'a', 1: 'b', 2: 'c'})]", "a,b,c")]
+    // ToLength clamps a negative to +0 rather than rejecting it.
+    [InlineData("[...Array.prototype.values.call({length: -1})]", "")]
+    // ToLength(null) is ToIntegerOrInfinity(ToNumber(null)) = 0.
+    [InlineData("[...Array.prototype.values.call({length: null})]", "")]
+    // ToLength(true) is 1.
+    [InlineData("[...Array.prototype.values.call({length: true, 0: 'a'})]", "a")]
+    // The whole reason the WPT corpus reached this: an object borrowing Array.prototype's @@iterator is a
+    // sequence of length 0, not a TypeError.
+    [InlineData("[...{[Symbol.iterator]: Array.prototype.values}]", "")]
+    // ToObject boxes a primitive, so a String object's own indices and length are what gets iterated.
+    [InlineData("[...Array.prototype.values.call('abc')]", "a,b,c")]
+    public void ANonArrayLikeReceiverIteratesRatherThanThrowing(string script, string expected)
+    {
+        _engine.Evaluate(script + ".join(',')").AsString().Should().Be(expected);
+    }
+
+    /// <summary>
+    /// A Number object carries no <c>length</c>, so it is the "absent means zero" case reached through
+    /// <i>ToObject</i> rather than directly.
+    /// </summary>
+    [Fact]
+    public void APrimitiveWithNoLengthBoxesToAnEmptyIteration()
+    {
+        _engine.Evaluate("[...Array.prototype.values.call(5)].length").AsNumber().Should().Be(0);
+    }
+
+    /// <summary>
+    /// <i>ToObject</i> is still step 1, so <c>undefined</c> and <c>null</c> remain a <c>TypeError</c> — the
+    /// one receiver rejection the algorithm does have.
+    /// </summary>
+    [Theory]
+    [InlineData("undefined")]
+    [InlineData("null")]
+    public void AnUndefinedOrNullReceiverIsStillATypeError(string receiver)
+    {
+        var ex = Assert.Throws<JavaScriptException>(() => _engine.Evaluate($"Array.prototype.values.call({receiver})"));
+        ex.Error.Get("name").AsString().Should().Be("TypeError");
+    }
+
+    /// <summary>
+    /// <c>keys</c> and <c>entries</c> have the same two-step body, so the same receiver reaches all three.
+    /// </summary>
+    [Fact]
+    public void KeysAndEntriesTakeTheSameReceivers()
+    {
+        _engine.Evaluate("[...Array.prototype.keys.call({})].length").AsNumber().Should().Be(0);
+        _engine.Evaluate("[...Array.prototype.keys.call({length: '2'})].join(',')").AsString().Should().Be("0,1");
+        _engine.Evaluate("[...Array.prototype.entries.call({})].length").AsNumber().Should().Be(0);
+        _engine.Evaluate("""
+            [...Array.prototype.entries.call({length: '2', 0: 'x', 1: 'y'})].map(e => e.join(':')).join(',')
+            """).AsString().Should().Be("0:x,1:y");
+    }
+
+    /// <summary>
+    /// The read is the iterator's, not <c>values</c>'s, so a throwing <c>length</c> getter has to survive
+    /// <c>values()</c> and erupt from the first <c>next()</c>. This is the ordering half of the defect and
+    /// the half a "throw earlier instead" fix would get wrong.
+    /// </summary>
+    [Fact]
+    public void AThrowingLengthGetterThrowsFromTheFirstNextNotFromValues()
+    {
+        _engine.Evaluate("""
+            var sentinel = new Error('boom');
+            var receiver = { get length() { throw sentinel; } };
+            var constructed = false, thrownFromNext = null;
+            var iterator = Array.prototype.values.call(receiver);
+            constructed = true;
+            try { iterator.next(); } catch (e) { thrownFromNext = e; }
+            constructed + ' ' + (thrownFromNext === sentinel);
+            """).AsString().Should().Be("true true");
+    }
+
+    /// <summary>
+    /// The same for a <c>length</c> whose coercion throws: <i>ToLength</i> runs inside the closure, so
+    /// <c>values()</c> is clean and <c>next()</c> carries the exception. (This is the shape
+    /// <c>Blob-constructor.any.js</c>'s "ToUint32 should be applied to the length" row hands the engine.)
+    /// </summary>
+    [Fact]
+    public void AThrowingLengthCoercionThrowsFromTheFirstNext()
+    {
+        _engine.Evaluate("""
+            var sentinel = new Error('boom');
+            var receiver = { length: { valueOf: null, toString: function () { throw sentinel; } } };
+            var iterator = Array.prototype.values.call(receiver);
+            var caught = null;
+            try { iterator.next(); } catch (e) { caught = e; }
+            caught === sentinel;
+            """).AsBoolean().Should().BeTrue();
+    }
+
+    /// <summary>
+    /// A <c>length</c> that cannot be coerced at all — a Symbol — is a <c>TypeError</c> from <c>next()</c>,
+    /// again not from <c>values()</c>.
+    /// </summary>
+    [Fact]
+    public void ASymbolLengthIsATypeErrorFromNext()
+    {
+        _engine.Evaluate("""
+            var iterator = Array.prototype.values.call({ length: Symbol('nope') });
+            var name = null;
+            try { iterator.next(); } catch (e) { name = e.name; }
+            name;
+            """).AsString().Should().Be("TypeError");
+    }
+
+    /// <summary>
+    /// Per-<c>next()</c> means per-<c>next()</c>: an array-like that grows between two steps yields the
+    /// elements it grew by. Caching the length at <c>values()</c> — or even at the first step — would stop
+    /// after the element that existed then.
+    /// </summary>
+    [Fact]
+    public void ALengthThatGrowsBetweenStepsYieldsTheNewElements()
+    {
+        _engine.Evaluate("""
+            var receiver = { length: 0 };
+            var iterator = Array.prototype.values.call(receiver);
+
+            receiver.length = 1; receiver[0] = 'a';
+            var first = iterator.next();
+
+            receiver.length = 2; receiver[1] = 'b';
+            var second = iterator.next();
+
+            var third = iterator.next();
+            first.value + ',' + second.value + ',' + third.value + ',' + third.done;
+            """).AsString().Should().Be("a,b,undefined,true");
+    }
+
+    /// <summary>
+    /// And the other direction: a shrink completes the iteration at the step that observes it.
+    /// </summary>
+    [Fact]
+    public void ALengthThatShrinksBetweenStepsCompletesTheIteration()
+    {
+        _engine.Evaluate("""
+            var receiver = { length: 3, 0: 'a', 1: 'b', 2: 'c' };
+            var iterator = Array.prototype.values.call(receiver);
+
+            var first = iterator.next();
+            receiver.length = 1;
+            var second = iterator.next();
+
+            first.value + ',' + second.value + ',' + second.done;
+            """).AsString().Should().Be("a,undefined,true");
+    }
+
+    /// <summary>
+    /// Once the closure has returned, the generator is completed and observes nothing further — so a
+    /// <c>length</c> that grows back after exhaustion does not restart the iteration, and the getter is not
+    /// even consulted.
+    /// </summary>
+    [Fact]
+    public void AnExhaustedArrayLikeIteratorDoesNotReadLengthAgain()
+    {
+        _engine.Evaluate("""
+            var reads = 0;
+            var backing = 1;
+            var receiver = { 0: 'a', 1: 'b', get length() { reads++; return backing; } };
+            var iterator = Array.prototype.values.call(receiver);
+
+            iterator.next();
+            iterator.next();          // observes length 1, completes
+            var readsAtCompletion = reads;
+
+            backing = 2;
+            var after = iterator.next();
+            after.done + ' ' + (reads === readsAtCompletion);
+            """).AsString().Should().Be("true true");
+    }
+
+    /// <summary>
+    /// The exact ordering <c>Blob-constructor.any.js</c>'s "Getters and value conversions should happen in
+    /// order until an exception is thrown" asserts, reduced to the language: the <c>length</c> getter and
+    /// its <c>valueOf</c> run once per step, interleaved with the index reads, and nothing runs at
+    /// <c>values()</c> time.
+    /// </summary>
+    [Fact]
+    public void LengthIsReadOncePerStepInterleavedWithTheIndexReads()
+    {
+        _engine.Evaluate("""
+            var received = [];
+            var receiver = {
+                get length() {
+                    received.push('length getter');
+                    return { valueOf: function () { received.push('length valueOf'); return 3; } };
+                },
+                get 0() { received.push('0 getter'); return 'a'; },
+                get 1() { received.push('1 getter'); return 'b'; },
+                get 2() { received.push('2 getter'); return 'c'; }
+            };
+
+            var iterator = Array.prototype.values.call(receiver);
+            received.push('|values returned|');
+            iterator.next();
+            iterator.next();
+            received.join(',');
+            """).AsString().Should().Be(
+            "|values returned|,length getter,length valueOf,0 getter,length getter,length valueOf,1 getter");
+    }
+
+    /// <summary>
+    /// A key+value step re-reads the length like the other two kinds, and reads the element exactly once.
+    /// </summary>
+    [Fact]
+    public void EntriesReReadsLengthPerStep()
+    {
+        _engine.Evaluate("""
+            var reads = 0;
+            var receiver = { 0: 'x', 1: 'y', get length() { reads++; return 2; } };
+            var seen = [...Array.prototype.entries.call(receiver)].map(e => e.join(':')).join(',');
+            seen + ' ' + reads;
+            """).AsString().Should().Be("0:x,1:y 3");
+    }
+
+    /// <summary>
+    /// Step 10.d.v of the closure is a bare <c>Get</c>, never a <c>HasProperty</c> first, so a hole in an
+    /// array-like is <c>undefined</c> and not a skipped element.
+    /// </summary>
+    [Fact]
+    public void AHoleInAnArrayLikeYieldsUndefined()
+    {
+        _engine.Evaluate("[...Array.prototype.values.call({length: 3, 0: 'a', 2: 'c'})].join('|')")
+            .AsString().Should().Be("a||c");
+    }
+
+    /// <summary>
+    /// A key-kind step reads no element at all — only the length.
+    /// </summary>
+    [Fact]
+    public void KeysReadsNoElement()
+    {
+        _engine.Evaluate("""
+            var reads = 0;
+            var receiver = { length: 2, get 0() { reads++; return 'a'; }, get 1() { reads++; return 'b'; } };
+            [...Array.prototype.keys.call(receiver)].join(',') + ' ' + reads;
+            """).AsString().Should().Be("0,1 0");
+    }
+
+    /// <summary>
+    /// The control: a real array is still iterated by the dense-array lane and is untouched by any of this,
+    /// and so is a typed array, whose own <c>%TypedArray%.prototype.values</c> keeps its
+    /// <i>ValidateTypedArray</i> precondition.
+    /// </summary>
+    [Fact]
+    public void RealArraysAndTypedArraysAreUnaffected()
+    {
+        _engine.Evaluate("[...[1, 2, 3]].join(',')").AsString().Should().Be("1,2,3");
+        _engine.Evaluate("[...[10, 20].entries()].map(e => e.join(':')).join(',')").AsString().Should().Be("0:10,1:20");
+        _engine.Evaluate("[...[7, 8].keys()].join(',')").AsString().Should().Be("0,1");
+        _engine.Evaluate("[...new Uint8Array([1, 2, 3]).values()].join(',')").AsString().Should().Be("1,2,3");
+
+        var detached = Assert.Throws<JavaScriptException>(() => _engine.Evaluate("""
+            var buffer = new ArrayBuffer(4);
+            var array = new Uint8Array(buffer);
+            buffer.transfer();
+            array.values();
+            """));
+        detached.Error.Get("name").AsString().Should().Be("TypeError");
+    }
+
+    /// <summary>
+    /// The sharpest probe for the ordering half: a <c>Proxy</c> logs every property access its receiver sees,
+    /// through both the <c>get</c> and the <c>getOwnPropertyDescriptor</c> trap — the second because the gate
+    /// this change removes probed <c>length</c> through <c>TryGetValue</c>, which walks own descriptors and
+    /// never fires <c>get</c>. <c>values()</c> must log nothing at all (<i>ToObject</i> and
+    /// <i>CreateArrayIterator</i> touch no property), and the first <c>next()</c> must log exactly a
+    /// <c>get</c> of <c>length</c> and then one of the index — steps 1.b and 10.d.v of the closure, in that
+    /// order and with no existence probe between them.
+    /// </summary>
+    [Fact]
+    public void ValuesReadsNothingAndTheFirstNextReadsLengthThenTheIndex()
+    {
+        _engine.Evaluate("""
+            var log = [];
+            var target = { length: 1, 0: 'a' };
+            var proxy = new Proxy(target, {
+                get: function (t, k) { log.push('get:' + String(k)); return t[k]; },
+                getOwnPropertyDescriptor: function (t, k) {
+                    log.push('gopd:' + String(k));
+                    return Object.getOwnPropertyDescriptor(t, k);
+                }
+            });
+
+            var iterator = Array.prototype.values.call(proxy);
+            var atConstruction = log.join(',');
+            var first = iterator.next();
+
+            '[' + atConstruction + '] [' + log.join(',') + '] ' + first.value;
+            """).AsString().Should().Be("[] [get:length,get:0] a");
+    }
+
+    /// <summary>
+    /// <i>ToLength</i> is <i>ToIntegerOrInfinity</i> clamped into <c>[0, 2^53-1]</c>, not <i>ToNumber</i>:
+    /// anything coercing to <c>NaN</c> is zero, a fraction truncates, and a negative clamps.
+    /// </summary>
+    [Theory]
+    [InlineData("{length: NaN, 0: 'a'}", "")]
+    [InlineData("{length: 'abc', 0: 'a'}", "")]
+    [InlineData("{length: {}, 0: 'a'}", "")]
+    [InlineData("{length: [], 0: 'a'}", "")]
+    [InlineData("{length: undefined, 0: 'a'}", "")]
+    [InlineData("{length: -Infinity, 0: 'a'}", "")]
+    [InlineData("{length: -0.5, 0: 'a'}", "")]
+    [InlineData("{length: false, 0: 'a'}", "")]
+    [InlineData("{length: 2.9, 0: 'a', 1: 'b', 2: 'c'}", "a,b")]
+    [InlineData("{length: ' 2 ', 0: 'a', 1: 'b', 2: 'c'}", "a,b")]
+    [InlineData("{length: '0x2', 0: 'a', 1: 'b', 2: 'c'}", "a,b")]
+    [InlineData("{length: ['2'], 0: 'a', 1: 'b', 2: 'c'}", "a,b")]
+    public void TheLengthIsCoercedByToLength(string receiver, string expected)
+    {
+        _engine.Evaluate($"[...Array.prototype.values.call({receiver})].join(',')").AsString().Should().Be(expected);
+    }
+
+    /// <summary>
+    /// A very large <c>length</c> is clamped by <i>ToLength</i> — never rejected, and never read as zero —
+    /// so the first step still yields index 0. Exactly one step is taken: the iteration itself is unbounded
+    /// by construction.
+    /// <para>
+    /// The rows stop below 2^32 deliberately. <i>ToLength</i>'s specified ceiling is 2^53-1, but the
+    /// array-like lane behind the iterator carries its length as a <c>uint</c>
+    /// (<c>ArrayOperations.GetLength</c>), so a length above 2^32-1 is decided by an out-of-range
+    /// double-to-integer conversion — saturating on .NET, unspecified on .NET Framework, where 2^53 reads
+    /// back as 0. That is pre-existing and independent of the receiver gate this class is about: such a
+    /// <c>length</c> is a non-negative <c>JsNumber</c> and so reached the very same iterator before the gate
+    /// was dropped. The sibling generics do not share it — <c>at</c> and <c>includes</c> go through
+    /// <c>GetLongLength</c>, which clamps at <i>MaxArrayLikeLength</i> — so it is one method's cast, and its
+    /// own change.
+    /// </para>
+    /// </summary>
+    [Theory]
+    [InlineData("Math.pow(2, 31)")]
+    [InlineData("4294967294")]
+    [InlineData("2147483648.7")]
+    public void AVeryLargeLengthStillYieldsItsFirstElement(string length)
+    {
+        _engine.Evaluate($$"""
+            var iterator = Array.prototype.values.call({ length: {{length}}, 0: 'a' });
+            var first = iterator.next();
+            first.value + ' ' + first.done;
+            """).AsString().Should().Be("a false");
+    }
+
+    /// <summary>
+    /// A shrink all the way below the index the iterator has already reached completes it at that step:
+    /// <c>index &lt; len</c> is false, so the closure returns without reading an element.
+    /// </summary>
+    [Fact]
+    public void ALengthThatShrinksBelowTheCurrentIndexCompletesTheIteration()
+    {
+        _engine.Evaluate("""
+            var reads = 0;
+            var receiver = { 0: 'a', 1: 'b', 2: 'c', length: 4 };
+            Object.defineProperty(receiver, '3', { get: function () { reads++; return 'd'; } });
+            var iterator = Array.prototype.values.call(receiver);
+
+            var first = iterator.next();
+            var second = iterator.next();
+            var third = iterator.next();   // position is now 3
+            receiver.length = 1;           // …and the length drops below it
+            var fourth = iterator.next();
+
+            [first.value, second.value, third.value, String(fourth.value), fourth.done, reads].join(',');
+            """).AsString().Should().Be("a,b,c,undefined,true,0");
+    }
+
+    /// <summary>
+    /// Step 10.d.v is an ordinary <i>Get</i>, so a hole resolves up the prototype chain rather than
+    /// answering <c>undefined</c> unconditionally — for an array-like…
+    /// </summary>
+    [Fact]
+    public void AHoleInAnArrayLikeResolvesThroughThePrototypeChain()
+    {
+        _engine.Evaluate("""
+            var receiver = Object.create({ 1: 'from proto' });
+            receiver.length = 3;
+            receiver[0] = 'a';
+            receiver[2] = 'c';
+            [...Array.prototype.values.call(receiver)].join('|');
+            """).AsString().Should().Be("a|from proto|c");
+    }
+
+    /// <summary>
+    /// …and for a real array, whose dense lane has to notice that <c>Array.prototype</c> gained an index and
+    /// stop answering holes out of its backing store alone.
+    /// </summary>
+    [Fact]
+    public void AHoleInARealArrayResolvesThroughThePrototypeChain()
+    {
+        _engine.Evaluate("""
+            (function () {
+                Array.prototype[1] = 'from proto';
+                try {
+                    return [...['a', , 'c']].join('|') + ' '
+                        + [...['a', , 'c'].entries()].map(e => e.join(':')).join(',');
+                } finally {
+                    delete Array.prototype[1];
+                }
+            })();
+            """).AsString().Should().Be("a|from proto|c 0:a,1:from proto,2:c");
+    }
+
+    /// <summary>
+    /// An entry step yields <c>[index, Get(O, index)]</c>, so an absent index is a present pair carrying
+    /// <c>undefined</c> — never a skipped pair.
+    /// </summary>
+    [Fact]
+    public void EntriesYieldsAPairForEveryIndexIncludingAbsentOnes()
+    {
+        _engine.Evaluate("[...Array.prototype.entries.call({length: 2})].map(e => e[0] + ':' + e[1]).join(',')")
+            .AsString().Should().Be("0:undefined,1:undefined");
+
+        _engine.Evaluate("[...Array.prototype.entries.call({length: 3, 0: 'a', 2: 'c'})].map(e => e[0] + ':' + e[1]).join(',')")
+            .AsString().Should().Be("0:a,1:undefined,2:c");
+    }
+
+    /// <summary>
+    /// <c>Array.prototype[Symbol.iterator]</c> is the very same function object as
+    /// <c>Array.prototype.values</c> (ECMA-262 23.1.3.41), which is why one gate broke both.
+    /// </summary>
+    [Fact]
+    public void SymbolIteratorIsTheSameFunctionObjectAsValues()
+    {
+        _engine.Evaluate("Array.prototype[Symbol.iterator] === Array.prototype.values").AsBoolean().Should().BeTrue();
+        _engine.Evaluate("[...{[Symbol.iterator]: Array.prototype[Symbol.iterator], length: 2, 0: 'a', 1: 'b'}].join(',')")
+            .AsString().Should().Be("a,b");
+    }
+
+    /// <summary>
+    /// The lane pin behind the "no performance regression" claim: dropping the gate must not have routed a
+    /// real array through the generic array-like iterator. <i>CreateArrayIterator</i>'s dispatch is a type
+    /// test on the receiver and <i>ToObject</i> hands an object straight back, so a <c>JsArray</c> still
+    /// reaches the dense iterator and everything else the array-like one.
+    /// </summary>
+    [Fact]
+    public void AnArrayReceiverStillReachesTheDenseArrayIterator()
+    {
+        _engine.Evaluate("[1, 2].values()").GetType().Name.Should().Be("ArrayIterator");
+        _engine.Evaluate("[1, 2].keys()").GetType().Name.Should().Be("ArrayIterator");
+        _engine.Evaluate("[1, 2].entries()").GetType().Name.Should().Be("ArrayIterator");
+        _engine.Evaluate("Array.prototype.values.call([1, 2])").GetType().Name.Should().Be("ArrayIterator");
+        _engine.Evaluate("Array.prototype.values.call({length: 2})").GetType().Name.Should().Be("ArrayLikeIterator");
+    }
+
+    /// <summary>
+    /// <c>arguments</c> already satisfied the old gate; it must keep working through the ungated path.
+    /// </summary>
+    [Fact]
+    public void ArgumentsObjectsStillIterate()
+    {
+        _engine.Evaluate("(function () { return [...Array.prototype.values.call(arguments)].join(','); })('p', 'q')")
+            .AsString().Should().Be("p,q");
+    }
+}

--- a/Jint.Tests/Runtime/PrototypeAccessorReceiverTests.cs
+++ b/Jint.Tests/Runtime/PrototypeAccessorReceiverTests.cs
@@ -51,7 +51,9 @@ public class PrototypeAccessorReceiverTests
     [Fact]
     public void ArrayPrototypeKeysPassesTheReceiverToAnInheritedLengthGetter()
     {
-        // Array.prototype.keys/values gate on the same IsArrayLike probe.
+        // Array.prototype.keys/values used to gate on the same IsArrayLike probe; the probe moved into
+        // the iterator's per-next LengthOfArrayLike (see ArrayIteratorReceiverTests), so the getter now
+        // runs from next() instead of from keys() — but it still has to run with the instance as `this`.
         var result = _engine.Evaluate("""
             class List {
                 constructor(items) { this._items = items; }

--- a/Jint.Tests/Wpt/Vendor/README.md
+++ b/Jint.Tests/Wpt/Vendor/README.md
@@ -328,7 +328,9 @@ assertion this change added to the shim.
 
 ## What the File API corpus says about this engine
 
-342 assertions across 14 files (11 in `blob/`, 2 in `file/`, 1 in the root), of which **3 do not pass**.
+342 assertions across 14 files (11 in `blob/`, 2 in `file/`, 1 in the root), **all of them passing**. Both
+groups that used to be red are worth an account, because between them they are everything this corpus has
+caught.
 
 The eight that used to be red were the whole of `Blob-textStream.any.js`, under a `NeedsBlobTextStream`
 category, because [the File API added](https://w3c.github.io/FileAPI/#dom-blob-textstream) `textStream()`
@@ -337,35 +339,40 @@ after this `Blob` was written. They pass since
 UTF-8 `TextDecoderStream`, which is four steps over pieces the engine already had — and the two entries and
 the category are gone with them.
 
-**The 3 that remain are `NeedsTriage`, and the defect is not in `Blob` at all.** All three rows of
-`Blob-constructor.any.js` fail with `TypeError: cannot construct iterator`, thrown by
-`Array.prototype.values`:
+### The three `Blob-constructor.any.js` rows this corpus found, and the engine defect behind them
+
+The other three sat under `NeedsTriage`, failing with `TypeError: cannot construct iterator` thrown by
+`Array.prototype.values` — and the defect was not in `Blob` at all. It is fixed
+([#3209](https://github.com/sebastienros/jint/issues/3209)); the account is kept because it is the
+best-documented thing this corpus has caught so far, and because the deleted entries are what now enforce the
+fix.
 
 ```js
-[...Array.prototype.values.call({})]                    // spec: []           Jint: TypeError
+[...Array.prototype.values.call({})]                    // spec: []           was: TypeError
 [...Array.prototype.values.call({length: '3', 0: 'a', 1: 'b', 2: 'c'})]
-                                                        // spec: [a, b, c]    Jint: TypeError
-[...Array.prototype.values.call({length: -1})]          // spec: []           Jint: TypeError
-[...Array.prototype.values.call({length: null})]        // spec: []           Jint: TypeError
-[...Array.prototype.values.call({length: true, 0: 'a'})]// spec: ['a']        Jint: TypeError
+                                                        // spec: [a, b, c]    was: TypeError
+[...Array.prototype.values.call({length: -1})]          // spec: []           was: TypeError
+[...Array.prototype.values.call({length: null})]        // spec: []           was: TypeError
+[...Array.prototype.values.call({length: true, 0: 'a'})]// spec: ['a']        was: TypeError
+[...{[Symbol.iterator]: Array.prototype.values}]        // spec: []           was: TypeError
 Array.prototype.values.call({get length() { throw e; }})// spec: throws at the first next()
-                                                        // Jint: throws at values()
+                                                        // was: threw at values()
 ```
 
 [`Array.prototype.values`](https://tc39.es/ecma262/#sec-array.prototype.values) is *ToObject(this)* followed
 by *CreateArrayIterator(O, value)*, and neither step reads `length`; the iterator's own closure does
-*LengthOfArrayLike* — a `Get` and a `ToLength` — on each `next()`. `ArrayPrototype.Values` instead gates on
+*LengthOfArrayLike* — a `Get` and a `ToLength` — on each `next()`. `ArrayPrototype.Values` instead gated on
 `ObjectInstance.IsArrayLike`, which demands a `length` that is *present*, already a `JsNumber`, and
-non-negative, and throws when it is not. That is wrong in six ways at once: absent means 0, a string or a
+non-negative, and threw when it was not. That was wrong in six ways at once: absent means 0, a string or a
 boolean is coerced, a negative clamps to 0, and the read belongs to `next()` rather than to `values()`.
-`keys` and `entries` have the same three-line body and the same defect.
+`keys` and `entries` had the same three-line body and the same defect. The fix drops the gate from all three —
+the per-`next()` read the specification asks for was already what the array-like iterator did — and
+`ArrayIteratorReceiverTests` pins every shape above plus growth and shrink between two steps.
 
-The corpus reaches it because `new Blob(x)` converts `x` to a WebIDL `sequence`, and the file deliberately
+The corpus reached it because `new Blob(x)` converts `x` to a WebIDL `sequence`, and the file deliberately
 hands it plain objects whose `@@iterator` *is* `Array.prototype[Symbol.iterator]` — which is how a browser's
-`Blob` sees `{length: 1, 0: 'PASS'}` as a one-element sequence. It reproduces with no web API enabled at all,
-which is what makes it an engine finding rather than a `Blob` one. The rest of `Blob-constructor.any.js`'s 73
-rows pass, including the sibling that supplies a numeric `length` and the one that supplies a hand-written
-`@@iterator`.
+`Blob` sees `{length: 1, 0: 'PASS'}` as a one-element sequence. It reproduced with no web API enabled at all,
+which is what made it an engine finding rather than a `Blob` one. `Blob-constructor.any.js` is 73-for-73 now.
 
 `Blob-stream.any.js` passes, and it is worth knowing why it can: it calls `garbageCollect()` from
 `/common/gc.js`, whose fallback merely allocates a lot of garbage, so it asserts that a blob's stream keeps

--- a/Jint.Tests/Wpt/WptExclusions.cs
+++ b/Jint.Tests/Wpt/WptExclusions.cs
@@ -325,7 +325,7 @@ internal enum WptDivergence
     /// documenting the divergence on itself and raising it upstream as
     /// https://github.com/w3c/webcrypto/issues/560.
     /// <para>
-    /// <b>The streams corpus filed five, and the File API corpus one more.</b> Each is analysed in
+    /// <b>The streams corpus filed five, and the workers corpus one more.</b> Each is analysed in
     /// <c>Vendor/README.md</c>; in one line apiece:
     /// </para>
     /// <list type="bullet">
@@ -346,18 +346,6 @@ internal enum WptDivergence
     /// the chunk in a reaction to the reader's promise and can never be synchronous with the enqueue.
     /// </description></item>
     /// <item><description>
-    /// <b>Three rows of <c>FileAPI/blob/Blob-constructor.any.js</c>, and the defect is not in <c>Blob</c> at
-    /// all — it is in <c>Array.prototype.values</c>/<c>keys</c>/<c>entries</c>.</b>
-    /// https://tc39.es/ecma262/#sec-array.prototype.values is <i>ToObject(this)</i> and then
-    /// <i>CreateArrayIterator</i>, which never reads <c>length</c>; the iterator's own step 1.b does
-    /// <i>LengthOfArrayLike</i> on each <c>next()</c>. <c>ArrayPrototype.Values</c> instead gates on
-    /// <c>ObjectInstance.IsArrayLike</c> — a <c>length</c> that is present, is already a <c>JsNumber</c>, and
-    /// is non-negative — and throws <c>TypeError: cannot construct iterator</c> when it is not, so
-    /// <c>[...Array.prototype.values.call({})]</c> is a <c>TypeError</c> where the specification says
-    /// <c>[]</c>. Reproduces with no web API involved at all; see <c>Vendor/README.md</c> for the six shapes
-    /// and what each one should answer.
-    /// </description></item>
-    /// <item><description>
     /// <b><c>self</c> is writable in a worker, where <c>WorkerGlobalScope.self</c> is read-only.</b>
     /// <c>workers/interfaces/WorkerGlobalScope/self.any.js</c>, "self = 1": the file assigns to <c>self</c> and
     /// asserts it did not change. <c>WebApiRegistration</c> installs <c>self</c> once, for every global, as an
@@ -375,6 +363,12 @@ internal enum WptDivergence
     /// </description></item>
     /// </list>
     /// <para>
+    /// The File API corpus filed one too, and it is gone: three rows of
+    /// <c>FileAPI/blob/Blob-constructor.any.js</c> were one <em>engine</em> defect rather than three
+    /// <c>Blob</c> ones — <c>Array.prototype.values</c>/<c>keys</c>/<c>entries</c> gated on
+    /// <c>ObjectInstance.IsArrayLike</c> where https://tc39.es/ecma262/#sec-array.prototype.values reads no
+    /// <c>length</c> at all, the iterator's own step 1.b doing <i>LengthOfArrayLike</i> on each
+    /// <c>next()</c>. Fixed under sebastienros/jint#3209, which is what the deleted entries now enforce.
     /// <b>The hr-time, DOM, structured-clone and fetch corpora filed ten more</b>, and <c>Vendor/README.md</c>
     /// analyses each with its citation. In one line apiece:
     /// </para>

--- a/Jint.Tests/Wpt/WptTestRunner.cs
+++ b/Jint.Tests/Wpt/WptTestRunner.cs
@@ -28,11 +28,12 @@ namespace Jint.Tests.Wpt;
 /// by https://github.com/sebastienros/jint/issues/3121, and both the WebCryptoAPI corpus found are fixed too:
 /// the point at which <c>SubtleCrypto</c> copies its caller's bytes by
 /// https://github.com/sebastienros/jint/issues/3179, and ECDH's mismatched-curve error by
-/// https://github.com/sebastienros/jint/issues/3180. The category holds the five the streams corpus filed,
-/// the one the File API corpus did — an <c>Array.prototype.values</c> defect with no web API in it at all —
-/// the one the workers corpus did, which is a <c>self</c> installed against <c>Window</c>'s definition for
-/// every global including a worker's, and the ten that groups 3 and 4 of
-/// https://github.com/sebastienros/jint/issues/3185 did. <c>Vendor/README.md</c> analyses each.
+/// https://github.com/sebastienros/jint/issues/3180. The one the File API corpus filed is fixed too — an
+/// <c>Array.prototype.values</c>/<c>keys</c>/<c>entries</c> defect with no web API in it at all, by
+/// https://github.com/sebastienros/jint/issues/3209 — so the category holds the five the streams corpus
+/// filed, the one the workers corpus did, which is a <c>self</c> installed against <c>Window</c>'s
+/// definition for every global including a worker's, and the ten that groups 3 and 4 of
+    /// https://github.com/sebastienros/jint/issues/3185 did. <c>Vendor/README.md</c> analyses each.
 /// </para>
 /// <para>
 /// <b>A corpus with sub-directories is one suite per directory</b> rather than one for the lot, because
@@ -939,15 +940,11 @@ public class WptTestRunner
         new("compression/decompression-corrupt-input.any.js", "trailing junk for * should give an error", WptDivergence.NeedsIncrementalInflater),
 
         // ---------------------------------------------------------------- FileAPI
-        // Three rows of Blob-constructor.any.js, and they are one engine defect rather than three Blob ones
-        // — see WptDivergence.NeedsTriage and Vendor/README.md. Recorded rather than fixed, because the
-        // change that first runs a suite is not the change that moves the engine.
-        new("FileAPI/blob/Blob-constructor.any.js",
-            "A plain object with @@iterator should be treated as a sequence for the blobParts argument.", WptDivergence.NeedsTriage),
-        new("FileAPI/blob/Blob-constructor.any.js",
-            "ToUint32 should be applied to the length and any exceptions should be propagated.", WptDivergence.NeedsTriage),
-        new("FileAPI/blob/Blob-constructor.any.js",
-            "Getters and value conversions should happen in order until an exception is thrown.", WptDivergence.NeedsTriage),
+        // Nothing: the corpus is 342-for-342. Blob.textStream() arrived with sebastienros/jint#3211, and the
+        // three Blob-constructor.any.js rows that sat here under NeedsTriage were one engine defect rather
+        // than three Blob ones — Array.prototype.values/keys/entries gated on ObjectInstance.IsArrayLike
+        // where https://tc39.es/ecma262/#sec-array.prototype.values reads no `length` at all
+        // (sebastienros/jint#3209). Vendor/README.md keeps both accounts.
 
         // ---------------------------------------------------------------- workers
         // Six rows, five of them one decision family and none of them a surprise: the worker global is the

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -91,29 +91,42 @@ public sealed partial class ArrayPrototype : ArrayInstance
             }, PropertyFlag.Configurable));
     }
 
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-array.prototype.keys - two steps, <i>ToObject(this)</i> and
+    /// <i>CreateArrayIterator(O, key)</i>, and neither reads <c>length</c>. See <see cref="Values"/> for
+    /// why there is no array-like test here.
+    /// </summary>
     [JsFunction]
     private ObjectInstance Keys(JsValue thisObject)
-    {
-        if (thisObject is ObjectInstance oi && oi.IsArrayLike)
-        {
-            return _realm.Intrinsics.ArrayIteratorPrototype.Construct(oi, ArrayIteratorType.Key);
-        }
+        => _realm.Intrinsics.ArrayIteratorPrototype.Construct(TypeConverter.ToObject(_realm, thisObject), ArrayIteratorType.Key);
 
-        Throw.TypeError(_realm, "cannot construct iterator");
-        return null;
-    }
-
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-array.prototype.values - <i>ToObject(this)</i> followed by
+    /// <i>CreateArrayIterator(O, value)</i>, and that is the whole algorithm: nothing here reads
+    /// <c>length</c>, and there is no array-like precondition for the receiver to fail.
+    /// <para>
+    /// The <c>length</c> read belongs to the iterator instead — step 1.b of the abstract closure is
+    /// <i>LengthOfArrayLike</i>, performed afresh on every <c>next()</c> — so a receiver with no
+    /// <c>length</c> yields nothing, a string or boolean one is coerced, a negative one clamps to zero,
+    /// and a throwing <c>length</c> getter throws from the first <c>next()</c> rather than from here.
+    /// Gating on <c>ObjectInstance.IsArrayLike</c> (present, already a <c>JsNumber</c>, non-negative)
+    /// made every one of those a <c>TypeError</c>, so <c>[...Array.prototype.values.call({})]</c> threw
+    /// where the specification says <c>[]</c>. That is what the per-step read in
+    /// <see cref="ArrayIteratorPrototype"/>'s array-like iterator already implements.
+    /// </para>
+    /// <para>
+    /// A <see cref="JsArray"/> receiver is unaffected: <c>ToObject</c> hands an object straight back and
+    /// <c>Construct</c> routes it to the dense-array iterator exactly as before — one virtual
+    /// <c>IsArrayLike</c> call lighter than the gate that used to precede it. A typed-array receiver is
+    /// unaffected too, and deliberately keeps its <i>ValidateTypedArray</i>: step 1.b.i of the closure asks
+    /// for it whenever the receiver has a <c>[[TypedArrayName]]</c> slot, which is why a detach or an
+    /// out-of-bounds resize mid-iteration is a <c>TypeError</c> here as much as it is under
+    /// <c>%TypedArray%.prototype.values</c>.
+    /// </para>
+    /// </summary>
     [JsFunction]
     internal ObjectInstance Values(JsValue thisObject)
-    {
-        if (thisObject is ObjectInstance oi && oi.IsArrayLike)
-        {
-            return _realm.Intrinsics.ArrayIteratorPrototype.Construct(oi, ArrayIteratorType.Value);
-        }
-
-        Throw.TypeError(_realm, "cannot construct iterator");
-        return null;
-    }
+        => _realm.Intrinsics.ArrayIteratorPrototype.Construct(TypeConverter.ToObject(_realm, thisObject), ArrayIteratorType.Value);
 
     [JsFunction(Length = 2)]
     private ObjectInstance With(JsValue thisObject, JsCallArguments arguments)
@@ -182,17 +195,14 @@ public sealed partial class ArrayPrototype : ArrayInstance
         return new JsArray(_constructor, a);
     }
 
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-array.prototype.entries - <i>ToObject(this)</i> then
+    /// <i>CreateArrayIterator(O, key+value)</i>. See <see cref="Values"/> for why there is no array-like
+    /// test here; the key+value kind re-reads <c>length</c> per <c>next()</c> like the other two.
+    /// </summary>
     [JsFunction]
     private ObjectInstance Entries(JsValue thisObject)
-    {
-        if (thisObject is ObjectInstance oi && oi.IsArrayLike)
-        {
-            return _realm.Intrinsics.ArrayIteratorPrototype.Construct(oi, ArrayIteratorType.KeyAndValue);
-        }
-
-        Throw.TypeError(_realm, "cannot construct iterator");
-        return null;
-    }
+        => _realm.Intrinsics.ArrayIteratorPrototype.Construct(TypeConverter.ToObject(_realm, thisObject), ArrayIteratorType.KeyAndValue);
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-array.prototype.fill


### PR DESCRIPTION
Closes #3209.

`Array.prototype.values`, `keys` and `entries` gated on `ObjectInstance.IsArrayLike` — which demands a `length` that is present, is *already* a `JsNumber`, and is non-negative — and threw `TypeError: cannot construct iterator` otherwise. [§23.1.3.38](https://tc39.es/ecma262/#sec-array.prototype.values) is *ToObject(this)* then *CreateArrayIterator(O, value)* and **reads no `length` at all**; the iterator's closure does *LengthOfArrayLike* — a `Get` plus *ToLength* — on each `next()`.

So absent means 0, a string or boolean coerces, a negative clamps to 0, and the read (and any throw from a `length` getter) belongs to the first `next()`, not to `values()`.

| | spec | before | after |
| --- | --- | --- | --- |
| `[...Array.prototype.values.call({})]` | `[]` | `TypeError` | `[]` |
| `…call({length:'3',0:'a',1:'b',2:'c'})` | `[a,b,c]` | `TypeError` | `["a","b","c"]` |
| `…call({length:-1})` | `[]` | `TypeError` | `[]` |
| `…call({length:null})` | `[]` | `TypeError` | `[]` |
| `…call({length:true,0:'a'})` | `['a']` | `TypeError` | `["a"]` |
| `…call({get length(){throw e}})` | throws at first `next()` | throws at `values()` | throws at `next()` |
| `[...{[Symbol.iterator]: Array.prototype.values}]` | `[]` | `TypeError` | `[]` |

Two more the issue did not list: `[...Array.prototype.values.call('abc')]` was a `TypeError` (a `JsString` is not an `ObjectInstance`) and is now `['a','b','c']`; `Symbol`/`BigInt`/number receivers now box to empty iterations instead of throwing.

### The timing half is the subtle half

A fix that merely widens the gate gets the common cases right and the observable-order cases wrong, so the read being *deferred* is pinned directly. A `Proxy` logging **both** `get` and `getOwnPropertyDescriptor` shows `values()` performing **zero accesses of any kind**, and the first `next()` performing exactly `get:length, get:0` in that order. The second trap is load-bearing: the old `IsArrayLike` gate probed through `TryGetValue`, which walks own descriptors and never fires `get`, so without it the test passes on the *unfixed* engine too.

A counting getter gives 0 reads after `values()`, then 1, 2, 3 after successive `next()` calls, and 3 again once exhausted — a completed closure observes nothing further. `LengthIsReadOncePerStepInterleavedWithTheIndexReads` pins the whole interleaving. Growth `0→1→3` yields `a, b`; shrinking to 1 with the position already at 3 gives `done` and **zero** reads of index 3.

### The dense lane survives

`ArrayIteratorPrototype.Construct` dispatches on `array is JsArray` → the dense `ArrayIterator`; `TypeConverter.ToObject` returns an `ObjectInstance` receiver by identity. So a real array reaches exactly the iterator it always did, now **one virtual `IsArrayLike` call lighter** than the gate that used to precede it. Pinned by `AnArrayReceiverStillReachesTheDenseArrayIterator`, which asserts the concrete iterator type for all three methods on an array and on an array-like — the inherited commit claimed this in prose with nothing to catch a regression.

A typed-array receiver deliberately **keeps** its *ValidateTypedArray*: step 1.b.i of the closure asks for it whenever the receiver has a `[[TypedArrayName]]` slot, which is why a detach or an out-of-bounds resize mid-iteration is still a `TypeError`. test262's `values/resizable-buffer-shrink-mid-iteration.js` asserts exactly that and passes.

### Verification

**test262, both runs on the same idle machine, same tree, the only difference being `ArrayPrototype.cs`:**

| | passed | failed | skipped |
| --- | --- | --- | --- |
| `upstream/main` (gate present) | 102495 | **0** | 189 |
| this branch (gate dropped) | 102495 | **0** | 189 |

Zero movement in either direction — which is consistent with the issue's claim that test262 does not cover a non-array receiver here: of the 15 files that call these methods with an explicit receiver, every one passes an array, a typed array, `{length: 2}`, or `undefined`/`null`.

45 test cases in the new `ArrayIteratorReceiverTests`: **26 fail against the unfixed engine**, 45/45 pass fixed, on net10.0 and net472. `Jint.Tests` 10118 / 7147, `Jint.Tests.PublicInterface` 2395 / 1874, `CommonScripts` 28 / 28, WPT 322 — all green.

Coverage the inherited commit lacked, now added: a shrink *below* the current index; `NaN`, `'abc'`, `{}`, `[]`, `-Infinity`, `-0.5`, `false`, fractional truncation, `' 2 '`, `'0x2'`, `['2']` for *ToLength*; `entries` yielding a pair for absent indices (`[0, undefined]`); `Array.prototype[Symbol.iterator] === Array.prototype.values`; and the prototype-supplied-hole case in **both** lanes, which was untested in either.

### WPT

The three `NeedsTriage` rows for `FileAPI/blob/Blob-constructor.any.js` are deleted — exactly the three the issue names, verified as 73-for-73 passing. With `main`'s `textStream()` rows already gone, the FileAPI exclusion section is now **empty**, so its banner carries a comment recording that the corpus is exclusion-free and why. `NeedsBrotli` and `NeedsBlobTextStream` are not resurrected by the rebase (grep-verified).

### One pre-existing defect found, filed not fixed

**#3235**: `ArrayOperations.ObjectOperations.GetLength()` casts a `double` length to `uint` without clamping, where its sibling `GetLongLength()` clamps at `MaxArrayLikeLength`. An out-of-range `double`→integer conversion saturates on .NET and is **unspecified** on .NET Framework, so `Array.prototype.values.call({length: 2**53, 0:'a'}).next()` yields `{value:'a'}` on net10.0 and `{done:true}` on net472. It is independent of this change — a numeric `length` of 2^53 passed the old gate and reached the identical iterator — and touches every caller of the `uint` overload, so it wants its own PR. The `ToLength` rows here therefore stop below 2^32, with the reasoning recorded in the test's XML doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
