### PR TITLE
Branch topology on main: 5.0.0 previews, and 4.x named in the push filter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build
 on:
 
   push:
-    branches: [ main, 3.x ]
+    branches: [ main, 4.x, 3.x ]
     paths-ignore:
     - 'doc/**'
     - '**.md'

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
     <PackageLicenseExpression>BSD-2-Clause</PackageLicenseExpression>
 
     <BuildNumber Condition="'$(BuildNumber)' == ''">0</BuildNumber>
-    <VersionPrefix>4.16.0</VersionPrefix>
+    <VersionPrefix>5.0.0</VersionPrefix>
     <VersionSuffix>beta-$(BuildNumber)</VersionSuffix>
 
     <PublishRepositoryUrl>true</PublishRepositoryUrl>


### PR DESCRIPTION
Two pieces of branch plumbing on `main`, both fallout from the new `4.x` maintenance branch (#3291).

### 1. `main` develops 5.0.0

`Directory.Build.props` still carried `VersionPrefix` 4.16.0. That was harmless while `main` was the only branch `build.yml` published from — it stops being harmless now that `4.x` publishes too.

`build.yml` packs every push with `-p:VersionSuffix=preview-$GITHUB_RUN_NUMBER` and pushes it to MyGet unconditionally. So `4.x` publishes `4.16.1-preview-N` alongside `main`'s `4.16.0-preview-N`, and SemVer orders those the wrong way round: `4.16.1-preview-5` sorts **above** `4.16.0-preview-9`. Anyone tracking the prerelease feed to follow 5.x development would silently be handed the maintenance build instead.

**Scope: the prerelease feed only.** Released packages are unaffected in either direction, because `release.yml` derives the version from the pushed `vX.Y.Z` tag and passes it explicitly (`-p:Version=${{ steps.version.outputs.version }}`), so `VersionPrefix` never reaches a released package.

### 2. `main`'s push filter names `4.x`

#3291 added `4.x` to the filter *on the `4.x` branch*, which is what actually governs a push there — GitHub runs a push workflow from the file on the pushed ref, so `4.x` builds and publishes with or without this line.

`main`'s copy going on saying `[ main, 3.x ]` therefore changes nothing, and is simply false: a reader of main's workflow would conclude the maintenance line is not built. Keeping the two in agreement also removes a conflict every future backport touching this file would otherwise hit.

### Verification

- `dotnet build -c Release Jint/Jint.csproj` — 0 warnings, 0 errors.
- Nothing in the tree asserts a version. The only remaining `4.16.0` is a prose reference in a `Jint.Tests/Runtime/DateTests.cs` comment describing behaviour that changed, which is still accurate.

Found while reviewing #3291.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014W5mbjGhyvgAS4pivXoc4S