### PR TITLE
Event and PerformanceMark: the user-timing and DOM defects the corpus found

### DIFF
--- a/Jint.Tests/Runtime/WebApi/EventTests.cs
+++ b/Jint.Tests/Runtime/WebApi/EventTests.cs
@@ -160,10 +160,11 @@ public class EventTests
     {
         var engine = WebEngine();
 
-        // WebIDL attributes live on the interface prototype object, so the instance owns none of them.
-        engine.Evaluate("Object.getOwnPropertyNames(new Event('x')).length").AsNumber().Should().Be(0);
+        // A WebIDL attribute lives on the interface prototype object unless it is unforgeable, so the one own
+        // property an instance carries is `isTrusted`.
+        engine.Evaluate("Object.getOwnPropertyNames(new Event('x')).join(',')").AsString().Should().Be("isTrusted");
 
-        foreach (var name in new[] { "type", "target", "currentTarget", "eventPhase", "bubbles", "cancelable", "defaultPrevented", "composed", "isTrusted", "timeStamp" })
+        foreach (var name in new[] { "type", "target", "currentTarget", "eventPhase", "bubbles", "cancelable", "defaultPrevented", "composed", "timeStamp" })
         {
             var descriptor = $"Object.getOwnPropertyDescriptor(Event.prototype, '{name}')";
             engine.Evaluate($"typeof {descriptor}.get").AsString().Should().Be("function");
@@ -171,6 +172,117 @@ public class EventTests
             engine.Evaluate($"{descriptor}.enumerable").AsBoolean().Should().BeTrue();
             engine.Evaluate($"{descriptor}.configurable").AsBoolean().Should().BeTrue();
         }
+    }
+
+    /// <summary>
+    /// <c>[LegacyUnforgeable] readonly attribute boolean isTrusted</c>
+    /// (https://dom.spec.whatwg.org/#dom-event-istrusted). WebIDL
+    /// (https://webidl.spec.whatwg.org/#LegacyUnforgeable) makes such a member "non-configurable and …
+    /// exist as an own property on the object itself rather than on its prototype", and
+    /// https://webidl.spec.whatwg.org/#es-attributes gives it
+    /// <c>{ [[Enumerable]]: true, [[Configurable]]: false }</c>.
+    /// </summary>
+    [Fact]
+    public void IsTrustedIsAnUnforgeableOwnAccessorOfEveryInstance()
+    {
+        var engine = WebEngine();
+
+        engine.Evaluate("Event.prototype.hasOwnProperty('isTrusted')").AsBoolean().Should().BeFalse();
+        engine.Evaluate("new Event('x').hasOwnProperty('isTrusted')").AsBoolean().Should().BeTrue();
+
+        engine.Execute("var d = Object.getOwnPropertyDescriptor(new Event('x'), 'isTrusted');");
+        engine.Evaluate("typeof d.get").AsString().Should().Be("function");
+        engine.Evaluate("d.set").IsUndefined().Should().BeTrue();
+        engine.Evaluate("d.enumerable").AsBoolean().Should().BeTrue();
+        engine.Evaluate("d.configurable").AsBoolean().Should().BeFalse();
+        engine.Evaluate("d.get.name").AsString().Should().Be("get isTrusted");
+        engine.Evaluate("d.get.length").AsNumber().Should().Be(0);
+
+        // One getter for the whole interface, not one per instance — which is what
+        // dom/events/Event-isTrusted.any.js asserts.
+        engine.Evaluate("""
+            Object.getOwnPropertyDescriptor(new Event('a'), 'isTrusted').get ===
+            Object.getOwnPropertyDescriptor(new Event('b'), 'isTrusted').get
+            """).AsBoolean().Should().BeTrue();
+
+        // Unforgeable: it cannot be redefined, shadowed or deleted.
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("Object.defineProperty(new Event('x'), 'isTrusted', { value: true })"));
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("Object.defineProperty(new Event('x'), 'isTrusted', { get: function () { return true; } })"));
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("Object.defineProperty(new Event('x'), 'isTrusted', { enumerable: false })"));
+        engine.Evaluate("delete new Event('x').isTrusted").AsBoolean().Should().BeFalse();
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("'use strict'; delete new Event('x').isTrusted"));
+
+        // A read-only accessor: an assignment is a no-op in sloppy mode and a TypeError in strict mode.
+        engine.Execute("var e = new Event('x'); e.isTrusted = true;");
+        engine.Evaluate("e.isTrusted").AsBoolean().Should().BeFalse();
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("'use strict'; new Event('x').isTrusted = true;"));
+
+        // The own property is enumerable, so it shows up in every script-visible enumeration.
+        engine.Evaluate("Object.keys(new Event('x')).join(',')").AsString().Should().Be("isTrusted");
+        engine.Evaluate("JSON.stringify(new Event('x'))").AsString().Should().Be("""{"isTrusted":false}""");
+        engine.Evaluate("Object.keys({ ...new Event('x') }).join(',')").AsString().Should().Be("isTrusted");
+        engine.Evaluate("'isTrusted' in new Event('x')").AsBoolean().Should().BeTrue();
+        engine.Evaluate("new Event('x').propertyIsEnumerable('isTrusted')").AsBoolean().Should().BeTrue();
+
+        // …on every event, whichever interface it came from, and however it was created.
+        engine.Evaluate("new CustomEvent('x').hasOwnProperty('isTrusted')").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.keys(new CustomEvent('x')).join(',')").AsString().Should().Be("isTrusted");
+        engine.Evaluate("""
+            class MyEvent extends Event {}
+            Object.getOwnPropertyDescriptor(new MyEvent('x'), 'isTrusted').get ===
+            Object.getOwnPropertyDescriptor(new Event('x'), 'isTrusted').get
+            """).AsBoolean().Should().BeTrue();
+
+        // The getter still brand-checks its receiver.
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("d.get.call({})"));
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("d.get.call(Event.prototype)"));
+    }
+
+    /// <summary>
+    /// An event's own <c>isTrusted</c> is the earliest of its own string keys, so a subclass field declared
+    /// in a JavaScript constructor comes after it — the ordering the interface's own creation implies.
+    /// </summary>
+    [Fact]
+    public void TheUnforgeableOwnPropertyComesBeforeAnythingScriptAdds()
+    {
+        var engine = WebEngine();
+
+        engine.Execute("""
+            class MyEvent extends Event {
+                constructor(type) { super(type); this.extra = 1; }
+            }
+            var e = new MyEvent('x');
+            """);
+
+        engine.Evaluate("Object.getOwnPropertyNames(e).join(',')").AsString().Should().Be("isTrusted,extra");
+        engine.Evaluate("Object.keys(e).join(',')").AsString().Should().Be("isTrusted,extra");
+        engine.Evaluate("JSON.stringify(e)").AsString().Should().Be("""{"isTrusted":false,"extra":1}""");
+
+        // The added property is ordinary; the unforgeable one still refuses to move.
+        engine.Evaluate("delete e.extra").AsBoolean().Should().BeTrue();
+        engine.Evaluate("delete e.isTrusted").AsBoolean().Should().BeFalse();
+        engine.Evaluate("Object.getOwnPropertyNames(e).join(',')").AsString().Should().Be("isTrusted");
+    }
+
+    /// <summary>
+    /// The engine's own events are trusted, which is the whole point of the attribute —
+    /// https://dom.spec.whatwg.org/#concept-event-fire.
+    /// </summary>
+    [Fact]
+    public void AnEngineFiredEventIsTrusted()
+    {
+        var engine = WebEngine();
+
+        engine.Execute("""
+            var controller = new AbortController();
+            var seen = null;
+            controller.signal.addEventListener('abort', function (e) { seen = e; });
+            controller.abort();
+            """);
+
+        engine.Evaluate("seen.isTrusted").AsBoolean().Should().BeTrue();
+        engine.Evaluate("seen.hasOwnProperty('isTrusted')").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.getOwnPropertyDescriptor(seen, 'isTrusted').configurable").AsBoolean().Should().BeFalse();
     }
 
     [Fact]

--- a/Jint.Tests/Runtime/WebApi/EventTests.cs
+++ b/Jint.Tests/Runtime/WebApi/EventTests.cs
@@ -388,6 +388,149 @@ public class EventTests
         engine.Evaluate("run({ passive: 1 })").AsString().Should().Be("false/true");
     }
 
