### PR TITLE
Constraints: let the time-based ones take their clock from a TimeProvider

### DIFF
--- a/Jint.Tests.PublicInterface/HostConstraintClockTests.cs
+++ b/Jint.Tests.PublicInterface/HostConstraintClockTests.cs
@@ -1,0 +1,201 @@
+#if NET8_0_OR_GREATER
+
+using Jint.Constraints;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// Pins the clock seam the time-based execution constraints expose: <c>Options.Constraints.TimeProvider</c>
+/// for the constraint the engine registers from <see cref="ConstraintsOptionsExtensions.TimeoutInterval"/>,
+/// and <see cref="OperationDeadlineConstraint(TimeProvider)"/> for the one the host constructs itself.
+/// <para>
+/// These live in the project <b>without</b> <c>InternalsVisibleTo</c>, so everything here compiling at all
+/// is the guarantee that an embedder can reach it. That is the point of the seam being public rather than
+/// internal: a host that configures a timeout has exactly the same untestable wall clock Jint's own suite
+/// had, and #3232 is about ending that for both of them at once.
+/// </para>
+/// <para>
+/// Only <c>net8.0</c> and later. <c>TimeProvider</c> arrived in .NET 8, and reaching it from Jint's
+/// downlevel targets would mean a second runtime dependency on a package that has exactly one.
+/// </para>
+/// </summary>
+public class HostConstraintClockTests
+{
+    private static readonly TimeSpan Interval = TimeSpan.FromMilliseconds(500);
+
+    /// <summary>
+    /// A callee long enough to reach the interpreter's amortized constraint check (every 64 statements),
+    /// so a row that expects the timeout to be consulted is not merely hoping it was.
+    /// </summary>
+    private const string Source = """
+        function work() {
+            var total = 0;
+            for (var i = 0; i < 200; i++) {
+                total += i;
+            }
+            return total;
+        }
+        """;
+
+    [Fact]
+    public void ATimeoutIntervalIsMeasuredAgainstTheConfiguredClock()
+    {
+        var clock = new ManualClock();
+        var engine = new Engine(options =>
+        {
+            options.Constraints.TimeProvider = clock;
+            options.TimeoutInterval(Interval);
+        });
+        engine.Execute(Source);
+        var work = engine.GetValue("work");
+
+        // The clock has not moved, so no amount of real time can fail this entry...
+        Invoking(() => work.Call()).Should().NotThrow();
+
+        // ...and one tick short of the interval it is still inside its budget. The deadline is armed by
+        // the per-entry reset, so this is measured from the start of *this* entry.
+        clock.Advance(Interval - TimeSpan.FromTicks(1));
+        Invoking(() => work.Call()).Should().NotThrow(
+            "the deadline is re-armed on entry, so the interval has not elapsed within this entry");
+
+        // ...but an entry that begins with the clock already past its own deadline fails on its first
+        // check. Advancing the whole interval *after* the entry has started is what a wall-clock test can
+        // never do, so it could only ever assert the one-sided "at least this much elapsed".
+        var advancing = new AdvancingClock(Interval);
+        var advancingEngine = new Engine(options =>
+        {
+            options.Constraints.TimeProvider = advancing;
+            options.TimeoutInterval(Interval);
+        });
+        advancingEngine.Execute(Source);
+
+        Invoking(() => advancingEngine.GetValue("work").Call())
+            .Should().Throw<TimeoutException>("the clock passed the deadline while the entry was running");
+    }
+
+    [Fact]
+    public void TheClockMayBeConfiguredAfterTheIntervalItAppliesTo()
+    {
+        // The factory the extension method registers runs while the engine is being constructed, not when
+        // the interval was configured, so neither order silently drops the clock.
+        var clock = new ManualClock();
+        var options = new Options().TimeoutInterval(Interval);
+        options.Constraints.TimeProvider = clock;
+
+        var engine = new Engine(options);
+        engine.Execute(Source);
+        var work = engine.GetValue("work");
+
+        Invoking(() => work.Call()).Should().NotThrow();
+
+        var advancing = new AdvancingClock(Interval);
+        var lateOptions = new Options().TimeoutInterval(Interval);
+        lateOptions.Constraints.TimeProvider = advancing;
+        var lateEngine = new Engine(lateOptions);
+        lateEngine.Execute(Source);
+
+        Invoking(() => lateEngine.GetValue("work").Call()).Should().Throw<TimeoutException>();
+    }
+
+    [Fact]
+    public void TheDefaultClockIsTheSystemOneAndBehavesExactlyAsItAlwaysDid()
+    {
+        var options = new Options();
+        options.Constraints.TimeProvider.Should().BeSameAs(TimeProvider.System);
+
+        // Explicitly naming the system clock is the same engine as never naming one: TimeProvider's own
+        // base GetTimestamp/TimestampFrequency are Stopwatch's, and the constraint folds it away.
+        var engine = new Engine(o =>
+        {
+            o.Constraints.TimeProvider = TimeProvider.System;
+            o.TimeoutInterval(TimeSpan.FromSeconds(30));
+        });
+        engine.Execute(Source);
+
+        Invoking(() => engine.GetValue("work").Call()).Should().NotThrow();
+    }
+
+    [Fact]
+    public void AClockThatReportsNoTickRateIsRejectedWhereItIsSupplied()
+    {
+        // A zero frequency turns every interval into zero ticks, which would arm a deadline equal to the
+        // operation's own start and fail its first check. Named where the clock is handed over rather than
+        // surfacing later as a timeout nobody can explain.
+        Invoking(() => new Engine(o =>
+            {
+                o.Constraints.TimeProvider = new FrequencylessClock();
+                o.TimeoutInterval(Interval);
+            }))
+            .Should().Throw<ArgumentException>().WithMessage("*TimestampFrequency*");
+
+        Invoking(() => new OperationDeadlineConstraint(new FrequencylessClock()))
+            .Should().Throw<ArgumentException>().WithMessage("*TimestampFrequency*");
+    }
+
+    [Fact]
+    public void AnOperationDeadlineWithoutAClockIsTheOneItAlwaysWas()
+    {
+        // The parameterless constructor and an explicit null are the same constraint, so the overload is
+        // additive: nothing an embedder already wrote changes meaning.
+        foreach (var deadline in new[] { new OperationDeadlineConstraint(), new OperationDeadlineConstraint(null) })
+        {
+            var engine = new Engine(options => options.Constraint(deadline));
+            engine.Execute(Source);
+
+            deadline.Begin(TimeSpan.FromMinutes(10));
+            try
+            {
+                Invoking(() => engine.GetValue("work").Call()).Should().NotThrow();
+            }
+            finally
+            {
+                deadline.End();
+            }
+        }
+    }
+
+    /// <summary>
+    /// A clock the test moves itself. Reports <see cref="TimeSpan.TicksPerSecond"/> so that a tick of this
+    /// clock and a tick of a <see cref="TimeSpan"/> are the same unit.
+    /// </summary>
+    private sealed class ManualClock : TimeProvider
+    {
+        private long _timestamp;
+
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        public override long GetTimestamp() => _timestamp;
+
+        internal void Advance(TimeSpan amount) => _timestamp += amount.Ticks;
+    }
+
+    /// <summary>
+    /// A clock that moves on by <paramref name="step"/> every time it is read. An entry arms its deadline
+    /// from one reading and checks it against the next, so a step of a whole interval means every entry
+    /// provably outlives its own budget — "the interval elapsed while this entry was running", stated
+    /// exactly, which is the claim a wall-clock row can only approximate with a sleep and a skip.
+    /// </summary>
+    private sealed class AdvancingClock(TimeSpan step) : TimeProvider
+    {
+        private long _timestamp;
+
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        public override long GetTimestamp()
+        {
+            var now = _timestamp;
+            _timestamp += step.Ticks;
+            return now;
+        }
+    }
+
+    /// <summary>A clock violating <see cref="TimeProvider"/>'s own positive-frequency requirement.</summary>
+    private sealed class FrequencylessClock : TimeProvider
+    {
+        public override long TimestampFrequency => 0;
+
+        public override long GetTimestamp() => 0;
+    }
+}
+
+#endif

