### PR TITLE
Backport: a removed property slot is a tombstone, not a free slot to reuse (#3273)

### DIFF
--- a/Jint.Benchmark/PropertyDeleteChurnBenchmark.cs
+++ b/Jint.Benchmark/PropertyDeleteChurnBenchmark.cs
@@ -1,0 +1,200 @@
+using BenchmarkDotNet.Attributes;
+using Jint.Collections;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// The delete side of the property stores, which had no coverage before #3273 and is the only path that
+/// change made more expensive. <see cref="StringDictionarySlim{TValue}"/> used to hand a removed entry's
+/// slot to the next add from a free list; it now leaves a tombstone and appends, because a JS property
+/// store enumerates in entry order and a reused slot puts a key back in a position older than its
+/// creation. The tombstones are reclaimed by compaction inside the resize an add would have needed
+/// anyway, so what is measured here is how much that reclamation costs on the shapes that provoke it.
+/// <para>
+/// The four collection rows are the distinguishable cases. <c>AddOnly</c> is the control: no removals, so
+/// nothing about its path changed. <c>AddThenRemoveNewest</c> removes the entry that was just added, which
+/// walks the high-water mark back and never compacts. <c>RotateOldest</c> is the one shape that keeps
+/// compacting — it adds a name never seen before and drops the oldest live one, so every step leaves a
+/// hole below the mark. <c>ReAddMiddle</c> looks like it should compact too and does not: after the first
+/// step the re-added name <em>is</em> the newest entry, so it takes the same shortcut
+/// <c>AddThenRemoveNewest</c> does. That asymmetry is the point of having both.
+/// </para>
+/// <para>
+/// They measure the collection rather than a script on purpose: an engine-level delete costs a property
+/// key conversion, a shape deopt check and a version bump on top, which would dilute the very difference
+/// this class exists to size. The two <c>Script*</c> rows put it back in proportion, and there is one per
+/// collection shape that behaves differently — <c>ScriptDeleteReAdd</c> re-adds the same name (the
+/// non-compacting shape, and the issue's own repro) and <c>ScriptRotateOldest</c> adds a fresh one and
+/// deletes the oldest (the compacting shape). Measuring only the first would have priced the shape that
+/// did not regress.
+/// </para>
+/// <para>
+/// Each script row gets its own engine through <see cref="IsolatedScript"/>, warmed with that row's script
+/// and nothing else, so engine construction stays out of the measurement. <c>ScriptRotateOldest</c>'s
+/// engine additionally carries one fixture that row alone needs — a JS array of the property names it
+/// churns through, built once in <c>[GlobalSetup]</c> so that string concatenation does not enter the
+/// measured loop. The measured script rebuilds its own object every invocation, which it must: the churn
+/// deletes names in the order it created them, so an object carried over from the previous invocation
+/// would have every one of those deletes miss and grow without bound.
+/// </para>
+/// </summary>
+[MemoryDiagnoser]
+public class PropertyDeleteChurnBenchmark
+{
+    /// <summary>Live key count of the table being churned — 16 and 64 sit either side of a resize step.</summary>
+    [Params(16, 64)]
+    public int Width { get; set; }
+
+    private const int Steps = 10_000;
+
+    /// <summary>
+    /// Churn rounds the script rows drive. Two orders of magnitude below <see cref="Steps"/> because an
+    /// engine-level delete-and-add costs roughly two orders of magnitude more than a collection one, which
+    /// is the whole comparison these rows exist to make.
+    /// </summary>
+    private const int ScriptSteps = 2_000;
+
+    /// <summary>Enumerations the <c>ScriptKeysAfterRotation</c> row drives over the already-churned object.</summary>
+    private const int EnumerationSteps = 200;
+
+    private string[] _keys = null!;
+    private string[] _fresh = null!;
+    private IsolatedScript _scriptDeleteReAdd;
+    private IsolatedScript _scriptRotateOldest;
+    private IsolatedScript _scriptKeysAfterRotation;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _keys = new string[Width];
+        for (var i = 0; i < Width; i++)
+        {
+            _keys[i] = "k" + i;
+        }
+
+        _fresh = new string[Steps];
+        for (var i = 0; i < Steps; i++)
+        {
+            _fresh[i] = "n" + i;
+        }
+
+        var literal = string.Join(",", _keys.Select(static k => k + ":1"));
+        _scriptDeleteReAdd = IsolatedScript.Warm($$"""
+            var o = { {{literal}} };
+            for (var n = 0; n < {{ScriptSteps}}; n++) { delete o.k{{Width / 2}}; o.k{{Width / 2}} = n; }
+            o.k{{Width / 2}};
+            """);
+
+        var names = $"var names = []; for (var i = 0; i < {ScriptSteps + Width}; i++) names[i] = 'n' + i;";
+        var rotate = $$"""
+            var o = {};
+            for (var i = 0; i < {{Width}}; i++) { o[names[i]] = i; }
+            for (var n = 0; n < {{ScriptSteps}}; n++) { o[names[{{Width}} + n]] = n; delete o[names[n]]; }
+            """;
+        _scriptRotateOldest = IsolatedScript.Warm(
+            rotate,
+            () =>
+            {
+                var engine = new Engine();
+                engine.Execute(names);
+                return engine;
+            });
+
+        _scriptKeysAfterRotation = IsolatedScript.Warm(
+            $"for (var n = 0; n < {EnumerationSteps}; n++) {{ Object.keys(o); }}",
+            () =>
+            {
+                var engine = new Engine();
+                engine.Execute(names);
+                engine.Execute(rotate);
+                return engine;
+            });
+    }
+
+    private StringDictionarySlim<object> Filled()
+    {
+        var dictionary = new StringDictionarySlim<object>();
+        for (var i = 0; i < _keys.Length; i++)
+        {
+            dictionary[_keys[i]] = _keys;
+        }
+
+        return dictionary;
+    }
+
+    /// <summary>Control: the add path with no removals at all, which is what the engine does far more of.</summary>
+    [Benchmark]
+    public int AddOnly()
+    {
+        var total = 0;
+        for (var step = 0; step < Steps / _keys.Length; step++)
+        {
+            total += Filled().Count;
+        }
+
+        return total;
+    }
+
+    /// <summary>Adding a key and immediately removing it: the high-water mark walks back, nothing compacts.</summary>
+    [Benchmark]
+    public int AddThenRemoveNewest()
+    {
+        var dictionary = Filled();
+        for (var step = 0; step < Steps; step++)
+        {
+            dictionary["churn"] = _keys;
+            dictionary.Remove("churn");
+        }
+
+        return dictionary.Count;
+    }
+
+    /// <summary>Steady-state rotation: every step adds a name never seen before and drops the oldest live one.</summary>
+    [Benchmark]
+    public int RotateOldest()
+    {
+        var dictionary = Filled();
+        for (var step = 0; step < Steps; step++)
+        {
+            dictionary[_fresh[step]] = _fresh;
+            dictionary.Remove(step < _keys.Length ? _keys[step] : _fresh[step - _keys.Length]);
+        }
+
+        return dictionary.Count;
+    }
+
+    /// <summary>The issue's own shape: delete a key from the middle of the table and add the same name back.</summary>
+    [Benchmark]
+    public int ReAddMiddle()
+    {
+        var dictionary = Filled();
+        var middle = _keys[_keys.Length / 2];
+        for (var step = 0; step < Steps; step++)
+        {
+            dictionary.Remove(middle);
+            dictionary[middle] = _fresh;
+        }
+
+        return dictionary.Count;
+    }
+
+    /// <summary>The same delete-and-re-add through the engine, so the collection delta can be put in proportion.</summary>
+    [Benchmark]
+    public void ScriptDeleteReAdd() => _scriptDeleteReAdd.Execute();
+
+    /// <summary>
+    /// <see cref="RotateOldest"/> through the engine: the compacting shape, which is the one
+    /// <see cref="ScriptDeleteReAdd"/> does not reach.
+    /// </summary>
+    [Benchmark]
+    public void ScriptRotateOldest() => _scriptRotateOldest.Execute();
+
+    /// <summary>
+    /// Reading the keys of an object that has already been churned, which is the cost the tombstones
+    /// impose on the <em>other</em> side. The rotation happens once, in this row's own engine fixture, so
+    /// what is measured is only the enumeration — and the enumerator has to step over every tombstone the
+    /// table is holding, which is exactly what the compaction threshold decides the number of.
+    /// </summary>
+    [Benchmark]
+    public void ScriptKeysAfterRotation() => _scriptKeysAfterRotation.Execute();
+}

