### PR TITLE
Intl: a host that changes one locale datum overrides one member, not twenty-three

### DIFF
--- a/Jint.Tests.PublicInterface/HostLocaleProviderTests.cs
+++ b/Jint.Tests.PublicInterface/HostLocaleProviderTests.cs
@@ -1,0 +1,191 @@
+#nullable enable
+
+using System.Numerics;
+using Jint.Native.Intl;
+using Jint.Native.Temporal;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// The three shipped locale-data providers are extension points, not fixed implementations: a host that
+/// disagrees with one datum derives from the default and overrides the one member that answers for it.
+/// Every test here overrides exactly one member and delegates nothing — what the rest of the interface
+/// answers has to come from the inherited implementation, or the extension point is not worth having.
+/// </summary>
+public class HostLocaleProviderTests
+{
+    [Fact]
+    public void OverridingOneCldrDatumLeavesTheOtherTwentyTwoMembersInherited()
+    {
+        var engine = new Engine(options => options.Intl.CldrProvider = new OneCurrencyName());
+
+        // the one overridden member
+        engine.Evaluate("new Intl.DisplayNames('en', { type: 'currency' }).of('EUR')")
+            .AsString().Should().Be("Space Credits");
+
+        // …and every other member still answers, without the subclass forwarding anything
+        engine.Evaluate("new Intl.DisplayNames('en', { type: 'currency' }).of('USD')")
+            .AsString().Should().Be("US Dollar");
+        engine.Evaluate("new Intl.ListFormat('en').format(['a', 'b'])")
+            .AsString().Should().Be("a and b");
+        engine.Evaluate("new Intl.NumberFormat('en', { style: 'unit', unit: 'meter' }).format(5)")
+            .AsString().Should().Be("5 m");
+        engine.Evaluate("new Intl.RelativeTimeFormat('en').format(3, 'day')")
+            .AsString().Should().Be("in 3 days");
+        engine.Evaluate("Intl.supportedValuesOf('unit').length").AsNumber().Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public void OverridingOneListPatternLeavesTheRestOfTheCldrDataInherited()
+    {
+        var engine = new Engine(options => options.Intl.CldrProvider = new GermanLists());
+
+        engine.Evaluate("new Intl.ListFormat('en').format(['a', 'b'])").AsString().Should().Be("a und b");
+        engine.Evaluate("new Intl.ListFormat('en').format(['a', 'b', 'c'])").AsString().Should().Be("a, b und c");
+
+        // the currency names, unit patterns and supported-value lists are the base class's
+        engine.Evaluate("new Intl.DisplayNames('en', { type: 'currency' }).of('EUR')")
+            .AsString().Should().Be("Euro");
+        engine.Evaluate("new Intl.NumberFormat('en', { style: 'unit', unit: 'meter' }).format(5)")
+            .AsString().Should().Be("5 m");
+    }
+
+    [Fact]
+    public void OverridingOneTimeZoneDatumLeavesTheOtherEightMembersInherited()
+    {
+        var engine = new Engine(options => options.Temporal.TimeZoneProvider = new FixedDefaultZone());
+
+        // the one overridden member
+        engine.Evaluate("Temporal.Now.timeZoneId()").AsString().Should().Be("Pacific/Auckland");
+
+        // offsets, validity, canonicalization and the available list all come from the base class
+        engine.Evaluate("Temporal.Instant.from('2024-01-15T12:00:00Z').toZonedDateTimeISO('America/New_York').offset")
+            .AsString().Should().Be("-05:00");
+        engine.Evaluate("Temporal.Instant.from('2024-07-15T12:00:00Z').toZonedDateTimeISO('America/New_York').offset")
+            .AsString().Should().Be("-04:00");
+        engine.Evaluate("Temporal.ZonedDateTime.from('2024-01-15T12:00:00[UTC]').timeZoneId")
+            .AsString().Should().Be("UTC");
+    }
+
+    [Fact]
+    public void OverridingOneCalendarLeavesTheOtherTenInherited()
+    {
+        var engine = new Engine(options => options.Temporal.CalendarProvider = new ShiftedHebrewEra());
+
+        var stock = new Engine();
+        var stockHebrewYear = stock.Evaluate("Temporal.PlainDate.from('2024-03-05').withCalendar('hebrew').year").AsNumber();
+
+        // the one overridden member, on the one calendar it claims
+        engine.Evaluate("Temporal.PlainDate.from('2024-03-05').withCalendar('hebrew').year")
+            .AsNumber().Should().Be(stockHebrewYear + 1000);
+
+        // every other calendar still reads the inherited BCL-backed arithmetic
+        foreach (var calendar in new[] { "islamic-civil", "coptic", "persian", "indian" })
+        {
+            var script = $"Temporal.PlainDate.from('2024-03-05').withCalendar('{calendar}').toString()";
+            engine.Evaluate(script).AsString().Should().Be(stock.Evaluate(script).AsString());
+        }
+
+        // …and so does the other direction, which the subclass never mentions
+        engine.Evaluate("Temporal.PlainDate.from({ year: 1445, monthCode: 'M08', day: 25, calendar: 'islamic-civil' }).toString()")
+            .AsString().Should().Be(
+                stock.Evaluate("Temporal.PlainDate.from({ year: 1445, monthCode: 'M08', day: 25, calendar: 'islamic-civil' }).toString()").AsString());
+    }
+
+    [Fact]
+    public void AnEngineThatConfiguresNothingStillReadsTheSharedSingletons()
+    {
+        var options = new Options();
+
+        options.Intl.CldrProvider.Should().BeSameAs(DefaultCldrProvider.Instance);
+        options.Temporal.TimeZoneProvider.Should().BeSameAs(DefaultTimeZoneProvider.Instance);
+        options.Temporal.CalendarProvider.Should().BeSameAs(DefaultCalendarProvider.Instance);
+    }
+}
+
+/// <summary>One currency's display name; the other twenty-two members are inherited.</summary>
+file sealed class OneCurrencyName : DefaultCldrProvider
+{
+    public override string? GetCurrencyDisplayName(string locale, string code)
+        => string.Equals(code, "EUR", StringComparison.Ordinal) ? "Space Credits" : base.GetCurrencyDisplayName(locale, code);
+}
+
+/// <summary>One list-pattern set; the other twenty-two members are inherited.</summary>
+file sealed class GermanLists : DefaultCldrProvider
+{
+    public override ListPatterns? GetListPatterns(string locale, string type, string style)
+        => new ListPatterns { Start = "{0}, {1}", Middle = "{0}, {1}", End = "{0} und {1}", Two = "{0} und {1}" };
+}
+
+/// <summary>One time zone datum — the system default; the other eight members are inherited.</summary>
+file sealed class FixedDefaultZone : DefaultTimeZoneProvider
+{
+    public override string GetDefaultTimeZone() => "Pacific/Auckland";
+}
+
+/// <summary>One calendar's ISO-to-fields conversion; the other three members are inherited.</summary>
+file sealed class ShiftedHebrewEra : DefaultCalendarProvider
+{
+    public override CalendarFields IsoToCalendarFields(string calendar, int isoYear, int isoMonth, int isoDay)
+    {
+        var fields = base.IsoToCalendarFields(calendar, isoYear, isoMonth, isoDay);
+        return string.Equals(calendar, "hebrew", StringComparison.Ordinal)
+            ? fields with { Year = fields.Year + 1000 }
+            : fields;
+    }
+}
+
+/// <summary>
+/// Present only to be compiled: a host reaching a member the engine never consults still has to be able
+/// to override it, and the compiler is the only thing that checks that all twenty-three are virtual.
+/// </summary>
+file sealed class EveryCldrMemberOverridden : DefaultCldrProvider
+{
+    public override ListPatterns? GetListPatterns(string locale, string type, string style) => base.GetListPatterns(locale, type, style);
+    public override RelativeTimePatterns? GetRelativeTimePatterns(string locale, string unit, string style) => base.GetRelativeTimePatterns(locale, unit, style);
+    public override string? GetRelativeTimeSpecialPhrase(string locale, string unit, int value, bool past, string style) => base.GetRelativeTimeSpecialPhrase(locale, unit, value, past, style);
+    public override string? GetNumberingSystemDigits(string numberingSystem) => base.GetNumberingSystemDigits(numberingSystem);
+    public override string? GetDefaultNumberingSystem(string locale) => base.GetDefaultNumberingSystem(locale);
+    public override CompactPatterns? GetCompactPatterns(string locale, string style) => base.GetCompactPatterns(locale, style);
+    public override CurrencyData? GetCurrencyData(string locale, string currencyCode) => base.GetCurrencyData(locale, currencyCode);
+    public override UnitPatterns? GetUnitPatterns(string locale, string unit, string style) => base.GetUnitPatterns(locale, unit, style);
+    public override DateTimePatterns? GetDateTimePatterns(string locale, string? dateStyle, string? timeStyle) => base.GetDateTimePatterns(locale, dateStyle, timeStyle);
+    public override string[]? GetMonthNames(string locale, string style, string? calendar) => base.GetMonthNames(locale, style, calendar);
+    public override string[]? GetWeekdayNames(string locale, string style) => base.GetWeekdayNames(locale, style);
+    public override string[]? GetDayPeriods(string locale, string style, string? calendar) => base.GetDayPeriods(locale, style, calendar);
+    public override string[]? GetEraNames(string locale, string style, string? calendar) => base.GetEraNames(locale, style, calendar);
+    public override string? GetCurrencyDisplayName(string locale, string code) => base.GetCurrencyDisplayName(locale, code);
+    public override string? GetLikelySubtags(string locale) => base.GetLikelySubtags(locale);
+    public override WeekInfo? GetWeekInfo(string locale) => base.GetWeekInfo(locale);
+    public override string SelectPluralCategory(string locale, double value, string type) => base.SelectPluralCategory(locale, value, type);
+    public override IReadOnlyCollection<string> GetSupportedCalendars() => base.GetSupportedCalendars();
+    public override IReadOnlyCollection<string> GetSupportedCollations() => base.GetSupportedCollations();
+    public override IReadOnlyCollection<string> GetSupportedCurrencies() => base.GetSupportedCurrencies();
+    public override IReadOnlyCollection<string> GetSupportedNumberingSystems() => base.GetSupportedNumberingSystems();
+    public override IReadOnlyCollection<string> GetSupportedTimeZones() => base.GetSupportedTimeZones();
+    public override IReadOnlyCollection<string> GetSupportedUnits() => base.GetSupportedUnits();
+}
+
+/// <summary>The same compile-time census for the nine time zone members.</summary>
+file sealed class EveryTimeZoneMemberOverridden : DefaultTimeZoneProvider
+{
+    public override long GetOffsetNanosecondsFor(string timeZoneId, BigInteger epochNanoseconds) => base.GetOffsetNanosecondsFor(timeZoneId, epochNanoseconds);
+    public override BigInteger[] GetPossibleInstantsFor(string timeZoneId, int year, int month, int day, int hour, int minute, int second, int millisecond, int microsecond, int nanosecond)
+        => base.GetPossibleInstantsFor(timeZoneId, year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
+    public override BigInteger? GetNextTransition(string timeZoneId, BigInteger epochNanoseconds) => base.GetNextTransition(timeZoneId, epochNanoseconds);
+    public override BigInteger? GetPreviousTransition(string timeZoneId, BigInteger epochNanoseconds) => base.GetPreviousTransition(timeZoneId, epochNanoseconds);
+    public override bool IsValidTimeZone(string timeZoneId) => base.IsValidTimeZone(timeZoneId);
+    public override string? CanonicalizeTimeZone(string timeZoneId) => base.CanonicalizeTimeZone(timeZoneId);
+    public override IReadOnlyCollection<string> GetAvailableTimeZones() => base.GetAvailableTimeZones();
+    public override string GetDefaultTimeZone() => base.GetDefaultTimeZone();
+    public override string? GetPrimaryTimeZoneIdentifier(string timeZoneId) => base.GetPrimaryTimeZoneIdentifier(timeZoneId);
+}
+
+/// <summary>And for the four calendar members.</summary>
+file sealed class EveryCalendarMemberOverridden : DefaultCalendarProvider
+{
+    public override bool IsSupported(string calendar) => base.IsSupported(calendar);
+    public override IReadOnlyCollection<string> GetSupportedCalendars() => base.GetSupportedCalendars();
+    public override CalendarFields IsoToCalendarFields(string calendar, int isoYear, int isoMonth, int isoDay) => base.IsoToCalendarFields(calendar, isoYear, isoMonth, isoDay);
+    public override IsoDateFields? CalendarFieldsToIso(string calendar, int year, string? monthCode, int month, int day, string overflow) => base.CalendarFieldsToIso(calendar, year, monthCode, month, day, overflow);
+}

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
@@ -1328,32 +1328,33 @@ namespace Jint.Native.Intl
         public string? DateTimePattern { get; init; }
         public string? TimePattern { get; init; }
     }
-    public sealed class DefaultCldrProvider : Jint.Native.Intl.ICldrProvider
+    public class DefaultCldrProvider : Jint.Native.Intl.ICldrProvider
     {
         public static readonly Jint.Native.Intl.DefaultCldrProvider Instance;
-        public Jint.Native.Intl.CompactPatterns? GetCompactPatterns(string locale, string style) { }
-        public Jint.Native.Intl.CurrencyData? GetCurrencyData(string locale, string currencyCode) { }
-        public string? GetCurrencyDisplayName(string locale, string code) { }
-        public Jint.Native.Intl.DateTimePatterns? GetDateTimePatterns(string locale, string? dateStyle, string? timeStyle) { }
-        public string[]? GetDayPeriods(string locale, string style, string? calendar) { }
-        public string? GetDefaultNumberingSystem(string locale) { }
-        public string[]? GetEraNames(string locale, string style, string? calendar) { }
-        public string? GetLikelySubtags(string locale) { }
-        public Jint.Native.Intl.ListPatterns? GetListPatterns(string locale, string type, string style) { }
-        public string[]? GetMonthNames(string locale, string style, string? calendar) { }
-        public string? GetNumberingSystemDigits(string numberingSystem) { }
-        public Jint.Native.Intl.RelativeTimePatterns? GetRelativeTimePatterns(string locale, string unit, string style) { }
-        public string? GetRelativeTimeSpecialPhrase(string locale, string unit, int value, bool past, string style) { }
-        public System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCalendars() { }
-        public System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCollations() { }
-        public System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCurrencies() { }
-        public System.Collections.Generic.IReadOnlyCollection<string> GetSupportedNumberingSystems() { }
-        public System.Collections.Generic.IReadOnlyCollection<string> GetSupportedTimeZones() { }
-        public System.Collections.Generic.IReadOnlyCollection<string> GetSupportedUnits() { }
-        public Jint.Native.Intl.UnitPatterns? GetUnitPatterns(string locale, string unit, string style) { }
-        public Jint.Native.Intl.WeekInfo? GetWeekInfo(string locale) { }
-        public string[]? GetWeekdayNames(string locale, string style) { }
-        public string SelectPluralCategory(string locale, double value, string type) { }
+        protected DefaultCldrProvider() { }
+        public virtual Jint.Native.Intl.CompactPatterns? GetCompactPatterns(string locale, string style) { }
+        public virtual Jint.Native.Intl.CurrencyData? GetCurrencyData(string locale, string currencyCode) { }
+        public virtual string? GetCurrencyDisplayName(string locale, string code) { }
+        public virtual Jint.Native.Intl.DateTimePatterns? GetDateTimePatterns(string locale, string? dateStyle, string? timeStyle) { }
+        public virtual string[]? GetDayPeriods(string locale, string style, string? calendar) { }
+        public virtual string? GetDefaultNumberingSystem(string locale) { }
+        public virtual string[]? GetEraNames(string locale, string style, string? calendar) { }
+        public virtual string? GetLikelySubtags(string locale) { }
+        public virtual Jint.Native.Intl.ListPatterns? GetListPatterns(string locale, string type, string style) { }
+        public virtual string[]? GetMonthNames(string locale, string style, string? calendar) { }
+        public virtual string? GetNumberingSystemDigits(string numberingSystem) { }
+        public virtual Jint.Native.Intl.RelativeTimePatterns? GetRelativeTimePatterns(string locale, string unit, string style) { }
+        public virtual string? GetRelativeTimeSpecialPhrase(string locale, string unit, int value, bool past, string style) { }
+        public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCalendars() { }
+        public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCollations() { }
+        public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCurrencies() { }
+        public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedNumberingSystems() { }
+        public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedTimeZones() { }
+        public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedUnits() { }
+        public virtual Jint.Native.Intl.UnitPatterns? GetUnitPatterns(string locale, string unit, string style) { }
+        public virtual Jint.Native.Intl.WeekInfo? GetWeekInfo(string locale) { }
+        public virtual string[]? GetWeekdayNames(string locale, string style) { }
+        public virtual string SelectPluralCategory(string locale, double value, string type) { }
     }
     public interface ICldrProvider
     {
@@ -1665,27 +1666,28 @@ namespace Jint.Native.Temporal
         public int MonthsInYear { get; init; }
         public int Year { get; init; }
     }
-    public sealed class DefaultCalendarProvider : Jint.Native.Temporal.ICalendarProvider
+    public class DefaultCalendarProvider : Jint.Native.Temporal.ICalendarProvider
     {
         public static readonly Jint.Native.Temporal.DefaultCalendarProvider Instance;
-        public Jint.Native.Temporal.IsoDateFields? CalendarFieldsToIso(string calendar, int year, string? monthCode, int month, int day, string overflow) { }
-        public System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCalendars() { }
-        public bool IsSupported(string calendar) { }
-        public Jint.Native.Temporal.CalendarFields IsoToCalendarFields(string calendar, int isoYear, int isoMonth, int isoDay) { }
+        protected DefaultCalendarProvider() { }
+        public virtual Jint.Native.Temporal.IsoDateFields? CalendarFieldsToIso(string calendar, int year, string? monthCode, int month, int day, string overflow) { }
+        public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCalendars() { }
+        public virtual bool IsSupported(string calendar) { }
+        public virtual Jint.Native.Temporal.CalendarFields IsoToCalendarFields(string calendar, int isoYear, int isoMonth, int isoDay) { }
     }
-    public sealed class DefaultTimeZoneProvider : Jint.Native.Temporal.ITimeZoneProvider
+    public class DefaultTimeZoneProvider : Jint.Native.Temporal.ITimeZoneProvider
     {
         public DefaultTimeZoneProvider() { }
         public static Jint.Native.Temporal.DefaultTimeZoneProvider Instance { get; }
-        public string? CanonicalizeTimeZone(string timeZoneId) { }
-        public System.Collections.Generic.IReadOnlyCollection<string> GetAvailableTimeZones() { }
-        public string GetDefaultTimeZone() { }
-        public System.Numerics.BigInteger? GetNextTransition(string timeZoneId, System.Numerics.BigInteger epochNanoseconds) { }
-        public long GetOffsetNanosecondsFor(string timeZoneId, System.Numerics.BigInteger epochNanoseconds) { }
-        public System.Numerics.BigInteger[] GetPossibleInstantsFor(string timeZoneId, int year, int month, int day, int hour, int minute, int second, int millisecond, int microsecond, int nanosecond) { }
-        public System.Numerics.BigInteger? GetPreviousTransition(string timeZoneId, System.Numerics.BigInteger epochNanoseconds) { }
-        public string? GetPrimaryTimeZoneIdentifier(string timeZoneId) { }
-        public bool IsValidTimeZone(string timeZoneId) { }
+        public virtual string? CanonicalizeTimeZone(string timeZoneId) { }
+        public virtual System.Collections.Generic.IReadOnlyCollection<string> GetAvailableTimeZones() { }
+        public virtual string GetDefaultTimeZone() { }
+        public virtual System.Numerics.BigInteger? GetNextTransition(string timeZoneId, System.Numerics.BigInteger epochNanoseconds) { }
+        public virtual long GetOffsetNanosecondsFor(string timeZoneId, System.Numerics.BigInteger epochNanoseconds) { }
+        public virtual System.Numerics.BigInteger[] GetPossibleInstantsFor(string timeZoneId, int year, int month, int day, int hour, int minute, int second, int millisecond, int microsecond, int nanosecond) { }
+        public virtual System.Numerics.BigInteger? GetPreviousTransition(string timeZoneId, System.Numerics.BigInteger epochNanoseconds) { }
+        public virtual string? GetPrimaryTimeZoneIdentifier(string timeZoneId) { }
+        public virtual bool IsValidTimeZone(string timeZoneId) { }
     }
     public interface ICalendarProvider
     {

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net472.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net472.verified.txt
@@ -1179,32 +1179,33 @@ namespace Jint.Native.Intl
         public string? DateTimePattern { get; init; }
         public string? TimePattern { get; init; }
     }
-    public sealed class DefaultCldrProvider : Jint.Native.Intl.ICldrProvider
+    public class DefaultCldrProvider : Jint.Native.Intl.ICldrProvider
     {
         public static readonly Jint.Native.Intl.DefaultCldrProvider Instance;
-        public Jint.Native.Intl.CompactPatterns? GetCompactPatterns(string locale, string style) { }
-        public Jint.Native.Intl.CurrencyData? GetCurrencyData(string locale, string currencyCode) { }
-        public string? GetCurrencyDisplayName(string locale, string code) { }
-        public Jint.Native.Intl.DateTimePatterns? GetDateTimePatterns(string locale, string? dateStyle, string? timeStyle) { }
-        public string[]? GetDayPeriods(string locale, string style, string? calendar) { }
-        public string? GetDefaultNumberingSystem(string locale) { }
-        public string[]? GetEraNames(string locale, string style, string? calendar) { }
-        public string? GetLikelySubtags(string locale) { }
-        public Jint.Native.Intl.ListPatterns? GetListPatterns(string locale, string type, string style) { }
-        public string[]? GetMonthNames(string locale, string style, string? calendar) { }
-        public string? GetNumberingSystemDigits(string numberingSystem) { }
-        public Jint.Native.Intl.RelativeTimePatterns? GetRelativeTimePatterns(string locale, string unit, string style) { }
-        public string? GetRelativeTimeSpecialPhrase(string locale, string unit, int value, bool past, string style) { }
-        public System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCalendars() { }
-        public System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCollations() { }
-        public System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCurrencies() { }
-        public System.Collections.Generic.IReadOnlyCollection<string> GetSupportedNumberingSystems() { }
-        public System.Collections.Generic.IReadOnlyCollection<string> GetSupportedTimeZones() { }
-        public System.Collections.Generic.IReadOnlyCollection<string> GetSupportedUnits() { }
-        public Jint.Native.Intl.UnitPatterns? GetUnitPatterns(string locale, string unit, string style) { }
-        public Jint.Native.Intl.WeekInfo? GetWeekInfo(string locale) { }
-        public string[]? GetWeekdayNames(string locale, string style) { }
-        public string SelectPluralCategory(string locale, double value, string type) { }
+        protected DefaultCldrProvider() { }
+        public virtual Jint.Native.Intl.CompactPatterns? GetCompactPatterns(string locale, string style) { }
+        public virtual Jint.Native.Intl.CurrencyData? GetCurrencyData(string locale, string currencyCode) { }
+        public virtual string? GetCurrencyDisplayName(string locale, string code) { }
+        public virtual Jint.Native.Intl.DateTimePatterns? GetDateTimePatterns(string locale, string? dateStyle, string? timeStyle) { }
+        public virtual string[]? GetDayPeriods(string locale, string style, string? calendar) { }
+        public virtual string? GetDefaultNumberingSystem(string locale) { }
+        public virtual string[]? GetEraNames(string locale, string style, string? calendar) { }
+        public virtual string? GetLikelySubtags(string locale) { }
+        public virtual Jint.Native.Intl.ListPatterns? GetListPatterns(string locale, string type, string style) { }
+        public virtual string[]? GetMonthNames(string locale, string style, string? calendar) { }
+        public virtual string? GetNumberingSystemDigits(string numberingSystem) { }
+        public virtual Jint.Native.Intl.RelativeTimePatterns? GetRelativeTimePatterns(string locale, string unit, string style) { }
+        public virtual string? GetRelativeTimeSpecialPhrase(string locale, string unit, int value, bool past, string style) { }
+        public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCalendars() { }
+        public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCollations() { }
+        public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCurrencies() { }
+        public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedNumberingSystems() { }
+        public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedTimeZones() { }
+        public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedUnits() { }
+        public virtual Jint.Native.Intl.UnitPatterns? GetUnitPatterns(string locale, string unit, string style) { }
+        public virtual Jint.Native.Intl.WeekInfo? GetWeekInfo(string locale) { }
+        public virtual string[]? GetWeekdayNames(string locale, string style) { }
+        public virtual string SelectPluralCategory(string locale, double value, string type) { }
     }
     public interface ICldrProvider
     {
@@ -1515,27 +1516,28 @@ namespace Jint.Native.Temporal
         public int MonthsInYear { get; init; }
         public int Year { get; init; }
     }
-    public sealed class DefaultCalendarProvider : Jint.Native.Temporal.ICalendarProvider
+    public class DefaultCalendarProvider : Jint.Native.Temporal.ICalendarProvider
     {
         public static readonly Jint.Native.Temporal.DefaultCalendarProvider Instance;
-        public Jint.Native.Temporal.IsoDateFields? CalendarFieldsToIso(string calendar, int year, string? monthCode, int month, int day, string overflow) { }
-        public System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCalendars() { }
-        public bool IsSupported(string calendar) { }
-        public Jint.Native.Temporal.CalendarFields IsoToCalendarFields(string calendar, int isoYear, int isoMonth, int isoDay) { }
+        protected DefaultCalendarProvider() { }
+        public virtual Jint.Native.Temporal.IsoDateFields? CalendarFieldsToIso(string calendar, int year, string? monthCode, int month, int day, string overflow) { }
+        public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCalendars() { }
+        public virtual bool IsSupported(string calendar) { }
+        public virtual Jint.Native.Temporal.CalendarFields IsoToCalendarFields(string calendar, int isoYear, int isoMonth, int isoDay) { }
     }
-    public sealed class DefaultTimeZoneProvider : Jint.Native.Temporal.ITimeZoneProvider
+    public class DefaultTimeZoneProvider : Jint.Native.Temporal.ITimeZoneProvider
     {
         public DefaultTimeZoneProvider() { }
         public static Jint.Native.Temporal.DefaultTimeZoneProvider Instance { get; }
-        public string? CanonicalizeTimeZone(string timeZoneId) { }
-        public System.Collections.Generic.IReadOnlyCollection<string> GetAvailableTimeZones() { }
-        public string GetDefaultTimeZone() { }
-        public System.Numerics.BigInteger? GetNextTransition(string timeZoneId, System.Numerics.BigInteger epochNanoseconds) { }
-        public long GetOffsetNanosecondsFor(string timeZoneId, System.Numerics.BigInteger epochNanoseconds) { }
-        public System.Numerics.BigInteger[] GetPossibleInstantsFor(string timeZoneId, int year, int month, int day, int hour, int minute, int second, int millisecond, int microsecond, int nanosecond) { }
-        public System.Numerics.BigInteger? GetPreviousTransition(string timeZoneId, System.Numerics.BigInteger epochNanoseconds) { }
-        public string? GetPrimaryTimeZoneIdentifier(string timeZoneId) { }
-        public bool IsValidTimeZone(string timeZoneId) { }
+        public virtual string? CanonicalizeTimeZone(string timeZoneId) { }
+        public virtual System.Collections.Generic.IReadOnlyCollection<string> GetAvailableTimeZones() { }
+        public virtual string GetDefaultTimeZone() { }
+        public virtual System.Numerics.BigInteger? GetNextTransition(string timeZoneId, System.Numerics.BigInteger epochNanoseconds) { }
+        public virtual long GetOffsetNanosecondsFor(string timeZoneId, System.Numerics.BigInteger epochNanoseconds) { }
+        public virtual System.Numerics.BigInteger[] GetPossibleInstantsFor(string timeZoneId, int year, int month, int day, int hour, int minute, int second, int millisecond, int microsecond, int nanosecond) { }
+        public virtual System.Numerics.BigInteger? GetPreviousTransition(string timeZoneId, System.Numerics.BigInteger epochNanoseconds) { }
+        public virtual string? GetPrimaryTimeZoneIdentifier(string timeZoneId) { }
+        public virtual bool IsValidTimeZone(string timeZoneId) { }
     }
     public interface ICalendarProvider
     {

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
@@ -1328,32 +1328,33 @@ namespace Jint.Native.Intl
         public string? DateTimePattern { get; init; }
         public string? TimePattern { get; init; }
     }
-    public sealed class DefaultCldrProvider : Jint.Native.Intl.ICldrProvider
+    public class DefaultCldrProvider : Jint.Native.Intl.ICldrProvider
     {
         public static readonly Jint.Native.Intl.DefaultCldrProvider Instance;
-        public Jint.Native.Intl.CompactPatterns? GetCompactPatterns(string locale, string style) { }
-        public Jint.Native.Intl.CurrencyData? GetCurrencyData(string locale, string currencyCode) { }
-        public string? GetCurrencyDisplayName(string locale, string code) { }
-        public Jint.Native.Intl.DateTimePatterns? GetDateTimePatterns(string locale, string? dateStyle, string? timeStyle) { }
-        public string[]? GetDayPeriods(string locale, string style, string? calendar) { }
-        public string? GetDefaultNumberingSystem(string locale) { }
-        public string[]? GetEraNames(string locale, string style, string? calendar) { }
-        public string? GetLikelySubtags(string locale) { }
-        public Jint.Native.Intl.ListPatterns? GetListPatterns(string locale, string type, string style) { }
-        public string[]? GetMonthNames(string locale, string style, string? calendar) { }
-        public string? GetNumberingSystemDigits(string numberingSystem) { }
-        public Jint.Native.Intl.RelativeTimePatterns? GetRelativeTimePatterns(string locale, string unit, string style) { }
-        public string? GetRelativeTimeSpecialPhrase(string locale, string unit, int value, bool past, string style) { }
-        public System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCalendars() { }
-        public System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCollations() { }
-        public System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCurrencies() { }
-        public System.Collections.Generic.IReadOnlyCollection<string> GetSupportedNumberingSystems() { }
-        public System.Collections.Generic.IReadOnlyCollection<string> GetSupportedTimeZones() { }
-        public System.Collections.Generic.IReadOnlyCollection<string> GetSupportedUnits() { }
-        public Jint.Native.Intl.UnitPatterns? GetUnitPatterns(string locale, string unit, string style) { }
-        public Jint.Native.Intl.WeekInfo? GetWeekInfo(string locale) { }
-        public string[]? GetWeekdayNames(string locale, string style) { }
-        public string SelectPluralCategory(string locale, double value, string type) { }
+        protected DefaultCldrProvider() { }
+        public virtual Jint.Native.Intl.CompactPatterns? GetCompactPatterns(string locale, string style) { }
+        public virtual Jint.Native.Intl.CurrencyData? GetCurrencyData(string locale, string currencyCode) { }
+        public virtual string? GetCurrencyDisplayName(string locale, string code) { }
+        public virtual Jint.Native.Intl.DateTimePatterns? GetDateTimePatterns(string locale, string? dateStyle, string? timeStyle) { }
+        public virtual string[]? GetDayPeriods(string locale, string style, string? calendar) { }
+        public virtual string? GetDefaultNumberingSystem(string locale) { }
+        public virtual string[]? GetEraNames(string locale, string style, string? calendar) { }
+        public virtual string? GetLikelySubtags(string locale) { }
+        public virtual Jint.Native.Intl.ListPatterns? GetListPatterns(string locale, string type, string style) { }
+        public virtual string[]? GetMonthNames(string locale, string style, string? calendar) { }
+        public virtual string? GetNumberingSystemDigits(string numberingSystem) { }
+        public virtual Jint.Native.Intl.RelativeTimePatterns? GetRelativeTimePatterns(string locale, string unit, string style) { }
+        public virtual string? GetRelativeTimeSpecialPhrase(string locale, string unit, int value, bool past, string style) { }
+        public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCalendars() { }
+        public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCollations() { }
+        public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCurrencies() { }
+        public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedNumberingSystems() { }
+        public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedTimeZones() { }
+        public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedUnits() { }
+        public virtual Jint.Native.Intl.UnitPatterns? GetUnitPatterns(string locale, string unit, string style) { }
+        public virtual Jint.Native.Intl.WeekInfo? GetWeekInfo(string locale) { }
+        public virtual string[]? GetWeekdayNames(string locale, string style) { }
+        public virtual string SelectPluralCategory(string locale, double value, string type) { }
     }
     public interface ICldrProvider
     {
@@ -1665,27 +1666,28 @@ namespace Jint.Native.Temporal
         public int MonthsInYear { get; init; }
         public int Year { get; init; }
     }
-    public sealed class DefaultCalendarProvider : Jint.Native.Temporal.ICalendarProvider
+    public class DefaultCalendarProvider : Jint.Native.Temporal.ICalendarProvider
     {
         public static readonly Jint.Native.Temporal.DefaultCalendarProvider Instance;
-        public Jint.Native.Temporal.IsoDateFields? CalendarFieldsToIso(string calendar, int year, string? monthCode, int month, int day, string overflow) { }
-        public System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCalendars() { }
-        public bool IsSupported(string calendar) { }
-        public Jint.Native.Temporal.CalendarFields IsoToCalendarFields(string calendar, int isoYear, int isoMonth, int isoDay) { }
+        protected DefaultCalendarProvider() { }
+        public virtual Jint.Native.Temporal.IsoDateFields? CalendarFieldsToIso(string calendar, int year, string? monthCode, int month, int day, string overflow) { }
+        public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCalendars() { }
+        public virtual bool IsSupported(string calendar) { }
+        public virtual Jint.Native.Temporal.CalendarFields IsoToCalendarFields(string calendar, int isoYear, int isoMonth, int isoDay) { }
     }
-    public sealed class DefaultTimeZoneProvider : Jint.Native.Temporal.ITimeZoneProvider
+    public class DefaultTimeZoneProvider : Jint.Native.Temporal.ITimeZoneProvider
     {
         public DefaultTimeZoneProvider() { }
         public static Jint.Native.Temporal.DefaultTimeZoneProvider Instance { get; }
-        public string? CanonicalizeTimeZone(string timeZoneId) { }
-        public System.Collections.Generic.IReadOnlyCollection<string> GetAvailableTimeZones() { }
-        public string GetDefaultTimeZone() { }
-        public System.Numerics.BigInteger? GetNextTransition(string timeZoneId, System.Numerics.BigInteger epochNanoseconds) { }
-        public long GetOffsetNanosecondsFor(string timeZoneId, System.Numerics.BigInteger epochNanoseconds) { }
-        public System.Numerics.BigInteger[] GetPossibleInstantsFor(string timeZoneId, int year, int month, int day, int hour, int minute, int second, int millisecond, int microsecond, int nanosecond) { }
-        public System.Numerics.BigInteger? GetPreviousTransition(string timeZoneId, System.Numerics.BigInteger epochNanoseconds) { }
-        public string? GetPrimaryTimeZoneIdentifier(string timeZoneId) { }
-        public bool IsValidTimeZone(string timeZoneId) { }
+        public virtual string? CanonicalizeTimeZone(string timeZoneId) { }
+        public virtual System.Collections.Generic.IReadOnlyCollection<string> GetAvailableTimeZones() { }
+        public virtual string GetDefaultTimeZone() { }
+        public virtual System.Numerics.BigInteger? GetNextTransition(string timeZoneId, System.Numerics.BigInteger epochNanoseconds) { }
+        public virtual long GetOffsetNanosecondsFor(string timeZoneId, System.Numerics.BigInteger epochNanoseconds) { }
+        public virtual System.Numerics.BigInteger[] GetPossibleInstantsFor(string timeZoneId, int year, int month, int day, int hour, int minute, int second, int millisecond, int microsecond, int nanosecond) { }
+        public virtual System.Numerics.BigInteger? GetPreviousTransition(string timeZoneId, System.Numerics.BigInteger epochNanoseconds) { }
+        public virtual string? GetPrimaryTimeZoneIdentifier(string timeZoneId) { }
+        public virtual bool IsValidTimeZone(string timeZoneId) { }
     }
     public interface ICalendarProvider
     {

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.0.verified.txt
@@ -1179,32 +1179,33 @@ namespace Jint.Native.Intl
         public string? DateTimePattern { get; init; }
         public string? TimePattern { get; init; }
     }
-    public sealed class DefaultCldrProvider : Jint.Native.Intl.ICldrProvider
+    public class DefaultCldrProvider : Jint.Native.Intl.ICldrProvider
     {
         public static readonly Jint.Native.Intl.DefaultCldrProvider Instance;
-        public Jint.Native.Intl.CompactPatterns? GetCompactPatterns(string locale, string style) { }
-        public Jint.Native.Intl.CurrencyData? GetCurrencyData(string locale, string currencyCode) { }
-        public string? GetCurrencyDisplayName(string locale, string code) { }
-        public Jint.Native.Intl.DateTimePatterns? GetDateTimePatterns(string locale, string? dateStyle, string? timeStyle) { }
-        public string[]? GetDayPeriods(string locale, string style, string? calendar) { }
-        public string? GetDefaultNumberingSystem(string locale) { }
-        public string[]? GetEraNames(string locale, string style, string? calendar) { }
-        public string? GetLikelySubtags(string locale) { }
-        public Jint.Native.Intl.ListPatterns? GetListPatterns(string locale, string type, string style) { }
-        public string[]? GetMonthNames(string locale, string style, string? calendar) { }
-        public string? GetNumberingSystemDigits(string numberingSystem) { }
-        public Jint.Native.Intl.RelativeTimePatterns? GetRelativeTimePatterns(string locale, string unit, string style) { }
-        public string? GetRelativeTimeSpecialPhrase(string locale, string unit, int value, bool past, string style) { }
-        public System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCalendars() { }
-        public System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCollations() { }
-        public System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCurrencies() { }
-        public System.Collections.Generic.IReadOnlyCollection<string> GetSupportedNumberingSystems() { }
-        public System.Collections.Generic.IReadOnlyCollection<string> GetSupportedTimeZones() { }
-        public System.Collections.Generic.IReadOnlyCollection<string> GetSupportedUnits() { }
-        public Jint.Native.Intl.UnitPatterns? GetUnitPatterns(string locale, string unit, string style) { }
-        public Jint.Native.Intl.WeekInfo? GetWeekInfo(string locale) { }
-        public string[]? GetWeekdayNames(string locale, string style) { }
-        public string SelectPluralCategory(string locale, double value, string type) { }
+        protected DefaultCldrProvider() { }
+        public virtual Jint.Native.Intl.CompactPatterns? GetCompactPatterns(string locale, string style) { }
+        public virtual Jint.Native.Intl.CurrencyData? GetCurrencyData(string locale, string currencyCode) { }
+        public virtual string? GetCurrencyDisplayName(string locale, string code) { }
+        public virtual Jint.Native.Intl.DateTimePatterns? GetDateTimePatterns(string locale, string? dateStyle, string? timeStyle) { }
+        public virtual string[]? GetDayPeriods(string locale, string style, string? calendar) { }
+        public virtual string? GetDefaultNumberingSystem(string locale) { }
+        public virtual string[]? GetEraNames(string locale, string style, string? calendar) { }
+        public virtual string? GetLikelySubtags(string locale) { }
+        public virtual Jint.Native.Intl.ListPatterns? GetListPatterns(string locale, string type, string style) { }
+        public virtual string[]? GetMonthNames(string locale, string style, string? calendar) { }
+        public virtual string? GetNumberingSystemDigits(string numberingSystem) { }
+        public virtual Jint.Native.Intl.RelativeTimePatterns? GetRelativeTimePatterns(string locale, string unit, string style) { }
+        public virtual string? GetRelativeTimeSpecialPhrase(string locale, string unit, int value, bool past, string style) { }
+        public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCalendars() { }
+        public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCollations() { }
+        public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCurrencies() { }
+        public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedNumberingSystems() { }
+        public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedTimeZones() { }
+        public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedUnits() { }
+        public virtual Jint.Native.Intl.UnitPatterns? GetUnitPatterns(string locale, string unit, string style) { }
+        public virtual Jint.Native.Intl.WeekInfo? GetWeekInfo(string locale) { }
+        public virtual string[]? GetWeekdayNames(string locale, string style) { }
+        public virtual string SelectPluralCategory(string locale, double value, string type) { }
     }
     public interface ICldrProvider
     {
@@ -1515,27 +1516,28 @@ namespace Jint.Native.Temporal
         public int MonthsInYear { get; init; }
         public int Year { get; init; }
     }
-    public sealed class DefaultCalendarProvider : Jint.Native.Temporal.ICalendarProvider
+    public class DefaultCalendarProvider : Jint.Native.Temporal.ICalendarProvider
     {
         public static readonly Jint.Native.Temporal.DefaultCalendarProvider Instance;
-        public Jint.Native.Temporal.IsoDateFields? CalendarFieldsToIso(string calendar, int year, string? monthCode, int month, int day, string overflow) { }
-        public System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCalendars() { }
-        public bool IsSupported(string calendar) { }
-        public Jint.Native.Temporal.CalendarFields IsoToCalendarFields(string calendar, int isoYear, int isoMonth, int isoDay) { }
+        protected DefaultCalendarProvider() { }
+        public virtual Jint.Native.Temporal.IsoDateFields? CalendarFieldsToIso(string calendar, int year, string? monthCode, int month, int day, string overflow) { }
+        public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCalendars() { }
+        public virtual bool IsSupported(string calendar) { }
+        public virtual Jint.Native.Temporal.CalendarFields IsoToCalendarFields(string calendar, int isoYear, int isoMonth, int isoDay) { }
     }
-    public sealed class DefaultTimeZoneProvider : Jint.Native.Temporal.ITimeZoneProvider
+    public class DefaultTimeZoneProvider : Jint.Native.Temporal.ITimeZoneProvider
     {
         public DefaultTimeZoneProvider() { }
         public static Jint.Native.Temporal.DefaultTimeZoneProvider Instance { get; }
-        public string? CanonicalizeTimeZone(string timeZoneId) { }
-        public System.Collections.Generic.IReadOnlyCollection<string> GetAvailableTimeZones() { }
-        public string GetDefaultTimeZone() { }
-        public System.Numerics.BigInteger? GetNextTransition(string timeZoneId, System.Numerics.BigInteger epochNanoseconds) { }
-        public long GetOffsetNanosecondsFor(string timeZoneId, System.Numerics.BigInteger epochNanoseconds) { }
-        public System.Numerics.BigInteger[] GetPossibleInstantsFor(string timeZoneId, int year, int month, int day, int hour, int minute, int second, int millisecond, int microsecond, int nanosecond) { }
-        public System.Numerics.BigInteger? GetPreviousTransition(string timeZoneId, System.Numerics.BigInteger epochNanoseconds) { }
-        public string? GetPrimaryTimeZoneIdentifier(string timeZoneId) { }
-        public bool IsValidTimeZone(string timeZoneId) { }
+        public virtual string? CanonicalizeTimeZone(string timeZoneId) { }
+        public virtual System.Collections.Generic.IReadOnlyCollection<string> GetAvailableTimeZones() { }
+        public virtual string GetDefaultTimeZone() { }
+        public virtual System.Numerics.BigInteger? GetNextTransition(string timeZoneId, System.Numerics.BigInteger epochNanoseconds) { }
+        public virtual long GetOffsetNanosecondsFor(string timeZoneId, System.Numerics.BigInteger epochNanoseconds) { }
+        public virtual System.Numerics.BigInteger[] GetPossibleInstantsFor(string timeZoneId, int year, int month, int day, int hour, int minute, int second, int millisecond, int microsecond, int nanosecond) { }
+        public virtual System.Numerics.BigInteger? GetPreviousTransition(string timeZoneId, System.Numerics.BigInteger epochNanoseconds) { }
+        public virtual string? GetPrimaryTimeZoneIdentifier(string timeZoneId) { }
+        public virtual bool IsValidTimeZone(string timeZoneId) { }
     }
     public interface ICalendarProvider
     {

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.1.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.1.verified.txt
@@ -1179,32 +1179,33 @@ namespace Jint.Native.Intl
         public string? DateTimePattern { get; init; }
         public string? TimePattern { get; init; }
     }
-    public sealed class DefaultCldrProvider : Jint.Native.Intl.ICldrProvider
+    public class DefaultCldrProvider : Jint.Native.Intl.ICldrProvider
     {
         public static readonly Jint.Native.Intl.DefaultCldrProvider Instance;
-        public Jint.Native.Intl.CompactPatterns? GetCompactPatterns(string locale, string style) { }
-        public Jint.Native.Intl.CurrencyData? GetCurrencyData(string locale, string currencyCode) { }
-        public string? GetCurrencyDisplayName(string locale, string code) { }
-        public Jint.Native.Intl.DateTimePatterns? GetDateTimePatterns(string locale, string? dateStyle, string? timeStyle) { }
-        public string[]? GetDayPeriods(string locale, string style, string? calendar) { }
-        public string? GetDefaultNumberingSystem(string locale) { }
-        public string[]? GetEraNames(string locale, string style, string? calendar) { }
-        public string? GetLikelySubtags(string locale) { }
-        public Jint.Native.Intl.ListPatterns? GetListPatterns(string locale, string type, string style) { }
-        public string[]? GetMonthNames(string locale, string style, string? calendar) { }
-        public string? GetNumberingSystemDigits(string numberingSystem) { }
-        public Jint.Native.Intl.RelativeTimePatterns? GetRelativeTimePatterns(string locale, string unit, string style) { }
-        public string? GetRelativeTimeSpecialPhrase(string locale, string unit, int value, bool past, string style) { }
-        public System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCalendars() { }
-        public System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCollations() { }
-        public System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCurrencies() { }
-        public System.Collections.Generic.IReadOnlyCollection<string> GetSupportedNumberingSystems() { }
-        public System.Collections.Generic.IReadOnlyCollection<string> GetSupportedTimeZones() { }
-        public System.Collections.Generic.IReadOnlyCollection<string> GetSupportedUnits() { }
-        public Jint.Native.Intl.UnitPatterns? GetUnitPatterns(string locale, string unit, string style) { }
-        public Jint.Native.Intl.WeekInfo? GetWeekInfo(string locale) { }
-        public string[]? GetWeekdayNames(string locale, string style) { }
-        public string SelectPluralCategory(string locale, double value, string type) { }
+        protected DefaultCldrProvider() { }
+        public virtual Jint.Native.Intl.CompactPatterns? GetCompactPatterns(string locale, string style) { }
+        public virtual Jint.Native.Intl.CurrencyData? GetCurrencyData(string locale, string currencyCode) { }
+        public virtual string? GetCurrencyDisplayName(string locale, string code) { }
+        public virtual Jint.Native.Intl.DateTimePatterns? GetDateTimePatterns(string locale, string? dateStyle, string? timeStyle) { }
+        public virtual string[]? GetDayPeriods(string locale, string style, string? calendar) { }
+        public virtual string? GetDefaultNumberingSystem(string locale) { }
+        public virtual string[]? GetEraNames(string locale, string style, string? calendar) { }
+        public virtual string? GetLikelySubtags(string locale) { }
+        public virtual Jint.Native.Intl.ListPatterns? GetListPatterns(string locale, string type, string style) { }
+        public virtual string[]? GetMonthNames(string locale, string style, string? calendar) { }
+        public virtual string? GetNumberingSystemDigits(string numberingSystem) { }
+        public virtual Jint.Native.Intl.RelativeTimePatterns? GetRelativeTimePatterns(string locale, string unit, string style) { }
+        public virtual string? GetRelativeTimeSpecialPhrase(string locale, string unit, int value, bool past, string style) { }
+        public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCalendars() { }
+        public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCollations() { }
+        public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCurrencies() { }
+        public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedNumberingSystems() { }
+        public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedTimeZones() { }
+        public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedUnits() { }
+        public virtual Jint.Native.Intl.UnitPatterns? GetUnitPatterns(string locale, string unit, string style) { }
+        public virtual Jint.Native.Intl.WeekInfo? GetWeekInfo(string locale) { }
+        public virtual string[]? GetWeekdayNames(string locale, string style) { }
+        public virtual string SelectPluralCategory(string locale, double value, string type) { }
     }
     public interface ICldrProvider
     {
@@ -1515,27 +1516,28 @@ namespace Jint.Native.Temporal
         public int MonthsInYear { get; init; }
         public int Year { get; init; }
     }
-    public sealed class DefaultCalendarProvider : Jint.Native.Temporal.ICalendarProvider
+    public class DefaultCalendarProvider : Jint.Native.Temporal.ICalendarProvider
     {
         public static readonly Jint.Native.Temporal.DefaultCalendarProvider Instance;
-        public Jint.Native.Temporal.IsoDateFields? CalendarFieldsToIso(string calendar, int year, string? monthCode, int month, int day, string overflow) { }
-        public System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCalendars() { }
-        public bool IsSupported(string calendar) { }
-        public Jint.Native.Temporal.CalendarFields IsoToCalendarFields(string calendar, int isoYear, int isoMonth, int isoDay) { }
+        protected DefaultCalendarProvider() { }
+        public virtual Jint.Native.Temporal.IsoDateFields? CalendarFieldsToIso(string calendar, int year, string? monthCode, int month, int day, string overflow) { }
+        public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCalendars() { }
+        public virtual bool IsSupported(string calendar) { }
+        public virtual Jint.Native.Temporal.CalendarFields IsoToCalendarFields(string calendar, int isoYear, int isoMonth, int isoDay) { }
     }
-    public sealed class DefaultTimeZoneProvider : Jint.Native.Temporal.ITimeZoneProvider
+    public class DefaultTimeZoneProvider : Jint.Native.Temporal.ITimeZoneProvider
     {
         public DefaultTimeZoneProvider() { }
         public static Jint.Native.Temporal.DefaultTimeZoneProvider Instance { get; }
-        public string? CanonicalizeTimeZone(string timeZoneId) { }
-        public System.Collections.Generic.IReadOnlyCollection<string> GetAvailableTimeZones() { }
-        public string GetDefaultTimeZone() { }
-        public System.Numerics.BigInteger? GetNextTransition(string timeZoneId, System.Numerics.BigInteger epochNanoseconds) { }
-        public long GetOffsetNanosecondsFor(string timeZoneId, System.Numerics.BigInteger epochNanoseconds) { }
-        public System.Numerics.BigInteger[] GetPossibleInstantsFor(string timeZoneId, int year, int month, int day, int hour, int minute, int second, int millisecond, int microsecond, int nanosecond) { }
-        public System.Numerics.BigInteger? GetPreviousTransition(string timeZoneId, System.Numerics.BigInteger epochNanoseconds) { }
-        public string? GetPrimaryTimeZoneIdentifier(string timeZoneId) { }
-        public bool IsValidTimeZone(string timeZoneId) { }
+        public virtual string? CanonicalizeTimeZone(string timeZoneId) { }
+        public virtual System.Collections.Generic.IReadOnlyCollection<string> GetAvailableTimeZones() { }
+        public virtual string GetDefaultTimeZone() { }
+        public virtual System.Numerics.BigInteger? GetNextTransition(string timeZoneId, System.Numerics.BigInteger epochNanoseconds) { }
+        public virtual long GetOffsetNanosecondsFor(string timeZoneId, System.Numerics.BigInteger epochNanoseconds) { }
+        public virtual System.Numerics.BigInteger[] GetPossibleInstantsFor(string timeZoneId, int year, int month, int day, int hour, int minute, int second, int millisecond, int microsecond, int nanosecond) { }
+        public virtual System.Numerics.BigInteger? GetPreviousTransition(string timeZoneId, System.Numerics.BigInteger epochNanoseconds) { }
+        public virtual string? GetPrimaryTimeZoneIdentifier(string timeZoneId) { }
+        public virtual bool IsValidTimeZone(string timeZoneId) { }
     }
     public interface ICalendarProvider
     {

--- a/Jint/Native/Intl/DefaultCldrProvider.cs
+++ b/Jint/Native/Intl/DefaultCldrProvider.cs
@@ -6,10 +6,34 @@ using Jint.Native.Intl.Data;
 namespace Jint.Native.Intl;
 
 /// <summary>
-/// Default CLDR provider that uses embedded data files and hardcoded patterns.
-/// Supports basic en-US/en-GB with English fallback for other locales.
+/// The locale data an engine uses unless the host replaces it: embedded CLDR files, with an English fallback.
 /// </summary>
-public sealed class DefaultCldrProvider : ICldrProvider
+/// <remarks>
+/// <para>
+/// Every member is <c>virtual</c>, so changing one datum means deriving from this class and overriding
+/// that one member. The other twenty-two are inherited, and nothing has to be delegated by hand.
+/// </para>
+/// <para>
+/// Install the derived instance on <see cref="Options.IntlOptions.CldrProvider"/>; leaving that property
+/// alone keeps <see cref="Instance"/>, the shared singleton every unconfigured engine reads.
+/// </para>
+/// <para>
+/// Overriding a member is not the same as adding data the engine never asks for: ten of the twenty-three
+/// members have no caller inside Jint today, so overriding one of those changes nothing script can see.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// sealed class GermanLists : DefaultCldrProvider
+/// {
+///     public override ListPatterns? GetListPatterns(string locale, string type, string style)
+///         => new ListPatterns { Start = "{0}, {1}", Middle = "{0}, {1}", End = "{0} und {1}", Two = "{0} und {1}" };
+/// }
+///
+/// options.Intl.CldrProvider = new GermanLists();
+/// </code>
+/// </example>
+public class DefaultCldrProvider : ICldrProvider
 {
     /// <summary>
     /// Singleton instance of the default provider.
@@ -23,13 +47,16 @@ public sealed class DefaultCldrProvider : ICldrProvider
     private static readonly Lazy<string[]> _supportedCurrencies = new(BuildSupportedCurrencies);
     private static readonly Lazy<Dictionary<string, string>> _currencyDisplayNames = new(BuildCurrencyDisplayNames);
 
-    private DefaultCldrProvider()
+    /// <summary>
+    /// Initializes a new instance a derived provider builds on; hosts wanting the data itself read <see cref="Instance"/>.
+    /// </summary>
+    protected DefaultCldrProvider()
     {
     }
 
     // === List Patterns ===
 
-    public ListPatterns? GetListPatterns(string locale, string type, string style)
+    public virtual ListPatterns? GetListPatterns(string locale, string type, string style)
     {
         // Try embedded CLDR data first
         var localePatterns = ListPatternsData.GetPatternsForLocale(locale);
@@ -61,7 +88,7 @@ public sealed class DefaultCldrProvider : ICldrProvider
 
     // === Relative Time Patterns ===
 
-    public RelativeTimePatterns? GetRelativeTimePatterns(string locale, string unit, string style)
+    public virtual RelativeTimePatterns? GetRelativeTimePatterns(string locale, string unit, string style)
     {
         // Try embedded CLDR data first
         var localeData = RelativeTimePatternsData.GetDataForLocale(locale);
@@ -119,7 +146,7 @@ public sealed class DefaultCldrProvider : ICldrProvider
         };
     }
 
-    public string? GetRelativeTimeSpecialPhrase(string locale, string unit, int value, bool past, string style)
+    public virtual string? GetRelativeTimeSpecialPhrase(string locale, string unit, int value, bool past, string style)
     {
         // Only provide English phrases
         if (!IsEnglish(locale))
@@ -173,18 +200,18 @@ public sealed class DefaultCldrProvider : ICldrProvider
 
     // === Number Formatting ===
 
-    public string? GetNumberingSystemDigits(string numberingSystem)
+    public virtual string? GetNumberingSystemDigits(string numberingSystem)
     {
         return NumberingSystemData.Digits.TryGetValue(numberingSystem, out var digits) ? digits : null;
     }
 
-    public string? GetDefaultNumberingSystem(string locale)
+    public virtual string? GetDefaultNumberingSystem(string locale)
     {
         // Default provider has no per-locale CLDR data; caller falls back to "latn".
         return null;
     }
 
-    public CompactPatterns? GetCompactPatterns(string locale, string style)
+    public virtual CompactPatterns? GetCompactPatterns(string locale, string style)
     {
         // Use existing CompactPatterns data
         // The default provider returns English patterns only
@@ -224,7 +251,7 @@ public sealed class DefaultCldrProvider : ICldrProvider
         return null;
     }
 
-    public CurrencyData? GetCurrencyData(string locale, string currencyCode)
+    public virtual CurrencyData? GetCurrencyData(string locale, string currencyCode)
     {
         // Default provider returns basic currency data from .NET
         try
@@ -260,7 +287,7 @@ public sealed class DefaultCldrProvider : ICldrProvider
         }
     }
 
-    public UnitPatterns? GetUnitPatterns(string locale, string unit, string style)
+    public virtual UnitPatterns? GetUnitPatterns(string locale, string unit, string style)
     {
         // Try embedded CLDR data first
         var localePatterns = UnitPatternsData.GetPatternsForLocale(locale);
@@ -329,13 +356,13 @@ public sealed class DefaultCldrProvider : ICldrProvider
 
     // === Date/Time Formatting ===
 
-    public DateTimePatterns? GetDateTimePatterns(string locale, string? dateStyle, string? timeStyle)
+    public virtual DateTimePatterns? GetDateTimePatterns(string locale, string? dateStyle, string? timeStyle)
     {
         // Default provider delegates to .NET's DateTimeFormatInfo
         return null;
     }
 
-    public string[]? GetMonthNames(string locale, string style, string? calendar)
+    public virtual string[]? GetMonthNames(string locale, string style, string? calendar)
     {
         var cacheKey = string.Concat(locale, "_", style);
         return _monthNameCache.GetOrAdd(cacheKey, _ =>
@@ -356,7 +383,7 @@ public sealed class DefaultCldrProvider : ICldrProvider
         });
     }
 
-    public string[]? GetWeekdayNames(string locale, string style)
+    public virtual string[]? GetWeekdayNames(string locale, string style)
     {
         var cacheKey = string.Concat(locale, "_", style);
         return _weekdayNameCache.GetOrAdd(cacheKey, _ =>
@@ -377,7 +404,7 @@ public sealed class DefaultCldrProvider : ICldrProvider
         });
     }
 
-    public string[]? GetDayPeriods(string locale, string style, string? calendar)
+    public virtual string[]? GetDayPeriods(string locale, string style, string? calendar)
     {
         var cacheKey = string.Concat(locale, "_", style);
         return _dayPeriodCache.GetOrAdd(cacheKey, _ =>
@@ -392,7 +419,7 @@ public sealed class DefaultCldrProvider : ICldrProvider
         });
     }
 
-    public string[]? GetEraNames(string locale, string style, string? calendar)
+    public virtual string[]? GetEraNames(string locale, string style, string? calendar)
     {
         if (!IsEnglish(locale))
         {
@@ -410,7 +437,7 @@ public sealed class DefaultCldrProvider : ICldrProvider
 
     // === Display Names ===
 
-    public string? GetCurrencyDisplayName(string locale, string code)
+    public virtual string? GetCurrencyDisplayName(string locale, string code)
     {
         if (!IsEnglish(locale))
         {
@@ -423,12 +450,12 @@ public sealed class DefaultCldrProvider : ICldrProvider
 
     // === Locale Data ===
 
-    public string? GetLikelySubtags(string locale)
+    public virtual string? GetLikelySubtags(string locale)
     {
         return LikelySubtagsData.TryResolve(locale, out var result) ? result : null;
     }
 
-    public WeekInfo? GetWeekInfo(string locale)
+    public virtual WeekInfo? GetWeekInfo(string locale)
     {
         // Extract region from locale for week data lookup
         var region = ExtractRegion(locale);
@@ -459,7 +486,7 @@ public sealed class DefaultCldrProvider : ICldrProvider
 
     // === Plural Rules ===
 
-    public string SelectPluralCategory(string locale, double value, string type)
+    public virtual string SelectPluralCategory(string locale, double value, string type)
     {
         // Basic English plural rules for cardinal numbers
         // English only has "one" and "other" categories
@@ -515,7 +542,7 @@ public sealed class DefaultCldrProvider : ICldrProvider
 
     // === Supported Values ===
 
-    public IReadOnlyCollection<string> GetSupportedCalendars()
+    public virtual IReadOnlyCollection<string> GetSupportedCalendars()
     {
         // Only return calendars that are fully supported per ECMA-402 and Intl.Era-monthcode spec
         // Note: "islamic" and "islamic-rgsa" are excluded because they require specific
@@ -529,7 +556,7 @@ public sealed class DefaultCldrProvider : ICldrProvider
         };
     }
 
-    public IReadOnlyCollection<string> GetSupportedCollations()
+    public virtual IReadOnlyCollection<string> GetSupportedCollations()
     {
         // https://tc39.es/ecma402/#sec-availablecanonicalcollations wants the collations the
         // implementation provides Intl.Collator functionality for, which is the union of the one
@@ -537,23 +564,23 @@ public sealed class DefaultCldrProvider : ICldrProvider
         return CollatorConstructor.AvailableCanonicalCollations;
     }
 
-    public IReadOnlyCollection<string> GetSupportedCurrencies()
+    public virtual IReadOnlyCollection<string> GetSupportedCurrencies()
     {
         return _supportedCurrencies.Value;
     }
 
-    public IReadOnlyCollection<string> GetSupportedNumberingSystems()
+    public virtual IReadOnlyCollection<string> GetSupportedNumberingSystems()
     {
         return NumberingSystemData.Digits.Keys.ToArray();
     }
 
-    public IReadOnlyCollection<string> GetSupportedTimeZones()
+    public virtual IReadOnlyCollection<string> GetSupportedTimeZones()
     {
         // Return only canonical (primary) timezone identifiers for supportedValuesOf
         return TimeZoneData.GetCanonicalTimeZones();
     }
 
-    public IReadOnlyCollection<string> GetSupportedUnits()
+    public virtual IReadOnlyCollection<string> GetSupportedUnits()
     {
         return new[]
         {

--- a/Jint/Native/Temporal/DefaultCalendarProvider.cs
+++ b/Jint/Native/Temporal/DefaultCalendarProvider.cs
@@ -1,14 +1,37 @@
 namespace Jint.Native.Temporal;
 
 /// <summary>
-/// Default <see cref="ICalendarProvider"/> implementation backed by
-/// <see cref="System.Globalization.Calendar"/> subclasses (Hebrew, Persian, UmAlQura, …)
-/// plus inline epoch arithmetic for Coptic / Ethiopic / Islamic-civil / Islamic-tbla / Indian.
-/// Range-limited per the underlying BCL calendars; for full historical accuracy
-/// (e.g. islamic-umalqura, Persian astronomical, Chinese/Dangi at extreme years)
-/// register a custom provider via <see cref="Options.TemporalOptions.CalendarProvider"/>.
+/// The non-ISO calendar arithmetic an engine uses unless the host replaces it, backed by BCL
+/// <see cref="System.Globalization.Calendar"/> subclasses and inline epoch arithmetic.
 /// </summary>
-public sealed class DefaultCalendarProvider : ICalendarProvider
+/// <remarks>
+/// <para>
+/// Every member is <c>virtual</c>, so correcting one calendar means deriving from this class and
+/// overriding the one member that answers for it. The rest are inherited, and delegate to the BCL as before.
+/// </para>
+/// <para>
+/// Install the derived instance on <see cref="Options.TemporalOptions.CalendarProvider"/>; leaving that
+/// property alone keeps <see cref="Instance"/>, which the engine recognizes by identity and answers inline.
+/// </para>
+/// <para>
+/// Range-limited per the underlying BCL calendars. Adding a calendar Jint does not know is not a
+/// one-member job: <see cref="IsSupported"/>, <see cref="GetSupportedCalendars"/> and both conversions
+/// all have to answer for it, or the inherited conversion throws on an identifier it has never seen.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// sealed class AstronomicalPersian : DefaultCalendarProvider
+/// {
+///     public override IsoDateFields? CalendarFieldsToIso(
+///         string calendar, int year, string? monthCode, int month, int day, string overflow)
+///         => calendar == "persian" ? MyTables.ToIso(year, month, day) : base.CalendarFieldsToIso(calendar, year, monthCode, month, day, overflow);
+/// }
+///
+/// options.Temporal.CalendarProvider = new AstronomicalPersian();
+/// </code>
+/// </example>
+public class DefaultCalendarProvider : ICalendarProvider
 {
     /// <summary>Singleton instance.</summary>
     public static readonly DefaultCalendarProvider Instance = new();
@@ -20,16 +43,19 @@ public sealed class DefaultCalendarProvider : ICalendarProvider
         "islamic-umalqura", "islamic-civil", "islamic-tbla",
     ];
 
-    private DefaultCalendarProvider() { }
+    /// <summary>
+    /// Initializes a new instance a derived provider builds on; hosts wanting the default arithmetic read <see cref="Instance"/>.
+    /// </summary>
+    protected DefaultCalendarProvider() { }
 
     /// <inheritdoc />
-    public bool IsSupported(string calendar) => NonIsoCalendars.IsNonIsoCalendar(calendar);
+    public virtual bool IsSupported(string calendar) => NonIsoCalendars.IsNonIsoCalendar(calendar);
 
     /// <inheritdoc />
-    public IReadOnlyCollection<string> GetSupportedCalendars() => SupportedCalendars;
+    public virtual IReadOnlyCollection<string> GetSupportedCalendars() => SupportedCalendars;
 
     /// <inheritdoc />
-    public CalendarFields IsoToCalendarFields(string calendar, int isoYear, int isoMonth, int isoDay)
+    public virtual CalendarFields IsoToCalendarFields(string calendar, int isoYear, int isoMonth, int isoDay)
     {
         var calDate = NonIsoCalendars.IsoToCalendarDate(calendar, new IsoDate(isoYear, isoMonth, isoDay));
         return new CalendarFields(
@@ -39,7 +65,7 @@ public sealed class DefaultCalendarProvider : ICalendarProvider
     }
 
     /// <inheritdoc />
-    public IsoDateFields? CalendarFieldsToIso(string calendar, int year, string? monthCode, int month, int day, string overflow)
+    public virtual IsoDateFields? CalendarFieldsToIso(string calendar, int year, string? monthCode, int month, int day, string overflow)
     {
         var iso = NonIsoCalendars.CalendarDateToIso(calendar, year, monthCode, month, day, overflow);
         return iso is null ? null : new IsoDateFields(iso.Value.Year, iso.Value.Month, iso.Value.Day);

--- a/Jint/Native/Temporal/DefaultTimeZoneProvider.cs
+++ b/Jint/Native/Temporal/DefaultTimeZoneProvider.cs
@@ -8,14 +8,33 @@ using System.Runtime.InteropServices;
 namespace Jint.Native.Temporal;
 
 /// <summary>
-/// Default time zone provider using .NET TimeZoneInfo.
+/// The time zone data an engine uses unless the host replaces it, read from .NET's <see cref="TimeZoneInfo"/>.
 /// </summary>
 /// <remarks>
-/// This provides basic IANA time zone support via .NET's built-in TimeZoneInfo class.
-/// On Windows, Windows time zone IDs are mapped to IANA identifiers where possible.
-/// For full IANA support, consider using TimeZoneConverter package with a custom provider.
+/// <para>
+/// Every member is <c>virtual</c>, so changing one answer — the default zone, one alias, one offset —
+/// means deriving from this class and overriding that one member. The other eight are inherited.
+/// </para>
+/// <para>
+/// Install the derived instance on <see cref="Options.TemporalOptions.TimeZoneProvider"/>; leaving that
+/// property alone keeps <see cref="Instance"/>, the shared singleton every unconfigured engine reads.
+/// </para>
+/// <para>
+/// On Windows, Windows time zone IDs are mapped to IANA identifiers where possible. Full IANA coverage
+/// is what a derived provider backed by TimeZoneConverter or NodaTime buys.
+/// </para>
 /// </remarks>
-public sealed class DefaultTimeZoneProvider : ITimeZoneProvider
+/// <example>
+/// <code>
+/// sealed class FixedZone : DefaultTimeZoneProvider
+/// {
+///     public override string GetDefaultTimeZone() => "Europe/Helsinki";
+/// }
+///
+/// options.Temporal.TimeZoneProvider = new FixedZone();
+/// </code>
+/// </example>
+public class DefaultTimeZoneProvider : ITimeZoneProvider
 {
     private static bool IsWindowsPlatform()
     {
@@ -137,7 +156,7 @@ public sealed class DefaultTimeZoneProvider : ITimeZoneProvider
     public static DefaultTimeZoneProvider Instance { get; } = new();
 
     /// <inheritdoc />
-    public long GetOffsetNanosecondsFor(string timeZoneId, BigInteger epochNanoseconds)
+    public virtual long GetOffsetNanosecondsFor(string timeZoneId, BigInteger epochNanoseconds)
     {
         if (string.Equals(timeZoneId, "UTC", StringComparison.Ordinal) ||
             string.Equals(timeZoneId, "Etc/UTC", StringComparison.Ordinal))
@@ -177,7 +196,7 @@ public sealed class DefaultTimeZoneProvider : ITimeZoneProvider
     }
 
     /// <inheritdoc />
-    public BigInteger[] GetPossibleInstantsFor(
+    public virtual BigInteger[] GetPossibleInstantsFor(
         string timeZoneId,
         int year, int month, int day,
         int hour, int minute, int second,
@@ -257,7 +276,7 @@ public sealed class DefaultTimeZoneProvider : ITimeZoneProvider
     }
 
     /// <inheritdoc />
-    public BigInteger? GetNextTransition(string timeZoneId, BigInteger epochNanoseconds)
+    public virtual BigInteger? GetNextTransition(string timeZoneId, BigInteger epochNanoseconds)
     {
         if (string.Equals(timeZoneId, "UTC", StringComparison.Ordinal) ||
             string.Equals(timeZoneId, "Etc/UTC", StringComparison.Ordinal))
@@ -327,7 +346,7 @@ public sealed class DefaultTimeZoneProvider : ITimeZoneProvider
     }
 
     /// <inheritdoc />
-    public BigInteger? GetPreviousTransition(string timeZoneId, BigInteger epochNanoseconds)
+    public virtual BigInteger? GetPreviousTransition(string timeZoneId, BigInteger epochNanoseconds)
     {
         if (string.Equals(timeZoneId, "UTC", StringComparison.Ordinal) ||
             string.Equals(timeZoneId, "Etc/UTC", StringComparison.Ordinal))
@@ -392,7 +411,7 @@ public sealed class DefaultTimeZoneProvider : ITimeZoneProvider
     }
 
     /// <inheritdoc />
-    public bool IsValidTimeZone(string timeZoneId)
+    public virtual bool IsValidTimeZone(string timeZoneId)
     {
         if (string.IsNullOrEmpty(timeZoneId))
             return false;
@@ -441,7 +460,7 @@ public sealed class DefaultTimeZoneProvider : ITimeZoneProvider
     }
 
     /// <inheritdoc />
-    public string? CanonicalizeTimeZone(string timeZoneId)
+    public virtual string? CanonicalizeTimeZone(string timeZoneId)
     {
         if (string.IsNullOrEmpty(timeZoneId))
             return null;
@@ -576,13 +595,13 @@ public sealed class DefaultTimeZoneProvider : ITimeZoneProvider
     }
 
     /// <inheritdoc />
-    public IReadOnlyCollection<string> GetAvailableTimeZones()
+    public virtual IReadOnlyCollection<string> GetAvailableTimeZones()
     {
         return CachedAvailableTimeZones.Value;
     }
 
     /// <inheritdoc />
-    public string GetDefaultTimeZone()
+    public virtual string GetDefaultTimeZone()
     {
         var local = TimeZoneInfo.Local;
 
@@ -604,7 +623,7 @@ public sealed class DefaultTimeZoneProvider : ITimeZoneProvider
     /// Gets the primary IANA identifier for a timezone, resolving aliases.
     /// E.g., "Asia/Calcutta" → "Asia/Kolkata", "America/Atka" → "America/Adak".
     /// </summary>
-    public string? GetPrimaryTimeZoneIdentifier(string timeZoneId)
+    public virtual string? GetPrimaryTimeZoneIdentifier(string timeZoneId)
     {
         if (string.IsNullOrEmpty(timeZoneId))
         {

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -1066,6 +1066,37 @@ Shipping it inside the `Jint` NuGet package, diagnostics for the declined shapes
 generated members through `MemberFilter` and the name policy are each their own follow-up.
 | Writable named projections, and named members on an `ArrayLikeObject` | `IsNameWritable` / `TrySetNamedValue` / `TryDeleteName`, and the same `NameCount` / `NameAt` / `TryGetNamedValue` triple on both classes | [§5.3](#53-host-objects-one-hook-set-for-named-properties-3338) |
 
+### 5.2 Changing one locale datum is one override ([#3335](https://github.com/sebastienros/jint/pull/3335))
+
+`DefaultCldrProvider`, `DefaultTimeZoneProvider` and `DefaultCalendarProvider` were `sealed`, so a host that
+disagreed with one currency name, one time zone alias or one calendar had to implement the whole interface —
+23, 9 and 4 members — and hand-delegate every member it did not care about to the singleton. Miss one and the
+engine silently loses a datum it used to have.
+
+All three are now unsealed with `virtual` members, matching `DefaultTimeSystem`, which has always had that
+shape. Nothing about an unconfigured engine changed: the `Options` properties still default to the same
+`Instance` singletons, and `Options.Temporal.CalendarProvider` still recognizes that singleton by identity
+and answers inline rather than going through the interface.
+
+```c#
+// 5.x — the other twenty-two members are inherited
+sealed class MyCldr : DefaultCldrProvider
+{
+    public override string? GetCurrencyDisplayName(string locale, string code)
+        => code == "EUR" ? "Space Credits" : base.GetCurrencyDisplayName(locale, code);
+}
+
+var engine = new Engine(options => options.Intl.CldrProvider = new MyCldr());
+```
+
+Two limits are worth knowing before reaching for this. Ten of `ICldrProvider`'s twenty-three members have no
+caller inside Jint today — `GetCurrencyData`, `GetMonthNames`, `GetWeekdayNames`, `GetDayPeriods`,
+`GetDateTimePatterns`, `GetCompactPatterns`, `GetNumberingSystemDigits`, `GetLikelySubtags`, `GetWeekInfo`
+and `SelectPluralCategory` — so overriding one of those changes nothing script can observe until the engine
+starts consulting it. And on the calendar side, *correcting* a calendar Jint already
+knows is one override, while *adding* one it does not know is four: `IsSupported`, `GetSupportedCalendars` and
+both conversions all have to answer for the new identifier.
+
 ### 5.3 Host objects: one hook set for named properties ([#3338](https://github.com/sebastienros/jint/pull/3338))
 
 `NamedPropertyObject` shipped read-only, which is not the shape the hosts it was designed for have: a
@@ -1146,37 +1177,6 @@ var rangeError = engine.Intrinsics.RangeError;
 The CLR name of `%URIError%` is `Intrinsics.UriError`; script still sees `URIError`. See [Raising an
 error from host code](../README.md#raising-an-error-from-host-code).
 | The three shipped locale-data providers are extensible — one datum is one override | derive from `DefaultCldrProvider` / `DefaultTimeZoneProvider` / `DefaultCalendarProvider` and assign the instance to the matching `Options` property | [5.2](#52-changing-one-locale-datum-is-one-override) |
-
-### 5.2 Changing one locale datum is one override ([#3322](https://github.com/sebastienros/jint/pull/3322))
-
-`DefaultCldrProvider`, `DefaultTimeZoneProvider` and `DefaultCalendarProvider` were `sealed`, so a host that
-disagreed with one currency name, one time zone alias or one calendar had to implement the whole interface —
-23, 9 and 4 members — and hand-delegate every member it did not care about to the singleton. Miss one and the
-engine silently loses a datum it used to have.
-
-All three are now unsealed with `virtual` members, matching `DefaultTimeSystem`, which has always had that
-shape. Nothing about an unconfigured engine changed: the `Options` properties still default to the same
-`Instance` singletons, and `Options.Temporal.CalendarProvider` still recognizes that singleton by identity
-and answers inline rather than going through the interface.
-
-```c#
-// 5.x — the other twenty-two members are inherited
-sealed class MyCldr : DefaultCldrProvider
-{
-    public override string? GetCurrencyDisplayName(string locale, string code)
-        => code == "EUR" ? "Space Credits" : base.GetCurrencyDisplayName(locale, code);
-}
-
-var engine = new Engine(options => options.Intl.CldrProvider = new MyCldr());
-```
-
-Two limits are worth knowing before reaching for this. Ten of `ICldrProvider`'s twenty-three members have no
-caller inside Jint today — `GetCurrencyData`, `GetMonthNames`, `GetWeekdayNames`, `GetDayPeriods`,
-`GetDateTimePatterns`, `GetCompactPatterns`, `GetNumberingSystemDigits`, `GetLikelySubtags`, `GetWeekInfo`
-and `SelectPluralCategory` — so overriding one of those changes nothing script can observe until the engine
-starts consulting it. And on the calendar side, *correcting* a calendar Jint already
-knows is one override, while *adding* one it does not know is four: `IsSupported`, `GetSupportedCalendars` and
-both conversions all have to answer for the new identifier.
 
 ## 6. AOT and trimming
 

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -1145,6 +1145,38 @@ var rangeError = engine.Intrinsics.RangeError;
 
 The CLR name of `%URIError%` is `Intrinsics.UriError`; script still sees `URIError`. See [Raising an
 error from host code](../README.md#raising-an-error-from-host-code).
+| The three shipped locale-data providers are extensible — one datum is one override | derive from `DefaultCldrProvider` / `DefaultTimeZoneProvider` / `DefaultCalendarProvider` and assign the instance to the matching `Options` property | [5.2](#52-changing-one-locale-datum-is-one-override) |
+
+### 5.2 Changing one locale datum is one override ([#3322](https://github.com/sebastienros/jint/pull/3322))
+
+`DefaultCldrProvider`, `DefaultTimeZoneProvider` and `DefaultCalendarProvider` were `sealed`, so a host that
+disagreed with one currency name, one time zone alias or one calendar had to implement the whole interface —
+23, 9 and 4 members — and hand-delegate every member it did not care about to the singleton. Miss one and the
+engine silently loses a datum it used to have.
+
+All three are now unsealed with `virtual` members, matching `DefaultTimeSystem`, which has always had that
+shape. Nothing about an unconfigured engine changed: the `Options` properties still default to the same
+`Instance` singletons, and `Options.Temporal.CalendarProvider` still recognizes that singleton by identity
+and answers inline rather than going through the interface.
+
+```c#
+// 5.x — the other twenty-two members are inherited
+sealed class MyCldr : DefaultCldrProvider
+{
+    public override string? GetCurrencyDisplayName(string locale, string code)
+        => code == "EUR" ? "Space Credits" : base.GetCurrencyDisplayName(locale, code);
+}
+
+var engine = new Engine(options => options.Intl.CldrProvider = new MyCldr());
+```
+
+Two limits are worth knowing before reaching for this. Ten of `ICldrProvider`'s twenty-three members have no
+caller inside Jint today — `GetCurrencyData`, `GetMonthNames`, `GetWeekdayNames`, `GetDayPeriods`,
+`GetDateTimePatterns`, `GetCompactPatterns`, `GetNumberingSystemDigits`, `GetLikelySubtags`, `GetWeekInfo`
+and `SelectPluralCategory` — so overriding one of those changes nothing script can observe until the engine
+starts consulting it. And on the calendar side, *correcting* a calendar Jint already
+knows is one override, while *adding* one it does not know is four: `IsSupported`, `GetSupportedCalendars` and
+both conversions all have to answer for the new identifier.
 
 ## 6. AOT and trimming
 


### PR DESCRIPTION
`DefaultCldrProvider`, `DefaultTimeZoneProvider` and `DefaultCalendarProvider` are the three shipped
locale-data providers, and all three were `sealed` with a `private` constructor. A host that disagreed
with **one** datum — one currency name, one time zone alias, one calendar — therefore had to implement
the whole interface from scratch (`ICldrProvider` is **23** members, `ITimeZoneProvider` 9,
`ICalendarProvider` 4) and hand-delegate every member it did not care about back to the singleton. Miss
one and the engine silently loses a datum it used to have.

The counter-example was already in the same assembly: `Jint/Runtime/DefaultTimeSystem.cs` is
`public class ... : ITimeSystem` with `public virtual` members, which is exactly why
`Jint.Tests.PublicInterface/TimeSystemTests.cs` can change `GetUtcNow` or `GetUtcOffset` alone and
inherit the rest. This PR gives the three locale providers that same shape.

## What changed

* The three classes are unsealed; all **36** members become `virtual` (23 + 9 + 4).
* `DefaultCldrProvider` and `DefaultCalendarProvider` get a `protected` constructor in place of the
  `private` one. `DefaultTimeZoneProvider` already had a public one, which the baseline shows.
* Class-level XML docs get a `<remarks>` saying what a host must do, and an `<example>` showing the
  one-member override.

Nothing an unconfigured engine does changed. `Options.Intl.CldrProvider`,
`Options.Temporal.TimeZoneProvider` and `Options.Temporal.CalendarProvider` still default to the same
`Instance` singletons, and `NonIsoCalendars` still short-circuits on
`provider != DefaultCalendarProvider.Instance` — a reference comparison, so it keeps answering the
default inline rather than through the interface.

## Performance: sealing was never buying devirtualization here

`Jint/AGENTS.md` says to seal whenever possible, so this is the argument for the exception. It is not
"the calls are cold" — one of them is not.

**Every in-box call site is typed to the interface, not to the concrete class.** The full census of
sites naming the concrete type is three `Options` field initializers plus the two reference comparisons
in `NonIsoCalendars.cs`; none of them dispatches. Everything else reads
`_engine.Options.Intl.CldrProvider` / `.Temporal.TimeZoneProvider` / `.Temporal.CalendarProvider`, whose
static type is the interface, so the JIT was already emitting an interface `callvirt`.

Sealing only lets the JIT devirtualize a call whose *static type at the call site* is the sealed class.
And C# already emits an implicit interface implementation as `virtual final` — so the only thing this
PR removes from the IL is a `final` that no call site was in a position to use. Guarded devirtualization
under dynamic PGO is unaffected either way: it guards on a method-table equality test, which works
identically for an unsealed class.

I deliberately left **no member non-virtual**, including the hottest one. For the record, that is
`ICldrProvider.GetUnitPatterns`: `JsNumberFormat.FormatUnit` / `FormatUnitBigInt` call it once **per
`format()` call**, so `arr.map(nf.format)` on a unit-style formatter reaches it per element (same for
`JsDurationFormat`, five sites). `GetEraNames` (`JsDateTimeFormat`), `GetListPatterns`
(`JsListFormat`) and `GetRelativeTimePatterns` (`JsRelativeTimeFormat`) are also per-`format()` rather
than per-construction. All four were already interface calls before this PR, so their dispatch is
byte-for-byte what it was.

**No benchmarks run** — measurement is serialised by the maintainer. If a row is wanted,
`Intl.NumberFormat({style:'unit'}).format` in a loop is the one that would show anything.

## Verification

* `dotnet build -c Release` — clean, 0 warnings.
* `Jint.Tests` — 10,645 passed / 0 failed (net10.0 and net8.0), 7,298 (net472).
* `Jint.Tests.PublicInterface` — 2,585 / 0 (net10.0), 1,985 / 0 (net472).
* `Jint.Tests.Test262` — **102,495** accounted for. Two runs on this branch came back
  102,494 passed / 1 failed and one earlier run 102,490 / 5; every failure is a bare
  `System.TimeoutException` at exactly `[30 s]` on a language test (`toSpliced-dense.js`,
  `short-circuit-compound-assignment.js`) with no Intl or Temporal on the stack. Stock `upstream/main`
  built and run in the same worktree under the same load failed **three**, including the same
  `short-circuit-compound-assignment.js`. The machine was at 93% CPU with 35 concurrent `dotnet`
  processes; the whole `Sm_expressions` group runs in 860 ms in isolation. So: load-induced, pre-existing,
  and the branch had fewer than main.
* Five API baselines regenerated by running the suite and copying `.received.txt` over
  `.verified.txt`. Never hand-edited.

## New tests

`Jint.Tests.PublicInterface/HostLocaleProviderTests.cs`, five tests. Each derives from one default
provider, overrides **exactly one** member, delegates nothing, and asserts both that the override reaches
script and that the untouched members still answer from the base class:

* `GetCurrencyDisplayName` → `Intl.DisplayNames({type:'currency'}).of('EUR')`, with `USD`, `ListFormat`,
  a unit-style `NumberFormat`, `RelativeTimeFormat` and `supportedValuesOf` all still inherited.
* `GetListPatterns` → `Intl.ListFormat().format()`.
* `GetDefaultTimeZone` → `Temporal.Now.timeZoneId()`, with DST offsets in both directions still inherited.
* `IsoToCalendarFields` → `withCalendar('hebrew').year`, with four other calendars and the reverse
  conversion still inherited.
* An unconfigured `Options` still holds the three singletons.

Three more `file` classes override all 36 members and exist only to be compiled: the compiler is the only
thing that checks nothing was missed.

## Two findings, reported rather than fixed

**A one-member override sufficed for all three providers, but the brief's own example is not reachable.**
`ICldrProvider.GetCurrencyData` — the member that carries the currency *symbol* — has no caller anywhere
in Jint. `Intl.NumberFormat`'s symbols come from a hardcoded `GetCurrencySymbol` switch in
`NumberFormatConstructor.cs`. So "a custom currency symbol reaching `Intl.NumberFormat().format()`"
cannot be written today; the test uses `GetCurrencyDisplayName` → `Intl.DisplayNames`, which is a
currency datum that *is* consulted. Wiring `GetCurrencyData` into `NumberFormatConstructor` is a real
fix and a separate PR.

**Ten of `ICldrProvider`'s 23 members have no in-box caller at all** — `GetCurrencyData`, `GetMonthNames`,
`GetWeekdayNames`, `GetDayPeriods`, `GetDateTimePatterns`, `GetCompactPatterns`,
`GetNumberingSystemDigits`, `GetLikelySubtags`, `GetWeekInfo`, `SelectPluralCategory`. Overriding one of
those changes nothing script can see. That is documented in §5.1 and in the class XML doc rather than
quietly left for a host to discover. The 13 that are consulted are listed above.

One asymmetry on the calendar side, also documented rather than changed: *correcting* a calendar Jint
already knows is one override, but *adding* one it does not know is four, because the inherited
conversions throw `NotSupportedException` on an identifier `NonIsoCalendars` has never seen.

## Migration guide

`docs/v5-migration.md` §5.1 — additive, not breaking. §5 had no subsections before this; I re-checked
after rebasing onto `60abeab86` and 5.1 is still free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014W5mbjGhyvgAS4pivXoc4S
