### PR TITLE
WebApi: Navigator and Scheduler get a real interface object and prototype

### DIFF
--- a/Jint.Tests/Runtime/WebApi/InterfaceObjectExposureTests.cs
+++ b/Jint.Tests/Runtime/WebApi/InterfaceObjectExposureTests.cs
@@ -8,9 +8,9 @@ using Jint.Runtime.Descriptors.Specialized;
 namespace Jint.Tests.Runtime.WebApi;
 
 /// <summary>
-/// The §5.1 interface objects that used not to be globals: the eight Streams interfaces a script never
-/// constructs by name, and the three — <c>Crypto</c>, <c>SubtleCrypto</c> and <c>Performance</c> — that had no
-/// interface object at all.
+/// The interface objects that used not to be globals: the eight Streams interfaces a script never constructs
+/// by name, and the five singletons — <c>Crypto</c>, <c>SubtleCrypto</c>, <c>Performance</c>,
+/// <c>Navigator</c> and <c>Scheduler</c> — that had no interface object at all.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -28,6 +28,13 @@ namespace Jint.Tests.Runtime.WebApi;
 public class InterfaceObjectExposureTests
 {
     /// <summary>Every interface object this exposure decision added, with the flag that provides it.</summary>
+    /// <remarks>
+    /// <c>Navigator</c> and <c>Scheduler</c> arrived last, in
+    /// https://github.com/sebastienros/jint/issues/3270, and for the reason the other three did:
+    /// their singleton's members had nowhere but the singleton to live, which cost them WebIDL's property
+    /// attributes and left <c>navigator.__proto__</c> pointing at <c>%Object.prototype%</c>. Both interfaces
+    /// are exposed in a browser and neither is constructible.
+    /// </remarks>
     public static TheoryData<string, WebApiFeatures> Exposed => new()
     {
         { "ReadableStreamDefaultReader", WebApiFeatures.Streams },
@@ -41,6 +48,8 @@ public class InterfaceObjectExposureTests
         { "Crypto", WebApiFeatures.Crypto },
         { "SubtleCrypto", WebApiFeatures.Crypto },
         { "Performance", WebApiFeatures.Performance },
+        { "Navigator", WebApiFeatures.Navigator },
+        { "Scheduler", WebApiFeatures.Scheduler },
     };
 
     [Theory]
@@ -169,6 +178,8 @@ public class InterfaceObjectExposureTests
     [InlineData("Crypto")]
     [InlineData("SubtleCrypto")]
     [InlineData("Performance")]
+    [InlineData("Navigator")]
+    [InlineData("Scheduler")]
     public void ANonConstructibleInterfaceObjectRefusesNew(string name)
     {
         var engine = new Engine(options => options.UseWebApis());
@@ -177,15 +188,18 @@ public class InterfaceObjectExposureTests
     }
 
     /// <summary>
-    /// The three interfaces WinterTC §5.1 lists that had no interface object at all. They are real now: the
-    /// members live on the interface prototype object, the instance inherits from it, and the brand check is
-    /// what it always was.
+    /// The five interfaces whose singleton had no interface object at all. They are real now: the members
+    /// live on the interface prototype object, the instance inherits from it, and the brand check is what it
+    /// always was. The last argument is what <c>typeof instance.member</c> answers, which separates an
+    /// operation from an attribute without needing two tests.
     /// </summary>
     [Theory]
-    [InlineData("crypto", "Crypto", "randomUUID")]
-    [InlineData("crypto.subtle", "SubtleCrypto", "digest")]
-    [InlineData("performance", "Performance", "now")]
-    public void TheThreeSingletonsAreRealInstancesOfTheirInterface(string instance, string name, string member)
+    [InlineData("crypto", "Crypto", "randomUUID", "function")]
+    [InlineData("crypto.subtle", "SubtleCrypto", "digest", "function")]
+    [InlineData("performance", "Performance", "now", "function")]
+    [InlineData("navigator", "Navigator", "userAgent", "string")]
+    [InlineData("scheduler", "Scheduler", "postTask", "function")]
+    public void TheSingletonsAreRealInstancesOfTheirInterface(string instance, string name, string member, string memberType)
     {
         var engine = new Engine(options => options.UseWebApis());
 
@@ -194,28 +208,47 @@ public class InterfaceObjectExposureTests
         engine.Evaluate("Object.getPrototypeOf(" + name + ".prototype) === Object.prototype").AsBoolean().Should().BeTrue();
         engine.Evaluate(name + ".prototype.constructor === " + name).AsBoolean().Should().BeTrue();
         engine.Evaluate(name + ".name").AsString().Should().Be(name);
+        engine.Evaluate(name + ".length").AsNumber().Should().Be(0);
+
+        // instanceof comes from the chain, not from a Symbol.hasInstance shim.
+        engine.Evaluate("Object.prototype.hasOwnProperty.call(" + name + ", Symbol.hasInstance)").AsBoolean().Should().BeFalse();
 
         // The members are the prototype's, which is what WebIDL says and what a browser shows.
         engine.Evaluate("Object.prototype.hasOwnProperty.call(" + name + ".prototype, '" + member + "')").AsBoolean().Should().BeTrue();
         engine.Evaluate("Object.prototype.hasOwnProperty.call(" + instance + ", '" + member + "')").AsBoolean().Should().BeFalse();
-        engine.Evaluate("typeof " + instance + "." + member).AsString().Should().Be("function");
+        engine.Evaluate("typeof " + instance + "." + member).AsString().Should().Be(memberType);
+
+        // And enumerable where they live, which is the WebIDL rule the instance's empty key list hides.
+        engine.Evaluate("Object.keys(" + name + ".prototype).indexOf('" + member + "') >= 0").AsBoolean().Should().BeTrue();
 
         // @@toStringTag rides the prototype too.
         engine.Evaluate("Object.prototype.toString.call(" + instance + ")").AsString().Should().Be("[object " + name + "]");
+        engine.Evaluate("Object.prototype.hasOwnProperty.call(" + instance + ", Symbol.toStringTag)").AsBoolean().Should().BeFalse();
 
-        // The object is still its own singleton and enumerates as empty, exactly as in a browser.
+        // The object is still its own singleton and has no own properties at all, exactly as in a browser.
         engine.Evaluate("Object.keys(" + instance + ").length").AsNumber().Should().Be(0);
+        engine.Evaluate("Reflect.ownKeys(" + instance + ").length").AsNumber().Should().Be(0);
+
+        // The prototype is the landing pad that keeps a __proto__ patch out of %Object.prototype%.
+        engine.Evaluate("Object.getPrototypeOf(" + instance + ") !== Object.prototype").AsBoolean().Should().BeTrue();
     }
 
     /// <summary>
-    /// The brand check every member of those three performs: an extracted member called on something else
+    /// The brand check every member of those five performs: an extracted member called on something else
     /// raises a <c>TypeError</c>, which is what stops the prototype being usable on an ordinary object.
     /// </summary>
+    /// <remarks>
+    /// <c>Scheduler</c>'s two are absent here on purpose: they return promises, so WebIDL turns the very same
+    /// <c>TypeError</c> into a rejection of the returned promise rather than a throw
+    /// (https://webidl.spec.whatwg.org/#dfn-create-operation-function). <c>SchedulerTests</c>'
+    /// <c>NeitherOperationEverThrows</c> is where that half is asserted.
+    /// </remarks>
     [Theory]
     [InlineData("Crypto.prototype.randomUUID.call({})")]
     [InlineData("Object.getOwnPropertyDescriptor(Crypto.prototype, 'subtle').get.call({})")]
     [InlineData("Performance.prototype.now.call({})")]
     [InlineData("Object.getOwnPropertyDescriptor(Performance.prototype, 'timeOrigin').get.call({})")]
+    [InlineData("Object.getOwnPropertyDescriptor(Navigator.prototype, 'userAgent').get.call({})")]
     public void APrototypeMemberBrandChecksItsReceiver(string expression)
     {
         var engine = new Engine(options => options.UseWebApis());
@@ -269,6 +302,8 @@ public class InterfaceObjectExposureTests
         engine.Evaluate("new ReadableStream().getReader() instanceof ReadableStreamDefaultReader").AsBoolean().Should().BeTrue();
         engine.Evaluate("crypto instanceof Crypto").AsBoolean().Should().BeTrue();
         engine.Evaluate("performance instanceof Performance").AsBoolean().Should().BeTrue();
+        engine.Evaluate("navigator instanceof Navigator").AsBoolean().Should().BeTrue();
+        engine.Evaluate("scheduler instanceof Scheduler").AsBoolean().Should().BeTrue();
     }
 
     /// <summary>
@@ -283,11 +318,15 @@ public class InterfaceObjectExposureTests
         engine.Evaluate("typeof ReadableStreamDefaultReader").AsString().Should().Be("undefined");
         engine.Evaluate("typeof Crypto").AsString().Should().Be("undefined");
 
-        engine.Advanced.EnableWebApis(WebApiFeatures.Streams | WebApiFeatures.Crypto | WebApiFeatures.Performance);
+        engine.Advanced.EnableWebApis(
+            WebApiFeatures.Streams | WebApiFeatures.Crypto | WebApiFeatures.Performance
+            | WebApiFeatures.Navigator | WebApiFeatures.Scheduler);
 
         engine.Evaluate("new ReadableStream().getReader() instanceof ReadableStreamDefaultReader").AsBoolean().Should().BeTrue();
         engine.Evaluate("crypto instanceof Crypto").AsBoolean().Should().BeTrue();
         engine.Evaluate("performance instanceof Performance").AsBoolean().Should().BeTrue();
+        engine.Evaluate("navigator instanceof Navigator").AsBoolean().Should().BeTrue();
+        engine.Evaluate("scheduler instanceof Scheduler").AsBoolean().Should().BeTrue();
     }
 
     /// <summary>The constructor name of whatever <paramref name="expression"/> throws, or "no throw".</summary>

