### PR TITLE
StructuredClone: an Error's cause, the two File API interfaces, and %Object.prototype%

### DIFF
--- a/Jint.Tests/Runtime/WebApi/SerializationRecordTests.cs
+++ b/Jint.Tests/Runtime/WebApi/SerializationRecordTests.cs
@@ -73,7 +73,7 @@ public class SerializationRecordTests
     [Fact]
     public void HoldsNothingEngineAffineForARichGraph()
     {
-        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Messaging));
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Messaging | WebApiFeatures.Files));
 
         // One value of every shape the serializer recognizes, plus a cycle and a shared reference.
         var value = engine.Evaluate("""
@@ -92,7 +92,10 @@ public class SerializationRecordTests
                     map: new Map([['k', shared]]),
                     set: new Set([shared, 1]),
                     error: new TypeError('bad'),
+                    causedError: new RangeError('caused', { cause: shared }),
                     domException: new DOMException('nope', 'AbortError'),
+                    blob: new Blob(['bytes'], { type: 'text/plain' }),
+                    file: new File(['bytes'], 'name.txt', { type: 'text/plain', lastModified: 1 }),
                     array: [1, shared],
                     shared: shared
                 };

--- a/Jint.Tests/Runtime/WebApi/StructuredCloneTests.cs
+++ b/Jint.Tests/Runtime/WebApi/StructuredCloneTests.cs
@@ -21,6 +21,16 @@ public class StructuredCloneTests
 
     private static string Err(Engine engine, string body) => engine.Evaluate("err(function() { " + body + " })").AsString();
 
+    /// <summary>
+    /// The same engine plus the File API, for the <c>Blob</c> and <c>File</c> serialization steps.
+    /// </summary>
+    private static Engine FileEngine()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.StructuredClone | WebApiFeatures.Files));
+        engine.Execute("function err(f) { try { f(); return 'no error'; } catch (e) { return e.name; } }");
+        return engine;
+    }
+
     // ---------------------------------------------------------------- the function itself
 
     [Fact]
@@ -488,13 +498,13 @@ public class StructuredCloneTests
     }
 
     [Fact]
-    public void CarriesOnlyTheErrorsNameMessageAndStack()
+    public void CarriesOnlyTheErrorsNameMessageCauseAndStack()
     {
         var engine = WebEngine();
 
         engine.Execute("var source = new TypeError('boom'); source.extra = 'dropped'; var clone = structuredClone(source);");
 
-        // An Error's serialization does not set `deep`, so nothing but the three recorded fields survives.
+        // An Error's serialization walks no property list, so nothing but the four recorded fields survives.
         engine.Evaluate("clone.extra === undefined").AsBoolean().Should().BeTrue();
 
         // `message` comes back as a writable, non-enumerable, configurable own property.
@@ -526,6 +536,123 @@ public class StructuredCloneTests
             var accessorClone = structuredClone(source);");
         engine.Evaluate("invoked").AsBoolean().Should().BeFalse();
         engine.Evaluate("Object.getOwnPropertyDescriptor(accessorClone, 'message') === undefined").AsBoolean().Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("Error")]
+    [InlineData("EvalError")]
+    [InlineData("RangeError")]
+    [InlineData("ReferenceError")]
+    [InlineData("SyntaxError")]
+    [InlineData("TypeError")]
+    [InlineData("URIError")]
+    public void CarriesTheErrorsCause(string name)
+    {
+        var engine = WebEngine();
+
+        engine.Execute($"var source = new {name}('Error message here', {{ cause: 'my cause' }}); source.foo = 'testing'; var clone = structuredClone(source);");
+
+        engine.Evaluate("clone.cause").AsString().Should().Be("my cause");
+        engine.Evaluate("clone.name").AsString().Should().Be(name);
+        engine.Evaluate("clone.message").AsString().Should().Be("Error message here");
+
+        // A property the script put there itself is still not carried: `cause` rides the error's own
+        // serialization, not a property walk.
+        engine.Evaluate("clone.foo === undefined").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void GivesTheCloneNoCauseWhenTheSourceHasNone()
+    {
+        var engine = WebEngine();
+
+        // `new Error(message)` installs no `cause` at all, and neither does Error.prototype, so the clone
+        // must not invent one — `'cause' in clone` stays false rather than becoming a property holding
+        // undefined.
+        engine.Execute("var clone = structuredClone(new Error('boom'));");
+        engine.Evaluate("'cause' in clone").AsBoolean().Should().BeFalse();
+        engine.Evaluate("clone.cause === undefined").AsBoolean().Should().BeTrue();
+
+        // An explicit `undefined` cause is a property, and survives as one.
+        engine.Execute("var explicitClone = structuredClone(new Error('boom', { cause: undefined }));");
+        engine.Evaluate("'cause' in explicitClone").AsBoolean().Should().BeTrue();
+        engine.Evaluate("explicitClone.cause === undefined").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void GivesTheCauseTheAttributesTheLanguageWouldHave()
+    {
+        var engine = WebEngine();
+
+        engine.Execute("var clone = structuredClone(new Error('boom', { cause: 'why' }));");
+
+        // InstallErrorCause uses CreateNonEnumerableDataPropertyOrThrow, so an error the engine built has a
+        // writable, non-enumerable, configurable own `cause`; the clone has to look the same.
+        engine.Evaluate("Object.keys(clone).length").AsNumber().Should().Be(0);
+        engine.Evaluate("Object.getOwnPropertyDescriptor(clone, 'cause').enumerable").AsBoolean().Should().BeFalse();
+        engine.Evaluate("Object.getOwnPropertyDescriptor(clone, 'cause').writable").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.getOwnPropertyDescriptor(clone, 'cause').configurable").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void SubSerializesTheCauseThroughTheOneMemoryMap()
+    {
+        var engine = WebEngine();
+
+        engine.Execute(@"
+            var payload = { a: 1 };
+            var source = new Error('boom', { cause: payload });
+            var clone = structuredClone({ e: source, p: payload });");
+
+        // The cause is cloned rather than shared ...
+        engine.Evaluate("clone.e.cause !== payload").AsBoolean().Should().BeTrue();
+        engine.Evaluate("clone.e.cause.a").AsNumber().Should().Be(1);
+
+        // ... and it went through the same memory map as everything else, so one source object is still one
+        // clone however many places reach it.
+        engine.Evaluate("clone.e.cause === clone.p").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void TerminatesOnAnErrorThatIsItsOwnCause()
+    {
+        var engine = WebEngine();
+
+        engine.Execute("var source = new Error('boom'); source.cause = source; var clone = structuredClone(source);");
+
+        engine.Evaluate("clone !== source").AsBoolean().Should().BeTrue();
+        engine.Evaluate("clone.cause === clone").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void RefusesAnUncloneableCause()
+    {
+        var engine = WebEngine();
+
+        Err(engine, "structuredClone(new Error('boom', { cause: function() {} }))").Should().Be("DataCloneError");
+        Err(engine, "structuredClone(new Error('boom', { cause: Symbol() }))").Should().Be("DataCloneError");
+    }
+
+    [Fact]
+    public void ReadsCauseAsAnOwnDataPropertyOnly()
+    {
+        var engine = WebEngine();
+
+        // Exactly what `message` does: an accessor is not invoked, and an inherited `cause` is not an own
+        // one, so neither reaches the clone.
+        engine.Execute(@"
+            var invoked = false;
+            var source = new Error('boom');
+            Object.defineProperty(source, 'cause', { get: function() { invoked = true; return 'from getter'; }, configurable: true });
+            var accessorClone = structuredClone(source);");
+        engine.Evaluate("invoked").AsBoolean().Should().BeFalse();
+        engine.Evaluate("'cause' in accessorClone").AsBoolean().Should().BeFalse();
+
+        engine.Execute(@"
+            var inherited = new Error('boom');
+            Object.setPrototypeOf(inherited, Object.create(Error.prototype, { cause: { value: 'inherited' } }));
+            var inheritedClone = structuredClone(inherited);");
+        engine.Evaluate("'cause' in inheritedClone").AsBoolean().Should().BeFalse();
     }
 
     [Fact]
@@ -845,6 +972,54 @@ public class StructuredCloneTests
         engine.Evaluate("buffer.byteLength").AsNumber().Should().Be(0);
     }
 
+    // ---------------------------------------------------------------- %Object.prototype%
+
+    [Fact]
+    public void ClonesObjectPrototypeAsAnOrdinaryObject()
+    {
+        var engine = WebEngine();
+
+        engine.Execute("var clone = structuredClone(Object.prototype);");
+
+        engine.Evaluate("clone !== Object.prototype").AsBoolean().Should().BeTrue();
+        engine.Evaluate("clone instanceof Object").AsBoolean().Should().BeTrue();
+
+        // Everything Object.prototype carries is non-enumerable, so the clone is empty.
+        engine.Evaluate("Object.getOwnPropertyNames(clone).length").AsNumber().Should().Be(0);
+    }
+
+    [Fact]
+    public void ObjectPrototypesCloneLosesItsImmutablePrototypeExoticness()
+    {
+        var engine = WebEngine();
+
+        engine.Execute(@"
+            var clone = structuredClone(Object.prototype);
+            var newProto = { some: 'proto' };
+            Object.setPrototypeOf(clone, newProto);");
+
+        // %Object.prototype% is an immutable prototype exotic object and this would have thrown on it; the
+        // clone is an ordinary object, which is exactly what step 24's note says the result must be.
+        engine.Evaluate("Object.getPrototypeOf(clone) === newProto").AsBoolean().Should().BeTrue();
+
+        // The source is untouched and still refuses.
+        Err(engine, "Object.setPrototypeOf(Object.prototype, { })").Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void ReachesObjectPrototypeInsideAGraph()
+    {
+        var engine = WebEngine();
+
+        engine.Execute("var clone = structuredClone({ p: Object.prototype, q: Object.prototype });");
+
+        engine.Evaluate("typeof clone.p").AsString().Should().Be("object");
+        engine.Evaluate("clone.p !== Object.prototype").AsBoolean().Should().BeTrue();
+
+        // One source object is one clone, through the same memory map as everything else.
+        engine.Evaluate("clone.p === clone.q").AsBoolean().Should().BeTrue();
+    }
+
     // ---------------------------------------------------------------- refusals
 
     [Theory]
@@ -892,6 +1067,209 @@ public class StructuredCloneTests
         engine.Execute("var caught; try { structuredClone(Symbol()); } catch (e) { caught = e; }");
         engine.Evaluate("caught instanceof real").AsBoolean().Should().BeTrue();
         engine.Evaluate("caught.name").AsString().Should().Be("DataCloneError");
+    }
+
+    // ---------------------------------------------------------------- Blob and File
+
+    [Fact]
+    public void ClonesABlobsByteSequenceAndType()
+    {
+        var engine = FileEngine();
+
+        engine.Execute("var source = new Blob(['foo'], { type: 'text/x-bar' }); var clone = structuredClone(source);");
+
+        engine.Evaluate("clone !== source").AsBoolean().Should().BeTrue();
+        engine.Evaluate("clone instanceof Blob").AsBoolean().Should().BeTrue();
+        engine.Evaluate("clone instanceof File").AsBoolean().Should().BeFalse();
+        engine.Evaluate("Object.getPrototypeOf(clone) === Blob.prototype").AsBoolean().Should().BeTrue();
+        engine.Evaluate("clone.size").AsNumber().Should().Be(3);
+        engine.Evaluate("clone.type").AsString().Should().Be("text/x-bar");
+        engine.Evaluate("clone.text()").UnwrapIfPromise().AsString().Should().Be("foo");
+    }
+
+    [Fact]
+    public void ClonesAnEmptyBlobAndOneWhoseBytesAreNotUtf8()
+    {
+        var engine = FileEngine();
+
+        engine.Execute("var empty = structuredClone(new Blob(['']));");
+        engine.Evaluate("empty.size").AsNumber().Should().Be(0);
+        engine.Evaluate("empty.type").AsString().Should().Be("");
+
+        // The battery's unpaired-surrogate rows: what is carried is a byte sequence, not text, so bytes that
+        // are not valid UTF-8 survive unchanged.
+        engine.Execute("var clone = structuredClone(new Blob([new Uint8Array([0xED, 0xA0, 0x80, 0x00])]));");
+        engine.Evaluate("clone.size").AsNumber().Should().Be(4);
+
+        engine.SetValue("cloneBytes", engine.Evaluate("clone.bytes()").UnwrapIfPromise());
+        engine.Evaluate("Array.from(cloneBytes).join(',')").AsString().Should().Be("237,160,128,0");
+    }
+
+    [Fact]
+    public void ClonesAFilesNameAndLastModifiedAsWell()
+    {
+        var engine = FileEngine();
+
+        engine.Execute("var source = new File(['foo'], 'bar', { type: 'text/x-bar', lastModified: 42 }); var clone = structuredClone(source);");
+
+        engine.Evaluate("clone !== source").AsBoolean().Should().BeTrue();
+        engine.Evaluate("clone instanceof File").AsBoolean().Should().BeTrue();
+        engine.Evaluate("clone instanceof Blob").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.getPrototypeOf(clone) === File.prototype").AsBoolean().Should().BeTrue();
+        engine.Evaluate("clone.name").AsString().Should().Be("bar");
+        engine.Evaluate("clone.lastModified").AsNumber().Should().Be(42);
+        engine.Evaluate("clone.type").AsString().Should().Be("text/x-bar");
+        engine.Evaluate("clone.size").AsNumber().Should().Be(3);
+        engine.Evaluate("clone.text()").UnwrapIfPromise().AsString().Should().Be("foo");
+    }
+
+    [Fact]
+    public void DeserializesAFileSubclassAsAPlainFile()
+    {
+        var engine = FileEngine();
+
+        // Only the primary interface takes part in serialization, so a subclass loses its own prototype.
+        engine.Execute("class FileSubclass extends File {} var source = new FileSubclass([], 'n'); var clone = structuredClone(source);");
+
+        engine.Evaluate("Object.getPrototypeOf(clone) === File.prototype").AsBoolean().Should().BeTrue();
+        engine.Evaluate("clone instanceof FileSubclass").AsBoolean().Should().BeFalse();
+        engine.Evaluate("clone.name").AsString().Should().Be("n");
+    }
+
+    [Fact]
+    public void DeserializesABlobWhoseInterfaceObjectWasDeletedFromTheGlobal()
+    {
+        var engine = FileEngine();
+
+        // The deserializer reaches the prototype through the realm's intrinsics, so a script that deleted the
+        // global cannot make a record undeliverable.
+        engine.Execute(@"
+            var blobInterface = globalThis.Blob;
+            var source = new blobInterface(['x']);
+            delete globalThis.Blob;
+            var clone = structuredClone(source);");
+
+        engine.Evaluate("typeof globalThis.Blob").AsString().Should().Be("undefined");
+        engine.Evaluate("clone instanceof blobInterface").AsBoolean().Should().BeTrue();
+        engine.Evaluate("clone.size").AsNumber().Should().Be(1);
+    }
+
+    [Fact]
+    public void ReachesABlobThroughEveryContainerAndKeepsItsIdentity()
+    {
+        var engine = FileEngine();
+
+        engine.Execute(@"
+            var blob = new Blob(['x'], { type: 'text/plain' });
+            var graph = { a: blob, list: [blob], map: new Map([['k', blob]]), set: new Set([blob]) };
+            graph.self = graph;
+            var clone = structuredClone(graph);");
+
+        engine.Evaluate("clone.a instanceof Blob").AsBoolean().Should().BeTrue();
+        engine.Evaluate("clone.a !== blob").AsBoolean().Should().BeTrue();
+        engine.Evaluate("clone.a.type").AsString().Should().Be("text/plain");
+
+        // One source blob is one clone, wherever it is reached from.
+        engine.Evaluate("clone.list[0] === clone.a").AsBoolean().Should().BeTrue();
+        engine.Evaluate("clone.map.get('k') === clone.a").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Array.from(clone.set)[0] === clone.a").AsBoolean().Should().BeTrue();
+        engine.Evaluate("clone.self === clone").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void RefusesABlobOrAFileInTheTransferList()
+    {
+        var engine = FileEngine();
+
+        // Neither has an [[ArrayBufferData]] internal slot nor a [[Detached]] one, so
+        // StructuredSerializeWithTransfer step 2.1 refuses it — [Serializable] is not [Transferable].
+        Err(engine, "structuredClone(0, { transfer: [new Blob(['x'])] })").Should().Be("DataCloneError");
+        Err(engine, "structuredClone(0, { transfer: [new File(['x'], 'n')] })").Should().Be("DataCloneError");
+    }
+
+    [Fact]
+    public void ClonesABlobWhoseSourceBufferHasSinceBeenDetached()
+    {
+        var engine = FileEngine();
+
+        engine.Execute(@"
+            var buffer = new ArrayBuffer(3);
+            new Uint8Array(buffer).set([1, 2, 3]);
+            var blob = new Blob([buffer]);
+            structuredClone(0, { transfer: [buffer] });
+            var clone = structuredClone(blob);");
+
+        // The blob took a copy at construction, so the buffer's detachment cannot reach it.
+        engine.Evaluate("buffer.byteLength").AsNumber().Should().Be(0);
+        engine.Evaluate("clone.size").AsNumber().Should().Be(3);
+
+        engine.SetValue("cloneBytes", engine.Evaluate("clone.bytes()").UnwrapIfPromise());
+        engine.Evaluate("Array.from(cloneBytes).join(',')").AsString().Should().Be("1,2,3");
+    }
+
+    [Fact]
+    public void SharesTheBlobsByteSequenceWithItsCloneRatherThanCopyingIt()
+    {
+        var engine = FileEngine();
+
+        engine.Execute("var source = new Blob(['abcdef']); var clone = structuredClone(source);");
+
+        var source = (Jint.WebApi.Files.JsBlob) engine.Evaluate("source").AsObject();
+        var clone = (Jint.WebApi.Files.JsBlob) engine.Evaluate("clone").AsObject();
+
+        // A Blob is immutable by specification and never hands its array out, so the record carries the byte
+        // sequence itself rather than a copy of it — unlike an ArrayBuffer, whose storage script can write to.
+        System.Runtime.InteropServices.MemoryMarshal.TryGetArray(source.Data, out var sourceSegment).Should().BeTrue();
+        System.Runtime.InteropServices.MemoryMarshal.TryGetArray(clone.Data, out var cloneSegment).Should().BeTrue();
+        ReferenceEquals(sourceSegment.Array, cloneSegment.Array).Should().BeTrue();
+    }
+
+    [Fact]
+    public void HandsEveryBroadcastDestinationItsOwnBlobOverOneRecord()
+    {
+        var sender = FileEngine();
+        var blob = sender.Evaluate("new Blob(['xyz'], { type: 'text/plain' })");
+        var record = new Jint.WebApi.StructuredClone.StructuredSerializer(sender, sender.Realm).Serialize(blob, transferList: null);
+
+        // A BroadcastChannel serializes once and every destination deserializes that one record, which is the
+        // case a transferred ArrayBuffer's storage has to be copied for. A Blob's byte sequence does not: it
+        // is immutable and never handed out, so the shared record stays readable however many receivers take
+        // it, and each gets a Blob of its own realm.
+        foreach (var _ in new[] { 1, 2 })
+        {
+            var receiver = FileEngine();
+            var revived = new Jint.WebApi.StructuredClone.StructuredDeserializer(receiver, receiver.Realm, sharedRecord: true)
+                .Deserialize(in record);
+
+            receiver.SetValue("revived", revived);
+            receiver.Evaluate("revived instanceof Blob").AsBoolean().Should().BeTrue();
+            receiver.Evaluate("Object.getPrototypeOf(revived) === Blob.prototype").AsBoolean().Should().BeTrue();
+            receiver.Evaluate("revived.type").AsString().Should().Be("text/plain");
+            receiver.Evaluate("revived.text()").UnwrapIfPromise().AsString().Should().Be("xyz");
+        }
+    }
+
+    [Fact]
+    public void RefusesToDeserializeABlobOnAnEngineThatDoesNotExposeTheInterface()
+    {
+        var sender = FileEngine();
+        var blob = sender.Evaluate("new Blob(['x'])");
+        var record = new Jint.WebApi.StructuredClone.StructuredSerializer(sender, sender.Realm).Serialize(blob, transferList: null);
+
+        // "If the interface identified by interfaceName is not exposed in targetRealm, then throw a
+        // DataCloneError" — an engine that never enabled the File API has no Blob to build.
+        var receiver = new Engine(options => options.UseWebApis(WebApiFeatures.StructuredClone));
+        var deserializer = new Jint.WebApi.StructuredClone.StructuredDeserializer(receiver, receiver.Realm);
+
+        var thrown = Assert.Throws<Jint.Runtime.JavaScriptException>(() => deserializer.Deserialize(in record));
+        thrown.Error.Get("name").AsString().Should().Be("DataCloneError");
+
+        // ... while an engine that did enable it receives the blob whole.
+        var fileReceiver = FileEngine();
+        var revived = new Jint.WebApi.StructuredClone.StructuredDeserializer(fileReceiver, fileReceiver.Realm).Deserialize(in record);
+        fileReceiver.SetValue("revived", revived);
+        fileReceiver.Evaluate("revived instanceof Blob").AsBoolean().Should().BeTrue();
+        fileReceiver.Evaluate("revived.size").AsNumber().Should().Be(1);
     }
 }
 #endif

--- a/Jint.Tests/Wpt/Vendor/README.md
+++ b/Jint.Tests/Wpt/Vendor/README.md
@@ -36,7 +36,7 @@ Twelve standards are vendored: `url/`, `encoding/`, `compression/`, `urlpattern/
 **three**, `html/webappapis/` as **three** (timers, microtask-queuing, structured-clone), `dom/` as **two**
 (events, abort), `fetch/api/` as **two** (headers, response), `WebCryptoAPI/` as **eight** and `streams/` as
 **seven** — their root files plus one suite per sub-directory, because `WptCorpus.TestFiles` lists a
-directory's own files and never descends. That is 269 theory cases over 40,617 assertions, of which 3,021 do
+directory's own files and never descends. That is 269 theory cases over 40,617 assertions, of which 2,980 do
 not pass and every one is named in the driver's table; the whole driver runs in about two minutes.
 
 The corpora arrived a group at a time, most of them under
@@ -538,30 +538,87 @@ Everything else passes, including all sixteen rows of `dom/abort/event.any.js`, 
 
 ## What the structured-clone battery says about this engine
 
-137 assertions, of which **33 do not pass**. Three are the environment: a `WebAssembly.Memory`-backed growable
-`SharedArrayBuffer`, an `ImageBitmap` and an `OffscreenCanvas`. Two rows that this corpus arrived excluding
-are green on the branch it landed on, which is worth recording because it is the table working as designed —
-"a non-serializable platform object fails" needed a `Response` to be non-serializable *with*, and every
-engine the driver builds now carries the object model; and "a subclass instance will be received as its
+137 assertions, of which **3 do not pass**, and all three are the environment: a `WebAssembly.Memory`-backed
+growable `SharedArrayBuffer`, an `ImageBitmap` and an `OffscreenCanvas`. Two rows that this corpus arrived
+excluding are green on the branch it landed on, which is worth recording because it is the table working as
+designed — "a non-serializable platform object fails" needed a `Response` to be non-serializable *with*, and
+every engine the driver builds now carries the object model; and "a subclass instance will be received as its
 closest transferable superclass" needed `ReadableStream` transfer, which
 [issue #3199](https://github.com/sebastienros/jint/issues/3199) implemented.
 
-**The other 30 are three defects**, each of which reproduces outside the harness:
+**The other 30 were three defects**, filed as `NeedsTriage` when the corpus landed and fixed by
+[issue #3212](https://github.com/sebastienros/jint/issues/3212). All three are kept written down here rather
+than deleted with their rows, because in the first two the fix deliberately follows web-platform-tests past
+what the prose of the owning standard currently says — a decision, not an oversight, and one the next person
+to read those steps should not have to rediscover.
 
-1. **An `Error`'s `cause` is not carried.** Seven rows, one per error type.
-   [HTML's serialization steps for an Error](https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal)
-   read `cause` when the object has it as an own property and serialize it into the record;
-   `StructuredSerializer` reads the name, the message and the stack and stops there, so
-   `structuredClone(new Error("x", { cause: "my cause" })).cause` is `undefined`.
-2. **`Blob` and `File` are not serializable at all** — 20 rows, every one a `DataCloneError`. Both are
-   `[Serializable]` in [the File API](https://w3c.github.io/FileAPI/#dfn-Blob), and Jint has both interfaces
-   (the `Files` feature is in `WebApiFeatures.Default`); what is missing is their serialization steps in
-   `StructuredSerializer`/`StructuredDeserializer`. Two further rows are the same defect seen from a different
-   angle — a `Blob` whose interface object has been deleted from the global must still deserialize, and a
-   `File` subclass must come back as a plain `File`.
-3. **`%Object.prototype%` is refused.** `structuredClone(Object.prototype)` raises `DataCloneError` where
-   HTML clones it as an ordinary object — it has no internal slot beyond `[[Prototype]]` and `[[Extensible]]`,
-   and being an immutable-prototype exotic object is exactly the property the test says the *clone* must lose.
+1. **An `Error`'s `cause` was not carried.** Seven rows, one per error type: `compare_Error` asserts
+   `assert_equals(actual.cause, input.cause)` and Jint answered `undefined`. **The HTML Standard as published
+   does not require this.**
+   [Step 17 of StructuredSerializeInternal](https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal)
+   records the name, the message and the stack; the word *cause* does not appear in the section at all, and
+   step 17.6's licence to attach "any interesting accompanying data" is explicitly scoped to data *"which are
+   not yet specified"* — which the editor reads as excluding `cause`, since ECMA-262 specifies it
+   ([whatwg/html#11321](https://github.com/whatwg/html/issues/11321): "Chromium and Firefox are actually not
+   conformant to the current spec, which does not allow copying `cause`"). The change that would specify it,
+   [whatwg/html#5749](https://github.com/whatwg/html/pull/5749), has been open since 2020 and is stalled on
+   the larger plan to move structured cloning into ECMA-262. Two of the three engines carry `cause` today and
+   the corpus asserts it, so Jint carries it: `SerializedError` gained `HasCause`/`Cause`, the error arm
+   became the one deep arm that is not a container (registered in the memory map first, so an error that is
+   its own cause terminates), and the clone gets it back through
+   [CreateNonEnumerableDataPropertyOrThrow](https://tc39.es/ecma262/#sec-installerrorcause), the same
+   writable/non-enumerable/configurable shape the language gives it.
+   What was deliberately **not** taken from that pull request is its rewrite of `message`, which would `Get`
+   the property rather than read an own data descriptor and install the result unconditionally: the same
+   battery asserts the published semantics with
+   `assert_equals(actual.hasOwnProperty("message"), input.hasOwnProperty("message"))`, so half-adopting the
+   proposal would have turned a passing row red. `cause` is therefore read exactly as `message` is — an own
+   *data* property, absent when the source has none.
+2. **`Blob` and `File` were not serializable at all** — 22 rows, every one a `DataCloneError`. (The issue
+   said 23; enumerating what the three globs and three named rows actually cover gives 6 + 7 + 6 + 1 + 1 + 1.)
+   Both are `[Serializable]` in [the File API](https://w3c.github.io/FileAPI/#dfn-Blob), and Jint has both
+   interfaces, so what was missing was only their serialization steps. Four things about the fix are worth
+   knowing.
+   The File API's `Blob` steps carry `[[SnapshotState]]` and `[[ByteSequence]]` and **nothing else** — `type`
+   is not in them, which would make `structuredClone(new Blob(['x'], { type: 'text/plain' })).type` the empty
+   string. `compare_Blob` asserts `assert_equals(actual.type, input.type)` and every engine carries it, so the
+   media type is carried here too; that is a gap in the prose rather than a decision anyone made.
+   `[[SnapshotState]]` has no representation, and that is not an omission: snapshot state is the state of the
+   *underlying storage*, and a `JsBlob` is always built from bytes already in memory.
+   The byte sequence is **shared with the clone, not copied**: a `Blob` is immutable by specification and
+   `JsBlob` never hands its array out, so the source, the record and every clone can hold one array with
+   nothing able to observe it — which is the opposite of an `ArrayBuffer`, whose storage script can write to
+   and which therefore copies. It is also why a `Blob` record is exempt from the copy a `sharedRecord`
+   deserialization otherwise makes.
+   `SerializedFile` derives from `SerializedBlob` and is matched first in both switches, for the reason
+   `SerializedQuotaExceededError` derives from `SerializedDomException`: it makes "and also the Blob fields"
+   literal and keeps a `File` from flattening into a `Blob`. Because the deserializer builds a fresh instance
+   from the realm's intrinsic, the two rows that look at the problem from a different angle fall out for free
+   — a `Blob` whose interface object was deleted from the global still deserializes (the intrinsic is not the
+   global property), and a `File` subclass comes back as a plain `File` (only the primary interface takes
+   part). The deserializer also implements the step those two rows sit next to: *"if the interface identified
+   by interfaceName is not exposed in targetRealm, throw a `DataCloneError`"*, which is reachable in Jint
+   because a `MessagePort`, a `BroadcastChannel` or a `Worker` can carry a blob to an engine that never
+   enabled `WebApiFeatures.Files`.
+3. **`%Object.prototype%` was refused**, and the cause was not a check aimed at platform objects catching
+   something by accident: the ordinary-object arm was a **type test on Jint's ordinary-object storage class**,
+   `case JsObject`, where the specification's test is about internal slots and exoticness. `Object.prototype`
+   is an `ObjectPrototype`, built by the source generator in builtin-shape mode, so it never matched and fell
+   through to the blanket refusal. HTML's
+   [step 23](https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal) refuses
+   "an exotic object [that] is not the `%Object.prototype%` intrinsic object associated with **any** realm" —
+   `%Object.prototype%` *is* exotic (immutable prototype) and is carved out by name — and step 24's own note
+   says the result "will be an empty object (not an immutable prototype exotic object)", which is exactly what
+   the test checks by calling `Object.setPrototypeOf` on the clone. The arm is now
+   `case JsObject or ObjectPrototype`, and matching the type is that predicate rather than an identity check
+   standing in for it: `ObjectPrototype` is sealed and `Intrinsics` builds exactly one per realm, so
+   `is ObjectPrototype` is true of every realm's `%Object.prototype%` and of nothing else.
+   The refusal stays conservative in the direction it was designed to be — everything the recognized steps
+   name is serialized and anything else is refused, which is what keeps a host's own `ObjectInstance`
+   subclass, and every platform object Jint has not declared `[Serializable]`, refused rather than silently
+   flattened into a plain object that has lost its state. Two shapes are still stricter than a browser for
+   that reason and are recorded on `ThrowUncloneable`: a namespace object (`Math`, `JSON`, `console`) and an
+   unmapped `arguments` object, both of which a browser clones as `{}`.
 
 ## What the fetch object model says about this engine
 
@@ -613,14 +670,14 @@ the shim did not record `PASS`, which is exactly the set the table names.
 | Web Cryptography | `WebCryptoAPI/` ×8 | 48 | 24,136 | 2,448 |
 | Streams | `streams/` ×7 | 65 | 1,154 | 16 |
 | Compression | `compression/` | 15 | 297 | 84 |
-| File API | `FileAPI/` ×3 | 14 | 342 | 11 |
+| File API | `FileAPI/` ×3 | 14 | 342 | 0 |
 | High Resolution Time | `hr-time/` | 2 | 7 | 1 |
 | User Timing | `user-timing/` | 19 | 78 | 9 |
 | HTML — workers | `workers/` ×3 | 11 | 15 | 7 |
-| HTML — timers, microtasks, structured clone | `html/webappapis/` ×3 | 10 | 153 | 33 |
+| HTML — timers, microtasks, structured clone | `html/webappapis/` ×3 | 10 | 153 | 3 |
 | DOM | `dom/` ×2 | 12 | 62 | 2 |
 | Fetch | `fetch/api/` ×2 | 29 | 388 | 88 |
-| **total** | **34** | **269** | **40,617** | **3,021** |
+| **total** | **34** | **269** | **40,617** | **2,980** |
 
 Two of those rows are worth a caveat. The Encoding figure is dominated by
 `textdecoder-fatal-single-byte.any.js`, 7,168 assertions of it and every one passing; of the 322 that do not,

--- a/Jint.Tests/Wpt/WptExclusions.cs
+++ b/Jint.Tests/Wpt/WptExclusions.cs
@@ -369,7 +369,7 @@ internal enum WptDivergence
     /// <c>ObjectInstance.IsArrayLike</c> where https://tc39.es/ecma262/#sec-array.prototype.values reads no
     /// <c>length</c> at all, the iterator's own step 1.b doing <i>LengthOfArrayLike</i> on each
     /// <c>next()</c>. Fixed under sebastienros/jint#3209, which is what the deleted entries now enforce.
-    /// <b>The hr-time, DOM, structured-clone and fetch corpora filed ten more</b>, and <c>Vendor/README.md</c>
+    /// <b>The hr-time, DOM and fetch corpora filed seven more</b>, and <c>Vendor/README.md</c>
     /// analyses each with its citation. In one line apiece:
     /// </para>
     /// <list type="bullet">
@@ -385,18 +385,6 @@ internal enum WptDivergence
     /// <item><description>
     /// <c>Event</c> has neither <c>srcElement</c> nor <c>returnValue</c>, both of which the DOM Standard's own
     /// interface declares.
-    /// </description></item>
-    /// <item><description>
-    /// An <c>Error</c>'s <c>cause</c> is not carried through <c>structuredClone</c>, where HTML's
-    /// serialization steps read it.
-    /// </description></item>
-    /// <item><description>
-    /// <c>Blob</c> and <c>File</c> are not serializable at all, though the File API declares both
-    /// <c>[Serializable]</c> and Jint has the interfaces.
-    /// </description></item>
-    /// <item><description>
-    /// <c>structuredClone(Object.prototype)</c> raises <c>DataCloneError</c> where HTML clones it as the
-    /// ordinary object it is.
     /// </description></item>
     /// <item><description>
     /// The <c>Headers</c> iterator prototype's <c>next</c> is not enumerable — the same attribute on the same
@@ -417,6 +405,15 @@ internal enum WptDivergence
     /// read before anything is changed, which is exactly why it is triage rather than a fix.
     /// </description></item>
     /// </list>
+    /// <para>
+    /// <b>The structured-clone corpus filed three more, and they are gone</b> — an <c>Error</c>'s
+    /// <c>cause</c> was not carried, <c>Blob</c> and <c>File</c> were not serializable at all, and
+    /// <c>structuredClone(Object.prototype)</c> raised a <c>DataCloneError</c>. All three are fixed, so the
+    /// thirty rows they held here left with them and that corpus now runs with three exclusions, all of them
+    /// environment rather than debt. The analysis is still in <c>Vendor/README.md</c>, because two of the
+    /// three are places where Jint follows web-platform-tests past what the prose of the relevant standard
+    /// currently says.
+    /// </para>
     /// <para>
     /// One further defect is recorded in <c>Vendor/README.md</c> with no entry here, because the test that
     /// finds it cannot be named: a throw from a <c>queueMicrotask</c> callback erupts from the pump instead of

--- a/Jint.Tests/Wpt/WptTestRunner.cs
+++ b/Jint.Tests/Wpt/WptTestRunner.cs
@@ -1033,26 +1033,11 @@ public class WptTestRunner
         new("html/webappapis/structured-clone/structured-clone.any.js", "ImageBitmap", WptDivergence.NeedsOffscreenCanvas),
         new("html/webappapis/structured-clone/structured-clone.any.js", "OffscreenCanvas", WptDivergence.NeedsOffscreenCanvas),
 
-        // Three defects, analysed in Vendor/README.md: an Error's `cause` is not carried, Blob and File are
-        // not serializable at all, and %Object.prototype% is refused where HTML clones it as an ordinary
-        // object. The Blob rows are named as three globs because that is how the battery names them.
-        new("html/webappapis/structured-clone/structured-clone.any.js", "Error object", WptDivergence.NeedsTriage),
-        new("html/webappapis/structured-clone/structured-clone.any.js", "EvalError object", WptDivergence.NeedsTriage),
-        new("html/webappapis/structured-clone/structured-clone.any.js", "RangeError object", WptDivergence.NeedsTriage),
-        new("html/webappapis/structured-clone/structured-clone.any.js", "ReferenceError object", WptDivergence.NeedsTriage),
-        new("html/webappapis/structured-clone/structured-clone.any.js", "SyntaxError object", WptDivergence.NeedsTriage),
-        new("html/webappapis/structured-clone/structured-clone.any.js", "TypeError object", WptDivergence.NeedsTriage),
-        new("html/webappapis/structured-clone/structured-clone.any.js", "URIError object", WptDivergence.NeedsTriage),
-        new("html/webappapis/structured-clone/structured-clone.any.js", "Blob *", WptDivergence.NeedsTriage),
-        new("html/webappapis/structured-clone/structured-clone.any.js", "Array Blob object, *", WptDivergence.NeedsTriage),
-        new("html/webappapis/structured-clone/structured-clone.any.js", "Object Blob object, *", WptDivergence.NeedsTriage),
-        new("html/webappapis/structured-clone/structured-clone.any.js", "File basic", WptDivergence.NeedsTriage),
-        new("html/webappapis/structured-clone/structured-clone.any.js",
-            "An object whose interface is deleted from the global must still deserialize", WptDivergence.NeedsTriage),
-        new("html/webappapis/structured-clone/structured-clone.any.js",
-            "A subclass instance will deserialize as its closest serializable superclass", WptDivergence.NeedsTriage),
-        new("html/webappapis/structured-clone/structured-clone.any.js",
-            "ObjectPrototype must lose its exotic-ness when cloned", WptDivergence.NeedsTriage),
+        // The three defects this corpus filed — an Error's `cause` was not carried, Blob and File were not
+        // serializable at all, and %Object.prototype% was refused — were fixed by
+        // https://github.com/sebastienros/jint/issues/3212, and their thirty rows left with them. What
+        // remains above is the environment: a WebAssembly-backed growable SharedArrayBuffer, and the two
+        // canvas interfaces.
     ];
 
     public static IEnumerable<object[]> UrlSuiteFiles() => Cases("url");

--- a/Jint/WebApi/StructuredClone/SerializationRecord.cs
+++ b/Jint/WebApi/StructuredClone/SerializationRecord.cs
@@ -17,10 +17,10 @@ namespace Jint.WebApi.StructuredClone;
 /// <remarks>
 /// <para>
 /// <b>Nothing reachable from here is engine-affine.</b> Every node is a plain CLR object — numbers, strings,
-/// <see cref="BigInteger"/>s, <c>byte[]</c>s, lists and the tagged records below — and there is deliberately
-/// no <c>JsValue</c>, <c>Engine</c>, <c>Realm</c> or <c>ObjectInstance</c> anywhere in the graph. That is what
-/// makes a record safe to build on one engine's thread and consume on another's, which is what
-/// <c>MessagePort</c> does: <see cref="StructuredSerializer"/> runs entirely on the sender and
+/// <see cref="BigInteger"/>s, <c>byte[]</c>s and windows over them, lists and the tagged records below — and
+/// there is deliberately no <c>JsValue</c>, <c>Engine</c>, <c>Realm</c> or <c>ObjectInstance</c> anywhere in
+/// the graph. That is what makes a record safe to build on one engine's thread and consume on another's,
+/// which is what <c>MessagePort</c> does: <see cref="StructuredSerializer"/> runs entirely on the sender and
 /// <see cref="StructuredDeserializer"/> entirely on the receiver, and the record is the only thing that
 /// crosses. <c>Jint.Tests.Runtime.WebApi.SerializationRecordTests</c> pins the property both from the type
 /// declarations and from a walk of an actual graph.
@@ -46,6 +46,12 @@ namespace Jint.WebApi.StructuredClone;
 /// standard's steps say, so it asks the deserializer to copy the storage instead
 /// (<see cref="StructuredDeserializer"/>'s <c>sharedRecord</c>). It has no transfer list, so there is never
 /// storage there that had to be moved rather than copied.
+/// </para>
+/// <para>
+/// <b>A <see cref="SerializedBlob"/> is the exception in the other direction.</b> Its bytes are a
+/// <c>Blob</c>'s associated byte sequence, which is immutable and which no <c>Blob</c> ever hands out, so
+/// they are shared with the source and with every clone rather than owned by one of them — and
+/// <c>sharedRecord</c> deliberately does not copy them. Such a record is readable any number of times.
 /// </para>
 /// <para>
 /// Sharing and cycles are carried by CLR reference identity: two references to one source object serialize to
@@ -409,11 +415,43 @@ internal enum SerializedErrorName : byte
 /// property, which is the difference between a clone that has no own <c>message</c> and one whose
 /// <c>message</c> is the empty string.
 /// </summary>
+/// <remarks>
+/// <b><c>cause</c> is carried, and the HTML Standard as published does not yet say so.</b> Step 17 records
+/// the name, the message and the stack, and its step 17.6 permits a user agent to attach "any interesting
+/// accompanying data <i>which are not yet specified</i>" — which the editor reads as excluding <c>cause</c>,
+/// since ECMA-262 does specify it (https://github.com/whatwg/html/issues/11321). The change that would
+/// specify it is https://github.com/whatwg/html/pull/5749, open since 2020 and stalled on the larger question
+/// of moving structured cloning into ECMA-262. Two of the three engines carry <c>cause</c> today and
+/// web-platform-tests asserts it — <c>structured-clone-battery-of-tests.js</c>'s <c>compare_Error</c> does
+/// <c>assert_equals(actual.cause, input.cause)</c> for all seven error types — so Jint carries it too.
+/// <para>
+/// What is deliberately <i>not</i> taken from that pull request is its rewrite of <c>message</c>, which would
+/// <c>Get</c> the property rather than read an own data descriptor and install the result unconditionally.
+/// The same battery asserts the published semantics
+/// (<c>assert_equals(actual.hasOwnProperty("message"), input.hasOwnProperty("message"))</c>), so adopting the
+/// proposal's half of that would break a passing row. <c>cause</c> is therefore read exactly the way
+/// <c>message</c> is read: as an own data property, absent when the source has none.
+/// </para>
+/// </remarks>
 internal sealed class SerializedError : SerializedObject
 {
     internal SerializedErrorName Name { get; init; }
 
     internal string? Message { get; init; }
+
+    /// <summary>
+    /// Whether the source carried <c>cause</c> as an own <i>data</i> property, which is the difference
+    /// between a clone that has no <c>cause</c> at all and one whose <c>cause</c> is <c>undefined</c> —
+    /// <c>new Error(m)</c> and <c>new Error(m, { cause: undefined })</c> respectively.
+    /// </summary>
+    internal bool HasCause { get; init; }
+
+    /// <summary>
+    /// The sub-serialization of <c>cause</c>, meaningful only when <see cref="HasCause"/> is set. Settable
+    /// for the reason every deep record's contents are: the error is registered in the memory map before its
+    /// cause is walked, so that an error which is its own cause terminates.
+    /// </summary>
+    internal SerializedValue Cause { get; set; }
 
     /// <summary>
     /// The <c>stack</c>, which neither specification requires but both say a user agent "should attach". An
@@ -454,5 +492,62 @@ internal sealed class SerializedQuotaExceededError : SerializedDomException
 
     /// <summary>The <c>[[Requested]]</c>: a number, or <see langword="null"/>.</summary>
     internal double? Requested { get; init; }
+}
+
+/// <summary>
+/// The <c>Blob</c> serialization steps, https://w3c.github.io/FileAPI/#dfn-Blob: <c>[[SnapshotState]]</c> and
+/// <c>[[ByteSequence]]</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The byte sequence is shared, not copied.</b> A <c>Blob</c> is immutable by specification — it "refers
+/// to a byte sequence", and Jint's <c>JsBlob</c> never hands its array out (<c>slice</c> takes a window,
+/// <c>arrayBuffer</c> and <c>bytes</c> copy) — so the source, the record and every clone made from it can
+/// hold one array with nothing able to observe the sharing. That is the opposite of
+/// <see cref="SerializedArrayBuffer"/>, whose storage script <i>can</i> write to and which therefore copies
+/// on the way in; it is also why this record is exempt from the copy a <c>sharedRecord</c> deserialization
+/// makes, and why holding a <see cref="ReadOnlyMemory{T}"/> rather than a <c>byte[]</c> costs nothing: a
+/// blob produced by <c>slice</c> is a window over its parent's array and stays one.
+/// </para>
+/// <para>
+/// <b><c>[[SnapshotState]]</c> has no representation here</b>, and that is not an omission: snapshot state is
+/// "the state of the underlying storage, if any such underlying storage exists", and a <c>JsBlob</c> is
+/// always built from bytes already in memory — Jint has no file-backed blob for a snapshot to be of. When one
+/// arrives, it goes here.
+/// </para>
+/// <para>
+/// <b><see cref="MediaType"/> is carried although the File API's steps do not list it.</b> Those two steps
+/// name only the snapshot state and the byte sequence, which would make <c>structuredClone(new Blob(['x'],
+/// { type: 'text/plain' })).type</c> the empty string; every engine carries the type and
+/// web-platform-tests asserts it (<c>compare_Blob</c>'s <c>assert_equals(actual.type, input.type)</c>). It is
+/// a gap in the specification's prose rather than a decision, so the type is carried.
+/// </para>
+/// </remarks>
+internal class SerializedBlob : SerializedObject
+{
+    /// <summary>The <c>[[ByteSequence]]</c>: the blob's associated byte sequence, shared rather than copied.</summary>
+    internal ReadOnlyMemory<byte> Bytes { get; init; }
+
+    /// <summary>The normalized media type, or the empty string.</summary>
+    internal string MediaType { get; init; } = "";
+}
+
+/// <summary>
+/// The <c>File</c> serialization steps, https://w3c.github.io/FileAPI/#file-section: the <c>Blob</c> steps'
+/// two fields, plus <c>[[Name]]</c> and <c>[[LastModified]]</c>.
+/// </summary>
+/// <remarks>
+/// A record of its own deriving from <see cref="SerializedBlob"/>, for the reason
+/// <see cref="SerializedQuotaExceededError"/> derives from <see cref="SerializedDomException"/>: it makes
+/// "and also the Blob fields" literal, and it forces the two switches that consume these records to match the
+/// derived type first, which is what keeps a <c>File</c> from arriving as a plain <c>Blob</c>.
+/// </remarks>
+internal sealed class SerializedFile : SerializedBlob
+{
+    /// <summary>The <c>[[Name]]</c>, https://w3c.github.io/FileAPI/#dfn-name.</summary>
+    internal string Name { get; init; } = "";
+
+    /// <summary>The <c>[[LastModified]]</c>, in milliseconds since the Unix epoch.</summary>
+    internal long LastModified { get; init; }
 }
 #endif

--- a/Jint/WebApi/StructuredClone/StructuredDeserializer.cs
+++ b/Jint/WebApi/StructuredClone/StructuredDeserializer.cs
@@ -7,6 +7,7 @@ using Jint.Native.TypedArray;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
 using Jint.WebApi.DomException;
+using Jint.WebApi.Files;
 using Jint.WebApi.Messaging;
 using Jint.WebApi.Streams;
 
@@ -240,9 +241,20 @@ internal sealed class StructuredDeserializer
                 result = DeserializeView(view);
                 break;
 
+            // Deep, and for one field only: the error is registered before its `cause` is deserialized, so an
+            // error that is its own cause comes back as one rather than recursing forever.
             case SerializedError error:
-                result = DeserializeError(error);
-                break;
+                {
+                    var target = DeserializeError(error);
+                    _memory[record] = target;
+
+                    if (error.HasCause)
+                    {
+                        _pending.Push(new ErrorCauseFrame(error.Cause, target));
+                    }
+
+                    return target;
+                }
 
             // Before the DOMException arm it derives from — https://webidl.spec.whatwg.org/#quotaexceedederror
             // deserializes into the interface, not into a DOMException wearing the name.
@@ -252,6 +264,16 @@ internal sealed class StructuredDeserializer
 
             case SerializedDomException domException:
                 result = DeserializeDomException(domException);
+                break;
+
+            // The File API's deserialization steps, and — as in the serializer — the derived interface first,
+            // or a File would come back as a Blob. https://w3c.github.io/FileAPI/#file-section
+            case SerializedFile file:
+                result = DeserializeFile(file);
+                break;
+
+            case SerializedBlob blob:
+                result = DeserializeBlob(blob);
                 break;
 
             // The three streams' transfer-receiving steps. Each builds its half of a cross-realm transform
@@ -445,6 +467,61 @@ internal sealed class StructuredDeserializer
         return result;
     }
 
+    /// <summary>
+    /// The <c>Blob</c> deserialization steps, https://w3c.github.io/FileAPI/#dfn-Blob: the byte sequence and
+    /// the snapshot state (which Jint has nothing to represent — see <see cref="SerializedBlob"/>), plus the
+    /// media type the steps omit but every engine carries.
+    /// </summary>
+    /// <remarks>
+    /// The byte sequence is adopted rather than copied even for a <c>sharedRecord</c>, unlike an
+    /// <c>ArrayBuffer</c>'s: a blob's bytes are immutable and never handed out, so several receivers holding
+    /// one array cannot observe one another.
+    /// </remarks>
+    private JsBlob DeserializeBlob(SerializedBlob record)
+    {
+        RequireFileApiExposed("Blob");
+
+        return new JsBlob(_engine, record.Bytes, record.MediaType)
+        {
+            _prototype = _realm.Intrinsics.Blob.PrototypeObject,
+        };
+    }
+
+    /// <summary>
+    /// The <c>File</c> deserialization steps, https://w3c.github.io/FileAPI/#file-section. The result is a
+    /// plain <c>File</c> in this realm whatever the source's prototype was, which is what makes a subclass
+    /// instance "deserialize as its closest serializable superclass": only the primary interface takes part.
+    /// </summary>
+    private JsFile DeserializeFile(SerializedFile record)
+    {
+        RequireFileApiExposed("File");
+
+        return new JsFile(_engine, record.Bytes, record.MediaType, record.Name, record.LastModified)
+        {
+            _prototype = _realm.Intrinsics.File.PrototypeObject,
+        };
+    }
+
+    /// <summary>
+    /// "If the interface identified by interfaceName is not exposed in targetRealm, then throw a
+    /// DataCloneError" — https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserialize.
+    /// Reachable because a record crosses engines: a <c>MessagePort</c>, a <c>BroadcastChannel</c> or a
+    /// <c>Worker</c> can carry a blob from an engine that enabled <see cref="WebApiFeatures.Files"/> to one
+    /// that did not.
+    /// </summary>
+    /// <remarks>
+    /// The feature set is asked, not the global object: <c>Intrinsics.Blob</c> exists on any engine that
+    /// reaches for it, and the global property can be deleted by script — which is exactly the case the
+    /// battery's "an object whose interface is deleted from the global must still deserialize" pins.
+    /// </remarks>
+    private void RequireFileApiExposed(string interfaceName)
+    {
+        if ((_engine._webApiFeatures & WebApiFeatures.Files) == WebApiFeatures.None)
+        {
+            StructuredSerializer.ThrowDataCloneError(_realm, interfaceName + " is not exposed in the target realm");
+        }
+    }
+
     private JsQuotaExceededError DeserializeQuotaExceededError(SerializedQuotaExceededError record)
     {
         var result = _realm.Intrinsics.QuotaExceededError.CreateException(record.Message, record.Quota, record.Requested);
@@ -547,6 +624,31 @@ internal sealed class StructuredDeserializer
         {
             _ = _target.CreateDataProperty(_currentKey, value);
         }
+    }
+
+    /// <summary>
+    /// One error's <c>cause</c>, installed the way the language installs it: CreateNonEnumerableDataProperty,
+    /// so the clone's descriptor is writable, non-enumerable and configurable — exactly what
+    /// https://tc39.es/ecma262/#sec-installerrorcause gives an error the engine constructed itself.
+    /// </summary>
+    /// <remarks>
+    /// It runs after the error's own arm, so <c>message</c> is already installed and <c>cause</c> lands
+    /// second, which is the own-key order <c>new Error(m, { cause: c })</c> produces.
+    /// </remarks>
+    private sealed class ErrorCauseFrame(SerializedValue cause, JsError target) : DeserializeFrame
+    {
+        private bool _done;
+
+        internal override bool TryGetNextSource(out SerializedValue source)
+        {
+            source = _done ? SerializedValue.Undefined : cause;
+            var pending = !_done;
+            _done = true;
+            return pending;
+        }
+
+        internal override void Accept(JsValue value)
+            => target.CreateNonEnumerableDataPropertyOrThrow(CommonProperties.Cause, value);
     }
 
     private sealed class MapFrame : DeserializeFrame

--- a/Jint/WebApi/StructuredClone/StructuredSerializer.cs
+++ b/Jint/WebApi/StructuredClone/StructuredSerializer.cs
@@ -8,6 +8,7 @@ using Jint.Native.Object;
 using Jint.Native.TypedArray;
 using Jint.Runtime;
 using Jint.WebApi.DomException;
+using Jint.WebApi.Files;
 using Jint.WebApi.Messaging;
 using Jint.WebApi.Streams;
 
@@ -201,6 +202,28 @@ internal sealed class StructuredSerializer
                 };
                 break;
 
+            // Step 19, "value is a platform object that is a serializable object", for the two the File API
+            // declares [Serializable]. https://w3c.github.io/FileAPI/#file-section runs the Blob steps and
+            // then adds the name and the last-modified time, so — as with QuotaExceededError above — the
+            // derived interface is matched first, or a File would flatten into a Blob.
+            case JsFile file:
+                record = new SerializedFile
+                {
+                    Bytes = file.Data,
+                    MediaType = file.MediaType,
+                    Name = file.Name,
+                    LastModified = file.LastModified,
+                };
+                break;
+
+            case JsBlob blob:
+                record = new SerializedBlob
+                {
+                    Bytes = blob.Data,
+                    MediaType = blob.MediaType,
+                };
+                break;
+
             // Steps 7-10: the boxed primitives, each identified by its data slot.
             case Native.Boolean.BooleanInstance boolean:
                 record = new SerializedBoxedPrimitive(SerializedValue.FromBoolean(boolean.BooleanData._value));
@@ -267,15 +290,31 @@ internal sealed class StructuredSerializer
                     return SerializedValue.FromObject(target);
                 }
 
-            // Step 17.
+            // Step 17. The one deep arm that is not a container: `cause` is sub-serialized, so the record is
+            // registered in the memory map first (step 25 before step 26) and an error that is its own cause
+            // terminates.
             case ErrorInstance error:
-                record = new SerializedError
                 {
-                    Name = ErrorNameFor(error.Get(CommonProperties.Name)),
-                    Message = ReadOwnDataMessage(error),
-                    Stack = ReadStack(error),
-                };
-                break;
+                    var errorName = ErrorNameFor(error.Get(CommonProperties.Name));
+                    var errorMessage = ReadOwnDataMessage(error);
+                    var hasCause = TryReadOwnDataCause(error, out var cause);
+
+                    var target = new SerializedError
+                    {
+                        Name = errorName,
+                        Message = errorMessage,
+                        HasCause = hasCause,
+                        Stack = ReadStack(error),
+                    };
+
+                    _memory[source] = target;
+                    if (hasCause)
+                    {
+                        _pending.Push(new ErrorCauseFrame(cause, target));
+                    }
+
+                    return SerializedValue.FromObject(target);
+                }
 
             // Step 18: an Array exotic object. A Proxy whose target is an array is not one — it is a Proxy
             // exotic object, and falls through to the refusal below, as the specification intends.
@@ -291,11 +330,19 @@ internal sealed class StructuredSerializer
             // it has "any internal slot other than [[Prototype]]": JsObject is the type every ordinary object
             // reaches — object literals, `new Foo()`, Object.create, JSON.parse output, and the host-facing
             // JsObject.Create / CreateFromEntries factories. See ThrowUncloneable for what that costs.
-            case JsObject plain:
+            //
+            // ObjectPrototype is step 23's one carve-out, not a special case of Jint's: %Object.prototype% is
+            // an immutable prototype exotic object, and step 23 refuses "an exotic object [that] is not the
+            // %Object.prototype% intrinsic object associated with ANY realm" — so it reaches step 24 like any
+            // ordinary object, and step 24's own note says the result "will be an empty object (not an
+            // immutable prototype exotic object)". The type test IS that predicate rather than an identity
+            // check standing in for it: ObjectPrototype is sealed and Intrinsics builds exactly one per realm,
+            // so `is ObjectPrototype` is true of every realm's %Object.prototype% and of nothing else.
+            case JsObject or ObjectPrototype:
                 {
                     var target = new SerializedPlainObject();
                     _memory[source] = target;
-                    _pending.Push(new PropertyFrame(plain, target.Properties, EnumerableOwnStringKeys(plain)));
+                    _pending.Push(new PropertyFrame(source, target.Properties, EnumerableOwnStringKeys(source)));
                     return SerializedValue.FromObject(target);
                 }
 
@@ -462,6 +509,30 @@ internal sealed class StructuredSerializer
         }
 
         return TypeConverter.ToString(messageDescriptor.Value);
+    }
+
+    /// <summary>
+    /// The same read <see cref="ReadOwnDataMessage"/> performs, for <c>cause</c>: an own <i>data</i> property
+    /// only, so an accessor is not invoked and an inherited <c>cause</c> is not one. See
+    /// <see cref="SerializedError"/> for why <c>cause</c> is carried at all and why it is read this way
+    /// rather than the way https://github.com/whatwg/html/pull/5749 proposes.
+    /// </summary>
+    /// <remarks>
+    /// Unlike <c>message</c>, the value is not coerced: it is whatever the source held, and it is
+    /// sub-serialized, so a <c>cause</c> that is itself an object is cloned and one that is uncloneable makes
+    /// the whole clone fail with a <c>DataCloneError</c>.
+    /// </remarks>
+    private static bool TryReadOwnDataCause(ErrorInstance source, out JsValue cause)
+    {
+        var descriptor = source.GetOwnProperty(CommonProperties.Cause);
+        if (descriptor == Runtime.Descriptors.PropertyDescriptor.Undefined || descriptor.IsAccessorDescriptor())
+        {
+            cause = JsValue.Undefined;
+            return false;
+        }
+
+        cause = descriptor.Value;
+        return true;
     }
 
     /// <summary>
@@ -706,11 +777,13 @@ internal sealed class StructuredSerializer
         // Steps 20, 22 and 23. Jint cannot enumerate an object's internal slots, so the refusal is decided
         // the other way round: everything the steps above recognize is serialized, and anything else is
         // refused. That is the conservative direction — it never produces a clone that has silently lost the
-        // state its source carried — but it is stricter than a browser for three shapes with no internal slot
-        // of their own that Jint nevertheless does not build as an ordinary object: a namespace object (Math,
-        // JSON, console), an intrinsic prototype (%Object.prototype%, which step 23 explicitly permits), and
-        // an arguments object. Cloning any of those is refused where a browser would answer with a plain
-        // object.
+        // state its source carried, and it is what keeps a host's own ObjectInstance subclass and every
+        // platform object Jint has yet to declare [Serializable] refused rather than silently flattened —
+        // but it is stricter than a browser for two shapes with no internal slot of their own that Jint
+        // nevertheless does not build as an ordinary object: a namespace object (Math, JSON, console) and an
+        // unmapped arguments object. Cloning either is refused where a browser would answer with a plain
+        // object. (%Object.prototype% used to be a third; the ordinary arm above now recognizes it, which is
+        // what step 23's carve-out asks for.)
         var description = value switch
         {
             JsProxy => "A Proxy",
@@ -812,6 +885,25 @@ internal sealed class StructuredSerializer
         {
             _properties.Add(new SerializedProperty(_currentKey, serialized));
         }
+    }
+
+    /// <summary>
+    /// One error's <c>cause</c>: a frame with exactly one source, so that the sub-serialization happens after
+    /// the error is in the memory map rather than during its own arm.
+    /// </summary>
+    private sealed class ErrorCauseFrame(JsValue cause, SerializedError target) : SerializeFrame
+    {
+        private bool _done;
+
+        internal override bool TryGetNextSource(out JsValue source)
+        {
+            source = _done ? JsValue.Undefined : cause;
+            var pending = !_done;
+            _done = true;
+            return pending;
+        }
+
+        internal override void Accept(SerializedValue serialized) => target.Cause = serialized;
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes items **4, 5 and 6** of #3212 — the three structured-clone defects, 30 of the corpus's failing tests. The other eight items are untouched and #3212 stays open.

---

### Item 4 — `Error.cause`, and a correction to the issue

`StructuredSerializer`'s step-17 arm read name/message/stack and stopped; `SerializedError` had no field for a cause and the arm was a leaf rather than a deep one.

**The issue's citation is wrong and I could not confirm it.** #3212 says "HTML's error-serialization steps read `cause`". They do not — the word *cause* does not occur in that section of `structured-data.html` at all. Step 17.6's licence covers data *"which are not yet specified"*, which the editor explicitly reads as **excluding** `cause` ([whatwg/html#11321](https://github.com/whatwg/html/issues/11321): *"Chromium and Firefox are actually not conformant to the current spec, which does not allow copying `cause`"*). The change that would specify it, [whatwg/html#5749](https://github.com/whatwg/html/pull/5749), has been open since 2020.

Implemented anyway — WPT asserts it, two of three engines do it, and the corpus rows are the acceptance criteria — but the true status is documented in three places rather than the false citation being repeated.

Only **half** of #5749 is taken: its `cause` handling, *not* its rewrite of `message` (`Get` + unconditional install), because the same battery asserts the published `message` semantics via `assert_equals(actual.hasOwnProperty("message"), input.hasOwnProperty("message"))` — adopting that half would have turned a passing row red. `cause` is read exactly as `message` is: an own **data** property. Serialization registers the error in the memory map *before* walking the cause (V8 does the same; #5749's literal ordering would infinite-loop on a self-cause), and the clone receives it through [`CreateNonEnumerableDataPropertyOrThrow`](https://tc39.es/ecma262/#sec-installerrorcause).

### Item 5 — `Blob` and `File`

File API §3/§4 declare both `[Serializable]`; the steps were simply absent. Implemented as written: `[[SnapshotState]]`, `[[ByteSequence]]`, `[[Name]]`, `[[LastModified]]`.

Two things the steps do not say, both checked against the raw spec HTML rather than assumed:

- **The Blob steps do not list `type`.** Every engine carries it and `compare_Blob` asserts it, so it is carried here and recorded as a prose gap rather than silently added.
- **The byte sequence is shared, not copied.** A `Blob` is immutable and `JsBlob` never hands its array out, so source, record and clone share one array — the *opposite* of `ArrayBuffer`, and the reason the record is exempt from the `sharedRecord` copy.

`SerializedFile : SerializedBlob`, matched first in both switches (the `QuotaExceededError`/`DOMException` pattern). Deserialization builds from the realm's **intrinsic**, which is what makes the "interface deleted from the global" and "subclass → plain `File`" rows fall out for free. The neighbouring step is implemented too — *"if the interface … is not exposed in targetRealm, throw a `DataCloneError`"* — keyed on `WebApiFeatures.Files`, which is reachable because a `MessagePort`, `BroadcastChannel` or `Worker` can carry a blob to an engine without that feature.

### Item 6 — the real predicate

Not a platform-object check misfiring. The ordinary-object arm was `case JsObject plain` — **a type test on Jint's ordinary-object storage class**, where HTML's test is about internal slots and exoticness. `Object.prototype` is an `ObjectPrototype` (source-generated, builtin-shape mode), so it never matched and fell through to the blanket refusal.

HTML **step 23** refuses "an exotic object [that] is not the `%Object.prototype%` intrinsic object associated with **any** realm" — `%Object.prototype%` *is* exotic (immutable prototype) and is carved out by name — and step 24's note says the clone "will be an empty object (not an immutable prototype exotic object)", which is exactly what the test checks with `Object.setPrototypeOf`.

Fix: `case JsObject or ObjectPrototype`. The type test **is** the spec predicate rather than an identity check standing in for it: `ObjectPrototype` is sealed and `Intrinsics` builds exactly one per realm, so it is true of every realm's `%Object.prototype%` and of nothing else. The refusal stays conservative in the direction it was designed to be — a host `ObjectInstance` subclass and every undeclared platform object stay refused rather than being silently flattened.

---

### Exclusion accounting

The driver's own staleness report, captured with the fix in place and the rows still present: **14 rows covering exactly 30 tests.** Cause 7/7; Blob/File `"Blob *"`→6, `"Array Blob object, *"`→7, `"Object Blob object, *"`→6, `"File basic"`→1, interface-deleted→1, subclass→1 = **22, confirming 22 rather than the issue's 23**; `Object.prototype` 1/1. All 14 deleted. `NeedsTriage` does **not** empty — 22 entries remain for the other #3212 items, streams and workers.

### Neighbouring obligations, all tested

Blob inside array / object / `Map` / `Set` / a cycle, each resolving to **one** clone through the memory map; a `Blob` and a `File` in the transfer list → `DataCloneError` (already correct — `[Serializable]` is not `[Transferable]`); a Blob whose source `ArrayBuffer` was since detached clones fine; byte-sequence sharing pinned via `MemoryMarshal`; one record deserialized by two `sharedRecord` receivers gives each its own Blob; cross-engine deserialize refused on a non-`Files` engine and accepted on a `Files` one. `SerializationRecordTests.HoldsNothingEngineAffineForARichGraph` is extended with a Blob, a File and a caused error so the new record shapes are covered by the engine-neutrality walk.

**One behaviour change worth flagging**: `port.postMessage(new Error('x', { cause: <uncloneable> }))` now throws `DataCloneError` where it previously succeeded. Spec-correct and matches browsers; the one internal path that could care (`CrossRealmTransform.CrossRealmTransformSendError`) already discards clone failures by design. No effect on #3228.

### Verification

Solution builds Release, 0 errors. `Jint.Tests` 10,239 (net10.0) / 7,147 (net472), identical with `JINT_HOST_CONTRACT_VERIFICATION=1`. `Jint.Tests.PublicInterface` 2,397 / 1,876, verifying 2,401 / 1,880. Whole WPT corpus **416/416**. test262 run despite not being required, to close the question: **102,495 passed, 0 failed.**

24 hand-written tests written first, all failing for the expected reason (`clone.cause` `Undefined`; `An object could not be cloned`); `StructuredCloneTests` is now 118/118.

| corpus | assertions | not passing before | after |
| --- | --- | --- | --- |
| `html/webappapis/` | 153 | **33** | **3** (all environment) |
| `FileAPI/` | 342 | 3 | **0** |

All three serializer files are whole-file `#if NET8_0_OR_GREATER`; **no non-web-API engine code is touched.**

### One correction beyond scope, flagged rather than hidden

`Vendor/README.md`'s corpus table was **already stale on `main`**: it said File API 11 where its own section and the exclusion table said 3, and #3236 then took it to 0 without updating the table. Both rows are corrected (HTML 33→3, File API 11→0) along with the column total. Leaving a knowably false figure beside one being fixed seemed worse than the small scope creep — happy to revert that row if you would rather it went back.

### Left undone

`structuredClone(Math)` / `JSON` / `console` and an unmapped `arguments` object still raise `DataCloneError` where a browser answers `{}`. No corpus row covers them, and widening the arm further needs its own tests and its own argument about the conservative-refusal design; recorded in the code comment and the README instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
