### PR TITLE
Eval: hand PerformEval's inDerivedConstructor to the parser, and clear the last five staging exclusions

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -1,5 +1,5 @@
 {
-  "SuiteGitSha": "3655e7464de3d52643ecddd4b5f9f4f3e7f62398",
+  "SuiteGitSha": "14e8c908e54ae2e770e473bcacf536f8cb654929",
   //"SuiteDirectory": "//mnt/c/work/test262",
   "TargetPath": "./Generated",
   "Namespace": "Jint.Tests.Test262",

--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -58,44 +58,6 @@
     "staging/sm/expressions/nullish-coalescing.js",
     "staging/sm/regress/regress-1507322-deep-weakmap.js",
 
-    // Acornima (the external parser) rejects a SuperCall inside a direct eval. Jint already parses
-    // eval code with AllowSuperOutsideMethod, but that covers SuperProperty only; Acornima 1.7.0 has
-    // no separate switch for a direct `super()`, so `eval("super()")` in a derived constructor fails
-    // to parse with "'super' keyword unexpected here" instead of running. PerformEval only forbids it
-    // when inDerivedConstructor is false (https://tc39.es/ecma262/#sec-performeval), which Jint
-    // already computes. Removed by adams85/acornima#44 (ParserOptions.AllowDirectSuperOutsideMethod,
-    // still a draft) plus a release and wiring the option in EvalFunction. bug1587574 is the same
-    // defect and not a field initializer's TDZ: its `class Q { f = 1; }` exists only to defeat
-    // SpiderMonkey's lazy parsing, and the ReferenceError it expects is the derived constructor's
-    // `this` TDZ, raised because the eval'd `super()` sits inside arrows that are never called.
-    "staging/sm/class/derivedConstructorArrowEvalNestedSuperCall.js",
-    "staging/sm/class/derivedConstructorArrowEvalSuperCall.js",
-    "staging/sm/fields/bug1587574.js",
-
-    // Acornima does not re-raise the CoverInitializedName early error when an object literal carrying
-    // a shorthand-with-initializer ends up as the *object of a member expression* inside a
-    // destructuring target. `[{a = 0}] = []` is valid because `{a = 0}` is refined into an
-    // ObjectAssignmentPattern, but in `[{a = 0}.x] = []` the element is the member expression
-    // `{a = 0}.x`, so `{a = 0}` stays an ObjectLiteral and
-    // https://tc39.es/ecma262/#sec-object-initializer-static-semantics-early-errors applies:
-    // "PropertyDefinition : CoverInitializedName - It is a Syntax Error if any source text is matched
-    // by this production." Jint accepts all four such forms. Reported as adams85/acornima#46; the
-    // valid halves of this file already pass.
-    "staging/sm/destructuring/bug1396261.js",
-
-    // Acornima scans the token immediately after an ASI-terminated `"use strict"` directive before it
-    // applies the directive, so a legacy octal literal or a legacy-octal/\8/\9 escape appearing in
-    // exactly that token escapes the strict-mode early errors of
-    // https://tc39.es/ecma262/#sec-numeric-literals-early-errors and
-    // https://tc39.es/ecma262/#sec-string-literals-early-errors. A `"use strict"` line followed by a
-    // line holding just `0755` is accepted, while the same pair with an explicit semicolon after the
-    // directive, or with any statement between the two, is correctly rejected — the strictness itself
-    // is applied either way (`with`, duplicate parameters and `arguments =` are all caught).
-    // Only the sloppy run fails; in the strict run the harness's own prologue makes the tokenizer
-    // strict from the first character. The file's checkPrologue half already passes. Reported as
-    // adams85/acornima#47.
-    "staging/sm/strict/deprecated-octal-noctal-tokens.js",
-
     // === PERMANENT EXCLUSIONS ===
     //
     // Everything above this banner is debt: a gap somebody is expected to pay down, each entry saying

--- a/Jint.Tests/Runtime/EvalSuperTests.cs
+++ b/Jint.Tests/Runtime/EvalSuperTests.cs
@@ -1,0 +1,150 @@
+﻿using Jint.Runtime;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// <see href="https://tc39.es/ecma262/#sec-performeval">PerformEval</see> admits a direct
+/// <c>super()</c> in eval code only when its <i>inDerivedConstructor</i> parameter is true. Jint hands
+/// that computed flag to the parser as <c>ParserOptions.AllowDirectSuperOutsideMethod</c> rather than
+/// switching the option on for every eval, so the parse itself refuses what the specification refuses.
+/// The option follows the eval'd unit's this binding, which is why an arrow function declared in the
+/// eval may call <c>super()</c> while an ordinary function declared there may not - the latter would
+/// have no home object to find one through.
+/// </summary>
+public class EvalSuperTests
+{
+    private static string NameOfThrownError(string source)
+    {
+        var ex = Invoking(() => new Engine().Execute(source)).Should().ThrowExactly<JavaScriptException>().Which;
+        return ex.Error.Get("name").AsString();
+    }
+
+    [Test]
+    public void ADirectEvalInADerivedConstructorMayCallSuper()
+    {
+        var engine = new Engine();
+        engine.Execute("""
+            var ran = false;
+            class B { constructor() { ran = true; } }
+            class D extends B { constructor() { eval("super()"); } }
+            new D();
+            """);
+
+        engine.Evaluate("ran").AsBoolean().Should().BeTrue();
+    }
+
+    // The two shapes staging/sm/class/derivedConstructorArrowEval*SuperCall.js pin: an arrow declared
+    // in the eval shares the derived constructor's this binding, however deeply it is nested.
+    [TestCase("""class D extends B { constructor() { eval("(() => super())()"); } }""")]
+    [TestCase("""class D extends B { constructor() { eval("(() => (() => super())())()"); } }""")]
+    [TestCase("""class D extends B { constructor() { eval("(() => { let f = () => super(); f(); })()"); } }""")]
+    public void AnArrowDeclaredInTheEvalMayCallSuper(string derivedClass)
+    {
+        var engine = new Engine();
+        engine.Execute("var ran = false; class B { constructor() { ran = true; } }");
+        engine.Execute(derivedClass);
+        engine.Execute("new D();");
+
+        engine.Evaluate("ran").AsBoolean().Should().BeTrue();
+    }
+
+    // Nothing but a direct eval inside a derived constructor may carry one.
+    [TestCase("""eval("super()");""")]
+    [TestCase("""(0, eval)("super()");""")]
+    [TestCase("""function f() { eval("super()"); } f();""")]
+    [TestCase("""class B { constructor() { eval("super()"); } } new B();""")]
+    [TestCase("""class B { m() { eval("super()"); } } new B().m();""")]
+    [TestCase("""class B { static m() { eval("super()"); } } B.m();""")]
+    public void EverywhereElseASuperCallInEvalIsASyntaxError(string source)
+    {
+        NameOfThrownError(source).Should().Be("SyntaxError");
+    }
+
+    [Test]
+    public void AnArrowInTheDerivedConstructorCarriesTheSameEntitlementIntoItsOwnEval()
+    {
+        // The arrow shares the constructor's this binding, so a direct eval it makes is still one made
+        // in a derived constructor. Calling super() twice is then the runtime error it always is - which
+        // is the point: the parse admitted it, the runtime judged it.
+        var ex = Invoking(() => new Engine().Execute("""
+            class B { constructor() {} }
+            class D extends B { constructor() { super(); (() => eval("super()"))(); } }
+            new D();
+            """)).Should().ThrowExactly<JavaScriptException>().Which;
+
+        ex.Error.Get("name").AsString().Should().Be("ReferenceError");
+    }
+
+    [Test]
+    public void AnOrdinaryFunctionDeclaredInTheEvalMayNotCallSuper()
+    {
+        // The option follows the this binding, and an ordinary function introduces one of its own,
+        // so this stays a Syntax Error even in the one context where the eval itself may carry a super call.
+        NameOfThrownError("""
+            class B { constructor() {} }
+            class D extends B { constructor() { super(); eval("(function () { super() })"); } }
+            new D();
+            """).Should().Be("SyntaxError");
+    }
+
+    [Test]
+    public void AComputedClassElementNameIsReachedByContainsSuperCall()
+    {
+        // A computed class element name is evaluated in the enclosing scope, so it is a super call of
+        // the eval'd unit itself - allowed in a derived constructor...
+        var engine = new Engine();
+        engine.Execute("""
+            var ran = false;
+            class B { constructor() { ran = true; } }
+            class D extends B { constructor() { eval("class X { [super()]() {} }"); } }
+            new D();
+            """);
+        engine.Evaluate("ran").AsBoolean().Should().BeTrue();
+
+        // ...and a Syntax Error anywhere else.
+        NameOfThrownError("""class B { m() { eval("class X { [super()]() {} }"); } } new B().m();""").Should().Be("SyntaxError");
+    }
+
+    [Test]
+    public void EvalOfAWholeDerivedClassIsUnaffected()
+    {
+        // The super call belongs to the class's own constructor, not to the eval'd unit, so no context
+        // gating applies to it.
+        var engine = new Engine();
+        engine.Execute("""var C = eval("(class extends Object { constructor() { super(); this.ok = 1; } })"); var instance = new C();""");
+        engine.Evaluate("instance.ok").AsNumber().Should().Be(1);
+    }
+
+    [Test]
+    public void TheEvalCacheKeepsThePermittedAndForbiddenParsesApart()
+    {
+        // One source, two contexts: the cached parse of the permitted one must not make the forbidden
+        // one run, and the forbidden one must not poison the permitted one afterwards.
+        var engine = new Engine();
+        engine.Execute("""
+            var log = [];
+            class B { constructor() { log.push("B"); } }
+            class D extends B { constructor() { eval("super()"); } }
+            class E { constructor() { try { eval("super()"); log.push("no error"); } catch (e) { log.push(e.name); } } }
+            new D(); new D(); new E(); new D();
+            """);
+
+        engine.Evaluate("log.join(',')").AsString().Should().Be("B,B,SyntaxError,B");
+    }
+
+    [Test]
+    public void ASuperPropertyInTheEvalStillFollowsTheThisBinding()
+    {
+        // The sibling option, AllowSuperOutsideMethod, is scoped the same way: a method's eval may read
+        // a super property at its top level or from an arrow, but not from an ordinary function.
+        var engine = new Engine();
+        engine.Execute("""
+            class B { m() { return [eval("super.constructor.name"), eval("(() => super.constructor.name)()")].join(","); } }
+            var result = new B().m();
+            """);
+        engine.Evaluate("result").AsString().Should().Be("Object,Object");
+
+        NameOfThrownError("""class B { m() { return eval("(function () { return super.x })"); } } new B().m();""").Should().Be("SyntaxError");
+        NameOfThrownError("""eval("super.x");""").Should().Be("SyntaxError");
+    }
+}

--- a/Jint.Tests/Runtime/EvalSuperTests.cs
+++ b/Jint.Tests/Runtime/EvalSuperTests.cs
@@ -5,7 +5,7 @@ namespace Jint.Tests.Runtime;
 /// <summary>
 /// <see href="https://tc39.es/ecma262/#sec-performeval">PerformEval</see> admits a direct
 /// <c>super()</c> in eval code only when its <i>inDerivedConstructor</i> parameter is true. Jint hands
-/// that computed flag to the parser as <c>ParserOptions.AllowDirectSuperOutsideMethod</c> rather than
+/// that computed flag to the parser as <c>ParserOptions.AllowSuperCallOutsideConstructor</c> rather than
 /// switching the option on for every eval, so the parse itself refuses what the specification refuses.
 /// The option follows the eval'd unit's this binding, which is why an arrow function declared in the
 /// eval may call <c>super()</c> while an ordinary function declared there may not - the latter would

--- a/Jint/Native/Function/EvalFunction.cs
+++ b/Jint/Native/Function/EvalFunction.cs
@@ -26,9 +26,13 @@ public sealed class EvalFunction : Function
 
     private Dictionary<CacheKey, CacheEntry>? _evalCache;
 
-    // Memoized `with`-adjustment of the active parser options (stable instance in steady state).
+    // Memoized `with`-adjustment of the active parser options (stable instances in steady state).
+    // Two of them, because one of the adjustments is not constant: PerformEval admits a direct
+    // super() only when inDerivedConstructor is true, so that parser option is passed through per
+    // call rather than switched on for every eval.
     private ParserOptions? _lastBaseParserOptions;
     private ParserOptions? _lastAdjustedParserOptions;
+    private ParserOptions? _lastAdjustedParserOptionsInDerivedConstructor;
 
     // Two-touch promotion: a source enters the cache only when seen twice, so one-shot eval
     // workloads pay just a failed lookup + key compare instead of an insert per call.
@@ -128,24 +132,21 @@ public sealed class EvalFunction : Function
         }
 
         var parserOptions = _engine.GetActiveParserOptions();
