### PR TITLE
[JsAccessible]: a generated member is filtered and named the way a reflected one is

### DIFF
--- a/Jint.Tests.PublicInterface/HostGeneratedInteropModels.cs
+++ b/Jint.Tests.PublicInterface/HostGeneratedInteropModels.cs
@@ -97,6 +97,43 @@ public sealed class ReflectedModel
 }
 
 /// <summary>
+/// An annotated type carrying a string indexer, which is probed ahead of the member itself. An indexer that
+/// answers for a name a declared member also carries has to win on both paths, and one that declines has to
+/// leave the member to answer on both paths.
+/// </summary>
+[JsAccessible]
+public sealed class GeneratedIndexed
+{
+    private readonly Dictionary<string, string> _entries = new(StringComparer.Ordinal);
+
+    public string? Name { get; set; }
+
+    public string? this[string key] => _entries.TryGetValue(key, out var value) ? value : null;
+
+    public JsValue Put(JsValue key, JsValue value)
+    {
+        _entries[key.ToString()] = value.ToString();
+        return value;
+    }
+}
+
+/// <summary>Byte-for-byte the same members as <see cref="GeneratedIndexed"/>, without the attribute.</summary>
+public sealed class ReflectedIndexed
+{
+    private readonly Dictionary<string, string> _entries = new(StringComparer.Ordinal);
+
+    public string? Name { get; set; }
+
+    public string? this[string key] => _entries.TryGetValue(key, out var value) ? value : null;
+
+    public JsValue Put(JsValue key, JsValue value)
+    {
+        _entries[key.ToString()] = value.ToString();
+        return value;
+    }
+}
+
+/// <summary>
 /// A nested annotated type. Its hint name has to carry the containing type: the MVP derived one from
 /// <c>{Namespace}.{Name}</c> alone, so this type and a top-level <c>Player</c> in the same namespace both
 /// claimed <c>Ns.Player.JsAccessible.g.cs</c> and the second <c>AddSource</c> threw.

--- a/Jint.Tests.PublicInterface/HostGeneratedInteropTests.cs
+++ b/Jint.Tests.PublicInterface/HostGeneratedInteropTests.cs
@@ -247,29 +247,234 @@ public class HostGeneratedInteropTests
     }
 
     /// <summary>
-    /// A host that has installed one of the four settings steering member resolution keeps the reflection
-    /// path even for an annotated type, because the generated lanes do not run through them yet. Not being
-    /// able to honour a filter and honouring it anyway are the same bug; declining is the difference.
+    /// A member a host filter hides is hidden in both lanes, and the members it allows keep theirs. The
+    /// second half is what a blanket "any filter turns the feature off" answer got wrong: honouring a filter
+    /// by abandoning the feature is safe, and is still not what the host asked for.
     /// </summary>
     [Fact]
-    public void AHostMemberFilterTurnsTheGeneratedLaneOff()
+    public void AHostMemberFilterHidesAMemberInBothLanes()
     {
-        var resolver = new TypeResolver { MemberFilter = static member => !string.Equals(member.Name, "Score", StringComparison.Ordinal) };
-        var engine = new Engine(options => options.Interop.TypeResolver = resolver);
-        engine.SetValue("model", new GeneratedModel { Score = 3, Ticks = 9 });
+        var generated = Contained(new GeneratedModel { Score = 3, Ticks = 9 }, resolver => resolver.MemberFilter = HidesScore);
+        var reflected = Contained(new ReflectedModel { Score = 3, Ticks = 9 }, resolver => resolver.MemberFilter = HidesScore);
 
-        engine.Evaluate("typeof model.Score").AsString().Should().Be("undefined");
-        engine.Evaluate("model.Ticks").AsNumber().Should().Be(9);
+        generated.Evaluate("typeof model.Score").AsString().Should().Be("undefined");
+        reflected.Evaluate("typeof model.Score").AsString().Should().Be("undefined");
+        generated.Evaluate("model.Ticks").AsNumber().Should().Be(9);
+        reflected.Evaluate("model.Ticks").AsNumber().Should().Be(9);
+
+        GeneratedLaneIsEngaged(generated, reflected, "model.Describe.length");
     }
 
