### PR TITLE
Wpt: the fetch budget bounds a redirect chain, not one hop

### DIFF
--- a/Jint.Tests/Wpt/WptHarness.cs
+++ b/Jint.Tests/Wpt/WptHarness.cs
@@ -160,14 +160,37 @@ internal static class WptHarness
     /// it as a stall for the whole file instead.
     /// </para>
     /// </remarks>
-    private static readonly TimeSpan _offThreadGrace = TimeSpan.FromSeconds(20);
+    private static readonly TimeSpan _offThreadGrace = TimeSpan.FromSeconds(60);
 
     /// <summary>
-    /// The bound on one request to the driver's own loopback server. It has to be well inside
-    /// <see cref="_offThreadGrace"/> — see there — and a request to a server in this process is either
-    /// answered at once or not at all.
+    /// The bound on one <c>fetch()</c> against the driver's own loopback server — which is the whole call,
+    /// <b>redirects included</b>, and not one hop.
     /// </summary>
-    private static readonly TimeSpan _fetchTimeout = TimeSpan.FromSeconds(10);
+    /// <remarks>
+    /// <para>
+    /// The distinction is the whole reason this number is what it is. <c>Options.WebApi.Fetch.Timeout</c>
+    /// bounds the call "from the call to the last byte of the body" (see <c>FetchOperation</c>), so
+    /// <c>fetch/api/redirect/redirect-count.any.js</c> spends one budget on <b>twenty-one sequential
+    /// round trips</b> plus every microtask checkpoint the engine pumps between them. This used to read ten
+    /// seconds, justified by the observation that "a request to a server in this process is either answered
+    /// at once or not at all" — true of one hop, and not true of the chain the option actually bounds. On a
+    /// contended CI runner that chain outran ten seconds and the row failed with a <c>TimeoutError</c>, which
+    /// then moved the corpus totals and reddened <c>WptCensusTests</c> alongside it (#3314).
+    /// </para>
+    /// <para>
+    /// So the budget is the engine's own default rather than a lowered one: the harness had no reason to be
+    /// stricter than the shipped configuration, and a lane whose slowest file makes twenty-one loopback round
+    /// trips is the last place to be. It still has to sit well inside <see cref="_offThreadGrace"/> — see
+    /// there — so that grace moves with it and a request the server never answers still becomes a failing
+    /// test rather than a stalled file.
+    /// </para>
+    /// <para>
+    /// Neither number costs a passing run anything. A timeout elapses only where a request is not answered
+    /// and the grace only where a file stops making progress, so raising both changes how long a genuine
+    /// failure takes to report and nothing else.
+    /// </para>
+    /// </remarks>
+    private static readonly TimeSpan _fetchTimeout = TimeSpan.FromSeconds(30);
 
     /// <summary>
     /// The files that run against <see cref="WptServer"/> — a real <c>fetch</c>, over a real socket, to the


### PR DESCRIPTION
Fixes #3314.

## The exception names the cause

#3314 says the missing fact is *which* `DOMException`, because "that distinction decides whether the fix is a budget, a handshake, or nothing at all." It is a budget:

```
[FAIL] Redirect 303 20 times: TimeoutError: The request exceeded the
       00:00:10 timeout set by Options.WebApi.Fetch.Timeout.
```

## The premise was right about the wrong thing

`_fetchTimeout` was ten seconds, justified in its own doc comment by: *"a request to a server in this process is either answered at once or not at all."* That is true of **one hop**.

But `Options.WebApi.Fetch.Timeout` bounds the **whole call** — `FetchOperation` documents it as "from the call to the last byte of the body" and starts its stopwatch once, for the call and not per hop. So `redirect-count.any.js` spends a single budget on **twenty-one sequential loopback round trips**, plus every microtask checkpoint the engine pumps between them. Ten seconds across twenty-one round trips is ~476 ms each — comfortable on an idle machine, not on a contended runner.

That is also why this row is the first casualty rather than an arbitrary one: every other file in the vendored fetch corpus makes one or two requests, and this one makes twenty-one against the same budget.

## The change

| | before | after |
| --- | --- | --- |
| `_fetchTimeout` | 10s | **30s** — the engine's own `Options.WebApi.Fetch.Timeout` default |
| `_offThreadGrace` | 20s | **60s** — keeps the documented invariant |

The harness had *lowered* the bound below what the engine ships, and the lane containing the corpus's longest redirect chain is the last place to be stricter than the shipped configuration. `_offThreadGrace` moves with it to preserve the invariant its own remarks state: the grace must stay well outside the fetch budget, or a request the server never answers gets reported as a stalled *file* instead of the failing *test* it is.

**Neither number costs a passing run anything.** A timeout elapses only where a request is not answered; a grace only where a file stops making progress. Both change how long a genuine failure takes to report, and nothing else.

## Why it is worth fixing rather than re-running

The census cascade means this is not contained to the fetch lane. A moved row changes the corpus totals, so `WptCensusTests.TheInventoryTableMatchesWhatTheCorpusMeasures` reddens for whoever runs next — including pull requests that contain no code. A **docs-only** branch (`docs/v5-guide-duplicate-38`) failed the Windows leg on exactly that census assertion within the same hour as the run that produced the `TimeoutError` above.

The same 10s rejection also took out `redirect-location.any.js` on a later attempt, so it was never specific to the 21-hop row — only *first* there.

## Verification

The whole WPT suite is **457 passed / 1 skipped / 458** on net10.0 locally, unchanged from before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0123vopKmTcfrYHFQn7qYYzk