### PR TITLE
Fetch: a fetched response's Headers carry the immutable guard

### DIFF
--- a/Jint.Tests/Runtime/WebApi/HeadersGuardTests.cs
+++ b/Jint.Tests/Runtime/WebApi/HeadersGuardTests.cs
@@ -1,0 +1,366 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Jint.Native;
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// A <c>Headers</c> object's guard, https://fetch.spec.whatwg.org/#concept-headers-guard: which of the
+/// standard's five values every construction site carries, and what each one lets a script do.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The matrix is here in one file rather than spread over <c>HeadersTests</c>, <c>RequestTests</c>,
+/// <c>ResponseTests</c>, <c>FetchTests</c> and <c>CacheTests</c> because a guard is only meaningful as a
+/// whole: an implementation that refused every mutation would pass half of these, and one that refused none
+/// would pass the other half. Every site is therefore pinned from both directions — the mutation that must
+/// throw, and the mutation that must still succeed.
+/// </para>
+/// <para>
+/// Only <c>immutable</c> changes behaviour in Jint. <c>request</c>, <c>request-no-cors</c> and
+/// <c>response</c> exist in the standard to enforce the forbidden-header-name lists, which Jint deliberately
+/// does not enforce — see <c>HeadersGuard</c>'s own documentation — and <c>request-no-cors</c> cannot arise
+/// at all, because <c>RequestInit</c>'s <c>mode</c> member is not implemented.
+/// </para>
+/// </remarks>
+public class HeadersGuardTests
+{
+    /// <summary>
+    /// How long a fetch may take to settle against the stub below. Not a measurement and not a budget: what is
+    /// asserted is always what the fetch produced, never how long it took.
+    /// </summary>
+    private static readonly TimeSpan TransportSignalCeiling = TimeSpan.FromMinutes(2);
+
+    /// <summary>
+    /// A transport that answers every request from memory, so nothing here touches a network.
+    /// </summary>
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        internal Func<HttpResponseMessage>? Responder { get; set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = Responder?.Invoke() ?? new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("ok"),
+            };
+
+            return Task.FromResult(response);
+        }
+    }
+
+    private static Engine WebEngine() => new(options => options.UseFetch());
+
+    private static Engine FetchEngine(HttpMessageHandler handler)
+        => new(options => options.UseFetch(fetch => fetch.HttpClient = new HttpClient(handler)));
+
+    /// <summary>Runs a fetch-driven script and waits for the promise it answers with.</summary>
+    private static string FetchResult(HttpMessageHandler handler, string source)
+        => FetchEngine(handler).Evaluate(source).UnwrapIfPromise(TransportSignalCeiling).AsString();
+
+    /// <summary>
+    /// The three mutating operations, each reporting what it did. Every guarded site is held to the same
+    /// script, so a site that refuses one operation and not another cannot pass.
+    /// </summary>
+    private const string TryMutate = """
+        function tryMutate(headers) {
+            const results = [];
+            for (const attempt of [
+                () => headers.append('x-guard', 'appended'),
+                () => headers.set('x-guard', 'set'),
+                () => headers.delete('x-existing'),
+            ]) {
+                try {
+                    attempt();
+                    results.push('ok');
+                } catch (e) {
+                    results.push(e.constructor.name + '/' + (e.message.indexOf('immutable') >= 0));
+                }
+            }
+            return results.join(',');
+        }
+        """;
+
+    [Fact]
+    public void ABareHeadersObjectIsMutable()
+    {
+        // "The new Headers(init) constructor steps are: Set this's guard to 'none'."
+        // https://fetch.spec.whatwg.org/#dom-headers
+        var engine = WebEngine();
+        engine.Execute(TryMutate);
+        engine.Execute("var h = new Headers({ 'x-existing': '1' });");
+
+        engine.Evaluate("tryMutate(h)").AsString().Should().Be("ok,ok,ok");
+        engine.Evaluate("h.get('x-guard')").AsString().Should().Be("set");
+        engine.Evaluate("h.has('x-existing')").AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void ARequestsHeadersAreMutable()
+    {
+        // "Set this's headers to a new Headers object … whose … guard is 'request'."
+        // https://fetch.spec.whatwg.org/#dom-request
+        var engine = WebEngine();
+        engine.Execute(TryMutate);
+        engine.Execute("var r = new Request('https://example.org/', { headers: { 'x-existing': '1' } });");
+
+        engine.Evaluate("tryMutate(r.headers)").AsString().Should().Be("ok,ok,ok");
+        engine.Evaluate("r.headers.get('x-guard')").AsString().Should().Be("set");
+
+        // A Request built from another Request copies the header list, and its own guard is "request" again.
+        engine.Execute("var copy = new Request(r);");
+        engine.Evaluate("tryMutate(copy.headers)").AsString().Should().Be("ok,ok,ok");
+
+        // clone() carries this's headers's guard, which for an ordinary Request is "request".
+        // https://fetch.spec.whatwg.org/#dom-request-clone
+        engine.Evaluate("tryMutate(r.clone().headers)").AsString().Should().Be("ok,ok,ok");
+    }
+
+    [Fact]
+    public void AResponsesHeadersAreMutable()
+    {
+        // "Set this's headers to a new Headers object … whose … guard is 'response'."
+        // https://fetch.spec.whatwg.org/#dom-response, and the same for Response.json:
+        // https://fetch.spec.whatwg.org/#dom-response-json creates its object with "response".
+        var engine = WebEngine();
+        engine.Execute(TryMutate);
+        engine.Execute("var r = new Response('body', { headers: { 'x-existing': '1' } });");
+
+        engine.Evaluate("tryMutate(r.headers)").AsString().Should().Be("ok,ok,ok");
+        engine.Evaluate("r.headers.get('x-guard')").AsString().Should().Be("set");
+
+        engine.Execute("var j = Response.json({ a: 1 });");
+        engine.Evaluate("tryMutate(j.headers)").AsString().Should().Be("ok,ok,ok");
+
+        // https://fetch.spec.whatwg.org/#dom-response-clone — the clone carries the same guard.
+        engine.Evaluate("tryMutate(new Response('body').clone().headers)").AsString().Should().Be("ok,ok,ok");
+    }
+
+    [Fact]
+    public void TheTwoImmutableStaticsRefuseEveryMutation()
+    {
+        // https://fetch.spec.whatwg.org/#dom-response-error and
+        // https://fetch.spec.whatwg.org/#dom-response-redirect both create their Response object with the
+        // "immutable" guard.
+        var engine = WebEngine();
+        engine.Execute(TryMutate);
+
+        engine.Evaluate("tryMutate(Response.error().headers)").AsString()
+            .Should().Be("TypeError/true,TypeError/true,TypeError/true");
+
+        engine.Evaluate("tryMutate(Response.redirect('https://example.org/a').headers)").AsString()
+            .Should().Be("TypeError/true,TypeError/true,TypeError/true");
+
+        // The guard travels through clone(), so the copy cannot be edited either.
+        engine.Evaluate("tryMutate(Response.error().clone().headers)").AsString()
+            .Should().Be("TypeError/true,TypeError/true,TypeError/true");
+    }
+
+    [Fact]
+    public void AFetchedResponsesHeadersAreImmutable()
+    {
+        // "Set responseObject to the result of creating a Response object, given response, 'immutable', and
+        // relevantRealm" — https://fetch.spec.whatwg.org/#dom-global-fetch. What the server said is not the
+        // script's to rewrite. sebastienros/jint#3281.
+        var handler = new StubHandler
+        {
+            Responder = () =>
+            {
+                var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("ok") };
+                response.Headers.Add("x-existing", "1");
+                return response;
+            },
+        };
+
+        FetchResult(handler, TryMutate + """
+            fetch('https://example.org/a').then(r => tryMutate(r.headers));
+            """).Should().Be("TypeError/true,TypeError/true,TypeError/true");
+
+        // And nothing stuck: the refused mutations left the list exactly as the transport built it.
+        FetchResult(handler, """
+            fetch('https://example.org/a').then(r => {
+                try { r.headers.append('name', 'value'); } catch (e) { }
+                try { r.headers.delete('x-existing'); } catch (e) { }
+                return r.headers.get('name') + '|' + r.headers.get('x-existing');
+            });
+            """).Should().Be("null|1");
+    }
+
+    [Fact]
+    public void AFetchedResponsesCloneIsImmutableToo()
+    {
+        // https://fetch.spec.whatwg.org/#dom-response-clone hands the clone "this's headers's guard", so the
+        // clone of an immutable response is immutable — cloning is not a way around the guard.
+        var handler = new StubHandler();
+
+        FetchResult(handler, TryMutate + """
+            fetch('https://example.org/a').then(r => tryMutate(r.clone().headers));
+            """).Should().Be("TypeError/true,TypeError/true,TypeError/true");
+    }
+
+    [Fact]
+    public void AFetchedResponsesHeadersCanStillBeReadEveryWay()
+    {
+        // Nothing about reading is guarded: get, has, getSetCookie, iteration and forEach are all unaffected
+        // by "immutable", which only ever appears in the three mutating algorithms.
+        var handler = new StubHandler
+        {
+            Responder = () =>
+            {
+                var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("ok") };
+                response.Headers.Add("x-multi", "one");
+                response.Headers.Add("x-multi", "two");
+                response.Headers.Add("set-cookie", "a=1");
+                response.Headers.Add("set-cookie", "b=2");
+                return response;
+            },
+        };
+
+        FetchResult(handler, """
+            fetch('https://example.org/a').then(r => {
+                const h = r.headers;
+                const seen = [];
+                h.forEach((value, name) => seen.push(name));
+                return [
+                    h.get('x-multi'),
+                    h.has('x-multi'),
+                    h.getSetCookie().join('|'),
+                    [...h.keys()].join('|'),
+                    [...h].length === seen.length,
+                ].join(';');
+            });
+            """).Should().Be("one, two;true;a=1|b=2;content-length|content-type|set-cookie|set-cookie|x-multi;true");
+    }
+
+    [Fact]
+    public void AFetchedResponsesHeadersCanBeCopiedIntoAMutableOne()
+    {
+        // The escape hatch, and the one an embedder rewrites to: a guard belongs to the Headers *object*, so
+        // filling a new one from an immutable one — https://fetch.spec.whatwg.org/#concept-headers-fill —
+        // copies the headers and not the guard. This is the browser-blessed way to add a header to a
+        // response that came off the wire, and the migration for anything that used to mutate in place.
+        var handler = new StubHandler
+        {
+            Responder = () =>
+            {
+                var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("ok") };
+                response.Headers.Add("x-existing", "1");
+                return response;
+            },
+        };
+
+        FetchResult(handler, """
+            fetch('https://example.org/a').then(async r => {
+                const copy = new Headers(r.headers);
+                copy.set('x-added', '2');
+
+                const rebuilt = new Response(await r.text(), { status: r.status, headers: copy });
+                rebuilt.headers.set('x-later', '3');
+
+                return [
+                    rebuilt.headers.get('x-existing'),
+                    rebuilt.headers.get('x-added'),
+                    rebuilt.headers.get('x-later'),
+                    r.headers.get('x-added') === null,
+                ].join('|');
+            });
+            """).Should().Be("1|2|3|true");
+    }
+
+    [Fact]
+    public void TheGuardIsCheckedAfterTheNameAndValueAre()
+    {
+        // "To validate a header (name, value) for a Headers object headers: 1. If name is not a header name
+        // or value is not a header value, then throw a TypeError. 2. If headers's guard is 'immutable', then
+        // throw a TypeError." — https://fetch.spec.whatwg.org/#headers-validate. Both are TypeErrors, so the
+        // order is observable only through the message, but it is observable, and the same order applies to
+        // delete, which validates (name, ``) before it looks at the guard.
+        var engine = WebEngine();
+        engine.Execute("var h = Response.error().headers;");
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("h.append('bad name', 'v')"))
+            .Message.Should().Contain("Invalid name");
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("h.set('bad name', 'v')"))
+            .Message.Should().Contain("Invalid name");
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("h.delete('bad name')"))
+            .Message.Should().Contain("Invalid name");
+
+        // A valid name reaches the guard check instead.
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("h.append('good-name', 'v')"))
+            .Message.Should().Contain("immutable");
+
+        // And an invalid *value* is refused before the guard too — the same step 1.
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("h.append('good-name', 'a\\nb')"))
+            .Message.Should().Contain("Invalid value");
+    }
+
+    [Fact]
+    public void ACachedRequestAndResponseAreBothImmutable()
+    {
+        // "Add a new Response object associated with response and a new Headers object whose guard is
+        // 'immutable'", and the same wording for the Request objects keys() answers with —
+        // https://w3c.github.io/ServiceWorker/#cache-matchall and #cache-keys. A cached object a script could
+        // edit would look like editing the cache, which it is not.
+        var engine = new Engine(options => options.UseCacheApi());
+        engine.Execute(TryMutate);
+
+        engine.Evaluate("""
+            (async () => {
+                const cache = await caches.open('v1');
+                await cache.put(
+                    new Request('https://example.org/a', { headers: { 'x-existing': '1' } }),
+                    new Response('hello', { headers: { 'x-existing': '1' } }));
+
+                const response = await cache.match('https://example.org/a');
+                const keys = await cache.keys();
+                return tryMutate(response.headers) + ';' + tryMutate(keys[0].headers);
+            })()
+            """).UnwrapIfPromise().AsString()
+            .Should().Be("TypeError/true,TypeError/true,TypeError/true;TypeError/true,TypeError/true,TypeError/true");
+    }
+
+    [Fact]
+    public void AFetchHandlersRequestStaysMutable()
+    {
+        // A deliberate divergence, recorded rather than silent. The Service Worker Standard's Handle Fetch
+        // creates the FetchEvent's Request "given request, a new Headers object's guard which is 'immutable'"
+        // — https://w3c.github.io/ServiceWorker/#on-fetch-request-algorithm — but Jint's inbound Request is
+        // built once for both routes, and the other route is Options.WebApi.Fetch's plain handler callback,
+        // which no algorithm governs: there the script *is* the endpoint rather than an interceptor watching
+        // a request the user agent is already making. Making the two disagree would be worse than either
+        // answer, so both carry "request". See FetchHandlerHosting.CreateRequest.
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Events | WebApiFeatures.Url | WebApiFeatures.Files));
+        engine.Execute(TryMutate + """
+            globalThis.handler = {
+                fetch(request) {
+                    return new Response(tryMutate(request.headers));
+                }
+            };
+            """);
+        engine.Advanced.SetFetchHandler(engine.GetValue("handler"));
+
+        var message = new HttpRequestMessage(HttpMethod.Get, "https://example.org/");
+        message.Headers.Add("x-existing", "1");
+
+        var operation = engine.Advanced.InvokeFetchHandler(message);
+        for (var i = 0; i < 100 && !operation.IsCompleted; i++)
+        {
+            engine.Advanced.ProcessTasks();
+        }
+
+        using var response = operation.GetResult();
+        using var stream = response.Content.ReadAsStream();
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        reader.ReadToEnd().Should().Be("ok,ok,ok");
+    }
+}
+#endif