--- a/Jint.Tests.PublicInterface/HostResultLimitsTests.cs
+++ b/Jint.Tests.PublicInterface/HostResultLimitsTests.cs
@@ -13,11 +13,24 @@ public class HostResultLimitsTests
 
     /// <summary>
     /// The budget one host operation gets in <see cref="OperationDeadlineSpansEvaluationAndConversion"/>.
-    /// Nothing has to fit inside a <em>slice</em> of it: the only entry that must complete is a warm
-    /// four-hundred-statement evaluation, and the whole budget is its headroom.
     /// </summary>
+    /// <remarks>
+    /// On the target frameworks that have <c>TimeProvider</c> the row drives the constraint's clock itself,
+    /// so the number is arbitrary and nothing has to fit inside any part of it. On the downlevel leg it is
+    /// wall clock, and nothing has to fit inside a <em>slice</em> of it either: the only entry that must
+    /// complete is a warm four-hundred-statement evaluation, and the whole budget is its headroom.
+    /// </remarks>
     private static readonly TimeSpan OperationBudget = TimeSpan.FromMilliseconds(400);
 
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// One tick of <see cref="ManualClock"/>, which is what the deterministic leg of
+    /// <see cref="OperationDeadlineSpansEvaluationAndConversion"/> spends to cross the budget. The clock
+    /// reports <see cref="TimeSpan.TicksPerSecond"/>, so a constraint tick and a <see cref="TimeSpan"/>
+    /// tick are the same thing and the row can straddle the deadline exactly.
+    /// </summary>
+    private static readonly TimeSpan OneClockTick = TimeSpan.FromTicks(1);
+#else
     /// <summary>
     /// How far past <see cref="OperationBudget"/> the host sleeps, so that no timer granularity anywhere
     /// can leave time on a budget the test needs gone.
