### PR TITLE
queueMicrotask: report a throwing callback instead of letting it erupt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -464,7 +464,7 @@ Feature flags live in `WebApiFeatures`, whose bit layout is fixed ahead of the i
 
 **`DiagnosticsSink` (`Jint/WebApi/DiagnosticsSink.cs`) is the one channel for the script errors a host cannot catch**, and the only web-API surface no feature flag governs: `Options.WebApi.Diagnostics.Sink` arms it on its own, so an engine that named no feature at all still gets it (`Options.Apply`'s condition, and the early return at the top of `WebApiRegistration.Apply` that gives such an engine the channel and *no* globals — not even `DOMException`). `WebApiFeatures.Reporting` (`1 << 15`) governs only the `reportError` global, whose whole implementation is HTML's *report an exception* reduced to its last step: this engine's global object is not an `EventTarget`, so nothing is fired, *notHandled* stays true, and "the user agent may report exception to a developer console" is the sink. Without a sink `reportError` is a no-op that never throws; its one failure is WebIDL's arity error for a bare `reportError()`.
 
-Three things to hold on to when touching it. **The sink decides erupt-versus-report, so it is snapshotted at engine build time** into `Engine._webApi.Diagnostics` (and into `TimerQueue.Diagnostics`, so `TimerEntry.Fire` costs a field read and an entry costs no extra reference) — deliberately unlike `ConsoleOptions.Sink`, which is read afresh per emit: a contract that flips mid-script would be unreasonable, and reading `Options.WebApi` from `Engine.OnPromiseRejectionTracker` would force the lazy options group on a *default* engine and mutate shared `Options` from an engine thread. **Only a `JavaScriptException` is ever reported.** Both catch sites (`TimerEntry.Fire`, `JsEventTarget.InvokePass`) key on that type alone with a `when (… is { } diagnostics)` filter, which is precisely the MustPropagate rule stated positively: `ExecutionCanceledException`, `TimeoutException`, `MemoryLimitExceededException`, `StatementsCountOverflowException`, `RecursionDepthOverflowException` and `OperationCanceledException` are all `JintException` but none is a `JavaScriptException`, so a budget still bounds. With no sink there is no `catch` clause at all, which is what keeps the sinkless engine byte-identical. **The promise half is additive and ordered:** `Engine.OnPromiseRejectionTracker` raises `Advanced.PromiseRejectionTracker` first and *then* calls `_webApi?.ReportPromiseRejection`, so the pre-existing public event cannot be perturbed by a sink. It reports at the tracker's cadence, not HTML's — `Promise.reject(e).catch(f)` produces a `RejectionHandled: false` report followed by a `true` one where a browser's deferred checkpoint would raise nothing, which is documented on the property rather than papered over.
+Three things to hold on to when touching it. **The sink decides erupt-versus-report, so it is snapshotted at engine build time** into `Engine._webApi.Diagnostics` (and into `TimerQueue.Diagnostics`, so `TimerEntry.Fire` costs a field read and an entry costs no extra reference) — deliberately unlike `ConsoleOptions.Sink`, which is read afresh per emit: a contract that flips mid-script would be unreasonable, and reading `Options.WebApi` from `Engine.OnPromiseRejectionTracker` would force the lazy options group on a *default* engine and mutate shared `Options` from an engine thread. **Only a `JavaScriptException` is ever reported.** All three catch sites (`TimerEntry.Fire`, `JsEventTarget.InvokePass`, `TimerFunctions.InvokeMicrotask` for a `queueMicrotask` callback, which HTML invokes with the same WebIDL `"report"` exception behaviour a timer handler gets) key on that type alone with a `when (… is { } diagnostics)` filter, which is precisely the MustPropagate rule stated positively: `ExecutionCanceledException`, `TimeoutException`, `MemoryLimitExceededException`, `StatementsCountOverflowException`, `RecursionDepthOverflowException` and `OperationCanceledException` are all `JintException` but none is a `JavaScriptException`, so a budget still bounds. With no sink there is no `catch` clause at all, which is what keeps the sinkless engine byte-identical. **The promise half is additive and ordered:** `Engine.OnPromiseRejectionTracker` raises `Advanced.PromiseRejectionTracker` first and *then* calls `_webApi?.ReportPromiseRejection`, so the pre-existing public event cannot be perturbed by a sink. It reports at the tracker's cadence, not HTML's — `Promise.reject(e).catch(f)` produces a `RejectionHandled: false` report followed by a `true` one where a browser's deferred checkpoint would raise nothing, which is documented on the property rather than papered over.
 
 ### Web platform tests
 
@@ -476,7 +476,7 @@ that table. `Prelude/testharness-shim.js` is Jint's own file, not a vendored one
 upstream's `testharness.js` these suites use, and `WptHarnessTests` exercises every assertion in it from both
 sides, because a shim that quietly passed everything would make five thousand cases green and mean nothing.
 
-Five things to know before touching it. **The exclusion table is the artefact**: a test that does not pass is
+Six things to know before touching it. **The exclusion table is the artefact**: a test that does not pass is
 named in `WptTestRunner._exclusions` with a `WptDivergence` category, and an entry must match at least one
 failing test and no passing one — so a fix, a rename, or a corpus bump makes the run fail until the table is
 brought back in line, and a `*` glob can never widen into a blanket. **`NeedsTriage` is the debt**: those are
@@ -492,9 +492,16 @@ run of a file is the union of all of its variants. And **every engine carries th
 groups need it: `url/urlencoded-parser.any.js` reaches the urlencoded parser through `Request.formData()` and
 `Response.formData()` as well as `URLSearchParams`, and the two vendored `fetch/api/` suites are about those
 three interfaces and nothing else, which is what let half of that corpus be vendored while the half that
-talks to a server could not.
+talks to a server could not. Last, **every engine carries a `DiagnosticsSink`**, because that is what makes an
+exception escaping a timer callback, a `queueMicrotask` callback or an event listener report-and-continue
+rather than erupt from the pump — the environment the corpus was written for, and the same choice
+`WorkerRequest.CreateDefaultOptions` already makes for a worker engine. It is a *recorder* rather than
+`DiagnosticsSink.Null` on purpose: before it existed such an exception erupted and the driver reported a
+harness error for the whole file, so `WptHarness` turns any recorded uncaught callback error into that same
+harness error unless the file declared `setup({allow_uncaught_exception: true})` — which is upstream's own
+rule, and the second and last member of the properties bag the shim acts on.
 
-A sixth thing is worth knowing because it decides *where* a divergence gets recorded. The driver's unit of
+A seventh thing is worth knowing because it decides *where* a divergence gets recorded. The driver's unit of
 report is a test, so a file that cannot produce one — a throw at file scope, a run that **stalls**, or a file
 whose tests are all registered *without a name* — is a harness error covering the whole file and has to go in
 `_notVendored` with its reason rather than in the exclusion table. The clearest three are opposite ends of

--- a/Jint.Tests.PublicInterface/WebApiDiagnosticsTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiDiagnosticsTests.cs
@@ -144,6 +144,40 @@ public class WebApiDiagnosticsTests
     }
 
     [Fact]
