### PR TITLE
Collections: a removed property slot is a tombstone, not a free slot to reuse

### DIFF
--- a/Jint.Benchmark/PropertyDeleteChurnBenchmark.cs
+++ b/Jint.Benchmark/PropertyDeleteChurnBenchmark.cs
@@ -1,0 +1,200 @@
+using BenchmarkDotNet.Attributes;
+using Jint.Collections;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// The delete side of the property stores, which had no coverage before #3273 and is the only path that
+/// change made more expensive. <see cref="StringDictionarySlim{TValue}"/> used to hand a removed entry's
+/// slot to the next add from a free list; it now leaves a tombstone and appends, because a JS property
+/// store enumerates in entry order and a reused slot puts a key back in a position older than its
+/// creation. The tombstones are reclaimed by compaction inside the resize an add would have needed
+/// anyway, so what is measured here is how much that reclamation costs on the shapes that provoke it.
+/// <para>
+/// The four collection rows are the distinguishable cases. <c>AddOnly</c> is the control: no removals, so
+/// nothing about its path changed. <c>AddThenRemoveNewest</c> removes the entry that was just added, which
+/// walks the high-water mark back and never compacts. <c>RotateOldest</c> is the one shape that keeps
+/// compacting — it adds a name never seen before and drops the oldest live one, so every step leaves a
+/// hole below the mark. <c>ReAddMiddle</c> looks like it should compact too and does not: after the first
+/// step the re-added name <em>is</em> the newest entry, so it takes the same shortcut
+/// <c>AddThenRemoveNewest</c> does. That asymmetry is the point of having both.
+/// </para>
+/// <para>
+/// They measure the collection rather than a script on purpose: an engine-level delete costs a property
+/// key conversion, a shape deopt check and a version bump on top, which would dilute the very difference
+/// this class exists to size. The two <c>Script*</c> rows put it back in proportion, and there is one per
+/// collection shape that behaves differently — <c>ScriptDeleteReAdd</c> re-adds the same name (the
+/// non-compacting shape, and the issue's own repro) and <c>ScriptRotateOldest</c> adds a fresh one and
+/// deletes the oldest (the compacting shape). Measuring only the first would have priced the shape that
+/// did not regress.
+/// </para>
+/// <para>
+/// Each script row gets its own engine through <see cref="IsolatedScript"/>, warmed with that row's script
+/// and nothing else, so engine construction stays out of the measurement. <c>ScriptRotateOldest</c>'s
+/// engine additionally carries one fixture that row alone needs — a JS array of the property names it
+/// churns through, built once in <c>[GlobalSetup]</c> so that string concatenation does not enter the
+/// measured loop. The measured script rebuilds its own object every invocation, which it must: the churn
+/// deletes names in the order it created them, so an object carried over from the previous invocation
+/// would have every one of those deletes miss and grow without bound.
+/// </para>
+/// </summary>
+[MemoryDiagnoser]
+public class PropertyDeleteChurnBenchmark
+{
+    /// <summary>Live key count of the table being churned — 16 and 64 sit either side of a resize step.</summary>
+    [Params(16, 64)]
+    public int Width { get; set; }
+
+    private const int Steps = 10_000;
+
+    /// <summary>
+    /// Churn rounds the script rows drive. Two orders of magnitude below <see cref="Steps"/> because an
+    /// engine-level delete-and-add costs roughly two orders of magnitude more than a collection one, which
+    /// is the whole comparison these rows exist to make.
+    /// </summary>
+    private const int ScriptSteps = 2_000;
+
+    /// <summary>Enumerations the <c>ScriptKeysAfterRotation</c> row drives over the already-churned object.</summary>
+    private const int EnumerationSteps = 200;
+
+    private string[] _keys = null!;
+    private string[] _fresh = null!;
+    private IsolatedScript _scriptDeleteReAdd;
+    private IsolatedScript _scriptRotateOldest;
+    private IsolatedScript _scriptKeysAfterRotation;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _keys = new string[Width];
+        for (var i = 0; i < Width; i++)
+        {
+            _keys[i] = "k" + i;
+        }
+
+        _fresh = new string[Steps];
+        for (var i = 0; i < Steps; i++)
+        {
+            _fresh[i] = "n" + i;
+        }
+
+        var literal = string.Join(",", _keys.Select(static k => k + ":1"));
+        _scriptDeleteReAdd = IsolatedScript.Warm($$"""
+            var o = { {{literal}} };
+            for (var n = 0; n < {{ScriptSteps}}; n++) { delete o.k{{Width / 2}}; o.k{{Width / 2}} = n; }
+            o.k{{Width / 2}};
+            """);
+
+        var names = $"var names = []; for (var i = 0; i < {ScriptSteps + Width}; i++) names[i] = 'n' + i;";
+        var rotate = $$"""
+            var o = {};
+            for (var i = 0; i < {{Width}}; i++) { o[names[i]] = i; }
+            for (var n = 0; n < {{ScriptSteps}}; n++) { o[names[{{Width}} + n]] = n; delete o[names[n]]; }
+            """;
+        _scriptRotateOldest = IsolatedScript.Warm(
+            rotate,
+            () =>
+            {
+                var engine = new Engine();
+                engine.Execute(names);
+                return engine;
+            });
+
+        _scriptKeysAfterRotation = IsolatedScript.Warm(
+            $"for (var n = 0; n < {EnumerationSteps}; n++) {{ Object.keys(o); }}",
+            () =>
+            {
+                var engine = new Engine();
+                engine.Execute(names);
+                engine.Execute(rotate);
+                return engine;
+            });
+    }
+
+    private StringDictionarySlim<object> Filled()
+    {
+        var dictionary = new StringDictionarySlim<object>();
+        for (var i = 0; i < _keys.Length; i++)
+        {
+            dictionary[_keys[i]] = _keys;
+        }
+
+        return dictionary;
+    }
+
+    /// <summary>Control: the add path with no removals at all, which is what the engine does far more of.</summary>
+    [Benchmark]
+    public int AddOnly()
+    {
+        var total = 0;
+        for (var step = 0; step < Steps / _keys.Length; step++)
+        {
+            total += Filled().Count;
+        }
+
+        return total;
+    }
+
+    /// <summary>Adding a key and immediately removing it: the high-water mark walks back, nothing compacts.</summary>
+    [Benchmark]
+    public int AddThenRemoveNewest()
+    {
+        var dictionary = Filled();
+        for (var step = 0; step < Steps; step++)
+        {
+            dictionary["churn"] = _keys;
+            dictionary.Remove("churn");
+        }
+
+        return dictionary.Count;
+    }
+
+    /// <summary>Steady-state rotation: every step adds a name never seen before and drops the oldest live one.</summary>
+    [Benchmark]
+    public int RotateOldest()
+    {
+        var dictionary = Filled();
+        for (var step = 0; step < Steps; step++)
+        {
+            dictionary[_fresh[step]] = _fresh;
+            dictionary.Remove(step < _keys.Length ? _keys[step] : _fresh[step - _keys.Length]);
+        }
+
+        return dictionary.Count;
+    }
+
+    /// <summary>The issue's own shape: delete a key from the middle of the table and add the same name back.</summary>
+    [Benchmark]
+    public int ReAddMiddle()
+    {
+        var dictionary = Filled();
+        var middle = _keys[_keys.Length / 2];
+        for (var step = 0; step < Steps; step++)
+        {
+            dictionary.Remove(middle);
+            dictionary[middle] = _fresh;
+        }
+
+        return dictionary.Count;
+    }
+
+    /// <summary>The same delete-and-re-add through the engine, so the collection delta can be put in proportion.</summary>
+    [Benchmark]
+    public void ScriptDeleteReAdd() => _scriptDeleteReAdd.Execute();
+
+    /// <summary>
+    /// <see cref="RotateOldest"/> through the engine: the compacting shape, which is the one
+    /// <see cref="ScriptDeleteReAdd"/> does not reach.
+    /// </summary>
+    [Benchmark]
+    public void ScriptRotateOldest() => _scriptRotateOldest.Execute();
+
+    /// <summary>
+    /// Reading the keys of an object that has already been churned, which is the cost the tombstones
+    /// impose on the <em>other</em> side. The rotation happens once, in this row's own engine fixture, so
+    /// what is measured is only the enumeration — and the enumerator has to step over every tombstone the
+    /// table is holding, which is exactly what the compaction threshold decides the number of.
+    /// </summary>
+    [Benchmark]
+    public void ScriptKeysAfterRotation() => _scriptKeysAfterRotation.Execute();
+}

