### PR TITLE
JSON: parsing claims the engine, exactly as serializing already did

### DIFF
--- a/Jint.Tests.PublicInterface/HostEngineConcurrencyTests.cs
+++ b/Jint.Tests.PublicInterface/HostEngineConcurrencyTests.cs
@@ -1,7 +1,9 @@
 #nullable enable
 
 using System.Diagnostics;
+using System.Text;
 using Jint.Native;
+using Jint.Native.Json;
 using Jint.Runtime;
 using Jint.Runtime.Debugger;
 using Jint.Runtime.Modules;
@@ -806,6 +808,98 @@ public class HostEngineConcurrencyTests
             _thread.Join(HandoffCeiling);
             _release.Dispose();
         }
+    }
+
+    /// <summary>
+    /// A JSON parse builds objects and arrays into the engine's realm for the whole document, so it is a
+    /// host entry in the sense this contract means, and a second thread reaching it is refused.
+    /// </summary>
+    /// <remarks>
+    /// It was the one conversion entry that was not. <c>JsonSerializer.Serialize</c> — its sibling, same
+    /// namespace, same <c>(Engine)</c> constructor shape — has always been bracketed, so a host had no way to
+    /// guess that one of the pair fails fast and the other builds concurrently into a busy engine. That
+    /// asymmetry is what the next test pins from the other side.
+    /// </remarks>
+    [Fact]
+    public async Task ConcurrentJsonParseIsRejectedAndTheEngineRecovers()
+    {
+        using var entered = new ManualResetEventSlim();
+        using var release = new ManualResetEventSlim();
+        var engine = CreateBlockingEngine(entered, release);
+        var running = StartOwningThread(() => engine.Execute("block()"));
+
+        await WaitUntilOwned(entered, running);
+        try
+        {
+            Invoking(() => new JsonParser(engine).Parse("""{"a":[1,2,3],"b":{"c":"d"}}"""))
+                .Should().Throw<InvalidOperationException>()
+                .WithMessage(ConcurrentUseMessage);
+        }
+        finally
+        {
+            release.Set();
+        }
+
+        await running;
+        new JsonParser(engine).Parse("""{"a":1}""").AsObject().Get("a").AsNumber().Should().Be(1);
+    }
+
+    /// <summary>
+    /// The span overloads take the same door. Both funnel through <c>Parse(ReadOnlySpan&lt;char&gt;)</c>, so
+    /// one guard covers all three — which is worth pinning, because a host reaching for the allocation-free
+    /// overload is exactly the host most likely to be doing so from a network or storage callback.
+    /// </summary>
+    [Fact]
+    public async Task ConcurrentJsonParseIsRejectedForTheSpanOverloadsToo()
+    {
+        using var entered = new ManualResetEventSlim();
+        using var release = new ManualResetEventSlim();
+        var engine = CreateBlockingEngine(entered, release);
+        var running = StartOwningThread(() => engine.Execute("block()"));
+
+        await WaitUntilOwned(entered, running);
+        try
+        {
+            Invoking(() => new JsonParser(engine).Parse("""{"a":1}""".AsSpan()))
+                .Should().Throw<InvalidOperationException>()
+                .WithMessage(ConcurrentUseMessage);
+
+            Invoking(() => new JsonParser(engine).Parse(Encoding.UTF8.GetBytes("""{"a":1}""").AsSpan()))
+                .Should().Throw<InvalidOperationException>()
+                .WithMessage(ConcurrentUseMessage);
+        }
+        finally
+        {
+            release.Set();
+        }
+
+        await running;
+    }
+
+    /// <summary>
+    /// The other half of the pair, so the two are pinned together and cannot drift apart again.
+    /// </summary>
+    [Fact]
+    public async Task ConcurrentJsonSerializeIsRejected()
+    {
+        using var entered = new ManualResetEventSlim();
+        using var release = new ManualResetEventSlim();
+        var engine = CreateBlockingEngine(entered, release);
+        var running = StartOwningThread(() => engine.Execute("block()"));
+
+        await WaitUntilOwned(entered, running);
+        try
+        {
+            Invoking(() => new JsonSerializer(engine).Serialize(JsNumber.Create(1)))
+                .Should().Throw<InvalidOperationException>()
+                .WithMessage(ConcurrentUseMessage);
+        }
+        finally
+        {
+            release.Set();
+        }
+
+        await running;
     }
 
     private static Engine CreateBlockingEngine(ManualResetEventSlim entered, ManualResetEventSlim release)

