### PR TITLE
Backport: LengthOfArrayLike, delete the uint overload rather than clamp it (#3248)

### DIFF
--- a/Jint.Tests/Runtime/ArrayLikeLengthClampTests.cs
+++ b/Jint.Tests/Runtime/ArrayLikeLengthClampTests.cs
@@ -1,0 +1,206 @@
+#nullable enable
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Every array-like algorithm starts with <see href="https://tc39.es/ecma262/#sec-lengthofarraylike">
+/// LengthOfArrayLike</see>, which is <i>ToLength(Get(O, "length"))</i>, and
+/// <see href="https://tc39.es/ecma262/#sec-tolength">ToLength</see> clamps into <c>[0, 2^53-1]</c>. It never
+/// truncates and it never wraps.
+/// <para>
+/// Jint carried that value in two widths and only the <c>ulong</c> one clamped: the <c>uint</c> overload cast
+/// the <c>double</c> straight across. An out-of-range <c>double</c>-to-integer conversion <em>saturates</em>
+/// on .NET but is <em>unspecified</em> on .NET Framework, where it keeps the low 32 bits — so a
+/// <c>length</c> of 2^53 read as 4294967295 on net10.0 and as 0 on net472, from the same script. These tests
+/// therefore pin one answer for both target frameworks; a row that disagrees between them is the bug.
+/// </para>
+/// </summary>
+public class ArrayLikeLengthClampTests
+{
+    private readonly Engine _engine = new();
+
+    private string Run(string body) => _engine.Evaluate("(function () {" + body + "})()").ToString();
+
+    /// <summary>
+    /// The iterator's step 1.b is <i>LengthOfArrayLike</i> performed afresh on every <c>next()</c>
+    /// (https://tc39.es/ecma262/#sec-createarrayiterator). A length above the index range is still a length,
+    /// so index 0 is present and the first step yields it.
+    /// </summary>
+    [Theory]
+    [InlineData("2147483648", "a")]           // 2^31
+    [InlineData("4294967295", "a")]           // 2^32 - 1
+    [InlineData("4294967296", "a")]           // 2^32     -- net472 kept the low 32 bits: 0
+    [InlineData("8589934592", "a")]           // 2^33     -- likewise 0
+    [InlineData("9007199254740991", "a")]     // 2^53 - 1 -- low 32 bits happen to be 0xFFFFFFFF
+    [InlineData("9007199254740992", "a")]     // 2^53     -- likewise 0
+    [InlineData("18446744073709551616", "a")] // 2^64
+    [InlineData("Infinity", "a")]
+    [InlineData("'9007199254740992'", "a")]   // a string above the range coerces, then clamps
+    [InlineData("-1", "")]                    // ToLength clamps a negative to +0
+    [InlineData("-Infinity", "")]
+    [InlineData("NaN", "")]
+    [InlineData("0", "")]
+    public void TheArrayIteratorSeesTheClampedLength(string length, string expected)
+    {
+        var result = Run(
+            "var o = {length: " + length + ", 0: 'a'};" +
+            "var r = Array.prototype.values.call(o).next();" +
+            "return r.done ? '' : r.value;");
+
+        Assert.Equal(expected, result);
+    }
+
+    /// <summary>
+    /// The same length through the for-of lane, which steps the iterator without materializing an
+    /// IteratorResult. One step and out, so a huge length costs nothing.
+    /// </summary>
+    [Theory]
+    [InlineData("4294967296", "a")]
+    [InlineData("9007199254740992", "a")]
+    [InlineData("Infinity", "a")]
+    [InlineData("-1", "none")]
+    public void TheForOfStepLaneSeesTheClampedLength(string length, string expected)
+    {
+        var result = Run(
+            "var o = {length: " + length + ", 0: 'a'};" +
+            "var seen = 'none';" +
+            "for (var v of Array.prototype.values.call(o)) { seen = v; break; }" +
+            "return seen;");
+
+        Assert.Equal(expected, result);
+    }
+
+    /// <summary>
+    /// Every <c>Array.prototype</c> generic below is specified over <i>LengthOfArrayLike</i>, so a length of
+    /// 2^53 means element 0 is read. A truncated length of 0 makes each of them return early instead — the
+    /// throwing accessor is how that early return is told apart from the read.
+    /// </summary>
+    [Theory]
+    [InlineData("Array.prototype.forEach.call(o, function () {})")]
+    [InlineData("Array.prototype.filter.call(o, function () { return true; })")]
+    [InlineData("Array.prototype.reduce.call(o, function () {}, 0)")]
+    [InlineData("Array.prototype.sort.call(o)")]
+    [InlineData("Array.prototype.join.call(o)")]
+    [InlineData("Array.prototype.toLocaleString.call(o)")]
+    [InlineData("Array.prototype.shift.call(o)")]
+    [InlineData("Array.prototype.flat.call(o)")]
+    [InlineData("Array.prototype.flatMap.call(o, function (x) { return x; })")]
+    [InlineData("String.raw({raw: o})")]
+    public void AGenericReadsElementZeroForALengthAboveTheIndexRange(string call)
+    {
+        var result = Run(
+            "var o = {get 0() { throw 'reached'; }, length: 9007199254740992};" +
+            "try { " + call + "; return 'not-reached'; } catch (e) { return e; }");
+
+        Assert.Equal("reached", result);
+    }
+
+    /// <summary>
+    /// The same generics for a length of exactly 0, which must <em>not</em> read element 0. The pair with the
+    /// theory above is what makes "the length was seen" and "the length was zero" distinguishable.
+    /// </summary>
+    [Theory]
+    [InlineData("Array.prototype.forEach.call(o, function () {})")]
+    [InlineData("Array.prototype.filter.call(o, function () { return true; })")]
+    [InlineData("Array.prototype.reduce.call(o, function () {}, 0)")]
+    [InlineData("Array.prototype.sort.call(o)")]
+    [InlineData("Array.prototype.join.call(o)")]
+    [InlineData("Array.prototype.toLocaleString.call(o)")]
+    [InlineData("Array.prototype.shift.call(o)")]
+    [InlineData("Array.prototype.flat.call(o)")]
+    [InlineData("Array.prototype.flatMap.call(o, function (x) { return x; })")]
+    [InlineData("String.raw({raw: o})")]
+    public void AGenericDoesNotReadElementZeroForALengthOfZero(string call)
+    {
+        var result = Run(
+            "var o = {get 0() { throw 'reached'; }, length: 0};" +
+            "try { " + call + "; return 'not-reached'; } catch (e) { return e; }");
+
+        Assert.Equal("not-reached", result);
+    }
+
+    /// <summary>
+    /// <see href="https://tc39.es/ecma262/#sec-array.from">Array.from</see> step 7.d hands the constructor
+    /// the length as a Number, so a constructor receiver reads the clamped value back out exactly. This is
+    /// the one place the specified value is observable without iterating it.
+    /// </summary>
+    [Theory]
+    [InlineData("2147483648", "2147483648")]
+    [InlineData("4294967295", "4294967295")]
+    [InlineData("4294967296", "4294967296")]
+    [InlineData("8589934592", "8589934592")]
+    [InlineData("9007199254740991", "9007199254740991")]
+    [InlineData("9007199254740992", "9007199254740991")]
+    [InlineData("18446744073709551616", "9007199254740991")]
+    [InlineData("Infinity", "9007199254740991")]
+    [InlineData("'9007199254740992'", "9007199254740991")]
+    [InlineData("-1", "0")]
+    [InlineData("-Infinity", "0")]
+    [InlineData("NaN", "0")]
+    public void ArrayFromHandsTheConstructorTheClampedLength(string length, string expected)
+    {
+        var result = Run(
+            "var seen;" +
+            "function C(n) { seen = n; }" +
+            "var o = {get 0() { throw 'stop'; }, length: " + length + "};" +
+            "try { Array.from.call(C, o); } catch (e) { }" +
+            "return String(seen);");
+
+        Assert.Equal(expected, result);
+    }
+
+    /// <summary>
+    /// The non-constructor branch is <i>ArrayCreate(len)</i>, whose step 1 is a RangeError for anything above
+    /// 2^32-1 (https://tc39.es/ecma262/#sec-arraycreate). A narrowed length either lands inside that range
+    /// and creates an array, or lands on 0 and creates an empty one.
+    /// </summary>
+    [Theory]
+    [InlineData("4294967296")]
+    [InlineData("9007199254740992")]
+    [InlineData("Infinity")]
+    public void ArrayFromRejectsALengthAboveTheArrayIndexRange(string length)
+    {
+        var result = Run(
+            "var o = {get 0() { throw 'element-read'; }, length: " + length + "};" +
+            "try { Array.from(o); return 'no-throw'; } catch (e) { return e instanceof RangeError ? 'RangeError' : String(e); }");
+
+        Assert.Equal("RangeError", result);
+    }
+
+    /// <summary>
+    /// <see href="https://tc39.es/ecma262/#sec-settypedarrayfromarraylike">SetTypedArrayFromArrayLike</see>
+    /// step 5 is <i>If srcLength + targetOffset &gt; targetLength, throw a RangeError</i>. A source length
+    /// that truncated to 0 passes that test and silently copies nothing.
+    /// </summary>
+    [Theory]
+    [InlineData("4294967296")]
+    [InlineData("9007199254740992")]
+    [InlineData("Infinity")]
+    public void TypedArraySetRejectsASourceLengthAboveTheTargetLength(string length)
+    {
+        var result = Run(
+            "var ta = new Uint8Array(4);" +
+            "try { ta.set({length: " + length + "}); return 'no-throw'; } catch (e) { return e instanceof RangeError ? 'RangeError' : String(e); }");
+
+        Assert.Equal("RangeError", result);
+    }
+
+    /// <summary>
+    /// The <em>offset</em> half of the same step. It is a Number all the way down in the specification
+    /// (step 6 is <i>If targetOffset is +infinity, throw a RangeError</i>, step 7 adds it to srcLength), and
+    /// narrowing it to an <c>int</c> before either step is the same unspecified conversion the length had.
+    /// </summary>
+    [Theory]
+    [InlineData("4294967296")]
+    [InlineData("1e20")]
+    [InlineData("9007199254740992")]
+    [InlineData("Infinity")]
+    public void TypedArraySetRejectsAnOffsetAboveTheTargetLength(string offset)
+    {
+        var result = Run(
+            "var ta = new Uint8Array(4);" +
+            "try { ta.set([1], " + offset + "); return 'no-throw:' + ta.join(','); } catch (e) { return e instanceof RangeError ? 'RangeError' : String(e); }");
+
+        Assert.Equal("RangeError", result);
+    }
+}

--- a/Jint.Tests/Runtime/ArrayLikeObjectLaneTests.cs
+++ b/Jint.Tests/Runtime/ArrayLikeObjectLaneTests.cs
@@ -65,7 +65,6 @@ public class ArrayLikeObjectLaneTests
         var host = new HostList(engine, "a", "b", "c");
         var operations = ArrayOperations.For(host, forWrite: false);
 
-        operations.GetLength().Should().Be(3u);
         operations.GetLongLength().Should().Be(3ul);
         operations.Get(1).Should().Be("b");
         operations.HasProperty(2).Should().Be(true);

--- a/Jint/Native/Array/ArrayConstructor.cs
+++ b/Jint/Native/Array/ArrayConstructor.cs
@@ -618,7 +618,7 @@ public sealed partial class ArrayConstructor : Constructor
         ICallable? callable,
         JsValue thisArg)
     {
-        var length = source.GetLength();
+        var length = source.GetLongLength();
 
         ObjectInstance a;
         // Step 6.b: IsConstructor(C) -- see the note on the iterator branch above.
@@ -635,8 +635,7 @@ public sealed partial class ArrayConstructor : Constructor
         var invoker = callable is not null ? CallbackInvoker.Rent(_engine, callable, 2) : default;
 
         var target = ArrayOperations.For(a, forWrite: true);
-        uint n = 0;
-        for (uint i = 0; i < length; i++)
+        for (ulong i = 0; i < length; i++)
         {
             // Check constraints periodically so a huge array-like length cannot run uninterrupted.
             if (i > 0 && i % ConstraintCheckInterval == 0)
@@ -650,11 +649,10 @@ public sealed partial class ArrayConstructor : Constructor
                 value = invoker.Call(thisArg, value, i);
 
                 // function can alter data
-                length = source.GetLength();
+                length = source.GetLongLength();
             }
 
             target.CreateDataPropertyOrThrow(i, value);
-            n++;
         }
 
         invoker.Return();