--- a/Jint.Tests/Runtime/OwnPropertyCreationOrderTests.cs
+++ b/Jint.Tests/Runtime/OwnPropertyCreationOrderTests.cs
@@ -1,0 +1,423 @@
+using System.Reflection;
+using Jint.Collections;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// <see href="https://tc39.es/ecma262/#sec-ordinaryownpropertykeys">OrdinaryOwnPropertyKeys</see> lists
+/// string keys, and then symbol keys, "in ascending chronological order of property creation". A
+/// <c>delete</c> destroys the property; adding the name back creates a <em>new</em> one, which is
+/// therefore the newest key — so the name moves to the end, and a brand-new name added after any delete
+/// appends rather than filling the gap.
+/// <para>
+/// The property stores are hash tables that used to reuse a removed entry's slot from a free list while
+/// enumerating in entry-array index order, so a re-added key came back in its old position and a new key
+/// landed in the hole (issue #3273). <see cref="PropertyDictionary"/> switches from its list backing to
+/// <see cref="StringDictionarySlim{TValue}"/> at nine entries, which is why the string cases below
+/// straddle that boundary deliberately; the symbol store is a
+/// <see cref="DictionarySlim{TKey,TValue}"/> from the first key, so it had no correct size at all.
+/// </para>
+/// </summary>
+public class OwnPropertyCreationOrderTests
+{
+    private static string Keys(Engine engine, string expression) => engine.Evaluate(expression).AsString();
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(7)]
+    [InlineData(8)]  // last size backed by ListDictionary
+    [InlineData(9)]  // first size backed by StringDictionarySlim
+    [InlineData(10)]
+    [InlineData(16)]
+    [InlineData(40)]
+    public void ADeletedKeyThatIsAddedBackIsTheNewestKey(int n)
+    {
+        var engine = new Engine();
+        var actual = Keys(engine, $$"""
+            var o = {};
+            for (var i = 0; i < {{n}}; i++) o['k' + i] = i;
+            delete o.k0;
+            o.k0 = 99;
+            Object.keys(o).join(',');
+            """);
+
+        var expected = new List<string>();
+        for (var i = 1; i < n; i++)
+        {
+            expected.Add("k" + i);
+        }
+        expected.Add("k0");
+
+        actual.Should().Be(string.Join(",", expected));
+    }
+
+    [Theory]
+    [InlineData(8)]
+    [InlineData(9)]
+    [InlineData(24)]
+    public void ADeletedKeyInTheMiddleThatIsAddedBackIsTheNewestKey(int n)
+    {
+        var engine = new Engine();
+        var actual = Keys(engine, $$"""
+            var o = {};
+            for (var i = 0; i < {{n}}; i++) o['k' + i] = i;
+            delete o.k3;
+            o.k3 = 99;
+            Object.keys(o).join(',');
+            """);
+
+        var expected = new List<string>();
+        for (var i = 0; i < n; i++)
+        {
+            if (i != 3)
+            {
+                expected.Add("k" + i);
+            }
+        }
+        expected.Add("k3");
+
+        actual.Should().Be(string.Join(",", expected));
+    }
+
+    /// <summary>
+    /// A brand-new name added after a delete appends too — the vacated position belongs to no key at all.
+    /// This is the half of the defect the free list made worst: two deletes and two unrelated adds put the
+    /// new names into the two holes, in reverse order (the free list is LIFO).
+    /// </summary>
+    [Fact]
+    public void NewKeysAddedAfterADeleteAppendRatherThanFillingTheGap()
+    {
+        var engine = new Engine();
+        var actual = Keys(engine, """
+            var o = {};
+            for (var i = 0; i < 9; i++) o['k' + i] = i;
+            delete o.k1;
+            delete o.k3;
+            o.a = 1;
+            o.b = 2;
+            Object.keys(o).join(',');
+            """);
+
+        actual.Should().Be("k0,k2,k4,k5,k6,k7,k8,a,b");
+    }
+
+    [Fact]
+    public void EmptyingAndRefillingRebuildsTheOrderFromScratch()
+    {
+        var engine = new Engine();
+        var actual = Keys(engine, """
+            var o = {};
+            for (var i = 0; i < 9; i++) o['k' + i] = i;
+            for (var i = 0; i < 9; i++) delete o['k' + i];
+            for (var i = 8; i >= 0; i--) o['k' + i] = i;
+            Object.keys(o).join(',');
+            """);
+
+        actual.Should().Be("k8,k7,k6,k5,k4,k3,k2,k1,k0");
+    }
+
+    /// <summary>
+    /// Every own-key listing goes through the one enumeration, so each of these is the same defect seen
+    /// from a different built-in. Kept explicit because they are what an embedder actually calls.
+    /// </summary>
+    [Theory]
+    [InlineData("Object.keys(o).join(',')", "k1,k2,k3,k4,k5,k6,k7,k8,k0")]
+    [InlineData("Object.values(o).join(',')", "1,2,3,4,5,6,7,8,99")]
+    [InlineData("Object.entries(o).map(function (e) { return e[0]; }).join(',')", "k1,k2,k3,k4,k5,k6,k7,k8,k0")]
+    [InlineData("Object.getOwnPropertyNames(o).join(',')", "k1,k2,k3,k4,k5,k6,k7,k8,k0")]
+    [InlineData("Object.keys(Object.getOwnPropertyDescriptors(o)).join(',')", "k1,k2,k3,k4,k5,k6,k7,k8,k0")]
+    [InlineData("Reflect.ownKeys(o).join(',')", "k1,k2,k3,k4,k5,k6,k7,k8,k0")]
+    [InlineData("Reflect.ownKeys(new Proxy(o, {})).join(',')", "k1,k2,k3,k4,k5,k6,k7,k8,k0")]
+    [InlineData("var r = []; for (var k in o) r.push(k); r.join(',')", "k1,k2,k3,k4,k5,k6,k7,k8,k0")]
+    [InlineData("Object.keys(Object.assign({}, o)).join(',')", "k1,k2,k3,k4,k5,k6,k7,k8,k0")]
+    [InlineData("Object.keys({ ...o }).join(',')", "k1,k2,k3,k4,k5,k6,k7,k8,k0")]
+    [InlineData("var { k5, ...rest } = o; Object.keys(rest).join(',')", "k1,k2,k3,k4,k6,k7,k8,k0")]
+    [InlineData("JSON.stringify(o)", """{"k1":1,"k2":2,"k3":3,"k4":4,"k5":5,"k6":6,"k7":7,"k8":8,"k0":99}""")]
+    public void EveryOwnKeyListingSeesTheReAddedKeyLast(string expression, string expected)
+    {
+        var engine = new Engine();
+        var actual = engine.Evaluate($$"""
+            var o = {};
+            for (var i = 0; i < 9; i++) o['k' + i] = i;
+            delete o.k0;
+            o.k0 = 99;
+            {{expression}};
+            """).AsString();
+
+        actual.Should().Be(expected);
+    }
+
+    [Fact]
+    public void DefinePropertyAsTheReAddIsAlsoACreation()
+    {
+        var engine = new Engine();
+        var actual = Keys(engine, """
+            var o = {};
+            for (var i = 0; i < 9; i++) o['k' + i] = i;
+            delete o.k0;
+            Object.defineProperty(o, 'k0', { value: 99, writable: true, enumerable: true, configurable: true });
+            Object.keys(o).join(',');
+            """);
+
+        actual.Should().Be("k1,k2,k3,k4,k5,k6,k7,k8,k0");
+    }
+
+    [Fact]
+    public void ReflectDeleteAndSetBehaveLikeTheOperators()
+    {
+        var engine = new Engine();
+        var actual = Keys(engine, """
+            var o = {};
+            for (var i = 0; i < 9; i++) o['k' + i] = i;
+            Reflect.deleteProperty(o, 'k0');
+            Reflect.set(o, 'k0', 99);
+            Object.keys(o).join(',');
+            """);
+
+        actual.Should().Be("k1,k2,k3,k4,k5,k6,k7,k8,k0");
+    }
+
+    /// <summary>
+    /// Integer-like keys are listed first in ascending numeric order whatever happens to them, so the
+    /// mixed case pins that the string half moves and the index half does not.
+    /// </summary>
+    [Fact]
+    public void IndexKeysStayAscendingWhileStringKeysFollowCreationOrder()
+    {
+        var engine = new Engine();
+        var actual = Keys(engine, """
+            var o = {};
+            o[2] = 'i2';
+            o[0] = 'i0';
+            for (var i = 0; i < 9; i++) o['s' + i] = i;
+            delete o.s0;
+            o.s0 = 99;
+            Object.keys(o).join(',');
+            """);
+
+        actual.Should().Be("0,2,s1,s2,s3,s4,s5,s6,s7,s8,s0");
+    }
+
+    [Fact]
+    public void AnArrayWithStringPropertiesFollowsTheSameRule()
+    {
+        var engine = new Engine();
+        var actual = Keys(engine, """
+            var a = [1, 2, 3];
+            for (var i = 0; i < 10; i++) a['p' + i] = i;
+            delete a.p0;
+            a.p0 = 99;
+            Object.keys(a).join(',');
+            """);
+
+        actual.Should().Be("0,1,2,p1,p2,p3,p4,p5,p6,p7,p8,p9,p0");
+    }
+
+    /// <summary>
+    /// Symbol keys are their own list in <see cref="Object" />.getOwnPropertySymbols and carry the same
+    /// chronological rule. The symbol store has no small-size backing to hide behind, so two keys are
+    /// already enough.
+    /// </summary>
+    [Theory]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(9)]
+    [InlineData(12)]
+    public void ADeletedSymbolThatIsAddedBackIsTheNewestSymbol(int n)
+    {
+        var engine = new Engine();
+        var actual = Keys(engine, $$"""
+            var o = {};
+            var s = [];
+            for (var i = 0; i < {{n}}; i++) { s.push(Symbol('s' + i)); o[s[i]] = i; }
+            delete o[s[0]];
+            o[s[0]] = 99;
+            Object.getOwnPropertySymbols(o).map(String).join(',');
+            """);
+
+        var expected = new List<string>();
+        for (var i = 1; i < n; i++)
+        {
+            expected.Add($"Symbol(s{i})");
+        }
+        expected.Add("Symbol(s0)");
+
+        actual.Should().Be(string.Join(",", expected));
+    }
+
+    /// <summary>
+    /// A built-in prototype starts in the shared built-in shape, where a string-key delete deopts into
+    /// <see cref="PropertyDictionary"/> first. <c>Map.prototype</c> has enough members (13) to land in the
+    /// hash backing rather than the list backing, so it is the shape path's witness for this bug.
+    /// </summary>
+    [Fact]
+    public void ADeoptedBuiltinShapeFollowsTheSameRule()
+    {
+        var engine = new Engine();
+        var before = Keys(engine, "Object.getOwnPropertyNames(Map.prototype).join(',')");
+        before.Should().Contain("get");
+
+        var after = Keys(engine, """
+            delete Map.prototype.get;
+            Map.prototype.get = 1;
+            Object.getOwnPropertyNames(Map.prototype).join(',');
+            """);
+
+        var expected = string.Join(",", before.Split(',').Where(static k => k != "get").Concat(["get"]));
+        after.Should().Be(expected);
+    }
+
+    [Fact]
+    public void RepeatedDeleteAndReAddOfTheSameKeyKeepsItLast()
+    {
+        var engine = new Engine();
+        var actual = Keys(engine, """
+            var o = {};
+            for (var i = 0; i < 12; i++) o['k' + i] = i;
+            for (var r = 0; r < 200; r++) { delete o.k5; o.k5 = r; }
+            Object.keys(o).join(',');
+            """);
+
+        actual.Should().Be("k0,k1,k2,k3,k4,k6,k7,k8,k9,k10,k11,k5");
+    }
+
+    /// <summary>
+    /// A randomized cross-check against a model kept in script: 20,000 add/delete operations over a key
+    /// space wide enough to cross the cutover, resize and compact many times. The model is the rule
+    /// itself — a new name appends, assigning an existing one leaves it where it is, a delete drops it —
+    /// so a mismatch means the store diverged from creation order somewhere in the churn rather than in
+    /// any one hand-picked scenario. Deterministic seed, so a failure is reproducible.
+    /// </summary>
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void RandomizedChurnKeepsTheStoreInCreationOrder(bool symbolKeys)
+    {
+        var subject = symbolKeys
+            ? "var key = function (i) { return syms[i]; }; var list = function (o) { return Object.getOwnPropertySymbols(o).map(String).join(','); }; var name = function (i) { return String(syms[i]); };"
+            : "var key = function (i) { return 'x' + i; }; var list = function (o) { return Object.keys(o).join(','); }; var name = function (i) { return 'x' + i; };";
+
+        var engine = new Engine();
+        var result = engine.Evaluate($$"""
+            var syms = [];
+            for (var i = 0; i < 60; i++) syms.push(Symbol('y' + i));
+            {{subject}}
+
+            var seed = 12345;
+            function rnd(n) { seed = (seed * 1103515245 + 12345) & 0x7fffffff; return seed % n; }
+
+            var o = {};
+            var model = [];
+            for (var step = 0; step < 20000; step++) {
+                var i = rnd(60);
+                if (rnd(2) === 0) {
+                    if (model.indexOf(i) < 0) model.push(i);
+                    o[key(i)] = step;
+                } else {
+                    var at = model.indexOf(i);
+                    if (at >= 0) model.splice(at, 1);
+                    delete o[key(i)];
+                }
+            }
+
+            var want = model.map(name).join(',');
+            list(o) === want ? 'OK:' + model.length : 'MISMATCH\n got  ' + list(o) + '\n want ' + want;
+            """).AsString();
+
+        result.Should().StartWith("OK:");
+        // A churn that ended with an empty or barely-filled store would prove very little.
+        int.Parse(result.Substring(3), System.Globalization.CultureInfo.InvariantCulture).Should().BeGreaterThan(9);
+    }
+
+    /// <summary>
+    /// Insertion order is preserved by never reusing a removed entry's slot, so the entry array has to be
+    /// reclaimed some other way: it is compacted when a resize would otherwise be needed. That makes the
+    /// storage of a long add/delete churn bounded by the live key count rather than by the number of
+    /// operations, which is the property that keeps the fix from being a leak.
+    /// </summary>
+    [Fact]
+    public void ChurningAKeyDoesNotGrowTheEntryArrayWithoutBound()
+    {
+        var dictionary = new StringDictionarySlim<int>();
+        for (var i = 0; i < 16; i++)
+        {
+            dictionary["k" + i] = i;
+        }
+
+        for (var r = 0; r < 100_000; r++)
+        {
+            dictionary.Remove("churn");
+            dictionary["churn"] = r;
+        }
+
+        dictionary.Count.Should().Be(17);
+        EntryCapacityOf(dictionary).Should().BeLessThan(128);
+    }
+
+    /// <summary>
+    /// The same bound, but for churn that does not simply re-add the newest key: every round adds a fresh
+    /// name and deletes one from the middle of the table, so no entry slot can be reclaimed on removal and
+    /// only compaction keeps the array in check.
+    /// </summary>
+    [Fact]
+    public void ChurningDistinctKeysDoesNotGrowTheEntryArrayWithoutBound()
+    {
+        var dictionary = new StringDictionarySlim<int>();
+        for (var i = 0; i < 16; i++)
+        {
+            dictionary["k" + i] = i;
+        }
+
+        for (var r = 0; r < 100_000; r++)
+        {
+            dictionary["n" + r] = r;
+            dictionary.Remove("k" + (r % 16));
+            dictionary["k" + (r % 16)] = r;
+            dictionary.Remove("n" + r);
+        }
+
+        dictionary.Count.Should().Be(16);
+        EntryCapacityOf(dictionary).Should().BeLessThan(256);
+    }
+
+    [Fact]
+    public void RemovalAndReAdditionKeepsTheCollectionEnumerableInInsertionOrder()
+    {
+        var dictionary = new StringDictionarySlim<int>();
+        for (var i = 0; i < 20; i++)
+        {
+            dictionary["k" + i] = i;
+        }
+
+        dictionary.Remove("k0");
+        dictionary.Remove("k7");
+        dictionary["k7"] = 700;
+        dictionary["fresh"] = 1;
+        dictionary["k0"] = 0;
+
+        var order = dictionary.Select(static pair => pair.Key.Name).ToList();
+
+        var expected = new List<string>();
+        for (var i = 1; i < 20; i++)
+        {
+            if (i != 7)
+            {
+                expected.Add("k" + i);
+            }
+        }
+        expected.Add("k7");
+        expected.Add("fresh");
+        expected.Add("k0");
+
+        order.Should().Equal(expected);
+        dictionary.Count.Should().Be(21);
+        dictionary["k7"].Should().Be(700);
+    }
+
+    private static int EntryCapacityOf<T>(StringDictionarySlim<T> dictionary)
+    {
+        var field = typeof(StringDictionarySlim<T>).GetField("_entries", BindingFlags.Instance | BindingFlags.NonPublic);
+        return ((Array) field!.GetValue(dictionary)!).Length;
+    }
+}