--- a/Jint.Tests/Runtime/WebApi/NavigatorTests.cs
+++ b/Jint.Tests/Runtime/WebApi/NavigatorTests.cs
@@ -3,6 +3,8 @@
 
 using System.Text.RegularExpressions;
 using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.Runtime.Descriptors.Specialized;
 
 namespace Jint.Tests.Runtime.WebApi;
 
@@ -41,21 +43,33 @@ public class NavigatorTests
         engine.Evaluate("navigator[Symbol.toStringTag]").AsString().Should().Be("Navigator");
     }
 
+    /// <summary>
+    /// https://webidl.spec.whatwg.org/#es-attributes — a <c>readonly attribute</c> is an accessor with no
+    /// setter, on the interface prototype object, carrying
+    /// <c>{ [[Enumerable]]: true, [[Configurable]]: true }</c>. Node 24 answers exactly that for
+    /// <c>Object.getOwnPropertyDescriptor(Navigator.prototype, 'userAgent')</c>.
+    /// </summary>
     [Fact]
-    public void ExposesUserAgentAsAReadOnlyAccessor()
+    public void ExposesUserAgentAsAReadOnlyAccessorOnTheInterfacePrototypeObject()
     {
         var engine = NavigatorEngine();
 
         // A WebIDL readonly attribute is an accessor with no setter, so a script cannot assign a different
         // user agent and fool the next reader.
-        var descriptor = engine.Evaluate("Object.getOwnPropertyDescriptor(navigator, 'userAgent')").AsObject();
+        var descriptor = engine.Evaluate("Object.getOwnPropertyDescriptor(Navigator.prototype, 'userAgent')").AsObject();
         descriptor.Get("get").IsCallable.Should().BeTrue();
         descriptor.Get("set").IsUndefined().Should().BeTrue();
         descriptor.Get("configurable").AsBoolean().Should().BeTrue();
-        descriptor.Get("enumerable").AsBoolean().Should().BeFalse();
+        descriptor.Get("enumerable").AsBoolean().Should().BeTrue();
 
-        // Same observable answer a browser gives, where the attribute lives on Navigator.prototype.
+        // The instance carries nothing of its own, which is why the enumerability above is invisible from it
+        // — the answer Node 24 gives to both questions.
+        engine.Evaluate("Object.prototype.hasOwnProperty.call(navigator, 'userAgent')").AsBoolean().Should().BeFalse();
         engine.Evaluate("JSON.stringify(Object.keys(navigator))").AsString().Should().Be("[]");
+        engine.Evaluate("Reflect.ownKeys(navigator).length").AsNumber().Should().Be(0);
+
+        // And it is enumerable where a browser has it.
+        engine.Evaluate("Object.keys(Navigator.prototype).indexOf('userAgent') >= 0").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -64,10 +78,10 @@ public class NavigatorTests
         var engine = NavigatorEngine();
 
         Assert.Throws<JavaScriptException>(
-            () => engine.Evaluate("Object.getOwnPropertyDescriptor(navigator, 'userAgent').get.call({})"))
+            () => engine.Evaluate("Object.getOwnPropertyDescriptor(Navigator.prototype, 'userAgent').get.call({})"))
             .Message.Should().Contain("Navigator");
 
-        engine.Evaluate("Object.getOwnPropertyDescriptor(navigator, 'userAgent').get.call(navigator)")
+        engine.Evaluate("Object.getOwnPropertyDescriptor(Navigator.prototype, 'userAgent').get.call(navigator)")
             .AsString().Should().StartWith("Jint/");
     }
 
@@ -83,9 +97,86 @@ public class NavigatorTests
             engine.Evaluate($"typeof navigator.{member}").AsString().Should().Be("undefined");
         }
 
-        // There is no Navigator interface object either, which is the same simplification console, crypto and
-        // performance carry.
-        engine.Evaluate("typeof Navigator").AsString().Should().Be("undefined");
+        // The interface prototype object carries nothing of theirs either — the absence is the interface's,
+        // not merely the instance's.
+        foreach (var member in new[] { "language", "languages", "onLine", "platform", "hardwareConcurrency" })
+        {
+            engine.Evaluate($"Object.prototype.hasOwnProperty.call(Navigator.prototype, '{member}')")
+                .AsBoolean().Should().BeFalse(member);
+        }
+    }
+
+    /// <summary>
+    /// The interface object and the interface prototype object, which <c>navigator</c> had neither of. Node 24
+    /// is the oracle for every line: <c>typeof Navigator</c> is <c>"function"</c>, the instance's
+    /// <c>[[Prototype]]</c> is <c>Navigator.prototype</c>, that object's is <c>%Object.prototype%</c>, and
+    /// <c>Reflect.ownKeys(navigator)</c> is the empty array.
+    /// </summary>
+    [Fact]
+    public void HasARealInterfaceObjectAndInterfacePrototypeObject()
+    {
+        var engine = NavigatorEngine();
+
+        engine.Evaluate("typeof Navigator").AsString().Should().Be("function");
+        engine.Evaluate("Navigator.name").AsString().Should().Be("Navigator");
+        engine.Evaluate("Navigator.length").AsNumber().Should().Be(0);
+
+        engine.Evaluate("navigator instanceof Navigator").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.getPrototypeOf(navigator) === Navigator.prototype").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.getPrototypeOf(Navigator.prototype) === Object.prototype").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Navigator.prototype.constructor === Navigator").AsBoolean().Should().BeTrue();
+
+        // instanceof is answered by the chain, never by a shim.
+        engine.Evaluate("Object.prototype.hasOwnProperty.call(Navigator, Symbol.hasInstance)").AsBoolean().Should().BeFalse();
+
+        // https://html.spec.whatwg.org/multipage/system-state.html#the-navigator-object declares no
+        // constructor operation, so the interface object is a function that refuses to construct —
+        // https://webidl.spec.whatwg.org/#es-interface-call. Node 24 answers 'TypeError: Illegal constructor'.
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new Navigator()"))
+            .Message.Should().Be("Illegal constructor");
+    }
+
+    /// <summary>
+    /// The containment half of https://github.com/sebastienros/jint/issues/3257, which #3266 closed for
+    /// <c>console</c> and left open here: a singleton sitting directly on <c>%Object.prototype%</c> makes
+    /// <c>navigator.__proto__.foo = …</c> a realm-wide poisoning. An interface prototype object is the
+    /// landing pad that contains it.
+    /// </summary>
+    [Fact]
+    public void PatchingNavigatorsPrototypeDoesNotReachObjectPrototype()
+    {
+        var engine = NavigatorEngine();
+
+        engine.Execute("navigator.__proto__.decorated = 42;");
+
+        // It still works on navigator, which is what a patching library is after.
+        engine.Evaluate("navigator.decorated").AsNumber().Should().Be(42);
+
+        // And it reaches nothing else.
+        engine.Evaluate("Object.prototype.hasOwnProperty.call(Object.prototype, 'decorated')").AsBoolean().Should().BeFalse();
+        engine.Evaluate("'decorated' in {}").AsBoolean().Should().BeFalse();
+        engine.Evaluate("({}).decorated").IsUndefined().Should().BeTrue();
+        engine.Evaluate("[].decorated").IsUndefined().Should().BeTrue();
+        engine.Evaluate("(function () {}).decorated").IsUndefined().Should().BeTrue();
+        engine.Evaluate("'s'.decorated").IsUndefined().Should().BeTrue();
+    }
+
+    /// <summary>
+    /// The interface prototype object is per realm, so one engine's patch is not another's.
+    /// </summary>
+    [Fact]
+    public void GivesEachEngineItsOwnNavigatorPrototype()
+    {
+        var options = new Options().UseWebApis();
+
+        var first = new Engine(options);
+        var second = new Engine(options);
+
+        first.Execute("navigator.__proto__.decorated = 42;");
+
+        first.Evaluate("navigator.decorated").AsNumber().Should().Be(42);
+        second.Evaluate("navigator.decorated").IsUndefined().Should().BeTrue();
+        second.Evaluate("Object.prototype.hasOwnProperty.call(Object.prototype, 'decorated')").AsBoolean().Should().BeFalse();
     }
 
     [Fact]
@@ -97,6 +188,13 @@ public class NavigatorTests
         descriptor.Writable.Should().BeTrue();
         descriptor.Enumerable.Should().BeTrue();
         descriptor.Configurable.Should().BeTrue();
+
+        // And still unmaterialized: an engine that never mentions `navigator` has built neither the object
+        // nor the interface behind it. The interface object's own half is pinned by
+        // InterfaceObjectExposureTests.CostsNothingUntilItIsRead.
+        descriptor.Should().BeOfType<LazyPropertyDescriptor<Engine>>();
+        (descriptor._flags & PropertyFlag.CustomJsValue).Should().NotBe(PropertyFlag.None);
+        descriptor._value.Should().BeNull();
     }
 
     [Fact]

--- a/Jint.Tests/Runtime/WebApi/SchedulerTests.cs
+++ b/Jint.Tests/Runtime/WebApi/SchedulerTests.cs
@@ -832,7 +832,7 @@ public class SchedulerTests
         (scheduler._flags & PropertyFlag.CustomJsValue).Should().NotBe(PropertyFlag.None);
         scheduler._value.Should().BeNull();
 
