### PR TITLE
Tests: a wedge ceiling, not a budget, for the async-module waits

### DIFF
--- a/Jint.Tests.PublicInterface/AsyncModuleLoaderTests.cs
+++ b/Jint.Tests.PublicInterface/AsyncModuleLoaderTests.cs
@@ -29,7 +29,7 @@ public class AsyncModuleLoaderTests
     private static Engine CreateEngine(IModuleLoader loader) => new(options =>
     {
         options.EnableModules(loader);
-        options.Constraints.PromiseTimeout = TimeSpan.FromMinutes(2);
+        options.Constraints.PromiseTimeout = TestBudgets.WedgeCeiling;
     });
     /// <summary>
     /// A loader that hands every request to the test and finishes nothing by itself, so a test can prove the
@@ -680,16 +680,26 @@ public class AsyncModuleLoaderTests
         import.Error!.Get("message").AsString().Should().Be("Could not load module.");
     });
 
+    /// <summary>
+    /// The same cancellation as <see cref="ACanceledFetchIsAnOrdinarySanitizedLoadFailure"/>, reaching a
+    /// caller that is awaiting rather than pumping. The rejection <em>value</em> is what is asserted, not
+    /// merely the exception type: a <see cref="PromiseRejectedException"/> is also what a promise budget
+    /// that ran out throws, so a type-only assertion would go on passing on a runner where the settle never
+    /// arrived — testing nothing, and never failing to say so. Asserting the sanitized message costs that
+    /// test its vacuity, which is why the engine comes through <see cref="CreateEngine"/>: the budget it
+    /// sets is what keeps the tightened assertion honest instead of flaky.
+    /// </summary>
     [Fact]
     public async Task ACanceledFetchSettlesWhileImportAsyncOwnsTheEngine()
     {
         var loader = new TokenCapturingLoader();
-        var engine = new Engine(options => options.EnableModules(loader));
+        var engine = CreateEngine(loader);
 
         var import = engine.Modules.ImportAsync("./doomed.js");
         loader.CancelPendingFetch();
 
-        await Invoking(() => import).Should().ThrowAsync<PromiseRejectedException>();
+        var rejection = await Invoking(() => import).Should().ThrowAsync<PromiseRejectedException>();
+        rejection.Which.RejectedValue.Get("message").AsString().Should().Be("Could not load module.");
     }
 
     /// <summary>

--- a/Jint.Tests.PublicInterface/HostEngineConcurrencyTests.cs
+++ b/Jint.Tests.PublicInterface/HostEngineConcurrencyTests.cs
@@ -27,9 +27,11 @@ public class HostEngineConcurrencyTests
 
     /// <summary>
     /// Reached only by a genuine wedge. Every wait in this class is released by a thread the test owns, so
-    /// no amount of runner load can lose the race and only a hang can spend two minutes here.
+    /// no amount of runner load can lose the race and only a hang can spend two minutes here. It is also
+    /// what an engine here is given as its <c>PromiseTimeout</c> when the settle it is waiting for is
+    /// delivered by the thread pool rather than by the test — see <see cref="TestBudgets.WedgeCeiling"/>.
     /// </summary>
-    private static readonly TimeSpan HandoffCeiling = TimeSpan.FromMinutes(2);
+    private static readonly TimeSpan HandoffCeiling = TestBudgets.WedgeCeiling;
 
     /// <summary>
     /// Runs the call that takes the engine and parks inside <c>block()</c> on a thread of the test's own.
@@ -491,8 +493,11 @@ public class HostEngineConcurrencyTests
         engine.SetValue("later", new Action<Action>(callback =>
             Task.Delay(50).ContinueWith(_ => callback(), TaskScheduler.Default)));
 
+        // The three siblings above already pass HandoffCeiling here; this call site was the one left on the
+        // parameterless overload, whose ceiling is a hard-coded ten seconds that no engine option reaches -
+        // and the release it is waiting for is a Task.Delay continuation, i.e. a thread-pool worker.
         engine.Evaluate("new Promise(resolve => later(() => resolve(42)))")
-            .UnwrapIfPromise()
+            .UnwrapIfPromise(HandoffCeiling)
             .AsNumber()
             .Should()
             .Be(42);