@@ -30,6 +43,7 @@ public class HostResultLimitsTests
     /// the past.
     /// </summary>
     private static readonly TimeSpan AttributionSlack = TimeSpan.FromMilliseconds(1);
+#endif
 
     /// <summary>
     /// A script whose evaluation <em>and</em> whose getter each run well past the interpreter's amortized
@@ -394,6 +408,67 @@ public class HostResultLimitsTests
         new JsonSerializer(engine).Serialize(value).AsString().Should().Be("""{"value":42}""");
     }
 
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// Evaluating a script and converting its result are two separate top-level entries, and the engine
+    /// rewinds every ordinary constraint at each of those boundaries. This one declines, so what the
+    /// evaluation entry left of the operation's budget is what the conversion entry gets.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The row drives the constraint's own clock, which is what lets it assert the thing it means rather
+    /// than a one-sided approximation of it. It used to spend the budget with <c>Thread.Sleep</c> and could
+    /// therefore make only two claims — "the evaluation did not throw" (skipped when a stalled runner made
+    /// it throw anyway) and "the conversion did throw" — because how much of a wall-clock budget an entry
+    /// consumes is a fact about the machine. That is exactly how it failed a macOS leg of a workers-only
+    /// change (#3221), and #3232 is the issue that removed the limitation.
+    /// </para>
+    /// <para>
+    /// Everything except the clock is the shipped path: a real <see cref="OperationDeadlineConstraint"/>
+    /// registered on a real <see cref="Engine"/>, the engine's own per-entry reset running at both
+    /// boundaries, and the constraint's own <c>Check</c> — reached from the interpreter's amortized lane
+    /// inside the getter — deciding to throw. The budget is now straddled to the tick: one tick short of it
+    /// a fresh entry still completes, and the tick that exhausts it fails the next one. Neither half was
+    /// expressible before.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void OperationDeadlineSpansEvaluationAndConversion()
+    {
+        var clock = new ManualClock();
+        var deadline = new OperationDeadlineConstraint(clock);
+        using var engine = new Engine(options => options.Constraint(deadline));
+
+        // Warm parsing, the getter's call path and ConvertResult. Nothing depends on it any more — the
+        // clock does not move on its own — but it keeps the row's shape comparable with the downlevel leg.
+        engine.Advanced.ConvertResult(engine.Evaluate(CheckedEvaluationSource));
+
+        deadline.Begin(OperationBudget);
+        try
+        {
+            // No time has passed, so this entry provably runs inside the budget rather than probably.
+            var value = engine.Evaluate(CheckedEvaluationSource);
+
+            // One tick short of the budget: the entry boundary in between refunded nothing, and there is
+            // still something left, so a fresh top-level entry completes.
+            clock.Advance(OperationBudget - OneClockTick);
+            engine.Advanced.ConvertResult(value).Should().NotBeNull(
+                "the operation still has a tick of its budget left");
+
+            // ...and the single tick that exhausts it fails the very next one. The conversion is a fresh
+            // top-level entry, and the engine's per-entry reset must not refund it the operation's budget.
+            clock.Advance(OneClockTick);
+            Invoking(() => engine.Advanced.ConvertResult(value))
+                .Should().ThrowExactly<TimeoutException>();
+        }
+        finally
+        {
+            deadline.End();
+        }
+
+        engine.Evaluate("1 + 1").AsNumber().Should().Be(2);
+    }
+#else
     [Fact]
     public void OperationDeadlineSpansEvaluationAndConversion()
     {
@@ -402,13 +477,15 @@ public class HostResultLimitsTests
         // what the evaluation entry left of the operation's budget is what the conversion entry gets —
         // here, nothing.
         //
-        // The budget is spent on the host's own clock rather than by a pause inside the script, and that
-        // is the whole point of the shape. A script pause long enough to exhaust the budget would fail
-        // the entry that ran it, so exhausting it from inside the engine means splitting the budget into
-        // slices and requiring the evaluation to fit in one — which is a claim about the runner, and is
-        // exactly how this row failed a macOS leg of a workers-only change (#3221). The budget is wall
-        // clock from Begin, host time counts against it just as engine time does, and Thread.Sleep only
-        // ever overshoots: no machine is slow enough to leave time on it.
+        // This is the leg without TimeProvider, so the budget is spent on the host's own clock rather
+        // than by a pause inside the script, and that is the whole point of the shape. A script pause
+        // long enough to exhaust the budget would fail the entry that ran it, so exhausting it from
+        // inside the engine means splitting the budget into slices and requiring the evaluation to fit
+        // in one — which is a claim about the runner, and is exactly how this row failed a macOS leg of
+        // a workers-only change (#3221). The budget is wall clock from Begin, host time counts against
+        // it just as engine time does, and Thread.Sleep only ever overshoots: no machine is slow enough
+        // to leave time on it. The net8.0-and-later leg above drives the clock instead and needs none
+        // of this.
         var deadline = new OperationDeadlineConstraint();
         using var engine = new Engine(options => options.Constraint(deadline));
 
@@ -446,6 +523,7 @@ public class HostResultLimitsTests
 
         engine.Evaluate("1 + 1").AsNumber().Should().Be(2);
     }
