### PR TITLE
console: its [[Prototype]] is a private empty object, not %Object.prototype%

### DIFF
--- a/Jint.Tests/Runtime/WebApi/ConsoleTests.cs
+++ b/Jint.Tests/Runtime/WebApi/ConsoleTests.cs
@@ -485,6 +485,117 @@ public class ConsoleTests
         engine.Evaluate("console[Symbol.toStringTag]").AsString().Should().Be("console");
     }
 
+    /// <summary>
+    /// https://console.spec.whatwg.org/#console-namespace — "For historical web-compatibility reasons, the
+    /// namespace object for console must have as its [[Prototype]] an empty object, created as if by
+    /// ObjectCreate(%ObjectPrototype%), instead of %ObjectPrototype%."
+    /// </summary>
+    /// <remarks>
+    /// The three columns are the three the rule constrains, and Node 24 answers <c>false</c>, <c>0</c> and
+    /// <c>true</c> to them. <c>idlharness.js</c> asserts exactly this, for <c>console</c> and for nothing
+    /// else.
+    /// </remarks>
+    [Fact]
+    public void SitsOnAPrivateEmptyPrototypeRatherThanOnObjectPrototype()
+    {
+        var engine = new Engine(options => options.UseWebApis());
+
+        engine.Evaluate("Object.getPrototypeOf(console) === Object.prototype").AsBoolean().Should().BeFalse();
+        engine.Evaluate("Reflect.ownKeys(Object.getPrototypeOf(console)).length").AsNumber().Should().Be(0);
+        engine.Evaluate("Object.getPrototypeOf(Object.getPrototypeOf(console)) === Object.prototype").AsBoolean().Should().BeTrue();
+
+        // "an empty object, created as if by ObjectCreate(%ObjectPrototype%)": an ordinary, extensible object
+        // and not a second exotic one, and the same object every time it is asked for.
+        engine.Evaluate("Object.getPrototypeOf(console) === Object.getPrototypeOf(console)").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.isExtensible(Object.getPrototypeOf(console))").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.prototype.toString.call(Object.getPrototypeOf(console))").AsString().Should().Be("[object Object]");
+
+        // The chain still ends at %Object.prototype%, so everything an ordinary object inherits is reachable
+        // through console exactly as before.
+        engine.Evaluate("typeof console.hasOwnProperty").AsString().Should().Be("function");
+        engine.Evaluate("console.hasOwnProperty('log')").AsBoolean().Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Where the members live is not what the rule changes: the operations stay own properties of the
+    /// namespace object, which is what a WebIDL namespace object carries
+    /// (https://webidl.spec.whatwg.org/#es-namespaces) and what Node 24 answers — its
+    /// <c>Object.getOwnPropertyNames(console)</c> lists every method, and the object above it lists nothing.
+    /// </summary>
+    [Fact]
+    public void KeepsItsMembersOnTheNamespaceObjectItself()
+    {
+        var engine = new Engine(options => options.UseWebApis());
+
+        var members = new[]
+        {
+            "log", "info", "warn", "error", "debug", "trace", "assert", "dir", "table", "timeStamp",
+            "group", "groupCollapsed", "groupEnd", "count", "countReset", "time", "timeLog", "timeEnd",
+        };
+
+        foreach (var member in members)
+        {
+            engine.Evaluate($"Object.prototype.hasOwnProperty.call(console, '{member}')").AsBoolean().Should().BeTrue(member);
+            engine.Evaluate($"Object.prototype.hasOwnProperty.call(Object.getPrototypeOf(console), '{member}')").AsBoolean().Should().BeFalse(member);
+        }
+
+        // The tag is an own symbol of the namespace object too, which is what keeps `[object console]` true.
+        engine.Evaluate("Object.getOwnPropertySymbols(console).indexOf(Symbol.toStringTag) >= 0").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.prototype.toString.call(console)").AsString().Should().Be("[object console]");
+    }
+
+    /// <summary>
+    /// The web-compatibility reason the rule exists, and the containment consequence of getting it wrong: a
+    /// library decorating logging through the object above <c>console</c> must reach a throwaway object, not
+    /// every object in the realm.
+    /// </summary>
+    [Fact]
+    public void PatchingConsolesPrototypeDoesNotReachObjectPrototype()
+    {
+        var engine = new Engine(options => options.UseWebApis());
+
+        // The idiom itself, verbatim: this is what the patching libraries the rule was written for do.
+        engine.Execute("console.__proto__.decorated = 42;");
+
+        // It still works on console, which is the whole point of allowing it.
+        engine.Evaluate("console.decorated").AsNumber().Should().Be(42);
+
+        // And it reaches nothing else.
+        engine.Evaluate("Object.prototype.hasOwnProperty.call(Object.prototype, 'decorated')").AsBoolean().Should().BeFalse();
+        engine.Evaluate("'decorated' in {}").AsBoolean().Should().BeFalse();
+        engine.Evaluate("({}).decorated").IsUndefined().Should().BeTrue();
+        engine.Evaluate("[].decorated").IsUndefined().Should().BeTrue();
+        engine.Evaluate("(function () {}).decorated").IsUndefined().Should().BeTrue();
+        engine.Evaluate("'s'.decorated").IsUndefined().Should().BeTrue();
+        engine.Evaluate("JSON.stringify(Object.keys({ a: 1 }))").AsString().Should().Be("[\"a\"]");
+
+        // Object.setPrototypeOf(console, x) was always contained; assert it stays so, and that replacing the
+        // prototype leaves %Object.prototype% untouched as well.
+        engine.Execute("Object.setPrototypeOf(console, { replaced: 1 });");
+        engine.Evaluate("console.replaced").AsNumber().Should().Be(1);
+        engine.Evaluate("console.decorated").IsUndefined().Should().BeTrue();
+        engine.Evaluate("Object.prototype.hasOwnProperty.call(Object.prototype, 'replaced')").AsBoolean().Should().BeFalse();
+    }
+
+    /// <summary>
+    /// The prototype is per realm, like the namespace object it sits under, so one engine's patch is not
+    /// another's.
+    /// </summary>
+    [Fact]
+    public void GivesEachEngineItsOwnConsolePrototype()
+    {
+        var options = new Options().UseWebApis();
+
+        var first = new Engine(options);
+        var second = new Engine(options);
+
+        first.Execute("console.__proto__.decorated = 42;");
+
+        first.Evaluate("console.decorated").AsNumber().Should().Be(42);
+        second.Evaluate("console.decorated").IsUndefined().Should().BeTrue();
+        second.Evaluate("Object.prototype.hasOwnProperty.call(Object.prototype, 'decorated')").AsBoolean().Should().BeFalse();
+    }
+
     [Fact]
     public void CountsAndTimersAreOwnedByTheEngine()
     {

--- a/Jint/WebApi/Console/ConsoleInstance.cs
+++ b/Jint/WebApi/Console/ConsoleInstance.cs
@@ -30,6 +30,17 @@ namespace Jint.WebApi.Console;
 /// holds and two engines never share a counter.
 /// </para>
 /// <para>
+/// Its <c>[[Prototype]]</c> is a private empty object rather than <c>%Object.prototype%</c>, which
+/// https://console.spec.whatwg.org/#console-namespace requires of this namespace object and of no other:
+/// "For historical web-compatibility reasons, the namespace object for console must have as its
+/// <c>[[Prototype]]</c> an empty object, created as if by <c>ObjectCreate(%ObjectPrototype%)</c>, instead of
+/// <c>%ObjectPrototype%</c>." The rule exists because libraries decorate logging by patching
+/// <c>console.__proto__</c>, and it is a containment boundary as much as a conformance one: with
+/// <c>%ObjectPrototype%</c> there, <c>console.__proto__.foo = …</c> would define <c>foo</c> on every object
+/// in the realm. The members stay own properties of this object, exactly as they are in a browser and in
+/// Node, so the empty object above it is only ever a landing pad.
+/// </para>
+/// <para>
 /// Two documented simplifications against WebIDL. The methods are non-enumerable, where a WebIDL namespace
 /// object's operations are enumerable; and the object is installed as an ordinary enumerable data property
 /// of the global rather than through an accessor pair. Neither is observable except to code inspecting
@@ -69,7 +80,13 @@ internal sealed partial class ConsoleInstance : BuiltinShapeObject
     internal ConsoleInstance(Engine engine, Realm realm, ObjectPrototype objectPrototype) : base(engine)
     {
         _realm = realm;
-        _prototype = objectPrototype;
+
+        // https://console.spec.whatwg.org/#console-namespace — the namespace object's [[Prototype]] is an
+        // empty object created as if by ObjectCreate(%ObjectPrototype%), not %ObjectPrototype% itself. It is
+        // built here rather than in the intrinsics because it belongs to this object and to nothing else: an
+        // engine whose script never names `console` never reaches this constructor, so the extra object costs
+        // an engine that does not use the feature nothing at all.
+        _prototype = OrdinaryObjectCreate(engine, objectPrototype);
     }
 
     protected override void Initialize()


### PR DESCRIPTION
Closes #3257. One line of behaviour change, and it costs nothing.

[Console Standard §console-namespace](https://console.spec.whatwg.org/#console-namespace):

> For historical web-compatibility reasons, the namespace object for `console` must have as its `[[Prototype]]` **an empty object, created as if by ObjectCreate(%ObjectPrototype%)**, instead of `%ObjectPrototype%`.

`ConsoleInstance` assigned `_prototype = objectPrototype` directly. It now builds a private empty object, in the constructor rather than in `Intrinsics.WebApi.cs`, because it belongs to that object and nothing else — which is also what keeps it free.

| | before | after | Node 24 |
| --- | --- | --- | --- |
| `getPrototypeOf(console) === Object.prototype` | `true` | `false` | `false` |
| `Reflect.ownKeys(proto).length` | **12** | `0` | `0` |
| `getPrototypeOf(proto) === Object.prototype` | `false` | `true` | `true` |

The 12 were literally `constructor`, `__defineGetter__`, …, `__proto__` — i.e. `%Object.prototype%` itself.

## The members do not move, and that is the point

Node was the oracle: `getOwnPropertyNames(console)` lists the operations as **own** properties and `Reflect.ownKeys(getPrototypeOf(console))` is `[]`. Jint already matched that, so the private prototype is purely a landing pad, exactly as WebIDL §3.8 has it. `KeepsItsMembersOnTheNamespaceObjectItself` **passes before and after** — the fix must not relocate anything, and that test is what proves it did not.

## Realm poisoning: demonstrated, not asserted

`console.__proto__.decorated = 42`

- **before** — `({}).decorated` is `42`, and `Object.prototype` genuinely gains the own property. Every object in the realm poisoned.
- **after** — `undefined`, and `Object.prototype` is untouched. `console.decorated` is still `42`, so **the patching idiom the rule exists for still works**; it is now contained.

Pinned across `{}`, `[]`, a function, a string, `in` and `Object.keys`, plus that `Object.setPrototypeOf(console, x)` stays contained too.

## Other namespace objects, audited against their own specs

`console` is the **only WebIDL `namespace`** in `Jint/WebApi/`. Of the singleton globals, `crypto`, `crypto.subtle`, `performance`, `caches` and the storages already inherit from their interface prototype objects and are correct. The ECMAScript namespace objects (`Math`, `JSON`, `Reflect`, `Atomics`, `Temporal`) take `%Object.prototype%` correctly — ECMA-262 states no exception.

**`navigator` and `scheduler` sit directly on `%Object.prototype%` and are deliberately not changed.** They are interface *instances*, not namespaces; their specs require the **interface prototype object**, which has own members, so an empty object would match nothing in a browser either. Jint exposes no `Navigator`/`Scheduler` interface object (a documented simplification) and `%Object.prototype%` is the stand-in. They **do** share the containment hazard — `navigator.__proto__.foo = …` still reaches `Object.prototype` — but the correct fix is real interface prototype objects, which is a different change. Filed separately rather than copying the console rule where it does not apply.

## Cost: exactly zero

`new Engine(o => o.UseWebApis())` allocates **24,272.0 B before and after — delta 0 B** (1000 iterations after 200 warmup, stable to the decimal across a reboot). `console` is a `LazyPropertyDescriptor<Engine>` and `WebApiRegistrationTests.InstallsUnmaterializedLazyDescriptors` already pins it unmaterialized, so the constructor is never reached by an engine that does not touch `console`. First read costs **+112 B** — one `JsObject`.

## Verification

Pre-fix, with the tests in their final form: **2 failed / 39 passed**, both failures exactly the predicted ones (`… === Object.prototype` expected False but found True; `Object.prototype` gained `decorated`). Post-fix `Jint.Tests.Runtime.WebApi` is **2604/2604**.

Solution builds Release (exercising the `net462`/`netstandard2.x` gate), 0 errors. `Jint.Tests` 10502 (net10.0) / 7256 (net472), identical with `JINT_HOST_CONTRACT_VERIFICATION=1`. `Jint.Tests.PublicInterface` 2485 / 1899, verifying 2489 / 1903. **test262 102,495 passed, 0 failed.** WPT **422/422 before and after — no row moved**, so the exclusion table needs no edit and none of its files are touched. (No `console/` suite is vendored; the corpus that would have caught this is `idlharness`.)

## A finding surfaced by a test that was written, failed, and removed

A fifth test asserting that `RestoreGlobalSnapshot` reverts a `console.__proto__` patch **failed**, and it was removed because **the claim is false**: `Intrinsics._console` memoizes the instance, so a restore reverts the descriptor but hands back the *same* object.

That matters beyond this PR: `WebApiRegistration`'s own doc, `WebApiRegistrationTests.cs:97` and `StorageTests.cs:531` all say the object "is rebuilt" for the next cycle. It is not. Filed separately — not fixed here, since it is a snapshot-semantics question rather than a console one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
