### PR TITLE
Tests: close the pump-admission start race, and make the park's own failures reportable

### DIFF
--- a/Jint.Tests.PublicInterface/HostPumpAdmissionTests.cs
+++ b/Jint.Tests.PublicInterface/HostPumpAdmissionTests.cs
@@ -20,8 +20,10 @@ namespace Jint.Tests.PublicInterface;
 /// </para>
 /// <para>
 /// Every handshake here is released by a thread the test owns. The one place a park is detected rather than
-/// signalled is <see cref="WaitUntilParked"/>: the pump runs no script, so the only thing it can announce
-/// itself with is the refusal it hands an unrelated public entry.
+/// signalled is <see cref="TopLevelPark"/>: the pump runs no script, so the only thing it can announce itself
+/// with is the refusal it hands an unrelated public entry — which is also why that detection and the park it
+/// detects have to be one object, since the probe is the only thing in a healthy run that can refuse the
+/// park's own entry.
 /// </para>
 /// </remarks>
 public class HostPumpAdmissionTests
@@ -32,7 +34,7 @@ public class HostPumpAdmissionTests
     /// <summary>
     /// Reached only by a genuine wedge — every wait below is released by a thread the test owns.
     /// </summary>
-    private static readonly TimeSpan WedgeCeiling = TimeSpan.FromMinutes(2);
+    private static readonly TimeSpan WedgeCeiling = TestBudgets.WedgeCeiling;
 
     /// <summary>
     /// How often a detection loop looks. It decides only when an observation is made, never what it has to be.
@@ -85,13 +87,13 @@ public class HostPumpAdmissionTests
         using var dispatcher = new CallbackDispatcher(() => callback());
         using var releasePark = new CancellationTokenSource();
 
-        var parked = StartPark(engine, WedgeCeiling, releasePark.Token);
-        await WaitUntilParked(engine, parked);
+        var park = TopLevelPark.Start(engine, WedgeCeiling, releasePark.Token);
+        park.WaitUntilOwningTheEngine();
 
         dispatcher.Release();
         await dispatcher.Attempted;
         releasePark.Cancel();
-        await parked;
+        await park.Completed;
 
         dispatcher.Failure.Should().BeNull("a top-level park is a window an authorized callback may wait in");
         dispatcher.Result.Should().Be(42);
@@ -106,8 +108,10 @@ public class HostPumpAdmissionTests
         using var dispatcher = new CallbackDispatcher(() => callback());
         using var releasePark = new CancellationTokenSource();
 
+        // Its reservation is taken synchronously by the call above, so — unlike the synchronous form — the
+        // detector's first probe cannot land before the park owns the engine.
         var parked = engine.Advanced.WaitForScheduledWorkAsync(WedgeCeiling, releasePark.Token);
-        await WaitUntilParked(engine, parked);
+        TopLevelPark.WaitUntilOwningTheEngine(engine, parked);
 
         dispatcher.Release();
         await dispatcher.Attempted;
@@ -137,7 +141,7 @@ public class HostPumpAdmissionTests
 
         var callback = AuthorizeStaleCallback(engine);
         var running = DedicatedThread.RunAsync(() => engine.Execute("block();"));
-        await WaitUntilSignalled(entered, running);
+        WaitUntilSignalled(entered, running);
         try
         {
             Invoking(() => callback())
@@ -163,8 +167,8 @@ public class HostPumpAdmissionTests
         using var engine = new Engine();
         using var releasePark = new CancellationTokenSource();
 
-        var parked = StartPark(engine, WedgeCeiling, releasePark.Token);
-        await WaitUntilParked(engine, parked);
+        var park = TopLevelPark.Start(engine, WedgeCeiling, releasePark.Token);
+        park.WaitUntilOwningTheEngine();
         try
         {
             Invoking(() => engine.Evaluate("1 + 1"))
@@ -176,7 +180,7 @@ public class HostPumpAdmissionTests
             releasePark.Cancel();
         }
 
-        await parked;
+        await park.Completed;
         engine.Evaluate("1 + 1").AsNumber().Should().Be(2);
     }
 
@@ -271,17 +275,16 @@ public class HostPumpAdmissionTests
         var callback = AuthorizeStaleCallback(engine, "(Promise.resolve().then(() => { globalThis.ran = true; }), 7)");
         using var dispatcher = new CallbackDispatcher(() => callback());
 
-        var reported = false;
-        var parked = DedicatedThread.RunAsync(() => reported = engine.Advanced.WaitForScheduledWork(AdmissionCeiling));
-        await WaitUntilParked(engine, parked);
+        var park = TopLevelPark.Start(engine, AdmissionCeiling);
+        park.WaitUntilOwningTheEngine();
 
         dispatcher.Release();
         await dispatcher.Attempted;
-        await parked;
+        await park.Completed;
 
         dispatcher.Failure.Should().BeNull();
         dispatcher.Result.Should().Be(7);
-        reported.Should().BeTrue("the reaction the callback queued is work the pump can run");
+        park.Reported.Should().BeTrue("the reaction the callback queued is work the pump can run");
 
         engine.Evaluate("ran").AsBoolean().Should().BeFalse("the wait does not pump");
         engine.Advanced.ProcessTasks();