+#endif
 
     [Fact]
     public void ExplicitMemoryOperationSpansEvaluationAndConversion()
@@ -563,4 +641,22 @@ public class HostResultLimitsTests
         {
         }
     }
+
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// A clock the test moves itself, so that "the operation's budget elapsed" is something the row states
+    /// rather than something it waits for. Reports <see cref="TimeSpan.TicksPerSecond"/> so that a tick of
+    /// this clock and a tick of a <see cref="TimeSpan"/> are the same unit.
+    /// </summary>
+    private sealed class ManualClock : TimeProvider
+    {
+        private long _timestamp;
+
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        public override long GetTimestamp() => _timestamp;
+
+        internal void Advance(TimeSpan amount) => _timestamp += amount.Ticks;
+    }
+#endif
 }

--- a/Jint/Constraints/ConstraintClock.cs
+++ b/Jint/Constraints/ConstraintClock.cs
@@ -1,0 +1,78 @@
+using System.Diagnostics;
+using Jint.Runtime;
+
+namespace Jint.Constraints;
+
+/// <summary>
+/// The timestamp arithmetic the time-based constraints share, and — on the target frameworks that have
+/// <c>TimeProvider</c> — the one place that decides what a host-supplied clock resolves to.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A time-based constraint is checked on the interpreter's amortized lane, so its clock read is on a path
+/// <c>AGENTS.md</c> says must not get measurably slower. <c>Resolve</c> is what keeps that promise:
+/// <c>TimeProvider.System</c> — and no provider at all — fold to <see langword="null"/>, and a
+/// <see langword="null"/> field is the constraint's signal to read <see cref="Stopwatch.GetTimestamp"/>
+/// directly, exactly as it did before the seam existed. <c>TimeProvider</c>'s own base implementations of
+/// <c>GetTimestamp()</c> and <c>TimestampFrequency</c> <em>are</em> <see cref="Stopwatch.GetTimestamp"/>
+/// and <see cref="Stopwatch.Frequency"/>, so the fold changes no answer — it only removes the
+/// indirection from the case nobody asked to move.
+/// </para>
+/// <para>
+/// The provider half is <c>net8.0</c>-and-later. <c>TimeProvider</c> arrived in .NET 8, and Jint's
+/// downlevel targets could only reach it through <c>Microsoft.Bcl.TimeProvider</c> — a second runtime
+/// dependency on a package that has exactly one, in exchange for a seam whose consumer is a test. The
+/// constraints therefore compile without any of it on <c>net462</c>, <c>netstandard2.0</c> and
+/// <c>netstandard2.1</c>: no field, no branch, the same instructions they emitted before.
+/// </para>
+/// </remarks>
+internal static class ConstraintClock
+{
+    /// <summary>
+    /// Converts a budget to timestamp ticks on <paramref name="frequency"/>'s scale, clamped so that adding
+    /// it to a timestamp cannot overflow. Without the clamp a large budget wraps <see cref="long"/> and
+    /// lands the deadline in the <em>past</em>, failing the operation immediately — the opposite of what was
+    /// asked for.
+    /// </summary>
+    internal static long ToTimestampTicks(TimeSpan budget, long frequency)
+    {
+        var ticks = budget.Ticks * ((double) frequency / TimeSpan.TicksPerSecond);
+        return ticks >= long.MaxValue / 2.0 ? long.MaxValue / 2 : (long) ticks;
+    }
+
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// The provider a constraint should store, or <see langword="null"/> for "read
+    /// <see cref="Stopwatch.GetTimestamp"/> directly".
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="provider"/> reports a non-positive <see cref="TimeProvider.TimestampFrequency"/>.
+    /// Rejected here rather than divided by later: a zero frequency turns every interval into zero ticks, so
+    /// the constraint would arm a deadline equal to its own start and fail the first check of every
+    /// execution. A named error where the clock is supplied beats a timeout nobody can explain.
+    /// </exception>
+    internal static TimeProvider? Resolve(TimeProvider? provider)
+    {
+        if (provider is null || ReferenceEquals(provider, TimeProvider.System))
+        {
+            return null;
+        }
+
+        if (provider.TimestampFrequency <= 0)
+        {
+            Throw.ArgumentException(
+                "A TimeProvider used by an execution constraint must report a positive TimestampFrequency.",
+                nameof(provider));
+        }
+
+        return provider;
+    }
+
+    /// <summary>
+    /// The tick frequency the timestamps of <paramref name="provider"/> are expressed in, for a provider
+    /// already put through <see cref="Resolve"/>.
+    /// </summary>
+    internal static long FrequencyOf(TimeProvider? provider)
+        => provider is null ? Stopwatch.Frequency : provider.TimestampFrequency;
+#endif
+}