--- a/Jint.Tests/Runtime/OwnPropertyCreationOrderTests.cs
+++ b/Jint.Tests/Runtime/OwnPropertyCreationOrderTests.cs
@@ -1,0 +1,423 @@
+using System.Reflection;
+using Jint.Collections;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// <see href="https://tc39.es/ecma262/#sec-ordinaryownpropertykeys">OrdinaryOwnPropertyKeys</see> lists
+/// string keys, and then symbol keys, "in ascending chronological order of property creation". A
+/// <c>delete</c> destroys the property; adding the name back creates a <em>new</em> one, which is
+/// therefore the newest key — so the name moves to the end, and a brand-new name added after any delete
+/// appends rather than filling the gap.
+/// <para>
+/// The property stores are hash tables that used to reuse a removed entry's slot from a free list while
+/// enumerating in entry-array index order, so a re-added key came back in its old position and a new key
+/// landed in the hole (issue #3273). <see cref="PropertyDictionary"/> switches from its list backing to
+/// <see cref="StringDictionarySlim{TValue}"/> at nine entries, which is why the string cases below
+/// straddle that boundary deliberately; the symbol store is a
+/// <see cref="DictionarySlim{TKey,TValue}"/> from the first key, so it had no correct size at all.
+/// </para>
+/// </summary>
+public class OwnPropertyCreationOrderTests
+{
+    private static string Keys(Engine engine, string expression) => engine.Evaluate(expression).AsString();
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(7)]
+    [InlineData(8)]  // last size backed by ListDictionary
+    [InlineData(9)]  // first size backed by StringDictionarySlim
+    [InlineData(10)]
+    [InlineData(16)]
+    [InlineData(40)]
+    public void ADeletedKeyThatIsAddedBackIsTheNewestKey(int n)
+    {
+        var engine = new Engine();
+        var actual = Keys(engine, $$"""
+            var o = {};
+            for (var i = 0; i < {{n}}; i++) o['k' + i] = i;
+            delete o.k0;
+            o.k0 = 99;
+            Object.keys(o).join(',');
+            """);
+
+        var expected = new List<string>();
+        for (var i = 1; i < n; i++)
+        {
+            expected.Add("k" + i);
+        }
+        expected.Add("k0");
+
+        actual.Should().Be(string.Join(",", expected));
+    }
+
+    [Theory]
+    [InlineData(8)]
+    [InlineData(9)]
+    [InlineData(24)]
+    public void ADeletedKeyInTheMiddleThatIsAddedBackIsTheNewestKey(int n)
+    {
+        var engine = new Engine();
+        var actual = Keys(engine, $$"""
+            var o = {};
+            for (var i = 0; i < {{n}}; i++) o['k' + i] = i;
+            delete o.k3;
+            o.k3 = 99;
+            Object.keys(o).join(',');
+            """);
+
+        var expected = new List<string>();
+        for (var i = 0; i < n; i++)
+        {
+            if (i != 3)
+            {
+                expected.Add("k" + i);
+            }
+        }
+        expected.Add("k3");
+
+        actual.Should().Be(string.Join(",", expected));
+    }
+
+    /// <summary>
+    /// A brand-new name added after a delete appends too — the vacated position belongs to no key at all.
+    /// This is the half of the defect the free list made worst: two deletes and two unrelated adds put the
+    /// new names into the two holes, in reverse order (the free list is LIFO).
+    /// </summary>
+    [Fact]
+    public void NewKeysAddedAfterADeleteAppendRatherThanFillingTheGap()
+    {
+        var engine = new Engine();
+        var actual = Keys(engine, """
+            var o = {};
+            for (var i = 0; i < 9; i++) o['k' + i] = i;
+            delete o.k1;
+            delete o.k3;
+            o.a = 1;
+            o.b = 2;
+            Object.keys(o).join(',');
+            """);
+
+        actual.Should().Be("k0,k2,k4,k5,k6,k7,k8,a,b");
+    }
+
+    [Fact]
+    public void EmptyingAndRefillingRebuildsTheOrderFromScratch()
+    {
+        var engine = new Engine();
+        var actual = Keys(engine, """
+            var o = {};
+            for (var i = 0; i < 9; i++) o['k' + i] = i;
+            for (var i = 0; i < 9; i++) delete o['k' + i];
+            for (var i = 8; i >= 0; i--) o['k' + i] = i;
+            Object.keys(o).join(',');
+            """);
+
+        actual.Should().Be("k8,k7,k6,k5,k4,k3,k2,k1,k0");
+    }
+
+    /// <summary>
+    /// Every own-key listing goes through the one enumeration, so each of these is the same defect seen
+    /// from a different built-in. Kept explicit because they are what an embedder actually calls.
+    /// </summary>
+    [Theory]
+    [InlineData("Object.keys(o).join(',')", "k1,k2,k3,k4,k5,k6,k7,k8,k0")]
+    [InlineData("Object.values(o).join(',')", "1,2,3,4,5,6,7,8,99")]
+    [InlineData("Object.entries(o).map(function (e) { return e[0]; }).join(',')", "k1,k2,k3,k4,k5,k6,k7,k8,k0")]
+    [InlineData("Object.getOwnPropertyNames(o).join(',')", "k1,k2,k3,k4,k5,k6,k7,k8,k0")]
+    [InlineData("Object.keys(Object.getOwnPropertyDescriptors(o)).join(',')", "k1,k2,k3,k4,k5,k6,k7,k8,k0")]
+    [InlineData("Reflect.ownKeys(o).join(',')", "k1,k2,k3,k4,k5,k6,k7,k8,k0")]
+    [InlineData("Reflect.ownKeys(new Proxy(o, {})).join(',')", "k1,k2,k3,k4,k5,k6,k7,k8,k0")]
+    [InlineData("var r = []; for (var k in o) r.push(k); r.join(',')", "k1,k2,k3,k4,k5,k6,k7,k8,k0")]
+    [InlineData("Object.keys(Object.assign({}, o)).join(',')", "k1,k2,k3,k4,k5,k6,k7,k8,k0")]
+    [InlineData("Object.keys({ ...o }).join(',')", "k1,k2,k3,k4,k5,k6,k7,k8,k0")]
+    [InlineData("var { k5, ...rest } = o; Object.keys(rest).join(',')", "k1,k2,k3,k4,k6,k7,k8,k0")]
+    [InlineData("JSON.stringify(o)", """{"k1":1,"k2":2,"k3":3,"k4":4,"k5":5,"k6":6,"k7":7,"k8":8,"k0":99}""")]
+    public void EveryOwnKeyListingSeesTheReAddedKeyLast(string expression, string expected)
+    {
+        var engine = new Engine();
+        var actual = engine.Evaluate($$"""
+            var o = {};
+            for (var i = 0; i < 9; i++) o['k' + i] = i;
+            delete o.k0;
+            o.k0 = 99;
+            {{expression}};
+            """).AsString();
+
+        actual.Should().Be(expected);
+    }
+
+    [Fact]
+    public void DefinePropertyAsTheReAddIsAlsoACreation()
+    {
+        var engine = new Engine();
+        var actual = Keys(engine, """
+            var o = {};
+            for (var i = 0; i < 9; i++) o['k' + i] = i;
+            delete o.k0;
+            Object.defineProperty(o, 'k0', { value: 99, writable: true, enumerable: true, configurable: true });
+            Object.keys(o).join(',');
+            """);
+
+        actual.Should().Be("k1,k2,k3,k4,k5,k6,k7,k8,k0");
+    }
+
+    [Fact]
+    public void ReflectDeleteAndSetBehaveLikeTheOperators()
+    {
+        var engine = new Engine();
+        var actual = Keys(engine, """
+            var o = {};
+            for (var i = 0; i < 9; i++) o['k' + i] = i;
+            Reflect.deleteProperty(o, 'k0');
+            Reflect.set(o, 'k0', 99);
+            Object.keys(o).join(',');
+            """);
+
+        actual.Should().Be("k1,k2,k3,k4,k5,k6,k7,k8,k0");
+    }
+
+    /// <summary>
+    /// Integer-like keys are listed first in ascending numeric order whatever happens to them, so the
+    /// mixed case pins that the string half moves and the index half does not.
+    /// </summary>
+    [Fact]
+    public void IndexKeysStayAscendingWhileStringKeysFollowCreationOrder()
+    {
+        var engine = new Engine();
+        var actual = Keys(engine, """
+            var o = {};
+            o[2] = 'i2';
+            o[0] = 'i0';
+            for (var i = 0; i < 9; i++) o['s' + i] = i;
+            delete o.s0;
+            o.s0 = 99;
+            Object.keys(o).join(',');
+            """);
+
+        actual.Should().Be("0,2,s1,s2,s3,s4,s5,s6,s7,s8,s0");
+    }
+
+    [Fact]
+    public void AnArrayWithStringPropertiesFollowsTheSameRule()
+    {
+        var engine = new Engine();
+        var actual = Keys(engine, """
+            var a = [1, 2, 3];
+            for (var i = 0; i < 10; i++) a['p' + i] = i;
+            delete a.p0;
+            a.p0 = 99;
+            Object.keys(a).join(',');
+            """);
+
+        actual.Should().Be("0,1,2,p1,p2,p3,p4,p5,p6,p7,p8,p9,p0");
+    }
+
+    /// <summary>
+    /// Symbol keys are their own list in <see cref="Object" />.getOwnPropertySymbols and carry the same
+    /// chronological rule. The symbol store has no small-size backing to hide behind, so two keys are
+    /// already enough.
+    /// </summary>
+    [Theory]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(9)]
+    [InlineData(12)]
+    public void ADeletedSymbolThatIsAddedBackIsTheNewestSymbol(int n)
+    {
+        var engine = new Engine();
+        var actual = Keys(engine, $$"""
+            var o = {};
+            var s = [];
+            for (var i = 0; i < {{n}}; i++) { s.push(Symbol('s' + i)); o[s[i]] = i; }
+            delete o[s[0]];
+            o[s[0]] = 99;
+            Object.getOwnPropertySymbols(o).map(String).join(',');
+            """);
+
+        var expected = new List<string>();
+        for (var i = 1; i < n; i++)
+        {
+            expected.Add($"Symbol(s{i})");
+        }
+        expected.Add("Symbol(s0)");
+
+        actual.Should().Be(string.Join(",", expected));
+    }
+
+    /// <summary>
+    /// A built-in prototype starts in the shared built-in shape, where a string-key delete deopts into
+    /// <see cref="PropertyDictionary"/> first. <c>Map.prototype</c> has enough members (13) to land in the
+    /// hash backing rather than the list backing, so it is the shape path's witness for this bug.
+    /// </summary>
+    [Fact]
+    public void ADeoptedBuiltinShapeFollowsTheSameRule()
+    {
+        var engine = new Engine();
+        var before = Keys(engine, "Object.getOwnPropertyNames(Map.prototype).join(',')");
+        before.Should().Contain("get");
+
+        var after = Keys(engine, """
+            delete Map.prototype.get;
+            Map.prototype.get = 1;
+            Object.getOwnPropertyNames(Map.prototype).join(',');
+            """);
+
+        var expected = string.Join(",", before.Split(',').Where(static k => k != "get").Concat(["get"]));
+        after.Should().Be(expected);
+    }
+
+    [Fact]
+    public void RepeatedDeleteAndReAddOfTheSameKeyKeepsItLast()
+    {
+        var engine = new Engine();
+        var actual = Keys(engine, """
+            var o = {};
+            for (var i = 0; i < 12; i++) o['k' + i] = i;
+            for (var r = 0; r < 200; r++) { delete o.k5; o.k5 = r; }
+            Object.keys(o).join(',');
+            """);
+
+        actual.Should().Be("k0,k1,k2,k3,k4,k6,k7,k8,k9,k10,k11,k5");
+    }
+
+    /// <summary>
+    /// A randomized cross-check against a model kept in script: 20,000 add/delete operations over a key
+    /// space wide enough to cross the cutover, resize and compact many times. The model is the rule
+    /// itself — a new name appends, assigning an existing one leaves it where it is, a delete drops it —
+    /// so a mismatch means the store diverged from creation order somewhere in the churn rather than in
+    /// any one hand-picked scenario. Deterministic seed, so a failure is reproducible.
+    /// </summary>
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void RandomizedChurnKeepsTheStoreInCreationOrder(bool symbolKeys)
+    {
+        var subject = symbolKeys
+            ? "var key = function (i) { return syms[i]; }; var list = function (o) { return Object.getOwnPropertySymbols(o).map(String).join(','); }; var name = function (i) { return String(syms[i]); };"
+            : "var key = function (i) { return 'x' + i; }; var list = function (o) { return Object.keys(o).join(','); }; var name = function (i) { return 'x' + i; };";
+
+        var engine = new Engine();
+        var result = engine.Evaluate($$"""
+            var syms = [];
+            for (var i = 0; i < 60; i++) syms.push(Symbol('y' + i));
+            {{subject}}
+
+            var seed = 12345;
+            function rnd(n) { seed = (seed * 1103515245 + 12345) & 0x7fffffff; return seed % n; }
+
+            var o = {};
+            var model = [];
+            for (var step = 0; step < 20000; step++) {
+                var i = rnd(60);
+                if (rnd(2) === 0) {
+                    if (model.indexOf(i) < 0) model.push(i);
+                    o[key(i)] = step;
+                } else {
+                    var at = model.indexOf(i);
+                    if (at >= 0) model.splice(at, 1);
+                    delete o[key(i)];
+                }
+            }
+
+            var want = model.map(name).join(',');
+            list(o) === want ? 'OK:' + model.length : 'MISMATCH\n got  ' + list(o) + '\n want ' + want;
+            """).AsString();
+
+        result.Should().StartWith("OK:");
+        // A churn that ended with an empty or barely-filled store would prove very little.
+        int.Parse(result.Substring(3), System.Globalization.CultureInfo.InvariantCulture).Should().BeGreaterThan(9);
+    }
+
+    /// <summary>
+    /// Insertion order is preserved by never reusing a removed entry's slot, so the entry array has to be
+    /// reclaimed some other way: it is compacted when a resize would otherwise be needed. That makes the
+    /// storage of a long add/delete churn bounded by the live key count rather than by the number of
+    /// operations, which is the property that keeps the fix from being a leak.
+    /// </summary>
+    [Fact]
+    public void ChurningAKeyDoesNotGrowTheEntryArrayWithoutBound()
+    {
+        var dictionary = new StringDictionarySlim<int>();
+        for (var i = 0; i < 16; i++)
+        {
+            dictionary["k" + i] = i;
+        }
+
+        for (var r = 0; r < 100_000; r++)
+        {
+            dictionary.Remove("churn");
+            dictionary["churn"] = r;
+        }
+
+        dictionary.Count.Should().Be(17);
+        EntryCapacityOf(dictionary).Should().BeLessThan(128);
+    }
+
+    /// <summary>
+    /// The same bound, but for churn that does not simply re-add the newest key: every round adds a fresh
+    /// name and deletes one from the middle of the table, so no entry slot can be reclaimed on removal and
+    /// only compaction keeps the array in check.
+    /// </summary>
+    [Fact]
+    public void ChurningDistinctKeysDoesNotGrowTheEntryArrayWithoutBound()
+    {
+        var dictionary = new StringDictionarySlim<int>();
+        for (var i = 0; i < 16; i++)
+        {
+            dictionary["k" + i] = i;
+        }
+
+        for (var r = 0; r < 100_000; r++)
+        {
+            dictionary["n" + r] = r;
+            dictionary.Remove("k" + (r % 16));
+            dictionary["k" + (r % 16)] = r;
+            dictionary.Remove("n" + r);
+        }
+
+        dictionary.Count.Should().Be(16);
+        EntryCapacityOf(dictionary).Should().BeLessThan(256);
+    }
+
+    [Fact]
+    public void RemovalAndReAdditionKeepsTheCollectionEnumerableInInsertionOrder()
+    {
+        var dictionary = new StringDictionarySlim<int>();
+        for (var i = 0; i < 20; i++)
+        {
+            dictionary["k" + i] = i;
+        }
+
+        dictionary.Remove("k0");
+        dictionary.Remove("k7");
+        dictionary["k7"] = 700;
+        dictionary["fresh"] = 1;
+        dictionary["k0"] = 0;
+
+        var order = dictionary.Select(static pair => pair.Key.Name).ToList();
+
+        var expected = new List<string>();
+        for (var i = 1; i < 20; i++)
+        {
+            if (i != 7)
+            {
+                expected.Add("k" + i);
+            }
+        }
+        expected.Add("k7");
+        expected.Add("fresh");
+        expected.Add("k0");
+
+        order.Should().Equal(expected);
+        dictionary.Count.Should().Be(21);
+        dictionary["k7"].Should().Be(700);
+    }
+
+    private static int EntryCapacityOf<T>(StringDictionarySlim<T> dictionary)
+    {
+        var field = typeof(StringDictionarySlim<T>).GetField("_entries", BindingFlags.Instance | BindingFlags.NonPublic);
+        return ((Array) field!.GetValue(dictionary)!).Length;
+    }
+}

