### PR TITLE
Workers: WorkerGlobalScope.self is a readonly attribute, not Window's [Replaceable] one

### DIFF
--- a/Jint.Tests/Runtime/WebApi/GlobalErrorEventTests.cs
+++ b/Jint.Tests/Runtime/WebApi/GlobalErrorEventTests.cs
@@ -100,6 +100,32 @@ public class GlobalErrorEventTests
         descriptor.Configurable.Should().BeTrue();
     }
 
+    /// <summary>
+    /// <c>[Replaceable]</c> means an assignment <i>replaces</i> the attribute rather than being refused —
+    /// https://webidl.spec.whatwg.org/#Replaceable — and the writable data property above is that behaviour
+    /// simplified. It holds in both modes, because a writable property gives strict mode nothing to refuse.
+    /// </summary>
+    /// <remarks>
+    /// The counterpart of <c>WorkerMechanismTests.TheWorkerGlobalsSelfIsAReadOnlyAttribute</c>, and the
+    /// reason that one is installed on the worker's global scope rather than here: HTML gives the two globals
+    /// different IDL — <c>[Replaceable] readonly attribute WindowProxy self</c> on Window
+    /// (https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-self) against a plain
+    /// <c>readonly attribute</c> on <c>WorkerGlobalScope</c>
+    /// (https://html.spec.whatwg.org/multipage/workers.html#dom-workerglobalscope-self) — so making this one
+    /// read-only too would be wrong, and would break shadowing a script may rely on.
+    /// </remarks>
+    [Fact]
+    public void TheTopLevelSelfIsReplaceable()
+    {
+        var (sloppy, _) = Silent();
+        sloppy.Execute("self = 'shadowed';");
+        sloppy.Evaluate("self").AsString().Should().Be("shadowed");
+
+        var (strict, _) = Silent();
+        strict.Execute("'use strict'; self = 'shadowed';");
+        strict.Evaluate("self").AsString().Should().Be("shadowed");
+    }
+
     [Fact]
     public void TheThreeOperationsAreWebIdlOperations()
     {

--- a/Jint.Tests/Runtime/WebApi/WorkerMechanismTests.cs
+++ b/Jint.Tests/Runtime/WebApi/WorkerMechanismTests.cs
@@ -1045,6 +1045,118 @@ public class WorkerMechanismTests
             "WorkerGlobalScope:function,DedicatedWorkerGlobalScope:function,self:true,postMessage:function,close:function,name:crunch,onmessage:null");
     }
 
