### PR TITLE
ShadowRealm: SetValue mirrors the engine's, and the trimming annotation is on the overload that needs it

### DIFF
--- a/Jint.Tests.PublicInterface/ShadowRealmSetValueTests.cs
+++ b/Jint.Tests.PublicInterface/ShadowRealmSetValueTests.cs
@@ -1,0 +1,247 @@
+#nullable enable
+
+using System.Reflection;
+using Jint.Native;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// <c>ShadowRealm.SetValue</c> is the mirror of <c>Engine.SetValue</c>: the same overload set, the same
+/// trimming annotations with the same messages, and the same nullability, differing only in which global
+/// object is written and what is returned for chaining.
+/// </summary>
+/// <remarks>
+/// It was not always. The <see cref="Delegate"/> overload carried
+/// <c>[RequiresUnreferencedCode("User supplied delegate")]</c> — a warning about a registration that
+/// reflects over nothing a trimmer can remove — while the reflective <c>object</c> overload beside it,
+/// which is the actual trimming hazard, carried no annotation at all. A trimming host projecting a host
+/// object into a shadow realm therefore got no diagnostic and a member that read as <c>undefined</c> at
+/// run time. Three overloads an embedder can reach on the engine were missing outright, and the two
+/// surfaces disagreed about whether <c>null</c> was allowed.
+/// </remarks>
+public class ShadowRealmSetValueTests
+{
+    public sealed class Company
+    {
+        public Company(string name) => Name = name;
+
+        public string Name { get; }
+
+        public string Shout() => Name.ToUpperInvariant();
+    }
+
+    /// <summary>
+    /// The mirror itself, asserted rather than described: same overloads, same type parameters, same
+    /// <c>[DynamicallyAccessedMembers]</c> and <c>[RequiresUnreferencedCode]</c>, same messages.
+    /// </summary>
+    [Fact]
+    public void TheOverloadSetAndItsTrimmingAnnotationsMirrorTheEngines()
+    {
+        var shadowRealm = DescribeSetValueOverloads(typeof(Native.ShadowRealm.ShadowRealm));
+        var engine = DescribeSetValueOverloads(typeof(Engine));
+
+        shadowRealm.Should().Equal(engine);
+
+        // and the mirror is of something, rather than of two empty sets
+        engine.Should().HaveCount(10);
+
+#if NET8_0_OR_GREATER
+        // Only where the attributes are real BCL types: PolySharp's downlevel stand-ins reach neither the
+        // emitted metadata nor the public API baselines, which is why net472 and the two netstandard
+        // baselines show none of this.
+        engine.Should().ContainSingle(x => x.Contains("[RequiresUnreferencedCode", StringComparison.Ordinal));
+        // the open paren matters: the [RequiresUnreferencedCode] message names the attribute too
+        engine.Count(x => x.Contains("[DynamicallyAccessedMembers(", StringComparison.Ordinal)).Should().Be(3);
+#endif
+    }
+
+    [Fact]
+    public void ATypedHostObjectIsProjectedIntoTheShadowRealmAndNowhereElse()
+    {
+        var engine = new Engine();
+        var shadowRealm = engine.Intrinsics.ShadowRealm.Construct();
+
+        shadowRealm.SetValue("company", new Company("acme")).Should().BeSameAs(shadowRealm);
+
+        shadowRealm.Evaluate("company.Name").Should().Be("acme");
+        shadowRealm.Evaluate("company.Shout()").Should().Be("ACME");
+        engine.Evaluate("typeof company").Should().Be("undefined");
+    }
+
+    [Fact]
+    public void AnUntypedHostObjectStillProjects()
+    {
+        var engine = new Engine();
+        var shadowRealm = engine.Intrinsics.ShadowRealm.Construct();
+
+        object company = new Company("acme");
+        shadowRealm.SetValue("company", company);
+
+        shadowRealm.Evaluate("company.Name").Should().Be("acme");
+    }
+
+    /// <summary>
+    /// The array overload exists so the annotation lands on the element type; what an embedder can observe
+    /// is that the elements' own members are the ones script reaches.
+    /// </summary>
+    [Fact]
+    public void AnArrayIsProjectedByItsElementType()
+    {
+        var engine = new Engine();
+        var shadowRealm = engine.Intrinsics.ShadowRealm.Construct();
+
+        shadowRealm.SetValue("companies", new[] { new Company("acme"), new Company("initech") });
+
+        shadowRealm.Evaluate("companies.length").Should().Be(2);
+        shadowRealm.Evaluate("companies[1].Name").Should().Be("initech");
+    }
+
+    [Fact]
+    public void ATypeIsProjectedAsAConstructorScriptCanName()
+    {
+        var engine = new Engine();
+        var shadowRealm = engine.Intrinsics.ShadowRealm.Construct();
+
+        shadowRealm.SetValue("Company", typeof(Company));
+
+        shadowRealm.Evaluate("new Company('acme').Name").Should().Be("acme");
+        engine.Evaluate("typeof Company").Should().Be("undefined");
+    }
+
+    /// <summary>
+    /// <c>ShadowRealm</c> took <c>string</c> and <c>object</c> where the engine took <c>string?</c> and
+    /// <c>object?</c>, so the two disagreed about a registration a host can plausibly make.
+    /// </summary>
+    [Fact]
+    public void ANullValueRegistersAsNullOnBothSurfaces()
+    {
+        var engine = new Engine();
+        var shadowRealm = engine.Intrinsics.ShadowRealm.Construct();
+
+        engine.SetValue("s", (string?) null);
+        engine.SetValue("o", (object?) null);
+        shadowRealm.SetValue("s", (string?) null);
+        shadowRealm.SetValue("o", (object?) null);
+
+        engine.Evaluate("s === null && o === null").Should().BeTrue();
+        shadowRealm.Evaluate("s === null && o === null").Should().BeTrue();
+    }
+
+    /// <summary>
+    /// The delegate overload is the one whose property attributes differ, on both surfaces: non-enumerable,
+    /// which is what ECMA-262 §17 gives a built-in global function, while every other overload installs the
+    /// ordinary enumerable data property.
+    /// </summary>
+    [Fact]
+    public void ADelegateIsInstalledNonEnumerableAndEverythingElseIsNot()
+    {
+        var engine = new Engine();
+        var shadowRealm = engine.Intrinsics.ShadowRealm.Construct();
+
+        shadowRealm.SetValue("fn", (Delegate) new Func<int>(() => 42));
+        shadowRealm.SetValue("num", 42);
+
+        shadowRealm.Evaluate("fn()").Should().Be(42);
+        shadowRealm.Evaluate("Object.keys(globalThis).indexOf('fn')").Should().Be(-1);
+        shadowRealm.Evaluate("Object.keys(globalThis).indexOf('num') >= 0").Should().BeTrue();
+    }
+
+    /// <summary>
+    /// The primitive overloads still bind to themselves rather than to the newly added generic one - which
+    /// is why each of them casts its <c>JsNumber</c> / <c>JsBoolean</c> to <c>JsValue</c> before handing it
+    /// on, exactly as the engine's do.
+    /// </summary>
+    [Fact]
+    public void ThePrimitiveOverloadsKeepTheirTypes()
+    {
+        var engine = new Engine();
+        var shadowRealm = engine.Intrinsics.ShadowRealm.Construct();
+
+        shadowRealm
+            .SetValue("s", "text")
+            .SetValue("d", 1.5)
+            .SetValue("i", 7)
+            .SetValue("b", true)
+            .SetValue("v", JsValue.Undefined);
+
+        shadowRealm.Evaluate("[typeof s, typeof d, typeof i, typeof b, typeof v].join(',')")
+            .Should().Be("string,number,number,boolean,undefined");
+        shadowRealm.Evaluate("s + '|' + d + '|' + i + '|' + b").Should().Be("text|1.5|7|true");
+    }
+
+    private static List<string> DescribeSetValueOverloads(Type type)
+    {
+        return type
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Where(m => string.Equals(m.Name, "SetValue", StringComparison.Ordinal))
+            .Select(Describe)
+            .OrderBy(x => x, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    private static string Describe(MethodInfo method)
+    {
+        var typeParameters = method.IsGenericMethodDefinition
+            ? "<" + string.Join(", ", method.GetGenericArguments().Select(a => a.Name + DescribeAnnotations(a.GetCustomAttributes(inherit: false)))) + ">"
+            : "";
+
+        var parameters = string.Join(", ", method.GetParameters().Select(DescribeParameter));
+
+        return "SetValue" + typeParameters + "(" + parameters + ")" + DescribeAnnotations(method.GetCustomAttributes(inherit: false));
+    }
+
+    private static string DescribeParameter(ParameterInfo parameter)
+    {
+        return parameter.ParameterType.Name
+               + DescribeNullability(parameter)
+               + DescribeAnnotations(parameter.GetCustomAttributes(inherit: false));
+    }
+
+    private static string DescribeNullability(ParameterInfo parameter)
+    {
+#if NET8_0_OR_GREATER
+        return new NullabilityInfoContext().Create(parameter).WriteState == NullabilityState.Nullable ? "?" : "";
+#else
+        _ = parameter;
+        return "";
+#endif
+    }
+
+    /// <summary>
+    /// Read by name rather than by type: on the downlevel targets both Jint and this test project get their
+    /// own internal PolySharp copy of these attributes, so <c>GetCustomAttribute&lt;T&gt;</c> would look for
+    /// the wrong one and quietly find nothing on either side of the comparison.
+    /// </summary>
+    private static string DescribeAnnotations(object[] attributes)
+    {
+        var described = attributes
+            .Select(DescribeAnnotation)
+            .Where(x => x is not null)
+            .OrderBy(x => x, StringComparer.Ordinal)
+            .ToList();
+
+        return described.Count == 0 ? "" : " " + string.Join(" ", described);
+    }
+
+    private static string? DescribeAnnotation(object attribute)
+    {
+        var name = attribute.GetType().FullName;
+        if (string.Equals(name, "System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute", StringComparison.Ordinal))
+        {
+            return "[RequiresUnreferencedCode(" + Read(attribute, "Message") + ")]";
+        }
+
+        if (string.Equals(name, "System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute", StringComparison.Ordinal))
+        {
+            return "[DynamicallyAccessedMembers(" + Read(attribute, "MemberTypes") + ")]";
+        }
+
+        return null;
+    }
+
+    private static string Read(object attribute, string propertyName)
+    {
+        var value = attribute.GetType().GetProperty(propertyName)?.GetValue(attribute);
+        return Convert.ToString(value, System.Globalization.CultureInfo.InvariantCulture) ?? "";
+    }
+}

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
@@ -1588,13 +1588,16 @@ namespace Jint.Native.ShadowRealm
         public Jint.Native.JsValue Evaluate(string sourceText, Jint.ScriptParsingOptions? parsingOptions = null) { }
         public Jint.Native.JsValue ImportValue(string specifier, string exportName) { }
         public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, Jint.Native.JsValue value) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("User supplied delegate")]
         public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, System.Delegate value) { }