-    [Fact]
-    public void AHostNameCreatorTurnsTheGeneratedLaneOff()
-    {
-        var resolver = new TypeResolver { MemberNameCreator = static member => [member.Name.ToUpperInvariant()] };
-        var engine = new Engine(options => options.Interop.TypeResolver = resolver);
-        engine.SetValue("model", new GeneratedModel { Score = 3 });
+    private static readonly Predicate<System.Reflection.MemberInfo> HidesScore =
+        static member => !string.Equals(member.Name, "Score", StringComparison.Ordinal);
 
-        engine.Evaluate("model.SCORE").AsNumber().Should().Be(3);
+    /// <summary>
+    /// A host name creator renames a generated member exactly as it renames a reflected one — the old name
+    /// stops resolving, the new one starts, and the lane behind it is still the generated one.
+    /// </summary>
+    [Fact]
+    public void AHostNameCreatorRenamesAMemberInBothLanes()
+    {
+        var generated = Contained(new GeneratedModel { Score = 3 }, resolver => resolver.MemberNameCreator = Prefixes);
+        var reflected = Contained(new ReflectedModel { Score = 3 }, resolver => resolver.MemberNameCreator = Prefixes);
+
+        generated.Evaluate("model.js_Score").AsNumber().Should().Be(3);
+        reflected.Evaluate("model.js_Score").AsNumber().Should().Be(3);
+        generated.Evaluate("typeof model.Score").AsString().Should().Be("undefined");
+        reflected.Evaluate("typeof model.Score").AsString().Should().Be("undefined");
+
+        GeneratedLaneIsEngaged(generated, reflected, "model.js_Describe.length");
+    }
+
+    private static readonly Func<System.Reflection.MemberInfo, IEnumerable<string>> Prefixes =
+        static member => ["js_" + member.Name];
+
+    /// <summary>
+    /// The camelCase name policy an embedder actually writes. Its effect on the members whose CLR name only
+    /// differs in the first character is nil — that is what the default comparer already does — so what this
+    /// says is that the whole feature survives installing it, which is what the blanket skip cost.
+    /// </summary>
+    [Fact]
+    public void ACamelCaseNameCreatorKeepsTheGeneratedLane()
+    {
+        var generated = Contained(new GeneratedModel { Score = 3 }, resolver => resolver.MemberNameCreator = CamelCases);
+        var reflected = Contained(new ReflectedModel { Score = 3 }, resolver => resolver.MemberNameCreator = CamelCases);
+
+        generated.Evaluate("model.score").AsNumber().Should().Be(3);
+        reflected.Evaluate("model.score").AsNumber().Should().Be(3);
+
+        GeneratedLaneIsEngaged(generated, reflected, "model.describe.length");
+    }
+
+    private static readonly Func<System.Reflection.MemberInfo, IEnumerable<string>> CamelCases =
+        static member => [char.ToLowerInvariant(member.Name[0]) + member.Name.Substring(1)];
+
+    /// <summary>
+    /// A host name comparer decides which names reach a member, generated or reflected. The default one
+    /// ignores the first character's casing; an ordinal one does not, and both lanes have to say so.
+    /// </summary>
+    [Fact]
+    public void AHostNameComparerDecidesWhichNamesReachAMemberInBothLanes()
+    {
+        var generated = Contained(new GeneratedModel { Score = 3 }, resolver => resolver.MemberNameComparer = StringComparer.Ordinal);
+        var reflected = Contained(new ReflectedModel { Score = 3 }, resolver => resolver.MemberNameComparer = StringComparer.Ordinal);
+
+        generated.Evaluate("model.Score").AsNumber().Should().Be(3);
+        reflected.Evaluate("model.Score").AsNumber().Should().Be(3);
+        generated.Evaluate("typeof model.score").AsString().Should().Be("undefined");
+        reflected.Evaluate("typeof model.score").AsString().Should().Be("undefined");
+
+        GeneratedLaneIsEngaged(generated, reflected, "model.Describe.length");
+    }
+
+    /// <summary>
+    /// Binding flags that no longer report a member hide it from both lanes — and leave the lanes they do
+    /// not narrow alone, which one setting taking the whole feature off could not express.
+    /// </summary>
+    [Fact]
+    public void NarrowedPropertyBindingFlagsHideThePropertiesInBothLanes()
+    {
+        static Engine Host(object model)
+        {
+            var engine = new Engine(options =>
+            {
+                options.Interop.TypeResolver = new TypeResolver();
+                options.Interop.ObjectWrapperReportedPropertyBindingFlags =
+                    System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic;
+            });
+            engine.SetValue("model", model);
+            return engine;
+        }
+
+        var generated = Host(new GeneratedModel { Score = 3, Counter = 6 });
+        var reflected = Host(new ReflectedModel { Score = 3, Counter = 6 });
+
+        generated.Evaluate("typeof model.Score").AsString().Should().Be("undefined");
+        reflected.Evaluate("typeof model.Score").AsString().Should().Be("undefined");
+
+        // the field lane was not narrowed, so it keeps both its member and its generated accessor
+        generated.Evaluate("model.Counter").AsNumber().Should().Be(6);
+        reflected.Evaluate("model.Counter").AsNumber().Should().Be(6);
+
+        GeneratedLaneIsEngaged(generated, reflected, "model.Describe.length");
+    }
+
+    /// <summary>
+    /// Annotating a type is not a way around the hardened profile. An engine configured for untrusted code
+    /// denies an annotated type exactly what it denies an un-annotated one — <c>GetType</c>, writes, the
+    /// namespace globals — and allows it exactly what it allows one, through the generated lanes.
+    /// </summary>
+    [Fact]
+    public void AHardenedEngineContainsAnAnnotatedTypeTheWayItContainsAnyOther()
+    {
+        static Engine Host(object model)
+        {
+            var engine = new Engine(options => options.ForUntrustedCode(new UntrustedCodeLimits(
+                timeoutInterval: TimeSpan.FromSeconds(5),
+                maxStatements: 100_000,
+                memoryLimit: 16_000_000,
+                maxRecursionDepth: 64,
+                maxArraySize: 10_000,
+                regexTimeout: TimeSpan.FromMilliseconds(100),
+                promiseTimeout: TimeSpan.FromMilliseconds(100),
+                maxOperationDuration: TimeSpan.FromSeconds(10))));
+            engine.SetValue("model", model);
+            return engine;
+        }
+
+        var generated = Host(new GeneratedModel { Score = 3 });
+        var reflected = Host(new ReflectedModel { Score = 3 });
+
+        foreach (var script in new[]
+                 {
+                     "typeof model.GetType",
+                     "typeof System",
+                     "model.Score = 9; model.Score",
+                     "String(model.Score)",
+                     "String(model.Describe('a', 'b'))",
+                 })
+        {
+            generated.Evaluate(script).ToString().Should().Be(reflected.Evaluate(script).ToString(), "`{0}` must answer the same on both lanes", script);
+        }
+
+        generated.Evaluate("typeof model.GetType").AsString().Should().Be("undefined");
+        generated.Evaluate("model.Score = 9; model.Score").AsNumber().Should().Be(3);
+
+        GeneratedLaneIsEngaged(generated, reflected, "model.Describe.length");
+    }
+
+    /// <summary>
+    /// The suite's own differential matrix, re-run against a host name policy. Every read, write and call
+    /// has to come out identical there too — which is the whole claim, made where it used to be untestable
+    /// because the feature turned itself off rather than run through the policy.
+    /// </summary>
+    [Theory]
+    [InlineData("model.score")]
+    [InlineData("typeof model.missing")]
+    [InlineData("model.name = 'set'; model.name")]
+    [InlineData("model.name = null; String(model.name) + '|' + (model.name === null)")]
+    [InlineData("model.score = 5.5; model.score")]
+    [InlineData("model.counter = 3; model.counter")]
+    [InlineData("model.tags = ['a','b']; model.tags[0]")]
+    [InlineData("model.doubled")]
+    [InlineData("model.stamped")]
+    [InlineData("String(model.tag)")]
+    [InlineData("String(model.echo('a'))")]
+    [InlineData("model.describe('a', 'b')")]
+    [InlineData("model.describe('a')")]
+    [InlineData("model.add(1, 2)")]
+    [InlineData("model.shout('quiet')")]
+    [InlineData("model.setHidden(4); model.hidden")]
+    [InlineData("Object.keys(model).length")]
+    public void TheWholeMatrixIsStillIndistinguishableUnderAHostNamePolicy(string script)
+    {
+        AssertSame(script, configureResolver: static resolver => resolver.MemberNameCreator = CamelCases);
+    }
+
+    /// <summary>
+    /// An indexer is probed before the member itself, so a type carrying one resolves its names the way an
+    /// un-annotated one does: the indexer wins where it answers, the declared member wins where it does not,
+    /// and the generated lanes never reorder the two.
+    /// </summary>
+    [Theory]
+    [InlineData("model.Name = 'declared'; model.Name")]
+    [InlineData("model.Put('Name', 'from-indexer'); model.Name")]
+    [InlineData("model.Name = 'declared'; model.Put('Name', 'from-indexer'); model.Name")]
+    [InlineData("model.Put('other', 'value'); model.other")]
+    [InlineData("String(model.missing)")]
+    [InlineData("String(model.Put('k', 'v'))")]
+    public void AnIndexerAndASameNamedMemberResolveIdentically(string script)
+    {
+        var generated = Probe(new GeneratedIndexed(), script);
+        var reflected = Probe(new ReflectedIndexed(), script);
+
+        generated.Should().Be(reflected, "an annotated type carrying an indexer must resolve names the way an un-annotated one does for `{0}`", script);
+    }
+
+    /// <summary>
+    /// An engine whose resolver the host has configured, and whose model is projected into it. The resolver
+    /// is fresh per engine because assigning one of these settings drops everything the resolver has already
+    /// resolved, and the shared default resolver is used by every other test in the process.
+    /// </summary>
+    private static Engine Contained(object model, Action<TypeResolver> configure)
+    {
+        var resolver = new TypeResolver();
+        configure(resolver);
+
+        var engine = new Engine(options => options.Interop.TypeResolver = resolver);
+        engine.SetValue("model", model);
+        return engine;
+    }
+
+    /// <summary>
+    /// Says the generated lane actually answered, using the one observable that differs between the two: a
+    /// generated method is a function object with its own <c>length</c>, a reflected one is not. Without it
+    /// every assertion above would also pass against a lane that had quietly turned itself off.
+    /// </summary>
+    private static void GeneratedLaneIsEngaged(Engine generated, Engine reflected, string arity)
+    {
+        generated.Evaluate(arity).AsNumber().Should().Be(2, "the generated lane must still answer for `{0}`", arity);
+        reflected.Evaluate(arity).AsNumber().Should().Be(0);
     }
 
     /// <summary>
@@ -373,10 +578,10 @@ public class HostGeneratedInteropTests
         }
     }
 