@@ -308,15 +311,8 @@ public class HostPumpAdmissionTests
         var callback = AuthorizeStaleCallback(engine, "(hold(), 3)");
         using var dispatcher = new CallbackDispatcher(() => callback());
 
-        var reported = true;
-        var elapsed = new Stopwatch();
-        var parked = DedicatedThread.RunAsync(() =>
-        {
-            elapsed.Start();
-            reported = engine.Advanced.WaitForScheduledWork(ShortParkCeiling);
-            elapsed.Stop();
-        });
-        await WaitUntilParked(engine, parked);
+        var park = TopLevelPark.Start(engine, ShortParkCeiling);
+        park.WaitUntilOwningTheEngine();
 
         dispatcher.Release();
         holding.Wait(AdmissionCeiling).Should().BeTrue("the callback has to be admitted for this to mean anything");
@@ -324,77 +320,33 @@ public class HostPumpAdmissionTests
         // The ceiling has run out several times over by now, and the park is still not back: it is waiting for
         // the engine thread the admitted callback holds.
         Thread.Sleep(ShortParkCeiling + ShortParkCeiling + ShortParkCeiling);
-        parked.IsCompleted.Should().BeFalse("the ceiling bounds the idle wait, not the call");
+        park.Completed.IsCompleted.Should().BeFalse("the ceiling bounds the idle wait, not the call");
 
         releaseCallback.Set();
         await dispatcher.Attempted;
-        await parked;
+        await park.Completed;
 
         dispatcher.Failure.Should().BeNull();
         dispatcher.Result.Should().Be(3);
-        reported.Should().BeFalse("the callback queued nothing, so there is still no work to report");
-        elapsed.Elapsed.Should().BeGreaterThan(ShortParkCeiling + ShortParkCeiling);
+        park.Reported.Should().BeFalse("the callback queued nothing, so there is still no work to report");
+        park.Elapsed.Should().BeGreaterThan(ShortParkCeiling + ShortParkCeiling);
         engine.Evaluate("1 + 1").AsNumber().Should().Be(2);
     }
 