+        public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicEvents)] System.Type type) { }
         public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, bool value) { }
         public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, double value) { }
         public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, int value) { }
-        public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, object obj) { }
-        public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, string value) { }
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(@"The runtime type of obj is not known at the call site, so the members Jint resolves by reflection cannot be preserved by the trimmer, and a removed one reads as undefined rather than as an error. Prefer SetValue<T>(string, T), whose type parameter carries [DynamicallyAccessedMembers]; pass an already-built JsValue; or root the type yourself.")]
+        public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, object? obj) { }
+        public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, string? value) { }
+        public Jint.Native.ShadowRealm.ShadowRealm SetValue<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicEvents)]  T>(string name, T? obj) { }
+        public Jint.Native.ShadowRealm.ShadowRealm SetValue<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicEvents)]  T>(string name, T[]? obj) { }
     }
     public sealed class ShadowRealmConstructor : Jint.Native.Constructor
     {

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net472.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net472.verified.txt
@@ -1440,11 +1440,14 @@ namespace Jint.Native.ShadowRealm
         public Jint.Native.JsValue ImportValue(string specifier, string exportName) { }
         public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, Jint.Native.JsValue value) { }
         public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, System.Delegate value) { }
+        public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, System.Type type) { }
         public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, bool value) { }
         public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, double value) { }
         public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, int value) { }
