### PR TITLE
Fetch: the iterator attributes, the disturbed-body lock, and WebIDL's record order

### DIFF
--- a/Jint.Tests/Runtime/WebApi/FormDataTests.cs
+++ b/Jint.Tests/Runtime/WebApi/FormDataTests.cs
@@ -308,5 +308,41 @@ public class FormDataTests
         engine.Execute("var m = new MyForm(); m.append('a', 'b');");
         engine.Evaluate("m.get('a')").AsString().Should().Be("b");
     }
+
+    [Fact]
+    public void TheIteratorPrototypesNextCarriesWebIdlsAttributes()
+    {
+        // "An iterator prototype object must have a next data property with attributes
+        // { [[Writable]]: true, [[Enumerable]]: true, [[Configurable]]: true } and whose value is the
+        // built-in function object CreateBuiltinFunction(nextSteps, 0, "next", <<>>)" —
+        // https://webidl.spec.whatwg.org/#es-iterator-prototype-object. Enumerable is the surprise: a
+        // built-in function property is non-enumerable everywhere in ECMA-262
+        // (https://tc39.es/ecma262/#sec-ecmascript-standard-built-in-objects), and WebIDL is the one binding
+        // that says otherwise.
+        var engine = WebEngine();
+        engine.Execute("var proto = Object.getPrototypeOf(new FormData().entries());");
+
+        engine.Evaluate("Object.getOwnPropertyNames(proto).join(',')").AsString().Should().Be("next");
+        engine.Execute("var d = Object.getOwnPropertyDescriptor(proto, 'next');");
+        engine.Evaluate("d.writable").AsBoolean().Should().BeTrue("next must be writable");
+        engine.Evaluate("d.enumerable").AsBoolean().Should().BeTrue("next must be enumerable");
+        engine.Evaluate("d.configurable").AsBoolean().Should().BeTrue("next must be configurable");
+        engine.Evaluate("d.value.length").AsNumber().Should().Be(0);
+        engine.Evaluate("d.value.name").AsString().Should().Be("next");
+
+        // The three kinds share one prototype, so the attributes above are the attributes of all of them.
+        engine.Evaluate("Object.getPrototypeOf(new FormData().keys()) === proto").AsBoolean().Should().BeTrue("the three kinds share one prototype");
+        engine.Evaluate("Object.getPrototypeOf(new FormData().values()) === proto").AsBoolean().Should().BeTrue("the three kinds share one prototype");
+
+        // The class string is the object's only other own property, and it keeps the attributes a class
+        // string carries — { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true } — rather
+        // than WebIDL's operation attributes.
+        engine.Evaluate("Object.getOwnPropertySymbols(proto).length").AsNumber().Should().Be(1);
+        engine.Execute("var t = Object.getOwnPropertyDescriptor(proto, Symbol.toStringTag);");
+        engine.Evaluate("t.value").AsString().Should().Be("FormData Iterator");
+        engine.Evaluate("t.writable").AsBoolean().Should().BeFalse();
+        engine.Evaluate("t.enumerable").AsBoolean().Should().BeFalse();
+        engine.Evaluate("t.configurable").AsBoolean().Should().BeTrue("the class string is configurable");
+    }
 }
 #endif

--- a/Jint.Tests/Runtime/WebApi/HeadersTests.cs
+++ b/Jint.Tests/Runtime/WebApi/HeadersTests.cs
@@ -241,5 +241,41 @@ public class HeadersTests
         Assert.Throws<JavaScriptException>(() => Eval("Headers()"))
             .Message.Should().Contain("requires 'new'");
     }
+
+    [Fact]
+    public void TheIteratorPrototypesNextCarriesWebIdlsAttributes()
+    {
+        // "An iterator prototype object must have a next data property with attributes
+        // { [[Writable]]: true, [[Enumerable]]: true, [[Configurable]]: true } and whose value is the
+        // built-in function object CreateBuiltinFunction(nextSteps, 0, "next", <<>>)" —
+        // https://webidl.spec.whatwg.org/#es-iterator-prototype-object. Enumerable is the surprise: a
+        // built-in function property is non-enumerable everywhere in ECMA-262
+        // (https://tc39.es/ecma262/#sec-ecmascript-standard-built-in-objects), and WebIDL is the one binding
+        // that says otherwise.
+        var engine = WebEngine();
+        engine.Execute("var proto = Object.getPrototypeOf(new Headers().entries());");
+
+        engine.Evaluate("Object.getOwnPropertyNames(proto).join(',')").AsString().Should().Be("next");
+        engine.Execute("var d = Object.getOwnPropertyDescriptor(proto, 'next');");
+        engine.Evaluate("d.writable").AsBoolean().Should().BeTrue("next must be writable");
+        engine.Evaluate("d.enumerable").AsBoolean().Should().BeTrue("next must be enumerable");
+        engine.Evaluate("d.configurable").AsBoolean().Should().BeTrue("next must be configurable");
+        engine.Evaluate("d.value.length").AsNumber().Should().Be(0);
+        engine.Evaluate("d.value.name").AsString().Should().Be("next");
+
+        // The three kinds share one prototype, so the attributes above are the attributes of all of them.
+        engine.Evaluate("Object.getPrototypeOf(new Headers().keys()) === proto").AsBoolean().Should().BeTrue("the three kinds share one prototype");
+        engine.Evaluate("Object.getPrototypeOf(new Headers().values()) === proto").AsBoolean().Should().BeTrue("the three kinds share one prototype");
+
+        // The class string is the object's only other own property, and it keeps the attributes a class
+        // string carries — { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true } — rather
+        // than WebIDL's operation attributes.
+        engine.Evaluate("Object.getOwnPropertySymbols(proto).length").AsNumber().Should().Be(1);
+        engine.Execute("var t = Object.getOwnPropertyDescriptor(proto, Symbol.toStringTag);");
+        engine.Evaluate("t.value").AsString().Should().Be("Headers Iterator");
+        engine.Evaluate("t.writable").AsBoolean().Should().BeFalse();
+        engine.Evaluate("t.enumerable").AsBoolean().Should().BeFalse();
+        engine.Evaluate("t.configurable").AsBoolean().Should().BeTrue("the class string is configurable");
+    }
 }
 #endif

--- a/Jint.Tests/Runtime/WebApi/HeadersTests.cs
+++ b/Jint.Tests/Runtime/WebApi/HeadersTests.cs
@@ -277,5 +277,105 @@ public class HeadersTests
         engine.Evaluate("t.enumerable").AsBoolean().Should().BeFalse();
         engine.Evaluate("t.configurable").AsBoolean().Should().BeTrue("the class string is configurable");
     }
