### PR TITLE
Drains: the admission window is not the pump's, and the guard for it would be the wrong one

### DIFF
--- a/.github/THREAT_MODEL.md
+++ b/.github/THREAT_MODEL.md
@@ -622,12 +622,19 @@ incorrect authorization context, cross-request disclosure, crashes, or hangs.
   unwrap or import, or a host thread is parked on `Engine.Advanced.WaitForScheduledWork` or its
   asynchronous form; Jint yields and transfers the reserved engine one callback turn at a time
   without admitting unrelated public callers.
-- How narrowly a window admits depends on whether an operation token is in force under it. A window
-  opened under one — a host call inside a running evaluation, an outstanding async engine API —
-  admits only callbacks issued under that same operation. A window opened where none is in force is
-  anonymous, and admits any callback this engine ever authorized, including one whose operation has
-  long since ended: that is the case at a top-level blocking drain and at a top-level park. A pump
-  reached from inside a running evaluation opens no window at all and refuses.
+- How narrowly a window admits is decided by whether an operation token is in force under it, never by
+  where the frame sits on the stack. A window opened under one — a host call that was handed a callback,
+  an outstanding async engine API — admits only callbacks issued under that same operation. A window
+  opened where none is in force is anonymous, and admits any callback this engine ever authorized,
+  including one whose operation ended long ago. A blocking drain therefore opens a window wherever it
+  runs, nested inside a running evaluation included, and it is anonymous exactly when the enclosing entry
+  has not yet handed a callback to a host call. That is deliberate rather than an oversight, and a pump is
+  deliberately not the same case: a pump executes no script, so a callback admitted there would be the only
+  script interleaved into somebody else's evaluation, whereas a drain runs queued jobs on every iteration
+  whether one is admitted or not. Note also that "top level" and "the frame that claimed the engine" are
+  different questions here — `Engine.Modules.Import` claims the engine before its own drain begins, so a
+  blocking import on an otherwise idle engine is one of these windows on exactly these terms. A pump reached from inside a running evaluation opens
+  no window at all and refuses.
 - Background Task and module completions only enqueue work; an owning host turn drains it.
 
 **Missing or residual mitigation.**
@@ -650,6 +657,11 @@ incorrect authorization context, cross-request disclosure, crashes, or hangs.
 - `WaitForScheduledWork`'s timeout bounds the idle wait, not the call. An admitted callback holds
   the engine and the park cannot return until it finishes, so a host budgeting a frame can be handed
   control back arbitrarily later by a callback of its own making.
+- Script can reach a blocking drain on its own — a module's top-level `await using` whose disposal is
+  asynchronous — so which frames open an admission window is not entirely the host's choice. What a window
+  admits is unchanged by that: only a callback this engine authorized, dispatched from another thread by
+  something outside the engine. Script gains no new capability, only influence over the moment an
+  already-dispatched callback takes its turn.
 - A host can still share projected CLR objects across otherwise separate engines.
 
 **Required host action.** Give an engine exclusive ownership for each complete operation and

