### PR TITLE
Wpt: derive the corpus inventory table instead of maintaining it by hand

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,10 +29,17 @@ jobs:
         os:
           - { name: 'linux', image: 'ubuntu-latest' }
           - { name: 'linux - ARM', image: 'ubuntu-24.04-arm' }
-          - { name: 'windows', image: 'windows-latest' }
+          # The WPT corpus inventory in Jint.Tests/Wpt/Vendor/README.md is measured on Windows — assertion
+          # counts move per operating system — so this is the one leg entitled to check it. The census reuses
+          # the outcomes the suites produce anyway and cost 65 s -> 85 s of Jint.Tests when it was measured
+          # always-on, which is why it is opt-in everywhere else rather than part of an ordinary run.
+          - { name: 'windows', image: 'windows-latest', census: '1' }
           - { name: 'macos', image: 'macos-latest' }
 
     runs-on: ${{ matrix.os.image }}
+
+    env:
+      JINT_WPT_CENSUS: ${{ matrix.os.census }}
 
     steps:
 

--- a/Jint.Tests/Jint.Tests.csproj
+++ b/Jint.Tests/Jint.Tests.csproj
@@ -34,6 +34,10 @@
     <EmbeddedResource Include="Wpt\Prelude\*.js">
       <LogicalName>wpt-prelude/%(Filename)%(Extension)</LogicalName>
     </EmbeddedResource>
+    <!-- The corpus inventory table lives in this README, and WptCensus holds it to what the run measured.
+         Embedding it means the check reads the bytes the build compiled rather than hunting for a source
+         tree; only rewriting the table with JINT_WPT_CENSUS=update goes looking for the file on disk. -->
+    <EmbeddedResource Include="Wpt\Vendor\README.md" LogicalName="wpt-vendor-readme.md" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jint.Tests/Wpt/Vendor/README.md
+++ b/Jint.Tests/Wpt/Vendor/README.md
@@ -872,6 +872,10 @@ citation and an argued decision, never a to-do — and the rule that age alone n
 
 ## The whole corpus, standard by standard
 