+
+    /// <summary>
+    /// The proxy-and-log harness web-platform-tests' <c>headers-record.any.js</c> uses: every
+    /// <c>Reflect</c> operation the conversion performs is appended to <c>log</c> as
+    /// <c>trap:key</c>.
+    /// </summary>
+    private const string RecordProbe = """
+        var log = [];
+        var handler = {};
+        for (const prop of Object.getOwnPropertyNames(Reflect)) {
+          handler[prop] = function (...args) {
+            const key = args.length > 1 ? String(args[1]) : '';
+            log.push(key === '' ? prop : prop + ':' + key);
+            return Reflect[prop](...args);
+          };
+        }
+        function probe(record) {
+          log = [];
+          try { new Headers(new Proxy(record, handler)); return log.join(' | '); }
+          catch (e) { return e.constructor.name + ' >> ' + log.join(' | '); }
+        }
+        """;
+
+    [Fact]
+    public void ConvertsARecordInWebIdlsOwnOrder()
+    {
+        // https://webidl.spec.whatwg.org/#es-record, whose step 4 walks [[OwnPropertyKeys]]() and, for each
+        // key: 4.1 [[GetOwnProperty]], and then, only when the descriptor exists and is enumerable,
+        // 4.2.1 "let typedKey be key converted to an IDL value of type K", 4.2.2 "let value be ? Get(O, key)"
+        // and 4.2.3 the value's own conversion. The key is converted BEFORE the Get, and K here is
+        // ByteString — https://webidl.spec.whatwg.org/#es-ByteString — so a key that is a Symbol, or a
+        // string with a code unit above 255, ends the whole conversion at 4.2.1 with a TypeError and the
+        // Get never happens.
+        var engine = WebEngine();
+        engine.Execute(RecordProbe);
+
+        // One property, and a second: the shape everything else is measured against.
+        engine.Evaluate("probe({ a: 'b' })").AsString()
+            .Should().Be("get:Symbol(Symbol.iterator) | ownKeys | getOwnPropertyDescriptor:a | get:a");
+        engine.Evaluate("probe({ a: 'b', c: 'd' })").AsString()
+            .Should().Be("get:Symbol(Symbol.iterator) | ownKeys | getOwnPropertyDescriptor:a | get:a "
+                + "| getOwnPropertyDescriptor:c | get:c");
+
+        // An invalid *name*: the conversion stops at step 4.2.1, so there is no second Get.
+        engine.Evaluate("probe({ a: 'b', '￿': 'd' })").AsString()
+            .Should().Be("TypeError >> get:Symbol(Symbol.iterator) | ownKeys | getOwnPropertyDescriptor:a "
+                + "| get:a | getOwnPropertyDescriptor:￿");
+
+        // An invalid *value* stops one step later, at 4.2.3, so the next key is never even looked at.
+        engine.Evaluate("probe({ a: '￿', c: 'd' })").AsString()
+            .Should().Be("TypeError >> get:Symbol(Symbol.iterator) | ownKeys | getOwnPropertyDescriptor:a "
+                + "| get:a");
+
+        // A Symbol key is an own property key like any other: its descriptor is fetched, and because it is
+        // enumerable the ByteString conversion of the key itself throws — before its Get, and after the
+        // string keys that preceded it have been read in full.
+        engine.Evaluate("probe({ a: 'b', [Symbol.toStringTag]: 'x', c: 'd' })").AsString()
+            .Should().Be("TypeError >> get:Symbol(Symbol.iterator) | ownKeys | getOwnPropertyDescriptor:a "
+                + "| get:a | getOwnPropertyDescriptor:c | get:c "
+                + "| getOwnPropertyDescriptor:Symbol(Symbol.toStringTag)");
+
+        // A non-enumerable one is skipped at step 4.2 instead, so it costs a descriptor and nothing else —
+        // no key conversion, therefore no TypeError, therefore a Headers that was built.
+        engine.Execute("""
+            var withSymbol = { a: 'b', [Symbol.toStringTag]: 'x', c: 'd' };
+            Object.defineProperty(withSymbol, Symbol.toStringTag, { enumerable: false });
+            """);
+        engine.Evaluate("probe(withSymbol)").AsString()
+            .Should().Be("get:Symbol(Symbol.iterator) | ownKeys | getOwnPropertyDescriptor:a | get:a "
+                + "| getOwnPropertyDescriptor:c | get:c | getOwnPropertyDescriptor:Symbol(Symbol.toStringTag)");
+
+        // A non-enumerable string key and a descriptor a proxy lies about are the same step 4.2: a
+        // descriptor apiece, no Get.
+        engine.Evaluate("probe(Object.defineProperties({}, { a: { value: 'b' }, c: { value: 'd', enumerable: true } }))")
+            .AsString()
+            .Should().Be("get:Symbol(Symbol.iterator) | ownKeys | getOwnPropertyDescriptor:a "
+                + "| getOwnPropertyDescriptor:c | get:c");
+    }
+
+    [Fact]
+    public void ARecordKeyThatIsNotAByteStringIsATypeError()
+    {
+        // The consequence of the order above that a script can see without a proxy. A Symbol fails at the
+        // ToString https://webidl.spec.whatwg.org/#es-ByteString starts with, rather than at its own
+        // above-0x00FF check, so the message is the language's rather than the binding's.
+        Assert.Throws<JavaScriptException>(() => Eval("new Headers({ [Symbol.toStringTag]: 'x' })"))
+            .Message.Should().Contain("Symbol");
+
+        Assert.Throws<JavaScriptException>(() => Eval("new Headers({ '￿': 'x' })"))
+            .Message.Should().Contain("ByteString");
+
+        // ... and the one it must not raise: a non-enumerable Symbol key is not a record member at all.
+        Eval("""
+            (() => {
+              const o = { a: 'b' };
+              Object.defineProperty(o, Symbol.toStringTag, { value: 'x', enumerable: false });
+              return new Headers(o).get('a');
+            })()
+            """).AsString().Should().Be("b");
+    }
 }
 #endif

--- a/Jint.Tests/Runtime/WebApi/RequestTests.cs
+++ b/Jint.Tests/Runtime/WebApi/RequestTests.cs
@@ -428,5 +428,28 @@ public class RequestTests
                 .Message.Should().Contain("Request");
         }
     }
+
+    [Fact]
+    public void ConsumingABufferedRequestBodyLeavesItsStreamDisturbedAndLocked()
+    {
+        // The Body mixin is one mixin — https://fetch.spec.whatwg.org/#body-mixin — so what
+        // https://fetch.spec.whatwg.org/#concept-body-fully-read does to a Response's stream it does to a
+        // Request's: step 3 acquires a reader, which locks the stream, and read-all-bytes never releases it.
+        var engine = WebEngine();
+        engine.Execute("var a = new Request('https://example.org', { method: 'POST', body: 'hi' }); a.text();");
+
+        engine.Evaluate("a.bodyUsed").AsBoolean().Should().BeTrue();
+        engine.Evaluate("a.body === null").AsBoolean().Should().BeFalse();
+        engine.Evaluate("a.body.locked").AsBoolean().Should().BeTrue();
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("a.body.getReader()"))
+            .Message.Should().Contain("locked");
+
+        // And the neighbour: reading `body` first, then consuming, locks that same stream rather than a new
+        // one, which is what keeps a copy of an unread request legal.
+        engine.Execute("var b = new Request('https://example.org', { method: 'POST', body: 'hi' }); var s = b.body;");
+        engine.Evaluate("b.bodyUsed").AsBoolean().Should().BeFalse();
+        engine.Evaluate("new Request(b).method").AsString().Should().Be("POST");
+    }
 }
 #endif

--- a/Jint.Tests/Runtime/WebApi/ResponseTests.cs
+++ b/Jint.Tests/Runtime/WebApi/ResponseTests.cs
@@ -291,5 +291,75 @@ public class ResponseTests
         Eval("(() => { class R extends Response {}; const r = new R('hi'); return r.status + ':' + (r instanceof R); })()")
             .AsString().Should().Be("200:true");
     }
+
+    [Theory]
+    [InlineData("text")]
+    [InlineData("json")]
+    [InlineData("arrayBuffer")]
+    [InlineData("blob")]
+    [InlineData("bytes")]
+    [InlineData("formData")]
+    public void ConsumingABufferedBodyLeavesItsStreamDisturbedAndLocked(string consume)
+    {
+        // https://fetch.spec.whatwg.org/#concept-body-consume-body ends in *fully read*, whose step 3 is
+        // "let reader be the result of getting a reader for body's stream" —
+        // https://streams.spec.whatwg.org/#readablestream-get-a-reader, which locks the stream — and whose
+        // read-all-bytes never releases it. So a consumed body's stream is disturbed
+        // (https://fetch.spec.whatwg.org/#concept-body-disturbed) *and* locked for good, and a second
+        // getReader() is the TypeError https://streams.spec.whatwg.org/#set-up-readable-stream-default-reader
+        // raises. web-platform-tests' response-stream-disturbed-5.any.js asserts exactly that.
+        var engine = WebEngine();
+        engine.Execute("var r = new Response('a=1', { headers: { 'content-type': 'application/x-www-form-urlencoded' } });");
+
+        // The rejection json() produces is caught here only so it is not an unhandled one; the point of the
+        // call is what it does to the body, which is the same either way.
+        engine.Execute($"r.{consume}().then(() => {{}}, () => {{}});");
+
+        engine.Evaluate("r.bodyUsed").AsBoolean().Should().BeTrue("consuming disturbs the body");
+        engine.Evaluate("r.body === null").AsBoolean().Should().BeFalse("the body concept is still non-null");
+        engine.Evaluate("r.body.locked").AsBoolean().Should().BeTrue("fully read never releases its reader");
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("r.body.getReader()"))
+            .Message.Should().Contain("locked");
+
+        // The same object every time, and asking again does not un-disturb it.
+        engine.Evaluate("r.body === r.body").AsBoolean().Should().BeTrue();
+        engine.Evaluate("r.bodyUsed").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void AskingForTheBodyBeforeConsumingItDoesNotDisturbIt()
+    {
+        // The other side of the same coin, and what response-stream-disturbed-1.any.js pins: materializing
+        // the stream is not reading it, and a reader that released its lock leaves the body usable.
+        var engine = WebEngine();
+        engine.Execute("var r = new Response('hi'); var s = r.body; s.getReader().releaseLock();");
+
+        engine.Evaluate("s.locked").AsBoolean().Should().BeFalse();
+        engine.Evaluate("r.bodyUsed").AsBoolean().Should().BeFalse();
+        engine.Evaluate("r.text()").UnwrapIfPromise().AsString().Should().Be("hi");
+
+        // Consuming it through the stream it already had locks that same stream, not a new one.
+        engine.Evaluate("r.body === s").AsBoolean().Should().BeTrue();
+        engine.Evaluate("s.locked").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void CloneAfterConsumingStillThrows()
+    {
+        // https://fetch.spec.whatwg.org/#dom-response-clone step 1 refuses a body that is *unusable*, which
+        // https://fetch.spec.whatwg.org/#body-unusable defines as disturbed **or locked**. Locking the
+        // buffered body's stream must not change that answer, in either direction.
+        var engine = WebEngine();
+        engine.Execute("var r = new Response('hi'); r.text();");
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("r.clone()"))
+            .Message.Should().Contain("already used");
+
+        // And reading `body` first — which is what materializes the stream — does not change it either.
+        engine.Execute("var q = new Response('hi'); q.text(); var b = q.body;");
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("q.clone()"))
+            .Message.Should().Contain("already used");
+    }
 }
 #endif