-    private static void AssertSame(string script, bool allowWrite = true)
+    private static void AssertSame(string script, bool allowWrite = true, Action<TypeResolver>? configureResolver = null)
     {
-        var generated = Probe(new GeneratedModel { Score = 3, Ticks = 4, Ratio = 0.5, Active = true, Name = "n", Tag = new JsString("t"), Tags = ["a", "b"], Counter = 6 }, script, allowWrite);
-        var reflected = Probe(new ReflectedModel { Score = 3, Ticks = 4, Ratio = 0.5, Active = true, Name = "n", Tag = new JsString("t"), Tags = ["a", "b"], Counter = 6 }, script, allowWrite);
+        var generated = Probe(new GeneratedModel { Score = 3, Ticks = 4, Ratio = 0.5, Active = true, Name = "n", Tag = new JsString("t"), Tags = ["a", "b"], Counter = 6 }, script, allowWrite, configureResolver);
+        var reflected = Probe(new ReflectedModel { Score = 3, Ticks = 4, Ratio = 0.5, Active = true, Name = "n", Tag = new JsString("t"), Tags = ["a", "b"], Counter = 6 }, script, allowWrite, configureResolver);
 
         generated.Should().Be(reflected, "the generated lane must be indistinguishable from the reflected one for `{0}`", script);
     }
@@ -386,12 +591,24 @@ public class HostGeneratedInteropTests
     /// value, a JavaScript throw, a CLR throw — to one comparable string. The two fixture type names are
     /// normalized out, since they are the only thing that legitimately differs.
     /// </summary>
-    private static string Probe(object model, string script, bool allowWrite = true)
+    private static string Probe(object model, string script, bool allowWrite = true, Action<TypeResolver>? configureResolver = null)
     {
         // Projected CLR writes are off by default in v5, and a write to a descriptor whose Set is null is a
         // silent no-op outside strict mode - so a write matrix run on a default engine would compare two
         // sets of nothing and pass whatever the accessors did. AllowWriteIsHonoured covers the default.
-        var engine = new Engine(options => options.Interop.AllowWrite = allowWrite);
+        var engine = new Engine(options =>
+        {
+            options.Interop.AllowWrite = allowWrite;
+
+            if (configureResolver is not null)
+            {
+                // a fresh one: assigning any of these settings drops everything the resolver has resolved,
+                // and the default resolver is shared with every other test in the process
+                var resolver = new TypeResolver();
+                configureResolver(resolver);
+                options.Interop.TypeResolver = resolver;
+            }
+        });
         engine.SetValue("model", model);
 
         try

--- a/Jint.Tests/Runtime/JsAccessibleAccessorSelectionTests.cs
+++ b/Jint.Tests/Runtime/JsAccessibleAccessorSelectionTests.cs
@@ -92,21 +92,66 @@ public class JsAccessibleAccessorSelectionTests
         Resolve<NotAnnotated>("Score").Should().BeOfType<PropertyAccessor>();
     }
 
