### PR TITLE
JsValue: four spellings of "as", one of which returned null through a non-nullable signature

### DIFF
--- a/Jint.Benchmark/UncacheableExpressionsBenchmark.cs
+++ b/Jint.Benchmark/UncacheableExpressionsBenchmark.cs
@@ -90,7 +90,7 @@ function output(d) {
     [Benchmark]
     public void Benchmark()
     {
-        var call = engine.GetValue("output").TryCast<ICallable>();
+        var call = (ICallable) engine.GetValue("output");
         for (int i = 0; i < N; ++i)
         {
             call.Call(JsValue.Undefined, targetJsObject);

--- a/Jint.Tests.PublicInterface/HostValueNarrowingTests.cs
+++ b/Jint.Tests.PublicInterface/HostValueNarrowingTests.cs
@@ -1,0 +1,92 @@
+#nullable enable
+
+using System.Linq;
+using System.Reflection;
+using Jint.Native;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// Narrowing a <see cref="JsValue"/> to a concrete runtime type is C#'s job, not Jint's. Through 4.16.x
+/// <c>JsValueExtensions</c> carried four spellings of the language's own <c>as</c> — <c>As&lt;T&gt;()</c>,
+/// <c>AsInstance&lt;TInstance&gt;()</c> and two <c>TryCast&lt;T&gt;()</c> overloads — and one of them was
+/// declared to return a non-nullable <c>TInstance</c> while returning <c>null</c> whenever the cast missed.
+/// A host's nullable flow analysis was told the result could not be null, so no check was written and the
+/// <see cref="System.NullReferenceException"/> surfaced somewhere else entirely.
+/// <para>
+/// These tests are written from outside the assembly, under <c>#nullable enable</c>, because that is the only
+/// place the compile-time half of the answer is observable at all.
+/// </para>
+/// </summary>
+public class HostValueNarrowingTests
+{
+    [Fact]
+    public void AMissedNarrowingIsTypedNullableSoTheHostHasToHandleIt()
+    {
+        var engine = new Engine();
+
+        // `as` types this JsArray?, so the compiler refuses to hand it to Sum below until the null is dealt
+        // with. AsInstance<JsArray>() returned this same null through a non-nullable signature.
+        var narrowed = engine.Evaluate("({ a: 1 })") as JsArray;
+
+        narrowed.Should().BeNull();
+    }
+
+    [Fact]
+    public void TheMatchingNarrowingHandsBackACheckedNonNullableBinding()
+    {
+        var engine = new Engine();
+
+        // The pattern form is the one that produces a binding the compiler already knows is non-null, which
+        // is what lets it reach a parameter that does not accept null.
+        if (engine.Evaluate("[1, 2, 3]") is not JsArray array)
+        {
+            Assert.Fail("An array literal must narrow to JsArray.");
+            return;
+        }
+
+        Sum(array).Should().Be(6);
+
+        static double Sum(JsArray value)
+        {
+            var total = 0d;
+            for (var i = 0; i < (int) value.Length; i++)
+            {
+                total += value.Get(i).AsNumber();
+            }
+
+            return total;
+        }
+    }
+
+    [Fact]
+    public void TheThrowingFormIsACastAndItThrowsWhereItMisses()
+    {
+        var engine = new Engine();
+
+        Invoking(() => (JsArray) engine.Evaluate("({ a: 1 })")).Should().Throw<System.InvalidCastException>();
+
+        ((JsArray) engine.Evaluate("[1]")).Get(0).AsNumber().Should().Be(1);
+    }
+
+    /// <summary>
+    /// The regression guard. A helper that narrows for the caller has no way to say "this may be null" that
+    /// the caller's compiler can see — its own signature is the only channel, and getting that wrong is
+    /// exactly what shipped. So <c>JsValueExtensions</c> declares no such helper at all: nothing on it is
+    /// generic in the type being narrowed to.
+    /// </summary>
+    [Fact]
+    public void JsValueExtensionsDeclaresNoGenericNarrowingHelper()
+    {
+        var offenders = typeof(JsValueExtensions)
+            .GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Where(m => m.IsGenericMethodDefinition && m.ReturnType.IsGenericParameter)
+            .Select(m => m.Name)
+            .ToArray();
+
+        offenders.Should().BeEmpty(
+            "narrowing a JsValue is `value as T`, `value is T t` or `(T) value`; a helper cannot express "
+            + "the nullability of the answer to the host's compiler, which is how AsInstance<T>() came to "
+            + "return null through a non-nullable signature");
+    }
+}

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
@@ -187,8 +187,6 @@ namespace Jint
     }
     public static class JsValueExtensions
     {
-        public static T? As<T>(this Jint.Native.JsValue value)
-            where T : Jint.Native.Object.ObjectInstance { }
         public static Jint.Native.JsArray AsArray(this Jint.Native.JsValue value) { }
         public static byte[]? AsArrayBuffer(this Jint.Native.JsValue value) { }
         public static long[] AsBigInt64Array(this Jint.Native.JsValue value) { }
@@ -200,8 +198,6 @@ namespace Jint
         public static float[] AsFloat32Array(this Jint.Native.JsValue value) { }
         public static double[] AsFloat64Array(this Jint.Native.JsValue value) { }
         public static Jint.Native.Function.Function AsFunctionInstance(this Jint.Native.JsValue value) { }
-        public static TInstance AsInstance<TInstance>(this Jint.Native.JsValue value)
-            where TInstance :  class { }
         public static short[] AsInt16Array(this Jint.Native.JsValue value) { }
         public static int[] AsInt32Array(this Jint.Native.JsValue value) { }
         public static sbyte[] AsInt8Array(this Jint.Native.JsValue value) { }
@@ -249,10 +245,6 @@ namespace Jint
         public static bool IsUint8Array(this Jint.Native.JsValue value) { }
         public static bool IsUint8ClampedArray(this Jint.Native.JsValue value) { }
         public static bool IsUndefined(this Jint.Native.JsValue value) { }
-        public static T? TryCast<T>(this Jint.Native.JsValue value)
-            where T :  class { }
-        public static T? TryCast<T>(this Jint.Native.JsValue value, System.Action<Jint.Native.JsValue> fail)
-            where T :  class { }
         public static Jint.Native.JsValue UnwrapIfPromise(this Jint.Native.JsValue value) { }
         public static Jint.Native.JsValue UnwrapIfPromise(this Jint.Native.JsValue value, System.Threading.CancellationToken cancellationToken) { }
         public static Jint.Native.JsValue UnwrapIfPromise(this Jint.Native.JsValue value, System.TimeSpan timeout) { }

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net472.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net472.verified.txt
@@ -168,8 +168,6 @@ namespace Jint
     }
     public static class JsValueExtensions
     {
-        public static T? As<T>(this Jint.Native.JsValue value)
-            where T : Jint.Native.Object.ObjectInstance { }
         public static Jint.Native.JsArray AsArray(this Jint.Native.JsValue value) { }
         public static byte[]? AsArrayBuffer(this Jint.Native.JsValue value) { }
         public static long[] AsBigInt64Array(this Jint.Native.JsValue value) { }
@@ -180,8 +178,6 @@ namespace Jint
         public static float[] AsFloat32Array(this Jint.Native.JsValue value) { }
         public static double[] AsFloat64Array(this Jint.Native.JsValue value) { }
         public static Jint.Native.Function.Function AsFunctionInstance(this Jint.Native.JsValue value) { }
-        public static TInstance AsInstance<TInstance>(this Jint.Native.JsValue value)
-            where TInstance :  class { }
         public static short[] AsInt16Array(this Jint.Native.JsValue value) { }
         public static int[] AsInt32Array(this Jint.Native.JsValue value) { }
         public static sbyte[] AsInt8Array(this Jint.Native.JsValue value) { }
@@ -229,10 +225,6 @@ namespace Jint
         public static bool IsUint8Array(this Jint.Native.JsValue value) { }
         public static bool IsUint8ClampedArray(this Jint.Native.JsValue value) { }
         public static bool IsUndefined(this Jint.Native.JsValue value) { }
-        public static T? TryCast<T>(this Jint.Native.JsValue value)
-            where T :  class { }
-        public static T? TryCast<T>(this Jint.Native.JsValue value, System.Action<Jint.Native.JsValue> fail)
-            where T :  class { }
         public static Jint.Native.JsValue UnwrapIfPromise(this Jint.Native.JsValue value) { }
         public static Jint.Native.JsValue UnwrapIfPromise(this Jint.Native.JsValue value, System.Threading.CancellationToken cancellationToken) { }
         public static Jint.Native.JsValue UnwrapIfPromise(this Jint.Native.JsValue value, System.TimeSpan timeout) { }

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
@@ -187,8 +187,6 @@ namespace Jint
     }
     public static class JsValueExtensions
     {
-        public static T? As<T>(this Jint.Native.JsValue value)
-            where T : Jint.Native.Object.ObjectInstance { }
         public static Jint.Native.JsArray AsArray(this Jint.Native.JsValue value) { }
         public static byte[]? AsArrayBuffer(this Jint.Native.JsValue value) { }
         public static long[] AsBigInt64Array(this Jint.Native.JsValue value) { }
@@ -200,8 +198,6 @@ namespace Jint
         public static float[] AsFloat32Array(this Jint.Native.JsValue value) { }
         public static double[] AsFloat64Array(this Jint.Native.JsValue value) { }
         public static Jint.Native.Function.Function AsFunctionInstance(this Jint.Native.JsValue value) { }
-        public static TInstance AsInstance<TInstance>(this Jint.Native.JsValue value)
-            where TInstance :  class { }
         public static short[] AsInt16Array(this Jint.Native.JsValue value) { }
         public static int[] AsInt32Array(this Jint.Native.JsValue value) { }
         public static sbyte[] AsInt8Array(this Jint.Native.JsValue value) { }
@@ -249,10 +245,6 @@ namespace Jint
         public static bool IsUint8Array(this Jint.Native.JsValue value) { }
         public static bool IsUint8ClampedArray(this Jint.Native.JsValue value) { }
         public static bool IsUndefined(this Jint.Native.JsValue value) { }
-        public static T? TryCast<T>(this Jint.Native.JsValue value)
-            where T :  class { }
-        public static T? TryCast<T>(this Jint.Native.JsValue value, System.Action<Jint.Native.JsValue> fail)
-            where T :  class { }
         public static Jint.Native.JsValue UnwrapIfPromise(this Jint.Native.JsValue value) { }
         public static Jint.Native.JsValue UnwrapIfPromise(this Jint.Native.JsValue value, System.Threading.CancellationToken cancellationToken) { }
         public static Jint.Native.JsValue UnwrapIfPromise(this Jint.Native.JsValue value, System.TimeSpan timeout) { }

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.0.verified.txt
@@ -168,8 +168,6 @@ namespace Jint
     }
     public static class JsValueExtensions
     {
-        public static T? As<T>(this Jint.Native.JsValue value)
-            where T : Jint.Native.Object.ObjectInstance { }
         public static Jint.Native.JsArray AsArray(this Jint.Native.JsValue value) { }
         public static byte[]? AsArrayBuffer(this Jint.Native.JsValue value) { }
         public static long[] AsBigInt64Array(this Jint.Native.JsValue value) { }
@@ -180,8 +178,6 @@ namespace Jint
         public static float[] AsFloat32Array(this Jint.Native.JsValue value) { }
         public static double[] AsFloat64Array(this Jint.Native.JsValue value) { }
         public static Jint.Native.Function.Function AsFunctionInstance(this Jint.Native.JsValue value) { }
-        public static TInstance AsInstance<TInstance>(this Jint.Native.JsValue value)
-            where TInstance :  class { }
         public static short[] AsInt16Array(this Jint.Native.JsValue value) { }
         public static int[] AsInt32Array(this Jint.Native.JsValue value) { }
         public static sbyte[] AsInt8Array(this Jint.Native.JsValue value) { }
@@ -229,10 +225,6 @@ namespace Jint
         public static bool IsUint8Array(this Jint.Native.JsValue value) { }
         public static bool IsUint8ClampedArray(this Jint.Native.JsValue value) { }
         public static bool IsUndefined(this Jint.Native.JsValue value) { }
-        public static T? TryCast<T>(this Jint.Native.JsValue value)
-            where T :  class { }
-        public static T? TryCast<T>(this Jint.Native.JsValue value, System.Action<Jint.Native.JsValue> fail)
-            where T :  class { }
         public static Jint.Native.JsValue UnwrapIfPromise(this Jint.Native.JsValue value) { }
         public static Jint.Native.JsValue UnwrapIfPromise(this Jint.Native.JsValue value, System.Threading.CancellationToken cancellationToken) { }
         public static Jint.Native.JsValue UnwrapIfPromise(this Jint.Native.JsValue value, System.TimeSpan timeout) { }

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.1.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.1.verified.txt
@@ -168,8 +168,6 @@ namespace Jint
     }
     public static class JsValueExtensions
     {
-        public static T? As<T>(this Jint.Native.JsValue value)
-            where T : Jint.Native.Object.ObjectInstance { }
         public static Jint.Native.JsArray AsArray(this Jint.Native.JsValue value) { }
         public static byte[]? AsArrayBuffer(this Jint.Native.JsValue value) { }
         public static long[] AsBigInt64Array(this Jint.Native.JsValue value) { }
@@ -180,8 +178,6 @@ namespace Jint
         public static float[] AsFloat32Array(this Jint.Native.JsValue value) { }
         public static double[] AsFloat64Array(this Jint.Native.JsValue value) { }
         public static Jint.Native.Function.Function AsFunctionInstance(this Jint.Native.JsValue value) { }
-        public static TInstance AsInstance<TInstance>(this Jint.Native.JsValue value)
-            where TInstance :  class { }
         public static short[] AsInt16Array(this Jint.Native.JsValue value) { }
         public static int[] AsInt32Array(this Jint.Native.JsValue value) { }
         public static sbyte[] AsInt8Array(this Jint.Native.JsValue value) { }
@@ -229,10 +225,6 @@ namespace Jint
         public static bool IsUint8Array(this Jint.Native.JsValue value) { }
         public static bool IsUint8ClampedArray(this Jint.Native.JsValue value) { }
         public static bool IsUndefined(this Jint.Native.JsValue value) { }
-        public static T? TryCast<T>(this Jint.Native.JsValue value)
-            where T :  class { }
-        public static T? TryCast<T>(this Jint.Native.JsValue value, System.Action<Jint.Native.JsValue> fail)
-            where T :  class { }
         public static Jint.Native.JsValue UnwrapIfPromise(this Jint.Native.JsValue value) { }
         public static Jint.Native.JsValue UnwrapIfPromise(this Jint.Native.JsValue value, System.Threading.CancellationToken cancellationToken) { }
         public static Jint.Native.JsValue UnwrapIfPromise(this Jint.Native.JsValue value, System.TimeSpan timeout) { }

--- a/Jint.Tests/Runtime/Domain/UuidPrototype.cs
+++ b/Jint.Tests/Runtime/Domain/UuidPrototype.cs
@@ -13,7 +13,12 @@ internal sealed class UuidPrototype : UuidInstance
 
     private UuidInstance EnsureUuidInstance(JsValue thisObject)
     {
-        return thisObject.TryCast<UuidInstance>(value => throw new JavaScriptException(Engine.Realm.Intrinsics.TypeError, "Invalid Uuid"));
+        if (thisObject is not UuidInstance instance)
+        {
+            throw new JavaScriptException(Engine.Realm.Intrinsics.TypeError, "Invalid Uuid");
+        }
+
+        return instance;
     }
 
     private JsValue ToGuidString(JsValue thisObject, JsValue[] arguments) => EnsureUuidInstance(thisObject).PrimitiveValue.ToString();

--- a/Jint.Tests/Runtime/FunctionTests.cs
+++ b/Jint.Tests/Runtime/FunctionTests.cs
@@ -364,20 +364,18 @@ assertEqual(booleanCount, 1);
     [Fact]
     public void CanInvokeCallForFunctionInstance()
     {
-        _engine.Evaluate(@"
+        ((Function) _engine.Evaluate(@"
                 (function () {
                     function foo(a = 123) { return a; }
                     foo()
-                })")
-            .As<Function>().Call();
+                })")).Call();
 
-        var result = _engine.Evaluate(@"
+        var result = ((Function) _engine.Evaluate(@"
                 (function () {
                     class Foo { test() { return 123 } }
                     let f = new Foo()
                     return f.test()
-                })")
-            .As<Function>().Call();
+                })")).Call();
 
         result.IsInteger().Should().BeTrue();
         result.AsInteger().Should().Be(123);

--- a/Jint.Tests/Runtime/OperatorOverloadingTests.cs
+++ b/Jint.Tests/Runtime/OperatorOverloadingTests.cs
@@ -366,7 +366,7 @@ public class OperatorOverloadingTests
         engine.SetValue("log", new Action<object>(Console.WriteLine));
 
         engine.Evaluate("let v1 = new Vector2D(1, 2);");
-        engine.Evaluate("new String(v1)").As<StringInstance>().StringData.ToString().Should().Be("(1, 2)");
+        ((StringInstance) engine.Evaluate("new String(v1)")).StringData.ToString().Should().Be("(1, 2)");
         engine.Evaluate("'### ' + v1 + ' ###'").Should().Be("### (1, 2) ###");
     }
 
@@ -389,7 +389,7 @@ public class OperatorOverloadingTests
         // (once in EvaluateOperatorOverloading, once in the operator switch).
         sideEffectCount.Should().Be(1);
 
-        var arr = result.As<Native.JsArray>();
+        var arr = (Native.JsArray) result;
         arr.Get(0).AsNumber().Should().Be(2.0);   // v.X = 1 + 1 = 2
         arr.Get(1).AsNumber().Should().Be(12.0);  // v.Y = 2 + 10 = 12
     }

--- a/Jint/JsValueExtensions.cs
+++ b/Jint/JsValueExtensions.cs
@@ -199,18 +199,6 @@ public static class JsValueExtensions
 
     [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static TInstance AsInstance<TInstance>(this JsValue value) where TInstance : class
-    {
-        if (!value.IsObject())
-        {
-            Throw.ArgumentException("The value is not an object");
-        }
-
-        return (value as TInstance)!;
-    }
-
-    [Pure]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static JsArray AsArray(this JsValue value)
     {
         if (!value.IsArray())
@@ -545,39 +533,6 @@ public static class JsValueExtensions
         }
 
         return ((JsTypedArray) value).ToNativeArray<double>();
-    }
-
-    [Pure]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static T? TryCast<T>(this JsValue value) where T : class
-    {
-        return value as T;
-    }
-
-    [Pure]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static T? TryCast<T>(this JsValue value, Action<JsValue> fail) where T : class
-    {
-        if (value is T o)
-        {
-            return o;
-        }
-
-        fail.Invoke(value);
-
-        return null;
-    }
-
-    [Pure]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static T? As<T>(this JsValue value) where T : ObjectInstance
-    {
-        if (value.IsObject())
-        {
-            return value as T;
-        }
-
-        return null;
     }
 
     [Pure]

--- a/Jint/Native/Error/ErrorPrototype.cs
+++ b/Jint/Native/Error/ErrorPrototype.cs
@@ -155,7 +155,7 @@ internal sealed partial class ErrorPrototype : ErrorInstance
     [JsFunction]
     public JsValue ToString(JsValue thisObject)
     {
-        var o = thisObject.TryCast<ObjectInstance>();
+        var o = thisObject as ObjectInstance;
         if (o is null)
         {
             Throw.TypeError(_realm, $"Method Error.prototype.toString called on incompatible receiver {thisObject}");

--- a/Jint/Runtime/Descriptors/PropertyDescriptor.cs
+++ b/Jint/Runtime/Descriptors/PropertyDescriptor.cs
@@ -466,7 +466,7 @@ public class PropertyDescriptor
 
         if (hasGet)
         {
-            if (!get!.IsUndefined() && get!.TryCast<ICallable>() == null)
+            if (!get!.IsUndefined() && get is not ICallable)
             {
                 Throw.TypeError(realm, "Getter must be a function");
             }
@@ -476,7 +476,7 @@ public class PropertyDescriptor
 
         if (hasSet)
         {
-            if (!set!.IsUndefined() && set!.TryCast<ICallable>() is null)
+            if (!set!.IsUndefined() && set is not ICallable)
             {
                 Throw.TypeError(realm, "Setter must be a function");
             }

--- a/Jint/Runtime/Interop/NamespaceReference.cs
+++ b/Jint/Runtime/Interop/NamespaceReference.cs
@@ -71,7 +71,7 @@ public class NamespaceReference : ObjectInstance, ICallable
             genericTypes[i] = tr.ReferenceType;
         }
 
-        var typeReference = GetPath(_path + "`" + arguments.Length.ToString(CultureInfo.InvariantCulture)).As<TypeReference>();
+        var typeReference = GetPath(_path + "`" + arguments.Length.ToString(CultureInfo.InvariantCulture)) as TypeReference;
 
         if (typeReference is null)
         {

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -55,6 +55,10 @@ This table is filled by the pull request that removes the member. A member that 
 | `Engine.ModuleOperations(Engine, IModuleLoader)` → `internal` | nothing. `Engine.Modules`' setter is `internal`, so an instance a host constructed could never be installed | [#3304](https://github.com/sebastienros/jint/pull/3304) |
 | `JsMap(Engine, Realm)` → `internal` | nothing. It required a `Realm`, which a host has no supported way to obtain; `JsSet`'s equivalent was already `internal` | [#3304](https://github.com/sebastienros/jint/pull/3304) |
 | The `Options` extension methods that mirrored a property — `Strict`, `Culture`, `LocalTimeZone`, `DebugMode`, `AllowClrWrite`, `LimitRecursion`, `SetTypeResolver` and sixteen more | the property they set — the full table is in [3.3](#33-options-is-configured-through-its-properties) | [#3310](https://github.com/sebastienros/jint/pull/3310) |
+| `JsValueExtensions.AsInstance<TInstance>(JsValue)` | `value as TInstance` for the answer that may be absent, `(TInstance) value` for the one that must not be — see [2.4](#24-the-four-spellings-of-as-are-gone) | [#3319](https://github.com/sebastienros/jint/pull/3319) |
+| `JsValueExtensions.As<T>(JsValue)` (`where T : ObjectInstance`) | `value as T`. The `IsObject()` test it ran first is implied by the constraint, so the two are the same question | [#3319](https://github.com/sebastienros/jint/pull/3319) |
+| `JsValueExtensions.TryCast<T>(JsValue)` | `value as T` — the body was exactly that, and it is not the `Try` pattern: no `bool`, no `out` | [#3319](https://github.com/sebastienros/jint/pull/3319) |
+| `JsValueExtensions.TryCast<T>(JsValue, Action<JsValue> fail)` | `value is T t`, with the failure written where it happens — see [2.4](#24-the-four-spellings-of-as-are-gone) | [#3319](https://github.com/sebastienros/jint/pull/3319) |
 
 ### 2.1 Sealed types
 
@@ -110,6 +114,59 @@ word has to mean one thing.
 reading `Options.Constraints.PromiseTimeout`, whose default is also ten seconds. A host that configured a
 different value was silently ignored. It now reads the promise's own engine. Nothing changes for a host that
 left the default, and the `TimeSpan` and `CancellationToken` overloads are untouched.
+
+### 2.4 The four spellings of `as` are gone
+
+`JsValueExtensions` carried four ways to narrow a `JsValue` to a concrete runtime type — `As<T>()`,
+`AsInstance<TInstance>()` and two `TryCast<T>()` overloads — and each was C#'s own `as` with a method name
+around it. Narrowing goes back to the language: `value as JsArray` for the answer that may be absent,
+`value is JsArray array` for the checked binding, `(JsArray) value` for the one that must not be absent.
+
+One of the four was also wrong. `AsInstance<TInstance>()` was declared to return a **non-nullable**
+`TInstance` and returned `null` whenever the value was not one, so the caller's nullable flow analysis was
+told the result could not be null, no check was written, and the `NullReferenceException` surfaced somewhere
+else entirely:
+
+```c#
+// 4.16.x — compiled with no warning, and threw at the second line, not the first
+JsArray array = engine.Evaluate("({ a: 1 })").AsInstance<JsArray>();
+var first = array.Get(0);
+
+// 5.x — the compiler types the answer JsArray? and will not let the second line past a check
+var array = engine.Evaluate("({ a: 1 })") as JsArray;
+var first = array?.Get(0);
+```
+
+Note that the two failure modes it had are now one. `AsInstance<TInstance>()` threw `ArgumentException` for a
+non-object and returned `null` for an object of the wrong type; `(TInstance) value` throws
+`InvalidCastException` for both, and `value as TInstance` answers `null` for both.
+
+The `Action<JsValue> fail` overload of `TryCast<T>()` is the least obvious replacement, because it was a
+"Try" that invoked a failure **callback** and then returned `null` — a control-flow idiom with no precedent
+in the BCL. Write the failure where it happens:
+
+```c#
+// 4.16.x
+private UuidInstance EnsureUuidInstance(JsValue thisObject)
+{
+    return thisObject.TryCast<UuidInstance>(
+        value => throw new JavaScriptException(Engine.Realm.Intrinsics.TypeError, "Invalid Uuid"));
+}
+
+// 5.x
+private UuidInstance EnsureUuidInstance(JsValue thisObject)
+{
+    if (thisObject is not UuidInstance instance)
+    {
+        throw new JavaScriptException(Engine.Realm.Intrinsics.TypeError, "Invalid Uuid");
+    }
+
+    return instance;
+}
+```
+
+That is the actual before/after of a prototype in this repository's own test suite, which was the only caller
+of the overload anywhere in the tree.
 
 ## 3. Renamed and reshaped API
 


### PR DESCRIPTION
`JsValueExtensions` carried four ways to narrow a `JsValue` to a concrete runtime type, and every one of them was C#'s own `as` with a method name around it:

| Member | What it was |
| --- | --- |
| `As<T>() where T : ObjectInstance` | an `IsObject()` test the constraint already implies, then `value as T` |
| `TryCast<T>()` | the body was literally `return value as T`, and it is not the Try pattern: no `bool`, no `out` |
| `TryCast<T>(Action<JsValue> fail)` | a "Try" that invoked a failure **callback** and then returned `null`. That control-flow idiom has no precedent in the BCL |
| `AsInstance<TInstance>()` | declared to return a **non-nullable** `TInstance`, and returning `null` whenever the value was not one — laundered past the compiler with `!` |

The fourth is the defect the others only surround:

```c#
public static TInstance AsInstance<TInstance>(this JsValue value) where TInstance : class
{
    if (!value.IsObject()) { Throw.ArgumentException("The value is not an object"); }
    return (value as TInstance)!;      // null when the cast fails
}
```

`value.AsInstance<JsArray>()` on a plain object returned null typed non-null, so a host's nullable flow analysis said no check was needed, none was written, and the `NullReferenceException` surfaced somewhere else entirely — with a stack that names the dereference rather than the narrowing. Every other `As*` in the file throws on a mismatch, so the one member that silently answered null was also the one that looked like it could not.

## What this does

All four are deleted. The replacements are the language's own: `value as JsArray` for the answer that may be absent, `value is JsArray array` for the checked binding, `(JsArray) value` for the one that must not be absent.

**Ten call sites** move to those constructs, and no private helper reintroduces them:

| Project | Call sites |
| --- | --- |
| `Jint/` | 4 — `ErrorPrototype.ToString`, `PropertyDescriptor.ToPropertyDescriptor` (×2), `NamespaceReference.Call` |
| `Jint.Tests/` | 5 — `UuidPrototype`, `FunctionTests` (×2), `OperatorOverloadingTests` (×2) |
| `Jint.Benchmark/` | 1 — `UncacheableExpressionsBenchmark` |

`Jint.Tests.PublicInterface`, `Jint.Tests.CommonScripts` and `Jint.Repl` had none, so nothing in the host-view suite — `RavenApiUsageTests` included — was pinned on any of the four.

Two notes on the engine-side moves. `NamespaceReference` used `As<TypeReference>()`, whose `IsObject()` test is redundant against a `TypeReference` cast, so it is a bare `as`. `PropertyDescriptor.ToPropertyDescriptor` asked `TryCast<ICallable>() is null` twice; `is not ICallable` is the same question without a generic method call between the value and the answer.

## Nothing kept

Every one of the four turned out to be deletable. `AsInstance`'s throwing-on-a-non-object behaviour is the closest thing to a load-bearing property in the set, and it had **no caller at all** — the only reference in the tree was its own declaration. It is worth recording that its two failure modes were never one thing anyway: `ArgumentException` for a non-object, silent `null` for an object of the wrong type. `(TInstance) value` throws `InvalidCastException` for both, which is stated in the migration guide.

## The guard

`Jint.Tests.PublicInterface/HostValueNarrowingTests.cs` pins the replacement from outside the assembly and under `#nullable enable`, which is the only place the compile-time half of the answer is observable. Three tests document the idiom; the fourth is the regression guard:

> `JsValueExtensions` may declare no generic method that returns its own type parameter — a helper that narrows for the caller has no channel but its own signature to tell the caller's compiler whether the answer can be null, and getting that wrong is exactly what shipped.

Verified red before the fix: with the four declarations restored, it fails naming them.

## Baselines and migration

The five public API baselines are regenerated from `.received.txt` (never hand-edited). The diff is four public members removed on each of the five, and nothing else moved.

`docs/v5-migration.md` §2 gains one row per removed member, and §2.4 carries the before/after — including for the `Action<JsValue> fail` overload, whose replacement is the least obvious of the four:

```c#
// 4.16.x
return thisObject.TryCast<UuidInstance>(
    value => throw new JavaScriptException(Engine.Realm.Intrinsics.TypeError, "Invalid Uuid"));

// 5.x
if (thisObject is not UuidInstance instance)
{
    throw new JavaScriptException(Engine.Realm.Intrinsics.TypeError, "Invalid Uuid");
}

return instance;
```

## Verification

- `dotnet build -c Release` — 0 errors, 0 compiler warnings (`TreatWarningsAsErrors` on).
- `dotnet test -c Release Jint.Tests` — 10645 passed on net10.0, 10645 on net8.0, 7298 on net472.
- `dotnet test -c Release Jint.Tests.PublicInterface` — 2567 passed on net10.0, 1967 on net472.

## One defect noticed and left alone

`ErrorPrototype.ToString` interpolates the receiver straight into a `Throw.TypeError` message (`$"...incompatible receiver {thisObject}"`), which runs user JavaScript through the value's `toString` while an error is being raised; `SafeToDisplayString` is the intended spelling. It is pre-existing and unrelated to this change, so the line is moved verbatim rather than fixed here.