--- a/Jint.Tests/Wpt/Vendor/README.md
+++ b/Jint.Tests/Wpt/Vendor/README.md
@@ -42,7 +42,7 @@ Twelve standards are vendored: `url/`, `encoding/`, `compression/`, `urlpattern/
 (events, abort), `fetch/api/` as **five** (basic, body, headers, redirect, response), `WebCryptoAPI/` as
 **eight** and `streams/` as **seven** — their root files plus one suite per sub-directory, because
 `WptCorpus.TestFiles` lists a directory's own files and never descends. That is 293 theory cases over 40,983
-assertions, of which 2,983 do not pass and every one is named in the driver's table; the whole driver runs in
+assertions, of which 2,982 do not pass and every one is named in the driver's table; the whole driver runs in
 about two minutes.
 
 Those three figures are a census taken at the pin rather than a running tally, so they are restated whenever a
@@ -185,9 +185,9 @@ is answering a request the corpus itself composed.
 
 **What it cost and what it bought.** The lane added 20 files and 326 assertions, and cost about **5 s**:
 medians of five `--filter Jint.Tests.Wpt` runs each side on one Windows machine, 68 s before and 73 s after,
-with the count identical on every run of both. Of those 326 assertions 232 pass; the 94 that do not are named
-in the exclusion table under six categories, five of which are engine defects filed separately (see
-`WptDivergence.NeedsTriage`) and the sixth of which is not an engine matter at all — the .NET HTTP stack does
+with the count identical on every run of both. Of those 326 assertions 233 pass; the 93 that do not are named
+in the exclusion table under five categories, four of which are engine defects filed separately (see
+`WptDivergence.NeedsTriage`) and the fifth of which is not an engine matter at all — the .NET HTTP stack does
 not carry a header value above ASCII, which
 `WptServerTests.AHeaderValueAboveAsciiDoesNotSurviveTheHttpStack` measures with no engine in the picture.
 
@@ -967,11 +967,14 @@ citation and an argued decision, never a to-do — and the rule that age alone n
 
 ## What the fetch *network* corpus says about this engine
 
-326 assertions across the twenty files [the server lane](#the-server-lane) added, of which **94 do not pass**.
+326 assertions across the twenty files [the server lane](#the-server-lane) added, of which **93 do not pass**.
 Unlike the object-model half above, most of these are not decisions — the corpus was making a real request for
-the first time, and it found five things. Each is filed as its own issue and deliberately **not** fixed here:
-the change that first runs a suite must not also be the change that moves the engine, or nobody can tell which
-of the two a number came from. They are the whole of `WptDivergence.NeedsTriage`, which was empty before.
+the first time, and it found five things. Each was filed as its own issue and deliberately **not** fixed by the
+change that first ran the suite: the change that first runs a suite must not also be the change that moves the
+engine, or nobody can tell which of the two a number came from. The four still open are the whole of
+`WptDivergence.NeedsTriage`, which was empty before. The fifth is fixed — a fetched response's `Headers` now
+carry the *immutable* guard ([#3281](https://github.com/sebastienros/jint/issues/3281)), so
+`response/response-headers-guard.any.js` passes whole.
 
 1. **No `Accept: */*` is appended** ([#3279](https://github.com/sebastienros/jint/issues/3279)). Step 8 of
    [HTTP-network-or-cache fetch](https://fetch.spec.whatwg.org/#concept-http-network-or-cache-fetch) says to
@@ -981,17 +984,12 @@ of the two a number came from. They are the whole of `WptDivergence.NeedsTriage`
    [HTTP-network fetch](https://fetch.spec.whatwg.org/#concept-http-network-fetch) gives it a null body, and
    `response.body` is a `ReadableStream` here. One row of `basic/response-null-body.any.js`; the nine
    null-body-status rows (204, 205, 304) all pass, so it is the method half alone.
-3. **A fetched response's `Headers` are mutable**
-   ([#3281](https://github.com/sebastienros/jint/issues/3281)). The
-   [response header list](https://fetch.spec.whatwg.org/#concept-response-header-list) a `fetch` resolves with
-   carries the *immutable* guard, so `append` must throw; it does not. The whole of
-   `response/response-headers-guard.any.js`.
-4. **`Content-Encoding`, `Content-Language` and `Content-Location` never leave a bodiless request**
+3. **`Content-Encoding`, `Content-Language` and `Content-Location` never leave a bodiless request**
    ([#3282](https://github.com/sebastienros/jint/issues/3282)). The BCL
    files those three as *content* headers, so a GET or HEAD — which has no `HttpContent` to hang them on —
    drops them silently, where Fetch has no such category and they are ordinary request headers. Eight rows of
    `redirect/redirect-method.any.js`; its POST rows pass, which is what localises it.
-5. **`clone()` hands both bodies the same buffer** ([#3283](https://github.com/sebastienros/jint/issues/3283)).
+4. **`clone()` hands both bodies the same buffer** ([#3283](https://github.com/sebastienros/jint/issues/3283)).
    [Body clone](https://fetch.spec.whatwg.org/#concept-body-clone) tees the stream, and the chunks the two
    branches deliver must be structured clones of one another rather than the same object. Fourteen rows of
    `response/response-clone.any.js`, one per typed-array kind.
@@ -1023,9 +1021,11 @@ the two halves of that check and the one command that rewrites the table.
 
 Measured at this pin, on Windows, with the driver's exclusion table in force. "Not passing" is every result
 the shim did not record `PASS`, which is exactly the set the table names. The last change to move a row is
-[#3260](https://github.com/sebastienros/jint/issues/3260), and it moved exactly one: Fetch, from 29 files /
+[#3281](https://github.com/sebastienros/jint/issues/3281), which gave a fetched response's `Headers` the
+*immutable* guard and moved Fetch's not-passing count alone, 169 to 168. Before it,
+[#3260](https://github.com/sebastienros/jint/issues/3260) moved exactly one row: Fetch, from 29 files /
 388 assertions / 75 not passing to 49 / 714 / 169 — [the server lane](#the-server-lane)'s twenty files, 326
-assertions, 232 of them passing. Every other row was re-derived in the same run and had not moved. The census
+assertions, 232 of them passing at the time. Every other row was re-derived in the same run and had not moved. The census
 before that was taken by hand for [#3212](https://github.com/sebastienros/jint/issues/3212), which moved five
 rows at once because Streams, Compression, User Timing and DOM had each gone stale against a fix that removed
 their exclusions without revisiting this table.
@@ -1044,8 +1044,8 @@ their exclusions without revisiting this table.
 | HTML — workers | `workers/` ×4 | 12 | 24 | 8 |
 | HTML — timers, microtasks, structured clone | `html/webappapis/` ×3 | 11 | 154 | 3 |
 | DOM | `dom/` ×2 | 13 | 76 | 0 |
-| Fetch | `fetch/api/` ×5 | 49 | 714 | 169 |
-| **total** | **38** | **293** | **40,983** | **2,983** |
+| Fetch | `fetch/api/` ×5 | 49 | 714 | 168 |
+| **total** | **38** | **293** | **40,983** | **2,982** |
 
 Re-censused whole rather than adjusted row by row, because several rows had gone stale between the changes
 that moved them: before [#3195](https://github.com/sebastienros/jint/issues/3195) the true figures were

--- a/Jint.Tests/Wpt/WptExclusions.cs
+++ b/Jint.Tests/Wpt/WptExclusions.cs
@@ -513,11 +513,6 @@ internal enum WptDivergence
     /// https://fetch.spec.whatwg.org/#concept-http-network-fetch gives it a null body.
     /// </description></item>
     /// <item><description>
-    /// https://github.com/sebastienros/jint/issues/3281 — <c>response/response-headers-guard.any.js</c>: a
-    /// fetched response's <c>Headers</c> are mutable where
-    /// https://fetch.spec.whatwg.org/#concept-response-header-list gives them the <i>immutable</i> guard.
-    /// </description></item>
-    /// <item><description>
     /// https://github.com/sebastienros/jint/issues/3282 — <c>redirect/redirect-method.any.js</c>:
     /// <c>Content-Encoding</c>, <c>Content-Language</c> and <c>Content-Location</c> set on a bodiless request
     /// never reach the wire, because the BCL files them as content headers and a GET has no content to hang

--- a/Jint.Tests/Wpt/WptTestRunner.cs
+++ b/Jint.Tests/Wpt/WptTestRunner.cs
@@ -1077,8 +1077,6 @@ public class WptTestRunner
             @"Request through fetch should have 'accept' header with value '\*/\*'", WptDivergence.NeedsTriage),
         new("fetch/api/basic/response-null-body.any.js",
             "Response.body is null for responses with method=HEAD", WptDivergence.NeedsTriage),