@@ -533,7 +538,13 @@ public class HostEngineConcurrencyTests
     public async Task BackgroundModuleCompletionCanFinishTheOwningImport()
     {
         var loader = new DeferredModuleLoader();
-        var engine = new Engine(options => options.EnableModules(loader));
+        // The settle is delivered by a thread-pool worker, so the engine's default ten-second budget would
+        // make the pool's injection rate part of the outcome. HandoffCeiling instead.
+        var engine = new Engine(options =>
+        {
+            options.EnableModules(loader);
+            options.Constraints.PromiseTimeout = HandoffCeiling;
+        });
 
         var pending = engine.Modules.ImportAsync("module");
         pending.IsCompleted.Should().BeFalse();

--- a/Jint.Tests.PublicInterface/HostMemoryLimitTests.cs
+++ b/Jint.Tests.PublicInterface/HostMemoryLimitTests.cs
@@ -689,6 +689,12 @@ public class HostMemoryLimitTests
         {
             options.LimitMemory(SingleAllocationBudget);
             options.EnableModules(loader);
+
+            // What this asserts is that the memory operation travels with the import and is released by it,
+            // never how long the import takes. The loader is completed from a thread-pool worker, so on the
+            // engine's default ten-second budget a saturated pool would decide the outcome instead of the
+            // memory scope. Same treatment the file's SynchronousImport... sibling already gives it.
+            options.Constraints.PromiseTimeout = TestBudgets.WedgeCeiling;
         });
         engine.SetValue("allocate", new Action(() => allocations.Add(new byte[AllocationSize])));
         var constraint = engine.Constraints.Find<MemoryLimitConstraint>()!;

--- a/Jint.Tests.PublicInterface/Jint.Tests.PublicInterface.csproj
+++ b/Jint.Tests.PublicInterface/Jint.Tests.PublicInterface.csproj
@@ -44,6 +44,12 @@
       that itself needs one is the shortage to avoid.
     -->
     <Compile Include="..\Jint.Tests\DedicatedThread.cs" Link="DedicatedThread.cs" />
+    <!--
+      Shared so that both suites spell "a ceiling only a wedge can reach" the same way, and say once what
+      the number means. See TestBudgets.WedgeCeiling for the distinction it exists to keep: a budget that
+      bounds a hang is not a budget a test asserts.
+    -->
+    <Compile Include="..\Jint.Tests\TestBudgets.cs" Link="TestBudgets.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jint.Tests.PublicInterface/ParsingLimitTests.cs
+++ b/Jint.Tests.PublicInterface/ParsingLimitTests.cs
@@ -450,6 +450,12 @@ public class ParsingLimitTests
             options.LimitMemory(16_000_000);
             options.Parsing.MaxSourceLength = 20;
             options.EnableModules(loader);
+
+            // The source is delivered from a thread-pool worker, twice. What is asserted is the
+            // ParsingLimitException, the released ownership and the removed pending-load entry - never a
+            // duration - so the promise budget is a ceiling on a wedge and must not be one the pool's
+            // injection rate can beat.
+            options.Constraints.PromiseTimeout = TestBudgets.WedgeCeiling;
         });
         var memory = engine.Constraints.Find<MemoryLimitConstraint>()!;
 

