### PR TITLE
Docs: point host-contract obligations at the switch, not at a build nobody can get

### DIFF
--- a/Jint/Native/Object/ArrayLikeObject.cs
+++ b/Jint/Native/Object/ArrayLikeObject.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Jint.Native.Array;
 using Jint.Native.Symbol;
@@ -71,7 +71,16 @@ namespace Jint.Native.Object;
 /// <see cref="ObjectInstance"/>. Live named getters are still available by overriding
 /// <see cref="ObjectInstance.GetOwnProperty"/> (and <see cref="GetOwnPropertyKeys"/> /
 /// <see cref="GetOwnProperties"/> to advertise them): such an override <b>must</b> delegate canonical array-index
-/// keys and <c>length</c> to <c>base</c>, which a Debug build of Jint verifies on every read.
+/// keys and <c>length</c> to <c>base</c>, which a build with host-contract verification on verifies on
+/// every read.
+/// </para>
+/// <para>
+/// <b>Turning that verification on.</b> Every obligation below is trusted on the hot path and checked only
+/// when host-contract verification is enabled. A Debug build of Jint has it on; the shipped <em>Release</em>
+/// package — which is the only one on NuGet — needs the AppContext switch set before the first use of any
+/// Jint type: <c>AppContext.SetSwitch("Jint.EnableHostContractVerification", true)</c>. Running a host's own
+/// integration suite that way is how these contracts get checked; it is not something to leave on in
+/// production, because each verifier redoes exactly the work the lane it guards exists to avoid.
 /// </para>
 /// <para>
 /// <b>Read-only by design.</b> There is no write hook in this version; every mutating <c>Array.prototype</c>
@@ -122,7 +131,8 @@ public abstract class ArrayLikeObject : ObjectInstance
     /// <para>
     /// <see langword="false"/> is <b>authoritative</b>: the engine trusts it, does not re-probe, and resolves the
     /// read on the prototype chain instead. It must agree with what <see cref="ObjectInstance.GetOwnProperty"/>
-    /// would report at the same instant — a Debug build of Jint verifies that on every read. Never hand back a
+    /// would report at the same instant — a build with host-contract verification on verifies that on every
+    /// read. Never hand back a
     /// CLR <see langword="null"/> value.
     /// </para>
     /// <para>
@@ -155,7 +165,8 @@ public abstract class ArrayLikeObject : ObjectInstance
     /// The engine trusts it and does not re-verify: a wrong <see langword="false"/> silently drops the element
     /// from every enumeration and existence check above while <c>list[index]</c> still reads it, and a wrong
     /// <see langword="true"/> advertises a key whose read yields <c>undefined</c> or resolves on the prototype.
-    /// A Debug build of Jint verifies both directions on every probe, so running a host suite against one is the
+    /// A build with host-contract verification on verifies both directions on every probe, so running a host
+    /// suite that way is the
     /// checker. Like <see cref="TryGetIndex"/> it must be O(1), allocation-free, free of observable side effects,
     /// and must answer <see langword="false"/> rather than throw for an index that has just gone out of range.
     /// </para>
@@ -166,7 +177,7 @@ public abstract class ArrayLikeObject : ObjectInstance
     /// The single funnel every engine-side index read goes through, so the host contract is enforced in one
     /// place: a <see langword="false"/> answer always leaves <paramref name="value"/> as <c>undefined</c> rather
     /// than whatever the host left in the <c>out</c> slot, and a <see langword="true"/> answer is checked for the
-    /// documented "never null" obligation in Debug.
+    /// documented "never null" obligation when host-contract verification is on.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal bool ReadIndex(uint index, out JsValue value)

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -1054,8 +1054,8 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
     /// read up the prototype chain. A <c>false</c> returned merely because the value was awkward to produce
     /// therefore does not fall back: it makes the read resolve on the prototype, or evaluate to
     /// <c>undefined</c>, for a property that exists. This is the same obligation
-    /// <see cref="ProbeOwnProperty"/> carries, and a Debug build of Jint verifies both directions of it on
-    /// every read.
+    /// <see cref="ProbeOwnProperty"/> carries, and a build with host-contract verification on verifies both
+    /// directions of it on every read.
     /// </para>
     /// <para>
     /// <b>When you cannot answer,</b> call <c>base.TryGetOwnPropertyValue(property, receiver, out value)</c>.

--- a/Jint/Native/Object/PropertyAccessSemantics.cs
+++ b/Jint/Native/Object/PropertyAccessSemantics.cs
@@ -1,4 +1,4 @@
-namespace Jint.Native.Object;
+﻿namespace Jint.Native.Object;
 
 /// <summary>
 /// How an <see cref="ObjectInstance"/> subclass resolves property reads.
@@ -31,8 +31,9 @@ public enum PropertyAccessSemantics
     /// <para>
     /// Declaring it explicitly is only needed for a type that overrides <c>Get</c> and is nevertheless ordinary
     /// — an override that adds tracing, or one that special-cases a name and delegates everything else to
-    /// <c>base.Get</c> while still agreeing with its own <c>GetOwnProperty</c>. Debug builds of Jint verify the
-    /// claim on every read, so running an integration suite against a Debug build acts as a checker.
+    /// <c>base.Get</c> while still agreeing with its own <c>GetOwnProperty</c>. A build with host-contract
+    /// verification on verifies the claim on every read, so running an integration suite that way acts as a
+    /// checker.
     /// </para>
     /// </summary>
     Ordinary = 0,


### PR DESCRIPTION
Five doc sites on the public extension points tell an embedder that **"a Debug build of Jint verifies"** their obligation. Jint ships Release only, so for anyone consuming the NuGet package that names a build they cannot obtain — which is the exact reachability problem `HostContractVerification` was introduced to solve. From `Jint/AGENTS.md`:

> The point of the switch is reach: the verifiers used to be `[Conditional("DEBUG")]`, and Jint ships Release only, so reaching them meant cloning and building the repository.

Two sites already said it correctly, naming the `Jint.EnableHostContractVerification` AppContext switch alongside the Debug build — `ObjectInstance.ProbeOwnProperty` and `HostContractVerification`'s own summary. The other five did not:

| Site | Contract it documents |
| --- | --- |
| `ArrayLikeObject` class doc | a `GetOwnProperty` override must delegate index keys and `length` to `base` |
| `ArrayLikeObject.TryGetIndex` | `false` is an authoritative own-miss, agreeing with `GetOwnProperty` |
| `ArrayLikeObject.HasIndex` | must equal `TryGetIndex` at the same instant |
| `ArrayLikeObject.ReadIndex` | the "never hand back a CLR null" obligation |
| `ObjectInstance.TryGetOwnPropertyValue` | `false` is an authoritative own-miss, both directions |
| `PropertyAccessSemantics.Ordinary` | a declared-Ordinary type really is ordinary |

Those are precisely the contracts whose violation is **silent** — a wrong `false` drops a key from every enumeration while indexed reads still see it — so they are the ones a host most needs to be able to check.

### What changed

They now read "a build with host-contract verification on", and `ArrayLikeObject`'s class doc carries the recipe once rather than five times: the switch name, that it must be set **before the first use of any Jint type** (the flag is read once at type initialization), that it is a suite-time tool rather than a production setting, and why — each verifier redoes exactly the work the lane it guards exists to avoid, so a figure measured with it on is not a cost.

Documentation only; no behaviour change, no signature change.

### Verification

`dotnet build -c Release Jint/Jint.csproj` — 0 warnings, 0 errors.

Found while auditing the public surface for v5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014W5mbjGhyvgAS4pivXoc4S