-        ParserOptions adjustedParserOptions;
-        if (ReferenceEquals(parserOptions, _lastBaseParserOptions))
+        if (!ReferenceEquals(parserOptions, _lastBaseParserOptions))
         {
-            adjustedParserOptions = _lastAdjustedParserOptions!;
+            _lastBaseParserOptions = parserOptions;
+            _lastAdjustedParserOptions = null;
+            _lastAdjustedParserOptionsInDerivedConstructor = null;
+        }
+
+        ParserOptions adjustedParserOptions;
+        if (inDerivedConstructor)
+        {
+            adjustedParserOptions = _lastAdjustedParserOptionsInDerivedConstructor ??= AdjustParserOptions(parserOptions, inDerivedConstructor: true);
         }
         else
         {
-            adjustedParserOptions = parserOptions with
-            {
-                AllowReturnOutsideFunction = false,
-                AllowNewTargetOutsideFunction = true,
-                AllowSuperOutsideMethod = true,
-                // This is a workaround, just makes some tests pass. Actually, we need these checks (done either by the parser or by the runtime).
-                // TODO: implement a correct solution
-                CheckPrivateFields = false
-            };
-            _lastBaseParserOptions = parserOptions;
-            _lastAdjustedParserOptions = adjustedParserOptions;
+            adjustedParserOptions = _lastAdjustedParserOptions ??= AdjustParserOptions(parserOptions, inDerivedConstructor: false);
         }
 
         // For indirect eval, parse in non-strict mode (strictness only from "use strict" in code)
