### PR TITLE
Fetch: clone() tees with cloneForBranch2, so the two bodies stop sharing a buffer

### DIFF
--- a/Jint.Tests/Runtime/WebApi/BodyCloneTeeTests.cs
+++ b/Jint.Tests/Runtime/WebApi/BodyCloneTeeTests.cs
@@ -1,0 +1,294 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// https://fetch.spec.whatwg.org/#concept-body-clone — the tee a <c>Response.clone()</c> or a
+/// <c>Request.clone()</c> runs, and the one property that separates it from
+/// <c>ReadableStream.prototype.tee()</c>: it is
+/// https://streams.spec.whatwg.org/#readablestream-tee, which is
+/// <c>ReadableStreamTee(stream, <b>true</b>)</c>, so every chunk the clone receives is a
+/// <a href="https://html.spec.whatwg.org/multipage/structured-data.html#structured-cloning">StructuredClone</a>
+/// of the chunk the original receives.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The engines here are built with <see cref="WebApiOptionsExtensions.UseFetch"/> and nothing else, which
+/// deliberately does <b>not</b> include <see cref="WebApiFeatures.StructuredClone"/>: the serializer the tee
+/// reaches is machinery, and the flag governs only the <c>structuredClone</c> global.
+/// <see cref="TheCloneStillClonesOnAnEngineWithNoStructuredCloneGlobal"/> is what pins that.
+/// </para>
+/// <para>
+/// A buffered body — <c>new Response('hi')</c> — is cloned by sharing its source and has no stream to tee,
+/// so none of this applies to it; <c>ResponseTests.CloneSharesTheBytesAndNotTheUsedFlag</c> covers that half.
+/// </para>
+/// </remarks>
+public class BodyCloneTeeTests
+{
+    private static Engine FetchEngine() => new(options => options.UseFetch());
+
+    /// <summary>
+    /// A sixteen-byte buffer whose bytes are all different, so that comparing content means something.
+    /// </summary>
+    private const string Fixture = """
+        var arrayBuffer = new ArrayBuffer(16);
+        new Uint8Array(arrayBuffer).set([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+        function bytesOf(v) {
+          const buffer = v instanceof ArrayBuffer ? v : v.buffer;
+          const offset = v instanceof ArrayBuffer ? 0 : v.byteOffset;
+          return Array.from(new Uint8Array(buffer, offset, v.byteLength)).join('-');
+        }
+        function bodyOf(chunk) {
+          return new Response(new ReadableStream({ start(c) { c.enqueue(chunk); c.close(); } }));
+        }
+        """;
+
+    private const string AllTrue =
+        "first-is-the-original:true,second-is-not:true,same-prototype:true,same-byteLength:true," +
+        "same-byteOffset:true,different-buffer:true,same-bytes:true";
+
+    /// <summary>
+    /// Every chunk kind <c>fetch/api/response/response-clone.any.js</c> covers. The assertions are the
+    /// corpus's own: identity, not merely equal content.
+    /// </summary>
+    [Theory]
+    [InlineData("new Int8Array(arrayBuffer, 1)")]
+    [InlineData("new Int16Array(arrayBuffer, 2, 2)")]
+    [InlineData("new Int32Array(arrayBuffer)")]
+    [InlineData("arrayBuffer")]
+    [InlineData("new Uint8Array(arrayBuffer)")]
+    [InlineData("new Uint8ClampedArray(arrayBuffer)")]
+    [InlineData("new Uint16Array(arrayBuffer, 2)")]
+    [InlineData("new Uint32Array(arrayBuffer)")]
+    [InlineData("new BigInt64Array(arrayBuffer)")]
+    [InlineData("new BigUint64Array(arrayBuffer)")]
+    [InlineData("new Float16Array(arrayBuffer)")]
+    [InlineData("new Float32Array(arrayBuffer)")]
+    [InlineData("new Float64Array(arrayBuffer)")]
+    [InlineData("new DataView(arrayBuffer, 2, 8)")]
+    public void TheClonedResponseGetsAStructuredCloneOfEveryChunk(string chunk)
+    {
+        var engine = FetchEngine();
+        engine.Execute(Fixture);
+
+        engine.Evaluate($$"""
+            (async () => {
+              const initial = {{chunk}};
+              const response = bodyOf(initial);
+              const clone = response.clone();
+
+              const first = (await response.body.getReader().read()).value;
+              const second = (await clone.body.getReader().read()).value;
+              const isBuffer = initial instanceof ArrayBuffer;
+
+              return [
+                'first-is-the-original:' + (first === initial),
+                'second-is-not:' + (second !== initial),
+                'same-prototype:' + (Object.getPrototypeOf(second) === Object.getPrototypeOf(initial)),
+                'same-byteLength:' + (second.byteLength === initial.byteLength),
+                'same-byteOffset:' + (isBuffer ? true : second.byteOffset === initial.byteOffset),
+                'different-buffer:' + (isBuffer ? second !== initial : second.buffer !== initial.buffer),
+                'same-bytes:' + (bytesOf(second) === bytesOf(initial)),
+              ].join(',');
+            })()
+            """).UnwrapIfPromise().AsString().Should().Be(AllTrue);
+    }
+
+    [Fact]
+    public void TheClonedRequestGetsAStructuredCloneOfEveryChunkToo()
+    {
+        // https://fetch.spec.whatwg.org/#dom-request-clone runs the very same clone-a-body algorithm, so the
+        // sibling has to hold the same property even though no corpus row names it.
+        var engine = FetchEngine();
+        engine.Execute(Fixture);
+
+        engine.Evaluate("""
+            (async () => {
+              const initial = new Uint8Array(arrayBuffer);
+              const request = new Request('https://example.org/', {
+                method: 'POST',
+                body: new ReadableStream({ start(c) { c.enqueue(initial); c.close(); } }),
+                duplex: 'half',
+              });
+              const clone = request.clone();
+
+              const first = (await request.body.getReader().read()).value;
+              const second = (await clone.body.getReader().read()).value;
+
+              return [
+                'first-is-the-original:' + (first === initial),
+                'second-is-not:' + (second !== initial),
+                'different-buffer:' + (second.buffer !== initial.buffer),
+                'same-bytes:' + (bytesOf(second) === bytesOf(initial)),
+              ].join(',');
+            })()
+            """).UnwrapIfPromise().AsString()
+            .Should().Be("first-is-the-original:true,second-is-not:true,different-buffer:true,same-bytes:true");
+    }
+
+    [Fact]
+    public void WritingThroughOneBodysChunkIsInvisibleToTheOther()
+    {
+        // The whole reason the standard clones: a consumer of one branch may not reach the bytes the other
+        // branch is about to read.
+        var engine = FetchEngine();
+        engine.Execute(Fixture);
+
+        engine.Evaluate("""
+            (async () => {
+              const initial = new Uint8Array(arrayBuffer);
+              const response = bodyOf(initial);
+              const clone = response.clone();
+
+              const second = (await clone.body.getReader().read()).value;
+              second[0] = 99;
+
+              const first = (await response.body.getReader().read()).value;
+              return first[0] + ':' + second[0];
+            })()
+            """).UnwrapIfPromise().AsString().Should().Be("1:99");
+    }
+
+    [Fact]
+    public void TheCloneStillClonesOnAnEngineWithNoStructuredCloneGlobal()
+    {
+        // UseFetch() expands to Events | Url | Files | Streams and pointedly not StructuredClone, so the
+        // global is absent — and the algorithm still runs, because the flag governs the global and not the
+        // serializer behind it. A clone() whose correctness depended on an unrelated flag would be the bug
+        // wearing a different hat.
+        var engine = FetchEngine();
+        engine.Execute(Fixture);
+
+        engine.Evaluate("typeof structuredClone").AsString().Should().Be("undefined");
+
+        engine.Evaluate("""
+            (async () => {
+              const initial = new Uint8Array(arrayBuffer);
+              const response = bodyOf(initial);
+              const clone = response.clone();
+              const first = (await response.body.getReader().read()).value;
+              const second = (await clone.body.getReader().read()).value;
+              return second !== initial && second.buffer !== initial.buffer && bytesOf(second) === bytesOf(first);
+            })()
+            """).UnwrapIfPromise().AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void AChunkTheSerializerRefusesErrorsBothBodiesWithADataCloneError()
+    {
+        // https://streams.spec.whatwg.org/#readable-stream-default-tee step 3.2 of the chunk steps: the
+        // original's own branch is errored too, even though its chunk was never in question.
+        var engine = FetchEngine();
+
+        engine.Evaluate("""
+            (async () => {
+              const response = new Response(new ReadableStream({
+                start(c) { c.enqueue(function notSerializable() {}); c.close(); },
+              }));
+              const clone = response.clone();
+
+              const failure = async stream => {
+                try { await stream.getReader().read(); return 'resolved'; }
+                catch (e) { return e.name; }
+              };
+
+              return (await failure(response.body)) + ',' + (await failure(clone.body));
+            })()
+            """).UnwrapIfPromise().AsString().Should().Be("DataCloneError,DataCloneError");
+    }
+
+    [Fact]
+    public void TeeItselfIsUntouchedAndStillHandsBothBranchesOneChunk()
+    {
+        // https://streams.spec.whatwg.org/#rs-tee passes cloneForBranch2 false, and that is normative: the
+        // chunks seen in each branch are the same object. Fixing clone() must not "fix" this.
+        var engine = FetchEngine();
+        engine.Execute(Fixture);
+
+        engine.Evaluate("""
+            (async () => {
+              const initial = new Uint8Array(arrayBuffer);
+              const [one, two] = new ReadableStream({ start(c) { c.enqueue(initial); c.close(); } }).tee();
+              const a = (await one.getReader().read()).value;
+              const b = (await two.getReader().read()).value;
+              return (a === initial) + ',' + (b === initial) + ',' + (a === b);
+            })()
+            """).UnwrapIfPromise().AsString().Should().Be("true,true,true");
+    }
+
+    [Fact]
+    public void ARequestBuiltFromARequestProxiesItsBodyAndDoesNotCloneTheChunks()
+    {
+        // https://fetch.spec.whatwg.org/#dom-request step 42 is "create a proxy for inputBody", which
+        // https://streams.spec.whatwg.org/#readablestream-create-a-proxy defines as a pipe through an
+        // identity TransformStream — chunks pass through unchanged. It is not the clone-a-body algorithm,
+        // so it must not start cloning.
+        var engine = FetchEngine();
+        engine.Execute(Fixture);
+
+        engine.Evaluate("""
+            (async () => {
+              const initial = new Uint8Array(arrayBuffer);
+              const source = new Request('https://example.org/', {
+                method: 'POST',
+                body: new ReadableStream({ start(c) { c.enqueue(initial); c.close(); } }),
+                duplex: 'half',
+              });
+              const proxy = new Request(source);
+
+              const a = (await source.body.getReader().read()).value;
+              const b = (await proxy.body.getReader().read()).value;
+              return (a === initial) + ',' + (b === initial);
+            })()
+            """).UnwrapIfPromise().AsString().Should().Be("true,true");
+    }
+
+    [Fact]
+    public void ANetworkStyleByteStreamBodyWasAlreadyCloningAndStillIs()
+    {
+        // A body whose stream is a byte stream reaches ReadableByteStreamTee, which clones every chunk for
+        // its second branch whatever cloneForBranch2 says — https://streams.spec.whatwg.org/#readable-stream-tee
+        // step 3 does not pass the argument on. `new Response(bytes).body` is such a stream.
+        var engine = FetchEngine();
+
+        engine.Evaluate("""
+            (async () => {
+              const response = new Response(new Uint8Array([1, 2, 3]));
+              const clone = response.clone();
+              const first = (await response.body.getReader().read()).value;
+              const second = (await clone.body.getReader().read()).value;
+              return (first !== second) + ',' + (first.buffer !== second.buffer) + ',' + second.join('-');
+            })()
+            """).UnwrapIfPromise().AsString().Should().Be("true,true,1-2-3");
+    }
+
+    [Fact]
+    public void CloningTwiceGivesThreeIndependentBuffers()
+    {
+        // clone() replaces the original's stream with the tee's first branch, so a second clone() tees that
+        // branch in turn. Each hop clones again, which is what keeps the third body independent too.
+        var engine = FetchEngine();
+        engine.Execute(Fixture);
+
+        engine.Evaluate("""
+            (async () => {
+              const initial = new Uint8Array(arrayBuffer);
+              const response = bodyOf(initial);
+              const a = response.clone();
+              const b = response.clone();
+
+              const read = async body => (await body.getReader().read()).value;
+              const one = await read(response.body);
+              const two = await read(a.body);
+              const three = await read(b.body);
+
+              const distinct = new Set([one.buffer, two.buffer, three.buffer]).size;
+              return distinct + ':' + [one, two, three].map(bytesOf).join('|');
+            })()
+            """).UnwrapIfPromise().AsString().Should().Be("3:" + string.Join("|", Enumerable.Repeat(string.Join("-", Enumerable.Range(1, 16)), 3)));
+    }
+}
+#endif

--- a/Jint.Tests/Wpt/Vendor/README.md
+++ b/Jint.Tests/Wpt/Vendor/README.md
@@ -1044,8 +1044,8 @@ their exclusions without revisiting this table.
 | HTML — workers | `workers/` ×4 | 12 | 24 | 8 |
 | HTML — timers, microtasks, structured clone | `html/webappapis/` ×3 | 11 | 154 | 3 |
 | DOM | `dom/` ×2 | 13 | 76 | 0 |
-| Fetch | `fetch/api/` ×5 | 49 | 714 | 168 |
-| **total** | **38** | **293** | **40,983** | **2,982** |
+| Fetch | `fetch/api/` ×5 | 49 | 714 | 154 |
+| **total** | **38** | **293** | **40,983** | **2,968** |
 
 Re-censused whole rather than adjusted row by row, because several rows had gone stale between the changes
 that moved them: before [#3195](https://github.com/sebastienros/jint/issues/3195) the true figures were

--- a/Jint.Tests/Wpt/WptExclusions.cs
+++ b/Jint.Tests/Wpt/WptExclusions.cs
@@ -518,11 +518,6 @@ internal enum WptDivergence
     /// never reach the wire, because the BCL files them as content headers and a GET has no content to hang
     /// them on.
     /// </description></item>
-    /// <item><description>
-    /// https://github.com/sebastienros/jint/issues/3283 — <c>response/response-clone.any.js</c>: the two
-    /// bodies <c>clone()</c> tees deliver the <i>same</i> buffer rather than the structured clone
-    /// https://fetch.spec.whatwg.org/#concept-body-clone requires.
-    /// </description></item>
     /// </list>
     /// </para>
     /// </summary>

--- a/Jint.Tests/Wpt/WptTestRunner.cs
+++ b/Jint.Tests/Wpt/WptTestRunner.cs
@@ -1079,8 +1079,6 @@ public class WptTestRunner
             "Response.body is null for responses with method=HEAD", WptDivergence.NeedsTriage),
         new("fetch/api/redirect/redirect-method.any.js", "Redirect 30* with GET", WptDivergence.NeedsTriage),
         new("fetch/api/redirect/redirect-method.any.js", "Redirect 30* with HEAD", WptDivergence.NeedsTriage),
-        new("fetch/api/response/response-clone.any.js",
-            "Check response clone use structureClone for teed ReadableStreams (*chunk)", WptDivergence.NeedsTriage),
 
         // The other half of accept-header.any.js, and not a defect: Accept-Language is a browser reporting
         // the user's language preferences, and there is no user here.

--- a/Jint/WebApi/Fetch/FetchBodyObject.cs
+++ b/Jint/WebApi/Fetch/FetchBodyObject.cs
@@ -314,19 +314,52 @@ internal static class FetchBody
     /// the second to the clone".
     /// </summary>
     /// <remarks>
+    /// <para>
     /// A body that has not materialized a stream is cloned by <i>sharing its source</i> instead, which is
     /// indistinguishable: neither object has a stream to tee, and each carries its own disturbance. Tee is
     /// used the moment a stream exists — for a network response, or for a body a script has already asked
     /// <c>body</c> for — because from then on the two objects' streams have to be different objects with
     /// independent queues.
+    /// </para>
     /// <para>
-    /// The tee goes through <see cref="ReadableStreamOperations.Tee"/> rather than straight to the default
-    /// algorithm, because https://streams.spec.whatwg.org/#readable-stream-tee dispatches on the kind of
-    /// controller the stream has: a body's own stream is a byte stream, and its two branches have to be byte
-    /// streams too or a clone would quietly lose BYOB reading.
+    /// <b>The teeing here is the standard's "tee a <c>ReadableStream</c>"</b>
+    /// (https://streams.spec.whatwg.org/#readablestream-tee), which is <c>ReadableStreamTee(stream, true)</c>
+    /// — so every chunk the clone receives is a StructuredClone of the chunk the original receives, and the
+    /// two bodies can never be handed one buffer. That is the entire difference between this and
+    /// <see cref="ProxyBody"/>, and it is a property a script can observe directly:
+    /// <c>(await original.body.getReader().read()).value !== (await clone.body.getReader().read()).value</c>.
     /// </para>
     /// </remarks>
     internal static void CloneBody(FetchBodyObject source, FetchBodyObject target)
+        => TeeInto(source, target, cloneForBranch2: true);
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readablestream-create-a-proxy, as
+    /// https://fetch.spec.whatwg.org/#dom-request step 42 asks for it: the body a <c>Request</c> built from
+    /// another <c>Request</c> gets.
+    /// </summary>
+    /// <remarks>
+    /// The standard pipes the input's stream through an identity <c>TransformStream</c>, which passes each
+    /// chunk on <b>unchanged</b>; Jint reaches the same observable result with a tee whose
+    /// <i>cloneForBranch2</i> is unset. Sharing the flag's <see langword="false"/> with <c>tee()</c> is the
+    /// point of the split: a proxy that structured-cloned would diverge from the standard in the other
+    /// direction, and quietly refuse a chunk an identity transform is happy to forward.
+    /// </remarks>
+    internal static void ProxyBody(FetchBodyObject source, FetchBodyObject target)
+        => TeeInto(source, target, cloneForBranch2: false);
+
+    /// <summary>
+    /// The shared tail of the two: keep the first branch, hand the second to <paramref name="target"/>.
+    /// </summary>
+    /// <remarks>
+    /// The tee goes through <see cref="ReadableStreamOperations.Tee"/> rather than straight to the default
+    /// algorithm, because https://streams.spec.whatwg.org/#readable-stream-tee dispatches on the kind of
+    /// controller the stream has: a body's own stream is a byte stream, and its two branches have to be byte
+    /// streams too or a clone would quietly lose BYOB reading. A byte stream's tee ignores
+    /// <paramref name="cloneForBranch2"/> and clones every chunk regardless, which is why a network
+    /// response's <c>clone()</c> never shared a buffer even before this flag existed.
+    /// </remarks>
+    private static void TeeInto(FetchBodyObject source, FetchBodyObject target, bool cloneForBranch2)
     {
         if (!source.HasBody)
         {
@@ -339,7 +372,7 @@ internal static class FetchBody
             return;
         }
 
-        var (branch1, branch2) = ReadableStreamOperations.Tee(stream);
+        var (branch1, branch2) = ReadableStreamOperations.Tee(stream, cloneForBranch2);
         source.ReplaceStream(branch1);
         target.SetStreamBody(branch2);
     }

--- a/Jint/WebApi/Fetch/RequestConstructor.cs
+++ b/Jint/WebApi/Fetch/RequestConstructor.cs
@@ -204,14 +204,15 @@ internal sealed class RequestConstructor : Constructor
         }
         else if (hasInputBody)
         {
-            // Step 42: "create a proxy for inputBody", which is the clone-a-body algorithm — a tee when the
-            // input has a stream, and a shared source when it does not.
+            // Step 42: "create a proxy for inputBody" — a tee when the input has a stream, and a shared
+            // source when it does not. Pointedly NOT the clone-a-body algorithm: a proxy is an identity
+            // transform, so the chunks pass through unchanged rather than being structured-cloned.
             if (inputRequest!.IsUnusable)
             {
                 Throw.TypeError(_realm, "Failed to construct 'Request': Request body is already used");
             }
 
-            FetchBody.CloneBody(inputRequest, request);
+            FetchBody.ProxyBody(inputRequest, request);
         }
 
         return request;