--- a/Jint/Collections/DictionarySlim.cs
+++ b/Jint/Collections/DictionarySlim.cs
@@ -16,6 +16,15 @@ namespace Jint.Collections;
 /// 1) It allows access to the value by ref replacing the common TryGetValue and Add pattern.
 /// 2) It does not store the hash code (assumes it is cheap to equate values).
 /// 3) It does not accept an equality comparer (assumes Object.GetHashCode() and Object.Equals() or overridden implementation are cheap and sufficient).
+/// <para>
+/// It additionally enumerates in <em>insertion order</em>, which the type it was derived from does not:
+/// this backs a JavaScript object's own symbol-keyed properties, and
+/// <see href="https://tc39.es/ecma262/#sec-ordinaryownpropertykeys">OrdinaryOwnPropertyKeys</see> requires
+/// them "in ascending chronological order of property creation". A removed entry therefore leaves a
+/// tombstone rather than joining a free list an add would pop from — reusing a vacated slot would hand a
+/// key an enumeration position older than its creation. See <see cref="Resize"/> for how the tombstones
+/// are reclaimed.
+/// </para>
 /// </summary>
 [DebuggerDisplay("Count = {Count}")]
 internal sealed class DictionarySlim<TKey, TValue> : IReadOnlyCollection<KeyValuePair<TKey, TValue>> where TKey : IEquatable<TKey>