-    [Fact]
-    public void AHostMemberFilterTakesTheWholeTypeBackToReflection()
+    /// <summary>
+    /// A host that installed one of the settings steering member resolution keeps the generated lane. The
+    /// registry's own name-keyed lookup is skipped — it is only equivalent to the reflected selection while
+    /// nothing steers that selection — and the reflected selection runs instead, with the generated accessor
+    /// swapped in for whatever it landed on. What the host configured decides which member that is; the lane
+    /// it is read through is unaffected.
+    /// </summary>
+    [Theory]
+    [InlineData("Score")]
+    [InlineData("Field")]
+    [InlineData("Echo")]
+    public void AMemberAHostFilterAllowsKeepsItsGeneratedAccessor(string member)
     {
         var resolver = new TypeResolver { MemberFilter = static _ => true };
-        Resolve<Annotated>("Score", resolver).Should().BeOfType<PropertyAccessor>();
+        var accessor = Resolve<Annotated>(member, resolver);
+
+        (accessor is GeneratedMemberAccessor or GeneratedMethodAccessor).Should().BeTrue("{0} resolved to {1}", member, accessor.GetType().Name);
     }
 
     [Fact]
-    public void ANarrowedPropertyBindingProfileTakesTheWholeTypeBackToReflection()
+    public void AMemberAHostFilterHidesResolvesToNothingRatherThanToItsGeneratedAccessor()
     {
-        var accessor = Resolve<Annotated>(
-            "Score",
-            new TypeResolver(),
-            options => options.Interop.ObjectWrapperReportedPropertyBindingFlags = System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        var resolver = new TypeResolver { MemberFilter = static m => !string.Equals(m.Name, "Score", StringComparison.Ordinal) };
 
-        accessor.Should().NotBeOfType<GeneratedMemberAccessor>();
+        Resolve<Annotated>("Score", resolver).Should().BeSameAs(ConstantValueAccessor.NullAccessor);
+        Resolve<Annotated>("Name", resolver).Should().BeOfType<GeneratedMemberAccessor>();
+    }
+
+    [Fact]
+    public void AHostNameCreatorRenamesTheGeneratedMemberRatherThanRemovingIt()
+    {
+        var resolver = new TypeResolver { MemberNameCreator = static m => ["js_" + m.Name] };
+
+        Resolve<Annotated>("js_Score", resolver).Should().BeOfType<GeneratedMemberAccessor>();
+        Resolve<Annotated>("js_Echo", resolver).Should().BeOfType<GeneratedMethodAccessor>();
+        Resolve<Annotated>("Score", resolver).Should().BeSameAs(ConstantValueAccessor.NullAccessor);
+    }
+
+    [Fact]
+    public void AHostNameComparerDecidesWhichNamesReachTheGeneratedMember()
+    {
+        var resolver = new TypeResolver { MemberNameComparer = StringComparer.Ordinal };
+
+        Resolve<Annotated>("Score", resolver).Should().BeOfType<GeneratedMemberAccessor>();
+
+        // the default comparer ignores the first character's casing; an ordinal one does not
+        Resolve<Annotated>("score", resolver).Should().BeSameAs(ConstantValueAccessor.NullAccessor);
+    }
+
+    /// <summary>
+    /// Binding flags that no longer report a member hide it from both lanes — and cost nothing to the lanes
+    /// they do not narrow, which is what the blanket skip used to get wrong.
+    /// </summary>
+    [Fact]
+    public void ANarrowedPropertyBindingProfileHidesThePropertiesAndLeavesTheFieldsAlone()
+    {
+        static Action<Options> NonPublicPropertiesOnly()
+            => options => options.Interop.ObjectWrapperReportedPropertyBindingFlags = System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic;
+
+        Resolve<Annotated>("Score", new TypeResolver(), NonPublicPropertiesOnly()).Should().BeSameAs(ConstantValueAccessor.NullAccessor);
+        Resolve<Annotated>("Field", new TypeResolver(), NonPublicPropertiesOnly()).Should().BeOfType<GeneratedMemberAccessor>();
     }
 }

--- a/Jint/Runtime/Interop/AGENTS.md
+++ b/Jint/Runtime/Interop/AGENTS.md
@@ -59,7 +59,7 @@ rather than approximately like it, and it is why `GeneratedMemberAccessor` reads
 runs every case against both an annotated type and an un-annotated twin and compares the results, so a
 drift shows up as a failure naming the script that diverged.
 
-Four consequences worth knowing before touching any of it.
+Five consequences worth knowing before touching any of it.
 
 - **Anything the two paths cannot agree on is not generated at all.** A method parameter not typed
   `JsValue` goes through a conversion chain steered by `Options.Interop.ValueCoercion` and the installed
@@ -68,11 +68,30 @@ Four consequences worth knowing before touching any of it.
   divergences doing it — `p.Name = null` storing the string `"null"`, and a hard cast to a `JsValue`
   subtype throwing `InvalidCastException` out of `Evaluate` where the reflected path raises a catchable
   `TypeError`. **Widening the supported set means proving the new shape's reflected binding first.**
-- **The generated lane is skipped for every annotated type when the host has installed a `MemberFilter`,
-  a `MemberNameCreator`, a `MemberNameComparer`, or binding flags that no longer report public instance
-  members** (`TypeResolver.GeneratedMembersAreConsultable`). Those four decide which members exist and
-  under what names, and the generated lanes do not run through them. Not being able to honour a filter
-  and honouring it anyway are the same bug; declining is the difference.
+- **A generated member is filtered and named the way a reflected one is, and there are two lanes that
+  reach it — only one of which is free.** While the resolver's `MemberFilter`, `MemberNameCreator` and
+  `MemberNameComparer` are all still the defaults *and* the engine's reported binding flags still include
+  public instance members, `ResolvePropertyDescriptorFactory` answers straight out of the registry's
+  name-keyed table (`TypeResolver.GeneratedNameLookupIsEquivalent`), reflecting over the type not at all,
+  which is what the feature is for. Change any of them and that shortcut stops being equivalent — the
+  table is keyed by CLR name under the default comparer and holds public instance members only — so
+  resolution falls through to the ordinary reflected selection in `TryFindMemberAccessor` and the
+  generated accessor is **substituted for the member that selection landed on**
+  (`TrySubstituteGeneratedAccessor`). Containment is then honoured by construction, because reflection
+  has already applied the filter, the name policy and the flags; the host keeps the generated read,
+  write and invoke lanes and pays one reflected selection per `(type, member, requirement, profile)`,
+  cached like every other. **Do not simplify the substitution into a name lookup.**
+  `JsAccessibleRegistry.TryGetAccessorForDeclaredMember` matches on *identity* — `DeclaringType == type`,
+  an ordinal name match, a non-static member of the matching kind, and for a method the registered
+  parameter count — precisely because a host name policy can route a *different* member to the name the
+  registry holds. The `Readable`/`Writable` parity check beside it is load-bearing in the other
+  direction: resolution is filtered by `MemberResolutionRequirement` further up, so a generated accessor
+  disagreeing with the reflected one there would turn a resolved member into an unresolved one.
+- **What neither lane covers is an annotated type carrying an indexer.** An indexer is probed before the
+  member itself (`ReflectionAccessor.GetValue`) and a generated accessor has no such probe, so such a
+  type keeps the reflection path for its properties and fields. That is also why the registry consult
+  sits *after* `IndexerAccessor.TryFindIndexer` rather than before it, and must stay there: an annotated
+  type must resolve names the way an un-annotated one does.
 - **The registry is process-wide and bumps a generation counter, which every `TypeResolver` compares
   against before answering from its cache.** Without that, a `RegisterAll()` landing after an engine had
   already resolved a member of the same type would go on being answered with the reflected accessor and

