### PR TITLE
Maintenance: give the 4.x branch its CI, its version and its row in the README

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build
 on:
 
   push:
-    branches: [ main, 3.x ]
+    branches: [ main, 4.x, 3.x ]
     paths-ignore:
     - 'doc/**'
     - '**.md'

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
     <PackageLicenseExpression>BSD-2-Clause</PackageLicenseExpression>
 
     <BuildNumber Condition="'$(BuildNumber)' == ''">0</BuildNumber>
-    <VersionPrefix>4.16.0</VersionPrefix>
+    <VersionPrefix>4.16.1</VersionPrefix>
     <VersionSuffix>beta-$(BuildNumber)</VersionSuffix>
 
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/README.md
+++ b/README.md
@@ -1154,6 +1154,17 @@ a hardened deployment baseline.
 
 ## Branches and releases
 
-- The recommended branch is __main__, any PR should target this branch
-- The __main__ branch is automatically built and published on [MyGet](https://www.myget.org/feed/Packages/jint). Add this feed to your NuGet sources to use it: https://www.myget.org/F/jint/api/v3/index.json
-- The __main__ branch is occasionally published on [NuGet](https://www.nuget.org/packages/jint)
+Three branches are live, and which one a change belongs on depends on whether it is allowed to change
+observable behaviour.
+
+| Branch | What it is | What lands on it |
+| --- | --- | --- |
+| __main__ | Development of the next major version, __5.x__. The default target for a pull request. | Anything, including breaking changes to the public API and to default behaviour. |
+| __4.x__ | Maintenance of the __4.16.x__ line, branched from `main` at the last commit before the 5.x work began. | Correctness and conformance fixes backported from `main`, and nothing that changes an existing API or an existing default. |
+| __3.x__ | Maintenance of the __3.x__ line, which still parses with Esprima rather than Acornima. | Security and severe-correctness fixes only. |
+
+- Open a pull request against __main__ unless the change is a backport, in which case target the
+  maintenance branch it belongs to
+- __main__, __4.x__ and __3.x__ are automatically built and published on [MyGet](https://www.myget.org/feed/Packages/jint). Add this feed to your NuGet sources to use it: https://www.myget.org/F/jint/api/v3/index.json
+- A release to [NuGet](https://www.nuget.org/packages/jint) is cut by pushing a `vX.Y.Z` tag to the
+  branch being released; the tag, not `Directory.Build.props`, is the version the package carries


### PR DESCRIPTION
The `4.x` branch was just cut at `e73c0ab92` ("Warm the stack-guard recovery test before it measures depth", #3080) so that `main` can become 5.x development. This PR is the housekeeping the branch needs in order to behave like a maintenance branch.

## Why that commit is the branch point

`e73c0ab92` is the last commit before two things that change what a *default* engine is, and therefore belong to a major version rather than to a patch line:

- `afa3f4d61` (#3079), the opt-in Web API foundation, and everything built on it since.
- The security-defaults stack — #3035, #3037, #3045, #3046, #3051, #3052, #3054, #3056, #3057, #3058, #3059, #3060 — which changes behaviour by default.

## What is in here

- **`.github/workflows/build.yml`** — the push trigger filtered on `[ main, 3.x ]`, so a push to `4.x` built nothing and published no preview package. `4.x` joins the list. `pr.yml` needs no change: it deliberately carries no `branches:` filter (a base-branch filter used to skip CI on every layer of a stacked PR except the bottom one), so a pull request based on `4.x` already gets the full matrix.
- **`Directory.Build.props`** — `VersionPrefix` moves to `4.16.1`. This numbers the MyGet preview stream coming off the branch; it is *not* what a release carries. `release.yml` derives the released version from the pushed `vX.Y.Z` tag and passes it to `dotnet pack`, so the tag remains the single source of truth.
- **`README.md`** — the "Branches and releases" section described `main` alone, which was accurate while `main` was the only branch anyone was asked to target. It now has a row per live branch (`main` = 5.x development, `4.x` = 4.16.x maintenance, `3.x` = the Esprima-era line) and says how a release is actually cut.

## What is deliberately left out

- **The AGENTS.md split (#3284).** `main` recently broke its single `AGENTS.md` into a root index plus co-located files. The maintenance branch keeps its single pre-split `AGENTS.md` on purpose: backporting the reorganisation would make every future cherry-pick from `main` conflict on documentation layout, for no benefit to a branch that only receives fixes.
- **Any code change.** The conformance and correctness backports for `4.16.1` are a separate PR onto this same branch.

Note on the README: #3294 landed the same "Branches and releases" table on `main` while this was open, so the two branches now carry identical wording (minus main's pointer to `docs/v5-migration.md`, which does not exist here). That is deliberate — a reader should get the same answer whichever branch they are looking at.

Verified with `dotnet build -c Release` on the solution: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014W5mbjGhyvgAS4pivXoc4S