--- a/Jint.Tests.PublicInterface/HostDrainAdmissionTests.cs
+++ b/Jint.Tests.PublicInterface/HostDrainAdmissionTests.cs
@@ -1,0 +1,208 @@
+#nullable enable
+
+using Jint.Native;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// Which authorized cross-thread callbacks a <em>blocking drain</em> admits, from the outside. README's
+/// Thread-safety section names the drain as one of the engine's callback-admission windows; these pin the
+/// two things about it that a reader comparing it with the pump would reasonably expect to be otherwise,
+/// and that a change made for symmetry would silently take away (sebastienros/jint#3262).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The drain opens its window unconditionally — nested inside a running evaluation, and inside
+/// <see cref="Engine.ModuleOperations.Import(string)"/>, which claims the engine before the drain re-enters
+/// and so is <em>not</em> a claiming scope even on a wholly idle engine. Keying the window on the claiming
+/// scope, the way a park on the pump must be keyed, would therefore refuse callbacks at a documented
+/// top-level window rather than only at a nested frame. The reason the two frames differ is that a park
+/// runs no script, so a callback admitted there would be the only script interleaved into somebody else's
+/// evaluation, whereas a drain runs queued jobs on every iteration whether one is admitted or not.
+/// </para>
+/// <para>
+/// Every test here arms its prober from <em>inside</em> the drain and ends the drain from the prober, so
+/// the window provably covers every attempt whatever the machine does: what is measured is never a race
+/// between "the drain has started" and "the callback was dispatched". A refusal fails the assertion rather
+/// than hanging, because a refused attempt still counts down to the one that releases the drain.
+/// </para>
+/// </remarks>
+public class HostDrainAdmissionTests
+{
+    /// <summary>
+    /// A wedge ceiling, never an assertion: nothing here waits it out on a healthy run.
+    /// </summary>
+    private static readonly TimeSpan Ceiling = TestBudgets.WedgeCeiling;
+
+    private const string ConcurrentUseMessage =
+        "This Engine is already in use by another thread or has an asynchronous operation in progress.";
+
+    /// <summary>
+    /// Invokes a converted engine callback from a thread of its own, a fixed number of times, and records
+    /// how each attempt ended. It is armed from inside the frame under test and, once its <em>last</em>
+    /// attempt has returned, completes <see cref="Finished"/> — which is the only thing the frame under
+    /// test is waiting for, so the window cannot close while an attempt is outstanding.
+    /// </summary>
+    private sealed class CallbackProber
+    {
+        private readonly ManualResetEventSlim _armed = new(false);
+
+        public int Admitted;
+        public int Refused;
+        public int Attempts;
+        public string? UnexpectedFailure;
+
+        public readonly TaskCompletionSource<int> Finished = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public CallbackProber(Func<Func<int>> callback, int attempts)
+        {
+            var thread = new Thread(() =>
+            {
+                _armed.Wait();
+
+                for (var i = 0; i < attempts; i++)
+                {
+                    Interlocked.Increment(ref Attempts);
+                    try
+                    {
+                        callback()();
+                        Interlocked.Increment(ref Admitted);
+                    }
+                    catch (InvalidOperationException e) when (e.Message.Contains(ConcurrentUseMessage, StringComparison.Ordinal))
+                    {
+                        Interlocked.Increment(ref Refused);
+                    }
+                    catch (Exception e)
+                    {
+                        UnexpectedFailure ??= e.GetType().Name + ": " + e.Message;
+                    }
+                }
+
+                Finished.TrySetResult(1);
+            })
+            {
+                IsBackground = true,
+            };
+
+            thread.Start();
+        }
+
+        public void Arm() => _armed.Set();
+
+        public string Describe() =>
+            $"admitted={Admitted} refused={Refused} attempts={Attempts} unexpected={UnexpectedFailure ?? "none"}";
+    }
+
+    private const int Attempts = 4;
+
+    /// <summary>
+    /// Hands a callback out under an evaluation that then ends, so what is dispatched later is authorized
+    /// but belongs to no operation still in force — the case an anonymous window admits and an
+    /// operation-scoped one does not.
+    /// </summary>
+    private static Func<Func<int>> StashACallbackFromAnEndedEvaluation(Engine engine)
+    {
+        Func<int>? stashed = null;
+        engine.SetValue("stash", new Action<Func<int>>(callback => stashed = callback));
+        engine.Execute("stash(() => 42);");
+        return () => stashed!;
+    }
+
+    /// <summary>
+    /// A blocking <c>Modules.Import</c> is one of the windows README enumerates, and it is reached here on
+    /// an otherwise idle engine from the host's own thread — yet the drain inside it is not the scope that
+    /// claimed the engine, because <c>Import</c> claimed it first. Guarding the window on the claiming
+    /// scope would close this one.
+    /// </summary>
+    [Fact]
+    public void ABlockingImportAdmitsACallbackAuthorizedUnderAnEarlierEvaluation()
+    {
+        var engine = new Engine(options => options.Constraints.PromiseTimeout = Ceiling);
+        var stashed = StashACallbackFromAnEndedEvaluation(engine);
+
+        var prober = new CallbackProber(stashed, Attempts);
+        engine.SetValue("arm", new Action(prober.Arm));
+        engine.SetValue("tick", new Func<Task>(() => Task.Delay(20)));
+        engine.SetValue("pending", new Func<Task<int>>(async () => await prober.Finished.Task.ConfigureAwait(false)));
+
+        // The first await suspends the module and hands the thread to Import's drain; everything after it
+        // therefore runs from a continuation the drain itself is executing, which is where arm() belongs.
+        engine.Modules.Add("m", """
+            await tick();
+            arm();
+            export const v = await pending();
+            """);
+
+        engine.Modules.Import("m");
+
+        prober.UnexpectedFailure.Should().BeNull();
+        prober.Attempts.Should().Be(Attempts);
+        prober.Refused.Should().Be(0, "a blocking import is a callback-admission window: " + prober.Describe());
+        prober.Admitted.Should().Be(Attempts, prober.Describe());
+        engine.Evaluate("1 + 1").AsNumber().Should().Be(2);
+    }
+
+    /// <summary>
+    /// The frame sebastienros/jint#3262 asks about: a drain reached from a host call the script itself
+    /// made, so an admitted callback takes its turn in the middle of a running evaluation. That is
+    /// deliberate — the drain is already interleaving arbitrary script from its own queue while it waits,
+    /// so refusing the callback would remove the callback and not the interleaving.
+    /// </summary>
+    [Fact]
+    public void ADrainNestedInsideARunningEvaluationAdmitsOneToo()
+    {
+        var engine = new Engine();
+        var stashed = StashACallbackFromAnEndedEvaluation(engine);
+
+        var prober = new CallbackProber(stashed, Attempts);
+        engine.SetValue("arm", new Action(prober.Arm));
+        engine.SetValue("tick", new Func<Task>(() => Task.Delay(20)));
+        engine.SetValue("pending", new Func<Task<int>>(async () => await prober.Finished.Task.ConfigureAwait(false)));
+        engine.SetValue("blockOn", new Func<JsValue, JsValue>(value => value.UnwrapIfPromise(Ceiling)));
+
+        // The reaction can only run from inside blockOn's drain — nothing else drains between statements —
+        // so the window is provably open before the first attempt and until after the last one returns.
+        engine.Execute("""
+            tick().then(() => arm());
+            blockOn(pending());
+            """);
+
+        prober.UnexpectedFailure.Should().BeNull();
+        prober.Attempts.Should().Be(Attempts);
+        prober.Refused.Should().Be(0, "a nested drain is a window on the same terms: " + prober.Describe());
+        prober.Admitted.Should().Be(Attempts, prober.Describe());
+        engine.Evaluate("1 + 1").AsNumber().Should().Be(2);
+    }
+
+    /// <summary>
+    /// The other half, and what keeps the paragraph above from meaning "a drain admits everything": how
+    /// narrowly a window admits is decided by whether an operation token is in force under it, never by
+    /// where the frame sits. Once a host call in this evaluation has been handed a callback, a token is in
+    /// force and the very same nested drain admits only that operation's callbacks.
+    /// </summary>
+    [Fact]
+    public void ADrainUnderAnOperationTokenAdmitsOnlyThatOperationsCallbacks()
+    {
+        var engine = new Engine();
+        var stashed = StashACallbackFromAnEndedEvaluation(engine);
+
+        var prober = new CallbackProber(stashed, Attempts);
+        engine.SetValue("arm", new Action(prober.Arm));
+        engine.SetValue("tick", new Func<Task>(() => Task.Delay(20)));
+        engine.SetValue("pending", new Func<Task<int>>(async () => await prober.Finished.Task.ConfigureAwait(false)));
+        engine.SetValue("blockOn", new Func<JsValue, JsValue>(value => value.UnwrapIfPromise(Ceiling)));
+        engine.SetValue("takesACallback", new Action<Func<int>>(_ => { }));
+
+        engine.Execute("""
+            takesACallback(() => 1);
+            tick().then(() => arm());
+            blockOn(pending());
+            """);
+
+        prober.UnexpectedFailure.Should().BeNull();
+        prober.Attempts.Should().Be(Attempts);
+        prober.Admitted.Should().Be(0, "the enclosing entry's token is in force: " + prober.Describe());
+        prober.Refused.Should().Be(Attempts, prober.Describe());
+        engine.Evaluate("1 + 1").AsNumber().Should().Be(2);
+    }
+}

