### PR TITLE
Streams: stop reporting the algorithms' own rejections as unhandled

### DIFF
--- a/Jint.Tests/Runtime/WebApi/StreamRejectionTrackingTests.cs
+++ b/Jint.Tests/Runtime/WebApi/StreamRejectionTrackingTests.cs
@@ -1,0 +1,430 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Native.Promise;
+using Jint.Runtime;
+using Jint.WebApi;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// What a host's <see cref="Engine.AdvancedOperations.PromiseRejectionTracker"/> hears while the streams
+/// algorithms do their own bookkeeping — which is nothing, because every rejection they make for themselves
+/// is one the specification accounts for in the very next step.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Five of the Streams Standard's operations end with "reject <c>p</c> …" immediately followed by "set
+/// <c>p.[[PromiseIsHandled]]</c> to true": <c>ReadableStreamError</c>,
+/// <c>ReadableStreamReaderGenericRelease</c>, <c>WritableStreamRejectCloseAndClosedPromiseIfNeeded</c> and
+/// the writer's <c>EnsureReadyPromiseRejected</c> / <c>EnsureClosedPromiseRejected</c>. In a browser that
+/// pair raises nothing, because HTML's <i>notify about rejected promises</i> re-reads
+/// <c>[[PromiseIsHandled]]</c> in a queued task — "If p.[[PromiseIsHandled]] is true, then continue" — long
+/// after the flag has been set. Jint's tracker fires at <c>HostPromiseRejectionTracker</c>'s own cadence and
+/// cannot re-read anything, so the flag is set before the rejection instead; the two orders are
+/// indistinguishable in every other way, since <c>[[PromiseIsHandled]]</c> gates the tracker and nothing
+/// else.
+/// </para>
+/// <para>
+/// The tests are therefore in two halves: the algorithms' own rejections must be silent, and every rejection
+/// that is <i>not</i> theirs — a promise handed to the script, a promise the script derived — must still be
+/// reported exactly as it was.
+/// </para>
+/// <para>
+/// https://streams.spec.whatwg.org/ ·
+/// https://html.spec.whatwg.org/multipage/webappapis.html#unhandled-promise-rejections
+/// </para>
+/// </remarks>
+public class StreamRejectionTrackingTests
+{
+    /// <summary>One <c>HostPromiseRejectionTracker</c> call, as a host hears it.</summary>
+    private sealed record Rejection(JsValue Promise, PromiseRejectionOperation Operation, string Reason)
+    {
+        public override string ToString() => $"{Operation}:{Reason}";
+    }
+
+    private static (Engine Engine, List<Rejection> Rejections) TrackingEngine(
+        WebApiFeatures features = WebApiFeatures.Streams | WebApiFeatures.Events)
+    {
+        var rejections = new List<Rejection>();
+        var engine = new Engine(options => options.UseWebApis(features));
+
+        engine.Advanced.PromiseRejectionTracker += (_, e) =>
+            rejections.Add(new Rejection(e.Promise, e.Operation, Describe(e.Value)));
+
+        engine.Execute("""
+            var log = [];
+            function sink(name) {
+              return new WritableStream({
+                write(chunk) { log.push(name + ':' + chunk); },
+                close() { log.push(name + ':close'); },
+                abort(reason) { log.push(name + ':abort:' + reason); }
+              });
+            }
+            function source(chunks) {
+              return new ReadableStream({
+                start(c) { for (const chunk of chunks) { c.enqueue(chunk); } c.close(); },
+                cancel(reason) { log.push('source:cancel:' + reason); }
+              });
+            }
+            """);
+
+        return (engine, rejections);
+    }
+
+    private static string Describe(JsValue? value)
+    {
+        if (value is ObjectInstance o && o.Get("name") is JsString name && o.Get("message") is JsString message)
+        {
+            return $"{name}: {message}";
+        }
+
+        return value?.ToString() ?? "<null>";
+    }
+
+    private static string Log(Engine engine) => engine.Evaluate("log.join(',')").AsString();
+
+    /// <summary>
+    /// What a host is left holding once the pairs cancel out: the rejections reported with no later
+    /// <c>"handle"</c> for the same promise. A <c>Reject</c> followed by a <c>Handle</c> is the cadence
+    /// difference <see cref="DiagnosticEvent.RejectionHandled"/> documents — Jint reports both operations as
+    /// they happen where HTML defers the decision to a checkpoint — and is not what this defect was about.
+    /// </summary>
+    private static List<string> Standing(List<Rejection> rejections)
+    {
+        var handled = new HashSet<object>(
+            rejections.Where(r => r.Operation == PromiseRejectionOperation.Handle).Select(r => (object) r.Promise),
+            ReferenceEqualityComparer.Instance);
+
+        return rejections
+            .Where(r => r.Operation == PromiseRejectionOperation.Reject && !handled.Contains(r.Promise))
+            .Select(r => r.Reason)
+            .ToList();
+    }
+
+    // ---- The algorithms' own bookkeeping: silent ----
+
+    [Fact]
+    public void ASuccessfulPipeToReportsNothingAtAll()
+    {
+        var (engine, rejections) = TrackingEngine();
+
+        engine.Execute("source(['a', 'b']).pipeTo(sink('dest')).then(() => log.push('piped'));");
+
+        Log(engine).Should().Be("dest:a,dest:b,dest:close,piped");
+        rejections.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ASuccessfulPipeThroughReportsNothingAtAll()
+    {
+        var (engine, rejections) = TrackingEngine();
+
+        engine.Execute("""
+            source(['a', 'b'])
+              .pipeThrough(new TransformStream())
+              .pipeTo(sink('dest'))
+              .then(() => log.push('piped'));
+            """);
+
+        Log(engine).Should().Be("dest:a,dest:b,dest:close,piped");
+        rejections.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ATextDecoderStreamPipeThroughReportsNothingAtAll()
+    {
+        var (engine, rejections) = TrackingEngine(
+            WebApiFeatures.Streams | WebApiFeatures.Events | WebApiFeatures.Encoding);
+
+        engine.Execute("""
+            new ReadableStream({ start(c) { c.enqueue(new Uint8Array([104, 105])); c.close(); } })
+              .pipeThrough(new TextDecoderStream())
+              .pipeTo(sink('dest'))
+              .then(() => log.push('piped'));
+            """);
+
+        Log(engine).Should().Be("dest:hi,dest:close,piped");
+        rejections.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ABlobStreamPipeThroughReportsNothingAtAll()
+    {
+        // The shape the defect was found in: Blob.stream() feeding a transform.
+        var (engine, rejections) = TrackingEngine(
+            WebApiFeatures.Streams | WebApiFeatures.Events | WebApiFeatures.Encoding | WebApiFeatures.Files);
+
+        engine.Execute("""
+            new Blob(['hi'])
+              .stream()
+              .pipeThrough(new TextDecoderStream())
+              .pipeTo(sink('dest'))
+              .then(() => log.push('piped'));
+            """);
+
+        Log(engine).Should().Be("dest:hi,dest:close,piped");
+        rejections.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void APlainDrainReportsNothingAtAll()
+    {
+        // The control the issue reported: no pipe, no phantom. It has to stay at zero too.
+        var (engine, rejections) = TrackingEngine();
+
+        engine.Execute("(async () => { for await (const chunk of source(['a', 'b'])) { log.push('read:' + chunk); } })();");
+
+        Log(engine).Should().Be("read:a,read:b");
+        rejections.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ScriptCalledReleaseLockOnAReaderReportsNothing()
+    {
+        // ReadableStreamReaderGenericRelease, reached by the script rather than by a pipe.
+        var (engine, rejections) = TrackingEngine();
+
+        engine.Execute("source(['a']).getReader().releaseLock();");
+
+        rejections.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ScriptCalledReleaseLockOnAWriterReportsNothing()
+    {
+        // WritableStreamDefaultWriterRelease, and with it both Ensure*PromiseRejected operations.
+        var (engine, rejections) = TrackingEngine();
+
+        engine.Execute("sink('dest').getWriter().releaseLock();");
+
+        rejections.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ReleasingAReaderOnAnAlreadyClosedStreamReportsNothing()
+    {
+        // The other branch of the release steps: the closed promise has already settled, so the reader is
+        // given a freshly rejected one instead.
+        var (engine, rejections) = TrackingEngine();
+
+        engine.Execute("""
+            var reader = new ReadableStream({ start(c) { c.close(); } }).getReader();
+            reader.closed.then(() => { reader.releaseLock(); log.push('released'); });
+            """);
+
+        Log(engine).Should().Be("released");
+        rejections.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ErroringAStreamThatHasAReaderReportsNothing()
+    {
+        // ReadableStreamError: "Reject reader.[[closedPromise]] with e" then "set …[[PromiseIsHandled]] to
+        // true". Nobody is watching reader.closed here, and a browser raises nothing either.
+        var (engine, rejections) = TrackingEngine();
+
+        engine.Execute("""
+            var controller;
+            var stream = new ReadableStream({ start(c) { controller = c; } });
+            stream.getReader();
+            controller.error(new Error('boom'));
+            """);
+
+        rejections.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ErroringAWritableStreamThatHasAWriterReportsNothing()
+    {
+        // WritableStreamRejectCloseAndClosedPromiseIfNeeded, plus the ready promise the erroring rejects.
+        var (engine, rejections) = TrackingEngine();
+
+        engine.Execute("""
+            var controller;
+            var stream = new WritableStream({ start(c) { controller = c; } });
+            stream.getWriter();
+            controller.error(new Error('boom'));
+            """);
+
+        rejections.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void TeeReportsNothing()
+    {
+        var (engine, rejections) = TrackingEngine();
+
+        engine.Execute("""
+            var branches = source(['a']).tee();
+            branches[0].pipeTo(sink('one')).then(() => log.push('one:piped'));
+            branches[1].pipeTo(sink('two')).then(() => log.push('two:piped'));
+            """);
+
+        Log(engine).Should().Contain("one:piped").And.Contain("two:piped");
+        rejections.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CancellingBothTeeBranchesReportsNothing()
+    {
+        var (engine, rejections) = TrackingEngine();
+
+        engine.Execute("""
+            var branches = new ReadableStream({
+              start(c) { c.enqueue('a'); },
+              cancel(reason) { log.push('source:cancel:' + reason); }
+            }).tee();
+            branches[0].cancel('done').then(() => log.push('one:cancelled'));
+            branches[1].cancel('done').then(() => log.push('two:cancelled'));
+            """);
+
+        // The source is cancelled once, with the composite reason « 'done', 'done' » the tee's cancel
+        // algorithms build.
+        Log(engine).Should().Be("source:cancel:done,done,one:cancelled,two:cancelled");
+        rejections.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AnAbortedPipeReportsOnlyTheAbortReason()
+    {
+        // The signal case: the pipe's own promise rejects and the script does not catch it, so exactly one
+        // rejection is reported — the AbortError. The released-reader and released-writer TypeErrors that
+        // Finalize makes on the way are the algorithms' own and stay silent.
+        var (engine, rejections) = TrackingEngine();
+
+        engine.Execute("""
+            var controller = new AbortController();
+            var to = new WritableStream({ write(chunk) { log.push('write:' + chunk); } });
+            var from = new ReadableStream({ start(c) { c.enqueue('a'); } });
+            from.pipeTo(to, { signal: controller.signal });
+            controller.abort();
+            """);
+
+        Standing(rejections).Should().ContainSingle().Which.Should().StartWith("AbortError:");
+    }
+
+    // ---- Everything that is not the algorithms' own: still reported ----
+
+    [Fact]
+    public void AnOrdinaryUnhandledRejectionIsStillReported()
+    {
+        var (engine, rejections) = TrackingEngine();
+
+        engine.Execute("Promise.reject(new Error('boom'));");
+
+        rejections.Select(r => r.ToString()).Should().Equal("Reject:Error: boom");
+    }
+
+    [Fact]
+    public void AFailedPipeStillReportsItsOwnRejection()
+    {
+        // The signal a host actually wants: pipeTo()'s promise is the script's, so nothing marks it handled.
+        var (engine, rejections) = TrackingEngine();
+
+        engine.Execute("""
+            var to = new WritableStream({ write() { throw new Error('dest failed'); } });
+            source(['a']).pipeTo(to);
+            """);
+
+        // Exactly one rejection is left standing, and it is the pipe's own promise. The released-writer and
+        // released-reader TypeErrors the shutdown makes on the way are gone entirely.
+        Standing(rejections).Should().Equal("Error: dest failed");
+
+        // The two pairs before it are a different thing, and are deliberately left alone: an algorithm that
+        // builds an already-rejected promise and attaches its own reaction one statement later — the WebIDL
+        // wrapper around the sink's throwing write(), and
+        // WritableStreamDefaultWriterCloseWithErrorPropagation's "a promise rejected with stream's stored
+        // error". Neither promise is the specification's to mark handled, so marking it would lose a real
+        // failure if the caller ever failed to attach; what a host sees instead is a Reject followed by its
+        // own Handle, which is the cadence DiagnosticEvent.RejectionHandled documents for every promise in
+        // the engine and not something streams may decide on their own.
+        rejections.Select(r => r.ToString()).Should().Equal(
+            "Reject:Error: dest failed",
+            "Handle:Error: dest failed",
+            "Reject:Error: dest failed",
+            "Handle:Error: dest failed",
+            "Reject:Error: dest failed");
+    }
+
+    [Fact]
+    public void AWriteThatFailsStillReportsItsOwnRejection()
+    {
+        // writer.write()'s promise is handed to the script and the specification never marks it handled, so
+        // it is reported like any other. This is the sibling the release steps are deliberately not.
+        var (engine, rejections) = TrackingEngine();
+
+        engine.Execute("""
+            var writer = new WritableStream({ write() { throw new Error('write failed'); } }).getWriter();
+            writer.write('a');
+            """);
+
+        Standing(rejections).Should().Contain("Error: write failed");
+    }
+
+    [Fact]
+    public void APromiseDerivedFromAReleasedReadersClosedPromiseIsStillReported()
+    {
+        // The over-suppression check. The reader's own closed promise is accounted for by the release steps;
+        // a promise the script derived from it is the script's own and is reported exactly as before — which
+        // is only possible because the release really does reject, rather than being made to settle some
+        // other way.
+        var (engine, rejections) = TrackingEngine();
+
+        engine.Execute("""
+            var reader = source(['a']).getReader();
+            reader.closed.then(() => log.push('never'));
+            reader.releaseLock();
+            """);
+
+        Log(engine).Should().Be("");
+        rejections.Select(r => r.ToString()).Should().Equal(
+            "Reject:TypeError: Reader was released and can no longer be used to monitor the stream's closedness");
+    }
+
+    [Fact]
+    public void AReleasedReadersClosedPromiseIsRejectedEvenThoughNothingIsReported()
+    {
+        // The other half of the same check: the flag suppresses the report, never the rejection. The script
+        // holds the promise across the release, nothing is reported, and the promise is nevertheless rejected
+        // with the release steps' TypeError — which is the state a browser leaves it in too, since
+        // ReadableStreamReaderGenericRelease sets [[PromiseIsHandled]] unconditionally.
+        var (engine, rejections) = TrackingEngine();
+
+        engine.Execute("""
+            var reader = source(['a']).getReader();
+            var closed = reader.closed;
+            reader.releaseLock();
+            """);
+
+        rejections.Should().BeEmpty();
+
+        engine.Execute("closed.catch(e => log.push('caught:' + e.name));");
+        Log(engine).Should().Be("caught:TypeError");
+        rejections.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AReleasedWritersReadyAndClosedPromisesAreRejectedEvenThoughNothingIsReported()
+    {
+        var (engine, rejections) = TrackingEngine();
+
+        // A destination with no room applies backpressure, so `ready` is still pending when the script takes
+        // it — which is the case worth asserting: the release rejects the very promise the script is
+        // holding, not a fresh one it will never see.
+        engine.Execute("""
+            var writer = new WritableStream({}, { highWaterMark: 0 }).getWriter();
+            var ready = writer.ready;
+            var closed = writer.closed;
+            writer.releaseLock();
+            ready.catch(e => log.push('ready:' + e.name));
+            closed.catch(e => log.push('closed:' + e.name));
+            """);
+
+        Log(engine).Should().Be("ready:TypeError,closed:TypeError");
+        rejections.Should().BeEmpty();
+    }
+}
+#endif

--- a/Jint/WebApi/Streams/ReadableStreamOperations.cs
+++ b/Jint/WebApi/Streams/ReadableStreamOperations.cs
@@ -183,8 +183,9 @@ internal static class ReadableStreamOperations
             return;
         }
 
-        reader.ClosedCapability.Reject(error);
-        StreamPromises.MarkHandled(reader.ClosedPromise);
+        // "Reject reader.[[closedPromise]] with e" and "set reader.[[closedPromise]].[[PromiseIsHandled]] to
+        // true" — the pair, in the one order a tracker that fires at rejection time can tell apart.
+        StreamPromises.RejectHandled(reader.ClosedCapability, error);
 
         if (reader is JsReadableStreamDefaultReader defaultReader)
         {
@@ -348,8 +349,7 @@ internal static class ReadableStreamOperations
                 break;
 
             default:
-                StreamPromises.MarkHandled(StreamPromises.PromiseOf(capability));
-                capability.Reject(stream.StoredError);
+                StreamPromises.RejectHandled(capability, stream.StoredError);
                 break;
         }
     }
@@ -372,20 +372,15 @@ internal static class ReadableStreamOperations
         var released = realm.Intrinsics.TypeError.Construct(
             "Reader was released and can no longer be used to monitor the stream's closedness");
 
-        if (stream.State == ReadableStreamState.Readable)
-        {
-            reader.ClosedCapability.Reject(released);
-        }
-        else
+        if (stream.State != ReadableStreamState.Readable)
         {
             // The closed promise has already settled, so it cannot be rejected: the reader is given a
             // freshly rejected one instead, which is what makes `reader.closed` observably a different
             // promise after releasing the lock on a closed stream.
             reader.ClosedCapability = StreamPromises.NewPromise(engine, realm);
-            reader.ClosedCapability.Reject(released);
         }
 
-        StreamPromises.MarkHandled(reader.ClosedPromise);
+        StreamPromises.RejectHandled(reader.ClosedCapability, released);
 
         // The default controller's [[ReleaseSteps]] do nothing; the byte controller's downgrades the
         // pull-into descriptor the underlying source may be writing into right now.

--- a/Jint/WebApi/Streams/StreamPromises.cs
+++ b/Jint/WebApi/Streams/StreamPromises.cs
@@ -104,7 +104,53 @@ internal static class StreamPromises
     /// Marks a promise as handled: "set <c>promise.[[PromiseIsHandled]]</c> to true". Used for the promises
     /// the algorithms create and settle for their own bookkeeping, which no script ever attaches to.
     /// </summary>
+    /// <remarks>
+    /// Only for a promise that is still <b>pending</b>. Marking one that has already been rejected is too
+    /// late to stop the rejection tracker having seen it — use <see cref="RejectHandled"/> for the
+    /// reject-and-account-for-it pair.
+    /// </remarks>
     internal static void MarkHandled(JsPromise promise) => promise.PromiseIsHandled = true;
+
+    /// <summary>
+    /// The pair five of the Streams Standard's operations end with: "reject <i>p</i> with
+    /// <paramref name="reason"/>", immediately followed by "set <i>p</i>.<c>[[PromiseIsHandled]]</c> to
+    /// true" — <c>ReadableStreamError</c>, <c>ReadableStreamReaderGenericRelease</c>,
+    /// <c>WritableStreamRejectCloseAndClosedPromiseIfNeeded</c> and the writer's
+    /// <c>EnsureReadyPromiseRejected</c> / <c>EnsureClosedPromiseRejected</c>. The rejection is real and
+    /// observable — a script holding the promise still sees it — and the flag says the algorithm has
+    /// accounted for it, so nobody owes it a handler.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>The flag is set before the rejection, and that ordering is the whole point of this helper.</b>
+    /// Written the specification's way round, <c>RejectPromise</c> step 7 calls
+    /// <c>HostPromiseRejectionTracker(promise, "reject")</c> while <c>[[PromiseIsHandled]]</c> is still
+    /// false, and a host watching <see cref="Engine.AdvancedOperations.PromiseRejectionTracker"/> or a
+    /// <see cref="DiagnosticsSink"/> is told about a rejection that the very next step accounts for. A
+    /// browser is not, because HTML's <i>notify about rejected promises</i> re-reads the flag in a queued
+    /// task — "If <i>p</i>.[[PromiseIsHandled]] is true, then continue" — by which time the algorithm has
+    /// set it. Jint's tracker fires at <c>HostPromiseRejectionTracker</c>'s own cadence and has nothing to
+    /// re-read, so the flag has to be true before the rejection instead.
+    /// </para>
+    /// <para>
+    /// Nothing else can tell the two orders apart: <c>[[PromiseIsHandled]]</c> gates the tracker and only
+    /// the tracker. The reactions still run, <c>await</c> still resumes, and a <c>catch</c> attached before
+    /// or after the release still sees the reason. Nor does it suppress a genuine failure the specification
+    /// would report: these five operations set the flag <i>unconditionally</i>, so a promise reaching one of
+    /// them is one no conforming implementation reports as unhandled either. The promises a script is meant
+    /// to observe — <c>writer.write()</c>, <c>writer.close()</c>, <c>stream.abort()</c>, <c>pipeTo()</c>'s
+    /// own — are deliberately not marked, and are reported exactly as before.
+    /// </para>
+    /// <para>
+    /// https://html.spec.whatwg.org/multipage/webappapis.html#unhandled-promise-rejections ·
+    /// https://tc39.es/ecma262/#sec-rejectpromise
+    /// </para>
+    /// </remarks>
+    internal static void RejectHandled(PromiseCapability capability, JsValue reason)
+    {
+        PromiseOf(capability).PromiseIsHandled = true;
+        capability.Reject(reason);
+    }
 
     /// <summary>
     /// "Upon fulfillment of <paramref name="promise"/>" / "upon rejection of <paramref name="promise"/>" —

--- a/Jint/WebApi/Streams/WritableStreamOperations.cs
+++ b/Jint/WebApi/Streams/WritableStreamOperations.cs
@@ -331,8 +331,7 @@ internal static class WritableStreamOperations
 
         if (stream.Writer is { } writer)
         {
-            writer.ClosedCapability.Reject(stream.StoredError);
-            StreamPromises.MarkHandled(writer.ClosedPromise);
+            StreamPromises.RejectHandled(writer.ClosedCapability, stream.StoredError);
         }
     }
 
@@ -407,8 +406,7 @@ internal static class WritableStreamOperations
                 break;
 
             case WritableStreamState.Erroring:
-                StreamPromises.MarkHandled(StreamPromises.PromiseOf(ready));
-                ready.Reject(stream.StoredError);
+                StreamPromises.RejectHandled(ready, stream.StoredError);
                 break;
 
             case WritableStreamState.Closed:
@@ -417,10 +415,8 @@ internal static class WritableStreamOperations
                 break;
 
             default:
-                StreamPromises.MarkHandled(StreamPromises.PromiseOf(ready));
-                ready.Reject(stream.StoredError);
-                StreamPromises.MarkHandled(StreamPromises.PromiseOf(closed));
-                closed.Reject(stream.StoredError);
+                StreamPromises.RejectHandled(ready, stream.StoredError);
+                StreamPromises.RejectHandled(closed, stream.StoredError);
                 break;
         }
     }
@@ -469,8 +465,7 @@ internal static class WritableStreamOperations
             writer.ClosedCapability = StreamPromises.NewPromise(writer.Engine, writer.Realm);
         }
 
-        writer.ClosedCapability.Reject(error);
-        StreamPromises.MarkHandled(writer.ClosedPromise);
+        StreamPromises.RejectHandled(writer.ClosedCapability, error);
     }
 
     /// <summary>
@@ -483,8 +478,7 @@ internal static class WritableStreamOperations
             writer.ReadyCapability = StreamPromises.NewPromise(writer.Engine, writer.Realm);
         }
 
-        writer.ReadyCapability.Reject(error);
-        StreamPromises.MarkHandled(writer.ReadyPromise);
+        StreamPromises.RejectHandled(writer.ReadyCapability, error);
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #3228.

A **successful** `pipeTo`/`pipeThrough` reported three unhandled rejections through `Advanced.PromiseRejectionTracker` — two `Writer was released…`, one `Reader was released…`. Script never saw them; every host with a `DiagnosticsSink` or a rejection-tracker handler saw three per pipe, naming engine-internal plumbing.

## Why the spec's own ordering does not produce them in a browser

Five Streams operations end with *"reject p"* immediately followed by *"set p.[[PromiseIsHandled]] to true"* — `ReadableStreamError`, `ReadableStreamReaderGenericRelease`, `WritableStreamRejectCloseAndClosedPromiseIfNeeded`, and the writer's `EnsureReadyPromiseRejected` / `EnsureClosedPromiseRejected` (checked verbatim against the live spec text).

The decisive fact is on the HTML side. [*Notify about rejected promises*](https://html.spec.whatwg.org/multipage/webappapis.html#notify-about-rejected-promises) re-reads the flag **in a queued global task**:

> For each promise p of list: **If p.[[PromiseIsHandled]] is true, then continue.**

So reject-then-set raises nothing in a browser, because the checkpoint happens later. Jint's tracker fires from `RejectPromise` step 7 and has nothing to re-read — so the flag has to be true *before*. `[[PromiseIsHandled]]` gates the tracker **and only the tracker** (confirmed by reading `JsPromise.RejectPromise` and both `PerformPromiseThen` overloads), so the two orders are otherwise indistinguishable.

`StreamPromises.RejectHandled(capability, reason)` is the whole fix; the five defective sites use it, and two sites that were **already correct** stop open-coding the pair and share it.

## The over-suppression question, answered

The worry was that setting `[[PromiseIsHandled]]` early also silences a *genuine* unhandled rejection — a script holding `reader.closed` or `writer.ready` and never attaching a handler.

**It does not, and the case is not reachable as a reportable rejection.** Those five operations set the flag **unconditionally**, so that script gets no `unhandledrejection` in a conforming browser either — HTML's checkpoint skips it. Setting it one step earlier is conformance, not over-suppression.

Three tests pin it, and one of them is the proof that propagation is untouched:

- `APromiseDerivedFromAReleasedReadersClosedPromiseIsStillReported` — `reader.closed.then(f)` with no rejection handler; the *derived* promise is still reported. **This test passes identically before and after the fix**, which is what shows the release genuinely still rejects.
- `AReleasedReadersClosedPromiseIsRejectedEvenThoughNothingIsReported` and the writer equivalent (using `highWaterMark: 0` so `ready` is genuinely *pending* when taken) — nothing is reported, and a `.catch` still fires with the release `TypeError`.

And the signal side stays loud: `pipeTo()`'s own promise, `writer.write()` and a plain `Promise.reject` are deliberately **not** marked and report exactly as before.

## Why the other two directions lost

**Suppressing at the tracker** would change every promise in the engine rather than these five. `DiagnosticEvent.RejectionHandled`'s docs *deliberately* commit to `HostPromiseRejectionTracker`'s cadence and cite `Promise.reject(e).catch(f)` producing a `false` then a `true` report on purpose. It would also need the event loop to grow a checkpoint and would put ECMAScript's own hook in scope.

**Documenting it** lost because the noise is avoidable in the spec's own vocabulary — and because **this repository had already made this exact call three times**: `StreamPromises.RejectedWith(handled: true)`, whose doc says the flag is set before *"so the engine's rejection tracker never sees a rejection the algorithm already accounted for"*; `ReaderGenericInitialize`; `SetUpDefaultWriter`; and outside the web APIs, `CyclicModule.LoadRequestedModulesWithBudget`, whose comment calls the alternative *"a phantom unhandled-rejection event"*. The remaining five sites were simply inconsistent with a decision already taken.

## Sibling audit — every path shared it

| path | before | after |
| --- | --- | --- |
| `pipeTo` (success) | **3** | 0 |
| `pipeThrough` / `TextDecoderStream` / `blob.stream()` | 6 | 0 |
| `tee()` + two pipes | 6 | 0 |
| script `reader.releaseLock()` | 1 | 0 |
| script `writer.releaseLock()` | 2 | 0 |
| `controller.error()` with a reader / with a writer | 1 / 2 | 0 |
| aborted pipe | 3 alongside the real `AbortError` | 0, `AbortError` kept |
| **`for await (… of stream)` drain** | **1** | 0 |

**The last row is beyond what the issue reported.** #3228 recorded *zero* for a plain drain; a `for await` drain releases its reader through the async iterator's return steps and did fire one. So the trigger was never only the pipe.

## Verification

Pre-fix, `ASuccessfulPipeToReportsNothingAtAll` produced exactly the three the issue names. Whole class pre-fix **15 failed / 4 passed of 19**; post-fix **19/19**.

Solution builds Release `--no-incremental`, Jint clean across all five TFMs with **0 warnings**. `Jint.Tests` 10444 (net10.0) / 7206 (net472); `Jint.Tests.PublicInterface` 2485 / 1899; both repeated with `JINT_HOST_CONTRACT_VERIFICATION=1`, identical, 0 failed.

WPT before and after on the same base, TRX-diffed row by row: **422 passed / 0 failed both times, 0 suites moved, 0 rows changed outcome.** Worth stating precisely what that does and does not prove: `WptDiagnosticsSink` keeps only `UncaughtCallbackError` and drops rejection reports, so the corpus does not gate on this directly — the no-movement result says the change altered no *behaviour* the suites assert, not that they were watching the tracker.

test262 not run, and the condition for it was not met: the diff is three files, all under `Jint/WebApi/Streams/`, all inside `#if NET8_0_OR_GREATER` and unreachable from a test262 engine. `JsPromise`, `PromiseOperations` and `Host.HostPromiseRejectionTracker` are untouched.

## Left undone, deliberately

A failing pipe still produces two Reject→Handle **pairs** — `StreamPromises.PromiseCall`'s WebIDL wrapper around a throwing sink `write()`, and `DefaultWriterCloseWithErrorPropagation`'s "a promise rejected with stream's stored error". These are **not** the same defect: the spec does not mark them handled, so pre-marking would lose a real failure if a caller ever failed to attach, and they self-balance into a `Reject` followed by its own `Handle` — exactly the cadence `DiagnosticEvent.RejectionHandled` already documents for every promise in the engine. `AFailedPipeStillReportsItsOwnRejection` asserts that sequence and a `Standing()` helper (rejects with no matching handle), so it is pinned rather than merely noted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