+**This table is generated, not maintained.** `Jint.Tests/Wpt/WptCensusTests.cs` derives every figure in it
+from the corpus and fails when the README disagrees — see [Taking the census](#taking-the-census) below for
+the two halves of that check and the one command that rewrites the table.
+
 Measured at this pin, on Windows, with the driver's exclusion table in force. "Not passing" is every result
 the shim did not record `PASS`, which is exactly the set the table names. Re-measured in full for
 [#3212](https://github.com/sebastienros/jint/issues/3212), which is why five rows move at once: the Fetch row
@@ -899,8 +903,8 @@ Re-censused whole rather than adjusted row by row, because several rows had gone
 that moved them: before [#3195](https://github.com/sebastienros/jint/issues/3195) the true figures were
 270 files / 40,631 assertions / 2,907 not passing, where this table read 269 / 40,617 / 2,980 — and Streams
 (16 against a real 11), Compression (84 against 22), User Timing (9 against 5) and DOM (2 against 0) were each
-carrying a number a later fix had already improved. Take the census again when a change moves any of them; it
-is one run of the driver with the results tallied per directory.
+carrying a number a later fix had already improved. That class of drift is what the census closes: those four
+rows were arithmetic the driver already did, and nothing checked the prose against it.
 
 Two of those rows are worth a caveat. The Encoding figure is dominated by
 `textdecoder-fatal-single-byte.any.js`, 7,168 assertions of it and every one passing; of the 322 that do not,
@@ -930,8 +934,69 @@ directories with no vendored file at all are `fetch/api/request/` (no API base U
 above, the `WebCryptoAPI` directories listed above, and `xhr/` (there is no `XMLHttpRequest` in the engine —
 the shim's is a vendored-corpus reader for the suites that need one, never an implementation).
 
+## Taking the census
+
+The table above is derived from the corpus by `Jint.Tests/Wpt/WptCensusTests.cs`, in two halves split by what
+each column costs to know.
+
+`TheInventoryTableNamesEveryStandardAndCountsItsFilesAndSuites` holds the **Standard**, **Suites** and
+**Files** columns. Those are read off the embedded corpus — a row's files are its directory's `.any.js` files,
+and its suites are the directories they sit in — so it needs no execution, runs on every platform and in every
+filtered run, and costs a few milliseconds. It is also what catches a corpus arriving with no row of its own:
+the census prefixes have to partition every vendored `.any.js`, so vendoring a new standard fails this test
+until the standard is named.
+
+`TheInventoryTableMatchesWhatTheCorpusMeasures` holds all five columns, which means running the suites. It is
+**opt-in**, because it is the only part that costs anything: it reuses every outcome the driver already
+produced — `WptHarness.Run` hands each file's results to `WptCensus` on the way back out — but a full
+`Jint.Tests` pass still measured 65 s → 85 s with it always on. The PR workflow's Windows leg sets the
+variable, so that is where the table is enforced; an ordinary run pays nothing. Windows only, in both modes,
+because assertion counts move per operating system — the Web Cryptography row most of all — and this table is
+measured on Windows.
+
+```bash
+# check the table (about a minute; it censuses the whole corpus)
+JINT_WPT_CENSUS=1 dotnet test -c Release Jint.Tests/Jint.Tests.csproj -f net10.0 \
+  --filter "FullyQualifiedName~Jint.Tests.Wpt.WptCensusTests"
+
+# rewrite the table from what the corpus measures, then commit the diff
+JINT_WPT_CENSUS=update dotnet test -c Release Jint.Tests/Jint.Tests.csproj -f net10.0 \
+  --filter "FullyQualifiedName~Jint.Tests.Wpt.WptCensusTests"
+```
+
+A failure prints the stated table and the measured one side by side, so the rows that moved are the rows that
+differ.
+
 ## Updating the pin
 
 Resolve `master` to a concrete commit, re-fetch every file in this directory at that commit, update the SHA
 above, and run the suites. Expect the exclusion table to need work in the same change: the driver fails on an
-entry that no longer applies, which is the point.
+entry that no longer applies, which is the point. Re-run the census afterwards — a bump moves nearly every row
+of the table above.
+
+### Verifying that nothing has drifted
+
+Vendored files are copied verbatim, and the failure mode is silent: a file that has quietly diverged from the
+pin still runs, still passes, and stops testing what upstream asserts. Checking is mechanical, and needs no
+downloads — a GitHub blob id *is* `git hash-object` of the content, and `.gitattributes` pins this whole
+directory to `text eol=lf` precisely so a Windows checkout cannot make the two disagree.
+
+```bash
+cd Jint.Tests/Wpt/Vendor
+SHA=$(grep -oE '\b[0-9a-f]{40}\b' README.md | head -1)
+
+# one call per directory that holds a vendored file (48 at this pin)
+for d in $(find . -type f \( -name '*.js' -o -name '*.json' \) -printf '%h\n' | sort -u | sed 's|^\./||'); do
+  gh api "repos/web-platform-tests/wpt/contents/$d?ref=$SHA" \
+     --jq '.[] | select(.type=="file") | "\(.sha) \(.path)"'
+done > /tmp/upstream.txt
+
+find . -type f \( -name '*.js' -o -name '*.json' \) | sort | while read -r f; do
+  rel="${f#./}"
+  up=$(grep -m1 " ${rel}$" /tmp/upstream.txt | cut -d' ' -f1)
+  [ -z "$up" ] && { echo "NOT-IN-UPSTREAM: $rel"; continue; }
+  [ "$(git hash-object "$f")" = "$up" ] || echo "DRIFT: $rel"
+done
+```
+
+Silence is a clean corpus. Verified at this pin: 359 files, no drift, no file absent upstream.

--- a/Jint.Tests/Wpt/WptCensus.cs
+++ b/Jint.Tests/Wpt/WptCensus.cs
@@ -1,0 +1,473 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.Text;
+
+namespace Jint.Tests.Wpt;
+
+/// <summary>
+/// The corpus inventory table in <c>Vendor/README.md</c> — "The whole corpus, standard by standard" — as a
+/// derived artifact rather than as prose somebody keeps up to date by hand.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Every figure in that table is arithmetic the driver already does.</b> A row's <c>Files</c> is the
+/// vendored <c>.any.js</c> count under its directory, its <c>Suites</c> is how many theories cover them, and
+/// its <c>Assertions</c> and <c>Not passing</c> are the totals the shim reported while the suite ran. Left as
+/// prose, all four drift the moment a fix removes an exclusion or a corpus grows a file, and the drift is
+/// invisible: nothing goes red, the table just quietly describes an engine that no longer exists. It has
+/// happened — the README's own note beside the table records four rows carrying a number a later fix had
+/// already improved, and a re-census correcting 269/40,617/2,980 to 270/40,631/2,907 in one go.
+/// </para>
+/// <para>
+/// <b>What is checked when</b> splits along what each column depends on.
+/// <see cref="WptCensusTests.TheInventoryTableNamesEveryStandardAndCountsItsFilesAndSuites"/> holds the
+/// <c>Standard</c>, <c>Suites</c> and <c>Files</c> columns — those three are read off the embedded corpus and
+/// need no execution at all, so it runs on every platform, in a filtered run, and for free.
+/// <see cref="WptCensusTests.TheInventoryTableMatchesWhatTheCorpusMeasures"/> holds all five, which needs the
+/// suites to have run. It runs on Windows only: assertion counts move per platform — the WebCryptoAPI row most
+/// of all, which is what the per-OS exclusion scoping exists for — and the table states in its own first line
+/// that it is measured on Windows.
+/// </para>
+/// <para>
+/// <b>The measured check pays for at most one pass over the corpus, and usually much less.</b> Every outcome
+/// the theories produce is handed here on the way back out of <see cref="WptHarness.Run"/>, so a file the
+/// driver has already run is tallied rather than re-run. The two classes are separate collections and xUnit
+/// runs them in parallel, so in a full <c>Jint.Tests</c> pass most of the corpus is already recorded by the
+/// time the census reaches it. What it cannot reuse it runs itself, which is what makes the check work as a
+/// standalone command as well: filter to that class and it censuses the corpus from cold.
+/// </para>
+/// <para>
+/// <b>It is still opt-in, because "much less" is not nothing:</b> always-on, it measured a full
+/// <c>Jint.Tests</c> pass at 65 s → 85 s. So it is gated on <see cref="UpdateVariable"/> — <c>1</c> checks the
+/// table, <c>update</c> rewrites it — and the PR workflow's Windows leg is what sets it, in the same shape as
+/// the <c>JINT_HOST_CONTRACT_VERIFICATION</c> leg beside it. An ordinary developer run pays only the free
+/// half.
+/// </para>
+/// </remarks>
+internal static class WptCensus
+{
+    /// <summary>
+    /// The environment variable that turns the check into a rewrite.
+    /// </summary>
+    internal const string UpdateVariable = "JINT_WPT_CENSUS";
+
+    /// <summary>
+    /// The README, embedded so that verification reads the same bytes the build compiled and needs no source
+    /// tree at all. Only the rewrite goes looking for the file on disk.
+    /// </summary>
+    private const string ReadmeResourceName = "wpt-vendor-readme.md";
+
+    private const string TableHeading = "## The whole corpus, standard by standard";
+    private const string TableHeader = "| Standard | Suites | Files | Assertions | Not passing |";
+    private const string TableDivider = "| --- | --- | --- | --- | --- |";
+
+    /// <summary>
+    /// Which README row a vendored path belongs to, in the order the table lists them.
+    /// </summary>
+    /// <remarks>
+    /// This is the one editorial half of the census: a directory prefix carries no standard's name, and two
+    /// of the rows deliberately group several ("HTML" is three <c>html/webappapis/</c> suites in one row and
+    /// <c>workers/</c> in another). The prefixes must still partition every vendored <c>.any.js</c> exactly —
+    /// a corpus arriving under a directory no row claims fails the check rather than going uncounted, which is
+    /// what stops a new standard being vendored with no row of its own.
+    /// </remarks>
+    private static readonly (string Standard, string Prefix)[] _standards =
+    [
+        ("URL", "url/"),
+        ("URL Pattern", "urlpattern/"),
+        ("Encoding", "encoding/"),
+        ("Web Cryptography", "WebCryptoAPI/"),
+        ("Streams", "streams/"),
+        ("Compression", "compression/"),
+        ("File API", "FileAPI/"),
+        ("High Resolution Time", "hr-time/"),
+        ("User Timing", "user-timing/"),
+        ("HTML — workers", "workers/"),
+        ("HTML — timers, microtasks, structured clone", "html/webappapis/"),
+        ("DOM", "dom/"),
+        ("Fetch", "fetch/api/"),
+    ];
+
+    private static readonly ConcurrentDictionary<string, Counts> _observed = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// What one file contributed to its standard's row.
+    /// </summary>
+    private readonly record struct Counts(int Assertions, int NotPassing);
+
+    /// <summary>
+    /// One line of the table. <paramref name="Suites"/> and <paramref name="Files"/> are read off the corpus;
+    /// the other two are only meaningful once every file of the row has run.
+    /// </summary>
+    private readonly record struct Row(
+        string Standard,
+        string Prefix,
+        int Suites,
+        int Files,
+        int Assertions,
+        int NotPassing);
+
+    /// <summary>
+    /// Records what a suite file produced. Called from <see cref="WptHarness.Run"/>, which is the single
+    /// funnel every vendored file's outcome comes back through — so the census sees the whole corpus without
+    /// the theories knowing it exists, and re-running one file simply overwrites its own entry.
+    /// </summary>
+    internal static void Record(string testFilePath, WptRunOutcome outcome)
+    {
+        var notPassing = 0;
+        foreach (var result in outcome.Results)
+        {
+            if (!result.Passed)
+            {
+                notPassing++;
+            }
+        }
+
+        _observed[testFilePath] = new Counts(outcome.Results.Count, notPassing);
+    }
+
+    /// <summary>
+    /// Every vendored <c>.any.js</c>, which is one theory case each and one row's worth of files.
+    /// </summary>
+    internal static List<string> VendoredTestFiles()
+    {
+        var files = new List<string>();
+        foreach (var path in WptCorpus.Paths)
+        {
+            if (path.EndsWith(".any.js", StringComparison.Ordinal))
+            {
+                files.Add(path);
+            }
+        }
+
+        files.Sort(StringComparer.Ordinal);
+        return files;
+    }
+
+    /// <summary>
+    /// Makes sure every vendored file has reported, running only the ones the driver has not already run.
+    /// </summary>
+    /// <returns>How many files this had to run itself, which is what the census actually cost.</returns>
+    /// <remarks>
+    /// A file the theories already covered is tallied from what they produced, so the two chains overlap
+    /// rather than duplicate. Racing a theory on the same file is harmless: a suite file's outcome does not
+    /// depend on when it ran — nothing in the corpus is timing-dependent, which is the same property the
+    /// harness deadline relies on — so both writers record the same pair.
+    /// </remarks>
+    internal static int Measure()
+    {
+        var ran = 0;
+        foreach (var file in VendoredTestFiles())
+        {
+            if (!_observed.ContainsKey(file))
+            {
+                // Records itself on the way back out.
+                WptHarness.Run(file);
+                ran++;
+            }
+        }
+
+        return ran;
+    }
+
+    /// <summary>
+    /// Renders the table. <paramref name="measured"/> false leaves the two counted columns out of the
+    /// comparison by rendering whatever the README already claims for them, so the caller can hold the three
+    /// derived columns without pretending to know the other two.
+    /// </summary>
+    internal static string Render(bool measured, IReadOnlyList<string>? readmeLines = null)
+    {
+        var claimed = measured ? null : ParseClaimedCounts(readmeLines ?? ReadReadme().Split('\n'));
+
+        var files = VendoredTestFiles();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var rows = new List<Row>();
+
+        foreach (var (standard, prefix) in _standards)
+        {
+            var suites = new HashSet<string>(StringComparer.Ordinal);
+            var count = 0;
+            var assertions = 0;
+            var notPassing = 0;
+
+            foreach (var file in files)
+            {
+                if (!file.StartsWith(prefix, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                seen.Add(file);
+
+                // A suite is a directory, because WptCorpus.TestFiles lists a directory's own files and never
+                // descends — so the theory count of a standard is the number of directories its files sit in.
+                suites.Add(WptCorpus.DirectoryOf(file));
+                count++;
+
+                if (measured)
+                {
+                    var counts = _observed[file];
+                    assertions += counts.Assertions;
+                    notPassing += counts.NotPassing;
+                }
+            }
+
+            if (!measured && claimed!.TryGetValue(standard, out var already))
+            {
+                (assertions, notPassing) = already;
+            }
+
+            rows.Add(new Row(standard, prefix, suites.Count, count, assertions, notPassing));
+        }
+
+        var unclaimed = new List<string>();
+        foreach (var file in files)
+        {
+            if (!seen.Contains(file))
+            {
+                unclaimed.Add(file);
+            }
+        }
+
+        if (unclaimed.Count > 0)
+        {
+            throw new InvalidOperationException(
+                "These vendored files belong to no census row, so no line of the inventory table counts them. "
+                + $"Add the standard to {nameof(WptCensus)}.{nameof(_standards)} and give it a row:"
+                + Environment.NewLine
+                + string.Join(Environment.NewLine, unclaimed));
+        }
+
+        return RenderTable(rows);
+    }
+
+    private static string RenderTable(List<Row> rows)
+    {
+        var table = new StringBuilder();
+        table.Append(TableHeader).Append('\n');
+        table.Append(TableDivider).Append('\n');
+
+        var suites = 0;
+        var files = 0;
+        var assertions = 0;
+        var notPassing = 0;
+
+        foreach (var row in rows)
+        {
+            var scope = row.Suites == 1 ? $"`{row.Prefix}`" : $"`{row.Prefix}` ×{row.Suites}";
+            table.Append(
+                    $"| {row.Standard} | {scope} | {Number(row.Files)} | {Number(row.Assertions)} | {Number(row.NotPassing)} |")
+                .Append('\n');
+
+            suites += row.Suites;
+            files += row.Files;
+            assertions += row.Assertions;
+            notPassing += row.NotPassing;
+        }
+
+        table.Append(
+                $"| **total** | **{Number(suites)}** | **{Number(files)}** | **{Number(assertions)}** | **{Number(notPassing)}** |")
+            .Append('\n');
+
+        return table.ToString();
+    }
+
+    private static string Number(int value) => value.ToString("N0", CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// The two measured columns as the README currently states them, keyed by standard, so a check that is
+    /// not entitled to an opinion on them can carry them through unchanged.
+    /// </summary>
+    private static Dictionary<string, (int Assertions, int NotPassing)> ParseClaimedCounts(IReadOnlyList<string> lines)
+    {
+        var claimed = new Dictionary<string, (int, int)>(StringComparer.Ordinal);
+
+        foreach (var line in TableLines(lines))
+        {
+            var cells = Cells(line);
+            if (cells.Length != 5 || cells[0].StartsWith("**", StringComparison.Ordinal) || cells[0] == "Standard"
+                || cells[0].StartsWith("---", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (TryParseNumber(cells[3], out var assertions) && TryParseNumber(cells[4], out var notPassing))
+            {
+                claimed[cells[0]] = (assertions, notPassing);
+            }
+        }
+
+        return claimed;
+    }
+
+    private static bool TryParseNumber(string cell, out int value) =>
+        int.TryParse(cell.Replace(",", "").Trim('*'), NumberStyles.Integer, CultureInfo.InvariantCulture, out value);
+
+    private static string[] Cells(string line) =>
+        Array.ConvertAll(line.Trim().Trim('|').Split('|'), cell => cell.Trim());
+
+    /// <summary>
+    /// The table's own lines, which are every consecutive pipe-prefixed line from the header on. The heading
+    /// above it is what makes the search unambiguous — the README carries a second table, of what is
+    /// deliberately not vendored.
+    /// </summary>
+    private static IEnumerable<string> TableLines(IReadOnlyList<string> lines)
+    {
+        var (start, end) = Locate(lines);
+        for (var i = start; i < end; i++)
+        {
+            yield return lines[i];
+        }
+    }
+
+    /// <summary>
+    /// Where the table sits in the README, as a half-open line range.
+    /// </summary>
+    internal static (int Start, int End) Locate(IReadOnlyList<string> lines)
+    {
+        var heading = -1;
+        for (var i = 0; i < lines.Count; i++)
+        {
+            if (string.Equals(lines[i].TrimEnd('\r'), TableHeading, StringComparison.Ordinal))
+            {
+                heading = i;
+                break;
+            }
+        }
+
+        if (heading < 0)
+        {
+            throw new InvalidOperationException(
+                $"Vendor/README.md no longer has a \"{TableHeading}\" section, which is where the census writes.");
+        }
+
+        for (var i = heading; i < lines.Count; i++)
+        {
+            if (!string.Equals(lines[i].TrimEnd('\r'), TableHeader, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var end = i;
+            while (end < lines.Count && lines[end].StartsWith("|", StringComparison.Ordinal))
+            {
+                end++;
+            }
+
+            return (i, end);
+        }
+
+        throw new InvalidOperationException(
+            $"Vendor/README.md's \"{TableHeading}\" section no longer holds a \"{TableHeader}\" table.");
+    }
+
+    /// <summary>
+    /// The inventory table exactly as the README states it, normalised to LF and ending in one newline.
+    /// </summary>
+    internal static string ReadmeTable(IReadOnlyList<string>? lines = null)
+    {
+        lines ??= ReadReadme().Split('\n');
+
+        var table = new StringBuilder();
+        foreach (var line in TableLines(lines))
+        {
+            table.Append(line.TrimEnd('\r')).Append('\n');
+        }
+
+        return table.ToString();
+    }
+
+    internal static string ReadReadme()
+    {
+        var assembly = typeof(WptCensus).Assembly;
+        using var stream = assembly.GetManifestResourceStream(ReadmeResourceName)
+            ?? throw new FileNotFoundException($"Embedded resource \"{ReadmeResourceName}\" is missing.", ReadmeResourceName);
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        return reader.ReadToEnd();
+    }
+
+    /// <summary>
+    /// Whether <see cref="UpdateVariable"/> asked for the census at all — <c>1</c>, <c>true</c> or
+    /// <c>update</c>. Unset is the default, and the reason the measured check costs a normal run nothing.
+    /// </summary>
+    internal static bool CensusRequested()
+    {
+        var value = Environment.GetEnvironmentVariable(UpdateVariable);
+        return string.Equals(value, "1", StringComparison.Ordinal)
+            || string.Equals(value, "true", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(value, "update", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Whether it asked for the table to be rewritten rather than checked.
+    /// </summary>
+    internal static bool UpdateRequested() =>
+        string.Equals(Environment.GetEnvironmentVariable(UpdateVariable), "update", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Writes the rendered table over the one in the working tree's <c>Vendor/README.md</c>, preserving the
+    /// file's own line endings.
+    /// </summary>
+    internal static string WriteReadmeTable(string table)
+    {
+        var path = LocateReadmeOnDisk();
+        var original = File.ReadAllText(path);
+        var crlf = original.Contains("\r\n", StringComparison.Ordinal);
+        var lines = original.Split('\n');
+
+        var (start, end) = Locate(lines);
+        var rebuilt = new List<string>(lines.Length);
+        rebuilt.AddRange(lines[..start]);
+        rebuilt.AddRange(table.TrimEnd('\n').Split('\n'));
+        rebuilt.AddRange(lines[end..]);
+
+        var joined = string.Join("\n", rebuilt.ConvertAll(line => line.TrimEnd('\r')));
+        File.WriteAllText(path, crlf ? joined.Replace("\n", "\r\n") : joined, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        return path;
+    }
+
+    /// <summary>
+    /// Finds the README in the working tree. The test runs out of <c>artifacts/bin/…</c>, so this walks up
+    /// looking for the repository rather than assuming a relative depth.
+    /// </summary>
+    private static string LocateReadmeOnDisk()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            var candidate = Path.Combine(directory.FullName, "Jint.Tests", "Wpt", "Vendor", "README.md");
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException(
+            $"{UpdateVariable} asked the census to rewrite Vendor/README.md, but no source tree was found above "
+            + $"\"{AppContext.BaseDirectory}\". Run the suites from the repository to update the table.");
+    }
+
+    /// <summary>
+    /// The message a mismatch reports: the two tables side by side, and how to rewrite it.
+    /// </summary>
+    internal static string Explain(string expected, string actual, string what)
+    {
+        var message = new StringBuilder();
+        message.Append("Vendor/README.md's inventory table is out of date (").Append(what).AppendLine(").");
+        message.AppendLine();
+        message.AppendLine("It says:");
+        message.AppendLine(actual.TrimEnd('\n'));
+        message.AppendLine();
+        message.AppendLine("The corpus says:");
+        message.AppendLine(expected.TrimEnd('\n'));
+        message.AppendLine();
+        message.Append($"Rewrite it by running the WPT suites with {UpdateVariable}=update set.");
+        return message.ToString();
+    }
+}
+#endif

--- a/Jint.Tests/Wpt/WptCensusTests.cs
+++ b/Jint.Tests/Wpt/WptCensusTests.cs
@@ -1,0 +1,117 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+namespace Jint.Tests.Wpt;
+
+/// <summary>
+/// Holds <c>Vendor/README.md</c>'s corpus inventory — "The whole corpus, standard by standard" — to what the
+/// corpus actually is, so the table is a derived artifact rather than prose somebody keeps up to date by hand.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Two tests, split by what each column of that table costs to know. The standards, their suite counts and
+/// their file counts are read straight off the embedded corpus and are checked always. The assertion and
+/// not-passing totals need the suites to have run, so they are checked once the corpus has reported — see
+/// <see cref="WptCensus"/> for how that is paid for, and why it is nearly free in a full run.
+/// </para>
+/// <para>
+/// Neither test touches the driver's rules. The exclusion table still decides what is forgiven and a failing
+/// test that no entry names still fails its own suite in <see cref="WptTestRunner"/>, whatever these say.
+/// </para>
+/// </remarks>
+public class WptCensusTests
+{
+    /// <summary>
+    /// The inventory table must name every standard the corpus holds, and its <c>Suites</c> and <c>Files</c>
+    /// columns must be what is actually vendored.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// These three columns are derived without running anything — a row's files are its directory's
+    /// <c>.any.js</c> files, and its suites are the directories those files sit in, because
+    /// <see cref="WptCorpus.TestFiles"/> lists a directory's own files and never descends. So this holds on
+    /// every platform and in every filtered run, for the cost of reading an embedded string.
+    /// </para>
+    /// <para>
+    /// It is also what catches a corpus arriving with no row of its own: the census prefixes have to partition
+    /// every vendored <c>.any.js</c>, so a new standard fails here rather than being silently left out of the
+    /// inventory. The two counted columns are carried through from what the README already claims, so this
+    /// test cannot fail for them — but the total row is recomputed from the rows above it, which means a table
+    /// whose rows and total disagree fails here too.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void TheInventoryTableNamesEveryStandardAndCountsItsFilesAndSuites()
+    {
+        var lines = WptCensus.ReadReadme().Split('\n');
+        var stated = WptCensus.ReadmeTable(lines);
+        var derived = WptCensus.Render(measured: false, lines);
+
+        if (!string.Equals(derived, stated, StringComparison.Ordinal))
+        {
+            Assert.Fail(WptCensus.Explain(derived, stated, "the standards, suite counts or file counts have moved"));
+        }
+    }
+
+    /// <summary>
+    /// The whole inventory table, including the assertion and not-passing totals, must be what the corpus
+    /// measures right now.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>This is the check the table has never had.</b> Every figure in it is arithmetic the driver already
+    /// does, and left as prose it drifts silently: a fix that removes an exclusion moves a row, nothing goes
+    /// red, and the table quietly describes an engine that no longer exists. The README records exactly that
+    /// happening — four rows at once carrying a number a later fix had already improved, corrected only when
+    /// somebody re-censused the whole corpus by hand.
+    /// </para>
+    /// <para>
+    /// <b>Opt-in, because it is the one part of the census that costs anything.</b> The totals can only be
+    /// known by running the corpus, and although this reuses every outcome the driver already produced, a full
+    /// <c>Jint.Tests</c> pass still measured 65 s → 85 s with it always on. So it is gated on
+    /// <c>JINT_WPT_CENSUS</c> and a developer's ordinary run pays nothing; the PR workflow's Windows leg sets
+    /// the variable, which is where the table is actually enforced. That mirrors the
+    /// <c>JINT_HOST_CONTRACT_VERIFICATION</c> leg beside it.
+    /// </para>
+    /// <para>
+    /// <c>JINT_WPT_CENSUS=1</c> checks the table; <c>JINT_WPT_CENSUS=update</c> rewrites it from the run. The
+    /// second is the whole maintenance procedure, and it replaces the hand re-census.
+    /// </para>
+    /// <para>
+    /// Windows only, in both modes, because assertion counts move per operating system and the table says in
+    /// its own first line that it is measured on Windows — updating it from a Linux run would write figures
+    /// the table does not claim. That is a deliberate hole: the three columns above are platform-independent
+    /// and are held everywhere.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void TheInventoryTableMatchesWhatTheCorpusMeasures()
+    {
+        Assert.SkipUnless(
+            WptCensus.CensusRequested(),
+            $"the census runs the corpus to total it, so it is opt-in: set {WptCensus.UpdateVariable}=1 to "
+            + $"check the inventory table, or {WptCensus.UpdateVariable}=update to rewrite it.");
+
+        Assert.SkipUnless(
+            OperatingSystem.IsWindows(),
+            "the inventory table is measured on Windows, and assertion counts move per platform.");
+
+        var updating = WptCensus.UpdateRequested();
+        WptCensus.Measure();
+
+        var measured = WptCensus.Render(measured: true);
+
+        if (updating)
+        {
+            var path = WptCensus.WriteReadmeTable(measured);
+            Assert.Skip($"{WptCensus.UpdateVariable} rewrote the inventory table in {path}.");
+        }
+
+        var stated = WptCensus.ReadmeTable();
+        if (!string.Equals(measured, stated, StringComparison.Ordinal))
+        {
+            Assert.Fail(WptCensus.Explain(measured, stated, "the corpus was censused and the totals disagree"));
+        }
+    }
+}
+#endif

--- a/Jint.Tests/Wpt/WptHarness.cs
+++ b/Jint.Tests/Wpt/WptHarness.cs
@@ -142,9 +142,15 @@ internal static class WptHarness
     internal static WptRunOutcome Run(string testFilePath)
     {
         var directory = WptCorpus.DirectoryOf(testFilePath);
-        return RunsInAWorker(testFilePath)
+        var outcome = RunsInAWorker(testFilePath)
             ? RunInWorker(testFilePath, directory)
             : Execute(directory, MetaScripts(testFilePath, directory), WptCorpus.Read(testFilePath), testFilePath);
+
+        // The corpus inventory in Vendor/README.md is tallied from the run rather than maintained by hand, and
+        // this is the one place every vendored file's outcome comes back through. Recording it here rather
+        // than in the theory keeps the census out of the driver's own rules entirely — see WptCensus.
+        WptCensus.Record(testFilePath, outcome);
+        return outcome;
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #3251, which asked for an analysis that *starts by trying to kill the idea*. It did, and it killed most of it: of the four things that issue floated — a corpus generator, a `wpt sync` tool, a report mode and a census — **only the census survives**, and it survives as a test rather than as a tool.

## The kill criteria, against `git log` rather than recollection

**1. Frequency — fires for sync, and *saves* the census.** The entire history of `Jint.Tests/Wpt/` is **27 commits over three days**. Ten of them added vendored files (+93, +83, +69, +48, +43, +13, +11, +1, +1, +1) — more than the four the issue assumed — but every one is inside a single campaign that has now ended. Sync is burst-shaped; extrapolating a rate from a burst is unfounded, and a documented recipe beats a tool.

The census is a different quantity, and this is the finding that turns the criterion around: **the inventory table has moved 6 times in ~36 hours, and 5 of those came from engine-fix commits, not corpus additions** (#3243, #3245, #3247, #3250). Two commits (#3238, #3244) fixed WPT-found defects and left the table stale behind them. Table staleness is driven by ongoing engine work, which is unbounded — so frequency argues *for* the census and *against* the sync tool.

**2. "A shell script suffices" — fires, and it is now written down instead of built.** The byte-verification is 48 `gh api` directory calls and `git hash-object`, ~20 lines, under a minute, no downloads (a GitHub blob id *is* `git hash-object`), and `.gitattributes` already pins the tree `text eol=lf` so a Windows checkout cannot confound it. Ran it: **359 files, zero drift, zero absent upstream.** It is documented in `Vendor/README.md` as a recipe. The criterion does *not* fire for the census, because assertion counts can only come from the driver's own results and a script would have to reimplement the harness to get them.

**3. The census wants to be a test.** It does. That is what shipped.

**4. Prior art — does not fire; adopting either model would be a downgrade.** Checked live, not from memory. **Deno**'s `tests/wpt/runner/expectations/` carries **no reasoning at all**: `schema.json` sets `additionalProperties: false`, and `wpt.ts update` rebuilds every leaf, so a hand-added comment is *erased*. **Node**'s `test/wpt/status/*.{json,cjs}` enforces only `fail.expected`; `skip` — **146 of ~240 entries** — is never checked against reality, and its one free-text field (`note`) is undocumented and never read by the runner. Neither has a divergence category. Jint's table is two-sided over *every* entry and mandates a category plus prose; adopting either shape would lose both properties.

One incidental finding: §3's motivating example — the not-vendored row claiming Jint does not expose `DedicatedWorkerGlobalScope` — **has already been corrected on main** (it cites #3195 now), which weakens that section further.

## What the census is

`Vendor/README.md`'s inventory table stops being prose somebody maintains and becomes a derived artifact. Two tests, split by what each column costs to know:

- **Standards, suite counts, file counts — checked always, 45 ms.** Derived by reading the embedded corpus, no execution. It is also what catches a corpus arriving with **no row of its own**: the prefixes must partition every vendored `.any.js`, so a new standard fails here rather than being silently left out.
- **Assertion and not-passing totals — opt-in.** These can only be known by running the corpus.

`WptCensus.Record` hooks `WptHarness.Run`, the single funnel every vendored file's outcome returns through — so the census sees the whole corpus **without the theories knowing it exists**, and the driver's own rules are untouched. `Measure()` then runs only the files the theories have not already run, so the two chains overlap rather than duplicate.

`JINT_WPT_CENSUS=1` checks the table; `JINT_WPT_CENSUS=update` rewrites it from the run — and that second mode *is* the maintenance procedure, replacing the hand re-census the README records having needed.

## Proof it fails when the table is wrong

Four perturbations, each reverted afterwards:

| perturbation | result |
| --- | --- |
| Fetch assertions 388→389 **and** total 40,657→40,658 — internally consistent, so only a measured check can see it | **FAIL**, exit 1, both tables side by side, fix command named |
| DOM files 13→14 | **FAIL**, exit 1, in **45 ms** (the always-on half) |
| removed `("DOM","dom/")` from the census rows | **FAIL**, exit 1, naming all 13 orphaned `dom/` files |
| Streams 1,170/4 → 1,999/9, then `JINT_WPT_CENSUS=update` | **repaired**, back to 1,170/4 and the total |

`update` round-trips byte-identically on a correct table (same `git hash-object`) and preserves LF. And the table on `main` today **is** correct: the census independently reproduced 40,657 / 2,889 and all 13 rows.

## Cost, and why it is gated

| | |
| --- | --- |
| always-on half | **45 ms**, every platform, every filtered run |
| measured half, default | **0** — skipped |
| measured half enabled | `Jint.Tests` net10.0 **70 s → 79 s**; an earlier always-on measurement read 65 s → 85 s |

+15–30 % is material, so the measured half is gated on `JINT_WPT_CENSUS` and wired into the PR workflow's **Windows leg only** — the table is Windows-measured and assertion counts move per operating system — mirroring the `JINT_HOST_CONTRACT_VERIFICATION` leg beside it. A non-Windows leg gets an empty variable, which does not match the gate.

## Two mechanisms built, measured and discarded

Worth recording so nobody rebuilds them:

- **xUnit assembly fixture** — gates correctly (`dotnet test` exits 1) but this runner reports `[Test Assembly Cleanup Failure] Xunit.Sdk.TestPipelineException` with the *message dropped*, prints `Passed!`, and swallows `Console.Out`/`Console.Error`. Useless as a maintainer-facing check.
- **`ITestCaseOrderer`** — invoked **per test method** here (`invocations=1 seen=1`), so it cannot order a fact after theories at all.

## Verification

| suite | result |
| --- | --- |
| Solution build, Release, all TFMs | 0 errors (1 pre-existing `MSB3277`) |
| `Jint.Tests` net10.0 | **10,515 passed / 5 skipped / 0 failed** — exactly +1 pass, +1 skip against baseline |
| `Jint.Tests` net472 | 7,256 / 4 / 0 |
| `Jint.Tests.PublicInterface` net10.0 / net472 | 2,503 / 9 and 1,909 / 9, 0 failed |
| `Jint.Tests` net10.0, `JINT_WPT_CENSUS=1` (CI-equivalent) | **10,516 / 4 / 0** |
| WPT area, census on, after rebase onto current `main` | **424 / 424** (422 corpus rows + 2 census tests) |

**The corpus is unchanged**: `git diff` over `Jint.Tests/Wpt/Vendor` touches only `README.md`, no vendored `.js`/`.json` is modified, and the diff contains **zero** `+|`/`-|` table lines. 35 suites, 273 files, 40,657 assertions, 2,889 not passing — identical. Independently, all 359 vendored files still byte-match the pinned upstream SHA.

## Against the verdict

- **The census can run the corpus twice.** If the census test happens to run before the theories, `Measure()` runs nearly the whole corpus itself — which is where the +15–30 % comes from, and it doubles exposure to any timing flake in the worker/atomics lanes. It passed cleanly on repeated runs and the blast radius is one CI leg, but ordering could not be forced: `ITestCaseOrderer` does not work under this runner, as above.
- **The measured half is Windows-only**, so a Linux-only contributor never sees it fail. That is deliberate — the table says in its own first line that it is Windows-measured, and updating it from a Linux run would write figures the table does not claim — but it is a hole, and the three platform-independent columns are what cover everyone else.
- **The pinned SHA is still only in prose.** Putting it somewhere machine-readable was considered and deliberately not done: nothing automated consumes it today (the recipe greps it out of the README), so a constant nothing reads is scaffolding.

## Filed rather than built

**#3260 — the wpt server**, which this analysis concluded is worth more than every tooling idea in the issue combined: 13 not-vendored rows cite it. Already open and being worked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
