### PR TITLE
Engine: hold the callback-admission window for the whole window the contract promises

### DIFF
--- a/.github/THREAT_MODEL.md
+++ b/.github/THREAT_MODEL.md
@@ -616,9 +616,11 @@ incorrect authorization context, cross-request disclosure, crashes, or hangs.
   engine call is rejected before work starts; top-level async APIs reserve ownership for the
   lifetime of their returned `Task` and transfer the active thread when a continuation resumes.
 - JavaScript callbacks converted to CLR delegates carry operation-scoped authorization. A host
-  may dispatch one to another thread while its CLR call or async operation is outstanding; Jint
-  yields and transfers the reserved engine one callback turn at a time without admitting unrelated
-  public callers.
+  may dispatch one to another thread while the engine holds an admission window — the engine
+  operation that made the call which received the callback has not returned, an async engine API is
+  outstanding, or the engine is draining its event loop for a blocking unwrap or import; Jint yields
+  and transfers the reserved engine one callback turn at a time without admitting unrelated public
+  callers.
 - Background Task and module completions only enqueue work; an owning host turn drains it.
 
 **Missing or residual mitigation.**
@@ -630,6 +632,10 @@ incorrect authorization context, cross-request disclosure, crashes, or hangs.
 - Authorized callback transfers may wait for the preceding callback turn to release ownership.
   The fail-fast guarantee applies to unrelated public host entries, not this explicitly serialized
   continuation of the operation that already owns the engine.
+- An authorized callback arriving when no admission window is open is refused with the same
+  `InvalidOperationException` an unrelated caller receives. Waiting there would mean blocking on a
+  thread that may itself be blocked on that callback, so the refusal is deliberate rather than a
+  gap; a host must keep the engine inside a window for as long as its callbacks may arrive.
 - A host can still share projected CLR objects across otherwise separate engines.
 
 **Required host action.** Give an engine exclusive ownership for each complete operation and

--- a/Jint.Tests.PublicInterface/HostEngineConcurrencyTests.cs
+++ b/Jint.Tests.PublicInterface/HostEngineConcurrencyTests.cs
@@ -343,6 +343,147 @@ public class HostEngineConcurrencyTests
         engine.Evaluate("1 + 1").AsNumber().Should().Be(2);
     }
 
