### PR TITLE
Docs: two migration-guide sections were both numbered 5.1

### DIFF
--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -1122,7 +1122,7 @@ Four things worth knowing before writing one:
   `TryDeleteName` alone is *not* a mistake: deletion is governed by `configurable`, which a projected name
   always reports `true`, so a read-only-but-removable projection is an ordinary shape.
 
-### 5.1 Every error constructor is reachable from host code ([#3337](https://github.com/sebastienros/jint/pull/3337))
+### 5.4 Every error constructor is reachable from host code ([#3337](https://github.com/sebastienros/jint/pull/3337))
 
 `Engine.Intrinsics` exposed `Error` and `TypeError` and kept the other five `internal`, so a host
 function could not raise the error the specification would raise — a `RangeError` for an
@@ -1296,3 +1296,10 @@ the section that matches the *shape* of the break, not the area of the code:
 
 Cite the pull request. Keep the entry to what an embedder has to do — the reasoning belongs in the
 pull request, and the reference material belongs in `README.md`.
+
+**Numbering is assigned at merge, not at authoring.** Several pull requests are usually in flight at
+once, each picking what looked like the next free subsection number when it was written, so the
+number is stale by the time it lands — and because two of them edit different parts of this file,
+git merges them cleanly and the duplicate only shows up in the rendered document. Whoever merges
+second renumbers, and repoints any `[§x.y](#xy-...)` link to the section. A collision that reaches
+`main` is a docs fix, not a rewrite of the section.


### PR DESCRIPTION
`main` currently renders **two** section 5 subsections numbered `5.1` — "Source-generated CLR interop" ([#3333](https://github.com/sebastienros/jint/pull/3333)) and "Every error constructor is reachable from host code" ([#3337](https://github.com/sebastienros/jint/pull/3337)).

Both were written while the other was in flight, both picked what was then the next free number, and because they edit different parts of `docs/v5-migration.md` git merged them **without a conflict**. That is the trap: nothing failed, and the duplicate is visible only in the rendered document.

- The error-constructor section becomes **5.4**. It has no inbound anchor links, so nothing else moves.
- **5.2** is left for the Intl provider section, which is already numbered that way on [#3335](https://github.com/sebastienros/jint/pull/3335) and fills the gap when it merges.
- **5.3** (named-property hooks, [#3338](https://github.com/sebastienros/jint/pull/3338)) is unchanged.

Also adds a paragraph to *Keeping this document current* recording that numbering is assigned at merge rather than at authoring, and that whoever merges second renumbers and repoints any `[§x.y](#xy-...)` link. Three collisions have been resolved by hand during the v5 campaign already; this is the first that reached `main`.