--- a/Jint/Collections/DictionarySlim.cs
+++ b/Jint/Collections/DictionarySlim.cs
@@ -16,6 +16,15 @@ namespace Jint.Collections;
 /// 1) It allows access to the value by ref replacing the common TryGetValue and Add pattern.
 /// 2) It does not store the hash code (assumes it is cheap to equate values).
 /// 3) It does not accept an equality comparer (assumes Object.GetHashCode() and Object.Equals() or overridden implementation are cheap and sufficient).
+/// <para>
+/// It additionally enumerates in <em>insertion order</em>, which the type it was derived from does not:
+/// this backs a JavaScript object's own symbol-keyed properties, and
+/// <see href="https://tc39.es/ecma262/#sec-ordinaryownpropertykeys">OrdinaryOwnPropertyKeys</see> requires
+/// them "in ascending chronological order of property creation". A removed entry therefore leaves a
+/// tombstone rather than joining a free list an add would pop from — reusing a vacated slot would hand a
+/// key an enumeration position older than its creation. See <see cref="Resize"/> for how the tombstones
+/// are reclaimed.
+/// </para>
 /// </summary>
 [DebuggerDisplay("Count = {Count}")]
 internal sealed class DictionarySlim<TKey, TValue> : IReadOnlyCollection<KeyValuePair<TKey, TValue>> where TKey : IEquatable<TKey>
@@ -25,9 +34,17 @@ internal sealed class DictionarySlim<TKey, TValue> : IReadOnlyCollection<KeyValu
     // The first add will cause a resize replacing these with real arrays of three elements.
     // Arrays are wrapped in a class to avoid being duplicated for each <TKey, TValue>
     private static readonly Entry[] InitialEntries = new Entry[1];
+
+    /// <summary>
+    /// <see cref="Entry.next"/> of a removed entry. Live entries carry -1 (end of bucket chain) or a
+    /// 0-based index, and a slot never written carries 0, so this is the one value below -1.
+    /// </summary>
+    private const int Tombstone = -2;
+
+    // Number of live entries.
     private int _count;
-    // 0-based index into _entries of head of free chain: -1 means empty
-    private int _freeList = -1;
+    // High-water mark: _entries[0.._lastIndex) are live entries and tombstones, in insertion order.
+    private int _lastIndex;
     // 1-based index into _entries; 0 means empty
     private int[] _buckets;
     private Entry[] _entries;
@@ -38,9 +55,8 @@ internal sealed class DictionarySlim<TKey, TValue> : IReadOnlyCollection<KeyValu
     {
         public TKey key;
         public TValue value;
-        // 0-based index of next entry in chain: -1 means end of chain
-        // also encodes whether this entry _itself_ is part of the free list by changing sign and subtracting 3,
-        // so -2 means end of free list, -3 means index 0 but on free list, -4 means index 1 but on free list, etc.
+        // 0-based index of next entry in chain: -1 means end of chain,
+        // Tombstone (-2) means this entry was removed and holds no key.
         public int next;
     }
 
@@ -67,7 +83,7 @@ internal sealed class DictionarySlim<TKey, TValue> : IReadOnlyCollection<KeyValu
     public void Clear()
     {
         _count = 0;
-        _freeList = -1;
+        _lastIndex = 0;
         _buckets = HashHelpers.SizeOneIntArray;
         _entries = InitialEntries;
     }
@@ -124,11 +140,17 @@ internal sealed class DictionarySlim<TKey, TValue> : IReadOnlyCollection<KeyValu
                 }
 
                 entries[entryIndex] = default;
-
-                entries[entryIndex].next = -3 - _freeList; // New head of free list
-                _freeList = entryIndex;
+                entries[entryIndex].next = Tombstone;
 
                 _count--;
+
+                // Removing the newest entry can hand its slot straight back without disturbing the order
+                // of anything older, which is what makes add-then-remove churn free of compaction.
+                if (entryIndex == _lastIndex - 1)
+                {
+                    _lastIndex = entryIndex;
+                }
+
                 return true;
             }
             lastIndex = entryIndex;
@@ -170,24 +192,16 @@ internal sealed class DictionarySlim<TKey, TValue> : IReadOnlyCollection<KeyValu
     [MethodImpl(MethodImplOptions.NoInlining)]
     private ref TValue AddKey(TKey key, int bucketIndex)
     {
+        // Always appends: the new entry is the newest key, and enumeration is entry order.
         Entry[] entries = _entries;
-        int entryIndex;
-        if (_freeList != -1)
+        if (_lastIndex == entries.Length || entries.Length == 1)
         {
-            entryIndex = _freeList;
-            _freeList = -3 - entries[_freeList].next;
-        }
-        else
-        {
-            if (_count == entries.Length || entries.Length == 1)
-            {
-                entries = Resize();
-                bucketIndex = key.GetHashCode() & (_buckets.Length - 1);
-                // entry indexes were not changed by Resize
-            }
-            entryIndex = _count;
+            entries = Resize();
+            bucketIndex = key.GetHashCode() & (_buckets.Length - 1);
+            // entry indexes of surviving entries were not reordered by Resize
         }
 
+        var entryIndex = _lastIndex++;
         entries[entryIndex].key = key;
         entries[entryIndex].next = _buckets[bucketIndex] - 1;
         _buckets[bucketIndex] = entryIndex + 1;
@@ -195,29 +209,86 @@ internal sealed class DictionarySlim<TKey, TValue> : IReadOnlyCollection<KeyValu
         return ref entries[entryIndex].value;
     }
 