-        foreach (var name in new[] { "TaskController", "TaskSignal", "TaskPriorityChangeEvent" })
+        foreach (var name in new[] { "Scheduler", "TaskController", "TaskSignal", "TaskPriorityChangeEvent" })
         {
             var descriptor = global.GetOwnProperty(name);
             descriptor.Should().BeOfType<LazyPropertyDescriptor<Engine>>();
@@ -864,11 +864,72 @@ public class SchedulerTests
         engine.Evaluate("scheduler.yield.length").AsNumber().Should().Be(0);
         engine.Evaluate("scheduler.yield.name").AsString().Should().Be("yield");
 
-        // The operations are not enumerable, so the object looks as empty as a browser's does.
+        // The operations live on the interface prototype object, where WebIDL puts them and where they are
+        // enumerable — https://webidl.spec.whatwg.org/#es-operations. The instance carries nothing of its
+        // own, so it looks as empty as a browser's does.
+        foreach (var member in new[] { "postTask", "yield" })
+        {
+            engine.Evaluate($"Object.prototype.hasOwnProperty.call(Scheduler.prototype, '{member}')").AsBoolean().Should().BeTrue(member);
+            engine.Evaluate($"Object.prototype.hasOwnProperty.call(scheduler, '{member}')").AsBoolean().Should().BeFalse(member);
+            engine.Evaluate($"Object.keys(Scheduler.prototype).indexOf('{member}') >= 0").AsBoolean().Should().BeTrue(member);
+        }
+
         engine.Evaluate("Object.keys(scheduler).length").AsNumber().Should().Be(0);
+        engine.Evaluate("Reflect.ownKeys(scheduler).length").AsNumber().Should().Be(0);
 
         // The scheduler object is the same one on every read.
         engine.Evaluate("scheduler === scheduler").AsBoolean().Should().BeTrue();
+    }
+
+    /// <summary>
+    /// The interface object and the interface prototype object, which <c>scheduler</c> had neither of.
+    /// https://wicg.github.io/scheduling-apis/#sec-scheduler declares
+    /// <c>[Exposed=(Window, Worker)] interface Scheduler</c> with no constructor operation, which is what
+    /// Chrome ships and what these lines assert.
+    /// </summary>
+    [Fact]
+    public void HasARealInterfaceObjectAndInterfacePrototypeObject()
+    {
+        var (engine, _) = SchedulerEngine();
+
+        engine.Evaluate("typeof Scheduler").AsString().Should().Be("function");
+        engine.Evaluate("Scheduler.name").AsString().Should().Be("Scheduler");
+        engine.Evaluate("Scheduler.length").AsNumber().Should().Be(0);
+
+        engine.Evaluate("scheduler instanceof Scheduler").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.getPrototypeOf(scheduler) === Scheduler.prototype").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.getPrototypeOf(Scheduler.prototype) === Object.prototype").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Scheduler.prototype.constructor === Scheduler").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.prototype.toString.call(scheduler)").AsString().Should().Be("[object Scheduler]");
+
+        // instanceof is answered by the chain, never by a shim.
+        engine.Evaluate("Object.prototype.hasOwnProperty.call(Scheduler, Symbol.hasInstance)").AsBoolean().Should().BeFalse();
+
+        // No constructor operation means an interface object that refuses to construct —
+        // https://webidl.spec.whatwg.org/#es-interface-call.
+        Assert.Throws<JavaScriptException>(() => engine.Execute("new Scheduler()"))
+            .Error.Get("message").AsString().Should().Be("Illegal constructor");
+    }
+
+    /// <summary>
+    /// The containment half of https://github.com/sebastienros/jint/issues/3257, which #3266 closed for
+    /// <c>console</c> and left open here: while the singleton sat directly on <c>%Object.prototype%</c>,
+    /// <c>scheduler.__proto__.foo = …</c> poisoned every object in the realm.
+    /// </summary>
+    [Fact]
+    public void PatchingSchedulersPrototypeDoesNotReachObjectPrototype()
+    {
+        var (engine, _) = SchedulerEngine();
+
+        engine.Execute("scheduler.__proto__.decorated = 42;");
+
+        engine.Evaluate("scheduler.decorated").AsNumber().Should().Be(42);
+
+        engine.Evaluate("Object.prototype.hasOwnProperty.call(Object.prototype, 'decorated')").AsBoolean().Should().BeFalse();
+        engine.Evaluate("'decorated' in {}").AsBoolean().Should().BeFalse();
+        engine.Evaluate("({}).decorated").IsUndefined().Should().BeTrue();
+        engine.Evaluate("[].decorated").IsUndefined().Should().BeTrue();
+        engine.Evaluate("(function () {}).decorated").IsUndefined().Should().BeTrue();
     }
 
     // --- Engine lifecycle -----------------------------------------------------------------------------

--- a/Jint.Tests/Runtime/WebApi/WebIdlPropertyAttributeTests.cs
+++ b/Jint.Tests/Runtime/WebApi/WebIdlPropertyAttributeTests.cs
@@ -71,9 +71,9 @@ namespace Jint.Tests.Runtime.WebApi;
 /// <b>A green matrix is not a conformance certificate.</b> It says every member carries the attributes its
 /// kind requires; it says nothing about whether the member is on the right object, whether the object has the
 /// right prototype, or whether the interface exists at all. <see cref="Divergences"/> is where that
-/// distinction bites — the two objects listed there carry ECMAScript attributes precisely because their
-/// object model is not the browser's, and flipping the flags without fixing the model would move them
-/// further from a browser rather than closer.
+/// distinction bit — it held the three members whose object model was not the browser's, and for which the
+/// right answer was never a flag but the interface object they had no place on. It is empty now, and the
+/// machinery stays for the next member that finds itself in the same position.
 /// </para>
 /// </remarks>
 public class WebIdlPropertyAttributeTests
@@ -101,16 +101,16 @@ public class WebIdlPropertyAttributeTests
     /// fails on one that has started agreeing with the rule, so a fix cannot leave a stale exemption behind.
     /// </summary>
     /// <remarks>
-    /// Both entries are the same finding. <c>navigator</c> and <c>scheduler</c> have no interface object and
-    /// no interface prototype object in Jint, so their members are own properties of the singleton rather
-    /// than of a prototype. WebIDL's enumerability rule assumes the member is where the specification puts
-    /// it: on <c>Navigator.prototype</c> and <c>Scheduler.prototype</c>, where a browser (and, for
-    /// <c>Navigator</c>, Node 24) puts them, they are enumerable and <c>Object.keys(navigator)</c> is the
-    /// empty array. Declaring them enumerable <i>here</i> would make <c>Object.keys(navigator)</c> answer
-    /// <c>["userAgent"]</c> and <c>Object.keys(scheduler)</c> answer <c>["postTask", "yield"]</c>, which no
-    /// implementation does. So the flags stay ECMAScript's, deliberately, and what fixes them is the
-    /// interface object — not a flag. See <see cref="TheTwoSingletonsWithoutAnInterfaceObjectKeepEmptyOwnKeys"/>,
-    /// which pins the property that reasoning rests on.
+    /// <b>Empty, and that is the news.</b> It used to hold <c>navigator.userAgent</c>, <c>scheduler.postTask</c>
+    /// and <c>scheduler.yield</c>, which were own properties of their singleton because Jint exposed no
+    /// <c>Navigator</c> and no <c>Scheduler</c> interface object for them to sit on. WebIDL's enumerability
+    /// rule assumes the member is where the specification puts it — on the interface prototype object, where
+    /// the enumerability is invisible from the instance — so declaring them enumerable on the singleton would
+    /// have made <c>Object.keys(navigator)</c> answer <c>["userAgent"]</c> and <c>Object.keys(scheduler)</c>
+    /// answer <c>["postTask", "yield"]</c>, which no implementation does. The fix was never a flag: it was the
+    /// interface object, and once the members moved onto <c>Navigator.prototype</c> and
+    /// <c>Scheduler.prototype</c> they became ordinary and the exemptions went with them.
+    /// <see cref="TheSingletonsAreEmptyOfOwnKeys"/> pins the property the whole argument rested on.
     /// <para>
     /// <c>console</c> is the counter-example that proves the rule rather than a precedent against it: it is a
     /// WebIDL <i>namespace</i> (https://webidl.spec.whatwg.org/#es-namespaces), whose members genuinely are
@@ -118,12 +118,7 @@ public class WebIdlPropertyAttributeTests
     /// are in Node.
     /// </para>
     /// </remarks>
-    private static readonly string[] Divergences =
-    [
-        "navigator.userAgent",
-        "scheduler.postTask",
-        "scheduler.yield",
-    ];
+    private static readonly string[] Divergences = [];
 
     /// <summary>
     /// Hosts the sweep cannot reach from the principal realm's global object, with the reason. Anything else
@@ -185,19 +180,22 @@ public class WebIdlPropertyAttributeTests
     }
 
     /// <summary>
-    /// The property the two divergences rest on: with the members sitting on the singleton rather than on an
-    /// interface prototype object, keeping them non-enumerable is what makes the own-key list match what a
-    /// browser answers. Node 24 reports <c>Object.keys(navigator)</c> as <c>[]</c>, with <c>userAgent</c> an
-    /// enumerable accessor on <c>Navigator.prototype</c>; a browser reports <c>Object.keys(scheduler)</c> as
-    /// <c>[]</c> for the same reason.
+    /// The property the deleted divergences rested on, kept as the pin it always was: a platform-object
+    /// singleton enumerates as empty, because its members belong to its interface prototype object. Node 24
+    /// reports <c>Object.keys(navigator)</c> as <c>[]</c> — and <c>Reflect.ownKeys(navigator)</c> as <c>[]</c>
+    /// too, since the instance has no own properties whatever — with <c>userAgent</c> an enumerable accessor
+    /// on <c>Navigator.prototype</c>; a browser reports the same of <c>scheduler</c>.
     /// </summary>
     [Fact]