--- a/Jint/WebApi/Fetch/RequestPrototype.cs
+++ b/Jint/WebApi/Fetch/RequestPrototype.cs
@@ -178,8 +178,10 @@ internal sealed partial class RequestPrototype : Prototype
             Signal = JsAbortSignal.CreateDependent(_engine, _realm, [request.Signal]),
         };
 
-        // A streaming body is teed and a buffered one shares its bytes; only the used flag is the clone's
-        // own, which is the whole point of cloning before reading twice.
+        // A streaming body is teed — with the chunks structurally cloned for the second branch, which is
+        // what https://fetch.spec.whatwg.org/#concept-body-clone asks for — and a buffered one shares its
+        // bytes; only the used flag is the clone's own, which is the whole point of cloning before reading
+        // twice.
         FetchBody.CloneBody(request, clone);
         return clone;
     }

--- a/Jint/WebApi/Fetch/ResponsePrototype.cs
+++ b/Jint/WebApi/Fetch/ResponsePrototype.cs
@@ -162,10 +162,11 @@ internal sealed partial class ResponsePrototype : Prototype
     /// body, because <c>clone</c> does not return a promise to reject.
     /// </summary>
     /// <remarks>
-    /// The body is cloned per https://fetch.spec.whatwg.org/#concept-body-clone: a streaming body is
-    /// <c>tee()</c>d, so each object gets its own branch with its own queue, and a body still held as bytes
-    /// simply shares them. Either way the used flag is the clone's own, which is what makes the
-    /// <c>const copy = response.clone(); await response.json(); await copy.text();</c> pattern work.
+    /// The body is cloned per https://fetch.spec.whatwg.org/#concept-body-clone: a streaming body is teed,
+    /// so each object gets its own branch with its own queue and its own structurally cloned chunks, and a
+    /// body still held as bytes simply shares them. Either way the used flag is the clone's own, which is
+    /// what makes the <c>const copy = response.clone(); await response.json(); await copy.text();</c>
+    /// pattern work.
     /// </remarks>
     [JsFunction(Name = "clone", Length = 0, Flags = PropertyFlag.ConfigurableEnumerableWritable)]
     private JsResponse Clone(JsValue thisObject)