+    /// <summary>
+    /// Makes room at the top of the entry array, which is the only place an add may write.
+    /// <para>
+    /// With no removals this is the plain doubling it has always been. Otherwise the tombstones left by
+    /// <see cref="Remove"/> are squeezed out — in place when the live entries fit in half the capacity,
+    /// and into a doubled array when they do not. Compaction preserves relative order, so it is invisible
+    /// to enumeration; insisting on the half is what keeps adds amortized O(1), since every call here is
+    /// followed by at least <c>capacity / 2</c> adds before the next one.
+    /// </para>
+    /// <para>
+    /// The half is measured rather than chosen. It is consulted only by a table that has both left
+    /// tombstones and filled its array, and because capacities are powers of two it does not tune the
+    /// cost continuously — it decides which power of two such a table settles on, and the interval
+    /// between compactions is then the capacity minus the live count. A quarter settles a rotating key
+    /// set at twice its live count and costs a compaction every <c>n</c> adds; a half settles it at four
+    /// times and costs one every <c>3n</c>. Measured against slot reuse that is +34.8% and +8.9%. Going
+    /// on to a three-quarters erases the rest and doubles the ceiling again, which is the trade this
+    /// stops short of; #3285 carries the curve and the memory figures at every setting.
+    /// </para>
+    /// </summary>
     private Entry[] Resize()
     {
-        Debug.Assert(_entries.Length == _count || _entries.Length == 1); // We only copy _count, so if it's longer we will miss some
-        int count = _count;
-        int newSize = _entries.Length * 2;
-        if ((uint) newSize > int.MaxValue) // uint cast handles overflow
-            throw new InvalidOperationException("Capacity Overflow");
+        Debug.Assert(_lastIndex == _entries.Length || _entries.Length == 1);
 
-        var entries = new Entry[newSize];
-        Array.Copy(_entries, 0, entries, 0, count);
+        var entries = _entries;
+        var count = _count;
+        var lastIndex = _lastIndex;
 
-        var newBuckets = new int[entries.Length];
-        while (count-- > 0)
+        Entry[] newEntries;
+        if (count == lastIndex || count + 1 > entries.Length - (entries.Length >> 1))
         {
-            int bucketIndex = entries[count].key.GetHashCode() & (newBuckets.Length - 1);
-            entries[count].next = newBuckets[bucketIndex] - 1;
-            newBuckets[bucketIndex] = count + 1;
+            var newSize = entries.Length * 2;
+            if ((uint) newSize > int.MaxValue) // uint cast handles overflow
+                throw new InvalidOperationException("Capacity Overflow");
+
+            newEntries = new Entry[newSize];
+            _buckets = new int[newSize];
+        }
+        else
+        {
+            newEntries = entries;
+            Array.Clear(_buckets, 0, _buckets.Length);
         }
 
-        _buckets = newBuckets;
-        _entries = entries;
+        if (count == lastIndex)
+        {
+            Array.Copy(entries, 0, newEntries, 0, count);
+        }
+        else
+        {
+            var write = 0;
+            for (var read = 0; read < lastIndex; read++)
+            {
+                if (entries[read].next != Tombstone)
+                {
+                    newEntries[write++] = entries[read];
+                }
+            }
 
-        return entries;
+            Debug.Assert(write == count);
+
+            if (ReferenceEquals(newEntries, entries))
+            {
+                // Release the keys and values the compacted-away tail still references.
+                Array.Clear(entries, count, lastIndex - count);
+            }
+        }
+
+        _lastIndex = count;
+        _entries = newEntries;
+
+        var buckets = _buckets;
+        while (count-- > 0)
+        {
+            int bucketIndex = newEntries[count].key.GetHashCode() & (buckets.Length - 1);
+            newEntries[count].next = buckets[bucketIndex] - 1;
+            buckets[bucketIndex] = count + 1;
+        }
+
+        return newEntries;
     }
 
     /// <summary>
@@ -261,7 +332,9 @@ internal sealed class DictionarySlim<TKey, TValue> : IReadOnlyCollection<KeyValu
 
             _count--;
 
-            while (_dictionary._entries[_index].next < -1)
+            // Skips the tombstones removals left behind; the live entries between them are still in
+            // insertion order, which is what this type exists to preserve.
+            while (_dictionary._entries[_index].next == Tombstone)
                 _index++;
 
             _current = new KeyValuePair<TKey, TValue>(

--- a/Jint/Collections/StringDictionarySlim.cs
+++ b/Jint/Collections/StringDictionarySlim.cs
@@ -19,6 +19,15 @@ namespace Jint.Collections;
 /// 1) It allows access to the value by ref replacing the common TryGetValue and Add pattern.
 /// 2) It does not store the hash code (assumes it is cheap to equate values).
 /// 3) It does not accept an equality comparer (assumes Object.GetHashCode() and Object.Equals() or overridden implementation are cheap and sufficient).
+/// <para>
+/// It additionally enumerates in <em>insertion order</em>, which the type it was derived from does not:
+/// this backs a JavaScript object's own string-keyed properties, and
+/// <see href="https://tc39.es/ecma262/#sec-ordinaryownpropertykeys">OrdinaryOwnPropertyKeys</see> requires
+/// them "in ascending chronological order of property creation". A removed entry therefore leaves a
+/// tombstone rather than joining a free list an add would pop from — reusing a vacated slot would hand a
+/// key an enumeration position older than its creation. See <see cref="Resize"/> for how the tombstones
+/// are reclaimed.
+/// </para>
 /// </summary>
 [DebuggerTypeProxy(typeof(DictionarySlimDebugView<>))]
 [DebuggerDisplay("Count = {Count}")]
@@ -29,9 +38,17 @@ internal sealed class StringDictionarySlim<TValue> : DictionaryBase<TValue>, IRe
     // The first add will cause a resize replacing these with real arrays of three elements.
     // Arrays are wrapped in a class to avoid being duplicated for each <TKey, TValue>
     private static readonly Entry[] InitialEntries = new Entry[1];
+
+    /// <summary>
+    /// <see cref="Entry.next"/> of a removed entry. Live entries carry -1 (end of bucket chain) or a
+    /// 0-based index, and a slot never written carries 0, so this is the one value below -1.
+    /// </summary>
+    private const int Tombstone = -2;
+
+    // Number of live entries.
     private int _count;
-    // 0-based index into _entries of head of free chain: -1 means empty
-    private int _freeList = -1;
+    // High-water mark: _entries[0.._lastIndex) are live entries and tombstones, in insertion order.
+    private int _lastIndex;
     // 1-based index into _entries; 0 means empty
     private int[] _buckets;
     private Entry[] _entries;
@@ -41,9 +58,8 @@ internal sealed class StringDictionarySlim<TValue> : DictionaryBase<TValue>, IRe
     {
         public Key key;
         public TValue value;
-        // 0-based index of next entry in chain: -1 means end of chain
-        // also encodes whether this entry _itself_ is part of the free list by changing sign and subtracting 3,
-        // so -2 means end of free list, -3 means index 0 but on free list, -4 means index 1 but on free list, etc.
+        // 0-based index of next entry in chain: -1 means end of chain,
+        // Tombstone (-2) means this entry was removed and holds no key.
         public int next;
     }
 
@@ -74,7 +90,7 @@ internal sealed class StringDictionarySlim<TValue> : DictionaryBase<TValue>, IRe
     public void Clear()
     {
         _count = 0;
-        _freeList = -1;
+        _lastIndex = 0;
         _buckets = HashHelpers.SizeOneIntArray;
         _entries = InitialEntries;
     }
@@ -87,17 +103,19 @@ internal sealed class StringDictionarySlim<TValue> : DictionaryBase<TValue>, IRe
     /// </summary>
     public void ClearPreservingCapacity()
     {
-        if (_count == 0)
+        if (_lastIndex == 0)
         {
-            // Never grew past the shared dummy arrays — nothing to keep, nothing to clear.
+            // Never grew past the shared dummy arrays — nothing to keep, nothing to clear. Tested on the
+            // high-water mark rather than on Count so that a table emptied by removals resets it: Count
+            // is already 0 there, and returning early would make the next refill append above the
+            // tombstones instead of starting at slot 0.
             return;
         }
 
-        // Bindings are only added (never removed) during a refill, so used entries are dense in [0, _count).
         Array.Clear(_buckets, 0, _buckets.Length);
-        Array.Clear(_entries, 0, _count);
+        Array.Clear(_entries, 0, _lastIndex);
         _count = 0;
-        _freeList = -1;
+        _lastIndex = 0;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -129,11 +147,17 @@ internal sealed class StringDictionarySlim<TValue> : DictionaryBase<TValue>, IRe
                 }
 
                 entries[entryIndex] = default;
-
-                entries[entryIndex].next = -3 - _freeList; // New head of free list
-                _freeList = entryIndex;
+                entries[entryIndex].next = Tombstone;
 
                 _count--;
+
+                // Removing the newest entry can hand its slot straight back without disturbing the order
+                // of anything older, which is what makes `o.k = v; delete o.k;` churn free of compaction.
+                if (entryIndex == _lastIndex - 1)
+                {
+                    _lastIndex = entryIndex;
+                }
+
                 return true;
             }
             lastIndex = entryIndex;
@@ -217,24 +241,16 @@ internal sealed class StringDictionarySlim<TValue> : DictionaryBase<TValue>, IRe
     [MethodImpl(MethodImplOptions.NoInlining)]
     private ref TValue AddKey(Key key, int bucketIndex)
     {
+        // Always appends: the new entry is the newest key, and enumeration is entry order.
         Entry[] entries = _entries;
-        int entryIndex;
-        if (_freeList != -1)
+        if (_lastIndex == entries.Length || entries.Length == 1)
         {
-            entryIndex = _freeList;
-            _freeList = -3 - entries[_freeList].next;
-        }
-        else
-        {
-            if (_count == entries.Length || entries.Length == 1)
-            {
-                entries = Resize();
-                bucketIndex = key.HashCode & (_buckets.Length - 1);
-                // entry indexes were not changed by Resize
-            }
-            entryIndex = _count;
+            entries = Resize();
+            bucketIndex = key.HashCode & (_buckets.Length - 1);
+            // entry indexes of surviving entries were not reordered by Resize
         }
 
+        var entryIndex = _lastIndex++;
         entries[entryIndex].key = key;
         entries[entryIndex].next = _buckets[bucketIndex] - 1;
         _buckets[bucketIndex] = entryIndex + 1;
@@ -242,29 +258,86 @@ internal sealed class StringDictionarySlim<TValue> : DictionaryBase<TValue>, IRe
         return ref entries[entryIndex].value;
     }
 