--- a/Jint/Runtime/Interop/JsAccessibleRegistry.cs
+++ b/Jint/Runtime/Interop/JsAccessibleRegistry.cs
@@ -1,5 +1,7 @@
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Threading;
 using Jint.Runtime.Interop.Reflection;
 
@@ -24,12 +26,11 @@ namespace Jint.Runtime.Interop;
 /// resolving is lock-free.
 /// </para>
 /// <para>
-/// <b>What the registry does not decide.</b> A registered member is consulted only when the engine's
-/// interop configuration still matches the one the generator assumed. A host that installed a
-/// <see cref="TypeResolver.MemberFilter"/>, a <see cref="TypeResolver.MemberNameCreator"/>, a
-/// <see cref="TypeResolver.MemberNameComparer"/>, or binding flags that no longer report public instance
-/// members keeps the reflection path for every type, annotated or not, because those four steer which
-/// members exist and under which names and the generated lanes do not yet run through them.
+/// <b>What the registry does not decide.</b> Whether a registered member is reachable at all, and under
+/// which name. <see cref="TypeResolver.MemberFilter"/>, <see cref="TypeResolver.MemberNameCreator"/>,
+/// <see cref="TypeResolver.MemberNameComparer"/> and the reported binding flags apply to a generated
+/// member exactly as they do to a reflected one, so a member a host hid stays hidden and a member it
+/// renamed answers only to the new name.
 /// </para>
 /// </remarks>
 public static class JsAccessibleRegistry
@@ -76,19 +77,72 @@ public static class JsAccessibleRegistry
     /// </summary>
     internal static bool IsEmpty => _byType.IsEmpty;
 
-    internal static bool TryGetAccessor(
-        Type type,
-        string memberName,
-        [NotNullWhen(true)] out ReflectionAccessor? accessor)
+    /// <summary>
+    /// The name-keyed lookup, matched the way <see cref="TypeResolver"/>'s default name comparer matches a
+    /// reflected member. Only equivalent to the reflected selection while the host has changed nothing that
+    /// steers it, which is why <see cref="TypeResolver"/> and not this method decides when to ask.
+    /// </summary>
+    internal static bool TryGetMember(Type type, string memberName, out GeneratedMember member)
     {
         if (_byType.TryGetValue(type, out var members))
         {
-            return members.TryGet(memberName, out accessor);
+            return members.TryGet(memberName, out member);
         }
 
-        accessor = null;
+        member = default;
         return false;
     }
+
+    /// <summary>
+    /// The generated lane for a member the reflected selection already chose, or <see langword="false"/> if
+    /// that member is not one of this type's registered ones. Everything registered is a public instance
+    /// property, field or method declared on <paramref name="type"/> itself, so anything else — an inherited
+    /// or static member, an extension method, a member whose name merely reads the same — is not it.
+    /// </summary>
+    internal static bool TryGetAccessorForDeclaredMember(
+        Type type,
+        MemberInfo reflected,
+        [NotNullWhen(true)] out ReflectionAccessor? accessor)
+    {
+        accessor = null;
+
+        if (!_byType.TryGetValue(type, out var members)
+            || !members.TryGet(reflected.Name, out var member)
+            // the name-keyed lookup is deliberately fuzzy, so the entry it returned still has to be the
+            // member being asked about rather than one whose name only differs in the first character
+            || !string.Equals(member.Name, reflected.Name, StringComparison.Ordinal)
+            || reflected.DeclaringType != type)
+        {
+            return false;
+        }
+
+        var matches = reflected switch
+        {
+            PropertyInfo property => member.Accessor is GeneratedMemberAccessor && !IsStatic(property),
+            FieldInfo field => member.Accessor is GeneratedMemberAccessor && !field.IsStatic,
+            MethodInfo method => member.Accessor is GeneratedMethodAccessor generated
+                                 && !method.IsStatic
+                                 && method.GetParameters().Length == generated.Length,
+            _ => false,
+        };
+
+        if (!matches)
+        {
+            return false;
+        }
+
+        accessor = member.Accessor;
+        return true;
+    }
+
+    private static bool IsStatic(PropertyInfo property) => (property.GetMethod ?? property.SetMethod)?.IsStatic ?? false;
+
+    /// <summary>
+    /// One registered member. The CLR name is carried beside the accessor because a containment question is
+    /// asked about the member, not about the name the script used to reach it.
+    /// </summary>
+    [StructLayout(LayoutKind.Auto)]
+    internal readonly record struct GeneratedMember(string Name, ReflectionAccessor Accessor);
 
     /// <summary>
     /// The registered members of one type, keyed the way <see cref="TypeResolver"/>'s default name comparer