--- a/Jint/Native/Array/ArrayIteratorPrototype.cs
+++ b/Jint/Native/Array/ArrayIteratorPrototype.cs
@@ -133,7 +133,7 @@ internal sealed partial class ArrayIteratorPrototype : IteratorPrototype
         private readonly ArrayIteratorType _kind;
         private readonly JsTypedArray? _typedArray;
         private readonly ArrayOperations? _operations;
-        private uint _position;
+        private ulong _position;
         private bool _closed;
 
         public ArrayLikeIterator(Engine engine, ObjectInstance objectInstance, ArrayIteratorType kind) : base(engine)
@@ -164,7 +164,7 @@ internal sealed partial class ArrayIteratorPrototype : IteratorPrototype
                 return false;
             }
 
-            uint len;
+            ulong len;
             if (_typedArray is not null)
             {
                 _typedArray._viewedArrayBuffer.AssertNotDetached();
@@ -177,7 +177,7 @@ internal sealed partial class ArrayIteratorPrototype : IteratorPrototype
             }
             else
             {
-                len = _operations!.GetLength();
+                len = _operations!.GetLongLength();
             }
 
             if (_position < len)
@@ -228,7 +228,7 @@ internal sealed partial class ArrayIteratorPrototype : IteratorPrototype
                     return false;
                 }
 
