### PR TITLE
Engine: give the pump the anonymous-wildcard identity, scoped to a top-level park

### DIFF
--- a/.github/THREAT_MODEL.md
+++ b/.github/THREAT_MODEL.md
@@ -615,12 +615,19 @@ incorrect authorization context, cross-request disclosure, crashes, or hangs.
 - Same-thread synchronous callback re-entry is allowed. Async entry from inside an active
   engine call is rejected before work starts; top-level async APIs reserve ownership for the
   lifetime of their returned `Task` and transfer the active thread when a continuation resumes.
-- JavaScript callbacks converted to CLR delegates carry operation-scoped authorization. A host
-  may dispatch one to another thread while the engine holds an admission window — the engine
-  operation that made the call which received the callback has not returned, an async engine API is
-  outstanding, or the engine is draining its event loop for a blocking unwrap or import; Jint yields
-  and transfers the reserved engine one callback turn at a time without admitting unrelated public
-  callers.
+- JavaScript callbacks converted to CLR delegates carry an authorization recorded when the engine
+  handed the callback out. A host may dispatch one to another thread while the engine holds an
+  admission window — the engine operation that made the call which received the callback has not
+  returned, an async engine API is outstanding, the engine is draining its event loop for a blocking
+  unwrap or import, or a host thread is parked on `Engine.Advanced.WaitForScheduledWork` or its
+  asynchronous form; Jint yields and transfers the reserved engine one callback turn at a time
+  without admitting unrelated public callers.
+- How narrowly a window admits depends on whether an operation token is in force under it. A window
+  opened under one — a host call inside a running evaluation, an outstanding async engine API —
+  admits only callbacks issued under that same operation. A window opened where none is in force is
+  anonymous, and admits any callback this engine ever authorized, including one whose operation has
+  long since ended: that is the case at a top-level blocking drain and at a top-level park. A pump
+  reached from inside a running evaluation opens no window at all and refuses.
 - Background Task and module completions only enqueue work; an owning host turn drains it.
 
 **Missing or residual mitigation.**
@@ -636,6 +643,13 @@ incorrect authorization context, cross-request disclosure, crashes, or hangs.
   `InvalidOperationException` an unrelated caller receives. Waiting there would mean blocking on a
   thread that may itself be blocked on that callback, so the refusal is deliberate rather than a
   gap; a host must keep the engine inside a window for as long as its callbacks may arrive.
+- A host that blocks its own engine turn on a *second* authorized callback — one it was not itself
+  handed — can wedge the engine, because that callback can only run after the turn that is waiting
+  for it. The shape already exists at the blocking drain; the park extends its reach by one frame.
+  It is outside the supported contract, and a raw `JsCallDelegate` still cannot reach it at all.
+- `WaitForScheduledWork`'s timeout bounds the idle wait, not the call. An admitted callback holds
+  the engine and the park cannot return until it finishes, so a host budgeting a frame can be handed
+  control back arbitrarily later by a callback of its own making.
 - A host can still share projected CLR objects across otherwise separate engines.
 
 **Required host action.** Give an engine exclusive ownership for each complete operation and