@@ -96,14 +150,14 @@ public static class JsAccessibleRegistry
     /// </summary>
     internal sealed class GeneratedTypeMembers
     {
-        private readonly Dictionary<string, ReflectionAccessor> _members;
+        private readonly Dictionary<string, GeneratedMember> _members;
 
-        internal GeneratedTypeMembers(Dictionary<string, ReflectionAccessor> members)
+        internal GeneratedTypeMembers(Dictionary<string, GeneratedMember> members)
         {
             _members = members;
         }
 
-        internal bool TryGet(string memberName, [NotNullWhen(true)] out ReflectionAccessor? accessor)
-            => _members.TryGetValue(memberName, out accessor);
+        internal bool TryGet(string memberName, out GeneratedMember member)
+            => _members.TryGetValue(memberName, out member);
     }
 }

--- a/Jint/Runtime/Interop/JsAccessibleTypeBuilder.cs
+++ b/Jint/Runtime/Interop/JsAccessibleTypeBuilder.cs
@@ -18,7 +18,7 @@ namespace Jint.Runtime.Interop;
 public sealed class JsAccessibleTypeBuilder
 {
     private readonly Type _type;
-    private readonly Dictionary<string, ReflectionAccessor> _members = new(TypeResolver.DefaultNameComparer);
+    private readonly Dictionary<string, JsAccessibleRegistry.GeneratedMember> _members = new(TypeResolver.DefaultNameComparer);
 
     internal JsAccessibleTypeBuilder(Type type)
     {
@@ -69,7 +69,7 @@ public sealed class JsAccessibleTypeBuilder
             Throw.ArgumentNullException(nameof(memberType));
         }
 
-        _members[name] = new GeneratedMemberAccessor(memberType, read, readBoxed, write, writeBoxed);
+        _members[name] = new JsAccessibleRegistry.GeneratedMember(name, new GeneratedMemberAccessor(memberType, read, readBoxed, write, writeBoxed));
     }
 
     /// <summary>
@@ -96,7 +96,7 @@ public sealed class JsAccessibleTypeBuilder
             Throw.ArgumentNullException(nameof(invoke));
         }
 
-        _members[name] = new GeneratedMethodAccessor(_type, name, length, invoke);
+        _members[name] = new JsAccessibleRegistry.GeneratedMember(name, new GeneratedMethodAccessor(_type, name, length, invoke));
     }
 
     internal JsAccessibleRegistry.GeneratedTypeMembers Build() => new(_members);

--- a/Jint/Runtime/Interop/Reflection/GeneratedMethodAccessor.cs
+++ b/Jint/Runtime/Interop/Reflection/GeneratedMethodAccessor.cs
@@ -33,6 +33,12 @@ internal sealed class GeneratedMethodAccessor : ReflectionAccessor
         _invoke = invoke;
     }
 
+    /// <summary>
+    /// The registered parameter count, which is what a reflected <see cref="System.Reflection.MethodInfo"/>
+    /// has to agree with before it can be recognised as the method this accessor was registered for.
+    /// </summary>
+    internal int Length => _length;
+
     public override bool Writable => false;
 
     protected override object? DoGetValue(object target, string memberName) => null;

--- a/Jint/Runtime/Interop/TypeResolver.cs
+++ b/Jint/Runtime/Interop/TypeResolver.cs
@@ -409,18 +409,19 @@ public sealed class TypeResolver
     }
 
     /// <summary>
-    /// Whether a generated member may stand in for the reflected one. The generated lanes reach a type's
-    /// public instance members under their CLR names, which is what the four settings below decide for every
-    /// other type - so a host that has changed any of them gets the reflection path for annotated types too,
-    /// rather than a lane that silently ignores the filter it installed. Routing the generated members
-    /// through those settings instead is a separate change; until it lands, this is the difference between
-    /// "not yet supported" and "quietly bypassed".
+    /// Whether the registry's own name-keyed lookup answers what the reflected selection would have chosen,
+    /// so a generated member can be resolved without reflecting over the type at all. It does exactly while
+    /// the host has changed nothing that steers the selection: the registry is keyed by CLR name under
+    /// <see cref="DefaultMemberNameComparer"/>, and it holds public instance members only.
     /// </summary>
-    internal bool GeneratedMembersAreConsultable(Engine engine)
+    /// <remarks>
+    /// A host that has changed one of them still gets the generated lanes — through
+    /// <see cref="TryFindMemberAccessor"/>, which runs the whole reflected selection and swaps the generated
+    /// accessor in for the member that selection landed on. This is only about whether the cheaper answer is
+    /// also the same answer.
+    /// </remarks>
+    private bool GeneratedNameLookupIsEquivalent(Engine engine)
     {
-        // A filter can only ever hide members, so one installed at all has to be honoured; the default
-        // predicate hides nothing. AllowGetType folds in the same way - it is a filter over a single name,
-        // and a member called GetType is never registered.
         if (!_memberFilterIsDefault
             || !_memberNameCreatorIsDefault
             || !ReferenceEquals(_memberNameComparer, DefaultMemberNameComparer.Instance))
@@ -432,6 +433,40 @@ public sealed class TypeResolver
         return (PropertyBindingFlags(engine) & PublicInstance) == PublicInstance
                && (FieldBindingFlags(engine) & PublicInstance) == PublicInstance
                && (MethodBindingFlags(engine) & PublicInstance) == PublicInstance;
+    }
+
+    /// <summary>
+    /// The generated lane for the member the reflected selection just chose, if that member is a registered
+    /// one and the two accessors answer the same questions about it. Reflection has already applied
+    /// <see cref="MemberFilter"/>, <see cref="MemberNameCreator"/>, <see cref="MemberNameComparer"/> and the
+    /// engine's binding flags by the time this is asked, so containment is honoured by construction and only
+    /// the read and write lanes are exchanged.
+    /// </summary>
+    private static bool TrySubstituteGeneratedAccessor(
+        Type type,
+        MemberInfo reflectedMember,
+        ReflectionAccessor reflected,
+        [NotNullWhen(true)] out ReflectionAccessor? generated)
+    {
+        generated = null;
+
+        if (JsAccessibleRegistry.IsEmpty
+            || !JsAccessibleRegistry.TryGetAccessorForDeclaredMember(type, reflectedMember, out var candidate))
+        {
+            return false;
+        }
+
+        // Resolution is filtered by MemberResolutionRequirement further up, so a generated accessor that
+        // disagreed with the reflected one about being readable or writable could turn a resolved member
+        // into an unresolved one. The generator declines every shape where they could disagree; this says so
+        // rather than trusting it.
+        if (candidate.Readable != reflected.Readable || candidate.Writable != reflected.Writable)
+        {
+            return false;
+        }
+
+        generated = candidate;
+        return true;
     }
 
     private ReflectionAccessor ResolvePropertyDescriptorFactory(
@@ -450,14 +485,21 @@ public sealed class TypeResolver
         // property/field/method lookup - and for nothing else, which is why they are consulted here rather
         // than ahead of the indexer probe: an annotated type carrying a string indexer must still resolve
         // names the way an un-annotated one does.
+        //
+        // This is the shortcut, taken only while the registry's own name-keyed lookup provably answers what
+        // the reflected selection would have. Everything else reaches the same generated accessors through
+        // TryFindMemberAccessor, which applies the host's filter and name policy first and substitutes
+        // afterwards; the answer is the same, the cost is one reflected selection instead of none.
         if (!isInteger
             && indexer is null
             && !JsAccessibleRegistry.IsEmpty
-            && GeneratedMembersAreConsultable(engine)
-            && JsAccessibleRegistry.TryGetAccessor(type, memberName, out var generated)
-            && requirement.IsSatisfiedBy(generated))
+            && GeneratedNameLookupIsEquivalent(engine)
+            && JsAccessibleRegistry.TryGetMember(type, memberName, out var generated)
+            // the one thing a default MemberFilter still decides, spelled the way Filter spells it
+            && (AllowGetType(engine) || !string.Equals(generated.Name, nameof(GetType), StringComparison.Ordinal))
+            && requirement.IsSatisfiedBy(generated.Accessor))
         {
-            return generated;
+            return generated.Accessor;
         }
 
         // properties and fields cannot be numbers