-        public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, object obj) { }
-        public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, string value) { }
+        public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, object? obj) { }
+        public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, string? value) { }
+        public Jint.Native.ShadowRealm.ShadowRealm SetValue<T>(string name, T? obj) { }
+        public Jint.Native.ShadowRealm.ShadowRealm SetValue<T>(string name, T[]? obj) { }
     }
     public sealed class ShadowRealmConstructor : Jint.Native.Constructor
     {

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
@@ -1588,13 +1588,16 @@ namespace Jint.Native.ShadowRealm
         public Jint.Native.JsValue Evaluate(string sourceText, Jint.ScriptParsingOptions? parsingOptions = null) { }
         public Jint.Native.JsValue ImportValue(string specifier, string exportName) { }
         public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, Jint.Native.JsValue value) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("User supplied delegate")]
         public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, System.Delegate value) { }
+        public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicEvents)] System.Type type) { }
         public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, bool value) { }
         public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, double value) { }
         public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, int value) { }
-        public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, object obj) { }
-        public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, string value) { }
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(@"The runtime type of obj is not known at the call site, so the members Jint resolves by reflection cannot be preserved by the trimmer, and a removed one reads as undefined rather than as an error. Prefer SetValue<T>(string, T), whose type parameter carries [DynamicallyAccessedMembers]; pass an already-built JsValue; or root the type yourself.")]
+        public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, object? obj) { }
+        public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, string? value) { }
+        public Jint.Native.ShadowRealm.ShadowRealm SetValue<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicEvents)]  T>(string name, T? obj) { }
+        public Jint.Native.ShadowRealm.ShadowRealm SetValue<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicEvents)]  T>(string name, T[]? obj) { }
     }
     public sealed class ShadowRealmConstructor : Jint.Native.Constructor
     {

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.0.verified.txt
@@ -1440,11 +1440,14 @@ namespace Jint.Native.ShadowRealm
         public Jint.Native.JsValue ImportValue(string specifier, string exportName) { }
         public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, Jint.Native.JsValue value) { }
         public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, System.Delegate value) { }
+        public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, System.Type type) { }
         public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, bool value) { }
         public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, double value) { }
         public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, int value) { }
-        public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, object obj) { }
-        public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, string value) { }
+        public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, object? obj) { }
+        public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, string? value) { }
+        public Jint.Native.ShadowRealm.ShadowRealm SetValue<T>(string name, T? obj) { }
+        public Jint.Native.ShadowRealm.ShadowRealm SetValue<T>(string name, T[]? obj) { }
     }
     public sealed class ShadowRealmConstructor : Jint.Native.Constructor
     {

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.1.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.1.verified.txt
@@ -1440,11 +1440,14 @@ namespace Jint.Native.ShadowRealm
         public Jint.Native.JsValue ImportValue(string specifier, string exportName) { }
         public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, Jint.Native.JsValue value) { }
         public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, System.Delegate value) { }
+        public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, System.Type type) { }
         public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, bool value) { }
         public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, double value) { }
         public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, int value) { }