+    /// <summary>
+    /// <c>self</c> is a plain <c>readonly attribute WorkerGlobalScope self</c> here —
+    /// https://html.spec.whatwg.org/multipage/workers.html#dom-workerglobalscope-self — where Window's is
+    /// <c>[Replaceable] readonly attribute WindowProxy self</c>
+    /// (https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-self), so the writable data
+    /// property <c>WebApiRegistration</c> installs for a top-level global is the wrong one for this one.
+    /// </summary>
+    /// <remarks>
+    /// <b>What "read-only" means is decided by the assigning code's own mode</b>, not by the descriptor:
+    /// ignored in sloppy mode, a <c>TypeError</c> in strict. Both are pinned, because a fix that satisfied
+    /// only one would be half a fix — the module body is strict, and an indirect <c>eval</c> is global code
+    /// with no directive prologue, which is the only sloppy code a module worker can reach at all.
+    /// </remarks>
+    [Fact]
+    public void TheWorkerGlobalsSelfIsAReadOnlyAttribute()
+    {
+        var host = new TestWorkerHost(Module("""
+            const d = Object.getOwnPropertyDescriptor(globalThis, 'self');
+            record('writable:' + d.writable);
+            record('enumerable:' + d.enumerable);
+            record('configurable:' + d.configurable);
+            record('value:' + (d.value === globalThis));
+
+            // Sloppy first, so that what it reports does not stand on the strict case's outcome. An
+            // indirect eval is global code with no directive prologue, which is the only sloppy code a
+            // module worker can reach at all.
+            try { (0, eval)("self = 'SLOPPY'"); record('sloppy:' + (self === globalThis)); }
+            catch (e) { record('sloppy:' + e.constructor.name); }
+
+            // And the module body itself is strict, where the same assignment is a TypeError.
+            try { self = 'STRICT'; record('strict:assigned'); }
+            catch (e) { record('strict:' + e.constructor.name); }
+
+            record('same:' + (self === globalThis));
+            record('brand:' + (self instanceof DedicatedWorkerGlobalScope));
+            """));
+
+        var parent = Parent(host);
+        parent.Execute("new Worker('./worker.js', { type: 'module' })");
+        Drain(parent, host.Connection);
+
+        host.Log.Should().Be(
+            "writable:false,enumerable:true,configurable:true,value:true," +
+            "sloppy:true,strict:TypeError,same:true,brand:true");
+    }
+
+    /// <summary>
+    /// The sibling attribute, and the contrast that makes the one above a per-interface decision rather than
+    /// a blanket one: <c>DedicatedWorkerGlobalScope.name</c> is
+    /// <c>[Replaceable] readonly attribute DOMString name</c> —
+    /// https://html.spec.whatwg.org/multipage/workers.html#dom-dedicatedworkerglobalscope-name — so the
+    /// writable data property that simplification installs is right for it and wrong for <c>self</c>.
+    /// </summary>
+    [Fact]
+    public void TheWorkerGlobalsNameIsReplaceable()
+    {
+        var host = new TestWorkerHost(Module("""
+            record('writable:' + Object.getOwnPropertyDescriptor(globalThis, 'name').writable);
+            name = 'renamed';
+            record('name:' + name);
+            """));
+
+        var parent = Parent(host);
+        parent.Execute("new Worker('./worker.js', { type: 'module', name: 'crunch' })");
+        Drain(parent, host.Connection);
+
+        host.Log.Should().Be("writable:true,name:renamed");
+    }
+
+    /// <summary>
+    /// The read-only <c>self</c> is a <i>replacement</i> of the descriptor <c>WebApiRegistration</c>
+    /// installed, so it can only be non-clobbering by identity — and that is the test. A <c>self</c> the host
+    /// owns is never that descriptor and is left exactly as the host left it, with the host's own
+    /// <c>[Replaceable]</c>-style writability intact.
+    /// </summary>
+    /// <remarks>
+    /// The materialization count is the second half: the replacement compares references and reads nothing,
+    /// so a host's own <i>lazy</i> global is not forced into existence merely by our looking at it — the rule
+    /// every install in <c>WebApiRegistration</c> and beside it follows.
+    /// </remarks>
+    [Fact]
+    public void AHostThatInstalledItsOwnSelfKeepsIt()
+    {
+        var factoryCalls = 0;
+
+        var host = new TestWorkerHost(Module("""
+            record('writable:' + Object.getOwnPropertyDescriptor(globalThis, 'self').writable);
+            record('host:' + (self.marker === 'host'));
+            self = 'replaced';
+            record('assigned:' + self);
+            """))
+        {
+            Tune = options => options.AddLazyGlobal("self", engine =>
+            {
+                factoryCalls++;
+                var value = new JsObject(engine);
+                value.FastSetDataProperty("marker", new JsString("host"));
+                return value;
+            }),
+        };
+
+        var parent = Parent(host);
+        parent.Execute("new Worker('./worker.js', { type: 'module' })");
+
+        factoryCalls.Should().Be(0, "nothing about installing the worker scope may materialize a host's lazy global");
+
+        Drain(parent, host.Connection);
+
+        host.Log.Should().Be("writable:true,host:true,assigned:replaced");
+        factoryCalls.Should().Be(1, "the worker's own first read is what materializes it");
+    }
+
     [Fact]
     public void TheWorkerObjectCarriesTheEventHandlerAttributes()
     {

--- a/Jint.Tests/Wpt/Vendor/README.md
+++ b/Jint.Tests/Wpt/Vendor/README.md
@@ -82,9 +82,12 @@ Three consequences worth knowing:
   the loader serves one module whose source is the shim, then the file's `// META: script=` helpers, then the
   file — the same three-step composition the top-level lane performs with three `Execute` calls, and sound
   because the shim assigns everything it exports onto `globalThis` explicitly. The one behavioural difference
-  is that module code is strict. No vendored file depends on sloppy mode; the nearest thing,
-  `interfaces/WorkerGlobalScope/self.any.js`'s `self = 1`, assigns to a property that is writable either way —
-  which is itself the one triage entry below.
+  is that module code is strict, and **two vendored rows now depend on sloppy mode**:
+  `interfaces/WorkerGlobalScope/self.any.js`'s `self = 1` and `Worker-replace-self.any.js` both assign to
+  `self` and assert the assignment was refused *silently*, which is what a read-only attribute does in sloppy
+  mode and not what it does here. They were writable-either-way when the lane was built, and became the lane's
+  own divergence the day [#3224](https://github.com/sebastienros/jint/issues/3224) made
+  `WorkerGlobalScope.self` read-only; they are `NeedsClassicWorkerScript` below.
 * **The worker gets the same environment the top-level engine gets**: `WebApiFeatures.Default` minus the
   grants a worker never inherits, plus the fetch object model, plus the shim's resource reader. A file's
   outcome therefore does not depend on which lane ran it.
@@ -102,7 +105,9 @@ which files are meant to take this route, so a corpus bump that adds another has
 The shim changed in one place for this. It used to install `self` unconditionally; it now does so only when
 the engine has not, because `WorkerGlobalScope.self` is read-only in HTML and an unconditional assignment
 would both overwrite what is under test and — the day the engine makes it read-only — throw out of a
-strict-mode function and take every suite with it.
+strict-mode function and take every suite with it. That day has come:
+[#3224](https://github.com/sebastienros/jint/issues/3224) landed, so `global.self !== global` is false on
+every worker engine and the guard is the only thing keeping the shim off a read-only attribute.
 
 One thing deliberately did **not** change: `GLOBAL.isWorker()` still answers `false` in the worker lane. The
 shim cannot tell the lanes apart and nothing in the corpus asks — `isWindow()` is the only one of the three
@@ -440,8 +445,11 @@ working *across* a point where a collection may have happened — the same terms
 
 **24 assertions across 12 files, of which 16 pass and 8 do not** — and the interesting figure is not the ratio
 but that **six of the eight were decided in writing before a line of this corpus was run**, in the divergence
-ledger of [issue #3167](https://github.com/sebastienros/jint/issues/3167). This is the smallest corpus here
-and the one that most nearly assays a *design* rather than an implementation.
+ledger of [issue #3167](https://github.com/sebastienros/jint/issues/3167): the two names the worker global
+declines (three rows, #6 and #7), the nesting grant it withholds (one row), and module-workers-only (#2 — the
+two `self` rows, which joined this count when the defect under them was fixed). The other two need a wpt
+server. This is the smallest corpus here and the one that most nearly assays a *design* rather than an
+implementation.
 
 What passes is the worker global doing its job. `Worker-custom-event.any.js` adds a listener for a custom
 event on `self` and dispatches one, so the worker global really is an event target.
@@ -487,20 +495,40 @@ and one importing through `redirect.py` — and they fail as *tests* rather than
 module loader refuses a specifier the vendored corpus does not hold and the parent hears the startup failure
 as an `error` event, which is the file's own reject path. They are `NeedsWptServer`.
 
-**The last two are `NeedsTriage`, and they are one defect, not in the worker code.**
-`interfaces/WorkerGlobalScope/self.any.js`'s "self = 1" assigns to `self` and asserts it did not change;
-`Worker-replace-self.any.js` does the same and then asserts `self instanceof WorkerGlobalScope`, so the second
-half of that one passes now and the assignment is all that is left.
-`WebApiRegistration` installs `self` once, for every global, as an ordinary writable data property, and its
-own comment says which definition that was written against: "HTML exposes `self` through a `[Replaceable]`
+**The last two were the corpus's one `NeedsTriage` defect, it is fixed, and the rows still do not pass —
+which is the more interesting half.** `interfaces/WorkerGlobalScope/self.any.js`'s "self = 1" assigns to
+`self` and asserts it did not change; `Worker-replace-self.any.js` does the same and then asserts
+`self instanceof WorkerGlobalScope`.
+
+`WebApiRegistration` installed `self` once, for every global, as an ordinary writable data property, and its
+own comment said which definition that was written against: "HTML exposes `self` through a `[Replaceable]`
 accessor pair on **Window**" — which was the only global there was at the time.
 [`WorkerGlobalScope`'s](https://html.spec.whatwg.org/multipage/workers.html#dom-workerglobalscope-self) is a
 plain `readonly attribute` with no `[Replaceable]`, so the worker inherited the window's semantics along with
-the property. The install predates `Worker` and is shared with the top-level lane, so it is recorded rather
-than fixed here, on the standing rule that the change which first runs a suite is not the change that moves
-the engine; it is filed as [#3224](https://github.com/sebastienros/jint/issues/3224). Fixing it means
-installing `self` per global rather than once; `DedicatedWorkerGlobalScope.name` is the same shape and the
-same question.
+the property. [#3224](https://github.com/sebastienros/jint/issues/3224) fixed it the way two different IDL
+definitions ask to be fixed, rather than by picking one: `WorkerGlobalScope.Install` replaces that one
+descriptor with a non-writable one on the worker's global and on no other, so the top-level `[Replaceable]`
+shape — where assignment *shadows*, and a script may rely on it — is untouched. The replacement is
+non-clobbering by descriptor identity, so a `self` the host installed is left exactly as the host left it,
+unread and therefore unmaterialized.
+
+What the two rows report now is the **lane**, not the engine. A read-only attribute refuses an assignment two
+different ways — silently in sloppy mode, with a `TypeError` in strict — and the corpus was written for the
+first. This lane's file is the body of a module, so before the fix both failed because the assignment
+*succeeded* — `self.any.js` with `expected object "DedicatedWorkerGlobalScope" but got 1`, and
+`Worker-replace-self.any.js` because `self instanceof WorkerGlobalScope` had become false — and they now fail
+with the `TypeError` strict mode owes (`FAIL: unexpected exception (TypeError) received while replacing
+self.`). Nothing short of a classic-script worker would move either, so they are
+`NeedsClassicWorkerScript` rather than debt, and the
+engine's half is pinned in both modes by `Jint.Tests/Runtime/WebApi/WorkerMechanismTests.cs` — the module body
+for strict, an indirect `eval` for the sloppy code this lane cannot otherwise reach.
+
+The sibling the triage note called "the same shape and the same question",
+`DedicatedWorkerGlobalScope.name`, turned out to be neither: it is
+[`[Replaceable] readonly attribute DOMString name`](https://html.spec.whatwg.org/multipage/workers.html#dom-dedicatedworkerglobalscope-name),
+so the writable data property it already had is what its own IDL asks for. It has a pin of its own beside
+`self`'s, because the contrast is the whole point: HTML decided the two attributes separately, and so does
+this engine.
 
 ## What the hr-time and user-timing corpora say about this engine
 

--- a/Jint.Tests/Wpt/WptExclusions.cs
+++ b/Jint.Tests/Wpt/WptExclusions.cs
@@ -119,6 +119,39 @@ internal enum WptDivergence
 
     /// <summary>
     /// <para>
+    /// The test asserts what a <b>sloppy-mode</b> assignment does, and the worker lane has no sloppy mode to
+    /// offer it. Jint runs module workers only (divergence 2 of
+    /// https://github.com/sebastienros/jint/issues/3167, and <c>WorkerType</c> says why), so a worker-scoped
+    /// <c>.any.js</c> file is the body of a <i>module</i> where a browser runs it as a classic
+    /// <c>.any.worker.js</c> script — and module code is strict. That is the one behavioural difference
+    /// between the two lanes, recorded in <c>Vendor/README.md</c> since the lane was built.
+    /// </para>
+    /// <para>
+    /// Both entries are the same assignment seen from two files: <c>self = …</c> against
+    /// <c>WorkerGlobalScope</c>'s
+    /// <see href="https://html.spec.whatwg.org/multipage/workers.html#dom-workerglobalscope-self">
+    /// <c>readonly attribute WorkerGlobalScope self</c></see>. A read-only attribute refuses an assignment
+    /// two different ways — silently in sloppy mode, with a <c>TypeError</c> in strict — and the corpus was
+    /// written for the first, so <c>self.any.js</c> asserts the value did not change and
+    /// <c>Worker-replace-self.any.js</c> asserts nothing was thrown. The engine implements the attribute
+    /// (https://github.com/sebastienros/jint/issues/3224): before that fix both rows failed because the
+    /// assignment <i>succeeded</i> — <c>self.any.js</c> reporting "expected object
+    /// &quot;DedicatedWorkerGlobalScope&quot; but got 1", and <c>Worker-replace-self.any.js</c> that
+    /// <c>self instanceof WorkerGlobalScope</c> had become false — and they now fail with the
+    /// <c>TypeError</c> strict mode owes, which is the same refusal in the other of its two voices.
+    /// </para>
+    /// <para>
+    /// So this is deliberately <b>not</b> <see cref="NeedsTriage"/>: there is no defect left to chase, and
+    /// nothing short of a classic-script worker would move either row. What keeps them honest is that the
+    /// engine's half is pinned from both sides in
+    /// <c>Jint.Tests/Runtime/WebApi/WorkerMechanismTests.cs</c>, in both modes — the module body for strict,
+    /// an indirect <c>eval</c> for the sloppy one this lane cannot otherwise reach.
+    /// </para>
+    /// </summary>
+    NeedsClassicWorkerScript,
+
+    /// <summary>
+    /// <para>
     /// The test asks an algorithm for a parameter .NET's own primitives refuse, and the refusal is what
     /// <c>Jint/WebApi/Crypto/</c> documents on the class that makes it rather than something the engine could
     /// choose differently. Four of them, each named in the message the operation rejects with:
@@ -323,26 +356,29 @@ internal enum WptDivergence
     /// <c>pipeTo()</c> that reached the sink's <c>write</c> synchronously with an <c>enqueue()</c> on the
     /// source — were fixed under sebastienros/jint#3195, so the five entries that used to be here now
     /// enforce them. <c>Vendor/README.md</c> keeps the analysis, because two of the three turned out to be
-    /// something other than the triage note predicted. <b>What the workers corpus filed is still open:</b>
+    /// something other than the triage note predicted.
     /// </para>
-    /// <list type="bullet">
-    /// <item><description>
-    /// <b><c>self</c> is writable in a worker, where <c>WorkerGlobalScope.self</c> is read-only.</b>
-    /// <c>workers/interfaces/WorkerGlobalScope/self.any.js</c>, "self = 1": the file assigns to <c>self</c> and
-    /// asserts it did not change. <c>WebApiRegistration</c> installs <c>self</c> once, for every global, as an
-    /// ordinary writable data property, and its own comment says which definition that was written against —
+    /// <para>
+    /// <b>The workers corpus filed one, and it is fixed.</b> <c>self</c> was installed once, for every
+    /// global, as an ordinary writable data property — against
     /// "HTML exposes <c>self</c> through a <c>[Replaceable]</c> accessor pair on <b>Window</b>"
-    /// (https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-self), which was the only global there
-    /// was at the time. <c>WorkerGlobalScope</c>'s is a plain
+    /// (https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-self), which was the only global
+    /// there was at the time — where <c>WorkerGlobalScope</c>'s is a plain
     /// <c>readonly attribute WorkerGlobalScope self</c>
     /// (https://html.spec.whatwg.org/multipage/workers.html#dom-workerglobalscope-self) with no
-    /// <c>[Replaceable]</c>, so the worker inherited the window's semantics along with the property. It is
-    /// <i>not</i> new worker code — the install predates <c>Worker</c> and is shared with the top-level lane —
-    /// which is why it is triaged here rather than fixed alongside the corpus that found it. Fixing it means
-    /// installing <c>self</c> per-global rather than once, and the sibling
-    /// <c>DedicatedWorkerGlobalScope.name</c> is the same shape and the same question.
-    /// </description></item>
-    /// </list>
+    /// <c>[Replaceable]</c>, so the worker inherited the window's semantics along with the property.
+    /// https://github.com/sebastienros/jint/issues/3224 gave the worker global its own definition, in
+    /// <c>WorkerGlobalScope.Install</c> and on that global alone, because the two globals genuinely differ
+    /// and the top-level one is right as it is. The two rows it held did <b>not</b> come back green, and that
+    /// is the interesting part: they assert what a <i>sloppy-mode</i> assignment does, and the worker lane
+    /// runs its file as a module, so a refused assignment is a <c>TypeError</c> there rather than a silent
+    /// no-op. They moved to <see cref="NeedsClassicWorkerScript"/>, which is the lane and not a defect. The
+    /// sibling <c>DedicatedWorkerGlobalScope.name</c>, which the old note here called "the same shape and the
+    /// same question", turned out to be neither: it is
+    /// <c>[Replaceable] readonly attribute DOMString name</c>
+    /// (https://html.spec.whatwg.org/multipage/workers.html#dom-dedicatedworkerglobalscope-name), so writable
+    /// is what its own IDL asks for.
+    /// </para>
     /// <para>
     /// The File API corpus filed one too, and it is gone: three rows of
     /// <c>FileAPI/blob/Blob-constructor.any.js</c> were one <em>engine</em> defect rather than three
@@ -358,7 +394,8 @@ internal enum WptDivergence
     /// property WebIDL's order never reaches — all fixed under sebastienros/jint#3212, so the thirteen
     /// entries that used to be here now enforce them and
     /// <c>dom/events/Event-constructors.any.js</c> left <c>_notVendored</c> with them. <c>Vendor/README.md</c>
-    /// analyses each with its citation. <b>The seventh is the one entry left:</b>
+    /// analyses each with its citation. <b>The seventh is the last entry in this category, and it is not a
+    /// defect:</b>
     /// </para>
     /// <list type="bullet">
     /// <item><description>
@@ -372,8 +409,8 @@ internal enum WptDivergence
     /// does any implementation produce the empty body the row asks for — Chrome, Edge, Firefox and Safari all
     /// report it 0/1 on wpt.fyi, where the file's thirteen other rows are 1/1 in all four. So the entry
     /// stays, but this category — "a bug or a specification detail to chase" — is the wrong one for it, and
-    /// giving it one of its own is filed rather than done here. <c>Vendor/README.md</c> has the citations and
-    /// the measurement.
+    /// giving it one of its own is deliberately left undone rather than folded into the change that read the
+    /// algorithm. <c>Vendor/README.md</c> has the citations and the measurement.
     /// </description></item>
     /// </list>
     /// <para>
@@ -393,6 +430,12 @@ internal enum WptDivergence
     /// with its analysis in <c>Vendor/README.md</c>. <c>TimerFunctions</c> now invokes the callback with
     /// WebIDL's <c>"report"</c> exception behaviour — the third instance of the catch shape
     /// <c>TimerEntry.Fire</c> and <c>JsEventTarget.InvokePass</c> carry — and the file is vendored and green.
+    /// </para>
+    /// <para>
+    /// <b>So the category currently holds no debt at all</b> — one entry, and its own paragraph says why that
+    /// entry is misfiled. That is the state to keep it in: a row belongs here only while somebody still owes
+    /// the engine a fix, and every corpus that filed one has had it paid. An entry that turns out not to be a
+    /// defect earns a category of its own rather than a longer explanation under this one.
     /// </para>
     /// </summary>
     NeedsTriage,

--- a/Jint.Tests/Wpt/WptTestRunner.cs
+++ b/Jint.Tests/Wpt/WptTestRunner.cs
@@ -30,10 +30,13 @@ namespace Jint.Tests.Wpt;
 /// https://github.com/sebastienros/jint/issues/3179, and ECDH's mismatched-curve error by
 /// https://github.com/sebastienros/jint/issues/3180, the one the File API corpus filed by
 /// https://github.com/sebastienros/jint/issues/3209 — an <c>Array.prototype.values</c>/<c>keys</c>/
-/// <c>entries</c> defect with no web API in it at all — and all five the streams corpus filed by
-/// https://github.com/sebastienros/jint/issues/3195. The category holds the one the workers corpus
-/// found, which is a <c>self</c> installed against <c>Window</c>'s definition for every global including
-/// a worker's, and the ten that groups 3 and 4 of https://github.com/sebastienros/jint/issues/3185 did.
+/// <c>entries</c> defect with no web API in it at all — all five the streams corpus filed by
+/// https://github.com/sebastienros/jint/issues/3195, the ones groups 3 and 4 of
+/// https://github.com/sebastienros/jint/issues/3185 recorded by
+/// https://github.com/sebastienros/jint/issues/3212, and the one the workers corpus found — a <c>self</c>
+/// installed against <c>Window</c>'s definition for every global including a worker's — by
+/// https://github.com/sebastienros/jint/issues/3224. <b>The category is down to one entry, and that one is
+/// not a defect</b>: an empty <c>FormData</c> body, which no browser serializes to nothing either.
 /// <c>Vendor/README.md</c> analyses each.
 /// </para>
 /// <para>
@@ -932,18 +935,24 @@ public class WptTestRunner
         new("workers/modules/dedicated-worker-import.any.js", "Static import (cross-origin).", WptDivergence.NeedsWptServer),
         new("workers/modules/dedicated-worker-import.any.js", "Static import (redirect).", WptDivergence.NeedsWptServer),
 
-        // The one genuine defect this corpus found, and it is not in the worker code: `self` is installed once
-        // for every global as a writable data property, against Window's [Replaceable] definition, and
-        // WorkerGlobalScope's is read-only. Recorded rather than fixed — the install predates Worker and is
-        // shared with the top-level lane, so moving it is not a change this corpus gets to make. Filed as
-        // https://github.com/sebastienros/jint/issues/3224; see WptDivergence.NeedsTriage.
+        // The one genuine defect this corpus found was not in the worker code — `self` was installed once for
+        // every global as a writable data property, against Window's [Replaceable] definition, where
+        // WorkerGlobalScope's is a plain readonly attribute — and it is fixed:
+        // https://github.com/sebastienros/jint/issues/3224 gave the worker global its own definition, on that
+        // global alone, because Window's is right as it is.
         //
-        // Worker-replace-self.any.js's one row is the same defect seen from the other side: it assigns to
-        // `self` and then asserts `self instanceof WorkerGlobalScope`. The interface object exists now
-        // (sebastienros/jint#3195), so what is left failing is only the writable assignment — once #3224 makes
-        // `self` read-only on a worker global, both rows go.
-        new("workers/interfaces/WorkerGlobalScope/self.any.js", "self = 1", WptDivergence.NeedsTriage),
-        new("workers/Worker-replace-self.any.js", "Test that self is not replaceable.", WptDivergence.NeedsTriage),
+        // These two rows stayed red across that fix, and the reason is the lane rather than the engine. Both
+        // assert what a SLOPPY-MODE assignment does — self.any.js that the value did not change,
+        // Worker-replace-self.any.js that nothing was thrown — and a read-only attribute refuses an assignment
+        // silently only in sloppy mode. This lane's file is the body of a module, so the refusal arrives as
+        // the TypeError strict mode owes: self.any.js used to fail with `expected object
+        // "DedicatedWorkerGlobalScope" but got 1` and now fails with `TypeError`, and Worker-replace-self
+        // reports the exception its own catch turns into an assert_unreached. Nothing short of a
+        // classic-script worker moves either, which is a divergence Jint declines by design — see
+        // WptDivergence.NeedsClassicWorkerScript, and WorkerMechanismTests for the engine's half pinned in
+        // both modes.
+        new("workers/interfaces/WorkerGlobalScope/self.any.js", "self = 1", WptDivergence.NeedsClassicWorkerScript),
+        new("workers/Worker-replace-self.any.js", "Test that self is not replaceable.", WptDivergence.NeedsClassicWorkerScript),
 
         // ---------------------------------------------------------------- encoding, the XMLHttpRequest half
         // The file runs each single-byte decoder twice: once through TextDecoder over a locally built

--- a/Jint/Engine.WebApi.cs
+++ b/Jint/Engine.WebApi.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using Jint.Native.Promise;
 using Jint.Native;
 using Jint.Runtime;
+using Jint.Runtime.Descriptors;
 using Jint.WebApi.Abort;
 using Jint.WebApi.Fetch;
 using Jint.WebApi.GlobalEvents;
@@ -298,6 +299,22 @@ internal sealed class WebApiEngineState
     /// </para>
     /// </remarks>
     internal WorkerLink? OwningWorkerLink { get; set; }
+
+    /// <summary>
+    /// The <c>self</c> descriptor <c>WebApiRegistration</c> installed on this engine's principal global
+    /// object, or <see langword="null"/> — which is what an engine carries when
+    /// <see cref="WebApiFeatures.GlobalEvents"/> is off, when the host already owned the name, and once a
+    /// worker has replaced it.
+    /// </summary>
+    /// <remarks>
+    /// It exists because the two globals HTML defines genuinely differ — <c>Window.self</c> is
+    /// <c>[Replaceable]</c> and <c>WorkerGlobalScope.self</c> is a plain <c>readonly attribute</c> — and an
+    /// engine being built does not know yet which one it will be. <c>WorkerGlobalScope.Install</c> is the one
+    /// reader, and it replaces the recorded descriptor by <i>identity</i>: that is the only way a replacement
+    /// can be non-clobbering, and it is what leaves a <c>self</c> the host installed exactly as the host left
+    /// it, unread and so unmaterialized.
+    /// </remarks>
+    internal PropertyDescriptor? InstalledSelf { get; set; }
 
     /// <summary>
     /// The host's fetch settings, or <see langword="null"/> when the feature is off. Read once — when the

--- a/Jint/WebApi/WebApiRegistration.cs
+++ b/Jint/WebApi/WebApiRegistration.cs
@@ -217,7 +217,22 @@ internal static class WebApiRegistration
             // PRINCIPAL realm's global object, deliberately: the property lives on that object, so answering
             // with whichever realm happens to be current when it is first read could make `self === globalThis`
             // false. https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-self
-            Install(global, engine, "self", static e => e._mainRealm.GlobalObject, PropertyFlag.ConfigurableEnumerableWritable);
+            //
+            // Window's shape is the only one that can be decided here, because an engine being built does not
+            // know yet whether it is going to be a worker — and WorkerGlobalScope.self is a plain
+            // `readonly attribute` with no [Replaceable]
+            // (https://html.spec.whatwg.org/multipage/workers.html#dom-workerglobalscope-self). So the
+            // descriptor is recorded, and WorkerGlobalScope.Install replaces exactly it and nothing else. That
+            // identity is what keeps the replacement non-clobbering: a `self` the host owns is never the one
+            // recorded here, because this call left it alone and recorded null.
+            //
+            // Recorded only when the install actually happened, never unconditionally: ApplyLive re-runs this
+            // whole method for an engine that already has `self`, and writing back the null that second call
+            // returns would erase a record a worker still needs.
+            if (Install(global, engine, "self", static e => e._mainRealm.GlobalObject, PropertyFlag.ConfigurableEnumerableWritable) is { } installedSelf)
+            {
+                engine._webApi!.InstalledSelf = installedSelf;
+            }
 
             // The two event interfaces the engine fires at that target. Ordinary WebIDL interface objects:
             // writable and configurable but not enumerable — https://webidl.spec.whatwg.org/#es-interfaces.
@@ -742,7 +757,12 @@ internal static class WebApiRegistration
     /// and enumerability without materializing a descriptor's value, so a host's own lazy global is not
     /// forced into existence merely by our looking.
     /// </remarks>
-    private static void Install(
+    /// <returns>
+    /// The descriptor installed, or <see langword="null"/> when the global object already owned the name.
+    /// Every caller but one ignores it; <c>self</c> needs it, because that descriptor is the only thing
+    /// <see cref="WorkerGlobalScope.Install"/> is allowed to replace.
+    /// </returns>
+    private static LazyPropertyDescriptor<Engine>? Install(
         ObjectInstance global,
         Engine engine,
         string name,
@@ -751,10 +771,12 @@ internal static class WebApiRegistration
     {
         if (global.HasOwnProperty(NameOf(name)))
         {
-            return;
+            return null;
         }
 
-        global.SetProperty(name, new LazyPropertyDescriptor<Engine>(engine, valueFactory, flags));
+        var descriptor = new LazyPropertyDescriptor<Engine>(engine, valueFactory, flags);
+        global.SetProperty(name, descriptor);
+        return descriptor;
     }
 
     /// <summary>

--- a/Jint/WebApi/Workers/WorkerGlobalScope.cs
+++ b/Jint/WebApi/Workers/WorkerGlobalScope.cs
@@ -38,7 +38,9 @@ namespace Jint.WebApi.Workers;
 /// <c>self instanceof EventTarget</c> stays false, because it would otherwise be an <c>instanceof</c> that
 /// lied about a relationship the object does not have. §5.3 names what such a global must expose —
 /// <c>onerror</c>, <c>onunhandledrejection</c>, <c>onrejectionhandled</c> and <c>self</c> — and all four are
-/// here.
+/// here. <c>self</c> arrives with <see cref="WebApiFeatures.GlobalEvents"/>, which every worker enables; what
+/// this file does to it is swap Window's <c>[Replaceable]</c> definition for
+/// <c>WorkerGlobalScope</c>'s read-only one, on this global and no other.
 /// </para>
 /// <para>
 /// <b>The members stay own properties of the global object</b>, where the two interface prototypes carry only
@@ -114,6 +116,11 @@ internal sealed class WorkerGlobalScope
         InstallDescriptor(global, "WorkerGlobalScope", new PropertyDescriptor(realm.Intrinsics.WorkerGlobalScope, PropertyFlag.NonEnumerable));
         InstallDescriptor(global, "DedicatedWorkerGlobalScope", new PropertyDescriptor(dedicated, PropertyFlag.NonEnumerable));
 
+        // `self` is already on this global — WebApiFeatures.GlobalEvents installed it, and every worker has
+        // that feature — but with Window's [Replaceable] definition rather than WorkerGlobalScope's read-only
+        // one. This is where the one global HTML defines differently gets the difference.
+        ReplaceSelfWithTheWorkerAttribute(global, engine);
+
         // WebIDL operations on the global are writable, enumerable and configurable —
         // https://webidl.spec.whatwg.org/#es-operations.
         InstallValue(global, "postMessage", scope.CreateFunction("postMessage", 1, scope.PostMessage));
@@ -126,8 +133,10 @@ internal sealed class WorkerGlobalScope
         // disagree, and the standard wins because it is prescribing the throw itself.
         InstallValue(global, "importScripts", scope.CreateFunction("importScripts", 0, scope.ImportScripts));
 
-        // https://html.spec.whatwg.org/multipage/workers.html#dom-dedicatedworkerglobalscope-name. A plain
-        // writable data property is the [Replaceable] simplification `self` is already installed with.
+        // https://html.spec.whatwg.org/multipage/workers.html#dom-dedicatedworkerglobalscope-name — a
+        // `[Replaceable] readonly attribute DOMString name`, which is exactly what `self` above it is NOT, so
+        // the plain writable data property that simplification installs is right for this one and wrong for
+        // that one. HTML decides the two attributes separately, and so does this file.
         InstallValue(global, "name", JsString.Create(name));
 
         scope.InstallEventHandler(global, "onmessage", JsMessagePort.MessageEventType);
@@ -227,6 +236,56 @@ internal sealed class WorkerGlobalScope
     /// what keeps that a dead end rather than a stale reference to the previous cycle's list.
     /// </remarks>
     private GlobalEventTarget Target => _engine._webApi!.GlobalEventTarget;
+
+    /// <summary>
+    /// Swaps the <c>[Replaceable]</c> <c>self</c> <c>WebApiRegistration</c> installed for
+    /// <c>WorkerGlobalScope</c>'s, which is a plain
+    /// <see href="https://html.spec.whatwg.org/multipage/workers.html#dom-workerglobalscope-self">
+    /// <c>readonly attribute WorkerGlobalScope self</c></see>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The two globals genuinely have different IDL — Window's is
+    /// <see href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-self">
+    /// <c>[Replaceable] readonly attribute WindowProxy self</c></see>, where assignment shadowing the
+    /// attribute is the correct simplification — and <c>WebApiRegistration</c> cannot tell them apart: an
+    /// engine being built does not know yet whether it will be a worker, so it installs Window's shape and
+    /// this is where the one global that has the other definition gets it. What <i>read-only</i> then means
+    /// is decided by the assigning code's own mode rather than by the descriptor: silently ignored in sloppy
+    /// mode, a <c>TypeError</c> in strict.
+    /// </para>
+    /// <para>
+    /// <b>A replacement can only be non-clobbering by identity</b>, so that is the test: the descriptor
+    /// <c>WebApiRegistration</c> recorded is the one thing that may be replaced. A <c>self</c> the host
+    /// installed — through a configuration callback, which runs before the registration, or on the built
+    /// engine before the provider handed it back — is never that descriptor and is left exactly as the host
+    /// left it. Nothing is read either, so a host's own lazy global is not materialized by our looking.
+    /// </para>
+    /// <para>
+    /// An engine that never installed one is left without <c>self</c> altogether, exactly as it was before:
+    /// whether a global carries the name at all is <see cref="WebApiFeatures.GlobalEvents"/>'s business —
+    /// <c>WorkerRequest.CreateDefaultOptions</c> turns it on for every worker — and this is only about which
+    /// of the two definitions the name carries.
+    /// </para>
+    /// </remarks>
+    private static void ReplaceSelfWithTheWorkerAttribute(ObjectInstance global, Engine engine)
+    {
+        var state = engine._webApi!;
+        if (state.InstalledSelf is not { } installed
+            || !ReferenceEquals(global.GetOwnProperty(JsString.Create("self")), installed))
+        {
+            return;
+        }
+
+        // SetProperty rather than a write into the descriptor's own fields, for the reason every install here
+        // goes through it: it bumps the own-property version each global-identifier and member-read inline
+        // cache revalidates against. Nothing has run on this engine yet, so the bump repairs nothing — it is
+        // the discipline rather than a fix.
+        global.SetProperty("self", new PropertyDescriptor(global, PropertyFlag.NonWritable));
+
+        // The recorded descriptor is not on the global object any more, so nothing may replace it again.
+        state.InstalledSelf = null;
+    }
 
     private static void InstallValue(ObjectInstance global, string name, JsValue value)
         => InstallDescriptor(global, name, new PropertyDescriptor(value, PropertyFlag.ConfigurableEnumerableWritable));


### PR DESCRIPTION
Closes #3224.

`WebApiRegistration.InstallGlobals` installed `self` once, for every global, as `ConfigurableEnumerableWritable` — and its own comment named the definition it was written against: Window's `[Replaceable] readonly attribute WindowProxy self`, the only global that existed at the time. `WorkerGlobalScope.self` is a plain `readonly attribute` with **no** `[Replaceable]` (both IDL blocks checked against the live spec). So a worker inherited Window's semantics along with the property.

## The mechanism

An engine being built does not yet know whether it will be a worker, so `Install` now **returns** the descriptor it installed, `WebApiEngineState.InstalledSelf` records it, and `WorkerGlobalScope.Install` replaces **exactly that descriptor, by reference**, with `new PropertyDescriptor(global, PropertyFlag.NonWritable)`.

Identity is the only way a *replacement* can be non-clobbering — and it reads nothing, so a host's own lazy `self` is never materialized just by our looking. The record is written only when the install actually happened, because `ApplyLive` re-runs `InstallGlobals` and would otherwise erase it. The guard was verified to bite: with the identity check removed, `AHostThatInstalledItsOwnSelfKeepsIt` fails; restored, it passes.

**`DedicatedWorkerGlobalScope.name` is left alone**, and the old triage note that called it "the same shape and the same question" was wrong: it is `[Replaceable] readonly attribute DOMString name`, so the writable data property is exactly what its IDL asks for. It now has a contrast pin so the two are not conflated again.

## The two exclusion rows cannot go green, and are recategorized rather than deleted

The task expected this PR to delete two rows. **It cannot, and the reason is structural rather than a defect.** Measured before and after:

| row | before | after |
| --- | --- | --- |
| `workers/interfaces/WorkerGlobalScope/self.any.js` — "self = 1" | FAIL, `expected object "DedicatedWorkerGlobalScope" but got 1` | FAIL, `TypeError` |
| `workers/Worker-replace-self.any.js` — "self is not replaceable" | FAIL, `expected true got false` | FAIL, `unexpected exception (TypeError) while replacing self` |

A `readonly attribute` refuses assignment **two ways** — silently in sloppy mode, `TypeError` in strict — and both files assert the *sloppy* shape. **Jint runs module workers only**, so the worker lane's file body is strict.

`Vendor/README.md` anticipated exactly this: the shim's `self` install was hardened because "the day the engine makes it read-only" a strict assignment would throw. That day is today. No descriptor shape can make a strict-mode assignment silent, and a no-op setter would pass the row while diverging from browsers in strict mode — test-gaming, not conformance.

So both rows move to a new `WptDivergence.NeedsClassicWorkerScript` — the **lane** (divergence 2 of #3167), not a defect. They still match a failing test and no passing one, so the table's discipline holds.

## `NeedsTriage` is now down to one entry, and it carries no debt

The only remaining entry is `response-consume-empty.any.js`'s "Consume empty FormData response body as text" — which **#3247 established is not a defect at all** (RFC 2046 §5.1.1 makes the close-delimiter mandatory; 0/1 in all four browsers). Its doc now says so plainly: the category carries no debt, every corpus that filed one has had it paid, and the single remaining entry is misfiled and earns a category of its own.

Stale prose corrected while there: the workers item rewritten as fixed, and `WptTestRunner`'s class doc — which still claimed the category held the workers `self` defect **and** "the ten that groups 3 and 4 of #3185 did" — brought in line.

**One finding handed back:** both the enum doc and `Vendor/README.md` claimed that giving the FormData row its own category "is filed rather than done here". **There is no such issue** — `gh issue list --state all` finds nothing. The doc now says it is deliberately left undone rather than repeating the claim, and it wants a real issue.

## Strict and sloppy, both pinned

`TheWorkerGlobalsSelfIsAReadOnlyAttribute` logs `writable:false, enumerable:true, configurable:true, value:true, sloppy:true, strict:TypeError, same:true, brand:true`. Sloppy runs **first**, so it does not stand on the strict case's outcome, and it is reached through an indirect `eval` — global code with no directive prologue, the only sloppy code a module worker can reach.

`TheTopLevelSelfIsReplaceable` pins the other half: assignment shadows at top level in **both** modes, with the existing descriptor pin untouched.

`self === globalThis` and `self instanceof DedicatedWorkerGlobalScope` both still hold *after* the two refused assignments, and #3250's chain tests still pass.

Pre-fix the same probe logged `writable:true, …, sloppy:false, strict:assigned, same:false, brand:false` — the strict assignment **succeeded** and `self` became `'STRICT'`.

## Verification

Solution builds Release, 0 errors. `Jint.Tests` 10429 (net10.0) / 7206 (net472), identical on the `JINT_HOST_CONTRACT_VERIFICATION=1` leg. `Jint.Tests.PublicInterface` 2465 / 1879, verifying 2469 / 1883.

WPT: per-suite theory counts identical, 277/277 green. At **assertion** level all 273 vendored files were dumped before and after: **37768 PASS / 2841 FAIL / 48 PRECONDITION_FAILED both times, and the two dumps are byte-identical** — no row moved at all, intended or otherwise. test262 not run: every changed file is inside `#if NET8_0_OR_GREATER` and nothing reaches non-web-API engine code.

One unexplained single-test failure appeared in the *first* verifying run and was not reproduced in five subsequent full verifying runs or five WebApi-namespace repeats; the name was not captured. Recorded rather than dismissed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
