### PR TITLE
Native AOT: degrade where a fallback exists, warn at the call site where it does not

### DIFF
--- a/Jint.AotExample/Jint.AotExample.csproj
+++ b/Jint.AotExample/Jint.AotExample.csproj
@@ -30,6 +30,16 @@
       UnconditionalSuppressMessage, which ILC does honour.
     -->
     <NoWarn>$(NoWarn);IL3000</NoWarn>
+
+    <!--
+      Jint's reflection-dependent entry points carry [RequiresUnreferencedCode], so AllowClr and
+      AddExtensionMethods raise IL2026 at every call below - which is the point of annotating them, and
+      is what an embedder now sees at their own call site rather than at run time. This project meets
+      the requirement in the way those messages name: it roots both assemblies with
+      TrimmerRootAssembly. The analyzer cannot see an MSBuild item, so it goes on asking; suppressing
+      it here is the acknowledgement, and the native run below is what actually checks the answer.
+    -->
+    <NoWarn>$(NoWarn);IL2026</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Jint.AotExample/Program.cs
+++ b/Jint.AotExample/Program.cs
@@ -15,7 +15,12 @@
 // Type.MakeGenericType + Activator.CreateInstance or MethodInfo.MakeGenericMethod. Reference-type
 // arguments share canonical code and work; value types need a specific instantiation the compiler
 // never saw. The sibling probe beside each gap pins that boundary rather than merely asserting it.
-// All five are https://github.com/sebastienros/jint/issues/3299.
+// All five were https://github.com/sebastienros/jint/issues/3299; three of them now degrade to an
+// untyped wrapper instead of throwing, and their rows below are Probes rather than gaps. The two
+// that remain are the two with no non-generic answer to degrade TO: there is no way to produce a
+// Task<double> without Task.FromResult<double>, and declining a generic host method would report
+// "no matching overload" for a method that plainly exists. Both would trade a diagnosable throw for
+// a wrong answer, so both stay gaps.
 
 using Jint;
 using Jint.Native;
@@ -68,10 +73,12 @@ Probe("List<string> crossing (GenericListWrapperFactory<string>)", static () =>
     Expect("b", engine.Evaluate("list[1]"));
 });
 
-// ObjectWrapper.TryBuildArrayLikeWrapper: typeof(GenericListWrapperFactory<>).MakeGenericType(int).
-// Its catch (MissingMethodException) fallback to the non-generic ListWrapper never engages, because
-// Native AOT raises NotSupportedException from Activator.CreateInstance, not MissingMethodException.
-KnownAotGap("List<int> crossing (GenericListWrapperFactory<int>)", static () =>
+// ObjectWrapper.TryBuildArrayLikeWrapper: typeof(GenericListWrapperFactory<>).MakeGenericType(int)
+// has no native code under AOT, and the site now degrades to the non-generic ListWrapper rather than
+// letting NotSupportedException reach script. This is a Probe, not a KnownAotGap, because the
+// degradation has to be correct and not merely quiet - a wrapper answering the wrong length would
+// satisfy a try/catch and fail here.
+Probe("List<int> crossing (ListWrapper fallback under AOT)", static () =>
 {
     var engine = new Engine(static cfg => cfg.AllowClr());
     engine.SetValue("list", new List<int> { 1, 2, 3 });
@@ -86,8 +93,11 @@ Probe("IReadOnlyList<string> crossing (ReadOnlyListWrapperFactory<string>)", sta
     Expect("x", engine.Evaluate("ro[0]"));
 });
 
-// Same site as above, IReadOnlyList<> branch.
-KnownAotGap("IReadOnlyList<double> crossing (ReadOnlyListWrapperFactory<double>)", static () =>
+// Same site as above, IReadOnlyList<> branch. ReadOnlyDoubles is not an IList either, so the
+// degradation goes one step further than the row above: no array-like wrapper at all, and the read is
+// served by a plain ObjectWrapper resolving the type's own indexer. Array-likeness is what is lost -
+// ro.length and the Array.prototype generics go with the typed factory, ro[0] does not.
+Probe("IReadOnlyList<double> crossing (plain ObjectWrapper fallback under AOT)", static () =>
 {
     var engine = new Engine(static cfg => cfg.AllowClr());
     engine.SetValue("ro", new ReadOnlyDoubles());
@@ -105,9 +115,9 @@ Probe("IEnumerable<string> snapshot (EnumerableSnapshotFactory<string>)", static
     Expect(2, engine.Evaluate("seq.length"));
 });
 
-// ObjectWrapper.ResolveEnumerableSnapshotFactory: same MakeGenericType + Activator shape, and the
-// same catch (MissingMethodException) that Native AOT walks straight past.
-KnownAotGap("IEnumerable<int> snapshot (EnumerableSnapshotFactory<int>)", static () =>
+// ObjectWrapper.ResolveEnumerableSnapshotFactory: same MakeGenericType + Activator shape, degrading
+// to ObjectEnumerableSnapshotFactory, which snapshots the sequence as objects rather than as int.
+Probe("IEnumerable<int> snapshot (object snapshot fallback under AOT)", static () =>
 {
     var engine = new Engine(static cfg =>
     {

--- a/Jint.AotExample/Program.cs
+++ b/Jint.AotExample/Program.cs
@@ -57,6 +57,10 @@ Probe("member, field, indexer and method access", static () =>
     Expect("Hello Mary!", engine.Evaluate("company.sayHello('Mary')"));
 });
 
+// Binds to SetValue<T>(string, T[]), which infers T = int rather than T = int[]. That is what keeps
+// this registration free of the four IL3050 an embedder used to pay here: annotating an ARRAY type
+// preserves all public methods of System.Array, Array.CreateInstance among them, which is
+// [RequiresDynamicCode] and has nothing to do with reading an element.
 Probe("int[] crossing", static () =>
 {
     var engine = new Engine(static cfg => cfg.AllowClr());
@@ -128,6 +132,17 @@ Probe("IEnumerable<int> snapshot (object snapshot fallback under AOT)", static (
     Expect(3, engine.Evaluate("seq.length"));
 });
 
+// The other half of the same overload: T = Company, so [DynamicallyAccessedMembers] preserves the
+// members script actually reads. Inferring T = Company[] preserved System.Array's members instead and
+// left companies[0].name to be trimmed away - a wrong answer with no diagnostic, the same failure mode
+// the extension-method probe below exists for.
+Probe("Company[] crossing, reading a member of an element", static () =>
+{
+    var engine = new Engine(static cfg => cfg.AllowClr());
+    engine.SetValue("companies", new[] { new Company() });
+    Expect("Jint", engine.Evaluate("companies[0].name"));
+});
+
 Probe("Dictionary<string, object> crossing", static () =>
 {
     var engine = new Engine(static cfg => cfg.AllowClr());
@@ -173,7 +188,10 @@ Probe("delegate crossing: CLR Func<int, int> -> JS", static () =>
     // SetValue(string, Delegate), and SetValue<T>'s [DynamicallyAccessedMembers] then demands every
     // public method of Func<int, int> - including the inherited, [RequiresUnreferencedCode]
     // Delegate.CreateDelegate overloads. The embedder's own project gets six IL2026/IL2111
-    // diagnostics for a one-line registration; see the AOT section of Jint/Runtime/Interop/AGENTS.md.
+    // diagnostics for a one-line registration. The array half of this had the same cause and was
+    // fixable with an overload; this half is not, because a `where T : Delegate` overload would have
+    // the same signature as SetValue<T> after substitution and make every delegate call site
+    // ambiguous. See the AOT section of Jint/Runtime/Interop/AGENTS.md.
     engine.SetValue("twice", (Delegate) new Func<int, int>(static x => x * 2));
 
     Expect(8, engine.Evaluate("twice(4)"));

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
@@ -71,9 +71,11 @@ namespace Jint
         public Jint.Engine SetValue(string name, bool value) { }
         public Jint.Engine SetValue(string name, double value) { }
         public Jint.Engine SetValue(string name, int value) { }
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(@"The runtime type of obj is not known at the call site, so the members Jint resolves by reflection cannot be preserved by the trimmer, and a removed one reads as undefined rather than as an error. Prefer SetValue<T>(string, T), whose type parameter carries [DynamicallyAccessedMembers]; pass an already-built JsValue; or root the type yourself.")]
         public Jint.Engine SetValue(string name, object? obj) { }
         public Jint.Engine SetValue(string name, string? value) { }
         public Jint.Engine SetValue<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicEvents)]  T>(string name, T? obj) { }
+        public Jint.Engine SetValue<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicEvents)]  T>(string name, T[]? obj) { }
         public static Jint.Prepared<Acornima.Ast.Module> PrepareModule(string code, string? source = null, Jint.ModulePreparationOptions? options = null) { }
         public static Jint.Prepared<Acornima.Ast.Script> PrepareScript(string code, string? source = null, bool strict = false, Jint.ScriptPreparationOptions? options = null) { }
         public class AdvancedOperations
@@ -513,6 +515,7 @@ namespace Jint
     }
     public static class OptionsExtensions
     {
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(@"Extension methods are discovered by reflecting over the supplied types' public methods, which trimming can remove - and a removed one fails as 'not a function' rather than as an error. The parameter cannot carry DynamicallyAccessedMembers because it is an array, so root the declaring types yourself: <TrimmerRootAssembly Include=""YourAssembly"" /> or a [DynamicDependency] on each registered type.")]
         public static Jint.Options AddExtensionMethods(this Jint.Options options, params System.Type[] types) { }
         public static Jint.Options AddImmutableCrossing(this Jint.Options options, params System.Type[] types) { }
         public static Jint.Options AddLazyGlobal(this Jint.Options options, string name, System.Func<Jint.Engine, Jint.Native.JsValue> valueFactory, Jint.Runtime.Descriptors.PropertyFlag flags = 21) { }
@@ -520,7 +523,9 @@ namespace Jint
         public static Jint.Options AddObjectConverter(this Jint.Options options, Jint.Runtime.Interop.IObjectConverter objectConverter, params System.Type[] handledTypes) { }
         public static Jint.Options AddObjectConverter<T>(this Jint.Options options)
             where T : Jint.Runtime.Interop.IObjectConverter, new () { }
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(@"AllowClr lets script name CLR types and namespaces as strings, so nothing in the host statically references what it exposes and trimming is free to remove all of it. When trimming, either root the assemblies you allow (<TrimmerRootAssembly Include=""YourAssembly"" />) or do not call AllowClr at all and hand each type to script explicitly instead - Engine.SetValue<T>, TypeReference.CreateTypeReference<T> and ModuleBuilder.ExportType<T> carry [DynamicallyAccessedMembers] annotations that preserve exactly what Jint reflects over, and need no root.")]
         public static Jint.Options AllowClr(this Jint.Options options) { }
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(@"AllowClr lets script name CLR types and namespaces as strings, so nothing in the host statically references what it exposes and trimming is free to remove all of it. When trimming, either root the assemblies you allow (<TrimmerRootAssembly Include=""YourAssembly"" />) or do not call AllowClr at all and hand each type to script explicitly instead - Engine.SetValue<T>, TypeReference.CreateTypeReference<T> and ModuleBuilder.ExportType<T> carry [DynamicallyAccessedMembers] annotations that preserve exactly what Jint reflects over, and need no root.")]
         public static Jint.Options AllowClr(this Jint.Options options, params System.Reflection.Assembly[] assemblies) { }
         public static Jint.Options AllowClrWrite(this Jint.Options options, bool allow = true) { }
         public static Jint.Options AllowOperatorOverloading(this Jint.Options options, bool allow = true) { }
@@ -2312,6 +2317,7 @@ namespace Jint.Runtime.Interop
         public override bool Set(Jint.Native.JsValue property, Jint.Native.JsValue value, Jint.Native.JsValue receiver) { }
         protected override void SetOwnProperty(Jint.Native.JsValue property, Jint.Runtime.Descriptors.PropertyDescriptor desc) { }
         public override object ToObject() { }
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(@"Members are resolved from target's runtime type by reflection and cannot be preserved by the trimmer from this signature; a removed one reads as undefined rather than as an error. Root the type, or project it through Engine.SetValue<T> / TypeReference.CreateTypeReference<T>, which annotate what they reflect over.")]
         public static Jint.Native.Object.ObjectInstance Create(Jint.Engine engine, object target, System.Type? type = null) { }
         public static Jint.Runtime.Descriptors.PropertyDescriptor GetPropertyDescriptor(Jint.Engine engine, object target, System.Reflection.MemberInfo member) { }
     }

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net462.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net462.verified.txt
@@ -74,6 +74,7 @@ namespace Jint
         public Jint.Engine SetValue(string name, object? obj) { }
         public Jint.Engine SetValue(string name, string? value) { }
         public Jint.Engine SetValue<T>(string name, T? obj) { }
+        public Jint.Engine SetValue<T>(string name, T[]? obj) { }
         public static Jint.Prepared<Acornima.Ast.Module> PrepareModule(string code, string? source = null, Jint.ModulePreparationOptions? options = null) { }
         public static Jint.Prepared<Acornima.Ast.Script> PrepareScript(string code, string? source = null, bool strict = false, Jint.ScriptPreparationOptions? options = null) { }
         public class AdvancedOperations

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
@@ -71,9 +71,11 @@ namespace Jint
         public Jint.Engine SetValue(string name, bool value) { }
         public Jint.Engine SetValue(string name, double value) { }
         public Jint.Engine SetValue(string name, int value) { }
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(@"The runtime type of obj is not known at the call site, so the members Jint resolves by reflection cannot be preserved by the trimmer, and a removed one reads as undefined rather than as an error. Prefer SetValue<T>(string, T), whose type parameter carries [DynamicallyAccessedMembers]; pass an already-built JsValue; or root the type yourself.")]
         public Jint.Engine SetValue(string name, object? obj) { }
         public Jint.Engine SetValue(string name, string? value) { }
         public Jint.Engine SetValue<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicEvents)]  T>(string name, T? obj) { }
