### PR TITLE
Options: configuration until an engine reads it, frozen afterwards

### DIFF
--- a/Jint.Tests.PublicInterface/HostErrorDisclosureTests.cs
+++ b/Jint.Tests.PublicInterface/HostErrorDisclosureTests.cs
@@ -386,18 +386,21 @@ public class HostErrorDisclosureTests
         safeImport.Error.Get("message").AsString().Should().NotContain(Secret);
         safeDecoratorCalls.Should().Be(1);
 
-        var changingLoader = new DeferredLoader();
-        var changingOptions = new Options()
-            .UseModules(changingLoader)
-            .ExposeDetailedErrors();
-        var changing = new Engine(changingOptions);
-        var detailedImport = changing.Modules.StartImport("./detailed.js");
-        changingLoader.Completion!.SetError(new HostFailure());
-        changing.Advanced.ProcessTasks();
-        changingOptions.Modules.ExposeDetailedLoadErrors = false;
-        var redactedImport = changing.Modules.StartImport("./redacted.js");
-        changingLoader.Completion!.SetError(new JavaScriptException(detailedImport.Error!));
-        changing.Advanced.ProcessTasks();
+        // The third engine is the configuration half: an error value a detailed engine produced, handed to
+        // an engine configured to redact, is redacted. It is a second engine rather than the same one
+        // reconfigured, because an engine's Options are read-only once it has been built from them.
+        var detailedLoader = new DeferredLoader();
+        var detailed = new Engine(new Options().UseModules(detailedLoader).ExposeDetailedErrors());
+        var detailedImport = detailed.Modules.StartImport("./detailed.js");
+        detailedLoader.Completion!.SetError(new HostFailure());
+        detailed.Advanced.ProcessTasks();
+        detailedImport.Error!.Get("message").AsString().Should().Be(Secret);
+
+        var redactingLoader = new DeferredLoader();
+        var redacting = new Engine(new Options().UseModules(redactingLoader));
+        var redactedImport = redacting.Modules.StartImport("./redacted.js");
+        redactingLoader.Completion!.SetError(new JavaScriptException(detailedImport.Error!));
+        redacting.Advanced.ProcessTasks();
 
         redactedImport.Error!.Get("message").AsString().Should().Be("Could not load module.");
         redactedImport.Error.Get("message").AsString().Should().NotContain(Secret);

--- a/Jint.Tests.PublicInterface/HostOptionsReadOnlyTests.cs
+++ b/Jint.Tests.PublicInterface/HostOptionsReadOnlyTests.cs
@@ -1,0 +1,347 @@
+#nullable enable
+
+using System.Globalization;
+using System.Reflection;
+using Jint.Constraints;
+using Jint.Runtime;
+using Jint.Runtime.Interop;
+using Jint.Runtime.Modules;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// <see cref="Options"/> is configuration until an engine reads it, and a frozen record afterwards.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The engine keeps the very instance it was handed — <c>Options.CreateEngineOptions</c> returns <c>this</c>
+/// unless a hardened profile made a private clone — and reads about thirty of its settings live, on hot
+/// paths: <c>Interop.AllowWrite</c> on every projected write, <c>Interop.ExceptionHandler</c> on every CLR
+/// call. Six other properties were read once and documented as having no effect afterwards. Which of the two
+/// a given property was could only be learnt by reading its documentation, and the first kind meant a host
+/// could grant CLR writes to a running engine with an ordinary assignment.
+/// </para>
+/// <para>
+/// So the engine makes the options read-only when it has finished reading them, following
+/// <c>JsonSerializerOptions.MakeReadOnly()</c>, and every setter and every registry refuses from that point.
+/// This suite is in the project without <c>InternalsVisibleTo</c> because it is a promise to third parties.
+/// </para>
+/// </remarks>
+public class HostOptionsReadOnlyTests
+{
+    [Fact]
+    public void AnEngineMakesTheOptionsItWasBuiltFromReadOnly()
+    {
+        var options = new Options();
+        options.IsReadOnly.Should().BeFalse();
+
+        _ = new Engine(options);
+
+        options.IsReadOnly.Should().BeTrue();
+    }
+
+    [Fact]
+    public void TheRefusalNamesTheSettingAndIsAnInvalidOperation()
+    {
+        var options = new Options();
+        _ = new Engine(options);
+
+        Invoking(() => options.Interop.AllowWrite = true)
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage("Options.Interop.AllowWrite cannot be changed*");
+    }
+
+    /// <summary>
+    /// The write that motivated all of this: <c>Interop.AllowWrite</c> is read on every projected write, so
+    /// setting it after construction used to hand a running engine the ability to mutate host objects.
+    /// </summary>
+    [Fact]
+    public void GrantingClrWritesToALiveEngineIsRefused()
+    {
+        var options = new Options();
+        options.Interop.Enabled = true;
+        var target = new Box();
+        var engine = new Engine(options);
+        engine.SetValue("box", target);
+
+        engine.Execute("box.Value = 1");
+        target.Value.Should().Be(0, "writes through projected CLR objects are denied by default");
+
+        Invoking(() => options.Interop.AllowWrite = true).Should().Throw<InvalidOperationException>();
+
+        engine.Execute("box.Value = 2");
+        target.Value.Should().Be(0, "and the refused write cannot have granted the engine anything");
+    }
+
+    [Theory]
+    [MemberData(nameof(EveryGroup))]
+    public void EveryOptionGroupRefusesAWrite(string name, Action<Options> write)
+    {
+        var options = new Options();
+        _ = new Engine(options);
+
+        Invoking(() => write(options))
+            .Should().Throw<InvalidOperationException>($"{name} belongs to a frozen Options")
+            .WithMessage($"{name} cannot be changed*");
+    }
+
+    public static TheoryData<string, Action<Options>> EveryGroup()
+    {
+        var data = new TheoryData<string, Action<Options>>
+        {
+            { "Options.Strict", static o => o.Strict = true },
+            { "Options.Culture", static o => o.Culture = CultureInfo.InvariantCulture },
+            { "Options.TimeZone", static o => o.TimeZone = TimeZoneInfo.Utc },
+            { "Options.TimeSystem", static o => o.TimeSystem = null! },
+            { "Options.ResultLimits", static o => o.ResultLimits = ResultLimits.Conservative },
+            { "Options.AgentCanSuspend", static o => o.AgentCanSuspend = true },
+            { "Options.ExperimentalFeatures", static o => o.ExperimentalFeatures = ExperimentalFeature.All },
+            { "Options.RetainFunctionSourceText", static o => o.RetainFunctionSourceText = true },
+            { "Options.ReferenceResolver", static o => o.SetReferenceResolver(NullPropagatingReferenceResolver.Instance) },
+            { "Options.Constraints.MaxRecursionDepth", static o => o.Constraints.MaxRecursionDepth = 8 },
+            { "Options.Parsing.MaxNodeCount", static o => o.Parsing.MaxNodeCount = 8 },
+            { "Options.Interop.Enabled", static o => o.Interop.Enabled = true },
+            { "Options.Debugger.Enabled", static o => o.Debugger.Enabled = true },
+            { "Options.Coverage.Enabled", static o => o.Coverage.Enabled = true },
+            { "Options.Host.StringCompilationAllowed", static o => o.Host.StringCompilationAllowed = false },
+            { "Options.Modules.RegisterRequire", static o => o.Modules.RegisterRequire = true },
+            { "Options.Json.MaxParseDepth", static o => o.Json.MaxParseDepth = 8 },
+            { "Options.Intl.CldrProvider", static o => o.Intl.CldrProvider = null! },
+            { "Options.Temporal.TimeZoneProvider", static o => o.Temporal.TimeZoneProvider = null! },
+            { "Options.Profiling.Enabled", static o => o.Profiling.Enabled = true },
+            { "Options.Profiling.MaxEvents", static o => o.Profiling.MaxEvents = 8 },
+        };
+
+#if NET8_0_OR_GREATER
+        data.Add("Options.WebApi.Features", static o => o.WebApi.Features = WebApiFeatures.Console);
+        data.Add("Options.WebApi.Console.Sink", static o => o.WebApi.Console.Sink = Jint.WebApi.ConsoleSink.Null);
+        data.Add("Options.WebApi.Timers.MaxActiveTimers", static o => o.WebApi.Timers.MaxActiveTimers = 8);
+        data.Add("Options.WebApi.Fetch.MaxRedirects", static o => o.WebApi.Fetch.MaxRedirects = 8);
+        data.Add("Options.WebApi.Diagnostics.Sink", static o => o.WebApi.Diagnostics.Sink = null);
+        data.Add("Options.WebApi.Storage.MaxTotalBytes", static o => o.WebApi.Storage.MaxTotalBytes = 8);
+        data.Add("Options.WebApi.Cache.Provider", static o => o.WebApi.Cache.Provider = null);
+        data.Add("Options.WebApi.Messaging.Broker", static o => o.WebApi.Messaging.Broker = null);
+        data.Add("Options.WebApi.Workers.MaxWorkers", static o => o.WebApi.Workers.MaxWorkers = 8);
+#endif
+
+        return data;
+    }
+
+    /// <summary>
+    /// A group is allocated on first touch, so most of them do not exist when the freeze happens. One
+    /// materialized afterwards has to be born frozen, or the very write that was meant to be refused would
+    /// be the one that creates a fresh, mutable group — and the engine reads <c>Intl</c> and <c>Temporal</c>
+    /// lazily, long after construction, so the write would have landed.
+    /// </summary>
+    [Fact]
+    public void AGroupMaterializedAfterTheFreezeIsBornFrozen()
+    {
+        var options = new Options();
+        options.MakeReadOnly();
+
+        Invoking(() => options.Json.MaxParseDepth = 8).Should().Throw<InvalidOperationException>();
+        Invoking(() => options.Intl.CldrProvider = null!).Should().Throw<InvalidOperationException>();
+        Invoking(() => options.Temporal.CalendarProvider = null!).Should().Throw<InvalidOperationException>();
+    }
+
+    /// <summary>
+    /// A registry is the half of the configuration that grows, and a plain <see cref="List{T}"/> cannot
+    /// refuse. Every <c>Add*</c> verb and every list behind one has to say no as loudly as an assignment.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(EveryRegistryMutation))]
+    public void EveryRegistryRefusesAChange(string description, Action<Options> mutate)
+    {
+        var options = new Options();
+        _ = new Engine(options);
+
+        Invoking(() => mutate(options))
+            .Should().Throw<InvalidOperationException>($"{description} changes a frozen Options");
+    }
+
+    public static TheoryData<string, Action<Options>> EveryRegistryMutation()
+    {
+        var data = new TheoryData<string, Action<Options>>
+        {
+            { "AddConstraint(instance)", static o => o.AddConstraint(new NoopConstraint()) },
+            { "AddConstraint(factory)", static o => o.AddConstraint(static () => new NoopConstraint()) },
+            { "RemoveConstraints", static o => o.RemoveConstraints(static _ => true) },
+            { "LimitStatements", static o => o.LimitStatements(1) },
+            { "LimitMemory", static o => o.LimitMemory(1024) },
+            { "LimitExecutionTime", static o => o.LimitExecutionTime(TimeSpan.FromSeconds(1)) },
+            { "ObserveCancellation", static o => o.ObserveCancellation(new CancellationTokenSource().Token) },
+            { "Constraints.Constraints.Add", static o => o.Constraints.Constraints.Add(new NoopConstraint()) },
+            { "Constraints.Constraints.Clear", static o => o.Constraints.Constraints.Clear() },
+            { "AddObjectConverter", static o => o.AddObjectConverter(new NoopConverter()) },
+            { "Interop.ObjectConverters.Add", static o => o.Interop.ObjectConverters.Add(new NoopConverter()) },
+            { "AddExtensionMethods", static o => o.AddExtensionMethods(typeof(string)) },
+            { "Interop.ExtensionMethodTypes.Add", static o => o.Interop.ExtensionMethodTypes.Add(typeof(string)) },
+            { "AddImmutableCrossing", static o => o.AddImmutableCrossing(typeof(string)) },
+            { "Interop.ImmutableCrossingTypes.AddRange", static o => o.Interop.ImmutableCrossingTypes.AddRange([typeof(string)]) },
+            { "AllowClr()", static o => o.AllowClr() },
+            { "AllowClr(assemblies)", static o => o.AllowClr(typeof(string).Assembly) },
+            { "Interop.AllowedAssemblies.Add", static o => o.Interop.AllowedAssemblies.Add(typeof(string).Assembly) },
+            { "Interop.AllowedAssemblies[0] =", static o => o.Interop.AllowedAssemblies.Insert(0, typeof(string).Assembly) },
+            { "AddLazyGlobal", static o => o.AddLazyGlobal("x", static _ => Native.JsValue.Undefined) },
+            { "Configure", static o => o.Configure(static _ => { }) },
+            { "SetTypeConverter", static o => o.SetTypeConverter(static engine => new DefaultTypeConverter(engine)) },
+            { "SetReferenceResolver", static o => o.SetReferenceResolver(NullPropagatingReferenceResolver.Instance) },
+            { "UseHostFactory", static o => o.UseHostFactory(static _ => new Jint.Runtime.Host()) },
+            { "UseModules", static o => o.UseModules(new StubModuleLoader()) },
+            { "CatchClrExceptions", static o => o.CatchClrExceptions() },
+            { "ExposeDetailedErrors", static o => o.ExposeDetailedErrors() },
+            { "ForUntrustedCode", static o => o.ForUntrustedCode(CreateLimits()) },
+        };
+
+#if NET8_0_OR_GREATER
+        data.Add("WebApi.Fetch.AllowedSchemes.Add", static o => o.WebApi.Fetch.AllowedSchemes.Add("ftp"));
+        data.Add("WebApi.Fetch.AllowedSchemes.Clear", static o => o.WebApi.Fetch.AllowedSchemes.Clear());
+        data.Add("UseWebApis", static o => o.UseWebApis());
+#endif
+
+        return data;
+    }
+
+    /// <summary>
+    /// Sharing one configured <see cref="Options"/> between engines is a documented embedding pattern, so a
+    /// second freeze has to be a no-op rather than a refusal.
+    /// </summary>
+    [Fact]
+    public void TheSameOptionsInstanceStillBuildsASecondEngine()
+    {
+        var options = new Options();
+        options.Strict = true;
+        options.AddLazyGlobal("answer", static _ => 42);
+
+        var first = new Engine(options);
+        var second = new Engine(options);
+
+        first.Evaluate("answer").AsNumber().Should().Be(42);
+        second.Evaluate("answer").AsNumber().Should().Be(42);
+        options.IsReadOnly.Should().BeTrue();
+    }
+
+    [Fact]
+    public void MakeReadOnlyIsIdempotentAndAvailableToTheHost()
+    {
+        var options = new Options();
+        options.Interop.Enabled = true;
+
+        options.MakeReadOnly();
+        options.MakeReadOnly();
+        options.IsReadOnly.Should().BeTrue();
+
+        Invoking(() => options.Interop.Enabled = false).Should().Throw<InvalidOperationException>();
+
+        // A frozen instance is still perfectly good engine input, and the engine reads it as it stands.
+        var engine = new Engine(options);
+        options.Interop.Enabled.Should().BeTrue();
+        engine.Evaluate("typeof importNamespace").AsString().Should().Be("function");
+    }
+
+    /// <summary>
+    /// The hardened profile is the one case where the engine keeps a private clone rather than the caller's
+    /// instance. The clone has to be mutable while the profile is expanded onto it, and frozen once the
+    /// engine has read it — and the caller's own object is frozen too, so that "an engine makes the options
+    /// you handed it read-only" needs no exception for the profiled case.
+    /// </summary>
+    [Fact]
+    public void AnUntrustedProfileStillAppliesAndBothInstancesEndUpReadOnly()
+    {
+        var options = new Options();
+        options.Interop.Enabled = true;
+        options.ForUntrustedCode(CreateLimits(maxStatements: 500));
+
+        var engine = new Engine(options);
+
+        options.IsReadOnly.Should().BeTrue();
+
+        // The profile revoked the CLR grant on the engine's own copy, and left the caller's reading alone.
+        engine.Evaluate("typeof importNamespace").AsString().Should().Be("undefined");
+        options.Interop.Enabled.Should().BeTrue();
+
+        // ... and the budget it registered is the engine's, not a value nobody enforces.
+        Invoking(() => engine.Execute("for (let i = 0; i < 1000000; i++) {}"))
+            .Should().Throw<StatementsCountOverflowException>();
+
+        // The same declaration still hardens the next engine built from it.
+        var second = new Engine(options);
+        second.Evaluate("typeof importNamespace").AsString().Should().Be("undefined");
+    }
+
+    /// <summary>
+    /// A configuration callback runs while the engine is being built, which is before the freeze — otherwise
+    /// the documented way to finish configuring an engine would have stopped working.
+    /// </summary>
+    [Fact]
+    public void AConfigurationCallbackStillWritesWhileTheEngineIsBeingBuilt()
+    {
+        var options = new Options();
+        options.Configure(_ => options.Interop.AllowGetType = true);
+
+        _ = new Engine(options);
+
+        options.Interop.AllowGetType.Should().BeTrue();
+        Invoking(() => options.Interop.AllowGetType = false).Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void ReadingIsUnaffected()
+    {
+        var options = new Options();
+        options.Constraints.MaxRecursionDepth = 12;
+        options.Interop.AllowedAssemblies.Add(typeof(string).Assembly);
+
+        _ = new Engine(options);
+
+        options.Constraints.MaxRecursionDepth.Should().Be(12);
+        options.Interop.AllowedAssemblies.Should().ContainSingle();
+        options.Interop.AllowedAssemblies[0].Should().BeSameAs(typeof(string).Assembly);
+        options.Interop.AllowedAssemblies.IsReadOnly.Should().BeTrue();
+        options.Interop.ObjectConverters.IsReadOnly.Should().BeTrue();
+    }
+
+    private static UntrustedCodeLimits CreateLimits(int maxStatements = 100_000) => new(
+        timeoutInterval: TimeSpan.FromSeconds(5),
+        maxStatements: maxStatements,
+        memoryLimit: 16_000_000,
+        maxRecursionDepth: 64,
+        maxArraySize: 10_000,
+        regexTimeout: TimeSpan.FromMilliseconds(100),
+        promiseTimeout: TimeSpan.FromMilliseconds(100),
+        maxOperationDuration: TimeSpan.FromSeconds(10));
+
+    private sealed class Box
+    {
+        public int Value { get; set; }
+    }
+
+    private sealed class NoopConverter : IObjectConverter
+    {
+        public bool TryConvert(Engine engine, object value, out Native.JsValue result)
+        {
+            result = Native.JsValue.Undefined;
+            return false;
+        }
+    }
+
+    private sealed class NoopConstraint : Constraint
+    {
+        public override void Check()
+        {
+        }
+
+        public override void Reset()
+        {
+        }
+    }
+
+    private sealed class StubModuleLoader : IModuleLoader
+    {
+        public ResolvedSpecifier Resolve(string? referencingModuleLocation, ModuleRequest moduleRequest)
+            => throw new NotSupportedException();
+
+        public Jint.Runtime.Modules.Module LoadModule(Engine engine, ResolvedSpecifier resolved)
+            => throw new NotSupportedException();
+    }
+}

--- a/Jint.Tests.PublicInterface/HostOptionsReadOnlyTests.cs
+++ b/Jint.Tests.PublicInterface/HostOptionsReadOnlyTests.cs
@@ -269,6 +269,47 @@ public class HostOptionsReadOnlyTests
         second.Evaluate("typeof importNamespace").AsString().Should().Be("undefined");
     }
 
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// <c>Engine.Advanced.EnableWebApis</c> is the one door that writes to a frozen <see cref="Options"/>, and
+    /// the suspension it opens is scoped to the group it is configuring — not to web-API groups at large, and
+    /// not to the registries.
+    /// </summary>
+    [Fact]
+    public void TheLiveWebApiDoorSuspendsTheGuardForTheGroupItIsConfiguringAndNothingElse()
+    {
+        var other = new Options();
+        _ = new Engine(other);
+
+        var options = new Options();
+        var engine = new Engine(options);
+        var ran = false;
+
+        engine.Advanced.EnableWebApis(WebApiFeatures.Timers, webApi =>
+        {
+            ran = true;
+
+            // The group being configured: a value setting is writable for the duration of the callback.
+            webApi.Timers.MaxActiveTimers = 3;
+
+            // A different frozen Options is not opened by it, even on this thread.
+            Invoking(() => other.WebApi.Timers.MaxActiveTimers = 3)
+                .Should().Throw<InvalidOperationException>();
+
+            // Nor is a registry, on either instance: a live enable sets a value, it never grows a registry.
+            Invoking(() => webApi.Fetch.AllowedSchemes.Add("ftp"))
+                .Should().Throw<InvalidOperationException>();
+        });
+
+        ran.Should().BeTrue();
+        options.WebApi.Timers.MaxActiveTimers.Should().Be(3);
+
+        // ... and the suspension ends with the call.
+        Invoking(() => options.WebApi.Timers.MaxActiveTimers = 4)
+            .Should().Throw<InvalidOperationException>();
+    }
+#endif
+
     /// <summary>
     /// A configuration callback runs while the engine is being built, which is before the freeze — otherwise
     /// the documented way to finish configuring an engine would have stopped working.

--- a/Jint.Tests.PublicInterface/OperatorOverloadingConfigurationTests.cs
+++ b/Jint.Tests.PublicInterface/OperatorOverloadingConfigurationTests.cs
@@ -10,7 +10,7 @@ namespace Jint.Tests.PublicInterface;
 /// honoured, everything after it is not. The snapshot is taken after <c>Options.Apply</c>, which is
 /// what runs a host's <c>Configure</c> callbacks, so both documented ways of setting the option at
 /// construction time work. Mutating the <see cref="Options"/> instance <em>after</em> the engine
-/// exists deliberately does not — see the test that says so.
+/// exists is refused outright — see the test that says so.
 /// </para>
 /// </summary>
 public class OperatorOverloadingConfigurationTests
@@ -82,21 +82,24 @@ public class OperatorOverloadingConfigurationTests
     }
 
     [Fact]
-    public void MutatingTheOptionsAfterConstructionDoesNotReachTheEngine()
+    public void MutatingTheOptionsAfterConstructionIsRefused()
     {
-        // Deliberate: the reading belongs to the engine, not to the Options instance it was built
-        // from. One Options instance is meant to be shared by many engines, including concurrently
-        // running ones, so a live read would let one host thread change how another engine's already
-        // running script evaluates `+`. Every other option the engine cares about is snapshotted the
-        // same way. A host that wants the option has to ask for it before the engine exists.
+        // One Options instance is meant to be shared by many engines, including concurrently running
+        // ones, so a write after construction could change how another engine's already running script
+        // evaluates `+`. It used to be a silent no-op for this particular setting and a live change for
+        // roughly thirty others, discoverable only by reading each property's documentation. Now the
+        // whole instance is read-only once an engine has been built from it.
         var options = new Options();
         var engine = new Engine(options);
 
-        options.Interop.AllowOperatorOverloading = true;
+        options.IsReadOnly.Should().BeTrue();
+        Invoking(() => options.Interop.AllowOperatorOverloading = true)
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage("*Options.Interop.AllowOperatorOverloading*");
 
         Add(engine).Should().Be(JsValue.Undefined);
 
-        // ... and the same Options instance still configures the next engine built from it.
-        Add(new Engine(options)).Should().Be(3);
+        // ... and the same Options instance still builds the next engine, with the configuration it had.
+        Add(new Engine(options)).Should().Be(JsValue.Undefined);
     }
 }