@@ -800,9 +842,18 @@ public sealed class TypeResolver
             }
         }
 
+        // Whether a generated lane may stand in for whatever this selection lands on. The instance lane only
+        // (the static one passes its own flags and registered members are never static), and only for a type
+        // carrying no indexer: an indexer is probed ahead of the member itself, and a generated accessor has
+        // no such probe - the same reason the shortcut in ResolvePropertyDescriptorFactory sits behind it.
+        var maySubstituteGenerated = bindingFlags is null && indexerToTry is null && !JsAccessibleRegistry.IsEmpty;
+
         if (property is not null)
         {
-            accessor = new PropertyAccessor(property, indexerToTry);
+            var reflected = new PropertyAccessor(property, indexerToTry);
+            accessor = maySubstituteGenerated && TrySubstituteGeneratedAccessor(type, property, reflected, out var substitute)
+                ? substitute
+                : reflected;
             return true;
         }
 
@@ -827,7 +878,10 @@ public sealed class TypeResolver
 
         if (field is not null)
         {
-            accessor = new FieldAccessor(field, indexerToTry);
+            var reflected = new FieldAccessor(field, indexerToTry);
+            accessor = maySubstituteGenerated && TrySubstituteGeneratedAccessor(type, field, reflected, out var substitute)
+                ? substitute
+                : reflected;
             return true;
         }
 
@@ -900,7 +954,16 @@ public sealed class TypeResolver
 
         if (methods?.Count > 0)
         {
-            accessor = new MethodAccessor(type, MethodDescriptor.Build(methods));
+            var reflected = new MethodAccessor(type, MethodDescriptor.Build(methods));
+
+            // A registered method is the sole candidate for its name by construction (the generator declines
+            // any name carrying more than one), so a name that collected several here is one the host's name
+            // policy merged and reflection has to bind.
+            accessor = maySubstituteGenerated
+                       && methods.Count == 1
+                       && TrySubstituteGeneratedAccessor(type, methods[0], reflected, out var substitute)
+                ? substitute
+                : reflected;
             return true;
         }
 

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -1202,11 +1202,17 @@ you annotated the type:
 | a `static` member, an indexer, a `const` field | resolved by a different lane |
 | an `abstract`, `static`, generic or nested-private type, and any value type | never the runtime type of a receiver, or unreachable from emitted code — and a value type's instance member would be written through a boxed copy |
 
-The generated lane is also skipped **entirely, for every annotated type**, when the host has installed a
-`TypeResolver.MemberFilter`, `MemberNameCreator` or `MemberNameComparer`, or binding flags that no longer
-report public instance members. Those four steer which members exist and under what names; the generated
-lanes do not run through them yet, and declining is the difference between "not yet supported" and "quietly
-bypasses the filter you installed".
+**What still contains it.** `TypeResolver.MemberFilter`, `MemberNameCreator`, `MemberNameComparer` and
+`Options.Interop.ObjectWrapperReported*BindingFlags` reach a generated member exactly as they reach a
+reflected one: a member your filter hides stays hidden, a member your name creator renames answers only to
+the new name, and flags that no longer report a member hide it from both. Installing one of them costs an
+annotated type nothing but one reflected member lookup per member, after which reads, writes and calls run
+through the generated code as before.
+
+One shape stays reflected whatever you configure: an annotated type that also declares an **indexer**. An
+indexer is probed before the member itself, and the generated accessors carry no such probe, so the whole
+type keeps the reflection path — which is what makes its names resolve in the order an un-annotated type's
+do.
 
 Consume the generator with an `Analyzer` project reference for now:
 