+    /// <summary>
+    /// How long a continuation running inside the drain keeps the engine thread, so that the callback
+    /// dispatched from another thread provably arrives while the owner is on the engine rather than inside
+    /// its blocking wait. This is the one place a clock is used to <em>occupy</em> rather than to wait for
+    /// something: what is under test is precisely what happens to a callback that arrives then, so the
+    /// arrival has to be inside a stretch this test controls. Nothing waits this out - the two tests below
+    /// both finish as soon as their callback has been served.
+    /// </summary>
+    private static readonly TimeSpan DrainOccupancy = TimeSpan.FromMilliseconds(250);
+
+    /// <summary>
+    /// Long enough that the continuation it settles runs from the drain rather than from the tail of
+    /// <c>Evaluate</c>, which drains the microtask queue before it returns.
+    /// </summary>
+    private static readonly TimeSpan ContinuationDelay = TimeSpan.FromMilliseconds(50);
+
+    /// <summary>
+    /// The window README's Thread-safety section and THREAT_MODEL.md TM-13 promise an authorized callback
+    /// may wait in - "such an authorized transfer may wait for the current callback turn" - reached
+    /// deterministically. An <c>async</c> host method returns at its first <c>await</c>, so by the time its
+    /// captured callback is invoked from another thread the host call it was handed to is long gone; the
+    /// owner thread is inside <c>UnwrapIfPromise</c>'s drain, running a continuation. The callback has to be
+    /// served after the owner's turn, not destroyed. sebastienros/jint#3206.
+    /// </summary>
+    [Fact]
+    public void AnAsyncHostMethodsCallbackIsServedWhileTheOwnerRunsTheDrain()
+    {
+        Func<int>? captured = null;
+        using var dispatcher = new CallbackDispatcher(() => captured!());
+
+        var engine = new Engine();
+        engine.SetValue("register", new Func<Func<int>, Task>(async callback =>
+        {
+            captured = callback;
+            await dispatcher.Attempted.ConfigureAwait(false);
+        }));
+        engine.SetValue("delay", new Func<Task>(() => Task.Delay(ContinuationDelay)));
+        engine.SetValue("hold", new Action(() =>
+        {
+            dispatcher.Release();
+            Thread.Sleep(DrainOccupancy);
+        }));
+
+        var result = engine.Evaluate("""
+            async function main() {
+                const pending = register(() => 42);
+                await delay();
+                hold();
+                await pending;
+                return 'done';
+            }
+            main();
+            """).UnwrapIfPromise(HandoffCeiling);
+
+        dispatcher.Failure.Should().BeNull("an authorized callback may wait for its turn, not be refused");
+        dispatcher.Result.Should().Be(42);
+        result.AsString().Should().Be("done");
+        engine.Evaluate("1 + 1").AsNumber().Should().Be(2);
+    }
+
+    /// <summary>
+    /// The other half of sebastienros/jint#3206: the stretch between an <c>async</c> host method returning at
+    /// its first <c>await</c> and the caller reaching anything that waits. Here the callback is dispatched
+    /// while the engine thread is still running script for the very evaluation that handed it out, so there
+    /// is no drain to be admitted into - the reservation the host call took has to outlive that call.
+    /// </summary>
+    [Fact]
+    public void AnAsyncHostMethodsCallbackIsServedWhileTheOwnerFinishesTheEvaluation()
+    {
+        Func<int>? captured = null;
+        using var dispatcher = new CallbackDispatcher(() => captured!());
+
+        var engine = new Engine();
+        engine.SetValue("register", new Func<Func<int>, Task<string>>(async callback =>
+        {
+            captured = callback;
+            await dispatcher.Attempted.ConfigureAwait(false);
+            return "done";
+        }));
+        engine.SetValue("hold", new Action(() =>
+        {
+            dispatcher.Release();
+            Thread.Sleep(DrainOccupancy);
+        }));
+
+        var result = engine.Evaluate("""
+            const pending = register(() => 42);
+            hold();
+            pending;
+            """).UnwrapIfPromise(HandoffCeiling);
+
+        dispatcher.Failure.Should().BeNull("an authorized callback may wait for its turn, not be refused");
+        dispatcher.Result.Should().Be(42);
+        result.AsString().Should().Be("done");
+        engine.Evaluate("1 + 1").AsNumber().Should().Be(2);
+    }
+
+    /// <summary>
+    /// The same window, reached by the shape the second comment on sebastienros/jint#3206 widened the report
+    /// to: any host API of the form "hand me a callback, I will call it later from my own thread", not only
+    /// an <c>async</c> method. Here the host call that received the callback returned synchronously long
+    /// before the callback is invoked, which is the shipped shape of
+    /// <see cref="DelayedCrossThreadCallbackReleasesBlockingPromiseOwnership"/> with the timing pinned.
+    /// </summary>
+    [Fact]
+    public void ACallbackStoredByAHostMethodIsServedWhileTheOwnerRunsTheDrain()
+    {
+        Action? captured = null;
+        using var dispatcher = new CallbackDispatcher(() =>
+        {
+            captured!();
+            return 0;
+        });
+
+        var engine = new Engine();
+        engine.SetValue("later", new Action<Action>(callback => captured = callback));
+        engine.SetValue("delay", new Func<Task>(() => Task.Delay(ContinuationDelay)));
+        engine.SetValue("attempted", new Func<Task>(() => dispatcher.Attempted));
+        engine.SetValue("hold", new Action(() =>
+        {
+            dispatcher.Release();
+            Thread.Sleep(DrainOccupancy);
+        }));
+
+        var result = engine.Evaluate("""
+            globalThis.marker = 0;
+            async function main() {
+                later(() => { globalThis.marker = 42; });
+                await delay();
+                hold();
+                await attempted();
+                return globalThis.marker;
+            }
+            main();
+            """).UnwrapIfPromise(HandoffCeiling);
+
+        dispatcher.Failure.Should().BeNull("an authorized callback may wait for its turn, not be refused");
+        result.AsNumber().Should().Be(42);
+        engine.Evaluate("1 + 1").AsNumber().Should().Be(2);
+    }
+
     [Fact]
     public void DelayedCrossThreadCallbackReleasesBlockingPromiseOwnership()
     {
@@ -593,6 +734,67 @@ public class HostEngineConcurrencyTests
 
         await running;
         operation.GetResult().Get("value").AsNumber().Should().Be(42);
+    }
+
+    /// <summary>
+    /// A thread of the test's own, parked until <see cref="Release"/>, which then invokes the engine
+    /// callback it was handed exactly once and records what came back.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately not <c>Task.Run</c>. What the two tests above measure is <em>where</em> the invocation
+    /// lands relative to the owner's turn, and a pool worker that has to be injected first lands wherever
+    /// the pool feels like - which is the same wall-clock race <see cref="StartOwningThread"/> exists to
+    /// avoid on the other side of the hand-off.
+    /// </remarks>
+    private sealed class CallbackDispatcher : IDisposable
+    {
+        private readonly ManualResetEventSlim _release = new();
+        private readonly TaskCompletionSource<bool> _attempted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly Thread _thread;
+
+        internal CallbackDispatcher(Func<int> invoke)
+        {
+            _thread = new Thread(() =>
+            {
+                _release.Wait(HandoffCeiling);
+                try
+                {
+                    Result = invoke();
+                }
+                catch (Exception exception)
+                {
+                    Failure = exception;
+                }
+                finally
+                {
+                    _attempted.TrySetResult(true);
+                }
+            })
+            {
+                IsBackground = true,
+                Name = "jint-callback-dispatcher",
+            };
+
+            _thread.Start();
+        }
+
+        /// <summary>
+        /// Completes once the callback has been invoked, whatever the outcome - so a script awaiting it
+        /// makes progress on a refusal as well as on a success, and a regression reports rather than hangs.
+        /// </summary>
+        internal Task Attempted => _attempted.Task;
+
+        internal Exception? Failure { get; private set; }
+
+        internal int Result { get; private set; }
+
+        internal void Release() => _release.Set();
+
+        public void Dispose()
+        {
+            _thread.Join(HandoffCeiling);
+            _release.Dispose();
+        }
     }
 
     private static Engine CreateBlockingEngine(ManualResetEventSlim entered, ManualResetEventSlim release)

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -109,6 +109,13 @@ public sealed partial class Engine : IDisposable
     private object? _asyncReleasePending;
     private object? _hostCallbackAdmissionClosed;
     private int _hostCallbackAdmission;