-                var len = _operations!.GetLength();
+                var len = _operations!.GetLongLength();
                 if (_position < len)
                 {
                     var stepped = _operations!.Get(_position);

--- a/Jint/Native/Array/ArrayOperations.cs
+++ b/Jint/Native/Array/ArrayOperations.cs
@@ -88,8 +88,21 @@ internal abstract class ArrayOperations : IEnumerable<JsValue>
 
     public abstract ulong GetSmallestIndex(ulong length);
 
-    public abstract uint GetLength();
-
+    /// <summary>
+    /// <see href="https://tc39.es/ecma262/#sec-lengthofarraylike">LengthOfArrayLike</see>, which is
+    /// <c>ToLength(Get(O, "length"))</c> and therefore lands in <c>[0, 2^53-1]</c>
+    /// (<see href="https://tc39.es/ecma262/#sec-tolength">ToLength</see>).
+    /// <para>
+    /// There is deliberately no narrower overload. One used to exist -- a <c>uint</c> sibling every generic
+    /// below reached for by name -- and it could not express the specified range at all: it cast the
+    /// <c>double</c> across unclamped, which <em>saturates</em> on .NET and is <em>unspecified</em> on .NET
+    /// Framework (there it keeps the low 32 bits), so a <c>length</c> of 2^53 was read as 4294967295 on one
+    /// target framework and as 0 on the other. That is the same hazard
+    /// <see cref="TypeConverter.ToIntegerOrInfinity"/> carries its own note about. Narrow at the call site,
+    /// inside a guard that proves the value fits, the way
+    /// <see href="https://tc39.es/ecma262/#sec-array.prototype.map">Array.prototype.map</see> does.
+    /// </para>
+    /// </summary>
     public abstract ulong GetLongLength();
 
     public abstract void SetLength(ulong length);
@@ -154,12 +167,12 @@ internal abstract class ArrayOperations : IEnumerable<JsValue>
         private readonly ArrayOperations _obj;
         private ulong _current;
         private bool _initialized;
-        private readonly uint _length;
+        private readonly ulong _length;
 
         public ArrayLikeIterator(ArrayOperations obj)
         {
             _obj = obj;
-            _length = obj.GetLength();
+            _length = obj.GetLongLength();
 
             Reset();
         }
@@ -225,12 +238,11 @@ internal abstract class ArrayOperations : IEnumerable<JsValue>
             return _target.GetSmallestIndex(length);
         }
 