--- a/Jint/Constraints/ConstraintsOptionsExtensions.cs
+++ b/Jint/Constraints/ConstraintsOptionsExtensions.cs
@@ -101,7 +101,16 @@ public static class ConstraintsOptionsExtensions
 
         if (timeoutInterval > TimeSpan.Zero && timeoutInterval < TimeSpan.MaxValue)
         {
+#if NET8_0_OR_GREATER
+            // The group rather than a captured clock: the factory runs while the engine is being
+            // constructed, so a TimeProvider assigned after this call still reaches the constraint and
+            // configuration order does not matter. TimeProvider is a .NET 8 type, so the downlevel
+            // targets register the constraint exactly as they always did.
+            var constraints = options.Constraints;
+            options.Constraint(() => new TimeConstraint(timeoutInterval, constraints.TimeProvider));
+#else
             options.Constraint(() => new TimeConstraint(timeoutInterval));
+#endif
         }
         return options;
     }

--- a/Jint/Constraints/OperationDeadlineConstraint.cs
+++ b/Jint/Constraints/OperationDeadlineConstraint.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using Jint.Runtime;
 
@@ -57,10 +58,19 @@ namespace Jint.Constraints;
 /// </para>
 /// </summary>
 /// <remarks>
+/// <para>
 /// The deadline is compared inline against <see cref="Stopwatch.GetTimestamp"/> rather than observed
 /// through a timer, for the same reason <c>TimeConstraint</c> is: a timer only makes elapsed time visible
 /// once its callback has been scheduled, so detection would be bounded by the thread pool rather than by
 /// the budget.
+/// </para>
+/// <para>
+/// On <c>net8.0</c> and later the host may hand the instance a <c>TimeProvider</c> instead, which then
+/// answers every timestamp the budget is measured against. The constructor that takes one is the whole
+/// seam: the instance is the host's to create, so the clock is the host's to supply, and nothing about the
+/// engine-registered <c>TimeoutInterval</c> constraint is involved. See <c>ConstraintClock</c> for why
+/// <c>TimeProvider.System</c> costs nothing.
+/// </para>
 /// </remarks>
 public sealed class OperationDeadlineConstraint : Constraint
 {
@@ -70,11 +80,56 @@ public sealed class OperationDeadlineConstraint : Constraint
     // not-started sentinel, and is also what a non-positive budget arms.
     private const long Disarmed = 0;
 
-    // Stopwatch timestamp the current operation must not pass, or Disarmed.
+#if NET8_0_OR_GREATER
+    // Null unless the host named a clock, which is what keeps Check() and Begin() on the direct
+    // Stopwatch read they have always used.
+    private readonly TimeProvider? _timeProvider;
+
+    // Stopwatch.Frequency unless _timeProvider is non-null; resolved once so arming a budget stays
+    // arithmetic on a field.
+    private readonly long _frequency;
+#endif
+
+    // Timestamp the current operation must not pass, on whichever clock this constraint reads, or Disarmed.
     private long _deadline;
 
     private CancellationToken _cancellationToken;
     private object? _scopeOwner;
+
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// Creates a constraint measuring its budget against the system's monotonic clock
+    /// (<see cref="Stopwatch.GetTimestamp"/>).
+    /// </summary>
+    public OperationDeadlineConstraint() : this(timeProvider: null)
+    {
+    }
+
+    /// <summary>
+    /// Creates a constraint measuring its budget against <paramref name="timeProvider"/>.
+    /// </summary>
+    /// <param name="timeProvider">
+    /// The clock the budget is measured against. <see langword="null"/> and
+    /// <see cref="TimeProvider.System"/> both mean the system's monotonic clock, and cost exactly what
+    /// they did before this overload existed. Only <see cref="TimeProvider.GetTimestamp"/> and
+    /// <see cref="TimeProvider.TimestampFrequency"/> are ever called — never
+    /// <see cref="TimeProvider.CreateTimer"/>, because this constraint schedules nothing and only ever
+    /// reads the clock from the thread driving the engine.
+    /// </param>
+    /// <remarks>
+    /// The point of the overload is that a host can test what its own budget does without waiting for it:
+    /// a fake clock makes "the operation ran out of time between these two entries" an exact statement
+    /// rather than a race against a loaded machine.
+    /// </remarks>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="timeProvider"/> reports a non-positive <see cref="TimeProvider.TimestampFrequency"/>.
+    /// </exception>
+    public OperationDeadlineConstraint(TimeProvider? timeProvider)
+    {
+        _timeProvider = ConstraintClock.Resolve(timeProvider);
+        _frequency = ConstraintClock.FrequencyOf(_timeProvider);
+    }
+#endif
 
     /// <summary>
     /// A deadline and a cancellation token are both external state that <see cref="Check"/> only reads and
@@ -120,7 +175,7 @@ public sealed class OperationDeadlineConstraint : Constraint
             return;
         }
 
-        var deadline = Stopwatch.GetTimestamp() + ToStopwatchTicks(budget);
+        var deadline = GetTimestamp() + ToTimestampTicks(budget);
 
         // Disarmed is the not-armed sentinel, so never store it as a real deadline
         _deadline = deadline == Disarmed ? Disarmed + 1 : deadline;
@@ -186,7 +241,7 @@ public sealed class OperationDeadlineConstraint : Constraint
         }
 
         var deadline = _deadline;