+
+    // A reservation taken for one host call that outlives it: see SuspendHostCallForCallbacks. Written only
+    // by the thread that owns the engine, and released when the scope that claimed the engine for that
+    // entry unwinds - HostCallScope's entry-root flag, plus this thread id, is what keeps a callback taking
+    // its turn under the reservation from releasing it out from under the entry.
+    private object? _entryReservation;
+    private int _entryReservationThreadId;
     private int _hostReentryThreadId;
     private MemoryLimitConstraint.OperationState? _transferredMemoryState;
     private ManualResetEventSlim? _ownershipReleased;
@@ -165,7 +172,7 @@ public sealed partial class Engine : IDisposable
 
         _ownerDepth = 1;
         _ownerToken = asyncOwner;
-        return new HostCallScope(this, callbackOwner);
+        return new HostCallScope(this, callbackOwner, isEntryRoot: true);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -287,9 +294,11 @@ public sealed partial class Engine : IDisposable
         {
             if (Volatile.Read(ref _asyncOwner) is null)
             {
+                // The reservation vanished under this transfer, so what is left is an ordinary claim of a
+                // free engine - and therefore an entry of its own, which may be handed a reservation later.
                 _ownerDepth = 1;
                 _ownerToken = null;
-                return new HostCallScope(this, callback ? owner : null);
+                return new HostCallScope(this, callback ? owner : null, isEntryRoot: true);
             }
 
             Volatile.Write(ref _ownerThreadId, 0);
@@ -331,7 +340,7 @@ public sealed partial class Engine : IDisposable
 
         _ownerDepth = 1;
         _ownerToken = null;
-        scope = new HostCallScope(this);
+        scope = new HostCallScope(this, callbackOwner: null, isEntryRoot: true);
         return true;
     }
 
@@ -377,6 +386,122 @@ public sealed partial class Engine : IDisposable
         }
     }
 