@@ -25,9 +34,17 @@ internal sealed class DictionarySlim<TKey, TValue> : IReadOnlyCollection<KeyValu
     // The first add will cause a resize replacing these with real arrays of three elements.
     // Arrays are wrapped in a class to avoid being duplicated for each <TKey, TValue>
     private static readonly Entry[] InitialEntries = new Entry[1];
+
+    /// <summary>
+    /// <see cref="Entry.next"/> of a removed entry. Live entries carry -1 (end of bucket chain) or a
+    /// 0-based index, and a slot never written carries 0, so this is the one value below -1.
+    /// </summary>
+    private const int Tombstone = -2;
+
+    // Number of live entries.
     private int _count;
-    // 0-based index into _entries of head of free chain: -1 means empty
-    private int _freeList = -1;
+    // High-water mark: _entries[0.._lastIndex) are live entries and tombstones, in insertion order.
+    private int _lastIndex;
     // 1-based index into _entries; 0 means empty
     private int[] _buckets;
     private Entry[] _entries;
@@ -38,9 +55,8 @@ internal sealed class DictionarySlim<TKey, TValue> : IReadOnlyCollection<KeyValu
     {
         public TKey key;
         public TValue value;
-        // 0-based index of next entry in chain: -1 means end of chain
-        // also encodes whether this entry _itself_ is part of the free list by changing sign and subtracting 3,
-        // so -2 means end of free list, -3 means index 0 but on free list, -4 means index 1 but on free list, etc.
+        // 0-based index of next entry in chain: -1 means end of chain,
+        // Tombstone (-2) means this entry was removed and holds no key.
         public int next;
     }
 