+    /// <summary>
+    /// Makes room at the top of the entry array, which is the only place an add may write.
+    /// <para>
+    /// With no removals this is the plain doubling it has always been. Otherwise the tombstones left by
+    /// <see cref="Remove"/> are squeezed out — in place when the live entries fit in half the capacity,
+    /// and into a doubled array when they do not. Compaction preserves relative order, so it is invisible
+    /// to enumeration; insisting on the half is what keeps adds amortized O(1), since every call here is
+    /// followed by at least <c>capacity / 2</c> adds before the next one.
+    /// </para>
+    /// <para>
+    /// The half is measured rather than chosen. It is consulted only by a table that has both left
+    /// tombstones and filled its array, and because capacities are powers of two it does not tune the
+    /// cost continuously — it decides which power of two such a table settles on, and the interval
+    /// between compactions is then the capacity minus the live count. A quarter settles a rotating key
+    /// set at twice its live count and costs a compaction every <c>n</c> adds; a half settles it at four
+    /// times and costs one every <c>3n</c>. Measured against slot reuse that is +34.8% and +8.9%. Going
+    /// on to a three-quarters erases the rest and doubles the ceiling again, which is the trade this
+    /// stops short of; #3285 carries the curve and the memory figures at every setting.
+    /// </para>
+    /// </summary>
     private Entry[] Resize()
     {
-        Debug.Assert(_entries.Length == _count || _entries.Length == 1); // We only copy _count, so if it's longer we will miss some
-        int count = _count;
-        int newSize = _entries.Length * 2;
-        if ((uint) newSize > int.MaxValue) // uint cast handles overflow
-            throw new InvalidOperationException("Capacity Overflow");
+        Debug.Assert(_lastIndex == _entries.Length || _entries.Length == 1);
 
-        var entries = new Entry[newSize];
-        Array.Copy(_entries, 0, entries, 0, count);
+        var entries = _entries;
+        var count = _count;
+        var lastIndex = _lastIndex;
 
-        var newBuckets = new int[entries.Length];
-        while (count-- > 0)
+        Entry[] newEntries;
+        if (count == lastIndex || count + 1 > entries.Length - (entries.Length >> 1))
         {
-            int bucketIndex = entries[count].key.HashCode & (newBuckets.Length - 1);
-            entries[count].next = newBuckets[bucketIndex] - 1;
-            newBuckets[bucketIndex] = count + 1;
+            var newSize = entries.Length * 2;
+            if ((uint) newSize > int.MaxValue) // uint cast handles overflow
+                throw new InvalidOperationException("Capacity Overflow");
+
+            newEntries = new Entry[newSize];
+            _buckets = new int[newSize];
+        }
+        else
+        {
+            newEntries = entries;
+            Array.Clear(_buckets, 0, _buckets.Length);
         }
 
-        _buckets = newBuckets;
-        _entries = entries;
+        if (count == lastIndex)
+        {
+            Array.Copy(entries, 0, newEntries, 0, count);
+        }
+        else
+        {
+            var write = 0;
+            for (var read = 0; read < lastIndex; read++)
+            {
+                if (entries[read].next != Tombstone)
+                {
+                    newEntries[write++] = entries[read];
+                }
+            }
 
-        return entries;
+            Debug.Assert(write == count);
+
+            if (ReferenceEquals(newEntries, entries))
+            {
+                // Release the key strings and values the compacted-away tail still references.
+                Array.Clear(entries, count, lastIndex - count);
+            }
+        }
+
+        _lastIndex = count;
+        _entries = newEntries;
+
+        var buckets = _buckets;
+        while (count-- > 0)
+        {
+            int bucketIndex = newEntries[count].key.HashCode & (buckets.Length - 1);
+            newEntries[count].next = buckets[bucketIndex] - 1;
+            buckets[bucketIndex] = count + 1;
+        }
+
+        return newEntries;
     }
 
     /// <summary>
@@ -308,7 +381,9 @@ internal sealed class StringDictionarySlim<TValue> : DictionaryBase<TValue>, IRe
 
             _count--;
 