+        public Jint.Engine SetValue<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicEvents)]  T>(string name, T[]? obj) { }
         public static Jint.Prepared<Acornima.Ast.Module> PrepareModule(string code, string? source = null, Jint.ModulePreparationOptions? options = null) { }
         public static Jint.Prepared<Acornima.Ast.Script> PrepareScript(string code, string? source = null, bool strict = false, Jint.ScriptPreparationOptions? options = null) { }
         public class AdvancedOperations
@@ -513,6 +515,7 @@ namespace Jint
     }
     public static class OptionsExtensions
     {
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(@"Extension methods are discovered by reflecting over the supplied types' public methods, which trimming can remove - and a removed one fails as 'not a function' rather than as an error. The parameter cannot carry DynamicallyAccessedMembers because it is an array, so root the declaring types yourself: <TrimmerRootAssembly Include=""YourAssembly"" /> or a [DynamicDependency] on each registered type.")]
         public static Jint.Options AddExtensionMethods(this Jint.Options options, params System.Type[] types) { }
         public static Jint.Options AddImmutableCrossing(this Jint.Options options, params System.Type[] types) { }
         public static Jint.Options AddLazyGlobal(this Jint.Options options, string name, System.Func<Jint.Engine, Jint.Native.JsValue> valueFactory, Jint.Runtime.Descriptors.PropertyFlag flags = 21) { }
@@ -520,7 +523,9 @@ namespace Jint
         public static Jint.Options AddObjectConverter(this Jint.Options options, Jint.Runtime.Interop.IObjectConverter objectConverter, params System.Type[] handledTypes) { }
         public static Jint.Options AddObjectConverter<T>(this Jint.Options options)
             where T : Jint.Runtime.Interop.IObjectConverter, new () { }
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(@"AllowClr lets script name CLR types and namespaces as strings, so nothing in the host statically references what it exposes and trimming is free to remove all of it. When trimming, either root the assemblies you allow (<TrimmerRootAssembly Include=""YourAssembly"" />) or do not call AllowClr at all and hand each type to script explicitly instead - Engine.SetValue<T>, TypeReference.CreateTypeReference<T> and ModuleBuilder.ExportType<T> carry [DynamicallyAccessedMembers] annotations that preserve exactly what Jint reflects over, and need no root.")]
         public static Jint.Options AllowClr(this Jint.Options options) { }
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(@"AllowClr lets script name CLR types and namespaces as strings, so nothing in the host statically references what it exposes and trimming is free to remove all of it. When trimming, either root the assemblies you allow (<TrimmerRootAssembly Include=""YourAssembly"" />) or do not call AllowClr at all and hand each type to script explicitly instead - Engine.SetValue<T>, TypeReference.CreateTypeReference<T> and ModuleBuilder.ExportType<T> carry [DynamicallyAccessedMembers] annotations that preserve exactly what Jint reflects over, and need no root.")]
         public static Jint.Options AllowClr(this Jint.Options options, params System.Reflection.Assembly[] assemblies) { }
         public static Jint.Options AllowClrWrite(this Jint.Options options, bool allow = true) { }
         public static Jint.Options AllowOperatorOverloading(this Jint.Options options, bool allow = true) { }
@@ -2312,6 +2317,7 @@ namespace Jint.Runtime.Interop
         public override bool Set(Jint.Native.JsValue property, Jint.Native.JsValue value, Jint.Native.JsValue receiver) { }
         protected override void SetOwnProperty(Jint.Native.JsValue property, Jint.Runtime.Descriptors.PropertyDescriptor desc) { }
         public override object ToObject() { }
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(@"Members are resolved from target's runtime type by reflection and cannot be preserved by the trimmer from this signature; a removed one reads as undefined rather than as an error. Root the type, or project it through Engine.SetValue<T> / TypeReference.CreateTypeReference<T>, which annotate what they reflect over.")]
         public static Jint.Native.Object.ObjectInstance Create(Jint.Engine engine, object target, System.Type? type = null) { }
         public static Jint.Runtime.Descriptors.PropertyDescriptor GetPropertyDescriptor(Jint.Engine engine, object target, System.Reflection.MemberInfo member) { }
     }

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.0.verified.txt
@@ -74,6 +74,7 @@ namespace Jint
         public Jint.Engine SetValue(string name, object? obj) { }
         public Jint.Engine SetValue(string name, string? value) { }
         public Jint.Engine SetValue<T>(string name, T? obj) { }
+        public Jint.Engine SetValue<T>(string name, T[]? obj) { }
         public static Jint.Prepared<Acornima.Ast.Module> PrepareModule(string code, string? source = null, Jint.ModulePreparationOptions? options = null) { }
         public static Jint.Prepared<Acornima.Ast.Script> PrepareScript(string code, string? source = null, bool strict = false, Jint.ScriptPreparationOptions? options = null) { }
         public class AdvancedOperations

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.1.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.1.verified.txt
@@ -74,6 +74,7 @@ namespace Jint
         public Jint.Engine SetValue(string name, object? obj) { }
         public Jint.Engine SetValue(string name, string? value) { }
         public Jint.Engine SetValue<T>(string name, T? obj) { }
+        public Jint.Engine SetValue<T>(string name, T[]? obj) { }
         public static Jint.Prepared<Acornima.Ast.Module> PrepareModule(string code, string? source = null, Jint.ModulePreparationOptions? options = null) { }
         public static Jint.Prepared<Acornima.Ast.Script> PrepareScript(string code, string? source = null, bool strict = false, Jint.ScriptPreparationOptions? options = null) { }
         public class AdvancedOperations

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -1832,6 +1832,13 @@ public sealed partial class Engine : IDisposable
     /// <summary>
     /// Registers an object value as variable, creates an interop wrapper when needed.
     /// </summary>