+    public void AThrowingMicrotaskCallbackIsReportedWhenASinkIsSet()
+    {
+        // queueMicrotask is invoked with the same WebIDL "report" exception behavior a timer handler is —
+        // https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-queuemicrotask.
+        var sink = new RecordingSink();
+        var engine = new Engine(options => options.UseWebApis(webApi => webApi.Diagnostics.Sink = sink));
+
+        engine.Execute("""
+            var second = false;
+            queueMicrotask(() => { throw new Error('boom'); });
+            queueMicrotask(() => { second = true; });
+            """);
+
+        // Execute drains the queue on its way out, so nothing erupts at the host and the microtask behind the
+        // failed one still ran.
+        engine.Evaluate("second").AsBoolean().Should().BeTrue();
+
+        var report = Assert.Single(sink.Reports);
+        report.Kind.Should().Be(DiagnosticEventKind.UncaughtCallbackError);
+        report.CallbackSource.Should().Be(DiagnosticCallbackSource.Microtask);
+        report.Exception!.Message.Should().Be("boom");
+    }
+
+    [Fact]
+    public void AThrowingMicrotaskCallbackStillEruptsWithoutASink()
+    {
+        var engine = new Engine(options => options.UseWebApis());
+
+        Assert.Throws<JavaScriptException>(
+                () => engine.Execute("queueMicrotask(() => { throw new Error('boom'); });"))
+            .Message.Should().Be("boom");
+    }
+
+    [Fact]
     public void AThrowingListenerIsReportedWhenASinkIsSet()
     {
         var sink = new RecordingSink();

--- a/Jint.Tests/Runtime/WebApi/DiagnosticsTests.cs
+++ b/Jint.Tests/Runtime/WebApi/DiagnosticsTests.cs
@@ -14,7 +14,8 @@ namespace Jint.Tests.Runtime.WebApi;
 /// <remarks>
 /// <para>
 /// Half of what is asserted here is what happens <i>without</i> a sink, because setting one is what changes
-/// the contract: with no sink a timer callback or an event listener that throws erupts, which is the
+/// the contract: with no sink a timer callback, a <c>queueMicrotask</c> callback or an event listener that
+/// throws erupts, which is the
 /// behaviour every other test in this folder was written against and which must stay exactly as it was.
 /// Every report-and-continue test therefore has an erupts-without-a-sink twin.
 /// </para>
@@ -282,6 +283,100 @@ public class DiagnosticsTests
         clock.Advance(5);
 
         Assert.Throws<RecursionDepthOverflowException>(() => engine.Advanced.ProcessTasks());
+        sink.Reports.Should().BeEmpty();
+    }
+
+    // queueMicrotask — https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-queuemicrotask
+
+    [Fact]
+    public void AThrowingMicrotaskCallbackIsReportedAndTheQueueCarriesOn()
+    {
+        var (engine, sink, _) = Reporting();
+
+        engine.Execute("""
+            queueMicrotask(() => { log.push('first'); throw new Error('boom'); });
+            queueMicrotask(() => log.push('second'));
+            """);
+
+        // "Queue a microtask to invoke callback ... and "report"": Execute drains the queue on its way out,
+        // so both callbacks have run by the time it returns and the exception never reaches the host.
+        Log(engine).Should().Be("first,second");
+
+        var report = Assert.Single(sink.Reports);
+        report.Kind.Should().Be(DiagnosticEventKind.UncaughtCallbackError);
+        report.CallbackSource.Should().Be(DiagnosticCallbackSource.Microtask);
+        report.Exception.Should().NotBeNull();
+        report.Exception!.Message.Should().Be("boom");
+        report.Value.Should().BeSameAs(report.Exception.Error);
+        report.Promise.Should().BeNull();
+    }
+
+    [Fact]
+    public void AThrowingMicrotaskCallbackEruptsWithoutASink()
+    {
+        // The twin of the test above, and the behaviour every engine without a sink keeps. It erupts from
+        // whatever is running the queue — here Execute's own drain, exactly as a timer's does.
+        var (engine, _) = Silent();
+
+        Assert.Throws<JavaScriptException>(
+                () => engine.Execute("queueMicrotask(() => { log.push('first'); throw new Error('boom'); });"))
+            .Message.Should().Be("boom");
+
+        Log(engine).Should().Be("first");
+    }
+
+    [Fact]
+    public void AReportedMicrotaskCallbackDoesNotStopTheJobsBehindIt()
+    {
+        // The engine's single job queue *is* the microtask queue, so a reported failure must leave everything
+        // already queued — a promise reaction, a later microtask, a due timer — exactly where it was.
+        var (engine, sink, clock) = Reporting();
+
+        engine.Execute("""
+            setTimeout(() => log.push('timeout'), 0);
+            queueMicrotask(() => { log.push('micro1'); throw new Error('boom'); });
+            Promise.resolve().then(() => log.push('promise'));
+            queueMicrotask(() => log.push('micro2'));
+            log.push('script');
+            """);
+
+        clock.Advance(1);
+        engine.Advanced.ProcessTasks();
+
+        Log(engine).Should().Be("script,micro1,promise,micro2,timeout");
+        Assert.Single(sink.Reports).CallbackSource.Should().Be(DiagnosticCallbackSource.Microtask);
+    }
+
+    [Fact]
+    public void AConstraintFailureInAMicrotaskCallbackStillErupts()
+    {
+        // The same MustPropagate rule the timer and listener sites keep: RecursionDepthOverflowException is a
+        // JintException but not a JavaScriptException, so the catch never sees it and the budget still bounds.
+        var (engine, sink, _) = Reporting(options => options.LimitRecursion(8));
+
+        Assert.Throws<RecursionDepthOverflowException>(() => engine.Execute("""
+            function recurse() { return recurse(); }
+            queueMicrotask(() => { log.push('entered'); recurse(); });
+            """));
+
+        // The overflow happened inside the queued callback rather than before it, which is what makes this a
+        // statement about the report site and not about the enqueue.
+        Log(engine).Should().Be("entered");
+        sink.Reports.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AStatementBudgetTrippedInsideAMicrotaskCallbackStillErupts()
+    {
+        // The other half of the same rule, over the budget a runaway callback actually trips: a microtask
+        // that never returns must not be able to spend the engine's statement budget and then have the
+        // overflow filed as a diagnostic.
+        var (engine, sink, _) = Reporting(options => options.MaxStatements(1000));
+
+        Assert.Throws<StatementsCountOverflowException>(
+            () => engine.Execute("queueMicrotask(() => { log.push('entered'); for (var i = 0; ; i++) { } });"));
+
+        Log(engine).Should().Be("entered");
         sink.Reports.Should().BeEmpty();
     }
 

--- a/Jint.Tests/Wpt/Prelude/testharness-shim.js
+++ b/Jint.Tests/Wpt/Prelude/testharness-shim.js
@@ -12,6 +12,9 @@
 //                       that gave up through `assert_implements_optional`.
 //   __wpt.outstanding — the names of the tests that have started and not finished. Empty means the file is
 //                       over, and while it is not, it is the message a stalled run reports.
+//   __wpt.allowUncaughtException — whether the file declared `setup({allow_uncaught_exception: true})`, which
+//                       is what tells the driver that a failure escaping an engine-invoked callback is the
+//                       point of the file rather than a defect. See `setup` below.
 // The driver supplies `__wptReadResource(path)` before this file runs; nothing else crosses the boundary.
 //
 // Deliberate divergences from upstream testharness.js, all of them recorded in Jint.Tests/Wpt/Vendor/README.md:
@@ -845,11 +848,16 @@
     }
 
     // `setup` takes either a function run for its side effects before the tests are registered, or a