--- a/Jint.Tests/Runtime/WebApi/UrlSearchParamsTests.cs
+++ b/Jint.Tests/Runtime/WebApi/UrlSearchParamsTests.cs
@@ -291,5 +291,41 @@ public class UrlSearchParamsTests
         engine.Evaluate("sub.first").AsString().Should().Be("1");
         engine.Evaluate("sub.toString()").AsString().Should().Be("a=1");
     }
+
+    [Fact]
+    public void TheIteratorPrototypesNextCarriesWebIdlsAttributes()
+    {
+        // "An iterator prototype object must have a next data property with attributes
+        // { [[Writable]]: true, [[Enumerable]]: true, [[Configurable]]: true } and whose value is the
+        // built-in function object CreateBuiltinFunction(nextSteps, 0, "next", <<>>)" —
+        // https://webidl.spec.whatwg.org/#es-iterator-prototype-object. Enumerable is the surprise: a
+        // built-in function property is non-enumerable everywhere in ECMA-262
+        // (https://tc39.es/ecma262/#sec-ecmascript-standard-built-in-objects), and WebIDL is the one binding
+        // that says otherwise.
+        var engine = WebEngine();
+        engine.Execute("var proto = Object.getPrototypeOf(new URLSearchParams().entries());");
+
+        engine.Evaluate("Object.getOwnPropertyNames(proto).join(',')").AsString().Should().Be("next");
+        engine.Execute("var d = Object.getOwnPropertyDescriptor(proto, 'next');");
+        engine.Evaluate("d.writable").AsBoolean().Should().BeTrue("next must be writable");
+        engine.Evaluate("d.enumerable").AsBoolean().Should().BeTrue("next must be enumerable");
+        engine.Evaluate("d.configurable").AsBoolean().Should().BeTrue("next must be configurable");
+        engine.Evaluate("d.value.length").AsNumber().Should().Be(0);
+        engine.Evaluate("d.value.name").AsString().Should().Be("next");
+
+        // The three kinds share one prototype, so the attributes above are the attributes of all of them.
+        engine.Evaluate("Object.getPrototypeOf(new URLSearchParams().keys()) === proto").AsBoolean().Should().BeTrue("the three kinds share one prototype");
+        engine.Evaluate("Object.getPrototypeOf(new URLSearchParams().values()) === proto").AsBoolean().Should().BeTrue("the three kinds share one prototype");
+
+        // The class string is the object's only other own property, and it keeps the attributes a class
+        // string carries — { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true } — rather
+        // than WebIDL's operation attributes.
+        engine.Evaluate("Object.getOwnPropertySymbols(proto).length").AsNumber().Should().Be(1);
+        engine.Execute("var t = Object.getOwnPropertyDescriptor(proto, Symbol.toStringTag);");
+        engine.Evaluate("t.value").AsString().Should().Be("URLSearchParams Iterator");
+        engine.Evaluate("t.writable").AsBoolean().Should().BeFalse();
+        engine.Evaluate("t.enumerable").AsBoolean().Should().BeFalse();
+        engine.Evaluate("t.configurable").AsBoolean().Should().BeTrue("the class string is configurable");
+    }
 }
 #endif