+    /// <summary>
+    /// Opens the engine's callback-admission window for a blocking drain, and keeps it open for the whole
+    /// of it: an authorized cross-thread callback arriving at any point during the drain is serialized
+    /// behind the drain's own turn instead of being refused.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The reservation (<see cref="_asyncOwner"/>) is what <see cref="EnterTransferredHostCallback"/> reads
+    /// to tell an authorized transfer - one the host was handed by this engine and may dispatch to another
+    /// thread - from an unrelated public caller. <see cref="DrainEventLoopUntil"/> used to take it for the
+    /// duration of <c>WaitForWork</c> alone, so on every iteration it was dropped again across
+    /// <see cref="RunAvailableContinuations"/> - which runs arbitrary script - and re-taken. A callback
+    /// landing in that gap took the "no reservation" path, was treated as an unrelated caller and destroyed
+    /// with <see cref="InvalidOperationException"/>, which contradicts what README.md's Thread-safety
+    /// section and THREAT_MODEL.md TM-13 both promise: "such an authorized transfer may wait for the current
+    /// callback turn". Whether a given callback was served or destroyed came down to where the OS scheduler
+    /// happened to put it (sebastienros/jint#3206, sebastienros/jint#3220).
+    /// </para>
+    /// <para>
+    /// This is the shape <c>AwaitPromiseSettlementAsync</c> has always had on the asynchronous side -
+    /// reservation for the whole outstanding operation, the <em>thread</em> claimed only around each
+    /// continuation cycle - and the drain is its synchronous twin. The per-iteration
+    /// <see cref="SuspendHostCallForCallbacks"/> around the wait therefore no longer takes a reservation of
+    /// its own: it finds this one and yields only the thread, which is all it ever needed to do.
+    /// </para>
+    /// <para>
+    /// Nothing else about who may enter changes. An unrelated public caller on another thread was refused
+    /// throughout the drain before - the drain thread held <see cref="_ownerThreadId"/> for all of it - and
+    /// is refused throughout it now. The window is deliberately scoped to a frame whose entire purpose is to
+    /// wait for outside work, because an admitted callback waits for the engine thread to yield and only
+    /// such a frame provably does; that is why the fail-fast branches in
+    /// <see cref="EnterTransferredHostCallback"/> stay fail-fast rather than becoming waits.
+    /// </para>
+    /// <para>
+    /// Returns a no-op window when a reservation already exists - an outstanding async host operation, or an
+    /// outer drain. That one is not ours to close, and the drain then behaves exactly as it did before.
+    /// </para>
+    /// </remarks>
+    internal HostCallbackAdmissionWindow OpenHostCallbackAdmissionWindow()
+    {
+        // Same identity rule as SuspendHostCallForCallbacks, deliberately: a drain entered with no operation
+        // token of its own reserves under the engine's ownership-released event, which is the anonymous
+        // owner EnterTransferredHostCallback recognizes as "any authorized callback may take a turn here".
+        var previousOwnerToken = _ownerToken;
+        var owner = previousOwnerToken ?? OwnershipReleasedEvent;
+        if (Interlocked.CompareExchange(ref _asyncOwner, owner, null) is not null)
+        {
+            return default;
+        }
+
+        _ownerToken = owner;
+        return new HostCallbackAdmissionWindow(
+            this,
+            owner,
+            previousOwnerToken,
+            Volatile.Read(ref _hostReentryThreadId),
+            Volatile.Read(ref _transferredMemoryState));
+    }
+
+    /// <summary>
+    /// Closes a window opened by <see cref="OpenHostCallbackAdmissionWindow"/>, once every callback admitted
+    /// through it has finished.
+    /// </summary>
+    private void CloseHostCallbackAdmissionWindow(
+        object owner,
+        object? previousOwnerToken,
+        int previousReentryThreadId,
+        MemoryLimitConstraint.OperationState? transferredMemoryState)
+    {
+        // Release the thread first. A callback admitted during the drain may be blocked in AcquireHostCall
+        // waiting for exactly this thread, and the teardown below waits for every admitted callback to
+        // finish - so closing while still holding the thread would wedge the two against each other. Every
+        // other caller of ResumeHostCall reaches it from a suspension that already released the thread; this
+        // one has to do it here, which is the whole difference between a window and a suspension.
+        var depth = _ownerDepth;
+        _ownerDepth = 0;
+        _ownerToken = null;
+        Volatile.Write(ref _ownerThreadId, 0);
+        Volatile.Read(ref _ownershipReleased)?.Set();
+
+        // The window suspends no memory segment of its own - it never yields the thread - so it hands back
+        // the state it was opened with, which leaves that accounting exactly as it found it.
+        ResumeHostCall(
+            owner,
+            previousOwnerToken,
+            depth,
+            previousReentryThreadId,
+            ownsReservation: true,
+            hasMemorySegment: false,
+            memorySegment: default,
+            transferredMemoryState);
+    }
+
+    /// <summary>
+    /// Yields the engine for the duration of a host call that was handed a JavaScript callback, so the host
+    /// may dispatch that callback to another thread, and reserves the engine against unrelated callers for
+    /// as long as the callback may still arrive.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The <em>thread</em> is yielded for the host call only. The <em>reservation</em> outlives it: when this
+    /// call is the one that took it, <see cref="ResumeHostCall"/> hands it to the host entry underneath
+    /// rather than dropping it, and <see cref="ExitHostCall"/> releases it when that entry unwinds. Dropping
+    /// it at the end of the host call is what sebastienros/jint#3206 reported: an <c>async</c> host method
+    /// returns at its first <c>await</c>, so the callback it captured is invoked long after this scope has
+    /// closed - and until the caller reaches something that reserves again (a blocking drain, an async
+    /// engine API) the engine looked unreserved while the calling thread was still on it, so an authorized
+    /// callback landing there was treated as an unrelated caller and destroyed.
+    /// </para>
+    /// <para>
+    /// The entry is the right scope because it is one that provably ends. Keying the hand-over on the
+    /// pending awaitable instead would tie the reservation to a <see cref="Task"/> the host may never
+    /// complete; keying it on the entry bounds it by the engine's own stack, and the entry's operation token
+    /// keeps a stale callback from an <em>earlier</em> entry refused exactly as before.
+    /// </para>
+    /// </remarks>
     internal HostCallSuspension SuspendHostCallForCallbacks(bool hasTransferredCallback)
     {
         if (!hasTransferredCallback)
@@ -426,6 +551,110 @@ public sealed partial class Engine : IDisposable
             previousTransferredMemoryState);
     }
 
