### PR TITLE
Wpt: the one row nothing requires gets its own category, leaving NeedsTriage empty

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -481,10 +481,14 @@ sides, because a shim that quietly passed everything would make five thousand ca
 Six things to know before touching it. **The exclusion table is the artefact**: a test that does not pass is
 named in `WptTestRunner._exclusions` with a `WptDivergence` category, and an entry must match at least one
 failing test and no passing one — so a fix, a rename, or a corpus bump makes the run fail until the table is
-brought back in line, and a `*` glob can never widen into a blanket. **`NeedsTriage` is the debt**: those are
-genuine defects the harness found, recorded rather than fixed so that the change which first ran a suite is
-not also the change that moved the engine. **The engine supplies its own `setTimeout`** — unlike the test262
-harness, which has no web APIs to enable and shims one onto the event loop, this driver enables
+brought back in line, and a `*` glob can never widen into a blanket. **`NeedsTriage` is the debt, and it is
+empty**: those are genuine defects the harness found, recorded rather than fixed so that the change which
+first ran a suite is not also the change that moved the engine — every one filed so far has been paid, and the
+emptiness is the signal, so a non-zero count there means the corpus has found something. A row that turns out
+not to be a defect at all leaves for `AssertsWhatNothingRequires`, the analogue of test262's
+`PERMANENT EXCLUSIONS` banner, earned the same way: a normative citation and an argued decision, never a
+to-do. **The engine supplies its own `setTimeout`** — unlike the test262 harness, which has no web APIs to
+enable and shims one onto the event loop, this driver enables
 `WebApiFeatures.Timers` and pumps with `Advanced.ProcessTasks()` bounded by `TimeUntilNextPumpScheduledWork()`,
 so a suite that schedules a timer exercises the shipped `TimerQueue`. **`// META: variant=` sharding is
 ignored**: the shim leaves `location.search` empty, so `subsetTest`/`subsetTestByKey` run everything and one

--- a/Jint.Tests/Wpt/Vendor/README.md
+++ b/Jint.Tests/Wpt/Vendor/README.md
@@ -210,7 +210,7 @@ settled; it is a change to `UrlCorpusTests` as well as to this directory, and it
 
 ## What the WebCryptoAPI corpus says about this engine
 