+    /// <remarks>
+    /// This overload binds only where the argument's static type is <see cref="object"/> — a typed
+    /// variable picks <see cref="SetValue{T}(string, T)"/>, whose type parameter carries
+    /// <c>[DynamicallyAccessedMembers]</c> and therefore preserves what Jint reflects over. Here there is
+    /// no type to annotate, which is the whole of the difference.
+    /// </remarks>
+    [RequiresUnreferencedCode("The runtime type of obj is not known at the call site, so the members Jint resolves by reflection cannot be preserved by the trimmer, and a removed one reads as undefined rather than as an error. Prefer SetValue<T>(string, T), whose type parameter carries [DynamicallyAccessedMembers]; pass an already-built JsValue; or root the type yourself.")]
     public Engine SetValue(string name, object? obj)
     {
         using var ownership = EnterHostCall();
@@ -1862,6 +1869,34 @@ public sealed partial class Engine : IDisposable
         return obj is Type t
             ? SetValue(name, t)
             : SetValue(name, JsValue.FromObject(this, obj));
+    }
+
+    /// <summary>
+    /// Registers an array as variable, creates an interop wrapper when needed. Behaves exactly like
+    /// <see cref="SetValue{T}(string, T)"/>; it exists so that the annotation lands on the
+    /// <em>element</em> type.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// C# picks this over <see cref="SetValue{T}(string, T)"/> for any array argument, because a parameter
+    /// of type <c>T[]</c> is more specific than one of type <c>T</c>. Nothing about what the engine does
+    /// changes — both bodies are the same call — so this is purely about what a trimmer is told.
+    /// </para>
+    /// <para>
+    /// What it fixes is that <c>SetValue("items", companies)</c> used to infer <c>T = Company[]</c>, and
+    /// <c>[DynamicallyAccessedMembers]</c> on an array type preserves the public members of
+    /// <see cref="Array"/> — never <c>Company</c>'s. So the one thing script actually reaches,
+    /// <c>items[0].name</c>, was the one thing not preserved. Inferring <c>T = Company</c> annotates the
+    /// type whose members are resolved. It also spares an embedder four <c>IL3050</c> diagnostics per
+    /// registration: preserving all public methods of an array type reaches
+    /// <see cref="Array.CreateInstance(Type, int)"/> and its overloads, which are
+    /// <c>[RequiresDynamicCode]</c> and have nothing to do with reading elements.
+    /// </para>
+    /// </remarks>
+    public Engine SetValue<[DynamicallyAccessedMembers(InteropHelper.DefaultDynamicallyAccessedMemberTypes)] T>(string name, T[]? obj)
+    {
+        using var ownership = EnterHostCall();
+        return SetValue(name, JsValue.FromObject(this, obj));
     }
 
     internal void LeaveExecutionContext()

--- a/Jint/Jint.csproj
+++ b/Jint/Jint.csproj
@@ -24,7 +24,30 @@
          the assembly that owns those types has no one to acknowledge it to. -->
     <NoWarn>$(NoWarn);JINT0001</NoWarn>
 
-    <!-- TODO AOT improvements -->
+    <!--
+      Trim and AOT analysis, suppressed so that Jint's own build is green. Read this before assuming it
+      means anything to a consumer: NoWarn is a property of THIS compilation and reaches nothing
+      downstream. ILC re-derives every diagnostic when it compiles the closed program, so an embedder
+      publishing Native AOT sees all 115 of them attributed to Jint's files in their own build. The
+      same is true of a source `#pragma warning disable IL....`, which reaches Roslyn and not ILC;
+      [UnconditionalSuppressMessage] is the form ILC honours, and it asserts safety, so it needs a
+      justification that is true.
+
+      What actually substantiates the IsAotCompatible property below is the `aot` CI leg, which
+      publishes Jint.AotExample with PublishAot=true and RUNS the native binary. The warnings say what
+      might break; the run says what does.
+
+      Paying these down is https://github.com/sebastienros/jint/issues/3305, which carries the
+      inventory by code and by file and a suggested order. Almost all of them are dataflow - a Type
+      reaching a call that demands [DynamicallyAccessedMembers] - so each one is fixed by propagating
+      the annotation back to whoever produced the Type, and the propagation only terminates at a public
+      API. That is why removing this line is not one change: it turns ~104 diagnostics into build errors
+      at once, TreatWarningsAsErrors being on repository-wide.
+
+      Do not resolve one of these by annotating an API the measured run shows to work. An embedder who
+      learns to suppress [RequiresDynamicCode] on the APIs that are fine will suppress it on the ones
+      that are not.
+    -->
     <NoWarn>$(NoWarn);IL3050;IL2080;IL2075;IL2072;IL2070;IL2069;IL2067;IL2060;</NoWarn>
 
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>

--- a/Jint/Options.Extensions.cs
+++ b/Jint/Options.Extensions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
@@ -18,6 +19,12 @@ namespace Jint;
 /// </summary>
 public static class OptionsExtensions
 {
+    /// <summary>
+    /// Shared by both <c>AllowClr</c> overloads, so the two cannot drift.
+    /// </summary>
+    private const string AllowClrRequiresUnreferencedCodeMessage =
+        "AllowClr lets script name CLR types and namespaces as strings, so nothing in the host statically references what it exposes and trimming is free to remove all of it. When trimming, either root the assemblies you allow (<TrimmerRootAssembly Include=\"YourAssembly\" />) or do not call AllowClr at all and hand each type to script explicitly instead - Engine.SetValue<T>, TypeReference.CreateTypeReference<T> and ModuleBuilder.ExportType<T> carry [DynamicallyAccessedMembers] annotations that preserve exactly what Jint reflects over, and need no root.";
+
     /// <summary>
     /// Configures the engine to run untrusted JavaScript with a hardened static surface and explicit,
     /// request-appropriate resource limits.
@@ -380,6 +387,19 @@ public static class OptionsExtensions
         return options;
     }
 