--- a/Jint.Tests.PublicInterface/SecurityConfigurationTests.cs
+++ b/Jint.Tests.PublicInterface/SecurityConfigurationTests.cs
@@ -124,8 +124,11 @@ public class SecurityConfigurationTests
             System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic;
         var engine = new Engine(options);
 
-        options.Interop.ObjectWrapperReportedPropertyBindingFlags =
-            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public;
+        // The options are read-only from here, so there is no longer a way to make the report and the
+        // engine disagree: the write that used to be the interesting half of this test is refused.
+        Invoking(() => options.Interop.ObjectWrapperReportedPropertyBindingFlags =
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public)
+            .Should().Throw<InvalidOperationException>();
 
         engine.Advanced.ValidateSecurityConfiguration().Diagnostics.Should().ContainSingle(
             diagnostic => diagnostic.Code == SecurityDiagnosticCodes.NonPublicClrMembersEnabled);
@@ -312,11 +315,15 @@ public class SecurityConfigurationTests
         options.Interop.ExposeDetailedResolutionErrors = true;
         var engine = new Engine(options);
 
-        options.Interop.Enabled = false;
-        options.Interop.AllowGetType = false;
-        options.Interop.AllowSystemReflection = false;
-        options.Interop.ExposeDetailedResolutionErrors = false;
-        options.Interop.TypeResolver = new TypeResolver { MemberFilter = static _ => false };
+        // Every one of these used to be a silent no-op against this engine's report. They are now refused
+        // outright, which is the same guarantee said out loud.
+        Invoking(() => options.Interop.Enabled = false).Should().Throw<InvalidOperationException>();
+        Invoking(() => options.Interop.AllowGetType = false).Should().Throw<InvalidOperationException>();
+        Invoking(() => options.Interop.AllowSystemReflection = false).Should().Throw<InvalidOperationException>();
+        Invoking(() => options.Interop.ExposeDetailedResolutionErrors = false).Should().Throw<InvalidOperationException>();
+        Invoking(() => options.Interop.TypeResolver = new TypeResolver { MemberFilter = static _ => false })
+            .Should().Throw<InvalidOperationException>();
+        Invoking(() => options.Interop.AllowedAssemblies.Clear()).Should().Throw<InvalidOperationException>();
 
         var report = engine.Advanced.ValidateSecurityConfiguration();
 