-        public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, object obj) { }
-        public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, string value) { }
+        public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, object? obj) { }
+        public Jint.Native.ShadowRealm.ShadowRealm SetValue(string name, string? value) { }
+        public Jint.Native.ShadowRealm.ShadowRealm SetValue<T>(string name, T? obj) { }
+        public Jint.Native.ShadowRealm.ShadowRealm SetValue<T>(string name, T[]? obj) { }
     }
     public sealed class ShadowRealmConstructor : Jint.Native.Constructor
     {

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -1797,7 +1797,7 @@ public sealed partial class Engine : IDisposable
     public Engine SetValue(string name, Delegate value)
     {
         using var ownership = EnterHostCall();
-        Realm.GlobalObject.FastSetProperty(name, new PropertyDescriptor(new DelegateWrapper(this, value), PropertyFlag.NonEnumerable));
+        GlobalValueRegistration.RegisterDelegate(this, Realm.GlobalObject, name, value);
         return this;
     }
 
@@ -1839,7 +1839,7 @@ public sealed partial class Engine : IDisposable
     public Engine SetValue(string name, JsValue value)
     {
         using var ownership = EnterHostCall();
-        Realm.GlobalObject.Set(name, value);
+        GlobalValueRegistration.Register(Realm.GlobalObject, name, value);
         return this;
     }
 
@@ -1852,15 +1852,12 @@ public sealed partial class Engine : IDisposable
     /// <c>[DynamicallyAccessedMembers]</c> and therefore preserves what Jint reflects over. Here there is
     /// no type to annotate, which is the whole of the difference.
     /// </remarks>
-    [RequiresUnreferencedCode("The runtime type of obj is not known at the call site, so the members Jint resolves by reflection cannot be preserved by the trimmer, and a removed one reads as undefined rather than as an error. Prefer SetValue<T>(string, T), whose type parameter carries [DynamicallyAccessedMembers]; pass an already-built JsValue; or root the type yourself.")]
+    [RequiresUnreferencedCode(GlobalValueRegistration.RequiresUnreferencedCodeMessage)]
     public Engine SetValue(string name, object? obj)
     {
         using var ownership = EnterHostCall();
-        var value = obj is Type t
-            ? TypeReference.CreateTypeReference(this, t)
-            : JsValue.FromObject(this, obj);
-
-        return SetValue(name, value);
+        GlobalValueRegistration.RegisterObject(this, Realm.GlobalObject, name, obj);
+        return this;
     }
 
     /// <summary>
@@ -1869,9 +1866,8 @@ public sealed partial class Engine : IDisposable
     public Engine SetValue(string name, [DynamicallyAccessedMembers(InteropHelper.DefaultDynamicallyAccessedMemberTypes)] Type type)
     {
         using var ownership = EnterHostCall();
-#pragma warning disable IL2111
-        return SetValue(name, TypeReference.CreateTypeReference(this, type));
-#pragma warning restore IL2111
+        GlobalValueRegistration.RegisterType(this, Realm.GlobalObject, name, type);
+        return this;
     }
 
     /// <summary>
@@ -1880,9 +1876,8 @@ public sealed partial class Engine : IDisposable
     public Engine SetValue<[DynamicallyAccessedMembers(InteropHelper.DefaultDynamicallyAccessedMemberTypes)] T>(string name, T? obj)
     {
         using var ownership = EnterHostCall();
-        return obj is Type t
-            ? SetValue(name, t)
-            : SetValue(name, JsValue.FromObject(this, obj));
+        GlobalValueRegistration.RegisterTyped(this, Realm.GlobalObject, name, obj);
+        return this;
     }
 
     /// <summary>
@@ -1910,7 +1905,8 @@ public sealed partial class Engine : IDisposable
     public Engine SetValue<[DynamicallyAccessedMembers(InteropHelper.DefaultDynamicallyAccessedMemberTypes)] T>(string name, T[]? obj)
     {
         using var ownership = EnterHostCall();
-        return SetValue(name, JsValue.FromObject(this, obj));
+        GlobalValueRegistration.RegisterArray(this, Realm.GlobalObject, name, obj);
+        return this;
     }
 
     internal void LeaveExecutionContext()

--- a/Jint/GlobalValueRegistration.cs
+++ b/Jint/GlobalValueRegistration.cs
@@ -1,0 +1,112 @@
+using System.Diagnostics.CodeAnalysis;
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime.Descriptors;
+using Jint.Runtime.Interop;
+
+namespace Jint;
+
+/// <summary>
+/// The one implementation behind <see cref="Engine.SetValue(string, JsValue)"/> and
+/// <see cref="Native.ShadowRealm.ShadowRealm.SetValue(string, JsValue)"/> and their overloads: the value
+/// conversion, and the property installation onto a global object.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The two public surfaces differ in exactly two things — which global object is written, and what is
+/// returned for chaining — so everything else lives here once. That is not tidiness: the two used to
+/// duplicate the bodies and drifted apart on the parts a compiler cannot compare, and the drift went the
+/// wrong way. <c>ShadowRealm</c>'s <see cref="Delegate"/> overload carried
+/// <c>[RequiresUnreferencedCode("User supplied delegate")]</c>, which warns about a registration that
+/// reflects over nothing a trimmer can remove, while its reflective <c>object</c> overload — the actual
+/// trimming hazard — carried no annotation at all, so a trimming host projecting a host object into a
+/// shadow realm got no diagnostic and a member that reads as <c>undefined</c> at run time.
+/// </para>
+/// <para>
+/// Each method here assumes the caller already holds the engine's host-call reservation
+/// (<c>Engine.EnterHostCall</c>), which is also what makes it safe for the caller to have read the target
+/// global object off its realm.
+/// </para>
+/// </remarks>
+internal static class GlobalValueRegistration
+{
+    /// <summary>
+    /// The message both <c>SetValue(string, object?)</c> overloads carry. It is a single constant so the
+    /// two cannot say different things about the same hazard, and so a reader of either baseline sees the
+    /// same sentence.
+    /// </summary>
+    internal const string RequiresUnreferencedCodeMessage = "The runtime type of obj is not known at the call site, so the members Jint resolves by reflection cannot be preserved by the trimmer, and a removed one reads as undefined rather than as an error. Prefer SetValue<T>(string, T), whose type parameter carries [DynamicallyAccessedMembers]; pass an already-built JsValue; or root the type yourself.";
+
+    /// <summary>
+    /// Installs an already-built value as an ordinary configurable/enumerable/writable data property.
+    /// </summary>
+    internal static void Register(ObjectInstance globalObject, string name, JsValue value)
+    {
+        globalObject.Set(name, value);
+    }
+
+    /// <summary>
+    /// Installs a delegate as a non-enumerable function property, which is what ECMA-262 §17 gives a
+    /// built-in global function — and the one registration whose property attributes differ from every
+    /// other overload's.
+    /// </summary>
+    internal static void RegisterDelegate(Engine engine, ObjectInstance globalObject, string name, Delegate value)
+    {
+        globalObject.FastSetProperty(name, new PropertyDescriptor(new DelegateWrapper(engine, value), PropertyFlag.NonEnumerable));
+    }
+
+    /// <summary>
+    /// Converts and installs a value whose type is not known at the call site.
+    /// </summary>
+    [RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
+    internal static void RegisterObject(Engine engine, ObjectInstance globalObject, string name, object? obj)
+    {
+        var value = obj is Type t
+            ? TypeReference.CreateTypeReference(engine, t)
+            : JsValue.FromObject(engine, obj);
+
+        globalObject.Set(name, value);
+    }
+
+    /// <summary>
+    /// Installs a CLR type as a constructor script can name.
+    /// </summary>
+    /// <remarks>
+    /// The installation is written out rather than routed back through <see cref="RegisterTyped{T}"/>, and
+    /// that is load-bearing. <c>Engine.SetValue(string, Type)</c> used to end in
+    /// <c>SetValue(name, TypeReference.CreateTypeReference(this, type))</c>, where <c>TypeReference</c> is
+    /// more specific than <c>JsValue</c> and so bound to the generic overload — whose
+    /// <c>[DynamicallyAccessedMembers]</c> then preserved every public method of <c>TypeReference</c>,
+    /// <see cref="TypeReference.CreateTypeReference(Engine, Type)"/> among them, which is an
+    /// <c>IL2111</c> the method had to suppress. Going straight to the global object clears it.
+    /// </remarks>
+    internal static void RegisterType(Engine engine, ObjectInstance globalObject, string name, [DynamicallyAccessedMembers(InteropHelper.DefaultDynamicallyAccessedMemberTypes)] Type type)
+    {
+        globalObject.Set(name, TypeReference.CreateTypeReference(engine, type));
+    }
+
+    /// <summary>
+    /// Converts and installs a value whose type <em>is</em> known at the call site, so the trimmer is told
+    /// what to preserve rather than warned that it cannot know.
+    /// </summary>
+    internal static void RegisterTyped<[DynamicallyAccessedMembers(InteropHelper.DefaultDynamicallyAccessedMemberTypes)] T>(Engine engine, ObjectInstance globalObject, string name, T? obj)
+    {
+        if (obj is Type t)
+        {
+            RegisterType(engine, globalObject, name, t);
+        }
+        else
+        {
+            globalObject.Set(name, JsValue.FromObject(engine, obj));
+        }
+    }
+
+    /// <summary>
+    /// The array form of <see cref="RegisterTyped{T}"/>, so that the annotation lands on the
+    /// <em>element</em> type.
+    /// </summary>
+    internal static void RegisterArray<[DynamicallyAccessedMembers(InteropHelper.DefaultDynamicallyAccessedMemberTypes)] T>(Engine engine, ObjectInstance globalObject, string name, T[]? obj)
+    {
+        globalObject.Set(name, JsValue.FromObject(engine, obj));
+    }
+}

--- a/Jint/Native/ShadowRealm/ShadowRealm.cs
+++ b/Jint/Native/ShadowRealm/ShadowRealm.cs
@@ -58,46 +58,118 @@ public sealed class ShadowRealm : ObjectInstance
         return value;
     }
 
-    [RequiresUnreferencedCode("User supplied delegate")]
+    /// <summary>
+    /// Registers a delegate with given name on this shadow realm's global object. Delegate becomes a
+    /// JavaScript function that can be called.
+    /// </summary>
+    /// <remarks>
+    /// <b>This is the one <c>SetValue</c> overload whose property attributes differ</b>, exactly as on
+    /// <see cref="Engine.SetValue(string, Delegate)"/>: a delegate is installed with
+    /// <see cref="PropertyFlag.NonEnumerable"/> — writable and configurable, but <em>not</em> enumerable —
+    /// while every other overload produces the ordinary configurable/enumerable/writable data property. So
+    /// a delegate registered here does not appear in <c>Object.keys(globalThis)</c> or a <c>for..in</c>
+    /// over the shadow realm's global object, and every other value does.
+    /// </remarks>
     public ShadowRealm SetValue(string name, Delegate value)
     {
-        _shadowRealm.GlobalObject.FastSetProperty(name, new PropertyDescriptor(new DelegateWrapper(_engine, value), PropertyFlag.NonEnumerable));
+        using var ownership = _engine.EnterHostCall();
+        GlobalValueRegistration.RegisterDelegate(_engine, _shadowRealm.GlobalObject, name, value);
         return this;
     }
 
-    public ShadowRealm SetValue(string name, string value)
+    /// <summary>
+    /// Registers a string value as variable on this shadow realm's global object.
+    /// </summary>
+    public ShadowRealm SetValue(string name, string? value)
     {
-        return SetValue(name, JsString.Create(value));
+        return SetValue(name, value is null ? JsValue.Null : JsString.Create(value));
     }
 
+    /// <summary>
+    /// Registers a double value as variable on this shadow realm's global object.
+    /// </summary>
     public ShadowRealm SetValue(string name, double value)
     {
-        return SetValue(name, JsNumber.Create(value));
+        return SetValue(name, (JsValue) JsNumber.Create(value));
     }
 
+    /// <summary>
+    /// Registers an integer value as variable on this shadow realm's global object.
+    /// </summary>
     public ShadowRealm SetValue(string name, int value)
     {
-        return SetValue(name, JsNumber.Create(value));
+        return SetValue(name, (JsValue) JsNumber.Create(value));
     }
 
+    /// <summary>
+    /// Registers a boolean value as variable on this shadow realm's global object.
+    /// </summary>
     public ShadowRealm SetValue(string name, bool value)
     {
-        return SetValue(name, value ? JsBoolean.True : JsBoolean.False);
+        return SetValue(name, (JsValue) (value ? JsBoolean.True : JsBoolean.False));
     }
 
+    /// <summary>
+    /// Registers a native JS value as variable on this shadow realm's global object.
+    /// </summary>
     public ShadowRealm SetValue(string name, JsValue value)
     {
-        _shadowRealm.GlobalObject.Set(name, value);
+        using var ownership = _engine.EnterHostCall();
+        GlobalValueRegistration.Register(_shadowRealm.GlobalObject, name, value);
         return this;
     }
 
-    public ShadowRealm SetValue(string name, object obj)
+    /// <summary>
+    /// Registers an object value as variable on this shadow realm's global object, creates an interop
+    /// wrapper when needed.
+    /// </summary>
+    /// <remarks>
+    /// This overload binds only where the argument's static type is <see cref="object"/> — a typed
+    /// variable picks <see cref="SetValue{T}(string, T)"/>, whose type parameter carries
+    /// <c>[DynamicallyAccessedMembers]</c> and therefore preserves what Jint reflects over. Here there is
+    /// no type to annotate, which is the whole of the difference.
+    /// </remarks>
+    [RequiresUnreferencedCode(GlobalValueRegistration.RequiresUnreferencedCodeMessage)]
+    public ShadowRealm SetValue(string name, object? obj)
     {
-        var value = obj is Type t
-            ? TypeReference.CreateTypeReference(_engine, t)
-            : JsValue.FromObject(_engine, obj);
+        using var ownership = _engine.EnterHostCall();
+        GlobalValueRegistration.RegisterObject(_engine, _shadowRealm.GlobalObject, name, obj);
+        return this;
+    }
 
-        return SetValue(name, value);
+    /// <summary>
+    /// Registers a CLR type as variable on this shadow realm's global object, creates an interop wrapper
+    /// when needed.
+    /// </summary>
+    public ShadowRealm SetValue(string name, [DynamicallyAccessedMembers(InteropHelper.DefaultDynamicallyAccessedMemberTypes)] Type type)
+    {
+        using var ownership = _engine.EnterHostCall();
+        GlobalValueRegistration.RegisterType(_engine, _shadowRealm.GlobalObject, name, type);
+        return this;
+    }
+
+    /// <summary>
+    /// Registers an object value as variable on this shadow realm's global object, creates an interop
+    /// wrapper when needed.
+    /// </summary>
+    public ShadowRealm SetValue<[DynamicallyAccessedMembers(InteropHelper.DefaultDynamicallyAccessedMemberTypes)] T>(string name, T? obj)
+    {
+        using var ownership = _engine.EnterHostCall();
+        GlobalValueRegistration.RegisterTyped(_engine, _shadowRealm.GlobalObject, name, obj);
+        return this;
+    }
+
+    /// <summary>
+    /// Registers an array as variable on this shadow realm's global object, creates an interop wrapper
+    /// when needed. Behaves exactly like <see cref="SetValue{T}(string, T)"/>; it exists so that the
+    /// annotation lands on the <em>element</em> type, for the reasons
+    /// <see cref="Engine.SetValue{T}(string, T[])"/> spells out.
+    /// </summary>
+    public ShadowRealm SetValue<[DynamicallyAccessedMembers(InteropHelper.DefaultDynamicallyAccessedMemberTypes)] T>(string name, T[]? obj)
+    {
+        using var ownership = _engine.EnterHostCall();
+        GlobalValueRegistration.RegisterArray(_engine, _shadowRealm.GlobalObject, name, obj);
+        return this;
     }
 
 

--- a/Jint/Runtime/Interop/AGENTS.md
+++ b/Jint/Runtime/Interop/AGENTS.md
@@ -89,9 +89,14 @@ saying it is deliberately not `NotSupportedException`.
    where the lane is generic. A `KnownAotGap` is for a shape that must *keep* throwing; it is checked
    in both directions, so a gap that closes fails the leg.
 
-The seven annotated members today are `OptionsExtensions.AllowClr` (two overloads),
-`OptionsExtensions.AddExtensionMethods`, `Engine.SetValue(string, object?)`, `ObjectWrapper.Create`, and
-`ClrHelper.Unwrap` / `Wrap`. `JsValue.FromObject` is deliberately not among them: it is the engine's own
+The eight annotated members today are `OptionsExtensions.AllowClr` (two overloads),
+`OptionsExtensions.AddExtensionMethods`, `Engine.SetValue(string, object?)`,
+`ShadowRealm.SetValue(string, object?)`, `ObjectWrapper.Create`, and `ClrHelper.Unwrap` / `Wrap`. The two
+`SetValue` families are one API pointed at two global objects and share one implementation
+(`Jint/GlobalValueRegistration.cs`) and one message constant, precisely so a fifth rule is not needed:
+they had drifted, and the drift put the annotation on `ShadowRealm`'s harmless `Delegate` overload while
+leaving its reflective one silent. **Annotate the pair, not the member** — and if you are about to write
+the same annotation twice, share the implementation instead. `JsValue.FromObject` is deliberately not among them: it is the engine's own
 conversion funnel with ~60 call sites inside Jint, the interpreter's operator-overloading path among
 them, so annotating it would either cascade `[RequiresUnreferencedCode]` across the interpreter or need
 a suppression per site. `Options.InteropOptions._defaultWrapObjectHandler` carries the one

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -340,6 +340,34 @@ Two things follow that are not visible in a signature. A default `Options` now a
 where it used to allocate ten eagerly; and `ForUntrustedCode`'s private snapshot copies every group rather
 than the six it happened to name, so a group added later cannot silently escape the profile.
 
+### 3.7 `ShadowRealm.SetValue` is `Engine.SetValue`, mirrored ([#3321](https://github.com/sebastienros/jint/pull/3321))
+
+The two are the same API pointed at different global objects, and they had drifted. `ShadowRealm` was
+missing three overloads, disagreed about `null`, and — the part that mattered — carried its trimming
+annotation on the wrong overload. All of it now matches, member for member:
+
+| | 4.16.x | 5.x |
+| --- | --- | --- |
+| `SetValue(string, Delegate)` | `[RequiresUnreferencedCode("User supplied delegate")]` | no annotation, as on the engine |
+| `SetValue(string, object)` | no annotation | `SetValue(string, object?)`, `[RequiresUnreferencedCode]` with the engine's message |
+| `SetValue(string, string)` | throws `ArgumentNullException` on `null` | `SetValue(string, string?)`; `null` registers as JavaScript `null` |
+| `SetValue(string, Type)` | — | added |
+| `SetValue<T>(string, T)` | — | added |
+| `SetValue<T>(string, T[])` | — | added |
+
+The annotation swap is the reason to read this section. A delegate registration reflects over nothing a
+trimmer can remove, so the warning was noise; the `object` overload is the one that resolves members from a
+runtime type, and it was silent. A trimming host projecting a host object into a shadow realm therefore got
+no diagnostic, and a trimmed-away member read as `undefined` at run time. See
+[§6.3](#63-apis-that-now-warn) for what the message says and what to do about it.
+
+Two consequences worth knowing. Passing a typed variable now picks `SetValue<T>` rather than
+`SetValue(string, object)`, which is an improvement — `[DynamicallyAccessedMembers]` preserves what Jint
+reflects over — but it also means a delegate registration wants the same cast the engine's does
+(`(Delegate) new Func<int, int>(…)`, see [§6.4](#64-what-you-owe-your-own-project)). And every overload now
+takes the engine's host-call reservation for the duration of the write, exactly as
+`ShadowRealm.Evaluate` already did, so registering a value from another thread while the engine is running
+is rejected with `InvalidOperationException` instead of racing the global object.
 
 ## 4. Breaking without a signature change
 
@@ -681,7 +709,7 @@ generics unless the type also implements `IList`.
 
 ### 6.3 APIs that now warn
 
-Seven members carry `[RequiresUnreferencedCode]`, so a trimming or AOT host sees the diagnostic at their
+Eight members carry `[RequiresUnreferencedCode]`, so a trimming or AOT host sees the diagnostic at their
 own call site rather than as a wrong answer at run time. Each message names what to do instead.
 
 | member | why | what to do |
@@ -689,9 +717,16 @@ own call site rather than as a wrong answer at run time. Each message names what
 | `Options.AllowClr()` and `AllowClr(params Assembly[])` | script names CLR types and namespaces as strings; nothing statically references what they expose | root the assemblies you allow, or drop `AllowClr` and hand each type to script explicitly |
 | `Options.AddExtensionMethods(params Type[])` | the types are reflected over, and a `Type[]` parameter cannot carry `[DynamicallyAccessedMembers]` - only a `Type` or a `string` can | root the declaring types; a trimmed-away extension method fails as `not a function`, with no diagnostic |
 | `Engine.SetValue(string, object?)` | no type at the call site to annotate | prefer `SetValue<T>(string, T)`, or pass a `JsValue` |
+| `ShadowRealm.SetValue(string, object?)` | the same overload on the same API, pointed at a shadow realm's global object; it carried no annotation at all until v5, while the harmless `Delegate` overload beside it carried one ([§3.7](#37-shadowrealmsetvalue-is-enginesetvalue-mirrored)) | the same: prefer `SetValue<T>(string, T)`, or pass a `JsValue` |
 | `ObjectWrapper.Create(Engine, object, Type?)` | same - and it is what a custom `WrapObjectHandler` calls | root the type, or project through `SetValue<T>` |
 
 (`ClrHelper.Unwrap` and `ClrHelper.Wrap`, reachable only from script through `clrHelper`, carry it too.)
+
+One annotation was **removed** in the same change, and a removal is worth as much as an addition here:
+`ShadowRealm.SetValue(string, Delegate)` warned that it required unreferenced code, which it does not — a
+delegate is handed over as a delegate and nothing is resolved from its type by reflection. Over-annotating
+teaches an embedder to suppress the diagnostic on APIs that are fine, which is exactly how the one that
+mattered stayed unread.
 
 `Options.Interop.Enabled = true` opens the same door unannotated: it is a property setter, and
 annotating it would warn on `= false` as well, which would be absurd. If you set it directly, you are
@@ -700,11 +735,11 @@ the grant, so on its own it installs `System`, `importNamespace` and `clrHelper`
 `Interop.AllowedAssemblies` stays empty and every namespace script names is unresolvable. `AllowClr()`
 opens the gate *and* names assemblies.
 
-Deliberately **not** annotated: `SetValue(string, Type)`, `SetValue<T>`,
-`TypeReference.CreateTypeReference`, `ModuleBuilder.ExportType` and `JsValue.FromObject`. The first
-four carry `[DynamicallyAccessedMembers]`, which *preserves* what Jint reflects over instead of merely
-warning about it - they are the AOT-friendly way to expose a type, which is exactly why the messages
-above point at them. Nothing carries `[RequiresDynamicCode]`, because §6.1 is what the measurement
+Deliberately **not** annotated: `SetValue(string, Type)`, `SetValue<T>` — on `Engine` and on
+`ShadowRealm` alike — `TypeReference.CreateTypeReference`, `ModuleBuilder.ExportType` and
+`JsValue.FromObject`. The first four carry `[DynamicallyAccessedMembers]`, which *preserves* what Jint
+reflects over instead of merely warning about it - they are the AOT-friendly way to expose a type, which
+is exactly why the messages above point at them. Nothing carries `[RequiresDynamicCode]`, because §6.1 is what the measurement
 says, and warning an AOT host away from an API that works would be worse than not warning at all.
 
 The attributes are on the `net8.0` and `net10.0` assets. The downlevel targets carry the same


### PR DESCRIPTION
`ShadowRealm.SetValue` is `Engine.SetValue` pointed at a different global object, and the two had drifted
on exactly the parts a compiler cannot compare. #3307 put `[RequiresUnreferencedCode]` on
`Engine.SetValue(string, object?)` — the overload that resolves members from a runtime type — and
deliberately left `SetValue(string, Delegate)` unannotated, because handing a delegate over reflects over
nothing a trimmer can remove. On `ShadowRealm` it was the other way round:

```c#
[RequiresUnreferencedCode("User supplied delegate")]     // the harmless one, with a placeholder message
public ShadowRealm SetValue(string name, Delegate value)

public ShadowRealm SetValue(string name, object obj)     // the reflective one, silent
```

So a trimming host projecting a host object into a shadow realm got no diagnostic, and a trimmed-away
member read as `undefined` at run time — the failure mode §6.4 of the migration guide says to plan for.
Three overloads an embedder can reach on the engine were missing outright, and the nullability differed.

## What changed

| | before | after |
| --- | --- | --- |
| `SetValue(string, Delegate)` | `[RequiresUnreferencedCode("User supplied delegate")]` | no annotation, as on the engine |
| `SetValue(string, object)` | no annotation | `SetValue(string, object?)`, `[RequiresUnreferencedCode]` with the engine's message verbatim |
| `SetValue(string, string)` | `ArgumentNullException` on `null` (`JsString.Create` rejects it) | `SetValue(string, string?)`; `null` registers as JavaScript `null` |
| `SetValue(string, Type)` | — | added, `[DynamicallyAccessedMembers]` |
| `SetValue<T>(string, T)` | — | added, `[DynamicallyAccessedMembers]` |
| `SetValue<T>(string, T[])` | — | added, `[DynamicallyAccessedMembers]` on the element type |

Ten overloads on each type now, member for member.

## Shared, not duplicated

`Jint/GlobalValueRegistration.cs` is the one implementation: the value conversion and the property
installation, taking the target global object as a parameter. The two public surfaces are the wrappers
that supply it and return `this` for chaining — which is genuinely all they differ by. The annotation
message is a `const` on that class, so the two `[RequiresUnreferencedCode]` attributes cannot say
different things about the same hazard.

The host-call reservation deliberately stays in the public wrappers rather than moving into the helper:
each entry takes it and then reads its own realm's global object under it, which is also what makes the
captured `ObjectInstance` safe to pass. `ShadowRealm.SetValue` did not take one at all before; it does
now, matching `ShadowRealm.Evaluate`.

Nothing on the interop path changed shape: these are static calls with one extra reference argument on a
setup-time API, and every body is the same sequence of operations it was.

## One suppression is gone, and it was hiding something

`Engine.SetValue(string, Type)` carried `#pragma warning disable IL2111`. The cause was that its
`return SetValue(name, TypeReference.CreateTypeReference(this, type))` bound to the **generic** overload
— `TypeReference` is more specific than `JsValue` — whose `[DynamicallyAccessedMembers]` then demanded
every public method of `TypeReference`, `CreateTypeReference` among them. Confirmed by removing the
pragma and rebuilding:

```
error IL2111: Method 'Jint.Runtime.Interop.TypeReference.CreateTypeReference(Engine, Type)' with
parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection.
```

The shared helper installs onto the global object directly instead of re-entering `SetValue`, so the
diagnostic does not arise and the suppression is deleted rather than copied to a second site.

## Tests

`Jint.Tests.PublicInterface/ShadowRealmSetValueTests.cs`, from the integrator's view:

- **`TheOverloadSetAndItsTrimmingAnnotationsMirrorTheEngines`** — reflects over both types and compares
  overload sets including type parameters, `[DynamicallyAccessedMembers]` and `[RequiresUnreferencedCode]`
  *with its message*. This is the test that makes a future divergence fail rather than ship. It reads the
  attributes by name rather than by type, because downlevel both Jint and the test project get their own
  internal PolySharp copies and `GetCustomAttribute<T>` would find neither.
- one test per newly reachable overload — a typed host object, an array read by element member
  (`companies[1].Name`), a `Type` projected as a constructor — each also asserting the value does **not**
  appear on the host engine's global.
- `null` through both the `string?` and `object?` overloads, asserted on the engine and the shadow realm
  in the same test, since that divergence was the point.
- the delegate overload's non-enumerability, and that the other overloads are enumerable.

All five API baselines regenerated from `.received.txt`; the `Engine` block is untouched, which is the
diff worth checking.

## Docs

- `docs/v5-migration.md` §3.7 (new) — the overload table, the annotation swap and why a removed annotation
  matters as much as an added one, the delegate cast an embedder now owes here too, and the reservation.
- §6.3 — seven annotated members become eight, with the `ShadowRealm` row; the "deliberately not
  annotated" list now says the `SetValue(string, Type)` / `SetValue<T>` exemption covers both types.
- `Jint/Runtime/Interop/AGENTS.md` — the annotated-member inventory, plus the rule the drift argues for:
  annotate the pair, and if you are about to write the same annotation twice, share the implementation.

## Left alone

Two things noticed here and deliberately out of scope:

- A value registered into a shadow realm is still built against the **host** realm —
  `JsValue.FromObject(_engine, …)` and `TypeReference.CreateTypeReference(_engine, …)` use
  `_engine.Realm`, so a wrapper installed on a shadow realm's global has a prototype from the principal
  realm. Pre-existing, unchanged by this PR, and not a mirroring question.
- `ShadowRealm.ImportValue` takes no host-call reservation, unlike `Evaluate` and now `SetValue`.