@@ -67,7 +83,7 @@ internal sealed class DictionarySlim<TKey, TValue> : IReadOnlyCollection<KeyValu
     public void Clear()
     {
         _count = 0;
-        _freeList = -1;
+        _lastIndex = 0;
         _buckets = HashHelpers.SizeOneIntArray;
         _entries = InitialEntries;
     }
@@ -124,11 +140,17 @@ internal sealed class DictionarySlim<TKey, TValue> : IReadOnlyCollection<KeyValu
                 }
 
                 entries[entryIndex] = default;
-
-                entries[entryIndex].next = -3 - _freeList; // New head of free list
-                _freeList = entryIndex;
+                entries[entryIndex].next = Tombstone;
 
                 _count--;
+
+                // Removing the newest entry can hand its slot straight back without disturbing the order
+                // of anything older, which is what makes add-then-remove churn free of compaction.
+                if (entryIndex == _lastIndex - 1)
+                {
+                    _lastIndex = entryIndex;
+                }
+
                 return true;
             }
             lastIndex = entryIndex;
@@ -170,24 +192,16 @@ internal sealed class DictionarySlim<TKey, TValue> : IReadOnlyCollection<KeyValu
     [MethodImpl(MethodImplOptions.NoInlining)]
     private ref TValue AddKey(TKey key, int bucketIndex)
     {
+        // Always appends: the new entry is the newest key, and enumeration is entry order.
         Entry[] entries = _entries;
-        int entryIndex;
-        if (_freeList != -1)
+        if (_lastIndex == entries.Length || entries.Length == 1)
         {
-            entryIndex = _freeList;
-            _freeList = -3 - entries[_freeList].next;
-        }
-        else
-        {
-            if (_count == entries.Length || entries.Length == 1)
-            {
-                entries = Resize();
-                bucketIndex = key.GetHashCode() & (_buckets.Length - 1);
-                // entry indexes were not changed by Resize
-            }
-            entryIndex = _count;
+            entries = Resize();
+            bucketIndex = key.GetHashCode() & (_buckets.Length - 1);
+            // entry indexes of surviving entries were not reordered by Resize
         }
 
+        var entryIndex = _lastIndex++;
         entries[entryIndex].key = key;
         entries[entryIndex].next = _buckets[bucketIndex] - 1;
         _buckets[bucketIndex] = entryIndex + 1;
@@ -195,29 +209,86 @@ internal sealed class DictionarySlim<TKey, TValue> : IReadOnlyCollection<KeyValu
         return ref entries[entryIndex].value;
     }
 