-        new("fetch/api/response/response-headers-guard.any.js",
-            "Ensure response headers are immutable", WptDivergence.NeedsTriage),
         new("fetch/api/redirect/redirect-method.any.js", "Redirect 30* with GET", WptDivergence.NeedsTriage),
         new("fetch/api/redirect/redirect-method.any.js", "Redirect 30* with HEAD", WptDivergence.NeedsTriage),
         new("fetch/api/response/response-clone.any.js",

--- a/Jint/WebApi/Fetch/FetchHandlerHosting.cs
+++ b/Jint/WebApi/Fetch/FetchHandlerHosting.cs
@@ -41,9 +41,23 @@ internal static class FetchHandlerHosting
     /// Builds the <c>Request</c> the handler is called with.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// The URL is required to be absolute, because the Fetch Standard's request URL is absolute and this
     /// engine has no document to resolve a relative one against — the same reason
     /// <c>new Request('/a')</c> is a <c>TypeError</c> in script.
+    /// </para>
+    /// <para>
+    /// Its headers carry the <c>request</c> guard rather than the <c>immutable</c> one, which is a deliberate
+    /// divergence from the Service Worker Standard: <i>Handle Fetch</i> creates a <c>FetchEvent</c>'s request
+    /// "given request, a new <c>Headers</c> object's guard which is <c>immutable</c>"
+    /// (https://w3c.github.io/ServiceWorker/#on-fetch-request-algorithm). One <c>Request</c> is built here for
+    /// <b>both</b> inbound routes, and the other route is <c>Engine.Advanced.SetFetchHandler</c>'s plain
+    /// callback, which no algorithm governs and where the script <i>is</i> the endpoint rather than an
+    /// interceptor observing a request the user agent is already making. Two inbound requests that disagreed
+    /// about whether their headers can be edited would be worse than either answer, and nothing downstream
+    /// reads this list back — a handler's edit reaches its own script and nothing else. A script that wants
+    /// the browser's discipline gets it by not editing.
+    /// </para>
     /// </remarks>
     /// <param name="engine">The engine the request is built for.</param>
     /// <param name="realm">The principal realm, whose intrinsics the request's prototypes come from.</param>

--- a/Jint/WebApi/Fetch/FetchOperation.cs
+++ b/Jint/WebApi/Fetch/FetchOperation.cs
@@ -415,7 +415,13 @@ internal sealed class FetchOperation
         var list = new HeaderList();
         list.Entries.AddRange(snapshot.Headers);
 
-        var response = _realm.Intrinsics.Response.CreateInstance(list);
+        // "Set responseObject to the result of creating a Response object, given response, "immutable", and
+        // relevantRealm" — https://fetch.spec.whatwg.org/#dom-global-fetch. What the server said is not the
+        // script's to rewrite: a header edited in place here would look like an edit of the response while
+        // reaching nothing that already read it, and a cache put or a handler's answer would carry the
+        // script's version of what the origin sent. A script that does need to add one builds its own
+        // Headers from these — filling copies the headers and not the guard.
+        var response = _realm.Intrinsics.Response.CreateInstance(list, HeadersGuard.Immutable);
         response.Status = snapshot.Status;
         response.StatusText = snapshot.StatusText;
         response.Url = snapshot.Url;

--- a/Jint/WebApi/Fetch/HeaderList.cs
+++ b/Jint/WebApi/Fetch/HeaderList.cs
@@ -21,13 +21,46 @@ internal readonly record struct HeaderEntry(string LowerName, string Value);
 /// <c>Headers</c> object in front of the list allows.
 /// </summary>
 /// <remarks>
+/// <para>
+/// Which guard each construction site carries, and where the algorithm that says so lives:
+/// </para>
+/// <list type="table">
+/// <item><term><c>new Headers()</c></term><description><see cref="None"/> — https://fetch.spec.whatwg.org/#dom-headers</description></item>
+/// <item><term><c>new Request()</c></term><description><see cref="Request"/> — https://fetch.spec.whatwg.org/#dom-request</description></item>
+/// <item><term><c>new Response()</c></term><description><see cref="Response"/> — https://fetch.spec.whatwg.org/#dom-response</description></item>
+/// <item><term><c>Response.json()</c></term><description><see cref="Response"/> — https://fetch.spec.whatwg.org/#dom-response-json</description></item>
+/// <item><term><c>Response.error()</c></term><description><see cref="Immutable"/> — https://fetch.spec.whatwg.org/#dom-response-error</description></item>
+/// <item><term><c>Response.redirect()</c></term><description><see cref="Immutable"/> — https://fetch.spec.whatwg.org/#dom-response-redirect</description></item>
+/// <item><term>the response <c>fetch</c> resolves with</term><description><see cref="Immutable"/> — https://fetch.spec.whatwg.org/#dom-global-fetch</description></item>
+/// <item><term><c>Cache.match</c>, <c>Cache.matchAll</c></term><description><see cref="Immutable"/> — https://w3c.github.io/ServiceWorker/#cache-matchall</description></item>
+/// <item><term><c>Cache.keys</c></term><description><see cref="Immutable"/> — https://w3c.github.io/ServiceWorker/#cache-keys</description></item>
+/// <item><term>a fetch handler's inbound <c>Request</c></term><description><see cref="Request"/>, deliberately — see <c>FetchHandlerHosting.CreateRequest</c></description></item>
+/// </list>
+/// <para>
+/// <c>clone()</c> is the one site that names no guard of its own: both
+/// https://fetch.spec.whatwg.org/#dom-request-clone and https://fetch.spec.whatwg.org/#dom-response-clone
+/// pass <i>this</i> object's guard on, so the clone of an immutable response is immutable too. Filling one
+/// <c>Headers</c> from another is the opposite — the guard belongs to the object rather than to the headers
+/// in it, so <c>new Headers(immutableOne)</c> copies the headers and not the refusal, which is how a script
+/// edits what came off the wire.
+/// </para>
+/// <para>
 /// Only <see cref="Immutable"/> changes behaviour here. The <c>request</c>, <c>request-no-cors</c> and
-/// <c>response</c> guards exist in the standard to enforce the <i>forbidden header name</i> and <i>forbidden
-/// response header name</i> lists, which are a browser's protection of headers the user agent alone controls
-/// (<c>Host</c>, <c>Cookie</c>, <c>Origin</c>, …). Jint runs server-side, where those headers are exactly what
-/// a script legitimately needs to set, so the lists are deliberately not enforced — the same choice Node and
-/// Deno make. The guards are still tracked, so that the two objects the standard makes immutable
-/// (<c>Response.error()</c>'s and <c>Response.redirect()</c>'s headers) really are.
+/// <c>response</c> guards exist in the standard to enforce the <i>forbidden request-header</i> and
+/// <i>forbidden response-header name</i> lists, which are a browser's protection of headers the user agent
+/// alone controls (<c>Host</c>, <c>Cookie</c>, <c>Origin</c>, …). Jint runs server-side, where those headers
+/// are exactly what a script legitimately needs to set, so the lists are deliberately not enforced — the same
+/// choice Node and Deno make. <c>request-no-cors</c> has no member at all, because the only step that sets it
+/// is the <c>new Request()</c> arm for a request whose mode is <c>no-cors</c>, and <c>RequestInit</c>'s
+/// <c>mode</c> member is accepted and ignored here: there is no origin for a cross-origin mode to mean
+/// anything against.
+/// </para>
+/// <para>
+/// The guard is what the <i>script</i> may not do. Every algorithm the engine runs itself reaches
+/// <see cref="HeaderList"/> directly, so an immutable guard never stands in the way of the transport building
+/// a response, of <c>Response.redirect()</c> appending its own <c>Location</c>, or of a host reading a
+/// handler's answer back out.
+/// </para>
 /// </remarks>
 internal enum HeadersGuard
 {
@@ -40,7 +73,11 @@ internal enum HeadersGuard
     /// <summary>A <c>Response</c>'s headers.</summary>
     Response,
 
-    /// <summary>Refuses every mutation with a <c>TypeError</c>.</summary>
+    /// <summary>
+    /// Refuses <c>append</c>, <c>set</c> and <c>delete</c> with a <c>TypeError</c> — and nothing else: every
+    /// way of <i>reading</i> a header list is unguarded, so <c>get</c>, <c>has</c>, <c>getSetCookie</c>,
+    /// <c>forEach</c> and iteration behave exactly as they do under any other guard.
+    /// </summary>
     Immutable,
 }
 

--- a/Jint/WebApi/Fetch/ResponseConstructor.cs
+++ b/Jint/WebApi/Fetch/ResponseConstructor.cs
@@ -223,13 +223,18 @@ internal sealed partial class ResponseConstructor : Constructor
     }
 
     /// <summary>