-2,449 of its 24,136 assertions do not pass, and every one is named in the driver's table under one of six
+2,449 of its 24,136 assertions do not pass, and every one is named in the driver's table under one of five
 categories, whose own documentation in `WptExclusions.cs` carries the citation. Three are the platform:
 `NeedsPlatformCryptoParameters` (AES-GCM's 96-bit-only iv and 96-to-128-bit tag, RSA-OAEP's empty-only label,
 RSA-PSS's hash-length-only salt — all four are limits of the BCL primitives, documented on the classes that
@@ -224,7 +224,7 @@ at all. [#3195](https://github.com/sebastienros/jint/issues/3195) installed it, 
 Common API §5.1 lists it, and the row joined its two siblings — the one assertion in this corpus that this
 change moved.
 
-The seventh category was `NeedsQuotaExceededErrorInterface`, the nine `Large length: *` rows of
+A sixth category was `NeedsQuotaExceededErrorInterface`, the nine `Large length: *` rows of
 `getRandomValues.any.js`. They pass since
 [#3189](https://github.com/sebastienros/jint/issues/3189) implemented WebIDL's
 [`QuotaExceededError`](https://webidl.spec.whatwg.org/#quotaexceedederror) interface, and the entry and the
@@ -234,12 +234,17 @@ That figure is Windows and Linux, whose AES-GCM takes a 96- to 128-bit tag. **ma
 `aes_gcm.https.any.js`: Apple's implementation takes a 128-bit tag and nothing else, so the four tag lengths
 between 96 and 120 bits are refused there and their rows are scoped to that platform in the table.
 
-The seventh is `NeedsTriage`, and it is **debt**. It held two genuine defects the corpus found, recorded
-rather than fixed so that the change which first ran these suites was not also the change that moved the
-engine. One is fixed: `SubtleCrypto` copied its caller's bytes before normalizing the algorithm where the
-specification copies them after, which was every "… during call" row, and issue #3179 moved each copy to its
-numbered step. The one still open is ECDH's mismatched-curve rows, which get the `OperationError` of the
-prose where a browser answers `InvalidAccessError`.
+A seventh was `NeedsTriage`, this corpus's **debt**, and it is paid. It held two genuine defects the corpus
+found, recorded rather than fixed so that the change which first ran these suites was not also the change
+that moved the engine. `SubtleCrypto` copied its caller's bytes before normalizing the algorithm where the
+specification copies them after, which was every "… during call" row, and
+[#3179](https://github.com/sebastienros/jint/issues/3179) moved each copy to its numbered step. ECDH's two
+mismatched-curve rows answered the `OperationError` of the prose where every browser answers
+`InvalidAccessError`, and [#3180](https://github.com/sebastienros/jint/issues/3180) made
+`EcAlgorithm.DeriveBits` run the key-agreement checks before the *maximumLength* ceiling — the divergence
+from the prose documented on `DeriveBits` itself and raised upstream as
+[w3c/webcrypto#560](https://github.com/w3c/webcrypto/issues/560). Both entries left the table when they
+started passing, which is the driver's own rule enforcing itself, so this corpus names no debt at all now.
 
 ## What the streams corpus says about this engine
 
@@ -803,9 +808,14 @@ of writing (chrome 152, edge 151, firefox 154, safari 26.6), that row is **0/1 i
 file's thirteen other rows are 1/1 in all four. No browser produces an empty body for an empty `FormData`
 either, which is what one would expect of a serializer that writes its close delimiter after the loop.
 
-So this row is not debt. It keeps its exclusion, but `NeedsTriage` is the wrong category for it — that
-category means "a bug or a specification detail to chase", and this is neither. Reclassifying it wants a
-category of its own, which is filed rather than done here.
+So this row is not debt. It keeps its exclusion, but `NeedsTriage` — "a bug or a specification detail to
+chase" — was the wrong category for it, and it no longer carries it.
+[#3261](https://github.com/sebastienros/jint/issues/3261) gave it one of its own,
+`AssertsWhatNothingRequires`: the corpus's analogue of test262's `=== PERMANENT EXCLUSIONS ===` banner, for a
+test that asserts what nothing requires of anybody. It is the only entry there, and moving it left
+`NeedsTriage` **empty**, which is the state that makes a future non-zero count in it mean something. The
+category's own documentation in `WptExclusions.cs` carries the rule for what may join it — a normative
+citation and an argued decision, never a to-do — and the rule that age alone never promotes an entry into it.
 
 ### The three that are fixed
 

--- a/Jint.Tests/Wpt/WptExclusions.cs
+++ b/Jint.Tests/Wpt/WptExclusions.cs
@@ -142,7 +142,15 @@ internal enum WptDivergence
     /// </para>
     /// <para>
     /// So this is deliberately <b>not</b> <see cref="NeedsTriage"/>: there is no defect left to chase, and
-    /// nothing short of a classic-script worker would move either row. What keeps them honest is that the
+    /// nothing short of a classic-script worker would move either row. It is just as deliberately not
+    /// <see cref="AssertsWhatNothingRequires"/>, which it superficially resembles by also being permanent and
+    /// also not debt. The line is what the standard asks. There, nothing asks for what the test asserts and
+    /// no implementation delivers it; here HTML asks for exactly what these two rows assert — a sloppy-mode
+    /// assignment to a read-only attribute <i>is</i> a silent no-op — and an implementation that runs the
+    /// file as the classic <c>.any.worker.js</c> script wpt generates for it satisfies them, which is what
+    /// upstream's <c>global=worker</c> key means the file to be. What makes them permanent is a lane Jint
+    /// chose, which is the family <see cref="NeedsDeclinedWorkerGlobals"/> and
+    /// <see cref="NeedsForbiddenHeaderNames"/> are in and not that one. What keeps them honest is that the
     /// engine's half is pinned from both sides in
     /// <c>Jint.Tests/Runtime/WebApi/WorkerMechanismTests.cs</c>, in both modes — the module body for strict,
     /// an indirect <c>eval</c> for the sloppy one this lane cannot otherwise reach.
@@ -328,7 +336,9 @@ internal enum WptDivergence
     NeedsOffscreenCanvas,
 
     /// <summary>
-    /// A genuine failure that is not attributable to a feature Jint has decided not to have. Every entry
+    /// A genuine failure that is not attributable to a feature Jint has decided not to have, over behaviour
+    /// something really does require — which is the line between this and
+    /// <see cref="AssertsWhatNothingRequires"/>. Every entry
     /// here is a bug or a specification detail to chase, and the phase of the harness work that stood the
     /// suites up deliberately recorded them rather than fixing them: the point was to find out what they
     /// say, and mixing engine fixes into the change that first ran them would have hidden which of the two
@@ -394,25 +404,12 @@ internal enum WptDivergence
     /// property WebIDL's order never reaches — all fixed under sebastienros/jint#3212, so the thirteen
     /// entries that used to be here now enforce them and
     /// <c>dom/events/Event-constructors.any.js</c> left <c>_notVendored</c> with them. <c>Vendor/README.md</c>
-    /// analyses each with its citation. <b>The seventh is the last entry in this category, and it is not a
-    /// defect:</b>
+    /// analyses each with its citation. <b>The seventh was the last entry in this category and it was never a
+    /// defect</b> — an empty <c>FormData</c> body serializing to its closing boundary rather than to nothing
+    /// — so it is not here any more: it is the whole of <see cref="AssertsWhatNothingRequires"/>, moved
+    /// there by https://github.com/sebastienros/jint/issues/3261, which is where that reading and its
+    /// citation now live.
     /// </para>
-    /// <list type="bullet">
-    /// <item><description>
-    /// An empty <c>FormData</c> response body serializes to its closing boundary rather than to nothing —
-    /// <c>response-consume-empty.any.js</c>, "Consume empty FormData response body as text", which asks that
-    /// <c>await new Response(new FormData()).text()</c> have length 0. <b>It is not a defect.</b> This one
-    /// wanted https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#multipart/form-data-encoding-algorithm
-    /// read before anything was changed, and reading it settles the question the other way: the algorithm
-    /// defines the escaping and delegates the framing to RFC 7578 and, through it, to RFC 2046 section 5.1.1,
-    /// whose grammar ends every <c>multipart-body</c> with a <c>close-delimiter</c> that is not optional. Nor
-    /// does any implementation produce the empty body the row asks for — Chrome, Edge, Firefox and Safari all
-    /// report it 0/1 on wpt.fyi, where the file's thirteen other rows are 1/1 in all four. So the entry
-    /// stays, but this category — "a bug or a specification detail to chase" — is the wrong one for it, and
-    /// giving it one of its own is deliberately left undone rather than folded into the change that read the
-    /// algorithm. <c>Vendor/README.md</c> has the citations and the measurement.
-    /// </description></item>
-    /// </list>
     /// <para>
     /// <b>The structured-clone corpus filed three more, and they are gone</b> — an <c>Error</c>'s
     /// <c>cause</c> was not carried, <c>Blob</c> and <c>File</c> were not serializable at all, and
@@ -432,13 +429,56 @@ internal enum WptDivergence
     /// <c>TimerEntry.Fire</c> and <c>JsEventTarget.InvokePass</c> carry — and the file is vendored and green.
     /// </para>
     /// <para>
-    /// <b>So the category currently holds no debt at all</b> — one entry, and its own paragraph says why that
-    /// entry is misfiled. That is the state to keep it in: a row belongs here only while somebody still owes
-    /// the engine a fix, and every corpus that filed one has had it paid. An entry that turns out not to be a
-    /// defect earns a category of its own rather than a longer explanation under this one.
+    /// <b>So the category is empty, and its emptiness is the signal.</b> That is the state to keep it in: a
+    /// row belongs here only while somebody still owes the engine a fix, and every corpus that filed one has
+    /// had it paid. Kept named rather than deleted for exactly that reason — a non-zero count here is a real
+    /// finding rather than a number a reader has to go and re-read to discover it is one permanent entry —
+    /// and it is legal to keep because nothing enumerates this type: the driver reads
+    /// <see cref="WptExclusion.Divergence"/> only to name the category in a staleness message, so a member
+    /// with no entries costs nothing and fails nothing. <see cref="NeedsMessageChannel"/> is the older
+    /// precedent for a named-but-empty category. An entry that turns out not to be a defect leaves for
+    /// <see cref="AssertsWhatNothingRequires"/> rather than earning a longer explanation under this one.
     /// </para>
     /// </summary>
     NeedsTriage,
+
+    /// <summary>
+    /// <para>
+    /// The test asserts behaviour <b>nothing requires of anybody</b> — not of Jint, and not of any
+    /// implementation. This is the corpus's analogue of test262's <c>=== PERMANENT EXCLUSIONS ===</c> banner
+    /// and it is earned the same way: only when the standard the test claims to be about does not ask for
+    /// what the test asks for, and only with a comment that records the decision and the normative citation
+    /// making it defensible, never a to-do nobody intends to do. It is the one member not spelled
+    /// <c>Needs…</c>, deliberately: every other names something absent that would turn its rows green if it
+    /// arrived, whereas here the divergence is in the test and no change to this engine would move it.
+    /// </para>
+    /// <para>
+    /// One entry today, moved out of <see cref="NeedsTriage"/> by
+    /// https://github.com/sebastienros/jint/issues/3261 — <c>fetch/api/response/response-consume-empty.any.js</c>,
+    /// "Consume empty FormData response body as text", which asks that
+    /// <c>await new Response(new FormData()).text()</c> have length 0 and gets the 50-byte closing boundary
+    /// <c>MultipartFormData</c> writes. HTML's
+    /// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#multipart/form-data-encoding-algorithm
+    /// defines the escaping and delegates the framing to RFC 7578, which defers in turn to RFC 2046, whose
+    /// section 5.1.1 grammar ends every <c>multipart-body</c> with a <c>close-delimiter</c> that is not
+    /// optional — so an empty entry list has no shorter conforming encoding than the one Jint writes. The
+    /// empirical half agrees: on wpt.fyi's four aligned stable runs that row is 0/1 in Chrome, Edge, Firefox
+    /// and Safari, where the file's thirteen other rows are 1/1 in all four. <c>Vendor/README.md</c> keeps
+    /// the grammar and the measurement.
+    /// </para>
+    /// <para>
+    /// Age never promotes an entry into this category: a row nobody has got round to stays
+    /// <see cref="NeedsTriage"/> however long it has sat there, because what this member records is intent
+    /// and not age. Reversing an entry is a perfectly ordinary change — a standard can move, and a reading
+    /// can turn out to be wrong — but it has to argue the decision and rewrite the reasoning rather than
+    /// merely delete the line. It is also not the place for a divergence Jint <i>chose</i>: a lane taken
+    /// (<see cref="NeedsClassicWorkerScript"/>), a name declined (<see cref="NeedsDeclinedWorkerGlobals"/>)
+    /// or a browser protection refused (<see cref="NeedsForbiddenHeaderNames"/>) are all cases where the
+    /// test asserts something the standard really does require and Jint answers otherwise on purpose, which
+    /// is a different fact about a row and keeps its own category.
+    /// </para>
+    /// </summary>
+    AssertsWhatNothingRequires,
 }
 
 /// <summary>

--- a/Jint.Tests/Wpt/WptTestRunner.cs
+++ b/Jint.Tests/Wpt/WptTestRunner.cs
@@ -35,14 +35,16 @@ namespace Jint.Tests.Wpt;
 /// https://github.com/sebastienros/jint/issues/3185 recorded by
 /// https://github.com/sebastienros/jint/issues/3212, and the one the workers corpus found — a <c>self</c>
 /// installed against <c>Window</c>'s definition for every global including a worker's — by
-/// https://github.com/sebastienros/jint/issues/3224. <b>The category is down to one entry, and that one is
-/// not a defect</b>: an empty <c>FormData</c> body, which no browser serializes to nothing either.
-/// <c>Vendor/README.md</c> analyses each.
+/// https://github.com/sebastienros/jint/issues/3224. <b>The category is empty, and its emptiness is the
+/// signal</b>: its last entry — an empty <c>FormData</c> body, which no browser serializes to nothing either
+/// — was never a defect, and https://github.com/sebastienros/jint/issues/3261 moved it to
+/// <see cref="WptDivergence.AssertsWhatNothingRequires"/>, the category for a test that asserts what nothing
+/// requires of anybody. <c>Vendor/README.md</c> analyses each.
 /// </para>
 /// <para>
 /// <b>A corpus with sub-directories is one suite per directory</b> rather than one for the lot, because
 /// <see cref="WptCorpus.TestFiles"/> lists a directory's own files and never descends. That is deliberate: a
-/// suite is a theory, a theory is a line in a test report, and thirty-four of them tell a reader which
+/// suite is a theory, a theory is a line in a test report, and thirty-five of them tell a reader which
 /// operation went red where a dozen would not. <c>compression/</c>, <c>urlpattern/</c>, <c>hr-time/</c> and
 /// <c>user-timing/</c> have a single directory apiece and are therefore one suite apiece.
 /// </para>
@@ -981,9 +983,10 @@ public class WptTestRunner
         // The one row this corpus still names, and it is not a defect: an empty FormData body is asked to
         // serialize to nothing, where HTML's encoding algorithm delegates the framing to RFC 7578 and RFC
         // 2046, whose grammar makes the close-delimiter mandatory — and where no browser passes the row
-        // either. Left here because moving it wants a category of its own. See WptDivergence.NeedsTriage.
+        // either. So it is the corpus's one permanent entry; see WptDivergence.AssertsWhatNothingRequires
+        // for the reading, and Vendor/README.md for the grammar and the wpt.fyi measurement.
         new("fetch/api/response/response-consume-empty.any.js",
-            "Consume empty FormData response body as text", WptDivergence.NeedsTriage),
+            "Consume empty FormData response body as text", WptDivergence.AssertsWhatNothingRequires),
 
         // ---------------------------------------------------------------- structured clone
         new("html/webappapis/structured-clone/structured-clone.any.js", "Growable SharedArrayBuffer", WptDivergence.NeedsWebAssembly),


### PR DESCRIPTION
Closes #3261. Tests and documentation only — no `Jint/` file is touched, and **no corpus row moves**.

`WptDivergence.NeedsTriage` means *"a genuine failure that is not attributable to a feature Jint has decided not to have"* — the category that carries **debt**. It held exactly one entry, and #3247 established that entry is not debt: HTML's `multipart/form-data` encoding delegates framing to RFC 7578 → RFC 2046, whose §5.1.1 grammar makes the closing delimiter non-optional, and the row is **0/1 in Chrome, Edge, Firefox and Safari** while its file's thirteen other rows are 1/1 in all four.

## The new category

**`AssertsWhatNothingRequires`**, placed immediately after `NeedsTriage` so the reading order is "an entry that turns out not to be a defect leaves for…" → that category. It is the corpus's analogue of test262's `=== PERMANENT EXCLUSIONS ===` and is earned the same way: only when the standard the test claims to be about does not ask for what the test asks, and only with the normative citation that makes the decision defensible.

**It is deliberately the one member not spelled `Needs…`**, and the doc says why: every other names something *absent* whose arrival would turn its rows green, whereas here the divergence is in the test and no change to this engine would ever move it.

## Why `NeedsClassicWorkerScript` does not join it

The line is **what the standard asks**, not "is it debt":

- For the `FormData` row, **nothing asks** for what the test asserts — HTML/RFC 7578/RFC 2046 positively forbid the empty body — and no implementation delivers it.
- For the two `self` rows (#3258), **HTML asks for exactly what they assert.** A sloppy-mode assignment to a read-only attribute *is* a silent no-op, and an implementation running the file as the classic `.any.worker.js` script wpt generates satisfies them — which is what upstream's `global=worker` key means the file to be. What makes them permanent is a **lane Jint chose** (module workers only, divergence 2 of #3167).

So they belong with `NeedsDeclinedWorkerGlobals` and `NeedsForbiddenHeaderNames`. Folding them in would widen the new category from *"nothing requires it"* to the much weaker *"not debt"* — which every declined-feature category also satisfies, collapsing them all and destroying the distinction the category exists to draw. The argument now sits at `NeedsClassicWorkerScript` itself, where a reader would question it.

## `NeedsTriage` stays, empty — and that is legal

Verified three ways rather than assumed: nothing enumerates the enum (`Enum.GetValues`/`typeof(WptDivergence)` have no hits anywhere in `Jint.Tests/Wpt/`, and `Divergence` is read at exactly two sites, both only interpolating the name into a staleness message); **`NeedsMessageChannel` is already a precedent**, with zero entries since #3197/#3167 and a doc explaining why it is kept; and the full run is green with `NeedsTriage` at zero. Its doc now records the decision and the reason — **its emptiness is the signal**.

## Three more stale claims found while re-reading

The issue named one. Re-reading the whole comment turned up three others, each a case where a change updated the code and not the prose:

| site | was | now |
| --- | --- | --- |
| `WptExclusions.cs` + `Vendor/README.md` | this category "is filed rather than done here" | done, citing #3261 |
| `WptTestRunner` class doc | "**thirty-four** of them tell a reader which operation went red" | **thirty-five** — #3229 wrote 34 correctly, then **#3258 vendored `workers/modules` as a 35th suite without moving the number**. Verified: 34 `[MemberData]` at `326b20ba2`, 35 at `ef533952b`, and `Vendor/README.md`'s census already said 35 |
| `Vendor/README.md`, WebCryptoAPI | "The seventh is `NeedsTriage`, and it is **debt** … The one still open is ECDH's mismatched-curve rows" | **#3183 (closing #3180) fixed them and removed their entries without touching this file.** Rewritten as paid, citing #3179, #3180 and w3c/webcrypto#560 |
| `Vendor/README.md`, WebCryptoAPI | "under one of **six** categories", then **two different** categories each called "the seventh" | **five** today, verified from the table, with a sixth and seventh that have since emptied |

The suite-count one is worth naming plainly: **that was my own #3258's miss**, not an old rot.

`AGENTS.md`'s "**`NeedsTriage` is the debt**" sentence now records that it is empty and where a non-defect row goes instead.

## Figures checked by measurement, not arithmetic

I suspected `Vendor/README.md`'s "2,449 of its 24,136" was high after the ECDH fix, so it was **measured** with a throwaway census rather than adjusted by subtraction — it came back exactly **24,136 / 2,449** for WebCryptoAPI and **388 / 29 files / 75 failing** for fetch. Both current, so nothing to change. (Given how many times this campaign has found that table stale, guessing would have been the wrong instinct.)

## No row moved — two independent proofs

**Structurally**: all 196 exclusion tuples — file, test-name pattern, `Platform`, `ExceptPlatform` — extracted from `HEAD` and from the working tree with the category field stripped, and they `diff` **byte-identical**. The only thing that changed on any entry is the `Divergence` value, which the enforcement never reads.

**Behaviourally**: the driver's two-sided rule makes a moved row impossible to hide — a row that started passing would fail its entry as stale, and one that started failing would be an unexcluded failure. Both runs are green.

`Jint.Tests` net10.0 **10,498 passed** / net472 **7,256 passed**, 0 failed. WPT **422 passed, 0 failed** — identical to a baseline taken on unmodified `upstream/main` before any edit. Release build, both TFMs, **0 warnings** under `TreatWarningsAsErrors`.

One observation reported rather than smoothed over: an *intermediate* net10.0 run showed 1 failure that did not reproduce on either logged run and whose name was not captured. It cannot be attributable to this change — the only executable difference in the whole commit is one enum value no code path reads — but this repo has a known flake ledger and it is a real observation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