-    private static Task StartPark(Engine engine, TimeSpan ceiling, CancellationToken cancellationToken)
-        => DedicatedThread.RunAsync(() =>
-        {
-            try
-            {
-                engine.Advanced.WaitForScheduledWork(ceiling, cancellationToken);
-            }
-            catch (OperationCanceledException)
-            {
-                // How the test ends the park; what it asserts is what happened while it was parked.
-            }
-        });
-
-    /// <summary>
-    /// Polls a guarded entry until the engine refuses it, which is the only signal a parked wait can give: it
-    /// runs no script, so there is nothing for it to announce itself with. Ends on the refusal, on
-    /// <paramref name="parked"/> finishing without ever taking the engine — reporting whatever stopped it —
-    /// or on <see cref="WedgeCeiling"/>.
-    /// </summary>
-    private static async Task WaitUntilParked(Engine engine, Task parked)
-    {
-        var elapsed = Stopwatch.StartNew();
-        while (true)
-        {
-            try
-            {
-                // An engine with nothing queued, so a probe landing before the park costs an empty loop.
-                engine.Advanced.ProcessTasks();
-            }
-            catch (InvalidOperationException e) when (e.Message.Contains("already in use", StringComparison.Ordinal))
-            {
-                return;
-            }
-
-            if (parked.IsCompleted)
-            {
-                await parked;
-                throw new XunitException("the park returned without ever owning the engine");
-            }
-
-            if (elapsed.Elapsed > WedgeCeiling)
-            {
-                throw new XunitException($"the park did not claim the engine within {WedgeCeiling}");
-            }
-
-            Thread.Sleep(ProbeInterval);
-        }
-    }
-
-    private static async Task WaitUntilSignalled(ManualResetEventSlim entered, Task running)
+    private static void WaitUntilSignalled(ManualResetEventSlim entered, Task running)
     {
         var elapsed = Stopwatch.StartNew();
         while (!entered.Wait(ProbeInterval))
         {
             if (running.IsCompleted)
             {
-                await running;
-                throw new XunitException("the owning call returned without ever entering block()");
+                // Deliberately not `await running`: that throws whatever stopped the call and loses the
+                // sentence saying what was being waited for, which is what a reader needs first.
+                var failure = running.Exception?.GetBaseException();
+                throw new XunitException(
+                    "the owning call returned without ever entering block(): "
+                    + (failure is null ? "it returned normally" : $"it failed with {failure.GetType().Name}: {failure.Message}"),
+                    failure);
             }
 
             if (elapsed.Elapsed > WedgeCeiling)
@@ -415,12 +367,21 @@ public class HostPumpAdmissionTests
         private readonly ManualResetEventSlim _release = new();
         private readonly TaskCompletionSource<bool> _attempted = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly Thread _thread;
+        private volatile bool _abandoned;
 
         internal CallbackDispatcher(Func<int> invoke)
         {
             _thread = new Thread(() =>
             {
                 _release.Wait(WedgeCeiling);
+                if (_abandoned)
+                {
+                    // The test failed before it got as far as releasing this dispatcher, so there is nothing
+                    // to dispatch and nothing to record. Leaving instead lets the failure be reported now
+                    // rather than after a two-minute join.
+                    return;
+                }
+
                 try
                 {
                     Result = invoke();
@@ -456,6 +417,10 @@ public class HostPumpAdmissionTests
 
         public void Dispose()
         {
+            // Abandoned rather than released: a test that failed before dispatching leaves this thread
+            // waiting out the wedge ceiling, and joining it would spend those two minutes reporting nothing.
+            _abandoned = !_release.IsSet;
+            _release.Set();
             _thread.Join(WedgeCeiling);
             _release.Dispose();
         }

--- a/Jint.Tests.PublicInterface/Jint.Tests.PublicInterface.csproj
+++ b/Jint.Tests.PublicInterface/Jint.Tests.PublicInterface.csproj
@@ -50,6 +50,13 @@
       bounds a hang is not a budget a test asserts.
     -->
     <Compile Include="..\Jint.Tests\TestBudgets.cs" Link="TestBudgets.cs" />
+    <!--
+      Shared so that both suites park a thread on the pump the same way, and close the one race that shape
+      has the same way. See TopLevelPark for why the detector is the only thing that can refuse the park it
+      is looking for, and why a refused entry is retried only when that detector was provably holding the
+      engine.
+    -->
+    <Compile Include="..\Jint.Tests\TopLevelPark.cs" Link="TopLevelPark.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jint.Tests/Runtime/WaitForScheduledWorkTests.cs
+++ b/Jint.Tests/Runtime/WaitForScheduledWorkTests.cs
@@ -135,10 +135,17 @@ public class WaitForScheduledWorkTests
     /// merely advisory — a second host loop cannot quietly become a second drainer.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Deliberately separate from <see cref="ASecondThreadWaitingIsRefused"/>, which asks the reverse question
     /// and would pass even with the wait's claim removed: the token linkage inside reads
     /// <c>Constraints.Find&lt;CancellationConstraint&gt;()</c>, which takes an admission of its own and would
     /// report the refusal from there. Only entering <em>while</em> a wait is parked distinguishes the two.
+    /// </para>
+    /// <para>
+    /// The park and the probe that detects it are one object (<see cref="TopLevelPark"/>) because they race
+    /// each other at the start: the probe is a claim attempt, and a top-level park's entry is refused by any
+    /// claim that beats it. That class documents the whole of it.
+    /// </para>
     /// </remarks>
     [Fact]
     public async Task AParkedWaitOwnsTheEngineForItsWholeDuration()
@@ -146,28 +153,17 @@ public class WaitForScheduledWorkTests
         using var engine = new Engine();
         using var releaseWait = new CancellationTokenSource();
 
-        var parked = DedicatedThread.RunAsync(() =>
-        {
-            try
-            {
-                engine.Advanced.WaitForScheduledWork(WedgeCeiling, releaseWait.Token);
-            }
-            catch (OperationCanceledException)
-            {
-                // How the test ends the park; the assertion is what happened while it was parked.
-            }
-        });
-
+        var park = TopLevelPark.Start(engine, WedgeCeiling, releaseWait.Token);
         try
         {
-            await WaitUntilRefused(engine, parked);
+            park.WaitUntilOwningTheEngine();
         }
         finally
         {
             releaseWait.Cancel();
         }
 
-        await parked;
+        await park.Completed;
 
         // The claim goes back with the wait rather than outliving it.
         engine.Evaluate("1 + 1").AsNumber().Should().Be(2);
@@ -190,7 +186,7 @@ public class WaitForScheduledWorkTests
         }));
 
         var running = DedicatedThread.RunAsync(() => engine.Execute("block()"));
-        await WaitUntilOwned(entered, running);
+        WaitUntilOwned(entered, running);
         try
         {
             Invoking(() => engine.Advanced.WaitForScheduledWork(TimeSpan.FromMilliseconds(50)))
@@ -288,60 +284,24 @@ public class WaitForScheduledWorkTests
     private static void SettleBeforeEnqueueing() => Thread.Sleep(SettleInterval);
 
     /// <summary>
-    /// Polls a guarded entry until the engine refuses it, which is the only signal a parked wait can give:
-    /// it runs no script, so there is nothing for it to announce itself with. Ends on the refusal, on
-    /// <paramref name="parked"/> finishing without ever taking the engine — reporting whatever stopped it —
-    /// or on <see cref="WedgeCeiling"/>.
-    /// </summary>
-    /// <remarks>
-    /// A poll rather than a handshake, and deliberately not one an assertion times: the loop only decides
-    /// <em>when</em> the observation is made, never what it has to be. Each probe is a
-    /// <see cref="Engine.AdvancedOperations.ProcessTasks"/> on an engine with nothing queued, so a probe that
-    /// lands before the park runs the empty loop and costs nothing.
-    /// </remarks>
-    private static async Task WaitUntilRefused(Engine engine, Task parked)
-    {
-        var elapsed = Stopwatch.StartNew();
-        while (true)
-        {
-            try
-            {
-                engine.Advanced.ProcessTasks();
-            }
-            catch (InvalidOperationException e) when (e.Message.Contains("already in use", StringComparison.Ordinal))
-            {
-                return;
-            }
-
-            if (parked.IsCompleted)
-            {
-                await parked;
-                throw new XunitException("the parked wait returned without ever owning the engine");
-            }
-
-            if (elapsed.Elapsed > WedgeCeiling)
-            {
-                throw new XunitException($"the wait did not claim the engine within {WedgeCeiling}");
-            }
-
-            Thread.Sleep(TimeSpan.FromMilliseconds(20));
-        }
-    }
-
-    /// <summary>
     /// Waits until <paramref name="running"/> is provably parked inside <c>block()</c>. Ends on the signal, on
     /// that thread finishing without ever reaching <c>block()</c> — reporting whatever stopped it rather than a
     /// timeout — or on <see cref="WedgeCeiling"/>.
     /// </summary>
-    private static async Task WaitUntilOwned(ManualResetEventSlim entered, Task running)
+    private static void WaitUntilOwned(ManualResetEventSlim entered, Task running)
     {
         var elapsed = Stopwatch.StartNew();
         while (!entered.Wait(TimeSpan.FromMilliseconds(20)))
         {
             if (running.IsCompleted)
             {
-                await running;
-                throw new XunitException("the owning call returned without ever entering block()");
+                // Deliberately not `await running`: that throws whatever stopped the call and loses the
+                // sentence saying what was being waited for, which is what a reader needs first.
+                var failure = running.Exception?.GetBaseException();
+                throw new XunitException(
+                    "the owning call returned without ever entering block(): "
+                    + (failure is null ? "it returned normally" : $"it failed with {failure.GetType().Name}: {failure.Message}"),
+                    failure);
             }
 
             if (elapsed.Elapsed > WedgeCeiling)

--- a/Jint.Tests/TopLevelPark.cs
+++ b/Jint.Tests/TopLevelPark.cs
@@ -1,0 +1,234 @@
+#nullable enable
+
+using System.Diagnostics;
+using Xunit.Sdk;
+
+namespace Jint.Tests;
+
+/// <summary>
+/// A <em>top-level</em> park on <see cref="Engine.AdvancedOperations.WaitForScheduledWork"/> run on a thread
+/// of its own, together with the only observation that can tell a test the park is in force.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The two halves live in one place because they are one handshake, not two. The pump runs no script, so a
+/// parked wait has nothing to announce itself with: a test can only learn that the park owns the engine by
+/// touching the engine from another thread and being refused. That probe is a claim attempt like any other,
+/// and a claim attempt is the one thing that can refuse the park's <em>own</em> entry — a top-level park may
+/// only be entered on an engine no other thread is holding, and the entry fails fast rather than waiting. In
+/// a healthy test the detector is therefore the only thing that can stop the park it is looking for.
+/// </para>
+/// <para>
+/// Only the entry is fragile, which is why nothing else here needs this treatment. Once the park owns the
+/// engine it yields the thread for each idle wait and re-claims it afterwards by <em>waiting</em>, so a
+/// probe — or an admitted callback — that claims the engine there delays the park rather than failing it.
+/// The drain's window is not fragile at either end for the same reason, and its tests
+/// (<c>HostDrainAdmissionTests</c>) need none of this.
+/// </para>
+/// <para>
+/// The race is narrow and its dominant cause is systematic rather than random. Measured on an idle 32-core
+/// machine over 50 rounds of exactly this shape: a warm probe holds the engine for 0–4 µs while the park
+/// thread's entry lands 6–17 µs after the detection loop starts, so the two miss each other. The very first
+/// probe in a process is the exception — it pays the JIT for <c>ProcessTasks</c> and holds for 1402 µs, which
+/// the entry lands inside — and that was the one round of the fifty that lost the race.
+/// <see cref="WarmTheProbePath"/> removes it. What remains is a probe preempted while holding, which is what
+/// a loaded CI runner produces and what no ordering can remove; a refused entry is therefore retried, but
+/// <em>only</em> when a detection probe was provably in flight across it. A refusal with the detector idle is
+/// not this race, and is left to fail the test.
+/// </para>
+/// </remarks>
+internal sealed class TopLevelPark
+{
+    /// <summary>
+    /// How often the detection loop looks. It decides only when an observation is made, never what it has to
+    /// be: every probe before the park is an empty <see cref="Engine.AdvancedOperations.ProcessTasks"/> loop.
+    /// </summary>
+    private static readonly TimeSpan ProbeInterval = TimeSpan.FromMilliseconds(20);
+
+    private readonly Engine _engine;
+
+    /// <summary>
+    /// Incremented on the way into a detection probe and again on the way out, so an odd value means a probe
+    /// owns the engine right now and any change at all means one ran. It is what makes a refused entry
+    /// attributable: the park thread samples it before an attempt and again if that attempt is refused.
+    /// </summary>
+    private long _probeState;
+
+    private int _refusedStarts;
+
+    /// <summary>
+    /// The park this class runs itself.
+    /// </summary>
+    private TopLevelPark(Engine engine, TimeSpan ceiling, CancellationToken cancellationToken)
+    {
+        _engine = engine;
+
+        // Last, and the thread's body reads nothing this constructor has not already set.
+        Completed = DedicatedThread.RunAsync(() => Park(ceiling, cancellationToken));
+    }
+
+    /// <summary>
+    /// A park the caller started itself.
+    /// </summary>
+    private TopLevelPark(Engine engine, Task parked)
+    {
+        _engine = engine;
+        Completed = parked;
+    }
+
+    /// <summary>
+    /// Parks on <paramref name="engine"/> from a thread of its own. The park ends when
+    /// <paramref name="cancellationToken"/> is cancelled, when work arrives, or when
+    /// <paramref name="ceiling"/> runs out — and <see cref="Completed"/> reports none of those as a failure,
+    /// because which of them a test uses is the test's own business.
+    /// </summary>
+    public static TopLevelPark Start(Engine engine, TimeSpan ceiling, CancellationToken cancellationToken = default)
+    {
+        // Before the thread exists, so that nothing is racing the engine while this runs, and so that the
+        // detection loop's first probe against the engine is a microsecond claim rather than a millisecond one.
+        WarmTheProbePath();
+
+        return new TopLevelPark(engine, ceiling, cancellationToken);
+    }
+
+    /// <summary>
+    /// The detection half on its own, for a park the caller started itself — the asynchronous form, whose
+    /// reservation is taken synchronously by the call that returns the task and which therefore has no start
+    /// race to retry.
+    /// </summary>
+    public static void WaitUntilOwningTheEngine(Engine engine, Task parked)
+        => new TopLevelPark(engine, parked).WaitUntilOwningTheEngine();
+
+    /// <summary>
+    /// Completes when the park returns, whatever ended it. Faults only on something this class does not
+    /// recognise — including a refusal the detector cannot account for.
+    /// </summary>
+    public Task Completed { get; }
+
+    /// <summary>
+    /// What the park answered: whether it found work for <see cref="Engine.AdvancedOperations.ProcessTasks"/>.
+    /// Read after awaiting <see cref="Completed"/>, which is what publishes it.
+    /// </summary>
+    public bool Reported { get; private set; }
+
+    /// <summary>
+    /// How long the park that actually held the engine took — an attempt refused at entry is not counted,
+    /// because it never waited for anything.
+    /// </summary>
+    public TimeSpan Elapsed { get; private set; }
+
+    /// <summary>
+    /// How many entries lost the start race to the detector's own probe. Zero on a healthy run; reported in
+    /// the failure messages so a suite that starts losing it says so.
+    /// </summary>
+    public int RefusedStarts => Volatile.Read(ref _refusedStarts);
+
+    /// <summary>
+    /// Blocks until the park provably owns the engine, which the engine proves by refusing an unrelated
+    /// public entry from this thread. Ends on that refusal, on the park returning without ever having owned
+    /// the engine — reporting what stopped it rather than hanging — or on <see cref="TestBudgets.WedgeCeiling"/>.
+    /// </summary>
+    public void WaitUntilOwningTheEngine()
+    {
+        var elapsed = Stopwatch.StartNew();
+        while (!ProbeIsRefused())
+        {
+            if (Completed.IsCompleted)
+            {
+                // Deliberately not `await Completed`: that throws whatever stopped the park and loses the
+                // sentence saying what was being waited for, which is the whole of what a reader needs here.
+                throw new XunitException(
+                    "the park returned without ever owning the engine: " + Describe(),
+                    Completed.Exception?.GetBaseException());
+            }
+
+            if (elapsed.Elapsed > TestBudgets.WedgeCeiling)
+            {
+                throw new XunitException($"the park did not claim the engine within {TestBudgets.WedgeCeiling}");
+            }
+
+            Thread.Sleep(ProbeInterval);
+        }
+    }
+
+    private void Park(TimeSpan ceiling, CancellationToken cancellationToken)
+    {
+        var retrying = Stopwatch.StartNew();
+        var backoff = new SpinWait();
+        while (true)
+        {
+            var probes = Volatile.Read(ref _probeState);
+            var attempt = Stopwatch.StartNew();
+            try
+            {
+                Reported = _engine.Advanced.WaitForScheduledWork(ceiling, cancellationToken);
+                Elapsed = attempt.Elapsed;
+                return;
+            }
+            catch (OperationCanceledException)
+            {
+                // How a test ends a park it has finished with; what it asserts is what happened while the
+                // park was in force.
+                Elapsed = attempt.Elapsed;
+                return;
+            }
+            catch (InvalidOperationException) when (ADetectionProbeWasInFlight(probes) && retrying.Elapsed < TestBudgets.WedgeCeiling)
+            {
+                // The start race, and the only refusal this class hides: the detector's own probe owned the
+                // engine across this attempt, so the engine was in use and the entry was right to refuse.
+                // The backoff is what keeps a retry from spinning a core for as long as that probe holds.
+                Interlocked.Increment(ref _refusedStarts);
+                backoff.SpinOnce();
+            }
+        }
+    }
+
+    private bool ProbeIsRefused()
+    {
+        // Bracketed so that a refused entry can be attributed to this probe rather than to the engine.
+        Interlocked.Increment(ref _probeState);
+        try
+        {
+            // An engine with nothing queued, so a probe landing before the park costs an empty loop.
+            _engine.Advanced.ProcessTasks();
+            return false;
+        }
+        catch (InvalidOperationException e) when (e.Message.Contains("already in use", StringComparison.Ordinal))
+        {
+            return true;
+        }
+        finally
+        {
+            Interlocked.Increment(ref _probeState);
+        }
+    }
+
+    /// <summary>
+    /// Whether a detection probe held the engine at any point between <paramref name="before"/> being sampled
+    /// and now: it was already inside one (an odd sample), or one has started or finished since.
+    /// </summary>
+    private bool ADetectionProbeWasInFlight(long before)
+        => (before & 1) == 1 || Volatile.Read(ref _probeState) != before;
+
+    private string Describe()
+    {
+        var refused = RefusedStarts;
+        var retried = refused == 0 ? "" : $", having lost the start race {refused} time(s) first";
+
+        return Completed.Exception?.GetBaseException() is { } failure
+            ? $"it failed with {failure.GetType().Name}: {failure.Message}{retried}"
+            : $"it returned normally{retried}";
+    }
+
+    /// <summary>
+    /// Pays the JIT for the detection probe's path on an engine of its own, rather than on the one under
+    /// test — where it would drain a queue a test may have filled deliberately. See the class remarks for the
+    /// measurement that makes this the difference between the first park in a process losing the start race
+    /// and not.
+    /// </summary>
+    private static void WarmTheProbePath()
+    {
+        using var warmup = new Engine();
+        warmup.Advanced.ProcessTasks();
+    }
+}


### PR DESCRIPTION
# Tests: the pump-admission probe was refusing the park it was detecting

`HostPumpAdmissionTests.AStaleAuthorizedCallbackIsAdmittedAtASynchronousPark` failed once on CI
(`linux - host-contract verification`, `Jint.Tests.PublicInterface` net10.0) on an unrelated docs-only PR:

```
HostPumpAdmissionTests.AStaleAuthorizedCallbackIsAdmittedAtASynchronousPark [FAIL]
System.InvalidOperationException : This Engine is already in use by another thread or has an
asynchronous operation in progress. Engine instances may only be used by one host operation at a time.
```

It is a test race, not a product defect. **Nothing under `Jint/` changed.**

## The reproduction

Two, because one of them quantifies the window and the other pins the mechanism.

### 1. Natural, on an idle 32-core machine

A measurement harness running the failing test's exact shape 50 times, recording each probe's
`[enter, exit]` and the timestamp at which the park thread called `WaitForScheduledWork`
(`Stopwatch` ticks, converted to µs, both threads' clocks are the same clock):

```
races=1/50
round 0: RACE LOST probes=1 parkCall=+205us holds=[1402us@+0]
round 1: ok        probes=2 parkCall=+17us  holds=[1us@+0, 65us@+21256]
round 2: ok        probes=2 parkCall=+7us   holds=[1us@+0, 23us@+28528]
round 3: ok        probes=2 parkCall=+6us   holds=[2us@+0, 15us@+30150]
...
round 49: ok       probes=2 parkCall=+8us   holds=[0us@+0, 16us@+31221]
```

Read it as: a **warm** probe holds the engine for 0–4 µs, and the park thread's entry lands 6–17 µs after
the detection loop starts — so the two normally miss each other by a hair. **Round 0 is the exception**: the
first `ProcessTasks` in a process pays the JIT and holds for **1402 µs**, and the entry landed inside it at
+205 µs. That round lost the race.

That also explains why the flake is so rare and why nobody reproduces it locally: after round 0 everything
is warm, and it then takes a *preempted* probe — a loaded CI runner — to widen the hold back out to
milliseconds. Running the class 40× pinned to one core, and 40× under CPU contention (4 spinners pinned to
the same 2 CPUs as the test process), produced 0 failures; the window is genuinely that narrow.

### 2. Deterministic, by forced ordering

The failing test verbatim, with two injections and nothing else: the probe's claim is widened from the
microseconds `ProcessTasks` costs on an idle engine to 300 ms of real work (`engine.Evaluate("hold()")`,
the same `Engine.EnterHostCall` claim), and the park thread is held until that claim is provably in flight.

```
Jint.Tests.PublicInterface.ZzStartRaceRepro.ForcedOrdering_AStaleAuthorizedCallbackIsAdmittedAtASynchronousPark [FAIL]
  Error Message:
   System.InvalidOperationException : This Engine is already in use by another thread or has an
   asynchronous operation in progress. Engine instances may only be used by one host operation at a time.
  Stack Trace:
     at Jint.Runtime.Throw.InvalidOperationException(String message, Exception exception)
   at Jint.Engine.WaitForScheduledWork(TimeSpan timeout, CancellationToken cancellationToken) in Jint\Engine.Pump.cs:line 337
   at Jint.Engine.AdvancedOperations.WaitForScheduledWork(...) in Jint\Engine.Pump.cs:line 718
   at ...StartPark>b__0() in ZzStartRaceRepro.cs:line 65
   at Jint.Tests.DedicatedThread.<>c__DisplayClass2_0.<RunAsync>b__0() in Jint.Tests\DedicatedThread.cs:line 66
--- End of stack trace from previous location ---
   at ...WaitUntilParked(Engine engine, Task parked) in ZzStartRaceRepro.cs:line 91
```

Same message as CI, and the stack names both halves of the bug: the refusal comes from the **park's entry**
(`Engine.Pump.cs:337`, `EnterHostCall`), and it surfaces from **`await parked` inside `WaitUntilParked`** —
line 91, one line above the `XunitException` that was written to explain it.

## The diagnosis

Confirmed as stated in the brief.

A *top-level* park is the one callback-admission window that has to be **detected rather than signalled**:
the pump runs no script, so the only thing a parked wait can announce itself with is the refusal it hands an
unrelated public entry. The class's own remarks already said so.

That detection probe is a claim attempt like any other. And a claim attempt is the one thing that can refuse
the park's **own** entry:

```csharp
internal bool WaitForScheduledWork(TimeSpan timeout, CancellationToken cancellationToken)
{
    using var ownership = EnterHostCall();          // <- Interlocked CAS on _ownerThreadId, throws on failure
    var isTopLevelPark = ownership.IsEntryRoot;
    using var admission = isTopLevelPark ? OpenHostCallbackAdmissionWindow() : default;
```

`EnterHostCall` **fails fast rather than waiting**, so whichever of the two threads claims the engine first
wins outright. `StartPark` caught only `OperationCanceledException`, so the loser faulted the park task;
`WaitUntilParked` then saw `parked.IsCompleted`, did `await parked`, and rethrew the underlying
`InvalidOperationException` — the `XunitException("the park returned without ever owning the engine")`
below it was unreachable, which is the reporting bug and is why the diagnosis cost a session.

Only the **entry** is fragile, which is why nothing else needs this treatment: once the park owns the engine
it yields the thread for each idle wait and re-claims it by *waiting* (`AcquireHostCall`), so a probe — or an
admitted callback — that claims the engine there delays the park rather than failing it.

## Why this shape, and not the drain's

`HostDrainAdmissionTests` (#3262) arms its prober from *inside* the drain and ends the drain *from* the
prober, so the window provably covers every attempt. **That shape cannot be reached here**, and the reason
is structural rather than incidental: a drain runs queued jobs, so script can run inside the window and call
`arm()`. A park runs no script at all, and I checked the whole of `Engine.WaitForScheduledWork` for any
host-controllable hook between the claim and the blocking wait — there is none. (`InspectScheduledWork`
reaches a host `TimeProvider` only through the net8-only web-API timer heap, which would gate the test on a
target framework and force it to enable timers; `BuildPumpWaitToken` and `EventLoop.WaitForWork` call no
user code.) There is also no non-claiming public way to ask whether an engine is currently claimed, so the
detector cannot get out of the way either.

Every ordering I tried has the same hole: the park's claim happens *inside* a call that then blocks, so
there is no moment at which the park thread can both hold a gate across its claim and release it afterwards.
Two threads, a fail-fast claim, and no in-window signal leaves exactly one sound answer, which is the one
the brief permits: retry the entry, bounded, and only when the retry is provably attributable.

## The fix

Both halves now live in one object — `Jint.Tests/TopLevelPark.cs`, shared into
`Jint.Tests.PublicInterface` the way `DedicatedThread` and `TestBudgets` already are — because they are one
handshake rather than two.

1. **The probe path is warmed** on a *throwaway* engine before the park thread exists. That removes the
   systematic cold-JIT case measured above (1402 µs → 0–4 µs), and does it without draining a queue the
   test under way may have filled deliberately.
2. **A refused entry is retried, but only when a detection probe was provably in flight across it.** The
   probe brackets itself in an interlocked counter (odd = a probe owns the engine now); the park thread
   samples it before an attempt and again on a refusal, and retries only if the sample was odd or the
   counter moved. A refusal with the detector idle across the whole attempt **is not this race and still
   fails the test**. The retry is additionally bounded by the wedge ceiling and backs off with `SpinWait`.
3. **The reporting bug is fixed**: a park that returns without ever owning the engine is reported with the
   sentence saying what was being waited for *and* the underlying exception as the inner one. The same
   `await running`-then-throw bug in `WaitUntilSignalled` / `WaitUntilOwned` is fixed the same way.

Everything the tests assert is unchanged; only how a park is started and detected moved.

### Audit

| test | verdict |
| --- | --- |
| `AStaleAuthorizedCallbackIsAdmittedAtASynchronousPark` | had the race — now on the helper |
| `AnUnrelatedPublicEntryIsRefusedWhileTheParkHoldsTheEngine` | had the race — now on the helper |
| `WorkQueuedByAnAdmittedCallbackIsReportedByThePark` | had the race, and did not catch it at all — now on the helper |
| `AnAdmittedCallbackHoldsTheParkPastItsCeiling` | had the race, and did not catch it at all — now on the helper |
| `AStaleAuthorizedCallbackIsAdmittedAtAnAsynchronousPark` | safe: `WaitForScheduledWorkAsync` takes its reservation *synchronously*, so the first probe cannot precede it. Uses the helper's detector for the fixed reporting |
| `AStaleAuthorizedCallbackIsRefusedInAnUnrelatedBlockingHostCall` | safe: no park; the refused callback never claims |
| `ANestedParkInsideARunningEvaluationAdmitsNothing` | safe: the park is a same-thread nested entry, which cannot be refused, and the prober's attempts are refused without claiming |
| `HostDrainAdmissionTests` (all three) | safe: armed from inside the window, and a drain's resume waits rather than failing. No change |
| `Jint.Tests` `WaitForScheduledWorkTests.AParkedWaitOwnsTheEngineForItsWholeDuration` | **the same race**, in the sibling suite — now on the helper |
| `WaitForScheduledWorkTests` others, `HostPumpWaitTests`, `WebApi.PumpWaitTests` | safe: the park is nested inside `Execute`, or the only cross-thread call is `AddToEventLoop`, which enqueues without claiming |

One more thing fixed while here: `CallbackDispatcher.Dispose` now **abandons** an unreleased dispatcher
instead of joining it. A test that failed before dispatching used to spend the full two-minute wedge ceiling
in disposal saying nothing — measured, on the mutation below, 2 min → **269 ms**.

## The assertion still bites (mutation proofs)

**Mutation A — the park opens no admission window** (`var isTopLevelPark = false && ownership.IsEntryRoot;`):

```
AnAdmittedCallbackHoldsTheParkPastItsCeiling [FAIL]
  Expected holding.Wait(AdmissionCeiling) to be True because the callback has to be admitted for this
  to mean anything, but found False.
AStaleAuthorizedCallbackIsAdmittedAtASynchronousPark [FAIL]
  Expected dispatcher.Failure to be <null> because a top-level park is a window an authorized callback
  may wait in, but found System.InvalidOperationException: This Engine is already in use...
WorkQueuedByAnAdmittedCallbackIsReportedByThePark [FAIL]
  Expected dispatcher.Failure to be <null>, but found System.InvalidOperationException: ...
Failed: 3, Passed: 4
```

The asynchronous-park test correctly survives this one: its window comes from the async reservation, not
from `isTopLevelPark`.

**Mutation B — a genuine refusal the detector cannot account for** (`Throw.InvalidOperationException` at the
top of `WaitForScheduledWork`) proves the retry masks nothing:

```
AStaleAuthorizedCallbackIsAdmittedAtASynchronousPark [FAIL]
  the park returned without ever owning the engine: it failed with InvalidOperationException: This Engine
  is already in use by another thread or has an asynchronous operation in progress. ...
  ---- System.InvalidOperationException : This Engine is already in use ...
Failed! - Failed: 1, Passed: 0, Duration: 269 ms
```

That is also the reporting fix in one line: the sentence, then the cause, in 269 ms.

**Mutation C — the retry itself.** Under the forced ordering, with a temporary hook holding the entry until
the detector's claim is in flight, the fixed helper passes and `RefusedStarts > 0` proves the retry path
actually ran; changing the retry filter to `when (false)` makes the very same test fail with the CI
exception again. So the demonstration depends on the retry rather than on luck.

## Verification

| leg | result |
| --- | --- |
| `dotnet build -c Release` (solution, all TFMs) | succeeded, 0 errors |
| `Jint.Tests.PublicInterface` net10.0 | 2508 passed, 9 skipped |
| `Jint.Tests.PublicInterface` net10.0, `JINT_HOST_CONTRACT_VERIFICATION=1` | 2512 passed, 5 skipped |
| `Jint.Tests.PublicInterface` net472 | 1914 passed, 9 skipped |
| `Jint.Tests.PublicInterface` net472, verification on | 1918 passed, 5 skipped |
| `Jint.Tests` net10.0, verification on | 10536 passed, 5 skipped |
| `Jint.Tests` net472 | 7256 passed, 4 skipped |
| `HostPumpAdmissionTests` × 50, verification on | **50/50** |
| `WaitForScheduledWorkTests` × 50, verification on | **50/50** |
| `HostPumpAdmissionTests` × 25 under CPU contention (2 CPUs, 4 spinners) | 25/25 |

## Against the verdict

- **It is a retry, and the brief preferred a handshake.** I could not find one, and I do not think one
  exists for a top-level park through the public surface — the argument is above. The residual risk is that
  I missed a hook; if one turns up, the helper is one object and the retry deletes cleanly. What the retry
  is *not* is a blanket catch: the attribution counter makes a refusal that the test did not cause fail as
  loudly as before, which mutation B demonstrates.
- **The warm-up is a mitigation, not a fix, and it hides how often the retry would fire.** With it, the
  measured cause of the only natural failure I could produce no longer occurs, so `RefusedStarts` will read
  0 on nearly every run and a genuine change in contention would be quiet. It is exposed as a property and
  printed in the failure messages so it can be looked at; I stopped short of asserting on it, since that
  would make a machine-dependent number into a pass/fail criterion.
- **`AnAdmittedCallbackHoldsTheParkPastItsCeiling` still has a timing requirement I did not remove.** Its
  200 ms ceiling has to outlast detection *plus* the dispatcher's wake, or the park times out before the
  callback is admitted and the test fails for the wrong reason. Detection is normally one probe (≤ 20 ms),
  so the margin is an order of magnitude, and this fix makes the first probe cheaper rather than dearer —
  but on a runner slow enough that a thread wake costs 200 ms it would still fail. Removing it would mean
  giving up the assertion that the ceiling bounds the idle wait rather than the call, which is the one
  genuinely new observable in #3259, so I left it.
- **I did not add a permanent regression test for the helper.** Making the ordering deterministic needs a
  seam inside `TopLevelPark` (which of the two threads reaches the engine first is not controllable from
  outside it), and a test carrying a production-shaped hook for a test helper seemed a worse trade than the
  three mutation proofs above. The forced-ordering scaffolding was local-only and is not in the commit.
- **The `CallbackDispatcher.Dispose` change is adjacent scope.** It is not the flake; it is what made the
  flake's failure mode cost two minutes per failing test instead of a quarter of a second, which is squarely
  in the "a failure should report rather than hang" family this file already cares about.
- **`WedgeCeiling` in `HostPumpAdmissionTests` now aliases `TestBudgets.WedgeCeiling`** rather than
  re-spelling `TimeSpan.FromMinutes(2)`. Same value, and it is what `TestBudgets`' own documentation asks
  for; if the reviewer would rather this PR touched nothing it did not have to, it is one line to revert.
