### PR TITLE
AOT: publish and run Jint.AotExample in CI, so compatibility is measured rather than asserted

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,7 @@ jobs:
           echo
           echo '| code | count |'
           echo '| --- | --- |'
-          grep -oE 'IL[0-9]{4}' aot-publish.log | sort | uniq -c | sort -rn | awk '{ print "| " $2 " | " $1 " |" }'
+          grep -hoE 'IL[0-9]{4}' aot-publish.log 2>/dev/null | sort | uniq -c | sort -rn | awk '{ print "| " $2 " | " $1 " |" }'
           echo
-          echo "total: $(grep -cE 'IL[0-9]{4}' aot-publish.log || true)"
+          echo "total: $(grep -hcE 'IL[0-9]{4}' aot-publish.log 2>/dev/null || echo 0)"
         } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,3 +58,53 @@ jobs:
 
     - name: Push with dotnet
       run: dotnet nuget push artifacts/*.nupkg --api-key ${{ secrets.MYGET_API_KEY }} --skip-duplicate --source https://www.myget.org/F/jint/api/v2/package
+
+  # The mirror of the PR workflow's "linux - native aot" job, and there for the reason the Test step above is:
+  # a merge is not the commit CI ran on. Its own file documents what it verifies; the short version is that
+  # <IsAotCompatible> is a property, and the published binary is the only evidence.
+  aot:
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Setup NET
+      uses: actions/setup-dotnet@v6
+      with:
+        dotnet-version: 10.0
+
+    - name: Checkout source code
+      uses: actions/checkout@v7
+
+    - name: Ensure the Native AOT toolchain is present
+      run: |
+        if command -v clang > /dev/null && dpkg -s zlib1g-dev > /dev/null 2>&1; then
+          echo "already present: $(clang --version | head -1)"
+        else
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends clang zlib1g-dev
+        fi
+
+    - name: Publish Jint.AotExample with Native AOT
+      run: |
+        set -o pipefail
+        dotnet publish Jint.AotExample/Jint.AotExample.csproj --configuration Release 2>&1 | tee aot-publish.log
+
+    - name: Run the native binary
+      run: |
+        set -o pipefail
+        ./artifacts/publish/Jint.AotExample/release/Jint.AotExample | tee aot-run.log
+        grep -q '^ALL PROBES PASSED' aot-run.log
+
+    - name: Summarise the trim and AOT analysis warnings
+      if: always()
+      run: |
+        {
+          echo '### Native AOT analysis diagnostics'
+          echo
+          echo '| code | count |'
+          echo '| --- | --- |'
+          grep -oE 'IL[0-9]{4}' aot-publish.log | sort | uniq -c | sort -rn | awk '{ print "| " $2 " | " $1 " |" }'
+          echo
+          echo "total: $(grep -cE 'IL[0-9]{4}' aot-publish.log || true)"
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -95,3 +95,75 @@ jobs:
     - name: Test Jint.Tests.PublicInterface
       run: dotnet test Jint.Tests.PublicInterface/Jint.Tests.PublicInterface.csproj --configuration Release --logger "console;verbosity=quiet" --logger "GitHubActions;summary-include-passed=false;summary-include-skipped=false"
 
+  # <IsAotCompatible> is a csproj property, not evidence. Jint sets it for net7.0+ and then suppresses the
+  # eight IL codes that would substantiate it, so nothing in the repository could tell an embedder whether a
+  # published Jint actually runs — until this leg. It publishes Jint.AotExample with PublishAot=true and
+  # *runs the native binary*, which is the only place a Native AOT failure appears: the analysis warnings say
+  # what might break, the run says what does. The warnings are summarised into the job summary rather than
+  # gating, because paying them down is separate work and a red leg for a known 122 would be ignored within
+  # a week. What gates is the binary: Jint.AotExample/Program.cs pins both directions, so a probe that stops
+  # working AND a known gap that starts working fail here.
+  #
+  # One OS is enough — the gaps are ILC generic-instantiation gaps, not platform ones — and Linux is the
+  # cheapest runner whose image already carries the native toolchain.
+  aot:
+
+    name: 'linux - native aot'
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Setup NET
+      uses: actions/setup-dotnet@v6
+      with:
+        dotnet-version: 10.0
+
+    - name: Checkout source code
+      uses: actions/checkout@v7
+
+    # Native AOT shells out to the platform C++ toolchain to link. The runner image already carries clang and
+    # zlib1g-dev, so this checks rather than installs: an unconditional apt-get update costs ~15 s on every
+    # run to reinstall what is already there, and an unconditional apt-get install fails on a stale index.
+    - name: Ensure the Native AOT toolchain is present
+      run: |
+        if command -v clang > /dev/null && dpkg -s zlib1g-dev > /dev/null 2>&1; then
+          echo "already present: $(clang --version | head -1)"
+        else
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends clang zlib1g-dev
+        fi
+
+    - name: Publish Jint.AotExample with Native AOT
+      run: |
+        set -o pipefail
+        dotnet publish Jint.AotExample/Jint.AotExample.csproj --configuration Release 2>&1 | tee aot-publish.log
+
+    # The binary either prints ALL PROBES PASSED and exits 0, or names the probe that failed and exits 1. The
+    # grep is not redundant: it is what catches a Program.cs that stopped running any probes at all.
+    - name: Run the native binary
+      run: |
+        set -o pipefail
+        ./artifacts/publish/Jint.AotExample/release/Jint.AotExample | tee aot-run.log
+        grep -q '^ALL PROBES PASSED' aot-run.log
+
+    - name: Summarise the trim and AOT analysis warnings
+      if: always()
+      run: |
+        {
+          echo '### Native AOT analysis diagnostics'
+          echo
+          echo 'ILC re-derives these over the whole closed program, so the `NoWarn` in `Jint/Jint.csproj` does not reach them.'
+          echo
+          echo '| code | count |'
+          echo '| --- | --- |'
+          grep -oE 'IL[0-9]{4}' aot-publish.log | sort | uniq -c | sort -rn | awk '{ print "| " $2 " | " $1 " |" }'
+          echo
+          echo "total: $(grep -cE 'IL[0-9]{4}' aot-publish.log || true)"
+          echo
+          echo '### Probe run'
+          echo
+          echo '```'
+          cat aot-run.log
+          echo '```'
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -147,6 +147,8 @@ jobs:
         ./artifacts/publish/Jint.AotExample/release/Jint.AotExample | tee aot-run.log
         grep -q '^ALL PROBES PASSED' aot-run.log
 
+    # if: always() so the inventory is still written when the run step above went red, which is exactly when
+    # someone wants to read it. Every command here therefore has to survive a missing log.
     - name: Summarise the trim and AOT analysis warnings
       if: always()
       run: |
@@ -157,13 +159,13 @@ jobs:
           echo
           echo '| code | count |'
           echo '| --- | --- |'
-          grep -oE 'IL[0-9]{4}' aot-publish.log | sort | uniq -c | sort -rn | awk '{ print "| " $2 " | " $1 " |" }'
+          grep -hoE 'IL[0-9]{4}' aot-publish.log 2>/dev/null | sort | uniq -c | sort -rn | awk '{ print "| " $2 " | " $1 " |" }'
           echo
-          echo "total: $(grep -cE 'IL[0-9]{4}' aot-publish.log || true)"
+          echo "total: $(grep -hcE 'IL[0-9]{4}' aot-publish.log 2>/dev/null || echo 0)"
           echo
           echo '### Probe run'
           echo
           echo '```'
-          cat aot-run.log
+          cat aot-run.log 2>/dev/null || echo '(the binary produced no output)'
           echo '```'
         } >> "$GITHUB_STEP_SUMMARY"

--- a/Jint.AotExample/Jint.AotExample.csproj
+++ b/Jint.AotExample/Jint.AotExample.csproj
@@ -6,11 +6,47 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <PublishAot>true</PublishAot>
+
+    <!--
+      Jint's own csproj suppresses eight IL warning codes (IL3050 and seven IL2xxx) so that Jint
+      compiles clean. That NoWarn is a property of Jint's *compilation* and reaches nothing here: ILC
+      re-derives the whole set when it compiles the closed program, and this project's publish is
+      where all 122 of them surface. Turning them into errors - which repository-wide
+      TreatWarningsAsErrors would otherwise do, since IlcTreatWarningsAsErrors defaults to it - would
+      make `dotnet publish` fail before it ever produced a binary, and the binary is the point: the
+      warnings say what *might* break, the run says what *does*.
+
+      So the warnings stay loud and non-fatal, and CI summarises them per code into the job summary.
+      Paying them down (annotating the APIs, then removing Jint's NoWarn) is separate work; when it
+      is finished this property should go, and a clean publish becomes the assertion.
+    -->
+    <IlcTreatWarningsAsErrors>false</IlcTreatWarningsAsErrors>
+
+    <!--
+      The one IL3000 in Program.cs is the probe reading Assembly.Location to tell a Native AOT run
+      from a JIT one; the diagnostic states exactly the fact it relies on. It is suppressed here
+      rather than with a source #pragma because a pragma reaches Roslyn and not ILC, and this
+      project is one file - if it ever grows, move the suppression back to the call site with
+      UnconditionalSuppressMessage, which ILC does honour.
+    -->
+    <NoWarn>$(NoWarn);IL3000</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Jint\Jint.csproj" />
+
+    <!--
+      Rooting Jint keeps the probe about *Jint's* AOT behaviour rather than about how much of Jint a
+      given program happens to reach; a real embedder would not do this, so treat the run as an upper
+      bound on what works, never a lower one.
+
+      Rooting this assembly is not cosmetic. Without it the trimmer removes CompanyExtensions.Shout -
+      nothing calls it from C# - and `company.shout()` then fails as "not a function": a wrong answer
+      with no AOT diagnostic anywhere. An embedder whose host types are reached only through Jint's
+      reflection owes itself the same root.
+    -->
     <TrimmerRootAssembly Include="Jint" />
+    <TrimmerRootAssembly Include="Jint.AotExample" />
   </ItemGroup>
 
 </Project>

--- a/Jint.AotExample/Program.cs
+++ b/Jint.AotExample/Program.cs
@@ -15,6 +15,7 @@
 // Type.MakeGenericType + Activator.CreateInstance or MethodInfo.MakeGenericMethod. Reference-type
 // arguments share canonical code and work; value types need a specific instantiation the compiler
 // never saw. The sibling probe beside each gap pins that boundary rather than merely asserting it.
+// All five are https://github.com/sebastienros/jint/issues/3299.
 
 using Jint;
 using Jint.Native;

--- a/Jint.AotExample/Program.cs
+++ b/Jint.AotExample/Program.cs
@@ -1,16 +1,310 @@
-﻿using Jint;
+// Jint.AotExample is Jint's Native AOT probe. It is published with PublishAot=true and *run* by CI
+// (the "aot" job in .github/workflows/pr.yml and build.yml), because that is the only place a Native
+// AOT failure actually shows up: <IsAotCompatible> is a property, not evidence, and Jint's own csproj
+// still suppresses the eight IL warning codes that would substantiate it.
+//
+// Two kinds of entry live below.
+//
+//   Probe(...)        must succeed on every runtime. A failure fails the run.
+//   KnownAotGap(...)  must succeed under a JIT and must throw NotSupportedException under Native AOT.
+//                     Both directions are checked, so a gap that closes fails the native run and
+//                     forces this file to be updated - the same discipline the vendored
+//                     web-platform-tests exclusion table uses.
+//
+// Every known gap is one shape: a generic instantiation over a VALUE TYPE built at run time, either
+// Type.MakeGenericType + Activator.CreateInstance or MethodInfo.MakeGenericMethod. Reference-type
+// arguments share canonical code and work; value types need a specific instantiation the compiler
+// never saw. The sibling probe beside each gap pins that boundary rather than merely asserting it.
 
-var engine = new Engine(cfg => cfg
-    .AllowClr()
-);
+using Jint;
+using Jint.Native;
+using Jint.Runtime.Interop;
 
-engine.SetValue("company", new Company());
+var failures = 0;
+var probes = 0;
+var gaps = 0;
+// A Native AOT image has no managed assembly file to point at, so Assembly.Location is the empty
+// string there and a path under every other host. Neither of the two obvious alternatives works:
+// PublishAot=true writes both RuntimeFeature.IsDynamicCodeSupported and .IsDynamicCodeCompiled as
+// false into runtimeconfig.json, so `dotnet run` on this very project reports itself as Native AOT;
+// and asking the capability directly - typeof(X<>).MakeGenericType(typeof(SomeStruct)) - is folded
+// by ILC at compile time, because both tokens are constants. Jint's own sites are not foldable
+// precisely because their Type comes from a value crossing the boundary at run time.
+// IL3000 says this property "always returns an empty string" once the app is published as a single
+// file or Native AOT image - which is the fact being read, not a mistake being made, so the csproj
+// suppresses that one code. A source #pragma would not do: it reaches Roslyn but not ILC, which
+// re-derives every IL diagnostic when it compiles the closed program.
+var dynamicCode = System.Reflection.Assembly.GetExecutingAssembly().Location.Length != 0;
 
-Console.WriteLine($"Company's name: {engine.Evaluate("company.name")}");
-Console.WriteLine($"Company's field: {engine.Evaluate("company.field")}");
-Console.WriteLine($"Company's indexer: {engine.Evaluate("company[42]")}");
-Console.WriteLine($"Company's greeting: {engine.Evaluate("company.sayHello('Mary')")}");
+Console.WriteLine(dynamicCode
+    ? "runtime: JIT - known AOT gaps are expected to WORK here"
+    : "runtime: Native AOT - known AOT gaps are expected to THROW here");
+Console.WriteLine();
 
+Probe("member, field, indexer and method access", static () =>
+{
+    var engine = new Engine(static cfg => cfg.AllowClr());
+    engine.SetValue("company", new Company());
+    Expect("Jint", engine.Evaluate("company.name"));
+    Expect("public field value", engine.Evaluate("company.field"));
+    Expect(42, engine.Evaluate("company[42]"));
+    Expect("Hello Mary!", engine.Evaluate("company.sayHello('Mary')"));
+});
+
+Probe("int[] crossing", static () =>
+{
+    var engine = new Engine(static cfg => cfg.AllowClr());
+    engine.SetValue("numbers", new[] { 1, 2, 3 });
+    Expect(6, engine.Evaluate("numbers[0] + numbers[1] + numbers[2]"));
+    Expect(12, engine.Evaluate("numbers.map(function (x) { return x * 2; }).reduce(function (a, b) { return a + b; }, 0)"));
+});
+
+Probe("List<string> crossing (GenericListWrapperFactory<string>)", static () =>
+{
+    var engine = new Engine(static cfg => cfg.AllowClr());
+    engine.SetValue("list", new List<string> { "a", "b" });
+    Expect(2, engine.Evaluate("list.length"));
+    Expect("b", engine.Evaluate("list[1]"));
+});
+
+// ObjectWrapper.TryBuildArrayLikeWrapper: typeof(GenericListWrapperFactory<>).MakeGenericType(int).
+// Its catch (MissingMethodException) fallback to the non-generic ListWrapper never engages, because
+// Native AOT raises NotSupportedException from Activator.CreateInstance, not MissingMethodException.
+KnownAotGap("List<int> crossing (GenericListWrapperFactory<int>)", static () =>
+{
+    var engine = new Engine(static cfg => cfg.AllowClr());
+    engine.SetValue("list", new List<int> { 1, 2, 3 });
+    Expect(3, engine.Evaluate("list.length"));
+    Expect(2, engine.Evaluate("list[1]"));
+});
+
+Probe("IReadOnlyList<string> crossing (ReadOnlyListWrapperFactory<string>)", static () =>
+{
+    var engine = new Engine(static cfg => cfg.AllowClr());
+    engine.SetValue("ro", new ReadOnlyStrings());
+    Expect("x", engine.Evaluate("ro[0]"));
+});
+
+// Same site as above, IReadOnlyList<> branch.
+KnownAotGap("IReadOnlyList<double> crossing (ReadOnlyListWrapperFactory<double>)", static () =>
+{
+    var engine = new Engine(static cfg => cfg.AllowClr());
+    engine.SetValue("ro", new ReadOnlyDoubles());
+    Expect(1.5, engine.Evaluate("ro[0]"));
+});
+
+Probe("IEnumerable<string> snapshot (EnumerableSnapshotFactory<string>)", static () =>
+{
+    var engine = new Engine(static cfg =>
+    {
+        cfg.AllowClr();
+        cfg.Interop.EnumerableConversion = EnumerableConversionMode.Snapshot;
+    });
+    engine.SetValue("seq", Strings());
+    Expect(2, engine.Evaluate("seq.length"));
+});
+
+// ObjectWrapper.ResolveEnumerableSnapshotFactory: same MakeGenericType + Activator shape, and the
+// same catch (MissingMethodException) that Native AOT walks straight past.
+KnownAotGap("IEnumerable<int> snapshot (EnumerableSnapshotFactory<int>)", static () =>
+{
+    var engine = new Engine(static cfg =>
+    {
+        cfg.AllowClr();
+        cfg.Interop.EnumerableConversion = EnumerableConversionMode.Snapshot;
+    });
+    engine.SetValue("seq", Numbers());
+    Expect(3, engine.Evaluate("seq.length"));
+});
+
+Probe("Dictionary<string, object> crossing", static () =>
+{
+    var engine = new Engine(static cfg => cfg.AllowClr());
+    engine.SetValue("map", new Dictionary<string, object> { ["a"] = 1, ["b"] = "two" });
+    Expect(1, engine.Evaluate("map.a"));
+    Expect("two", engine.Evaluate("map.b"));
+});
+
+Probe("Dictionary<string, int> crossing", static () =>
+{
+    var engine = new Engine(static cfg => cfg.AllowClr());
+    engine.SetValue("map", new Dictionary<string, int> { ["a"] = 1 });
+    Expect(1, engine.Evaluate("map.a"));
+});
+
+Probe("delegate crossing: JS function -> Func<int, int>", static () =>
+{
+    var engine = new Engine(static cfg => cfg.AllowClr());
+    engine.SetValue("applier", new Applier());
+    Expect(10, engine.Evaluate("applier.apply(function (x) { return x * 2; }, 5)"));
+});
+
+Probe("delegate crossing: JS function -> Func<string, string>", static () =>
+{
+    var engine = new Engine(static cfg => cfg.AllowClr());
+    engine.SetValue("applier", new Applier());
+    Expect("ab", engine.Evaluate("applier.applyString(function (s) { return s + 'b'; }, 'a')"));
+});
+
+// DefaultTypeConverter.GetFromResultMethod: Task.FromResult<double> through MakeGenericMethod.
+KnownAotGap("delegate crossing: JS function -> Func<double, Task<double>>", static () =>
+{
+    var engine = new Engine(static cfg => cfg.AllowClr());
+    engine.SetValue("applier", new Applier());
+    Expect(10, engine.Evaluate("applier.applyAsync(function (x) { return x * 2; }, 5)"));
+});
+
+Probe("delegate crossing: CLR Func<int, int> -> JS", static () =>
+{
+    var engine = new Engine(static cfg => cfg.AllowClr());
+
+    // Deliberately cast. An uncast `new Func<int, int>(...)` binds to SetValue<T> rather than
+    // SetValue(string, Delegate), and SetValue<T>'s [DynamicallyAccessedMembers] then demands every
+    // public method of Func<int, int> - including the inherited, [RequiresUnreferencedCode]
+    // Delegate.CreateDelegate overloads. The embedder's own project gets six IL2026/IL2111
+    // diagnostics for a one-line registration; see the AOT section of Jint/Runtime/Interop/AGENTS.md.
+    engine.SetValue("twice", (Delegate) new Func<int, int>(static x => x * 2));
+
+    Expect(8, engine.Evaluate("twice(4)"));
+});
+
+Probe("generic method call, reference type argument", static () =>
+{
+    var engine = new Engine(static cfg => cfg.AllowClr());
+    engine.SetValue("g", new GenericHost());
+    Expect("hi", engine.Evaluate("g.identity('hi')"));
+});
+
+// MethodInfoFunction.ResolveMethod: methodInfo.MakeGenericMethod(double).
+KnownAotGap("generic method call, value type argument", static () =>
+{
+    var engine = new Engine(static cfg => cfg.AllowClr());
+    engine.SetValue("g", new GenericHost());
+    Expect(7, engine.Evaluate("g.identity(7)"));
+});
+
+Probe("TypeReference: constructing a CLR type from script", static () =>
+{
+    var engine = new Engine(static cfg => cfg.AllowClr());
+    engine.SetValue("Company", typeof(Company));
+    Expect("Jint", engine.Evaluate("new Company().name"));
+});
+
+// Only passes because the csproj roots this assembly as well as Jint. Without that, the extension
+// method's metadata is trimmed and `company.shout()` fails as "not a function" - a wrong answer
+// rather than an AOT diagnostic, which is why the probe is here.
+Probe("extension methods", static () =>
+{
+    var engine = new Engine(static cfg =>
+    {
+        cfg.AllowClr(typeof(Company).Assembly);
+        cfg.AddExtensionMethods(typeof(CompanyExtensions));
+    });
+    engine.SetValue("company", new Company());
+    Expect("JINT", engine.Evaluate("company.shout()"));
+});
+
+Probe("JSON round trip", static () =>
+{
+    var engine = new Engine();
+    Expect("{\"a\":1,\"b\":[1,2,3]}", engine.Evaluate("JSON.stringify({ a: 1, b: [1, 2, 3] })"));
+    Expect(2, engine.Evaluate("JSON.parse('{\"a\":2}').a"));
+});
+
+// The hypothesised AOT-safe subset: no interop at all, so none of the reflection above is reachable.
+Probe("interop disabled engine", static () =>
+{
+    var engine = new Engine(static o => o.Interop.Enabled = false);
+    Expect(55, engine.Evaluate("(function fib(n) { return n < 2 ? n : fib(n - 1) + fib(n - 2); })(10)"));
+    Expect("ABC", engine.Evaluate("'abc'.toUpperCase()"));
+    Expect(6, engine.Evaluate("[1,2,3].reduce((a, b) => a + b, 0)"));
+    Expect(true, engine.Evaluate("/^a+b$/.test('aaab')"));
+    Expect("1,2,3", engine.Evaluate("[...new Set([1,2,3])].join(',')"));
+});
+
+Probe("promise and async function", static () =>
+{
+    var engine = new Engine();
+    Expect(42, engine.Evaluate("(async function () { return 42; })()").UnwrapIfPromise());
+});
+
+Console.WriteLine();
+if (failures == 0)
+{
+    Console.WriteLine($"ALL PROBES PASSED ({probes} probes, {gaps} known AOT gaps)");
+    return 0;
+}
+
+Console.WriteLine($"{failures} PROBE(S) FAILED");
+return 1;
+
+static IEnumerable<int> Numbers()
+{
+    yield return 1;
+    yield return 2;
+    yield return 3;
+}
+
+static IEnumerable<string> Strings()
+{
+    yield return "a";
+    yield return "b";
+}
+
+void Probe(string name, Action action)
+{
+    probes++;
+    try
+    {
+        action();
+        Console.WriteLine($"PASS  {name}");
+    }
+    catch (Exception ex)
+    {
+        failures++;
+        Console.WriteLine($"FAIL  {name}: {ex.GetType().FullName}: {ex.Message}");
+    }
+}
+
+void KnownAotGap(string name, Action action)
+{
+    gaps++;
+    try
+    {
+        action();
+    }
+    catch (NotSupportedException ex) when (!dynamicCode)
+    {
+        Console.WriteLine($"GAP   {name}: {ex.Message.Split(". ")[0]}.");
+        return;
+    }
+    catch (Exception ex)
+    {
+        failures++;
+        Console.WriteLine($"FAIL  {name}: {ex.GetType().FullName}: {ex.Message}");
+        return;
+    }
+
+    if (dynamicCode)
+    {
+        Console.WriteLine($"PASS  {name} (known AOT gap, works under a JIT)");
+        return;
+    }
+
+    failures++;
+    Console.WriteLine($"FAIL  {name}: this known AOT gap now WORKS - promote it from KnownAotGap to Probe");
+}
+
+static void Expect(object expected, JsValue actual)
+{
+    var got = actual.ToObject();
+    var expectedText = Convert.ToString(expected, System.Globalization.CultureInfo.InvariantCulture);
+    var actualText = Convert.ToString(got, System.Globalization.CultureInfo.InvariantCulture);
+    if (!string.Equals(expectedText, actualText, StringComparison.Ordinal))
+    {
+        throw new InvalidOperationException($"expected <{expectedText}> but got <{actualText}>");
+    }
+}
 
 public class Company
 {
@@ -20,3 +314,37 @@ public class Company
     public int this[int index] => index;
 }
 
+public static class CompanyExtensions
+{
+    public static string Shout(this Company company) => company.Name.ToUpperInvariant();
+}
+
+public class Applier
+{
+    public int Apply(Func<int, int> f, int value) => f(value);
+    public string ApplyString(Func<string, string> f, string value) => f(value);
+    public double ApplyAsync(Func<double, Task<double>> f, double value) => f(value).GetAwaiter().GetResult();
+}
+
+public class GenericHost
+{
+    public T Identity<T>(T value) => value;
+}
+
+public sealed class ReadOnlyStrings : IReadOnlyList<string>
+{
+    private readonly List<string> _items = ["x", "y"];
+    public string this[int index] => _items[index];
+    public int Count => _items.Count;
+    public IEnumerator<string> GetEnumerator() => _items.GetEnumerator();
+    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => _items.GetEnumerator();
+}
+
+public sealed class ReadOnlyDoubles : IReadOnlyList<double>
+{
+    private readonly List<double> _items = [1.5, 2.5];
+    public double this[int index] => _items[index];
+    public int Count => _items.Count;
+    public IEnumerator<double> GetEnumerator() => _items.GetEnumerator();
+    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => _items.GetEnumerator();
+}

--- a/Jint/Runtime/Interop/AGENTS.md
+++ b/Jint/Runtime/Interop/AGENTS.md
@@ -15,3 +15,58 @@ rest of the list is split across the files indexed from the repository-root [`AG
 - **A registered `IObjectConverter` used to disable the compiled interop member-read lane engine-wide.** It can now declare the CLR types it handles — through the registration overload `AddObjectConverter(converter, params Type[] handledTypes)`, not an interface member — so unrelated *members* keep the read lane. A converter registered untyped still degrades every wrapped member. Note the two lanes are gated differently: the type filter covers the compiled member-read lane, while the compiled method-invoker lane keys on the method's return type being unobservable to a converter (`ReturnValueIsInvisibleToObjectConverters`), so even a typed converter still costs the invoker lane on any method with an observable return type. Nothing links the declaration to the `switch` inside `TryConvert`, so the two drift: a case added to the converter and not to the registration is skipped on exactly the members the declaration excluded and honoured everywhere else, invisibly. Host-contract verification checks a `true` answer against the registration's own `ObjectConverterTypeFilter` — the same predicate the read lane consults, deliberately reused so the promise and the check cannot diverge.
 - **Dictionary-valued reads re-wrap on every access, and only a host promise can stop them.** `record.value.customer.country` over a wrapped `JsonObject`/`IDictionary` resolves each level through the dictionary lane, which probes the target and converts the value afresh every time — the read itself is compiled, but its *result* was never cached, and the bounded recent-wrapper ring (8 slots) cannot hold a nested walk's nodes. The engine cannot fix this alone: a value-identity change inside the host's dictionary is invisible to it. `Options.AddImmutableCrossing(params Type[])` supplies the missing fact — instances of the declared types, while exposed to this engine, are immutable — and in exchange an `ObjectWrapper` over such a target memoizes each key's resolved descriptor, so a repeated read touches neither reflection nor the indexer and each child node is wrapped once per wrapper lifetime. Assignability is the rule (an interface covers its implementations), and unlike `ObjectConverterTypeFilter` this one never guesses in the permissive direction — a wrong claim here would serve stale reads rather than merely cost a fast lane, so an open generic declaration claims nothing. Three things to know before relying on it. The memo lives in a **store of its own**, not in `_properties`: enumeration stays live from the target (a key added CLR-side afterwards still enumerates), no `_propertiesVersion` is bumped, and anything a script actually defines — `Object.freeze`, `Object.defineProperty`, a host `SetOwnProperty` — outranks it and drops it. A **write** through the wrapper evicts that key's memo, which is insurance for the host that was wrong and not a licence to be; write behaviour itself is unchanged. And the memo is **per wrapper**, so it only pays while the wrapper is alive — a stable root (anything reached through `Engine.SetValue`) memoizes its whole subtree, but a node reached through a transient wrapper, such as an element of a wrapped list, still re-resolves on each crossing; that lane is the ring's job, or `TrackObjectWrapperIdentity`'s. The same promise also reaches reflected members, where `ReflectionDescriptor` stops invoking the CLR getter entirely after the first read, superseding both `CacheRecentObjectWrappers` and `TrackObjectWrapperIdentity` for a declared type. No promise is needed for questions *about* the keys rather than their values: `ObjectWrapper.ProbeOwnProperty` answers a string-keyed generic dictionary from the target's own `ContainsKey`, so `in`, `hasOwnProperty`, `propertyIsEnumerable`, `Object.keys`/`values`/`entries`, `for..in`, `Object.assign`, spread and `JSON.stringify` stop converting a value and building a descriptor per key only to discard both. That lane never decides a key is *missing* — a `false` falls through to the descriptor path, because a dictionary wrapper still resolves CLR members for names the dictionary does not carry — so the only way it can disagree with `GetOwnProperty` is a target whose own `ContainsKey` and `TryGetValue` disagree with each other.
 - **A non-default `IReferenceResolver` used to disable the member and call inline caches engine-wide.** It can now declare `ReferenceResolverInterests` at registration or via `Options.ReferenceResolverInterests`. The scope was always the non-computed member-read caches, the dense-array indexed-read lane and the member-call callee lane; identifier caches were never affected.
+
+### Native AOT: what is measured, and what is still only asserted
+
+`Jint.csproj` sets `<IsAotCompatible>` for net7.0+ and, in the same property group, suppresses eight IL
+codes — `IL3050` (*requires dynamic code*, the one that says an API cannot work under Native AOT) plus
+`IL2060`, `IL2067`, `IL2069`, `IL2070`, `IL2072`, `IL2075`, `IL2080`. **The property is not evidence, and
+the suppressions are why.** Nothing about them has changed; what has changed is that a CI leg now
+publishes `Jint.AotExample` with `PublishAot=true` and *runs the native binary* (`aot` in
+`.github/workflows/pr.yml` and `build.yml`), because the run is the only thing that distinguishes a
+warning that matters from one that does not.
+
+Two facts about the suppressions are worth knowing before trusting either of them. Jint's `NoWarn` is a
+property of Jint's own *compilation* and reaches nothing downstream: ILC re-derives the whole set when it
+compiles the closed program, so **an embedder publishing Native AOT sees all 122 of them**, attributed to
+Jint's files, in their build. And a source `#pragma warning disable IL3050` — `ObjectWrapper` has
+several — is Roslyn-only for the same reason; `[UnconditionalSuppressMessage]` is the one ILC honours.
+
+What the leg proves today: an engine with `AllowClr()` reading properties, fields, indexers and methods
+off a host object works natively, as do arrays, `Dictionary<,>`, delegates in both directions, extension
+methods, `TypeReference` construction, JSON, promises, and an `Interop.Enabled = false` engine. What it
+proves does *not* work is one shape, in five places — **a generic instantiation over a value type built at
+run time**. Reference-type arguments share canonical code and are fine; `int`, `double` and friends need a
+specific instantiation ILC never saw, and raise `NotSupportedException` at the crossing:
+
+| site | shape | fails as |
+| --- | --- | --- |
+| `ObjectWrapper.TryBuildArrayLikeWrapper` | `typeof(GenericListWrapperFactory<>).MakeGenericType(int)` | `List<int>` reaching script |
+| `ObjectWrapper.TryBuildArrayLikeWrapper` | `typeof(ReadOnlyListWrapperFactory<>).MakeGenericType(double)` | `IReadOnlyList<double>` reaching script |
+| `ObjectWrapper.ResolveEnumerableSnapshotFactory` | `typeof(EnumerableSnapshotFactory<>).MakeGenericType(int)` | `IEnumerable<int>` under `EnumerableConversionMode.Snapshot` |
+| `DefaultTypeConverter.GetFromResultMethod` | `Task.FromResult<double>` through `MakeGenericMethod` | a JS function converted to `Func<double, Task<double>>` |
+| `MethodInfoFunction.ResolveMethod` | `methodInfo.MakeGenericMethod(double)` | any generic host method called with a number |
+
+The first three already carry a `catch (MissingMethodException)` fallback written for exactly this
+scenario, and **it never engages**: Native AOT raises `NotSupportedException` from
+`Activator.CreateInstance`, not `MissingMethodException`, so the non-generic `ListWrapper` /
+`ObjectEnumerableSnapshotFactory` fallback beside it is dead code under AOT. Do not add another such
+fallback without checking which exception the runtime actually throws.
+
+Two costs land in the *embedder's* project rather than in Jint's, both from
+`Engine.SetValue<T>`'s `[DynamicallyAccessedMembers]`, and both from ordinary one-line registrations. An
+uncast `SetValue("f", new Func<int, int>(…))` binds to `SetValue<T>` rather than to
+`SetValue(string, Delegate)`, and the annotation then demands every public method of `Func<int, int>` —
+including the inherited, `[RequiresUnreferencedCode]` `Delegate.CreateDelegate` overloads: six IL2026 and
+IL2111 **errors** in the host's own build, cleared by casting to `Delegate`. `SetValue("a", new[] { 1, 2, 3 })`
+costs four IL3050 the same way, through `Array.CreateInstance`. Widening either annotation is not the fix;
+knowing that the annotation is what an embedder pays is the point.
+
+`Jint.AotExample/Program.cs` pins all of this in both directions. A `Probe` must pass on every runtime; a
+`KnownAotGap` must pass under a JIT **and** throw under Native AOT, so a gap that closes fails the leg and
+forces the file to be updated — the same discipline as the web-platform-tests exclusion table. Treat the
+run as an upper bound rather than a lower one: the example roots the whole `Jint` assembly, which a real
+embedder would not do. It roots its own assembly too, and that one is not cosmetic — without it the
+trimmer removes an extension method nothing calls from C#, and `company.shout()` fails as *not a function*
+with no AOT diagnostic anywhere. Reflection-reached host types need rooting; the failure mode is a wrong
+answer, not an error.

--- a/Jint/Runtime/Interop/AGENTS.md
+++ b/Jint/Runtime/Interop/AGENTS.md
@@ -51,7 +51,10 @@ The first three already carry a `catch (MissingMethodException)` fallback writte
 scenario, and **it never engages**: Native AOT raises `NotSupportedException` from
 `Activator.CreateInstance`, not `MissingMethodException`, so the non-generic `ListWrapper` /
 `ObjectEnumerableSnapshotFactory` fallback beside it is dead code under AOT. Do not add another such
-fallback without checking which exception the runtime actually throws.
+fallback without checking which exception the runtime actually throws. All five rows, and what a fix
+would have to decide, are [issue #3299](https://github.com/sebastienros/jint/issues/3299); none is fixed
+yet, and **not one member is annotated `[RequiresDynamicCode]`**, so an embedder's first warning is the
+run-time throw.
 
 Two costs land in the *embedder's* project rather than in Jint's, both from
 `Engine.SetValue<T>`'s `[DynamicallyAccessedMembers]`, and both from ordinary one-line registrations. An


### PR DESCRIPTION
`Jint.csproj` sets `<IsAotCompatible>` for net7.0+ and, in the same property group, suppresses the
eight IL codes that would substantiate it:

```xml
<!-- TODO AOT improvements -->
<NoWarn>$(NoWarn);IL3050;IL2080;IL2075;IL2072;IL2070;IL2069;IL2067;IL2060;</NoWarn>
```

`Jint.AotExample` was in the solution so it *compiled*. Nothing ever published it — and a publish is
where AOT warnings and runtime failures appear.

This PR stands up the measurement. It does **not** remove the suppressions and does not annotate any
API; that is separate work, and this is the input to it.

## What is new

An `aot` job in `pr.yml` and `build.yml` that publishes `Jint.AotExample` with `PublishAot=true`, runs
the produced native binary, requires it to pass, and writes the analysis-warning counts into the job
summary. `ubuntu-latest` — the gaps are ILC generic-instantiation gaps rather than platform ones, and
the runner image already carries `clang` and `zlib1g-dev`, so the toolchain step checks rather than
installs (an unconditional `apt-get update` costs ~15 s a run to reinstall what is there; an
unconditional `apt-get install` fails on a stale index).

Two things had to change for a publish to be possible at all:

* **`dotnet publish Jint.AotExample -c Release` failed before this PR.** ILC reports the 122
  diagnostics below, and `IlcTreatWarningsAsErrors` defaults to the repository's
  `TreatWarningsAsErrors`, so no binary was ever produced. The example now sets it `false`, with the
  reasoning in the csproj: the warnings say what *might* break, and only the run says what *does*. When
  the warnings are paid down the property goes and a clean publish becomes the assertion.
* **The example roots its own assembly.** Without it the trimmer removes an extension method nothing
  calls from C#, and `company.shout()` fails as *not a function* — a wrong answer with no AOT
  diagnostic anywhere.

`Jint.AotExample/Program.cs` grows from four `Console.WriteLine`s into a probe with two kinds of entry:
a `Probe` must pass on every runtime, and a `KnownAotGap` must pass under a JIT **and** throw under
Native AOT. Both directions are checked, so a gap that closes fails the leg and forces the file to be
updated — the discipline `Jint.Tests/Wpt`'s exclusion table already uses here. Every gap sits beside a
sibling probe with a reference-type argument, so the boundary is pinned rather than described.

## What the run found

Five genuine runtime failures, all one shape: **a generic instantiation over a value type built at run
time.** Reference-type arguments share canonical code and work. Filed as #3299; nothing is fixed here.

| site | script that reaches it |
| --- | --- |
| `ObjectWrapper.TryBuildArrayLikeWrapper` → `MakeGenericType(int)` | `List<int>` reaching script |
| same site, `IReadOnlyList<>` branch | `IReadOnlyList<double>` reaching script |
| `ObjectWrapper.ResolveEnumerableSnapshotFactory` | `IEnumerable<int>` under `Snapshot` conversion |
| `DefaultTypeConverter.GetFromResultMethod` | JS function → `Func<double, Task<double>>` |
| `MethodInfoFunction.ResolveMethod` | any generic host method called with a number |

The first three already carry a `catch (MissingMethodException)` fallback written for exactly this
case, and **it never engages**: Native AOT raises `NotSupportedException` from
`Activator.CreateInstance`. Widening that `catch` would make those three degrade to the non-generic
wrapper instead of throwing into script — the smallest useful follow-up, and independent of the rest.

Verbatim output of the published binary (also reproduced on the Linux leg):

```
runtime: Native AOT - known AOT gaps are expected to THROW here

PASS  member, field, indexer and method access
PASS  int[] crossing
PASS  List<string> crossing (GenericListWrapperFactory<string>)
GAP   List<int> crossing (GenericListWrapperFactory<int>): 'Jint.Runtime.Interop.GenericListWrapperFactory`1[System.Int32]' is missing native code or metadata.
PASS  IReadOnlyList<string> crossing (ReadOnlyListWrapperFactory<string>)
GAP   IReadOnlyList<double> crossing (ReadOnlyListWrapperFactory<double>): 'Jint.Runtime.Interop.ReadOnlyListWrapperFactory`1[System.Double]' is missing native code or metadata.
PASS  IEnumerable<string> snapshot (EnumerableSnapshotFactory<string>)
GAP   IEnumerable<int> snapshot (EnumerableSnapshotFactory<int>): 'Jint.Runtime.Interop.EnumerableSnapshotFactory`1[System.Int32]' is missing native code or metadata.
PASS  Dictionary<string, object> crossing
PASS  Dictionary<string, int> crossing
PASS  delegate crossing: JS function -> Func<int, int>
PASS  delegate crossing: JS function -> Func<string, string>
GAP   delegate crossing: JS function -> Func<double, Task<double>>: 'System.Threading.Tasks.Task.FromResult[System.Double](System.Double)' is missing native code.
PASS  delegate crossing: CLR Func<int, int> -> JS
PASS  generic method call, reference type argument
GAP   generic method call, value type argument: 'GenericHost.Identity[System.Double](System.Double)' is missing native code.
PASS  TypeReference: constructing a CLR type from script
PASS  extension methods
PASS  JSON round trip
PASS  interop disabled engine
PASS  promise and async function

ALL PROBES PASSED (16 probes, 5 known AOT gaps)
```

`Interop.Enabled = false` passes every probe, which is at least a defensible floor to promise an
embedder.

## Warning inventory

`dotnet publish Jint.AotExample -c Release`, .NET SDK 10.0.400. **122 diagnostics for Jint** — including
all eight suppressed codes, because `Jint.csproj`'s `NoWarn` is a property of Jint's own *compilation*
and ILC re-derives the set over the closed program. An embedder publishing Native AOT sees all 122
attributed to Jint's files in their own build. (The same is true of the `#pragma warning disable IL3050`
in `ObjectWrapper` — Roslyn honours it, ILC does not; `[UnconditionalSuppressMessage]` is the form that
reaches ILC.)

### By code

| code | count | suppressed in `Jint.csproj`? | what it means |
| --- | --- | --- | --- |
| `IL2072` | 35 | yes | return value flowed to a `[DynamicallyAccessedMembers]` target without matching annotations |
| `IL2067` | 21 | yes | parameter flowed to a `[DynamicallyAccessedMembers]` target without matching annotations |
| `IL3050` | 20 | yes | **requires dynamic code** - the API cannot work under Native AOT |
| `IL2070` | 13 | yes | `this` argument to a `Type.Get*` call is unannotated |
| `IL2080` | 6 | yes | field value flowed to a `[DynamicallyAccessedMembers]` target |
| `IL2075` | 6 | yes | return value used as `this` for a `Type.Get*` call |
| `IL2026` | 5 | no | calls a `[RequiresUnreferencedCode]` member |
| `IL2062` | 4 | no | value passed as a `Type` cannot be statically determined |
| `IL2060` | 3 | yes | `MakeGenericMethod` cannot be statically analyzed |
| `IL2055` | 3 | no | `MakeGenericType` cannot be statically analyzed |
| `IL2077` | 2 | no | field flowed to a `[DynamicallyAccessedMembers]` target |
| `IL2098` | 1 | no | `[DynamicallyAccessedMembers]` on a parameter that is neither `Type` nor `string` |
| `IL2111` | 1 | no | a method with `[DynamicallyAccessedMembers]` parameters is accessed via reflection |
| `IL2069` | 1 | yes | value stored in an annotated field without matching annotations |
| `IL2076` | 1 | no | return value flowed to a generic argument with `[DynamicallyAccessedMembers]` |
| **total** | **122** | | |

### By file

75 of the 122 are in four files.

| file | total | codes |
| --- | --- | --- |
| `Jint/Runtime/Interop/DefaultTypeConverter.cs` | 29 | IL2026 x2, IL2060 x2, IL2062 x3, IL2067 x6, IL2070, IL2072 x4, IL2080 x6, IL3050 x5 |
| `Jint/Runtime/Interop/ObjectWrapper.cs` | 26 | IL2055 x3, IL2067 x4, IL2070 x2, IL2072 x8, IL2075 x3, IL2076, IL3050 x5 |
| `Jint/Runtime/Interop/TypeResolver.cs` | 13 | IL2067 x3, IL2070 x5, IL2072 x2, IL2075 x3 |
| `Jint/Runtime/Interop/MethodInfoFunction.cs` | 7 | IL2060, IL2067 x3, IL2072 x2, IL3050 |
| `Jint/Runtime/Interop/InteropHelper.cs` | 4 | IL2072 x4 |
| `Jint/Runtime/Interop/TypeReference.cs` | 4 | IL2072 x4 |
| `Jint/Engine.cs` | 3 | IL2062, IL2067, IL2111 |
| `Jint/Runtime/Interop/DefaultObjectConverter.cs` | 3 | IL2026, IL3050 x2 |
| `Jint/Runtime/Interop/DelegateWrapper.cs` | 3 | IL2072 x3 |
| `Jint/Runtime/Interop/TypeDescriptor.cs` | 3 | IL2067, IL2072, IL2077 |
| `Jint/Runtime/Interop/ClrHelper.cs` | 2 | IL2072 x2 |
| `Jint/Runtime/Interop/CompiledMethodInvoker.cs` | 2 | IL3050 x2 |
| `Jint/Runtime/Interop/Reflection/CompiledMemberAccessor.cs` | 2 | IL3050 x2 |
| `Jint/Runtime/Interop/Reflection/ReflectionAccessor.cs` | 2 | IL2072, IL2077 |
| `Jint/Options.cs` | 2 | IL2026 x2 |
| `Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs` | 2 | IL2072 x2 |
| `Jint/Runtime/Interop/Reflection/DynamicObjectAccessor.cs` | 2 | IL3050 x2 |
| `Jint/Runtime/Interop/Reflection/ExtensionMethodCache.cs` | 2 | IL2067, IL2070 |
| `Jint/Native/JsValue.cs` | 2 | IL2070 x2 |
| `ILC (assembly-level)` | 1 | IL2098 |
| `Jint/Runtime/Interop/CompiledDelegateInvoker.cs` | 1 | IL2070 |
| `Jint/Runtime/Interop/MethodDescriptor.cs` | 1 | IL2072 |
| `Jint/Runtime/Interop/NamespaceReference.cs` | 1 | IL3050 |
| `Jint/Runtime/Interop/ObjectWrapper.Specialized.cs` | 1 | IL2069 |
| `Jint/Runtime/Interop/Reflection/IndexerAccessor.cs` | 1 | IL2067 |
| `Jint/Native/ShadowRealm/ShadowRealm.cs` | 1 | IL2067 |
| `Jint/Runtime/Interpreter/Expressions/JintUnaryExpression.cs` | 1 | IL2072 |
| `Jint/Extensions/ReflectionExtensions.cs` | 1 | IL2070 |
| **total** | **122** | |

### The 20 IL3050 — "requires dynamic code"

| location | member | dynamic-code API |
| --- | --- | --- |
| `Jint/Runtime/Interop/DefaultObjectConverter.cs:217` | `DefaultObjectConverter.ConvertSystemTextJsonValue(Engine,JsonNode)` | `System.Text.Json.JsonSerializer.Deserialize<Double>(JsonNode,JsonSerializerOptions)` |
| `Jint/Runtime/Interop/DefaultObjectConverter.cs:531` | `DefaultObjectConverter.TryConvertArrayLiveView(Engine,Object,Type,JsValue&)` | `System.Type.MakeArrayType()` |
| `Jint/Runtime/Interop/CompiledMethodInvoker.cs:228` | `CompiledMethodInvoker.TryCreateInvocationDelegate(MethodInfo,Type,ParameterInfo[],Type,Delegate&,Type&)` | `System.Linq.Expressions.Expression.TryGetActionType(Type[],Type&)` |
| `Jint/Runtime/Interop/CompiledMethodInvoker.cs:236` | `CompiledMethodInvoker.TryCreateInvocationDelegate(MethodInfo,Type,ParameterInfo[],Type,Delegate&,Type&)` | `System.Linq.Expressions.Expression.TryGetFuncType(Type[],Type&)` |
| `Jint/Runtime/Interop/DefaultTypeConverter.cs:512` | `DefaultTypeConverter.BuildDelegate(Type,Func`3<JsValue,JsValue[],JsValue>,Expression)` | `System.Linq.Expressions.Expression.NewArrayInit(Type,IEnumerable`1<Expression>)` |
| `Jint/Runtime/Interop/DefaultTypeConverter.cs:607` | `DefaultTypeConverter.GetFromResultMethod(DefaultTypeConverter.TypeConversionKey)` | `System.Reflection.MethodInfo.MakeGenericMethod(Type[])` |
| `Jint/Runtime/Interop/DefaultTypeConverter.cs:610` | `DefaultTypeConverter.GetFromResultMethod(DefaultTypeConverter.TypeConversionKey)` | `System.Reflection.MethodInfo.MakeGenericMethod(Type[])` |
| `Jint/Runtime/Interop/MethodInfoFunction.cs:179` | `MethodInfoFunction.ResolveMethod(MethodDescriptor,ParameterInfo[],JsValue[])` | `System.Reflection.MethodInfo.MakeGenericMethod(Type[])` |
| `Jint/Runtime/Interop/NamespaceReference.cs:83` | `NamespaceReference.Native.ICallable.Call(JsValue,JsValue[])` | `System.Type.MakeGenericType(Type[])` |
| `Jint/Runtime/Interop/Reflection/CompiledMemberAccessor.cs:397` | `Reflection.CompiledMemberAccessor.TryCreateOpenDelegate(MethodInfo,Type[],Type,Delegate&,Type&)` | `System.Linq.Expressions.Expression.TryGetActionType(Type[],Type&)` |
| `Jint/Runtime/Interop/Reflection/CompiledMemberAccessor.cs:407` | `Reflection.CompiledMemberAccessor.TryCreateOpenDelegate(MethodInfo,Type[],Type,Delegate&,Type&)` | `System.Linq.Expressions.Expression.TryGetFuncType(Type[],Type&)` |
| `Jint/Runtime/Interop/DefaultTypeConverter.cs:146` | `DefaultTypeConverter.TryConvertInternal(Object,Type,IFormatProvider,Boolean,Object&,String&)` | `System.Type.MakeGenericType(Type[])` |
| `Jint/Runtime/Interop/DefaultTypeConverter.cs:157` | `DefaultTypeConverter.TryConvertInternal(Object,Type,IFormatProvider,Boolean,Object&,String&)` | `System.Type.MakeGenericType(Type[])` |
| `Jint/Runtime/Interop/ObjectWrapper.cs:191` | `ObjectWrapper.<>c.<TryBuildArrayLikeWrapper>b__7_0(Type)` | `System.Type.MakeArrayType()` |
| `Jint/Runtime/Interop/ObjectWrapper.cs:193` | `ObjectWrapper.<>c.<TryBuildArrayLikeWrapper>b__7_0(Type)` | `System.Type.MakeGenericType(Type[])` |
| `Jint/Runtime/Interop/ObjectWrapper.cs:209` | `ObjectWrapper.<>c.<TryBuildArrayLikeWrapper>b__7_0(Type)` | `System.Type.MakeGenericType(Type[])` |
| `Jint/Runtime/Interop/ObjectWrapper.cs:215` | `ObjectWrapper.<>c.<TryBuildArrayLikeWrapper>b__7_0(Type)` | `System.Type.MakeGenericType(Type[])` |
| `Jint/Runtime/Interop/ObjectWrapper.cs:286` | `ObjectWrapper.<>c.<ResolveEnumerableSnapshotFactory>b__9_0(Type)` | `System.Type.MakeGenericType(Type[])` |
| `Jint/Runtime/Interop/Reflection/DynamicObjectAccessor.cs:50` | `Reflection.DynamicObjectAccessor.JintGetMemberBinder.JintGetMemberBinder(String,Boolean)` | `System.Dynamic.GetMemberBinder.GetMemberBinder(String,Boolean)` |
| `Jint/Runtime/Interop/Reflection/DynamicObjectAccessor.cs:62` | `Reflection.DynamicObjectAccessor.JintSetMemberBinder.JintSetMemberBinder(String,Boolean)` | `System.Dynamic.SetMemberBinder.SetMemberBinder(String,Boolean)` |

Note that `Expression<T>.Compile()` itself is **not** among them: it is not annotated
`[RequiresDynamicCode]` because it falls back to the expression interpreter, so the ~14 `…Compile()`
sites work under AOT and merely lose their compiled fast path. What is annotated is the surrounding
scaffolding — `Expression.TryGetFuncType` / `TryGetActionType` / `NewArrayInit`, `MakeGenericType`,
`MakeGenericMethod`, `MakeArrayType`, the `System.Dynamic` binders, and `JsonSerializer.Deserialize<T>`.

## Two costs that land in the embedder's project

Both from `Engine.SetValue<T>`'s `[DynamicallyAccessedMembers]`, both from a one-line registration in
the *host's* code. Found because they broke this example's own build:

* `engine.SetValue("f", new Func<int, int>(x => x * 2))` binds to `SetValue<T>` rather than
  `SetValue(string, Delegate)`, and the annotation then demands every public method of `Func<int, int>`
  — including the inherited, `[RequiresUnreferencedCode]` `Delegate.CreateDelegate` overloads: **three
  IL2026 and three IL2111, as errors**. Casting to `(Delegate)` clears them, which is what the example
  now does, with the reason at the call site.
* `engine.SetValue("numbers", new[] { 1, 2, 3 })` costs **four IL3050** the same way, through
  `Array.CreateInstance`. Those four are the only diagnostics in the inventory attributed to
  `Jint.AotExample` rather than to Jint, and they are counted separately above.

## Docs

`Jint/Runtime/Interop/AGENTS.md` gains a section: what the leg verifies, what stays suppressed, that
`<IsAotCompatible>` is not evidence on its own, the five-row gap table, the wrong-exception fallback,
and the two embedder-side costs. The repository-root `AGENTS.md` is untouched — it is 1.5 KiB from its
budget and already routes CLR-interop work to that file.

## Verified locally

* `dotnet build -c Release` on the solution — clean.
* `dotnet publish Jint.AotExample/Jint.AotExample.csproj --configuration Release` — exit 0, produces a
  20.9 MB `win-x64` binary.
* Native binary — output above, exit 0.
* `dotnet run --project Jint.AotExample -c Release` (JIT) — `ALL PROBES PASSED (16 probes, 5 known AOT
  gaps)`, every gap taking its works-under-a-JIT branch.
* Both workflow files parse, and the summary step was dry-run against the real publish log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014W5mbjGhyvgAS4pivXoc4S