+    /// <summary>
+    /// Ends a suspension taken by <see cref="SuspendHostCallForCallbacks"/>: reclaims the thread and, when
+    /// this suspension is the one that reserved the engine, hands that reservation to the host entry
+    /// underneath instead of dropping it.
+    /// </summary>
+    private void ResumeSuspendedHostCall(
+        object owner,
+        object? previousOwnerToken,
+        int depth,
+        int previousReentryThreadId,
+        bool ownsReservation,
+        bool hasMemorySegment,
+        MemoryLimitConstraint.SegmentToken memorySegment,
+        MemoryLimitConstraint.OperationState? previousTransferredMemoryState)
+    {
+        if (!ownsReservation)
+        {
+            ResumeHostCall(
+                owner,
+                previousOwnerToken,
+                depth,
+                previousReentryThreadId,
+                ownsReservation: false,
+                hasMemorySegment,
+                memorySegment,
+                previousTransferredMemoryState);
+            return;
+        }
+
+        // No admission gate and no drain here, unlike the reservation-owning path in ResumeHostCall: the
+        // reservation is not ending, so a callback admitted a moment ago simply waits for the thread the
+        // line below reclaims, exactly as one arriving a moment later will.
+        AcquireHostCall(System.Environment.CurrentManagedThreadId);
+        Volatile.Write(ref _transferredMemoryState, previousTransferredMemoryState);
+        if (hasMemorySegment)
+        {
+            _memoryLimitConstraint!.EndSegment(in memorySegment);
+        }
+
+        _ownerDepth = depth;
+        _ownerToken = previousOwnerToken;
+        Volatile.Write(ref _hostReentryThreadId, previousReentryThreadId);
+
+        // Ordered so that a thread seeing the reservation also sees whose it is;
+        // ReleaseEntryReservationIfHeld reads them the other way round.
+        _entryReservationThreadId = System.Environment.CurrentManagedThreadId;
+        Volatile.Write(ref _entryReservation, owner);
+    }
+
+    /// <summary>
+    /// Called when a host entry's own scope unwinds, to release any reservation
+    /// <see cref="ResumeSuspendedHostCall"/> handed to that entry.
+    /// </summary>
+    /// <remarks>
+    /// Keyed on the scope that <em>claimed</em> the engine, deliberately not on <see cref="_ownerDepth"/>
+    /// reaching zero: a suspension zeroes that depth, so a callback taking its turn while the entry is
+    /// suspended also unwinds through zero. Releasing there would make the second callback-taking host call
+    /// of a single script (<c>list.Where(...).Sum(...)</c>) wait, inside its own callback, for the very
+    /// admission that callback still holds.
+    /// </remarks>
+    private void ReleaseEntryReservationIfHeld()
+    {
+        var reservation = Volatile.Read(ref _entryReservation);
+        if (reservation is null || _entryReservationThreadId != System.Environment.CurrentManagedThreadId)
+        {
+            return;
+        }
+
+        ReleaseEntryReservation(reservation);
+    }
+
+    /// <summary>
+    /// Drops a handed-over reservation once every callback admitted under it has finished. The thread is
+    /// already released by the time this runs, which is what lets an admitted callback take its turn while
+    /// this waits for it.
+    /// </summary>
+    private void ReleaseEntryReservation(object reservation)
+    {
+        _entryReservation = null;
+        _entryReservationThreadId = 0;
+
+        lock (reservation)
+        {
+            Volatile.Write(ref _hostCallbackAdmissionClosed, reservation);
+            while (Volatile.Read(ref _hostCallbackAdmission) > 0)
+            {
+                Monitor.Wait(reservation);
+            }
+
+            Interlocked.CompareExchange(ref _asyncOwner, null, reservation);
+            Interlocked.CompareExchange(ref _hostCallbackAdmissionClosed, null, reservation);
+        }
+    }
+
+    /// <summary>
+    /// Reclaims the engine for a suspended host call, once every callback admitted while it was suspended
+    /// has finished.
+    /// </summary>
+    /// <remarks>
+    /// The caller must not hold <see cref="_ownerThreadId"/>. The admission drain below blocks until no
+    /// admitted callback is outstanding, and an admitted callback reaches its turn by acquiring that very
+    /// field, so a caller still holding it would wedge the two against each other. Closing the admission
+    /// gate before <see cref="AcquireHostCall"/> rather than after is the other half of the same rule.
+    /// </remarks>
     private void ResumeHostCall(
         object owner,
         object? previousOwnerToken,
@@ -574,12 +803,20 @@ public sealed partial class Engine : IDisposable
         private readonly MemoryLimitConstraint.SegmentToken _memorySegment;
         private readonly bool _hasMemorySegment;
 
+        /// <summary>
+        /// Whether this scope is the one that claimed the engine for a host entry, as opposed to a nested
+        /// re-entry or a callback taking its turn under a reservation. Only such a scope may release a
+        /// reservation handed to the entry - see <see cref="ReleaseEntryReservationIfHeld"/>.
+        /// </summary>
+        private readonly bool _isEntryRoot;
+
         internal HostCallScope(Engine engine)
         {
             _engine = engine;
             _callbackOwner = null;
             _memorySegment = default;
             _hasMemorySegment = false;
+            _isEntryRoot = false;
         }
 
         internal HostCallScope(Engine engine, object? callbackOwner)
@@ -588,8 +825,23 @@ public sealed partial class Engine : IDisposable
             _callbackOwner = callbackOwner;
             _memorySegment = default;
             _hasMemorySegment = false;
+            _isEntryRoot = false;
         }
 