+    /// <summary>
+    /// Makes room at the top of the entry array, which is the only place an add may write.
+    /// <para>
+    /// With no removals this is the plain doubling it has always been. Otherwise the tombstones left by
+    /// <see cref="Remove"/> are squeezed out — in place when the live entries fit in half the capacity,
+    /// and into a doubled array when they do not. Compaction preserves relative order, so it is invisible
+    /// to enumeration; insisting on the half is what keeps adds amortized O(1), since every call here is
+    /// followed by at least <c>capacity / 2</c> adds before the next one.
+    /// </para>
+    /// <para>
+    /// The half is measured rather than chosen. It is consulted only by a table that has both left
+    /// tombstones and filled its array, and because capacities are powers of two it does not tune the
+    /// cost continuously — it decides which power of two such a table settles on, and the interval
+    /// between compactions is then the capacity minus the live count. A quarter settles a rotating key
+    /// set at twice its live count and costs a compaction every <c>n</c> adds; a half settles it at four
+    /// times and costs one every <c>3n</c>. Measured against slot reuse that is +34.8% and +8.9%. Going
+    /// on to a three-quarters erases the rest and doubles the ceiling again, which is the trade this
+    /// stops short of; #3285 carries the curve and the memory figures at every setting.
+    /// </para>
+    /// </summary>
     private Entry[] Resize()
     {
-        Debug.Assert(_entries.Length == _count || _entries.Length == 1); // We only copy _count, so if it's longer we will miss some
-        int count = _count;
-        int newSize = _entries.Length * 2;
-        if ((uint) newSize > int.MaxValue) // uint cast handles overflow
-            throw new InvalidOperationException("Capacity Overflow");
+        Debug.Assert(_lastIndex == _entries.Length || _entries.Length == 1);
 
-        var entries = new Entry[newSize];
-        Array.Copy(_entries, 0, entries, 0, count);
+        var entries = _entries;
+        var count = _count;
+        var lastIndex = _lastIndex;
 
-        var newBuckets = new int[entries.Length];
-        while (count-- > 0)
+        Entry[] newEntries;
+        if (count == lastIndex || count + 1 > entries.Length - (entries.Length >> 1))
         {
-            int bucketIndex = entries[count].key.GetHashCode() & (newBuckets.Length - 1);
-            entries[count].next = newBuckets[bucketIndex] - 1;
-            newBuckets[bucketIndex] = count + 1;
+            var newSize = entries.Length * 2;
+            if ((uint) newSize > int.MaxValue) // uint cast handles overflow
+                throw new InvalidOperationException("Capacity Overflow");
+
+            newEntries = new Entry[newSize];
+            _buckets = new int[newSize];
+        }
+        else
+        {
+            newEntries = entries;
+            Array.Clear(_buckets, 0, _buckets.Length);
         }
 
-        _buckets = newBuckets;
-        _entries = entries;
+        if (count == lastIndex)
+        {
+            Array.Copy(entries, 0, newEntries, 0, count);
+        }
+        else
+        {
+            var write = 0;
+            for (var read = 0; read < lastIndex; read++)
+            {
+                if (entries[read].next != Tombstone)
+                {
+                    newEntries[write++] = entries[read];
+                }
+            }
 
-        return entries;
+            Debug.Assert(write == count);
+
+            if (ReferenceEquals(newEntries, entries))
+            {
+                // Release the keys and values the compacted-away tail still references.
+                Array.Clear(entries, count, lastIndex - count);
+            }
+        }
+
+        _lastIndex = count;
+        _entries = newEntries;
+
+        var buckets = _buckets;
+        while (count-- > 0)
+        {
+            int bucketIndex = newEntries[count].key.GetHashCode() & (buckets.Length - 1);
+            newEntries[count].next = buckets[bucketIndex] - 1;
+            buckets[bucketIndex] = count + 1;
+        }
+
+        return newEntries;
     }
 
     /// <summary>
@@ -261,7 +332,9 @@ internal sealed class DictionarySlim<TKey, TValue> : IReadOnlyCollection<KeyValu
 
             _count--;
 
-            while (_dictionary._entries[_index].next < -1)
+            // Skips the tombstones removals left behind; the live entries between them are still in
+            // insertion order, which is what this type exists to preserve.
+            while (_dictionary._entries[_index].next == Tombstone)
                 _index++;
 
             _current = new KeyValuePair<TKey, TValue>(

--- a/Jint/Collections/StringDictionarySlim.cs
+++ b/Jint/Collections/StringDictionarySlim.cs
@@ -19,6 +19,15 @@ namespace Jint.Collections;
 /// 1) It allows access to the value by ref replacing the common TryGetValue and Add pattern.
 /// 2) It does not store the hash code (assumes it is cheap to equate values).
 /// 3) It does not accept an equality comparer (assumes Object.GetHashCode() and Object.Equals() or overridden implementation are cheap and sufficient).
+/// <para>
+/// It additionally enumerates in <em>insertion order</em>, which the type it was derived from does not:
+/// this backs a JavaScript object's own string-keyed properties, and
+/// <see href="https://tc39.es/ecma262/#sec-ordinaryownpropertykeys">OrdinaryOwnPropertyKeys</see> requires
+/// them "in ascending chronological order of property creation". A removed entry therefore leaves a
+/// tombstone rather than joining a free list an add would pop from — reusing a vacated slot would hand a
+/// key an enumeration position older than its creation. See <see cref="Resize"/> for how the tombstones
+/// are reclaimed.
+/// </para>
 /// </summary>
 [DebuggerTypeProxy(typeof(DictionarySlimDebugView<>))]
 [DebuggerDisplay("Count = {Count}")]
@@ -29,9 +38,17 @@ internal sealed class StringDictionarySlim<TValue> : DictionaryBase<TValue>, IRe
     // The first add will cause a resize replacing these with real arrays of three elements.
     // Arrays are wrapped in a class to avoid being duplicated for each <TKey, TValue>
     private static readonly Entry[] InitialEntries = new Entry[1];
+
+    /// <summary>
+    /// <see cref="Entry.next"/> of a removed entry. Live entries carry -1 (end of bucket chain) or a
+    /// 0-based index, and a slot never written carries 0, so this is the one value below -1.
+    /// </summary>
+    private const int Tombstone = -2;
+
+    // Number of live entries.
     private int _count;
-    // 0-based index into _entries of head of free chain: -1 means empty
-    private int _freeList = -1;
+    // High-water mark: _entries[0.._lastIndex) are live entries and tombstones, in insertion order.
+    private int _lastIndex;
     // 1-based index into _entries; 0 means empty
     private int[] _buckets;
     private Entry[] _entries;
@@ -41,9 +58,8 @@ internal sealed class StringDictionarySlim<TValue> : DictionaryBase<TValue>, IRe
     {
         public Key key;
         public TValue value;
-        // 0-based index of next entry in chain: -1 means end of chain
-        // also encodes whether this entry _itself_ is part of the free list by changing sign and subtracting 3,
-        // so -2 means end of free list, -3 means index 0 but on free list, -4 means index 1 but on free list, etc.
+        // 0-based index of next entry in chain: -1 means end of chain,
+        // Tombstone (-2) means this entry was removed and holds no key.
         public int next;
     }
 
@@ -74,7 +90,7 @@ internal sealed class StringDictionarySlim<TValue> : DictionaryBase<TValue>, IRe
     public void Clear()
     {
         _count = 0;
-        _freeList = -1;
+        _lastIndex = 0;
         _buckets = HashHelpers.SizeOneIntArray;
         _entries = InitialEntries;
     }
@@ -87,17 +103,19 @@ internal sealed class StringDictionarySlim<TValue> : DictionaryBase<TValue>, IRe
     /// </summary>
     public void ClearPreservingCapacity()
     {
-        if (_count == 0)
+        if (_lastIndex == 0)
         {
-            // Never grew past the shared dummy arrays — nothing to keep, nothing to clear.
+            // Never grew past the shared dummy arrays — nothing to keep, nothing to clear. Tested on the
+            // high-water mark rather than on Count so that a table emptied by removals resets it: Count
+            // is already 0 there, and returning early would make the next refill append above the
+            // tombstones instead of starting at slot 0.
             return;
         }
 
-        // Bindings are only added (never removed) during a refill, so used entries are dense in [0, _count).
         Array.Clear(_buckets, 0, _buckets.Length);
-        Array.Clear(_entries, 0, _count);
+        Array.Clear(_entries, 0, _lastIndex);
         _count = 0;
-        _freeList = -1;
+        _lastIndex = 0;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -129,11 +147,17 @@ internal sealed class StringDictionarySlim<TValue> : DictionaryBase<TValue>, IRe
                 }
 
                 entries[entryIndex] = default;
-
-                entries[entryIndex].next = -3 - _freeList; // New head of free list
-                _freeList = entryIndex;
+                entries[entryIndex].next = Tombstone;
 
                 _count--;
+
+                // Removing the newest entry can hand its slot straight back without disturbing the order
+                // of anything older, which is what makes `o.k = v; delete o.k;` churn free of compaction.
+                if (entryIndex == _lastIndex - 1)
+                {
+                    _lastIndex = entryIndex;
+                }
+
                 return true;
             }
             lastIndex = entryIndex;