+    /// <summary>
+    /// Registers types whose public static methods are offered to script as extension methods on their
+    /// first parameter's type.
+    /// </summary>
+    /// <remarks>
+    /// The types are scanned by reflection, and the parameter cannot say so to the trimmer:
+    /// <c>[DynamicallyAccessedMembers]</c> is only honoured on a <see cref="Type"/> or a
+    /// <see cref="string"/>, never on an array of them. So a trimmed build keeps this array's
+    /// <em>types</em> and can still drop the very methods being registered — and a dropped one is not an
+    /// error, it is <c>company.shout is not a function</c> with no diagnostic anywhere. Root the declaring
+    /// types when trimming.
+    /// </remarks>
+    [RequiresUnreferencedCode("Extension methods are discovered by reflecting over the supplied types' public methods, which trimming can remove - and a removed one fails as 'not a function' rather than as an error. The parameter cannot carry DynamicallyAccessedMembers because it is an array, so root the declaring types yourself: <TrimmerRootAssembly Include=\"YourAssembly\" /> or a [DynamicDependency] on each registered type.")]
     public static Options AddExtensionMethods(this Options options, params Type[] types)
     {
         options.Interop.ExtensionMethodTypes.AddRange(types);
@@ -438,6 +458,12 @@ public static class OptionsExtensions
     /// Allows scripts to resolve CLR types from the core assembly containing <see cref="object"/> through
     /// <c>System</c> and <c>importNamespace</c>.
     /// </summary>
+    /// <remarks>
+    /// Script names the types it wants as strings, so nothing in the host statically references what this
+    /// exposes and a trimmed build is free to remove all of it. Native AOT is a different question and a
+    /// milder one — most of what CLR interop does works there; see <c>docs/v5-migration.md</c>.
+    /// </remarks>
+    [RequiresUnreferencedCode(AllowClrRequiresUnreferencedCodeMessage)]
     public static Options AllowClr(this Options options)
     {
         options.Interop.Enabled = true;
@@ -455,6 +481,7 @@ public static class OptionsExtensions
     /// The supplied assemblies are a closed namespace-resolution allow-list. They do not restrict CLR objects,
     /// delegates, or <see cref="TypeReference"/> values explicitly exported by the host.
     /// </remarks>
+    [RequiresUnreferencedCode(AllowClrRequiresUnreferencedCodeMessage)]
     public static Options AllowClr(this Options options, params Assembly[] assemblies)
     {
         options.Interop.Enabled = true;

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -1,4 +1,5 @@
-﻿using System.Dynamic;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Dynamic;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
@@ -772,8 +773,25 @@ public sealed partial class Options
         /// ObjectInstance using class ObjectWrapper. This function can be used to
         /// change the behavior.
         /// </summary>
-        internal static readonly WrapObjectDelegate _defaultWrapObjectHandler =
-            static (engine, target, type) => ObjectWrapper.Create(engine, target, type);
+        internal static readonly WrapObjectDelegate _defaultWrapObjectHandler = DefaultWrapObject;
+
+        /// <summary>
+        /// The engine's own projection funnel: every host object that reaches script without a more
+        /// specific conversion arrives here.
+        /// </summary>
+        /// <remarks>
+        /// It cannot carry <c>[RequiresUnreferencedCode]</c> itself — it has to be assignable to the public
+        /// <see cref="WrapObjectDelegate"/>, and a host replacing the handler would then be unable to call
+        /// back into it. The requirement is declared where a host can act on it instead: on
+        /// <see cref="OptionsExtensions.AllowClr(Options)"/>, on <see cref="Engine.SetValue(string, object)"/>,
+        /// and on <see cref="ObjectWrapper.Create"/> itself, which is what a custom handler calls.
+        /// The suppression is <see cref="UnconditionalSuppressMessageAttribute"/> rather than a
+        /// <c>#pragma</c> because a pragma reaches Roslyn and not ILC, which re-derives every diagnostic
+        /// over the closed program.
+        /// </remarks>
+        [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Declared on the public entry points a host object crosses to get here: OptionsExtensions.AllowClr, Engine.SetValue(string, object), ObjectWrapper.Create.")]
+        private static ObjectInstance DefaultWrapObject(Engine engine, object target, Type? type)
+            => ObjectWrapper.Create(engine, target, type);
 
         public WrapObjectDelegate WrapObjectHandler { get; set; } = _defaultWrapObjectHandler;
 

--- a/Jint/Runtime/Interop/AGENTS.md
+++ b/Jint/Runtime/Interop/AGENTS.md
@@ -89,7 +89,7 @@ saying it is deliberately not `NotSupportedException`.
    where the lane is generic. A `KnownAotGap` is for a shape that must *keep* throwing; it is checked
    in both directions, so a gap that closes fails the leg.
 
-The six annotated members today are `OptionsExtensions.AllowClr` (both overloads),
+The seven annotated members today are `OptionsExtensions.AllowClr` (two overloads),
 `OptionsExtensions.AddExtensionMethods`, `Engine.SetValue(string, object?)`, `ObjectWrapper.Create`, and
 `ClrHelper.Unwrap` / `Wrap`. `JsValue.FromObject` is deliberately not among them: it is the engine's own
 conversion funnel with ~60 call sites inside Jint, the interpreter's operator-overloading path among

--- a/Jint/Runtime/Interop/AGENTS.md
+++ b/Jint/Runtime/Interop/AGENTS.md
@@ -16,60 +16,111 @@ rest of the list is split across the files indexed from the repository-root [`AG
 - **Dictionary-valued reads re-wrap on every access, and only a host promise can stop them.** `record.value.customer.country` over a wrapped `JsonObject`/`IDictionary` resolves each level through the dictionary lane, which probes the target and converts the value afresh every time — the read itself is compiled, but its *result* was never cached, and the bounded recent-wrapper ring (8 slots) cannot hold a nested walk's nodes. The engine cannot fix this alone: a value-identity change inside the host's dictionary is invisible to it. `Options.AddImmutableCrossing(params Type[])` supplies the missing fact — instances of the declared types, while exposed to this engine, are immutable — and in exchange an `ObjectWrapper` over such a target memoizes each key's resolved descriptor, so a repeated read touches neither reflection nor the indexer and each child node is wrapped once per wrapper lifetime. Assignability is the rule (an interface covers its implementations), and unlike `ObjectConverterTypeFilter` this one never guesses in the permissive direction — a wrong claim here would serve stale reads rather than merely cost a fast lane, so an open generic declaration claims nothing. Three things to know before relying on it. The memo lives in a **store of its own**, not in `_properties`: enumeration stays live from the target (a key added CLR-side afterwards still enumerates), no `_propertiesVersion` is bumped, and anything a script actually defines — `Object.freeze`, `Object.defineProperty`, a host `SetOwnProperty` — outranks it and drops it. A **write** through the wrapper evicts that key's memo, which is insurance for the host that was wrong and not a licence to be; write behaviour itself is unchanged. And the memo is **per wrapper**, so it only pays while the wrapper is alive — a stable root (anything reached through `Engine.SetValue`) memoizes its whole subtree, but a node reached through a transient wrapper, such as an element of a wrapped list, still re-resolves on each crossing; that lane is the ring's job, or `TrackObjectWrapperIdentity`'s. The same promise also reaches reflected members, where `ReflectionDescriptor` stops invoking the CLR getter entirely after the first read, superseding both `CacheRecentObjectWrappers` and `TrackObjectWrapperIdentity` for a declared type. No promise is needed for questions *about* the keys rather than their values: `ObjectWrapper.ProbeOwnProperty` answers a string-keyed generic dictionary from the target's own `ContainsKey`, so `in`, `hasOwnProperty`, `propertyIsEnumerable`, `Object.keys`/`values`/`entries`, `for..in`, `Object.assign`, spread and `JSON.stringify` stop converting a value and building a descriptor per key only to discard both. That lane never decides a key is *missing* — a `false` falls through to the descriptor path, because a dictionary wrapper still resolves CLR members for names the dictionary does not carry — so the only way it can disagree with `GetOwnProperty` is a target whose own `ContainsKey` and `TryGetValue` disagree with each other.
 - **A non-default `IReferenceResolver` used to disable the member and call inline caches engine-wide.** It can now declare `ReferenceResolverInterests` at registration or via `Options.ReferenceResolverInterests`. The scope was always the non-computed member-read caches, the dense-array indexed-read lane and the member-call callee lane; identifier caches were never affected.
 
-### Native AOT: what is measured, and what is still only asserted
+### Native AOT: what is measured, what is annotated, and what is still suppressed
 
 `Jint.csproj` sets `<IsAotCompatible>` for net7.0+ and, in the same property group, suppresses eight IL
-codes — `IL3050` (*requires dynamic code*, the one that says an API cannot work under Native AOT) plus
-`IL2060`, `IL2067`, `IL2069`, `IL2070`, `IL2072`, `IL2075`, `IL2080`. **The property is not evidence, and
-the suppressions are why.** Nothing about them has changed; what has changed is that a CI leg now
-publishes `Jint.AotExample` with `PublishAot=true` and *runs the native binary* (`aot` in
-`.github/workflows/pr.yml` and `build.yml`), because the run is the only thing that distinguishes a
-warning that matters from one that does not.
+codes — `IL3050` (*requires dynamic code*) plus `IL2060`, `IL2067`, `IL2069`, `IL2070`, `IL2072`,
+`IL2075`, `IL2080`. **The property is not evidence, and the suppressions are why.** What makes the
+claim checkable is that a CI leg publishes `Jint.AotExample` with `PublishAot=true` and *runs the
+native binary* (`aot` in `.github/workflows/pr.yml` and `build.yml`), because the run is the only thing
+that distinguishes a warning that matters from one that does not.
 
 Two facts about the suppressions are worth knowing before trusting either of them. Jint's `NoWarn` is a
-property of Jint's own *compilation* and reaches nothing downstream: ILC re-derives the whole set when it
-compiles the closed program, so **an embedder publishing Native AOT sees all 122 of them**, attributed to
-Jint's files, in their build. And a source `#pragma warning disable IL3050` — `ObjectWrapper` has
-several — is Roslyn-only for the same reason; `[UnconditionalSuppressMessage]` is the one ILC honours.
+property of Jint's own *compilation* and reaches nothing downstream: ILC re-derives the whole set when
+it compiles the closed program, so **an embedder publishing Native AOT sees all of them**, attributed
+to Jint's files, in their build. And a source `#pragma warning disable IL3050` — `ObjectWrapper` has
+several — is Roslyn-only for the same reason; `[UnconditionalSuppressMessage]` is the one ILC honours,
+and is what to reach for when a suppression is genuinely justified. Paying the remaining 115 down is
+[#3305](https://github.com/sebastienros/jint/issues/3305), which carries the inventory by code and by
+file, why it is not one change, and a suggested order; `Jint.csproj`'s own comment says the same.
 
-What the leg proves today: an engine with `AllowClr()` reading properties, fields, indexers and methods
-off a host object works natively, as do arrays, `Dictionary<,>`, delegates in both directions, extension
-methods, `TypeReference` construction, JSON, promises, and an `Interop.Enabled = false` engine. What it
-proves does *not* work is one shape, in five places — **a generic instantiation over a value type built at
-run time**. Reference-type arguments share canonical code and are fine; `int`, `double` and friends need a
-specific instantiation ILC never saw, and raise `NotSupportedException` at the crossing:
+#### What the leg proves
 
-| site | shape | fails as |
+An engine with `AllowClr()` reading properties, fields, indexers and methods off a host object works
+natively, as do `T[]`, `List<T>`, `IReadOnlyList<T>`, `IEnumerable<T>`, `Dictionary<,>`, delegates in
+both directions, extension methods, `TypeReference` construction, JSON, promises, and an
+`Interop.Enabled = false` engine. What it proves does *not* work is one shape — **a generic
+instantiation over a value type built at run time**. Reference-type arguments share canonical code and
+are fine; `int`, `double` and friends need a specific instantiation ILC never saw.
+
+Five sites had that shape ([#3299](https://github.com/sebastienros/jint/issues/3299)). Three now
+degrade; two still throw, and that is the interesting half:
+
+| site | shape | today |
 | --- | --- | --- |
-| `ObjectWrapper.TryBuildArrayLikeWrapper` | `typeof(GenericListWrapperFactory<>).MakeGenericType(int)` | `List<int>` reaching script |
-| `ObjectWrapper.TryBuildArrayLikeWrapper` | `typeof(ReadOnlyListWrapperFactory<>).MakeGenericType(double)` | `IReadOnlyList<double>` reaching script |
-| `ObjectWrapper.ResolveEnumerableSnapshotFactory` | `typeof(EnumerableSnapshotFactory<>).MakeGenericType(int)` | `IEnumerable<int>` under `EnumerableConversionMode.Snapshot` |
-| `DefaultTypeConverter.GetFromResultMethod` | `Task.FromResult<double>` through `MakeGenericMethod` | a JS function converted to `Func<double, Task<double>>` |
-| `MethodInfoFunction.ResolveMethod` | `methodInfo.MakeGenericMethod(double)` | any generic host method called with a number |
+| `ObjectWrapper.TryBuildArrayLikeWrapper` | `GenericListWrapperFactory<int>` | degrades to `ListWrapper` |
+| same site, `IReadOnlyList<>` branch | `ReadOnlyListWrapperFactory<double>` | degrades to a plain `ObjectWrapper` (loses array-likeness, keeps the indexer) |
+| `ObjectWrapper.ResolveEnumerableSnapshotFactory` | `EnumerableSnapshotFactory<int>` | degrades to `ObjectEnumerableSnapshotFactory` |
+| `DefaultTypeConverter.GetFromResultMethod` | `Task.FromResult<double>` | throws `NotSupportedException` |
+| `MethodInfoFunction.ResolveMethod` | `methodInfo.MakeGenericMethod(double)` | throws `NotSupportedException` |
 
-The first three already carry a `catch (MissingMethodException)` fallback written for exactly this
-scenario, and **it never engages**: Native AOT raises `NotSupportedException` from
-`Activator.CreateInstance`, not `MissingMethodException`, so the non-generic `ListWrapper` /
-`ObjectEnumerableSnapshotFactory` fallback beside it is dead code under AOT. Do not add another such
-fallback without checking which exception the runtime actually throws. All five rows, and what a fix
-would have to decide, are [issue #3299](https://github.com/sebastienros/jint/issues/3299); none is fixed
-yet, and **not one member is annotated `[RequiresDynamicCode]`**, so an embedder's first warning is the
-run-time throw.
+The three that degrade do so through `ObjectWrapper.IsMissingGenericInstantiation`, which catches
+`NotSupportedException` as well as the `MissingMethodException` the original `catch` named. **The
+original never fired**: Native AOT raises `NotSupportedException` from `Activator.CreateInstance`, so
+the fallback beside it was dead code exactly where it was needed. Do not add another such fallback
+without checking which exception the runtime actually throws.
 
-Two costs land in the *embedder's* project rather than in Jint's, both from
-`Engine.SetValue<T>`'s `[DynamicallyAccessedMembers]`, and both from ordinary one-line registrations. An
-uncast `SetValue("f", new Func<int, int>(…))` binds to `SetValue<T>` rather than to
-`SetValue(string, Delegate)`, and the annotation then demands every public method of `Func<int, int>` —
-including the inherited, `[RequiresUnreferencedCode]` `Delegate.CreateDelegate` overloads: six IL2026 and
-IL2111 **errors** in the host's own build, cleared by casting to `Delegate`. `SetValue("a", new[] { 1, 2, 3 })`
-costs four IL3050 the same way, through `Array.CreateInstance`. Widening either annotation is not the fix;
-knowing that the annotation is what an embedder pays is the point.
+**The last two are not oversights, and must not be "fixed" by widening a `catch`.** Neither has a
+non-generic answer to degrade *to*: nothing produces a `Task<double>` without `Task.FromResult<double>`,
+and `ResolveMethod` returning `null` means *this candidate does not apply*, so swallowing the failure
+would report "no matching overload" for a method that plainly exists. Both would trade a diagnosable
+throw for a wrong answer, which is why `ResolveMethod`'s `catch (ArgumentException)` carries a comment
+saying it is deliberately not `NotSupportedException`.
 
-`Jint.AotExample/Program.cs` pins all of this in both directions. A `Probe` must pass on every runtime; a
-`KnownAotGap` must pass under a JIT **and** throw under Native AOT, so a gap that closes fails the leg and
-forces the file to be updated — the same discipline as the web-platform-tests exclusion table. Treat the
-run as an upper bound rather than a lower one: the example roots the whole `Jint` assembly, which a real
-embedder would not do. It roots its own assembly too, and that one is not cosmetic — without it the
-trimmer removes an extension method nothing calls from C#, and `company.shout()` fails as *not a function*
-with no AOT diagnostic anywhere. Reflection-reached host types need rooting; the failure mode is a wrong
-answer, not an error.
+#### The rule for new work here
+
+**A new reflection lane needs an annotation and a probe.** Concretely, when you add one:
+
+1. Decide what it *requires*, and say so on the public entry point that reaches it.
+   `[RequiresUnreferencedCode]` when behaviour depends on metadata a trimmer may remove;
+   `[RequiresDynamicCode]` only when the thing genuinely cannot work natively — the measurement above
+   is the standard of proof, not the ILC warning count. Over-annotating is worse than not annotating:
+   it teaches an embedder to suppress the diagnostic on APIs that are fine.
+2. Prefer `[DynamicallyAccessedMembers]` wherever a `Type` or a type parameter is in the signature. It
+   *preserves* what you reflect over instead of merely warning, and it is why `SetValue<T>`,
+   `SetValue(string, Type)`, `TypeReference.CreateTypeReference` and `ModuleBuilder.ExportType` carry
+   no `[RequiresUnreferencedCode]` and never should. Note that the attribute is honoured on a `Type` or
+   a `string` only — never on a `Type[]`, which is why `Options.AddExtensionMethods` had to take the
+   `[RequiresUnreferencedCode]` instead.
+3. Annotate the *element*, not the container. `SetValue<T>(string, T[])` exists because inferring
+   `T = Company[]` preserved `System.Array`'s members and left `companies[0].name` — the one thing
+   script reaches — to be trimmed away.
+4. Add a `Probe` to `Jint.AotExample/Program.cs`, with a sibling using the other kind of type argument
+   where the lane is generic. A `KnownAotGap` is for a shape that must *keep* throwing; it is checked
+   in both directions, so a gap that closes fails the leg.
+
+The six annotated members today are `OptionsExtensions.AllowClr` (both overloads),
+`OptionsExtensions.AddExtensionMethods`, `Engine.SetValue(string, object?)`, `ObjectWrapper.Create`, and
+`ClrHelper.Unwrap` / `Wrap`. `JsValue.FromObject` is deliberately not among them: it is the engine's own
+conversion funnel with ~60 call sites inside Jint, the interpreter's operator-overloading path among
+them, so annotating it would either cascade `[RequiresUnreferencedCode]` across the interpreter or need
+a suppression per site. `Options.InteropOptions._defaultWrapObjectHandler` carries the one
+`[UnconditionalSuppressMessage]`, because it has to stay assignable to the public `WrapObjectDelegate`.
+
+#### Two costs that land in the embedder's project
+
+Both come from `Engine.SetValue<T>`'s `[DynamicallyAccessedMembers]`, and from a one-line registration
+in the *host's* code. The array half is fixed; the delegate half is not, and the asymmetry is the point.
+
+* `SetValue("a", new[] { 1, 2, 3 })` cost four `IL3050` through `Array.CreateInstance`, because
+  preserving all public methods of an array type reaches it. `SetValue<T>(string, T[])` now wins
+  overload resolution for any array (`T[]` is more specific than `T`) and infers `T = int`. Gone.
+* `SetValue("f", new Func<int, int>(…))` binds to `SetValue<T>` rather than to
+  `SetValue(string, Delegate)`, and the annotation then demands every public method of
+  `Func<int, int>` — including the inherited, `[RequiresUnreferencedCode]` `Delegate.CreateDelegate`
+  overloads: three `IL2026` and three `IL2111` **as errors** in the host's build, cleared by casting to
+  `Delegate`. **The same trick does not work here**: an overload constrained `where T : Delegate` has
+  the same signature as `SetValue<T>` after substitution and would make every delegate call site
+  ambiguous. Widening the annotation is not the fix either; knowing that the annotation is what an
+  embedder pays is the point.
+
+#### Reading the example
+
+`Jint.AotExample/Program.cs` pins all of this in both directions, and its csproj records why it
+suppresses `IL2026` and `IL3000` rather than silencing them at a call site. Treat the run as an upper
+bound rather than a lower one: the example roots the whole `Jint` assembly, which a real embedder would
+not do. It roots its own assembly too, and that one is not cosmetic — without it the trimmer removes an
+extension method nothing calls from C#, and `company.shout()` fails as *not a function* with no AOT
+diagnostic anywhere. Reflection-reached host types need rooting; the failure mode is a wrong answer,
+not an error. The embedder-facing form of all of it is section 6 of
+[`docs/v5-migration.md`](../../../docs/v5-migration.md).

--- a/Jint/Runtime/Interop/ClrHelper.cs
+++ b/Jint/Runtime/Interop/ClrHelper.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using Jint.Native;
 
 namespace Jint.Runtime.Interop;
@@ -34,6 +35,7 @@ internal sealed class ClrHelper
     /// <summary>
     /// Cast `obj as ISomeInterface` to `obj`
     /// </summary>
+    [RequiresUnreferencedCode("Re-projects the target on its own runtime type, whose members are resolved by reflection. Reachable only from script, on an engine whose host enabled CLR interop.")]
 #pragma warning disable CA1822
     public JsValue Unwrap(ObjectWrapper obj)
 #pragma warning restore CA1822
@@ -46,6 +48,7 @@ internal sealed class ClrHelper
     /// <summary>
     /// Cast `obj` to `obj as ISomeInterface`
     /// </summary>
+    [RequiresUnreferencedCode("Re-projects the target on a script-chosen interface, whose members are resolved by reflection. Reachable only from script, on an engine whose host enabled CLR interop.")]
 #pragma warning disable CA1822
     public JsValue Wrap(ObjectWrapper obj, TypeReference type)
 #pragma warning restore CA1822

--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -138,6 +138,13 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
     /// <summary>
     /// Creates a new object wrapper for given object instance and exposed type.
     /// </summary>
+    /// <remarks>
+    /// Everything this projects is resolved from <paramref name="target"/>'s runtime type by reflection.
+    /// Neither parameter can say so to the trimmer — <c>object</c> cannot carry
+    /// <c>[DynamicallyAccessedMembers]</c> at all, and the optional <c>type</c> is a hint about which type
+    /// to expose rather than a promise that its members survive.
+    /// </remarks>
+    [RequiresUnreferencedCode("Members are resolved from target's runtime type by reflection and cannot be preserved by the trimmer from this signature; a removed one reads as undefined rather than as an error. Root the type, or project it through Engine.SetValue<T> / TypeReference.CreateTypeReference<T>, which annotate what they reflect over.")]
     public static ObjectInstance Create(Engine engine, object target, Type? type = null)
     {
         if (target == null)

--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -177,63 +177,15 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
         // virtual call into the cached factory
         var factory = _arrayLikeWrapperResolution.GetOrAdd(type, static t =>
         {
-#pragma warning disable IL2055
-#pragma warning disable IL2070
-#pragma warning disable IL3050
-
-            Type? factoryType = null;
-
-            // single-rank zero-based CLR arrays (T[]) get a fixed-size live wrapper; T[] implements
-            // IList<T> and would otherwise flow into GenericListWrapper<T> below, whose growth paths
-            // call IList<T>.Add and would leak NotSupportedException from the underlying array.
-            // The MakeArrayType equality intentionally excludes multi-rank (T[,]) and non-zero-based
-            // (T[*]) arrays, which keep their previous handling.
-            if (t.IsArray && t.GetElementType() is { } elementType && t == elementType.MakeArrayType())
-            {
-                factoryType = typeof(ArrayWrapperFactory<>).MakeGenericType(elementType);
-            }
-            else
-            {
-                // check for generic interfaces
-                foreach (var i in t.GetInterfaces())
-                {
-                    if (!i.IsGenericType)
-                    {
-                        continue;
-                    }
-
-                    var arrayItemType = i.GenericTypeArguments[0];
-
-                    if (i.GetGenericTypeDefinition() == typeof(IList<>))
-                    {
-                        factoryType = typeof(GenericListWrapperFactory<>).MakeGenericType(arrayItemType);
-                        break;
-                    }
-
-                    if (i.GetGenericTypeDefinition() == typeof(IReadOnlyList<>))
-                    {
-                        factoryType = typeof(ReadOnlyListWrapperFactory<>).MakeGenericType(arrayItemType);
-                        break;
-                    }
-                }
-            }
-#pragma warning restore IL3050
-#pragma warning restore IL2070
-#pragma warning restore IL2055
-
-            if (factoryType is null)
-            {
-                return null;
-            }
-
-            // Activator.CreateInstance may fail in trimmed/AOT scenarios where the constructor
-            // was removed by the linker - fall back to the non-generic ListWrapper in that case
             try
             {
-                return (ArrayLikeWrapperFactory) Activator.CreateInstance(factoryType)!;
+                var factoryType = ResolveArrayLikeWrapperFactoryType(t);
+                return factoryType is null ? null : (ArrayLikeWrapperFactory) Activator.CreateInstance(factoryType)!;
             }
-            catch (MissingMethodException)
+            catch (Exception e) when (IsMissingGenericInstantiation(e))
             {
+                // no typed factory on this runtime; the caller degrades to the non-generic ListWrapper,
+                // or to a plain ObjectWrapper when the target is not even an IList
                 return null;
             }
         });
@@ -267,6 +219,84 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
         return result is not null;
     }
 
+    /// <summary>
+    /// The closed factory type for <paramref name="t"/>, or <see langword="null"/> when it is not array-like.
+    /// Split out of the resolution above so that the instantiation and the activation sit under one
+    /// <c>try</c>: both are ways of asking for a generic instantiation, and either can be the one a runtime
+    /// declines.
+    /// </summary>
+    private static Type? ResolveArrayLikeWrapperFactoryType(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type t)
+    {
+#pragma warning disable IL2055
+#pragma warning disable IL2070
+#pragma warning disable IL3050
+
+        // single-rank zero-based CLR arrays (T[]) get a fixed-size live wrapper; T[] implements
+        // IList<T> and would otherwise flow into GenericListWrapper<T> below, whose growth paths
+        // call IList<T>.Add and would leak NotSupportedException from the underlying array.
+        // The MakeArrayType equality intentionally excludes multi-rank (T[,]) and non-zero-based
+        // (T[*]) arrays, which keep their previous handling.
+        if (t.IsArray && t.GetElementType() is { } elementType && t == elementType.MakeArrayType())
+        {
+            return typeof(ArrayWrapperFactory<>).MakeGenericType(elementType);
+        }
+
+        // check for generic interfaces
+        foreach (var i in t.GetInterfaces())
+        {
+            if (!i.IsGenericType)
+            {
+                continue;
+            }
+
+            var arrayItemType = i.GenericTypeArguments[0];
+
+            if (i.GetGenericTypeDefinition() == typeof(IList<>))
+            {
+                return typeof(GenericListWrapperFactory<>).MakeGenericType(arrayItemType);
+            }
+
+            if (i.GetGenericTypeDefinition() == typeof(IReadOnlyList<>))
+            {
+                return typeof(ReadOnlyListWrapperFactory<>).MakeGenericType(arrayItemType);
+            }
+        }
+
+#pragma warning restore IL3050
+#pragma warning restore IL2070
+#pragma warning restore IL2055
+
+        return null;
+    }
+
+    /// <summary>
+    /// Whether <paramref name="e"/> is a runtime refusing to produce a generic instantiation it was not
+    /// built with, which is the one failure the typed-factory sites above are allowed to degrade from.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="MissingMethodException"/> is the trimmed-assembly case the original <c>catch</c> was
+    /// written for: the closed factory survived but its constructor did not. It never fired on the runtime
+    /// that actually needs it. Native AOT shares one canonical body across every reference-type argument,
+    /// so <c>GenericListWrapperFactory&lt;string&gt;</c> works while <c>GenericListWrapperFactory&lt;int&gt;</c>
+    /// needs native code only a compile-time sighting would have produced — and asking for it raises
+    /// <see cref="NotSupportedException"/> ("is missing native code or metadata"), which walked straight past
+    /// a <c>catch (MissingMethodException)</c> and into script (#3299).
+    /// </para>
+    /// <para>
+    /// Neither exception can mean anything else at these two sites, which is what makes catching them safe:
+    /// the argument is a type that already crossed into the engine, the factories are Jint's own internal
+    /// sealed types, and each has a public parameterless constructor that does nothing. Anything a factory's
+    /// constructor could itself throw arrives wrapped in a <see cref="TargetInvocationException"/> and is not
+    /// caught here. This is deliberately not applied to <c>MethodInfoFunction.ResolveMethod</c> or to
+    /// <c>DefaultTypeConverter.GetFromResultMethod</c>, where there is no non-generic answer to degrade to
+    /// and swallowing the failure would produce a wrong result rather than a slower one.
+    /// </para>
+    /// </remarks>
+    private static bool IsMissingGenericInstantiation(Exception e)
+        => e is NotSupportedException or MissingMethodException;
+
     private static readonly ConcurrentDictionary<Type, EnumerableSnapshotFactory> _enumerableSnapshotResolution = new();
 
     private static EnumerableSnapshotFactory ResolveEnumerableSnapshotFactory(
@@ -286,9 +316,10 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
                         var factoryType = typeof(EnumerableSnapshotFactory<>).MakeGenericType(i.GenericTypeArguments[0]);
                         return (EnumerableSnapshotFactory) Activator.CreateInstance(factoryType)!;
                     }
-                    catch (MissingMethodException)
+                    catch (Exception e) when (IsMissingGenericInstantiation(e))
                     {
-                        // trimmed/AOT: the closed factory was removed, snapshot as objects instead
+                        // trimmed, or Native AOT with no code for this instantiation: snapshot as
+                        // objects instead. See IsMissingGenericInstantiation for why both exceptions.
                         break;
                     }
                 }

--- a/Jint/Runtime/Interop/Reflection/ReflectionAccessor.cs
+++ b/Jint/Runtime/Interop/Reflection/ReflectionAccessor.cs
@@ -209,7 +209,15 @@ internal abstract class ReflectionAccessor
         engine.CheckAmortizedConstraintsAtHostBoundary();
     }
 
-    protected virtual object? ConvertValueToSet(Engine engine, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicFields)] object value)
+    /// <remarks>
+    /// <paramref name="value"/> carried a <c>[DynamicallyAccessedMembers]</c> annotation until it was
+    /// noticed that the attribute is honoured only on a <see cref="Type"/> or a <see cref="string"/>
+    /// parameter — on an <see cref="object"/> it is inert, which is what <c>IL2098</c> was reporting in
+    /// every embedder's Native AOT publish. The requirement it meant to express is not expressible from
+    /// here: the conversion target is <c>_memberType</c> when there is one and <c>value.GetType()</c>
+    /// otherwise, and neither is a parameter the caller could annotate.
+    /// </remarks>
+    protected virtual object? ConvertValueToSet(Engine engine, object value)
     {
         var memberType = _memberType ?? value.GetType();
         return engine.TypeConverter.Convert(value, memberType, CultureInfo.InvariantCulture);

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -12,7 +12,7 @@ withdrawn before it ships. Anything not listed here is intended to keep working 
 - [3. Renamed and reshaped API](#3-renamed-and-reshaped-api)
 - [4. Breaking without a signature change](#4-breaking-without-a-signature-change)
 - [5. New in v5](#5-new-in-v5)
-- [6. AOT](#6-aot)
+- [6. AOT and trimming](#6-aot-and-trimming)
 - [Keeping this document current](#keeping-this-document-current)
 
 ## 1. Target frameworks
@@ -377,13 +377,130 @@ changes an engine that does not.
 | Statement-level code coverage | `options.Coverage.Enabled = true` | [Code coverage (opt-in)](../README.md#code-coverage-opt-in) |
 | `NamedPropertyObject` — one base class for a host object projecting *named* properties, the string-keyed sibling of `ArrayLikeObject` | derive from it instead of overriding `GetOwnProperty` / `ProbeOwnProperty` / `GetOwnPropertyKeys` / `TryGetOwnPropertyValue` / `GetOwnProperties` by hand | [Projecting host data](../README.md#embedding-performance) |
 
-## 6. AOT
+## 6. AOT and trimming
 
-*Not yet written.* A separate task is measuring the current NativeAOT and trimming state; this
-section will record what works, what warns, and what a trimmed host has to configure.
+Jint 4.16 asserted Native AOT compatibility with the `IsAotCompatible` property and nothing else. In
+v5 the claim is measured: a CI leg publishes `Jint.AotExample` with `PublishAot=true` and *runs* the
+native binary ([#3300](https://github.com/sebastienros/jint/pull/3300)), and this section is what that
+run says. `Jint.AotExample/Program.cs` is the worked example and the executable form of every claim
+below.
 
-`Jint.csproj` sets `IsAotCompatible` for net7.0+ targets, and `Jint.AotExample/` is the worked
-example.
+### 6.1 What works natively
+
+Everything a script does inside the engine - the language, `JSON`, `RegExp`, promises, `async`,
+modules - needs no reflection and works natively. So does the great majority of CLR interop, which is
+the part that was never certain:
+
+| | |
+| --- | --- |
+| properties, fields, indexers, methods on a host object | works |
+| `T[]`, `List<T>`, `IReadOnlyList<T>`, `IEnumerable<T>`, `Dictionary<K,V>` | works |
+| delegates in both directions (`Func<int, int>` to and from script) | works |
+| extension methods, `TypeReference` construction from script | works |
+| generic host methods with a **reference-type** argument | works |
+| an engine with `options.Interop.Enabled = false` | works, and needs none of this section |
+
+### 6.2 The one thing that does not: a generic instantiation over a value type
+
+Native AOT shares one compiled body across every reference-type argument, so `Identity<string>` works.
+A value-type argument needs a specific instantiation the compiler had to have seen, and two places in
+Jint build one at run time:
+
+| shape | script that reaches it | what you get |
+| --- | --- | --- |
+| a JS function converted to `Func<double, Task<double>>` (any `Task<T>` / `ValueTask<T>` over a value type) | calling a host method that takes such a delegate | `NotSupportedException` |
+| a generic host method called with a number | `host.identity(7)` - `host.identity('hi')` is fine | `NotSupportedException` |
+
+Both throw rather than degrade, deliberately: there is no non-generic way to produce a `Task<double>`,
+and declining the generic method would report *no matching overload* for a method that plainly exists.
+A wrong answer is worse than a diagnosable throw. If you need either shape under Native AOT, give the
+host method a non-generic overload, or take `Task<object>` and box.
+
+Three shapes that used to throw here now degrade instead
+([#3299](https://github.com/sebastienros/jint/issues/3299)): `List<int>`, `IReadOnlyList<double>` and
+an `IEnumerable<int>` under `EnumerableConversionMode.Snapshot` fall back to an untyped wrapper and
+answer correctly. The only loss is that a collection reached through the last-resort fallback is not
+array-*like*: `IReadOnlyList<double>` keeps `ro[0]` but loses `ro.length` and the `Array.prototype`
+generics unless the type also implements `IList`.
+
+### 6.3 APIs that now warn
+
+Six members carry `[RequiresUnreferencedCode]`, so a trimming or AOT host sees the diagnostic at their
+own call site rather than as a wrong answer at run time. Each message names what to do instead.
+
+| member | why | what to do |
+| --- | --- | --- |
+| `Options.AllowClr()` and `AllowClr(params Assembly[])` | script names CLR types and namespaces as strings; nothing statically references what they expose | root the assemblies you allow, or drop `AllowClr` and hand each type to script explicitly |
+| `Options.AddExtensionMethods(params Type[])` | the types are reflected over, and a `Type[]` parameter cannot carry `[DynamicallyAccessedMembers]` - only a `Type` or a `string` can | root the declaring types; a trimmed-away extension method fails as `not a function`, with no diagnostic |
+| `Engine.SetValue(string, object?)` | no type at the call site to annotate | prefer `SetValue<T>(string, T)`, or pass a `JsValue` |
+| `ObjectWrapper.Create(Engine, object, Type?)` | same - and it is what a custom `WrapObjectHandler` calls | root the type, or project through `SetValue<T>` |
+
+(`ClrHelper.Unwrap` and `ClrHelper.Wrap`, reachable only from script through `clrHelper`, carry it too.)
+
+`Options.Interop.Enabled = true` is the unannotated equivalent of `AllowClr`; it is a property setter,
+and annotating it would warn on `= false` as well, which would be absurd. If you set it directly, you
+are taking on what `AllowClr`'s message says.
+
+Deliberately **not** annotated: `SetValue(string, Type)`, `SetValue<T>`,
+`TypeReference.CreateTypeReference`, `ModuleBuilder.ExportType` and `JsValue.FromObject`. The first
+four carry `[DynamicallyAccessedMembers]`, which *preserves* what Jint reflects over instead of merely
+warning about it - they are the AOT-friendly way to expose a type, which is exactly why the messages
+above point at them. Nothing carries `[RequiresDynamicCode]`, because §6.1 is what the measurement
+says, and warning an AOT host away from an API that works would be worse than not warning at all.
+
+The attributes are on the `net8.0` and `net10.0` assets. The downlevel targets carry the same
+annotations as internal polyfills, so they are invisible to a consumer - which costs nothing, since
+Native AOT does not exist there either.
+
+### 6.4 What you owe your own project
+
+**Root the host types Jint reaches only by reflection.** A type nothing in your C# calls is trimmed,
+and Jint then reports it as `undefined` or *not a function* rather than as an error - silently. There
+is no diagnostic for this anywhere; it is the failure mode to plan for.
+
+```xml
+<ItemGroup>
+  <TrimmerRootAssembly Include="YourAssembly" />
+</ItemGroup>
+```
+
+**Cast a delegate registration.** `engine.SetValue("f", new Func<int, int>(x => x * 2))` binds to
+`SetValue<T>`, not to `SetValue(string, Delegate)`, and `SetValue<T>`'s `[DynamicallyAccessedMembers]`
+then demands every public method of `Func<int, int>` - including the inherited,
+`[RequiresUnreferencedCode]` `Delegate.CreateDelegate` overloads. That is three `IL2026` and three
+`IL2111` in *your* build, as errors under `TreatWarningsAsErrors`. Casting clears them:
+
+```csharp
+engine.SetValue("f", (Delegate) new Func<int, int>(x => x * 2));
+```
+
+This is not fixable inside Jint: an overload constrained `where T : Delegate` would have the same
+signature as `SetValue<T>` after substitution and make every delegate call site ambiguous.
+
+**Array registrations need nothing.** `engine.SetValue("a", new[] { 1, 2, 3 })` used to cost four
+`IL3050` through `Array.CreateInstance` for the same reason. A new `SetValue<T>(string, T[])` overload
+now wins for any array and infers `T = int` rather than `T = int[]`, which removes them. It also fixes
+a real trimming bug: `SetValue("items", companies)` used to preserve the public members of
+`System.Array`, never `Company`'s, so `companies[0].name` was the one thing not preserved. Nothing in
+your code changes; the overload is picked automatically.
+
+**Expect Jint's own diagnostics in your build.** Jint's `NoWarn` is a property of Jint's compilation
+and reaches nothing downstream - ILC re-derives every diagnostic over the closed program - so an AOT
+publish reports the remaining trim-analysis warnings against Jint's files in *your* build. They are
+tracked in [#3299](https://github.com/sebastienros/jint/issues/3299); until they are paid down, set
+`<IlcTreatWarningsAsErrors>false</IlcTreatWarningsAsErrors>` or `NoWarn` the codes, and treat the run
+as the evidence rather than the warning count.
+
+### 6.5 The AOT-safe subset
+
+An engine that never enables interop needs none of the above:
+
+```csharp
+var engine = new Engine(options => options.Interop.Enabled = false);
+```
+
+That is the floor Jint is prepared to promise. Everything above it is a matter of rooting what you
+expose.
 
 ## Keeping this document current
 

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -425,7 +425,7 @@ generics unless the type also implements `IList`.
 
 ### 6.3 APIs that now warn
 
-Six members carry `[RequiresUnreferencedCode]`, so a trimming or AOT host sees the diagnostic at their
+Seven members carry `[RequiresUnreferencedCode]`, so a trimming or AOT host sees the diagnostic at their
 own call site rather than as a wrong answer at run time. Each message names what to do instead.
 
 | member | why | what to do |


### PR DESCRIPTION
#3300 stood up the measurement and #3299 recorded what it found: five interop shapes throw at run
time under Native AOT, not one member is annotated, and Jint's `NoWarn` reaches nothing downstream.
This acts on all three.

## 1. Three of the five gaps now degrade instead of throwing

Cases 1–3 already carried a fallback written for exactly this scenario, and **it never engaged**:
Native AOT raises `NotSupportedException` from `Activator.CreateInstance` for an instantiation it has
no code for, while the `catch` beside it named `MissingMethodException` — the trimmed-away-constructor
case, not this one. So the non-generic `ListWrapper` / `ObjectEnumerableSnapshotFactory` fallback was
dead code exactly where it was needed, and script got the exception.

Both sites now catch either, through `ObjectWrapper.IsMissingGenericInstantiation`, which carries the
reasoning for why catching them is safe: the factories are Jint's own `internal sealed` types with a
public parameterless constructor that does nothing, so neither exception can mean anything else there,
and anything such a constructor *could* throw arrives wrapped in `TargetInvocationException` instead.
The array-like site also moves its `MakeGenericType` calls inside the `try` — both the instantiation
and the activation are ways of asking for a generic instantiation, and either could be the one a
runtime declines.

**Verified by the run, not by reading.** The three rows in `Jint.AotExample/Program.cs` become
`Probe`s rather than `KnownAotGap`s, which is the part that matters: a fallback only counts if it
gives the *right* answer, and a `Probe` asserts the value where a `try`/`catch` would have been
satisfied by any wrapper at all.

| row | under Native AOT now |
| --- | --- |
| `List<int>` | `ListWrapper` — `length` is 3, `[1]` is 2 |
| `IReadOnlyList<double>` | plain `ObjectWrapper` (the type is not an `IList`) — `[0]` is 1.5; array-likeness is what it loses |
| `IEnumerable<int>` under `Snapshot` | `ObjectEnumerableSnapshotFactory` — `length` is 3, elements boxed |

### The other two stay gaps, deliberately

Neither has a non-generic answer to degrade *to*. Nothing produces a `Task<double>` without
`Task.FromResult<double>`, and `MethodInfoFunction.ResolveMethod` returning `null` means *this
candidate does not apply*, so swallowing the failure would report "no matching overload" for a method
that plainly exists. Both would trade a diagnosable throw for a wrong answer — which is why
`ResolveMethod`'s existing `catch (ArgumentException)` already carries a comment saying it is
deliberately not `NotSupportedException`. Widening it would undo that decision.

## 2. Annotating the public surface

The judgement call here is what **not** to annotate, so that is stated first.

**`[DynamicallyAccessedMembers]` beats `[RequiresUnreferencedCode]` and must not be replaced by it.**
`SetValue(string, Type)`, `SetValue<T>`, `TypeReference.CreateTypeReference` and
`ModuleBuilder.ExportType` already carry it, which *preserves* what Jint reflects over rather than
merely warning about it. They are the AOT-friendly way to expose a type, and the new messages point at
them by name.

**`JsValue.FromObject` / `FromObjectWithType` are not annotated.** They are the engine's own conversion
funnel — ~60 call sites inside Jint, the interpreter's operator-overloading path among them — so
annotating them would either cascade `[RequiresUnreferencedCode]` across the interpreter (telling a
trimming host that arithmetic is unsafe) or need a suppression per site, which is a claim nobody can
back. The reflection they perform is reached through `ObjectWrapper.Create`, which *is* annotated, and
that is where the warning belongs.

**Nothing gets `[RequiresDynamicCode]`.** §1 is what the measurement says: almost all of CLR interop
works natively, and the two shapes that do not are value-type generic instantiations that no signature
can predict. Annotating `SetValue` or `AllowClr` with it would tell an AOT embedder that a thing which
demonstrably works does not, and teach them to suppress the diagnostic on exactly the APIs where it
will later be true. (`PolySharp` does supply the attribute downlevel, so this was a choice and not a
constraint.)

What **is** annotated — six members, each because the requirement cannot be expressed any other way:

| member | why it cannot be `[DynamicallyAccessedMembers]` |
| --- | --- |
| `Options.AllowClr()` and `AllowClr(params Assembly[])` | script names types and namespaces as *strings*; there is no `Type` in the signature at all |
| `Options.AddExtensionMethods(params Type[])` | the attribute is honoured on a `Type` or a `string`, **never on a `Type[]`** |
| `Engine.SetValue(string, object?)` | no type at the call site; binds only where the static type is literally `object` |
| `ObjectWrapper.Create(Engine, object, Type?)` | same — and it is what a custom `WrapObjectHandler` calls |
| `ClrHelper.Unwrap` / `ClrHelper.Wrap` | re-project on a runtime or script-chosen type; internal, reachable only from script |

`AddExtensionMethods` is the one that had already bitten: #3300 found `CompanyExtensions.Shout`
trimmed away and `company.shout()` failing as *not a function*, with no diagnostic anywhere. Now the
registration itself says so.

One `[UnconditionalSuppressMessage]`, on `Options.InteropOptions`'s default wrap handler. It cannot
carry the attribute — it has to stay assignable to the public `WrapObjectDelegate` — and it is
`[UnconditionalSuppressMessage]` rather than a `#pragma` because a pragma reaches Roslyn and not ILC.

`Options.Interop.Enabled = true` is the unannotated equivalent of `AllowClr`. Annotating a property
setter would warn on `= false` as well, which would be absurd, so it is documented instead.

## 3. `SetValue<T>(string, T[])`, which fixes a trimming bug as well as a diagnostic

`engine.SetValue("items", companies)` inferred `T = Company[]`, and `[DynamicallyAccessedMembers]` on
an **array** type preserves the public members of `System.Array` — never `Company`'s. So
`companies[0].name`, the one thing script actually reaches, was the one thing not preserved.

A new overload wins overload resolution for any array (`T[]` is more specific than `T`), runs the
identical body, and infers `T = Company`. Nothing in a host's code changes. It also clears the four
`IL3050` #3300 measured for `SetValue("a", new[] { 1, 2, 3 })`: preserving all public methods of an
array type reaches `Array.CreateInstance`, which is `[RequiresDynamicCode]` and has nothing to do with
reading an element. After this change **no diagnostic in the publish is attributed to
`Jint.AotExample` at all**.

**The delegate half of that report is not fixable the same way, and this says so rather than trying.**
An overload constrained `where T : Delegate` has the same signature as `SetValue<T>` after
substitution and would make every delegate call site ambiguous — a source break. `OverloadResolutionPriority`
on `SetValue(string, Delegate)` would work mechanically but silently change the property attributes a
delegate registration produces (`FastSetProperty` non-enumerable versus `Set`), which is a behaviour
change nobody asked for. So the cast stays documented, in the migration guide, in
`Jint/Runtime/Interop/AGENTS.md`, and at the example's own call site.

## 4. The suppressions

**Not removed, and the report is that this is more than one PR's worth.** Almost all of the 104
suppressed diagnostics are dataflow — a `Type` reaching a call that demands
`[DynamicallyAccessedMembers]` — so each is fixed by propagating the annotation back to whoever
produced the `Type`, and the propagation only terminates at a public API. Removing the line turns them
into build errors all at once, `TreatWarningsAsErrors` being on repository-wide.

What changed is that the line now says what it is worth. It records that `NoWarn` is a property of
Jint's own compilation and reaches nothing downstream, that a `#pragma` is Roslyn-only for the same
reason, that the CI *run* rather than the warning count is what substantiates `IsAotCompatible`, and
that resolving one of these by annotating an API the run shows to work is the wrong move. It points at
**#3305**, filed here, which carries the inventory by code and by file and a suggested order,
smallest blast radius first.

One diagnostic is cleared rather than described: `ReflectionAccessor.ConvertValueToSet` carried
`[DynamicallyAccessedMembers]` on an `object` parameter, where the attribute is **inert** — which is
exactly what the single `IL2098` in every embedder's publish was reporting. Removed, with a note that
the requirement is not expressible from there.

### Inventory, before and after

| | #3300 | this PR |
| --- | --- | --- |
| total published diagnostics | 126 | **115** |
| `IL2026` | 5 | **0** |
| attributed to `Jint.AotExample` | 4 (`IL3050`) | **0** |
| `IL2098` | 1 | **0** |

| code | count | in `NoWarn`? |
| --- | --- | --- |
| `IL2072` | 36 | yes |
| `IL3050` | 20 | yes |
| `IL2067` | 20 | yes |
| `IL2070` | 12 | yes |
| `IL2080` | 6 | yes |
| `IL2075` | 6 | yes |
| `IL2062` | 4 | no |
| `IL2060` | 3 | yes |
| `IL2055` | 3 | no |
| `IL2077` | 2 | no |
| `IL2111` | 1 | no |
| `IL2076` | 1 | no |
| `IL2069` | 1 | yes |
| **total** | **115** | |

## 5. Docs

* `docs/v5-migration.md` section 6 was an explicit placeholder and is now the embedder-facing account:
  what works natively, the value-type generic instantiation that does not and why the two remaining
  sites throw rather than degrade, the six annotated members and the four deliberately unannotated
  ones, the delegate cast a host still owes, the array registration they no longer do, and the
  `Interop.Enabled = false` floor.
* `Jint/Runtime/Interop/AGENTS.md` gains the rule for future work — a new reflection lane needs an
  annotation and a probe; annotate the element rather than the container; prefer
  `[DynamicallyAccessedMembers]` wherever a `Type` is in the signature; reach for
  `[RequiresDynamicCode]` only where the measured run says the thing cannot work.
* The repository-root `AGENTS.md` is untouched.

`Jint.AotExample` suppresses `IL2026` project-wide with the reason at the property: it meets the
requirement the way the new messages name — it roots both assemblies with `TrimmerRootAssembly` — and
an analyzer cannot see an MSBuild item. The native run is what actually checks the answer.

## Verified locally

* `dotnet build -c Release` on the solution — 0 errors, 1 pre-existing `MSB3277`.
* `dotnet test -c Release` per project — `Jint.Tests` 10603 + 7256, `Jint.Tests.PublicInterface`
  2545 + 1945, `Jint.Tests.Test262` 102495, `Jint.Tests.CommonScripts` 28 + 28,
  `Jint.Tests.SourceGenerators` 54. All passed.
* `JINT_HOST_CONTRACT_VERIFICATION=1` over `Jint.Tests` (10603 + 7256) and
  `Jint.Tests.PublicInterface` (2549 + 1949). All passed.
* Five API baselines regenerated and accepted, never hand-edited.
* `dotnet publish Jint.AotExample --configuration Release` — exit 0, 115 analysis diagnostics.
* The published native binary, and `dotnet run` under a JIT — both `ALL PROBES PASSED (20 probes, 2
  known AOT gaps)`, each gap taking its expected branch on each runtime:

```
runtime: Native AOT - known AOT gaps are expected to THROW here

PASS  member, field, indexer and method access
PASS  int[] crossing
PASS  List<string> crossing (GenericListWrapperFactory<string>)
PASS  List<int> crossing (ListWrapper fallback under AOT)
PASS  IReadOnlyList<string> crossing (ReadOnlyListWrapperFactory<string>)
PASS  IReadOnlyList<double> crossing (plain ObjectWrapper fallback under AOT)
PASS  IEnumerable<string> snapshot (EnumerableSnapshotFactory<string>)
PASS  IEnumerable<int> snapshot (object snapshot fallback under AOT)
PASS  Company[] crossing, reading a member of an element
PASS  Dictionary<string, object> crossing
PASS  Dictionary<string, int> crossing
PASS  delegate crossing: JS function -> Func<int, int>
PASS  delegate crossing: JS function -> Func<string, string>
GAP   delegate crossing: JS function -> Func<double, Task<double>>: 'System.Threading.Tasks.Task.FromResult[System.Double](System.Double)' is missing native code.
PASS  delegate crossing: CLR Func<int, int> -> JS
PASS  generic method call, reference type argument
GAP   generic method call, value type argument: 'GenericHost.Identity[System.Double](System.Double)' is missing native code.
PASS  TypeReference: constructing a CLR type from script
PASS  extension methods
PASS  JSON round trip
PASS  interop disabled engine
PASS  promise and async function

ALL PROBES PASSED (20 probes, 2 known AOT gaps)
```

Closes part of #3299 (cases 1–3); cases 4 and 5 stay open there with the reason recorded. Follow-up
tracked as #3305.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014W5mbjGhyvgAS4pivXoc4S