@@ -335,7 +342,8 @@ public class SecurityConfigurationTests
     {
         var options = CreateSafeModuleOptions();
         var engine = new Engine(options);
-        options.Modules.ModuleLoader = new Options().Modules.ModuleLoader;
+        Invoking(() => options.Modules.ModuleLoader = new Options().Modules.ModuleLoader)
+            .Should().Throw<InvalidOperationException>();
 
         engine.Advanced.ValidateSecurityConfiguration().Diagnostics.Should().ContainSingle(
             diagnostic => diagnostic.Code == SecurityDiagnosticCodes.ModuleLoadingEnabled);
@@ -353,12 +361,12 @@ public class SecurityConfigurationTests
         options.Constraints.StackOverflowGuard = false;
         var engine = new Engine(options);
 
-        options.Parsing.MaxSourceLength = 100_000;
-        options.Parsing.MaxNodeCount = 25_000;
-        options.RetainFunctionSourceText = false;
-        options.Constraints.RegexTimeout = TimeSpan.FromSeconds(1);
-        options.Constraints.MaxRecursionDepth = 64;
-        options.Constraints.StackOverflowGuard = true;
+        Invoking(() => options.Parsing.MaxSourceLength = 100_000).Should().Throw<InvalidOperationException>();
+        Invoking(() => options.Parsing.MaxNodeCount = 25_000).Should().Throw<InvalidOperationException>();
+        Invoking(() => options.RetainFunctionSourceText = false).Should().Throw<InvalidOperationException>();
+        Invoking(() => options.Constraints.RegexTimeout = TimeSpan.FromSeconds(1)).Should().Throw<InvalidOperationException>();
+        Invoking(() => options.Constraints.MaxRecursionDepth = 64).Should().Throw<InvalidOperationException>();
+        Invoking(() => options.Constraints.StackOverflowGuard = true).Should().Throw<InvalidOperationException>();
 
         var codes = engine.Advanced.ValidateSecurityConfiguration().Diagnostics
             .Select(static diagnostic => diagnostic.Code);

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
@@ -292,6 +292,7 @@ namespace Jint
         public Jint.Options.HostOptions Host { get; }
         public Jint.Options.InteropOptions Interop { get; }
         public Jint.Options.IntlOptions Intl { get; }
+        public bool IsReadOnly { get; }
         public Jint.Options.JsonOptions Json { get; }
         public Jint.Options.ModuleOptions Modules { get; }
         public Jint.Options.ParsingOptions Parsing { get; }
@@ -305,6 +306,7 @@ namespace Jint
         public Jint.Runtime.ITimeSystem TimeSystem { get; set; }
         public System.TimeZoneInfo TimeZone { get; set; }
         public Jint.Options.WebApiOptions WebApi { get; }
+        public void MakeReadOnly() { }
         public sealed class CacheOptions
         {
             public CacheOptions() { }
@@ -318,7 +320,7 @@ namespace Jint
         public sealed class ConstraintOptions
         {
             public ConstraintOptions() { }
-            public System.Collections.Generic.List<Jint.Constraint> Constraints { get; }
+            public Jint.OptionsList<Jint.Constraint> Constraints { get; }
             public uint MaxArraySize { get; set; }
             public int MaxAtomicsPauseIterations { get; set; }
             public int MaxExecutionStackCount { get; set; }
@@ -349,7 +351,7 @@ namespace Jint
         public sealed class FetchOptions
         {
             public FetchOptions() { }
-            public System.Collections.Generic.List<string> AllowedSchemes { get; }
+            public Jint.OptionsList<string> AllowedSchemes { get; }
             public System.Net.Http.HttpClient? HttpClient { get; set; }
             public System.Func<Jint.Engine, System.Net.Http.HttpClient>? HttpClientFactory { get; set; }
             public int MaxConcurrentRequests { get; set; }
@@ -371,7 +373,7 @@ namespace Jint
             public bool AllowOperatorOverloading { get; set; }
             public bool AllowSystemReflection { get; set; }
             public bool AllowWrite { get; set; }
-            public System.Collections.Generic.List<System.Reflection.Assembly> AllowedAssemblies { get; set; }
+            public Jint.OptionsList<System.Reflection.Assembly> AllowedAssemblies { get; }
             public Jint.ArrayConversionMode ArrayConversion { get; set; }
             public bool AttachArrayPrototype { get; set; }
             public Jint.Options.BuildCallStackDelegate? BuildCallStackHandler { get; set; }
@@ -388,10 +390,10 @@ namespace Jint
             public Jint.Options.ExceptionHandlerDelegate ExceptionHandler { get; set; }
             public bool ExposeDetailedExceptionMessages { get; set; }
             public bool ExposeDetailedResolutionErrors { get; set; }
-            public System.Collections.Generic.List<System.Type> ExtensionMethodTypes { get; }
-            public System.Collections.Generic.List<System.Type> ImmutableCrossingTypes { get; }
+            public Jint.OptionsList<System.Type> ExtensionMethodTypes { get; }
+            public Jint.OptionsList<System.Type> ImmutableCrossingTypes { get; }
             public Jint.Options.MemberAccessorDelegate MemberAccessor { get; set; }
-            public System.Collections.Generic.List<Jint.Runtime.Interop.IObjectConverter> ObjectConverters { get; }
+            public Jint.OptionsList<Jint.Runtime.Interop.IObjectConverter> ObjectConverters { get; }
             public System.Reflection.BindingFlags ObjectWrapperReportedFieldBindingFlags { get; set; }
             public System.Reflection.MemberTypes ObjectWrapperReportedMemberTypes { get; set; }
             public System.Reflection.BindingFlags ObjectWrapperReportedMethodBindingFlags { get; set; }
@@ -523,6 +525,24 @@ namespace Jint
             where T : Jint.Runtime.Host { }
         public static Jint.Options UseModules(this Jint.Options options, Jint.Runtime.Modules.IModuleLoader moduleLoader) { }
         public static Jint.Options UseModules(this Jint.Options options, string basePath, bool restrictToBasePath = true) { }
+    }
+    public sealed class OptionsList<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.IEnumerable
+    {
+        public int Count { get; }
+        public bool IsReadOnly { get; }
+        public T this[int index] { get; set; }
+        public void Add(T item) { }
+        public void AddRange(System.Collections.Generic.IEnumerable<T> items) { }
+        public void Clear() { }
+        public bool Contains(T item) { }
+        public void CopyTo(T[] array, int arrayIndex) { }
+        public System.Collections.Generic.List<T>.Enumerator GetEnumerator() { }
+        public int IndexOf(T item) { }
+        public void Insert(int index, T item) { }
+        public bool Remove(T item) { }
+        public int RemoveAll(System.Predicate<T> match) { }
+        public void RemoveAt(int index) { }
+        public T[] ToArray() { }
     }
     public static class OptionsSecurityExtensions
     {

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net472.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net472.verified.txt
@@ -271,6 +271,7 @@ namespace Jint
         public Jint.Options.HostOptions Host { get; }
         public Jint.Options.InteropOptions Interop { get; }
         public Jint.Options.IntlOptions Intl { get; }
+        public bool IsReadOnly { get; }
         public Jint.Options.JsonOptions Json { get; }
         public Jint.Options.ModuleOptions Modules { get; }
         public Jint.Options.ParsingOptions Parsing { get; }
@@ -283,10 +284,11 @@ namespace Jint
         public Jint.Options.TemporalOptions Temporal { get; }
         public Jint.Runtime.ITimeSystem TimeSystem { get; set; }
         public System.TimeZoneInfo TimeZone { get; set; }
+        public void MakeReadOnly() { }
         public sealed class ConstraintOptions
         {
             public ConstraintOptions() { }
-            public System.Collections.Generic.List<Jint.Constraint> Constraints { get; }
+            public Jint.OptionsList<Jint.Constraint> Constraints { get; }
             public uint MaxArraySize { get; set; }
             public int MaxAtomicsPauseIterations { get; set; }
             public int MaxExecutionStackCount { get; set; }
@@ -321,7 +323,7 @@ namespace Jint
             public bool AllowOperatorOverloading { get; set; }
             public bool AllowSystemReflection { get; set; }
             public bool AllowWrite { get; set; }
-            public System.Collections.Generic.List<System.Reflection.Assembly> AllowedAssemblies { get; set; }
+            public Jint.OptionsList<System.Reflection.Assembly> AllowedAssemblies { get; }
             public Jint.ArrayConversionMode ArrayConversion { get; set; }
             public bool AttachArrayPrototype { get; set; }
             public Jint.Options.BuildCallStackDelegate? BuildCallStackHandler { get; set; }
@@ -338,10 +340,10 @@ namespace Jint
             public Jint.Options.ExceptionHandlerDelegate ExceptionHandler { get; set; }
             public bool ExposeDetailedExceptionMessages { get; set; }
             public bool ExposeDetailedResolutionErrors { get; set; }
-            public System.Collections.Generic.List<System.Type> ExtensionMethodTypes { get; }
-            public System.Collections.Generic.List<System.Type> ImmutableCrossingTypes { get; }
+            public Jint.OptionsList<System.Type> ExtensionMethodTypes { get; }
+            public Jint.OptionsList<System.Type> ImmutableCrossingTypes { get; }
             public Jint.Options.MemberAccessorDelegate MemberAccessor { get; set; }
-            public System.Collections.Generic.List<Jint.Runtime.Interop.IObjectConverter> ObjectConverters { get; }
+            public Jint.OptionsList<Jint.Runtime.Interop.IObjectConverter> ObjectConverters { get; }
             public System.Reflection.BindingFlags ObjectWrapperReportedFieldBindingFlags { get; set; }
             public System.Reflection.MemberTypes ObjectWrapperReportedMemberTypes { get; set; }
             public System.Reflection.BindingFlags ObjectWrapperReportedMethodBindingFlags { get; set; }
@@ -431,6 +433,24 @@ namespace Jint
             where T : Jint.Runtime.Host { }
         public static Jint.Options UseModules(this Jint.Options options, Jint.Runtime.Modules.IModuleLoader moduleLoader) { }
         public static Jint.Options UseModules(this Jint.Options options, string basePath, bool restrictToBasePath = true) { }
+    }
+    public sealed class OptionsList<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.IEnumerable
+    {
+        public int Count { get; }
+        public bool IsReadOnly { get; }
+        public T this[int index] { get; set; }
+        public void Add(T item) { }
+        public void AddRange(System.Collections.Generic.IEnumerable<T> items) { }
+        public void Clear() { }
+        public bool Contains(T item) { }
+        public void CopyTo(T[] array, int arrayIndex) { }
+        public System.Collections.Generic.List<T>.Enumerator GetEnumerator() { }
+        public int IndexOf(T item) { }
+        public void Insert(int index, T item) { }
+        public bool Remove(T item) { }
+        public int RemoveAll(System.Predicate<T> match) { }
+        public void RemoveAt(int index) { }
+        public T[] ToArray() { }
     }
     public static class OptionsSecurityExtensions
     {

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
@@ -292,6 +292,7 @@ namespace Jint
         public Jint.Options.HostOptions Host { get; }
         public Jint.Options.InteropOptions Interop { get; }
         public Jint.Options.IntlOptions Intl { get; }
+        public bool IsReadOnly { get; }
         public Jint.Options.JsonOptions Json { get; }
         public Jint.Options.ModuleOptions Modules { get; }
         public Jint.Options.ParsingOptions Parsing { get; }
@@ -305,6 +306,7 @@ namespace Jint
         public Jint.Runtime.ITimeSystem TimeSystem { get; set; }
         public System.TimeZoneInfo TimeZone { get; set; }
         public Jint.Options.WebApiOptions WebApi { get; }
+        public void MakeReadOnly() { }
         public sealed class CacheOptions
         {
             public CacheOptions() { }
@@ -318,7 +320,7 @@ namespace Jint
         public sealed class ConstraintOptions
         {
             public ConstraintOptions() { }
-            public System.Collections.Generic.List<Jint.Constraint> Constraints { get; }
+            public Jint.OptionsList<Jint.Constraint> Constraints { get; }
             public uint MaxArraySize { get; set; }
             public int MaxAtomicsPauseIterations { get; set; }
             public int MaxExecutionStackCount { get; set; }
@@ -349,7 +351,7 @@ namespace Jint
         public sealed class FetchOptions
         {
             public FetchOptions() { }
-            public System.Collections.Generic.List<string> AllowedSchemes { get; }
+            public Jint.OptionsList<string> AllowedSchemes { get; }
             public System.Net.Http.HttpClient? HttpClient { get; set; }
             public System.Func<Jint.Engine, System.Net.Http.HttpClient>? HttpClientFactory { get; set; }
             public int MaxConcurrentRequests { get; set; }
@@ -371,7 +373,7 @@ namespace Jint
             public bool AllowOperatorOverloading { get; set; }
             public bool AllowSystemReflection { get; set; }
             public bool AllowWrite { get; set; }
-            public System.Collections.Generic.List<System.Reflection.Assembly> AllowedAssemblies { get; set; }
+            public Jint.OptionsList<System.Reflection.Assembly> AllowedAssemblies { get; }
             public Jint.ArrayConversionMode ArrayConversion { get; set; }
             public bool AttachArrayPrototype { get; set; }
             public Jint.Options.BuildCallStackDelegate? BuildCallStackHandler { get; set; }
@@ -388,10 +390,10 @@ namespace Jint
             public Jint.Options.ExceptionHandlerDelegate ExceptionHandler { get; set; }
             public bool ExposeDetailedExceptionMessages { get; set; }
             public bool ExposeDetailedResolutionErrors { get; set; }
-            public System.Collections.Generic.List<System.Type> ExtensionMethodTypes { get; }
-            public System.Collections.Generic.List<System.Type> ImmutableCrossingTypes { get; }
+            public Jint.OptionsList<System.Type> ExtensionMethodTypes { get; }
+            public Jint.OptionsList<System.Type> ImmutableCrossingTypes { get; }
             public Jint.Options.MemberAccessorDelegate MemberAccessor { get; set; }
-            public System.Collections.Generic.List<Jint.Runtime.Interop.IObjectConverter> ObjectConverters { get; }
+            public Jint.OptionsList<Jint.Runtime.Interop.IObjectConverter> ObjectConverters { get; }
             public System.Reflection.BindingFlags ObjectWrapperReportedFieldBindingFlags { get; set; }
             public System.Reflection.MemberTypes ObjectWrapperReportedMemberTypes { get; set; }
             public System.Reflection.BindingFlags ObjectWrapperReportedMethodBindingFlags { get; set; }
@@ -523,6 +525,24 @@ namespace Jint
             where T : Jint.Runtime.Host { }
         public static Jint.Options UseModules(this Jint.Options options, Jint.Runtime.Modules.IModuleLoader moduleLoader) { }
         public static Jint.Options UseModules(this Jint.Options options, string basePath, bool restrictToBasePath = true) { }
+    }
+    public sealed class OptionsList<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.IEnumerable
+    {
+        public int Count { get; }
+        public bool IsReadOnly { get; }
+        public T this[int index] { get; set; }
+        public void Add(T item) { }
+        public void AddRange(System.Collections.Generic.IEnumerable<T> items) { }
+        public void Clear() { }
+        public bool Contains(T item) { }
+        public void CopyTo(T[] array, int arrayIndex) { }
+        public System.Collections.Generic.List<T>.Enumerator GetEnumerator() { }
+        public int IndexOf(T item) { }
+        public void Insert(int index, T item) { }
+        public bool Remove(T item) { }
+        public int RemoveAll(System.Predicate<T> match) { }
+        public void RemoveAt(int index) { }
+        public T[] ToArray() { }
     }
     public static class OptionsSecurityExtensions
     {

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.0.verified.txt
@@ -271,6 +271,7 @@ namespace Jint
         public Jint.Options.HostOptions Host { get; }
         public Jint.Options.InteropOptions Interop { get; }
         public Jint.Options.IntlOptions Intl { get; }
+        public bool IsReadOnly { get; }
         public Jint.Options.JsonOptions Json { get; }
         public Jint.Options.ModuleOptions Modules { get; }
         public Jint.Options.ParsingOptions Parsing { get; }
@@ -283,10 +284,11 @@ namespace Jint
         public Jint.Options.TemporalOptions Temporal { get; }
         public Jint.Runtime.ITimeSystem TimeSystem { get; set; }
         public System.TimeZoneInfo TimeZone { get; set; }
+        public void MakeReadOnly() { }
         public sealed class ConstraintOptions
         {
             public ConstraintOptions() { }
-            public System.Collections.Generic.List<Jint.Constraint> Constraints { get; }
+            public Jint.OptionsList<Jint.Constraint> Constraints { get; }
             public uint MaxArraySize { get; set; }
             public int MaxAtomicsPauseIterations { get; set; }
             public int MaxExecutionStackCount { get; set; }
@@ -321,7 +323,7 @@ namespace Jint
             public bool AllowOperatorOverloading { get; set; }
             public bool AllowSystemReflection { get; set; }
             public bool AllowWrite { get; set; }
-            public System.Collections.Generic.List<System.Reflection.Assembly> AllowedAssemblies { get; set; }
+            public Jint.OptionsList<System.Reflection.Assembly> AllowedAssemblies { get; }
             public Jint.ArrayConversionMode ArrayConversion { get; set; }
             public bool AttachArrayPrototype { get; set; }
             public Jint.Options.BuildCallStackDelegate? BuildCallStackHandler { get; set; }
@@ -338,10 +340,10 @@ namespace Jint
             public Jint.Options.ExceptionHandlerDelegate ExceptionHandler { get; set; }
             public bool ExposeDetailedExceptionMessages { get; set; }
             public bool ExposeDetailedResolutionErrors { get; set; }
-            public System.Collections.Generic.List<System.Type> ExtensionMethodTypes { get; }
-            public System.Collections.Generic.List<System.Type> ImmutableCrossingTypes { get; }
+            public Jint.OptionsList<System.Type> ExtensionMethodTypes { get; }
+            public Jint.OptionsList<System.Type> ImmutableCrossingTypes { get; }
             public Jint.Options.MemberAccessorDelegate MemberAccessor { get; set; }
-            public System.Collections.Generic.List<Jint.Runtime.Interop.IObjectConverter> ObjectConverters { get; }
+            public Jint.OptionsList<Jint.Runtime.Interop.IObjectConverter> ObjectConverters { get; }
             public System.Reflection.BindingFlags ObjectWrapperReportedFieldBindingFlags { get; set; }
             public System.Reflection.MemberTypes ObjectWrapperReportedMemberTypes { get; set; }
             public System.Reflection.BindingFlags ObjectWrapperReportedMethodBindingFlags { get; set; }
@@ -431,6 +433,24 @@ namespace Jint
             where T : Jint.Runtime.Host { }
         public static Jint.Options UseModules(this Jint.Options options, Jint.Runtime.Modules.IModuleLoader moduleLoader) { }
         public static Jint.Options UseModules(this Jint.Options options, string basePath, bool restrictToBasePath = true) { }
+    }
+    public sealed class OptionsList<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.IEnumerable
+    {
+        public int Count { get; }
+        public bool IsReadOnly { get; }
+        public T this[int index] { get; set; }
+        public void Add(T item) { }
+        public void AddRange(System.Collections.Generic.IEnumerable<T> items) { }
+        public void Clear() { }
+        public bool Contains(T item) { }
+        public void CopyTo(T[] array, int arrayIndex) { }
+        public System.Collections.Generic.List<T>.Enumerator GetEnumerator() { }
+        public int IndexOf(T item) { }
+        public void Insert(int index, T item) { }
+        public bool Remove(T item) { }
+        public int RemoveAll(System.Predicate<T> match) { }
+        public void RemoveAt(int index) { }
+        public T[] ToArray() { }
     }
     public static class OptionsSecurityExtensions
     {

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.1.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.1.verified.txt
@@ -271,6 +271,7 @@ namespace Jint
         public Jint.Options.HostOptions Host { get; }
         public Jint.Options.InteropOptions Interop { get; }
         public Jint.Options.IntlOptions Intl { get; }
+        public bool IsReadOnly { get; }
         public Jint.Options.JsonOptions Json { get; }
         public Jint.Options.ModuleOptions Modules { get; }
         public Jint.Options.ParsingOptions Parsing { get; }
@@ -283,10 +284,11 @@ namespace Jint
         public Jint.Options.TemporalOptions Temporal { get; }
         public Jint.Runtime.ITimeSystem TimeSystem { get; set; }
         public System.TimeZoneInfo TimeZone { get; set; }
+        public void MakeReadOnly() { }
         public sealed class ConstraintOptions
         {
             public ConstraintOptions() { }
-            public System.Collections.Generic.List<Jint.Constraint> Constraints { get; }
+            public Jint.OptionsList<Jint.Constraint> Constraints { get; }
             public uint MaxArraySize { get; set; }
             public int MaxAtomicsPauseIterations { get; set; }
             public int MaxExecutionStackCount { get; set; }
@@ -321,7 +323,7 @@ namespace Jint
             public bool AllowOperatorOverloading { get; set; }
             public bool AllowSystemReflection { get; set; }
             public bool AllowWrite { get; set; }
-            public System.Collections.Generic.List<System.Reflection.Assembly> AllowedAssemblies { get; set; }
+            public Jint.OptionsList<System.Reflection.Assembly> AllowedAssemblies { get; }
             public Jint.ArrayConversionMode ArrayConversion { get; set; }
             public bool AttachArrayPrototype { get; set; }
             public Jint.Options.BuildCallStackDelegate? BuildCallStackHandler { get; set; }
@@ -338,10 +340,10 @@ namespace Jint
             public Jint.Options.ExceptionHandlerDelegate ExceptionHandler { get; set; }
             public bool ExposeDetailedExceptionMessages { get; set; }
             public bool ExposeDetailedResolutionErrors { get; set; }
-            public System.Collections.Generic.List<System.Type> ExtensionMethodTypes { get; }
-            public System.Collections.Generic.List<System.Type> ImmutableCrossingTypes { get; }
+            public Jint.OptionsList<System.Type> ExtensionMethodTypes { get; }
+            public Jint.OptionsList<System.Type> ImmutableCrossingTypes { get; }
             public Jint.Options.MemberAccessorDelegate MemberAccessor { get; set; }
-            public System.Collections.Generic.List<Jint.Runtime.Interop.IObjectConverter> ObjectConverters { get; }
+            public Jint.OptionsList<Jint.Runtime.Interop.IObjectConverter> ObjectConverters { get; }
             public System.Reflection.BindingFlags ObjectWrapperReportedFieldBindingFlags { get; set; }
             public System.Reflection.MemberTypes ObjectWrapperReportedMemberTypes { get; set; }
             public System.Reflection.BindingFlags ObjectWrapperReportedMethodBindingFlags { get; set; }
@@ -431,6 +433,24 @@ namespace Jint
             where T : Jint.Runtime.Host { }
         public static Jint.Options UseModules(this Jint.Options options, Jint.Runtime.Modules.IModuleLoader moduleLoader) { }
         public static Jint.Options UseModules(this Jint.Options options, string basePath, bool restrictToBasePath = true) { }
+    }
+    public sealed class OptionsList<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.IEnumerable
+    {
+        public int Count { get; }
+        public bool IsReadOnly { get; }
+        public T this[int index] { get; set; }
+        public void Add(T item) { }
+        public void AddRange(System.Collections.Generic.IEnumerable<T> items) { }
+        public void Clear() { }
+        public bool Contains(T item) { }
+        public void CopyTo(T[] array, int arrayIndex) { }
+        public System.Collections.Generic.List<T>.Enumerator GetEnumerator() { }
+        public int IndexOf(T item) { }
+        public void Insert(int index, T item) { }
+        public bool Remove(T item) { }
+        public int RemoveAll(System.Predicate<T> match) { }
+        public void RemoveAt(int index) { }
+        public T[] ToArray() { }
     }
     public static class OptionsSecurityExtensions
     {

--- a/Jint.Tests.PublicInterface/WebApiTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiTests.cs
@@ -26,6 +26,17 @@ public class WebApiTests
         }
     }
 
+    /// <summary>
+    /// The shape a host uses to keep swapping where console output goes: the mutable part is the host's own
+    /// object, and the engine's configuration never changes.
+    /// </summary>
+    private sealed class ForwardingSink : ConsoleSink
+    {
+        internal ConsoleSink Target { get; set; } = Null;
+
+        public override void Write(ConsoleLogLevel level, string message) => Target.Write(level, message);
+    }
+
     [Fact]
     public void ADefaultEngineHasNoWebGlobals()
     {
@@ -145,21 +156,39 @@ public class WebApiTests
         sink.Records.ConvertAll(r => r.Message).Should().Equal("x: 1", "g", "  deep", "x: 1", "flat");
     }
 
+    /// <summary>
+    /// A sink is still swappable between evaluations — but through a sink the host owns, not by writing to
+    /// the <see cref="Options"/> instance the engine was built from, which is read-only from that moment.
+    /// The forwarding sink is two lines, and unlike the option write it cannot reach a second engine that
+    /// happens to share the same options.
+    /// </summary>
     [Fact]
     public void ASwappedSinkTakesEffectOnTheNextRecord()
     {
         var first = new RecordingSink();
         var second = new RecordingSink();
-        var options = new Options().UseConsole(first);
+        var forwarding = new ForwardingSink { Target = first };
+        var options = new Options().UseConsole(forwarding);
         var engine = new Engine(options);
 
         engine.Execute("console.log('one')");
-        options.WebApi.Console.Sink = second;
+        forwarding.Target = second;
         engine.Execute("console.log('two')");
 
         first.Records.Should().HaveCount(1);
         second.Records.Should().HaveCount(1);
         second.Records[0].Message.Should().Be("two");
+    }
+
+    [Fact]
+    public void WritingTheSinkOnAnEnginesOptionsIsRefused()
+    {
+        var options = new Options().UseConsole(new RecordingSink());
+        _ = new Engine(options);
+
+        Invoking(() => options.WebApi.Console.Sink = new RecordingSink())
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage("*Options.WebApi.Console.Sink*");
     }
 
     [Fact]

--- a/Jint.Tests/Runtime/AsyncTests.cs
+++ b/Jint.Tests/Runtime/AsyncTests.cs
@@ -2638,15 +2638,16 @@ public class AsyncTests
         // and the TCS in WaitForEventAsync gets cancelled (stale). The engine must
         // remain usable for subsequent calls — the stale TCS must be detected and
         // replaced on the next EvaluateAsync invocation.
+        //
+        // One budget for both halves, because the Options an engine was built from are read-only afterwards.
+        // It is generous enough that the recovery half asserts success rather than racing the machine, and
+        // the first half reaches it anyway because the slow IO never completes at all.
+        var neverCompletes = new TaskCompletionSource<int>();
         var engine = new Engine(options =>
         {
-            options.Constraints.PromiseTimeout = TimeSpan.FromMilliseconds(50);
+            options.Constraints.PromiseTimeout = TimeSpan.FromSeconds(1);
         });
-        engine.SetValue("slowIO", new Func<Task<int>>(async () =>
-        {
-            await Task.Delay(10_000);
-            return 999;
-        }));
+        engine.SetValue("slowIO", new Func<Task<int>>(() => neverCompletes.Task));
         engine.SetValue("fastIO", new Func<Task<int>>(async () =>
         {
             await Task.Delay(10);
@@ -2658,9 +2659,6 @@ public class AsyncTests
         {
             await engine.EvaluateAsync("(async () => await slowIO())()");
         }).Should().ThrowExactlyAsync<PromiseRejectedException>();
-
-        // Increase timeout for recovery (generous — the recovery half asserts success)
-        engine.Options.Constraints.PromiseTimeout = GenerousPromiseTimeout;
 
         // Engine should still work
         var result = await engine.EvaluateAsync("(async () => await fastIO())()");

--- a/Jint.Tests/Runtime/InteropTests.ArrayIdentityCache.cs
+++ b/Jint.Tests/Runtime/InteropTests.ArrayIdentityCache.cs
@@ -60,19 +60,22 @@ public partial class InteropTests
     {
         // the identity map may hold a wrapper for a different exposed view of the same array;
         // a type-guard miss must replace the entry (last view wins), not throw on Add
+        // The view the handler chooses is switched host-side rather than by replacing the handler on the
+        // engine's Options, which are read-only once the engine has been built from them.
+        var exposeAsList = true;
         var engine = new Engine(options =>
         {
             options.Interop.ArrayConversion = ArrayConversionMode.LiveView;
             options.Interop.TrackObjectWrapperIdentity = true;
-            options.Interop.WrapObjectHandler = static (e, target, type) =>
-                ObjectWrapper.Create(e, target, target is int[] ? typeof(System.Collections.IList) : type);
+            options.Interop.WrapObjectHandler = (e, target, type) =>
+                ObjectWrapper.Create(e, target, (exposeAsList && target is int[]) ? typeof(System.Collections.IList) : type);
         });
 
         var array = new[] { 1, 2, 3 };
         engine.SetValue("a", array);
         engine.Evaluate("a[0]").AsNumber().Should().Be(1);
 
-        engine.Options.Interop.WrapObjectHandler = static (e, target, type) => ObjectWrapper.Create(e, target, type);
+        exposeAsList = false;
         engine.SetValue("b", array);
         engine.Evaluate("b[0]").AsNumber().Should().Be(1);
     }

--- a/Jint.Tests/Runtime/ModuleTests.cs
+++ b/Jint.Tests/Runtime/ModuleTests.cs
@@ -222,11 +222,13 @@ public class ModuleTests
     [Fact]
     public void ShouldPropagateParseError()
     {
-        _engine.Options.Modules.ExposeDetailedLoadErrors = true;
-        _engine.Modules.Add("imported", "export const invalid;");
-        _engine.Modules.Add("my-module", "import { invalid } from 'imported';");
+        // Its own engine: Options are read-only once an engine has been built from them, and the shared
+        // default this class's _engine uses would have carried the exposure into every other test besides.
+        var engine = new Engine(options => options.Modules.ExposeDetailedLoadErrors = true);
+        engine.Modules.Add("imported", "export const invalid;");
+        engine.Modules.Add("my-module", "import { invalid } from 'imported';");
 
-        var exc = Invoking(() =>  _engine.Modules.Import("my-module")).Should().ThrowExactly<JavaScriptException>().Which;
+        var exc = Invoking(() =>  engine.Modules.Import("my-module")).Should().ThrowExactly<JavaScriptException>().Which;
         exc.Message.Should().Be("Error while loading module: error in module 'imported': Missing initializer in const declaration (imported:1:21)");
         exc.Location.SourceFile.Should().Be("imported");
     }
@@ -234,11 +236,11 @@ public class ModuleTests
     [Fact]
     public void ShouldPropagateLinkError()
     {
-        _engine.Options.Modules.ExposeDetailedLoadErrors = true;
-        _engine.Modules.Add("imported", "export invalid;");
-        _engine.Modules.Add("my-module", "import { value } from 'imported';");
+        var engine = new Engine(options => options.Modules.ExposeDetailedLoadErrors = true);
+        engine.Modules.Add("imported", "export invalid;");
+        engine.Modules.Add("my-module", "import { value } from 'imported';");
 
-        var exc = Invoking(() =>  _engine.Modules.Import("my-module")).Should().ThrowExactly<JavaScriptException>().Which;
+        var exc = Invoking(() =>  engine.Modules.Import("my-module")).Should().ThrowExactly<JavaScriptException>().Which;
         exc.Message.Should().Be("Error while loading module: error in module 'imported': Unexpected identifier 'invalid' (imported:1:8)");
         exc.Location.SourceFile.Should().Be("imported");
     }

--- a/Jint.Tests/Runtime/WebApi/LiveEnableTests.cs
+++ b/Jint.Tests/Runtime/WebApi/LiveEnableTests.cs
@@ -131,10 +131,15 @@ public class LiveEnableTests
     }
 
     /// <summary>
-    /// The clock a state was built on is the engine's forever: a <c>TimeProvider</c> assigned to the options
-    /// after construction must not reach an engine that already exists, or the timers and
+    /// The clock a state was built on is the engine's forever: a <c>TimeProvider</c> named by the live door's
+    /// own configuration callback must not reach an engine that already has a state, or the timers and
     /// <c>performance.now()</c> would be reading two different clocks.
     /// </summary>
+    /// <remarks>
+    /// The callback is the only way to say it at all now — an engine's <see cref="Options"/> are read-only
+    /// once it has been built from them — and it is deliberately the strongest form of the question: even the
+    /// sanctioned post-construction door cannot move a clock an engine is already running on.
+    /// </remarks>
     [Fact]
     public void ExtendingAnExistingStateDoesNotAdoptALaterClock()
     {
@@ -142,8 +147,9 @@ public class LiveEnableTests
         var engine = new Engine(options);
         var original = engine._webApi!.TimeProvider;
 
-        options.WebApi.Timers.TimeProvider = new FakeTimeProvider();
-        engine.Advanced.EnableWebApis(WebApiFeatures.Timers);
+        engine.Advanced.EnableWebApis(
+            WebApiFeatures.Timers,
+            webApi => webApi.Timers.TimeProvider = new FakeTimeProvider());
 
         engine._webApi!.TimeProvider.Should().BeSameAs(original);
         engine._webApi.Timers.Should().NotBeNull();

--- a/Jint/AGENTS.md
+++ b/Jint/AGENTS.md
@@ -71,6 +71,17 @@ being constructed **concurrently** and every engine build reads several groups: 
 uses the same helper and adds a `Clone()` that `CreateEngineOptions` calls, which is what keeps the
 untrusted-code profile's private snapshot from sharing state with the host's options.
 
+**`Options` is configuration until an engine reads it, and frozen afterwards.** The `Engine` constructor ends
+with `MakeReadOnly()`, which cascades to every group and registry; a group materialized later is born frozen,
+which is why `Materialize` takes the owner's state. So a new setting needs `ThrowIfReadOnly()` in its setter
+(`[CallerMemberName]` names it), a new registry is an `OptionsList<T>` rather than a `List<T>`, and a new
+group implements `IOptionsGroup` and joins the two cascades in `Options.ReadOnly.cs`. Nothing Jint writes to
+`Options` may happen after that line — the profile re-expansion and the host's `Configure` callbacks both run
+inside `Options.Apply`, well before it. The one sanctioned post-construction write is
+`Engine.Advanced.EnableWebApis`'s callback, which suspends the guard for the web-API groups on the calling
+thread alone; toggling a group's flag instead would open it to every thread, since the `Options` may be one
+other engines are being built from right now.
+
 ### Type co-location
 
 Keep small supporting types — enums, record structs, tiny helpers — **in the same file** as the type they serve, provided they share a namespace and the file stays readable (e.g. `ModuleImportPhase` lives in `ModuleRequest.cs`). Split them out when the type has several independent consumers, is `public` and needs its own XML-doc discoverability, or when the file would exceed ~500 lines or mix unrelated concepts.

--- a/Jint/Engine.Advanced.WebApi.cs
+++ b/Jint/Engine.Advanced.WebApi.cs
@@ -120,6 +120,12 @@ public partial class Engine
         /// is an ordinary mutation of the engine's global object. Calling it during an evaluation is not
         /// prevented, but a read already in flight may have resolved the old binding.
         /// </para>
+        /// <para>
+        /// <b><paramref name="configure"/> writes to the engine's own <see cref="Options"/> instance</b>, which
+        /// is read-only from construction onwards and is unfrozen here and nowhere else. That instance is
+        /// shared with every engine built from it, and for an engine built by <c>new Engine()</c> it is one
+        /// Jint keeps process-wide — so give an engine its own <see cref="Options"/> before configuring it here.
+        /// </para>
         /// </remarks>
         /// <example>
         /// A pooled engine that learns per request what the script needs:

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -1525,6 +1525,24 @@ public sealed partial class Engine : IDisposable
         _defaultParserOptions = scriptParsingDefaults.GetParserOptions(Options);
         _defaultParser = JintParser.Create(_defaultParserOptions, in _parsingConstraints);
         _securityConfigurationSnapshot = EngineSecurityConfigurationSnapshot.Capture(this);
+
+        // Last, and after everything Jint itself writes: Options.Apply has run the host's configuration
+        // callbacks and the untrusted-code profile's re-expansion, and every field derived above has been
+        // taken. From here the engine reads these options live — Interop.AllowWrite on every projected write,
+        // Interop.ExceptionHandler on every CLR call, Intl.CldrProvider when a locale is first needed — so a
+        // host write after this point would reach an engine that already exists. It cannot any more.
+        //
+        // The instance is usually the caller's own: CreateEngineOptions returns `this` unless a hardened
+        // profile made a private clone, and cloning instead would cost every engine build. Freezing is what
+        // makes the aliasing safe. Idempotent, so a second engine built from the same Options is unaffected.
+        //
+        // Both, and not only the one this engine kept: with a hardened profile they are different objects,
+        // and a host that got `Options is read-only after you build an engine from it` for the ordinary case
+        // and not for the profiled one would have to know which case it was in to know what its own object
+        // does. The clone the engine kept is the one that must not move; the source is frozen so that the
+        // rule can be stated without an exception.
+        Options.MakeReadOnly();
+        sourceOptions.MakeReadOnly();
     }
 
     private static void ValidateModuleOptions(Options.ModuleOptions modules)

--- a/Jint/Options.Extensions.cs
+++ b/Jint/Options.Extensions.cs
@@ -99,7 +99,7 @@ public static class OptionsExtensions
         options.Constraints.OperationDeadlineConstraintRequested = false;
 
         options.Interop.Enabled = false;
-        options.Interop.AllowedAssemblies = [];
+        options.Interop.AllowedAssemblies.Clear();
         options.Interop.AllowGetType = false;
         options.Interop.AllowSystemReflection = false;
         options.Interop.AllowWrite = false;
@@ -320,7 +320,7 @@ public static class OptionsExtensions
     /// </summary>
     public static Options SetTypeConverter(this Options options, Func<Engine, ITypeConverter> typeConverterFactory)
     {
-        options._configurations.Add(new EngineConfiguration(
+        options.AddConfiguration(new EngineConfiguration(
             engine => engine.TypeConverter = typeConverterFactory(engine),
             EngineConfigurationProvenance.User));
         return options;
@@ -341,7 +341,7 @@ public static class OptionsExtensions
         options.Interop.Enabled = true;
         options.Interop.ClrAccessConfiguration = ClrAccessConfiguration.Compatibility;
         options.Interop.AllowedAssemblies.Add(typeof(object).Assembly);
-        options.Interop.AllowedAssemblies = options.Interop.AllowedAssemblies.Distinct().ToList();
+        RemoveDuplicateAssemblies(options.Interop.AllowedAssemblies);
         return options;
     }
 
@@ -359,8 +359,22 @@ public static class OptionsExtensions
         options.Interop.Enabled = true;
         options.Interop.ClrAccessConfiguration = ClrAccessConfiguration.Explicit;
         options.Interop.AllowedAssemblies.AddRange(assemblies);
-        options.Interop.AllowedAssemblies = options.Interop.AllowedAssemblies.Distinct().ToList();
+        RemoveDuplicateAssemblies(options.Interop.AllowedAssemblies);
         return options;
+    }
+
+    /// <summary>
+    /// De-duplicates the allow-list in place, keeping the first occurrence of each assembly.
+    /// </summary>
+    /// <remarks>
+    /// Both <c>AllowClr</c> overloads used to end with <c>AllowedAssemblies = AllowedAssemblies.Distinct().ToList()</c>.
+    /// Replacing the registry wholesale is exactly what a registry that has to refuse changes cannot allow, so
+    /// the de-duplication happens through the registry instead of around it.
+    /// </remarks>
+    private static void RemoveDuplicateAssemblies(OptionsList<Assembly> assemblies)
+    {
+        var seen = new HashSet<Assembly>();
+        assemblies.RemoveAll(assembly => !seen.Add(assembly));
     }
 
     /// <summary>
@@ -697,7 +711,7 @@ public static class OptionsExtensions
             Throw.ArgumentNullException(nameof(valueFactory));
         }
 
-        options._configurations.Add(new EngineConfiguration(
+        options.AddConfiguration(new EngineConfiguration(
             engine => engine.Realm.GlobalObject.SetProperty(
                 name,
                 new LazyPropertyDescriptor<Engine>(engine, valueFactory, flags)),
@@ -714,13 +728,13 @@ public static class OptionsExtensions
     /// <param name="configuration">The action to register.</param>
     public static Options Configure(this Options options, Action<Engine> configuration)
     {
-        options._configurations.Add(new EngineConfiguration(configuration, EngineConfigurationProvenance.User));
+        options.AddConfiguration(new EngineConfiguration(configuration, EngineConfigurationProvenance.User));
         return options;
     }
 
     internal static Options ConfigureFirstParty(this Options options, Action<Engine> configuration)
     {
-        options._configurations.Add(new EngineConfiguration(configuration, EngineConfigurationProvenance.FirstParty));
+        options.AddConfiguration(new EngineConfiguration(configuration, EngineConfigurationProvenance.FirstParty));
         return options;
     }
 

--- a/Jint/Options.Profiling.cs
+++ b/Jint/Options.Profiling.cs
@@ -10,7 +10,7 @@ public sealed partial class Options
     /// before this existed.
     /// </summary>
     /// <seealso cref="Engine.AdvancedOperations.StartProfiling"/>
-    public ProfilingOptions Profiling => Materialize(ref _profiling);
+    public ProfilingOptions Profiling => Materialize(ref _profiling, _readOnly);
 
     private ProfilingOptions? _profiling;
 
@@ -20,10 +20,9 @@ public sealed partial class Options
     /// <remarks>
     /// Like every other <see cref="Options"/> group this may be shared by any number of engines, including
     /// concurrent ones: nothing on it is engine-affine, and both members are read once, on the thread that
-    /// calls <see cref="Engine.AdvancedOperations.StartProfiling"/>, into the session it starts. Changing
-    /// either afterwards does not reach a session already running.
+    /// calls <see cref="Engine.AdvancedOperations.StartProfiling"/>, into the session it starts.
     /// </remarks>
-    public sealed class ProfilingOptions
+    public sealed partial class ProfilingOptions
     {
         /// <summary>
         /// The default value of <see cref="MaxEvents"/>.
@@ -44,7 +43,7 @@ public sealed partial class Options
         /// reference per distinct function seen (see <see cref="Engine.AdvancedOperations.StartProfiling"/>),
         /// so an engine that runs untrusted script can refuse profiling outright by leaving this false.
         /// </remarks>
-        public bool Enabled { get; set; }
+        public bool Enabled { get; set { ThrowIfReadOnly(); field = value; } }
 
         /// <summary>
         /// Upper bound on the number of events one profiling session records, defaults to
@@ -63,6 +62,7 @@ public sealed partial class Options
             get => _maxEvents;
             set
             {
+                ThrowIfReadOnly();
                 if (value <= 0)
                 {
                     Throw.ArgumentOutOfRangeException(nameof(value), "MaxEvents must be positive.");

--- a/Jint/Options.ReadOnly.cs
+++ b/Jint/Options.ReadOnly.cs
@@ -258,7 +258,7 @@ public sealed partial class Options
 
 #if NET8_0_OR_GREATER
     /// <summary>
-    /// Non-zero while <c>Engine.Advanced.EnableWebApis</c> is running a host's configuration callback on
+    /// The group <c>Engine.Advanced.EnableWebApis</c> is running a host's configuration callback against on
     /// this thread, which is the one sanctioned write to an engine's own options after construction.
     /// </summary>
     /// <remarks>
@@ -271,18 +271,44 @@ public sealed partial class Options
     /// the calling thread cannot be seen or disturbed by either.
     /// </para>
     /// <para>
-    /// Only the web-API groups consult it, which is exactly as wide as the callback: an
+    /// It holds the group being configured rather than a depth count, so the suspension is scoped to one
+    /// <see cref="Options"/> instance as well as to one thread: a callback that has got hold of some
+    /// <i>other</i> <see cref="Options"/> is writing to a frozen object and is refused there, exactly as it
+    /// would be outside the callback. <see cref="WebApiOptions.Owns"/> is the membership test, and it
+    /// reference-compares against the eight backing fields rather than putting a back-pointer on each
+    /// sub-group — so nothing has to be re-parented by <c>Clone</c>, and a sub-group materialized inside the
+    /// callback is covered the moment the accessor publishes it.
+    /// </para>
+    /// <para>
+    /// Two things it deliberately does not cover. The other option groups: an
     /// <c>Action&lt;WebApiOptions&gt;</c> cannot reach <c>Interop</c> or <c>Constraints</c> in the first place.
+    /// And the registries — a live enable may set a value, never grow an <see cref="OptionsList{T}"/>, because
+    /// a registry on a shared <see cref="Options"/> is read by every engine built from it and a value at least
+    /// replaces rather than accumulates.
     /// </para>
     /// </remarks>
     [ThreadStatic]
-    private static int _liveWebApiConfiguration;
+    private static WebApiOptions? _liveWebApiConfigurationTarget;
 
-    private static bool IsConfiguringWebApisLive => _liveWebApiConfiguration > 0;
+    private static bool IsConfiguringWebApisLive(IOptionsGroup group)
+        => _liveWebApiConfigurationTarget is { } target && target.Owns(group);
 
-    internal static void BeginLiveWebApiConfiguration() => _liveWebApiConfiguration++;
+    /// <summary>
+    /// Suspends the read-only guard for <paramref name="target"/>'s subtree on this thread.
+    /// </summary>
+    /// <returns>
+    /// The suspension this one replaced, so that a callback re-entering <c>EnableWebApis</c> restores it
+    /// rather than clearing it.
+    /// </returns>
+    internal static WebApiOptions? BeginLiveWebApiConfiguration(WebApiOptions target)
+    {
+        var previous = _liveWebApiConfigurationTarget;
+        _liveWebApiConfigurationTarget = target;
+        return previous;
+    }
 
-    internal static void EndLiveWebApiConfiguration() => _liveWebApiConfiguration--;
+    internal static void EndLiveWebApiConfiguration(WebApiOptions? previous)
+        => _liveWebApiConfigurationTarget = previous;
 
     public sealed partial class WebApiOptions : IOptionsGroup
     {
@@ -301,9 +327,23 @@ public sealed partial class Options
             Options.SetReadOnly(_workers, value);
         }
 
+        /// <summary>
+        /// Whether <paramref name="group"/> is this group or one of its eight sub-groups.
+        /// </summary>
+        internal bool Owns(IOptionsGroup group)
+            => ReferenceEquals(group, this)
+                || ReferenceEquals(group, _console)
+                || ReferenceEquals(group, _timers)
+                || ReferenceEquals(group, _fetch)
+                || ReferenceEquals(group, _diagnostics)
+                || ReferenceEquals(group, _storage)
+                || ReferenceEquals(group, _cache)
+                || ReferenceEquals(group, _messaging)
+                || ReferenceEquals(group, _workers);
+
         private void ThrowIfReadOnly([CallerMemberName] string? setting = null)
         {
-            if (_readOnly && !IsConfiguringWebApisLive)
+            if (_readOnly && !IsConfiguringWebApisLive(this))
             {
                 Throw.OptionsReadOnly("Options.WebApi." + setting);
             }
@@ -318,7 +358,7 @@ public sealed partial class Options
 
         private void ThrowIfReadOnly([CallerMemberName] string? setting = null)
         {
-            if (_readOnly && !IsConfiguringWebApisLive)
+            if (_readOnly && !IsConfiguringWebApisLive(this))
             {
                 Throw.OptionsReadOnly("Options.WebApi.Messaging." + setting);
             }
@@ -333,7 +373,7 @@ public sealed partial class Options
 
         private void ThrowIfReadOnly([CallerMemberName] string? setting = null)
         {
-            if (_readOnly && !IsConfiguringWebApisLive)
+            if (_readOnly && !IsConfiguringWebApisLive(this))
             {
                 Throw.OptionsReadOnly("Options.WebApi.Workers." + setting);
             }
@@ -348,7 +388,7 @@ public sealed partial class Options
 
         private void ThrowIfReadOnly([CallerMemberName] string? setting = null)
         {
-            if (_readOnly && !IsConfiguringWebApisLive)
+            if (_readOnly && !IsConfiguringWebApisLive(this))
             {
                 Throw.OptionsReadOnly("Options.WebApi.Storage." + setting);
             }
@@ -363,7 +403,7 @@ public sealed partial class Options
 
         private void ThrowIfReadOnly([CallerMemberName] string? setting = null)
         {
-            if (_readOnly && !IsConfiguringWebApisLive)
+            if (_readOnly && !IsConfiguringWebApisLive(this))
             {
                 Throw.OptionsReadOnly("Options.WebApi.Cache." + setting);
             }
@@ -382,7 +422,7 @@ public sealed partial class Options
 
         private void ThrowIfReadOnly([CallerMemberName] string? setting = null)
         {
-            if (_readOnly && !IsConfiguringWebApisLive)
+            if (_readOnly && !IsConfiguringWebApisLive(this))
             {
                 Throw.OptionsReadOnly("Options.WebApi.Fetch." + setting);
             }
@@ -397,7 +437,7 @@ public sealed partial class Options
 
         private void ThrowIfReadOnly([CallerMemberName] string? setting = null)
         {
-            if (_readOnly && !IsConfiguringWebApisLive)
+            if (_readOnly && !IsConfiguringWebApisLive(this))
             {
                 Throw.OptionsReadOnly("Options.WebApi.Console." + setting);
             }
@@ -412,7 +452,7 @@ public sealed partial class Options
 
         private void ThrowIfReadOnly([CallerMemberName] string? setting = null)
         {
-            if (_readOnly && !IsConfiguringWebApisLive)
+            if (_readOnly && !IsConfiguringWebApisLive(this))
             {
                 Throw.OptionsReadOnly("Options.WebApi.Timers." + setting);
             }
@@ -427,7 +467,7 @@ public sealed partial class Options
 
         private void ThrowIfReadOnly([CallerMemberName] string? setting = null)
         {
-            if (_readOnly && !IsConfiguringWebApisLive)
+            if (_readOnly && !IsConfiguringWebApisLive(this))
             {
                 Throw.OptionsReadOnly("Options.WebApi.Diagnostics." + setting);
             }

--- a/Jint/Options.ReadOnly.cs
+++ b/Jint/Options.ReadOnly.cs
@@ -1,0 +1,571 @@
+using System.Collections;
+using System.Runtime.CompilerServices;
+using Jint.Runtime;
+
+namespace Jint;
+
+/// <summary>
+/// An <see cref="Options"/> group or registry that stops accepting changes once an engine has read it.
+/// </summary>
+/// <remarks>
+/// Internal, and implemented explicitly by every group, so that <c>MakeReadOnly</c> stays a single verb on
+/// <see cref="Options"/> itself: freezing one group and not its siblings would say nothing a host could use.
+/// </remarks>
+internal interface IOptionsGroup
+{
+    void SetReadOnly(bool value);
+}
+
+public sealed partial class Options
+{
+    private bool _readOnly;
+
+    /// <summary>
+    /// Whether this configuration has been frozen, after which every setter on it and on its groups throws.
+    /// </summary>
+    /// <remarks>
+    /// Modelled on <c>JsonSerializerOptions.IsReadOnly</c>, and true for the same reason: a component has
+    /// taken this instance as its configuration and reads it live.
+    /// </remarks>
+    public bool IsReadOnly => _readOnly;
+
+    /// <summary>
+    /// Freezes this configuration, so that a later write throws instead of reaching an engine that already read it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The <see cref="Engine"/> constructor calls this on the instance it keeps, which is what makes an
+    /// <see cref="Options"/> object configuration up to that point and a frozen record afterwards. It is
+    /// idempotent, and it cascades to every option group and every registry the instance holds — including a
+    /// group materialized after the freeze, which is born frozen.
+    /// </para>
+    /// <para>
+    /// A host may call it itself to publish a configured <see cref="Options"/> that nothing downstream can
+    /// change. Building further engines from a frozen instance keeps working: an engine only ever reads it.
+    /// </para>
+    /// </remarks>
+    public void MakeReadOnly() => SetReadOnly(true);
+
+    /// <summary>
+    /// Cascades the read-only state to every materialized group. Thawing is used in exactly one place —
+    /// <see cref="CreateEngineOptions"/>, whose private clone has to be hardened before the engine reads it.
+    /// </summary>
+    internal void SetReadOnly(bool value)
+    {
+        _readOnly = value;
+        SetReadOnly(_constraints, value);
+        SetReadOnly(_parsing, value);
+        SetReadOnly(_interop, value);
+        SetReadOnly(_debugger, value);
+        SetReadOnly(_coverage, value);
+        SetReadOnly(_host, value);
+        SetReadOnly(_modules, value);
+        SetReadOnly(_intl, value);
+        SetReadOnly(_temporal, value);
+        SetReadOnly(_json, value);
+        SetReadOnly(_profiling, value);
+#if NET8_0_OR_GREATER
+        SetReadOnly(_webApi, value);
+#endif
+    }
+
+    private static void SetReadOnly(IOptionsGroup? group, bool value) => group?.SetReadOnly(value);
+
+    private void ThrowIfReadOnly([CallerMemberName] string? setting = null)
+    {
+        if (_readOnly)
+        {
+            Throw.OptionsReadOnly("Options." + setting);
+        }
+    }
+
+    public sealed partial class ConstraintOptions : IOptionsGroup
+    {
+        private bool _readOnly;
+
+        void IOptionsGroup.SetReadOnly(bool value)
+        {
+            _readOnly = value;
+            Constraints.SetReadOnly(value);
+            ConstraintFactories.SetReadOnly(value);
+        }
+
+        private void ThrowIfReadOnly([CallerMemberName] string? setting = null)
+        {
+            if (_readOnly)
+            {
+                Throw.OptionsReadOnly("Options.Constraints." + setting);
+            }
+        }
+    }
+
+    public sealed partial class ParsingOptions : IOptionsGroup
+    {
+        private bool _readOnly;
+
+        void IOptionsGroup.SetReadOnly(bool value) => _readOnly = value;
+
+        private void ThrowIfReadOnly([CallerMemberName] string? setting = null)
+        {
+            if (_readOnly)
+            {
+                Throw.OptionsReadOnly("Options.Parsing." + setting);
+            }
+        }
+    }
+
+    public sealed partial class InteropOptions : IOptionsGroup
+    {
+        private bool _readOnly;
+
+        void IOptionsGroup.SetReadOnly(bool value)
+        {
+            _readOnly = value;
+            ExtensionMethodTypes.SetReadOnly(value);
+            ObjectConverters.SetReadOnly(value);
+            ImmutableCrossingTypes.SetReadOnly(value);
+            AllowedAssemblies.SetReadOnly(value);
+        }
+
+        private void ThrowIfReadOnly([CallerMemberName] string? setting = null)
+        {
+            if (_readOnly)
+            {
+                Throw.OptionsReadOnly("Options.Interop." + setting);
+            }
+        }
+    }
+
+    public sealed partial class DebuggerOptions : IOptionsGroup
+    {
+        private bool _readOnly;
+
+        void IOptionsGroup.SetReadOnly(bool value) => _readOnly = value;
+
+        private void ThrowIfReadOnly([CallerMemberName] string? setting = null)
+        {
+            if (_readOnly)
+            {
+                Throw.OptionsReadOnly("Options.Debugger." + setting);
+            }
+        }
+    }
+
+    public sealed partial class CoverageOptions : IOptionsGroup
+    {
+        private bool _readOnly;
+
+        void IOptionsGroup.SetReadOnly(bool value) => _readOnly = value;
+
+        private void ThrowIfReadOnly([CallerMemberName] string? setting = null)
+        {
+            if (_readOnly)
+            {
+                Throw.OptionsReadOnly("Options.Coverage." + setting);
+            }
+        }
+    }
+
+    public sealed partial class HostOptions : IOptionsGroup
+    {
+        private bool _readOnly;
+
+        void IOptionsGroup.SetReadOnly(bool value) => _readOnly = value;
+
+        private void ThrowIfReadOnly([CallerMemberName] string? setting = null)
+        {
+            if (_readOnly)
+            {
+                Throw.OptionsReadOnly("Options.Host." + setting);
+            }
+        }
+    }
+
+    public sealed partial class ModuleOptions : IOptionsGroup
+    {
+        private bool _readOnly;
+
+        void IOptionsGroup.SetReadOnly(bool value) => _readOnly = value;
+
+        private void ThrowIfReadOnly([CallerMemberName] string? setting = null)
+        {
+            if (_readOnly)
+            {
+                Throw.OptionsReadOnly("Options.Modules." + setting);
+            }
+        }
+    }
+
+    public sealed partial class JsonOptions : IOptionsGroup
+    {
+        private bool _readOnly;
+
+        void IOptionsGroup.SetReadOnly(bool value) => _readOnly = value;
+
+        private void ThrowIfReadOnly([CallerMemberName] string? setting = null)
+        {
+            if (_readOnly)
+            {
+                Throw.OptionsReadOnly("Options.Json." + setting);
+            }
+        }
+    }
+
+    public sealed partial class IntlOptions : IOptionsGroup
+    {
+        private bool _readOnly;
+
+        void IOptionsGroup.SetReadOnly(bool value) => _readOnly = value;
+
+        private void ThrowIfReadOnly([CallerMemberName] string? setting = null)
+        {
+            if (_readOnly)
+            {
+                Throw.OptionsReadOnly("Options.Intl." + setting);
+            }
+        }
+    }
+
+    public sealed partial class TemporalOptions : IOptionsGroup
+    {
+        private bool _readOnly;
+
+        void IOptionsGroup.SetReadOnly(bool value) => _readOnly = value;
+
+        private void ThrowIfReadOnly([CallerMemberName] string? setting = null)
+        {
+            if (_readOnly)
+            {
+                Throw.OptionsReadOnly("Options.Temporal." + setting);
+            }
+        }
+    }
+
+    public sealed partial class ProfilingOptions : IOptionsGroup
+    {
+        private bool _readOnly;
+
+        void IOptionsGroup.SetReadOnly(bool value) => _readOnly = value;
+
+        private void ThrowIfReadOnly([CallerMemberName] string? setting = null)
+        {
+            if (_readOnly)
+            {
+                Throw.OptionsReadOnly("Options.Profiling." + setting);
+            }
+        }
+    }
+
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// Non-zero while <c>Engine.Advanced.EnableWebApis</c> is running a host's configuration callback on
+    /// this thread, which is the one sanctioned write to an engine's own options after construction.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Thread-local rather than a flag toggled on the group, deliberately. The callback is handed the engine's
+    /// own <c>WebApi</c> group, and that group may belong to an <see cref="Options"/> instance other engines
+    /// are being built from at the same moment — including the process-wide instance a parameterless
+    /// <c>new Engine()</c> uses. Clearing the group's own read-only flag for the duration would open it to
+    /// every thread and let a concurrent engine build close it again mid-callback; suspending the guard on
+    /// the calling thread cannot be seen or disturbed by either.
+    /// </para>
+    /// <para>
+    /// Only the web-API groups consult it, which is exactly as wide as the callback: an
+    /// <c>Action&lt;WebApiOptions&gt;</c> cannot reach <c>Interop</c> or <c>Constraints</c> in the first place.
+    /// </para>
+    /// </remarks>
+    [ThreadStatic]
+    private static int _liveWebApiConfiguration;
+
+    private static bool IsConfiguringWebApisLive => _liveWebApiConfiguration > 0;
+
+    internal static void BeginLiveWebApiConfiguration() => _liveWebApiConfiguration++;
+
+    internal static void EndLiveWebApiConfiguration() => _liveWebApiConfiguration--;
+
+    public sealed partial class WebApiOptions : IOptionsGroup
+    {
+        private bool _readOnly;
+
+        void IOptionsGroup.SetReadOnly(bool value)
+        {
+            _readOnly = value;
+            Options.SetReadOnly(_console, value);
+            Options.SetReadOnly(_timers, value);
+            Options.SetReadOnly(_fetch, value);
+            Options.SetReadOnly(_diagnostics, value);
+            Options.SetReadOnly(_storage, value);
+            Options.SetReadOnly(_cache, value);
+            Options.SetReadOnly(_messaging, value);
+            Options.SetReadOnly(_workers, value);
+        }
+
+        private void ThrowIfReadOnly([CallerMemberName] string? setting = null)
+        {
+            if (_readOnly && !IsConfiguringWebApisLive)
+            {
+                Throw.OptionsReadOnly("Options.WebApi." + setting);
+            }
+        }
+    }
+
+    public sealed partial class MessagingOptions : IOptionsGroup
+    {
+        private bool _readOnly;
+
+        void IOptionsGroup.SetReadOnly(bool value) => _readOnly = value;
+
+        private void ThrowIfReadOnly([CallerMemberName] string? setting = null)
+        {
+            if (_readOnly && !IsConfiguringWebApisLive)
+            {
+                Throw.OptionsReadOnly("Options.WebApi.Messaging." + setting);
+            }
+        }
+    }
+
+    public sealed partial class WorkerOptions : IOptionsGroup
+    {
+        private bool _readOnly;
+
+        void IOptionsGroup.SetReadOnly(bool value) => _readOnly = value;
+
+        private void ThrowIfReadOnly([CallerMemberName] string? setting = null)
+        {
+            if (_readOnly && !IsConfiguringWebApisLive)
+            {
+                Throw.OptionsReadOnly("Options.WebApi.Workers." + setting);
+            }
+        }
+    }
+
+    public sealed partial class StorageOptions : IOptionsGroup
+    {
+        private bool _readOnly;
+
+        void IOptionsGroup.SetReadOnly(bool value) => _readOnly = value;
+
+        private void ThrowIfReadOnly([CallerMemberName] string? setting = null)
+        {
+            if (_readOnly && !IsConfiguringWebApisLive)
+            {
+                Throw.OptionsReadOnly("Options.WebApi.Storage." + setting);
+            }
+        }
+    }
+
+    public sealed partial class CacheOptions : IOptionsGroup
+    {
+        private bool _readOnly;
+
+        void IOptionsGroup.SetReadOnly(bool value) => _readOnly = value;
+
+        private void ThrowIfReadOnly([CallerMemberName] string? setting = null)
+        {
+            if (_readOnly && !IsConfiguringWebApisLive)
+            {
+                Throw.OptionsReadOnly("Options.WebApi.Cache." + setting);
+            }
+        }
+    }
+
+    public sealed partial class FetchOptions : IOptionsGroup
+    {
+        private bool _readOnly;
+
+        void IOptionsGroup.SetReadOnly(bool value)
+        {
+            _readOnly = value;
+            AllowedSchemes.SetReadOnly(value);
+        }
+
+        private void ThrowIfReadOnly([CallerMemberName] string? setting = null)
+        {
+            if (_readOnly && !IsConfiguringWebApisLive)
+            {
+                Throw.OptionsReadOnly("Options.WebApi.Fetch." + setting);
+            }
+        }
+    }
+
+    public sealed partial class ConsoleOptions : IOptionsGroup
+    {
+        private bool _readOnly;
+
+        void IOptionsGroup.SetReadOnly(bool value) => _readOnly = value;
+
+        private void ThrowIfReadOnly([CallerMemberName] string? setting = null)
+        {
+            if (_readOnly && !IsConfiguringWebApisLive)
+            {
+                Throw.OptionsReadOnly("Options.WebApi.Console." + setting);
+            }
+        }
+    }
+
+    public sealed partial class TimerOptions : IOptionsGroup
+    {
+        private bool _readOnly;
+
+        void IOptionsGroup.SetReadOnly(bool value) => _readOnly = value;
+
+        private void ThrowIfReadOnly([CallerMemberName] string? setting = null)
+        {
+            if (_readOnly && !IsConfiguringWebApisLive)
+            {
+                Throw.OptionsReadOnly("Options.WebApi.Timers." + setting);
+            }
+        }
+    }
+
+    public sealed partial class DiagnosticsOptions : IOptionsGroup
+    {
+        private bool _readOnly;
+
+        void IOptionsGroup.SetReadOnly(bool value) => _readOnly = value;
+
+        private void ThrowIfReadOnly([CallerMemberName] string? setting = null)
+        {
+            if (_readOnly && !IsConfiguringWebApisLive)
+            {
+                Throw.OptionsReadOnly("Options.WebApi.Diagnostics." + setting);
+            }
+        }
+    }
+#endif
+}
+
+/// <summary>
+/// A registry on an <see cref="Options"/> group — the object converters, the extension-method types, the
+/// registered constraints — which refuses every change once the options are read-only.
+/// </summary>
+/// <remarks>
+/// It exists because a plain <see cref="List{T}"/> cannot refuse one: freezing the settings around a registry
+/// a host can still <c>Add</c> to would leave the half of the configuration that grows unguarded.
+/// <see cref="ICollection{T}.IsReadOnly"/> answers the same question the surrounding
+/// <see cref="Options.IsReadOnly"/> does, so the ordinary collection contract already describes it.
+/// </remarks>
+public sealed class OptionsList<T> : IList<T>, IReadOnlyList<T>
+{
+    private readonly List<T> _items;
+    private readonly string _name;
+    private bool _readOnly;
+
+    internal OptionsList(string name) : this(name, new List<T>())
+    {
+    }
+
+    internal OptionsList(string name, List<T> items)
+    {
+        _name = name;
+        _items = items;
+    }
+
+    internal OptionsList<T> Clone() => new(_name, new List<T>(_items));
+
+    internal void SetReadOnly(bool value) => _readOnly = value;
+
+    /// <inheritdoc />
+    public int Count => _items.Count;
+
+    /// <summary>
+    /// Whether the surrounding <see cref="Options"/> have been made read-only, in which case every change throws.
+    /// </summary>
+    public bool IsReadOnly => _readOnly;
+
+    /// <inheritdoc />
+    public T this[int index]
+    {
+        get => _items[index];
+        set
+        {
+            ThrowIfReadOnly();
+            _items[index] = value;
+        }
+    }
+
+    /// <inheritdoc />
+    public void Add(T item)
+    {
+        ThrowIfReadOnly();
+        _items.Add(item);
+    }
+
+    /// <summary>
+    /// Appends every element of <paramref name="items"/>.
+    /// </summary>
+    public void AddRange(IEnumerable<T> items)
+    {
+        ThrowIfReadOnly();
+        _items.AddRange(items);
+    }
+
+    /// <inheritdoc />
+    public void Clear()
+    {
+        ThrowIfReadOnly();
+        _items.Clear();
+    }
+
+    /// <inheritdoc />
+    public void Insert(int index, T item)
+    {
+        ThrowIfReadOnly();
+        _items.Insert(index, item);
+    }
+
+    /// <inheritdoc />
+    public bool Remove(T item)
+    {
+        ThrowIfReadOnly();
+        return _items.Remove(item);
+    }
+
+    /// <inheritdoc />
+    public void RemoveAt(int index)
+    {
+        ThrowIfReadOnly();
+        _items.RemoveAt(index);
+    }
+
+    /// <summary>
+    /// Removes every element matching <paramref name="match"/> and answers how many were removed.
+    /// </summary>
+    public int RemoveAll(Predicate<T> match)
+    {
+        ThrowIfReadOnly();
+        return _items.RemoveAll(match);
+    }
+
+    /// <inheritdoc />
+    public bool Contains(T item) => _items.Contains(item);
+
+    /// <inheritdoc />
+    public void CopyTo(T[] array, int arrayIndex) => _items.CopyTo(array, arrayIndex);
+
+    /// <inheritdoc />
+    public int IndexOf(T item) => _items.IndexOf(item);
+
+    /// <summary>
+    /// Copies the registry into a new array.
+    /// </summary>
+    public T[] ToArray() => _items.ToArray();
+
+    /// <summary>
+    /// Returns an allocation-free enumerator over the registry.
+    /// </summary>
+    public List<T>.Enumerator GetEnumerator() => _items.GetEnumerator();
+
+    IEnumerator<T> IEnumerable<T>.GetEnumerator() => _items.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => _items.GetEnumerator();
+
+    private void ThrowIfReadOnly()
+    {
+        if (_readOnly)
+        {
+            Throw.OptionsReadOnly(_name);
+        }
+    }
+}

--- a/Jint/Options.WebApi.cs
+++ b/Jint/Options.WebApi.cs
@@ -26,7 +26,7 @@ public sealed partial class Options
     /// never does it.
     /// </para>
     /// </remarks>
-    public WebApiOptions WebApi => Materialize(ref _webApi);
+    public WebApiOptions WebApi => Materialize(ref _webApi, _readOnly);
 
     private WebApiOptions? _webApi;
 
@@ -38,7 +38,7 @@ public sealed partial class Options
     /// concurrent ones: nothing on it is engine-affine. The one obligation that carries is on
     /// <see cref="ConsoleOptions.Sink"/> — see its documentation.
     /// </remarks>
-    public sealed class WebApiOptions
+    public sealed partial class WebApiOptions
     {
         /// <summary>
         /// Which web APIs this engine exposes. Defaults to <see cref="WebApiFeatures.None"/>, which installs
@@ -51,13 +51,13 @@ public sealed partial class Options
         /// <c>Engine.Advanced.EnableWebApis</c>. What a given engine actually has is
         /// <c>engine.Advanced.WebApiFeatures</c>.
         /// </remarks>
-        public WebApiFeatures Features { get; set; }
+        public WebApiFeatures Features { get; set { ThrowIfReadOnly(); field = value; } }
 
         /// <summary>
         /// Settings for the <c>console</c> object, installed when <see cref="Features"/> contains
         /// <see cref="WebApiFeatures.Console"/>.
         /// </summary>
-        public ConsoleOptions Console => Materialize(ref _console);
+        public ConsoleOptions Console => Materialize(ref _console, _readOnly);
 
         private ConsoleOptions? _console;
 
@@ -65,7 +65,7 @@ public sealed partial class Options
         /// Settings for the timer functions, installed when <see cref="Features"/> contains
         /// <see cref="WebApiFeatures.Timers"/>.
         /// </summary>
-        public TimerOptions Timers => Materialize(ref _timers);
+        public TimerOptions Timers => Materialize(ref _timers, _readOnly);
 
         private TimerOptions? _timers;
 
@@ -73,7 +73,7 @@ public sealed partial class Options
         /// Settings for <c>fetch</c>, installed when <see cref="Features"/> contains
         /// <see cref="WebApiFeatures.Fetch"/> — which <see cref="WebApiFeatures.Default"/> never does.
         /// </summary>
-        public FetchOptions Fetch => Materialize(ref _fetch);
+        public FetchOptions Fetch => Materialize(ref _fetch, _readOnly);
 
         private FetchOptions? _fetch;
 
@@ -83,7 +83,7 @@ public sealed partial class Options
         /// itself, and <see cref="WebApiFeatures.Reporting"/> additionally gives script the
         /// <c>reportError</c> function that feeds it.
         /// </summary>
-        public DiagnosticsOptions Diagnostics => Materialize(ref _diagnostics);
+        public DiagnosticsOptions Diagnostics => Materialize(ref _diagnostics, _readOnly);
 
         private DiagnosticsOptions? _diagnostics;
 
@@ -91,7 +91,7 @@ public sealed partial class Options
         /// Settings for <c>localStorage</c> and <c>sessionStorage</c>, installed when <see cref="Features"/>
         /// contains <see cref="WebApiFeatures.Storage"/>.
         /// </summary>
-        public StorageOptions Storage => Materialize(ref _storage);
+        public StorageOptions Storage => Materialize(ref _storage, _readOnly);
 
         private StorageOptions? _storage;
 
@@ -99,7 +99,7 @@ public sealed partial class Options
         /// Settings for the <c>caches</c> object, installed when <see cref="Features"/> contains
         /// <see cref="WebApiFeatures.CacheApi"/> — which <see cref="WebApiFeatures.Default"/> never does.
         /// </summary>
-        public CacheOptions Cache => Materialize(ref _cache);
+        public CacheOptions Cache => Materialize(ref _cache, _readOnly);
 
         private CacheOptions? _cache;
 
@@ -107,7 +107,7 @@ public sealed partial class Options
         /// Settings for channel messaging, installed when <see cref="Features"/> contains
         /// <see cref="WebApiFeatures.Messaging"/>.
         /// </summary>
-        public MessagingOptions Messaging => Materialize(ref _messaging);
+        public MessagingOptions Messaging => Materialize(ref _messaging, _readOnly);
 
         private MessagingOptions? _messaging;
 
@@ -116,7 +116,7 @@ public sealed partial class Options
         /// <see cref="WebApiFeatures.Workers"/> — which <see cref="WebApiFeatures.Default"/> never does — and
         /// <see cref="Options.WorkerOptions.Provider"/> names a provider.
         /// </summary>
-        public WorkerOptions Workers => Materialize(ref _workers);
+        public WorkerOptions Workers => Materialize(ref _workers, _readOnly);
 
         private WorkerOptions? _workers;
 
@@ -149,7 +149,7 @@ public sealed partial class Options
     /// pair to be entangled with — it addresses a <i>name</i> — so which channels are in earshot of each other
     /// is the one thing about it a host has to be able to say.
     /// </remarks>
-    public sealed class MessagingOptions
+    public sealed partial class MessagingOptions
     {
         /// <summary>
         /// Which <c>BroadcastChannel</c> objects can hear each other: one broker is one agent cluster and one
@@ -165,11 +165,10 @@ public sealed partial class Options
         /// engine's own pump. See <see cref="BroadcastChannelBroker"/>, including what it keeps alive.
         /// </para>
         /// <para>
-        /// Read once, when the engine is built, so assigning it afterwards does not affect an engine that
-        /// already exists.
+        /// Read once, when the engine is built.
         /// </para>
         /// </remarks>
-        public BroadcastChannelBroker? Broker { get; set; }
+        public BroadcastChannelBroker? Broker { get; set { ThrowIfReadOnly(); field = value; } }
 
         internal MessagingOptions Clone() => (MessagingOptions) MemberwiseClone();
     }
@@ -183,7 +182,7 @@ public sealed partial class Options
     /// Sharing one <see cref="Provider"/> between them is the normal case — see <see cref="WorkerProvider"/>
     /// for how a provider serving a pool reaches per-request policy.
     /// </remarks>
-    public sealed class WorkerOptions
+    public sealed partial class WorkerOptions
     {
         /// <summary>
         /// The host's answer to <c>new Worker(...)</c>. <see langword="null"/> — the default — leaves the
@@ -197,11 +196,10 @@ public sealed partial class Options
         /// pooled-host warning about setting this through the live <c>EnableWebApis</c> door.
         /// </para>
         /// <para>
-        /// Read once, when the engine is built, so assigning it afterwards does not affect an engine that
-        /// already exists.
+        /// Read once, when the engine is built.
         /// </para>
         /// </remarks>
-        public WorkerProvider? Provider { get; set; }
+        public WorkerProvider? Provider { get; set { ThrowIfReadOnly(); field = value; } }
 
         /// <summary>
         /// How many live worker connections one engine may have at once. Defaults to 16. A
@@ -225,7 +223,7 @@ public sealed partial class Options
         /// effectively unbounded, and a value of zero or less refuses every worker.
         /// </para>
         /// </remarks>
-        public int MaxWorkers { get; set; } = 16;
+        public int MaxWorkers { get; set { ThrowIfReadOnly(); field = value; } } = 16;
 
         /// <summary>
         /// How many messages may sit undelivered in one direction of one worker connection. Defaults to
@@ -247,7 +245,7 @@ public sealed partial class Options
         /// value of zero or less refuses every message.
         /// </para>
         /// </remarks>
-        public int MaxQueuedMessages { get; set; } = 16384;
+        public int MaxQueuedMessages { get; set { ThrowIfReadOnly(); field = value; } } = 16384;
 
         internal WorkerOptions Clone() => (WorkerOptions) MemberwiseClone();
     }
@@ -271,7 +269,7 @@ public sealed partial class Options
     /// is occasionally what a host wants.
     /// </para>
     /// </remarks>
-    public sealed class StorageOptions
+    public sealed partial class StorageOptions
     {
         /// <summary>
         /// Five mebibytes: the quota browsers converged on, and what a defaulted
@@ -289,7 +287,7 @@ public sealed partial class Options
         /// instance to an <see cref="Options"/> object several engines share to give them one store, and
         /// remember that a provider reached from concurrently running engines must be thread-safe.
         /// </remarks>
-        public StorageProvider? LocalStorageProvider { get; set; }
+        public StorageProvider? LocalStorageProvider { get; set { ThrowIfReadOnly(); field = value; } }
 
         /// <summary>
         /// The map behind <c>sessionStorage</c>. <see langword="null"/> — the default — gives each engine its
@@ -299,7 +297,7 @@ public sealed partial class Options
         /// With the in-box provider the two globals differ only in that they are two stores: the lifetime
         /// difference the names carry in a browser is something only a host-supplied provider can express.
         /// </remarks>
-        public StorageProvider? SessionStorageProvider { get; set; }
+        public StorageProvider? SessionStorageProvider { get; set { ThrowIfReadOnly(); field = value; } }
 
         /// <summary>
         /// The quota a defaulted <see cref="InMemoryStorageProvider"/> enforces, in the UTF-16 bytes its
@@ -313,7 +311,7 @@ public sealed partial class Options
         /// host-supplied provider enforces whatever limit it likes and this value never reaches it. There is
         /// no "unlimited" sentinel — <see cref="long.MaxValue"/> is how that is spelled.
         /// </remarks>
-        public long MaxTotalBytes { get; set; } = DefaultMaxTotalBytes;
+        public long MaxTotalBytes { get; set { ThrowIfReadOnly(); field = value; } } = DefaultMaxTotalBytes;
 
         internal StorageOptions Clone() => (StorageOptions) MemberwiseClone();
     }
@@ -327,7 +325,7 @@ public sealed partial class Options
     /// Sharing one <see cref="Provider"/> between them is what makes them share a cache, and such a provider
     /// must be thread-safe — see <see cref="CacheStorageProvider"/>.
     /// </remarks>
-    public sealed class CacheOptions
+    public sealed partial class CacheOptions
     {
         /// <summary>
         /// Where the caches live, or <see langword="null"/> to give each engine a private
@@ -348,11 +346,10 @@ public sealed partial class Options
         /// host storage.
         /// </para>
         /// <para>
-        /// Read once, when the engine is built, so assigning it afterwards does not affect an engine that
-        /// already exists.
+        /// Read once, when the engine is built.
         /// </para>
         /// </remarks>
-        public CacheStorageProvider? Provider { get; set; }
+        public CacheStorageProvider? Provider { get; set { ThrowIfReadOnly(); field = value; } }
 
         internal CacheOptions Clone() => (CacheOptions) MemberwiseClone();
     }
@@ -394,7 +391,7 @@ public sealed partial class Options
     /// mean something different for a stream than for a document, and that flag's documentation says which.
     /// </para>
     /// </remarks>
-    public sealed class FetchOptions
+    public sealed partial class FetchOptions
     {
         /// <summary>
         /// The <see cref="System.Net.Http.HttpClient"/> every request goes through, or <see langword="null"/>
@@ -412,7 +409,7 @@ public sealed partial class Options
         /// follow them underneath that check, so set it to <see langword="false"/> on a handler you supply.
         /// </para>
         /// </remarks>
-        public System.Net.Http.HttpClient? HttpClient { get; set; }
+        public System.Net.Http.HttpClient? HttpClient { get; set { ThrowIfReadOnly(); field = value; } }
 
         /// <summary>
         /// A per-request source of <see cref="System.Net.Http.HttpClient"/>s, which wins over
@@ -424,7 +421,7 @@ public sealed partial class Options
         /// hands each tenant its own <c>IHttpClientFactory</c>-managed client. It must not return
         /// <see langword="null"/>, and it must not block: it runs while the calling script is suspended.
         /// </remarks>
-        public Func<Engine, System.Net.Http.HttpClient>? HttpClientFactory { get; set; }
+        public Func<Engine, System.Net.Http.HttpClient>? HttpClientFactory { get; set { ThrowIfReadOnly(); field = value; } }
 
         /// <summary>
         /// The URL schemes a request may use. Defaults to <c>https</c> and <c>http</c>; a request to anything
@@ -435,7 +432,7 @@ public sealed partial class Options
         /// already lowercased. Emptying the list refuses every request. Read once per request, so a host may
         /// change it between evaluations; it is not read on a background thread.
         /// </remarks>
-        public List<string> AllowedSchemes { get; } = new() { "https", "http" };
+        public OptionsList<string> AllowedSchemes { get; private set; } = new("Options.WebApi.Fetch.AllowedSchemes") { "https", "http" };
 
         /// <summary>
         /// The last word on whether a request may be made. Defaults to allowing everything the scheme list
@@ -458,7 +455,7 @@ public sealed partial class Options
         /// message naming the rule would let a script map the host's internal network by probing it.
         /// </para>
         /// </remarks>
-        public Func<Uri, bool> UrlFilter { get; set; } = static _ => true;
+        public Func<Uri, bool> UrlFilter { get; set { ThrowIfReadOnly(); field = value; } } = static _ => true;
 
         /// <summary>
         /// The most bytes a response body may decompress to. Defaults to 32 MiB; a body that exceeds it is
@@ -482,13 +479,13 @@ public sealed partial class Options
         /// a cap that quietly meant "no cap" would be the more dangerous reading of the two.
         /// </para>
         /// </remarks>
-        public long MaxResponseBytes { get; set; } = 32 * 1024 * 1024;
+        public long MaxResponseBytes { get; set { ThrowIfReadOnly(); field = value; } } = 32 * 1024 * 1024;
 
         /// <summary>
         /// How many redirects one request may follow before the promise rejects with a <c>TypeError</c>.
         /// Defaults to 20, which is what browsers use.
         /// </summary>
-        public int MaxRedirects { get; set; } = 20;
+        public int MaxRedirects { get; set { ThrowIfReadOnly(); field = value; } } = 20;
 
         /// <summary>
         /// How long one <c>fetch</c> may take, from the call to the last byte of the body. Defaults to 30
@@ -501,7 +498,7 @@ public sealed partial class Options
         /// <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> and any non-positive value mean no timeout, which leaves the
         /// underlying <see cref="System.Net.Http.HttpClient"/>'s own timeout as the only bound.
         /// </remarks>
-        public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(30);
+        public TimeSpan Timeout { get; set { ThrowIfReadOnly(); field = value; } } = TimeSpan.FromSeconds(30);
 
         /// <summary>
         /// How many requests one engine may have in flight at once. Defaults to 10; a <c>fetch</c> call that
@@ -514,28 +511,41 @@ public sealed partial class Options
         /// or when the engine's globals are restored. <see cref="int.MaxValue"/> is the way to spell
         /// effectively unbounded; zero or less refuses every request.
         /// </remarks>
-        public int MaxConcurrentRequests { get; set; } = 10;
+        public int MaxConcurrentRequests { get; set { ThrowIfReadOnly(); field = value; } } = 10;
 
-        internal FetchOptions Clone() => (FetchOptions) MemberwiseClone();
+        internal FetchOptions Clone()
+        {
+            var clone = (FetchOptions) MemberwiseClone();
+            clone.AllowedSchemes = AllowedSchemes.Clone();
+            return clone;
+        }
     }
 
     /// <summary>
     /// Settings for the <c>console</c> object. Requires .NET 8 or higher.
     /// </summary>
-    public sealed class ConsoleOptions
+    public sealed partial class ConsoleOptions
     {
         /// <summary>
         /// Where <c>console</c> output goes. Defaults to <see cref="ConsoleSink.Null"/>, which discards
         /// everything — enabling the feature never starts writing to the host's standard output by surprise.
         /// </summary>
         /// <remarks>
-        /// The sink is read afresh on every emit, so a host may swap it between evaluations. A sink assigned
-        /// to an <see cref="Options"/> instance shared by concurrently running engines is called from each of
-        /// their threads and must be thread-safe; one belonging to a single engine is only ever called on
-        /// that engine's thread. Assigning <see langword="null"/> is read back as
+        /// <para>
+        /// The sink is read afresh on every emit, but this property is not the place to swap it: like every
+        /// other setting it is read-only once an engine has been built from these options. A host that wants
+        /// to redirect output between evaluations gives the engine a sink of its own that forwards to a
+        /// target it holds, which is also the only form that cannot reach a second engine sharing the same
+        /// options by accident.
+        /// </para>
+        /// <para>
+        /// A sink assigned to an <see cref="Options"/> instance shared by concurrently running engines is
+        /// called from each of their threads and must be thread-safe; one belonging to a single engine is
+        /// only ever called on that engine's thread. Assigning <see langword="null"/> is read back as
         /// <see cref="ConsoleSink.Null"/>.
+        /// </para>
         /// </remarks>
-        public ConsoleSink Sink { get; set; } = ConsoleSink.Null;
+        public ConsoleSink Sink { get; set { ThrowIfReadOnly(); field = value; } } = ConsoleSink.Null;
 
         internal ConsoleOptions Clone() => (ConsoleOptions) MemberwiseClone();
     }
@@ -553,7 +563,7 @@ public sealed partial class Options
     /// makes this safe in a request handler that returns as soon as the script does.
     /// </para>
     /// </remarks>
-    public sealed class TimerOptions
+    public sealed partial class TimerOptions
     {
         /// <summary>
         /// The clock the timers are scheduled against. Defaults to <see cref="TimeProvider.System"/>; a fake
@@ -566,15 +576,14 @@ public sealed partial class Options
         /// <see cref="Options.TimeSystem"/>, which is what <c>Date</c> is built on: one is a monotonic clock
         /// for measuring durations, the other a wall clock for naming instants.
         /// </para>
-        /// Read once, when the engine is built, so assigning it afterwards does not affect an engine that
-        /// already exists. Only <see cref="TimeProvider.GetTimestamp"/>,
+        /// Read once, when the engine is built. Only <see cref="TimeProvider.GetTimestamp"/>,
         /// <see cref="TimeProvider.GetUtcNow"/> (once, for the time origin) and
         /// <see cref="TimeProvider.GetElapsedTime(long, long)"/> are ever called:
         /// <see cref="TimeProvider.CreateTimer"/> is deliberately not, because a background timer would run
         /// script off the engine's thread. Assigning <see langword="null"/> is read back as
         /// <see cref="TimeProvider.System"/>.
         /// </remarks>
-        public TimeProvider TimeProvider { get; set; } = TimeProvider.System;
+        public TimeProvider TimeProvider { get; set { ThrowIfReadOnly(); field = value; } } = TimeProvider.System;
 
         /// <summary>
         /// The most timers one engine may have registered at once. Defaults to 1000. A
@@ -589,7 +598,7 @@ public sealed partial class Options
         /// engine is built. There is no "unlimited" sentinel: <see cref="int.MaxValue"/> is the way to spell
         /// effectively unbounded, and a value of zero or less refuses every timer.
         /// </remarks>
-        public int MaxActiveTimers { get; set; } = 1000;
+        public int MaxActiveTimers { get; set { ThrowIfReadOnly(); field = value; } } = 1000;
 
         /// <summary>
         /// How much of a pump an engine may spend running <c>requestIdleCallback</c> callbacks. Defaults to
@@ -614,7 +623,7 @@ public sealed partial class Options
         /// hard deadline it does not want script to eat into. Read once, when the engine is built.
         /// </para>
         /// </remarks>
-        public TimeSpan IdleBudget { get; set; } = TimeSpan.FromMilliseconds(50);
+        public TimeSpan IdleBudget { get; set { ThrowIfReadOnly(); field = value; } } = TimeSpan.FromMilliseconds(50);
 
         internal TimerOptions Clone() => (TimerOptions) MemberwiseClone();
     }
@@ -623,7 +632,7 @@ public sealed partial class Options
     /// Settings for the engine's diagnostics channel — the script errors nobody caught. Requires .NET 8 or
     /// higher.
     /// </summary>
-    public sealed class DiagnosticsOptions
+    public sealed partial class DiagnosticsOptions
     {
         /// <summary>
         /// Where an unhandled promise rejection, a value handed to <c>reportError</c>, and an exception that
@@ -643,15 +652,15 @@ public sealed partial class Options
         /// continue, and discard the report".
         /// </para>
         /// <para>
-        /// Read once, when the engine is built, so assigning it afterwards does not affect an engine that
-        /// already exists — unlike <see cref="ConsoleOptions.Sink"/>, because this one also decides whether a
+        /// Read once, when the engine is built — unlike <see cref="ConsoleOptions.Sink"/>, which is read on
+        /// every emit, because this one also decides whether a
         /// callback's exception erupts, and that contract has to hold still for an engine's lifetime. A sink
         /// on an <see cref="Options"/> instance shared by concurrently running engines is called from each of
         /// their threads and must be thread-safe; see <see cref="DiagnosticsSink"/> for that and for what may
         /// be done with the values a report carries.
         /// </para>
         /// </remarks>
-        public DiagnosticsSink? Sink { get; set; }
+        public DiagnosticsSink? Sink { get; set { ThrowIfReadOnly(); field = value; } }
 
         internal DiagnosticsOptions Clone() => (DiagnosticsOptions) MemberwiseClone();
     }

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -3,6 +3,7 @@ using System.Dynamic;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using Jint.Native;
 using Jint.Native.Function;
@@ -26,11 +27,31 @@ public sealed partial class Options
 
     private ITimeSystem? _timeSystem;
     internal List<EngineConfiguration> _configurations { get; private set; } = new();
-    internal bool HasUserHostFactory { get; set; }
+
+    /// <summary>
+    /// The one door onto <see cref="_configurations"/>, so that <c>Configure</c>, <c>AddLazyGlobal</c> and
+    /// <c>SetTypeConverter</c> refuse after the freeze exactly as an assignment does.
+    /// </summary>
+    /// <param name="configuration">The callback to run against every engine built from these options.</param>
+    /// <param name="verb">
+    /// Filled in by the compiler with the extension method the host actually called, so that the refusal names
+    /// that rather than this private door.
+    /// </param>
+    internal void AddConfiguration(EngineConfiguration configuration, [CallerMemberName] string? verb = null)
+    {
+        if (_readOnly)
+        {
+            Throw.OptionsReadOnlyCall("Options." + verb);
+        }
+
+        _configurations.Add(configuration);
+    }
+
+    internal bool HasUserHostFactory { get; set { ThrowIfReadOnly(); field = value; } }
     internal bool HasUserEngineConstructionCallback =>
         HasUserHostFactory
         || _configurations.Exists(static configuration => configuration.Provenance == EngineConfigurationProvenance.User);
-    internal UntrustedCodeLimits? UntrustedCodeLimits { get; set; }
+    internal UntrustedCodeLimits? UntrustedCodeLimits { get; set { ThrowIfReadOnly(); field = value; } }
 
     public delegate JsValue? MemberAccessorDelegate(Engine engine, object target, string member);
 
@@ -59,77 +80,98 @@ public sealed partial class Options
     /// groups, so a plain <c>??=</c> would let two builds each get their own instance and only one of them
     /// see a later host mutation. Groups are read while an engine is being built and never on an execution
     /// path, so the null check costs nothing that matters.
+    /// <para>
+    /// <paramref name="readOnly"/> is the owner's own frozen state, and a group materialized after the freeze
+    /// is born frozen. Without it the freeze would have a hole exactly where it matters least visibly: a group
+    /// the engine build never touched — <see cref="Intl"/>, <see cref="Temporal"/> — would be allocated fresh
+    /// and mutable by the very host write that was supposed to be refused, and the engine reads those groups
+    /// lazily, so the write would land.
+    /// </para>
     /// </remarks>
-    private static T Materialize<T>(ref T? field) where T : class, new()
-        => field ?? Interlocked.CompareExchange(ref field, new T(), null) ?? field;
+    private static T Materialize<T>(ref T? field, bool readOnly) where T : class, IOptionsGroup, new()
+    {
+        var existing = field;
+        if (existing is not null)
+        {
+            return existing;
+        }
+
+        var created = new T();
+        if (readOnly)
+        {
+            created.SetReadOnly(true);
+        }
+
+        return Interlocked.CompareExchange(ref field, created, null) ?? created;
+    }
 
     /// <summary>
     /// Execution constraints for the engine.
     /// </summary>
-    public ConstraintOptions Constraints => Materialize(ref _constraints);
+    public ConstraintOptions Constraints => Materialize(ref _constraints, _readOnly);
 
     private ConstraintOptions? _constraints;
 
     /// <summary>
     /// Resource limits applied while parsing scripts and modules.
     /// </summary>
-    public ParsingOptions Parsing => Materialize(ref _parsing);
+    public ParsingOptions Parsing => Materialize(ref _parsing, _readOnly);
 
     private ParsingOptions? _parsing;
 
     /// <summary>
     /// CLR interop related options.
     /// </summary>
-    public InteropOptions Interop => Materialize(ref _interop);
+    public InteropOptions Interop => Materialize(ref _interop, _readOnly);
 
     private InteropOptions? _interop;
 
     /// <summary>
     /// Debugger configuration.
     /// </summary>
-    public DebuggerOptions Debugger => Materialize(ref _debugger);
+    public DebuggerOptions Debugger => Materialize(ref _debugger, _readOnly);
 
     private DebuggerOptions? _debugger;
 
     /// <summary>
     /// Script code coverage configuration. Off by default.
     /// </summary>
-    public CoverageOptions Coverage => Materialize(ref _coverage);
+    public CoverageOptions Coverage => Materialize(ref _coverage, _readOnly);
 
     private CoverageOptions? _coverage;
 
     /// <summary>
     /// Host options.
     /// </summary>
-    public HostOptions Host => Materialize(ref _host);
+    public HostOptions Host => Materialize(ref _host, _readOnly);
 
     private HostOptions? _host;
 
     /// <summary>
     /// Module options
     /// </summary>
-    public ModuleOptions Modules => Materialize(ref _modules);
+    public ModuleOptions Modules => Materialize(ref _modules, _readOnly);
 
     private ModuleOptions? _modules;
 
     /// <summary>
     /// Internationalization (Intl) options.
     /// </summary>
-    public IntlOptions Intl => Materialize(ref _intl);
+    public IntlOptions Intl => Materialize(ref _intl, _readOnly);
 
     private IntlOptions? _intl;
 
     /// <summary>
     /// Temporal API options.
     /// </summary>
-    public TemporalOptions Temporal => Materialize(ref _temporal);
+    public TemporalOptions Temporal => Materialize(ref _temporal, _readOnly);
 
     private TemporalOptions? _temporal;
 
     /// <summary>
     /// Whether the code should be always considered to be in strict mode. Can improve performance.
     /// </summary>
-    public bool Strict { get; set; }
+    public bool Strict { get; set { ThrowIfReadOnly(); field = value; } }
 
     /// <summary>
     /// Whether the engine's default parser retains the full source text of parsed functions so that
@@ -142,12 +184,12 @@ public sealed partial class Options
     /// When parsing via an explicit <see cref="ScriptParsingOptions"/>/<see cref="ModuleParsingOptions"/> or a
     /// prepared script/module, the corresponding <see cref="IParsingOptions.RetainFunctionSourceText"/> setting applies.
     /// </remarks>
-    public bool RetainFunctionSourceText { get; set; }
+    public bool RetainFunctionSourceText { get; set { ThrowIfReadOnly(); field = value; } }
 
     /// <summary>
     /// The culture the engine runs on, defaults to current culture.
     /// </summary>
-    public CultureInfo Culture { get; set; } = _defaultCulture;
+    public CultureInfo Culture { get; set { ThrowIfReadOnly(); field = value; } } = _defaultCulture;
 
     /// <summary>
     /// Configures a time system to use. Defaults to DefaultTimeSystem using local time.
@@ -155,13 +197,17 @@ public sealed partial class Options
     public ITimeSystem TimeSystem
     {
         get => _timeSystem ??= new DefaultTimeSystem(TimeZone, Culture);
-        set => _timeSystem = value;
+        set
+        {
+            ThrowIfReadOnly();
+            _timeSystem = value;
+        }
     }
 
     /// <summary>
     /// The time zone the engine runs on, defaults to local. Same as setting DefaultTimeSystem with the time zone.
     /// </summary>
-    public TimeZoneInfo TimeZone { get; set; } = _defaultTimeZone;
+    public TimeZoneInfo TimeZone { get; set { ThrowIfReadOnly(); field = value; } } = _defaultTimeZone;
 
     /// <summary>
     /// Reference resolver allows customizing behavior for reference resolving. This can be useful in cases where
@@ -198,6 +244,7 @@ public sealed partial class Options
 
     internal void SetReferenceResolverCore(IReferenceResolver resolver, ReferenceResolverInterests interests)
     {
+        ThrowIfReadOnly(nameof(ReferenceResolver));
         _referenceResolver = resolver;
         _referenceResolverInterests = interests;
     }
@@ -206,7 +253,7 @@ public sealed partial class Options
     /// Options for the built-in JSON (de)serializer which
     /// gets used using <c>JSON.parse</c> or <c>JSON.stringify</c>
     /// </summary>
-    public JsonOptions Json => Materialize(ref _json);
+    public JsonOptions Json => Materialize(ref _json, _readOnly);
 
     private JsonOptions? _json;
 
@@ -224,6 +271,7 @@ public sealed partial class Options
         get => _resultLimits;
         set
         {
+            ThrowIfReadOnly();
             if (value is null)
             {
                 Throw.ArgumentNullException(nameof(value));
@@ -238,7 +286,7 @@ public sealed partial class Options
     /// <summary>
     /// What experimental features are allowed, functionality may lacking or even plain wrong. Defaults to having none.
     /// </summary>
-    public ExperimentalFeature ExperimentalFeatures { get; set; }
+    public ExperimentalFeature ExperimentalFeatures { get; set { ThrowIfReadOnly(); field = value; } }
 
     /// <summary>
     /// Whether the agent can suspend (block) via Atomics.wait().
@@ -248,7 +296,7 @@ public sealed partial class Options
     /// <remarks>
     /// https://tc39.es/ecma262/#sec-agentcansuspend
     /// </remarks>
-    public bool AgentCanSuspend { get; set; }
+    public bool AgentCanSuspend { get; set { ThrowIfReadOnly(); field = value; } }
 
     /// <summary>
     /// Copies the <b>restrictive</b> half of <paramref name="source"/>'s configuration onto
@@ -552,6 +600,10 @@ public sealed partial class Options
 #if NET8_0_OR_GREATER
         clone._webApi = _webApi?.Clone();
 #endif
+        // The clone inherits the source's frozen state through MemberwiseClone, and the profile below is a
+        // long sequence of writes. A host may legitimately hand a frozen Options to a second engine, so the
+        // private snapshot is thawed for the expansion; the engine freezes it again once it has read it.
+        clone.SetReadOnly(false);
         OptionsExtensions.ApplyUntrustedCodeOptions(clone, UntrustedCodeLimits);
         return clone;
     }
@@ -626,35 +678,34 @@ public sealed partial class Options
     }
 
 
-    public sealed class DebuggerOptions
+    public sealed partial class DebuggerOptions
     {
         /// <summary>
         /// Whether debugger functionality is enabled, defaults to false.
         /// </summary>
-        public bool Enabled { get; set; }
+        public bool Enabled { get; set { ThrowIfReadOnly(); field = value; } }
 
         /// <summary>
         /// Configures the statement handling strategy, defaults to Ignore.
         /// </summary>
-        public DebuggerStatementHandling StatementHandling { get; set; } = DebuggerStatementHandling.Ignore;
+        public DebuggerStatementHandling StatementHandling { get; set { ThrowIfReadOnly(); field = value; } } = DebuggerStatementHandling.Ignore;
 
         /// <summary>
         /// Configures the step mode used when entering the script.
         /// </summary>
-        public StepMode InitialStepMode { get; set; } = StepMode.None;
+        public StepMode InitialStepMode { get; set { ThrowIfReadOnly(); field = value; } } = StepMode.None;
 
         internal DebuggerOptions Clone() => (DebuggerOptions) MemberwiseClone();
     }
 
     /// <summary>
-    /// Script code coverage configuration. Read once, while the engine is being constructed; changing it
-    /// afterwards only reaches engines built later.
+    /// Script code coverage configuration.
     /// </summary>
     /// <remarks>
     /// Nothing here is engine-affine, so an <see cref="Options"/> instance carrying it stays shareable across
     /// engines — each engine gets its own counters, and reading one engine's report never sees another's.
     /// </remarks>
-    public sealed class CoverageOptions
+    public sealed partial class CoverageOptions
     {
         /// <summary>
         /// Whether the engine counts what it executes, defaults to false. When set, the engine collects hit
@@ -667,18 +718,18 @@ public sealed partial class Options
         /// exact execution constraint or enabling the debugger does, so measured code runs the instrumented
         /// path. See <see cref="Engine.AdvancedOperations.GetCoverage"/>.
         /// </remarks>
-        public bool Enabled { get; set; }
+        public bool Enabled { get; set { ThrowIfReadOnly(); field = value; } }
 
         /// <summary>
         /// What is counted, defaults to <see cref="CoverageGranularity.Statements"/>. The granularity decides
         /// what the report contains, not how the engine executes: both values collect through the same lane.
         /// </summary>
-        public CoverageGranularity Granularity { get; set; } = CoverageGranularity.Statements;
+        public CoverageGranularity Granularity { get; set { ThrowIfReadOnly(); field = value; } } = CoverageGranularity.Statements;
 
         internal CoverageOptions Clone() => (CoverageOptions) MemberwiseClone();
     }
 
-    public sealed class InteropOptions
+    public sealed partial class InteropOptions
     {
         /// <summary>
         /// Whether the <c>System</c> namespace object, <c>importNamespace</c> and <c>clrHelper</c> are
@@ -700,9 +751,9 @@ public sealed partial class Options
         /// own diagnostic — so a host hardening an engine sees the difference rather than having to know it.
         /// </para>
         /// </remarks>
-        public bool Enabled { get; set; }
+        public bool Enabled { get; set { ThrowIfReadOnly(); field = value; } }
 
-        internal ClrAccessConfiguration ClrAccessConfiguration { get; set; }
+        internal ClrAccessConfiguration ClrAccessConfiguration { get; set { ThrowIfReadOnly(); field = value; } }
 
         /// <summary>
         /// Whether to expose instance <see cref="object.GetType"/> members and the type-widening operations
@@ -716,13 +767,12 @@ public sealed partial class Options
         /// <see cref="TypeResolver.MemberFilter"/> policy. A <see cref="Jint.Runtime.Interop.TypeReference"/> converted
         /// to a <see cref="Type"/> object and back preserves that already-explicit capability.
         /// <para>
-        /// Read once, while the engine is being constructed. Changing it afterwards has no effect on an
-        /// engine that already exists: resolved members are cached under the value captured then, so a later
-        /// change could only be honoured by some reads and not others. Enabling it grants powerful reflection
-        /// capabilities and is not recommended for untrusted scripts.
+        /// Read once, while the engine is being constructed: resolved members are cached under the value
+        /// captured then. Enabling it grants powerful reflection capabilities and is not recommended for
+        /// untrusted scripts.
         /// </para>
         /// </remarks>
-        public bool AllowGetType { get; set; }
+        public bool AllowGetType { get; set { ThrowIfReadOnly(); field = value; } }
 
         /// <summary>
         /// Whether Jint should allow resolving or wrapping types from the <c>System.Reflection</c> namespace.
@@ -733,7 +783,7 @@ public sealed partial class Options
         /// Namespace resolution reads this once when the engine installs its CLR globals. Configure it before
         /// constructing the engine.
         /// </remarks>
-        public bool AllowSystemReflection { get; set; }
+        public bool AllowSystemReflection { get; set { ThrowIfReadOnly(); field = value; } }
 
         /// <summary>
         /// Whether direct writes through projected CLR objects are allowed, including fields, properties,
@@ -743,27 +793,26 @@ public sealed partial class Options
         /// This option controls the wrapper's write operations. It does not prevent scripts from calling CLR
         /// methods or extension methods whose implementations mutate host state.
         /// </remarks>
-        public bool AllowWrite { get; set; }
+        public bool AllowWrite { get; set { ThrowIfReadOnly(); field = value; } }
 
         /// <summary>
         /// Whether operator overloading resolution is allowed, defaults to false.
         /// </summary>
         /// <remarks>
         /// Read once per engine, at the end of construction and so after any callback registered with
-        /// <c>Options.Configure</c> has run. Setting it on an <see cref="Options"/> instance an engine
-        /// has already been built from does not reach that engine — only engines built afterwards.
+        /// <c>Options.Configure</c> has run.
         /// </remarks>
-        public bool AllowOperatorOverloading { get; set; }
+        public bool AllowOperatorOverloading { get; set { ThrowIfReadOnly(); field = value; } }
 
         /// <summary>
         /// Types holding extension methods that should be considered when resolving methods.
         /// </summary>
-        public List<Type> ExtensionMethodTypes { get; private set; } = new();
+        public OptionsList<Type> ExtensionMethodTypes { get; private set; } = new("Options.Interop.ExtensionMethodTypes");
 
         /// <summary>
         /// Object converters to try when build-in conversions.
         /// </summary>
-        public List<IObjectConverter> ObjectConverters { get; private set; } = new();
+        public OptionsList<IObjectConverter> ObjectConverters { get; private set; } = new("Options.Interop.ObjectConverters");
 
         /// <summary>
         /// CLR types whose instances the host promises are immutable while they are exposed to the engine —
@@ -779,7 +828,7 @@ public sealed partial class Options
         /// <see cref="TrackObjectWrapperIdentity"/> and a shared <see cref="TypeResolver"/> already describe,
         /// and owned by the host in exactly the same way. Read once, while the engine is being constructed.
         /// </remarks>
-        public List<Type> ImmutableCrossingTypes { get; private set; } = new();
+        public OptionsList<Type> ImmutableCrossingTypes { get; private set; } = new("Options.Interop.ImmutableCrossingTypes");
 
         /// <summary>
         /// Whether identity map is persisted for object wrappers in order to maintain object identity. This can cause
@@ -790,7 +839,7 @@ public sealed partial class Options
         /// under <see cref="ArrayConversionMode.LiveView"/> — instead of re-converting on every read.
         /// Defaults to false.
         /// </summary>
-        public bool TrackObjectWrapperIdentity { get; set; }
+        public bool TrackObjectWrapperIdentity { get; set { ThrowIfReadOnly(); field = value; } }
 
         /// <summary>
         /// Whether a small bounded cache of most recently wrapped CLR objects is kept so that the same
@@ -805,7 +854,7 @@ public sealed partial class Options
         /// stays cached (CLR-side mutations are not re-copied); set this to false for a fresh snapshot per
         /// crossing (the pre-4.14 behavior).
         /// </summary>
-        public bool CacheRecentObjectWrappers { get; set; } = true;
+        public bool CacheRecentObjectWrappers { get; set { ThrowIfReadOnly(); field = value; } } = true;
 
         /// <summary>
         /// How CLR arrays (<c>T[]</c>) are exposed to script code. Defaults to
@@ -817,7 +866,7 @@ public sealed partial class Options
         /// See the enum members for the exact semantic differences (write-through, identity, wrapper caches,
         /// <c>Array.isArray</c>, resizing and multidimensional arrays).
         /// </summary>
-        public ArrayConversionMode ArrayConversion { get; set; } = ArrayConversionMode.Copy;
+        public ArrayConversionMode ArrayConversion { get; set { ThrowIfReadOnly(); field = value; } } = ArrayConversionMode.Copy;
 
         /// <summary>
         /// How a CLR sequence that is <em>only</em> an <see cref="System.Collections.Generic.IEnumerable{T}"/> — a LINQ
@@ -827,7 +876,7 @@ public sealed partial class Options
         /// <see cref="System.Collections.Generic.IList{T}"/>, <c>T[]</c>) and dictionaries are unaffected by this
         /// option; they are exposed exactly as before. See the enum members.
         /// </summary>
-        public EnumerableConversionMode EnumerableConversion { get; set; } = EnumerableConversionMode.Lazy;
+        public EnumerableConversionMode EnumerableConversion { get; set { ThrowIfReadOnly(); field = value; } } = EnumerableConversionMode.Lazy;
 
         /// <summary>
         /// If no known type could be guessed, objects are by default wrapped as an
@@ -854,14 +903,14 @@ public sealed partial class Options
         private static ObjectInstance DefaultWrapObject(Engine engine, object target, Type? type)
             => ObjectWrapper.Create(engine, target, type);
 
-        public WrapObjectDelegate WrapObjectHandler { get; set; } = _defaultWrapObjectHandler;
+        public WrapObjectDelegate WrapObjectHandler { get; set { ThrowIfReadOnly(); field = value; } } = _defaultWrapObjectHandler;
 
         /// <summary>
         /// The handler used to build stack traces. Changing this enables mapping
         /// stack traces to code different from the code being executed, eg. when
         /// executing code transpiled from TypeScript.
         /// </summary>
-        public BuildCallStackDelegate? BuildCallStackHandler { get; set; }
+        public BuildCallStackDelegate? BuildCallStackHandler { get; set { ThrowIfReadOnly(); field = value; } }
 
         /// <summary>
         /// Named default so the interop member inline cache (see JintMemberExpression's wrapper lane) can
@@ -872,7 +921,7 @@ public sealed partial class Options
         /// <summary>
         ///
         /// </summary>
-        public MemberAccessorDelegate MemberAccessor { get; set; } = _defaultMemberAccessor;
+        public MemberAccessorDelegate MemberAccessor { get; set { ThrowIfReadOnly(); field = value; } } = _defaultMemberAccessor;
 
         /// <summary>
         /// Exceptions that thrown from CLR code are converted to JavaScript errors and
@@ -880,7 +929,7 @@ public sealed partial class Options
         /// to the CLR host and interrupt the script execution. If handler returns true these exceptions are converted
         /// to JS errors that can be caught by the script.
         /// </summary>
-        public ExceptionHandlerDelegate ExceptionHandler { get; set; } = _defaultExceptionHandler;
+        public ExceptionHandlerDelegate ExceptionHandler { get; set { ThrowIfReadOnly(); field = value; } } = _defaultExceptionHandler;
 
         /// <summary>
         /// Whether the CLR exception behind a caught interop error is also chained into the
@@ -900,7 +949,7 @@ public sealed partial class Options
         /// chain would put the host's .NET frames in front of the JavaScript ones there.
         /// </para>
         /// </summary>
-        public bool ChainClrExceptionAsInnerException { get; set; }
+        public bool ChainClrExceptionAsInnerException { get; set { ThrowIfReadOnly(); field = value; } }
 
         /// <summary>
         /// When <c>true</c>, JavaScript errors created from CLR exceptions expose the original exception
@@ -912,7 +961,7 @@ public sealed partial class Options
         /// <see cref="JintException.TryGetClrException"/>. This setting only changes the script-visible
         /// message. Treat it as a development option.
         /// </remarks>
-        public bool ExposeDetailedExceptionMessages { get; set; }
+        public bool ExposeDetailedExceptionMessages { get; set { ThrowIfReadOnly(); field = value; } }
 
         /// <summary>
         /// Called after a JavaScript error object is created from a CLR exception, either because
@@ -920,7 +969,7 @@ public sealed partial class Options
         /// Allows decorating the error object with additional properties or modifying its state.
         /// The decorator receives the engine instance, the created error object, and the original CLR exception.
         /// </summary>
-        public ClrExceptionErrorDecoratorDelegate? ClrExceptionErrorDecorator { get; set; }
+        public ClrExceptionErrorDecoratorDelegate? ClrExceptionErrorDecorator { get; set { ThrowIfReadOnly(); field = value; } }
 
         /// <summary>
         /// Called after the JavaScript error object for a failed CLR method or constructor resolution has been
@@ -929,7 +978,7 @@ public sealed partial class Options
         /// resolution information via <see cref="ClrResolutionErrorInfo"/> regardless of
         /// <see cref="ExposeDetailedResolutionErrors"/>, which only selects the default message.
         /// </summary>
-        public ClrResolutionErrorDecoratorDelegate? ClrResolutionErrorDecorator { get; set; }
+        public ClrResolutionErrorDecoratorDelegate? ClrResolutionErrorDecorator { get; set { ThrowIfReadOnly(); field = value; } }
 
         /// <summary>
         /// Assemblies from which <see cref="Jint.Runtime.Interop.NamespaceReference"/> may resolve CLR types.
@@ -945,7 +994,7 @@ public sealed partial class Options
         /// types whose complete declaring-type chain is public. Resolved types must also satisfy
         /// <see cref="TypeResolver.MemberFilter"/> and <see cref="AllowSystemReflection"/>.
         /// </remarks>
-        public List<Assembly> AllowedAssemblies { get; set; } = new();
+        public OptionsList<Assembly> AllowedAssemblies { get; private set; } = new("Options.Interop.AllowedAssemblies");
 
         /// <summary>
         /// Type and member resolving strategy, which allows filtering allowed members and configuring member
@@ -954,13 +1003,13 @@ public sealed partial class Options
         /// <remarks>
         /// As this object holds caching state same instance should be shared between engines, if possible.
         /// </remarks>
-        public TypeResolver TypeResolver { get; set; } = TypeResolver.Default;
+        public TypeResolver TypeResolver { get; set { ThrowIfReadOnly(); field = value; } } = TypeResolver.Default;
 
         /// <summary>
         /// When writing values to CLR objects, how should JS values be coerced to CLR types.
         /// Defaults to only coercing to string values when writing to string targets.
         /// </summary>
-        public ValueCoercionType ValueCoercion { get; set; } = ValueCoercionType.String;
+        public ValueCoercionType ValueCoercion { get; set { ThrowIfReadOnly(); field = value; } } = ValueCoercionType.String;
 
         /// <summary>
         /// How CLR enum values are exposed to script code when they cross into JavaScript, defaults to
@@ -968,7 +1017,7 @@ public sealed partial class Options
         /// the write direction is governed by <see cref="ValueCoercion"/> and always accepts both the member name
         /// and the numeric value.
         /// </summary>
-        public EnumConversionMode EnumConversion { get; set; } = EnumConversionMode.Number;
+        public EnumConversionMode EnumConversion { get; set { ThrowIfReadOnly(); field = value; } } = EnumConversionMode.Number;
 
         /// <summary>
         /// Strategy to create a CLR object to hold converted <see cref="ObjectInstance"/>.
@@ -976,7 +1025,7 @@ public sealed partial class Options
         internal static readonly Func<ObjectInstance, IDictionary<string, object?>> _defaultCreateClrObject =
             static _ => new ExpandoObject();
 
-        public Func<ObjectInstance, IDictionary<string, object?>>? CreateClrObject { get; set; } = _defaultCreateClrObject;
+        public Func<ObjectInstance, IDictionary<string, object?>>? CreateClrObject { get; set { ThrowIfReadOnly(); field = value; } } = _defaultCreateClrObject;
 
         /// <summary>
         /// Strategy to create a CLR object from TypeReference.
@@ -985,7 +1034,7 @@ public sealed partial class Options
         internal static readonly Func<Engine, Type, JsValue[], object?> _defaultCreateTypeReferenceObject =
             static (_, _, _) => null;
 
-        public Func<Engine, Type, JsValue[], object?> CreateTypeReferenceObject { get; set; } = _defaultCreateTypeReferenceObject;
+        public Func<Engine, Type, JsValue[], object?> CreateTypeReferenceObject { get; set { ThrowIfReadOnly(); field = value; } } = _defaultCreateTypeReferenceObject;
 
         internal static readonly ExceptionHandlerDelegate _defaultExceptionHandler = static exception => false;
 
@@ -993,18 +1042,18 @@ public sealed partial class Options
         /// When not null, is used to serialize any CLR object in an
         /// <see cref="IObjectWrapper"/> passing through 'JSON.stringify'.
         /// </summary>
-        public SerializeToJsonDelegate? SerializeToJson { get; set; }
+        public SerializeToJsonDelegate? SerializeToJson { get; set { ThrowIfReadOnly(); field = value; } }
 
         /// <summary>
         /// What kind of date time should be produced when JavaScript date is converted to DateTime. If Local, uses <see cref="Options.TimeZone"/>.
         /// Defaults to <see cref="System.DateTimeKind.Utc"/>.
         /// </summary>
-        public DateTimeKind DateTimeKind { get; set; } = DateTimeKind.Utc;
+        public DateTimeKind DateTimeKind { get; set { ThrowIfReadOnly(); field = value; } } = DateTimeKind.Utc;
 
         /// <summary>
         /// Should the Array prototype be attached instead of Object prototype to the wrapped interop objects when type looks suitable. Defaults to true.
         /// </summary>
-        public bool AttachArrayPrototype { get; set; } = true;
+        public bool AttachArrayPrototype { get; set { ThrowIfReadOnly(); field = value; } } = true;
 
         /// <summary>
         /// When true, JavaScript prototype methods take precedence over CLR methods of the same name on wrapped CLR objects
@@ -1018,12 +1067,12 @@ public sealed partial class Options
         /// already defers to a same-named <c>Array.prototype</c> method on indexed array-like wrappers by default;
         /// this option additionally makes real CLR instance methods defer.
         /// </remarks>
-        public bool PreferJsPrototypeMethods { get; set; }
+        public bool PreferJsPrototypeMethods { get; set { ThrowIfReadOnly(); field = value; } }
 
         /// <summary>
         /// Whether the engine should throw an error when a member is not found on a CLR object. Defaults to false.
         /// </summary>
-        public bool ThrowOnUnresolvedMember { get; set; }
+        public bool ThrowOnUnresolvedMember { get; set { ThrowIfReadOnly(); field = value; } }
 
         /// <summary>
         /// When <c>true</c>, the <see cref="Jint.Runtime.JavaScriptException"/> thrown when a CLR method or
@@ -1037,32 +1086,32 @@ public sealed partial class Options
         /// what the script sees (rewrite the message, attach an error code), use <see cref="ClrResolutionErrorDecorator"/>.
         /// </para>
         /// </summary>
-        public bool ExposeDetailedResolutionErrors { get; set; }
+        public bool ExposeDetailedResolutionErrors { get; set { ThrowIfReadOnly(); field = value; } }
 
         /// <summary>
         /// Types of CLR members reported by <see cref="ObjectWrapper"/> when enumerating properties/serializing <see cref="ObjectWrapper.ToObject"/>.
         /// Supported values are: <see cref="MemberTypes.Field"/>, <see cref="MemberTypes.Property"/>, <see cref="MemberTypes.Method"/>.
         /// All other values are ignored.
         /// </summary>
-        public MemberTypes ObjectWrapperReportedMemberTypes { get; set; } = MemberTypes.Field | MemberTypes.Property | MemberTypes.Method;
+        public MemberTypes ObjectWrapperReportedMemberTypes { get; set { ThrowIfReadOnly(); field = value; } } = MemberTypes.Field | MemberTypes.Property | MemberTypes.Method;
 
         /// <summary>
         /// Reported member binding flags when reflecting, defaults to <see cref="BindingFlags.Instance" /> | <see cref="BindingFlags.Public" />.
         /// </summary>
         /// <inheritdoc cref="AllowGetType" path="/remarks"/>
-        public BindingFlags ObjectWrapperReportedFieldBindingFlags { get; set; } = BindingFlags.Instance | BindingFlags.Public;
+        public BindingFlags ObjectWrapperReportedFieldBindingFlags { get; set { ThrowIfReadOnly(); field = value; } } = BindingFlags.Instance | BindingFlags.Public;
 
         /// <summary>
         /// Reported member binding flags when reflecting, defaults to <see cref="BindingFlags.Instance" /> | <see cref="BindingFlags.Public" />.
         /// </summary>
         /// <inheritdoc cref="AllowGetType" path="/remarks"/>
-        public BindingFlags ObjectWrapperReportedPropertyBindingFlags { get; set; } = BindingFlags.Instance | BindingFlags.Public;
+        public BindingFlags ObjectWrapperReportedPropertyBindingFlags { get; set { ThrowIfReadOnly(); field = value; } } = BindingFlags.Instance | BindingFlags.Public;
 
         /// <summary>
         /// Reported member binding flags when reflecting, defaults to <see cref="BindingFlags.Instance" /> | <see cref="BindingFlags.Public" /> | <see cref="BindingFlags.Static" />.
         /// </summary>
         /// <inheritdoc cref="AllowGetType" path="/remarks"/>
-        public BindingFlags ObjectWrapperReportedMethodBindingFlags { get; set; } = BindingFlags.Instance | BindingFlags.Public | BindingFlags.Static;
+        public BindingFlags ObjectWrapperReportedMethodBindingFlags { get; set { ThrowIfReadOnly(); field = value; } } = BindingFlags.Instance | BindingFlags.Public | BindingFlags.Static;
 
         /// <summary>
         /// Customizes the property keys reported by <see cref="ObjectWrapper"/> when a wrapped CLR object is
@@ -1074,20 +1123,20 @@ public sealed partial class Options
         /// </summary>
         internal static readonly ReportedPropertyKeysDelegate _defaultReportedPropertyKeys = static (_, _) => null;
 
-        public ReportedPropertyKeysDelegate ObjectWrapperReportedPropertyKeys { get; set; } = _defaultReportedPropertyKeys;
+        public ReportedPropertyKeysDelegate ObjectWrapperReportedPropertyKeys { get; set { ThrowIfReadOnly(); field = value; } } = _defaultReportedPropertyKeys;
 
         internal InteropOptions Clone()
         {
             var clone = (InteropOptions) MemberwiseClone();
-            clone.ExtensionMethodTypes = new List<Type>(ExtensionMethodTypes);
-            clone.ObjectConverters = new List<IObjectConverter>(ObjectConverters);
-            clone.ImmutableCrossingTypes = new List<Type>(ImmutableCrossingTypes);
-            clone.AllowedAssemblies = new List<Assembly>(AllowedAssemblies);
+            clone.ExtensionMethodTypes = ExtensionMethodTypes.Clone();
+            clone.ObjectConverters = ObjectConverters.Clone();
+            clone.ImmutableCrossingTypes = ImmutableCrossingTypes.Clone();
+            clone.AllowedAssemblies = AllowedAssemblies.Clone();
             return clone;
         }
     }
 
-    public sealed class ConstraintOptions
+    public sealed partial class ConstraintOptions
     {
         /// <summary>
         /// Registered constraint instances.
@@ -1100,33 +1149,32 @@ public sealed partial class Options
         /// (<see cref="OptionsExtensions.AddConstraint(Options, Func{Constraint})"/>) so each engine gets
         /// its own instance; the built-in constraint extension methods already do that.
         /// </remarks>
-        public List<Constraint> Constraints { get; private set; } = new();
+        public OptionsList<Constraint> Constraints { get; private set; } = new("Options.Constraints.Constraints");
 
         /// <summary>
         /// Registered constraint factories. Each engine built from these options invokes every factory
         /// exactly once while constructing, so the constraints — and the per-execution state they carry —
         /// belong to that engine alone.
         /// </summary>
-        internal List<Func<Constraint>> ConstraintFactories { get; private set; } = new();
+        internal OptionsList<Func<Constraint>> ConstraintFactories { get; private set; } = new("Options.Constraints.Constraints");
 
-        internal int? RequestedMaxStatements { get; set; }
+        internal int? RequestedMaxStatements { get; set { ThrowIfReadOnly(); field = value; } }
 
-        internal long? RequestedMemoryLimit { get; set; }
+        internal long? RequestedMemoryLimit { get; set { ThrowIfReadOnly(); field = value; } }
 
-        internal TimeSpan? RequestedTimeoutInterval { get; set; }
+        internal TimeSpan? RequestedTimeoutInterval { get; set { ThrowIfReadOnly(); field = value; } }
 
-        internal bool CancellationConstraintRequested { get; set; }
+        internal bool CancellationConstraintRequested { get; set { ThrowIfReadOnly(); field = value; } }
 
-        internal bool OperationDeadlineConstraintRequested { get; set; }
+        internal bool OperationDeadlineConstraintRequested { get; set { ThrowIfReadOnly(); field = value; } }
 
         /// <summary>
         /// Maximum recursion depth allowed, defaults to -1 (no checks).
         /// </summary>
         /// <remarks>
         /// <para>
-        /// Read once, while the engine is being constructed. Changing it afterwards has no effect on an
-        /// engine that already exists — the call stack decides from the same value whether to track depth at
-        /// all, so the limit could not be raised later even if every check re-read it.
+        /// Read once, while the engine is being constructed — the call stack decides from the same value
+        /// whether to track depth at all, so the limit could not be raised later even if every check re-read it.
         /// </para>
         /// <para>
         /// A limit that cannot be reached is not a limit, so <see cref="int.MaxValue"/> arms nothing and gives
@@ -1137,7 +1185,7 @@ public sealed partial class Options
         /// still distinguishes the two spellings — a host that meant to set a limit is told which mistake it made.
         /// </para>
         /// </remarks>
-        public int MaxRecursionDepth { get; set; } = -1;
+        public int MaxRecursionDepth { get; set { ThrowIfReadOnly(); field = value; } } = -1;
 
         /// <summary>
         /// <see cref="MaxRecursionDepth"/> reduced to the two states the engine can be in: a non-negative depth
@@ -1152,14 +1200,13 @@ public sealed partial class Options
         /// Chrome and V8 based engines (ClearScript) that can handle 13955.
         /// When set to a different value except -1, it can reduce slight performance/stack trace readability drawback. (after hitting the engine's own limit),
         /// When max stack size to be exceeded, Engine throws an exception <see cref="JavaScriptException" />.
-        /// Read once, while the engine is being constructed; changing it afterwards has no effect on an
-        /// engine that already exists.
+        /// Read once, while the engine is being constructed.
         /// This lane is probed at the call expression only, so a recursion that reaches a function body by
         /// another route — <c>new</c>, an accessor, a coercion, a Proxy trap — still overflows the native
         /// stack; <see cref="StackOverflowGuard"/> is the one that covers those, and setting this property
         /// takes precedence over it.
         /// </remarks>
-        public int MaxExecutionStackCount { get; set; } = StackGuard.Disabled;
+        public int MaxExecutionStackCount { get; set { ThrowIfReadOnly(); field = value; } } = StackGuard.Disabled;
 
         /// <summary>
         /// Whether every entry into an interpreted function probes the remaining native stack and throws a
@@ -1211,11 +1258,10 @@ public sealed partial class Options
         /// lane nothing to hop with.
         /// </para>
         /// <para>
-        /// Read once, while the engine is being constructed; changing it afterwards has no effect on an
-        /// engine that already exists.
+        /// Read once, while the engine is being constructed.
         /// </para>
         /// </remarks>
-        public bool StackOverflowGuard { get; set; } = true;
+        public bool StackOverflowGuard { get; set { ThrowIfReadOnly(); field = value; } } = true;
 
         /// <summary>
         /// Maximum time a Regex is allowed to run, defaults to 10 seconds.
@@ -1231,7 +1277,7 @@ public sealed partial class Options
         /// <see cref="OptionsSecurityExtensions.ValidateSecurityConfiguration(Options, SecurityConfigurationPolicy)"/>
         /// reports an untimed engine as an error.
         /// </remarks>
-        public TimeSpan RegexTimeout { get; set; } = TimeSpan.FromSeconds(10);
+        public TimeSpan RegexTimeout { get; set { ThrowIfReadOnly(); field = value; } } = TimeSpan.FromSeconds(10);
 
         /// <summary>
         /// The largest interval .NET's <see cref="System.Text.RegularExpressions.Regex"/> accepts as a match
@@ -1252,17 +1298,17 @@ public sealed partial class Options
         /// Maximum time allowed for unwrapping a Promise and getting its resolved/rejected value.
         /// Defaults to 10 seconds.
         /// </summary>
-        public TimeSpan PromiseTimeout { get; set; } = TimeSpan.FromSeconds(10);
+        public TimeSpan PromiseTimeout { get; set { ThrowIfReadOnly(); field = value; } } = TimeSpan.FromSeconds(10);
 
         /// <summary>
         /// The maximum size for JavaScript array, defaults to <see cref="uint.MaxValue"/>.
         /// </summary>
-        public uint MaxArraySize { get; set; } = uint.MaxValue;
+        public uint MaxArraySize { get; set { ThrowIfReadOnly(); field = value; } } = uint.MaxValue;
 
         /// <summary>
         /// How many iterations is Atomics.pause allowed to instruct to wait using <see cref="System.Threading.Thread.SpinWait"/>, defaults to 10 000.
         /// </summary>
-        public int MaxAtomicsPauseIterations { get; set; } = 10_000;
+        public int MaxAtomicsPauseIterations { get; set { ThrowIfReadOnly(); field = value; } } = 10_000;
 
 #if NET8_0_OR_GREATER
         /// <summary>
@@ -1279,8 +1325,8 @@ public sealed partial class Options
         /// </para>
         /// <para>
         /// Read when the engine builds its constraints, so it may be set in any order relative to
-        /// <see cref="ConstraintsOptionsExtensions.LimitExecutionTime"/>; assigning it afterwards only reaches
-        /// engines built later. Leaving it at <see cref="TimeProvider.System"/> costs exactly what it cost
+        /// <see cref="ConstraintsOptionsExtensions.LimitExecutionTime"/>.
+        /// Leaving it at <see cref="TimeProvider.System"/> costs exactly what it cost
         /// before this property existed — see <c>ConstraintClock</c> for the fold that makes that true.
         /// </para>
         /// <para>
@@ -1289,14 +1335,14 @@ public sealed partial class Options
         /// constructor instead.
         /// </para>
         /// </remarks>
-        public TimeProvider TimeProvider { get; set; } = TimeProvider.System;
+        public TimeProvider TimeProvider { get; set { ThrowIfReadOnly(); field = value; } } = TimeProvider.System;
 #endif
 
         internal ConstraintOptions Clone()
         {
             var clone = (ConstraintOptions) MemberwiseClone();
-            clone.Constraints = new List<Constraint>(Constraints);
-            clone.ConstraintFactories = new List<Func<Constraint>>(ConstraintFactories);
+            clone.Constraints = Constraints.Clone();
+            clone.ConstraintFactories = ConstraintFactories.Clone();
             return clone;
         }
     }
@@ -1305,7 +1351,7 @@ public sealed partial class Options
     /// Resource limits applied before and during parsing. These limits also apply to code compiled by
     /// <c>eval</c>, function constructors, ShadowRealm evaluation, and module loaders.
     /// </summary>
-    public sealed class ParsingOptions
+    public sealed partial class ParsingOptions
     {
         /// <summary>
         /// The maximum number of UTF-16 code units the parser may receive.
@@ -1315,13 +1361,13 @@ public sealed partial class Options
         /// This counts <see cref="string.Length"/>, not encoded bytes. Module loaders which decode bytes are
         /// checked after decoding. Generated source-offset padding and function-constructor wrappers also count.
         /// </remarks>
-        public int? MaxSourceLength { get; set; }
+        public int? MaxSourceLength { get; set { ThrowIfReadOnly(); field = value; } }
 
         /// <summary>
         /// The maximum number of AST nodes the parser may produce.
         /// <see langword="null"/> (the default) means no limit.
         /// </summary>
-        public int? MaxNodeCount { get; set; }
+        public int? MaxNodeCount { get; set { ThrowIfReadOnly(); field = value; } }
 
         internal ParsingOptions Clone() => (ParsingOptions) MemberwiseClone();
     }
@@ -1329,11 +1375,11 @@ public sealed partial class Options
     /// <summary>
     /// Host related customization, still work in progress.
     /// </summary>
-    public sealed class HostOptions
+    public sealed partial class HostOptions
     {
         internal static readonly Func<Engine, Host> _defaultFactory = static _ => new Host();
 
-        internal Func<Engine, Host> Factory { get; set; } = _defaultFactory;
+        internal Func<Engine, Host> Factory { get; set { ThrowIfReadOnly(); field = value; } } = _defaultFactory;
 
         /// <summary>
         /// Whether calling 'eval' with custom code and function constructors taking function code as string is allowed.
@@ -1342,7 +1388,7 @@ public sealed partial class Options
         /// <remarks>
         /// https://tc39.es/ecma262/#sec-hostensurecancompilestrings
         /// </remarks>
-        public bool StringCompilationAllowed { get; set; } = true;
+        public bool StringCompilationAllowed { get; set { ThrowIfReadOnly(); field = value; } } = true;
 
         /// <summary>
         /// Possibility to override Jint's default <c>Function.prototype.toString()</c> implementation.
@@ -1360,7 +1406,7 @@ public sealed partial class Options
         /// </remarks>
         internal static readonly Func<Function, Node, string?> _defaultFunctionToStringHandler = static (_, _) => null;
 
-        public Func<Function, Node, string?> FunctionToStringHandler { get; set; } = _defaultFunctionToStringHandler;
+        public Func<Function, Node, string?> FunctionToStringHandler { get; set { ThrowIfReadOnly(); field = value; } } = _defaultFunctionToStringHandler;
 
         internal HostOptions Clone() => (HostOptions) MemberwiseClone();
     }
@@ -1368,17 +1414,17 @@ public sealed partial class Options
     /// <summary>
     /// Module related customization
     /// </summary>
-    public sealed class ModuleOptions
+    public sealed partial class ModuleOptions
     {
         /// <summary>
         /// Whether to register require function to engine which will delegate to module loader, defaults to false.
         /// </summary>
-        public bool RegisterRequire { get; set; }
+        public bool RegisterRequire { get; set { ThrowIfReadOnly(); field = value; } }
 
         /// <summary>
         /// Module loader implementation, by default exception will be thrown if module loading is not enabled.
         /// </summary>
-        public IModuleLoader ModuleLoader { get; set; } = FailFastModuleLoader.Instance;
+        public IModuleLoader ModuleLoader { get; set { ThrowIfReadOnly(); field = value; } } = FailFastModuleLoader.Instance;
 
         /// <summary>
         /// Maximum number of distinct module records an engine may register over its lifetime. Charged once per
@@ -1387,7 +1433,7 @@ public sealed partial class Options
         /// <see cref="int.MaxValue"/> means unlimited (the default). A non-positive finite value throws at
         /// engine construction.
         /// </summary>
-        public int MaxModuleCount { get; set; } = int.MaxValue;
+        public int MaxModuleCount { get; set { ThrowIfReadOnly(); field = value; } } = int.MaxValue;
 
         /// <summary>
         /// Maximum cumulative UTF-8 encoded source bytes across all modules registered in an engine's lifetime.
@@ -1397,7 +1443,7 @@ public sealed partial class Options
         /// count. <see cref="long.MaxValue"/> means unlimited (the default). A non-positive finite value throws
         /// at engine construction.
         /// </summary>
-        public long MaxTotalModuleSourceBytes { get; set; } = long.MaxValue;
+        public long MaxTotalModuleSourceBytes { get; set { ThrowIfReadOnly(); field = value; } } = long.MaxValue;
 
         /// <summary>
         /// Maximum conservative import-chain depth in a module graph load. Root is depth 1. Strongly connected
@@ -1408,7 +1454,7 @@ public sealed partial class Options
         /// <see cref="int.MaxValue"/> means unlimited (the default). A non-positive finite value throws at
         /// engine construction.
         /// </summary>
-        public int MaxModuleGraphDepth { get; set; } = int.MaxValue;
+        public int MaxModuleGraphDepth { get; set { ThrowIfReadOnly(); field = value; } } = int.MaxValue;
 
         /// <summary>
         /// Maximum number of module-loader <see cref="IModuleLoader.Resolve"/> calls per top-level import or
@@ -1419,14 +1465,14 @@ public sealed partial class Options
         /// engines never fail from accumulated registrations. <see cref="int.MaxValue"/> means unlimited
         /// (the default). A non-positive finite value throws at engine construction.
         /// </summary>
-        public int MaxModuleResolutionHops { get; set; } = int.MaxValue;
+        public int MaxModuleResolutionHops { get; set { ThrowIfReadOnly(); field = value; } } = int.MaxValue;
 
         /// <summary>
         /// An optional policy consulted after resolution but before a module is loaded or fetched. A denial
         /// throws <see cref="ModuleResolutionException"/> and follows existing sync/rejection behaviour.
         /// <c>null</c> means no policy (the default — everything the loader resolves is allowed).
         /// </summary>
-        public IModuleLoadPolicy? LoadPolicy { get; set; }
+        public IModuleLoadPolicy? LoadPolicy { get; set { ThrowIfReadOnly(); field = value; } }
 
         /// <summary>
         /// When <c>true</c>, module loading failures expose the original exception message to script code.
@@ -1434,7 +1480,7 @@ public sealed partial class Options
         /// with a generic message. The original exception remains available to the host through
         /// <see cref="JintException.TryGetClrException"/>.
         /// </summary>
-        public bool ExposeDetailedLoadErrors { get; set; }
+        public bool ExposeDetailedLoadErrors { get; set { ThrowIfReadOnly(); field = value; } }
 
         internal ModuleOptions Clone() => (ModuleOptions) MemberwiseClone();
     }
@@ -1442,13 +1488,13 @@ public sealed partial class Options
     /// <summary>
     /// JSON.parse / JSON.stringify related customization
     /// </summary>
-    public sealed class JsonOptions
+    public sealed partial class JsonOptions
     {
         /// <summary>
         /// The maximum depth allowed when parsing JSON files using "JSON.parse",
         /// defaults to 64.
         /// </summary>
-        public int MaxParseDepth { get; set; } = 64;
+        public int MaxParseDepth { get; set { ThrowIfReadOnly(); field = value; } } = 64;
 
         internal JsonOptions Clone() => (JsonOptions) MemberwiseClone();
     }
@@ -1456,7 +1502,7 @@ public sealed partial class Options
     /// <summary>
     /// Internationalization (Intl) API related customization.
     /// </summary>
-    public sealed class IntlOptions
+    public sealed partial class IntlOptions
     {
         /// <summary>
         /// CLDR provider for locale data. Defaults to DefaultCldrProvider
@@ -1466,7 +1512,7 @@ public sealed partial class Options
         /// Set this to a custom ICldrProvider implementation (e.g., ICU-based provider)
         /// to enable full locale support for the Intl API.
         /// </remarks>
-        public ICldrProvider CldrProvider { get; set; } = DefaultCldrProvider.Instance;
+        public ICldrProvider CldrProvider { get; set { ThrowIfReadOnly(); field = value; } } = DefaultCldrProvider.Instance;
 
         internal IntlOptions Clone() => (IntlOptions) MemberwiseClone();
     }
@@ -1474,7 +1520,7 @@ public sealed partial class Options
     /// <summary>
     /// Temporal API related customization.
     /// </summary>
-    public sealed class TemporalOptions
+    public sealed partial class TemporalOptions
     {
         /// <summary>
         /// Time zone provider for Temporal operations. Defaults to DefaultTimeZoneProvider
@@ -1484,7 +1530,7 @@ public sealed partial class Options
         /// Set this to a custom ITimeZoneProvider implementation (e.g., using TimeZoneConverter or NodaTime)
         /// for full IANA time zone support and better Windows compatibility.
         /// </remarks>
-        public ITimeZoneProvider TimeZoneProvider { get; set; } = DefaultTimeZoneProvider.Instance;
+        public ITimeZoneProvider TimeZoneProvider { get; set { ThrowIfReadOnly(); field = value; } } = DefaultTimeZoneProvider.Instance;
 
         /// <summary>
         /// Calendar provider for non-ISO calendar arithmetic and field conversion.
@@ -1496,7 +1542,7 @@ public sealed partial class Options
         /// (e.g. backed by ICU4N or NodaTime) for richer support of islamic-umalqura,
         /// Persian astronomical, or Chinese/Dangi calendars at extreme dates.
         /// </remarks>
-        public ICalendarProvider CalendarProvider { get; set; } = DefaultCalendarProvider.Instance;
+        public ICalendarProvider CalendarProvider { get; set { ThrowIfReadOnly(); field = value; } } = DefaultCalendarProvider.Instance;
 
         internal TemporalOptions Clone() => (TemporalOptions) MemberwiseClone();
     }

--- a/Jint/Runtime/Interop/ImmutableCrossingTypeFilter.cs
+++ b/Jint/Runtime/Interop/ImmutableCrossingTypeFilter.cs
@@ -34,7 +34,7 @@ internal sealed class ImmutableCrossingTypeFilter
     /// Builds the filter for an engine's declared types, or <see langword="null"/> when the host declared
     /// none — in which case no wrapper ever asks and the whole mechanism costs a single null check.
     /// </summary>
-    internal static ImmutableCrossingTypeFilter? Create(List<Type> declaredTypes)
+    internal static ImmutableCrossingTypeFilter? Create(OptionsList<Type> declaredTypes)
     {
         if (declaredTypes.Count == 0)
         {

--- a/Jint/Runtime/Interop/Reflection/ExtensionMethodCache.cs
+++ b/Jint/Runtime/Interop/Reflection/ExtensionMethodCache.cs
@@ -44,7 +44,7 @@ internal sealed class ExtensionMethodCache
         _allExtensionMethods = extensionMethods;
     }
 
-    internal static ExtensionMethodCache Build(List<Type> extensionMethodContainerTypes)
+    internal static ExtensionMethodCache Build(OptionsList<Type> extensionMethodContainerTypes)
     {
         if (extensionMethodContainerTypes.Count == 0)
         {

--- a/Jint/Runtime/Throw.cs
+++ b/Jint/Runtime/Throw.cs
@@ -276,6 +276,34 @@ internal static class Throw
         throw new InvalidOperationException(message, exception);
     }
 
+    /// <summary>
+    /// Shared by the two <see cref="Options"/> read-only refusals, so they cannot drift.
+    /// </summary>
+    private const string OptionsReadOnlyExplanation =
+        ": these options are read-only because an engine has been built from them. "
+        + "Most settings are read off Engine.Options while the engine runs, so a later change would reach an engine that already exists. "
+        + "Configure the options fully before constructing the engine, or build the second engine from its own Options instance.";
+
+    /// <summary>
+    /// A write to an <see cref="Options"/> setting or registry after an engine has been built from it.
+    /// </summary>
+    /// <param name="setting">The full path of the setting, e.g. <c>Options.Interop.AllowWrite</c>.</param>
+    [DoesNotReturn]
+    public static void OptionsReadOnly(string setting)
+    {
+        throw new InvalidOperationException(setting + " cannot be changed" + OptionsReadOnlyExplanation);
+    }
+
+    /// <summary>
+    /// A configuration method called on an <see cref="Options"/> an engine has already been built from.
+    /// </summary>
+    /// <param name="method">The method the host called, e.g. <c>Options.AddLazyGlobal</c>.</param>
+    [DoesNotReturn]
+    public static void OptionsReadOnlyCall(string method)
+    {
+        throw new InvalidOperationException(method + " cannot be called" + OptionsReadOnlyExplanation);
+    }
+
     [DoesNotReturn]
     public static void PromiseRejectedException(JsValue error)
     {

--- a/Jint/WebApi/WebApiRegistration.cs
+++ b/Jint/WebApi/WebApiRegistration.cs
@@ -104,7 +104,23 @@ internal static class WebApiRegistration
         // code ever does it. That is exactly what this call is: the host asking, on the engine's own thread,
         // for something the options never said.
         var options = engine.Options;
-        configure?.Invoke(options.WebApi);
+        if (configure is not null)
+        {
+            // The engine froze its options when it was built, and this callback is documented to configure
+            // the very group the engine reads its web-API settings from — the one sanctioned write to an
+            // engine's own options after construction. The suspension is scoped to the web-API groups and to
+            // this thread; see Options.BeginLiveWebApiConfiguration for why the group's own flag is the wrong
+            // thing to toggle when the Options may be shared with engines being built right now.
+            Options.BeginLiveWebApiConfiguration();
+            try
+            {
+                configure(options.WebApi);
+            }
+            finally
+            {
+                Options.EndLiveWebApiConfiguration();
+            }
+        }
 
         var combined = existing | added;
         engine._webApiFeatures = combined;

--- a/Jint/WebApi/WebApiRegistration.cs
+++ b/Jint/WebApi/WebApiRegistration.cs
@@ -108,17 +108,18 @@ internal static class WebApiRegistration
         {
             // The engine froze its options when it was built, and this callback is documented to configure
             // the very group the engine reads its web-API settings from — the one sanctioned write to an
-            // engine's own options after construction. The suspension is scoped to the web-API groups and to
-            // this thread; see Options.BeginLiveWebApiConfiguration for why the group's own flag is the wrong
-            // thing to toggle when the Options may be shared with engines being built right now.
-            Options.BeginLiveWebApiConfiguration();
+            // engine's own options after construction. The suspension is scoped to this group's subtree and
+            // to this thread; see Options.BeginLiveWebApiConfiguration for why the group's own flag is the
+            // wrong thing to toggle when the Options may be shared with engines being built right now.
+            var webApi = options.WebApi;
+            var previous = Options.BeginLiveWebApiConfiguration(webApi);
             try
             {
-                configure(options.WebApi);
+                configure(webApi);
             }
             finally
             {
-                Options.EndLiveWebApiConfiguration();
+                Options.EndLiveWebApiConfiguration(previous);
             }
         }
 

--- a/Jint/WebApi/WebSockets/WebSocketPolicy.cs
+++ b/Jint/WebApi/WebSockets/WebSocketPolicy.cs
@@ -54,7 +54,7 @@ internal static class WebSocketPolicy
         return filter is null || filter(uri);
     }
 
-    private static bool IsSchemeAllowed(List<string> allowed, string scheme)
+    private static bool IsSchemeAllowed(OptionsList<string> allowed, string scheme)
     {
         // The parser has already lowercased the scheme and the constructor has already refused everything
         // that is not one of these two.

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -879,8 +879,12 @@ share the same `Options`, and a sink you own does not.
 Three details worth knowing:
 
 - **`Engine.Advanced.EnableWebApis(features, configure)` still works.** Its callback is the one sanctioned
-  write to an engine's own options after construction, and the guard is suspended for the web-API groups —
-  and for nothing else — while it runs.
+  write to an engine's own options after construction, and it is the only place the freeze is suspended. The
+  suspension covers that engine's own web-API group and its sub-groups, on the calling thread, for the
+  duration of the callback — no other `Options` instance, no other group, and not the registries: a live
+  enable sets a value, it never grows an `OptionsList<T>`. Note that the instance it writes to is shared with
+  every engine built from it, and for an engine built by `new Engine()` it is one Jint keeps process-wide, so
+  give an engine its own `Options` before configuring it there.
 - **A group is allocated on first touch, and one materialized after the freeze is born frozen.** So
   `options.Intl.CldrProvider = …` on an engine's options throws even though nothing had ever touched
   `Intl`.

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -463,6 +463,37 @@ reflects over — but it also means a delegate registration wants the same cast 
 takes the engine's host-call reservation for the duration of the write, exactly as
 `ShadowRealm.Evaluate` already did, so registering a value from another thread while the engine is running
 is rejected with `InvalidOperationException` instead of racing the global object.
+### 3.8 The option registries are `OptionsList<T>` ([#3327](https://github.com/sebastienros/jint/pull/3327))
+
+Six registries changed type from `List<T>` to `OptionsList<T>`, so that they can refuse a change after an
+engine has read them — see [4.16](#416-options-is-configuration-until-an-engine-reads-it-and-frozen-afterwards),
+which is the reason. `OptionsList<T>` is an `IList<T>` and an `IReadOnlyList<T>` with `AddRange`, `RemoveAll`
+and `ToArray`, so the calls a host already writes compile unchanged:
+
+```c#
+// compiles in both
+options.Interop.ExtensionMethodTypes.Add(typeof(StringExtensions));
+options.Interop.AllowedAssemblies.AddRange(assemblies);
+foreach (var converter in options.Interop.ObjectConverters) { /* … */ }
+```
+
+What does not compile is **replacing** one wholesale. `Options.Interop.AllowedAssemblies` was the only one
+with a public setter, and lost it:
+
+```c#
+// 4.16.x
+options.Interop.AllowedAssemblies = new List<Assembly> { typeof(Foo).Assembly };
+
+// 5.x
+options.Interop.AllowedAssemblies.Clear();
+options.Interop.AllowedAssemblies.Add(typeof(Foo).Assembly);
+```
+
+The six are `Interop.ExtensionMethodTypes`, `Interop.ObjectConverters`, `Interop.ImmutableCrossingTypes`,
+`Interop.AllowedAssemblies`, `Constraints.Constraints` and `WebApi.Fetch.AllowedSchemes`. A variable or
+parameter declared `List<T>` and assigned from one needs its type changed; `IList<T>`, `IReadOnlyList<T>`,
+`IEnumerable<T>` and `var` are unaffected.
+
 
 ## 4. Breaking without a signature change
 
@@ -771,6 +802,90 @@ public sealed class ContentDataObject : ObjectInstance
 A host that overrode nothing needs no change. A host that overrides `PreventExtensions` and returns `true`
 now owes the object `Extensible == false` afterwards — call `base.PreventExtensions()`; host-contract
 verification reports an override that does not.
+### 4.16 `Options` is configuration until an engine reads it, and frozen afterwards ([#3327](https://github.com/sebastienros/jint/pull/3327))
+
+An `Engine` keeps the very `Options` instance it was handed — `CreateEngineOptions` returns `this` unless a
+hardened profile made a private clone — and reads about thirty of its settings **live**, on hot paths.
+So this compiled, and granted CLR writes to a running engine:
+
+```c#
+// 4.16.x: the engine reads Interop.AllowWrite on every projected write, so this reaches it
+var engine = new Engine(options);
+options.Interop.AllowWrite = true;
+engine.Execute("host.Balance = 0");   // writes through
+
+// 5.x
+options.Interop.AllowWrite = true;
+// InvalidOperationException: Options.Interop.AllowWrite cannot be changed: these options are read-only
+// because an engine has been built from them.
+```
+
+Six other properties did the opposite — read once at construction, and documented with *changing it
+afterwards has no effect*. Which of the two behaviours a given property had was discoverable only by reading
+its XML documentation. Now there is one rule: the `Engine` constructor calls `MakeReadOnly()` on the options
+when it has finished reading them, and every setter and every registry on the instance and on its groups
+throws an `InvalidOperationException` naming the setting from that point. Those six documentation paragraphs
+are gone; the exception says it instead. The model is `JsonSerializerOptions.MakeReadOnly()` / `IsReadOnly`,
+and the two members are spelled the same way.
+
+Nothing about *building* engines changes. Sharing one configured `Options` between engines — including
+concurrently constructed ones — is exactly as supported as before, because a second freeze is a no-op:
+
+```c#
+var options = new Options();
+options.Strict = true;
+var first = new Engine(options);
+var second = new Engine(options);   // still fine
+options.IsReadOnly;                 // true
+```
+
+A configuration callback still runs before the freeze, so both documented ways of configuring at construction
+time are unaffected:
+
+```c#
+options.Configure(engine => { /* runs during construction; may still write to options */ });
+new Engine(o => o.Interop.AllowWrite = true);
+```
+
+**What to change.** Configure the options fully before constructing the engine, or give the second engine its
+own `Options`. Three shapes need rewriting:
+
+```c#
+// 1. Reconfiguring between evaluations. Build a second engine from a second Options instead.
+var engine = new Engine(options);
+options.Modules.ExposeDetailedLoadErrors = true;   // now throws
+
+// 2. Swapping a handler mid-run. Put the mutable part in an object you own.
+options.Interop.WrapObjectHandler = SomeOtherHandler;   // now throws
+// instead:
+var mode = Mode.First;
+options.Interop.WrapObjectHandler = (e, target, type) => Wrap(mode, e, target, type);
+mode = Mode.Second;                                     // your field, not the engine's configuration
+
+// 3. Swapping the console sink. Same shape: a sink of your own that forwards.
+options.WebApi.Console.Sink = second;                   // now throws
+sealed class ForwardingSink : ConsoleSink
+{
+    public ConsoleSink Target { get; set; } = Null;
+    public override void Write(ConsoleLogLevel level, string message) => Target.Write(level, message);
+}
+```
+
+`Options.WebApi.Console.Sink` is the one member whose documentation used to *invite* the post-construction
+write ("read afresh on every emit, so a host may swap it between evaluations"). The forwarding sink above is
+its replacement, and it is strictly better: the option write reached every other engine that happened to
+share the same `Options`, and a sink you own does not.
+
+Three details worth knowing:
+
+- **`Engine.Advanced.EnableWebApis(features, configure)` still works.** Its callback is the one sanctioned
+  write to an engine's own options after construction, and the guard is suspended for the web-API groups —
+  and for nothing else — while it runs.
+- **A group is allocated on first touch, and one materialized after the freeze is born frozen.** So
+  `options.Intl.CldrProvider = …` on an engine's options throws even though nothing had ever touched
+  `Intl`.
+- **`MakeReadOnly()` is public and idempotent**, so a host that builds a configured `Options` in one place
+  and hands it around can freeze it itself, before any engine exists.
 
 ## 5. New in v5
 


### PR DESCRIPTION
## The defect

`Jint/Engine.cs` — `Options = sourceOptions.CreateEngineOptions();`, and `CreateEngineOptions()` (`Jint/Options.cs:529-532` at the branch point) returns `this` unless an untrusted profile is set. So an `Engine` **aliases the caller's `Options` instance**. Meanwhile ~30 settings are read **live off `Engine.Options` on hot paths**:

- `Interop.AllowWrite` — `Jint/Runtime/Interop/ObjectWrapper.cs:404,422`, `Jint/Runtime/Descriptors/Specialized/ReflectionDescriptor.cs:71,155`, `Jint/Native/Array/ArrayOperations.cs:627,815`
- `Interop.ExceptionHandler` — `Jint/Runtime/Interop/ClrFunction.cs:75`

A host that flips `options.Interop.AllowWrite = true` after constructing an engine therefore **grants CLR writes to a running engine**, with nothing to observe:

```c#
var engine = new Engine(options);
options.Interop.AllowWrite = true;
engine.Execute("host.Balance = 0");   // 4.16.x: writes through
```

Six other properties are the opposite — read once at construction — and carried a doc paragraph saying *"changing it afterwards has no effect"* (`Options.cs:650,719,780,1127,1155,1214`). **Which of the two behaviours a given property had was discoverable only by reading its XML doc. That is the bug.**

## What this does

Follows `JsonSerializerOptions.MakeReadOnly()` / `IsReadOnly`, and spells the two members the same way.

- `public void MakeReadOnly()` and `public bool IsReadOnly { get; }` on `Options`, cascading to all 20 nested groups.
- Every setter on `Options` and on every group guards with `ThrowIfReadOnly()` (`[CallerMemberName]`, so the `InvalidOperationException` names the setting — `Options.Interop.AllowWrite cannot be changed: …`). One new `Throw.*` pair: `Throw.OptionsReadOnly` / `OptionsReadOnlyCall`.
- The `Engine` constructor calls `Options.MakeReadOnly()` **last**, after `Options.Apply` (which runs the host's `Configure` callbacks and the untrusted profile's re-expansion) and after every field derived from the options. Nothing Jint itself writes to `Options` happens after that line.
- The six *"changing it afterwards has no effect"* paragraphs are deleted. The exception says it instead.
- Cost: one `bool` field per group, checked in setters only. Property **reads** are untouched — the getters stay auto-implemented (the setters use the C# 14 `field` keyword, so no getter was rewritten), no locks, no volatile.

### Collection mutators count

`List<T>` cannot refuse an `Add`, so six registries become `OptionsList<T>` — a new `public sealed class` implementing `IList<T>` / `IReadOnlyList<T>` over a `List<T>` (struct enumerator, `AddRange`, `RemoveAll`, `ToArray`), whose `ICollection<T>.IsReadOnly` answers the same question `Options.IsReadOnly` does:

`Interop.ExtensionMethodTypes`, `Interop.ObjectConverters`, `Interop.ImmutableCrossingTypes`, `Interop.AllowedAssemblies`, `Constraints.Constraints`, `WebApi.Fetch.AllowedSchemes` (plus the internal `Constraints.ConstraintFactories`).

That makes `AddConstraint`, `AddObjectConverter`, `AddExtensionMethods`, `AddImmutableCrossing`, `AllowClr`, `RemoveConstraints`, `LimitStatements` / `LimitMemory` / `LimitExecutionTime` / `ObserveCancellation` refuse through the list itself. `Configure`, `AddLazyGlobal` and `SetTypeConverter` go through a new guarded `Options.AddConfiguration`, so the engine-configuration registry refuses too. `Options.Interop.AllowedAssemblies` loses its public setter (`AllowClr`'s `= AllowedAssemblies.Distinct().ToList()` becomes an in-place de-duplication).

## Design decisions

1. **`MakeReadOnly()` is idempotent**, and it is **public on `Options` only** — `internal` on the groups, through an internal `IOptionsGroup` interface implemented explicitly. Freezing one group and not its siblings would say nothing a host could use, and the whole tree freezes together, so one `IsReadOnly` answers for all of it.
2. **The same `Options` instance passed to a second `Engine` keeps working.** A second freeze is a no-op, and building an engine from a frozen instance only reads it. What no longer works is *mutating* it between engines — which was the bug, since the first engine was already reading it.
3. **`CreateEngineOptions()` still returns `this`.** Cloning would regress engine-construction cost; freezing is the fix. Its clone path (untrusted profile only) thaws the private snapshot before the profile is expanded onto it, and the engine freezes it again afterwards.
4. **Both instances are frozen**, not only the one the engine kept. With a hardened profile they are different objects; freezing only the clone would mean "an engine makes the options you handed it read-only" needs an exception a host would have to know it was in.
5. **A group materialized after the freeze is born frozen.** Groups are allocated on first touch, so most do not exist when the freeze happens — and the engine reads `Intl` and `Temporal` *lazily*, long after construction. Without this, `options.Intl.CldrProvider = …` would have allocated a fresh mutable group and landed. `Materialize` therefore takes the owner's state.
6. **`Engine.Advanced.EnableWebApis(features, configure)` keeps working**, as the one sanctioned post-construction write. The guard is suspended for the web-API groups **on the calling thread** (`[ThreadStatic]`), not by clearing the group's flag: an `Options` may be shared with engines being constructed at that very moment — including the process-wide instance a parameterless `new Engine()` uses — so clearing the flag would open it to every thread and let a concurrent build close it again mid-callback. An `Action<WebApiOptions>` cannot reach `Interop` or `Constraints`, so the suspension is exactly as wide as the callback.
7. **`Options.WebApi.Console.Sink` loses its documented live swap.** Its doc said "read afresh on every emit, so a host may swap it between evaluations" — the only member that *invited* the post-construction write. One rule beats a special case, and the replacement (a two-line `ConsoleSink` that forwards to a target the host holds) is strictly better: the option write also reached every other engine sharing those `Options`. Documented in the migration guide, and both shapes are pinned in `WebApiTests`.

## Failing-test-first confirmation

New suite: **`Jint.Tests.PublicInterface/HostOptionsReadOnlyTests.cs`** — the only project without `InternalsVisibleTo`. 70 cases: every group refuses a write (theory over 30 settings), every registry refuses a change (theory over 31 verbs and list mutations), the CLR-write grant is refused, a group materialized after the freeze is born frozen, the same `Options` builds two engines, a `ForUntrustedCode` profile still applies and both instances end up read-only, a `Configure` callback still writes during construction, reads are unaffected.

**Run against the unfixed code first**: with the two `MakeReadOnly()` calls commented out of the `Engine` constructor and nothing else changed, **68 of the 70 fail**. The two that pass are the ones that call `MakeReadOnly()` themselves rather than relying on the constructor.

## Tests that changed, and why

Nine existing tests asserted the *old* behaviour — that a post-construction option write is a silent no-op — by performing one. They now assert the refusal, or were restructured:

- `SecurityConfigurationTests` ×4 and `OperatorOverloadingConfigurationTests` — the mutation that used to be the interesting half is now `Invoking(…).Should().Throw<InvalidOperationException>()`, and the report assertions stand unchanged. The same guarantee, said out loud.
- `HostErrorDisclosureTests.ModulePolicyProvenance…` — the third block reconfigured one engine; it is two engines now.
- `Jint.Tests`: `AsyncTests.EngineReusableAfterEvaluateAsyncTimeout` (one budget for both halves, with a slow IO that never completes), `InteropTests.IdentityMapHandlesExposedTypeChangeForArrays` (the view is switched host-side inside one handler), `WebApi.LiveEnableTests.ExtendingAnExistingStateDoesNotAdoptALaterClock` (asks the question through the live door, which is the stronger form), and `ModuleTests.ShouldPropagate{Parse,Link}Error`.

The last two are worth a note: they did `_engine.Options.Modules.ExposeDetailedLoadErrors = true` on an engine built by `new Engine()`, which uses Jint's **process-wide `_defaultEngineOptions`** — so every other `new Engine()` in the test run inherited the exposure. Pre-existing, and only visible because the write now throws.

## Migration guide

`docs/v5-migration.md` gains **3.8** (the `OptionsList<T>` signature change) and **4.15** (the freeze, under *Breaking without a signature change*), with before/after for the three shapes that need rewriting: reconfiguring between evaluations, swapping a handler mid-run, and swapping the console sink. `Jint/AGENTS.md`'s "Configuring an engine" section gains the rule a future setting has to follow.

## Verification

- `dotnet build -c Release` clean, 0 errors, 0 C# warnings (`TreatWarningsAsErrors` is on).
- `Jint.Tests` — net472 7298, net8.0 10645, net10.0 10645, all green.
- `Jint.Tests.PublicInterface` — net472 2033, net10.0 2646, all green.
- `Jint.Tests.CommonScripts` — 28 + 28 green.
- `Jint.Tests.Test262` — 102,495 passed, 0 failed.
- All five API baselines regenerated by running the suite and copying the `.received.txt` files over; none hand-edited.

Rebased on `800168ac0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014W5mbjGhyvgAS4pivXoc4S