-        if (deadline != 0 && Stopwatch.GetTimestamp() >= deadline)
+        if (deadline != 0 && GetTimestamp() >= deadline)
         {
             Throw.TimeoutException("The operation's time budget elapsed.");
         }
@@ -206,14 +261,24 @@ public sealed class OperationDeadlineConstraint : Constraint
     {
     }
 
-    /// <summary>
-    /// Converts a budget to <see cref="Stopwatch"/> ticks, clamped so that adding it to a timestamp cannot
-    /// overflow. Without the clamp a large budget wraps <see cref="long"/> and lands the deadline in the
-    /// <em>past</em>, failing the operation immediately — the opposite of what was asked for.
-    /// </summary>
-    private static long ToStopwatchTicks(TimeSpan budget)
+#if NET8_0_OR_GREATER
+    // Converts a budget to ticks on this constraint's own clock, clamped so that adding it to a timestamp
+    // cannot overflow. See ConstraintClock.ToTimestampTicks.
+    private long ToTimestampTicks(TimeSpan budget) => ConstraintClock.ToTimestampTicks(budget, _frequency);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private long GetTimestamp()
     {
-        var ticks = budget.Ticks * ((double) Stopwatch.Frequency / TimeSpan.TicksPerSecond);
-        return ticks >= long.MaxValue / 2.0 ? long.MaxValue / 2 : (long) ticks;
+        var provider = _timeProvider;
+        return provider is null ? Stopwatch.GetTimestamp() : provider.GetTimestamp();
     }
+#else
+    // Converts a budget to ticks on this constraint's own clock, clamped so that adding it to a timestamp
+    // cannot overflow. See ConstraintClock.ToTimestampTicks.
+    private static long ToTimestampTicks(TimeSpan budget)
+        => ConstraintClock.ToTimestampTicks(budget, Stopwatch.Frequency);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static long GetTimestamp() => Stopwatch.GetTimestamp();
+#endif
 }

--- a/Jint/Constraints/TimeConstraint.cs
+++ b/Jint/Constraints/TimeConstraint.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using Jint.Runtime;
 
 namespace Jint.Constraints;
@@ -8,6 +9,7 @@ namespace Jint.Constraints;
 /// constraint is reset.
 /// </summary>
 /// <remarks>
+/// <para>
 /// The deadline is compared inline rather than observed through a <c>CancellationTokenSource</c>
 /// timer. A timer only makes the elapsed time visible once its callback has run on the thread pool,
 /// so detection was bounded by scheduling rather than by the timeout itself — the same reason the
@@ -15,23 +17,48 @@ namespace Jint.Constraints;
 /// <see cref="Stopwatch.GetTimestamp"/> per check, which the amortized check cadence already bounds,
 /// and in exchange every execution stops allocating a token source and registering (then cancelling)
 /// a timer.