-        public override uint GetLength()
-        {
-            var integerLength = GetIntegerLength();
-            return (uint) (integerLength >= 0 ? integerLength : 0);
-        }
-
+        /// <summary>
+        /// The only <see cref="ArrayOperations"/> whose length is not bounded by the array index range: an
+        /// arbitrary array-like carries whatever <c>ToLength</c> made of its own <c>"length"</c>, so the clamp
+        /// at <see cref="MaxArrayLikeLength"/> is what keeps the conversion in range on every target framework.
+        /// </summary>
         public override ulong GetLongLength()
         {
             var integerLength = GetIntegerLength();
@@ -280,9 +292,6 @@ internal abstract class ArrayOperations : IEnumerable<JsValue>
 
         public override ulong GetSmallestIndex(ulong length)
             => _target.GetSmallestIndex();
-
-        public override uint GetLength()
-            => _target.GetLength();
 
         public override ulong GetLongLength()
             => _target.GetLongLength();
@@ -389,8 +398,10 @@ internal abstract class ArrayOperations : IEnumerable<JsValue>
         // Object.defineProperty(ta, "length", ...) installs an ordinary own property that shadows the
         // accessor, and Array.prototype.sort.call(ta) must then sort only that many elements.
         // %TypedArray%.prototype's own methods do not come through here -- they read the intrinsic length
-        // directly -- so nothing that must ignore an own "length" is affected.
-        public override uint GetLength()
+        // directly -- so nothing that must ignore an own "length" is affected. The clamp is ToLength's own
+        // 2^53-1, not the array index range: a shadowing own "length" is an ordinary property and nothing
+        // narrows what LengthOfArrayLike makes of it.
+        public override ulong GetLongLength()
         {
             if (_useIntrinsicLength)
             {
@@ -406,13 +417,11 @@ internal abstract class ArrayOperations : IEnumerable<JsValue>
                     return 0;
                 }
 
-                return (uint) System.Math.Min(length, MaxArrayLength);
+                return (ulong) System.Math.Min(length, MaxArrayLikeLength);
             }
 
             return 0;
         }