+        internal HostCallScope(Engine engine, object? callbackOwner, bool isEntryRoot)
+        {
+            _engine = engine;
+            _callbackOwner = callbackOwner;
+            _memorySegment = default;
+            _hasMemorySegment = false;
+            _isEntryRoot = isEntryRoot;
+        }
+
+        /// <summary>
+        /// A callback taking its turn under a reservation, charged to the memory operation it was authorized
+        /// under. Never an entry root: the reservation it runs under belongs to the entry that yielded, and
+        /// releasing it here would pull it out from under that entry.
+        /// </summary>
         internal HostCallScope(
             Engine engine,
             object? callbackOwner,
@@ -599,6 +851,7 @@ public sealed partial class Engine : IDisposable
             _callbackOwner = callbackOwner;
             _memorySegment = memorySegment;
             _hasMemorySegment = true;
+            _isEntryRoot = false;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -612,7 +865,13 @@ public sealed partial class Engine : IDisposable
             _engine.ExitHostCall();
             if (_callbackOwner is not null)
             {
+                // Before the reservation release below, which waits for this very count to reach zero.
                 _engine.ReleaseHostCallbackAdmission(_callbackOwner);
+            }
+
+            if (_isEntryRoot)
+            {
+                _engine.ReleaseEntryReservationIfHeld();
             }
         }
     }
@@ -632,6 +891,44 @@ public sealed partial class Engine : IDisposable
         {
             get => Volatile.Read(ref _memoryState);
             set => Volatile.Write(ref _memoryState, value);
+        }
+    }
+
+    /// <summary>
+    /// The scope <see cref="OpenHostCallbackAdmissionWindow"/> returns. Unlike
+    /// <see cref="HostCallSuspension"/> it does <em>not</em> yield the thread: the engine stays claimed by
+    /// the opener, and only the reservation an authorized callback needs in order to wait for its turn is
+    /// held for the scope's duration.
+    /// </summary>
+    internal readonly struct HostCallbackAdmissionWindow : IDisposable
+    {
+        private readonly Engine? _engine;
+        private readonly object _owner;
+        private readonly object? _previousOwnerToken;
+        private readonly int _previousReentryThreadId;
+        private readonly MemoryLimitConstraint.OperationState? _transferredMemoryState;
+
+        internal HostCallbackAdmissionWindow(
+            Engine engine,
+            object owner,
+            object? previousOwnerToken,
+            int previousReentryThreadId,
+            MemoryLimitConstraint.OperationState? transferredMemoryState)
+        {
+            _engine = engine;
+            _owner = owner;
+            _previousOwnerToken = previousOwnerToken;
+            _previousReentryThreadId = previousReentryThreadId;
+            _transferredMemoryState = transferredMemoryState;
+        }
+
+        public void Dispose()
+        {
+            _engine?.CloseHostCallbackAdmissionWindow(
+                _owner,
+                _previousOwnerToken,
+                _previousReentryThreadId,
+                _transferredMemoryState);
         }
     }
 