@@ -1215,8 +1221,8 @@ Consume the generator with an `Analyzer` project reference for now:
                   OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
 ```
 
-Shipping it inside the `Jint` NuGet package, diagnostics for the declined shapes above, and routing the
-generated members through `MemberFilter` and the name policy are each their own follow-up.
+Shipping it inside the `Jint` NuGet package and diagnostics for the declined shapes above are each their own
+follow-up.
 
 ### 5.2 Changing one locale datum is one override ([#3335](https://github.com/sebastienros/jint/pull/3335))
 


### PR DESCRIPTION
`[JsAccessible]` accessors were consulted from `TypeResolver` *before* the reflected path's containment
steps, so `TypeResolver.MemberFilter`, the name policy and the reported binding flags applied to reflected
members and not to generated ones. #3333 mitigated that by **skipping the generated lane entirely, for every
annotated type**, as soon as any of those four was non-default. Safe — containment won — but a host that
installs a camelCase `MemberNameCreator` lost the whole feature for every annotated type, silently.

This routes the generated members through the same containment instead, and removes the skip.

## How the policy metadata is carried: it is not

The obvious designs both fail, and for the same reason.

A **policy token the generator emits** cannot work at all: `MemberFilter` is `Predicate<MemberInfo>` and
`MemberNameCreator` is `Func<MemberInfo, IEnumerable<string>>`. Anything that is not a `MemberInfo` would
need a *parallel* policy surface for the host to implement twice — which is precisely the divergence this
pull request exists to remove.

A **lazily resolved `MemberInfo` per registered member** (`type.GetProperty(name, DeclaredOnly)`, memoized)
answers the filter question, but not the name question. Under a host name policy, "which member does this
name reach" is a question about *every* member of the type, including the ones the generator declined: an
unregistered member can legitimately claim a registered one's exposed name, and only the full reflected
selection knows which wins.

So the generated accessor carries **no policy metadata at all** — the direction is inverted. Reflection
picks the member under the host's filter, name policy and binding flags, and the registry is then asked
whether *that member* is one of its own; if it is, the generated accessor is substituted for the reflected
one. Containment is honoured by construction, and the only metadata needed is what the registry already
held: the CLR name, plus the accessor's kind and, for a method, its arity.

**The hot path is untouched.** All of this happens inside `TypeResolver.ResolvePropertyDescriptorFactory`,
whose result is cached per `(type, member, requirement, profile)` exactly as before. A read, a write or a
call never reflects on either path. And the configuration the feature exists for — the default one, which is
also the trimmed and AOT one — keeps the registry's own name-keyed shortcut and still resolves without
reflecting over the type at all.

## Two lanes

| host configuration | how a generated member is reached | reflection at resolution |
| --- | --- | --- |
| everything default | `JsAccessibleRegistry`'s name-keyed table, straight from `ResolvePropertyDescriptorFactory` (`GeneratedNameLookupIsEquivalent`) | none |
| any of `MemberFilter`, `MemberNameCreator`, `MemberNameComparer`, narrowed binding flags | the ordinary reflected selection in `TryFindMemberAccessor`, with the generated accessor substituted for the member it landed on (`TrySubstituteGeneratedAccessor`) | one selection, cached |

Two guards in the substitution are load-bearing rather than defensive.
`JsAccessibleRegistry.TryGetAccessorForDeclaredMember` matches on **identity** — `DeclaringType == type`, an
ordinal name match, a non-static member of the matching kind, and for a method the registered parameter
count — because a host name policy can route a *different* member to the name the registry holds. And it
compares `Readable`/`Writable` against the reflected accessor, because resolution is filtered by
`MemberResolutionRequirement` further up, so a disagreement there would turn a resolved member into an
unresolved one.

## The blanket skip is gone; one narrow decline is left, and it is not new

`GeneratedMembersAreConsultable` is now `GeneratedNameLookupIsEquivalent`: the same four conditions, but they
now select *which* lane answers rather than whether the feature applies. Nothing turns the feature off.

What remains is the pre-existing rule that **an annotated type carrying an indexer keeps the reflection
path**. An indexer is probed before the member itself (`ReflectionAccessor.GetValue`) and a generated
accessor has no such probe, so this is the same decline that already made the registry consult sit *after*
`IndexerAccessor.TryFindIndexer` — it is what keeps an annotated type resolving names in the order an
un-annotated one does, and the new differential theory pins it.

## Failing first

The five new integrator-facing tests were run against `main`'s blanket-skip behaviour before the engine
change, and each failed on the discriminator that says the lane is engaged — a generated method is a
function object with its own `length`, a reflected one is not:

```
Failed AHostMemberFilterHidesAMemberInBothLanes
  Expected generated.Evaluate(arity).AsNumber() to be 2.0 because the generated lane must still
  answer for `model.Describe.length`, but found 0.0 (difference of -2).
Failed AHostNameCreatorRenamesAMemberInBothLanes            ... `model.js_Describe.length` ... found 0.0
Failed ACamelCaseNameCreatorKeepsTheGeneratedLane           ... `model.describe.length`  ... found 0.0
Failed AHostNameComparerDecidesWhichNamesReachAMemberInBothLanes ... found 0.0
Failed NarrowedPropertyBindingFlagsHideThePropertiesInBothLanes  ... found 0.0

Failed!  - Failed: 5, Passed: 110, Total: 115
```

and seven in `Jint.Tests.Runtime.JsAccessibleAccessorSelectionTests`, which asks the resolver directly which
accessor a member lands on.

## Tests

Every new integrator-facing case is differential, generated against the un-annotated twin, which is the
contract:

- a `MemberFilter` that hides `Score` hides it in both lanes, and the members it allows keep their generated
  accessors;
- a prefixing `MemberNameCreator` renames a member in both lanes — the old name stops resolving;
- the camelCase `MemberNameCreator` an embedder actually writes keeps the whole feature;
- an ordinal `MemberNameComparer` decides which names reach a member in both lanes;
- narrowed property binding flags hide the properties in both lanes and leave the fields alone;
- the hardened profile (`ForUntrustedCode`) contains an annotated type the way it contains any other;
- an indexer plus a same-named member resolves identically, in both directions;
- and the whole read/write/call matrix is re-run under a host name policy — the claim made where it used to
  be untestable, because the feature had turned itself off.

## Verification

`dotnet build -c Release` clean. `Jint.Tests`, `Jint.Tests.PublicInterface` (also with
`JINT_HOST_CONTRACT_VERIFICATION=1`), `Jint.Tests.SourceGenerators` green. test262 102,495 passed / 0 failed.
No public API change, so the five baselines and the documentation register are untouched.

Out of scope by design, and not made harder: generator diagnostics for the declined shapes, and packing the
analyzer into the NuGet package.