--- a/Jint/Native/Json/JsonParser.cs
+++ b/Jint/Native/Json/JsonParser.cs
@@ -1119,6 +1119,16 @@ public sealed class JsonParser
     /// </remarks>
     public JsValue Parse(ReadOnlySpan<char> code)
     {
+        // The one choke point: both other overloads funnel here, so this is where the engine is claimed.
+        // A parse runs no user code, but it builds objects and arrays into the engine's realm for the whole
+        // document, which is engine-owned state — so it is a host entry in the sense the concurrency contract
+        // means, and a second thread reaching it while the engine is in use is refused rather than admitted.
+        // Its sibling JsonSerializer has always been bracketed (through ExecuteWithConstraints); this closes
+        // the half that was not. On the in-box callers — JSON.parse, a JSON module, response.json(), a JWK
+        // import — the engine is already claimed by this thread, so this is the re-entrant branch: a volatile
+        // read and a depth increment, once per document.
+        using var ownership = _engine.EnterHostCall();
+
         State state = Reset(code);
 
         Peek(ref state);

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -966,6 +966,23 @@ Three details worth knowing:
 - **`MakeReadOnly()` is public and idempotent**, so a host that builds a configured `Options` in one place
   and hands it around can freeze it itself, before any engine exists.
 
+### 4.17 `JsonParser.Parse` takes the engine's host-call reservation ([#3330](https://github.com/sebastienros/jint/issues/3330))
+
+All three `Parse` overloads now claim the engine for the duration of the parse, so a second thread reaching
+one while the engine is in use is rejected with `InvalidOperationException` instead of building objects and
+arrays into that engine's realm concurrently.
+
+It was the last conversion entry that did not. `JsonSerializer.Serialize` — its sibling, same namespace, same
+`(Engine)` constructor shape — has always been bracketed, and so is `JsValue.FromObject`, so a host had no way
+to guess that this one was different. It is also the wrong half to have left open: serializing walks a graph
+the host already holds, while parsing *creates* engine-owned state.
+
+Nothing changes for a host that parses on the engine's own thread, which includes every use from inside
+script (`JSON.parse`), from a JSON module, from `response.json()` and from a JWK import — the guard takes its
+re-entrant branch there. A host parsing while the engine is *idle* is unaffected too: the reservation claims
+an unowned engine rather than refusing it. What changes is a parse issued from a background thread while the
+engine is busy, which now fails loudly instead of corrupting quietly.
+
 ## 5. New in v5
 
 Everything here is opt-in: nothing below is installed unless the host asks for it, so none of it


### PR DESCRIPTION
Closes #3330.

`JsonSerializer.Serialize` reaches `ExecuteWithConstraints`, which opens with `EnterHostCall()`, so a second thread calling it while the engine is busy is refused. `JsonParser.Parse` — its sibling, same namespace, same `(Engine)` constructor shape — had no ownership check on any of its three overloads, and a parse builds objects and arrays into the engine's realm for the whole document.

Measured on `main` before the change, with the engine thread inside a host call:

| public API taking an `Engine` | before | after |
| --- | --- | --- |
| `engine.Evaluate` (control) | `InvalidOperationException` | unchanged |
| `JsValue.FromObject` | `InvalidOperationException` | unchanged |
| `new JsonSerializer(e).Serialize(value)` | `InvalidOperationException` | unchanged |
| `new JsonParser(e).Parse(string)` | **ran concurrently** | `InvalidOperationException` |
| `new JsonParser(e).Parse(ReadOnlySpan<char>)` | **ran concurrently** | `InvalidOperationException` |
| `new JsonParser(e).Parse(ReadOnlySpan<byte>)` | **ran concurrently** | `InvalidOperationException` |

It is also the wrong half of the pair to have left open: serializing walks a graph the host already holds, while parsing *creates* engine-owned state.

## One guard, three overloads

It goes on `Parse(ReadOnlySpan<char>)`, the choke point both other overloads funnel through, so one `using` covers all three.

The cost is a volatile read and a depth increment, once per document. Every in-box caller — `JSON.parse`, a JSON module, `response.json()`, a JWK import — is already inside a host call and so takes the re-entrant branch, against a parse that allocates an object graph.

## Why not `ExecuteWithConstraints`, which the sibling uses

The issue left this to be decided here. Two reasons, and the first is decisive:

1. **A `ReadOnlySpan<char>` cannot be captured by the `Func<T>` `ExecuteWithConstraints` takes**, so bracketing the choke point is not expressible. Bracketing only the `string` overload would leave the span overloads unguarded — and those are the ones a network or storage caller reaches for, which is exactly the caller most likely to be on a background thread.
2. It would also change what a **top-level** parse is budgeted against. That turns out to matter, but as a defect of its own rather than as a side effect of this one — see below.

## A second defect found on the way, filed separately

A direct `JsonParser.Parse` observes constraints (the scanner calls `_engine.Constraints.Check()` every 10 000 characters) but is not itself a constraint-bracketed entry, so it inherits a deadline armed at the end of an unrelated earlier run:

```csharp
var engine = new Engine(o => o.LimitExecutionTime(TimeSpan.FromMilliseconds(200)));
engine.Evaluate("1 + 1");        // arms, then re-arms on exit
Thread.Sleep(1000);              // ... and an unrelated second passes
new JsonParser(engine).Parse(bigDocument);
// TimeoutException - from a deadline that expired before the parse started
```

Reproduced, not reasoned about. It is the mechanism the root `AGENTS.md` already documents for a host-side `Constraints.Check()` — reaching an API where nobody would look for it. Filed on its own because the fix is the `ExecuteWithConstraints` bracket that reason 1 above blocks, so it needs a `ref struct`-friendly host-entry scope rather than a one-line change.

## Compatibility

Nothing changes for a host parsing on the engine's own thread, or on an idle engine — the reservation claims an unowned engine rather than refusing it. What changes is a parse issued from a background thread while the engine is busy, which now fails loudly instead of corrupting quietly. `docs/v5-migration.md` §4.16 carries the row.

## Tests

In `HostEngineConcurrencyTests`, beside the entries they now match, and pinning the sibling too so the two cannot drift apart again.

**Verified failing without the guard**, which is the shape the claim predicts: the two `Parse` cases fail, the `Serialize` case passes.

## Verification

| | |
| --- | --- |
| `Jint.Tests` | 10645 / 10645 on net10.0 and net8.0, 7298 / 7298 on net472 |
| `Jint.Tests.PublicInterface` | 2589 / 2589 on net10.0, 1989 / 1989 on net472 |
| test262 | 102495 passed, **0 failed** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RAUkvPP8wvjwQEA1Yiwxm