+    /// <summary>
+    /// <c>initEvent(type, bubbles, cancelable)</c> — "If this's dispatch flag is set, then return. Initialize
+    /// this with type, bubbles, and cancelable" (https://dom.spec.whatwg.org/#dom-event-initevent), where
+    /// <i>initialize an event</i> (https://dom.spec.whatwg.org/#concept-event-initialize) also unsets the
+    /// three propagation/cancel flags, clears <c>isTrusted</c> and clears <c>target</c>.
+    /// </summary>
+    [Fact]
+    public void InitEventReinitializesTheEvent()
+    {
+        var engine = WebEngine();
+
+        engine.Evaluate("Event.prototype.initEvent.length").AsNumber().Should().Be(1);
+        engine.Evaluate("typeof new Event('x').initEvent").AsString().Should().Be("function");
+
+        // The two optional arguments default to false.
+        engine.Execute("var e = new Event('a', { bubbles: true, cancelable: true }); e.initEvent('b');");
+        engine.Evaluate("e.type").AsString().Should().Be("b");
+        engine.Evaluate("e.bubbles").AsBoolean().Should().BeFalse();
+        engine.Evaluate("e.cancelable").AsBoolean().Should().BeFalse();
+
+        engine.Execute("var f = new Event('a'); f.initEvent('b', true, true);");
+        engine.Evaluate("f.bubbles").AsBoolean().Should().BeTrue();
+        engine.Evaluate("f.cancelable").AsBoolean().Should().BeTrue();
+
+        // The arguments are a DOMString and two booleans, so everything is coerced rather than refused.
+        engine.Execute("var g = new Event('a'); g.initEvent(7, 1, '');");
+        engine.Evaluate("g.type").AsString().Should().Be("7");
+        engine.Evaluate("g.bubbles").AsBoolean().Should().BeTrue();
+        engine.Evaluate("g.cancelable").AsBoolean().Should().BeFalse();
+
+        // "Unset event's stop propagation flag, stop immediate propagation flag, and canceled flag."
+        engine.Execute("""
+            var h = new Event('a', { cancelable: true });
+            h.preventDefault();
+            h.stopPropagation();
+            h.initEvent('b', false, true);
+            """);
+        engine.Evaluate("h.defaultPrevented").AsBoolean().Should().BeFalse();
+        engine.Evaluate("h.returnValue").AsBoolean().Should().BeTrue();
+
+        // The stop-propagation flag really is gone: a re-dispatched event still reaches its listener.
+        engine.Execute("""
+            var target = new EventTarget();
+            var hits = 0;
+            target.addEventListener('b', function () { hits++; });
+            target.dispatchEvent(h);
+            """);
+        engine.Evaluate("hits").AsNumber().Should().Be(1);
+
+        // It is not `composed` that initialize touches — the composed flag survives, which is exactly the
+        // limitation the specification notes ("incapable of setting composed").
+        engine.Execute("var i = new Event('a', { composed: true }); i.initEvent('b');");
+        engine.Evaluate("i.composed").AsBoolean().Should().BeTrue();
+
+        engine.Evaluate("new Event('a').initEvent('b')").IsUndefined().Should().BeTrue();
+    }
+
+    /// <summary>
+    /// "Initialize event's target to null" and "Set event's isTrusted attribute to false" — the two steps of
+    /// <i>initialize an event</i> that are not about the type or the flags.
+    /// </summary>
+    [Fact]
+    public void InitEventClearsTargetAndTrust()
+    {
+        var engine = WebEngine();
+
+        engine.Execute("""
+            var target = new EventTarget();
+            var e = new Event('a');
+            target.dispatchEvent(e);
+            """);
+        engine.Evaluate("e.target === target").AsBoolean().Should().BeTrue();
+
+        engine.Execute("e.initEvent('b');");
+        engine.Evaluate("e.target").IsNull().Should().BeTrue();
+        engine.Evaluate("e.srcElement").IsNull().Should().BeTrue();
+
+        // A trusted event that a script re-initializes is no longer trusted.
+        engine.Execute("""
+            var controller = new AbortController();
+            var trusted = null;
+            controller.signal.addEventListener('abort', function (ev) { trusted = ev; });
+            controller.abort();
+            """);
+        engine.Evaluate("trusted.isTrusted").AsBoolean().Should().BeTrue();
+        engine.Execute("trusted.initEvent('x');");
+        engine.Evaluate("trusted.isTrusted").AsBoolean().Should().BeFalse();
+    }
+
+    /// <summary>
+    /// Step 1 of both init methods: "If this's dispatch flag is set, then return." An event being dispatched
+    /// cannot be re-initialized out from under the dispatch.
+    /// </summary>
+    [Fact]
+    public void InitEventIsIgnoredDuringADispatch()
+    {
+        var engine = WebEngine();
+
+        engine.Execute("""
+            var target = new EventTarget();
+            var seen = [];
+            target.addEventListener('a', function (ev) {
+                ev.initEvent('b', true, true);
+                seen.push(ev.type, ev.bubbles, ev.cancelable);
+            });
+            var e = new Event('a');
+            target.dispatchEvent(e);
+            """);
+
+        engine.Evaluate("seen.join(',')").AsString().Should().Be("a,false,false");
+        engine.Evaluate("e.type").AsString().Should().Be("a");
+    }
+
+    /// <summary>
+    /// <c>initCustomEvent(type, bubbles, cancelable, detail)</c> — the same two steps plus "Set this's detail
+    /// attribute to detail" (https://dom.spec.whatwg.org/#dom-customevent-initcustomevent).
+    /// </summary>
+    [Fact]
+    public void InitCustomEventAlsoSetsTheDetail()
+    {
+        var engine = WebEngine();
+
+        engine.Evaluate("CustomEvent.prototype.initCustomEvent.length").AsNumber().Should().Be(1);
+        engine.Evaluate("'initCustomEvent' in Event.prototype").AsBoolean().Should().BeFalse();
+
+        engine.Execute("var e = new CustomEvent('a', { detail: 1 }); e.initCustomEvent('b', true, true, 42);");
+        engine.Evaluate("e.type").AsString().Should().Be("b");
+        engine.Evaluate("e.bubbles").AsBoolean().Should().BeTrue();
+        engine.Evaluate("e.cancelable").AsBoolean().Should().BeTrue();
+        engine.Evaluate("e.detail").AsNumber().Should().Be(42);
+
+        // The IDL default for detail is null, so an omitted argument clears it rather than leaving it.
+        engine.Execute("var f = new CustomEvent('a', { detail: 1 }); f.initCustomEvent('b');");
+        engine.Evaluate("f.detail").IsNull().Should().BeTrue();
+
+        // A CustomEvent still inherits initEvent, which leaves detail alone.
+        engine.Execute("var g = new CustomEvent('a', { detail: 3 }); g.initEvent('b');");
+        engine.Evaluate("g.detail").AsNumber().Should().Be(3);
+
+        // It brand-checks the receiver like every other CustomEvent member.
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("CustomEvent.prototype.initCustomEvent.call(new Event('x'), 'y')"));
+    }
+
     [Fact]
     public void RefusesAReceiverThatIsNotAnEvent()
     {

--- a/Jint.Tests/Runtime/WebApi/EventTests.cs
+++ b/Jint.Tests/Runtime/WebApi/EventTests.cs
@@ -164,7 +164,7 @@ public class EventTests
         // property an instance carries is `isTrusted`.
         engine.Evaluate("Object.getOwnPropertyNames(new Event('x')).join(',')").AsString().Should().Be("isTrusted");
 
-        foreach (var name in new[] { "type", "target", "currentTarget", "eventPhase", "bubbles", "cancelable", "defaultPrevented", "composed", "timeStamp" })
+        foreach (var name in new[] { "type", "target", "srcElement", "currentTarget", "eventPhase", "bubbles", "cancelable", "defaultPrevented", "composed", "timeStamp" })
         {
             var descriptor = $"Object.getOwnPropertyDescriptor(Event.prototype, '{name}')";
             engine.Evaluate($"typeof {descriptor}.get").AsString().Should().Be("function");
@@ -172,6 +172,13 @@ public class EventTests
             engine.Evaluate($"{descriptor}.enumerable").AsBoolean().Should().BeTrue();
             engine.Evaluate($"{descriptor}.configurable").AsBoolean().Should().BeTrue();
         }
+
+        // `returnValue` is the one writable attribute of the interface, so it is an accessor pair.
+        var returnValue = "Object.getOwnPropertyDescriptor(Event.prototype, 'returnValue')";
+        engine.Evaluate($"typeof {returnValue}.get").AsString().Should().Be("function");
+        engine.Evaluate($"typeof {returnValue}.set").AsString().Should().Be("function");
+        engine.Evaluate($"{returnValue}.enumerable").AsBoolean().Should().BeTrue();
+        engine.Evaluate($"{returnValue}.configurable").AsBoolean().Should().BeTrue();
     }
 
     /// <summary>
@@ -283,6 +290,102 @@ public class EventTests
         engine.Evaluate("seen.isTrusted").AsBoolean().Should().BeTrue();
         engine.Evaluate("seen.hasOwnProperty('isTrusted')").AsBoolean().Should().BeTrue();
         engine.Evaluate("Object.getOwnPropertyDescriptor(seen, 'isTrusted').configurable").AsBoolean().Should().BeFalse();
+    }
+
+    /// <summary>
+    /// <c>readonly attribute EventTarget? srcElement</c>, whose "getter steps are to return this's target" —
+    /// https://dom.spec.whatwg.org/#dom-event-srcelement.
+    /// </summary>
+    [Fact]
+    public void SrcElementIsAnAliasOfTarget()
+    {
+        var engine = WebEngine();
+
+        engine.Evaluate("new Event('x').srcElement").IsNull().Should().BeTrue();
+
+        engine.Execute("""
+            var target = new EventTarget();
+            var during = null;
+            var after = null;
+            target.addEventListener('x', function (e) { during = e.srcElement; });
+            var e = new Event('x');
+            target.dispatchEvent(e);
+            after = e.srcElement;
+            """);
+
+        engine.Evaluate("during === target").AsBoolean().Should().BeTrue();
+
+        // "target" is not unset when the dispatch ends, and srcElement follows it wherever it goes.
+        engine.Evaluate("after === e.target").AsBoolean().Should().BeTrue();
+    }
+
+    /// <summary>
+    /// <c>attribute boolean returnValue</c> — "The returnValue getter steps are to return false if this's
+    /// canceled flag is set; otherwise true. The returnValue setter steps are to set the canceled flag with
+    /// this if the given value is false; otherwise do nothing" —
+    /// https://dom.spec.whatwg.org/#dom-event-returnvalue.
+    /// </summary>
+    [Fact]
+    public void ReturnValueIsTheCanceledFlagInverted()
+    {
+        var engine = WebEngine();
+
+        engine.Evaluate("new Event('x').returnValue").AsBoolean().Should().BeTrue();
+
+        // The setter runs "set the canceled flag", which a non-cancelable event ignores — exactly as
+        // preventDefault() does.
+        engine.Execute("var plain = new Event('x'); plain.returnValue = false;");
+        engine.Evaluate("plain.returnValue").AsBoolean().Should().BeTrue();
+        engine.Evaluate("plain.defaultPrevented").AsBoolean().Should().BeFalse();
+
+        engine.Execute("var cancelable = new Event('x', { cancelable: true }); cancelable.returnValue = false;");
+        engine.Evaluate("cancelable.returnValue").AsBoolean().Should().BeFalse();
+        engine.Evaluate("cancelable.defaultPrevented").AsBoolean().Should().BeTrue();
+
+        // "otherwise do nothing" — assigning true never clears a flag that is already set.
+        engine.Execute("cancelable.returnValue = true;");
+        engine.Evaluate("cancelable.returnValue").AsBoolean().Should().BeFalse();
+
+        // The IDL type is `boolean`, so the assigned value goes through ToBoolean rather than being rejected.
+        engine.Execute("var zero = new Event('x', { cancelable: true }); zero.returnValue = 0;");
+        engine.Evaluate("zero.defaultPrevented").AsBoolean().Should().BeTrue();
+        engine.Execute("var one = new Event('x', { cancelable: true }); one.returnValue = 1;");
+        engine.Evaluate("one.defaultPrevented").AsBoolean().Should().BeFalse();
+
+        // preventDefault() and the setter are the same algorithm seen from two sides.
+        engine.Execute("var prevented = new Event('x', { cancelable: true }); prevented.preventDefault();");
+        engine.Evaluate("prevented.returnValue").AsBoolean().Should().BeFalse();
+    }
+
+    /// <summary>
+    /// "Set the canceled flag" is gated on the in-passive-listener flag as well as on <c>cancelable</c>
+    /// (https://dom.spec.whatwg.org/#set-the-canceled-flag), so a passive listener's <c>returnValue = false</c>
+    /// is ignored just as its <c>preventDefault()</c> is — which is what
+    /// <c>dom/events/AddEventListenerOptions-passive.any.js</c> asserts.
+    /// </summary>
+    [Fact]
+    public void ReturnValueIsIgnoredInsideAPassiveListener()
+    {
+        var engine = WebEngine();
+
+        engine.Execute("""
+            function run(options) {
+                var target = new EventTarget();
+                var prevented;
+                var handler = function (e) { e.returnValue = false; prevented = e.defaultPrevented; };
+                target.addEventListener('x', handler, options);
+                var uncanceled = target.dispatchEvent(new Event('x', { bubbles: true, cancelable: true }));
+                target.removeEventListener('x', handler, options);
+                return prevented + '/' + uncanceled;
+            }
+            """);
+
+        engine.Evaluate("run(undefined)").AsString().Should().Be("true/false");
+        engine.Evaluate("run({})").AsString().Should().Be("true/false");
+        engine.Evaluate("run({ passive: false })").AsString().Should().Be("true/false");
+        engine.Evaluate("run({ passive: true })").AsString().Should().Be("false/true");
+        engine.Evaluate("run({ passive: 0 })").AsString().Should().Be("true/false");
+        engine.Evaluate("run({ passive: 1 })").AsString().Should().Be("false/true");
     }
 
     [Fact]

--- a/Jint.Tests/Runtime/WebApi/PerformanceTimelineTests.cs
+++ b/Jint.Tests/Runtime/WebApi/PerformanceTimelineTests.cs
@@ -87,6 +87,41 @@ public class PerformanceTimelineTests
             .Message.Should().Contain("finite");
     }
 
+    /// <summary>
+    /// https://webidl.spec.whatwg.org/#es-dictionary step 1 — "If <i>jsDict</i> is not an Object and
+    /// <i>jsDict</i> is neither <c>undefined</c> nor <c>null</c>, then throw a <c>TypeError</c>" — for
+    /// <c>PerformanceMarkOptions</c>, which both <c>performance.mark()</c> and the <c>PerformanceMark</c>
+    /// constructor take in their second argument.
+    /// </summary>
+    [Fact]
+    public void MarkOptionsThatIsNeitherNullishNorAnObjectIsATypeError()
+    {
+        var engine = Timeline();
+
+        foreach (var value in new[] { "123", "NaN", "Infinity", "'string'", "true", "10n", "Symbol()" })
+        {
+            Assert.Throws<JavaScriptException>(() => engine.Evaluate($"performance.mark('m', {value})"))
+                .Message.Should().Contain("PerformanceMarkOptions");
+            Assert.Throws<JavaScriptException>(() => engine.Evaluate($"new PerformanceMark('m', {value})"))
+                .Message.Should().Contain("PerformanceMarkOptions");
+        }
+
+        // undefined and null are the empty dictionary rather than an error, so `detail` takes its IDL default.
+        engine.Evaluate("performance.mark('m', undefined).detail").IsNull().Should().BeTrue();
+        engine.Evaluate("performance.mark('m', null).detail").IsNull().Should().BeTrue();
+        engine.Evaluate("new PerformanceMark('m', undefined).detail").IsNull().Should().BeTrue();
+        engine.Evaluate("new PerformanceMark('m', null).detail").IsNull().Should().BeTrue();
+
+        // A boxed Number is an Object, so it is a dictionary whose members are simply absent.
+        engine.Evaluate("new PerformanceMark('m', new Number(5)).detail").IsNull().Should().BeTrue();
+
+        // The refusal is the conversion's, so it happens for both halves at the same point: after the mark
+        // name has been stringified and before any of the algorithm's own steps.
+        engine.Execute("var stringified = 0; var name = { toString() { stringified++; return 'm'; } };");
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new PerformanceMark(name, 1)"));
+        engine.Evaluate("stringified").AsNumber().Should().Be(1);
+    }
+
     [Fact]
     public void MarkStructuredClonesItsDetail()
     {

--- a/Jint.Tests/Runtime/WebApi/WebSocketEventTests.cs
+++ b/Jint.Tests/Runtime/WebApi/WebSocketEventTests.cs
@@ -105,7 +105,9 @@ public class WebSocketEventTests
         Assert.Throws<JavaScriptException>(() => engine.Evaluate("MessageEvent.prototype.data"))
             .Error.Get("name").AsString().Should().Be("TypeError");
 
-        engine.Evaluate("Object.getOwnPropertyNames(new CloseEvent('x')).length").AsNumber().Should().Be(0);
+        // …so the only own property either instance carries is the one WebIDL puts there: `Event`'s
+        // `[LegacyUnforgeable]` isTrusted — https://dom.spec.whatwg.org/#dom-event-istrusted.
+        engine.Evaluate("Object.getOwnPropertyNames(new CloseEvent('x')).join(',')").AsString().Should().Be("isTrusted");
     }
 
     /// <summary>