-
-        public override ulong GetLongLength() => GetLength();
 
         // Every caller of this is a spec step spelled "Perform ? Set(O, "length", len, true)" -- Array.from,
         // Array.fromAsync and the Array.prototype generics that a typed array can be the receiver of. A typed
@@ -472,9 +481,7 @@ internal abstract class ArrayOperations : IEnumerable<JsValue>
 
         public override ulong GetSmallestIndex(ulong length) => 0;
 
-        public override uint GetLength() => (uint) _target.Length;
-
-        public override ulong GetLongLength() => GetLength();
+        public override ulong GetLongLength() => (ulong) _target.Length;
 
         public override void SetLength(ulong length) => throw new NotSupportedException();
 
@@ -533,8 +540,6 @@ internal abstract class ArrayOperations : IEnumerable<JsValue>
         public override ObjectInstance Target => _target;
 
         public override ulong GetSmallestIndex(ulong length) => 0;
-
-        public override uint GetLength() => _length;
 
         public override ulong GetLongLength() => _length;
 
@@ -607,9 +612,7 @@ internal abstract class ArrayOperations : IEnumerable<JsValue>
 
         public override ulong GetSmallestIndex(ulong length) => 0;
 
-        public override uint GetLength() => (uint) _collection.Count;
-
-        public override ulong GetLongLength() => GetLength();
+        public override ulong GetLongLength() => (ulong) _collection.Count;
 
         public override void SetLength(ulong length)
         {
@@ -697,8 +700,6 @@ internal abstract class ArrayOperations : IEnumerable<JsValue>
 
         public override ulong GetSmallestIndex(ulong length) => 0;
 
-        public override uint GetLength() => _target.Length;
-
         public override ulong GetLongLength() => _target.Length;
 
         public override void SetLength(ulong length) => _target.Set(CommonProperties.Length, length, true);
@@ -758,9 +759,7 @@ internal abstract class ArrayOperations : IEnumerable<JsValue>
 
         public override ulong GetSmallestIndex(ulong length) => 0;
 
-        public override uint GetLength() => (uint) _target.Length;
-
-        public override ulong GetLongLength() => GetLength();
+        public override ulong GetLongLength() => (ulong) _target.Length;
 
         public override void SetLength(ulong length)
         {

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -498,7 +498,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
         var initialValue = arguments.At(1);
 
         var o = ArrayOperations.For(_realm, thisObject, forWrite: true);
-        var len = o.GetLength();
+        var len = o.GetLongLength();
 
         var callable = GetCallable(callbackfn);
 
@@ -507,7 +507,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
             Throw.TypeError(_realm, "Reduce of empty array with no initial value");
         }
 
-        var k = 0;
+        ulong k = 0;
         JsValue accumulator = Undefined;
         if (arguments.Length > 1)
         {
@@ -523,7 +523,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
                     _engine.Constraints.Check();
                 }
 
-                if (kPresent = o.TryGetValue((uint) k, out var temp))
+                if (kPresent = o.TryGetValue(k, out var temp))
                 {
                     accumulator = temp;
                 }
@@ -545,7 +545,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
                 _engine.Constraints.Check();
             }
 