--- a/Jint.Tests/Wpt/Vendor/README.md
+++ b/Jint.Tests/Wpt/Vendor/README.md
@@ -40,7 +40,7 @@ Twelve standards are vendored: `url/`, `encoding/`, `compression/`, `urlpattern/
 **three**, `html/webappapis/` as **three** (timers, microtask-queuing, structured-clone), `dom/` as **two**
 (events, abort), `fetch/api/` as **two** (headers, response), `WebCryptoAPI/` as **eight** and `streams/` as
 **seven** — their root files plus one suite per sub-directory, because `WptCorpus.TestFiles` lists a
-directory's own files and never descends. That is 271 theory cases over 40,632 assertions, of which 2,907 do
+directory's own files and never descends. That is 271 theory cases over 40,632 assertions, of which 2,894 do
 not pass and every one is named in the driver's table; the whole driver runs in about two minutes.
 
 The corpora arrived a group at a time, most of them under
@@ -688,45 +688,106 @@ to read those steps should not have to rediscover.
 
 ## What the fetch object model says about this engine
 
-388 assertions across 29 files, of which **88 do not pass**. 73 of them are one documented decline:
-`HeadersGuard` refuses to enforce the *forbidden header name* and *forbidden response header name* lists,
-because they are a browser's protection of headers the user agent alone controls and Jint runs server-side,
-where those headers are exactly what a script legitimately needs to set — the same choice Node and Deno make.
-That is the whole of `headers-forbidden-override.any.js`'s 72 forbidden rows (its 18 "is allowed to use" rows
-pass) and one row of `header-setcookie.any.js`. One more row is `NeedsApiBaseUrl`: `Response.redirect("/")`
-with no document to resolve against.
+388 assertions across 29 files, of which **75 do not pass** — and every one of those is a decision rather
+than a defect. 73 are one documented decline: `HeadersGuard` refuses to enforce the *forbidden header name*
+and *forbidden response header name* lists, because they are a browser's protection of headers the user agent
+alone controls and Jint runs server-side, where those headers are exactly what a script legitimately needs to
+set — the same choice Node and Deno make. That is the whole of `headers-forbidden-override.any.js`'s 72
+forbidden rows (its 18 "is allowed to use" rows pass) and one row of `header-setcookie.any.js`. One more row
+is `NeedsApiBaseUrl`: `Response.redirect("/")` with no document to resolve against.
 
-**The remaining 14 are four defects:**
+**The seventy-fifth is a row no implementation passes**, and the three genuine defects that used to sit
+beside it are fixed under [#3212](https://github.com/sebastienros/jint/issues/3212).
 
-1. **The `Headers` iterator prototype's `next` is not enumerable** — three rows of `headers-basic.any.js`
-   (`keys`, `values`, `entries`).
-   [WebIDL's iterator prototype object](https://webidl.spec.whatwg.org/#es-iterator-prototype-object) gives it
-   `{ [[Writable]]: true, [[Enumerable]]: true, [[Configurable]]: true }`. This is the same attribute on the
-   same kind of object as the streams corpus's async-iterator defect above, and the fix is the same one flag
-   on `HeadersIteratorPrototype`.
-2. **A `Response` whose body came from bytes is not disturbed by consuming it** — eight of the twelve rows of
+### The one row that is not debt
+
+**An empty `FormData` body does not serialize to an empty body** — one row of `response-consume-empty.any.js`,
+which asks that `await new Response(new FormData()).text()` have length 0 and gets the 50-byte closing
+boundary `MultipartFormData` writes.
+
+The triage note said to read
+[the multipart/form-data encoding algorithm](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#multipart/form-data-encoding-algorithm)
+before changing anything. Reading it settles the question the other way. HTML's algorithm normalizes the
+newlines in each entry's name and value and then says to "return the byte sequence resulting from encoding
+the entry list using the rules described by RFC 7578" — it defines the *escaping* and delegates the *framing*
+entirely. RFC 7578 defers in turn to RFC 2046, whose section 5.1.1 grammar is
+
+```
+multipart-body := [preamble CRLF]
+                  dash-boundary transport-padding CRLF
+                  body-part *encapsulation
+                  close-delimiter transport-padding
+                  [CRLF epilogue]
+```
+
+The `close-delimiter` is not optional there, so an empty entry list has no shorter conforming encoding than
+the one Jint writes. Nothing in either document licenses the empty body the row asks for.
+
+The empirical half agrees, decisively. Measured on wpt.fyi against the four aligned stable runs at the time
+of writing (chrome 152, edge 151, firefox 154, safari 26.6), that row is **0/1 in all four**, while the
+file's thirteen other rows are 1/1 in all four. No browser produces an empty body for an empty `FormData`
+either, which is what one would expect of a serializer that writes its close delimiter after the loop.
+
+So this row is not debt. It keeps its exclusion, but `NeedsTriage` is the wrong category for it — that
+category means "a bug or a specification detail to chase", and this is neither. Reclassifying it wants a
+category of its own, which is filed rather than done here.
+
+### The three that are fixed
+
+1. **The `Headers` iterator prototype's `next` was not enumerable** — three rows of `headers-basic.any.js`
+   (`keys`, `values`, `entries`), each through the file's own `checkIteratorProperties`, which reads the
+   descriptor and asserts all three attributes.
+   [WebIDL's iterator prototype object](https://webidl.spec.whatwg.org/#es-iterator-prototype-object) gives
+   `next` `{ [[Writable]]: true, [[Enumerable]]: true, [[Configurable]]: true }`; writable and configurable
+   were already right and enumerable was the whole of it, because a built-in function property is
+   non-enumerable everywhere in ECMA-262
+   ([standard built-in objects](https://tc39.es/ecma262/#sec-ecmascript-standard-built-in-objects)) and that
+   is what `[JsFunction]` defaults to. The fix is the `Flags` the streams corpus's async-iterator defect
+   introduced, spelled on three declarations rather than one: **no vendored row reaches
+   `FormDataIteratorPrototype` or `UrlSearchParamsIteratorPrototype`**, and both carried exactly the same
+   defect with nothing to find it. The `@@toStringTag` on all three was already right — WebIDL gives a class
+   string `{ [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }`.
+
+2. **A consumed byte-source body handed back a stream that was not locked** — eight of the twelve rows of
    `response-stream-disturbed-5.any.js`. After `response.blob()` (or `text`/`json`/`arrayBuffer`) has been
-   called, `response.body.getReader()` must throw a `TypeError` because
-   [the body is disturbed](https://fetch.spec.whatwg.org/#concept-body-disturbed) and its stream locked; here
-   it succeeds. The four rows whose body source is a `ReadableStream` the test built itself **pass**, which
-   locates the defect precisely: the stream `.body` exposes for a byte-source body is created lazily and is
-   not the one the consume path locked.
-3. **An empty `FormData` body does not serialize to an empty body** — one row of
-   `response-consume-empty.any.js`, which asks that `await new Response(new FormData()).text()` have length 0
-   and gets the 50-byte closing boundary `MultipartFormData` writes. Worth confirming against
-   [the multipart/form-data encoding algorithm](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#multipart/form-data-encoding-algorithm)
-   before changing anything, which is why it is triage rather than a fix.
-4. **A `record<ByteString, ByteString>` conversion performs one operation too many** — two rows of
+   called, `response.body.getReader()` must throw a `TypeError`; here it succeeded.
+   The triage note put this down to the stream `.body` exposes being "not the one the consume path locked",
+   and the wrong half of that is the instructive one: the consume path locked nothing, and *disturbed* is not
+   what `getReader()` refuses. It refuses a **locked** stream and only a locked one —
+   [SetUpReadableStreamDefaultReader](https://streams.spec.whatwg.org/#set-up-readable-stream-default-reader)
+   step 1 — so the disturbed-but-unlocked stream Jint handed back was given a reader quite correctly.
+   What makes a browser refuse it is that consuming a body runs
+   [fully read](https://fetch.spec.whatwg.org/#concept-body-fully-read), whose step 3 is "let reader be the
+   result of [getting a reader](https://streams.spec.whatwg.org/#readablestream-get-a-reader) for body's
+   stream" — which locks it — and whose read-all-bytes step never releases that reader. The stream a consumed
+   body exposes is therefore disturbed, closed *and locked for good*. That is also exactly why the four rows
+   whose body source is a `ReadableStream` **passed**: those go through `FetchBody.FullyRead`, which acquires
+   the reader and holds it. `GetOrCreateStream` defers building the stream for a bytes-source body, so what
+   it has to reproduce on first ask is the state fully read would have left — and it was reproducing only the
+   `disturbed` half.
+
+3. **A `record<ByteString, ByteString>` conversion performed one operation too many** — two rows of
    `headers-record.any.js`, "Correct operation ordering with two properties one of which has an invalid name"
    (6 where 5 are allowed) and "Basic operation with Symbol keys" (8 where 7 are). Both count the operations a
    proxy records while [WebIDL's record conversion](https://webidl.spec.whatwg.org/#es-record) walks the
-   object, so what they pin is the order of `OwnPropertyKeys`, `GetOwnProperty` and `Get` rather than the
-   header list behind it.
+   object, so what they pin is the order of `[[OwnPropertyKeys]]`, `[[GetOwnProperty]]` and `Get` rather than
+   the header list behind it — and measured through the file's own logging proxy, the extra operation was the
+   same one on both rows: a `[[Get]]` of the very key that ends the conversion. Step 4.2 is 4.2.1 "let
+   *typedKey* be *key* converted to an IDL value of type *K*" and *then* 4.2.2 "let *value* be
+   `? Get(O, key)`"; `FillFromRecord` did the `Get` first and converted the key inside `append`.
+   Writing step 3 as the unfiltered `? O.[[OwnPropertyKeys]]()` the specification asks for also removed an
+   inconsistency that predated the rows: `JsProxy.GetOwnPropertyKeys` honours Jint's `types` filter only when
+   there is no `ownKeys` trap — correctly, since the spec's internal method has no filter — so a Symbol key
+   already reached the walk through a proxy while `new Headers({ [Symbol.toStringTag]: 'x' })` on a plain
+   object was silently accepted where a browser throws.
 
 ## The whole corpus, standard by standard
 
 Measured at this pin, on Windows, with the driver's exclusion table in force. "Not passing" is every result
-the shim did not record `PASS`, which is exactly the set the table names.
+the shim did not record `PASS`, which is exactly the set the table names. Re-measured in full for
+[#3212](https://github.com/sebastienros/jint/issues/3212), which is why five rows move at once: the Fetch row
+is that change's own, and Streams, Compression, User Timing and DOM had gone stale against fixes that
+removed their exclusions without revisiting this table. Every per-standard section above was already right.
 
 | Standard | Suites | Files | Assertions | Not passing |
 | --- | --- | --- | --- | --- |
@@ -742,8 +803,8 @@ the shim did not record `PASS`, which is exactly the set the table names.
 | HTML — workers | `workers/` ×3 | 11 | 15 | 7 |
 | HTML — timers, microtasks, structured clone | `html/webappapis/` ×3 | 11 | 154 | 3 |
 | DOM | `dom/` ×2 | 13 | 76 | 0 |
-| Fetch | `fetch/api/` ×2 | 29 | 388 | 88 |
-| **total** | **34** | **271** | **40,632** | **2,907** |
+| Fetch | `fetch/api/` ×2 | 29 | 388 | 75 |
+| **total** | **34** | **271** | **40,632** | **2,894** |
 
 Two of those rows are worth a caveat. The Encoding figure is dominated by
 `textdecoder-fatal-single-byte.any.js`, 7,168 assertions of it and every one passing; of the 322 that do not,

--- a/Jint.Tests/Wpt/WptExclusions.cs
+++ b/Jint.Tests/Wpt/WptExclusions.cs
@@ -359,20 +359,16 @@ internal enum WptDivergence
     /// <c>ObjectInstance.IsArrayLike</c> where https://tc39.es/ecma262/#sec-array.prototype.values reads no
     /// <c>length</c> at all, the iterator's own step 1.b doing <i>LengthOfArrayLike</i> on each
     /// <c>next()</c>. Fixed under sebastienros/jint#3209, which is what the deleted entries now enforce.
-    /// <b>The hr-time, DOM and fetch corpora filed seven more, and four of them are gone</b> — the
+    /// <b>The hr-time, DOM and fetch corpora filed seven more, and five of them are gone</b> — the
     /// <c>PerformanceMarkOptions</c> dictionary conversion, <c>Event.isTrusted</c>'s
-    /// <c>[LegacyUnforgeable]</c> shape, <c>Event</c>'s missing <c>srcElement</c>/<c>returnValue</c>, and the
-    /// <c>Headers</c> iterator prototype's non-enumerable <c>next</c> — all fixed under
-    /// sebastienros/jint#3212, so the nine entries that used to be here now enforce them and
+    /// <c>[LegacyUnforgeable]</c> shape, <c>Event</c>'s missing <c>srcElement</c>/<c>returnValue</c>, the
+    /// <c>Headers</c> iterator prototype's non-enumerable <c>next</c>, and the stream a consumed
+    /// bytes-source body handed back unlocked — all fixed under sebastienros/jint#3212, so the eleven
+    /// entries that used to be here now enforce them and
     /// <c>dom/events/Event-constructors.any.js</c> left <c>_notVendored</c> with them. <c>Vendor/README.md</c>
     /// analyses each with its citation. In one line apiece:
     /// </para>
     /// <list type="bullet">
-    /// <item><description>
-    /// A <c>Response</c> whose body came from bytes is not disturbed by consuming it, so
-    /// <c>response.body.getReader()</c> succeeds where https://fetch.spec.whatwg.org/#concept-body-disturbed
-    /// requires a <c>TypeError</c>; the rows whose body source is a <c>ReadableStream</c> pass.
-    /// </description></item>
     /// <item><description>
     /// A <c>record&lt;ByteString, ByteString&gt;</c> conversion performs one operation more than WebIDL's own
     /// order allows — two rows of <c>headers-record.any.js</c>, which count them through a proxy.

--- a/Jint.Tests/Wpt/WptExclusions.cs
+++ b/Jint.Tests/Wpt/WptExclusions.cs
@@ -325,26 +325,16 @@ internal enum WptDivergence
     /// documenting the divergence on itself and raising it upstream as
     /// https://github.com/w3c/webcrypto/issues/560.
     /// <para>
-    /// <b>The streams corpus filed five, and the workers corpus one more.</b> Each is analysed in
-    /// <c>Vendor/README.md</c>; in one line apiece:
+    /// <b>The streams corpus filed five rows, and they are gone.</b> The three defects behind them — the
+    /// async iterator prototype's non-enumerable <c>next</c> and <c>return</c>, a <c>TransformStream</c>
+    /// whose <c>readable.cancel()</c> rejected where
+    /// https://streams.spec.whatwg.org/#transform-stream-default-source-cancel fulfils it, and a
+    /// <c>pipeTo()</c> that reached the sink's <c>write</c> synchronously with an <c>enqueue()</c> on the
+    /// source — were fixed under sebastienros/jint#3195, so the five entries that used to be here now
+    /// enforce them. <c>Vendor/README.md</c> keeps the analysis, because two of the three turned out to be
+    /// something other than the triage note predicted. <b>What the workers corpus filed is still open:</b>
     /// </para>
     /// <list type="bullet">
-    /// <item><description>
-    /// The async iterator prototype's <c>next</c> and <c>return</c> are not enumerable, where
-    /// https://webidl.spec.whatwg.org/#js-asynchronous-iterator-prototype-object gives both
-    /// <c>{ [[Writable]]: true, [[Enumerable]]: true, [[Configurable]]: true }</c>.
-    /// </description></item>
-    /// <item><description>
-    /// Three rows across <c>transform-streams/errors.any.js</c> and <c>general.any.js</c> in which the promise
-    /// <c>readable.cancel()</c> returned <i>rejects</i> with the writable side's error where
-    /// https://streams.spec.whatwg.org/#transform-stream-default-source-cancel fulfils it — one defect seen
-    /// from three angles (<c>writer.abort()</c>, <c>controller.error()</c>, <c>controller.terminate()</c>).
-    /// </description></item>
-    /// <item><description>
-    /// <c>piping/general-addition.any.js</c>: an <c>enqueue()</c> on the source of a running <c>pipeTo()</c>
-    /// reaches the sink's <c>write</c> synchronously, where https://streams.spec.whatwg.org/#rs-pipe-to reads
-    /// the chunk in a reaction to the reader's promise and can never be synchronous with the enqueue.
-    /// </description></item>
     /// <item><description>
     /// <b><c>self</c> is writable in a worker, where <c>WorkerGlobalScope.self</c> is read-only.</b>
     /// <c>workers/interfaces/WorkerGlobalScope/self.any.js</c>, "self = 1": the file assigns to <c>self</c> and
@@ -369,18 +359,15 @@ internal enum WptDivergence
     /// <c>ObjectInstance.IsArrayLike</c> where https://tc39.es/ecma262/#sec-array.prototype.values reads no
     /// <c>length</c> at all, the iterator's own step 1.b doing <i>LengthOfArrayLike</i> on each
     /// <c>next()</c>. Fixed under sebastienros/jint#3209, which is what the deleted entries now enforce.
-    /// <b>The hr-time, DOM and fetch corpora filed seven more, and three of them are gone</b> — the
+    /// <b>The hr-time, DOM and fetch corpora filed seven more, and four of them are gone</b> — the
     /// <c>PerformanceMarkOptions</c> dictionary conversion, <c>Event.isTrusted</c>'s
-    /// <c>[LegacyUnforgeable]</c> shape, and <c>Event</c>'s missing <c>srcElement</c>/<c>returnValue</c>,
-    /// all fixed under sebastienros/jint#3212, so the six entries that used to be here now enforce them and
+    /// <c>[LegacyUnforgeable]</c> shape, <c>Event</c>'s missing <c>srcElement</c>/<c>returnValue</c>, and the
+    /// <c>Headers</c> iterator prototype's non-enumerable <c>next</c> — all fixed under
+    /// sebastienros/jint#3212, so the nine entries that used to be here now enforce them and
     /// <c>dom/events/Event-constructors.any.js</c> left <c>_notVendored</c> with them. <c>Vendor/README.md</c>
     /// analyses each with its citation. In one line apiece:
     /// </para>
     /// <list type="bullet">
-    /// <item><description>
-    /// The <c>Headers</c> iterator prototype's <c>next</c> is not enumerable — the same attribute on the same
-    /// kind of object as the streams corpus's async-iterator entry above.
-    /// </description></item>
     /// <item><description>
     /// A <c>Response</c> whose body came from bytes is not disturbed by consuming it, so
     /// <c>response.body.getReader()</c> succeeds where https://fetch.spec.whatwg.org/#concept-body-disturbed

--- a/Jint.Tests/Wpt/WptExclusions.cs
+++ b/Jint.Tests/Wpt/WptExclusions.cs
@@ -371,9 +371,18 @@ internal enum WptDivergence
     /// </para>
     /// <list type="bullet">
     /// <item><description>
-    /// An empty <c>FormData</c> response body serializes to its closing boundary rather than to nothing. This
-    /// one wants https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#multipart/form-data-encoding-algorithm
-    /// read before anything is changed, which is exactly why it is triage rather than a fix.
+    /// An empty <c>FormData</c> response body serializes to its closing boundary rather than to nothing —
+    /// <c>response-consume-empty.any.js</c>, "Consume empty FormData response body as text", which asks that
+    /// <c>await new Response(new FormData()).text()</c> have length 0. <b>It is not a defect.</b> This one
+    /// wanted https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#multipart/form-data-encoding-algorithm
+    /// read before anything was changed, and reading it settles the question the other way: the algorithm
+    /// defines the escaping and delegates the framing to RFC 7578 and, through it, to RFC 2046 section 5.1.1,
+    /// whose grammar ends every <c>multipart-body</c> with a <c>close-delimiter</c> that is not optional. Nor
+    /// does any implementation produce the empty body the row asks for — Chrome, Edge, Firefox and Safari all
+    /// report it 0/1 on wpt.fyi, where the file's thirteen other rows are 1/1 in all four. So the entry
+    /// stays, but this category — "a bug or a specification detail to chase" — is the wrong one for it, and
+    /// giving it one of its own is filed rather than done here. <c>Vendor/README.md</c> has the citations and
+    /// the measurement.
     /// </description></item>
     /// </list>
     /// <para>

--- a/Jint.Tests/Wpt/WptExclusions.cs
+++ b/Jint.Tests/Wpt/WptExclusions.cs
@@ -359,20 +359,17 @@ internal enum WptDivergence
     /// <c>ObjectInstance.IsArrayLike</c> where https://tc39.es/ecma262/#sec-array.prototype.values reads no
     /// <c>length</c> at all, the iterator's own step 1.b doing <i>LengthOfArrayLike</i> on each
     /// <c>next()</c>. Fixed under sebastienros/jint#3209, which is what the deleted entries now enforce.
-    /// <b>The hr-time, DOM and fetch corpora filed seven more, and five of them are gone</b> — the
+    /// <b>The hr-time, DOM and fetch corpora filed seven, and six of them are gone</b> — the
     /// <c>PerformanceMarkOptions</c> dictionary conversion, <c>Event.isTrusted</c>'s
     /// <c>[LegacyUnforgeable]</c> shape, <c>Event</c>'s missing <c>srcElement</c>/<c>returnValue</c>, the
-    /// <c>Headers</c> iterator prototype's non-enumerable <c>next</c>, and the stream a consumed
-    /// bytes-source body handed back unlocked — all fixed under sebastienros/jint#3212, so the eleven
+    /// <c>Headers</c> iterator prototype's non-enumerable <c>next</c>, the stream a consumed bytes-source
+    /// body handed back unlocked, and a <c>record&lt;ByteString, ByteString&gt;</c> conversion that read a
+    /// property WebIDL's order never reaches — all fixed under sebastienros/jint#3212, so the thirteen
     /// entries that used to be here now enforce them and
     /// <c>dom/events/Event-constructors.any.js</c> left <c>_notVendored</c> with them. <c>Vendor/README.md</c>
-    /// analyses each with its citation. In one line apiece:
+    /// analyses each with its citation. <b>The seventh is the one entry left:</b>
     /// </para>
     /// <list type="bullet">
-    /// <item><description>
-    /// A <c>record&lt;ByteString, ByteString&gt;</c> conversion performs one operation more than WebIDL's own
-    /// order allows — two rows of <c>headers-record.any.js</c>, which count them through a proxy.
-    /// </description></item>
     /// <item><description>
     /// An empty <c>FormData</c> response body serializes to its closing boundary rather than to nothing. This
     /// one wants https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#multipart/form-data-encoding-algorithm

--- a/Jint.Tests/Wpt/WptTestRunner.cs
+++ b/Jint.Tests/Wpt/WptTestRunner.cs
@@ -970,12 +970,6 @@ public class WptTestRunner
         new("fetch/api/headers/headers-forbidden-override.any.js", "header * is forbidden to use value *", WptDivergence.NeedsForbiddenHeaderNames),
         new("fetch/api/headers/header-setcookie.any.js", "Set-Cookie is a forbidden response header", WptDivergence.NeedsForbiddenHeaderNames),
 
-        // Two rows counting the operations a record<> conversion performs; Jint does one more than the
-        // specification's order allows. See Vendor/README.md.
-        new("fetch/api/headers/headers-record.any.js",
-            "Correct operation ordering with two properties one of which has an invalid name", WptDivergence.NeedsTriage),
-        new("fetch/api/headers/headers-record.any.js", "Basic operation with Symbol keys", WptDivergence.NeedsTriage),
-
         new("fetch/api/response/response-consume-stream.any.js", "Getting a redirect Response stream", WptDivergence.NeedsApiBaseUrl),
 
         new("fetch/api/response/response-consume-empty.any.js",

--- a/Jint.Tests/Wpt/WptTestRunner.cs
+++ b/Jint.Tests/Wpt/WptTestRunner.cs
@@ -972,6 +972,10 @@ public class WptTestRunner
 
         new("fetch/api/response/response-consume-stream.any.js", "Getting a redirect Response stream", WptDivergence.NeedsApiBaseUrl),
 
+        // The one row this corpus still names, and it is not a defect: an empty FormData body is asked to
+        // serialize to nothing, where HTML's encoding algorithm delegates the framing to RFC 7578 and RFC
+        // 2046, whose grammar makes the close-delimiter mandatory — and where no browser passes the row
+        // either. Left here because moving it wants a category of its own. See WptDivergence.NeedsTriage.
         new("fetch/api/response/response-consume-empty.any.js",
             "Consume empty FormData response body as text", WptDivergence.NeedsTriage),
 

--- a/Jint.Tests/Wpt/WptTestRunner.cs
+++ b/Jint.Tests/Wpt/WptTestRunner.cs
@@ -978,13 +978,6 @@ public class WptTestRunner
 
         new("fetch/api/response/response-consume-stream.any.js", "Getting a redirect Response stream", WptDivergence.NeedsApiBaseUrl),
 
-        // Eight of the twelve rows of a file whose other four pass: after a Response whose body came from
-        // *bytes* — a string, or the loader's answer — has been consumed, `response.body.getReader()` must
-        // throw because the body is disturbed, and here it does not. The four rows whose body source is a
-        // ReadableStream the test built itself pass, which is what locates the defect. See Vendor/README.md.
-        new("fetch/api/response/response-stream-disturbed-5.any.js", "* (body source: string)", WptDivergence.NeedsTriage),
-        new("fetch/api/response/response-stream-disturbed-5.any.js", "* (body source: fetch)", WptDivergence.NeedsTriage),
-
         new("fetch/api/response/response-consume-empty.any.js",
             "Consume empty FormData response body as text", WptDivergence.NeedsTriage),
 

--- a/Jint.Tests/Wpt/WptTestRunner.cs
+++ b/Jint.Tests/Wpt/WptTestRunner.cs
@@ -970,12 +970,6 @@ public class WptTestRunner
         new("fetch/api/headers/headers-forbidden-override.any.js", "header * is forbidden to use value *", WptDivergence.NeedsForbiddenHeaderNames),
         new("fetch/api/headers/header-setcookie.any.js", "Set-Cookie is a forbidden response header", WptDivergence.NeedsForbiddenHeaderNames),
 
-        // WebIDL gives an iterator prototype object's `next` { writable, enumerable, configurable }; Jint's is
-        // non-enumerable. The same defect the streams corpus filed against the async iterator prototype.
-        new("fetch/api/headers/headers-basic.any.js", "Check keys method", WptDivergence.NeedsTriage),
-        new("fetch/api/headers/headers-basic.any.js", "Check values method", WptDivergence.NeedsTriage),
-        new("fetch/api/headers/headers-basic.any.js", "Check entries method", WptDivergence.NeedsTriage),
-
         // Two rows counting the operations a record<> conversion performs; Jint does one more than the
         // specification's order allows. See Vendor/README.md.
         new("fetch/api/headers/headers-record.any.js",

--- a/Jint/WebApi/Fetch/FetchBodyObject.cs
+++ b/Jint/WebApi/Fetch/FetchBodyObject.cs
@@ -136,10 +136,24 @@ internal abstract class FetchBodyObject : ObjectInstance
     /// on first ask. <see langword="null"/> for a null body.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// A body extracted from bytes has a stream from the moment it is extracted, per the standard; deferring
     /// its creation to the first read of <c>body</c> is invisible, because asking is the only way to observe
     /// it. What the deferral buys is the buffered fast path in <see cref="FetchBody.Consume"/>: a script that
     /// only ever calls <c>text()</c> never builds a stream, a controller or a reader.
+    /// </para>
+    /// <para>
+    /// Invisible, though, only if the stream handed over <i>after</i> a consume is the one the standard would
+    /// be holding by then — and that is not merely a disturbed stream. Consuming runs <i>fully read</i>
+    /// (https://fetch.spec.whatwg.org/#concept-body-fully-read), whose step 3 is "let reader be the result of
+    /// getting a reader for body's stream" — https://streams.spec.whatwg.org/#readablestream-get-a-reader,
+    /// which <b>locks</b> it — and whose read-all-bytes step never releases that reader. So the stream a
+    /// consumed body exposes is disturbed, closed <i>and locked for good</i>, which is what makes
+    /// <c>response.body.getReader()</c> after <c>response.text()</c> the <c>TypeError</c>
+    /// https://streams.spec.whatwg.org/#set-up-readable-stream-default-reader raises. Nothing can read such a
+    /// stream, so it is built empty: filling it from the source would copy a body that has already been
+    /// handed over, only to throw the copy away.
+    /// </para>
     /// </remarks>
     internal JsReadableStream? GetOrCreateStream(Realm realm)
     {
@@ -153,14 +167,15 @@ internal abstract class FetchBodyObject : ObjectInstance
             return Stream;
         }
 
-        var bytes = Source!.Value;
-        var stream = ByteStreams.CreateFromBytes(Engine, realm, bytes);
+        // Cancel is what sets `disturbed` — https://streams.spec.whatwg.org/#readable-stream-cancel step 1 —
+        // and closes the stream, and the reader acquired after it is the one fully read never gave back.
+        var consumed = SourceDisturbed;
+        var stream = ByteStreams.CreateFromBytes(Engine, realm, consumed ? default : Source!.Value);
 
-        // A source that has already been consumed hands back a stream that is disturbed to match, so
-        // `r.text(); r.body.locked` and `r.bodyUsed` keep telling the same story.
-        if (SourceDisturbed)
+        if (consumed)
         {
             ReadableStreamOperations.Cancel(stream, Undefined);
+            ReadableStreamOperations.AcquireDefaultReader(stream);
         }
 
         Stream = stream;

--- a/Jint/WebApi/Fetch/HeadersIteratorPrototype.cs
+++ b/Jint/WebApi/Fetch/HeadersIteratorPrototype.cs
@@ -42,7 +42,20 @@ internal sealed partial class HeadersIteratorPrototype : IteratorPrototype
         CreateSymbols_Generated();
     }
 
-    [JsFunction(Name = "next")]
+    /// <summary>
+    /// https://webidl.spec.whatwg.org/#es-iterator-prototype-object — "an iterator prototype object must
+    /// have a <c>next</c> data property with attributes <c>{ [[Writable]]: true, [[Enumerable]]: true,
+    /// [[Configurable]]: true }</c>".
+    /// </summary>
+    /// <remarks>
+    /// The attributes are WebIDL's, not ECMA-262's, and enumerable is the one that has to be spelled out: a
+    /// built-in function property is non-enumerable everywhere in the language
+    /// (https://tc39.es/ecma262/#sec-ecmascript-standard-built-in-objects), which is what
+    /// <c>[JsFunction]</c> defaults to. The <c>@@toStringTag</c> below keeps the language's shape, because
+    /// a class string is <c>{ [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }</c> in
+    /// WebIDL too.
+    /// </remarks>
+    [JsFunction(Name = "next", Length = 0, Flags = PropertyFlag.ConfigurableEnumerableWritable)]
     private JsValue NextHandler(JsValue thisObject) => Next(thisObject, Arguments.Empty);
 
     internal IteratorInstance ConstructEntryIterator(JsHeaders headers)

--- a/Jint/WebApi/Fetch/JsHeaders.cs
+++ b/Jint/WebApi/Fetch/JsHeaders.cs
@@ -4,6 +4,7 @@ using Jint.Native.Iterator;
 using Jint.Native.Object;
 using Jint.Native.Symbol;
 using Jint.Runtime;
+using Jint.Runtime.Descriptors;
 
 namespace Jint.WebApi.Fetch;
 
@@ -99,27 +100,67 @@ internal sealed class JsHeaders : ObjectInstance
     }
 
     /// <summary>
-    /// "Otherwise, init is a record: for each key → value of init, append (key, value)." A record's members
-    /// are its own enumerable string-keyed properties, in own-property order —
-    /// https://webidl.spec.whatwg.org/#es-record.
+    /// "Otherwise, init is a record: for each key → value of init, append (key, value)."
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The record is converted <i>in full</i> before the fill appends anything, because the conversion is
+    /// what turns the argument into a <c>record&lt;ByteString, ByteString&gt;</c> in the first place —
+    /// https://webidl.spec.whatwg.org/#es-record. Its step 3 is <c>? O.[[OwnPropertyKeys]]()</c>, with no
+    /// filter, so a Symbol key is a member of the walk like any other; and its step 4 is, per key,
+    /// </para>
+    /// <list type="number">
+    /// <item><description><c>[[GetOwnProperty]]</c>, and</description></item>
+    /// <item><description>
+    /// when the descriptor exists and is enumerable: "let <i>typedKey</i> be <i>key</i> converted to an IDL
+    /// value of type <i>K</i>", then "let <i>value</i> be <c>? Get(O, key)</c>", then the value's own
+    /// conversion.
+    /// </description></item>
+    /// </list>
+    /// <para>
+    /// The <b>key</b> is converted before the <c>Get</c>, which is the whole of what
+    /// <c>fetch/api/headers/headers-record.any.js</c> counts through a proxy: <i>K</i> is <c>ByteString</c>,
+    /// so a Symbol key — or a string carrying a code unit above 255 — ends the conversion there, and the
+    /// <c>Get</c> that would have followed never happens.
+    /// </para>
+    /// </remarks>
     private void FillFromRecord(Realm realm, ObjectInstance init)
     {
-        foreach (var key in init.GetOwnPropertyKeys(Types.String))
+        var keys = init.GetOwnPropertyKeys();
+        var record = new List<(string Name, string Value)>(keys.Count);
+
+        foreach (var key in keys)
         {
             var descriptor = init.GetOwnProperty(key);
-            if (!descriptor.Enumerable)
+            if (descriptor == PropertyDescriptor.Undefined || !descriptor.Enumerable)
             {
                 continue;
             }
 
-            AppendChecked(realm, key, init.Get(key));
+            var name = FetchValues.ToByteString(realm, key);
+            record.Add((name, FetchValues.ToByteString(realm, init.Get(key))));
+        }
+
+        foreach (var (name, value) in record)
+        {
+            AppendConverted(realm, name, value);
         }
     }
 
     /// <summary>
-    /// The <c>append</c> operation, https://fetch.spec.whatwg.org/#dom-headers-append, shared by the fill
-    /// above and by <c>Headers.prototype.append</c>.
+    /// The <c>append</c> operation, https://fetch.spec.whatwg.org/#dom-headers-append, for the fill above,
+    /// whose two <c>ByteString</c> conversions belong to the record conversion that precedes it.
+    /// </summary>
+    private void AppendConverted(Realm realm, string name, string value)
+    {
+        var (headerName, headerValue) = ValidateConverted(realm, "append", name, value);
+        RequireMutable(realm, "append");
+        List.Append(headerName, headerValue);
+    }
+
+    /// <summary>
+    /// The same operation for <c>Headers.prototype.append</c>, where the <c>ByteString</c> conversions are
+    /// WebIDL's argument conversions and so happen here.
     /// </summary>
     internal void AppendChecked(Realm realm, JsValue name, JsValue value)
     {
@@ -129,15 +170,20 @@ internal sealed class JsHeaders : ObjectInstance
     }
 
     /// <summary>
+    /// The <c>ByteString</c> argument conversions, in declaration order, and then <see cref="ValidateConverted"/>.
+    /// </summary>
+    internal static (string Name, string Value) Validate(Realm realm, string operation, JsValue name, JsValue value)
+        => ValidateConverted(realm, operation, FetchValues.ToByteString(realm, name), FetchValues.ToByteString(realm, value));
+
+    /// <summary>
     /// Steps 1 and 2 of every mutating operation: normalize the value, then refuse a name that is not a token
     /// or a value carrying NUL, CR or LF.
     /// </summary>
-    internal static (string Name, string Value) Validate(Realm realm, string operation, JsValue name, JsValue value)
+    private static (string Name, string Value) ValidateConverted(Realm realm, string operation, string name, string value)
     {
-        var headerName = FetchValues.ToByteString(realm, name);
-        var headerValue = HeaderList.Normalize(FetchValues.ToByteString(realm, value));
+        var headerValue = HeaderList.Normalize(value);
 
-        if (!HeaderList.IsName(headerName))
+        if (!HeaderList.IsName(name))
         {
             Throw.TypeError(realm, $"Failed to execute '{operation}' on 'Headers': Invalid name");
         }
@@ -147,7 +193,7 @@ internal sealed class JsHeaders : ObjectInstance
             Throw.TypeError(realm, $"Failed to execute '{operation}' on 'Headers': Invalid value");
         }
 
-        return (headerName, headerValue);
+        return (name, headerValue);
     }
 
     /// <summary>

--- a/Jint/WebApi/Files/FormDataIteratorPrototype.cs
+++ b/Jint/WebApi/Files/FormDataIteratorPrototype.cs
@@ -38,7 +38,20 @@ internal sealed partial class FormDataIteratorPrototype : IteratorPrototype
         CreateSymbols_Generated();
     }
 
-    [JsFunction(Name = "next")]
+    /// <summary>
+    /// https://webidl.spec.whatwg.org/#es-iterator-prototype-object — "an iterator prototype object must
+    /// have a <c>next</c> data property with attributes <c>{ [[Writable]]: true, [[Enumerable]]: true,
+    /// [[Configurable]]: true }</c>".
+    /// </summary>
+    /// <remarks>
+    /// The attributes are WebIDL's, not ECMA-262's, and enumerable is the one that has to be spelled out: a
+    /// built-in function property is non-enumerable everywhere in the language
+    /// (https://tc39.es/ecma262/#sec-ecmascript-standard-built-in-objects), which is what
+    /// <c>[JsFunction]</c> defaults to. The <c>@@toStringTag</c> below keeps the language's shape, because
+    /// a class string is <c>{ [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }</c> in
+    /// WebIDL too.
+    /// </remarks>
+    [JsFunction(Name = "next", Length = 0, Flags = PropertyFlag.ConfigurableEnumerableWritable)]
     private JsValue NextHandler(JsValue thisObject) => Next(thisObject, Arguments.Empty);
 
     internal FormDataIterator ConstructEntryIterator(JsFormData formData)

--- a/Jint/WebApi/Url/UrlSearchParamsIteratorPrototype.cs
+++ b/Jint/WebApi/Url/UrlSearchParamsIteratorPrototype.cs
@@ -44,7 +44,20 @@ internal sealed partial class UrlSearchParamsIteratorPrototype : IteratorPrototy
         CreateSymbols_Generated();
     }
 
-    [JsFunction(Name = "next")]
+    /// <summary>
+    /// https://webidl.spec.whatwg.org/#es-iterator-prototype-object — "an iterator prototype object must
+    /// have a <c>next</c> data property with attributes <c>{ [[Writable]]: true, [[Enumerable]]: true,
+    /// [[Configurable]]: true }</c>".
+    /// </summary>
+    /// <remarks>
+    /// The attributes are WebIDL's, not ECMA-262's, and enumerable is the one that has to be spelled out: a
+    /// built-in function property is non-enumerable everywhere in the language
+    /// (https://tc39.es/ecma262/#sec-ecmascript-standard-built-in-objects), which is what
+    /// <c>[JsFunction]</c> defaults to. The <c>@@toStringTag</c> below keeps the language's shape, because
+    /// a class string is <c>{ [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }</c> in
+    /// WebIDL too.
+    /// </remarks>
+    [JsFunction(Name = "next", Length = 0, Flags = PropertyFlag.ConfigurableEnumerableWritable)]
     private JsValue NextHandler(JsValue thisObject) => Next(thisObject, Arguments.Empty);
 
     internal IteratorInstance ConstructEntryIterator(JsUrlSearchParams parameters)


### PR DESCRIPTION
Fixes items **7, 8 and 9** of #3212, and returns a verdict on item 10 rather than a fix. With #3243, #3244 and #3245 merged, this closes out the eleven — **#3212 can close with this**.

13 corpus rows go green; **exactly 13 rows move across the whole 40,631-assertion corpus**, all FAIL→PASS, verified row by row.

---

### Item 7 — iterator prototype `next` — and two siblings nobody was watching

[WebIDL §3.7.9.2](https://webidl.spec.whatwg.org/#es-iterator-prototype-object) requires `next` to be `{ writable, enumerable, configurable }`. Only `enumerable` was wrong; `writable`, `configurable`, `length` 0, `name` and the `@@toStringTag` shape were already right, and the new tests pin all of them so the next change to that object cannot quietly move one.

`Headers` had the failing rows, but the same defect was in **`FormData` and `URLSearchParams` iterator prototypes too** — and no vendored row reaches either, so it was invisible debt. Fixed all three; that is the entire change, one attribute per file, made expressible by #3238's `Flags` property.

### Item 8 — the recorded cause was wrong in its operative half

It said the stream `.body` exposes "is not the one the consume path locked". **The consume path locked nothing**, and `disturbed` is not what `getReader()` refuses: [SetUpReadableStreamDefaultReader](https://streams.spec.whatwg.org/#set-up-readable-stream-default-reader) step 1 refuses a **locked** stream and only a locked one, so Jint handing a reader to a disturbed-but-unlocked stream was quite correct.

What a browser does is [*fully read*](https://fetch.spec.whatwg.org/#concept-body-fully-read) step 3 — *"let reader be the result of getting a reader for body's stream"* — whose read-all-bytes never releases it. So a consumed body's stream is disturbed, closed **and locked for good**. That also explains why the `ReadableStream`-source rows already passed: they go through `FetchBody.FullyRead`, which holds its reader.

`GetOrCreateStream` now cancels *and* acquires a default reader, building the stream empty since nothing can read a locked one.

### Item 9 — the extra operation, and a pre-existing inconsistency it exposed

Measured through the WPT file's own logging proxy, the extra operation is the same on both rows: the `[[Get]]` of the key that ends the conversion. [WebIDL §3.2.23](https://webidl.spec.whatwg.org/#es-record) step 4.2 is *typedKey* conversion **then** `? Get(O, key)`; `FillFromRecord` did the `Get` first and converted the key inside `append`.

Writing step 3 as the unfiltered `? O.[[OwnPropertyKeys]]()` removed a real inconsistency along the way: `JsProxy.GetOwnPropertyKeys` honours Jint's `types` filter only when there is no `ownKeys` trap — correctly, since the spec's internal method has no filter — so a Symbol key already reached the walk **through a proxy** while `new Headers({ [Symbol.toStringTag]: 'x' })` on a plain object was silently accepted where a browser throws.

Measured before → after: invalid-name row **6 → 5** operations, Symbol-keys row **8 → 7**; the three already-correct shapes unchanged.

### Item 10 — **not a defect. Row left in place.**

HTML's algorithm normalizes newlines per entry and then returns *"the byte sequence resulting from encoding the entry list using the rules described by RFC 7578"* — it defines the **escaping** and delegates the **framing**. RFC 7578 defers to RFC 2046, whose §5.1.1 grammar ends every `multipart-body` with a `close-delimiter` that is **not optional**. An empty entry list has no shorter conforming encoding than the 50 bytes Jint writes.

The empirical half is decisive: on wpt.fyi across four aligned stable runs (chrome 152, edge 151, firefox 154, safari 26.6), *"Consume empty FormData response body as text"* is **0/1 in all four**, while the file's thirteen other rows are 1/1 in all four (methodology validated against three control rows). No implementation passes it.

The row stays excluded, and its prose in `WptExclusions.cs` and `Vendor/README.md` now records that verdict instead of "wants a spec read". **`NeedsTriage` is the wrong category for it** — it wants one meaning *"the test asserts what nothing requires"*, the WPT analogue of test262's `PERMANENT EXCLUSIONS`. Recommended as a separate issue rather than invented here.

### Item 8's neighbours, all pinned

`clone()` after consumption still throws (unusable is disturbed **or** locked, and it was already disturbed), including with `body` read first; `bodyUsed` timing unchanged; `Request` covered as well as `Response`, with its new test **watched failing against unfixed code** (source reverted, run, restored); all six consumers as a theory — `text`/`json`/`arrayBuffer`/`blob`/`bytes`/`formData`, `bytes()` beyond the four the issue named; and the opposite direction, where `getReader()` + `releaseLock()` leaves the body usable and consuming then locks *that same* stream.

### Exclusion accounting

13 `NeedsTriage` rows deleted — 3 `headers-basic`, 2 `headers-record`, 2 globs covering 8 rows of `response-stream-disturbed-5`. **Two `NeedsTriage` entries remain repo-wide**: the workers `self = 1` row (#3224) and the empty-FormData row above. The doc comment now has exactly two live bullets.

**Doc-staleness caught, as warned:** three `NeedsTriage` bullets still described the *streams* defects that #3238 had fixed and whose rows were already gone. Rewritten to past tense.

### Verification

Solution builds Release, 0 errors, all TFMs. `Jint.Tests` 10275 (net10.0) / 7147 (net472); `Jint.Tests.PublicInterface` 2405 / 1879; both repeated with `JINT_HOST_CONTRACT_VERIFICATION=1` (2409 / 1883). WPT 420/420 after rebase.

Row-level census across all 270 files, before and after:

| corpus | assertions | fail before | fail after |
| --- | --- | --- | --- |
| **fetch/api** | 388 | **88** | **75** |
| every other corpus | 40,243 | 2,819 | 2,819 |
| **total** | **40,631** | **2,907** | **2,894** |

**Exactly 13 rows moved, all FAIL→PASS, and they are exactly the 13 intended.** Zero rows changed in the other direction, none appeared or disappeared, and no other corpus moved by a single assertion. Stated because it is a finding rather than a rounding error.

Every engine change is inside `Jint/WebApi/`, so `Jint.Tests.Test262` was not run.

### Left undone

- **188 of the 190 `[JsFunction]` declarations under `Jint/WebApi/` are non-enumerable**, where [WebIDL §3.7.6](https://webidl.spec.whatwg.org/#es-operations) gives a regular operation `{ writable, enumerable, configurable }`. No vendored row catches it (`idlharness` is not vendored). Already filed as **#3239**; deliberately out of scope here.
- `FillFromSequence` still interleaves conversion and fill — the same shape item 9 fixed on the record arm. No vendored row counts it; noted rather than changed.
- The `Vendor/README.md` corpus table was stale on `main` for rows unrelated to this work; re-measured and corrected rather than leaving known-wrong figures beside new ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