@@ -517,6 +518,26 @@ public sealed class EvalFunction : Function
     {
         templates.AsSpan().CopyTo(slots);
     }
+
+    /// <summary>
+    /// The parse-time half of PerformEval's early errors (https://tc39.es/ecma262/#sec-performeval).
+    /// Eval code is a Script, so the parser has to be told which of the surrounding context's
+    /// permissions carry into it. <paramref name="inDerivedConstructor"/> is the specification's own
+    /// parameter: a direct <c>super()</c> is admitted only for a direct eval inside a derived
+    /// constructor, never for the evals the specification forbids one in. The option follows the
+    /// eval'd unit's this binding, so it reaches arrow functions declared there but not ordinary
+    /// ones - exactly the places where the runtime's <c>super()</c> would find a home object.
+    /// </summary>
+    private static ParserOptions AdjustParserOptions(ParserOptions parserOptions, bool inDerivedConstructor) => parserOptions with
+    {
+        AllowReturnOutsideFunction = false,
+        AllowNewTargetOutsideFunction = true,
+        AllowSuperOutsideMethod = true,
+        AllowDirectSuperOutsideMethod = inDerivedConstructor,
+        // This is a workaround, just makes some tests pass. Actually, we need these checks (done either by the parser or by the runtime).
+        // TODO: implement a correct solution
+        CheckPrivateFields = false
+    };
 
     private sealed class EvalScriptAnalyzer : AstVisitor
     {

--- a/Jint/Native/Function/EvalFunction.cs
+++ b/Jint/Native/Function/EvalFunction.cs
@@ -533,7 +533,7 @@ public sealed class EvalFunction : Function
         AllowReturnOutsideFunction = false,
         AllowNewTargetOutsideFunction = true,
         AllowSuperOutsideMethod = true,
-        AllowDirectSuperOutsideMethod = inDerivedConstructor,
+        AllowSuperCallOutsideConstructor = inDerivedConstructor,
         // This is a workaround, just makes some tests pass. Actually, we need these checks (done either by the parser or by the runtime).
         // TODO: implement a correct solution
         CheckPrivateFields = false


### PR DESCRIPTION
Closes the last five entries under the `=== STAGING EXCLUSIONS ===` banner, which is the whole of what remains in #3021. All five were blocked on the same external dependency — the parser — and none of them was a Jint defect that could be fixed in this repository alone. It also moves the test262 pin to the current upstream tip, which is a no-op for the engine (details at the end).

## Ready to merge

The dependency this PR waited on has shipped: **Acornima `1.8.0` was released on 2026-08-28 and landed on `main` in #3496**, so `Directory.Packages.props` is no longer touched here — this branch is rebased onto `main` at `0aa624402` and contains only the wiring, the test, and the exclusion deletions. Everything below was verified against the released package, not a local build.

What `1.8.0` carries, against what this PR needed:

| needed | shipped in `1.8.0` as |
| --- | --- |
| [adams85/acornima#44](https://github.com/adams85/acornima/pull/44) — `ParserOptions.AllowSuperCallOutsideConstructor`, plus the alignment of `AllowSuperOutsideMethod` | merged as-is |
| [adams85/acornima#48](https://github.com/adams85/acornima/pull/48) — the `CoverInitializedName` early error in an assignment target | superseded by the maintainer's own [adams85/acornima#52](https://github.com/adams85/acornima/pull/52), which closes the same file |
| [adams85/acornima#49](https://github.com/adams85/acornima/pull/49) — legacy octal constructs in the token after an ASI-terminated `"use strict"` | merged as-is |

Two more fixes rode along in the release that this PR did not depend on: [#51](https://github.com/adams85/acornima/pull/51) (legacy octal right after a strict function body) and a regression fix for `super()` in a class field when the class is declared inside another class's constructor.

## The option was renamed on merge

We contributed #44 as `ParserOptions.AllowDirectSuperOutsideMethod`; it shipped as **`ParserOptions.AllowSuperCallOutsideConstructor`**. The new name says what the option admits (a direct super *call*) and where the code being parsed came from (the *constructor* of a derived class — [PerformEval](https://tc39.es/ecma262/#sec-performeval)'s *inDerivedConstructor*) rather than naming the parser-internal `AllowDirectSuper` flag it seeds, and it reads better beside the `AllowSuperOutsideMethod` it implies. Nothing but the name changed: same default (`false`), same scoping, same semantics.

## What the five files needed

**Three of them — `class/derivedConstructorArrowEvalSuperCall.js`, `class/derivedConstructorArrowEvalNestedSuperCall.js`, `fields/bug1587574.js` — needed a parser option and its wiring here.**

Jint already parses eval code with `AllowSuperOutsideMethod`, but that covers `SuperProperty` only, so `eval("super()")` in a derived constructor failed to parse with *'super' keyword unexpected here* instead of running. [PerformEval](https://tc39.es/ecma262/#sec-performeval) forbids a direct `super()` only when *inDerivedConstructor* is false, and `EvalFunction.PerformEval` already computes that flag for its own post-parse early error. So the wiring is to **pass the computed flag to the parser**, not to switch the option on for every eval:

```csharp
AllowSuperCallOutsideConstructor = inDerivedConstructor,
```

That is why the adjusted `ParserOptions` are now memoized in two slots rather than one — the adjustment is no longer constant, and one of the two variants must never be handed to an eval the specification forbids a `super()` in. The `_evalCache` entry check already compares the `ParserOptions` it was parsed with, so one source evaluated from both contexts gets one parse each and neither can serve the other. `TheEvalCacheKeepsThePermittedAndForbiddenParsesApart` pins exactly that.

The option is scoped, not global: it follows the eval'd unit's this binding, so it reaches arrow functions declared in the eval but not ordinary ones. That is what lets Jint enable it for the whole eval and still have the parser refuse `eval("(function () { super() })")`, which the specification refuses too — and it is why the two arrow-nesting files pass rather than merely the flat one.

`fields/bug1587574.js` is the same defect and not the field-initializer TDZ the old exclusion comment guessed at: its `class Q { f = 1; }` exists only to defeat SpiderMonkey's lazy parsing, and the `ReferenceError` it expects is the derived constructor's `this` TDZ, raised because the eval'd `super()` sits inside arrows that are never called.

**`destructuring/bug1396261.js` and `strict/deprecated-octal-noctal-tokens.js` needed no Jint change at all** — acornima#52 and acornima#49 close them, and the only thing this PR does for them is delete their exclusion entries.

## A behaviour change that is already on `main`

acornima#44 also aligned `AllowSuperOutsideMethod` with the new option, at the maintainer's request: it now follows the top level's this binding instead of blanket-allowing `super` anywhere in the parsed unit. `AllowSuper` is no longer a short-circuit on the option, it is the root scope seeded with `ScopeFlags.Super` — which `EnterScope` propagates through arrow function scopes but not through ordinary function ones.

Since Jint sets `AllowSuperOutsideMethod` for **every** eval, this reached every eval the moment #3496 merged — it is not something this PR introduces, but this PR is where it gets pinned. Measured, the whole of the difference is one row:

```js
class B { m() { return "base-m"; } }
class D extends B { m() { return eval("(function () { return super.m(); })()"); } }
new D().m();
```

| | Acornima 1.7.0 | Acornima 1.8.0 (`main` today) |
| --- | --- | --- |
| `super.m()` in an **ordinary function** declared in eval code | `TypeError: Cannot read property 'm' of undefined` | `SyntaxError: 'super' keyword unexpected here` |

The new answer is the correct one: [SuperProperty](https://tc39.es/ecma262/#sec-super-keyword) is permitted only where the code is method code, so an ordinary `FunctionExpression` body is a Syntax Error — V8 answers `SyntaxError` here too. The old behaviour parsed it and deferred to a confusing runtime `TypeError` once `[[HomeObject]]` turned out to be undefined. Nothing was lost: `super.x` in eval inside a method, inside an arrow in eval, inside a nested eval, and in a derived constructor after `super()` all answer exactly as they did. `EvalSuperTests.ASuperPropertyInTheEvalStillFollowsTheThisBinding` pins both halves.

## Verification

Run on one machine (Windows) against the released Acornima `1.8.0`, with this branch rebased onto `main` at `0aa624402`.

**Test262, at the pin `main` has today (`3655e746`).** The baseline is the `windows` leg of #3496's own CI run (`38b6d45c2` — `main` plus the `1.8.0` bump, with all five exclusions still in place); no exclusion has changed on `main` since, so it is the same suite this branch runs.

| | before (`main` + Acornima 1.8.0) | after (this branch) |
| --- | --- | --- |
| `Jint.Tests.Test262` | 102,507 passed / **0 failed** / 177 skipped | **102,517 passed / 0 failed / 167 skipped** |

+10 passed, −10 skipped: five files × two modes, total unchanged at 102,684, and no other row moved. Per file, both the sloppy and the strict run now pass:

| file | closed by |
| --- | --- |
| `staging/sm/class/derivedConstructorArrowEvalSuperCall.js` | acornima#44 + the wiring here |
| `staging/sm/class/derivedConstructorArrowEvalNestedSuperCall.js` | acornima#44 + the wiring here |
| `staging/sm/fields/bug1587574.js` | acornima#44 + the wiring here |
| `staging/sm/destructuring/bug1396261.js` | acornima#52 |
| `staging/sm/strict/deprecated-octal-noctal-tokens.js` | acornima#49 |

- `dotnet build -c Release` for the solution, all TFMs (`net472;netstandard2.0;netstandard2.1;net8.0;net10.0`): 0 errors, and the same single pre-existing `MSB3277` reference-conflict warning `main` builds with.
- `Jint.Tests` 11,026 passed / 0 failed / 5 skipped (net10.0) and 7,646 / 0 / 4 (net472); `Jint.Tests.PublicInterface` 3,306 / 0 / 21 (net10.0), 3,296 / 0 / 21 (net8.0) and 2,673 / 0 / 21 (net472) — the same three rows #3496's run reports for `main`; `Jint.Tests.CommonScripts` 28 / 0; `Jint.Tests.SourceGenerators` 71 / 0.
- **Public API is untouched** — `PublicApiTest` passes for every shipped target framework, so the snapshot records no diff.

`Jint.Tests/Runtime/EvalSuperTests.cs` is new and covers the wiring from the outside: where a `super()` in eval is admitted, where it is a `SyntaxError`, that an arrow in the eval inherits the entitlement while an ordinary function does not, that a computed class element name counts as a super call of the eval'd unit and a field initializer never does, and that the two parses stay apart in the eval cache. Every expectation in it was cross-checked against V8 (node 24). It was written for xUnit and is converted to NUnit on the rebase, since #3409 moved `Jint.Tests` over in the meantime.

## The test262 pin moves to the upstream tip

`SuiteGitSha` goes from `3655e746` to [`14e8c908`](https://github.com/tc39/test262/commit/14e8c908e54ae2e770e473bcacf536f8cb654929), the tip of `tc39/test262` `main` today. The range is 13 commits, and only two of them touch `test/`:

| commit | what it is | Jint |
| --- | --- | --- |
| [`ac7b5f8c`](https://github.com/tc39/test262/commit/ac7b5f8c39) — *Add tests for out-of-order braced quantifier in regexp literals* | two new negative parse tests, `/a{2,1}/` and `/a{2,1}/u`, for the *MV of the first DecimalDigits is strictly greater than the second* early error of [sec-patterns-static-semantics-early-errors](https://tc39.es/ecma262/#sec-patterns-static-semantics-early-errors) | already a `SyntaxError` at parse time (*numbers out of order in {} quantifier*), and the same through `eval`, `Function`, and `new RegExp(…)` under no flag, `u` and `v` — checked in the REPL before the run |
| [`14e8c908`](https://github.com/tc39/test262/commit/14e8c908e5) — *Remove duplicate testTypedArray.js includes* | four files list `testTypedArray.js` once instead of twice | nothing |

The other eleven are CI tables, the CircleCI removal, an ESMeta version bump and tooling scripts. `features.txt` is unchanged, so no feature enters or leaves `ExcludedFeatures`, and no exclusion of any kind is added.

| | `3655e746` | `14e8c908` |
| --- | --- | --- |
| `Jint.Tests.Test262` (this branch) | 102,517 passed / 0 failed / 167 skipped / 102,684 | **102,521 passed / 0 failed / 167 skipped / 102,688** |

+4 passed and +4 total — the two new files, each run in sloppy and strict mode — with nothing skipped and nothing failing. `Generated/` was regenerated for the run (the settings hash moved and the new file names appear in the generated suite), so the green is the new suite's, not a stale one's.

## After this

`#3021` has nothing left in it: the `STAGING EXCLUSIONS` banner keeps only the 20 entries for tests that cannot finish under an interpreter — unbounded recursion that kills the test host, an `Infinity`-length loop, and eighteen that only end at the 30-second timeout — none of which was among the 109 that issue indexed.