--- a/Jint.Tests/Wpt/Vendor/README.md
+++ b/Jint.Tests/Wpt/Vendor/README.md
@@ -518,20 +518,37 @@ vendored resource and against every shape it declines.
 
 ## What the DOM events and abort corpora say about this engine
 
-62 assertions across twelve files, of which **two do not pass**, and both are `Event`'s legacy members:
+62 assertions across twelve files, of which **one does not pass**. Both of the two that used to fail were
+`Event`'s legacy members, and one is fixed:
 
-1. **`Event.isTrusted` is on the prototype, where WebIDL makes it an own property.**
+1. **`Event.isTrusted` was on the prototype, where WebIDL makes it an own property — fixed.**
    `dom/events/Event-isTrusted.any.js` takes `Object.getOwnPropertyDescriptor(new Event("x"), "isTrusted")`
    from two separate events and requires both to be an accessor and to be the *same* getter.
    [The DOM Standard](https://dom.spec.whatwg.org/#dom-event-istrusted) declares it
-   `[LegacyUnforgeable]`, which [WebIDL](https://webidl.spec.whatwg.org/#LegacyUnforgeable) defines as an own,
-   non-configurable accessor installed on every instance rather than on the interface prototype object.
-   `EventPrototype` declares it beside `type` and `bubbles` as an ordinary configurable prototype accessor.
+   `[LegacyUnforgeable]`, which [WebIDL](https://webidl.spec.whatwg.org/#LegacyUnforgeable) defines as
+   "non-configurable and … exist[ing] as an own property on the object itself rather than on its prototype",
+   with the attributes [§3.7.6](https://webidl.spec.whatwg.org/#es-attributes) gives it —
+   `{ [[Set]]: undefined, [[Enumerable]]: true, [[Configurable]]: false }` — and which the same section
+   *removes* from the interface prototype object's attribute set. `EventPrototype` declared it beside `type`
+   and `bubbles` as an ordinary configurable prototype accessor.
+
+   It is an own property of every event now, and it is **free**. `JsEvent.GetOwnProperty` answers it from the
+   realm's one shared descriptor and `GetInitialOwnStringPropertyKeys` lists the name ahead of anything script
+   adds — the shape `Function` uses for `length`/`name`/`prototype` and `JsError` for `message`. Measured on
+   `net10.0` with `GC.GetAllocatedBytesForCurrentThread`, over 20,000 iterations, before and after the change:
+   `new Event('x')` is **112 bytes** either way, and `new Event('x').isTrusted` is **112 bytes** either way.
+   That is worth stating precisely because the obvious implementation is not free: giving an event one stored
+   own property costs a `PropertyDictionary`, a list node and a descriptor, which the same probe measures at
+   **+184 bytes**, more than doubling an event — and the engine creates one per `dispatchEvent` and more
+   throughout the abort, message, worker and fetch paths. Two things did change for every event, both of them
+   the point: `Object.keys(new Event('x'))` is `["isTrusted"]` and `JSON.stringify(new Event('x'))` is
+   `{"isTrusted":false}`, which is what a browser answers.
 2. **`Event` has no `srcElement` and no `returnValue`.** Both are in the DOM Standard's own interface —
-   [`srcElement`](https://dom.spec.whatwg.org/#dom-event-srcelement) as a `[LegacyUnforgeable]` alias of
-   `target`, [`returnValue`](https://dom.spec.whatwg.org/#dom-event-returnvalue) as a writable alias of
-   "not `defaultPrevented`" whose setter runs *set the canceled flag* — so they are missing members rather than
-   a legacy extension nobody requires. The test that finds `returnValue` is
+   [`srcElement`](https://dom.spec.whatwg.org/#dom-event-srcelement), a plain `readonly attribute` whose
+   "getter steps are to return this's target", and
+   [`returnValue`](https://dom.spec.whatwg.org/#dom-event-returnvalue), whose getter is "false if this's
+   canceled flag is set; otherwise true" and whose setter runs *set the canceled flag* — so they are missing
+   members rather than a legacy extension nobody requires. The test that finds `returnValue` is
    `AddEventListenerOptions-passive.any.js`'s "returnValue should be ignored if-and-only-if the passive option
    is true", which is also the only one of that file's five rows to fail;
    `dom/events/Event-constructors.any.js` finds both, but registers every test without a name, which is what

--- a/Jint.Tests/Wpt/Vendor/README.md
+++ b/Jint.Tests/Wpt/Vendor/README.md
@@ -454,7 +454,7 @@ is what it costs, and it is a cost paid by real third-party worker code and not 
 
 ## What the hr-time and user-timing corpora say about this engine
 
-85 assertions, of which **10 do not pass**, and the split is almost exactly the one
+85 assertions, of which **6 do not pass**, and the split is almost exactly the one
 `PerformanceInstance` predicts in its own documentation.
 
 Five are `NeedsPerformanceObserver` and one is `NeedsPerformanceEventTarget`: the class lists
@@ -466,14 +466,19 @@ depend on an observer at all, and one more (`supported-usertiming-types.any.js`,
 scope. The other fifteen read the timeline through `getEntries()` and pass, including the whole of
 `mark.any.js`, `measure-l3.any.js` and `measure_syntax_err.any.js`.
 
-**The remaining four are one genuine defect**, and a narrow one. `mark-errors.any.js` runs each of its five
-cases twice — once through `performance.mark(name, x)` and once through `new PerformanceMark(name, x)` — and
-only the constructor accepts a non-object where
-[WebIDL's dictionary conversion](https://webidl.spec.whatwg.org/#es-dictionary) refuses one: a `Number`, a
-`NaN`, an `Infinity` or a `String` in the options position should be a `TypeError`, and
-`performance.mark` makes it one. The constructor's own `{startTime: -1}` row passes, so what is missing is
-exactly the "not an object and not `null`/`undefined` is a `TypeError`" step in
-`PerformanceMarkConstructor`, not the option handling behind it.
+**The four that used to sit beside them were one genuine defect, and it is fixed.**
+`mark-errors.any.js` runs each of its five cases twice — once through `performance.mark(name, x)` and once
+through `new PerformanceMark(name, x)` — and the constructor's half of four of them failed. The reading that
+`performance.mark` "refused correctly" was the trap: the file calls it **unbound**, as
+`testInfo.testFunction(self.performance.mark)`, so its `TypeError` came from the brand check on a `this` of
+`undefined` and not from any conversion at all. `performance.mark('m', 123)` called properly returned a mark.
+Both halves share one conversion — `UserTiming.ReadMarkOptions`, reached through
+`PerformanceMarkConstructor.ReadArguments`, which `performance.mark` runs as its own step 1 — and it treated
+every non-object as the empty dictionary where step 1 of
+[WebIDL's dictionary conversion](https://webidl.spec.whatwg.org/#es-dictionary) says "if *jsDict* is not an
+Object and *jsDict* is neither undefined nor null, then throw a TypeError". Fixing the shared conversion fixed
+both halves at once, and `Jint.Tests/Runtime/WebApi/PerformanceTimelineTests.cs` pins the bound call the corpus
+cannot make.
 
 ## What the timers and microtask corpora say about this engine
 

--- a/Jint.Tests/Wpt/Vendor/README.md
+++ b/Jint.Tests/Wpt/Vendor/README.md
@@ -132,7 +132,6 @@ without revisiting the reason fails rather than quietly adding a red suite.
 | `user-timing/supported-usertiming-types.any.js` | Reads `PerformanceObserver.supportedEntryTypes` at *file scope* to decide which promise tests to register, so on an engine with no `PerformanceObserver` it throws before the first test exists. The rows that reach for an observer from inside a test body are excluded one by one instead, under `NeedsPerformanceObserver`. |
 | `html/webappapis/timers/evil-spec-example.any.js` | `setTimeout`'s string handler, which `TimerFunctions` documents declining: compiling the string is `eval` by another name and reachable even where a host disabled string compilation, so it is a `TypeError` here as it is in Node. The file's whole subject is that form, and it uses it at file scope. |
 | `html/webappapis/microtask-queuing/queue-microtask-exceptions.any.js` | A defect, and one that cannot be an exclusion — see [What the timers and microtask corpora say](#what-the-timers-and-microtask-corpora-say-about-this-engine). |
-| `dom/events/Event-constructors.any.js` | Registers fourteen of its fifteen tests **without a name**, so every one of them is reported under the same name and no per-test exclusion can single out the two that fail. Those two assert the whole initial state of a new event, and what they now fail on is `assert_true("initEvent" in ev)` — [`initEvent()`](https://dom.spec.whatwg.org/#dom-event-initevent), the one legacy member of the interface still absent. The `srcElement` and `returnValue` they also assert are implemented; see below. |
 | `dom/events/*.window.js`, `dom/events/*.html`, `dom/abort/*.html` | For a browsing context, like every non-`.any.js` file. |
 | `fetch/api/request/*` | Every file builds its `Request` from a **relative** url — `""`, `"./"`, `"../resources/…"` — and `RequestConstructor` documents why that cannot work: the specification resolves such a string against "the entry settings object's API base URL", which is a document's url, and an embedded engine has no document. Most of them do it at file scope, so there is not even a test to exclude. A host that wants a relative url resolves it itself with `new URL(relative, base).href`. |
 | `fetch/api/abort/*`, `fetch/api/basic/*`, `fetch/api/body/*`, `fetch/api/cors/*`, `fetch/api/credentials/*`, `fetch/api/policies/*`, `fetch/api/redirect/*` | A client talking to wptserve: `.py` handlers that echo headers, trickle bytes, redirect, stall, or check CORS preflights. There is no server here and the shim's `fetch` is a reader over the vendored tree. |
@@ -166,7 +165,8 @@ sample, without which its `performance.now()`-against-`Date.now()` correlation w
 event) and `html/webappapis/timers/clearinterval-from-callback.any.js` **1.3 s** (a 500 ms interval, then a
 750 ms timer proving it was cleared). Measured file by file at the pin, the 74 files those two groups added
 come to **7.6 s** of the driver's run; the two encoding files are the largest single contribution at 0.9 s for
-7,504 assertions.
+7,504 assertions. `dom/events/Event-constructors.any.js`, added afterwards, is fourteen synchronous
+constructor assertions and does not register.
 
 Everything else upstream that is not a `.any.js` file is out of scope by construction: `.window.js`, `.html`,
 `.worker.js` and `.xhtml` tests are for a browsing context or a worker — which is what excludes
@@ -518,8 +518,10 @@ vendored resource and against every shape it declines.
 
 ## What the DOM events and abort corpora say about this engine
 
-62 assertions across twelve files, and **every one of them passes**. The two that used to fail were both
-`Event`'s legacy members, and both are fixed:
+76 assertions across thirteen files, and **every one of them passes**. Four of them did not, and all four
+were `Event`'s legacy members: two named tests, below, and the two unnamed ones that kept
+`Event-constructors.any.js` out of the corpus altogether, which is the thirteenth file and the end of this
+section.
 
 1. **`Event.isTrusted` was on the prototype, where WebIDL makes it an own property.**
    `dom/events/Event-isTrusted.any.js` takes `Object.getOwnPropertyDescriptor(new Event("x"), "isTrusted")`
@@ -554,11 +556,23 @@ vendored resource and against every shape it declines.
    `AddEventListenerOptions-passive.any.js`'s "returnValue should be ignored if-and-only-if the passive option
    is true", which was the only one of that file's five rows to fail.
 
-The reading that `dom/events/Event-constructors.any.js` stays out of the corpus for these two members alone
-was **incomplete**, and the not-vendored table above now says so: each of its two unnamed failures also
-asserts `assert_true("initEvent" in ev)`, and
-[`initEvent()`](https://dom.spec.whatwg.org/#dom-event-initevent) is a third legacy member of the same
-interface, still absent.
+**`dom/events/Event-constructors.any.js` is vendored now, and getting it there needed a third member.** The
+file used to sit in the not-vendored table because all fourteen of its tests are registered **without a
+name**, so the driver reports every one of them under the same one and no per-test exclusion can single out
+the two that fail. The reason recorded for those two was `srcElement` and `returnValue` — and that reading was
+incomplete. Each of them asserts the whole initial state of a new event, `assert_true("initEvent" in ev)`
+included, so implementing the two members above left the file exactly as red as it was, failing one assertion
+later. [`initEvent()`](https://dom.spec.whatwg.org/#dom-event-initevent) is the third legacy member of the
+same interface, and `initCustomEvent()` its `CustomEvent` counterpart; both are implemented, both are
+*initialize an event* ([step by step](https://dom.spec.whatwg.org/#concept-event-initialize)) behind a
+dispatch-flag guard, and the file now runs with all fourteen of its tests passing. Its copy is byte-identical
+to upstream's at the pin — `git hash-object` gives `faa623ea92991b72742477a18471449f5382f1a8`, which is the
+blob id GitHub reports for that path at commit `6c7127bdd9`.
+
+One step of *initialize an event* has nothing to do here. "Set event's initialized flag" is read by exactly
+one algorithm in the standard — `dispatchEvent`'s `InvalidStateError` guard — and unset by exactly one,
+`document.createEvent()`. There is no `document` here, so every event Jint can build has the flag set from
+birth and no observation can tell a stored flag from an assumed one.
 
 Everything else passes, including all sixteen rows of `dom/abort/event.any.js`, all fourteen of
 `AbortSignal.any()`'s composition and ordering rules, and `AbortSignal.timeout()` firing in registration order

--- a/Jint.Tests/Wpt/Vendor/README.md
+++ b/Jint.Tests/Wpt/Vendor/README.md
@@ -132,7 +132,7 @@ without revisiting the reason fails rather than quietly adding a red suite.
 | `user-timing/supported-usertiming-types.any.js` | Reads `PerformanceObserver.supportedEntryTypes` at *file scope* to decide which promise tests to register, so on an engine with no `PerformanceObserver` it throws before the first test exists. The rows that reach for an observer from inside a test body are excluded one by one instead, under `NeedsPerformanceObserver`. |
 | `html/webappapis/timers/evil-spec-example.any.js` | `setTimeout`'s string handler, which `TimerFunctions` documents declining: compiling the string is `eval` by another name and reachable even where a host disabled string compilation, so it is a `TypeError` here as it is in Node. The file's whole subject is that form, and it uses it at file scope. |
 | `html/webappapis/microtask-queuing/queue-microtask-exceptions.any.js` | A defect, and one that cannot be an exclusion — see [What the timers and microtask corpora say](#what-the-timers-and-microtask-corpora-say-about-this-engine). |
-| `dom/events/Event-constructors.any.js` | Registers fourteen of its fifteen tests **without a name**, so every one of them is reported under the same name and no per-test exclusion can single out the two that fail. Those two are Event's legacy `srcElement` and `returnValue` members; both are recorded as defects below, and `returnValue` also has an exclusion of its own in `AddEventListenerOptions-passive.any.js`, where the test that finds it *is* named. |
+| `dom/events/Event-constructors.any.js` | Registers fourteen of its fifteen tests **without a name**, so every one of them is reported under the same name and no per-test exclusion can single out the two that fail. Those two assert the whole initial state of a new event, and what they now fail on is `assert_true("initEvent" in ev)` — [`initEvent()`](https://dom.spec.whatwg.org/#dom-event-initevent), the one legacy member of the interface still absent. The `srcElement` and `returnValue` they also assert are implemented; see below. |
 | `dom/events/*.window.js`, `dom/events/*.html`, `dom/abort/*.html` | For a browsing context, like every non-`.any.js` file. |
 | `fetch/api/request/*` | Every file builds its `Request` from a **relative** url — `""`, `"./"`, `"../resources/…"` — and `RequestConstructor` documents why that cannot work: the specification resolves such a string against "the entry settings object's API base URL", which is a document's url, and an embedded engine has no document. Most of them do it at file scope, so there is not even a test to exclude. A host that wants a relative url resolves it itself with `new URL(relative, base).href`. |
 | `fetch/api/abort/*`, `fetch/api/basic/*`, `fetch/api/body/*`, `fetch/api/cors/*`, `fetch/api/credentials/*`, `fetch/api/policies/*`, `fetch/api/redirect/*` | A client talking to wptserve: `.py` handlers that echo headers, trickle bytes, redirect, stall, or check CORS preflights. There is no server here and the shim's `fetch` is a reader over the vendored tree. |
@@ -518,10 +518,10 @@ vendored resource and against every shape it declines.
 
 ## What the DOM events and abort corpora say about this engine
 
-62 assertions across twelve files, of which **one does not pass**. Both of the two that used to fail were
-`Event`'s legacy members, and one is fixed:
+62 assertions across twelve files, and **every one of them passes**. The two that used to fail were both
+`Event`'s legacy members, and both are fixed:
 
-1. **`Event.isTrusted` was on the prototype, where WebIDL makes it an own property — fixed.**
+1. **`Event.isTrusted` was on the prototype, where WebIDL makes it an own property.**
    `dom/events/Event-isTrusted.any.js` takes `Object.getOwnPropertyDescriptor(new Event("x"), "isTrusted")`
    from two separate events and requires both to be an accessor and to be the *same* getter.
    [The DOM Standard](https://dom.spec.whatwg.org/#dom-event-istrusted) declares it
@@ -543,16 +543,22 @@ vendored resource and against every shape it declines.
    throughout the abort, message, worker and fetch paths. Two things did change for every event, both of them
    the point: `Object.keys(new Event('x'))` is `["isTrusted"]` and `JSON.stringify(new Event('x'))` is
    `{"isTrusted":false}`, which is what a browser answers.
-2. **`Event` has no `srcElement` and no `returnValue`.** Both are in the DOM Standard's own interface —
+2. **`Event` had no `srcElement` and no `returnValue`.** Both are in the DOM Standard's own interface —
    [`srcElement`](https://dom.spec.whatwg.org/#dom-event-srcelement), a plain `readonly attribute` whose
    "getter steps are to return this's target", and
    [`returnValue`](https://dom.spec.whatwg.org/#dom-event-returnvalue), whose getter is "false if this's
-   canceled flag is set; otherwise true" and whose setter runs *set the canceled flag* — so they are missing
-   members rather than a legacy extension nobody requires. The test that finds `returnValue` is
+   canceled flag is set; otherwise true" and whose setter runs *set the canceled flag* — so they were missing
+   members rather than a legacy extension nobody requires. `returnValue` in particular is not a property over
+   a field: its setter is `preventDefault()` under another name, so a non-cancelable event and a passive
+   listener both ignore it and assigning `true` can never clear a flag already set. The test that finds it is
    `AddEventListenerOptions-passive.any.js`'s "returnValue should be ignored if-and-only-if the passive option
-   is true", which is also the only one of that file's five rows to fail;
-   `dom/events/Event-constructors.any.js` finds both, but registers every test without a name, which is what
-   keeps it out of the corpus.
+   is true", which was the only one of that file's five rows to fail.
+
+The reading that `dom/events/Event-constructors.any.js` stays out of the corpus for these two members alone
+was **incomplete**, and the not-vendored table above now says so: each of its two unnamed failures also
+asserts `assert_true("initEvent" in ev)`, and
+[`initEvent()`](https://dom.spec.whatwg.org/#dom-event-initevent) is a third legacy member of the same
+interface, still absent.
 
 Everything else passes, including all sixteen rows of `dom/abort/event.any.js`, all fourteen of
 `AbortSignal.any()`'s composition and ordering rules, and `AbortSignal.timeout()` firing in registration order

--- a/Jint.Tests/Wpt/Vendor/dom/events/Event-constructors.any.js
+++ b/Jint.Tests/Wpt/Vendor/dom/events/Event-constructors.any.js
@@ -1,0 +1,120 @@
+// META: title=Event constructors
+
+test(function() {
+  assert_throws_js(
+    TypeError,
+    () => Event(""),
+    "Calling Event constructor without 'new' must throw")
+})
+test(function() {
+  assert_throws_js(TypeError, function() {
+    new Event()
+  })
+})
+test(function() {
+  var test_error = { name: "test" }
+  assert_throws_exactly(test_error, function() {
+    new Event({ toString: function() { throw test_error; } })
+  })
+})
+test(function() {
+  var ev = new Event("")
+  assert_equals(ev.type, "")
+  assert_equals(ev.target, null)
+  assert_equals(ev.srcElement, null)
+  assert_equals(ev.currentTarget, null)
+  assert_equals(ev.eventPhase, Event.NONE)
+  assert_equals(ev.bubbles, false)
+  assert_equals(ev.cancelable, false)
+  assert_equals(ev.defaultPrevented, false)
+  assert_equals(ev.returnValue, true)
+  assert_equals(ev.isTrusted, false)
+  assert_true(ev.timeStamp > 0)
+  assert_true("initEvent" in ev)
+})
+test(function() {
+  var ev = new Event("test")
+  assert_equals(ev.type, "test")
+  assert_equals(ev.target, null)
+  assert_equals(ev.srcElement, null)
+  assert_equals(ev.currentTarget, null)
+  assert_equals(ev.eventPhase, Event.NONE)
+  assert_equals(ev.bubbles, false)
+  assert_equals(ev.cancelable, false)
+  assert_equals(ev.defaultPrevented, false)
+  assert_equals(ev.returnValue, true)
+  assert_equals(ev.isTrusted, false)
+  assert_true(ev.timeStamp > 0)
+  assert_true("initEvent" in ev)
+})
+test(function() {
+  assert_throws_js(TypeError, function() { Event("test") },
+                   'Calling Event constructor without "new" must throw');
+})
+test(function() {
+  var ev = new Event("I am an event", { bubbles: true, cancelable: false})
+  assert_equals(ev.type, "I am an event")
+  assert_equals(ev.bubbles, true)
+  assert_equals(ev.cancelable, false)
+})
+test(function() {
+  var ev = new Event("@", { bubblesIGNORED: true, cancelable: true})
+  assert_equals(ev.type, "@")
+  assert_equals(ev.bubbles, false)
+  assert_equals(ev.cancelable, true)
+})
+test(function() {
+  var ev = new Event("@", { "bubbles\0IGNORED": true, cancelable: true})
+  assert_equals(ev.type, "@")
+  assert_equals(ev.bubbles, false)
+  assert_equals(ev.cancelable, true)
+})
+test(function() {
+  var ev = new Event("Xx", { cancelable: true})
+  assert_equals(ev.type, "Xx")
+  assert_equals(ev.bubbles, false)
+  assert_equals(ev.cancelable, true)
+})
+test(function() {
+  var ev = new Event("Xx", {})
+  assert_equals(ev.type, "Xx")
+  assert_equals(ev.bubbles, false)
+  assert_equals(ev.cancelable, false)
+})
+test(function() {
+  var ev = new Event("Xx", {bubbles: true, cancelable: false, sweet: "x"})
+  assert_equals(ev.type, "Xx")
+  assert_equals(ev.bubbles, true)
+  assert_equals(ev.cancelable, false)
+  assert_equals(ev.sweet, undefined)
+})
+test(function() {
+  var called = []
+  var ev = new Event("Xx", {
+    get cancelable() {
+      called.push("cancelable")
+      return false
+    },
+    get bubbles() {
+      called.push("bubbles")
+      return true;
+    },
+    get sweet() {
+      called.push("sweet")
+      return "x"
+    }
+  })
+  assert_array_equals(called, ["bubbles", "cancelable"])
+  assert_equals(ev.type, "Xx")
+  assert_equals(ev.bubbles, true)
+  assert_equals(ev.cancelable, false)
+  assert_equals(ev.sweet, undefined)
+})
+test(function() {
+  var ev = new CustomEvent("$", {detail: 54, sweet: "x", sweet2: "x", cancelable:true})
+  assert_equals(ev.type, "$")
+  assert_equals(ev.bubbles, false)
+  assert_equals(ev.cancelable, true)
+  assert_equals(ev.sweet, undefined)
+  assert_equals(ev.detail, 54)
+})

--- a/Jint.Tests/Wpt/WptExclusions.cs
+++ b/Jint.Tests/Wpt/WptExclusions.cs
@@ -369,25 +369,14 @@ internal enum WptDivergence
     /// <c>ObjectInstance.IsArrayLike</c> where https://tc39.es/ecma262/#sec-array.prototype.values reads no
     /// <c>length</c> at all, the iterator's own step 1.b doing <i>LengthOfArrayLike</i> on each
     /// <c>next()</c>. Fixed under sebastienros/jint#3209, which is what the deleted entries now enforce.
-    /// <b>The hr-time, DOM, structured-clone and fetch corpora filed ten more</b>, of which three are fixed
-    /// under sebastienros/jint#3212 — the <c>PerformanceMarkOptions</c> dictionary conversion,
-    /// <c>Event.isTrusted</c>'s <c>[LegacyUnforgeable]</c> shape, and <c>Event</c>'s missing
-    /// <c>srcElement</c>/<c>returnValue</c> — so the six entries that used to be here now enforce them.
-    /// <c>Vendor/README.md</c> analyses what is left, each with its citation. In one line apiece:
+    /// <b>The hr-time, DOM and fetch corpora filed seven more, and three of them are gone</b> — the
+    /// <c>PerformanceMarkOptions</c> dictionary conversion, <c>Event.isTrusted</c>'s
+    /// <c>[LegacyUnforgeable]</c> shape, and <c>Event</c>'s missing <c>srcElement</c>/<c>returnValue</c>,
+    /// all fixed under sebastienros/jint#3212, so the six entries that used to be here now enforce them and
+    /// <c>dom/events/Event-constructors.any.js</c> left <c>_notVendored</c> with them. <c>Vendor/README.md</c>
+    /// analyses each with its citation. In one line apiece:
     /// </para>
     /// <list type="bullet">
-    /// <item><description>
-    /// An <c>Error</c>'s <c>cause</c> is not carried through <c>structuredClone</c>, where HTML's
-    /// serialization steps read it.
-    /// </description></item>
-    /// <item><description>
-    /// <c>Blob</c> and <c>File</c> are not serializable at all, though the File API declares both
-    /// <c>[Serializable]</c> and Jint has the interfaces.
-    /// </description></item>
-    /// <item><description>
-    /// <c>structuredClone(Object.prototype)</c> raises <c>DataCloneError</c> where HTML clones it as the
-    /// ordinary object it is.
-    /// </description></item>
     /// <item><description>
     /// The <c>Headers</c> iterator prototype's <c>next</c> is not enumerable — the same attribute on the same
     /// kind of object as the streams corpus's async-iterator entry above.

--- a/Jint.Tests/Wpt/WptExclusions.cs
+++ b/Jint.Tests/Wpt/WptExclusions.cs
@@ -369,15 +369,12 @@ internal enum WptDivergence
     /// <c>ObjectInstance.IsArrayLike</c> where https://tc39.es/ecma262/#sec-array.prototype.values reads no
     /// <c>length</c> at all, the iterator's own step 1.b doing <i>LengthOfArrayLike</i> on each
     /// <c>next()</c>. Fixed under sebastienros/jint#3209, which is what the deleted entries now enforce.
-    /// <b>The hr-time, DOM and fetch corpora filed seven more</b>, and <c>Vendor/README.md</c>
-    /// analyses each with its citation. In one line apiece:
+    /// <b>The hr-time, DOM, structured-clone and fetch corpora filed seven more</b>, of which the
+    /// <c>PerformanceMarkOptions</c> dictionary conversion is fixed under sebastienros/jint#3212 — the four
+    /// entries that used to be here now enforce it. <c>Vendor/README.md</c> analyses what is left, each with
+    /// its citation. In one line apiece:
     /// </para>
     /// <list type="bullet">
-    /// <item><description>
-    /// <c>new PerformanceMark(name, 123)</c> accepts a non-object where WebIDL's dictionary conversion refuses
-    /// one; <c>performance.mark(name, 123)</c> refuses it correctly, so the two halves of
-    /// <c>user-timing/mark-errors.any.js</c> disagree.
-    /// </description></item>
     /// <item><description>
     /// <c>Event.isTrusted</c> is a prototype accessor where https://dom.spec.whatwg.org/#dom-event-istrusted
     /// declares it <c>[LegacyUnforgeable]</c> — an own, non-configurable accessor on every instance.

--- a/Jint.Tests/Wpt/WptExclusions.cs
+++ b/Jint.Tests/Wpt/WptExclusions.cs
@@ -369,16 +369,13 @@ internal enum WptDivergence
     /// <c>ObjectInstance.IsArrayLike</c> where https://tc39.es/ecma262/#sec-array.prototype.values reads no
     /// <c>length</c> at all, the iterator's own step 1.b doing <i>LengthOfArrayLike</i> on each
     /// <c>next()</c>. Fixed under sebastienros/jint#3209, which is what the deleted entries now enforce.
-    /// <b>The hr-time, DOM, structured-clone and fetch corpora filed seven more</b>, of which the
-    /// <c>PerformanceMarkOptions</c> dictionary conversion is fixed under sebastienros/jint#3212 — the four
-    /// entries that used to be here now enforce it. <c>Vendor/README.md</c> analyses what is left, each with
-    /// its citation. In one line apiece:
+    /// <b>The hr-time, DOM, structured-clone and fetch corpora filed ten more</b>, of which the
+    /// <c>PerformanceMarkOptions</c> dictionary conversion and <c>Event.isTrusted</c>'s
+    /// <c>[LegacyUnforgeable]</c> shape are fixed under sebastienros/jint#3212 — the five entries that used to
+    /// be here now enforce them. <c>Vendor/README.md</c> analyses what is left, each with its citation. In one
+    /// line apiece:
     /// </para>
     /// <list type="bullet">
-    /// <item><description>
-    /// <c>Event.isTrusted</c> is a prototype accessor where https://dom.spec.whatwg.org/#dom-event-istrusted
-    /// declares it <c>[LegacyUnforgeable]</c> — an own, non-configurable accessor on every instance.
-    /// </description></item>
     /// <item><description>
     /// <c>Event</c> has neither <c>srcElement</c> nor <c>returnValue</c>, both of which the DOM Standard's own
     /// interface declares.

--- a/Jint.Tests/Wpt/WptExclusions.cs
+++ b/Jint.Tests/Wpt/WptExclusions.cs
@@ -369,16 +369,24 @@ internal enum WptDivergence
     /// <c>ObjectInstance.IsArrayLike</c> where https://tc39.es/ecma262/#sec-array.prototype.values reads no
     /// <c>length</c> at all, the iterator's own step 1.b doing <i>LengthOfArrayLike</i> on each
     /// <c>next()</c>. Fixed under sebastienros/jint#3209, which is what the deleted entries now enforce.
-    /// <b>The hr-time, DOM, structured-clone and fetch corpora filed ten more</b>, of which the
-    /// <c>PerformanceMarkOptions</c> dictionary conversion and <c>Event.isTrusted</c>'s
-    /// <c>[LegacyUnforgeable]</c> shape are fixed under sebastienros/jint#3212 — the five entries that used to
-    /// be here now enforce them. <c>Vendor/README.md</c> analyses what is left, each with its citation. In one
-    /// line apiece:
+    /// <b>The hr-time, DOM, structured-clone and fetch corpora filed ten more</b>, of which three are fixed
+    /// under sebastienros/jint#3212 — the <c>PerformanceMarkOptions</c> dictionary conversion,
+    /// <c>Event.isTrusted</c>'s <c>[LegacyUnforgeable]</c> shape, and <c>Event</c>'s missing
+    /// <c>srcElement</c>/<c>returnValue</c> — so the six entries that used to be here now enforce them.
+    /// <c>Vendor/README.md</c> analyses what is left, each with its citation. In one line apiece:
     /// </para>
     /// <list type="bullet">
     /// <item><description>
-    /// <c>Event</c> has neither <c>srcElement</c> nor <c>returnValue</c>, both of which the DOM Standard's own
-    /// interface declares.
+    /// An <c>Error</c>'s <c>cause</c> is not carried through <c>structuredClone</c>, where HTML's
+    /// serialization steps read it.
+    /// </description></item>
+    /// <item><description>
+    /// <c>Blob</c> and <c>File</c> are not serializable at all, though the File API declares both
+    /// <c>[Serializable]</c> and Jint has the interfaces.
+    /// </description></item>
+    /// <item><description>
+    /// <c>structuredClone(Object.prototype)</c> raises <c>DataCloneError</c> where HTML clones it as the
+    /// ordinary object it is.
     /// </description></item>
     /// <item><description>
     /// The <c>Headers</c> iterator prototype's <c>next</c> is not enumerable — the same attribute on the same

--- a/Jint.Tests/Wpt/WptTestRunner.cs
+++ b/Jint.Tests/Wpt/WptTestRunner.cs
@@ -242,12 +242,13 @@ public class WptTestRunner
         // ---------------------------------------------------------------- dom
         // Fourteen of its fifteen tests are registered without a name, so every one of them is reported under
         // the same name and no per-test exclusion can single out the two that fail — which is what puts this
-        // row here rather than in the exclusion table. The two are Event's legacy `srcElement` and
-        // `returnValue` members, which this engine does not have; both are recorded as defects in
-        // Vendor/README.md, and `returnValue` also has an exclusion of its own in
-        // AddEventListenerOptions-passive.any.js, where the test that finds it *is* named.
+        // row here rather than in the exclusion table. Those two assert the whole initial state of a new
+        // event, and the corpus's reading that they fail for `srcElement` and `returnValue` was incomplete:
+        // each also asserts `"initEvent" in ev`, and initEvent() — https://dom.spec.whatwg.org/#dom-event-initevent
+        // — is a third legacy member of the same interface. The other two are implemented now, so it is the
+        // only thing left keeping the file out. See Vendor/README.md.
         ("dom/events/Event-constructors.any.js",
-            "registers every test without a name, so its two failures cannot be named; see Vendor/README.md"),
+            "registers every test without a name, so its two initEvent failures cannot be named; see Vendor/README.md"),
 
         // ---------------------------------------------------------------- html/webappapis
         // setTimeout's string handler, which TimerFunctions documents declining: compiling the string is eval
@@ -977,13 +978,6 @@ public class WptTestRunner
         new("user-timing/case-sensitivity.any.js", "getEntriesByType values are case sensitive", WptDivergence.NeedsPerformanceObserver),
         new("user-timing/mark-l3.any.js", "mark entries' detail and startTime are customizable.", WptDivergence.NeedsPerformanceObserver),
         new("user-timing/measure-with-dict.any.js", "measure entries' detail and start/end are customizable", WptDivergence.NeedsPerformanceObserver),
-
-        // ---------------------------------------------------------------- dom
-        // Event's `returnValue`, https://dom.spec.whatwg.org/#dom-event-returnvalue — a defect rather than a
-        // decline; Vendor/README.md analyses it, and Event-constructors.any.js is not vendored because its own
-        // failures include it and it registers every one of its tests without a name.
-        new("dom/events/AddEventListenerOptions-passive.any.js",
-            "returnValue should be ignored if-and-only-if the passive option is true", WptDivergence.NeedsTriage),
 
         // ---------------------------------------------------------------- fetch
         // The forbidden-header-name lists, which HeadersGuard documents declining. The 18 "is allowed to use"

--- a/Jint.Tests/Wpt/WptTestRunner.cs
+++ b/Jint.Tests/Wpt/WptTestRunner.cs
@@ -978,16 +978,6 @@ public class WptTestRunner
         new("user-timing/mark-l3.any.js", "mark entries' detail and startTime are customizable.", WptDivergence.NeedsPerformanceObserver),
         new("user-timing/measure-with-dict.any.js", "measure entries' detail and start/end are customizable", WptDivergence.NeedsPerformanceObserver),
 
-        // A defect, and a narrow one: the file runs each case twice, once through `performance.mark(name, x)`
-        // and once through `new PerformanceMark(name, x)`, and only the constructor accepts a non-object where
-        // WebIDL's dictionary conversion refuses one. The `[performance.mark]` half of all five rows passes,
-        // and so does the constructor's own `{startTime: -1}` row, so what is missing is exactly the
-        // "not an object and not null/undefined is a TypeError" step. See Vendor/README.md.
-        new("user-timing/mark-errors.any.js", "[new PerformanceMark]: Number should be rejected as the mark-options.", WptDivergence.NeedsTriage),
-        new("user-timing/mark-errors.any.js", "[new PerformanceMark]: NaN should be rejected as the mark-options.", WptDivergence.NeedsTriage),
-        new("user-timing/mark-errors.any.js", "[new PerformanceMark]: Infinity should be rejected as the mark-options.", WptDivergence.NeedsTriage),
-        new("user-timing/mark-errors.any.js", "[new PerformanceMark]: String should be rejected as the mark-options.", WptDivergence.NeedsTriage),
-
         // ---------------------------------------------------------------- dom
         // Event's two legacy members. `returnValue` is https://dom.spec.whatwg.org/#dom-event-returnvalue and
         // `isTrusted` is [LegacyUnforgeable], so it must be an *own* property of every event rather than an

--- a/Jint.Tests/Wpt/WptTestRunner.cs
+++ b/Jint.Tests/Wpt/WptTestRunner.cs
@@ -239,17 +239,6 @@ public class WptTestRunner
         ("user-timing/supported-usertiming-types.any.js",
             "reads PerformanceObserver at file scope; PerformanceInstance documents declining the observer"),
 
-        // ---------------------------------------------------------------- dom
-        // Fourteen of its fifteen tests are registered without a name, so every one of them is reported under
-        // the same name and no per-test exclusion can single out the two that fail — which is what puts this
-        // row here rather than in the exclusion table. Those two assert the whole initial state of a new
-        // event, and the corpus's reading that they fail for `srcElement` and `returnValue` was incomplete:
-        // each also asserts `"initEvent" in ev`, and initEvent() — https://dom.spec.whatwg.org/#dom-event-initevent
-        // — is a third legacy member of the same interface. The other two are implemented now, so it is the
-        // only thing left keeping the file out. See Vendor/README.md.
-        ("dom/events/Event-constructors.any.js",
-            "registers every test without a name, so its two initEvent failures cannot be named; see Vendor/README.md"),
-
         // ---------------------------------------------------------------- html/webappapis
         // setTimeout's string handler, which TimerFunctions documents declining: compiling the string is eval
         // by another name and reachable even where a host disabled string compilation, so it is a TypeError
@@ -566,6 +555,9 @@ public class WptTestRunner
         ["dom/events/AddEventListenerOptions-once.any.js"] = 4,
         ["dom/events/AddEventListenerOptions-passive.any.js"] = 5,
         ["dom/events/AddEventListenerOptions-signal.any.js"] = 11,
+        // Every one of its fourteen tests is registered without a name, so the driver reports them all under
+        // the same one. The floor is still fourteen results: the count is per registration, not per name.
+        ["dom/events/Event-constructors.any.js"] = 14,
         ["dom/events/Event-isTrusted.any.js"] = 1,
         ["dom/events/EventTarget-add-remove-listener.any.js"] = 1,
         ["dom/events/EventTarget-addEventListener.any.js"] = 1,

--- a/Jint.Tests/Wpt/WptTestRunner.cs
+++ b/Jint.Tests/Wpt/WptTestRunner.cs
@@ -979,14 +979,11 @@ public class WptTestRunner
         new("user-timing/measure-with-dict.any.js", "measure entries' detail and start/end are customizable", WptDivergence.NeedsPerformanceObserver),
 
         // ---------------------------------------------------------------- dom
-        // Event's two legacy members. `returnValue` is https://dom.spec.whatwg.org/#dom-event-returnvalue and
-        // `isTrusted` is [LegacyUnforgeable], so it must be an *own* property of every event rather than an
-        // accessor on the prototype. Both are defects rather than declines; Vendor/README.md analyses them,
-        // and Event-constructors.any.js is not vendored because its own two failures are the same pair and it
-        // registers every one of its tests without a name.
+        // Event's `returnValue`, https://dom.spec.whatwg.org/#dom-event-returnvalue — a defect rather than a
+        // decline; Vendor/README.md analyses it, and Event-constructors.any.js is not vendored because its own
+        // failures include it and it registers every one of its tests without a name.
         new("dom/events/AddEventListenerOptions-passive.any.js",
             "returnValue should be ignored if-and-only-if the passive option is true", WptDivergence.NeedsTriage),
-        new("dom/events/Event-isTrusted.any.js", "undefined", WptDivergence.NeedsTriage),
 
         // ---------------------------------------------------------------- fetch
         // The forbidden-header-name lists, which HeadersGuard documents declining. The 18 "is allowed to use"

--- a/Jint/WebApi/Events/CustomEventPrototype.cs
+++ b/Jint/WebApi/Events/CustomEventPrototype.cs
@@ -15,8 +15,6 @@ namespace Jint.WebApi.Events;
 /// <remarks>
 /// Its <c>[[Prototype]]</c> is <c>Event.prototype</c>, which is what gives a <c>CustomEvent</c> every
 /// <c>Event</c> member and makes <c>new CustomEvent('x') instanceof Event</c> hold.
-/// <c>initCustomEvent()</c> is deliberately absent — the specification marks it legacy and tells new
-/// interfaces not to introduce one.
 /// </remarks>
 [JsObject(UseShape = true)]
 internal sealed partial class CustomEventPrototype : Prototype
@@ -47,11 +45,44 @@ internal sealed partial class CustomEventPrototype : Prototype
     /// https://dom.spec.whatwg.org/#dom-customevent-detail
     /// </summary>
     [JsAccessor("detail", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
-    private JsValue DetailGet(JsValue thisObject)
+    private JsValue DetailGet(JsValue thisObject) => Brand(thisObject).Detail;
+
+    /// <summary>
+    /// https://dom.spec.whatwg.org/#dom-customevent-initcustomevent — <c>initEvent()</c>'s two steps followed
+    /// by "set this's detail attribute to <i>detail</i>".
+    /// </summary>
+    /// <remarks>
+    /// The IDL default of <c>detail</c> is <c>null</c>, so calling this with fewer arguments <i>clears</i> a
+    /// detail the constructor set rather than leaving it alone. <c>length</c> is 1 for the reason
+    /// <c>initEvent</c>'s is: only <c>type</c> is required.
+    /// </remarks>
+    [JsFunction(Name = "initCustomEvent", Length = 1)]
+    private JsValue InitCustomEvent(JsValue thisObject, JsValue type, JsValue bubbles, JsValue cancelable, JsValue detail)
+    {
+        var ev = Brand(thisObject);
+        if (ev.DispatchFlag)
+        {
+            return Undefined;
+        }
+
+        ev.InitializeEvent(
+            TypeConverter.ToJsString(type),
+            TypeConverter.ToBoolean(bubbles),
+            TypeConverter.ToBoolean(cancelable));
+
+        ev.Detail = detail.IsUndefined() ? Null : detail;
+        return Undefined;
+    }
+
+    /// <summary>
+    /// The WebIDL brand check every member performs: a receiver that is not a <c>CustomEvent</c> raises a
+    /// <c>TypeError</c>.
+    /// </summary>
+    private JsCustomEvent Brand(JsValue thisObject)
     {
         if (thisObject is JsCustomEvent customEvent)
         {
-            return customEvent.Detail;
+            return customEvent;
         }
 
         Throw.TypeError(_realm, "Illegal invocation: receiver is not a CustomEvent");

--- a/Jint/WebApi/Events/EventPrototype.cs
+++ b/Jint/WebApi/Events/EventPrototype.cs
@@ -266,6 +266,39 @@ internal sealed partial class EventPrototype : Prototype
     }
 
     /// <summary>
+    /// https://dom.spec.whatwg.org/#dom-event-initevent — "If this's dispatch flag is set, then return.
+    /// Initialize this with <i>type</i>, <i>bubbles</i>, and <i>cancelable</i>."
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>length</c> is 1 because WebIDL counts required arguments and the two booleans are optional with an
+    /// IDL default of <c>false</c>. They are <c>boolean</c>s rather than anything stricter, so an omitted or
+    /// odd argument is coerced by <i>ToBoolean</i> rather than refused, and <c>type</c> is a
+    /// <c>DOMString</c>, so anything at all is stringified.
+    /// </para>
+    /// <para>
+    /// Step 1 is what stops a listener re-initializing the very event it is being handed: the dispatch flag is
+    /// set for the whole of <c>dispatchEvent</c>, so the call is a silent no-op there rather than an error.
+    /// </para>
+    /// </remarks>
+    [JsFunction(Name = "initEvent", Length = 1)]
+    private JsValue InitEvent(JsValue thisObject, JsValue type, JsValue bubbles, JsValue cancelable)
+    {
+        var ev = Brand(thisObject);
+        if (ev.DispatchFlag)
+        {
+            return Undefined;
+        }
+
+        ev.InitializeEvent(
+            TypeConverter.ToJsString(type),
+            TypeConverter.ToBoolean(bubbles),
+            TypeConverter.ToBoolean(cancelable));
+
+        return Undefined;
+    }
+
+    /// <summary>
     /// The WebIDL brand check every member performs: a receiver that is not a platform object implementing the
     /// interface raises a <c>TypeError</c>.
     /// </summary>

--- a/Jint/WebApi/Events/EventPrototype.cs
+++ b/Jint/WebApi/Events/EventPrototype.cs
@@ -76,6 +76,15 @@ internal sealed partial class EventPrototype : Prototype
     private JsValue TargetGet(JsValue thisObject) => Brand(thisObject).Target;
 
     /// <summary>
+    /// https://dom.spec.whatwg.org/#dom-event-srcelement — "The <c>srcElement</c> getter steps are to return
+    /// this's target." A second name for the same value, marked <c>// legacy</c> in the IDL and normative
+    /// all the same; unlike <c>isTrusted</c> it carries no extended attribute, so it is an ordinary
+    /// configurable prototype accessor like the rest.
+    /// </summary>
+    [JsAccessor("srcElement", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsValue SrcElementGet(JsValue thisObject) => Brand(thisObject).Target;
+
+    /// <summary>
     /// https://dom.spec.whatwg.org/#dom-event-currenttarget
     /// </summary>
     [JsAccessor("currentTarget", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
@@ -98,6 +107,36 @@ internal sealed partial class EventPrototype : Prototype
     /// </summary>
     [JsAccessor("cancelable", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
     private JsBoolean CancelableGet(JsValue thisObject) => JsBoolean.Create(Brand(thisObject).Cancelable);
+
+    /// <summary>
+    /// https://dom.spec.whatwg.org/#dom-event-returnvalue — "The <c>returnValue</c> getter steps are to
+    /// return false if this's canceled flag is set; otherwise true."
+    /// </summary>
+    [JsAccessor("returnValue", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsBoolean ReturnValueGet(JsValue thisObject) => JsBoolean.Create(!Brand(thisObject).CanceledFlag);
+
+    /// <summary>
+    /// The setter half: "set the canceled flag with this if the given value is false; otherwise do nothing".
+    /// </summary>
+    /// <remarks>
+    /// It is <i>set the canceled flag</i> (https://dom.spec.whatwg.org/#set-the-canceled-flag) and not a
+    /// write, so this is <c>preventDefault()</c> under another name: a non-cancelable event and a passive
+    /// listener both ignore it, and assigning <c>true</c> can never clear a flag already set. The IDL type is
+    /// <c>boolean</c>, so the assigned value goes through
+    /// https://webidl.spec.whatwg.org/#es-boolean — <i>ToBoolean</i> — rather than being refused, which is why
+    /// <c>e.returnValue = 0</c> cancels and <c>e.returnValue = 1</c> does not.
+    /// </remarks>
+    [JsAccessor("returnValue", AccessorKind.Set, Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsValue ReturnValueSet(JsValue thisObject, JsValue value)
+    {
+        var ev = Brand(thisObject);
+        if (!TypeConverter.ToBoolean(value))
+        {
+            ev.SetCanceledFlag();
+        }
+
+        return Undefined;
+    }
 
     /// <summary>
     /// https://dom.spec.whatwg.org/#dom-event-defaultprevented

--- a/Jint/WebApi/Events/EventPrototype.cs
+++ b/Jint/WebApi/Events/EventPrototype.cs
@@ -1,9 +1,11 @@
 #if NET8_0_OR_GREATER
 using Jint.Native;
 using Jint.Native.Array;
+using Jint.Native.Function;
 using Jint.Native.Object;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
+using Jint.Runtime.Interop;
 
 namespace Jint.WebApi.Events;
 
@@ -110,13 +112,64 @@ internal sealed partial class EventPrototype : Prototype
     private JsBoolean ComposedGet(JsValue thisObject) => JsBoolean.Create(Brand(thisObject).Composed);
 
     /// <summary>
-    /// https://dom.spec.whatwg.org/#dom-event-istrusted. <c>[LegacyUnforgeable]</c> in the IDL, which makes it
-    /// a non-configurable own accessor of the instance in a browser; it is an ordinary prototype accessor here,
-    /// so a script can shadow it. Nothing in the engine trusts the JavaScript-visible value — the flag the
-    /// dispatch algorithm reads is the CLR one.
+    /// The attribute getter for <c>isTrusted</c> — the one member of the interface that does <b>not</b> live
+    /// on this object. https://dom.spec.whatwg.org/#dom-event-istrusted declares it
+    /// <c>[LegacyUnforgeable]</c>, so https://webidl.spec.whatwg.org/#es-attributes removes it from the
+    /// prototype's attribute set ("Remove from <i>attributes</i> all the attributes that are unforgeable")
+    /// and installs it on every instance instead — see <see cref="JsEvent.GetOwnProperty"/>.
     /// </summary>
-    [JsAccessor("isTrusted", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
-    private JsBoolean IsTrustedGet(JsValue thisObject) => JsBoolean.Create(Brand(thisObject).IsTrusted);
+    /// <remarks>
+    /// <para>
+    /// It is nevertheless created here, once per realm, because that is what an attribute getter is: one
+    /// function object for the interface rather than one per object that carries it.
+    /// <c>dom/events/Event-isTrusted.any.js</c> reads the descriptor off two separate events and requires the
+    /// same getter in both, and every event's descriptor is built from this one.
+    /// </para>
+    /// <para>
+    /// Realm-pinned rather than built against whichever realm happens to be running when the first event asks
+    /// for it, for the reason the internal <see cref="ClrFunction"/> constructor documents. Its <c>length</c>
+    /// is a configurable, non-writable, non-enumerable <c>0</c>, which is what every other member of this
+    /// prototype carries.
+    /// </para>
+    /// </remarks>
+    internal Function IsTrustedGetter =>
+        _isTrustedGetter ??= new ClrFunction(
+            _engine,
+            _realm,
+            "get isTrusted",
+            (thisObject, _) => JsBoolean.Create(Brand(thisObject).IsTrusted),
+            length: 0,
+            PropertyFlag.Configurable);
+
+    private ClrFunction? _isTrustedGetter;
+
+    /// <summary>
+    /// The descriptor every event's own <c>isTrusted</c> is answered with:
+    /// <c>{ [[Get]]: <see cref="IsTrustedGetter"/>, [[Set]]: undefined, [[Enumerable]]: true,
+    /// [[Configurable]]: false }</c>, per https://webidl.spec.whatwg.org/#es-attributes.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// One instance for the realm, shared by every event, so carrying the property costs an event nothing and
+    /// reading it allocates nothing either. An accessor descriptor is unwrapped by invoking its getter with
+    /// the <i>receiver</i>, so one descriptor answering for every event is exactly right.
+    /// </para>
+    /// <para>
+    /// Sharing is safe because the descriptor is non-configurable and has no setter, which puts it out of
+    /// reach of every mutating branch of <c>ObjectInstance.ValidateAndApplyPropertyDescriptor</c>
+    /// (https://tc39.es/ecma262/#sec-validateandapplypropertydescriptor): an incoming <c>[[Value]]</c> or
+    /// <c>[[Writable]]</c> field makes that descriptor a data one and the data-versus-accessor mismatch is
+    /// refused before any write; a differing <c>[[Enumerable]]</c>, or a <c>[[Configurable]]</c> of
+    /// <see langword="true"/>, is refused for the same reason, so the only assignments that survive write back
+    /// the values already there; and a <c>[[Get]]</c>/<c>[[Set]]</c> field is applied to a <i>copy</i>. It is
+    /// the argument the engine already makes process-wide for
+    /// <c>PropertyDescriptor.AllForbiddenDescriptor</c>, which every function's <c>length</c> shares.
+    /// </para>
+    /// </remarks>
+    internal PropertyDescriptor IsTrustedDescriptor =>
+        _isTrustedDescriptor ??= new GetSetPropertyDescriptor(IsTrustedGetter, set: null, enumerable: true, configurable: false);
+
+    private GetSetPropertyDescriptor? _isTrustedDescriptor;
 
     /// <summary>
     /// https://dom.spec.whatwg.org/#dom-event-timestamp

--- a/Jint/WebApi/Events/JsEvent.cs
+++ b/Jint/WebApi/Events/JsEvent.cs
@@ -2,6 +2,8 @@
 using System.Runtime.InteropServices;
 using Jint.Native;
 using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
 
 namespace Jint.WebApi.Events;
 
@@ -13,24 +15,31 @@ namespace Jint.WebApi.Events;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Every IDL attribute of <c>Event</c> is read-only, so the whole state lives in CLR fields here and
-/// <see cref="EventPrototype"/> reads it through a brand check, exactly as <c>DOMException</c> does. An
-/// instance therefore has no own property at all, which is what a browser reports for
-/// <c>Object.getOwnPropertyNames(new Event('x'))</c>.
+/// The whole state lives in CLR fields here and <see cref="EventPrototype"/> reads it through a brand check,
+/// exactly as <c>DOMException</c> does. One member is not on the prototype: <c>isTrusted</c> is
+/// <c>[LegacyUnforgeable]</c>, so it is an own accessor of every instance — see
+/// <see cref="GetOwnProperty"/>, which synthesizes it rather than storing it. It is the one name
+/// <c>Object.getOwnPropertyNames(new Event('x'))</c> reports, in a browser and here.
 /// </para>
 /// <para>
 /// The class is not sealed because <see cref="JsCustomEvent"/> derives from it, which is how
 /// <c>CustomEvent</c>'s brand check can be "is a <c>JsEvent</c> that also carries a detail".
 /// </para>
 /// <para>
-/// Deliberately absent, all of them marked legacy by the specification and none of them reachable by a
-/// script written for a non-browser runtime: <c>srcElement</c>, <c>cancelBubble</c>, <c>returnValue</c>,
-/// <c>initEvent()</c> and <c>initCustomEvent()</c>. <c>relatedTarget</c> and the touch target list belong to
+/// Deliberately absent, both marked legacy by the specification: <c>cancelBubble</c> and
+/// <c>initEvent()</c>/<c>initCustomEvent()</c>. <c>relatedTarget</c> and the touch target list belong to
 /// interfaces (<c>UIEvent</c>, <c>TouchEvent</c>) that do not exist here.
 /// </para>
 /// </remarks>
 internal class JsEvent : ObjectInstance
 {
+    /// <summary>
+    /// The one own property every event carries — https://dom.spec.whatwg.org/#dom-event-istrusted.
+    /// </summary>
+    private static readonly JsString _isTrusted = new("isTrusted");
+
+    private static readonly Key _isTrustedKey = "isTrusted";
+
     /// <summary>Not currently dispatched — https://dom.spec.whatwg.org/#dom-event-none.</summary>
     internal const int PhaseNone = 0;
 
@@ -125,6 +134,75 @@ internal class JsEvent : ObjectInstance
             CanceledFlag = true;
         }
     }
+
+    /// <summary>
+    /// The unforgeable <c>isTrusted</c>, synthesized on demand rather than stored.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>[LegacyUnforgeable]</c> (https://webidl.spec.whatwg.org/#LegacyUnforgeable) means the property is
+    /// "non-configurable and … exist[s] as an own property on the object itself rather than on its
+    /// prototype", and https://webidl.spec.whatwg.org/#es-attributes gives it
+    /// <c>{ [[Get]]: getter, [[Set]]: undefined, [[Enumerable]]: true, [[Configurable]]: false }</c>. The
+    /// getter is the interface's, one per realm, so two events answer the identical function object.
+    /// </para>
+    /// <para>
+    /// Nothing is written into the property dictionary for it, and nothing is allocated to answer it: the
+    /// descriptor is the realm's single <see cref="EventPrototype.IsTrustedDescriptor"/>. That matters
+    /// because events are not rare — one per <c>dispatchEvent</c>, and more throughout the abort, message,
+    /// worker and fetch paths — and a stored descriptor would cost a <c>PropertyDictionary</c>, a list node
+    /// and the descriptor, measured at <b>+184 bytes on a 112-byte event</b>. As it is, an event allocates
+    /// exactly what it did before this member existed, and so does a read of it. The shape is
+    /// <c>Function</c>'s for <c>length</c>/<c>name</c>/<c>prototype</c> and <c>JsError</c>'s for
+    /// <c>message</c>: an own property the type always has, answered from
+    /// <see cref="ObjectInstance.GetOwnProperty"/> and listed by
+    /// <see cref="ObjectInstance.GetInitialOwnStringPropertyKeys"/>.
+    /// </para>
+    /// <para>
+    /// Because the property is non-configurable and has no setter, it can be neither deleted nor redefined
+    /// into anything else, so it is a constant of the type: always present, never removable. That is what
+    /// keeps the interpreter's version-gated prototype cache sound for an event receiver — no own property
+    /// of an event ever joins or leaves its own-property set without <c>_propertiesVersion</c> moving. The
+    /// one redefinition the specification does permit is an identical one
+    /// (<c>{ get: theSameGetter, set: undefined }</c>), which the ordinary machinery stores in the dictionary;
+    /// the two lookups below prefer that copy so the key is never reported twice.
+    /// </para>
+    /// </remarks>
+    public override PropertyDescriptor GetOwnProperty(JsValue property)
+    {
+        if (_isTrusted.Equals(property))
+        {
+            var stored = base.GetOwnProperty(property);
+            return ReferenceEquals(stored, PropertyDescriptor.Undefined) ? IsTrustedDescriptor : stored;
+        }
+
+        return base.GetOwnProperty(property);
+    }
+
+    internal override IEnumerable<JsValue> GetInitialOwnStringPropertyKeys()
+    {
+        if (!HasStoredIsTrusted)
+        {
+            yield return _isTrusted;
+        }
+    }
+
+    public override IEnumerable<KeyValuePair<JsValue, PropertyDescriptor>> GetOwnProperties()
+    {
+        if (!HasStoredIsTrusted)
+        {
+            yield return new KeyValuePair<JsValue, PropertyDescriptor>(_isTrusted, IsTrustedDescriptor);
+        }
+
+        foreach (var entry in base.GetOwnProperties())
+        {
+            yield return entry;
+        }
+    }
+
+    private bool HasStoredIsTrusted => _properties?.ContainsKey(_isTrustedKey) == true;
+
+    private PropertyDescriptor IsTrustedDescriptor => _engine.Realm.Intrinsics.Event.PrototypeObject.IsTrustedDescriptor;
 }
 
 /// <summary>

--- a/Jint/WebApi/Events/JsEvent.cs
+++ b/Jint/WebApi/Events/JsEvent.cs
@@ -26,10 +26,11 @@ namespace Jint.WebApi.Events;
 /// <c>CustomEvent</c>'s brand check can be "is a <c>JsEvent</c> that also carries a detail".
 /// </para>
 /// <para>
-/// Deliberately absent, both marked legacy by the specification: <c>cancelBubble</c> and
-/// <c>initEvent()</c>/<c>initCustomEvent()</c>. <c>relatedTarget</c> and the touch target list belong to
-/// interfaces (<c>UIEvent</c>, <c>TouchEvent</c>) that do not exist here. The other two legacy members,
-/// <c>srcElement</c> and <c>returnValue</c>, <i>are</i> implemented — see <see cref="EventPrototype"/>.
+/// Deliberately absent: <c>cancelBubble</c>, which the specification marks legacy and which no script
+/// written for a non-browser runtime reaches for. <c>relatedTarget</c> and the touch target list belong to
+/// interfaces (<c>UIEvent</c>, <c>TouchEvent</c>) that do not exist here. The interface's other legacy
+/// members — <c>srcElement</c>, <c>returnValue</c>, <c>initEvent()</c> and <c>initCustomEvent()</c> —
+/// <i>are</i> implemented; see <see cref="EventPrototype"/> and <see cref="CustomEventPrototype"/>.
 /// </para>
 /// </remarks>
 internal class JsEvent : ObjectInstance
@@ -68,19 +69,23 @@ internal class JsEvent : ObjectInstance
     /// https://dom.spec.whatwg.org/#dom-event-type. Spelled <c>EventType</c> rather than <c>Type</c> because
     /// <see cref="JsValue.Type"/> already means the JavaScript type of the value itself.
     /// </summary>
-    internal JsString EventType { get; }
+    /// <remarks>
+    /// Settable only through <see cref="InitializeEvent"/>, which is the whole of what <c>initEvent()</c>
+    /// does; nothing else on the interface can change an event's type once it exists.
+    /// </remarks>
+    internal JsString EventType { get; private set; }
 
     /// <summary>
     /// The same string as <see cref="EventType"/>, materialized once. Dispatch compares it against every
     /// listener's type, and a <see cref="JsString"/> can be a rope whose <c>ToString</c> is not free.
     /// </summary>
-    internal string TypeName { get; }
+    internal string TypeName { get; private set; }
 
     /// <summary>https://dom.spec.whatwg.org/#dom-event-bubbles.</summary>
-    internal bool Bubbles { get; }
+    internal bool Bubbles { get; private set; }
 
     /// <summary>https://dom.spec.whatwg.org/#dom-event-cancelable.</summary>
-    internal bool Cancelable { get; }
+    internal bool Cancelable { get; private set; }
 
     /// <summary>https://dom.spec.whatwg.org/#dom-event-composed — the composed flag.</summary>
     internal bool Composed { get; }
@@ -123,6 +128,40 @@ internal class JsEvent : ObjectInstance
     /// <c>composedPath()</c> answers from.
     /// </summary>
     internal bool DispatchFlag { get; set; }
+
+    /// <summary>
+    /// https://dom.spec.whatwg.org/#concept-event-initialize — <i>initialize an event</i>, which is the whole
+    /// body of <c>initEvent()</c> and the first two steps of <c>initCustomEvent()</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Step 1, "set event's initialized flag", has nothing to set. The flag is unset by exactly one algorithm
+    /// in the standard, <c>document.createEvent()</c>, and read by exactly one, <c>dispatchEvent</c>'s
+    /// <c>InvalidStateError</c> guard. There is no <c>document</c> here, so every event Jint can build has the
+    /// flag set from birth and no observation can tell a stored flag from an assumed one.
+    /// </para>
+    /// <para>
+    /// What it deliberately does <b>not</b> touch is the composed flag, which is why the specification notes
+    /// that <c>initEvent()</c> "is redundant with event constructors and incapable of setting composed".
+    /// </para>
+    /// </remarks>
+    internal void InitializeEvent(JsString type, bool bubbles, bool cancelable)
+    {
+        // Step 2.
+        StopPropagationFlag = false;
+        StopImmediatePropagationFlag = false;
+        CanceledFlag = false;
+
+        // Steps 3 and 4.
+        IsTrusted = false;
+        Target = Null;
+
+        // Steps 5 to 7.
+        EventType = type;
+        TypeName = type.ToString();
+        Bubbles = bubbles;
+        Cancelable = cancelable;
+    }
 
     /// <summary>
     /// https://dom.spec.whatwg.org/#concept-event-initialize step "set the canceled flag": a non-cancelable
@@ -224,7 +263,11 @@ internal sealed class JsCustomEvent : JsEvent
     /// https://dom.spec.whatwg.org/#dom-customevent-detail. The IDL default is <c>null</c>, not
     /// <c>undefined</c>.
     /// </summary>
-    internal JsValue Detail { get; }
+    /// <remarks>
+    /// Settable only through <c>initCustomEvent()</c>, whose step 3 is "set this's detail attribute to
+    /// detail" — https://dom.spec.whatwg.org/#dom-customevent-initcustomevent.
+    /// </remarks>
+    internal JsValue Detail { get; set; }
 }
 
 /// <summary>

--- a/Jint/WebApi/Events/JsEvent.cs
+++ b/Jint/WebApi/Events/JsEvent.cs
@@ -28,7 +28,8 @@ namespace Jint.WebApi.Events;
 /// <para>
 /// Deliberately absent, both marked legacy by the specification: <c>cancelBubble</c> and
 /// <c>initEvent()</c>/<c>initCustomEvent()</c>. <c>relatedTarget</c> and the touch target list belong to
-/// interfaces (<c>UIEvent</c>, <c>TouchEvent</c>) that do not exist here.
+/// interfaces (<c>UIEvent</c>, <c>TouchEvent</c>) that do not exist here. The other two legacy members,
+/// <c>srcElement</c> and <c>returnValue</c>, <i>are</i> implemented — see <see cref="EventPrototype"/>.
 /// </para>
 /// </remarks>
 internal class JsEvent : ObjectInstance

--- a/Jint/WebApi/Performance/UserTiming.cs
+++ b/Jint/WebApi/Performance/UserTiming.cs
@@ -106,14 +106,28 @@ internal static class UserTiming
     /// The <c>PerformanceMarkOptions</c> dictionary conversion.
     /// </summary>
     /// <remarks>
+    /// <para>
+    /// Step 1 of https://webidl.spec.whatwg.org/#es-dictionary is the whole of the type test: "If
+    /// <i>jsDict</i> is not an Object and <i>jsDict</i> is neither <c>undefined</c> nor <c>null</c>, then
+    /// throw a <c>TypeError</c>." So the two nullish values are the empty dictionary and everything else that
+    /// is not an object — a number, a string, a boolean, a BigInt, a symbol — is refused at the boundary
+    /// rather than silently treated as one.
+    /// </para>
+    /// <para>
     /// The IDL default of <c>detail</c> is <c>null</c>, which is why an absent dictionary, an absent member
     /// and an explicit <see langword="undefined"/> all give the same answer — and why
     /// <c>performance.mark('x').detail</c> is <c>null</c> rather than <c>undefined</c>.
+    /// </para>
     /// </remarks>
     internal static MarkOptions ReadMarkOptions(Realm realm, JsValue options, string context)
     {
         if (options is not ObjectInstance dictionary)
         {
+            if (!options.IsUndefined() && !options.IsNull())
+            {
+                Throw.TypeError(realm, context + ": the provided value is not of type 'PerformanceMarkOptions'.");
+            }
+
             return new MarkOptions(JsValue.Null, HasStartTime: false, StartTime: 0);
         }
 


### PR DESCRIPTION
Fixes items **1, 2 and 3** of #3212 — the user-timing and DOM `Event` defects. With #3243 (items 4–6) that leaves four of the eleven; #3212 stays open.

**Two of the three recorded analyses were wrong**, and both corrections are in the docs rather than quietly worked around.

---

### Item 1 — `PerformanceMark` options

The issue says `performance.mark(name, 123)` "refuses it correctly", so the two halves of `mark-errors.any.js` disagree. **They did not disagree.** `mark-errors.any.js` calls the method **unbound** (`testInfo.testFunction(self.performance.mark)`), so the `TypeError` its passing half observed came from the brand check on a `this` of `undefined` — not from any conversion. `performance.mark(name, 123)` did not refuse a non-object either.

Both halves already shared one conversion, `UserTiming.ReadMarkOptions` (reached through `PerformanceMarkConstructor.ReadArguments`, which `performance.mark` runs as its own step 1), and it treated every non-object as the empty dictionary. Fixed in that shared path per [WebIDL §3.2.19 step 1](https://webidl.spec.whatwg.org/#es-dictionary) — *"If jsDict is not an Object and jsDict is neither undefined nor null, then throw a TypeError"* — which is exactly what `EventConstructor.ReadEventInit` already did.

### Item 2 — `isTrusted`, and its allocation cost

[DOM](https://dom.spec.whatwg.org/#dom-event-istrusted) declares it `[LegacyUnforgeable]`; [WebIDL §3.4.10](https://webidl.spec.whatwg.org/#LegacyUnforgeable) makes that *"non-configurable and … an own property on the object itself rather than on its prototype"*, and [§3.7.6](https://webidl.spec.whatwg.org/#es-attributes) both gives it `{[[Set]]: undefined, [[Enumerable]]: true, [[Configurable]]: false}` and **removes** it from the prototype. Implemented as a virtual own property — the shape `Function` already uses for `length`/`name` and `JsError` for `message`.

**The per-instance cost is zero**, which is not the obvious outcome and was measured rather than asserted (`GC.GetAllocatedBytesForCurrentThread`, 20,000 iterations, best of 7, net10.0, engine reverted to `main` for the before column):

| workload | before | after |
| --- | --- | --- |
| `new Event('x')` | 112 B | **112 B** |
| `new CustomEvent('x')` | 120 B | **120 B** |
| `new Event('x'); e.isTrusted` | 112 B | **112 B** |
| `t.dispatchEvent(new Event('x'))` | 192 B | 192 B |
| `Object.getOwnPropertyDescriptor(e,'isTrusted')` | 112 B | 616 B |

Nothing per instance and nothing per read. The only row that moved is the descriptor *query*, which previously returned `undefined`; the 504 B is ECMAScript's own `FromPropertyDescriptor` result — what any accessor costs.

Worth stating because the naive implementation is **not** free: one *stored* own property on an event measures **296 B against 112 B — +184 B, +164%**. Two things buy the zero: the descriptor is one shared instance per realm (an accessor is unwrapped by calling its getter with the *receiver*), and it is never stored. Sharing is safe by the argument the engine already makes process-wide for `AllForbiddenDescriptor` — a non-configurable, setter-less descriptor is unreachable by every mutating branch of `ValidateAndApplyPropertyDescriptor`.

Behaviour that changed for every event, and is the point: `Object.keys(new Event('x'))` is now `["isTrusted"]` and `JSON.stringify` gives `{"isTrusted":false}`, as a browser answers. One existing test asserted the old count and was updated.

### Item 3 — `srcElement` and `returnValue`

The recorded analysis called `srcElement` `[LegacyUnforgeable]`. Re-deriving from the [interface IDL](https://dom.spec.whatwg.org/#interface-event) shows it carries **no** extended attribute — only `isTrusted` does — so it is an ordinary prototype accessor returning `this`'s target.

`returnValue` is implemented as the **algorithm**, not a field: the getter is `!canceledFlag` and the setter runs [*set the canceled flag*](https://dom.spec.whatwg.org/#set-the-canceled-flag), so it is `preventDefault()` under another name — ignored by a non-cancelable event *and* inside a passive listener, and `= true` never clears a flag already set. Its IDL type is `boolean`, so `= 0` cancels and `= 1` does not.

### `Event-constructors.any.js` — vendored, but it needed a third member

Items 2 and 3 did **not** make it vendorable, and the recorded reason was incomplete: each of its two unnamed failures asserts the whole initial state of a new event, `assert_true("initEvent" in ev)` included, so fixing `srcElement`/`returnValue` left it failing one assertion later.

`initEvent()` and `initCustomEvent()` are implemented — [*initialize an event*](https://dom.spec.whatwg.org/#concept-event-initialize) step for step behind the dispatch-flag guard, deliberately not touching the composed flag — and the file is vendored. Its "set the initialized flag" step has nothing to set here: that flag is unset only by `document.createEvent()` and read only by `dispatchEvent`'s `InvalidStateError` guard, and there is no `document`.

Byte-verified: `git hash-object` of the vendored copy is `faa623ea92991b72742477a18471449f5382f1a8`, the blob id GitHub reports for that path at the pin. Minimum-test floor 14 — the file has 14 tests, not the 15 the old prose claimed. All 14 pass.

**This is beyond the three items and is its own commit**, so it can be dropped without touching the rest.

### Exclusion accounting

`NeedsTriage` 29 → 23 rows: 4 × `mark-errors.any.js`, `Event-isTrusted.any.js`, `AddEventListenerOptions-passive.any.js`. `_notVendored` loses its `Event-constructors.any.js` row. The `NeedsTriage` doc comment and three `Vendor/README.md` sections were rewritten to match.

### Verification

Solution builds Release, 0 errors. All production changes are under `Jint/WebApi/`.

| suite | net472 | net10.0 |
| --- | --- | --- |
| `Jint.Tests` | 7147 | 10234 |
| `Jint.Tests` + `JINT_HOST_CONTRACT_VERIFICATION=1` | 7147 | 10234 |
| `Jint.Tests.PublicInterface` | 1879 | 2405 |
| `Jint.Tests.PublicInterface` + verification | 1883 | 2409 |

WPT 417/417 files. Per-row before/after with only the engine reverted — **exactly 8 rows moved, all FAIL→PASS, all intended**: `dom/events` 37/4 → 41/0, `user-timing` 69/9 → 73/5, and every other corpus (`dom/abort`, `hr-time`, `html/*`, `fetch/api/*`, `streams`, `workers`, `WebCryptoAPI`, `encoding`, `url`, `urlpattern`, `FileAPI`, `compression`) byte-identical.

test262 not run: nothing reaches non-web-API engine code — the `ObjectInstance` virtuals are overridden only on `JsEvent`, which test262 never creates.

### Left undone

`cancelBubble` is still absent — the last legacy `Event` member, not in the issue and needed by no vendored file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