--- a/Jint/WebApi/Streams/ReadableStreamOperations.cs
+++ b/Jint/WebApi/Streams/ReadableStreamOperations.cs
@@ -87,14 +87,26 @@ internal static class ReadableStreamOperations
     /// https://streams.spec.whatwg.org/#readable-stream-tee — which of the two tee algorithms applies is
     /// decided by the kind of controller the stream has, and only here.
     /// </summary>
-    internal static (JsReadableStream Branch1, JsReadableStream Branch2) Tee(JsReadableStream stream)
+    /// <param name="stream">The stream to tee.</param>
+    /// <param name="cloneForBranch2">
+    /// The specification's second argument: <see langword="false"/> for <c>tee()</c>, which is the only
+    /// caller that hands both branches the same chunk object, and <see langword="true"/> for every caller
+    /// that goes through https://streams.spec.whatwg.org/#readablestream-tee — the wrapper other standards
+    /// use, and the one https://fetch.spec.whatwg.org/#concept-body-clone reaches.
+    /// <para>
+    /// It has no effect on a byte stream, exactly as the specification writes it: step 3 dispatches to
+    /// ReadableByteStreamTee(<i>stream</i>) without passing the argument on, because that algorithm already
+    /// clones every chunk for its second branch unconditionally.
+    /// </para>
+    /// </param>
+    internal static (JsReadableStream Branch1, JsReadableStream Branch2) Tee(JsReadableStream stream, bool cloneForBranch2)
     {
         if (stream.Controller is JsReadableByteStreamController)
         {
             return ReadableByteStreamTee.Tee(stream);
         }
 
-        return ReadableStreamTee.Tee(stream);
+        return ReadableStreamTee.Tee(stream, cloneForBranch2);
     }
 
     /// <summary>