@@ -217,24 +241,16 @@ internal sealed class StringDictionarySlim<TValue> : DictionaryBase<TValue>, IRe
     [MethodImpl(MethodImplOptions.NoInlining)]
     private ref TValue AddKey(Key key, int bucketIndex)
     {
+        // Always appends: the new entry is the newest key, and enumeration is entry order.
         Entry[] entries = _entries;
-        int entryIndex;
-        if (_freeList != -1)
+        if (_lastIndex == entries.Length || entries.Length == 1)
         {
-            entryIndex = _freeList;
-            _freeList = -3 - entries[_freeList].next;
-        }
-        else
-        {
-            if (_count == entries.Length || entries.Length == 1)
-            {
-                entries = Resize();
-                bucketIndex = key.HashCode & (_buckets.Length - 1);
-                // entry indexes were not changed by Resize
-            }
-            entryIndex = _count;
+            entries = Resize();
+            bucketIndex = key.HashCode & (_buckets.Length - 1);
+            // entry indexes of surviving entries were not reordered by Resize
         }
 
+        var entryIndex = _lastIndex++;
         entries[entryIndex].key = key;
         entries[entryIndex].next = _buckets[bucketIndex] - 1;
         _buckets[bucketIndex] = entryIndex + 1;
@@ -242,29 +258,86 @@ internal sealed class StringDictionarySlim<TValue> : DictionaryBase<TValue>, IRe
         return ref entries[entryIndex].value;
     }
 
+    /// <summary>
+    /// Makes room at the top of the entry array, which is the only place an add may write.
+    /// <para>
+    /// With no removals this is the plain doubling it has always been. Otherwise the tombstones left by
+    /// <see cref="Remove"/> are squeezed out — in place when the live entries fit in half the capacity,
+    /// and into a doubled array when they do not. Compaction preserves relative order, so it is invisible
+    /// to enumeration; insisting on the half is what keeps adds amortized O(1), since every call here is
+    /// followed by at least <c>capacity / 2</c> adds before the next one.
+    /// </para>
+    /// <para>
+    /// The half is measured rather than chosen. It is consulted only by a table that has both left
+    /// tombstones and filled its array, and because capacities are powers of two it does not tune the
+    /// cost continuously — it decides which power of two such a table settles on, and the interval
+    /// between compactions is then the capacity minus the live count. A quarter settles a rotating key
+    /// set at twice its live count and costs a compaction every <c>n</c> adds; a half settles it at four
+    /// times and costs one every <c>3n</c>. Measured against slot reuse that is +34.8% and +8.9%. Going
+    /// on to a three-quarters erases the rest and doubles the ceiling again, which is the trade this
+    /// stops short of; #3285 carries the curve and the memory figures at every setting.
+    /// </para>
+    /// </summary>
     private Entry[] Resize()
     {
-        Debug.Assert(_entries.Length == _count || _entries.Length == 1); // We only copy _count, so if it's longer we will miss some
-        int count = _count;
-        int newSize = _entries.Length * 2;
-        if ((uint) newSize > int.MaxValue) // uint cast handles overflow
-            throw new InvalidOperationException("Capacity Overflow");
+        Debug.Assert(_lastIndex == _entries.Length || _entries.Length == 1);
 
-        var entries = new Entry[newSize];
-        Array.Copy(_entries, 0, entries, 0, count);
+        var entries = _entries;
+        var count = _count;
+        var lastIndex = _lastIndex;
 
-        var newBuckets = new int[entries.Length];
-        while (count-- > 0)
+        Entry[] newEntries;
+        if (count == lastIndex || count + 1 > entries.Length - (entries.Length >> 1))
         {
-            int bucketIndex = entries[count].key.HashCode & (newBuckets.Length - 1);
-            entries[count].next = newBuckets[bucketIndex] - 1;
-            newBuckets[bucketIndex] = count + 1;
+            var newSize = entries.Length * 2;
+            if ((uint) newSize > int.MaxValue) // uint cast handles overflow
+                throw new InvalidOperationException("Capacity Overflow");
+
+            newEntries = new Entry[newSize];
+            _buckets = new int[newSize];
+        }
+        else
+        {
+            newEntries = entries;
+            Array.Clear(_buckets, 0, _buckets.Length);
         }
 
-        _buckets = newBuckets;
-        _entries = entries;
+        if (count == lastIndex)
+        {
+            Array.Copy(entries, 0, newEntries, 0, count);
+        }
+        else
+        {
+            var write = 0;
+            for (var read = 0; read < lastIndex; read++)
+            {
+                if (entries[read].next != Tombstone)
+                {
+                    newEntries[write++] = entries[read];
+                }
+            }
 
-        return entries;
+            Debug.Assert(write == count);
+
+            if (ReferenceEquals(newEntries, entries))
+            {
+                // Release the key strings and values the compacted-away tail still references.
+                Array.Clear(entries, count, lastIndex - count);
+            }
+        }
+
+        _lastIndex = count;
+        _entries = newEntries;
+
+        var buckets = _buckets;
+        while (count-- > 0)
+        {
+            int bucketIndex = newEntries[count].key.HashCode & (buckets.Length - 1);
+            newEntries[count].next = buckets[bucketIndex] - 1;
+            buckets[bucketIndex] = count + 1;
+        }
+
+        return newEntries;
     }
 
     /// <summary>