--- a/Jint.Tests.PublicInterface/HostPumpAdmissionTests.cs
+++ b/Jint.Tests.PublicInterface/HostPumpAdmissionTests.cs
@@ -1,0 +1,463 @@
+#nullable enable
+
+using System.Diagnostics;
+using Xunit.Sdk;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// Which callbacks a host parked on <see cref="Engine.AdvancedOperations.WaitForScheduledWork"/> — or on its
+/// asynchronous sibling — may be interrupted by, and which it may not. The pump is a callback-admission
+/// window: a host that parks its engine's own thread there has said "run scheduled work here", which is the
+/// undertaking to yield that lets an authorized cross-thread callback wait for its turn instead of being
+/// refused (sebastienros/jint#3242, sebastienros/jint#3240).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The window is deliberately scoped to a <em>top-level</em> park. A pump reached from inside a running
+/// evaluation has undertaken nothing — the thread is in the middle of somebody else's script — so it keeps
+/// refusing, which <see cref="ANestedParkInsideARunningEvaluationAdmitsNothing"/> is the pin for.
+/// </para>
+/// <para>
+/// Every handshake here is released by a thread the test owns. The one place a park is detected rather than
+/// signalled is <see cref="WaitUntilParked"/>: the pump runs no script, so the only thing it can announce
+/// itself with is the refusal it hands an unrelated public entry.
+/// </para>
+/// </remarks>
+public class HostPumpAdmissionTests
+{
+    private const string ConcurrentUseMessage =
+        "*already in use by another thread or has an asynchronous operation in progress*";
+
+    /// <summary>
+    /// Reached only by a genuine wedge — every wait below is released by a thread the test owns.
+    /// </summary>
+    private static readonly TimeSpan WedgeCeiling = TimeSpan.FromMinutes(2);
+
+    /// <summary>
+    /// How often a detection loop looks. It decides only when an observation is made, never what it has to be.
+    /// </summary>
+    private static readonly TimeSpan ProbeInterval = TimeSpan.FromMilliseconds(20);
+
+    /// <summary>
+    /// A park short enough that an admitted callback outlives it, for the one test about what a ceiling
+    /// actually bounds.
+    /// </summary>
+    private static readonly TimeSpan ShortParkCeiling = TimeSpan.FromMilliseconds(200);
+
+    /// <summary>
+    /// The bound on waiting for something an admitted callback is supposed to do. Nothing spends it on a
+    /// working engine — it is what turns "the callback was never admitted" into a report rather than into a
+    /// two-minute wedge.
+    /// </summary>
+    private static readonly TimeSpan AdmissionCeiling = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// How many times the nested-park test tries the callback, and how long it leaves between tries. Neither
+    /// number selects the state being asserted about — see that test's remarks — so they only decide how many
+    /// observations are made and how far apart.
+    /// </summary>
+    private const int NestedProbeCount = 12;
+
+    private static readonly TimeSpan NestedProbeInterval = TimeSpan.FromMilliseconds(40);
+
+    /// <summary>
+    /// A callback the engine authorized under an operation that has since <em>ended</em> — the stale case, and
+    /// the only one the pump's old reservation identity could never match. The conversion happens while
+    /// <c>capture(...)</c> is on the stack, so the authorization names that
+    /// <see cref="Engine.Execute(string, string?)"/>'s token; by the time it returns, that token is dead and
+    /// nothing but the anonymous wildcard can admit it.
+    /// </summary>
+    private static Func<int> AuthorizeStaleCallback(Engine engine, string body = "42")
+    {
+        Func<int>? callback = null;
+        engine.SetValue("capture", new Action<Func<int>>(value => callback = value));
+        engine.Execute($"capture(() => {body});");
+        callback.Should().NotBeNull("the host method was handed a converted callback");
+        return callback!;
+    }
+
+    [Fact]
+    public async Task AStaleAuthorizedCallbackIsAdmittedAtASynchronousPark()
+    {
+        using var engine = new Engine();
+        var callback = AuthorizeStaleCallback(engine);
+        using var dispatcher = new CallbackDispatcher(() => callback());
+        using var releasePark = new CancellationTokenSource();
+
+        var parked = StartPark(engine, WedgeCeiling, releasePark.Token);
+        await WaitUntilParked(engine, parked);
+
+        dispatcher.Release();
+        await dispatcher.Attempted;
+        releasePark.Cancel();
+        await parked;
+
+        dispatcher.Failure.Should().BeNull("a top-level park is a window an authorized callback may wait in");
+        dispatcher.Result.Should().Be(42);
+        engine.Evaluate("1 + 1").AsNumber().Should().Be(2);
+    }
+
+    [Fact]
+    public async Task AStaleAuthorizedCallbackIsAdmittedAtAnAsynchronousPark()
+    {
+        using var engine = new Engine();
+        var callback = AuthorizeStaleCallback(engine);
+        using var dispatcher = new CallbackDispatcher(() => callback());
+        using var releasePark = new CancellationTokenSource();
+
+        var parked = engine.Advanced.WaitForScheduledWorkAsync(WedgeCeiling, releasePark.Token);
+        await WaitUntilParked(engine, parked);
+
+        dispatcher.Release();
+        await dispatcher.Attempted;
+        releasePark.Cancel();
+        await Awaiting(() => parked).Should().ThrowAsync<OperationCanceledException>();
+
+        dispatcher.Failure.Should().BeNull("the asynchronous park reserves under the same anonymous identity");
+        dispatcher.Result.Should().Be(42);
+        engine.Evaluate("1 + 1").AsNumber().Should().Be(2);
+    }
+
+    /// <summary>
+    /// The boundary the change does not move: a host blocking its engine's thread in an ordinary synchronous
+    /// call has undertaken nothing, so the same authorized callback is refused there exactly as before.
+    /// </summary>
+    [Fact]
+    public async Task AStaleAuthorizedCallbackIsRefusedInAnUnrelatedBlockingHostCall()
+    {
+        using var entered = new ManualResetEventSlim();
+        using var release = new ManualResetEventSlim();
+        using var engine = new Engine();
+        engine.SetValue("block", new Action(() =>
+        {
+            entered.Set();
+            release.Wait(WedgeCeiling);
+        }));
+
+        var callback = AuthorizeStaleCallback(engine);
+        var running = DedicatedThread.RunAsync(() => engine.Execute("block();"));
+        await WaitUntilSignalled(entered, running);
+        try
+        {
+            Invoking(() => callback())
+                .Should().Throw<InvalidOperationException>()
+                .WithMessage(ConcurrentUseMessage);
+        }
+        finally
+        {
+            release.Set();
+        }
+
+        await running;
+        engine.Evaluate("1 + 1").AsNumber().Should().Be(2);
+    }
+
+    /// <summary>
+    /// The fail-fast guarantee is untouched: an unrelated public entry from another thread is refused for the
+    /// whole park, which is what keeps one-drainer-per-engine self-enforcing.
+    /// </summary>
+    [Fact]
+    public async Task AnUnrelatedPublicEntryIsRefusedWhileTheParkHoldsTheEngine()
+    {
+        using var engine = new Engine();
+        using var releasePark = new CancellationTokenSource();
+
+        var parked = StartPark(engine, WedgeCeiling, releasePark.Token);
+        await WaitUntilParked(engine, parked);
+        try
+        {
+            Invoking(() => engine.Evaluate("1 + 1"))
+                .Should().Throw<InvalidOperationException>()
+                .WithMessage(ConcurrentUseMessage);
+        }
+        finally
+        {
+            releasePark.Cancel();
+        }
+
+        await parked;
+        engine.Evaluate("1 + 1").AsNumber().Should().Be(2);
+    }
+
+    /// <summary>
+    /// The guard's pin. A pump called from host code the script itself invoked is <em>not</em> a window: the
+    /// engine thread is in the middle of an evaluation that was never handed this callback, and admitting one
+    /// there would interleave its script into the middle of that evaluation.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Every attempt provably lands inside the evaluation, and no clock decides that. The probing thread is
+    /// started by a host call the script makes immediately before the park, so the engine is owned by the
+    /// evaluating thread from before the first attempt; and the park is ended by <em>the prober</em>, which
+    /// cancels it only once its last attempt has returned, so the evaluation cannot finish while an attempt is
+    /// still outstanding. The interval and the count above therefore choose only how many observations are
+    /// made and how far apart, never which state they are made in.
+    /// </para>
+    /// <para>
+    /// A ceiling used to end the park, and that was a bug in this test rather than in the engine: an attempt
+    /// landing after the ceiling ran out met an engine <see cref="Engine.Execute(string, string?)"/> had
+    /// already released, where an authorized callback is admitted by claiming a free engine and nothing about
+    /// the pump is involved. On a slow enough runner the probing loop outlived the park, and those admissions
+    /// were reported as if the guard had failed.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task ANestedParkInsideARunningEvaluationAdmitsNothing()
+    {
+        using var engine = new Engine();
+        using var endPark = new CancellationTokenSource();
+        var callback = AuthorizeStaleCallback(engine);
+
+        var attempts = 0;
+        var admitted = 0;
+        var refused = 0;
+        Task? prober = null;
+
+        engine.SetValue("armProber", new Action(() => prober = DedicatedThread.RunAsync(() =>
+        {
+            for (var i = 0; i < NestedProbeCount; i++)
+            {
+                Thread.Sleep(NestedProbeInterval);
+                attempts++;
+                try
+                {
+                    callback();
+                    admitted++;
+                }
+                catch (InvalidOperationException)
+                {
+                    refused++;
+                }
+            }
+
+            // Only now, with every attempt returned, may the evaluation be allowed to finish.
+            endPark.Cancel();
+        })));
+        engine.SetValue("park", new Func<bool>(() =>
+        {
+            try
+            {
+                return engine.Advanced.WaitForScheduledWork(WedgeCeiling, endPark.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                // How the prober ends the park; what this test asserts is what happened while it was parked.
+                return false;
+            }
+        }));
+
+        engine.Execute("armProber(); globalThis.reported = park();");
+
+        await prober!;
+
+        attempts.Should().Be(NestedProbeCount);
+        admitted.Should().Be(0, "a pump inside a running evaluation has undertaken nothing");
+        refused.Should().Be(NestedProbeCount);
+        engine.Evaluate("reported").AsBoolean().Should().BeFalse();
+        engine.Evaluate("1 + 1").AsNumber().Should().Be(2);
+    }
+
+    /// <summary>
+    /// An admitted callback is an ordinary engine turn, so work it queues wakes the park it was admitted into
+    /// and is reported as work for <see cref="Engine.AdvancedOperations.ProcessTasks"/> — which is the whole
+    /// point of admitting it there.
+    /// </summary>
+    [Fact]
+    public async Task WorkQueuedByAnAdmittedCallbackIsReportedByThePark()
+    {
+        using var engine = new Engine();
+        engine.Execute("globalThis.ran = false;");
+        var callback = AuthorizeStaleCallback(engine, "(Promise.resolve().then(() => { globalThis.ran = true; }), 7)");
+        using var dispatcher = new CallbackDispatcher(() => callback());
+
+        var reported = false;
+        var parked = DedicatedThread.RunAsync(() => reported = engine.Advanced.WaitForScheduledWork(AdmissionCeiling));
+        await WaitUntilParked(engine, parked);
+
+        dispatcher.Release();
+        await dispatcher.Attempted;
+        await parked;
+
+        dispatcher.Failure.Should().BeNull();
+        dispatcher.Result.Should().Be(7);
+        reported.Should().BeTrue("the reaction the callback queued is work the pump can run");
+
+        engine.Evaluate("ran").AsBoolean().Should().BeFalse("the wait does not pump");
+        engine.Advanced.ProcessTasks();
+        engine.Evaluate("ran").AsBoolean().Should().BeTrue();
+    }
+
+    /// <summary>
+    /// The one genuinely new observable: the ceiling bounds the <em>idle wait</em>, not the call. An admitted
+    /// callback holds the engine, and the park cannot return until it has the thread back — so a
+    /// frame-budgeted host can be handed control back well after its ceiling.
+    /// </summary>
+    [Fact]
+    public async Task AnAdmittedCallbackHoldsTheParkPastItsCeiling()
+    {
+        using var engine = new Engine();
+        using var holding = new ManualResetEventSlim();
+        using var releaseCallback = new ManualResetEventSlim();
+        engine.SetValue("hold", new Action(() =>
+        {
+            holding.Set();
+            releaseCallback.Wait(WedgeCeiling);
+        }));
+
+        var callback = AuthorizeStaleCallback(engine, "(hold(), 3)");
+        using var dispatcher = new CallbackDispatcher(() => callback());
+
+        var reported = true;
+        var elapsed = new Stopwatch();
+        var parked = DedicatedThread.RunAsync(() =>
+        {
+            elapsed.Start();
+            reported = engine.Advanced.WaitForScheduledWork(ShortParkCeiling);
+            elapsed.Stop();
+        });
+        await WaitUntilParked(engine, parked);
+
+        dispatcher.Release();
+        holding.Wait(AdmissionCeiling).Should().BeTrue("the callback has to be admitted for this to mean anything");
+
+        // The ceiling has run out several times over by now, and the park is still not back: it is waiting for
+        // the engine thread the admitted callback holds.
+        Thread.Sleep(ShortParkCeiling + ShortParkCeiling + ShortParkCeiling);
+        parked.IsCompleted.Should().BeFalse("the ceiling bounds the idle wait, not the call");
+
+        releaseCallback.Set();
+        await dispatcher.Attempted;
+        await parked;
+
+        dispatcher.Failure.Should().BeNull();
+        dispatcher.Result.Should().Be(3);
+        reported.Should().BeFalse("the callback queued nothing, so there is still no work to report");
+        elapsed.Elapsed.Should().BeGreaterThan(ShortParkCeiling + ShortParkCeiling);
+        engine.Evaluate("1 + 1").AsNumber().Should().Be(2);
+    }
+
+    private static Task StartPark(Engine engine, TimeSpan ceiling, CancellationToken cancellationToken)
+        => DedicatedThread.RunAsync(() =>
+        {
+            try
+            {
+                engine.Advanced.WaitForScheduledWork(ceiling, cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                // How the test ends the park; what it asserts is what happened while it was parked.
+            }
+        });
+
+    /// <summary>
+    /// Polls a guarded entry until the engine refuses it, which is the only signal a parked wait can give: it
+    /// runs no script, so there is nothing for it to announce itself with. Ends on the refusal, on
+    /// <paramref name="parked"/> finishing without ever taking the engine — reporting whatever stopped it —
+    /// or on <see cref="WedgeCeiling"/>.
+    /// </summary>
+    private static async Task WaitUntilParked(Engine engine, Task parked)
+    {
+        var elapsed = Stopwatch.StartNew();
+        while (true)
+        {
+            try
+            {
+                // An engine with nothing queued, so a probe landing before the park costs an empty loop.
+                engine.Advanced.ProcessTasks();
+            }
+            catch (InvalidOperationException e) when (e.Message.Contains("already in use", StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            if (parked.IsCompleted)
+            {
+                await parked;
+                throw new XunitException("the park returned without ever owning the engine");
+            }
+
+            if (elapsed.Elapsed > WedgeCeiling)
+            {
+                throw new XunitException($"the park did not claim the engine within {WedgeCeiling}");
+            }
+
+            Thread.Sleep(ProbeInterval);
+        }
+    }
+
+    private static async Task WaitUntilSignalled(ManualResetEventSlim entered, Task running)
+    {
+        var elapsed = Stopwatch.StartNew();
+        while (!entered.Wait(ProbeInterval))
+        {
+            if (running.IsCompleted)
+            {
+                await running;
+                throw new XunitException("the owning call returned without ever entering block()");
+            }
+
+            if (elapsed.Elapsed > WedgeCeiling)
+            {
+                throw new XunitException($"the owning thread did not enter block() within {WedgeCeiling}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// A thread of the test's own, parked until <see cref="Release"/>, which then invokes the engine callback
+    /// it was handed exactly once and records what came back. Deliberately not <c>Task.Run</c>: a pool worker
+    /// has to be injected first and would land wherever the pool feels like, which is the wall-clock race
+    /// every handshake here exists to avoid.
+    /// </summary>
+    private sealed class CallbackDispatcher : IDisposable
+    {
+        private readonly ManualResetEventSlim _release = new();
+        private readonly TaskCompletionSource<bool> _attempted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly Thread _thread;
+
+        internal CallbackDispatcher(Func<int> invoke)
+        {
+            _thread = new Thread(() =>
+            {
+                _release.Wait(WedgeCeiling);
+                try
+                {
+                    Result = invoke();
+                }
+                catch (Exception exception)
+                {
+                    Failure = exception;
+                }
+                finally
+                {
+                    _attempted.TrySetResult(true);
+                }
+            })
+            {
+                IsBackground = true,
+                Name = "jint-pump-admission-dispatcher",
+            };
+
+            _thread.Start();
+        }
+
+        /// <summary>
+        /// Completes once the callback has been invoked, whatever the outcome — so a regression reports rather
+        /// than hangs.
+        /// </summary>
+        internal Task Attempted => _attempted.Task;
+
+        internal Exception? Failure { get; private set; }
+
+        internal int Result { get; private set; }
+
+        internal void Release() => _release.Set();
+
+        public void Dispose()
+        {
+            _thread.Join(WedgeCeiling);
+            _release.Dispose();
+        }
+    }
+}

--- a/Jint/Engine.Pump.cs
+++ b/Jint/Engine.Pump.cs
@@ -315,9 +315,29 @@ public partial class Engine
     /// The body of <see cref="AdvancedOperations.WaitForScheduledWork"/>, which owns the engine for the whole
     /// of it — see that method's remarks for why.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A <em>top-level</em> park is a callback-admission window, and needs the pair
+    /// <see cref="DrainEventLoopUntil"/> already has: the reservation an authorized cross-thread callback is
+    /// matched against, held for the whole park, plus a per-iteration release of the thread that callback has
+    /// to acquire in order to take its turn. Neither alone is enough here — the reservation without the yield
+    /// admits a callback that then blocks in <c>AcquireHostCall</c> until the park ends, and the yield without
+    /// the reservation is an unreserved engine, which is what an unrelated caller is refused by.
+    /// </para>
+    /// <para>
+    /// Both are keyed on the scope that <em>claimed</em> the engine, deliberately not on
+    /// <see cref="_ownerDepth"/> (see <see cref="ReleaseEntryReservationIfHeld"/> for what that mistake costs).
+    /// A pump reached from inside a running evaluation — host code the script itself invoked — has undertaken
+    /// nothing: the thread is in the middle of somebody else's script, and admitting a callback there would
+    /// interleave its turn into the middle of that evaluation. Such a park keeps refusing, exactly as it did.
+    /// </para>
+    /// </remarks>
     internal bool WaitForScheduledWork(TimeSpan timeout, CancellationToken cancellationToken)
     {
         using var ownership = EnterHostCall();
+
+        var isTopLevelPark = ownership.IsEntryRoot;
+        using var admission = isTopLevelPark ? OpenHostCallbackAdmissionWindow() : default;
 
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -347,7 +367,14 @@ public partial class Engine
 
                 try
                 {
-                    _eventLoop.WaitForWork(completedEvent: null, interval, waitToken);
+                    // Yields the thread for the idle wait alone, finding the window's reservation rather than
+                    // taking one of its own — the shape DrainEventLoopUntil's per-iteration suspension has. A
+                    // callback admitted here holds the engine until it finishes, and the resume below waits
+                    // for it, which is why the ceiling bounds this wait and not the call around it.
+                    using (SuspendHostCallForCallbacks(hasTransferredCallback: isTopLevelPark))
+                    {
+                        _eventLoop.WaitForWork(completedEvent: null, interval, waitToken);
+                    }
                 }
                 catch (OperationCanceledException)
                 {
@@ -373,6 +400,7 @@ public partial class Engine
     /// released here, because everything after the first <c>await</c> belongs to this method.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// The discipline is the one every async host entry uses: <see cref="ReserveAsyncHostOperation"/> holds the
     /// engine across every await, since no thread stays claimed over one, and each moment that actually reads
     /// engine state re-claims the resuming thread with <see cref="EnterTransferredHostCall"/> — which is what
@@ -382,6 +410,15 @@ public partial class Engine
     /// exists to keep a converted host callback admissible while script is suspended, and this wait runs no
     /// script at all. It also leaves <c>_pendingAsyncOperations</c> alone for the same reason — that counter
     /// answers "is an evaluation suspended", and the reservation alone is what a restore has to refuse.
+    /// </para>
+    /// <para>
+    /// What it does share with the synchronous form is the reservation's <em>identity</em>: the anonymous
+    /// wildcard rather than a token of its own. Running no script is exactly why — a fresh token can only ever
+    /// be carried by a callback converted under the frame that minted it, and this frame converts none, so
+    /// such a token matches nothing at all rather than matching narrowly. There is no claiming-scope guard
+    /// here because there is nothing for one to do: the reservation is taken synchronously and refuses an
+    /// engine any thread already owns, so this form can never be reached from inside a running evaluation.
+    /// </para>
     /// </remarks>
     private async Task<bool> WaitForScheduledWorkCoreAsync(object owner, TimeSpan timeout, CancellationToken cancellationToken)
     {
@@ -622,10 +659,20 @@ public partial class Engine
         /// an asynchronous operation in progress."</i> That is the engine's ordinary admission rule rather than
         /// anything this method adds, and it is what makes one-thread-per-engine self-enforcing. Enqueueing
         /// into a waiting engine from another thread is unaffected — that path is deliberately unguarded, and
-        /// is what wakes the wait. One consequence worth knowing: an authorized host callback arriving from
-        /// another thread while this wait is parked is refused for as long as it is parked, where a
-        /// <c>Thread.Sleep</c> would have admitted it. A host that needs such callbacks admitted while idle
-        /// should not park the engine's own thread here.
+        /// is what wakes the wait.
+        /// </para>
+        /// <para>
+        /// <b>Authorized callbacks are admitted, and one of them can outlast the ceiling.</b> A park is one of
+        /// the engine's callback-admission windows (README's Thread-safety section lists them all): a
+        /// JavaScript callback the host was handed and converted to a CLR delegate may be dispatched here from
+        /// another thread and will wait for its turn rather than being refused, which is the point of parking
+        /// the engine's own thread rather than sleeping it. Unrelated public callers are refused throughout,
+        /// exactly as they were. The consequence to plan for is that <paramref name="timeout"/> bounds the
+        /// <b>idle wait, not the call</b>: an admitted callback holds the engine, and this cannot return until
+        /// it finishes, so a host budgeting a frame can be handed control back well after its ceiling by a
+        /// callback of its own making. Only a <em>top-level</em> park is a window — one reached from inside a
+        /// running evaluation, from host code the script itself invoked, has undertaken nothing and goes on
+        /// refusing.
         /// </para>
         /// <para>
         /// <b>Do not call it from inside a job</b> — from host code reached by a promise reaction, a timer
@@ -677,17 +724,20 @@ public partial class Engine
         /// <remarks>
         /// <para>
         /// Everything <see cref="WaitForScheduledWork"/> documents applies — it does not pump, a
-        /// <see langword="true"/> is a hint, the wait is bounded by the engine's own next due time, and a
+        /// <see langword="true"/> is a hint, the wait is bounded by the engine's own next due time, a
         /// registered <see cref="Constraints.CancellationConstraint"/> ends it as
-        /// <see cref="ExecutionCanceledException"/>. Only the ownership differs.
+        /// <see cref="ExecutionCanceledException"/>, and it is a callback-admission window on the same terms,
+        /// including that an admitted callback can carry the returned task past <paramref name="timeout"/>.
+        /// Only the ownership differs.
         /// </para>
         /// <para>
         /// <b>Ownership spans the whole await.</b> No thread stays claimed across an <c>await</c>, so this
         /// reserves the engine the way every other asynchronous host entry does: the reservation is taken
         /// <em>synchronously</em>, so an engine already in use is refused with the admission
         /// <see cref="InvalidOperationException"/> before a <see cref="Task"/> exists, and it is held until the
-        /// returned task completes. While it is held the engine refuses every guarded entry from every thread,
-        /// this one included — so <see cref="ProcessTasks"/> belongs after the <c>await</c>, never beside it.
+        /// returned task completes. While it is held the engine refuses every unrelated guarded entry from
+        /// every thread, this one included — so <see cref="ProcessTasks"/> belongs after the <c>await</c>,
+        /// never beside it.
         /// The continuation resumes on whichever thread the runtime hands it, which is why the engine is
         /// re-claimed for each look at its schedule.
         /// </para>
@@ -709,7 +759,13 @@ public partial class Engine
             // Taken here rather than inside the async body so that the admission failure is reported to the
             // caller synchronously, exactly as EvaluateAsync and its siblings report it; the body owns the
             // release, because everything after its first await belongs to it.
-            var owner = _engine.ReserveAsyncHostOperation();
+            //
+            // Under the engine's anonymous wildcard rather than a token of this operation's own: a park runs
+            // no script, so nothing can ever be converted under it and carry that token, and reserving under
+            // one refuses every authorized callback instead of admitting the ones this frame issued. Nothing
+            // is in force to keep here either — the reservation requires an unowned engine, and an unowned
+            // engine has no operation token.
+            var owner = _engine.ReserveAsyncHostOperation(_engine.OwnershipReleasedEvent);
             return _engine.WaitForScheduledWorkCoreAsync(owner, timeout, cancellationToken);
         }
     }

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -735,7 +735,24 @@ public sealed partial class Engine : IDisposable
         }
     }
 
-    internal object ReserveAsyncHostOperation()
+    /// <summary>
+    /// Reserves the engine for an asynchronous host operation and returns the reservation's identity.
+    /// </summary>
+    /// <param name="reservationOwner">
+    /// The identity to reserve under, or <see langword="null"/> for a fresh token of this operation's own.
+    /// <para>
+    /// That identity is the whole of what <see cref="EnterTransferredHostCallback"/> matches an authorized
+    /// cross-thread callback against, so it decides <em>which</em> callbacks may wait for a turn here. The
+    /// rule is the one <see cref="OpenHostCallbackAdmissionWindow"/> and
+    /// <see cref="SuspendHostCallForCallbacks"/> apply: a frame under which an operation token is in force
+    /// keeps that token, so only a callback issued under it may wait; a frame with no token of its own
+    /// reserves under <see cref="OwnershipReleasedEvent"/>, the anonymous wildcard that means "any authorized
+    /// callback may take a turn here". A fresh token is right for a frame that <em>runs script</em> - every
+    /// <c>*Async</c> entry - because a callback converted during it carries that very token. It is wrong for
+    /// a frame that runs none, where nothing can ever carry it and the match is empty rather than narrow.
+    /// </para>
+    /// </param>
+    internal object ReserveAsyncHostOperation(object? reservationOwner = null)
     {
         var activeOwner = Volatile.Read(ref _ownerThreadId);
         if (activeOwner != 0)
@@ -743,7 +760,7 @@ public sealed partial class Engine : IDisposable
             Throw.InvalidOperationException(ConcurrentUseMessage);
         }
 
-        var owner = new object();
+        var owner = reservationOwner ?? new object();
         if (Interlocked.CompareExchange(ref _asyncOwner, owner, null) is not null)
         {
             Throw.InvalidOperationException(ConcurrentUseMessage);
@@ -809,6 +826,14 @@ public sealed partial class Engine : IDisposable
         /// reservation handed to the entry - see <see cref="ReleaseEntryReservationIfHeld"/>.
         /// </summary>
         private readonly bool _isEntryRoot;
+
+        /// <summary>
+        /// Whether this scope claimed the engine, rather than nesting inside a claim somebody else made. It
+        /// is the same claiming-scope rule <see cref="ReleaseEntryReservationIfHeld"/> is keyed on, and never
+        /// <see cref="_ownerDepth"/> reaching zero, for the reason recorded there. A frame that only opens an
+        /// admission window while it is the outermost one - <see cref="WaitForScheduledWork"/> - asks this.
+        /// </summary>
+        internal bool IsEntryRoot => _isEntryRoot;
 
         internal HostCallScope(Engine engine)
         {

--- a/README.md
+++ b/README.md
@@ -2406,23 +2406,31 @@ An `Engine` is single-operation, not thread-safe. Public host entries fail fast 
 is still outstanding; callers are never silently serialized. Same-thread re-entry from a host callback is
 supported for synchronous APIs. A JavaScript callback converted to a CLR delegate may also be dispatched
 to another thread by the host, and Jint admits such a transfer whenever it holds an open callback-admission
-window. There are three: from the moment a host call is handed the callback until the engine operation that
+window. There are four: from the moment a host call is handed the callback until the engine operation that
 made that call — the `Evaluate`, `Execute`, `Invoke` or callback turn on the stack — returns; while one of
-the async engine APIs is outstanding; and while the engine is driving its event loop for a blocking
-`UnwrapIfPromise` or `Modules.Import`. Inside a window Jint reserves the engine against unrelated callers
-and transfers ownership to that callback one turn at a time. Such an authorized transfer may wait for the
-current callback turn; ordinary public callers still fail immediately rather than being serialized. The
-three hand over to one another in the usual shape: an `async` host method returns at its first `await`, so
-its callback is normally invoked long after that method's own call returned — the first window covers the
-rest of the evaluation that called it, and by the time that evaluation returns the script is awaiting the
-promise the method handed back, which is the third. Outside every window — the engine thread is running
-script for an operation that was never handed this callback, and has undertaken to yield to nobody — an
-authorized callback is refused exactly like an unrelated caller, because serializing it there would mean
-blocking on a thread that may itself be blocked on that callback. A host that dispatches callbacks
-asynchronously should therefore keep the engine inside one of the windows for as long as they may arrive:
-await the async API, or block on the promise. Starting an async engine API
-from inside an active engine call is rejected: the callback must return before ownership can transfer
-safely. A top-level awaited async operation may resume on a different thread after ownership transfers.
+the async engine APIs is outstanding; while the engine is driving its event loop for a blocking
+`UnwrapIfPromise` or `Modules.Import`; and while a host thread is parked on
+`Engine.Advanced.WaitForScheduledWork` or `WaitForScheduledWorkAsync`. Inside a window Jint reserves the
+engine against unrelated callers and transfers ownership to that callback one turn at a time. Such an
+authorized transfer may wait for the current callback turn; ordinary public callers still fail immediately
+rather than being serialized. The first three hand over to one another in the usual shape: an `async` host
+method returns at its first `await`, so its callback is normally invoked long after that method's own call
+returned — the first window covers the rest of the evaluation that called it, and by the time that
+evaluation returns the script is awaiting the promise the method handed back, which is the third. The
+fourth is for the other shape entirely, a host loop that pumps one engine from one thread and idles on the
+pump in between. How narrowly a window admits depends on where it was opened: one opened inside a running
+operation admits only callbacks issued under that operation, while one opened at the top level — a blocking
+drain, or a park — is anonymous and admits any callback this engine ever authorized, including one whose
+operation ended long ago. A park reached from *inside* a running evaluation is not a window at all and goes
+on refusing. Outside every window — the engine thread is running script for an operation that was never
+handed this callback, and has undertaken to yield to nobody — an authorized callback is refused exactly like
+an unrelated caller, because serializing it there would mean blocking on a thread that may itself be blocked
+on that callback. A host that dispatches callbacks asynchronously should therefore keep the engine inside one
+of the windows for as long as they may arrive: await the async API, block on the promise, or park on the
+pump. One consequence of the last: `WaitForScheduledWork`'s timeout bounds the idle wait, not the call, so an
+admitted callback can hand a frame-budgeted host control back well after its ceiling. Starting an async
+engine API from inside an active engine call is rejected: the callback must return before ownership can
+transfer safely. A top-level awaited async operation may resume on a different thread after ownership transfers.
 Background task and module completions may enqueue work safely, but they do not grant permission for other
 host calls while the owning async operation is pending.
 


### PR DESCRIPTION
Closes #3242. The analysis and verdict are in [that issue's comment](https://github.com/sebastienros/jint/issues/3242); this implements it, and both of its structural claims checked out exactly in the code.

#3240 established that an **authorized** cross-thread callback must be able to wait wherever the engine thread has undertaken to yield. The pump was the one frame left where it could not.

## Two forms, two different fixes

**`WaitForScheduledWorkAsync`** minted a fresh `new object()`. Every other reservation is minted by a frame under which script runs, so callbacks converted during it carry that token — but this frame provably runs none (`InspectScheduledWork` reads queue state and executes nothing), so its token was an **empty** match, not a narrow one. It now reserves under the anonymous wildcard. Nothing else is needed: the reservation is taken synchronously and refuses an engine any thread already owns, so this form can never be reached from inside a running evaluation.

**The synchronous `WaitForScheduledWork`** — which the issue's premise got wrong — took **no reservation at all**, so it refused from the *null-owner* branch, **and** held `_ownerThreadId` for the whole park. A reservation alone would have admitted a callback that then blocked in `AcquireHostCall` until the park ended. It needed the pair `DrainEventLoopUntil` already has: a window for the whole park, plus a per-iteration suspension around `WaitForWork` yielding only the thread.

`SuspendHostCallForCallbacks`, `DrainEventLoopUntil`, `AwaitPromiseSettlementAsync` and the `*Async` entries are unchanged — they hold an operation token, and under the uniform rule that is correct.

## The guard, and proof the suite cannot see it

A pump reached from inside a running evaluation has undertaken nothing, so it must keep refusing. The guard is `HostCallScope.IsEntryRoot` — #3240's claiming-scope rule, never `_ownerDepth == 0`, which #3240 got wrong first.

Evidence, by forcing the guard true, rebuilding, running, restoring:

| | with guard | guard removed |
| --- | --- | --- |
| `ANestedParkInsideARunningEvaluationAdmitsNothing` | admitted **0** / 12 | **`Expected admitted to be 0, but found 12`** |
| `HostPumpWaitTests` (2) | pass | pass |
| `WaitForScheduledWorkTests` (9) | pass | pass |

So the pre-existing suites genuinely cannot see it — the new pin is the only thing that catches its removal. Worth noting `HostPumpWaitTests.WaitForScheduledWorkWakesOnACrossThreadPost` is *itself* a nested park and stays green either way, which is exactly why it could not serve as the pin.

## Probes, before and after

| behaviour | before | after |
| --- | --- | --- |
| stale authorized callback at a **sync** park | **FAIL** — refused at `Engine.cs:202` | admitted, returns 42 |
| same at an **async** park | **FAIL** — same refusal | admitted, returns 42 |
| parked in an unrelated blocking host `Action` | refused | refused (unchanged) |
| unrelated **public** entry while parked | refused | refused (unchanged) |
| **nested** pump inside a running evaluation | 12/12 refused | 12/12 refused |
| admitted callback enqueues a microtask | **FAIL** — park burned its 10 s ceiling, reported no work | park wakes, reports `true` |
| admitted callback outruns the ceiling | **FAIL** — `hold()` never reached | park returns after the callback, elapsed > 2× ceiling |

Pre-fix `Failed: 4, Passed: 3`; post-fix `Passed: 7` — and the class dropped from 21 s to 2 s, the two 10 s burns being gone.

## Fail-fast is unchanged

Throughout both parks the reservation is non-null, so `EnterHostCall(asyncOwner: null)` from any other thread still throws. Pinned by two new tests, by `WaitUntilParked`'s own handshake (which *is* a refused `ProcessTasks()`), and by pre-existing untouched tests — `AParkedWaitOwnsTheEngineForItsWholeDuration`, `ASecondThreadWaitingIsRefused`, and **`CanonicalJsCallDelegateCannotBypassOwnership`**, all green and not edited.

## Documentation

TM-13's enumeration gains the park, and its scope claim is **corrected**: "carry operation-scoped authorization" was only ever true where an operation token is in force. The new bullet says what is actually true —

> How narrowly a window admits depends on whether an operation token is in force under it. A window opened under one admits only callbacks issued under that same operation. A window opened where none is in force is anonymous, and admits any callback this engine ever authorized, including one whose operation has long since ended: that is the case at a top-level blocking drain and at a top-level park. A pump reached from inside a running evaluation opens no window at all and refuses.

Two residual bullets added: the wedge shape the park extends (already reachable through the drain, outside the supported contract, and still unreachable by a raw `JsCallDelegate`), and **"`WaitForScheduledWork`'s timeout bounds the idle wait, not the call"** — the one genuinely new observable, which also replaces the now-false paragraph in the method's own remarks and updates README's window enumeration from three to four.

## Verification

Solution builds Release, 0 errors. `Jint.Tests` 10425 (net10.0) / 7206 (net472); `Jint.Tests.PublicInterface` 2492 / 1906; both repeated with `JINT_HOST_CONTRACT_VERIFICATION=1` (2496 / 1910). **test262 102,495 passed / 0 failed on both this branch and an `upstream/main` baseline taken in this same worktree — identical.**

Because this is threading: 10× the pump/concurrency/async/event-loop classes on net10.0 (65/65 and 400/400 every time), 5× on net472 (65/65 and 215/215). No flakes.

## One asymmetry this creates, worth knowing

**The drain does not have this guard.** `DrainEventLoopUntil` opens the wildcard window even when nested inside a running evaluation. That is pre-existing and outside the sanctioned scope here, so it is untouched — but it means the pump is now *stricter* than the drain about nesting rather than merely equal to it. If that should be closed it is a separate change with its own argument; filed separately.

Also naming debt, no behaviour: `SuspendHostCallForCallbacks(hasTransferredCallback:)` now reads oddly at two call sites — the drain already passes a literal `true` with no callback transferred to that frame, and the pump passes its guard bool. The parameter really means "yield the thread for callbacks".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