-    // properties bag. Of the bag only `single_test` is honoured, because it is the only member that decides
-    // what the file *is* rather than how a browser schedules it: it turns the whole file into one test, and a
-    // file that declared it and got nothing back would register no test at all and be reported as an empty
-    // run. Everything else in the bag — `explicit_done`, `allow_uncaught_exception`, the timeouts — is browser
-    // scheduling or a top-level error channel this shim does not have, and is accepted and ignored.
+    // properties bag. Two of the bag's members are honoured, because they decide what the file *is* rather
+    // than how a browser schedules it; the rest — `explicit_done`, the timeouts — is browser scheduling and is
+    // accepted and ignored.
+    //
+    //   * `single_test` turns the whole file into one test, and a file that declared it and got nothing back
+    //     would register no test at all and be reported as an empty run.
+    //   * `allow_uncaught_exception` is upstream's declaration that a failure is *expected* to escape a
+    //     callback the engine invoked. Upstream fails such a run through its own global `onerror` unless the
+    //     flag is set; the driver does the same through the DiagnosticsSink every engine it builds carries,
+    //     and this is where it reads the flag. See WptHarness.WptDiagnosticsSink.
     function setup(funcOrProperties) {
         if (typeof funcOrProperties === 'function') {
             funcOrProperties();
@@ -860,6 +868,9 @@
             // finished by the file calling `done()`. The name is the source file, which is this shim's own
             // choice — see the header.
             fileTest = async_test(typeof __wptTestFile === 'string' ? __wptTestFile : 'single_test');
+        }
+        if (funcOrProperties && funcOrProperties.allow_uncaught_exception) {
+            global.__wpt.allowUncaughtException = true;
         }
     }
 
@@ -1049,6 +1060,7 @@
     // that had in fact just finished.
     global.__wpt = {
         results: results,
-        outstanding: outstanding
+        outstanding: outstanding,
+        allowUncaughtException: false
     };
 })(globalThis);

--- a/Jint.Tests/Wpt/Vendor/README.md
+++ b/Jint.Tests/Wpt/Vendor/README.md
@@ -20,7 +20,11 @@ output by inflating it with pako rather than with the engine's own `Decompressio
 
 `Jint.Tests/Wpt/WptTestRunner.cs`, one xUnit theory case per `.any.js` file, on a fresh engine built with
 `UseWebApis(WebApiFeatures.Default)` plus the fetch object model — `Headers`, `Request` and `Response`, and
-pointedly not `fetch`, so no suite gets outbound network access. `Jint.Tests/Wpt/Prelude/testharness-shim.js`
+pointedly not `fetch`, so no suite gets outbound network access — and a `DiagnosticsSink`, which is what makes
+an exception escaping a timer callback, an event listener or a `queueMicrotask` callback report-and-continue
+rather than erupt from the pump. `WptDiagnosticsSink` says why the driver needs one and why it records the
+reports instead of discarding them; the timers-and-microtask section below has the same account in prose.
+`Jint.Tests/Wpt/Prelude/testharness-shim.js`
 — *not* vendored — stands in for upstream's `testharness.js`; its header says what it implements and where it
 deliberately differs. `WptHarness.cs` documents the three decisions a reader is most likely to want: the
 engine supplies its own `setTimeout` — the shim's `step_timeout` is a forwarder onto it, so the streams