-    public void TheTwoSingletonsWithoutAnInterfaceObjectKeepEmptyOwnKeys()
+    public void TheSingletonsAreEmptyOfOwnKeys()
     {
         var engine = BuildEngine();
 
-        engine.Evaluate("JSON.stringify(Object.keys(navigator))").AsString().Should().Be("[]");
-        engine.Evaluate("JSON.stringify(Object.keys(scheduler))").AsString().Should().Be("[]");
+        foreach (var singleton in new[] { "navigator", "scheduler", "crypto", "performance" })
+        {
+            engine.Evaluate($"JSON.stringify(Object.keys({singleton}))").AsString().Should().Be("[]", singleton);
+            engine.Evaluate($"Reflect.ownKeys({singleton}).length").AsNumber().Should().Be(0, singleton);
+        }
 
         // And the counter-example: console is a WebIDL namespace, so its operations really are own
         // enumerable properties of the namespace object, exactly as they are in Node.

--- a/Jint/Options.WebApi.cs
+++ b/Jint/Options.WebApi.cs
@@ -755,7 +755,9 @@ public enum WebApiFeatures
     /// The <c>navigator</c> object, whose single member is <c>userAgent</c> — the one thing WinterTC's
     /// Minimum Common API (https://min-common-api.proposal.wintertc.org/) requires of it and the one a script
     /// identifies a runtime by. Everything else a browser's <c>Navigator</c> carries describes a user agent
-    /// with a user, a document and a network stack, so it is absent rather than faked.
+    /// with a user, a document and a network stack, so it is absent rather than faked. The <c>Navigator</c>
+    /// interface object comes with it — <c>userAgent</c> is its prototype's, which is where a browser and
+    /// Node keep it, so <c>Reflect.ownKeys(navigator)</c> is the empty array.
     /// </summary>
     Navigator = 1 << 11,
 
@@ -771,10 +773,12 @@ public enum WebApiFeatures
     Streams = 1 << 12,
 
     /// <summary>
-    /// The <c>scheduler</c> object — <c>postTask()</c> and <c>yield()</c> — with <c>TaskController</c>,
-    /// <c>TaskSignal</c> and <c>TaskPriorityChangeEvent</c>: prioritized tasks, from
-    /// https://wicg.github.io/scheduling-apis/. Tasks run only while the engine is being pumped, exactly as
-    /// the timers do, and a <c>delay</c> rides the same timer queue.
+    /// The <c>scheduler</c> object — <c>postTask()</c> and <c>yield()</c> — with the <c>Scheduler</c>,
+    /// <c>TaskController</c>, <c>TaskSignal</c> and <c>TaskPriorityChangeEvent</c> interface objects:
+    /// prioritized tasks, from https://wicg.github.io/scheduling-apis/. The two operations are
+    /// <c>Scheduler.prototype</c>'s, which is where the draft puts them, so
+    /// <c>Reflect.ownKeys(scheduler)</c> is the empty array. Tasks run only while the engine is being pumped,
+    /// exactly as the timers do, and a <c>delay</c> rides the same timer queue.
     /// </summary>
     Scheduler = 1 << 13,
 

--- a/Jint/Runtime/Intrinsics.WebApi.cs
+++ b/Jint/Runtime/Intrinsics.WebApi.cs
@@ -64,7 +64,8 @@ public sealed partial class Intrinsics
     private PerformanceEntryConstructor? _performanceEntry;
     private PerformanceMarkConstructor? _performanceMark;
     private PerformanceMeasureConstructor? _performanceMeasure;
-    private NavigatorInstance? _navigator;
+    private NavigatorConstructor? _navigator;
+    private JsNavigator? _navigatorObject;
 
     internal DomExceptionConstructor DomException =>
         _domException ??= new DomExceptionConstructor(_engine, _realm, Function.PrototypeObject, Error.PrototypeObject);
@@ -292,8 +293,18 @@ public sealed partial class Intrinsics
     internal PerformanceMeasureConstructor PerformanceMeasure =>
         _performanceMeasure ??= new PerformanceMeasureConstructor(_engine, _realm, PerformanceEntry);
 
-    internal NavigatorInstance Navigator =>
-        _navigator ??= new NavigatorInstance(_engine, _realm, Object.PrototypeObject);
+    /// <summary>
+    /// The <c>Navigator</c> interface object. Reaching it builds <c>Navigator.prototype</c>, which is what the
+    /// <c>navigator</c> object inherits from and where its one member lives.
+    /// </summary>
+    internal NavigatorConstructor Navigator =>
+        _navigator ??= new NavigatorConstructor(_engine, _realm, Function.PrototypeObject, Object.PrototypeObject);
+
+    /// <summary>
+    /// The <c>navigator</c> object — the realm's one instance, carrying no state and no own properties.
+    /// </summary>
+    internal JsNavigator NavigatorObject =>
+        _navigatorObject ??= JsNavigator.Create(_engine, _realm);
 
     private ReadableStreamConstructor? _readableStream;
     private ReadableStreamDefaultReaderConstructor? _readableStreamDefaultReader;
@@ -372,17 +383,25 @@ public sealed partial class Intrinsics
     internal ByteLengthQueuingStrategyConstructor ByteLengthQueuingStrategy =>
         _byteLengthQueuingStrategy ??= new ByteLengthQueuingStrategyConstructor(_engine, _realm, Function.PrototypeObject, Object.PrototypeObject);
 
-    private SchedulerInstance? _scheduler;
+    private SchedulerConstructor? _scheduler;
+    private JsScheduler? _schedulerObject;
     private TaskSignalConstructor? _taskSignal;
     private TaskControllerConstructor? _taskController;
     private TaskPriorityChangeEventConstructor? _taskPriorityChangeEvent;
 
     /// <summary>
+    /// The <c>Scheduler</c> interface object. Reaching it builds <c>Scheduler.prototype</c>, which is what the
+    /// <c>scheduler</c> object inherits from and where both of its operations live.
+    /// </summary>
+    internal SchedulerConstructor Scheduler =>
+        _scheduler ??= new SchedulerConstructor(_engine, _realm, Function.PrototypeObject, Object.PrototypeObject);
+
+    /// <summary>
     /// The <c>scheduler</c> object, which reaches the engine's prioritized task queues and the timer queue a
     /// delayed <c>postTask</c> waits on — both created by <c>WebApiRegistration</c> alongside the global.
     /// </summary>
-    internal SchedulerInstance Scheduler =>
-        _scheduler ??= SchedulerInstance.Create(_engine, _realm, Object.PrototypeObject);
+    internal JsScheduler SchedulerObject =>
+        _schedulerObject ??= JsScheduler.Create(_engine, _realm);
 
     /// <summary>
     /// <c>TaskSignal</c> inherits from <c>AbortSignal</c>, so reaching it builds <c>AbortSignal</c> — and

--- a/Jint/WebApi/Navigator/JsNavigator.cs
+++ b/Jint/WebApi/Navigator/JsNavigator.cs
@@ -1,0 +1,30 @@
+#if NET8_0_OR_GREATER
+using Jint.Native.Object;
+using Jint.Runtime;
+
+namespace Jint.WebApi.Navigator;
+
+/// <summary>
+/// The <c>navigator</c> object — the realm's one instance of the <c>Navigator</c> interface.
+/// <para>
+/// https://html.spec.whatwg.org/multipage/system-state.html#the-navigator-object
+/// </para>
+/// </summary>
+/// <remarks>
+/// It carries no state and no own properties at all: <c>userAgent</c> is <see cref="NavigatorPrototype"/>'s,
+/// and what this object <i>is</i> is the brand — the thing that member checks its receiver against, and what
+/// <c>navigator instanceof Navigator</c> asks about. Node 24 answers <c>[]</c> to
+/// <c>Reflect.ownKeys(navigator)</c> for exactly this reason.
+/// </remarks>
+internal sealed class JsNavigator : ObjectInstance
+{
+    private JsNavigator(Engine engine) : base(engine, ObjectClass.Object)
+    {
+    }
+
+    internal static JsNavigator Create(Engine engine, Realm realm) => new(engine)
+    {
+        _prototype = realm.Intrinsics.Navigator.PrototypeObject,
+    };
+}
+#endif

--- a/Jint/WebApi/Navigator/NavigatorConstructor.cs
+++ b/Jint/WebApi/Navigator/NavigatorConstructor.cs
@@ -1,0 +1,61 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Function;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Navigator;
+
+/// <summary>
+/// The <c>Navigator</c> interface object.
+/// <para>
+/// https://html.spec.whatwg.org/multipage/system-state.html#the-navigator-object
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// The IDL block is <c>[Exposed=Window] interface Navigator { };</c> plus the seven mixins it includes, and it
+/// declares <b>no constructor operation</b> — so the interface object exists and is a function but refuses to
+/// construct anything, https://webidl.spec.whatwg.org/#es-interface-call. Node 24 answers
+/// <c>TypeError: Illegal constructor</c> to <c>new Navigator()</c>, which is the message used here.
+/// </para>
+/// <para>
+/// <b>Why it is a global at all, given <c>[Exposed=Window]</c>.</b> That question was already answered when
+/// <c>navigator</c> itself was installed: the object is <c>[Exposed=Window]</c> by the very same declaration,
+/// and WinterTC's Minimum Common API asks a non-browser runtime for <c>globalThis.navigator.userAgent</c>
+/// anyway. Having decided the instance belongs on a Jint global, withholding the interface object would leave
+/// <c>navigator instanceof Navigator</c> unwritable while the object it names sat one link up the prototype
+/// chain — the half-truth sebastienros/jint#3250 exists to remove. Node 24, whose global is not a <c>Window</c> either, exposes
+/// both for the same reason.
+/// </para>
+/// </remarks>
+internal sealed class NavigatorConstructor : Constructor
+{
+    private static readonly JsString _functionName = new("Navigator");
+
+    internal NavigatorConstructor(
+        Engine engine,
+        Realm realm,
+        FunctionPrototype functionPrototype,
+        ObjectPrototype objectPrototype)
+        : base(engine, realm, _functionName)
+    {
+        _prototype = functionPrototype;
+        PrototypeObject = new NavigatorPrototype(engine, realm, this, objectPrototype);
+        _length = new PropertyDescriptor(JsNumber.PositiveZero, PropertyFlag.Configurable);
+        _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
+    }
+
+    internal NavigatorPrototype PrototypeObject { get; }
+
+    /// <summary>
+    /// An interface without a constructor operation is not constructible.
+    /// </summary>
+    public override ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget)
+    {
+        Throw.TypeError(_realm, "Illegal constructor");
+        return null!;
+    }
+}
+#endif

--- a/Jint/WebApi/Navigator/NavigatorPrototype.cs
+++ b/Jint/WebApi/Navigator/NavigatorPrototype.cs
@@ -8,20 +8,21 @@ using Jint.Runtime.Descriptors;
 namespace Jint.WebApi.Navigator;
 
 /// <summary>