--- a/Jint.Tests/Runtime/NodeCompat/BuiltinModuleTests.cs
+++ b/Jint.Tests/Runtime/NodeCompat/BuiltinModuleTests.cs
@@ -362,9 +362,16 @@ public class BuiltinModuleTests
     public async Task ComposesWithAnAsynchronousLoader()
     {
         var loader = new RecordingAsyncLoader();
-        var engine = new Engine(options => options
-            .EnableModules(loader)
-            .UseNodeBuiltinModules(o => o.Platform = "linux"));
+        var engine = new Engine(options =>
+        {
+            options.EnableModules(loader).UseNodeBuiltinModules(o => o.Platform = "linux");
+
+            // RecordingAsyncLoader yields, so the hosted import below is finished by a thread-pool
+            // continuation. This test asserts what each import resolves to and which of them reached the
+            // loader, never how long either took, so the budget is a ceiling on a wedge: on the engine's
+            // default ten seconds a saturated pool turns it into "Timeout of 00:00:10 reached".
+            options.Constraints.PromiseTimeout = TestBudgets.WedgeCeiling;
+        });
 
         engine.Modules.ModuleLoader.Should().BeAssignableTo<IAsyncModuleLoader>();
 

--- a/Jint.Tests/TestBudgets.cs
+++ b/Jint.Tests/TestBudgets.cs
@@ -1,0 +1,44 @@
+#nullable enable
+
+namespace Jint.Tests;
+
+/// <summary>
+/// Wall-clock budgets shared by both test suites, and the one distinction that decides which of them a
+/// test may use: a budget is either part of what the test <em>asserts</em>, or it is a ceiling that exists
+/// only so a wedge is reported instead of hanging the run. The two must not be sized alike, and only the
+/// second kind belongs here.
+/// </summary>
+internal static class TestBudgets
+{
+    /// <summary>
+    /// The promise budget for an engine whose wait is released from <em>outside</em> the engine: a module
+    /// load settling from a loader's own thread, a host <c>Task</c> completing, a callback dispatched from
+    /// the thread pool.
+    /// <para>
+    /// This is a <b>wedge ceiling, never an assertion</b>. A test using it asserts an outcome — a value, an
+    /// exception type, a message — and never a duration, so a healthy run spends none of this budget and
+    /// widening it can hide nothing. What it removes is the thread pool from the set of things that decide
+    /// the outcome: xUnit runs test bodies on pool workers, a saturated pool injects a further worker at
+    /// roughly one per 500 ms, and a continuation that misses the engine's default ten-second
+    /// <c>PromiseTimeout</c> fails the test with "Timeout of 00:00:10 reached" — a symptom with nothing to
+    /// do with what the test is about. Two minutes cannot be reached by a loaded runner, only by a genuine
+    /// hang, and a hang reported after two minutes is still a reported failure.
+    /// </para>
+    /// <para>
+    /// The counter-example, so the contrast is on the record: a test that asserts a budget <em>is</em>
+    /// respected — <c>HostMemoryLimitTests.SynchronousImportDoesNotChargeAsyncLoaderWaitToExecutionTimeout</c>
+    /// with its 200 ms execution timeout, <c>HostModuleImportStateTests</c> with its 300 ms gate,
+    /// <c>AsyncModuleLoaderTests.AWarmAnswerServesTheBlockingImportEvenWhereDrainingIsImpossible</c> with
+    /// its deliberately short 500 ms — states that budget itself and must never be routed through here.
+    /// Ask of every use: would this test still fail if the behaviour it pins regressed? If widening the
+    /// budget could mask the regression, the budget is the assertion and this constant is the wrong answer.
+    /// </para>
+    /// <para>
+    /// The name is the suite's own: several classes already keep a private <c>WedgeCeiling</c> of exactly
+    /// this length, and others the same value under a local name (<c>HandoffCeiling</c>,
+    /// <c>TransportSignalCeiling</c>). This is where the reasoning lives; a file is free to go on naming it
+    /// for what it bounds there, as long as it is this constant it names.
+    /// </para>
+    /// </summary>
+    public static readonly TimeSpan WedgeCeiling = TimeSpan.FromMinutes(2);
+}


### PR DESCRIPTION
Closes #3234.

Four tests built a bare `new Engine` — default **10 second `PromiseTimeout`** — then used `Modules.ImportAsync` where the load's settle rides a **thread-pool continuation**. On a saturated runner the pool does not inject a worker in time and the test fails with a timeout that has nothing to do with what it asserts.

All four are **wedge ceilings**, not assertions: each asserts an outcome — a value, an exception type, a message, a fetch count — and never a duration. So the fix is the #3123/#3154/#3221 treatment, and widening can hide nothing.

## The shared constant, and what it says at its definition

`Jint.Tests/TestBudgets.cs` — `WedgeCeiling = 2 min`, linked into `Jint.Tests.PublicInterface` the way `DedicatedThread.cs` already is. The name is the suite's own: `WaitForScheduledWorkTests` and `HostPumpWaitTests` already keep a private `WedgeCeiling` of exactly that length.

Its doc states the distinction that decides who may use it — *a budget is either part of what the test asserts, or it is a ceiling so a wedge is reported instead of hanging the run; the two must not be sized alike* — carries the "would this still fail if the behaviour regressed?" test, and **names the counter-examples** so nobody mistakes it for an assertable budget: `SynchronousImportDoesNotChargeAsyncLoaderWaitToExecutionTimeout`'s 200 ms, `HostModuleImportStateTests`' 300 ms gate, `AWarmAnswerServes…`'s 500 ms.

The two contrast tests are untouched, including `SynchronousImport…`'s value-identical inline `TimeSpan.FromMinutes(2)`.

## Would each still fail if the pinned behaviour regressed?

Yes for every changed site — widening changes only how long a genuine wedge takes to be *reported*, never whether it is:

- **Background / ImportAsyncTransfers / ImportAsyncParsingFailure** each assert the ownership refusal (synchronous, budget-independent), then a specific exception type or value, then that the engine is reusable. A settle that stopped finishing the import still fails — at 2 min instead of 10 s.
- **ComposesWith** asserts `sep === "/"` without the loader being reached, `value === 7`, and exactly one loader request. Nothing time-derived.
- **DelayedCrossThread** asserts `42` and reusability; a lost ownership release surfaces as `InvalidOperationException`.

## The vacuous-pass sibling, and the proof it needed both halves

`ACanceledFetchSettlesWhileImportAsyncOwnsTheEngine` asserted only `ThrowAsync<PromiseRejectedException>` — and a starvation timeout throws **exactly that type**. Under starvation it "passed" 3/3 **while taking 31.97 / 32.05 / 32.4 s**, i.e. it consumed a 10 s timeout and reported success.

It now asserts the rejection **value** (`message === "Could not load module."`, the same sanitized message its pumping sibling asserts). Running the tightened assertion against the **un-widened** budget shows why the two changes had to ship together:

```
--- ACanceledFetchSettlesWhileImportAsyncOwnsTheEngine | Failed: 1 | Time: 31.567s
      System.ArgumentException : Expected string but got Undefined
```

A timeout's rejection value is a `JsString`, so `Get("message")` is `Undefined`. Silent vacuity became a real failure — which is precisely why tightening alone would have created a flake.

## Starved runs, before and after

Starvation without a CPU-burner storm — `ForceMinWorkerThreads=1`, `ForceMaxWorkerThreads=4`, plus a startup hook keeping 1200 *sleeping* work items queued from a feeder thread. Measured global-queue dispatch delay **21.4–21.9 s**, stable across processes. One process per test.

| test | before |
| --- | --- |
| `BackgroundModuleCompletionCanFinishTheOwningImport` | **FAIL 3/3** — `Timeout of 00:00:10 reached` |
| `ImportAsyncTransfersOwnershipWithItsMemoryOperation` | **FAIL 3/3** — expected `MemoryLimitExceededException`, got `PromiseRejectedException` |
| `ImportAsyncParsingFailureReleasesOwnershipMemoryAndPendingLoad` | **FAIL 3/3** — expected `ParsingLimitException`, got `PromiseRejectedException` |
| `ACanceledFetchSettlesWhileImportAsyncOwnsTheEngine` | **vacuous pass 3/3**, 31.97–32.40 s |
| `ComposesWithAnAsynchronousLoader` | FAIL under `-parallelMode none` |

**After: 18/18 green** — 12 invocations under `aggressive`, 6 under `none`. The waits visibly *spend* the ceiling rather than escaping it (43.1 s, 43.3 s, 64.5 s, 43.0 s), and `ComposesWith` finishes at 23.5 s where it previously died at the 10 s mark.

## Sibling audit

Verified by reading every loader, not only by search. **Complete for the module family**: `AsyncModuleLoaderTests`' six `CreateEngine` bypasses each checked individually (inline settles, no-module cases, a `StartImport` with no wait, the deliberate 500 ms, one settling from a dedicated `Thread` rather than the pool); `HostErrorDisclosureTests`' loaders return already-completed tasks; five other module test files contain zero pool primitives at all.

**Six sites found and deliberately left**, each a different mechanism or a wider blast radius:

1. **`UntrustedCodeProfileTests.OperationScopeCannotEndWhileAsyncWorkOwnsTheEngine`** — the tightest pairing in the repo: a **100 ms** `PromiseTimeout` over a `RunContinuationsAsynchronously` settle. Left because 100 ms is a *profile* value whose relation to `maxOperationDuration` and `SecurityConfiguration`'s `PromiseTimeoutLong` diagnostic needs deciding, and that file belongs to the security surface. **Worth filing first.**
2. **The parameterless `UnwrapIfPromise()` blind spot** — it hard-codes 10 s and ignores `Options.Constraints.PromiseTimeout` entirely, so a file's own documented budget policy does not reach its bare call sites. 342 of them across 52 files; most are microtask-only and safe. Needs its own sweep.
3. **`EvaluateAsync` + `TaskCompletionSource(RunContinuationsAsynchronously)` on bare engines** — ~10 sites. Includes a **second vacuous pass**, `AsyncRejectionReleasesOwnership`, which also asserts only the exception type.
4. `InteropDisposeTests` (8 tests), 5. one `WebApiFetchTests` window (left — another agent owned that area), 6. `ParsingLimitTests`' last pool-parking site, which wants the `DedicatedThread.RunAsync` remedy rather than a budget.

Also worth knowing: `HostModuleImportStateTests`' margin is **~1.4×**, not the 100× its 30 s-versus-300 ms numbers suggest, since measured dispatch delay is 21.5 s. Left alone as instructed, but its own decision.

## Verification

7 files, +100/−10 after rebase. **No engine code.** Solution builds Release, 0 errors. `Jint.Tests.PublicInterface` 2405 (net10.0) / 1879 (net472); verifying leg 2409 / 1883. `Jint.Tests` verifying leg 10261 / 7147. All green.

One pre-existing failure was seen on the plain `Jint.Tests` net10.0 leg and **proved not to be this change**: `WebApi.SchedulerTests.AHostsOwnPumpRunsTheTasks` still fails with both of this branch's `Jint.Tests` edits reverted and `TestBudgets.cs` removed. Its 20 ms delayed task becomes due *during* `Execute`'s microtask drain on a loaded machine; it passes 5/5 in isolation. Flagged rather than touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