@@ -36,7 +40,7 @@ Twelve standards are vendored: `url/`, `encoding/`, `compression/`, `urlpattern/
 **three**, `html/webappapis/` as **three** (timers, microtask-queuing, structured-clone), `dom/` as **two**
 (events, abort), `fetch/api/` as **two** (headers, response), `WebCryptoAPI/` as **eight** and `streams/` as
 **seven** — their root files plus one suite per sub-directory, because `WptCorpus.TestFiles` lists a
-directory's own files and never descends. That is 269 theory cases over 40,617 assertions, of which 2,980 do
+directory's own files and never descends. That is 271 theory cases over 40,632 assertions, of which 2,907 do
 not pass and every one is named in the driver's table; the whole driver runs in about two minutes.
 
 The corpora arrived a group at a time, most of them under
@@ -131,7 +135,6 @@ without revisiting the reason fails rather than quietly adding a red suite.
 | `workers/interfaces/WorkerGlobalScope/location/*` | The whole assertion of `returns-same-object.any.js` is `location === location`. The harness shim installs a stub `location` of its own — `/common/subset-tests.js` reads `location.search` to pick a shard — so a vendored copy would pass **against the shim** while Jint deliberately has no `WorkerLocation` at all. A test that can only assert the harness is worse than no test, which is why this is a row here and not an exclusion. |
 | `user-timing/supported-usertiming-types.any.js` | Reads `PerformanceObserver.supportedEntryTypes` at *file scope* to decide which promise tests to register, so on an engine with no `PerformanceObserver` it throws before the first test exists. The rows that reach for an observer from inside a test body are excluded one by one instead, under `NeedsPerformanceObserver`. |
 | `html/webappapis/timers/evil-spec-example.any.js` | `setTimeout`'s string handler, which `TimerFunctions` documents declining: compiling the string is `eval` by another name and reachable even where a host disabled string compilation, so it is a `TypeError` here as it is in Node. The file's whole subject is that form, and it uses it at file scope. |
-| `html/webappapis/microtask-queuing/queue-microtask-exceptions.any.js` | A defect, and one that cannot be an exclusion — see [What the timers and microtask corpora say](#what-the-timers-and-microtask-corpora-say-about-this-engine). |
 | `dom/events/*.window.js`, `dom/events/*.html`, `dom/abort/*.html` | For a browsing context, like every non-`.any.js` file. |
 | `fetch/api/request/*` | Every file builds its `Request` from a **relative** url — `""`, `"./"`, `"../resources/…"` — and `RequestConstructor` documents why that cannot work: the specification resolves such a string against "the entry settings object's API base URL", which is a document's url, and an embedded engine has no document. Most of them do it at file scope, so there is not even a test to exclude. A host that wants a relative url resolves it itself with `new URL(relative, base).href`. |
 | `fetch/api/abort/*`, `fetch/api/basic/*`, `fetch/api/body/*`, `fetch/api/cors/*`, `fetch/api/credentials/*`, `fetch/api/policies/*`, `fetch/api/redirect/*` | A client talking to wptserve: `.py` handlers that echo headers, trickle bytes, redirect, stall, or check CORS preflights. There is no server here and the shim's `fetch` is a reader over the vendored tree. |
@@ -482,23 +485,44 @@ cannot make.
 
 ## What the timers and microtask corpora say about this engine
 
-16 assertions across nine files, and **every one of them passes** — which is the answer that matters, because
+17 assertions across ten files, and **every one of them passes** — which is the answer that matters, because
 these are the files that test the `TimerQueue` from the outside: `setTimeout` and `setInterval` sharing one id
 space so `clearInterval` cancels a timeout, an interval cleared from its own callback staying cleared,
 `setInterval(0)` and `setTimeout(0)` firing in registration order, `setInterval(fn)` with no interval at all
 behaving as `0`, a negative delay clamping to `0`, and `2**32` wrapping to `0` through WebIDL's `long`
 conversion. Four of them are `setup({single_test: true})` files, which the shim did not previously implement.
 
-One file is **not vendored, and it is a defect rather than a decline**.
+**The tenth file was a defect rather than a decline, and it is fixed.**
 `queue-microtask-exceptions.any.js` throws from a `queueMicrotask` callback and expects to observe it as an
 `error` event at the global scope. [HTML's `queueMicrotask`](https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-queuemicrotask)
-says "queue a microtask to invoke *callback*, given null and **"report"**", and WebIDL's *report* exception
-behaviour is HTML's *report an exception* — fire `error` at the global scope, then tell the console. Jint
-instead lets the throw erupt from whatever is pumping the event loop: `TimerFunctions.QueueMicrotaskCallback`
-enqueues a bare `callback.Call(...)`, where `TimerEntry.Fire` and `JsEventTarget.InvokePass` both have the
+says "queue a microtask to invoke *callback*, given null and **"report"**", and WebIDL's
+[*report the exception*](https://webidl.spec.whatwg.org/#report-the-exception) is HTML's *report an
+exception* — fire `error` at the global scope, then tell the console. Jint instead let the throw erupt from
+whatever was pumping the event loop: `TimerFunctions.QueueMicrotaskCallback` enqueued a bare
+`callback.Call(...)`, where `TimerEntry.Fire` and `JsEventTarget.InvokePass` both carry the
 `catch (JavaScriptException) when (… is { } diagnostics)` filter that reaches
-`WebApiEngineState.FireGlobalErrorEvent`. So the exception leaves the engine before any listener can see it,
-the file is a harness error rather than a failing test, and there is no test left for an exclusion to name.
+`WebApiEngineState.FireGlobalErrorEvent`. So the exception left the engine before any listener could see it,
+the file was a harness error rather than a failing test, and there was no test left for an exclusion to name —
+which is why it lived here rather than in the table. Item 11 of
+[issue #3212](https://github.com/sebastienros/jint/issues/3212) gave the callback the third instance of that
+same filter, and the file is vendored and green. Its copy is byte-identical to upstream's at the pin —
+`git hash-object` gives `01f32ac9ba14962fa99d4b263a8ca0f5a0daa161`, which is the blob id GitHub reports for
+that path at commit `6c7127bdd9`.
+
+Vendoring it needed one thing of the **driver**, and it is worth stating plainly because it is a decision
+about the environment rather than about the engine. Jint reports an exception escaping an engine-invoked
+callback — and carries on — only where the host installed a `DiagnosticsSink`; with none, the throw erupts,
+which is the documented contract an embedder who configured nothing keeps. A conformance corpus is written
+against the other half of it, so the driver's engines now carry a sink, exactly as the shipped
+`WorkerRequest.CreateDefaultOptions` already installs `DiagnosticsSink.Null` on every worker engine and for
+the same stated reason. The sink is a **recorder** rather than `Null`, because the report must not simply
+disappear: before it existed, such an exception erupted and the driver reported a harness error for the whole
+file, and upstream's own `testharness.js` does the same thing through a global `onerror` unless the file
+declared `setup({allow_uncaught_exception: true})`. So the shim now honours that one flag — it is the second
+member of the properties bag it acts on, beside `single_test` — and `WptHarness` turns any recorded uncaught
+callback error the file did not declare itself ready for into the same harness error the eruption used to be.
+Nothing else in the corpus moved: the sink changed no assertion's outcome anywhere, which the exclusion table
+proves for itself, since a row that stopped matching a failing test would fail its suite.
 
 ## Encoding, the single-byte half
 
@@ -710,16 +734,16 @@ the shim did not record `PASS`, which is exactly the set the table names.
 | URL Pattern | `urlpattern/` | 3 | 373 | 0 |
 | Encoding | `encoding/` | 20 | 11,544 | 322 |
 | Web Cryptography | `WebCryptoAPI/` ×8 | 48 | 24,136 | 2,448 |
-| Streams | `streams/` ×7 | 65 | 1,154 | 16 |
-| Compression | `compression/` | 15 | 297 | 84 |
+| Streams | `streams/` ×7 | 65 | 1,154 | 11 |
+| Compression | `compression/` | 15 | 297 | 22 |
 | File API | `FileAPI/` ×3 | 14 | 342 | 0 |
 | High Resolution Time | `hr-time/` | 2 | 7 | 1 |
-| User Timing | `user-timing/` | 19 | 78 | 9 |
+| User Timing | `user-timing/` | 19 | 78 | 5 |
 | HTML — workers | `workers/` ×3 | 11 | 15 | 7 |
-| HTML — timers, microtasks, structured clone | `html/webappapis/` ×3 | 10 | 153 | 3 |
-| DOM | `dom/` ×2 | 12 | 62 | 2 |
+| HTML — timers, microtasks, structured clone | `html/webappapis/` ×3 | 11 | 154 | 3 |
+| DOM | `dom/` ×2 | 13 | 76 | 0 |
 | Fetch | `fetch/api/` ×2 | 29 | 388 | 88 |
-| **total** | **34** | **269** | **40,617** | **2,980** |
+| **total** | **34** | **271** | **40,632** | **2,907** |
 
 Two of those rows are worth a caveat. The Encoding figure is dominated by
 `textdecoder-fatal-single-byte.any.js`, 7,168 assertions of it and every one passing; of the 322 that do not,

--- a/Jint.Tests/Wpt/Vendor/html/webappapis/microtask-queuing/queue-microtask-exceptions.any.js
+++ b/Jint.Tests/Wpt/Vendor/html/webappapis/microtask-queuing/queue-microtask-exceptions.any.js
@@ -1,0 +1,15 @@
+// META: global=window,worker
+"use strict";
+
+setup({
+  allow_uncaught_exception: true
+});
+
+async_test(t => {
+  const error = new Error("boo");
+  self.addEventListener("error", t.step_func_done(ev => {
+    assert_equals(ev.error, error);
+  }));
+
+  queueMicrotask(() => { throw error; });
+}, "It rethrows exceptions");

--- a/Jint.Tests/Wpt/WptExclusions.cs
+++ b/Jint.Tests/Wpt/WptExclusions.cs
@@ -406,9 +406,13 @@ internal enum WptDivergence
     /// currently says.
     /// </para>
     /// <para>
-    /// One further defect is recorded in <c>Vendor/README.md</c> with no entry here, because the test that
-    /// finds it cannot be named: a throw from a <c>queueMicrotask</c> callback erupts from the pump instead of
-    /// being reported, which takes its whole file down and leaves no test for an exclusion to cover.
+    /// <b>One further defect never had an entry here at all, and it is gone too.</b> A throw from a
+    /// <c>queueMicrotask</c> callback erupted from the pump instead of being reported, which took its whole
+    /// file down and left no test for an exclusion to cover, so
+    /// <c>html/webappapis/microtask-queuing/queue-microtask-exceptions.any.js</c> sat in <c>_notVendored</c>
+    /// with its analysis in <c>Vendor/README.md</c>. <c>TimerFunctions</c> now invokes the callback with
+    /// WebIDL's <c>"report"</c> exception behaviour — the third instance of the catch shape
+    /// <c>TimerEntry.Fire</c> and <c>JsEventTarget.InvokePass</c> carry — and the file is vendored and green.
     /// </para>
     /// </summary>
     NeedsTriage,

--- a/Jint.Tests/Wpt/WptHarness.cs
+++ b/Jint.Tests/Wpt/WptHarness.cs
@@ -31,6 +31,62 @@ internal readonly record struct WptTestResult(string Name, string Status, string
 internal sealed record WptRunOutcome(IReadOnlyList<WptTestResult> Results, string? HarnessError);
 
 /// <summary>
+/// The driver's <see cref="DiagnosticsSink"/>, and the reason every engine it builds has one.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Installing a sink is what gives an engine-invoked callback the browser's behaviour.</b> Jint reports an
+/// exception escaping a timer handler, an event listener or a <c>queueMicrotask</c> callback — and carries on
+/// — only where the host gave it somewhere to report to; with no sink the throw erupts from whatever is
+/// pumping, which is the documented contract and the one an embedder that configured nothing keeps. A
+/// conformance corpus is written against the other half of that contract: HTML invokes those callbacks with
+/// WebIDL's <c>"report"</c> exception behaviour, so <c>html/webappapis/microtask-queuing/queue-microtask-exceptions.any.js</c>
+/// registers an <c>error</c> listener and expects the failure to arrive there rather than to take the file
+/// down. The shipped code already makes this exact choice one level in: <c>WorkerRequest.CreateDefaultOptions</c>
+/// installs <see cref="DiagnosticsSink.Null"/> on every worker engine, for the same reason and in the same
+/// words. So the driver's engines get a sink too — and the worker lane's engine gets <i>this</i> one rather
+/// than the default null, so a file's environment does not depend on which lane ran it.
+/// </para>
+/// <para>
+/// <b>What it must not do is make the report disappear.</b> Before there was a sink, an exception escaping a
+/// callback erupted and the driver reported a harness error for the whole file — loudly, which is what
+/// upstream's own harness does too: <c>testharness.js</c> installs a global <c>onerror</c> and fails the run
+/// unless the file declared <c>setup({allow_uncaught_exception: true})</c>. Swallowing it instead would let a
+/// file go green while a real defect hid inside a callback nobody was watching, which is the one thing a
+/// corpus this size must not be able to do. So the reports are recorded, and
+/// <see cref="WptHarness"/> turns any that the file did not declare itself ready for into the same harness
+/// error the eruption used to be.
+/// </para>
+/// <para>
+/// Only <see cref="DiagnosticEventKind.UncaughtCallbackError"/> is kept. The other kinds are not failures a
+/// file has to declare: a promise rejection reaches the sink at <c>HostPromiseRejectionTracker</c>'s cadence
+/// and every <c>promise_rejects_*</c> assertion in the corpus produces a pair of them, <c>reportError</c> is a
+/// suite calling an API, and <c>WorkerError</c> is the worker lane's copy of an
+/// <see cref="DiagnosticEventKind.UncaughtCallbackError"/> this sink has already been told about directly.
+/// </para>
+/// <para>
+/// It needs no synchronization even though the worker lane shares one instance between two engines:
+/// <see cref="WptWorkerProvider"/> is the cooperative provider, so the parent and every worker are pumped in
+/// turn on the test's own thread and nothing here is ever reached from a second one.
+/// </para>
+/// </remarks>
+internal sealed class WptDiagnosticsSink : DiagnosticsSink
+{
+    private readonly List<string> _uncaught = [];
+
+    /// <summary>What escaped a callback the engine invoked, as text, in report order.</summary>
+    internal IReadOnlyList<string> UncaughtCallbackErrors => _uncaught;
+
+    public override void Report(DiagnosticEvent report)
+    {
+        if (report.Kind == DiagnosticEventKind.UncaughtCallbackError)
+        {
+            _uncaught.Add($"{report.CallbackSource}: {report.Exception?.Message}");
+        }
+    }
+}
+
+/// <summary>
 /// Runs one vendored <c>.any.js</c> file on a fresh engine and hands back what the shim recorded.
 /// </summary>
 /// <remarks>
@@ -213,8 +269,12 @@ internal static class WptHarness
 
         body.Append(WptCorpus.Read(testFilePath));
 
-        var provider = new WptWorkerProvider(body.ToString(), directory);
-        var parent = BuildEngine(directory, provider);
+        // One sink for both engines of the run: the worker's own callback errors are reported on the worker
+        // engine and the relay to the parent is a WorkerError this ignores, so a single recorder sees each
+        // failure exactly once whichever side it happened on.
+        var sink = new WptDiagnosticsSink();
+        var provider = new WptWorkerProvider(body.ToString(), directory, sink);
+        var parent = BuildEngine(directory, sink, provider);
 
         Engine? worker = null;
         try
@@ -223,7 +283,12 @@ internal static class WptHarness
             parent.Execute("globalThis.__wptWorker = new Worker(__wptWorkerSpecifier, { type: 'module' });");
 
             var stalled = PumpWorker(parent, provider, out worker);
-            return new WptRunOutcome(worker is null ? [] : ReadResults(worker), stalled);
+
+            // The shim — and therefore the flag that says whether the file declared itself ready for an
+            // uncaught exception — lives on the worker engine, which is also where the results are read.
+            return new WptRunOutcome(
+                worker is null ? [] : ReadResults(worker),
+                stalled ?? (worker is null ? null : UndeclaredCallbackErrors(worker, sink)));
         }
         catch (Exception ex)
         {
@@ -336,7 +401,8 @@ internal static class WptHarness
 
     private static WptRunOutcome Execute(string directory, List<string> metaScripts, string source, string sourceName)
     {
-        var engine = BuildEngine(directory);
+        var sink = new WptDiagnosticsSink();
+        var engine = BuildEngine(directory, sink);
 
         try
         {
@@ -356,7 +422,7 @@ internal static class WptHarness
             var stalled = Outstanding(engine) is { } outstanding
                 ? Pump(engine, outstanding)
                 : "the harness shim did not install __wpt";
-            return new WptRunOutcome(ReadResults(engine), stalled);
+            return new WptRunOutcome(ReadResults(engine), stalled ?? UndeclaredCallbackErrors(engine, sink));
         }
         catch (Exception ex)
         {
@@ -397,12 +463,47 @@ internal static class WptHarness
         return scripts;
     }
 
-    private static Engine BuildEngine(string directory, WptWorkerProvider? workers = null)
+    /// <summary>
+    /// Whether the run recorded an exception escaping an engine-invoked callback that the file never said it
+    /// was expecting, described as a harness error for the whole file. <see langword="null"/> when there is
+    /// nothing to report.
+    /// </summary>
+    /// <remarks>
+    /// This is upstream's rule rather than an invention: <c>testharness.js</c> installs a global
+    /// <c>onerror</c> and turns an uncaught exception into an error for the whole run unless the file declared
+    /// <c>setup({allow_uncaught_exception: true})</c>. It is also exactly what the driver did before its
+    /// engines had a sink, when such an exception erupted from the pump — see <see cref="WptDiagnosticsSink"/>
+    /// for why that had to be kept.
+    /// </remarks>
+    private static string? UndeclaredCallbackErrors(Engine engine, WptDiagnosticsSink sink)
+    {
+        if (sink.UncaughtCallbackErrors.Count == 0 || AllowsUncaughtException(engine))
+        {
+            return null;
+        }
+
+        return "an exception escaped a callback the engine invoked and the file did not declare "
+            + "setup({allow_uncaught_exception: true}): "
+            + string.Join("; ", sink.UncaughtCallbackErrors);
+    }
+
+    /// <summary>The shim's record of <c>setup({allow_uncaught_exception: true})</c>.</summary>
+    private static bool AllowsUncaughtException(Engine engine)
+        => engine.GetValue("__wpt") is ObjectInstance wpt
+            && TypeConverter.ToBoolean(wpt.Get("allowUncaughtException"));
+
+    private static Engine BuildEngine(string directory, WptDiagnosticsSink sink, WptWorkerProvider? workers = null)
     {
         var engine = new Engine(options =>
         {
             // Everything except outbound network access, which is what a suite under test is allowed to see.
             options.UseWebApis(WebApiFeatures.Default);
+
+            // What makes an exception escaping a timer callback, an event listener or a queueMicrotask
+            // callback report-and-continue rather than erupt from the pump, which is the environment the
+            // corpus was written for. See WptDiagnosticsSink for the whole rationale, including why the
+            // reports are recorded rather than discarded.
+            options.WebApi.Diagnostics.Sink = sink;
 
             // Only for the worker lane, and only then: an engine that no vendored file asks to create a worker
             // from is byte-for-byte the engine every other suite has always run on. `Worker` is absent without

--- a/Jint.Tests/Wpt/WptHarnessTests.cs
+++ b/Jint.Tests/Wpt/WptHarnessTests.cs
@@ -911,6 +911,45 @@ public class WptHarnessTests
     }
 
     [Fact]
+    public void AnExceptionEscapingACallbackIsAHarnessErrorForTheWholeFile()
+    {
+        // The driver's engines carry a DiagnosticsSink, so such an exception no longer erupts from the pump —
+        // and this is the rule that keeps it from disappearing instead. It is upstream's own: testharness.js
+        // fails a run whose global `onerror` fired unless the file declared allow_uncaught_exception.
+        var outcome = Run("""
+            test(() => {}, 'row');
+            queueMicrotask(() => { throw new Error('escaped'); });
+            """);
+
+        outcome.HarnessError.Should().NotBeNull();
+        outcome.HarnessError.Should().Contain("allow_uncaught_exception");
+        outcome.HarnessError.Should().Contain("escaped");
+
+        // The tests that did run are still reported, exactly as they are for a top-level throw.
+        outcome.Results.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void AFileThatDeclaresAllowUncaughtExceptionIsNotFailedByOne()
+    {
+        // The other half, and the reason html/webappapis/microtask-queuing/queue-microtask-exceptions.any.js
+        // can be vendored: its whole subject is a callback that throws, and it says so.
+        var outcome = Run("""
+            setup({ allow_uncaught_exception: true });
+            async_test(t => {
+                self.addEventListener('error', t.step_func_done(ev => {
+                    assert_equals(ev.error.message, 'expected');
+                }));
+                queueMicrotask(() => { throw new Error('expected'); });
+            }, 'row');
+            """);
+
+        outcome.HarnessError.Should().BeNull();
+        outcome.Results.Should().HaveCount(1);
+        outcome.Results[0].Status.Should().Be("PASS");
+    }
+
+    [Fact]
     public void AThrowOutOfTheTopLevelIsAHarnessErrorForTheWholeFile()
     {
         var outcome = Run("test(() => {}, 'row'); missingGlobal();");

--- a/Jint.Tests/Wpt/WptTestRunner.cs
+++ b/Jint.Tests/Wpt/WptTestRunner.cs
@@ -246,14 +246,6 @@ public class WptTestRunner
         ("html/webappapis/timers/evil-spec-example.any.js",
             "setTimeout's string handler, which TimerFunctions declines"),
 
-        // The file's one test throws from a queueMicrotask callback and expects an `error` event at the global
-        // scope. HTML gives queueMicrotask WebIDL's "report" exception behaviour, and Jint lets the throw
-        // erupt from whatever is pumping instead, so the exception leaves the engine before the listener can
-        // see it and the file is a harness error rather than a failing test. Recorded as a defect in
-        // Vendor/README.md; it cannot be an exclusion, because there is no test left to name.
-        ("html/webappapis/microtask-queuing/queue-microtask-exceptions.any.js",
-            "an exception from a queueMicrotask callback erupts instead of being reported; see Vendor/README.md"),
-
         // ---------------------------------------------------------------- fetch
         // Every file in request/ builds its Request from a *relative* url — "", "./", "../resources/…" — and
         // RequestConstructor documents why that cannot work: the specification resolves such a string against
@@ -548,6 +540,7 @@ public class WptTestRunner
         ["html/webappapis/timers/type-long-setinterval.any.js"] = 1,
         ["html/webappapis/timers/type-long-settimeout.any.js"] = 1,
 
+        ["html/webappapis/microtask-queuing/queue-microtask-exceptions.any.js"] = 1,
         ["html/webappapis/microtask-queuing/queue-microtask.any.js"] = 5,
 
         ["html/webappapis/structured-clone/structured-clone.any.js"] = 130,

--- a/Jint.Tests/Wpt/WptWorkerProvider.cs
+++ b/Jint.Tests/Wpt/WptWorkerProvider.cs
@@ -47,14 +47,17 @@ internal sealed class WptWorkerProvider : WorkerProvider
 {
     private readonly string _moduleSource;
     private readonly string _directory;
+    private readonly WptDiagnosticsSink _sink;
     private readonly List<WorkerConnection> _live = [];
 
     /// <param name="moduleSource">The shim, the META helpers and the test file, already concatenated.</param>
     /// <param name="directory">The directory a worker-side <c>fetch()</c> resolves a corpus file against.</param>
-    internal WptWorkerProvider(string moduleSource, string directory)
+    /// <param name="sink">The run's diagnostics recorder, shared with the parent engine.</param>
+    internal WptWorkerProvider(string moduleSource, string directory, WptDiagnosticsSink sink)
     {
         _moduleSource = moduleSource;
         _directory = directory;
+        _sink = sink;
     }
 
     /// <summary>
@@ -77,6 +80,11 @@ internal sealed class WptWorkerProvider : WorkerProvider
     {
         var options = request.CreateDefaultOptions();
         options.Modules.ModuleLoader = new WptWorkerModuleLoader(request.Specifier, _moduleSource);
+
+        // CreateDefaultOptions already installs DiagnosticsSink.Null, which is what makes a worker's callback
+        // errors report-and-continue; this replaces it with the run's recorder so that the driver can hold a
+        // worker-lane file to the same rule a top-level one is held to — see WptDiagnosticsSink.
+        options.WebApi.Diagnostics.Sink = _sink;
 
         var engine = new Engine(options);
 

--- a/Jint/Engine.WebApi.cs
+++ b/Jint/Engine.WebApi.cs
@@ -694,7 +694,8 @@ internal sealed class WebApiEngineState
 
     /// <summary>
     /// HTML's <i>report an exception</i> for a <see cref="JavaScriptException"/> that escaped a callback the
-    /// engine invoked — a timer handler, an event listener. Step 5 only: the callers own step 6, because the
+    /// engine invoked — a timer handler, a <c>queueMicrotask</c> callback, an event listener. Step 5 only: the
+    /// callers own step 6, because the
     /// sink report they make carries the exception itself and not merely its value.
     /// </summary>
     /// <remarks>

--- a/Jint/Options.WebApi.cs
+++ b/Jint/Options.WebApi.cs
@@ -580,14 +580,16 @@ public partial class Options
     {
         /// <summary>
         /// Where an unhandled promise rejection, a value handed to <c>reportError</c>, and an exception that
-        /// escaped a timer callback or an event listener are reported. Defaults to <see langword="null"/>,
+        /// escaped a timer callback, a <c>queueMicrotask</c> callback or an event listener are reported.
+        /// Defaults to <see langword="null"/>,
         /// which is not a sink that discards but the absence of a channel: nothing is reported, and an
         /// exception escaping a callback the engine invoked erupts as it always did.
         /// </summary>
         /// <remarks>
         /// <para>
         /// <b>Setting this changes behaviour, which is why it has no default.</b> With a sink, a
-        /// <c>JavaScriptException</c> from a timer handler or an event listener is reported and the engine
+        /// <c>JavaScriptException</c> from a timer handler, a <c>queueMicrotask</c> callback or an event
+        /// listener is reported and the engine
         /// carries on — the exception behaviour HTML and DOM specify for those callbacks. Errors that bound
         /// execution (a timeout, a cancellation, the statement, memory and recursion budgets) are never
         /// reported and always erupt. <see cref="DiagnosticsSink.Null"/> is the way to say "report and

--- a/Jint/WebApi/DiagnosticsSink.cs
+++ b/Jint/WebApi/DiagnosticsSink.cs
@@ -29,10 +29,12 @@ namespace Jint.WebApi;
 /// </para>
 /// <para>
 /// <b>Setting a sink changes what happens to an exception that escapes an engine-invoked callback.</b> With
-/// no sink — the default, <see langword="null"/> — a <c>JavaScriptException</c> thrown by a timer callback or
-/// by an event listener erupts out of whatever was running it, because swallowing it would lose it entirely.
+/// no sink — the default, <see langword="null"/> — a <c>JavaScriptException</c> thrown by a timer callback, a
+/// <c>queueMicrotask</c> callback or an event listener erupts out of whatever was running it, because
+/// swallowing it would lose it entirely.
 /// With a sink it is reported here and the engine carries on, which is what the specifications say to do:
-/// HTML invokes a timer handler with exception behavior <c>"report"</c>, and DOM's <i>inner invoke</i>
+/// HTML invokes a timer handler and a <c>queueMicrotask</c> callback with exception behavior <c>"report"</c>,
+/// and DOM's <i>inner invoke</i>
 /// reports a throwing listener and moves to the next one. Errors that exist to <i>bound</i> execution are
 /// never reported and always erupt — a timeout, a cancellation, the statement, memory and recursion budgets —
 /// because a budget that turns into a diagnostic no longer bounds anything.
@@ -235,7 +237,8 @@ public enum DiagnosticEventKind
     ReportedError,
 
     /// <summary>
-    /// An exception escaped a callback the engine invoked — a timer handler, an event listener — and a sink
+    /// An exception escaped a callback the engine invoked — a timer handler, a <c>queueMicrotask</c> callback,
+    /// an event listener — and a sink
     /// being set is why it was reported instead of erupting.
     /// <see cref="DiagnosticEvent.Exception"/> and <see cref="DiagnosticEvent.CallbackSource"/> say what and
     /// where.
@@ -292,5 +295,13 @@ public enum DiagnosticCallbackSource
     /// the next one — https://dom.spec.whatwg.org/#concept-event-listener-inner-invoke.
     /// </summary>
     EventListener,
+
+    /// <summary>
+    /// A <c>queueMicrotask</c> callback. HTML queues a microtask to invoke it "given null and <c>"report"</c>"
+    /// — https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-queuemicrotask — which is the
+    /// same WebIDL exception behavior a timer handler is invoked with, and the same one WebIDL's <i>report the
+    /// exception</i> defines: https://webidl.spec.whatwg.org/#report-the-exception.
+    /// </summary>
+    Microtask,
 }
 #endif

--- a/Jint/WebApi/Timers/TimerFunctions.cs
+++ b/Jint/WebApi/Timers/TimerFunctions.cs
@@ -185,8 +185,42 @@ internal sealed class TimerFunctions
 
         // The current generation, unlike a timer's: this job is registered and queued in one act, so there is
         // no window in which the cycle could have ended in between.
-        _engine.AddToEventLoop(() => callback.Call(JsValue.Undefined));
+        _engine.AddToEventLoop(() => InvokeMicrotask(callback));
         return JsValue.Undefined;
+    }
+
+    /// <summary>
+    /// The microtask <c>queueMicrotask</c> queued: "invoke <i>callback</i> given null and <c>"report"</c>",
+    /// step 2 of https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-queuemicrotask.
+    /// </summary>
+    /// <remarks>
+    /// WebIDL's <c>"report"</c> exception behavior is <i>report the exception</i>
+    /// (https://webidl.spec.whatwg.org/#report-the-exception) and returning undefined, which is what the catch
+    /// does whenever the host gave the engine somewhere to report to — the same shape
+    /// <c>TimerEntry.Fire</c> and <c>JsEventTarget.InvokePass</c> have, for the same reasons.
+    /// </remarks>
+    private void InvokeMicrotask(ICallable callback)
+    {
+        try
+        {
+            callback.Call(JsValue.Undefined);
+        }
+        catch (JavaScriptException exception) when (_engine._webApi?.Diagnostics is { } diagnostics)
+        {
+            // Report the exception is HTML's report an exception, whose step 5 fires an `error` event at the
+            // global scope before step 6 reaches the console. A no-op unless the GlobalEvents feature is on and
+            // a script is listening; see WebApiEngineState.FireGlobalErrorEvent.
+            _engine._webApi?.FireGlobalErrorEvent(exception);
+
+            // Only a JavaScriptException, which is exactly the class of failure a script could have caught
+            // itself. Everything that exists to bound execution — ExecutionCanceledException,
+            // TimeoutException, the statement, memory and recursion budgets — is a JintException but not a
+            // JavaScriptException, so none of it is caught here and a constraint still stops the engine. With
+            // no sink there is no catch at all and the throw erupts out of whatever is running the queue,
+            // exactly as one from a promise reaction handler without a capability does; everything still
+            // queued runs either way.
+            diagnostics.Report(DiagnosticEvent.ForUncaughtCallbackError(exception, DiagnosticCallbackSource.Microtask));
+        }
     }
 }
 #endif

--- a/Jint/WebApi/WebApiOptionsExtensions.cs
+++ b/Jint/WebApi/WebApiOptionsExtensions.cs
@@ -346,7 +346,8 @@ public static class WebApiOptionsExtensions
     /// <c>reportError</c> function script uses to add to them.
     /// </summary>
     /// <remarks>
-    /// The sink is what turns an exception escaping a timer callback or an event listener from something that
+    /// The sink is what turns an exception escaping a timer callback, a <c>queueMicrotask</c> callback or an
+    /// event listener from something that
     /// erupts into something that is reported — read <see cref="DiagnosticsSink"/> before installing one. Only
     /// <c>reportError</c> needs the feature flag; a host that wants the reports without giving script a way to
     /// add to them can assign <c>options.WebApi.Diagnostics.Sink</c> on its own.

--- a/README.md
+++ b/README.md
@@ -1005,7 +1005,8 @@ Four rules are worth knowing before you rely on it:
   recursion budgets keep erupting past both the event and the sink, exactly as they always have. An `error`
   listener is not a way to swallow a constraint.
 - **A sink is still what turns a callback failure into a *report*.** Firing the event is a step of reporting,
-  so with no sink a throwing timer callback or event listener erupts as before and no listener sees it.
+  so with no sink a throwing timer callback, `queueMicrotask` callback or event listener erupts as before and
+  no listener sees it.
   `reportError` is the exception, being itself a request to report: it fires the event with or without a sink.
 - **Rejection events arrive at the tracker's cadence, not HTML's microtask checkpoint** — the same documented
   divergence `DiagnosticEvent.RejectionHandled` carries, so `Promise.reject(e).catch(f)` raises


### PR DESCRIPTION
Fixes item **11** of #3212 — the last of the eleven that needed engine work. With #3243 (items 4–6) and #3244 (items 1–3) merged, this leaves items 7–10, which are in flight separately.

`TimerFunctions.QueueMicrotaskCallback` enqueued a bare `AddToEventLoop(() => callback.Call(…))`. [HTML](https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-queuemicrotask) queues that microtask to invoke the callback *"given null and **"report"**"*, and WebIDL's `"report"` is [*report the exception*](https://webidl.spec.whatwg.org/#report-the-exception). With no catch at all the throw erupted from whatever was pumping, leaving the engine before any listener could see it.

The fix is a **third instance of the established shape**, not a new mechanism — the filter is `JsEventTarget.InvokePass`'s verbatim, the body is `TimerEntry.Fire`'s, including the same snapshot read and the same fire-then-report order:

```csharp
catch (JavaScriptException exception) when (_engine._webApi?.Diagnostics is { } diagnostics)
```

### The contract holds, and the type system enforces it

Only a `JavaScriptException` is ever reported, so everything that exists to *bound* execution still propagates. That is pinned by two tests asserting from a log that the failure happened **inside** the queued callback rather than before it: `LimitRecursion(8)` → `RecursionDepthOverflowException` with the sink's reports empty, and `MaxStatements(1000)` → `StatementsCountOverflowException`, likewise.

Better than a filter, it turns out this is enforced at compile time: broadening the catch to `JintException` **does not compile**, because `DiagnosticEvent.ForUncaughtCallbackError` takes a `JavaScriptException`. Two `CS1503`s, and the mutation is impossible rather than merely tested against.

The **sinkless path is unchanged in shape** — a `when` filter, no unconditional `try`/rethrow — so with no sink there is no catch and the exception erupts exactly as before. Pinned from inside (`AThrowingMicrotaskCallbackEruptsWithoutASink`, which passed *before* this change too, since it pins existing behaviour) and from outside the assembly.

### A finding about the WPT driver, not the engine

`queue-microtask-exceptions.any.js` was in `_notVendored` because it takes its whole file down. **The engine fix alone was not enough to make it vendorable**, and this was proved rather than reasoned: with the engine fixed and the file vendored but the driver untouched, the suite failed with `Expected outcome.HarnessError to be <null> … but found "JavaScriptException: boo"`.

The driver set no `DiagnosticsSink`. Report-and-continue requires one by design, and `FireGlobalErrorEvent` sits *inside* the sink-gated catch, so without a sink the file's own `self.addEventListener('error', …)` can never fire.

The driver now installs one, with two deliberate choices:

- **A sink at all** — the same choice shipped code already makes one level in: `WorkerRequest.CreateDefaultOptions` installs `DiagnosticsSink.Null` on every worker engine for this reason. The worker lane now gets the driver's sink instead, so a file's environment does not depend on which lane ran it.
- **A recorder rather than `DiagnosticsSink.Null`** — discarding would let a file go green while a defect hid in a callback nobody watched, losing exactly the loud signal eruption used to provide. `WptHarness.UndeclaredCallbackErrors` turns any recorded uncaught callback error into the same harness error **unless** the file declared `setup({ allow_uncaught_exception: true })` — upstream's own rule, which the shim now honours. It is the second and last member of that properties bag the shim acts on; the comment claiming the flag was "accepted and ignored" is rewritten. Both halves are pinned in `WptHarnessTests`.

Byte-verified: `git hash-object` of the vendored copy is `01f32ac9ba14962fa99d4b263a8ca0f5a0daa161`, identical to the blob id GitHub reports for that path at the pin. Minimum-test floor 1, its actual count.

### Verification

Pre-fix (enum member added so the tests compile, behaviour untouched): 2 failures, both the eruption out of `RunAvailableContinuations`. Post-fix `DiagnosticsTests` is 29/29.

Solution builds Release, 0 errors — the `#if NET8_0_OR_GREATER` gate holds across `net462`/`netstandard2.0`/`netstandard2.1`/`net472`.

| run | net10.0 | net472 |
| --- | --- | --- |
| `Jint.Tests` | 10269 | 7147 |
| `Jint.Tests` + `JINT_HOST_CONTRACT_VERIFICATION=1` | 10269 | 7147 |
| `Jint.Tests.PublicInterface` | 2407 | 1879 |
| `Jint.Tests.PublicInterface` + verification | 2411 | 1883 |

(The verification env var was confirmed to genuinely propagate by diffing the *skipped test names* on `HostArrayLikeHasIndexTests` — the `Verifying`/`NotVerifying` sets swap.)

WPT **417 → 420** theory cases, 0 failures both times. The only corpus row that moved is `RunsTheMicrotaskQueuingSuite` 1 → 2; the other +2 are the new `WptHarnessTests` rows. That the driver's new sink perturbed **no assertion anywhere** is proved by the table itself rather than by inspection: an excluded test that started passing, or a passing one that started failing, fails its suite.

### One correction beyond scope

Measuring the corpus at assertion level to check my own +1 turned up **four stale rows** in `Vendor/README.md`'s inventory, left behind by earlier merged fixes: streams 16→11, compression 84→22, user timing 9→5, DOM 12→13 files / 62→76 / 2→0. Corrected rather than adding a new figure on top of wrong totals. That is the only place this diff touches figures owned by other PRs — no code, exclusion row or test of theirs is touched.

### Left undone

The other engine-invoked callback queues — `IdleCallbackQueue` and `SchedulerQueue` — have **no report path either**. Item 11 names `queueMicrotask` only, so they are untouched; filed separately as an audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
