### PR TITLE
Errors: a host can raise every error type the spec defines, not the two that happened to be public

### DIFF
--- a/Jint.Tests.PublicInterface/HostRaisedErrorTests.cs
+++ b/Jint.Tests.PublicInterface/HostRaisedErrorTests.cs
@@ -1,0 +1,159 @@
+using Jint.Native;
+using Jint.Native.Error;
+using Jint.Runtime;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// A host function must be able to fail with the error the specification would raise — a <c>RangeError</c>
+/// for an out-of-range argument, a <c>URIError</c> for malformed input — and not only with the two error
+/// constructors that happened to be reachable.
+/// </summary>
+/// <remarks>
+/// Every <c>%NativeError%</c> constructor is a property of <see cref="Jint.Runtime.Intrinsics"/>, and until v5
+/// five of the seven were <c>internal</c> — an accident of who had needed what, never a policy, and a porous
+/// one: the same objects are installed as globals, so <c>(ErrorConstructor) engine.GetValue("RangeError")</c>
+/// reached them anyway. These tests pin the supported spelling instead.
+/// </remarks>
+public class HostRaisedErrorTests
+{
+    private static ErrorConstructor ConstructorFor(Engine engine, string name) => name switch
+    {
+        "Error" => engine.Intrinsics.Error,
+        "EvalError" => engine.Intrinsics.EvalError,
+        "RangeError" => engine.Intrinsics.RangeError,
+        "ReferenceError" => engine.Intrinsics.ReferenceError,
+        "SyntaxError" => engine.Intrinsics.SyntaxError,
+        "TypeError" => engine.Intrinsics.TypeError,
+        // The only intrinsic whose CLR name is not its script name.
+        "URIError" => engine.Intrinsics.UriError,
+        _ => throw new ArgumentOutOfRangeException(nameof(name), name, "not an error constructor"),
+    };
+
+    [Theory]
+    [InlineData("Error")]
+    [InlineData("EvalError")]
+    [InlineData("RangeError")]
+    [InlineData("ReferenceError")]
+    [InlineData("SyntaxError")]
+    [InlineData("TypeError")]
+    [InlineData("URIError")]
+    public void AHostFunctionCanRaiseEveryErrorTypeTheSpecDefines(string name)
+    {
+        var engine = new Engine();
+        var errorConstructor = ConstructorFor(engine, name);
+
+        engine.SetValue("fail", new Action(() => throw new JavaScriptException(errorConstructor, "boom")));
+
+        var caught = engine.Evaluate($$"""
+            (function () {
+                try {
+                    fail();
+                } catch (e) {
+                    return {
+                        instanceOfError: e instanceof Error,
+                        instanceOfExact: e instanceof {{name}},
+                        constructorIdentity: e.constructor === {{name}},
+                        prototypeIdentity: Object.getPrototypeOf(e) === {{name}}.prototype,
+                        isError: Error.isError(e),
+                        name: e.name,
+                        message: e.message,
+                        stringForm: String(e)
+                    };
+                }
+                return null;
+            })()
+            """).AsObject();
+
+        caught.Get("instanceOfError").AsBoolean().Should().BeTrue();
+        caught.Get("instanceOfExact").AsBoolean().Should()
+            .BeTrue($"an error raised through Intrinsics.{name} must be an instance of the script's {name}");
+        caught.Get("constructorIdentity").AsBoolean().Should().BeTrue();
+        caught.Get("prototypeIdentity").AsBoolean().Should().BeTrue();
+        caught.Get("isError").AsBoolean().Should().BeTrue();
+        caught.Get("name").AsString().Should().Be(name);
+        caught.Get("message").AsString().Should().Be("boom");
+        caught.Get("stringForm").AsString().Should().Be($"{name}: boom");
+    }
+
+    [Theory]
+    [InlineData("Error")]
+    [InlineData("EvalError")]
+    [InlineData("RangeError")]
+    [InlineData("ReferenceError")]
+    [InlineData("SyntaxError")]
+    [InlineData("TypeError")]
+    [InlineData("URIError")]
+    public void AnUncaughtHostErrorReachesTheHostAsThatErrorType(string name)
+    {
+        var engine = new Engine();
+        var errorConstructor = ConstructorFor(engine, name);
+
+        engine.SetValue("fail", new Action(() => throw new JavaScriptException(errorConstructor, "boom")));
+
+        var exception = Invoking(() => engine.Evaluate("fail()")).Should().Throw<JavaScriptException>().Which;
+
+        exception.Message.Should().Be("boom");
+        var error = exception.Error.AsObject();
+        error.Get("name").AsString().Should().Be(name);
+        error.Engine.Should().BeSameAs(engine, "the error belongs to the engine whose intrinsic built it");
+
+        engine.SetValue("raised", error);
+        engine.Evaluate($"raised instanceof {name} && Object.getPrototypeOf(raised) === {name}.prototype")
+            .AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void TheErrorBelongsToThePrincipalRealmEvenAfterAnotherRealmExists()
+    {
+        // Intrinsics is per-realm, and a ShadowRealm builds a second set. An error a host raises through
+        // engine.Intrinsics must still be an instance of the RangeError the surrounding script can see.
+        var engine = new Engine();
+        engine.Evaluate("new ShadowRealm()");
+
+        var rangeError = engine.Intrinsics.RangeError;
+        engine.SetValue("fail", new Action(() => throw new JavaScriptException(rangeError, "boom")));
+
+        engine.Evaluate("try { fail(); } catch (e) { e instanceof RangeError && Object.getPrototypeOf(e) === RangeError.prototype; }")
+            .AsBoolean().Should().BeTrue("engine.Intrinsics is the principal realm's, whatever was created after it");
+    }
+
+    [Fact]
+    public void TheIntrinsicIsTheObjectTheScriptSeesAsThatGlobal()
+    {
+        var engine = new Engine();
+
+        engine.SetValue("rangeError", engine.Intrinsics.RangeError);
+
+        engine.Evaluate("rangeError === RangeError").AsBoolean().Should().BeTrue();
+        engine.Evaluate("rangeError === globalThis.RangeError").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void ARangeErrorCanCarryTheClrExceptionThatCausedIt()
+    {
+        var engine = new Engine();
+        var cause = new ArgumentOutOfRangeException("index");
+
+        engine.SetValue("fail", new Action(() => throw new JavaScriptException(engine.Intrinsics.RangeError, "index out of range", cause)));
+
+        var exception = Invoking(() => engine.Evaluate("fail()")).Should().Throw<JavaScriptException>().Which;
+
+        exception.Error.AsObject().Get("name").AsString().Should().Be("RangeError");
+        JintException.TryGetClrException(exception, out var clrException).Should().BeTrue();
+        clrException.Should().BeSameAs(cause);
+    }
+
+    [Fact]
+    public void AHostErrorConstructorAlsoBuildsAPlainErrorObject()
+    {
+        // ErrorConstructor.Construct is the value-producing half of the same capability: a host that wants to
+        // hand an error back rather than throw it needs no exception at all.
+        var engine = new Engine();
+
+        engine.SetValue("makeRangeError", new Func<string, JsValue>(message => engine.Intrinsics.RangeError.Construct(message)));
+
+        engine.Evaluate("var e = makeRangeError('too big');");
+        engine.Evaluate("e instanceof RangeError && e.message === 'too big'").AsBoolean().Should().BeTrue();
+    }
+}

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
@@ -1854,6 +1854,7 @@ namespace Jint.Runtime
         public Jint.Native.TypedArray.BigUint64ArrayConstructor BigUint64Array { get; }
         public Jint.Native.Error.ErrorConstructor Error { get; }
         public Jint.Native.Function.EvalFunction Eval { get; }
+        public Jint.Native.Error.ErrorConstructor EvalError { get; }
         public Jint.Native.TypedArray.Float16ArrayConstructor Float16Array { get; }
         public Jint.Native.TypedArray.Float32ArrayConstructor Float32Array { get; }
         public Jint.Native.TypedArray.Float64ArrayConstructor Float64Array { get; }
@@ -1863,14 +1864,18 @@ namespace Jint.Runtime
         public Jint.Native.TypedArray.Int8ArrayConstructor Int8Array { get; }
         public Jint.Native.Map.MapConstructor Map { get; }
         public Jint.Native.Object.ObjectConstructor Object { get; }
+        public Jint.Native.Error.ErrorConstructor RangeError { get; }
+        public Jint.Native.Error.ErrorConstructor ReferenceError { get; }
         public Jint.Native.RegExp.RegExpConstructor RegExp { get; }
         public Jint.Native.Set.SetConstructor Set { get; }
         public Jint.Native.ShadowRealm.ShadowRealmConstructor ShadowRealm { get; }
+        public Jint.Native.Error.ErrorConstructor SyntaxError { get; }
         public Jint.Native.Error.ErrorConstructor TypeError { get; }
         public Jint.Native.TypedArray.Uint16ArrayConstructor Uint16Array { get; }
         public Jint.Native.TypedArray.Uint32ArrayConstructor Uint32Array { get; }
         public Jint.Native.TypedArray.Uint8ArrayConstructor Uint8Array { get; }
         public Jint.Native.TypedArray.Uint8ClampedArrayConstructor Uint8ClampedArray { get; }
+        public Jint.Native.Error.ErrorConstructor UriError { get; }
     }
     public class JavaScriptException : Jint.JintException
     {

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net472.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net472.verified.txt
@@ -1701,6 +1701,7 @@ namespace Jint.Runtime
         public Jint.Native.TypedArray.BigUint64ArrayConstructor BigUint64Array { get; }
         public Jint.Native.Error.ErrorConstructor Error { get; }
         public Jint.Native.Function.EvalFunction Eval { get; }
+        public Jint.Native.Error.ErrorConstructor EvalError { get; }
         public Jint.Native.TypedArray.Float16ArrayConstructor Float16Array { get; }
         public Jint.Native.TypedArray.Float32ArrayConstructor Float32Array { get; }
         public Jint.Native.TypedArray.Float64ArrayConstructor Float64Array { get; }
@@ -1710,14 +1711,18 @@ namespace Jint.Runtime
         public Jint.Native.TypedArray.Int8ArrayConstructor Int8Array { get; }
         public Jint.Native.Map.MapConstructor Map { get; }
         public Jint.Native.Object.ObjectConstructor Object { get; }
+        public Jint.Native.Error.ErrorConstructor RangeError { get; }
+        public Jint.Native.Error.ErrorConstructor ReferenceError { get; }
         public Jint.Native.RegExp.RegExpConstructor RegExp { get; }
         public Jint.Native.Set.SetConstructor Set { get; }
         public Jint.Native.ShadowRealm.ShadowRealmConstructor ShadowRealm { get; }
+        public Jint.Native.Error.ErrorConstructor SyntaxError { get; }
         public Jint.Native.Error.ErrorConstructor TypeError { get; }
         public Jint.Native.TypedArray.Uint16ArrayConstructor Uint16Array { get; }
         public Jint.Native.TypedArray.Uint32ArrayConstructor Uint32Array { get; }
         public Jint.Native.TypedArray.Uint8ArrayConstructor Uint8Array { get; }
         public Jint.Native.TypedArray.Uint8ClampedArrayConstructor Uint8ClampedArray { get; }
+        public Jint.Native.Error.ErrorConstructor UriError { get; }
     }
     public class JavaScriptException : Jint.JintException
     {

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
@@ -1854,6 +1854,7 @@ namespace Jint.Runtime
         public Jint.Native.TypedArray.BigUint64ArrayConstructor BigUint64Array { get; }
         public Jint.Native.Error.ErrorConstructor Error { get; }
         public Jint.Native.Function.EvalFunction Eval { get; }
+        public Jint.Native.Error.ErrorConstructor EvalError { get; }
         public Jint.Native.TypedArray.Float16ArrayConstructor Float16Array { get; }
         public Jint.Native.TypedArray.Float32ArrayConstructor Float32Array { get; }
         public Jint.Native.TypedArray.Float64ArrayConstructor Float64Array { get; }
@@ -1863,14 +1864,18 @@ namespace Jint.Runtime
         public Jint.Native.TypedArray.Int8ArrayConstructor Int8Array { get; }
         public Jint.Native.Map.MapConstructor Map { get; }
         public Jint.Native.Object.ObjectConstructor Object { get; }
+        public Jint.Native.Error.ErrorConstructor RangeError { get; }
+        public Jint.Native.Error.ErrorConstructor ReferenceError { get; }
         public Jint.Native.RegExp.RegExpConstructor RegExp { get; }
         public Jint.Native.Set.SetConstructor Set { get; }
         public Jint.Native.ShadowRealm.ShadowRealmConstructor ShadowRealm { get; }
+        public Jint.Native.Error.ErrorConstructor SyntaxError { get; }
         public Jint.Native.Error.ErrorConstructor TypeError { get; }
         public Jint.Native.TypedArray.Uint16ArrayConstructor Uint16Array { get; }
         public Jint.Native.TypedArray.Uint32ArrayConstructor Uint32Array { get; }
         public Jint.Native.TypedArray.Uint8ArrayConstructor Uint8Array { get; }
         public Jint.Native.TypedArray.Uint8ClampedArrayConstructor Uint8ClampedArray { get; }
+        public Jint.Native.Error.ErrorConstructor UriError { get; }
     }
     public class JavaScriptException : Jint.JintException
     {

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.0.verified.txt
@@ -1701,6 +1701,7 @@ namespace Jint.Runtime
         public Jint.Native.TypedArray.BigUint64ArrayConstructor BigUint64Array { get; }
         public Jint.Native.Error.ErrorConstructor Error { get; }
         public Jint.Native.Function.EvalFunction Eval { get; }
+        public Jint.Native.Error.ErrorConstructor EvalError { get; }
         public Jint.Native.TypedArray.Float16ArrayConstructor Float16Array { get; }
         public Jint.Native.TypedArray.Float32ArrayConstructor Float32Array { get; }
         public Jint.Native.TypedArray.Float64ArrayConstructor Float64Array { get; }
@@ -1710,14 +1711,18 @@ namespace Jint.Runtime
         public Jint.Native.TypedArray.Int8ArrayConstructor Int8Array { get; }
         public Jint.Native.Map.MapConstructor Map { get; }
         public Jint.Native.Object.ObjectConstructor Object { get; }
+        public Jint.Native.Error.ErrorConstructor RangeError { get; }
+        public Jint.Native.Error.ErrorConstructor ReferenceError { get; }
         public Jint.Native.RegExp.RegExpConstructor RegExp { get; }
         public Jint.Native.Set.SetConstructor Set { get; }
         public Jint.Native.ShadowRealm.ShadowRealmConstructor ShadowRealm { get; }
+        public Jint.Native.Error.ErrorConstructor SyntaxError { get; }
         public Jint.Native.Error.ErrorConstructor TypeError { get; }
         public Jint.Native.TypedArray.Uint16ArrayConstructor Uint16Array { get; }
         public Jint.Native.TypedArray.Uint32ArrayConstructor Uint32Array { get; }
         public Jint.Native.TypedArray.Uint8ArrayConstructor Uint8Array { get; }
         public Jint.Native.TypedArray.Uint8ClampedArrayConstructor Uint8ClampedArray { get; }
+        public Jint.Native.Error.ErrorConstructor UriError { get; }
     }
     public class JavaScriptException : Jint.JintException
     {

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.1.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.1.verified.txt
@@ -1701,6 +1701,7 @@ namespace Jint.Runtime
         public Jint.Native.TypedArray.BigUint64ArrayConstructor BigUint64Array { get; }
         public Jint.Native.Error.ErrorConstructor Error { get; }
         public Jint.Native.Function.EvalFunction Eval { get; }
+        public Jint.Native.Error.ErrorConstructor EvalError { get; }
         public Jint.Native.TypedArray.Float16ArrayConstructor Float16Array { get; }
         public Jint.Native.TypedArray.Float32ArrayConstructor Float32Array { get; }
         public Jint.Native.TypedArray.Float64ArrayConstructor Float64Array { get; }
@@ -1710,14 +1711,18 @@ namespace Jint.Runtime
         public Jint.Native.TypedArray.Int8ArrayConstructor Int8Array { get; }
         public Jint.Native.Map.MapConstructor Map { get; }
         public Jint.Native.Object.ObjectConstructor Object { get; }
+        public Jint.Native.Error.ErrorConstructor RangeError { get; }
+        public Jint.Native.Error.ErrorConstructor ReferenceError { get; }
         public Jint.Native.RegExp.RegExpConstructor RegExp { get; }
         public Jint.Native.Set.SetConstructor Set { get; }
         public Jint.Native.ShadowRealm.ShadowRealmConstructor ShadowRealm { get; }
+        public Jint.Native.Error.ErrorConstructor SyntaxError { get; }
         public Jint.Native.Error.ErrorConstructor TypeError { get; }
         public Jint.Native.TypedArray.Uint16ArrayConstructor Uint16Array { get; }
         public Jint.Native.TypedArray.Uint32ArrayConstructor Uint32Array { get; }
         public Jint.Native.TypedArray.Uint8ArrayConstructor Uint8Array { get; }
         public Jint.Native.TypedArray.Uint8ClampedArrayConstructor Uint8ClampedArray { get; }
+        public Jint.Native.Error.ErrorConstructor UriError { get; }
     }
     public class JavaScriptException : Jint.JintException
     {

--- a/Jint/Native/AGENTS.md
+++ b/Jint/Native/AGENTS.md
@@ -25,4 +25,19 @@ Follow the specification as closely as practical, support both strict and sloppy
 
 Proposal-stage **TC39** built-ins are registered unconditionally — there is no per-feature option or ES-version gate for anything ECMAScript defines, however early its stage. `Options.ExperimentalFeatures` is about CLR interop and has nothing to do with which built-ins exist.
 
+## Which `Intrinsics` members are public
+
+A property on `Jint.Runtime.Intrinsics` is `public` when a host has a reason to **call** the object it
+returns from C#, not because the intrinsic exists. Today that is the seven `ErrorConstructor` properties —
+`new JavaScriptException(intrinsic, message)` takes one, so picking the error the specification would pick is
+a host operation — plus the handful of constructors a host builds instances with (`Array`, `Map`, `Set`, the
+typed arrays, `ArrayBuffer`, `RegExp`, `ShadowRealm`, `Object`, `Function`, `Eval`). Everything else stays
+`internal`, and the *type* is what enforces it: every remaining intrinsic's type is `internal` too, so its
+property could not be promoted without first widening a class. Widen the class only when a host must invoke
+it — an intrinsic a host would merely hand back to script is already reachable as `engine.GetValue("Name")`,
+which is not a reason to freeze a second spelling into the public surface. A new error constructor
+(`AggregateError`, `SuppressedError`) is the case that qualifies on the first test but fails on the second:
+both are `internal sealed` classes that do not derive from `ErrorConstructor`, so exposing them is a type
+promotion to argue on its own, not a modifier to flip.
+
 **That rule stops at the language.** The WHATWG web APIs under `Jint/WebApi/` are host APIs, not language features, and are deliberately **opt-in**: nothing is installed unless `Options.WebApi.Features` names it, and a default engine is byte-for-byte the engine it was before they existed. Do not "fix" that gating by registering them unconditionally — see [Web APIs](../WebApi/AGENTS.md#web-apis) for how it works and why.

--- a/Jint/Runtime/Intrinsics.cs
+++ b/Jint/Runtime/Intrinsics.cs
@@ -340,25 +340,37 @@ public sealed partial class Intrinsics
     internal NumberParseFunction ParseFloat =>
         _parseFloat ??= new NumberParseFunction(_engine, _realm, Function.PrototypeObject, isParseInt: false);
 
+    /// <summary>
+    /// %Error%. This and the six <c>NativeError</c> constructors below are public because a host raises a
+    /// script-catchable error by handing one to <see cref="JavaScriptException"/>,
+    /// so choosing the error the specification would choose — a <see cref="RangeError"/> for an out-of-range
+    /// argument, a <see cref="TypeError"/> for a wrong type — is a host operation, not an engine-internal one.
+    /// </summary>
     public ErrorConstructor Error =>
         _error ??= new ErrorConstructor(_engine, _realm, Function.PrototypeObject, Object.PrototypeObject, _errorFunctionName, static intrinsics => intrinsics.Error.PrototypeObject);
 
-    internal ErrorConstructor EvalError =>
+    /// <summary>%EvalError%. See <see cref="Error"/> for why this is public.</summary>
+    public ErrorConstructor EvalError =>
         _evalError ??= new ErrorConstructor(_engine, _realm, Error, Error.PrototypeObject, _evalErrorFunctionName, static intrinsics => intrinsics.EvalError.PrototypeObject);
 
-    internal ErrorConstructor SyntaxError =>
+    /// <summary>%SyntaxError%. See <see cref="Error"/> for why this is public.</summary>
+    public ErrorConstructor SyntaxError =>
         _syntaxError ??= new ErrorConstructor(_engine, _realm, Error, Error.PrototypeObject, _syntaxErrorFunctionName, static intrinsics => intrinsics.SyntaxError.PrototypeObject);
 
+    /// <summary>%TypeError%. See <see cref="Error"/> for why this is public.</summary>
     public ErrorConstructor TypeError =>
         _typeError ??= new ErrorConstructor(_engine, _realm, Error, Error.PrototypeObject, _typeErrorFunctionName, static intrinsics => intrinsics.TypeError.PrototypeObject);
 
-    internal ErrorConstructor RangeError =>
+    /// <summary>%RangeError%. See <see cref="Error"/> for why this is public.</summary>
+    public ErrorConstructor RangeError =>
         _rangeError ??= new ErrorConstructor(_engine, _realm, Error, Error.PrototypeObject, _rangeErrorFunctionName, static intrinsics => intrinsics.RangeError.PrototypeObject);
 
-    internal ErrorConstructor ReferenceError =>
+    /// <summary>%ReferenceError%. See <see cref="Error"/> for why this is public.</summary>
+    public ErrorConstructor ReferenceError =>
         _referenceError ??= new ErrorConstructor(_engine, _realm, Error, Error.PrototypeObject, _referenceErrorFunctionName, static intrinsics => intrinsics.ReferenceError.PrototypeObject);
 
-    internal ErrorConstructor UriError =>
+    /// <summary>%URIError%, spelled <c>URIError</c> in script. See <see cref="Error"/> for why this is public.</summary>
+    public ErrorConstructor UriError =>
         _uriError ??= new ErrorConstructor(_engine, _realm, Error, Error.PrototypeObject, _uriErrorFunctionName, static intrinsics => intrinsics.UriError.PrototypeObject);
 
     internal ThrowTypeError ThrowTypeError =>

--- a/README.md
+++ b/README.md
@@ -3573,9 +3573,35 @@ same host-side decorator can attach a safe error code to interop and module fail
 
 ### Raising an error from host code
 
-To fail a host function in a way the script can catch, throw a `JavaScriptException`. The overload taking a
-CLR exception records it for `TryGetClrException`, so the script sees an ordinary `Error` while you keep the
-original:
+To fail a host function in a way the script can catch, throw a `JavaScriptException`, built from the error
+constructor the specification would use. All seven live on `engine.Intrinsics`, and the error a script
+catches is a real one — `instanceof` works, `e.constructor` is the global, `e.name` and `e.stack` are what
+they would be had script thrown it:
+
+| Host code | The script catches | Use it for |
+| --- | --- | --- |
+| `engine.Intrinsics.Error` | `Error` | a failure with no better-fitting kind |
+| `engine.Intrinsics.RangeError` | `RangeError` | an argument outside its allowed range |
+| `engine.Intrinsics.TypeError` | `TypeError` | an argument of the wrong type, or an operation the value does not support |
+| `engine.Intrinsics.ReferenceError` | `ReferenceError` | a name that does not resolve |
+| `engine.Intrinsics.SyntaxError` | `SyntaxError` | input your host function had to parse and could not |
+| `engine.Intrinsics.EvalError` | `EvalError` | reserved by the specification; rarely the right answer |
+| `engine.Intrinsics.UriError` | `URIError` | malformed URI-encoded input (note the CLR spelling) |
+
+```c#
+engine.SetValue("itemAt", new Func<int, string>(index =>
+{
+    if (index < 0 || index >= items.Count)
+    {
+        throw new JavaScriptException(engine.Intrinsics.RangeError, $"index {index} is out of range");
+    }
+
+    return items[index];
+}));
+```
+
+The overload taking a CLR exception records it for `TryGetClrException`, so the script sees an ordinary
+error while you keep the original:
 
 ```c#
 engine.SetValue("parse", new Action<string>(s =>
@@ -3586,10 +3612,13 @@ engine.SetValue("parse", new Action<string>(s =>
     }
     catch (XmlException e)
     {
-        throw new JavaScriptException(engine.Intrinsics.Error, "XML parsing failed", e);
+        throw new JavaScriptException(engine.Intrinsics.SyntaxError, "XML parsing failed", e);
     }
 }));
 ```
+
+To hand an error back as a *value* rather than throw it — a result object, a callback argument — build one
+with `engine.Intrinsics.RangeError.Construct("...")`, which returns the same kind of object.
 
 Do not throw the exception projected into the script instead
 (`new JavaScriptException(JsValue.FromObject(engine, e))`). That value is not an `Error` — it has no `stack`

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -786,7 +786,7 @@ none of it changes an engine that does not.
 | Statement-level code coverage | `options.Coverage.Enabled = true` | [Code coverage (opt-in)](../README.md#code-coverage-opt-in) |
 | `NamedPropertyObject` — one base class for a host object projecting *named* properties, the string-keyed sibling of `ArrayLikeObject` | derive from it instead of overriding `GetOwnProperty` / `ProbeOwnProperty` / `GetOwnPropertyKeys` / `TryGetOwnPropertyValue` / `GetOwnProperties` by hand | [Projecting host data](../README.md#embedding-performance) |
 
-### 5.1 Every error constructor is reachable from host code ([#3324](https://github.com/sebastienros/jint/pull/3324))
+### 5.1 Every error constructor is reachable from host code ([#3337](https://github.com/sebastienros/jint/pull/3337))
 
 `Engine.Intrinsics` exposed `Error` and `TypeError` and kept the other five `internal`, so a host
 function could not raise the error the specification would raise — a `RangeError` for an

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -774,8 +774,8 @@ verification reports an override that does not.
 
 ## 5. New in v5
 
-Everything here is opt-in: nothing below is installed unless the host asks for it, so none of it
-changes an engine that does not.
+Everything in the table below is opt-in: nothing in it is installed unless the host asks for it, so
+none of it changes an engine that does not.
 
 | Area | Enable with | Reference |
 | --- | --- | --- |
@@ -785,6 +785,30 @@ changes an engine that does not.
 | Script profiling | `options.Profiling.Enabled = true` | [Profiling scripts (opt-in)](../README.md#profiling-scripts-opt-in) |
 | Statement-level code coverage | `options.Coverage.Enabled = true` | [Code coverage (opt-in)](../README.md#code-coverage-opt-in) |
 | `NamedPropertyObject` — one base class for a host object projecting *named* properties, the string-keyed sibling of `ArrayLikeObject` | derive from it instead of overriding `GetOwnProperty` / `ProbeOwnProperty` / `GetOwnPropertyKeys` / `TryGetOwnPropertyValue` / `GetOwnProperties` by hand | [Projecting host data](../README.md#embedding-performance) |
+
+### 5.1 Every error constructor is reachable from host code ([#3324](https://github.com/sebastienros/jint/pull/3324))
+
+`Engine.Intrinsics` exposed `Error` and `TypeError` and kept the other five `internal`, so a host
+function could not raise the error the specification would raise — a `RangeError` for an
+out-of-range argument being the common case. All seven are now `public`; nothing else changed and
+nothing was removed.
+
+```c#
+throw new JavaScriptException(engine.Intrinsics.RangeError, $"index {index} is out of range");
+```
+
+Additive, so no migration is required. If you reached one through the global instead, that keeps
+working and can now be written directly:
+
+```c#
+// before
+var rangeError = (ErrorConstructor) engine.GetValue("RangeError");
+// after
+var rangeError = engine.Intrinsics.RangeError;
+```
+
+The CLR name of `%URIError%` is `Intrinsics.UriError`; script still sees `URIError`. See [Raising an
+error from host code](../README.md#raising-an-error-from-host-code).
 
 ## 6. AOT and trimming
 


### PR DESCRIPTION
## The defect

`Jint/Runtime/Intrinsics.cs` exposed two of the seven error constructors and hid five:

```
public   ErrorConstructor Error
internal ErrorConstructor EvalError
internal ErrorConstructor SyntaxError
public   ErrorConstructor TypeError
internal ErrorConstructor RangeError
internal ErrorConstructor ReferenceError
internal ErrorConstructor UriError
```

So a host function could fail with a `TypeError` but not with a `RangeError` — the error the specification
prescribes for an out-of-range argument, and one of the most common things a host needs to raise.

The split is an accident of who needed what, not a policy. It is also **porous**, and I verified that rather
than assuming it: on unmodified `main`, with a throwaway test in `Jint.Tests.PublicInterface` (the one project
without `InternalsVisibleTo`), this passes on both the `net10.0` and the `net472` legs —

```csharp
var rangeError = (ErrorConstructor) engine.GetValue("RangeError");
engine.SetValue("f", new Action(() => throw new JavaScriptException(rangeError, "out of range")));
engine.Evaluate("try { f(); } catch (e) { [e instanceof RangeError, e.constructor === RangeError, e.name, e.message].join('|'); }")
// => "true|true|RangeError|out of range"
```

`GlobalObject.Properties.cs` installs the very same objects under `[JsIntrinsicReference("RangeError")]` and
`ErrorConstructor` is public and sealed, so the cast succeeds. The `internal` modifier was withholding a
spelling, not a capability — which is the strongest argument that promoting it removes nothing and freezes
nothing new beyond a property name.

## What this changes

**All seven `ErrorConstructor` properties are now `public`.** One word each, plus a doc comment on `Error`
saying why the family is public and a one-liner on each sibling. Nothing else in `Intrinsics` moved.

```csharp
throw new JavaScriptException(engine.Intrinsics.RangeError, $"index {index} is out of range");
```

### Was anything else in `Intrinsics` in the same accidental position? No.

I checked every `internal` member of `Intrinsics` against the visibility of the type it returns.
**`ErrorConstructor` is the only public intrinsic type whose `Intrinsics` properties were split.** Every other
`internal` property returns an `internal` type — `DateConstructor`, `MathInstance`, `JsonInstance`,
`PromiseConstructor`, `ProxyConstructor`, `ReflectInstance`, `SymbolConstructor`, `StringConstructor`,
`NumberConstructor`, `BooleanConstructor`, `BigIntConstructor`, the iterator prototypes, and the rest — so
flipping the modifier there would not even compile without first widening a class. That is a real design
decision to argue on its own, not an oversight, and none of it is in this PR.

The two near-misses worth naming: `AggregateError` and `SuppressedError` *are* error constructors, but
`AggregateErrorConstructor` and `SuppressedErrorConstructor` are `internal sealed` classes deriving from
`Constructor`, not from `ErrorConstructor`. They would need a type promotion, and they would still not fit
`new JavaScriptException(ErrorConstructor, …)`. Left alone deliberately; the rule I wrote into
`Jint/Native/AGENTS.md` names them as the case that needs its own argument.

## Design decision: no factory, no `JsErrorKind` enum

The brief invited an ergonomic front door — `engine.Throw(JsErrorKind.Range, message)` or
`JsError.Create(...)` — and explicitly allowed concluding it is not worth the surface. That is my conclusion,
and the reasoning is:

1. **It is not shorter, and it is not clearer.** `engine.Intrinsics.RangeError` against `JsErrorKind.Range`
   is a wash on characters and a loss on names: JavaScript already calls this thing `RangeError`, and an enum
   introduces a second spelling an embedder has to translate. The intrinsics also now list all seven
   adjacently under `engine.Intrinsics.`, which is where an embedder already looks and where IntelliSense
   surfaces them without any new type.
2. **A public enum is a frozen member list, and this list is not frozen.** ECMAScript already has two error
   constructors the enum could not name (`AggregateError`, `SuppressedError`, per point above), and it will
   grow more. An enum-based front door would be permanently narrower than the door behind it — a factory that
   cannot express the errors the engine can construct is worse than no factory.
3. **It cannot carry the overload that matters.** The README-recommended form is
   `new JavaScriptException(ctor, message, clrException)`, which is what keeps `TryGetClrException` working.
   An enum factory would need a parallel overload set to reach it, and every future `JavaScriptException`
   constructor would need mirroring.
4. **Neither throw shape reads well.** Returning the exception gives `throw engine.Throw(...)`, which says
   "throw" twice. Throwing from inside — the `[DoesNotReturn]` shape Jint's *internal* `Throw.*` helpers use —
   hides control flow at a host call site, where the reader is not a Jint contributor and has no reason to
   know that `engine.Throw(...)` does not return. Internal `Throw.*` earns that trade by keeping non-error
   paths allocation-free across thousands of call sites; a host raising one error does not.

Per the repository's internal-first ladder, the smaller frozen contract wins: seven property modifiers, no new
public type. The ergonomics come from the README instead, which now has a table mapping each constructor to
what a host should use it for.

## Also in this PR

- **`Jint/Native/AGENTS.md`** — a new short section stating the rule for what `Intrinsics` promotes: a type a
  host can legitimately *call* from C#, not every constructor; and that the type's own visibility is what
  enforces it. (Deliberately *not* in `Jint/AGENTS.md`, which is already over its 32 KiB budget — #3323.)
- **`README.md`** — "Raising an error from host code" now leads with picking the right constructor, has the
  seven-row table, keeps the CLR-exception example (retargeted to `SyntaxError`, which is what an XML parse
  failure actually is), and mentions `ErrorConstructor.Construct(message)` for handing an error back as a
  value rather than throwing it.
- **`docs/v5-migration.md` §5.1** — additive entry. §5 had no numbered subsections, so 5.1 was the next free
  number; the section intro was reworded by one line so "everything here is opt-in" scopes to its table and
  not to the new subsection.
- **Five API baselines regenerated** by running the suite and copying `.received.txt` over `.verified.txt`,
  never hand-edited. The diff is exactly five added lines per file and nothing else.

## Tests

New `Jint.Tests.PublicInterface/HostRaisedErrorTests.cs` — the project without `InternalsVisibleTo`, so it
proves a third party can reach this:

- A theory over all seven raising from a host `Action` and catching in script, asserting `e instanceof <Ctor>`,
  `e.constructor === <Ctor>`, `Object.getPrototypeOf(e) === <Ctor>.prototype`, `Error.isError(e)`, `e.name`,
  `e.message`, and `String(e)`. This pins `UriError` → `URIError`, the one intrinsic whose CLR name is not its
  script name.
- The same seven uncaught, asserting the `JavaScriptException` that reaches the host carries that error type
  and that `error.Engine` is the engine whose intrinsic built it.
- **Realm:** an error raised through `engine.Intrinsics` after `new ShadowRealm()` has built a second
  intrinsics set is still an instance of the principal realm's `RangeError`, prototype identity included.
- `engine.Intrinsics.RangeError === RangeError === globalThis.RangeError` — the intrinsic is the object the
  script sees.
- The CLR-exception overload on a `RangeError` still reaches `JintException.TryGetClrException`.
- `ErrorConstructor.Construct(message)` as the value-producing half.

18 tests, green on both legs (`net10.0`, `net472`).

## Verification

| Run | Result |
| --- | --- |
| `dotnet build -c Release` | clean, 0 errors (`TreatWarningsAsErrors` on) |
| `Jint.Tests` | 10,645 passed / 0 failed (net10.0 and net8.0), 7,298 passed / 0 failed (net472) |
| `Jint.Tests.PublicInterface` | 2,598 passed / 0 failed (net10.0), 1,998 passed / 0 failed (net472) |
| `Jint.Tests.Test262` | **102,495 passed / 0 failed**, 189 skipped |

The test262 number is the expected one and held exactly. (Two earlier full runs on this box reported three
bare `System.TimeoutException` failures with no assertion message — `staging/sm/**` tests that pass in
isolation in well under a second. That was machine load from concurrent suites, not this change; the clean
run above is the one to read.)