-            var i = (uint) k;
+            var i = k;
             if (o.TryGetValue(i, out var kvalue))
             {
                 accumulator = invoker.Call(Undefined, accumulator, kvalue, i);
@@ -573,16 +573,16 @@ public sealed partial class ArrayPrototype : ArrayInstance
         var thisArg = arguments.At(1);
 
         var o = ArrayOperations.For(_realm, thisObject, forWrite: false);
-        var len = o.GetLength();
+        var len = o.GetLongLength();
 
         var callable = GetCallable(callbackfn);
 
         var a = _realm.Intrinsics.Array.ArraySpeciesCreate(TypeConverter.ToObject(_realm, thisObject), 0);
         var operations = ArrayOperations.For(a, forWrite: true);
 
-        uint to = 0;
+        ulong to = 0;
         var invoker = CallbackInvoker.Rent(_engine, callable, 3, o.Target);
-        for (uint k = 0; k < len; k++)
+        for (ulong k = 0; k < len; k++)
         {
             if (k > 0 && k % ConstraintCheckInterval == 0)
             {
@@ -666,7 +666,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
     private JsValue Flat(JsValue thisObject, JsValue arg0)
     {
         var operations = ArrayOperations.For(_realm, thisObject, forWrite: false);
-        var sourceLen = operations.GetLength();
+        var sourceLen = operations.GetLongLength();
         double depthNum = 1;
         var depth = arg0;
         if (!depth.IsUndefined())
@@ -711,7 +711,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
         var mapperFunction = arg0;
         var thisArg = arg1;
 
-        var sourceLen = O.GetLength();
+        var sourceLen = O.GetLongLength();
 
         if (!mapperFunction.IsCallable)
         {
@@ -744,7 +744,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
     private ulong FlattenIntoArray(
         ObjectInstance target,
         ArrayOperations source,
-        uint sourceLen,
+        ulong sourceLen,
         ulong start,
         double depth,
         ICallable? mapperFunction = null,
@@ -819,7 +819,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
     private void FlattenIntoArrayDense(
         ref JsValueListBuilder builder,
         ArrayOperations source,
-        uint sourceLen,
+        ulong sourceLen,
         double depth,
         ICallable? mapperFunction = null,
         JsValue? thisArg = null)
@@ -886,12 +886,12 @@ public sealed partial class ArrayPrototype : ArrayInstance
         var thisArg = arg1;
 
         var o = ArrayOperations.For(_realm, thisObject, forWrite: false);
-        var len = o.GetLength();
+        var len = o.GetLongLength();
 
         var callable = GetCallable(callbackfn);
 
         var invoker = CallbackInvoker.Rent(_engine, callable, 3, o.Target);
-        for (uint k = 0; k < len; k++)
+        for (ulong k = 0; k < len; k++)
         {
             if (k > 0 && k % ConstraintCheckInterval == 0)
             {
@@ -1490,14 +1490,14 @@ public sealed partial class ArrayPrototype : ArrayInstance
         var obj = ArrayOperations.For(_realm, thisObject, forWrite: true);
         var compareFn = GetCompareFunction(arg0);
 
-        var len = obj.GetLength();
+        var len = obj.GetLongLength();
         if (len <= 1)
         {
             return obj.Target;
         }
 
         // capacity capped to a sane upper bound so a 1e9-length sparse array doesn't preallocate everything
-        var items = new List<JsValue>((int) System.Math.Min(1024, len));
+        var items = new List<JsValue>((int) System.Math.Min(1024UL, len));
         for (ulong k = 0; k < len; ++k)
         {
             if (k > 0 && k % ConstraintCheckInterval == 0)
@@ -1713,7 +1713,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
     private JsValue Shift(JsValue thisObject)
     {
         var o = ArrayOperations.For(_realm, thisObject, forWrite: true);
-        var len = o.GetLength();
+        var len = o.GetLongLength();
         if (len == 0)
         {
             o.SetLength(0);
@@ -1724,15 +1724,18 @@ public sealed partial class ArrayPrototype : ArrayInstance
         // replaces O(n) per-element Set/HasProperty calls.
         if (o.Target is JsArray jsArr && jsArr._dense is { } dense && jsArr.CanUseFastAccess)
         {
-            var first = (len <= (uint) dense.Length ? dense[0] : null) ?? Undefined;
-            jsArr.TryMoveDenseRange(sourceIndex: 1, destIndex: 0, count: len - 1);
-            jsArr.ClearDenseRange(len - 1, 1);
-            jsArr.SetLength((ulong) (len - 1));
+            // An array exotic object caps its own "length" at 2^32-1, so LengthOfArrayLike of one is
+            // always an index. The narrowing is safe inside this guard and nowhere outside it.
+            var indexLen = (uint) len;
+            var first = (indexLen <= (uint) dense.Length ? dense[0] : null) ?? Undefined;
+            jsArr.TryMoveDenseRange(sourceIndex: 1, destIndex: 0, count: indexLen - 1);
+            jsArr.ClearDenseRange(indexLen - 1, 1);
+            jsArr.SetLength((ulong) (indexLen - 1));
             return first;
         }
 
         var firstSlow = o.Get(0);
-        for (uint k = 1; k < len; k++)
+        for (ulong k = 1; k < len; k++)
         {
             if (k % ConstraintCheckInterval == 0)
             {
@@ -1835,7 +1838,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
     {
         var separator = arg0;
         var o = ArrayOperations.For(_realm, thisObject, forWrite: false);
-        var len = o.GetLength();
+        var len = o.GetLongLength();
 
         var sep = TypeConverter.ToString(separator.IsUndefined() ? JsString.CommaString : separator);
 
@@ -1877,7 +1880,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
             var separatorLength = sep.Length;
             var singleCharSeparator = separatorLength == 1 ? sep[0] : '\0';
 
-            for (uint k = 1; k < len; k++)
+            for (ulong k = 1; k < len; k++)
             {
                 if (k % ConstraintCheckInterval == 0)
                 {
@@ -1919,7 +1922,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
         const string Separator = ",";
 
         var array = ArrayOperations.For(_realm, thisObject, forWrite: false);
-        var len = array.GetLength();
+        var len = array.GetLongLength();
         if (len == 0)
         {
             return JsString.Empty;
@@ -1940,7 +1943,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
         try
         {
             using var r = new ValueStringBuilder();
-            for (uint k = 0; k < len; k++)
+            for (ulong k = 0; k < len; k++)
             {
                 if (k > 0)
                 {

--- a/Jint/Native/String/StringConstructor.cs
+++ b/Jint/Native/String/StringConstructor.cs
@@ -143,15 +143,15 @@ rangeError:
         var cooked = TypeConverter.ToObject(_realm, arguments.At(0));
         var raw = cooked.Get(JintTaggedTemplateExpression.PropertyRaw);
         var operations = ArrayOperations.For(_realm, raw, forWrite: false);
-        var length = operations.GetLength();
+        var length = operations.GetLongLength();
 
-        if (length <= 0)
+        if (length == 0)
         {
             return JsString.Empty;
         }
 
         using var result = new ValueStringBuilder();
-        for (var i = 0; i < length; i++)
+        for (ulong i = 0; i < length; i++)
         {
             // Check constraints periodically so a huge raw.length cannot run uninterrupted.
             if (i > 0)
@@ -161,15 +161,15 @@ rangeError:
                     _engine.Constraints.Check();
                 }
 
-                if (i < arguments.Length && !arguments[i].IsUndefined())
+                if (i < (ulong) arguments.Length && !arguments[(int) i].IsUndefined())
                 {
-                    var substitution = TypeConverter.ToString(arguments[i]);
+                    var substitution = TypeConverter.ToString(arguments[(int) i]);
                     JsString.ThrowIfLengthExceeded(_realm, (long) result.Length + substitution.Length);
                     result.Append(substitution);
                 }
             }
 
-            var segment = TypeConverter.ToString(operations.Get((ulong) i));
+            var segment = TypeConverter.ToString(operations.Get(i));
             JsString.ThrowIfLengthExceeded(_realm, (long) result.Length + segment.Length);
             result.Append(segment);
         }

--- a/Jint/Native/TypedArray/IntrinsicTypedArrayPrototype.cs
+++ b/Jint/Native/TypedArray/IntrinsicTypedArrayPrototype.cs
@@ -1070,7 +1070,7 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
         }
         else
         {
-            SetTypedArrayFromArrayLike(target, (int) targetOffset, source);
+            SetTypedArrayFromArrayLike(target, targetOffset, source);
         }
 
         return Undefined;
@@ -1172,7 +1172,7 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-settypedarrayfromarraylike
     /// </summary>
-    private void SetTypedArrayFromArrayLike(JsTypedArray target, int targetOffset, JsValue source)
+    private void SetTypedArrayFromArrayLike(JsTypedArray target, double targetOffset, JsValue source)
     {
         var targetBuffer = target._viewedArrayBuffer;
         targetBuffer.AssertNotDetached();
@@ -1185,20 +1185,30 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
 
         var targetLength = targetRecord.TypedArrayLength;
         var src = ArrayOperations.For(_realm, source, forWrite: false);
-        var srcLength = src.GetLength();
+        var srcLength = src.GetLongLength();
 
-        if (double.IsNegativeInfinity(targetOffset))
+        // Step 6. The offset stays a Number all the way here, as the specification writes it: it used to be
+        // narrowed with an unguarded (int) cast at the call site, which saturates on .NET and is unspecified
+        // on .NET Framework -- ta.set([1], 1e20) reached step 7 with int.MinValue there and wrote at a
+        // negative index instead of raising the RangeError.
+        if (double.IsPositiveInfinity(targetOffset))
         {
             Throw.RangeError(_realm, "offset is out of bounds");
         }
 
+        // Step 7. Both operands are exact as doubles (srcLength is at most 2^53-1 and targetOffset is a
+        // non-negative integral Number), so this is the specified comparison and it cannot wrap.
         if (srcLength + targetOffset > targetLength)
         {
             Throw.RangeError(_realm, "offset is out of bounds");
         }
 
+        // Past step 7 both quantities are bounded by targetLength, which is a typed array length.
+        var offset = (int) targetOffset;
+        var count = (int) srcLength;
+
         var k = 0;
-        while (k < srcLength)
+        while (k < count)
         {
             if (k > 0 && k % ConstraintCheckInterval == 0)
             {
@@ -1206,7 +1216,7 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
             }
 
             var jsValue = src.Get((ulong) k);
-            target.IntegerIndexedElementSet(targetOffset + k, jsValue);
+            target.IntegerIndexedElementSet(offset + k, jsValue);
             k++;
         }
     }


### PR DESCRIPTION
Backport of #3248 (issue #3235) to `4.x` for **4.16.2**, alongside the already-merged #3318.

## The defect is live on `4.x`, and the two target frameworks disagree

`ArrayOperations` carries the array-like length in two widths, and only the `ulong` one clamps. `ObjectOperations.GetLength()` casts `ToInteger(Get(O, "length"))` straight to `uint` — still, unchanged, on `4.x` at `a717f4ba3`:

```csharp
public override uint GetLength()
{
    var integerLength = GetIntegerLength();
    return (uint) (integerLength >= 0 ? integerLength : 0);
}
```

An out-of-range double-to-integer conversion **saturates on .NET but is *unspecified* on .NET Framework**, where it keeps the low 32 bits — the same hazard `TypeConverter.ToIntegerOrInfinity` already carries a note about. So a `length` of 2^53 reads as `4294967295` on net10.0 and as **0** on net472, from the same script on a default `new Engine()`. 2^53-1 agrees only by luck, because its low 32 bits happen to be `0xFFFFFFFF`.

Measured on the parent commit with the test file this PR adds:

| | `ArrayLikeLengthClampTests` |
| --- | --- |
| **`4.x` before, net10.0** | 10 of 59 rows fail |
| **`4.x` before, net472** | **36 of the same 59** fail |
| **`4.x` after, both** | 0 fail |

The target framework, not the script, was deciding the answer. [LengthOfArrayLike](https://tc39.es/ecma262/#sec-lengthofarraylike) is *ToLength(Get(O, "length"))*, and [ToLength](https://tc39.es/ecma262/#sec-tolength) clamps into `[0, 2^53-1]` — it never truncates and never wraps.

## Why the overload is deleted rather than clamped

Clamping the cast would make the two frameworks agree while leaving a signature that still cannot express what it returns: `MaxArrayLikeLength` is 2^53-1 and a `uint` tops out four million times lower. `ObjectOperations` was the only subclass whose length could exceed the index range — for the other seven, `GetLength()` and `GetLongLength()` returned literally the same number — and every one of the seventeen callers implements a step spelled *LengthOfArrayLike*. There was nothing for the narrower method to be right about.

Two consequences a script sees immediately rather than after four billion iterations: `Array.from` raises *ArrayCreate*'s `RangeError` for a length above 2^32-1 instead of allocating a 4294967295-length array, and `%TypedArray%.prototype.set`'s *offset* — which had the identical defect two lines away — stops silently doing nothing on net472, where `(int) 1e20` is `int.MinValue` and passed step 7.

## Eligibility under the branch policy

`4.x` takes *"correctness and conformance fixes backported from `main`, and nothing that changes an existing API or an existing default."* `ArrayOperations` is an `internal abstract class`, so no public API moves, and no default changes. This is the only other commit in `e73c0ab92..main` that qualifies.

## The one conflict is ordering, not content

#3263 (the empty rest of an exhausted array) landed on `4.x` **before** this and on `main` **after** it, so `DestructuringPatternAssignmentExpression` needs both changes: this commit's `var length = (uint) Math.Min(GetLongLength(), MaxArrayLength)` *and* the `restLength` clamp already on the branch. The resolved region is byte-identical to `main`.

So are eight of the nine files. The ninth, `ArrayOperations.cs`, differs only by `4.x`'s deliberate absence of the projected-CLR-write containment the 5.x security stack (#3054, #3072) added — verified by diffing against `upstream/main` after the pick.

## Verification

- `Jint.Tests`: **0 failed** — 6,833 passed on net10.0, 6,748 on net472.
- test262: **0 failed / 102,495 passed**, which is what an array-generic change owes.
- Both legs run, because the whole point is that they used to disagree.