--- a/Jint/WebApi/Streams/ReadableStreamPrototype.cs
+++ b/Jint/WebApi/Streams/ReadableStreamPrototype.cs
@@ -169,12 +169,16 @@ internal sealed partial class ReadableStreamPrototype : Prototype
     }
 
     /// <summary>
-    /// https://streams.spec.whatwg.org/#rs-tee
+    /// https://streams.spec.whatwg.org/#rs-tee — "return ? ReadableStreamTee(this, false)".
     /// </summary>
+    /// <remarks>
+    /// The <see langword="false"/> is the whole difference between this and the tee a <c>clone()</c> runs:
+    /// both branches of <c>tee()</c> are handed the very same chunk object, deliberately and normatively.
+    /// </remarks>
     [JsFunction(Name = "tee", Length = 0, Flags = PropertyFlag.ConfigurableEnumerableWritable)]
     private JsArray Tee(JsValue thisObject)
     {
-        var (branch1, branch2) = ReadableStreamOperations.Tee(Brand(thisObject));
+        var (branch1, branch2) = ReadableStreamOperations.Tee(Brand(thisObject), cloneForBranch2: false);
         return new JsArray(_engine, [branch1, branch2]);
     }
 

--- a/Jint/WebApi/Streams/ReadableStreamTee.cs
+++ b/Jint/WebApi/Streams/ReadableStreamTee.cs
@@ -2,20 +2,28 @@
 using Jint.Native;
 using Jint.Native.Promise;
 using Jint.Runtime;