-    /// Builds a <c>Response</c> for a response the engine produced itself, which is what <c>fetch</c> settles
-    /// its promise with.
+    /// "Create a Response object", https://fetch.spec.whatwg.org/#response-class, for a response the engine
+    /// produced itself — which is what <c>fetch</c> settles its promise with.
     /// </summary>
-    internal JsResponse CreateInstance(HeaderList headerList)
+    /// <remarks>
+    /// The guard is a parameter for the reason the specification's own algorithm takes one: it is a property
+    /// of the <i>caller's</i> algorithm and not of the response, and every caller names it. A response the
+    /// transport built carries <c>immutable</c>, which is what stops a script rewriting what the server said.
+    /// </remarks>
+    internal JsResponse CreateInstance(HeaderList headerList, HeadersGuard guard)
     {
         var headers = _realm.Intrinsics.Headers.CreateInstance(headerList);
-        headers.List.Guard = HeadersGuard.Response;
+        headers.List.Guard = guard;
 
         return new JsResponse(_engine, headers)
         {

--- a/README.md
+++ b/README.md
@@ -1181,6 +1181,16 @@ and validated, because it decides whether a body may be a stream at all (see bel
 `mode`, `referrer` and `integrity` are accepted and ignored, the same convention Node and workerd follow,
 because there is no origin, cookie jar or HTTP cache here to honour them with.
 
+A `Headers` object carries the standard's
+[guard](https://fetch.spec.whatwg.org/#concept-headers-guard), so **the headers of a response `fetch`
+resolved with are immutable**: `append`, `set` and `delete` on them throw a `TypeError`, exactly as they do
+in a browser and in Node's own `fetch`. So do `Response.error()`'s, `Response.redirect()`'s, and the objects
+`caches.match()` and `cache.keys()` answer with. Everything a script builds itself — `new Headers()`,
+`new Request()`, `new Response()`, `Response.json()` — stays writable, and reading is never guarded. To add
+a header to a response that came off the wire, copy it —
+`new Response(body, { headers: new Headers(r.headers) })` — because filling one `Headers` from another
+copies the headers and not the guard.
+
 ### Bodies stream, in both directions
 
 `response.body` is a real `ReadableStream`, and a network response is read **on demand**: the promise


### PR DESCRIPTION
Fetch: a fetched response's `Headers` carry the immutable guard

Fixes #3281.

## ⚠️ Breaking change, stated first

**A script can no longer edit the headers of a response `fetch` resolved with.** `append`, `set` and `delete`
on them now throw a `TypeError`; before this they succeeded and the change stuck.

```js
const r = await fetch(url);
r.headers.set('x-added', '1');   // was: fine. is now: TypeError: … Headers are immutable
```

This is what a browser does and what Node's own `fetch` does — undici throws the same `TypeError`, which is
why "TypeError: immutable" is a well-known SvelteKit/Dexie support thread rather than an exotic corner. It is
also what the standard says, without ambiguity (below). But an embedder whose script proxies an upstream
response and adds a header in place **will start throwing**, and that is a real migration, not a theoretical
one. The remedy is one line and is now in `README.md`:

```js
// the browser-blessed way, and the only one that ever worked in a browser
const rebuilt = new Response(r.body, { status: r.status, headers: new Headers(r.headers) });
rebuilt.headers.set('x-added', '1');
```

Filling one `Headers` from another copies the headers and **not** the guard, which is what makes that work.

## What the standard says

The `fetch()` method's own step, verbatim from
[§5.6](https://fetch.spec.whatwg.org/#dom-global-fetch):

> Set *responseObject* to the result of [creating a `Response` object](https://fetch.spec.whatwg.org/#response-class),
> given *response*, "`immutable`", and *relevantRealm*.

and every mutating operation runs [validate a header](https://fetch.spec.whatwg.org/#headers-validate), whose
step 2 is:

> If *headers*'s [guard](https://fetch.spec.whatwg.org/#concept-headers-guard) is "`immutable`", then throw a
> `TypeError`.

Jint built that response through `ResponseConstructor.CreateInstance`, which hard-coded
`HeadersGuard.Response`.

## The change

`ResponseConstructor.CreateInstance` now **takes the guard as a parameter**, for the reason the specification's
own *create a Response object* does: the guard belongs to the calling algorithm rather than to the response,
and every caller names it. Its one caller — `FetchOperation.ResolveWithResponse`, where the transport's
snapshot becomes the `Response` the promise settles with — names `immutable`.

That is the whole behavioural diff — one argument. The documentation around it is the larger part of the
change, because the point of the issue was the model and not the symptom.

## The guard model, audited site by site

Every place a `Headers` object is created, checked against the algorithm rather than against the name. Only
the last row was wrong:

| site | guard | algorithm |
| --- | --- | --- |
| `new Headers()` | `none` | [#dom-headers](https://fetch.spec.whatwg.org/#dom-headers) — "Set this's guard to none" |
| `new Request()` | `request` | [#dom-request](https://fetch.spec.whatwg.org/#dom-request) |
| `new Response()` | `response` | [#dom-response](https://fetch.spec.whatwg.org/#dom-response) |
| `Response.json()` | `response` | [#dom-response-json](https://fetch.spec.whatwg.org/#dom-response-json) |
| `Response.error()` | `immutable` | [#dom-response-error](https://fetch.spec.whatwg.org/#dom-response-error) |
| `Response.redirect()` | `immutable` | [#dom-response-redirect](https://fetch.spec.whatwg.org/#dom-response-redirect) |
| `Request.clone()` / `Response.clone()` | inherits | [#dom-request-clone](https://fetch.spec.whatwg.org/#dom-request-clone), [#dom-response-clone](https://fetch.spec.whatwg.org/#dom-response-clone) — "given … **this's headers's guard**" |
| `Cache.match` / `matchAll` | `immutable` | [#cache-matchall](https://w3c.github.io/ServiceWorker/#cache-matchall) |
| `Cache.keys` | `immutable` | [#cache-keys](https://w3c.github.io/ServiceWorker/#cache-keys) |
| **the response `fetch` resolves with** | **was `response`** | **[#dom-global-fetch](https://fetch.spec.whatwg.org/#dom-global-fetch) — `immutable`** |

`HeadersGuard`'s own documentation now carries that table, so the next person adding a construction site has to
answer the question rather than copy a neighbour.

### The three mutating operations were already right

The guard test's position is observable — [validate a header](https://fetch.spec.whatwg.org/#headers-validate)
checks the name and value (step 1, `TypeError`) *before* the guard (step 2, `TypeError`) — and `append`, `set`
and `delete` all already did it in that order, `delete` validating `(name, ``)` as its own step 1 says. No code
changed there; a test now pins the ordering, because both throws are `TypeError` and only the message tells
them apart.

### What is deliberately left, said out loud rather than silently

- **The forbidden-header-name lists stay unenforced.** `request`, `request-no-cors` and `response` exist in the
  standard to enforce [forbidden request-header](https://fetch.spec.whatwg.org/#forbidden-request-header) and
  [forbidden response-header name](https://fetch.spec.whatwg.org/#forbidden-response-header-name), which are a
  browser protecting headers the user agent alone controls. Jint runs server-side, where `Host` and `Cookie`
  are exactly what a script legitimately sets — the same choice Node and Deno make. This predates the PR;
  `WptDivergence.NeedsForbiddenHeaderNames` is where the corpus records it.
- **`request-no-cors` has no enum member at all.** The only step that sets it is the `new Request()` arm for a
  request whose mode is `no-cors`, and `RequestInit`'s `mode` is accepted and ignored here (README's own
  wording), so the guard is unreachable. An unreachable member would be dead code, and the enum's docs now say
  why it is absent.
- **`getSetCookie` and the `Set-Cookie` steps are untouched**, and unaffected: reading is never guarded.
- **A fetch handler's inbound `Request` keeps the `request` guard**, which diverges from
  [Handle Fetch](https://w3c.github.io/ServiceWorker/#on-fetch-request-algorithm) ("given *request*, a new
  `Headers` object's guard which is **immutable**"). One `Request` is built for both inbound routes
  (`FetchHandlerHosting.CreateRequest`), and the other route is `Engine.Advanced.SetFetchHandler`'s plain
  callback, which no algorithm governs and where the script *is* the endpoint rather than an interceptor
  watching a request the user agent is already making. Two inbound requests disagreeing about editability would
  be worse than either answer. Documented on the method, listed in the enum's table, and pinned by a test that
  fails if it silently changes. Reasonable to overrule — see "Against the verdict".

## Verify against unfixed code

The tests were written first and run against the tree before the fix. Two failed, both of them the defect:

```
Failed  HeadersGuardTests.AFetchedResponsesHeadersAreImmutable
  Expected … to be the same string, but they differ at index 0:
   ↓ (actual)
  "ok,ok,ok"
  "TypeError/true,TypeError/true,TypeError/true"
   ↑ (expected).

Failed  HeadersGuardTests.AFetchedResponsesCloneIsImmutableToo
  Expected … to be the same string, but they differ at index 0:
   ↓ (actual)
  "ok,ok,ok"
  "TypeError/true,TypeError/true,TypeError/true"
   ↑ (expected).

Failed!  - Failed: 2, Passed: 9, Skipped: 0, Total: 11
```

`"ok,ok,ok"` is `append`, `set` and `delete` each succeeding. The other nine passed before the fix and after
it, which is the point of writing them: they are the sites that must **stay** mutable.

`Jint.Tests/Runtime/WebApi/HeadersGuardTests.cs` is the whole matrix in one file rather than five, because a
guard is only meaningful as a whole — an implementation that refused everything would pass half of these and
one that refused nothing would pass the other half. Eleven cases: every guard value from both directions, the
clone that inherits the refusal, the fill that escapes it, that reading is never guarded (`get`, `has`,
`getSetCookie`, `forEach`, iteration on an immutable object), the validate-before-guard step order, the cache's
two immutable answers, and the fetch handler's deliberate divergence.

## The corpus rows

**One row turns green and nothing else moves — measured, not inferred.**

```
fetch/api/response/response-headers-guard.any.js — "Ensure response headers are immutable"
```

Verified by building the fix against #3260's branch with its exclusion entry still in place, where the
two-sided rule names the row itself:

```
Failed  WptTestRunner.RunsTheFetchResponseSuite(file: "fetch/api/response/response-headers-guard.any.js")
  fetch/api/response/response-headers-guard.any.js:
  1 exclusion(s) that no longer apply — remove or narrow them:
    "Ensure response headers are immutable" (NeedsTriage) covers 1 test(s) that pass …

Failed!  - Failed: 1, Passed: 456, Skipped: 1, Total: 458
```

That single failure **is** the proof: every other file in the 458-case corpus stayed exactly where it was, in
both directions. With the entry removed the run is `457 passed, 0 failed`. Two files were worth checking by
hand and neither is affected — `fetch/api/body/mime-type.any.js` and `response-init-001.any.js` both mutate
headers, and both do it on objects the script constructed itself.

**This PR removes that entry**, in a second commit. `test/3260-wpt-server` **had been pushed to `origin` by the
time this was ready** (it had not been earlier in the session, and it is checked in the instructions for a
reason), so the branch is rebased onto it and the two-sided rule is satisfied here rather than deferred.

### Read this before merging: the base

This branch is **`origin/test/3260-wpt-server`, not `main`** — it carries #3260's commit underneath. Two
consequences:

- If #3260 lands first, rebase this onto `main` and it is unchanged.
- If you would rather review this against `main`, **drop the second commit**:

  ```
  git checkout -B fix/3281-main fix/3281-headers-guard~1
  git rebase --onto main fix/3281-headers-guard~2
  ```

  That was run and checked, not merely asserted: it replays cleanly onto `main` at `d84920aab`, the solution
  builds with 0 errors, and the 11 guard tests plus the 423-file WPT corpus pass there. Nothing in the first
  commit references `Jint.Tests/Wpt/`. The row removal then becomes #3260's problem again, which is exactly
  the shape the sibling PR #3286 (for #3283, from the same triage batch) already has.

The second commit also had to touch #3260's own `Vendor/README.md` prose, because those figures are
hand-written and the entry's removal changes them: 94 → 93 not passing across the server lane's 326
assertions, five `NeedsTriage` issues → four, and the "last change to move a row" note. The derived inventory
table was **regenerated** rather than edited (`JINT_WPT_CENSUS=update`): Fetch 169 → 168, total 2,983 → 2,982.
`JINT_WPT_CENSUS=1` then passes, which is the check the Windows PR leg runs.

## Cost

**None per `Headers`, and no new field.** `HeaderList.Guard` already existed and was already assigned at every
construction site; this change alters which value one of them assigns. The standing cost of the field itself,
measured with `GC.GetAllocatedBytesForCurrentThread` over 100,000 allocations of the two shapes: **8 bytes per
`HeaderList`** on 64-bit — 24 → 32 with alignment padding, one `int`-sized enum behind one reference field.
That is per `Headers` object, so per request and per response, and it is what `main` already pays.

No hot path gains a branch: `RequireMutable` is called by the three mutating operations only, and every
algorithm the engine runs itself reaches `HeaderList` directly — which is why an immutable guard never stands
in the way of the transport building a response, of `Response.redirect()` appending its own `Location`, or of a
host reading a handler's answer back out.

## Verification

Against the pushed tree (i.e. on #3260's base):

- `dotnet build -c Release` for the **solution** — 0 errors. `Jint` builds all five TFMs (`net462`,
  `netstandard2.0`, `netstandard2.1`, `net8.0`, `net10.0`), which is where a leak past the
  `#if NET8_0_OR_GREATER` gate would show; there is none. The single `MSB3277` warning is pre-existing, in
  `Jint.Tests.CommonScripts`'s `net472` leg, and unrelated.
- `Jint.Tests` — net10.0 **10,578 passed** / 0 failed / 5 skipped; net472 **7,256** / 0 / 4.
- `Jint.Tests.PublicInterface` — net10.0 **2,503** / 0 / 9; net472 **1,909** / 0 / 9.
- `JINT_HOST_CONTRACT_VERIFICATION=1` — `Jint.Tests` net10.0 **10,578** / 0 / 5, net472 **7,256** / 0 / 4;
  `Jint.Tests.PublicInterface` net10.0 **2,507** / 0 / 5, net472 **1,913** / 0 / 5. (The skip set narrowing
  from 9 to 5 is how you can see the switch really was on.)
- **WPT suite — 458 passed, 0 failed, 0 skipped** with `JINT_WPT_CENSUS=1`, so both the exclusion table and the
  inventory table are checked.
- `WebIdlPropertyAttributeTests` is green and unmoved: no member was added, removed or re-flagged.

The first commit alone, on `upstream/main` before the rebase, was also run in full: solution build clean;
`Jint.Tests` net10.0 10,547 / 0 / 5 and net472 7,256 / 0 / 4; `Jint.Tests.PublicInterface` net10.0 2,508 / 0 / 9
and net472 1,914 / 0 / 9; verifying legs 10,547 / 7,256 and 2,512 / 1,918; WPT **424 passed, 0 failed** with the
census check on — `main`'s corpus cannot reach a real fetch, so nothing there moved either way.

**test262 was not run, and nothing here can reach it.** Every engine file changed is under `Jint/WebApi/Fetch/`,
gated `#if NET8_0_OR_GREATER` end to end and installed only from `Options.Apply` behind a `WebApiFeatures` bit;
`grep -rn "UseWebApis\|WebApiFeatures\|UseFetch" Jint.Tests.Test262/*.cs` returns nothing.

## Against the verdict

Things a reviewer could reasonably decide differently, stated rather than argued away.

- **The base.** Stacking on #3260 is the thing most likely to be wrong. It satisfies the two-sided rule now
  instead of leaving an entry that will fail somebody's run later, but it also means this PR carries a 2,000-line
  commit that is not its own, on a branch two commits behind `main`, and the sibling #3286 chose the opposite.
  The "drop the second commit" recipe above exists precisely so that call is cheap to reverse.
- **The fetch handler's request should probably be immutable too**, and a reviewer who thinks the Service
  Worker algorithm wins should say so — the argument for keeping it mutable rests on the plain-callback route
  that no algorithm covers, not on the event route, which really is Handle Fetch. Changing it is a two-line
  edit plus flipping `AFetchHandlersRequestStaysMutable`. It was left because it is a *second* breaking change
  in a PR that already carries one, in a direction the issue did not ask about, and because a host's fetch
  handler edit reaches nothing but its own script.
- **The breaking change could have been made opt-out.** An `Options.WebApi.Fetch` switch to keep the old
  mutability would spare an embedder the migration. Not done: a per-engine flag on a guard the standard states
  unconditionally is a second behaviour to test, document and support forever, `main` is targeting v5, and the
  workaround is one constructor call. Reasonable to want it anyway for a large existing deployment.
- **`CreateInstance` taking a guard parameter is one caller wide.** A reviewer could keep the hard-coded value
  and just change it to `Immutable`. The parameter was chosen because the specification's own algorithm takes
  one and because the hard-coded value is exactly how the bug happened — but it does not change behaviour, and
  collapsing it back would not fail a test.
- **The `HeadersGuard` doc table can go stale.** Nothing machine-checks that it lists every construction site.
  `HeadersGuardTests` covers all ten rows, so a site that changes guard fails a test — but a *new* site nobody
  adds a test for is invisible to both. A verifier would be over-engineering for an internal enum with ten call
  sites; if the file grows, that judgement should be revisited.
- **`AFetchedResponsesHeadersCanStillBeReadEveryWay` asserts `content-length` among the iterated names.** That
  is the BCL computing a length for the stub's `StringContent`, not the standard requiring one. It makes the
  test slightly sensitive to `HttpClient`'s framing behaviour. Left as-is because the assertion's subject is
  the *ordering and combining* of an immutable list, and a name it did not expect would be worth seeing.