--- a/Jint/Engine.Pump.cs
+++ b/Jint/Engine.Pump.cs
@@ -371,7 +371,7 @@ public partial class Engine
                     // taking one of its own — the shape DrainEventLoopUntil's per-iteration suspension has. A
                     // callback admitted here holds the engine until it finishes, and the resume below waits
                     // for it, which is why the ceiling bounds this wait and not the call around it.
-                    using (SuspendHostCallForCallbacks(hasTransferredCallback: isTopLevelPark))
+                    using (SuspendHostCallForCallbacks(yieldForCallbacks: isTopLevelPark))
                     {
                         _eventLoop.WaitForWork(completedEvent: null, interval, waitToken);
                     }

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -423,6 +423,31 @@ public sealed partial class Engine : IDisposable
     /// Returns a no-op window when a reservation already exists - an outstanding async host operation, or an
     /// outer drain. That one is not ours to close, and the drain then behaves exactly as it did before.
     /// </para>
+    /// <para>
+    /// Opened by <em>every</em> drain, nested ones included: there is deliberately no guard on the scope
+    /// that claimed the engine. What would justify one is a frame that <em>runs no script</em> - a park on
+    /// <see cref="AdvancedOperations.WaitForScheduledWork"/>, whose <c>InspectScheduledWork</c> executes
+    /// nothing - because there an admitted callback would be the only script interleaved into somebody
+    /// else's evaluation. A drain is the opposite case: <see cref="RunAvailableContinuations"/> runs
+    /// arbitrary script on every iteration whether a callback is admitted or not, so refusing the callback
+    /// would remove the callback without removing the interleaving. Measured at a nested drain against the
+    /// same probes at a top-level one, three candidate hazards behave identically: a host method reached
+    /// from a drain continuation and blocking on a second authorized callback wedges either way, an
+    /// admitted callback blocking on host state the outer frame holds is stalled either way, and a turn
+    /// charged to the outer evaluation's statement budget can kill that evaluation either way - the last of
+    /// which the drain's own continuations already do, with no callback involved at all.
+    /// </para>
+    /// <para>
+    /// The claiming scope would in any case be the wrong question here, for a reason that has nothing to do
+    /// with script: <see cref="ModuleOperations.Import(string)"/> claims the engine before this drain
+    /// re-enters, so a blocking import <em>on an otherwise idle engine, from the host's own thread</em> is
+    /// not a claiming scope either. That drain is one of the windows README.md's Thread-safety section
+    /// enumerates, so keying the window on the claiming scope would close a documented top-level window
+    /// rather than a nested one. Nor is there a middle option: reserving under a fresh token instead would
+    /// admit only callbacks converted <em>inside</em> the drain, which is the "latent fourth" gap
+    /// sebastienros/jint#3206 removed by opening one window before any conversion can happen.
+    /// sebastienros/jint#3262.
+    /// </para>
     /// </remarks>
     internal HostCallbackAdmissionWindow OpenHostCallbackAdmissionWindow()
     {
@@ -502,9 +527,17 @@ public sealed partial class Engine : IDisposable
     /// keeps a stale callback from an <em>earlier</em> entry refused exactly as before.
     /// </para>
     /// </remarks>
-    internal HostCallSuspension SuspendHostCallForCallbacks(bool hasTransferredCallback)
+    /// <param name="yieldForCallbacks">
+    /// Whether to yield the thread at all; <see langword="false"/> makes this a no-op scope. It says what
+    /// the caller wants from the frame, deliberately not who handed a callback to whom: at the interop call
+    /// sites it is "this host call was passed a JavaScript callback", while
+    /// <see cref="DrainEventLoopUntil"/> passes a constant <see langword="true"/> for its idle wait, having
+    /// been handed nothing - the reservation it finds is one it opened itself, and all it wants here is the
+    /// thread released so a callback admitted through that window can take its turn.
+    /// </param>
+    internal HostCallSuspension SuspendHostCallForCallbacks(bool yieldForCallbacks)
     {
-        if (!hasTransferredCallback)
+        if (!yieldForCallbacks)
         {
             return default;
         }
@@ -2489,6 +2522,14 @@ public sealed partial class Engine : IDisposable
         // below. A drain is exactly the frame the thread-safety contract lets an authorized
         // cross-thread callback wait in, and dropping the reservation across RunAvailableContinuations
         // every iteration turned that promise into a scheduling coin flip (sebastienros/jint#3206).
+        // Unconditionally, including for a nested drain: see the window's own remarks for why the
+        // claiming-scope guard a park needs would be both unnecessary and, for a blocking import, wrong.
+        // Note also that guarding *this line* alone would not even narrow admission. The per-iteration
+        // suspension below would then own its reservation rather than finding this one, and a suspension
+        // that owns one hands it to the enclosing entry instead of dropping it (ResumeSuspendedHostCall) -
+        // so the window would survive the drain and stay open for the rest of that entry. Measured: a
+        // callback dispatched after a nested drain returned is refused as things stand and admitted with
+        // that guard in place. The guard is not a narrowing; it is a widening in duration.
         using var admission = OpenHostCallbackAdmissionWindow();
 
         // Claim this thread as the one draining the loop so background threads (Task completions)
@@ -2585,7 +2626,7 @@ public sealed partial class Engine : IDisposable
                     // settle arriving from a background thread only enqueues, and this thread is the one that
                     // has to run it — before the wake it idled out the rest of the poll slice first, which a
                     // chain of sequential asynchronous loads paid on every hop.
-                    using (SuspendHostCallForCallbacks(hasTransferredCallback: true))
+                    using (SuspendHostCallForCallbacks(yieldForCallbacks: true))
                     {
                         _eventLoop.WaitForWork(completedEvent, waitInterval, waitToken);
                     }

--- a/README.md
+++ b/README.md
@@ -2418,11 +2418,13 @@ method returns at its first `await`, so its callback is normally invoked long af
 returned — the first window covers the rest of the evaluation that called it, and by the time that
 evaluation returns the script is awaiting the promise the method handed back, which is the third. The
 fourth is for the other shape entirely, a host loop that pumps one engine from one thread and idles on the
-pump in between. How narrowly a window admits depends on where it was opened: one opened inside a running
-operation admits only callbacks issued under that operation, while one opened at the top level — a blocking
-drain, or a park — is anonymous and admits any callback this engine ever authorized, including one whose
-operation ended long ago. A park reached from *inside* a running evaluation is not a window at all and goes
-on refusing. Outside every window — the engine thread is running script for an operation that was never
+pump in between. How narrowly a window admits is decided by whether an operation token is in force
+under it, not by where on the stack it was opened: one opened under a host call that was handed a callback
+admits only that operation's callbacks, while one opened where none is in force is anonymous and admits any
+callback this engine ever authorized, including one whose operation ended long ago. The third window in
+particular is open wherever a drain runs — nested inside a running evaluation, and inside a blocking
+`Modules.Import`, which claims the engine before its own drain begins. A park reached from *inside* a running
+evaluation is not a window at all and goes on refusing. Outside every window — the engine thread is running script for an operation that was never
 handed this callback, and has undertaken to yield to nobody — an authorized callback is refused exactly like
 an unrelated caller, because serializing it there would mean blocking on a thread that may itself be blocked
 on that callback. A host that dispatches callbacks asynchronously should therefore keep the engine inside one


### PR DESCRIPTION
Closes #3262. **Verdict: leave the drain alone and document the difference — no behaviour change.**

Not because a nested drain is harmless, but because **`IsEntryRoot` is provably the wrong predicate for the drain**, and applied to the window alone it is *inert in the admitting direction while widening the window in duration*.

## The measurement that reframes the issue

Instrumented `Engine.cs`, ran both suites (13,003 tests):

| | `Jint.Tests.PublicInterface` | `Jint.Tests` |
| --- | --- | --- |
| top-level drains (`IsEntryRoot` true) | 105 | 1843 |
| **nested** drains | **155** | **678** |
| …that opened a real window | 155 | 674 |
| …anonymous / operation-tokened | 155 / 0 | 674 / 0 |
| **callbacks admitted under a nested window** | **0** | **0** |

Nested drains are **more common than top-level ones**, and **827 of the 833 are `Engine.Modules.Import`** — `ModuleOperations.Import` takes `EnterHostCall()` before `ExecuteWithConstraints` and the drain re-enter, so the drain is never a claiming scope **even on a wholly idle engine with no script running**. The other 6 are a module's top-level `await using` reaching `DisposeCapability.DisposeResources → UnwrapIfPromise` — *pure script*, no host frame chose that drain.

**The shape #3262 assumes** — `UnwrapIfPromise` inside a host call inside script — **never occurs in the corpus.** It had to be constructed.

So "nested" was the wrong axis. A real embedder depends on this: a stale authorized callback dispatched during a plain `engine.Modules.Import` on an idle engine is admitted **5/6** today, and README names that window explicitly.

Also measured, and now documented: the nested drain is **not uniformly anonymous** — it inherits the enclosing entry's operation token whenever one is in force. Once a host call in that evaluation has been handed a callback, the same drain admits **0/8** instead of 7/8.

## The argument in one line

**The pump's guard preserves an invariant — a park runs no script. The drain has no such invariant, so the guard would remove the callback without removing the interleaving.**

Probe results:

| probe | nested | top-level |
| --- | --- | --- |
| A — host method from a drain continuation blocks on a second authorized callback | wedged | wedged |
| admitted callback needs a lock the *outer host frame* holds | not acquired | not acquired |
| admitted callback vs the outer evaluation's `MaxStatements` | outer killed | outer survives |
| **control**: the drain's *own* continuation vs that budget | **outer killed** | outer killed |

The wedge does not get worse. The one nested-vs-top-level difference is a property of *running script in a nested drain*, not of admitting a callback — the control shows the drain's own continuation already kills the outer evaluation with **no callback involved**.

## Mutation evidence: the obvious fix is inert, and the thorough one breaks a documented window

**M1** — the literal "same guard" (`ownership.IsEntryRoot ? OpenHostCallbackAdmissionWindow() : default`): all three new pins **pass, 3× in a row**, and all 14 probes read *identically to `main`*. It is inert, because the per-iteration `SuspendHostCallForCallbacks` then owns its own reservation and #3240's W1 hand-over gives it to the enclosing entry. A differential probe makes the direction explicit: a callback dispatched *after* the nested drain returned reads `REFUSED` on `main` and `NOT-REFUSED` under M1 — **the guard is a widening in duration, not a narrowing.**

**M2** — guard on both the window and the suspension: the two admission pins **fail**, *including the top-level `Modules.Import` one* (`admitted=0 refused=6`). The interleaving is untouched (`OWN-CONTINUATION nested: outer KILLED` unchanged), so M2 buys no property — it only costs a documented window.

## What shipped

Three pins in `HostDrainAdmissionTests`, each arming its prober from *inside* the drain and ending the drain *from* the prober, so the window provably covers every attempt with no start-race — the same by-construction handshake #3259 landed for the pump.

`TM-13` gains the corrected criterion and a new residual bullet; `README`'s thread-safety section gains the same rule. `SuspendHostCallForCallbacks(hasTransferredCallback:)` → `yieldForCallbacks:`, which is what it actually means at both call sites.

**This corrects a claim #3259 makes.** Its wording says breadth depends on *"where it was opened … a top-level blocking drain"*. The measurements show that is not the criterion — it is **whether an operation token is in force**, never where the frame sits on the stack. `Engine.Modules.Import` is the counter-example: it claims the engine *before* its own drain begins, so a blocking import on an idle engine is an anonymous window despite being about as top-level as anything gets.

This PR is rebased on #3259; both its enumeration additions (the park) and this correction are preserved.

## Verification

Solution builds Release, 0 errors. `Jint.Tests` 10510 (net10.0) / 7256 (net472); `Jint.Tests.PublicInterface` 2496 / 1902; with `JINT_HOST_CONTRACT_VERIFICATION=1`, 10510 / 7256 and 2500 / 1906. **test262 102,495 passed / 0 failed.** Threading repeats with no flakes: net10.0 10/10 at 284/284 and 10/10 at 111/111; net472 5/5 at 241/241 and 111/111. `CanonicalJsCallDelegateCannotBypassOwnership` untouched and green throughout.

## Against the verdict

- **M2 does remove one wedge** (`WEDGE nested: wedged=False`). It is the only measured behavioural gain, it costs the documented `Modules.Import` window, and the same wedge stays reachable at a top-level drain regardless — so it buys no property, only one fewer route to a hazard already documented as unsupported.
- **Script can open a window the host never asked for** via `await using`. That grants untrusted script no new capability — a window only lets through a callback the *host* dispatches — but it is a genuine widening of *who decides when a window is open*, and it is recorded in TM-13 rather than argued away.
- **A cheaper claim that did not survive**: an early budget probe suggested an admitted callback did something a continuation did not. The control disproved it once the loop was large enough to overflow. It is reported above as the control rather than dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