+using Jint.WebApi.StructuredClone;
 
 namespace Jint.WebApi.Streams;
 
 /// <summary>
 /// https://streams.spec.whatwg.org/#readable-stream-default-tee — the algorithm behind
-/// <c>ReadableStream.prototype.tee()</c>.
+/// <c>ReadableStream.prototype.tee()</c>, and the one <c>clone</c> reaches through
+/// https://streams.spec.whatwg.org/#readablestream-tee.
 /// </summary>
 /// <remarks>
 /// <para>
 /// The two branches read from one reader over the original stream, which is locked for as long as they
-/// exist. Each branch has its own queue and its own consumer, so one may run far ahead of the other; a chunk
-/// is handed to both branches <b>by reference</b> (this is the non-byte-stream tee, which never clones), so
-/// two consumers of a mutable chunk can interfere with each other. That is the standard's own caveat, not an
-/// implementation shortcut.
+/// exist. Each branch has its own queue and its own consumer, so one may run far ahead of the other.
+/// </para>
+/// <para>
+/// <b>Whether the second branch gets the chunk itself or a structured clone of it is the algorithm's
+/// <i>cloneForBranch2</i> parameter, and nothing else.</b> <c>tee()</c> passes <see langword="false"/> — the
+/// chunks seen in each branch are then the same object, so two consumers of a mutable chunk can interfere
+/// with each other, which is the standard's own caveat rather than an implementation shortcut. Every other
+/// specification reaches the tee through the "tee a <c>ReadableStream</c>" wrapper, which passes
+/// <see langword="true"/>; https://fetch.spec.whatwg.org/#concept-body-clone is the one that matters here,
+/// and it is what stops a <c>Response</c> and its <c>clone()</c> sharing a buffer.
 /// </para>
 /// <para>
 /// Cancelling one branch does not cancel the original: only when <i>both</i> have been cancelled is the
@@ -29,6 +37,7 @@ internal sealed class ReadableStreamTee
     private readonly JsReadableStream _stream;
     private readonly JsReadableStreamDefaultReader _reader;
     private readonly PromiseCapability _cancelCapability;
+    private readonly bool _cloneForBranch2;
 
     private bool _reading;
     private bool _readAgain;
@@ -39,21 +48,27 @@ internal sealed class ReadableStreamTee
     private JsReadableStream _branch1 = null!;
     private JsReadableStream _branch2 = null!;
 
-    private ReadableStreamTee(JsReadableStream stream)
+    private ReadableStreamTee(JsReadableStream stream, bool cloneForBranch2)
     {
         _engine = stream.Engine;
         _realm = stream.Realm;
         _stream = stream;
         _reader = ReadableStreamOperations.AcquireDefaultReader(stream);
         _cancelCapability = StreamPromises.NewPromise(_engine, _realm);
+        _cloneForBranch2 = cloneForBranch2;
     }
 
     /// <summary>
     /// Tees <paramref name="stream"/> and returns its two branches, in order.
     /// </summary>