-/// The <c>navigator</c> object.
+/// <c>Navigator.prototype</c> — the interface prototype object, and where the one member of the
+/// <c>navigator</c> object lives.
 /// <para>
-/// https://html.spec.whatwg.org/multipage/system-state.html#navigator
+/// https://html.spec.whatwg.org/multipage/system-state.html#the-navigator-object
 /// </para>
 /// </summary>
 /// <remarks>
 /// <para>
-/// It exists for exactly one member. WinterTC's Minimum Common API
+/// The interface exists for exactly one member. WinterTC's Minimum Common API
 /// (https://min-common-api.proposal.wintertc.org/) requires a conforming runtime to expose
 /// <c>globalThis.navigator.userAgent</c>, and a great deal of published JavaScript feature-detects a runtime
 /// through it; everything else the HTML Standard hangs off <c>Navigator</c> — <c>language</c>,
 /// <c>onLine</c>, <c>hardwareConcurrency</c>, <c>clipboard</c>, <c>geolocation</c> — describes a user agent
 /// with a user, a document and a network stack, none of which an embedded interpreter has. Those members are
-/// <b>absent</b> rather than present-and-lying, so feature detection sees the truth.
+/// <b>absent from this object</b> rather than present-and-lying, so feature detection sees the truth.
 /// </para>
 /// <para>
 /// The value is <c>Jint/&lt;version&gt;</c>. WinterTC asks for a value conforming to RFC 7231's
@@ -33,31 +34,32 @@ namespace Jint.WebApi.Navigator;
 /// embedding application. Read it as WinterTC says to: "a single, complete, opaque, unstructured value".
 /// </para>
 /// <para>
-/// <b>There is no <c>Navigator</c> interface object and no <c>Navigator.prototype</c></b>, so
-/// <c>userAgent</c> is an own accessor of this object rather than one on an interface prototype; it still
-/// brand-checks its receiver.
+/// <b>The member is here, not on the instance</b>, which is where WebIDL puts it and what Node 24 shows:
+/// <c>userAgent</c> is an enumerable accessor on <c>Navigator.prototype</c> while
+/// <c>Reflect.ownKeys(navigator)</c> is the empty array. That is what lets it carry WebIDL's attributes
+/// (https://webidl.spec.whatwg.org/#es-attributes) without <c>Object.keys(navigator)</c> reporting
+/// <c>["userAgent"]</c>, which no implementation does — the enumerability is invisible from an instance with
+/// no own properties. It still brand-checks its receiver, so extracting the getter and calling it on
+/// something else raises a <c>TypeError</c> exactly as a browser does.
 /// </para>
 /// <para>
-/// <b>That is why it keeps an ECMAScript built-in's property attributes</b> — non-enumerable — where every
-/// other attribute under <c>Jint/WebApi/</c> carries WebIDL's <c>{ [[Enumerable]]: true,
-/// [[Configurable]]: true }</c> (https://webidl.spec.whatwg.org/#es-attributes). WebIDL's rule assumes the
-/// member is where the specification puts it, and Node 24 is the oracle for what that looks like:
-/// <c>userAgent</c> is an enumerable accessor on <c>Navigator.prototype</c>, and
-/// <c>Object.keys(navigator)</c> is nevertheless the empty array, because the instance has no own properties
-/// at all. Non-enumerable <i>here</i> is what reproduces that answer; declaring it enumerable would make
-/// <c>Object.keys(navigator)</c> report <c>["userAgent"]</c>, which no implementation does, so a blanket flip
-/// would move this object further from a browser rather than closer. What fixes it is the interface object,
-/// not a flag. The exemption is recorded, and checked for staleness, in
-/// <c>Jint.Tests.Runtime.WebApi.WebIdlPropertyAttributeTests</c>.
-/// </para>
-/// <para>
-/// The object is also installed as an ordinary enumerable data property of the global rather than through the
-/// <c>[Replaceable]</c> accessor pair WebIDL gives it.
+/// One documented simplification remains: the <c>navigator</c> object is installed as an ordinary enumerable
+/// data property of the global rather than through the <c>[Replaceable]</c> accessor pair WebIDL gives it.
 /// </para>
 /// </remarks>