@@ -671,7 +968,7 @@ public sealed partial class Engine : IDisposable
 
         public void Dispose()
         {
-            _engine?.ResumeHostCall(
+            _engine?.ResumeSuspendedHostCall(
                 _owner,
                 _previousOwnerToken,
                 _depth,
@@ -2162,6 +2459,12 @@ public sealed partial class Engine : IDisposable
         System.Threading.CancellationToken cancellationToken = default)
     {
         using var ownership = EnterHostCall();
+
+        // Hold the callback-admission window for the whole drain, not only for the blocking wait
+        // below. A drain is exactly the frame the thread-safety contract lets an authorized
+        // cross-thread callback wait in, and dropping the reservation across RunAvailableContinuations
+        // every iteration turned that promise into a scheduling coin flip (sebastienros/jint#3206).
+        using var admission = OpenHostCallbackAdmissionWindow();
 
         // Claim this thread as the one draining the loop so background threads (Task completions)
         // don't race to execute JavaScript continuations on the engine. Save/restore to support

--- a/README.md
+++ b/README.md
@@ -2382,10 +2382,22 @@ An `Engine` is single-operation, not thread-safe. Public host entries fail fast 
 `InvalidOperationException` when another thread is using the same engine or while one of its async APIs
 is still outstanding; callers are never silently serialized. Same-thread re-entry from a host callback is
 supported for synchronous APIs. A JavaScript callback converted to a CLR delegate may also be dispatched
-to another thread by the host: while host code is running, or while the async operation that received the
-callback remains outstanding, Jint reserves the engine against unrelated callers and transfers ownership
-to that callback one turn at a time. Such an authorized transfer may wait for the current callback turn;
-ordinary public callers still fail immediately rather than being serialized. Starting an async engine API
+to another thread by the host, and Jint admits such a transfer whenever it holds an open callback-admission
+window. There are three: from the moment a host call is handed the callback until the engine operation that
+made that call — the `Evaluate`, `Execute`, `Invoke` or callback turn on the stack — returns; while one of
+the async engine APIs is outstanding; and while the engine is driving its event loop for a blocking
+`UnwrapIfPromise` or `Modules.Import`. Inside a window Jint reserves the engine against unrelated callers
+and transfers ownership to that callback one turn at a time. Such an authorized transfer may wait for the
+current callback turn; ordinary public callers still fail immediately rather than being serialized. The
+three hand over to one another in the usual shape: an `async` host method returns at its first `await`, so
+its callback is normally invoked long after that method's own call returned — the first window covers the
+rest of the evaluation that called it, and by the time that evaluation returns the script is awaiting the
+promise the method handed back, which is the third. Outside every window — the engine thread is running
+script for an operation that was never handed this callback, and has undertaken to yield to nobody — an
+authorized callback is refused exactly like an unrelated caller, because serializing it there would mean
+blocking on a thread that may itself be blocked on that callback. A host that dispatches callbacks
+asynchronously should therefore keep the engine inside one of the windows for as long as they may arrive:
+await the async API, or block on the promise. Starting an async engine API
 from inside an active engine call is rejected: the callback must return before ownership can transfer
 safely. A top-level awaited async operation may resume on a different thread after ownership transfers.
 Background task and module completions may enqueue work safely, but they do not grant permission for other


### PR DESCRIPTION
Closes #3206. Closes #3220.

README's thread-safety section and THREAT_MODEL TM-13 both promise that an authorized cross-thread callback **may wait** for the current turn, and that only *unrelated* public callers fail fast. The engine did not honour that: the reservation an authorized callback needs (`Engine._asyncOwner`) was held for far less than the documented window, and a callback arriving outside it was destroyed with `InvalidOperationException`.

`main` is red on this today — `AsyncTests.ShouldFromAsyncTaskCallbacks` — and it has been costing CI reruns in three different costumes.

### The three windows

- **W1 — from the end of a host call's synchronous body until the caller reserves again.** `SuspendHostCallForCallbacks` took the reservation; `ResumeHostCall` dropped it. An `async` host method returns at its first `await`, so the body ends *there*, while the engine thread goes on running the rest of that evaluation holding `_ownerThreadId` with no reservation.
- **W2 — every drain iteration.** `DrainEventLoopUntil` reserved only around `EventLoop.WaitForWork`, so the reservation was dropped and re-taken once per turn — absent across `isSettled`, `RunAvailableContinuations` (which runs arbitrary script) and `TimeUntilNextPumpScheduledWork`.
- **W3 — the second fall-through**, inside `lock (owner)` when `_hostCallbackAdmissionClosed` is set.

A latent fourth: a callback *converted during* a drain set `_ownerToken` via `CaptureHostCallbackOwner`, making the drain's next reservation a specific token instead of the anonymous wildcard, silently refusing callbacks from earlier entries.

### The issue's suggested fix deadlocks — so the reservation was widened instead

#3206 proposed routing both fall-throughs through the existing `AcquireHostCall` wait, and flagged one ordering caveat to check. Implemented as suggested, it **wedges an existing contract test**: `SharedPreparedCallbackBinderUsesTheTargetFunctionsEngine` hung for its full two-minute ceiling and then failed. Its callback belongs to an evaluation that ended long ago while the engine is parked in an unrelated blocking host call — waiting there is a deadlock, escaping only because that test's own `block()` has a timeout.

So **waiting is only safe where a thread has undertaken to yield**, and this ships the other half of the fix: the reservation is *widened to cover the promised window*, rather than the refusal being converted into a wait.

- `SuspendHostCallForCallbacks` **hands its reservation to the host entry underneath** rather than dropping it, and the scope that *claimed* the engine releases it. The entry is the right scope because it provably ends; keying on the pending awaitable would tie the reservation to a `Task` the host may never complete. Closes W1.
- `DrainEventLoopUntil` opens the reservation once for the whole drain; the per-iteration suspension now finds it and yields only the thread — the shape `AwaitPromiseSettlementAsync` already had. Closes W2.
- **W3 stays fail-fast deliberately.** It is the moment a window *closes*, and that gate is what makes a teardown terminate; admitting there reopens unbounded starvation. Now documented rather than silent.

Fail-fast for unrelated public entries is untouched: throughout both windows the engine thread holds `_ownerThreadId`, so a second thread was refused before and is refused now, and only `expectedOwner is not null` can ever wait.

**Two ordering rules**, stated at their call sites. A thread closing a reservation must release `_ownerThreadId` first, because the close waits for admitted callbacks and an admitted callback reaches its turn by acquiring that field. And the entry release is keyed on the **claiming scope**, never on `_ownerDepth == 0` — that was wrong in the first attempt and **the suite caught it**: a suspension zeroes the depth, so a callback taking its turn while the entry is suspended also unwinds through zero, and `list.Where(…).Sum(…)` self-deadlocked inside its own callback. Diagnosed from a `dotnet-dump` of the wedged test host.

### Evidence

Three deterministic repros, all failing on unfixed `main` at `EnterTransferredHostCallback`'s `owner is null` fall-through, all passing here — `HostEngineConcurrencyTests` is 29/29 on net10.0 and net472.

Matched-pair rates, same machine, back to back (the machine was not idle, so both sides are load-inflated equally):

| shape | unfixed `main` | fixed |
| --- | --- | --- |
| `ShouldCompleteWithAsyncTaskCallbacks` | 9 / 3000 | **0 / 3000** |
| `ShouldFromAsyncTaskCallbacks` (red on `main` today) | 6 / 3000 | **0 / 3000** |
| `DelayedCrossThreadCallback` | 1 / 2000 | **0 / 2000** |
| `ShouldPromiseBeResolved2` | 0 / 2000 | 0 / 2000 |

~16 failures in 8000 pre-fix against 0 in 8000. An intermediate build carrying *only* the drain window still showed 1/3000, which is what identified W1 as a separate window rather than a symptom of W2.

**#3220 is closed by this.** Both of its named members: `ShouldCompleteWithAsyncTaskCallbacks` 9/3000 → 0, and `ShouldPromiseBeResolved2`'s costume reproduced as `DelayedCrossThreadCallback` 1/2000 → 0 with the exact `Promise was rejected with value Timeout of 00:00:10 reached` symptom it reports. Its hypothesis — "a host `Task` callback re-entering while the engine still counts an asynchronous operation as outstanding" — is the same mechanism.

All four required legs green on the final tree: `Jint.Tests` 10212 (net10.0) / 7147 (net472) and `Jint.Tests.PublicInterface` 2400 / 1879, both repeated with `JINT_HOST_CONTRACT_VERIFICATION=1` (2404 / 1883).

### Residual exposure, measured

| probe | unfixed `main` | fixed |
| --- | --- | --- |
| A — host method called from a drain continuation blocks on an unrelated authorized callback | no wedge (callback refused) | **wedged** |
| B — same, from inside a callback admitted during the drain's blocking wait | **wedged** | **wedged** |

Probe B wedges on `main` today, so this **widens an existing hazard class rather than creating one**. It requires a host to block its engine turn on a callback it was not itself given, which `CanonicalJsCallDelegateCannotBypassOwnership` already documents as unsupported. Recorded in THREAT_MODEL as residual rather than left implicit.

### Two things found and deliberately not fixed

**`HostMemoryLimitTests.TransferredHostCallbackCountsAllocationsOnItsThread` is a separate defect** — it reproduced on the *fixed* build, and `_asyncOwner` is held by the `EvaluateAsync` reservation throughout, so the null-owner window is never entered. The pool thread's `allocate()` is charged to the same operation by the cross-thread accounting; if it lands before the engine thread reaches `ScriptEvaluation`'s post-script check, that check trips **inside `EvaluateAsync`'s synchronous phase**, where no `Task` exists yet, so the exception is rethrown synchronously. Rates confirm independence: 10/6000 on unfixed `main`, 4/6000 here, with no mechanism by which this change would help. Filed separately.

**`Engine.Advanced.WaitForScheduledWork`'s reservation is a fresh `new object()`**, so a callback authorized under an earlier entry is refused while a host is parked on the pump — the same class of gap with a non-null owner instead of null. Widening it means giving pump reservations the anonymous-wildcard identity, which widens the admission surface (TM-13) and is not needed for #3206 or #3220. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