@@ -308,7 +381,9 @@ internal sealed class StringDictionarySlim<TValue> : DictionaryBase<TValue>, IRe
 
             _count--;
 
-            while (_dictionary._entries[_index].next < -1)
+            // Skips the tombstones removals left behind; the live entries between them are still in
+            // insertion order, which is what this type exists to preserve.
+            while (_dictionary._entries[_index].next == Tombstone)
                 _index++;
 
             _current = new KeyValuePair<Key, TValue>(


### PR DESCRIPTION
Backport of #3285 (issue #3273) to `4.x` for **4.16.1**.

## The defect is live on `4.x`

`Jint/Collections/StringDictionarySlim.cs` and `DictionarySlim.cs` are **byte-identical** between `4.x` and `main` before the fix, so the bug is present unchanged. Verified by running the repro against `4.x` at `474996a9e`:

```js
var o = {}; for (var i = 0; i < 9; i++) o['k' + i] = i; delete o.k0; o.k0 = 99;
var s = []; for (var j = 0; j < 3; j++) s.push(Symbol('s' + j));
var p = {}; for (var j = 0; j < 3; j++) p[s[j]] = j;
delete p[s[0]]; p[s[0]] = 9;
```

| | `Object.keys(o)` | `getOwnPropertySymbols(p)` |
| --- | --- | --- |
| **`4.x` before** | `k0,k1,k2,k3,k4,k5,k6,k7,k8` | `s0,s1,s2` |
| **`4.x` after** | `k1,k2,k3,k4,k5,k6,k7,k8,k0` | `s1,s2,s0` |
| Node 24 | `k1,…,k8,k0` | `s1,s2,s0` |

[OrdinaryOwnPropertyKeys](https://tc39.es/ecma262/#sec-ordinaryownpropertykeys) returns own keys "in ascending chronological order of property creation". `delete o.k` destroys the property; `o.k = v` creates a new one, which is therefore the **newest** key.

It reaches everything that lists own keys — `Object.keys`/`values`/`entries`, `getOwnPropertyNames`, `getOwnPropertyDescriptors`, `getOwnPropertySymbols`, `Reflect.ownKeys` (including through a `Proxy`), `for..in`, `JSON.stringify`, spread and rest, `Object.assign`, `structuredClone`, `Object.defineProperty` as the re-add — on a plain `new Engine()` with no options.

Two things are wider than the issue title suggests, and both carry over:

- **Symbol keys have no cutover at all.** `_symbols` is a `DictionarySlim` directly, with no `HybridDictionary` in front, so it is wrong from **two** keys rather than nine.
- **A *new* key added after a delete lands in the hole too**, LIFO — not only a re-added one. `delete o.k1; delete o.k3; o.a = 1; o.b = 2` interleaves `a` and `b` into the middle of unrelated keys, in reverse.

## Why the suite was green with it present

test262 asserts own-key order in ~98 places and **every one is under the nine-key cutover**, so nothing in the suite builds a nine-key object and deletes from it. 102,495/0 before and after.

## The fix

A removed slot becomes a **tombstone** rather than joining a free list, so `AddKey` always appends and enumeration stays in creation order. Tombstones are squeezed out at `Resize` — in place when the live entries fit in half the capacity, into a doubled array when they do not. Compaction preserves relative order, so it is invisible to enumeration. Removing the **newest** entry hands its slot straight back, so `o.k = v; delete o.k` churn never compacts at all.

It also fixes a latent second bug in the same file: `ClearPreservingCapacity` returned early on `_count == 0`, which is exactly the state of a table emptied by *removals* (count zero, high-water mark non-zero) — so the clear was skipped and the next refill would append above the tombstones. Its one caller is `FunctionEnvironment.Reset`.

## Performance

The half-capacity threshold is measured rather than chosen, and the numbers on `main` are in #3285: against slot reuse, a rotating key set costs **+8.5% / +9.9%** at the collection (+1.4 ns and +1.8 ns per add-and-delete pair) while `o.k = v; delete o.k` churn and re-adding a middle key both get **3–4% faster**. A quarter-capacity threshold measured +34.8% / +29.0% and was rejected; three-quarters erases the rest but doubles the entry-array ceiling again.

**Those figures were taken on `main` and are not re-measured here.** The collection files were byte-identical before the change, so the same code is being compared — but `4.x` is a different build with a different surrounding engine, and I have not run the paired benchmark on this branch. The residual cost has its own follow-up on `main` (#3315, a circular window that would make rotation compaction-free).

## Verification on this branch

Cherry-picked `8acbf6ff8` clean — **no conflicts**, the two collection files being identical is why.

| | net10.0 | net472 |
| --- | --- | --- |
| `Jint.Tests` | **6,774** / 0 failed / 4 skipped | **6,689** / 0 / 4 |
| `Jint.Tests.PublicInterface` | **1,500** / 0 / 9 | **1,493** / 0 / 9 |
| `Jint.Tests.Test262` | **102,495 passed / 0 failed / 189 skipped** | — |
| Solution build, Release, all TFMs | 0 errors | |

The 40 new order tests pass, covering both sides of the nine-entry cutover.

## Scope note

This is the **only** backport candidate from the recent `main` work. The other correctness fixes of the same batch — #3286 (`clone()` teeing without a structured clone) and #3288 (a fetched response's `Headers` missing the immutable guard) — are both in `Jint/WebApi/`, which **does not exist on `4.x`**: no `Jint/WebApi/`, no `Jint/NodeCompat/`, no `Jint.Tests/Wpt/`. The web platform APIs are a 5.x feature and stay there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