-[JsObject]
-internal sealed partial class NavigatorInstance : BuiltinShapeObject
+[JsObject(UseShape = true)]
+internal sealed partial class NavigatorPrototype : Prototype
 {
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
+    private readonly NavigatorConstructor _constructor;
+
+    /// <summary>
+    /// https://webidl.spec.whatwg.org/#dfn-class-string — "the class string of an interface prototype object
+    /// is the interface's qualified name", so <c>Object.prototype.toString.call(navigator)</c> answers
+    /// <c>[object Navigator]</c>. Node 24 answers <c>[object Object]</c> here, because its <c>Navigator</c> is
+    /// an ordinary JavaScript class rather than a WebIDL platform object; a browser answers
+    /// <c>[object Navigator]</c>, and so does this.
+    /// </summary>
     [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
     private static readonly JsString NavigatorToStringTag = new("Navigator");
 
@@ -67,12 +69,14 @@ internal sealed partial class NavigatorInstance : BuiltinShapeObject
     /// </summary>
     private static readonly JsString UserAgent = new("Jint/" + ProductVersion());
 
-    private readonly Realm _realm;
-
-    internal NavigatorInstance(Engine engine, Realm realm, ObjectPrototype objectPrototype) : base(engine)
+    internal NavigatorPrototype(
+        Engine engine,
+        Realm realm,
+        NavigatorConstructor constructor,
+        ObjectPrototype objectPrototype) : base(engine, realm)
     {
-        _realm = realm;
         _prototype = objectPrototype;
+        _constructor = constructor;
     }
 
     protected override void Initialize()
@@ -86,10 +90,10 @@ internal sealed partial class NavigatorInstance : BuiltinShapeObject
     /// <c>NavigatorID</c> mixin's <c>userAgent</c> attribute, which is where WinterTC's
     /// <c>globalThis.navigator.userAgent</c> requirement lands.
     /// </summary>
-    [JsAccessor("userAgent")]
+    [JsAccessor("userAgent", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
     private JsString UserAgentGet(JsValue thisObject)
     {
-        if (thisObject is not NavigatorInstance)
+        if (thisObject is not JsNavigator)
         {
             Throw.TypeError(_realm, "Failed to read the 'userAgent' property from 'Navigator': illegal invocation, receiver is not a Navigator object.");
         }

--- a/Jint/WebApi/Scheduling/JsScheduler.cs
+++ b/Jint/WebApi/Scheduling/JsScheduler.cs
@@ -1,0 +1,60 @@
+#if NET8_0_OR_GREATER
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.WebApi.Timers;
+
+namespace Jint.WebApi.Scheduling;
+
+/// <summary>
+/// The <c>scheduler</c> object — the realm's one instance of the <c>Scheduler</c> interface, and the owner of
+/// the queues its two operations put work on.
+/// <para>
+/// https://wicg.github.io/scheduling-apis/#sec-scheduler
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// The split against <see cref="SchedulerPrototype"/> is the one WebIDL draws: the <i>members</i> are the
+/// interface's and live on the prototype, while the queues a posted task lands on are state of this object.
+/// The prototype's members brand-check their receiver and then operate on it, so an extracted
+/// <c>postTask</c> is exactly as usable as a browser's.
+/// </para>
+/// <para>
+/// Both queues belong to the <i>engine</i> rather than to this object, which is why they are read from
+/// <c>Engine._webApi</c> once, here, instead of on every call: the task queue is the engine's event loop's,
+/// and the timer queue a delayed <c>postTask</c> waits on is the very one <c>setTimeout</c> uses — so a
+/// delayed task occupies one of the engine's timer slots while it waits.
+/// </para>
+/// </remarks>
+internal sealed class JsScheduler : ObjectInstance
+{
+    private JsScheduler(Engine engine, SchedulerQueue tasks, TimerQueue timers) : base(engine, ObjectClass.Object)
+    {
+        Tasks = tasks;
+        Timers = timers;
+    }
+
+    /// <summary>The prioritized task queues, https://wicg.github.io/scheduling-apis/#scheduler-task-queue.</summary>
+    internal SchedulerQueue Tasks { get; }
+
+    /// <summary>The engine's timer queue, which is what a <c>delay</c> waits on.</summary>
+    internal TimerQueue Timers { get; }
+
+    internal static JsScheduler Create(Engine engine, Realm realm)
+    {
+        var state = engine._webApi;
+        if (state?.Scheduler is not { } tasks || state.Timers is not { } timers)
+        {
+            // Unreachable: the global that reaches this property is installed only where both queues were
+            // created, in the same block of WebApiRegistration.
+            Throw.InvalidOperationException("The scheduler object was reached on an engine that has no scheduler queue.");
+            return null!;
+        }
+
+        return new JsScheduler(engine, tasks, timers)
+        {
+            _prototype = realm.Intrinsics.Scheduler.PrototypeObject,
+        };
+    }
+}
+#endif

--- a/Jint/WebApi/Scheduling/SchedulerConstructor.cs
+++ b/Jint/WebApi/Scheduling/SchedulerConstructor.cs
@@ -1,0 +1,66 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Function;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Scheduling;
+
+/// <summary>
+/// The <c>Scheduler</c> interface object.
+/// <para>
+/// https://wicg.github.io/scheduling-apis/#sec-scheduler
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// The IDL is <c>[Exposed=(Window, Worker)] interface Scheduler { Promise&lt;any&gt; postTask(...);
+/// Promise&lt;undefined&gt; yield(); };</c> — <b>no constructor operation</b>, so the interface object exists
+/// and is a function but refuses to construct anything,
+/// https://webidl.spec.whatwg.org/#es-interface-call. Its two siblings in the same specification do declare
+/// one (<c>TaskController</c> and <c>TaskPriorityChangeEvent</c>), which is why they are constructible here
+/// and this is not.
+/// </para>
+/// <para>
+/// <b>Why it is a global, given the interface is a WICG draft rather than a living standard.</b> The draft
+/// status was already priced in when the feature was taken: <c>WebApiFeatures.Scheduler</c> installs
+/// <c>scheduler</c>, <c>TaskController</c>, <c>TaskSignal</c> and <c>TaskPriorityChangeEvent</c>, three of
+/// which are interface objects. Withholding the fourth would make this API the only one whose singleton
+/// cannot answer <c>scheduler instanceof Scheduler</c> — the feature detection a library that chunks work
+/// opens with — while its own controller and signal can. The interface object also has to exist whether or
+/// not it is named: <c>Scheduler.prototype</c> is where the two operations live, and its <c>constructor</c>
+/// property is that object. So the only question a global settles is whether a script can reach it by name
+/// instead of through <c>Object.getPrototypeOf(scheduler).constructor</c>, and Chrome, which is the only
+/// implementation there is, exposes it.
+/// </para>
+/// </remarks>
+internal sealed class SchedulerConstructor : Constructor
+{
+    private static readonly JsString _functionName = new("Scheduler");
+
+    internal SchedulerConstructor(
+        Engine engine,
+        Realm realm,
+        FunctionPrototype functionPrototype,
+        ObjectPrototype objectPrototype)
+        : base(engine, realm, _functionName)
+    {
+        _prototype = functionPrototype;
+        PrototypeObject = new SchedulerPrototype(engine, realm, this, objectPrototype);
+        _length = new PropertyDescriptor(JsNumber.PositiveZero, PropertyFlag.Configurable);
+        _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
+    }
+
+    internal SchedulerPrototype PrototypeObject { get; }
+
+    /// <summary>
+    /// An interface without a constructor operation is not constructible.
+    /// </summary>
+    public override ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget)
+    {
+        Throw.TypeError(_realm, "Illegal constructor");
+        return null!;
+    }
+}
+#endif

--- a/Jint/WebApi/Scheduling/SchedulerPrototype.cs
+++ b/Jint/WebApi/Scheduling/SchedulerPrototype.cs
@@ -10,7 +10,8 @@ using Jint.WebApi.Timers;
 namespace Jint.WebApi.Scheduling;
 
 /// <summary>
-/// The <c>scheduler</c> object — an instance of the <c>Scheduler</c> interface.
+/// <c>Scheduler.prototype</c> — the interface prototype object, and where both members of the
+/// <c>scheduler</c> object live.
 /// <para>
 /// https://wicg.github.io/scheduling-apis/#sec-scheduler
 /// </para>
@@ -37,34 +38,30 @@ namespace Jint.WebApi.Scheduling;
 /// https://webidl.spec.whatwg.org/#dfn-create-operation-function).
 /// </para>
 /// <para>
-/// <b>There is no <c>Scheduler</c> interface object and no <c>Scheduler.prototype</c></b>, so
-/// <c>postTask</c> and <c>yield</c> are own properties of this object rather than of a prototype; both still
-/// brand-check their receiver.
+/// <b>The two operations are here, not on the instance</b>, which is where WebIDL puts them and what Chrome
+/// shows. That is what lets them carry WebIDL's attributes
+/// (https://webidl.spec.whatwg.org/#es-operations) without <c>Object.keys(scheduler)</c> reporting
+/// <c>["postTask", "yield"]</c>, which no implementation does — the enumerability is invisible from an
+/// instance with no own properties. Both still brand-check their receiver, and because the return type is a
+/// promise that check surfaces as a rejection rather than a throw.
 /// </para>
 /// <para>
-/// <b>That is why the two of them keep an ECMAScript built-in's property attributes</b>, where every other
-/// operation under <c>Jint/WebApi/</c> carries WebIDL's <c>{ [[Writable]]: true, [[Enumerable]]: true,
-/// [[Configurable]]: true }</c> (https://webidl.spec.whatwg.org/#es-operations). WebIDL's rule assumes the
-/// member is where the specification puts it — on <c>Scheduler.prototype</c>, which is what a browser builds
-/// — and there the enumerability is invisible from the instance: <c>Object.keys(scheduler)</c> is the empty
-/// array, because the object has no own properties at all. Declaring these two enumerable <i>here</i> would
-/// make it answer <c>["postTask", "yield"]</c>, which no implementation does, so a blanket flip would move
-/// this object further from a browser rather than closer. What fixes it is the interface object, not a flag.
-/// <c>console</c> is the counter-example that proves the rule rather than a precedent against it: it is a
-/// WebIDL <i>namespace</i> (https://webidl.spec.whatwg.org/#es-namespaces), whose members genuinely are own
-/// properties of the namespace object, so its operations are enumerable here exactly as they are in Node.
-/// The exemption is recorded, and checked for staleness, in
-/// <c>Jint.Tests.Runtime.WebApi.WebIdlPropertyAttributeTests</c>.
+/// The queues each operation works on belong to <see cref="JsScheduler"/>, the instance: the members here
+/// brand-check their receiver and then operate on it, which is the split WebIDL draws and what makes an
+/// extracted <c>postTask</c> behave as a browser's does.
 /// </para>
 /// <para>
-/// The object is also installed as an ordinary enumerable data property of the global rather than through the
-/// <c>[Replaceable]</c> accessor pair
+/// One documented simplification remains: the <c>scheduler</c> object is installed as an ordinary enumerable
+/// data property of the global rather than through the <c>[Replaceable]</c> accessor pair
 /// https://wicg.github.io/scheduling-apis/#dom-windoworworkerglobalscope-scheduler gives it.
 /// </para>
 /// </remarks>
-[JsObject]
-internal sealed partial class SchedulerInstance : BuiltinShapeObject
+[JsObject(UseShape = true)]
+internal sealed partial class SchedulerPrototype : Prototype
 {
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
+    private readonly SchedulerConstructor _constructor;
+
     [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
     private static readonly JsString SchedulerToStringTag = new("Scheduler");
 
@@ -72,36 +69,14 @@ internal sealed partial class SchedulerInstance : BuiltinShapeObject
     private static readonly JsString _priorityProperty = new("priority");
     private static readonly JsString _signalProperty = new("signal");
 
-    private readonly Realm _realm;
-    private readonly SchedulerQueue _tasks;
-    private readonly TimerQueue _timers;
-
-    private SchedulerInstance(
+    internal SchedulerPrototype(
         Engine engine,
         Realm realm,
-        ObjectPrototype objectPrototype,
-        SchedulerQueue tasks,
-        TimerQueue timers)
-        : base(engine)
+        SchedulerConstructor constructor,
+        ObjectPrototype objectPrototype) : base(engine, realm)
     {
-        _realm = realm;
-        _tasks = tasks;
-        _timers = timers;
         _prototype = objectPrototype;
-    }
-
-    internal static SchedulerInstance Create(Engine engine, Realm realm, ObjectPrototype objectPrototype)
-    {
-        var state = engine._webApi;
-        if (state?.Scheduler is not { } tasks || state.Timers is not { } timers)
-        {
-            // Unreachable: the global that reaches this property is installed only where both queues were
-            // created, in the same block of WebApiRegistration.
-            Throw.InvalidOperationException("The scheduler object was reached on an engine that has no scheduler queue.");
-            return null!;
-        }
-
-        return new SchedulerInstance(engine, realm, objectPrototype, tasks, timers);
+        _constructor = constructor;
     }
 
     protected override void Initialize()
@@ -115,7 +90,7 @@ internal sealed partial class SchedulerInstance : BuiltinShapeObject
     /// method steps are to return the result of scheduling a postTask task for this given callback and
     /// options", https://wicg.github.io/scheduling-apis/#schedule-a-posttask-task.
     /// </summary>
-    [JsFunction(Name = "postTask", Length = 1)]
+    [JsFunction(Name = "postTask", Length = 1, Flags = PropertyFlag.ConfigurableEnumerableWritable)]
     private JsValue PostTask(JsValue thisObject, JsValue callback, JsValue options)
     {
         // Step 1: the promise exists before anything can fail, because everything that can fail from here on
@@ -124,7 +99,7 @@ internal sealed partial class SchedulerInstance : BuiltinShapeObject
 
         try
         {
-            Brand(thisObject, "Failed to execute 'postTask' on 'Scheduler'");
+            var scheduler = Brand(thisObject, "Failed to execute 'postTask' on 'Scheduler'");
 
             if (callback is not ICallable callable)
             {
@@ -147,7 +122,7 @@ internal sealed partial class SchedulerInstance : BuiltinShapeObject
             var state = new SchedulingState(signal, prioritySource, priority ?? SchedulerTaskPriority.UserVisible);
 
             // Steps 9 and 10.
-            var task = new SchedulerTask(_tasks, capability, callable, in state, isContinuation: false);
+            var task = new SchedulerTask(scheduler.Tasks, capability, callable, in state, isContinuation: false);
             task.RegisterAbortSteps();
 
             // Steps 12 to 14: a delay defers the *enqueueing*, so the task takes its enqueue order — and
@@ -155,11 +130,11 @@ internal sealed partial class SchedulerInstance : BuiltinShapeObject
             // the moment postTask was called.
             if (delay > 0)
             {
-                ScheduleAfterDelay(task, delay);
+                ScheduleAfterDelay(scheduler, task, delay);
             }
             else
             {
-                _tasks.Enqueue(task);
+                scheduler.Tasks.Enqueue(task);
             }
         }
         catch (JavaScriptException ex)
@@ -181,17 +156,17 @@ internal sealed partial class SchedulerInstance : BuiltinShapeObject
     /// ahead of the work queued behind it. See <see cref="SchedulerQueue.CurrentState"/> for how far that
     /// inheritance reaches here.
     /// </remarks>
-    [JsFunction(Name = "yield", Length = 0)]
+    [JsFunction(Name = "yield", Length = 0, Flags = PropertyFlag.ConfigurableEnumerableWritable)]
     private JsValue Yield(JsValue thisObject)
     {
         var capability = NewPromiseCapability();
 
         try
         {
-            Brand(thisObject, "Failed to execute 'yield' on 'Scheduler'");
+            var scheduler = Brand(thisObject, "Failed to execute 'yield' on 'Scheduler'");
 
             // Steps 2 to 6: the inherited state, or user-visible with nothing to abort it.
-            var inherited = _tasks.CurrentState ?? new SchedulingState(null, null, SchedulerTaskPriority.UserVisible);
+            var inherited = scheduler.Tasks.CurrentState ?? new SchedulingState(null, null, SchedulerTaskPriority.UserVisible);
 
             // Step 4.
             if (inherited.AbortSource is { Aborted: true } abortSource)
@@ -202,9 +177,9 @@ internal sealed partial class SchedulerInstance : BuiltinShapeObject
 
             // Steps 7 to 10: no callback — the task's only step is to resolve the promise — and the queue is
             // the continuation one, whose effective priority is a notch above the task queue beside it.
-            var task = new SchedulerTask(_tasks, capability, callback: null, in inherited, isContinuation: true);
+            var task = new SchedulerTask(scheduler.Tasks, capability, callback: null, in inherited, isContinuation: true);
             task.RegisterAbortSteps();
-            _tasks.Enqueue(task);
+            scheduler.Tasks.Enqueue(task);
         }
         catch (JavaScriptException ex)
         {
@@ -219,24 +194,26 @@ internal sealed partial class SchedulerInstance : BuiltinShapeObject
     /// … given delay": the wait is an entry on the engine's own timer queue, so it elapses only while the
     /// engine is being pumped and it occupies one of the engine's timer slots until then.
     /// </summary>
-    private void ScheduleAfterDelay(SchedulerTask task, long delay)
+    private void ScheduleAfterDelay(JsScheduler scheduler, SchedulerTask task, long delay)
     {
-        if (_timers.Count >= _timers.MaxActiveTimers)
+        var timers = scheduler.Timers;
+        if (timers.Count >= timers.MaxActiveTimers)
         {
             // Not a specified failure mode — the specification assumes a browser's resources — but a delayed
             // task is a timer, and a script must not be able to register them without bound.
             ThrowQuotaExceededError(
-                $"Failed to execute 'postTask' on 'Scheduler': the engine already has {_timers.MaxActiveTimers} active timers, which is its Options.WebApi.Timers.MaxActiveTimers limit.");
+                timers,
+                $"Failed to execute 'postTask' on 'Scheduler': the engine already has {timers.MaxActiveTimers} active timers, which is its Options.WebApi.Timers.MaxActiveTimers limit.");
         }
 
         var entry = new TimerEntry(
-            _timers,
-            new DelayedEnqueue(_tasks, task),
+            timers,
+            new DelayedEnqueue(scheduler.Tasks, task),
             [],
             delay,
             repeat: false,
             _engine.CaptureEventLoopRegistration());
-        task.SetDelayTimer(_timers, _timers.Schedule(entry));
+        task.SetDelayTimer(timers, timers.Schedule(entry));
     }
 
     /// <summary>
@@ -323,12 +300,12 @@ internal sealed partial class SchedulerInstance : BuiltinShapeObject
     /// The engine's own timer cap, reported as https://webidl.spec.whatwg.org/#quotaexceedederror — the
     /// interface, carrying the cap and the count, rather than the bare name on a <c>DOMException</c>.
     /// </summary>
-    private void ThrowQuotaExceededError(string message)
+    private void ThrowQuotaExceededError(TimerQueue timers, string message)
     {
         var exception = _realm.Intrinsics.QuotaExceededError.CreateException(
             message,
-            quota: _timers.RefusalQuota,
-            requested: _timers.RefusalRequested);
+            quota: timers.RefusalQuota,
+            requested: timers.RefusalRequested);
 
         var location = _engine._lastSyntaxElement?.Location ?? default;
         Throw.JavaScriptException(_engine, exception, in location);
@@ -338,12 +315,15 @@ internal sealed partial class SchedulerInstance : BuiltinShapeObject
     /// The WebIDL brand check every member performs: a receiver that is not a platform object implementing the
     /// interface raises a <c>TypeError</c> — which, for these two, the caller turns into a rejection.
     /// </summary>
-    private void Brand(JsValue thisObject, string what)
+    private JsScheduler Brand(JsValue thisObject, string what)
     {
-        if (thisObject is not SchedulerInstance)
+        if (thisObject is not JsScheduler scheduler)
         {
             Throw.TypeError(_realm, what + ": illegal invocation, receiver is not a Scheduler object.");
+            return null!;
         }
+
+        return scheduler;
     }
 
     /// <summary>

--- a/Jint/WebApi/WebApiRegistration.cs
+++ b/Jint/WebApi/WebApiRegistration.cs
@@ -290,8 +290,14 @@ internal static class WebApiRegistration
         {
             // WebIDL exposes navigator through a [Replaceable] accessor pair; an ordinary enumerable data
             // property is the same simplification console and crypto are installed with, documented on
-            // NavigatorInstance.
-            Install(global, engine, "navigator", static e => e.Realm.Intrinsics.Navigator, PropertyFlag.ConfigurableEnumerableWritable);
+            // NavigatorPrototype.
+            Install(global, engine, "navigator", static e => e.Realm.Intrinsics.NavigatorObject, PropertyFlag.ConfigurableEnumerableWritable);
+
+            // Its interface object, which `navigator instanceof Navigator` needs and which is where
+            // `userAgent` actually lives. HTML declares it [Exposed=Window] with no constructor operation, so
+            // it is a function that refuses to construct; NavigatorConstructor says why an engine whose global
+            // is not a Window carries the name anyway, and Node 24 — whose global is not one either — agrees.
+            Install(global, engine, "Navigator", static e => e.Realm.Intrinsics.Navigator, PropertyFlag.NonEnumerable);
         }
 
         if ((features & WebApiFeatures.Fetch) != WebApiFeatures.None)
@@ -341,8 +347,13 @@ internal static class WebApiRegistration
         {
             // WebIDL exposes scheduler through a [Replaceable] accessor pair; an ordinary enumerable data
             // property is the same simplification console, crypto and performance are installed with, and it
-            // is documented on SchedulerInstance.
-            Install(global, engine, "scheduler", static e => e.Realm.Intrinsics.Scheduler, PropertyFlag.ConfigurableEnumerableWritable);
+            // is documented on SchedulerPrototype.
+            Install(global, engine, "scheduler", static e => e.Realm.Intrinsics.SchedulerObject, PropertyFlag.ConfigurableEnumerableWritable);
+
+            // The interface object of that singleton, alongside the three this API already exposed. Not
+            // constructible: https://wicg.github.io/scheduling-apis/#sec-scheduler declares no constructor
+            // operation, unlike TaskController and TaskPriorityChangeEvent below.
+            Install(global, engine, "Scheduler", static e => e.Realm.Intrinsics.Scheduler, PropertyFlag.NonEnumerable);
 
             Install(global, engine, "TaskController", static e => e.Realm.Intrinsics.TaskController, PropertyFlag.NonEnumerable);
             Install(global, engine, "TaskSignal", static e => e.Realm.Intrinsics.TaskSignal, PropertyFlag.NonEnumerable);

--- a/README.md
+++ b/README.md
@@ -225,11 +225,11 @@ its own `console` (or any other name in the table below), enabling the feature l
 | `Event` / `EventTarget` / `CustomEvent` / `AbortController` / `AbortSignal` | `Events` | ✔ shipped |
 | `URL` / `URLSearchParams` / `URLPattern` | `Url` | ✔ shipped |
 | `Blob` (incl. `stream()` and `textStream()`) / `File` / `FormData` | `Files` | ✔ shipped |
-| `navigator.userAgent` | `Navigator` | ✔ shipped |
+| `navigator.userAgent` / `Navigator` | `Navigator` | ✔ shipped |
 | `ReadableStream` / `WritableStream` / `TransformStream` (all three transferable) / `ByteLengthQueuingStrategy` / `CountQueuingStrategy` | `Streams` | ✔ shipped |
 | `TextEncoderStream` / `TextDecoderStream` | `Encoding` **and** `Streams` | ✔ shipped |
 | `CompressionStream` / `DecompressionStream` (`gzip`, `deflate`, `deflate-raw`, `brotli`) | `Compression` **and** `Streams` | ✔ shipped |
-| `scheduler.postTask` / `scheduler.yield` / `TaskController` / `TaskSignal` | `Scheduler` | ✔ shipped |
+| `scheduler.postTask` / `scheduler.yield` / `Scheduler` / `TaskController` / `TaskSignal` | `Scheduler` | ✔ shipped |
 | `requestIdleCallback` / `cancelIdleCallback` / `IdleDeadline` | `IdleCallback` | ✔ shipped |
 | `MessageChannel` / `MessagePort` / `MessageEvent` (incl. cross-engine ports and port transfer) / `BroadcastChannel` | `Messaging` | ✔ shipped |
 | `Worker` (module workers only, over a host-supplied `WorkerProvider`) | `Workers` — **opt-in on its own, and does nothing without a provider** | ✔ shipped |
@@ -608,6 +608,11 @@ order the two were queued in; among the tasks pending together the highest prior
 oldest; and every runnable task runs before any *due* timer — the one place this deliberately differs from a
 browser, which is free to make the opposite choice for a `background` task and typically does.
 
+`Scheduler` is a real interface object — `scheduler instanceof Scheduler` holds, `postTask` and `yield` live
+on `Scheduler.prototype`, and `Object.keys(scheduler)` is `[]` — joining the `TaskController`, `TaskSignal`
+and `TaskPriorityChangeEvent` this feature already exposed. It is not constructible, which is what the draft's
+IDL says.
+
 ### Events dispatch to one target, because there is no tree
 
 `EventTarget` is constructible and `Event`, `CustomEvent`, `AbortController` and `AbortSignal` behave as the
@@ -669,6 +674,12 @@ token with no comment component, so nothing about your operating system or your 
 and it is there because [WinterTC's Minimum Common API](https://min-common-api.proposal.wintertc.org/)
 requires `globalThis.navigator.userAgent` of a conforming runtime. Everything else a browser's `Navigator`
 carries describes a user agent with a user, a document and a network stack, so it is absent rather than faked.
+
+`Navigator` is a real interface object, so `navigator instanceof Navigator` holds and `userAgent` lives on
+`Navigator.prototype` where a browser's and Node's do — which is why `Object.keys(navigator)` and
+`Reflect.ownKeys(navigator)` are both `[]`, exactly as they are in Node 24. It is not constructible, which is
+what its IDL says. Having a prototype of its own also means `navigator.__proto__.foo = …`, the idiom a
+patching library reaches for, lands on that object instead of on `Object.prototype`.
 
 ### Channel messaging can span two engines
 


### PR DESCRIPTION
Closes #3270. `Navigator` and `Scheduler` get the interface object and interface prototype object WebIDL gives them, the two singletons' members move onto those prototypes, and the three exemptions #3272 had to carve out **disappear** — `WebIdlPropertyAttributeTests.Divergences` is now `[]`.

## The shape, per interface

Both take the usual triple: interface object → `[JsObject(UseShape = true)] : Prototype` → a plain `ObjectInstance` singleton with **no own properties at all**.

- **`Navigator`** — `NavigatorConstructor` → `NavigatorPrototype` (`constructor`, `@@toStringTag` = `"Navigator"`, `userAgent` as `Configurable | Enumerable`) → `JsNavigator`, which carries no state and exists to *be the brand*.
- **`Scheduler`** — `SchedulerConstructor` → `SchedulerPrototype` (`constructor`, `@@toStringTag`, `postTask`/`yield` as `ConfigurableEnumerableWritable`) → `JsScheduler`, which holds the `SchedulerQueue` and `TimerQueue`. That is the split WebIDL draws and the one `JsPerformance` already uses: the members are the interface's, the queues are the instance's, and each member brand-checks its receiver and then operates on *it* — so an extracted `postTask` behaves exactly as a browser's does.

**Neither is constructible.** HTML's `[Exposed=Window] interface Navigator { }` and the draft's `[Exposed=(Window,Worker)] interface Scheduler { … }` declare **no constructor operation**, so per [WebIDL §3.7.1](https://webidl.spec.whatwg.org/#es-interface-call) each is a function that throws — `TypeError: Illegal constructor`, which is Node 24's exact message. `TaskController` and `TaskPriorityChangeEvent` in the same draft *do* declare one, which is why they stay constructible and this does not.

**Why they are globals despite `[Exposed=Window]`.** That question was settled when the singletons were installed: `navigator` carries the same `[Exposed=Window]` declaration and is a Jint global anyway, because WinterTC asks a non-browser runtime for `globalThis.navigator.userAgent`. Having decided the instance belongs, withholding the interface object leaves `navigator instanceof Navigator` unwritable while the object it names sits one link up the chain — the half-truth #3250 exists to remove. Node 24's global is not a `Window` either and exposes both. For `Scheduler` the draft status was already priced in: the feature installs three interface objects today, and withholding the fourth would make this the one API whose singleton cannot answer `scheduler instanceof Scheduler` while its own controller and signal can. The interface object has to exist regardless — `Scheduler.prototype.constructor` *is* it — so a global only settles reachability by name, and Chrome, the only implementation, exposes it.

Both installs follow #3250: lazy non-clobbering `LazyPropertyDescriptor<Engine>` on the **principal** realm's global, interface-object attributes `{w:true, e:false, c:true}`, never in a `ShadowRealm`, behind the singleton's own feature flag.

## Against Node 24, run live: 16 of 18 identical

`typeof Navigator`, `name`/`length`, `Reflect.ownKeys(navigator)` → `[]`, `Object.keys(navigator)` → `[]`, both prototype links, `instanceof`, **no own `Symbol.hasInstance`**, `constructor === Navigator`, `userAgent` an accessor with get/no-set/`enumerable:true`/`configurable:true` on `Navigator.prototype`, `new Navigator()` → `TypeError: Illegal constructor`, `constructor` `{w:t,e:f,c:t}`, `prototype` `{w:f,e:f,c:f}`, containment.

Two differ, both deliberate:

| | Jint | Node 24 | why |
| --- | --- | --- | --- |
| `Object.keys(Navigator.prototype)` | `["userAgent"]` | adds `hardwareConcurrency, locks, language, languages, platform` | absent-rather-than-faked, unchanged policy — now re-pinned against the *prototype* rather than the instance |
| `Object.prototype.toString.call(navigator)` | `[object Navigator]` | `[object Object]` | Node's `Navigator` is an ordinary JS class with no `@@toStringTag`; [WebIDL's class-string rule](https://webidl.spec.whatwg.org/#dfn-class-string) and a browser both say `[object Navigator]`, and Jint's pre-existing answer is preserved by moving the tag to the prototype |

Node has no `scheduler` at all, so there the oracle is the WICG IDL plus Chrome's shape.

## The containment hazard #3266 identified is closed

Before, both singletons were `BuiltinShapeObject`s whose `[[Prototype]]` was `Object.prototype`, so patching "the scheduler's prototype" patched `Object.prototype`. Same script, before → after:

| | before | after |
|---|---|---|
| `({}).poisonedByNavigator` | **`42`** | `undefined` |
| `'poisonedByNavigator' in {}` | **`true`** | `false` |
| `[].poisonedByScheduler` | **`43`** | `undefined` |
| `Object.prototype` own `poisonedBy*` | **`true`** | `false` |
| `getPrototypeOf(navigator) === Object.prototype` | **`true`** | `false` |

Pinned by `PatchingNavigatorsPrototypeDoesNotReachObjectPrototype`, the scheduler twin, and `GivesEachEngineItsOwnNavigatorPrototype` (per-realm).

## Cost: +16 B on a default engine

`GC.GetAllocatedBytesForCurrentThread` over 2,000 constructions, bit-identical on every repeat:

| | before | after | Δ |
|---|---|---|---|
| `new Engine()` | 9,256 B | 9,272 B | **+16 B** — two reference fields on `Intrinsics` |
| `new Engine(o => o.UseWebApis())` | 24,280 B | 24,392 B | +112 B (+0.46%) |
| `UseWebApis(Navigator)` | 11,176 B | 11,288 B | +112 B |
| `UseWebApis()` + read `navigator.userAgent` | 27,440 B | 27,912 B | +472 B |

Nothing materializes until a script names one: `CostsNothingUntilItIsRead` covers both new names (descriptor still `CustomJsValue`, `_value == null`), and `NavigatorTests.IsAnEnumerableDataPropertyOfTheGlobal` was strengthened to assert the same of the singleton's own descriptor. The +472 B is what a script that actually *reads* a member pays for a prototype it did not have before.

## Verified failing first

Tests written and run against unfixed code: **20 failed / 129 passed**, across `NavigatorTests` ×5, `SchedulerTests` ×4, `InterfaceObjectExposureTests` ×9, `WebIdlPropertyAttributeTests` ×2. Representative:

```
navigator.userAgent is a WebIDL Attribute and should be
  { writable: n/a, enumerable: true, configurable: true }, but is { … enumerable: false … }
Reflect.ownKeys(navigator).length … to be 0.0 because navigator, but found 2.0
typeof Navigator — actual "undefined", expected "function"
```

After: **149 / 149**.

## Suites

Release solution build clean on all five TFMs (1 warning = the pre-existing `MSB3277` in `Jint.Tests.CommonScripts`/net472, identical to baseline).

| suite | net10.0 | net472 |
|---|---|---|
| `Jint.Tests` | 10,532 / 4 skipped / **0 failed** | 7,256 / 4 / 0 |
| `Jint.Tests` verifying | 10,532 / 4 / 0 | 7,256 / 4 / 0 |
| `Jint.Tests.PublicInterface` | 2,503 / 9 / 0 | 1,909 / 9 / 0 |
| `Jint.Tests.PublicInterface` verifying | 2,507 / 5 / 0 | 1,913 / 5 / 0 |
| `Jint.Tests.CommonScripts` | 28 / 0 / 0 | 28 / 0 / 0 |
| `Jint.Tests.SourceGenerators` | 54 / 0 / 0 | — |
| `Jint.Tests.Test262` | **102,495 passed / 0 failed** | — |

**WPT 422 / 422 both sides, no row moved** — and "before" was measured rather than assumed, from a `git archive` export of the base commit built in a scratch directory. No row *could* have moved silently: the exclusion table refuses an entry that has started passing and the `_minimumTests` floors refuse a file that registered fewer, so a green run on both sides is itself the assertion. The corpus census in `Vendor/README.md` is unchanged. The only vendored files naming `Navigator` are the two `workers/WorkerNavigator*` suites, both still excluded under `NeedsDeclinedWorkerGlobals`.

The **WinterTC conformance tables in `README.md` did not move**, checked rather than assumed: §5.1's interface list — transcribed verbatim in `WinterTcMinimumCommonApiTests.CommonInterfaces`, the pin behind the table — names neither `Navigator` nor `Scheduler`, and the only navigator row is §5.2's `navigator.userAgent`, whose provider is unchanged. Both new names went into the separate per-flag table an embedder actually reads.

## Deliberately left undone

- **No `WorkerNavigator`.** A worker still gets its parent's `navigator`; divergences 6 and 7 in #3167's ledger and their two WPT exclusions stand.
- **The `[Replaceable]` simplification stays** — `navigator` and `scheduler` remain ordinary enumerable data properties of the global rather than the accessor pair, the same simplification `console`, `crypto`, `performance` and `self` carry. Node's `navigator` descriptor is an accessor; that is the one remaining shape difference.
- **`Scheduler.prototype`'s brand check is not in `APrototypeMemberBrandChecksItsReceiver`**, because a promise-returning operation rejects rather than throws. The pre-existing `SchedulerTests.NeitherOperationEverThrows` covers that half, and the omission is documented on the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