-    internal static (JsReadableStream Branch1, JsReadableStream Branch2) Tee(JsReadableStream stream)
+    /// <param name="stream">The stream to tee, which is locked by the tee's own reader for good.</param>
+    /// <param name="cloneForBranch2">
+    /// The specification's <i>cloneForBranch2</i>: when set, every chunk the second branch is given is a
+    /// StructuredClone of the chunk the first branch is given.
+    /// </param>
+    internal static (JsReadableStream Branch1, JsReadableStream Branch2) Tee(JsReadableStream stream, bool cloneForBranch2)
     {
-        var tee = new ReadableStreamTee(stream);
+        var tee = new ReadableStreamTee(stream, cloneForBranch2);
 
         tee._branch1 = ReadableStreamOperations.CreateReadableStream(
             tee._engine, tee._realm, static () => JsValue.Undefined, tee.PullAlgorithm, tee.Cancel1Algorithm);
@@ -154,7 +169,30 @@ internal sealed class ReadableStreamTee
             {
                 _tee._readAgain = false;
 
-                // Both branches receive the very same chunk: this tee never clones.
+                // Step 3: "let chunk1 and chunk2 be chunk" — the two branches receive the very same object
+                // unless cloneForBranch2 asks for the second to get a StructuredClone of it.
+                var chunk2 = chunk;
+
+                if (!_tee._canceled2 && _tee._cloneForBranch2)
+                {
+                    try
+                    {
+                        chunk2 = StructuredCloner.Clone(_tee._engine, _tee._realm, chunk, transferList: null);
+                    }
+                    catch (JavaScriptException e)
+                    {
+                        // Step 3.2: a chunk the serializer refuses — a function, a Symbol, a detached buffer —
+                        // errors BOTH branches with the DataCloneError and cancels the original with it. The
+                        // first branch is errored too even though its own chunk was fine, and `reading` is
+                        // deliberately left set: this read is the tee's last.
+                        var error = e.Error;
+                        ReadableStreamDefaultControllerOperations.Error(_tee._branch1.DefaultController, error);
+                        ReadableStreamDefaultControllerOperations.Error(_tee._branch2.DefaultController, error);
+                        _tee._cancelCapability.Resolve(ReadableStreamOperations.Cancel(_tee._stream, error));
+                        return;
+                    }
+                }
+
                 if (!_tee._canceled1)
                 {
                     ReadableStreamDefaultControllerOperations.Enqueue(_tee._branch1.DefaultController, chunk);
@@ -162,7 +200,7 @@ internal sealed class ReadableStreamTee
 
                 if (!_tee._canceled2)
                 {
-                    ReadableStreamDefaultControllerOperations.Enqueue(_tee._branch2.DefaultController, chunk);
+                    ReadableStreamDefaultControllerOperations.Enqueue(_tee._branch2.DefaultController, chunk2);
                 }
 
                 _tee._reading = false;


### PR DESCRIPTION
Fetch: `clone()` structured-clones the chunks its tee hands the clone

Fixes #3283.

`Response.clone()` and `Request.clone()` ran Jint's ordinary `ReadableStreamTee`, so the two bodies were handed the **same chunk object** and therefore the same buffer. A consumer of one could read — or write — the bytes the other was about to deliver.

```js
const original = new Response(new ReadableStream({
  start(c) { c.enqueue(new Uint8Array([1, 2, 3])); c.close(); },
}));
const clone = original.clone();
const a = (await original.body.getReader().read()).value;
const b = (await clone.body.getReader().read()).value;
a.buffer === b.buffer;   // was true; is now false
```

## What the standard says

[Clone a body](https://fetch.spec.whatwg.org/#concept-body-clone) step 1 tees body's stream, and "teeing" is the Streams Standard's exported wrapper, whose whole definition is:

> To [tee a `ReadableStream`](https://streams.spec.whatwg.org/#readablestream-tee) *stream*, return ? ReadableStreamTee(*stream*, **true**).
>
> Because we pass true as the second argument to ReadableStreamTee, the second branch returned will have its chunks cloned (using HTML's serializable objects framework) from those of the first branch. This prevents consumption of one of the branches from interfering with the other.

[ReadableStreamDefaultTee](https://streams.spec.whatwg.org/#readable-stream-default-tee)'s chunk steps, verbatim:

> 2. Let *chunk1* and *chunk2* be *chunk*.
> 3. If *canceled2* is false and *cloneForBranch2* is true,
>    1. Let *cloneResult* be StructuredClone(*chunk2*).
>    2. If *cloneResult* is an abrupt completion,
>       1. Perform ! ReadableStreamDefaultControllerError(*branch1*.[[controller]], *cloneResult*.[[Value]]).
>       2. Perform ! ReadableStreamDefaultControllerError(*branch2*.[[controller]], *cloneResult*.[[Value]]).
>       3. Resolve *cancelPromise* with ! ReadableStreamCancel(*stream*, *cloneResult*.[[Value]]).
>       4. Return.
>    3. Otherwise, set *chunk2* to *cloneResult*.[[Value]].

Jint had no *cloneForBranch2* at all, so every caller got the `false` behaviour.

## The change

*cloneForBranch2* is now the parameter the specification writes, threaded through `ReadableStreamOperations.Tee`, and **all three call sites state their own answer**:

| call site | passes | why |
| --- | --- | --- |
| `ReadableStream.prototype.tee()` | `false` | [§rs-tee](https://streams.spec.whatwg.org/#rs-tee) is literally "return ? ReadableStreamTee(**this**, false)". Both branches seeing one object is normative, not a shortcut. |
| `FetchBody.CloneBody` — behind `Response.clone()` and `Request.clone()` | `true` | [clone a body](https://fetch.spec.whatwg.org/#concept-body-clone), through the wrapper above. This is the fix. |
| `new Request(otherRequest)` | `false` | Step 42 is "create a proxy for *inputBody*", and [create a proxy](https://streams.spec.whatwg.org/#readablestream-create-a-proxy) is a pipe through an identity `TransformStream`, which forwards a chunk **unchanged**. |

That third row is why `CloneBody` was split: the constructor path was calling a method named after an algorithm it does not run. It is now `FetchBody.ProxyBody`, both delegate to one private `TeeInto`, and the comment that used to say "which is the clone-a-body algorithm" says the opposite, correctly.

The refusal path — the one nobody tests by accident — is implemented as step 3.2 writes it: a chunk the serializer will not serialize errors **both** branches with the `DataCloneError`, the first included even though its own chunk was fine, and resolves the cancel promise with `ReadableStreamCancel` of the original. `reading` is deliberately left set; that read is the tee's last.

Only a `JavaScriptException` is caught. An `ExecutionCanceledException`, a `MemoryLimitExceededException` or a `RecursionDepthOverflowException` raised while the serializer walks a chunk's getters still propagates out of the job rather than becoming a stream error — the same MustPropagate rule the four `DiagnosticsSink` catch sites use, stated positively.

### A byte-stream body was never affected

[ReadableStreamTee](https://streams.spec.whatwg.org/#readable-stream-tee) step 3 dispatches to `ReadableByteStreamTee(stream)` **without passing the argument on**, because that algorithm clones every chunk for its second branch unconditionally (`CloneAsUint8Array`) — and Jint's already did. So the defect only ever reached a body built from a script's own `ReadableStream`, which is exactly the shape the fourteen corpus rows use and exactly the shape that was red. `new Response(bytes).clone()` and a network response's `clone()` were correct before this PR and are pinned as still correct after it.

## The decision the issue asks for: what happens when `WebApiFeatures.StructuredClone` is off

**The tee reaches `StructuredCloner` directly, and no feature flag gates it. `UseFetch()`'s closure is unchanged.**

`clone()` belongs to `WebApiFeatures.Fetch`, whose closure is `Events | Url | Files | Streams` — pointedly not `StructuredClone`. So on a `UseFetch()` engine `typeof structuredClone === "undefined"`, and the question is real rather than hypothetical.

The argument, since the brief asks for one rather than a default:

1. **The flag governs a global, not an algorithm.** What `WebApiFeatures.StructuredClone` installs is one lazy global named `structuredClone`. What the tee invokes is HTML's `StructuredClone` abstract operation — machinery, with no script-visible name of its own. Fetch does not call `globalThis.structuredClone`; it runs the algorithm, the same way it runs "extract a body" without a flag for that.
2. **The repository had already decided this three times.** `performance.mark`'s `detail` (`UserTiming.cs`), `MessagePort.postMessage` and `BroadcastChannel.postMessage` all call `StructuredCloner.Clone` from under `Performance` and `Messaging` respectively, with no `StructuredClone` flag in sight and none added to their closures. Fetch reaching it is the fourth instance of an established pattern, not a new coupling.
3. **The alternative that gates it is the bug wearing a hat.** If the clone step were skipped when the flag is off, `clone()`'s *correctness* would depend on an unrelated feature bit, and an embedder who enabled fetch and nothing else would silently keep the exact behaviour this PR exists to remove. The brief's own constraint — "`fetch` must not silently keep the buggy behaviour when a flag is absent" — rules it out.
4. **The alternative that expands the closure is too wide.** Adding `StructuredClone` to Fetch's expansion would install a `structuredClone` global on every fetch engine. That closure exists for interfaces fetch *returns* (`response.body` is a `ReadableStream`, `response.blob()` is a `Blob`), so that the installed surface is not self-contradictory — not for algorithms it runs internally. A new global appearing because you enabled fetch is a wider grant than the fix needs.

`BodyCloneTeeTests.TheCloneStillClonesOnAnEngineWithNoStructuredCloneGlobal` pins both halves at once: the global is absent, and the clone happens anyway.

## The sibling, and what else tees

- **`Request.clone()` had the identical defect.** It runs the same [clone a body](https://fetch.spec.whatwg.org/#concept-body-clone), and it is fixed by the same change. `TheClonedRequestGetsAStructuredCloneOfEveryChunkToo` pins it; it failed against the unfixed tree along with the rest. No corpus row named it, which is why it gets its own test.
- **`ReadableStream.prototype.tee()` is the only other tee in the engine**, and it must go on sharing chunks. Two tests prove it did not change: the pre-existing `ReadableStreamTeeTests.HandsBothBranchesTheVerySameChunkObject`, and a new `TeeItselfIsUntouchedAndStillHandsBothBranchesOneChunk` that asserts `a === initial && b === initial && a === b` for a `Uint8Array` on a fetch-enabled engine. That second one **passes against both the fixed and the unfixed tree**, which is the point: it is a guard, not a claim.
- `grep -rn "\.Tee(" Jint/` finds exactly three call sites and the two dispatch lines, all listed in the table above. Nothing under `Caches/`, `Workers/` or `FetchEvents/` tees a body.

## Verified against unfixed code

The tests were written first and run against `upstream/main` before the engine change existed. **19 of 22 failed:**

```
Failed  TheClonedResponseGetsAStructuredCloneOfEveryChunk(chunk: "new Int8Array(arrayBuffer, 1)")
Failed  TheClonedResponseGetsAStructuredCloneOfEveryChunk(chunk: "new Int16Array(arrayBuffer, 2, 2)")
Failed  TheClonedResponseGetsAStructuredCloneOfEveryChunk(chunk: "new Int32Array(arrayBuffer)")
Failed  TheClonedResponseGetsAStructuredCloneOfEveryChunk(chunk: "arrayBuffer")
Failed  TheClonedResponseGetsAStructuredCloneOfEveryChunk(chunk: "new Uint8Array(arrayBuffer)")
Failed  TheClonedResponseGetsAStructuredCloneOfEveryChunk(chunk: "new Uint8ClampedArray(arrayBuffer)")
Failed  TheClonedResponseGetsAStructuredCloneOfEveryChunk(chunk: "new Uint16Array(arrayBuffer, 2)")
Failed  TheClonedResponseGetsAStructuredCloneOfEveryChunk(chunk: "new Uint32Array(arrayBuffer)")
Failed  TheClonedResponseGetsAStructuredCloneOfEveryChunk(chunk: "new BigInt64Array(arrayBuffer)")
Failed  TheClonedResponseGetsAStructuredCloneOfEveryChunk(chunk: "new BigUint64Array(arrayBuffer)")
Failed  TheClonedResponseGetsAStructuredCloneOfEveryChunk(chunk: "new Float16Array(arrayBuffer)")
Failed  TheClonedResponseGetsAStructuredCloneOfEveryChunk(chunk: "new Float32Array(arrayBuffer)")
Failed  TheClonedResponseGetsAStructuredCloneOfEveryChunk(chunk: "new Float64Array(arrayBuffer)")
Failed  TheClonedResponseGetsAStructuredCloneOfEveryChunk(chunk: "new DataView(arrayBuffer, 2, 8)")
Failed  TheClonedRequestGetsAStructuredCloneOfEveryChunkToo
Failed  WritingThroughOneBodysChunkIsInvisibleToTheOther
Failed  TheCloneStillClonesOnAnEngineWithNoStructuredCloneGlobal
Failed  AChunkTheSerializerRefusesErrorsBothBodiesWithADataCloneError
Failed  CloningTwiceGivesThreeIndependentBuffers

Failed!  - Failed: 19, Passed: 3, Skipped: 0, Total: 22
```

The three that passed are the three regression guards — `tee()`, the `new Request(request)` proxy, and the byte-stream body — which is what makes them guards.

A sample of the red output, showing the assertions are on identity the way the corpus's are:

```
TheClonedResponseGetsAStructuredCloneOfEveryChunk(chunk: "new Uint8Array(arrayBuffer)")
  Expected string to be the same string, but they differ at index 41:
             (actual)   "…nd-is-not:false,same-prototype:true,same-byteLengt…"
             (expected) "…nd-is-not:true,same-prototype:true,same-byteLength…"

WritingThroughOneBodysChunkIsInvisibleToTheOther
  "99:99"   (actual)
  "1:99"    (expected)

AChunkTheSerializerRefusesErrorsBothBodiesWithADataCloneError
  "resolved,resolved"               (actual)
  "DataCloneError,DataCloneError"   (expected)
```

With the fix: **22 / 22 pass.**

The theory covers every chunk kind the corpus does — the twelve typed-array kinds including `Float16Array` and `BigInt64Array`, plus `ArrayBuffer` and `DataView` — and asserts what the corpus asserts, not merely equal content: `first === initial`, `second !== initial`, same prototype, same `byteLength`, same `byteOffset`, `second.buffer !== initial.buffer`, and same bytes.

## Cost

Structured-cloning every chunk is not free and a streaming embedder pays it, so here is the number. Bytes allocated per `clone()` plus a full drain of **both** bodies, net10.0 Release, 50 iterations after 20 warm-up iterations on one engine, `GC.GetTotalAllocatedBytes(precise: true)`:

| chunks × size | before | after | Δ | Δ per chunk |
| ---: | ---: | ---: | ---: | ---: |
| 1 × 1 KiB | 19,566 | 21,662 | +2,096 | 2,096 |
| 8 × 1 KiB | 39,262 | 56,030 | +16,768 | 2,096 |
| 64 × 1 KiB | 200,998 | 335,147 | +134,149 | 2,096 |
| 1 × 64 KiB | 19,694 | 86,302 | +66,608 | 66,608 |
| 8 × 64 KiB | 40,286 | 573,159 | +532,873 | 66,609 |
| 64 × 64 KiB | 205,670 | 4,468,699 | +4,263,029 | 66,610 |

The delta is exactly **N × (chunk bytes + 1,072)**, linear in both directions and identical at both chunk sizes. The chunk bytes are the copy the standard asks for; the fixed 1,072 B is the two-phase serializer's per-chunk record (`SerializationRecord` → `StructuredDeserializer`, which is the design `StructuredCloner`'s own doc comment argues for, so that `structuredClone` and channel messaging cannot drift apart).

**A `BufferSource` fast path was considered and declined.** Copying a typed array's region directly — the way `ReadableByteStreamTee` already does with `CloneArrayBufferRegion` — would remove most of that 1,072 B for the common case. It is not in this PR because it would be a *second* structured-clone implementation for the shapes that already work, and the record path is what gets detached buffers, resizable buffers, `SharedArrayBuffer` refusal and `DataView` offsets right. If it is wanted it should be a follow-up with its own tests, argued on measurement rather than folded into a correctness fix.

Note the cost is only paid by a body whose stream is a *default* stream; a network response's body is a byte stream and was already cloning, so this row of the table did not move for the case an embedder streaming a large HTTP response is actually in.

## Verification

- `dotnet build -c Release` for the **solution**, clean. `Jint` rebuilt non-incrementally for all five TFMs (`net462`, `netstandard2.0`, `netstandard2.1`, `net8.0`, `net10.0`): 0 errors, 0 new warnings. The one MSB3277 warning is pre-existing, in `Jint.Tests.CommonScripts`'s `net472` leg, and unrelated.
- `Jint.Tests` — net10.0: **10,558 passed**, 0 failed, 5 skipped. net472: **7,256 passed**, 0 failed, 4 skipped.
- `Jint.Tests.PublicInterface` — net10.0: **2,508 passed**, 0 failed, 9 skipped. net472: **1,914 passed**, 0 failed, 9 skipped.
- With `JINT_HOST_CONTRACT_VERIFICATION=1` — `Jint.Tests` net10.0: **10,558 / 0 / 5**; net472: **7,256 / 0 / 4**. `Jint.Tests.PublicInterface` net10.0: **2,512 / 0 / 5**; net472: **1,918 / 0 / 5**. (The skip set narrowing from 9 to 5 in the public-interface project is how you can see the switch really was on.)
- **WPT suite: 423 passed, 0 failed, 1 skipped** (`WptCensusTests.TheInventoryTableMatchesWhatTheCorpusMeasures`, a pre-existing conditional skip). **The exclusion table did not move** — `WptExclusions.cs` is untouched, and `response-clone.any.js` is not vendored on `main`.
- **test262 was not run, and nothing here is reachable from it.** Every file changed is under `Jint/WebApi/`, gated `#if NET8_0_OR_GREATER` end to end and installed only from `Options.Apply` behind a `WebApiFeatures` bit; `grep -rn "UseWebApis\|WebApiFeatures\|UseFetch" Jint.Tests.Test262/*.cs` returns nothing, so the conformance harness cannot reach a line of it.

## The corpus rows

Once `fetch/api/response/response-clone.any.js` is vendored, this turns **fourteen** rows green — one per chunk kind:

```
Check response clone use structureClone for teed ReadableStreams (Int8Arraychunk)
… (Int16Arraychunk) (Int32Arraychunk) (ArrayBufferchunk) (Uint8Arraychunk)
… (Uint8ClampedArraychunk) (Uint16Arraychunk) (Uint32Arraychunk)
… (BigInt64Arraychunk) (BigUint64Arraychunk)
… (Float16Arraychunk) (Float32Arraychunk) (Float64Arraychunk) (DataViewchunk)
```

**Outstanding, and it has to be said plainly.** Those rows live in the branch of #3260 (`test/3260-wpt-server`), which recorded them as `WptDivergence.NeedsTriage`. That branch **has not been pushed to `origin`** — checked immediately before pushing this one (`git ls-remote --heads origin` finds no `3260`/`wpt-server` ref) — so this PR is based on `upstream/main` and **does not remove the exclusion entry**. `AGENTS.md`'s exclusion table is two-sided: an entry that stops matching a failing test fails the run. So **whichever of the two branches lands second must delete the `NeedsTriage` entry for `response/response-clone.any.js` and re-run the WPT suite.** If #3260 merges first, that is a one-line follow-up on this branch; if this merges first, it belongs in #3260's rebase. Nothing in this PR can do it, because the entry does not exist on `main`.

## Against the verdict

Things a reviewer could reasonably decide differently, stated as they are rather than argued away:

- **The `CloneBody` / `ProxyBody` split is more than the bug needed.** A single `bool` parameter with a named argument at each call site would have fixed the defect with a smaller diff. The split was chosen because the constructor path was named after an algorithm it does not implement, and correcting that is what stops the next person from "unifying" the two and re-introducing this — but it is a judgement call, and reverting it to one parameterised method would not change any behaviour or any test.
- **`ProxyBody` is still not create-a-proxy.** The standard's algorithm pipes through an identity `TransformStream`, which leaves the input's stream *locked and disturbed*; Jint's tee replaces it with a branch instead. That divergence predates this PR and is untouched by it — the only thing established here is that the path must not clone chunks. If a reviewer wants the real algorithm, it is a separate change with separate tests.
- **Fixed 1,072 B per chunk is real overhead** and this PR knowingly ships it rather than adding a `BufferSource` fast path. The case for the record path is one implementation of structured clone, not two; the case against is that the common chunk in a fetch body is precisely a `Uint8Array`. Reasonable to want the fast path in the same change. See "Cost" for why it is not here.
- **The `DataCloneError` path changes behaviour for a body nobody should have.** A `Response` whose stream enqueues a function used to let `response.body.getReader().read()` hand that function to the reader; after `clone()`, both bodies now error. That is what the standard says, and it matches browsers, but it is a behaviour change for a script that was relying on `body` being a raw pass-through. It only bites a body that has been `clone()`d — an uncloned body is untouched.
- **`new Request(existingRequest)` deliberately still shares chunks.** If a reviewer believes Jint should structured-clone there for safety, that is a defensible position and a one-word change — but it would diverge from the specification in the *other* direction, and would start refusing chunks (functions, `Symbol`s, `MessagePort`s already transferred) that an identity transform forwards happily. The `false` is a decision, and `ARequestBuiltFromARequestProxiesItsBodyAndDoesNotCloneTheChunks` pins it so that flipping it is deliberate.
- **The allocation figures are single-run, not a `gate`-mode benchmark.** They come from an allocation counter, not from BenchmarkDotNet, so they carry no confidence interval. They are quoted because allocation counts are deterministic enough for this claim (the per-chunk delta is identical to within 2 bytes across three chunk counts and two chunk sizes), not because a timing claim is being made. No timing claim is being made.