-            while (_dictionary._entries[_index].next < -1)
+            // Skips the tombstones removals left behind; the live entries between them are still in
+            // insertion order, which is what this type exists to preserve.
+            while (_dictionary._entries[_index].next == Tombstone)
                 _index++;
 
             _current = new KeyValuePair<Key, TValue>(


### PR DESCRIPTION
# A removed property slot is a tombstone, not a free slot to reuse

Fixes #3273.

[OrdinaryOwnPropertyKeys](https://tc39.es/ecma262/#sec-ordinaryownpropertykeys) lists string keys, and
then symbol keys, "in ascending chronological order of property creation". `delete o.k` destroys the
property; `o.k = v` creates a new one, which is therefore the newest key.

Both property stores are hash tables derived from `DictionarySlim`, whose entries enumerate in
array-index order and whose removals joined a free list the next add popped from. Reusing a vacated slot
hands a key an enumeration position older than its creation.

```
// Remove                                   // AddKey
entries[entryIndex] = default;              if (_freeList != -1)
entries[entryIndex].next = -3 - _freeList;  {
_freeList = entryIndex;                         entryIndex = _freeList;   // <-- the removed key's slot
                                                _freeList = -3 - entries[_freeList].next;
                                            }
```

A removal now leaves a tombstone and an add always appends. The tombstones are reclaimed inside the
resize an add would have needed anyway.

## The defect is wider than the issue reports

Two things the issue's repro does not show, both found while surveying the blast radius:

**Symbol keys have the same bug and no correct size at all.** `ObjectInstance._symbols` is a
`DictionarySlim<JsSymbol, PropertyDescriptor>` directly — there is no `HybridDictionary` list backing to
hide behind, so it is wrong from the second symbol up, not from the ninth.

```js
var a = Symbol('a'), b = Symbol('b'), c = Symbol('c');
var o = {}; o[a] = 1; o[b] = 2; o[c] = 3;
delete o[a]; o[a] = 9;
Object.getOwnPropertySymbols(o).map(String).join(',');
// before: Symbol(a),Symbol(b),Symbol(c)      Node 24: Symbol(b),Symbol(c),Symbol(a)
```

**A brand-new key added after any delete also lands in the hole**, in LIFO order — it is not only
re-added names that move. This is the larger half of the defect:

```js
var o = {}; for (var i = 0; i < 9; i++) o['k' + i] = i;
delete o.k1; delete o.k3; o.a = 1; o.b = 2;
Object.keys(o).join(',');
// before: k0,b,k2,a,k4,k5,k6,k7,k8          Node 24: k0,k2,k4,k5,k6,k7,k8,a,b
```

Taken to its limit, deleting all nine keys and refilling them in reverse enumerated them in *forward*
order — a complete inversion of creation order.

## Blast-radius survey

Every row was run on a plain `new Engine()` and compared against Node 24.19.0 running the same script.
"Affected" means Jint disagreed with Node before this change and agrees after it.

| surface | affected | note |
| --- | --- | --- |
| `Object.keys` / `values` / `entries` | yes | |
| `Object.getOwnPropertyNames` | yes | |
| `Object.getOwnPropertyDescriptors` | yes | key order of the returned object |
| `Reflect.ownKeys` | yes | including through a pass-through `Proxy` |
| `for..in` | yes | |
| `JSON.stringify`, and a `JSON.parse`/`stringify` round trip | yes | |
| object spread `{...o}`, object rest `{k5, ...rest}` | yes | |
| `Object.assign` as source | yes | |
| `structuredClone` | yes | web API; verified in the REPL, not in the test file (plain engine) |
| `Object.defineProperty` as the re-add | yes | a define of an absent name is a creation |
| `Reflect.deleteProperty` + `Reflect.set` | yes | identical to the operators |
| a frozen object's listing | yes | freeze does not reorder; it was already wrong before freezing |
| an `Array`'s non-index string properties | yes | the index half is unaffected, the string half is not |
| **symbol keys** (`getOwnPropertySymbols`) | **yes, from 2 keys** | own store, no cutover — see above |
| a built-in shape that deopts into **hash** mode | yes | `Map.prototype`, 13 members |
| integer-like (array-index) keys | no | listed ascending numerically by a separate path |
| 1–8 string keys | no | `HybridDictionary`'s `ListDictionary` backing appends and unlinks |
| a shaped object while the shape holds | no | |
| a built-in shape that deopts into **list** mode | no | `Storage.prototype`, 7 members |
| crossing the cutover after a delete | no | `SwitchToDictionary` copies the list in order into a store that appends |

The shape paths need no separate fix: `ObjectInstance.RemoveOwnProperty` deopts a `ShapeMode` or
`BuiltinShapeMode` receiver into `_properties` *before* removing, so a deopted object is an ordinary
dictionary object and inherits the fix. Which backing it deopts into is decided by member count, which
is exactly why `Storage.prototype` was already right and `Map.prototype` was not.

## The fix

`Jint/Collections/StringDictionarySlim.cs` and `Jint/Collections/DictionarySlim.cs`, identically.

- `_freeList` is replaced by `_lastIndex`, a high-water mark: `_entries[0.._lastIndex)` holds live
  entries and tombstones, in insertion order. `_count` is now only the live count.
- `Remove` writes `next = Tombstone` (-2) instead of threading a free chain. If the removed entry was
  the newest, `_lastIndex` walks back and the slot is handed straight back — this makes
  `o.k = v; delete o.k;` churn never reach a resize.
- `AddKey` always appends at `_lastIndex++`. With no removals this is one branch *fewer* than before.
- `Resize` is the only place an add can find full, so it is where tombstones are reclaimed. With no
  removals it is the plain doubling it always was (`Array.Copy`, same trigger, same growth). Otherwise
  it compacts the live entries down, preserving their relative order: **in place** when the live entries
  fit in half the capacity, into a **doubled** array when they do not. The half is measured; see the
  threshold sweep.
- The enumerator is structurally unchanged — it already skipped free-list entries and yields exactly
  `Count` items, so it needed only the sentinel renamed.
- `ClearPreservingCapacity`'s early return moves from `_count == 0` to `_lastIndex == 0`. See the
  consumer audit.

### Worst-case analysis of the compaction cost

Let `C = _entries.Length`, `L = _lastIndex`, `n = _count`.

`AddKey` resizes iff `L == C`. `Resize` grows iff `n == L` or `n + 1 > C − ⌊C/2⌋`, else compacts in
place. Both branches are Θ(C); the grow branch additionally allocates `Entry[2C]` and `int[2C]`.

Free tail slots immediately after a resize:

| branch | free tail | because |
| --- | --- | --- |
| grow | `2C − n ≥ C` | `n ≤ C` |
| compact | `C − n ≥ ⌊C/2⌋ + 1` | it only compacted because `n + 1 ≤ C − ⌊C/2⌋` |

Each add consumes exactly one tail slot and removals only ever return them, so **at least `C/2` adds
must happen between two resize events**. The Θ(C) cost therefore amortizes to ≤ 2 element-copies per
add. That is the entire job of the threshold, and it is why it is not cosmetic: with a plain "compact
whenever there is any tombstone" rule, a full table with one hole would compact on every add and adds
would go quadratic.

**"Grow only, never compact" is not an option either.** `add a fresh name; delete an old one` in a loop
consumes a fresh slot per add with `n` constant, so `L` climbs to `C`, doubles, climbs again — unbounded
growth on a bounded working set. Compaction is a correctness requirement in space, not an optimization.

That leaves the *fraction* as the only free variable, and it is a memory-for-time trade rather than a
correctness one. It is measured below; **the half is what the measurement chose**, and the first draft
of this PR shipped a quarter, which cost +34.8% on a rotating key set.

## Rejected alternatives

| alternative | why not |
| --- | --- |
| **Keep the free list, but only append when the key is being *re*-added** | Incoherent — it fixes nothing. A vacated slot is always older than *any* subsequent key, so a brand-new name placed in it is just as wrong (the `o.a = 1; o.b = 2` case above). Any slot reuse whatsoever breaks chronological order. |
| **Per-entry insertion sequence + sort at enumeration** (V8's `NameDictionary` design) | 4 bytes per entry, plus O(n log n) and an allocation on *every* enumeration. Jint enumerates these stores on hot paths — `GetOwnPropertyKeys`, `for..in`, `HasNoEnumerableEntry`, `JsonSerializer`, `GlobalSnapshot` — and the whole point of the array-order enumeration is that it is a sequential scan. It is priceable now: what this design would buy back is the ~1.6 ns per rotation step the compaction still costs, and what it would pay is a sort per enumeration. Paying at read time to save at delete time is the wrong trade for this engine. |
| **A circular window over the entry array** — a `_firstIndex` beside the high-water mark, so removing the *oldest* entry hands its slot back the way removing the newest already does | Not rejected on the merits: it is the right answer for the one shape that still costs. Rotation becomes O(1) with no compaction at all and a *smaller* table than any threshold setting here. It is not in this PR because it puts a new invariant into the hottest data structure in the engine and a wrap check into the enumerator, whose whole value is being a sequential scan — not a change to land on top of a correctness fix at the end of its verification. Filed as #3315. |
| **Doubly-linked insertion-order list through the entries** (SpiderMonkey's shape table) | 8 bytes per entry and two pointer writes per add/remove, and it turns enumeration into pointer chasing — losing the sequential scan that the current layout gets for free. The tombstone design gets exact order with **zero** extra bytes per entry and keeps the scan. |
| **Fix it in the property-store usage only** — a separate order-preserving type, or a flag on the existing one | Enumerated the consumers first (below): of the four, two are property stores where order is a contract, and the other two never benefit from the free list at all — `BuiltinShape.Index` never removes, and environments are built and torn down. So a flag would buy nothing and cost a branch, and a second type would duplicate ~300 lines of hot code. `DictionarySlim<TKey,TValue>` in particular has **exactly one** consumer and it is a property store. |
| **Leave it, document the divergence** | Not defensible. It is a normative requirement, not an implementation-defined corner; Node/V8, SpiderMonkey and JSC all agree; and it is silently observable through `JSON.stringify`, which embedders diff. |

## Consumer audit

Every consumer of the two collection types, and whether enumeration order is a contract there.

`StringDictionarySlim<TValue>` — three:

| consumer | order | removes? |
| --- | --- | --- |
| `PropertyDictionary` = `HybridDictionary<PropertyDescriptor>` — `ObjectInstance._properties`, `ObjectWrapper._crossingMemo`, `TypeReference._properties`, `SuspendData.FastProperties`, the object-literal builder, the `GlobalSnapshot` rebuild | **contract** | yes |
| `HybridDictionary<Binding>` — `DeclarativeEnvironment`, `FunctionEnvironment`, `ModuleEnvironment._importBindings` | cache only — bindings resolve by name; the sole enumeration is `GetAllBindingNames`, which feeds the debugger and `GlobalEnvironment`'s name list | yes (`DeleteBinding`) |
| `BuiltinShape.Index` (`StringDictionarySlim<int>`) — name→slot lookup | cache only, and never enumerated: all seven call sites are `TryGetValue` | **no** |

`DictionarySlim<TKey, TValue>` — one, and it is a property store:

| consumer | order | removes? |
| --- | --- | --- |
| `SymbolDictionary` = `DictionarySlim<JsSymbol, PropertyDescriptor>` — `ObjectInstance._symbols` | **contract** | yes |

### Who assumed live entries were dense in `[0, _count)`

That assumption is now false, so it was chased deliberately. **Exactly two places held it, and both are
inside the collection files:**

- `Resize` — `Debug.Assert(_entries.Length == _count)` and `Array.Copy(_entries, 0, entries, 0, count)`.
  Now keyed on `_lastIndex`, with the copy replaced by the compacting walk.
- `ClearPreservingCapacity` — `Array.Clear(_entries, 0, _count)`, behind an early return on
  `_count == 0`. Both moved to `_lastIndex`. **The early return was a latent bug of its own**: its one
  caller is `FunctionEnvironment.Reset` (the pooled-environment reset), and an environment whose
  bindings had been deleted has `_count == 0` with a non-zero mark, so the old guard returned early and
  the next refill would have appended *above* the tombstones instead of starting at slot 0.

Nothing outside `Jint/Collections/` can hold the assumption at all: `_entries`, `_buckets`, `_count` and
`_lastIndex` are `private`, and a grep across `Jint/`, all three test projects and `Jint.Benchmark`
finds no other reader, reflective or otherwise. Every external consumer uses `Count` either as a
`List<T>` capacity hint or as a comparison, plus enumeration — and enumeration still yields exactly
`Count` items. That last property is load-bearing for `Engine.GlobalSnapshot.CaptureProperties` /
`CaptureSymbols` and `ObjectInstanceDebugView.Entries`, which allocate a fixed array of size `Count` and
fill it with a `foreach`; all three still hold.

## Tests

`Jint.Tests/Runtime/OwnPropertyCreationOrderTests.cs`, 40 cases. **33 of them were watched failing
against the unfixed tree** (see below); the 7 that passed are the sub-cutover string sizes and the two
storage-bound guards, which are the fix's own regression net rather than the bug's.

- both sides of the cutover pinned explicitly (n = 1, 2, 7, **8**, **9**, 10, 16, 40), plus a middle-key
  variant at 8/9/24;
- one row per own-key listing (13 expressions), each with the Node answer as the expectation;
- new-keys-append-after-a-delete, and the empty-and-refill inversion;
- symbols at 2, 3, 9 and 12 keys;
- `defineProperty` as the re-add, `Reflect.deleteProperty`+`set`, mixed index/string keys, an array's
  string properties, a deopted `Map.prototype`, 200 rounds of same-key churn;
- **a randomized cross-check**: 20,000 seeded add/delete operations over a 60-key space (string and
  symbol variants) against a model kept in script — a new name appends, assigning an existing one leaves
  it alone, a delete drops it. This is the row that says the compaction preserves order in general
  rather than in hand-picked scenarios, and both variants were red before the fix;
- two collection-level bounds (100,000 churn rounds each) asserting the entry array stays proportional
  to the live key count, which is what stops the fix being a leak.

### The red run

`Jint.Tests` filtered to the new class, with only the two collection files reverted to `upstream/main`
and everything else identical:

```
Failed!  - Failed:    33, Passed:     7, Skipped:     0, Total:    40
```

```
Failed Jint.Tests.Runtime.OwnPropertyCreationOrderTests.NewKeysAddedAfterADeleteAppendRatherThanFillingTheGap
  Expected string to be the same string, but they differ at index 3:
     ↓ (actual)
 "k0,b,k2,a,k4,k5,k6,k7,k8"
 "k0,k2,k4,k5,k6,k7,k8,a,b"
     ↑ (expected).

Failed Jint.Tests.Runtime.OwnPropertyCreationOrderTests.EmptyingAndRefillingRebuildsTheOrderFromScratch
  Expected string to be the same string, but they differ at index 1:
   ↓ (actual)
 "k0,k1,k2,k3,k4,k5,k6,k7,k8"
 "k8,k7,k6,k5,k4,k3,k2,k1,k0"
   ↑ (expected).
```

The 33 span every test method in the class:
`ADeletedKeyThatIsAddedBackIsTheNewestKey`, `ADeletedKeyInTheMiddleThatIsAddedBackIsTheNewestKey`,
`ADeletedSymbolThatIsAddedBackIsTheNewestSymbol`, `ADeoptedBuiltinShapeFollowsTheSameRule`,
`AnArrayWithStringPropertiesFollowsTheSameRule`, `DefinePropertyAsTheReAddIsAlsoACreation`,
`EmptyingAndRefillingRebuildsTheOrderFromScratch`, `EveryOwnKeyListingSeesTheReAddedKeyLast`,
`IndexKeysStayAscendingWhileStringKeysFollowCreationOrder`,
`NewKeysAddedAfterADeleteAppendRatherThanFillingTheGap`, `RandomizedChurnKeepsTheStoreInCreationOrder`,
`ReflectDeleteAndSetBehaveLikeTheOperators`,
`RemovalAndReAdditionKeepsTheCollectionEnumerableInInsertionOrder`,
`RepeatedDeleteAndReAddOfTheSameKeyKeepsItLast`.

With the fix restored: `Passed! - Failed: 0, Passed: 40`.

## Verification

Release throughout, re-run end to end on the final tree — the threshold change must not move
behaviour, and in particular the 40 order tests have to still pass on both sides of the nine-entry
cutover, which they do.

| suite | TFM | result |
| --- | --- | --- |
| solution build (`net472`, `netstandard2.0`, `netstandard2.1`, `net8.0`, `net10.0`) | all | succeeded, 0 errors, 1 warning† |
| `Jint.Tests` | net10.0 | **10645** passed / 0 failed / 5 skipped |
| `Jint.Tests` | net472 | **7298** / 0 / 4 |
| `Jint.Tests.PublicInterface` | net10.0 | **2563** / 0 / 9 |
| `Jint.Tests.PublicInterface` | net472 | **1963** / 0 / 9 |
| `Jint.Tests.CommonScripts` | net10.0 | **28** / 0 / 0 |
| `Jint.Tests.CommonScripts` | net472 | **28** / 0 / 0 |
| `Jint.Tests.SourceGenerators` | net10.0 | **54** / 0 / 0 |
| `Jint.Tests`, `JINT_HOST_CONTRACT_VERIFICATION=1` | net10.0 | **10645** / 0 / 5 |
| `Jint.Tests`, `JINT_HOST_CONTRACT_VERIFICATION=1` | net472 | **7298** / 0 / 4 |
| `Jint.Tests.PublicInterface`, `JINT_HOST_CONTRACT_VERIFICATION=1` | net10.0 | **2567** / 0 / 5 |
| `Jint.Tests.PublicInterface`, `JINT_HOST_CONTRACT_VERIFICATION=1` | net472 | **1967** / 0 / 5 |
| web-platform-tests (`Jint.Tests/Wpt`) | net10.0 | **457** / 0 / 1 (458 rows) |
| **`Jint.Tests.Test262`** | net10.0 | **102,495 passed / 0 failed / 189 skipped** (102,684) |
| **`Jint.Tests.Test262` — baseline, same machine, back to back** | net10.0 | **102,495 passed / 0 failed / 189 skipped** (102,684) |

† `MSB3277` (assembly-version conflicts among test-platform packages) from `Jint.Tests.CommonScripts` on
net472. Pre-existing and unrelated — this change touches no project file or package reference.

The baseline was produced by reverting *only* `Jint/Collections/DictionarySlim.cs` and
`Jint/Collections/StringDictionarySlim.cs` to `upstream/main` in the same tree, so the two runs differ by
nothing else. test262 is byte-identical before and after: no regression, and **no exclusion becomes
removable** — nothing in `ExcludedFiles` is order-related, and every one of the suite's own-key-order
assertions is over a handful of keys, i.e. under the cutover. That is why the suite was green with the
bug present.

### Flakes, stated plainly

- The **first** full test262 run on the rebased branch reported **1 failure**:
  `staging/sm/expressions/short-circuit-compound-assignment.js` (non-strict), `System.TimeoutException`
  after 33 s against the engine's 30 s default. The file is about `&&=`/`||=`/`??=` and touches no
  property deletion or enumeration. Run alone it passes in **367 ms** (8 cases); the full-suite re-run
  was clean at 102,495/0. The machine was running two other agents' heavy suites at the time.
- Before the rebase, one `Jint.Tests.PublicInterface` run had 1 failure in
  `UntrustedCodeProfileTests.OperationScopeCannotEndWhileAsyncWorkOwnsTheEngine` (a wall-clock-budget
  async test). It passed alone and on a full re-run, and did not recur on the rebased tree.
- Before the rebase, one *baseline* test262 run (upstream collections, i.e. no change under test)
  reported **3 failures**; an immediate repeat of the same tree was clean at 102,495/0. I did not
  capture the names before re-running — that is a gap in the record and it is stated rather than
  smoothed over.
- The verification run in the table above was re-run end to end on the final tree, in one sequence with
  nothing else on the machine, and was **clean first time** — no flake, no re-run, both test262 arms
  back to back.
- On the measurement side, the runner of the first paired arm was killed during its eighth round. The
  raw per-round data for the seven rounds that completed survived and is what that arm's table reports;
  the arms after it were launched detached and all completed their eight.

## Benchmark

Paired interleaved measurement (`Jint.Benchmark/measure-paired.ps1`), 8 rounds per arm with the order
alternating every round, serial on an otherwise quiet box. The baseline arm is **this branch with only
the two collection files reverted**: `PropertyDeleteChurnBenchmark` does not exist on `main`, and the
script fails a run where a row is seen on one side only, so the two arms differ by exactly the change
under test and by nothing else. A row is a change only when its 95% CI excludes zero, and `AddOnly` is
carried in every arm as the control — a table that never removes cannot reach the tombstone path at all,
so if that row moves the measurement is wrong rather than the code.

`Jint.Benchmark/PropertyDeleteChurnBenchmark.cs` ships in this PR because the delete side of these
stores had **no coverage at all**, which is how a slot-reuse defect could be fixed with no way to price
the fix. Seven rows, and why each one:

| row | what it isolates |
| --- | --- |
| `AddOnly` | control — no removals, so `count == lastIndex` and the threshold is not even consulted |
| `AddThenRemoveNewest` | the `Remove` shortcut: the entry just added is removed, the mark walks back, nothing compacts |
| `ReAddMiddle` | the issue's own shape — delete from the middle, add the same name back. Compacts **once**, and then the re-added name is itself the newest and takes the shortcut too |
| `RotateOldest` | the only shape that keeps compacting: adds a name never seen before, drops the oldest live one, so every step leaves a hole below the mark |
| `ScriptDeleteReAdd` | `ReAddMiddle` through the engine |
| `ScriptRotateOldest` | `RotateOldest` through the engine — the row that says whether the collection cost reaches an embedder |
| `ScriptKeysAfterRotation` | `Object.keys` over an already-churned object: the cost the tombstones impose on the **read** side, which the threshold makes worse rather than better |

`[Params(16, 64)]` puts the live width either side of a resize step. The first four measure the
collection rather than a script deliberately: an engine-level `delete` costs a property-key conversion,
a shape deopt check and a `_propertiesVersion` bump on top, which would dilute the very difference they
exist to size. The three script rows put it back in proportion and follow the one-engine-per-row rule
through `IsolatedScript`.

### The first measurement, and the row that failed it

Measured against the design as first written — compact in place when that alone frees a **quarter** of
the capacity:

| row | median % | 95% CI | sign | verdict |
| --- | ---: | --- | ---: | --- |
| `AddOnly[16]` | −0.15 | [−1.16, +0.80] | 3/7 | no change |
| `AddOnly[64]` | −0.25 | [−2.65, +0.75] | 3/7 | no change |
| `AddThenRemoveNewest[16]` | −3.13 | [−4.36, −2.55] | 0/8 | **faster** |
| `AddThenRemoveNewest[64]` | −3.54 | [−3.78, −3.39] | 0/8 | **faster** |
| `ReAddMiddle[16]` | −4.10 | [−5.85, −3.72] | 0/8 | **faster** |
| `ReAddMiddle[64]` | −3.75 | [−5.53, −3.41] | 0/8 | **faster** |
| **`RotateOldest[16]`** | **+34.84** | **[+34.16, +35.88]** | **7/7** | **SLOWER** |
| **`RotateOldest[64]`** | **+29.03** | **[+27.34, +30.08]** | **7/7** | **SLOWER** |
| `ScriptRotateOldest[16]` | +1.96 | [−0.49, +4.06] | 5/7 | no change |
| **`ScriptRotateOldest[64]`** | **+6.50** | **[+0.92, +7.80]** | **6/7** | **SLOWER** |
| `ScriptDeleteReAdd[16]` | +8.27 | [+1.91, +9.54] | 6/7 | see below |
| `ScriptDeleteReAdd[64]` | +4.44 | [−5.61, +5.87] | 4/7 | no change |

The design's cheap cases got cheaper — dropping the free-list bookkeeping from the add path is a genuine
saving, and the newest-entry shortcut means `ReAddMiddle` compacts exactly once and then never again.
**And the one compacting shape cost +34.8% / +29.0%**, an order of magnitude above what the
"≤ 4 element-copies per add" amortisation argument reasons to. In absolute terms: +6.1 ns and +5.1 ns on
a 17.4 ns / 18.1 ns add-and-remove pair.

`ScriptRotateOldest` is the row that decided this could not simply be accepted. At 64 keys the
engine-level rotation is **+6.5%** with the interval excluding zero, so the collection cost does reach a
script and "unmeasurable end to end" was not available as an answer.

Two things about this arm are stated rather than smoothed over. The runner was killed during round 8, so
the rows marked `/7` are over the seven rounds that completed — every one of those rounds' raw data is
retained, and the analysis is `measure-paired.ps1`'s own parsing and statistics re-run over it. And
`ScriptDeleteReAdd` **is not resolvable at this precision**: an earlier 8-round run of the same arm put
it at −1.40 [−7.29, +3.98] and +11.68 [−5.28, +20.53], this one at +8.27 and +4.44. Its interval spans
several percent whichever way it lands, and no reading of it is relied on anywhere below.

## The threshold, swept

The previous revision of this section said the quarter was *chosen, not measured*. Here is the
measurement.

### It is a step function, not a curve

`Resize` grows rather than compacting when `count + 1 > capacity − free`. Capacities are powers of two,
so sweeping `free` does not sweep the outcome continuously: it selects which power of two a
delete-churned table settles on, and the compaction interval is then `capacity − live`, which depends on
the capacity settled at and not on the fraction that chose it. Replaying the exact index arithmetic of
`AddKey` / `Remove` / `Resize` over 10,000 rotation steps with 16 live keys:

| `free` | settled capacity | compactions / 10k steps |
| --- | ---: | ---: |
| 1/16, 1/8, 1/4, 3/8 | 32 (2× live) | 624 |
| 1/2, 5/8 | 64 (4× live) | 207 |
| 3/4 | 128 (8× live) | 88 |

An eighth, a quarter and three-eighths are the *same arm*, and the eighth was measured to confirm that
rather than assume it. `AddOnly` never removes, so it never consults the threshold at all;
`AddThenRemoveNewest` and `ReAddMiddle` reach zero compactions at every setting. **The sweep moves one
row and nothing else.**

### Measured, each against the same baseline arm

| `free` | `RotateOldest[16]` | `RotateOldest[64]` | control `AddOnly[16]` / `[64]` |
| --- | ---: | ---: | --- |
| 1/8 | +34.38 [+32.58, +35.97] | +28.58 [+26.77, +29.94] | +0.26 / −0.67 — clean |
| 1/4 (first draft) | +34.84 [+34.16, +35.88] | +29.03 [+27.34, +30.08] | −0.15 / −0.25 — clean |
| **1/2 (this PR)** | **+8.93 [+7.83, +9.60]** | **+9.67 [+9.46, +11.38]** | −0.76 / −0.21 — clean |
| 3/4 | +1.21 [+0.86, +3.80] | −0.78 [−2.76, +0.78] | −1.15 / **−2.06 [−3.14, −1.08]** |

Read the last row with the caution its own control demands: `AddOnly[64]` moved −2.06% with an interval
excluding zero, and nothing in that arm can touch a table that never removes, so that arm carries a ~2%
offset in the candidate's favour. Corrected for it, three-quarters is roughly +3.3 / +1.3 rather than
+1.2 / −0.8 — still erasing most of what a half leaves.

The improvement is larger than element-counting predicts: a half takes 7.00 element touches per step to
4.32, a factor of 1.6, and measures a factor of 3.9. Two things are happening and both are consequences
of the threshold — the compaction **frequency** falls 3×, and the same live set now sits in twice the
buckets, so the two lookups every rotation step performs get cheaper as well. The second is not a
compaction saving at all. It is the table being bigger, which is the honest way to read what the memory
is buying.

## The memory side of every setting

The threshold is consulted only by a table that has **both** left tombstones and filled its array. An
add-only table takes the `count == lastIndex` branch and grows exactly as it always did, at every
setting, so none of this applies to an object that never deletes a property.

For one that does, the entry array settles on the smallest power of two with
`live + 1 ≤ capacity × (1 − free)`. Against the free-list version's ceiling — the smallest power of two
that holds the live keys — over every live count from 9 to 4096:

| `free` | mean ceiling | worst ceiling | 16 live keys | 64 live keys |
| --- | ---: | ---: | ---: | ---: |
| free list (`main`) | 1.00× | 1.00× | 576 B | 2,304 B |
| 1/8 | 1.25× | 2.00× | 1,152 B | 4,608 B |
| 1/4 (first draft) | 1.50× | 2.00× | 1,152 B | 4,608 B |
| **1/2 (this PR)** | **2.00×** | **4.00×** | **2,304 B** | **9,216 B** |
| 3/4 | 4.01× | 8.00× | 4,608 B | 18,432 B |

(36 bytes per capacity slot on x64: a 32-byte `Entry` — `Key` is a string reference plus its
pre-computed hash — and the 4-byte bucket.)

**That is the trade, and it is why this stops at a half.** Three-quarters buys the ~9 points a half
leaves on one synthetic row and doubles the ceiling again — four times the live key count on average,
eight times in the worst case, so an object holding 64 churned keys would carry an 18 KB entry array
where `main` carries 2.3 KB. A half costs at most four times the live count, typically two, and only for
objects that actually churn. The earlier note that the ceiling "loosens by ~1.33×" was the analytic
`1 / (1 − free)` before power-of-two rounding; measured against the free-list capacity it was already
1.50× on average at a quarter, and it is 2.00× now.

There is a second cost on the same side of the ledger, and the threshold makes it **worse** rather than
better: enumeration steps over the tombstones. A rotating table at a half holds its live keys in an array
up to four times their number, so `Object.keys` skips more dead slots than it did at a quarter.
`ScriptKeysAfterRotation` exists to price exactly that.

## Where it landed

Same protocol, the whole class, at the setting this PR ships:

| row | median % | 95% CI | sign | verdict |
| --- | ---: | --- | ---: | --- |
| `AddOnly[16]` | +0.47 | [−0.18, +1.13] | 5/8 | no change |
| `AddOnly[64]` | −0.59 | [−0.80, −0.03] | 1/8 | noise floor † |
| `AddThenRemoveNewest[16]` | −1.83 | [−2.06, −1.27] | 0/8 | **faster** |
| `AddThenRemoveNewest[64]` | −3.97 | [−5.67, −2.99] | 0/8 | **faster** |
| `ReAddMiddle[16]` | −6.10 | [−6.16, −4.09] | 0/8 | **faster** |
| `ReAddMiddle[64]` | −3.85 | [−3.95, −3.72] | 0/8 | **faster** |
| **`RotateOldest[16]`** | **+8.51** | **[+6.36, +9.06]** | **8/8** | **SLOWER** |
| **`RotateOldest[64]`** | **+9.89** | **[+8.10, +10.55]** | **8/8** | **SLOWER** |
| `ScriptRotateOldest[16]` | +2.77 | [−0.80, +3.90] | 6/8 | no change |
| `ScriptRotateOldest[64]` | +3.65 | [−0.95, +7.14] | 5/8 | no change |
| **`ScriptKeysAfterRotation[16]`** | **+3.93** | **[+3.16, +5.68]** | **8/8** | **SLOWER** |
| **`ScriptKeysAfterRotation[64]`** | **+1.63** | **[+0.58, +2.63]** | **7/8** | **SLOWER** |
| `ScriptDeleteReAdd[16]` | −1.42 | [−3.56, +4.14] | 2/8 | not resolvable |
| `ScriptDeleteReAdd[64]` | +8.80 | [+2.93, +15.33] | 7/8 | not resolvable |

† `AddOnly[64]`'s interval clears zero by 0.03 points. It is the control, nothing in this change can
reach a table that never removes, and it read −0.25 / −0.21 / −0.67 in the three other arms. Read it as
the harness's floor, not as a result.

Absolute, so the percentages can be sized:

| row | baseline | this PR | per operation |
| --- | ---: | ---: | --- |
| `RotateOldest[16]` | 174.9 µs | 188.8 µs | 17.5 → 18.9 ns per add-and-delete pair (**+1.4 ns**) |
| `RotateOldest[64]` | 180.8 µs | 198.9 µs | 18.1 → 19.9 ns (**+1.8 ns**) |
| `ScriptRotateOldest[16]` | 479.8 µs | 484.6 µs | 240 → 242 ns per rotation step through the engine |
| `ScriptRotateOldest[64]` | 484.2 µs | 502.0 µs | 242 → 251 ns |
| `ScriptKeysAfterRotation[16]` | 80.4 µs | 84.0 µs | 402 → 420 ns per `Object.keys` of 16 keys (**+18 ns**) |
| `ScriptKeysAfterRotation[64]` | 249.0 µs | 253.7 µs | 1,245 → 1,269 ns of 64 keys (**+24 ns**) |

Three readings, and one row that refuses to give one.

**The threshold did the work it was swept for.** The rotating shape went from +34.8% / +29.0% to
+8.5% / +9.9% — in absolute terms from +6.1 ns and +5.1 ns per add-and-delete pair to +1.4 ns and
+1.8 ns. That is the residual, it is real, it is 8/8 sign-consistent, and it stands.

**End to end, the rotation is no longer resolvable.** `ScriptRotateOldest` spans zero at both widths
where at a quarter the 64-key row was +6.50 [+0.92, +7.80]. Stated properly: "no change" here means *not
resolvable at eight rounds*, not *proven equal*. The collection row says ~1.4–1.8 ns is still paid per
step, and on a ~240 ns engine-level step that is 0.6–0.8% — below what this harness resolves, which is
exactly why the collection rows exist.

**The read side is where the tombstones now show.** `ScriptKeysAfterRotation` is +3.9% and +1.6%, both
intervals clear of zero: about +18 ns and +24 ns on an `Object.keys` of a churned object. That is the
enumerator stepping over dead slots, it is the one cost this threshold makes *larger* rather than
smaller, and the row was added after the sweep precisely so it would be priced rather than asserted. It
is priced only at the shipped setting; a quarter would leave roughly half as many tombstones alive and
three-quarters roughly twice as many, which is the same trade running the other way.

**`ScriptDeleteReAdd` has now been measured three times and disagrees with itself every time** —
−1.40 / +11.68, then +8.27 / +4.44, then −1.42 / +8.80, with intervals several percent wide throughout.
Its collection twin (`ReAddMiddle`, −3.9% to −6.1% and 0/8 sign-consistent in every arm) says the path
it exercises got *faster*, and the collection twin is the row with the signal. Nothing in this PR's
argument rests on the script row, and calling it "no change" would be a stronger claim than the data
supports.

## Against the verdict

Things that argue against what shipped, stated so a reviewer does not have to find them:

- **In-place compaction moves live entries within the array.** A `ref TValue` obtained from
  `GetValueRefOrAddDefault` and held across a later add can now alias a *different* key's value, where
  before an intervening `Resize` allocated a fresh array and the stale ref merely pointed at inert
  memory. Both are misuse, but the failure mode changed from silently stale to silently wrong. Audited:
  the only two sites that hold such a ref (`DeclarativeEnvironment.SetOrUpdateValue`,
  `FunctionEnvironment.cs:147`) use it immediately and never add in between. There is no test pinning
  this, because there is no legitimate way to provoke it.
- **The threshold is measured now, but choosing a half over three-quarters is a judgement, not a
  measurement.** The sweep says what each setting costs in time and in space; it cannot say which an
  embedder would rather spend. Someone whose workload is rotating key sets and who does not care about
  four-versus-eight times the live key count would pick three-quarters and be right for their engine.
  What is no longer true is that the constant is arbitrary.
- **A rotating key set is still +8.9% / +9.7% at the collection**, and `ScriptRotateOldest[64]` still
  carries a cost the interval cannot separate from zero at eight rounds but which the collection number
  says is real. That is the residual, and it is accepted rather than solved.
- **The delete-churned memory ceiling is 2.00× the free-list version's on average and 4.00× at worst**,
  for the same live key count — up from 1.50× / 2.00× at a quarter. Bounded and confined to objects that
  actually churn, but it is a real regression in space and it got worse in this revision, deliberately.
- **Enumerating a churned object steps over its tombstones**, and a half leaves more of them alive than a
  quarter did. `ScriptKeysAfterRotation` prices it rather than leaving it asserted; it is the one row
  where the threshold choice is a cost rather than a saving.
- **The structural fix for rotation was identified and not taken.** A circular window over the entry
  array — a `_firstIndex` beside the high-water mark, so removing the *oldest* entry hands its slot back
  the way removing the newest already does — would make the rotating shape O(1) with **no** compaction
  and a *smaller* table than either setting here. It costs a wrap check in `AddKey` and in the
  enumerator, which is the sequential scan this layout exists for, and it puts a new invariant into the
  hottest data structure in the engine. That is not a change to land on top of a correctness fix at the
  end of its verification; it is filed as #3315, with the measurement and the design.
- **The fix is in the collection, not in the property-store usage.** Two of the four consumers do not
  need insertion order, so they now pay for a guarantee they do not use. The audit argues the cost is
  zero for them (`BuiltinShape.Index` never removes; environments never reach a compaction because the
  pooled reset clears outright), and `AddOnly` — which is that shape — does not move in any arm. It is
  still an argument plus a control row rather than a direct measurement of those two consumers.