+/// </para>
+/// <para>
+/// The clock is <see cref="Stopwatch"/> unless <c>Options.Constraints.TimeProvider</c> named another one,
+/// in which case that provider answers every timestamp this constraint reads. The field is
+/// <see langword="null"/> for a default engine — see <c>ConstraintClock.Resolve</c> for the fold and
+/// for why the branch it costs is the shape this seam had to take.
+/// </para>
 /// </remarks>
 internal sealed class TimeConstraint : Constraint
 {
     private readonly long _timeoutTicks;
 
-    // Stopwatch timestamp the current execution must not pass; 0 means "no execution has started",
-    // which mirrors the previous null-CancellationTokenSource state where Check never failed.
+#if NET8_0_OR_GREATER
+    // Null in every engine that did not name a clock, which is what keeps Check() on the direct
+    // Stopwatch read it has always used.
+    private readonly TimeProvider? _timeProvider;
+#endif
+
+    // Timestamp the current execution must not pass, on whichever clock this constraint reads; 0 means
+    // "no execution has started", which mirrors the previous null-CancellationTokenSource state where
+    // Check never failed.
     private long _deadline;
 
+#if NET8_0_OR_GREATER
+    internal TimeConstraint(TimeSpan timeout, TimeProvider? timeProvider)
+    {
+        _timeProvider = ConstraintClock.Resolve(timeProvider);
+
+        // Options.TimeoutInterval only constructs this for 0 < timeout < TimeSpan.MaxValue. The clamp
+        // inside keeps `now + _timeoutTicks` from overflowing for very large intervals, which would
+        // otherwise wrap to a deadline already in the past.
+        _timeoutTicks = ConstraintClock.ToTimestampTicks(timeout, ConstraintClock.FrequencyOf(_timeProvider));
+    }
+#else
     internal TimeConstraint(TimeSpan timeout)
     {
-        // Options.TimeoutInterval only constructs this for 0 < timeout < TimeSpan.MaxValue. The
-        // clamp keeps `now + _timeoutTicks` from overflowing for very large intervals, which would
+        // Options.TimeoutInterval only constructs this for 0 < timeout < TimeSpan.MaxValue. The clamp
+        // inside keeps `now + _timeoutTicks` from overflowing for very large intervals, which would
         // otherwise wrap to a deadline already in the past.
-        var ticks = timeout.Ticks * ((double) Stopwatch.Frequency / TimeSpan.TicksPerSecond);
-        _timeoutTicks = ticks >= long.MaxValue / 2.0 ? long.MaxValue / 2 : (long) ticks;
+        _timeoutTicks = ConstraintClock.ToTimestampTicks(timeout, Stopwatch.Frequency);
     }
+#endif
 
     /// <summary>
     /// A deadline is external state that <see cref="Check"/> only reads, and a clock only advances, so
@@ -42,7 +69,7 @@ internal sealed class TimeConstraint : Constraint
     public override void Check()
     {
         var deadline = _deadline;
-        if (deadline != 0 && Stopwatch.GetTimestamp() >= deadline)
+        if (deadline != 0 && GetTimestamp() >= deadline)
         {
             Throw.TimeoutException();
         }
@@ -50,9 +77,21 @@ internal sealed class TimeConstraint : Constraint
 
     public override void Reset()
     {
-        var deadline = Stopwatch.GetTimestamp() + _timeoutTicks;
+        var deadline = GetTimestamp() + _timeoutTicks;
 
         // 0 is the not-started sentinel, so never store it as a real deadline
         _deadline = deadline == 0 ? 1 : deadline;
     }
+
+#if NET8_0_OR_GREATER
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private long GetTimestamp()
+    {
+        var provider = _timeProvider;
+        return provider is null ? Stopwatch.GetTimestamp() : provider.GetTimestamp();
+    }
+#else
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static long GetTimestamp() => Stopwatch.GetTimestamp();
+#endif
 }

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -1160,6 +1160,34 @@ public partial class Options
         /// </summary>
         public int MaxAtomicsPauseIterations { get; set; } = 10_000;
 
+#if NET8_0_OR_GREATER
+        /// <summary>
+        /// The clock <see cref="ConstraintsOptionsExtensions.TimeoutInterval"/>'s constraint measures against.
+        /// Defaults to <see cref="TimeProvider.System"/>; a fake one makes a timeout test exact instead of a
+        /// race against the machine it runs on.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Only <see cref="TimeProvider.GetTimestamp"/> and <see cref="TimeProvider.TimestampFrequency"/> are
+        /// ever called. <see cref="TimeProvider.CreateTimer"/> deliberately is not: the constraint schedules
+        /// nothing, it compares an inline deadline on the thread already running the script, which is what
+        /// bounds detection by the timeout rather than by the thread pool.
+        /// </para>
+        /// <para>
+        /// Read when the engine builds its constraints, so it may be set in any order relative to
+        /// <see cref="ConstraintsOptionsExtensions.TimeoutInterval"/>; assigning it afterwards only reaches
+        /// engines built later. Leaving it at <see cref="TimeProvider.System"/> costs exactly what it cost
+        /// before this property existed — see <c>ConstraintClock</c> for the fold that makes that true.
+        /// </para>
+        /// <para>
+        /// It governs the constraint the engine registers. <see cref="Constraints.OperationDeadlineConstraint"/>
+        /// is created by the host rather than by the engine, so it takes its clock through its own
+        /// constructor instead.
+        /// </para>
+        /// </remarks>
+        public TimeProvider TimeProvider { get; set; } = TimeProvider.System;
+#endif
+
         internal ConstraintOptions Clone()
         {
             var clone = (ConstraintOptions) MemberwiseClone();


### PR DESCRIPTION
Closes #3232.

`TimerQueue` takes its clock from a `TimeProvider`, which is what lets #3216's timer tests drive it with a `ManualClock`. `TimeConstraint` and `OperationDeadlineConstraint` read `Stopwatch.GetTimestamp()` directly, so nothing can move *their* clock — every test of them is a real-time test whose best claim is one-sided plus a skip. That is the root of a recurring flake family: #3123, #3154, #3221, and a sighting in #3230.

## The measurement, and why it is not a BenchmarkDotNet run

A paired A/B is **structurally incapable** of resolving this. AGENTS.md calibrates `measure-paired.ps1` at a ~1–2.5% detection floor; the effect is **~0.02%**. A run would have produced a "no change" that is uninformative in both directions. So the resolvable quantity was measured directly and converted.

**Per-check delta** — one variant per process so the `foreach (c in _amortizedConstraints) c.Check()` site stays monomorphic as it is in a real engine, 1M calls per sample, 41 samples, min reported, six rounds across two sessions:

| shape | ns/check, min per round |
| --- | --- |
| `direct` — today | 17.68 / 18.84 / 17.69 / *20.17\** / 18.66 / 18.62 |
| `hybrid` — shipped | 17.63 / 18.72 / 17.70 / 19.34 / 18.93 / 18.77 |
| `always` — rejected | 18.38 / 18.44 / 17.72 / 19.04 / 19.13 / 18.70 |

\* contaminated (p90 50 ns). Per-round `hybrid − direct`: −0.05, −0.12, +0.00, (−0.84), +0.26, +0.15 → **|Δ| ≤ 0.26 ns per check.**

**JIT codegen**, read both ways and confirmed against the *shipped* `TimeConstraint:Check` dumped out of `Jint.Repl` — it matches the micro-benchmark instruction for instruction. The entire default-path delta:

```
mov   rcx, gword ptr [rcx+0x08]   ; _timeProvider, same cache line as _deadline
test  rcx, rcx
jne   ...                          ; never taken by default
```

plus a `push rsi`/`pop rsi` pair. 74 → 99 bytes, three instructions, in the shadow of an ~18 ns `QueryPerformanceCounter`.

**Converted to a row**: measured **exactly 15,625** amortized `Check()` calls per evaluation of `ConstrainedExecutionBenchmark`'s workload (= 1,000,000 / 64), and the *whole* amortized-timeout lane costs 0.47–0.53 ms of a ~20.4 ms evaluation (2.37–2.64%).

So `≤0.26 ns × 15,625 = ≤4.1 µs` ⇒ **≤0.02% of the most check-dense row in the suite, and ≤0.8% of what the timeout lane already costs it.** On `net462`/`netstandard2.x` the field and branch do not exist at all.

## Public, with the fast path resolved once

`Options.Constraints.TimeProvider` and an `OperationDeadlineConstraint(TimeProvider)` overload, both `net8.0`+.

**Internal-only was rejected because it cannot do the job.** The one-sided rows live in `Jint.Tests.PublicInterface` — the one project *without* `InternalsVisibleTo` — so an internal seam could not have fixed the test that motivates the issue without moving it out of the project whose entire purpose is proving third-party reachability. And the problem is not Jint's alone: every embedder configuring `TimeoutInterval` has the same untestable wall clock.

Also rejected: **always virtual through `TimeProvider.System`** (measured essentially free, but needs `Microsoft.Bcl.TimeProvider` downlevel — a second runtime dependency on a project that has exactly one), and **a Jint-owned all-TFM clock abstraction** (mints a public duplicate of a BCL concept and costs the downlevel targets a branch they currently do not pay).

The issue's suggested `TimeProvider.System` fast-path check is what shipped — just resolved **once** in `ConstraintClock.Resolve` into a null field rather than compared per check. Cheaper, and it makes "no provider" and "the system provider" the same object state.

## The test that motivated it, now deterministic

`HostResultLimitsTests.OperationDeadlineSpansEvaluationAndConversion`.

**Before:** spent the budget with a 500 ms `Thread.Sleep` and could make only two claims — *"the evaluation did not throw"*, wrapped in `Assert.SkipWhen` because a stalled runner legitimately makes it throw, and *"the conversion did throw"*. How much of a wall-clock budget an entry consumes is a fact about the machine, which is exactly how it failed a macOS leg of a workers-only change.

**After:** it straddles the budget **to the tick** — one tick short, a fresh entry still completes; the single tick that exhausts it fails the next one. No sleep, no skip, and the row goes from 247 ms to microseconds. **Neither half was expressible before.**

Everything except the clock is the shipped path: real constraint, real engine, the engine's own per-entry reset at both boundaries, and the constraint's own `Check` reached from the interpreter's amortized lane inside the getter. The `net472` leg keeps the old row.

Both halves confirmed **by mutation**: arming `Begin` off the seam → *"Expected TimeoutException, but no exception was thrown"*; arming the deadline one tick early → the first half fails instead.

## No behaviour changed

Same exception types and messages (`Throw.TimeoutException` calls untouched), same firing condition (`deadline != 0 && now >= deadline`), same `IsAmortizable`, same no-op `Reset()` on the operation deadline. The interval→ticks arithmetic and its overflow clamp moved to `ConstraintClock.ToTimestampTicks` **unaltered**. A default engine resolves to a null provider and reads `Stopwatch.GetTimestamp()`/`Stopwatch.Frequency` — the prior values exactly.

`ConstraintsOptionsExtensions`' factory reads the options group at engine-construction time, so configuration order does not matter; `HostConstraintClockTests` pins that along with the clock being honoured, `TimeProvider.System` behaving as the default, a zero-frequency clock being rejected, and `OperationDeadlineConstraint()` ≡ `(null)`.

## Verification

`Jint.Tests` 10498 (net10.0) / 7256 (net472); `Jint.Tests.PublicInterface` 2490 / 1899; both repeated with `JINT_HOST_CONTRACT_VERIFICATION=1` (2494 / 1903). Solution builds Release on all five TFMs.

**test262, both runs on this machine**: this change 102,495 passed / 189 skipped; `upstream/main` baseline with the files set aside and the tree verified pristine, 102,495 / 189. **Zero drift.**

## Left undone

- **`AtomicsWaiterDeadlines`**, which the issue also names — it is core on all TFMs so the `net8`-gated seam does not reach it, and its natural clock is `Options.WebApi.Timers.TimeProvider`. Worth a follow-up once that area settles.
- **The remaining one-sided rows** — two in `HostCallLoopConstraintTests` still carry `Assert.SkipWhen`. The seam makes them fixable and `HostConstraintClockTests` demonstrates the technique; converting them is a self-contained follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
