### PR TITLE
Intl: the currency symbol a host supplies now reaches format(), and two members that could not work are gone

### DIFF
--- a/Jint.Tests.PublicInterface/HostLocaleProviderTests.cs
+++ b/Jint.Tests.PublicInterface/HostLocaleProviderTests.cs
@@ -15,7 +15,7 @@ namespace Jint.Tests.PublicInterface;
 public class HostLocaleProviderTests
 {
     [Fact]
-    public void OverridingOneCldrDatumLeavesTheOtherTwentyTwoMembersInherited()
+    public void OverridingOneCldrDatumLeavesTheOtherTwentyMembersInherited()
     {
         var engine = new Engine(options => options.Intl.CldrProvider = new OneCurrencyName());
 
@@ -33,6 +33,42 @@ public class HostLocaleProviderTests
         engine.Evaluate("new Intl.RelativeTimeFormat('en').format(3, 'day')")
             .AsString().Should().Be("in 3 days");
         engine.Evaluate("Intl.supportedValuesOf('unit').length").AsNumber().Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public void OverridingOneCurrencyReachesNumberFormat()
+    {
+        var engine = new Engine(options => options.Intl.CldrProvider = new OneCurrency());
+
+        // the three displays the provider answers for
+        engine.Evaluate("new Intl.NumberFormat('en', { style: 'currency', currency: 'XCD' }).format(12.5)")
+            .AsString().Should().Be("EC$12.50");
+        engine.Evaluate("new Intl.NumberFormat('en', { style: 'currency', currency: 'XCD', currencyDisplay: 'narrowSymbol' }).format(12.5)")
+            .AsString().Should().Be("$12.50");
+        engine.Evaluate("new Intl.NumberFormat('en', { style: 'currency', currency: 'XCD', currencyDisplay: 'name' }).format(12.5)")
+            .AsString().Should().StartWith("East Caribbean dollars");
+
+        // the code display is the currency code by specification, whatever the provider says
+        engine.Evaluate("new Intl.NumberFormat('en', { style: 'currency', currency: 'XCD', currencyDisplay: 'code' }).format(12.5)")
+            .AsString().Should().Be("XCD12.50");
+
+        // …and every currency the subclass does not claim still reads the inherited data
+        engine.Evaluate("new Intl.NumberFormat('en', { style: 'currency', currency: 'USD' }).format(12.5)")
+            .AsString().Should().Be("$12.50");
+        engine.Evaluate("new Intl.NumberFormat('en', { style: 'currency', currency: 'CAD', currencyDisplay: 'narrowSymbol' }).format(12.5)")
+            .AsString().Should().Be("$12.50");
+    }
+
+    [Fact]
+    public void OverridingOneWeekInfoReachesIntlLocale()
+    {
+        var engine = new Engine(options => options.Intl.CldrProvider = new SundayIsTheWeekend());
+
+        engine.Evaluate("new Intl.Locale('en-US').getWeekInfo().firstDay").AsNumber().Should().Be(3);
+        engine.Evaluate("JSON.stringify(new Intl.Locale('en-US').getWeekInfo().weekend)").AsString().Should().Be("[7]");
+
+        // an explicit -u-fw- still wins over the provider, per the specification
+        engine.Evaluate("new Intl.Locale('en-US-u-fw-mon').getWeekInfo().firstDay").AsNumber().Should().Be(1);
     }
 
     [Fact]
@@ -103,14 +139,30 @@ public class HostLocaleProviderTests
     }
 }
 
-/// <summary>One currency's display name; the other twenty-two members are inherited.</summary>
+/// <summary>One currency's display name; the other twenty members are inherited.</summary>
 file sealed class OneCurrencyName : DefaultCldrProvider
 {
     public override string? GetCurrencyDisplayName(string locale, string code)
         => string.Equals(code, "EUR", StringComparison.Ordinal) ? "Space Credits" : base.GetCurrencyDisplayName(locale, code);
 }
 
-/// <summary>One list-pattern set; the other twenty-two members are inherited.</summary>
+/// <summary>One currency's symbols and name; every other currency is the inherited data.</summary>
+file sealed class OneCurrency : DefaultCldrProvider
+{
+    public override CurrencyData? GetCurrencyData(string locale, string currencyCode)
+        => string.Equals(currencyCode, "XCD", StringComparison.Ordinal)
+            ? new CurrencyData { Symbol = "EC$", NarrowSymbol = "$", DisplayName = "East Caribbean dollars" }
+            : base.GetCurrencyData(locale, currencyCode);
+}
+
+/// <summary>One locale's week layout; every other member is inherited.</summary>
+file sealed class SundayIsTheWeekend : DefaultCldrProvider
+{
+    public override WeekInfo? GetWeekInfo(string locale)
+        => new WeekInfo { FirstDay = DayOfWeek.Wednesday, Weekend = [DayOfWeek.Sunday] };
+}
+
+/// <summary>One list-pattern set; the other twenty members are inherited.</summary>
 file sealed class GermanLists : DefaultCldrProvider
 {
     public override ListPatterns? GetListPatterns(string locale, string type, string style)
@@ -137,7 +189,7 @@ file sealed class ShiftedHebrewEra : DefaultCalendarProvider
 
 /// <summary>
 /// Present only to be compiled: a host reaching a member the engine never consults still has to be able
-/// to override it, and the compiler is the only thing that checks that all twenty-three are virtual.
+/// to override it, and the compiler is the only thing that checks that all twenty-one are virtual.
 /// </summary>
 file sealed class EveryCldrMemberOverridden : DefaultCldrProvider
 {
@@ -155,9 +207,7 @@ file sealed class EveryCldrMemberOverridden : DefaultCldrProvider
     public override string[]? GetDayPeriods(string locale, string style, string? calendar) => base.GetDayPeriods(locale, style, calendar);
     public override string[]? GetEraNames(string locale, string style, string? calendar) => base.GetEraNames(locale, style, calendar);
     public override string? GetCurrencyDisplayName(string locale, string code) => base.GetCurrencyDisplayName(locale, code);
-    public override string? GetLikelySubtags(string locale) => base.GetLikelySubtags(locale);
     public override WeekInfo? GetWeekInfo(string locale) => base.GetWeekInfo(locale);
-    public override string SelectPluralCategory(string locale, double value, string type) => base.SelectPluralCategory(locale, value, type);
     public override IReadOnlyCollection<string> GetSupportedCalendars() => base.GetSupportedCalendars();
     public override IReadOnlyCollection<string> GetSupportedCollations() => base.GetSupportedCollations();
     public override IReadOnlyCollection<string> GetSupportedCurrencies() => base.GetSupportedCurrencies();

--- a/Jint.Tests.PublicInterface/UndocumentedPublicApi.txt
+++ b/Jint.Tests.PublicInterface/UndocumentedPublicApi.txt
@@ -12,7 +12,7 @@
 #
 # The names are ISO documentation comment ids, which is what the compiler writes into Jint.xml.
 #
-undocumented: 658
+undocumented: 635
 F:Jint.ModuleParsingOptions.Default
 F:Jint.ModulePreparationOptions.Default
 F:Jint.Native.Function.Function._length
@@ -175,29 +175,6 @@ M:Jint.Native.Error.ErrorConstructor.Construct(System.String)
 M:Jint.Native.Intl.CompactPatterns.#ctor
 M:Jint.Native.Intl.CurrencyData.#ctor
 M:Jint.Native.Intl.DateTimePatterns.#ctor
-M:Jint.Native.Intl.DefaultCldrProvider.GetCompactPatterns(System.String,System.String)
-M:Jint.Native.Intl.DefaultCldrProvider.GetCurrencyData(System.String,System.String)
-M:Jint.Native.Intl.DefaultCldrProvider.GetCurrencyDisplayName(System.String,System.String)
-M:Jint.Native.Intl.DefaultCldrProvider.GetDateTimePatterns(System.String,System.String,System.String)
-M:Jint.Native.Intl.DefaultCldrProvider.GetDayPeriods(System.String,System.String,System.String)
-M:Jint.Native.Intl.DefaultCldrProvider.GetDefaultNumberingSystem(System.String)
-M:Jint.Native.Intl.DefaultCldrProvider.GetEraNames(System.String,System.String,System.String)
-M:Jint.Native.Intl.DefaultCldrProvider.GetLikelySubtags(System.String)
-M:Jint.Native.Intl.DefaultCldrProvider.GetListPatterns(System.String,System.String,System.String)
-M:Jint.Native.Intl.DefaultCldrProvider.GetMonthNames(System.String,System.String,System.String)
-M:Jint.Native.Intl.DefaultCldrProvider.GetNumberingSystemDigits(System.String)
-M:Jint.Native.Intl.DefaultCldrProvider.GetRelativeTimePatterns(System.String,System.String,System.String)
-M:Jint.Native.Intl.DefaultCldrProvider.GetRelativeTimeSpecialPhrase(System.String,System.String,System.Int32,System.Boolean,System.String)
-M:Jint.Native.Intl.DefaultCldrProvider.GetSupportedCalendars
-M:Jint.Native.Intl.DefaultCldrProvider.GetSupportedCollations
-M:Jint.Native.Intl.DefaultCldrProvider.GetSupportedCurrencies
-M:Jint.Native.Intl.DefaultCldrProvider.GetSupportedNumberingSystems
-M:Jint.Native.Intl.DefaultCldrProvider.GetSupportedTimeZones
-M:Jint.Native.Intl.DefaultCldrProvider.GetSupportedUnits
-M:Jint.Native.Intl.DefaultCldrProvider.GetUnitPatterns(System.String,System.String,System.String)
-M:Jint.Native.Intl.DefaultCldrProvider.GetWeekInfo(System.String)
-M:Jint.Native.Intl.DefaultCldrProvider.GetWeekdayNames(System.String,System.String)
-M:Jint.Native.Intl.DefaultCldrProvider.SelectPluralCategory(System.String,System.Double,System.String)
 M:Jint.Native.Intl.ListPatterns.#ctor
 M:Jint.Native.Intl.RelativeTimePatterns.#ctor
 M:Jint.Native.Intl.UnitPatterns.#ctor

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
@@ -1369,7 +1369,6 @@ namespace Jint.Native.Intl
         public virtual string[]? GetDayPeriods(string locale, string style, string? calendar) { }
         public virtual string? GetDefaultNumberingSystem(string locale) { }
         public virtual string[]? GetEraNames(string locale, string style, string? calendar) { }
-        public virtual string? GetLikelySubtags(string locale) { }
         public virtual Jint.Native.Intl.ListPatterns? GetListPatterns(string locale, string type, string style) { }
         public virtual string[]? GetMonthNames(string locale, string style, string? calendar) { }
         public virtual string? GetNumberingSystemDigits(string numberingSystem) { }
@@ -1384,7 +1383,6 @@ namespace Jint.Native.Intl
         public virtual Jint.Native.Intl.UnitPatterns? GetUnitPatterns(string locale, string unit, string style) { }
         public virtual Jint.Native.Intl.WeekInfo? GetWeekInfo(string locale) { }
         public virtual string[]? GetWeekdayNames(string locale, string style) { }
-        public virtual string SelectPluralCategory(string locale, double value, string type) { }
     }
     public interface ICldrProvider
     {
@@ -1395,7 +1393,6 @@ namespace Jint.Native.Intl
         string[]? GetDayPeriods(string locale, string style, string? calendar);
         string? GetDefaultNumberingSystem(string locale);
         string[]? GetEraNames(string locale, string style, string? calendar);
-        string? GetLikelySubtags(string locale);
         Jint.Native.Intl.ListPatterns? GetListPatterns(string locale, string type, string style);
         string[]? GetMonthNames(string locale, string style, string? calendar);
         string? GetNumberingSystemDigits(string numberingSystem);
@@ -1410,7 +1407,6 @@ namespace Jint.Native.Intl
         Jint.Native.Intl.UnitPatterns? GetUnitPatterns(string locale, string unit, string style);
         Jint.Native.Intl.WeekInfo? GetWeekInfo(string locale);
         string[]? GetWeekdayNames(string locale, string style);
-        string SelectPluralCategory(string locale, double value, string type);
     }
     public sealed class ListPatterns
     {
@@ -1445,7 +1441,6 @@ namespace Jint.Native.Intl
     {
         public WeekInfo() { }
         public required System.DayOfWeek FirstDay { get; init; }
-        public required int MinimalDays { get; init; }
         public System.DayOfWeek[]? Weekend { get; init; }
     }
 }

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net472.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net472.verified.txt
@@ -1216,7 +1216,6 @@ namespace Jint.Native.Intl
         public virtual string[]? GetDayPeriods(string locale, string style, string? calendar) { }
         public virtual string? GetDefaultNumberingSystem(string locale) { }
         public virtual string[]? GetEraNames(string locale, string style, string? calendar) { }
-        public virtual string? GetLikelySubtags(string locale) { }
         public virtual Jint.Native.Intl.ListPatterns? GetListPatterns(string locale, string type, string style) { }
         public virtual string[]? GetMonthNames(string locale, string style, string? calendar) { }
         public virtual string? GetNumberingSystemDigits(string numberingSystem) { }
@@ -1231,7 +1230,6 @@ namespace Jint.Native.Intl
         public virtual Jint.Native.Intl.UnitPatterns? GetUnitPatterns(string locale, string unit, string style) { }
         public virtual Jint.Native.Intl.WeekInfo? GetWeekInfo(string locale) { }
         public virtual string[]? GetWeekdayNames(string locale, string style) { }
-        public virtual string SelectPluralCategory(string locale, double value, string type) { }
     }
     public interface ICldrProvider
     {
@@ -1242,7 +1240,6 @@ namespace Jint.Native.Intl
         string[]? GetDayPeriods(string locale, string style, string? calendar);
         string? GetDefaultNumberingSystem(string locale);
         string[]? GetEraNames(string locale, string style, string? calendar);
-        string? GetLikelySubtags(string locale);
         Jint.Native.Intl.ListPatterns? GetListPatterns(string locale, string type, string style);
         string[]? GetMonthNames(string locale, string style, string? calendar);
         string? GetNumberingSystemDigits(string numberingSystem);
@@ -1257,7 +1254,6 @@ namespace Jint.Native.Intl
         Jint.Native.Intl.UnitPatterns? GetUnitPatterns(string locale, string unit, string style);
         Jint.Native.Intl.WeekInfo? GetWeekInfo(string locale);
         string[]? GetWeekdayNames(string locale, string style);
-        string SelectPluralCategory(string locale, double value, string type);
     }
     public sealed class ListPatterns
     {
@@ -1292,7 +1288,6 @@ namespace Jint.Native.Intl
     {
         public WeekInfo() { }
         public required System.DayOfWeek FirstDay { get; init; }
-        public required int MinimalDays { get; init; }
         public System.DayOfWeek[]? Weekend { get; init; }
     }
 }

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
@@ -1369,7 +1369,6 @@ namespace Jint.Native.Intl
         public virtual string[]? GetDayPeriods(string locale, string style, string? calendar) { }
         public virtual string? GetDefaultNumberingSystem(string locale) { }
         public virtual string[]? GetEraNames(string locale, string style, string? calendar) { }
-        public virtual string? GetLikelySubtags(string locale) { }
         public virtual Jint.Native.Intl.ListPatterns? GetListPatterns(string locale, string type, string style) { }
         public virtual string[]? GetMonthNames(string locale, string style, string? calendar) { }
         public virtual string? GetNumberingSystemDigits(string numberingSystem) { }
@@ -1384,7 +1383,6 @@ namespace Jint.Native.Intl
         public virtual Jint.Native.Intl.UnitPatterns? GetUnitPatterns(string locale, string unit, string style) { }
         public virtual Jint.Native.Intl.WeekInfo? GetWeekInfo(string locale) { }
         public virtual string[]? GetWeekdayNames(string locale, string style) { }
-        public virtual string SelectPluralCategory(string locale, double value, string type) { }
     }
     public interface ICldrProvider
     {
@@ -1395,7 +1393,6 @@ namespace Jint.Native.Intl
         string[]? GetDayPeriods(string locale, string style, string? calendar);
         string? GetDefaultNumberingSystem(string locale);
         string[]? GetEraNames(string locale, string style, string? calendar);
-        string? GetLikelySubtags(string locale);
         Jint.Native.Intl.ListPatterns? GetListPatterns(string locale, string type, string style);
         string[]? GetMonthNames(string locale, string style, string? calendar);
         string? GetNumberingSystemDigits(string numberingSystem);
@@ -1410,7 +1407,6 @@ namespace Jint.Native.Intl
         Jint.Native.Intl.UnitPatterns? GetUnitPatterns(string locale, string unit, string style);
         Jint.Native.Intl.WeekInfo? GetWeekInfo(string locale);
         string[]? GetWeekdayNames(string locale, string style);
-        string SelectPluralCategory(string locale, double value, string type);
     }
     public sealed class ListPatterns
     {
@@ -1445,7 +1441,6 @@ namespace Jint.Native.Intl
     {
         public WeekInfo() { }
         public required System.DayOfWeek FirstDay { get; init; }
-        public required int MinimalDays { get; init; }
         public System.DayOfWeek[]? Weekend { get; init; }
     }
 }

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.0.verified.txt
@@ -1216,7 +1216,6 @@ namespace Jint.Native.Intl
         public virtual string[]? GetDayPeriods(string locale, string style, string? calendar) { }
         public virtual string? GetDefaultNumberingSystem(string locale) { }
         public virtual string[]? GetEraNames(string locale, string style, string? calendar) { }
-        public virtual string? GetLikelySubtags(string locale) { }
         public virtual Jint.Native.Intl.ListPatterns? GetListPatterns(string locale, string type, string style) { }
         public virtual string[]? GetMonthNames(string locale, string style, string? calendar) { }
         public virtual string? GetNumberingSystemDigits(string numberingSystem) { }
@@ -1231,7 +1230,6 @@ namespace Jint.Native.Intl
         public virtual Jint.Native.Intl.UnitPatterns? GetUnitPatterns(string locale, string unit, string style) { }
         public virtual Jint.Native.Intl.WeekInfo? GetWeekInfo(string locale) { }
         public virtual string[]? GetWeekdayNames(string locale, string style) { }
-        public virtual string SelectPluralCategory(string locale, double value, string type) { }
     }
     public interface ICldrProvider
     {
@@ -1242,7 +1240,6 @@ namespace Jint.Native.Intl
         string[]? GetDayPeriods(string locale, string style, string? calendar);
         string? GetDefaultNumberingSystem(string locale);
         string[]? GetEraNames(string locale, string style, string? calendar);
-        string? GetLikelySubtags(string locale);
         Jint.Native.Intl.ListPatterns? GetListPatterns(string locale, string type, string style);
         string[]? GetMonthNames(string locale, string style, string? calendar);
         string? GetNumberingSystemDigits(string numberingSystem);
@@ -1257,7 +1254,6 @@ namespace Jint.Native.Intl
         Jint.Native.Intl.UnitPatterns? GetUnitPatterns(string locale, string unit, string style);
         Jint.Native.Intl.WeekInfo? GetWeekInfo(string locale);
         string[]? GetWeekdayNames(string locale, string style);
-        string SelectPluralCategory(string locale, double value, string type);
     }
     public sealed class ListPatterns
     {
@@ -1292,7 +1288,6 @@ namespace Jint.Native.Intl
     {
         public WeekInfo() { }
         public required System.DayOfWeek FirstDay { get; init; }
-        public required int MinimalDays { get; init; }
         public System.DayOfWeek[]? Weekend { get; init; }
     }
 }

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.1.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.1.verified.txt
@@ -1216,7 +1216,6 @@ namespace Jint.Native.Intl
         public virtual string[]? GetDayPeriods(string locale, string style, string? calendar) { }
         public virtual string? GetDefaultNumberingSystem(string locale) { }
         public virtual string[]? GetEraNames(string locale, string style, string? calendar) { }
-        public virtual string? GetLikelySubtags(string locale) { }
         public virtual Jint.Native.Intl.ListPatterns? GetListPatterns(string locale, string type, string style) { }
         public virtual string[]? GetMonthNames(string locale, string style, string? calendar) { }
         public virtual string? GetNumberingSystemDigits(string numberingSystem) { }
@@ -1231,7 +1230,6 @@ namespace Jint.Native.Intl
         public virtual Jint.Native.Intl.UnitPatterns? GetUnitPatterns(string locale, string unit, string style) { }
         public virtual Jint.Native.Intl.WeekInfo? GetWeekInfo(string locale) { }
         public virtual string[]? GetWeekdayNames(string locale, string style) { }
-        public virtual string SelectPluralCategory(string locale, double value, string type) { }
     }
     public interface ICldrProvider
     {
@@ -1242,7 +1240,6 @@ namespace Jint.Native.Intl
         string[]? GetDayPeriods(string locale, string style, string? calendar);
         string? GetDefaultNumberingSystem(string locale);
         string[]? GetEraNames(string locale, string style, string? calendar);
-        string? GetLikelySubtags(string locale);
         Jint.Native.Intl.ListPatterns? GetListPatterns(string locale, string type, string style);
         string[]? GetMonthNames(string locale, string style, string? calendar);
         string? GetNumberingSystemDigits(string numberingSystem);
@@ -1257,7 +1254,6 @@ namespace Jint.Native.Intl
         Jint.Native.Intl.UnitPatterns? GetUnitPatterns(string locale, string unit, string style);
         Jint.Native.Intl.WeekInfo? GetWeekInfo(string locale);
         string[]? GetWeekdayNames(string locale, string style);
-        string SelectPluralCategory(string locale, double value, string type);
     }
     public sealed class ListPatterns
     {
@@ -1292,7 +1288,6 @@ namespace Jint.Native.Intl
     {
         public WeekInfo() { }
         public required System.DayOfWeek FirstDay { get; init; }
-        public required int MinimalDays { get; init; }
         public System.DayOfWeek[]? Weekend { get; init; }
     }
 }

--- a/Jint.Tests.Test262/IcuCldrProvider.cs
+++ b/Jint.Tests.Test262/IcuCldrProvider.cs
@@ -304,20 +304,6 @@ public sealed class IcuCldrProvider : ICldrProvider
 
     // === Locale Data ===
 
-    public string? GetLikelySubtags(string locale)
-    {
-        try
-        {
-            var icuLocale = new UCultureInfo(locale);
-            var maximized = UCultureInfo.AddLikelySubtags(icuLocale);
-            return maximized?.Name ?? _fallback.GetLikelySubtags(locale);
-        }
-        catch
-        {
-            return _fallback.GetLikelySubtags(locale);
-        }
-    }
-
     public WeekInfo? GetWeekInfo(string locale)
         => _fallback.GetWeekInfo(locale);
 
@@ -344,28 +330,4 @@ public sealed class IcuCldrProvider : ICldrProvider
 
     public IReadOnlyCollection<string> GetSupportedUnits()
         => _fallback.GetSupportedUnits();
-
-    // === Plural Rules ===
-
-    public string SelectPluralCategory(string locale, double value, string type)
-    {
-        try
-        {
-            var culture = new UCultureInfo(locale);
-            var pluralType = string.Equals(type, "ordinal", StringComparison.Ordinal)
-                ? PluralType.Ordinal
-                : PluralType.Cardinal;
-
-            var rules = PluralRules.GetInstance(culture, pluralType);
-            var category = rules.Select(value);
-
-            // ICU4N returns the category name (e.g., "one", "other", "few", "many", "zero", "two")
-            return category ?? "other";
-        }
-        catch
-        {
-            // Fallback to default provider's English rules
-            return _fallback.SelectPluralCategory(locale, value, type);
-        }
-    }
 }

--- a/Jint/Native/Intl/CldrDataTypes.cs
+++ b/Jint/Native/Intl/CldrDataTypes.cs
@@ -76,18 +76,23 @@ public sealed class RelativeTimePatterns
 public sealed class CurrencyData
 {
     /// <summary>
-    /// Currency symbol. E.g., "$".
+    /// Gets the symbol <c>currencyDisplay: "symbol"</c> writes, which may name the country. E.g., "US$".
     /// </summary>
     public required string Symbol { get; init; }
 
     /// <summary>
-    /// Narrow currency symbol. E.g., "$" instead of "US$".
+    /// Gets the symbol <c>currencyDisplay: "narrowSymbol"</c> writes. E.g., "$" instead of "US$".
     /// </summary>
+    /// <remarks>Null falls back to <see cref="Symbol"/>.</remarks>
     public string? NarrowSymbol { get; init; }
 
     /// <summary>
-    /// Display name for the currency. E.g., "US Dollar".
+    /// Gets the name <c>currencyDisplay: "name"</c> writes beside an amount. E.g., "US dollars".
     /// </summary>
+    /// <remarks>
+    /// This is not the name <c>Intl.DisplayNames</c> shows — CLDR spells that one "US Dollar" and
+    /// <see cref="ICldrProvider.GetCurrencyDisplayName"/> answers for it.
+    /// </remarks>
     public required string DisplayName { get; init; }
 }
 
@@ -172,17 +177,13 @@ public sealed class DateTimePatterns
 public sealed class WeekInfo
 {
     /// <summary>
-    /// First day of the week.
+    /// Gets the day a week starts on.
     /// </summary>
     public required DayOfWeek FirstDay { get; init; }
 
     /// <summary>
-    /// Minimal days in first week of year.
+    /// Gets the days that are weekend, which <c>getWeekInfo</c> reports sorted with Sunday last.
     /// </summary>
-    public required int MinimalDays { get; init; }
-
-    /// <summary>
-    /// Weekend days.
-    /// </summary>
+    /// <remarks>Null and empty both report an empty <c>weekend</c> array.</remarks>
     public DayOfWeek[]? Weekend { get; init; }
 }

--- a/Jint/Native/Intl/DefaultCldrProvider.cs
+++ b/Jint/Native/Intl/DefaultCldrProvider.cs
@@ -11,15 +11,16 @@ namespace Jint.Native.Intl;
 /// <remarks>
 /// <para>
 /// Every member is <c>virtual</c>, so changing one datum means deriving from this class and overriding
-/// that one member. The other twenty-two are inherited, and nothing has to be delegated by hand.
+/// that one member. The other twenty are inherited, and nothing has to be delegated by hand.
 /// </para>
 /// <para>
 /// Install the derived instance on <see cref="Options.IntlOptions.CldrProvider"/>; leaving that property
 /// alone keeps <see cref="Instance"/>, the shared singleton every unconfigured engine reads.
 /// </para>
 /// <para>
-/// Overriding a member is not the same as adding data the engine never asks for: ten of the twenty-three
-/// members have no caller inside Jint today, so overriding one of those changes nothing script can see.
+/// Overriding a member is not the same as adding data the engine never asks for: six still have no caller
+/// inside Jint — the four that answer for <c>Intl.DateTimeFormat</c>, plus <see cref="GetCompactPatterns"/>
+/// and <see cref="GetNumberingSystemDigits"/> — so overriding one of those changes nothing script can see.
 /// </para>
 /// </remarks>
 /// <example>
@@ -56,6 +57,7 @@ public class DefaultCldrProvider : ICldrProvider
 
     // === List Patterns ===
 
+    /// <inheritdoc />
     public virtual ListPatterns? GetListPatterns(string locale, string type, string style)
     {
         // Try embedded CLDR data first
@@ -88,6 +90,7 @@ public class DefaultCldrProvider : ICldrProvider
 
     // === Relative Time Patterns ===
 
+    /// <inheritdoc />
     public virtual RelativeTimePatterns? GetRelativeTimePatterns(string locale, string unit, string style)
     {
         // Try embedded CLDR data first
@@ -146,6 +149,7 @@ public class DefaultCldrProvider : ICldrProvider
         };
     }
 
+    /// <inheritdoc />
     public virtual string? GetRelativeTimeSpecialPhrase(string locale, string unit, int value, bool past, string style)
     {
         // Only provide English phrases
@@ -200,17 +204,20 @@ public class DefaultCldrProvider : ICldrProvider
 
     // === Number Formatting ===
 
+    /// <inheritdoc />
     public virtual string? GetNumberingSystemDigits(string numberingSystem)
     {
         return NumberingSystemData.Digits.TryGetValue(numberingSystem, out var digits) ? digits : null;
     }
 
+    /// <inheritdoc />
     public virtual string? GetDefaultNumberingSystem(string locale)
     {
         // Default provider has no per-locale CLDR data; caller falls back to "latn".
         return null;
     }
 
+    /// <inheritdoc />
     public virtual CompactPatterns? GetCompactPatterns(string locale, string style)
     {
         // Use existing CompactPatterns data
@@ -251,42 +258,112 @@ public class DefaultCldrProvider : ICldrProvider
         return null;
     }
 
+    /// <inheritdoc />
     public virtual CurrencyData? GetCurrencyData(string locale, string currencyCode)
     {
-        // Default provider returns basic currency data from .NET
-        try
+        return new CurrencyData
         {
-            var culture = IntlUtilities.GetCultureInfo(locale);
-            if (culture is null)
-            {
-                return null;
-            }
-            var region = new RegionInfo(culture.Name);
-
-            // Common currency symbols
-            var symbol = currencyCode switch
-            {
-                "USD" => "$",
-                "EUR" => "\u20AC",
-                "GBP" => "\u00A3",
-                "JPY" => "\u00A5",
-                "CNY" => "\u00A5",
-                _ => currencyCode
-            };
-
-            return new CurrencyData
-            {
-                Symbol = symbol,
-                NarrowSymbol = symbol,
-                DisplayName = currencyCode
-            };
-        }
-        catch
-        {
-            return null;
-        }
+            Symbol = LocaleAwareCurrencySymbol(locale, currencyCode),
+            NarrowSymbol = NarrowCurrencySymbol(currencyCode),
+            DisplayName = CurrencyAmountName(currencyCode)
+        };
     }
 
+    /// <summary>
+    /// Some locales prefix a foreign currency with its country, so that "$" stays the local currency.
+    /// </summary>
+    private static string LocaleAwareCurrencySymbol(string locale, string currencyCode)
+    {
+        if (string.Equals(currencyCode, "USD", StringComparison.Ordinal))
+        {
+            var parts = locale.Split('-');
+            var language = parts[0];
+            var region = parts.Length > 1 ? parts[parts.Length - 1] : "";
+
+            // Taiwan, Korea and the Chinese locales other than Hong Kong write USD as "US$"
+            if (string.Equals(region, "TW", StringComparison.Ordinal) ||
+                string.Equals(region, "KR", StringComparison.Ordinal) ||
+                (string.Equals(language, "zh", StringComparison.Ordinal) && !string.Equals(region, "HK", StringComparison.Ordinal)))
+            {
+                return "US$";
+            }
+        }
+
+        return CurrencySymbol(currencyCode);
+    }
+
+    private static string CurrencySymbol(string currencyCode)
+    {
+        return currencyCode switch
+        {
+            "USD" => "$",
+            "EUR" => "\u20AC",
+            "GBP" => "\u00A3",
+            "JPY" => "\u00A5",
+            "CNY" => "\u00A5",
+            "KRW" => "\u20A9",
+            "INR" => "\u20B9",
+            "RUB" => "\u20BD",
+            "BRL" => "R$",
+            "CAD" => "CA$",
+            "AUD" => "A$",
+            "CHF" => "CHF",
+            "HKD" => "HK$",
+            "SGD" => "S$",
+            "SEK" => "kr",
+            "NOK" => "kr",
+            "DKK" => "kr",
+            "MXN" => "MX$",
+            "NZD" => "NZ$",
+            "ZAR" => "R",
+            "TWD" => "NT$",
+            "THB" => "\u0E3F",
+            "PLN" => "z\u0142",
+            "TRY" => "\u20BA",
+            "ILS" => "\u20AA",
+            "AED" => "\u062F.\u0625",
+            "SAR" => "\uFDFC",
+            "PHP" => "\u20B1",
+            "MYR" => "RM",
+            "IDR" => "Rp",
+            "CZK" => "K\u010D",
+            "HUF" => "Ft",
+            _ => currencyCode
+        };
+    }
+
+    private static string NarrowCurrencySymbol(string currencyCode)
+    {
+        // Most currencies narrow to their ordinary symbol; the exceptions are the ones whose
+        // ordinary symbol carries a country prefix to disambiguate it from another dollar.
+        return currencyCode switch
+        {
+            "CAD" or "AUD" or "HKD" or "SGD" or "NZD" or "MXN" or "TWD" => "$",
+            _ => CurrencySymbol(currencyCode)
+        };
+    }
+
+    private static string CurrencyAmountName(string currencyCode)
+    {
+        return currencyCode switch
+        {
+            "USD" => "US dollars",
+            "EUR" => "euros",
+            "GBP" => "British pounds",
+            "JPY" => "Japanese yen",
+            "CNY" => "Chinese yuan",
+            "KRW" => "South Korean won",
+            "INR" => "Indian rupees",
+            "RUB" => "Russian rubles",
+            "BRL" => "Brazilian reals",
+            "CAD" => "Canadian dollars",
+            "AUD" => "Australian dollars",
+            "CHF" => "Swiss francs",
+            _ => currencyCode
+        };
+    }
+
+    /// <inheritdoc />
     public virtual UnitPatterns? GetUnitPatterns(string locale, string unit, string style)
     {
         // Try embedded CLDR data first
@@ -356,12 +433,14 @@ public class DefaultCldrProvider : ICldrProvider
 
     // === Date/Time Formatting ===
 
+    /// <inheritdoc />
     public virtual DateTimePatterns? GetDateTimePatterns(string locale, string? dateStyle, string? timeStyle)
     {
         // Default provider delegates to .NET's DateTimeFormatInfo
         return null;
     }
 
+    /// <inheritdoc />
     public virtual string[]? GetMonthNames(string locale, string style, string? calendar)
     {
         var cacheKey = string.Concat(locale, "_", style);
@@ -383,6 +462,7 @@ public class DefaultCldrProvider : ICldrProvider
         });
     }
 
+    /// <inheritdoc />
     public virtual string[]? GetWeekdayNames(string locale, string style)
     {
         var cacheKey = string.Concat(locale, "_", style);
@@ -404,6 +484,7 @@ public class DefaultCldrProvider : ICldrProvider
         });
     }
 
+    /// <inheritdoc />
     public virtual string[]? GetDayPeriods(string locale, string style, string? calendar)
     {
         var cacheKey = string.Concat(locale, "_", style);
@@ -419,6 +500,7 @@ public class DefaultCldrProvider : ICldrProvider
         });
     }
 
+    /// <inheritdoc />
     public virtual string[]? GetEraNames(string locale, string style, string? calendar)
     {
         if (!IsEnglish(locale))
@@ -437,6 +519,7 @@ public class DefaultCldrProvider : ICldrProvider
 
     // === Display Names ===
 
+    /// <inheritdoc />
     public virtual string? GetCurrencyDisplayName(string locale, string code)
     {
         if (!IsEnglish(locale))
@@ -450,75 +533,24 @@ public class DefaultCldrProvider : ICldrProvider
 
     // === Locale Data ===
 
-    public virtual string? GetLikelySubtags(string locale)
-    {
-        return LikelySubtagsData.TryResolve(locale, out var result) ? result : null;
-    }
-
+    /// <inheritdoc />
     public virtual WeekInfo? GetWeekInfo(string locale)
     {
         // Extract region from locale for week data lookup
         var region = ExtractRegion(locale);
 
-        var firstDayNum = WeekData.GetFirstDayOfWeek(region);
-        var minDays = WeekData.GetMinDays(region);
-
-        // Convert CLDR day number (1=Monday, 7=Sunday) to DayOfWeek
-        var firstDay = firstDayNum switch
+        var weekendNumbers = WeekData.GetWeekend(region);
+        var weekend = new DayOfWeek[weekendNumbers.Length];
+        for (var i = 0; i < weekendNumbers.Length; i++)
         {
-            1 => DayOfWeek.Monday,
-            2 => DayOfWeek.Tuesday,
-            3 => DayOfWeek.Wednesday,
-            4 => DayOfWeek.Thursday,
-            5 => DayOfWeek.Friday,
-            6 => DayOfWeek.Saturday,
-            7 => DayOfWeek.Sunday,
-            _ => DayOfWeek.Monday
-        };
+            weekend[i] = IntlUtilities.CldrDayNumberToDayOfWeek(weekendNumbers[i]);
+        }
 
         return new WeekInfo
         {
-            FirstDay = firstDay,
-            MinimalDays = minDays,
-            Weekend = new[] { DayOfWeek.Saturday, DayOfWeek.Sunday }
+            FirstDay = IntlUtilities.CldrDayNumberToDayOfWeek(WeekData.GetFirstDayOfWeek(region)),
+            Weekend = weekend
         };
-    }
-
-    // === Plural Rules ===
-
-    public virtual string SelectPluralCategory(string locale, double value, string type)
-    {
-        // Basic English plural rules for cardinal numbers
-        // English only has "one" and "other" categories
-        // For ordinal: "one" (1st, 21st), "two" (2nd, 22nd), "few" (3rd, 23rd), "other" (4th, 11th, etc.)
-
-        var absValue = System.Math.Abs(value);
-
-        if (string.Equals(type, "ordinal", StringComparison.Ordinal))
-        {
-            // English ordinal rules
-            var intValue = (int) absValue;
-            var mod10 = intValue % 10;
-            var mod100 = intValue % 100;
-
-            if (mod10 == 1 && mod100 != 11)
-            {
-                return "one"; // 1st, 21st, 31st, ...
-            }
-            if (mod10 == 2 && mod100 != 12)
-            {
-                return "two"; // 2nd, 22nd, 32nd, ...
-            }
-            if (mod10 == 3 && mod100 != 13)
-            {
-                return "few"; // 3rd, 23rd, 33rd, ...
-            }
-            return "other"; // 4th, 5th, 11th, 12th, 13th, ...
-        }
-
-        // English cardinal rules: "one" for 1, "other" for everything else
-        // Note: Many languages have more complex rules (zero, two, few, many)
-        return absValue == 1 ? "one" : "other";
     }
 
     private static string? ExtractRegion(string locale)
@@ -542,6 +574,7 @@ public class DefaultCldrProvider : ICldrProvider
 
     // === Supported Values ===
 
+    /// <inheritdoc />
     public virtual IReadOnlyCollection<string> GetSupportedCalendars()
     {
         // Only return calendars that are fully supported per ECMA-402 and Intl.Era-monthcode spec
@@ -556,6 +589,7 @@ public class DefaultCldrProvider : ICldrProvider
         };
     }
 
+    /// <inheritdoc />
     public virtual IReadOnlyCollection<string> GetSupportedCollations()
     {
         // https://tc39.es/ecma402/#sec-availablecanonicalcollations wants the collations the
@@ -564,22 +598,26 @@ public class DefaultCldrProvider : ICldrProvider
         return CollatorConstructor.AvailableCanonicalCollations;
     }
 
+    /// <inheritdoc />
     public virtual IReadOnlyCollection<string> GetSupportedCurrencies()
     {
         return _supportedCurrencies.Value;
     }
 
+    /// <inheritdoc />
     public virtual IReadOnlyCollection<string> GetSupportedNumberingSystems()
     {
         return NumberingSystemData.Digits.Keys.ToArray();
     }
 
+    /// <inheritdoc />
     public virtual IReadOnlyCollection<string> GetSupportedTimeZones()
     {
         // Return only canonical (primary) timezone identifiers for supportedValuesOf
         return TimeZoneData.GetCanonicalTimeZones();
     }
 
+    /// <inheritdoc />
     public virtual IReadOnlyCollection<string> GetSupportedUnits()
     {
         return new[]

--- a/Jint/Native/Intl/ICldrProvider.cs
+++ b/Jint/Native/Intl/ICldrProvider.cs
@@ -65,11 +65,16 @@ public interface ICldrProvider
     CompactPatterns? GetCompactPatterns(string locale, string style);
 
     /// <summary>
-    /// Gets currency data for a locale and currency code.
+    /// Gets the symbols and name <c>Intl.NumberFormat</c> writes beside an amount in this currency.
     /// </summary>
     /// <param name="locale">The locale identifier.</param>
     /// <param name="currencyCode">ISO 4217 currency code (e.g., "USD").</param>
-    /// <returns>Currency data or null if not available.</returns>
+    /// <returns>Currency data, or null to fall back to the currency code itself.</returns>
+    /// <remarks>
+    /// Read once per <c>Intl.NumberFormat</c> construction, not per <c>format()</c> call, and only when
+    /// <c>style</c> is <c>"currency"</c>. <c>currencyDisplay: "code"</c> never reads it: the specification
+    /// fixes that display to the currency code.
+    /// </remarks>
     CurrencyData? GetCurrencyData(string locale, string currencyCode);
 
     /// <summary>
@@ -140,29 +145,15 @@ public interface ICldrProvider
     // === Locale Data ===
 
     /// <summary>
-    /// Gets the likely subtags expansion for a locale.
-    /// </summary>
-    /// <param name="locale">The locale to expand.</param>
-    /// <returns>Expanded locale or null if not available.</returns>
-    string? GetLikelySubtags(string locale);
-
-    /// <summary>
-    /// Gets week information for a locale.
+    /// Gets the day a week starts on and the days that are weekend, for a locale.
     /// </summary>
     /// <param name="locale">The locale identifier.</param>
-    /// <returns>Week info or null if not available.</returns>
+    /// <returns>Week info, or null to fall back to the embedded CLDR week data.</returns>
+    /// <remarks>
+    /// Read by <c>Intl.Locale.prototype.getWeekInfo</c>, once per call. A <c>-u-fw-</c> extension on the
+    /// locale takes precedence over <see cref="WeekInfo.FirstDay"/>, as the specification requires.
+    /// </remarks>
     WeekInfo? GetWeekInfo(string locale);
-
-    // === Plural Rules ===
-
-    /// <summary>
-    /// Selects the plural category for a numeric value in a locale.
-    /// </summary>
-    /// <param name="locale">The locale identifier.</param>
-    /// <param name="value">The numeric value to categorize.</param>
-    /// <param name="type">Plural type: "cardinal" or "ordinal".</param>
-    /// <returns>Plural category: "zero", "one", "two", "few", "many", or "other".</returns>
-    string SelectPluralCategory(string locale, double value, string type);
 
     // === Supported Values ===
 

--- a/Jint/Native/Intl/IntlUtilities.cs
+++ b/Jint/Native/Intl/IntlUtilities.cs
@@ -27,6 +27,28 @@ internal static class IntlUtilities
     }
 
     /// <summary>
+    /// Converts a CLDR week day number (1 = Monday through 7 = Sunday) to its <see cref="DayOfWeek"/>,
+    /// which numbers the same seven days from Sunday. Anything out of range reads as Monday.
+    /// </summary>
+    internal static DayOfWeek CldrDayNumberToDayOfWeek(int day) => day switch
+    {
+        1 => DayOfWeek.Monday,
+        2 => DayOfWeek.Tuesday,
+        3 => DayOfWeek.Wednesday,
+        4 => DayOfWeek.Thursday,
+        5 => DayOfWeek.Friday,
+        6 => DayOfWeek.Saturday,
+        7 => DayOfWeek.Sunday,
+        _ => DayOfWeek.Monday
+    };
+
+    /// <summary>
+    /// The inverse of <see cref="CldrDayNumberToDayOfWeek"/>: Sunday is 7 rather than 0, which is the
+    /// numbering both CLDR and <c>Intl.Locale.prototype.getWeekInfo</c> use.
+    /// </summary>
+    internal static int DayOfWeekToCldrDayNumber(DayOfWeek day) => day == DayOfWeek.Sunday ? 7 : (int) day;
+
+    /// <summary>
     /// Implements the normative-optional legacy-constructor chaining behaviour shared by
     /// Intl.Collator, Intl.DateTimeFormat and Intl.NumberFormat (ChainCollator / ChainDateTimeFormat /
     /// ChainNumberFormat). When the constructor is invoked as a plain function (NewTarget is undefined)

--- a/Jint/Native/Intl/LocalePrototype.cs
+++ b/Jint/Native/Intl/LocalePrototype.cs
@@ -330,25 +330,47 @@ internal sealed partial class LocalePrototype : Prototype
     private JsObject GetWeekInfo(JsValue thisObject)
     {
         var locale = ValidateLocale(thisObject);
-        var region = locale.Region;
+        var weekInfo = Engine.Options.Intl.CldrProvider.GetWeekInfo(locale.Locale);
 
         var result = OrdinaryObjectCreate(Engine, Engine.Realm.Intrinsics.Object.PrototypeObject);
 
-        // First day of week (1=Monday, 7=Sunday)
-        // Use fw extension if present, otherwise from CLDR data
+        // First day of week (1=Monday, 7=Sunday). The fw extension wins over the provider; without one,
+        // a provider with no opinion falls back to the embedded CLDR data.
         int firstDayNum;
         if (locale.FirstDayOfWeek != null)
         {
             firstDayNum = ConvertDayNameToNumber(locale.FirstDayOfWeek);
         }
+        else if (weekInfo != null)
+        {
+            firstDayNum = IntlUtilities.DayOfWeekToCldrDayNumber(weekInfo.FirstDay);
+        }
         else
         {
-            firstDayNum = WeekData.GetFirstDayOfWeek(region);
+            firstDayNum = WeekData.GetFirstDayOfWeek(locale.Region);
         }
         result.CreateDataPropertyOrThrow("firstDay", firstDayNum);
 
-        // Weekend days from CLDR data
-        var weekendDays = WeekData.GetWeekend(region);
+        // [[Weekend]] is a list of day numbers in ascending order, so sort whatever the provider gave.
+        int[] weekendDays;
+        if (weekInfo?.Weekend is { } providerWeekend)
+        {
+            weekendDays = new int[providerWeekend.Length];
+            for (var i = 0; i < providerWeekend.Length; i++)
+            {
+                weekendDays[i] = IntlUtilities.DayOfWeekToCldrDayNumber(providerWeekend[i]);
+            }
+            System.Array.Sort(weekendDays);
+        }
+        else if (weekInfo != null)
+        {
+            weekendDays = [];
+        }
+        else
+        {
+            weekendDays = WeekData.GetWeekend(locale.Region);
+        }
+
         var weekend = new JsArray(Engine, (uint) weekendDays.Length);
         for (var i = 0; i < weekendDays.Length; i++)
         {

--- a/Jint/Native/Intl/NumberFormatConstructor.cs
+++ b/Jint/Native/Intl/NumberFormatConstructor.cs
@@ -272,16 +272,20 @@ internal sealed partial class NumberFormatConstructor : Constructor
         numberFormatInfo.CurrencyDecimalDigits = clampedMaxFractionDigits;
         numberFormatInfo.PercentDecimalDigits = clampedMaxFractionDigits;
 
-        // Apply currency symbol based on currencyDisplay option
+        // Apply currency symbol based on currencyDisplay option. "code" is the currency code by
+        // specification, so it is the one display the provider is not asked about.
         if (currency != null)
         {
+            var currencyData = currencyDisplay is "code"
+                ? null
+                : _engine.Options.Intl.CldrProvider.GetCurrencyData(resolvedLocale, currency);
+
             numberFormatInfo.CurrencySymbol = currencyDisplay switch
             {
                 "code" => currency, // e.g., "USD"
-                "symbol" => GetLocaleAwareCurrencySymbol(currency, resolvedLocale), // e.g., "$" or "US$" depending on locale
-                "narrowSymbol" => GetCurrencyNarrowSymbol(currency), // e.g., "$"
-                "name" => GetCurrencyName(currency), // e.g., "US dollars"
-                _ => GetLocaleAwareCurrencySymbol(currency, resolvedLocale)
+                "narrowSymbol" => currencyData?.NarrowSymbol ?? currencyData?.Symbol ?? currency, // e.g., "$"
+                "name" => currencyData?.DisplayName ?? currency, // e.g., "US dollars"
+                _ => currencyData?.Symbol ?? currency // "symbol": "$", or "US$" depending on locale
             };
         }
 
@@ -714,125 +718,6 @@ internal sealed partial class NumberFormatConstructor : Constructor
             "KRW" or "PYG" or "RWF" or "UGX" or "UYI" or "VND" or "VUV" or
             "XAF" or "XOF" or "XPF" => 0, // 0 decimal places
             _ => 2 // Default 2 decimal places
-        };
-    }
-
-    /// <summary>
-    /// Gets the locale-aware currency symbol for a currency code.
-    /// Some locales display foreign currencies with a country code prefix (e.g., "US$" for USD in zh-TW).
-    /// </summary>
-    private static string GetLocaleAwareCurrencySymbol(string currency, string locale)
-    {
-        // Get the base language and region from the locale
-        var parts = locale.Split('-');
-        var lang = parts[0];
-        var region = parts.Length > 1 ? parts[parts.Length - 1] : "";
-
-        // Check if this is a foreign currency that needs a prefix
-        // zh-TW and ko-KR display USD as "US$" to distinguish from local currency
-        if (string.Equals(currency, "USD", StringComparison.Ordinal))
-        {
-            // In Taiwan, Korea, and Chinese locales (except Hong Kong), USD is displayed as "US$"
-            if (string.Equals(region, "TW", StringComparison.Ordinal) ||
-                string.Equals(region, "KR", StringComparison.Ordinal) ||
-                (string.Equals(lang, "zh", StringComparison.Ordinal) && !string.Equals(region, "HK", StringComparison.Ordinal)))
-            {
-                return "US$";
-            }
-        }
-
-        // For other cases, use the standard symbol
-        return GetCurrencySymbol(currency);
-    }
-
-    /// <summary>
-    /// Gets the currency symbol for a currency code.
-    /// </summary>
-    private static string GetCurrencySymbol(string currency)
-    {
-        return currency switch
-        {
-            "USD" => "$",
-            "EUR" => "€",
-            "GBP" => "£",
-            "JPY" => "¥",
-            "CNY" => "¥",
-            "KRW" => "₩",
-            "INR" => "₹",
-            "RUB" => "₽",
-            "BRL" => "R$",
-            "CAD" => "CA$",
-            "AUD" => "A$",
-            "CHF" => "CHF",
-            "HKD" => "HK$",
-            "SGD" => "S$",
-            "SEK" => "kr",
-            "NOK" => "kr",
-            "DKK" => "kr",
-            "MXN" => "MX$",
-            "NZD" => "NZ$",
-            "ZAR" => "R",
-            "TWD" => "NT$",
-            "THB" => "฿",
-            "PLN" => "zł",
-            "TRY" => "₺",
-            "ILS" => "₪",
-            "AED" => "د.إ",
-            "SAR" => "﷼",
-            "PHP" => "₱",
-            "MYR" => "RM",
-            "IDR" => "Rp",
-            "CZK" => "Kč",
-            "HUF" => "Ft",
-            _ => currency // Fall back to the code itself
-        };
-    }
-
-    /// <summary>
-    /// Gets the narrow currency symbol (usually same as regular symbol).
-    /// </summary>
-    private static string GetCurrencyNarrowSymbol(string currency)
-    {
-        // For most currencies, narrow symbol is the same as regular symbol
-        // Some exceptions exist but they're relatively rare
-        return currency switch
-        {
-            "USD" => "$",
-            "EUR" => "€",
-            "GBP" => "£",
-            "JPY" => "¥",
-            "CNY" => "¥",
-            "CAD" => "$", // Narrow: $ instead of CA$
-            "AUD" => "$", // Narrow: $ instead of A$
-            "HKD" => "$", // Narrow: $ instead of HK$
-            "SGD" => "$", // Narrow: $ instead of S$
-            "NZD" => "$", // Narrow: $ instead of NZ$
-            "MXN" => "$", // Narrow: $ instead of MX$
-            "TWD" => "$", // Narrow: $ instead of NT$
-            _ => GetCurrencySymbol(currency)
-        };
-    }
-
-    /// <summary>
-    /// Gets the currency name for a currency code.
-    /// </summary>
-    private static string GetCurrencyName(string currency)
-    {
-        return currency switch
-        {
-            "USD" => "US dollars",
-            "EUR" => "euros",
-            "GBP" => "British pounds",
-            "JPY" => "Japanese yen",
-            "CNY" => "Chinese yuan",
-            "KRW" => "South Korean won",
-            "INR" => "Indian rupees",
-            "RUB" => "Russian rubles",
-            "BRL" => "Brazilian reals",
-            "CAD" => "Canadian dollars",
-            "AUD" => "Australian dollars",
-            "CHF" => "Swiss francs",
-            _ => currency // Fall back to the code
         };
     }
 

--- a/README.md
+++ b/README.md
@@ -2794,7 +2794,7 @@ data and full IANA timezone DST history are reachable via two pluggable provider
 | Extension point | Default | What it covers | Reusable example |
 | --- | --- | --- | --- |
 | `Options.Temporal.TimeZoneProvider` (`ITimeZoneProvider`) | `DefaultTimeZoneProvider` (BCL `TimeZoneInfo` + Windows↔IANA mapping) | UTC offsets, DST transitions, IANA canonicalization | [`NodaTimeZoneProvider.cs`](Jint.Tests.Test262/NodaTimeZoneProvider.cs) — uses NodaTime TZDB for full historical accuracy |
-| `Options.Intl.CldrProvider` (`ICldrProvider`) | `DefaultCldrProvider` (English + .NET `CultureInfo`) | locale names, currencies, units, plural rules, calendar month/era names | [`IcuCldrProvider.cs`](Jint.Tests.Test262/IcuCldrProvider.cs) — uses ICU4N for full CLDR coverage |
+| `Options.Intl.CldrProvider` (`ICldrProvider`) | `DefaultCldrProvider` (English + .NET `CultureInfo`) | currency symbols and names, unit patterns, list and relative-time patterns, era names, week info, and the `Intl.supportedValuesOf` lists | [`IcuCldrProvider.cs`](Jint.Tests.Test262/IcuCldrProvider.cs) — uses ICU4N for full CLDR coverage |
 
 The provider files in `Jint.Tests.Test262/` are **MIT-licensed copy-and-modify templates**,
 not a stable API contract. They are also exactly how the test suite reaches its current
@@ -2811,10 +2811,11 @@ var engine = new Engine(options =>
 });
 ```
 
-A separate `ICalendarProvider` for non-ISO calendar arithmetic (Islamic UmAlQura, Persian
-astronomical, Chinese/Dangi at extreme dates) is on the roadmap; until then non-ISO
-calendars use `System.Globalization.Calendar` subclasses, which constrains some date
-ranges (see [`Jint/Native/Temporal/NonIsoCalendars.cs`](Jint/Native/Temporal/NonIsoCalendars.cs)).
+`Options.Temporal.CalendarProvider` (`ICalendarProvider`) is the third of these, for non-ISO
+calendar arithmetic. Its default, `DefaultCalendarProvider`, is backed by
+`System.Globalization.Calendar` subclasses, which constrains some date ranges — derive from it and
+override one conversion to correct a calendar (see
+[`Jint/Native/Temporal/NonIsoCalendars.cs`](Jint/Native/Temporal/NonIsoCalendars.cs)).
 
 ## Running untrusted code
 

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -64,6 +64,9 @@ This table is filled by the pull request that removes the member. A member that 
 | `AstExtensions` (the whole class, with its two `GetKey` overloads) → `internal` | nothing. `GetKey` extracts a property key from an Acornima expression and needs a live execution context to do it for a computed one, so it was never callable from host code at a meaningful moment; it appeared in IntelliSense for every host with `using Jint;` and an `Expression` in scope | [#3320](https://github.com/sebastienros/jint/pull/3320) |
 | `GlobalSymbolRegistry()` (public parameterless constructor) → `internal` | nothing. The well-known symbols on it are `static` and still readable — `GlobalSymbolRegistry.Iterator` and its fourteen siblings are unchanged. The *instance* half holds the symbols one engine's `Symbol.for` created, and `Engine.GlobalSymbolRegistry` is `internal`, so a host-constructed registry could never be installed | [#3320](https://github.com/sebastienros/jint/pull/3320) |
 | `ManualPromise(JsValue, Action<JsValue>, Action<JsValue>)` → `internal` | `Engine.Tasks.RegisterPromise()`, the only thing that ever returned one. Settling requires the resolving functions the engine built for that particular promise, so a hand-constructed handle settled nothing. The properties, `with` and `var (promise, resolve, reject) = …` are unchanged | [#3320](https://github.com/sebastienros/jint/pull/3320) |
+| `ICldrProvider.SelectPluralCategory` (and `DefaultCldrProvider`'s override) | nothing. It took a `double`, which cannot carry the CLDR plural operands — `1` and `1.00` are different categories in most languages and the same `double` — so it could not implement plural selection correctly even if the engine had asked. `Intl.PluralRules`, `Intl.NumberFormat`, `Intl.RelativeTimeFormat` and `Intl.DurationFormat` all use the engine's own operand-aware rules | [#3336](https://github.com/sebastienros/jint/issues/3336) |
+| `ICldrProvider.GetLikelySubtags` (and `DefaultCldrProvider`'s override) | nothing. It expressed only the *maximize* half of the Unicode Add/Remove Likely Subtags algorithm, and `Intl.Locale.prototype.minimize` needs both halves plus subtag-level lookups the signature has no room for. The table is a Unicode constant, not a locale opinion | [#3336](https://github.com/sebastienros/jint/issues/3336) |
+| `WeekInfo.MinimalDays` | nothing. ECMA-402 removed `minimalDays` from `getWeekInfo()`'s result, and test262 asserts the keys are exactly `firstDay` and `weekend`, so no caller could ever have reached it | [#3336](https://github.com/sebastienros/jint/issues/3336) |
 
 ### 2.1 Sealed types
 
@@ -1322,7 +1325,6 @@ engine.Evaluate("new Proxy([], {})").AsArray();    // ArgumentException: The val
 
 `IsArray()` answers `false` for both, which it always did, and `TryGetArray` declines. A host that wants the
 proxy-following answer asks script for it — `Array.isArray(value)` is unchanged, and still `true` for both.
-
 ### 4.21 `WebApi.Enable`'s callback configures one engine, not every engine ([#3359](https://github.com/sebastienros/jint/pull/3359))
 
 `Engine.WebApi.Enable(features, configure)` used to hand the callback the very `Options`
@@ -1349,6 +1351,33 @@ wrote. Shared configuration is spelled by configuring the options before buildin
 var options = new Options().UseWebApis(WebApiFeatures.Fetch);
 options.WebApi.Fetch.HttpClient = sharedClient;   // every engine built from this
 ```
+
+### 4.22 `Intl` reads the CLDR provider for currency symbols and week info ([#3336](https://github.com/sebastienros/jint/issues/3336))
+
+`Intl.NumberFormat`'s currency symbols came from a hardcoded switch inside the engine, and
+`Intl.Locale.prototype.getWeekInfo` read the embedded CLDR week data directly. Both now go through
+`Options.Intl.CldrProvider` — `GetCurrencyData` and `GetWeekInfo` — so overriding either reaches script:
+
+```c#
+// 5.x — one override, and Intl.NumberFormat().format() shows it
+sealed class MyCurrencies : DefaultCldrProvider
+{
+    public override CurrencyData? GetCurrencyData(string locale, string currencyCode)
+        => currencyCode == "XCD"
+            ? new CurrencyData { Symbol = "EC$", NarrowSymbol = "$", DisplayName = "East Caribbean dollars" }
+            : base.GetCurrencyData(locale, currencyCode);
+}
+```
+
+That switch is now `DefaultCldrProvider`'s data, so an engine that configures no provider — or one whose
+provider derives from `DefaultCldrProvider` — formats exactly as it did in 4.16.
+
+**What could break:** a host implementing `ICldrProvider` from scratch rather than deriving from
+`DefaultCldrProvider`. Its `GetCurrencyData` and `GetWeekInfo` were dead code and are now read, so whatever
+they return is what script sees. Returning `null` from `GetCurrencyData` formats the currency *code*
+(`"USD12.50"`), which is what `currencyDisplay: "code"` has always produced; returning `null` from
+`GetWeekInfo` keeps the embedded week data. `currencyDisplay: "code"` never consults the provider, because
+the specification fixes that display to the currency code.
 
 ## 5. New in v5
 
@@ -1460,7 +1489,7 @@ follow-up.
 
 `DefaultCldrProvider`, `DefaultTimeZoneProvider` and `DefaultCalendarProvider` were `sealed`, so a host that
 disagreed with one currency name, one time zone alias or one calendar had to implement the whole interface —
-23, 9 and 4 members — and hand-delegate every member it did not care about to the singleton. Miss one and the
+21, 9 and 4 members — and hand-delegate every member it did not care about to the singleton. Miss one and the
 engine silently loses a datum it used to have.
 
 All three are now unsealed with `virtual` members, matching `DefaultTimeSystem`, which has always had that
@@ -1469,7 +1498,7 @@ shape. Nothing about an unconfigured engine changed: the `Options` properties st
 and answers inline rather than going through the interface.
 
 ```c#
-// 5.x — the other twenty-two members are inherited
+// 5.x — the other twenty members are inherited
 sealed class MyCldr : DefaultCldrProvider
 {
     public override string? GetCurrencyDisplayName(string locale, string code)
@@ -1479,11 +1508,12 @@ sealed class MyCldr : DefaultCldrProvider
 var engine = new Engine(options => options.Intl.CldrProvider = new MyCldr());
 ```
 
-Two limits are worth knowing before reaching for this. Ten of `ICldrProvider`'s twenty-three members have no
-caller inside Jint today — `GetCurrencyData`, `GetMonthNames`, `GetWeekdayNames`, `GetDayPeriods`,
-`GetDateTimePatterns`, `GetCompactPatterns`, `GetNumberingSystemDigits`, `GetLikelySubtags`, `GetWeekInfo`
-and `SelectPluralCategory` — so overriding one of those changes nothing script can observe until the engine
-starts consulting it. And on the calendar side, *correcting* a calendar Jint already
+Two limits are worth knowing before reaching for this. Six of `ICldrProvider`'s twenty-one members have no
+caller inside Jint today — `GetMonthNames`, `GetWeekdayNames`, `GetDayPeriods`, `GetDateTimePatterns`,
+`GetCompactPatterns` and `GetNumberingSystemDigits` — so overriding one of those changes nothing script can
+observe until the engine starts consulting it; [#3336](https://github.com/sebastienros/jint/issues/3336)
+tracks the remaining six, and wired `GetCurrencyData` and `GetWeekInfo` on the way, per
+[4.21](#422-intl-reads-the-cldr-provider-for-currency-symbols-and-week-info). And on the calendar side, *correcting* a calendar Jint already
 knows is one override, while *adding* one it does not know is four: `IsSupported`, `GetSupportedCalendars` and
 both conversions all have to answer for the new identifier.
 


### PR DESCRIPTION
Part of #3336.

`ICldrProvider.GetCurrencyData` carries the currency symbol, and nothing read it. `Intl.NumberFormat`'s symbols came from a hardcoded switch in `NumberFormatConstructor`, so a host implementing `GetCurrencyData` to add or correct a symbol saw no effect on `format()` — the obvious reason to implement it at all.

## The failing test, first

`Jint.Tests.PublicInterface/HostLocaleProviderTests.cs` gains a host provider that overrides `GetCurrencyData` and nothing else. Against `main`:

```
  Failed Jint.Tests.PublicInterface.HostLocaleProviderTests.OverridingOneCurrencyReachesNumberFormat [5 ms]
  Error Message:
   Expected engine.Evaluate("new Intl.NumberFormat('en', { style: 'currency', currency: 'XCD' }).format(12.5)").AsString() to be the same string, but they differ at index 0:
   ↓ (actual)
  "XCD12.50"
  "EC$12.50"
   ↑ (expected).
```

The same shape held for `GetWeekInfo`, which `Intl.Locale.prototype.getWeekInfo` also did not consult:

```
  Failed Jint.Tests.PublicInterface.HostLocaleProviderTests.OverridingOneWeekInfoReachesIntlLocale [40 ms]
  Error Message:
   Expected engine.Evaluate("new Intl.Locale('en-US').getWeekInfo().firstDay").AsNumber() to be 3.0, but found 7.0 (difference of 4).
```

## What this does

The symbol switch, the narrow-symbol table and the amount-name table move out of `NumberFormatConstructor` and become `DefaultCldrProvider.GetCurrencyData`'s data. `NumberFormatConstructor` asks the provider and falls back to the currency code, which is what the switch's default arm produced. `currencyDisplay: "code"` is the one display that never asks: ECMA-402 fixes it to the currency code.

An unconfigured engine formats exactly as before. That is not an assertion — the three tables were compared entry by entry against the removed switches (32 symbols, 12 names, and the narrow lookup across all 33 codes either table mentions, including the `_ =>` fallback), and every one matches.

`getWeekInfo` is wired the same way, with the `-u-fw-` extension still winning over the provider and a `null` answer still falling back to the embedded CLDR week data. `[[Weekend]]` is specified as ascending, so whatever a provider hands back is sorted before it reaches script.

## The other nine, member by member

The issue listed ten members with no in-box caller. Verified against `main` first — a grep of every `CldrProvider.` call site in `Jint/` finds exactly thirteen members consulted, so all ten were still unwired.

| Member | Verdict | Reason |
| --- | --- | --- |
| `GetCurrencyData` | **wired here** | `Intl.NumberFormat` currency symbols and the `currencyDisplay: "name"` text. Read once per formatter construction, only when `style: "currency"`. |
| `GetWeekInfo` | **wired here** | `Intl.Locale.prototype.getWeekInfo`, once per call. `WeekInfo.MinimalDays` is removed with it — ECMA-402 dropped `minimalDays` from the result, and `intl402/Locale/prototype/getWeekInfo/output-object-keys.js` asserts `Reflect.ownKeys` is exactly `['firstDay', 'weekend']`, so nothing could ever have read it. |
| `SelectPluralCategory` | **removed** | It cannot work. CLDR plural selection needs the operands `i, v, w, f, t, c`, and a `double` carries none of them: `format(1)` at `minimumFractionDigits: 2` is `"1.00"`, whose `en` category is `other` rather than `one`, from the same `double`. The return is also non-nullable, so a provider has no way to decline. `JsPluralRules` already implements the operand-aware algorithm and serves `Intl.PluralRules`, `NumberFormat`, `RelativeTimeFormat` and `DurationFormat`. |
| `GetLikelySubtags` | **removed** | It is half an algorithm. `Data/LikelySubtags.cs` implements TR35 Add *and* Remove Likely Subtags for `maximize`/`minimize`, and `minimize` works by re-maximizing candidate `(language, script, region)` triples — which `string? GetLikelySubtags(string locale)` cannot express in either direction. The table is a Unicode constant, not a locale opinion a host holds. |
| `GetMonthNames` | gap — **deferred** | `Intl.DateTimeFormat` reads .NET `DateTimeFormatInfo`. Real consumer; wiring it is a DateTimeFormat-core change. |
| `GetWeekdayNames` | gap — **deferred** | same |
| `GetDayPeriods` | gap — **deferred** | same |
| `GetDateTimePatterns` | gap — **deferred** | same, and its default returns `null` unconditionally, so it has never had an implementation |
| `GetCompactPatterns` | gap — **deferred** | `notation: "compact"` reads `Data.CompactPatterns.GetPatterns(Locale)` inside `JsNumberFormat`'s formatting, so a naive wiring lands on the per-`format()` path |
| `GetNumberingSystemDigits` | gap — **deferred** | the sharpest of the six: `GetSupportedNumberingSystems` *is* wired, so a host can list a numbering system through `Intl.supportedValuesOf` that the constructor then rejects and nothing would transliterate. Wiring it means resolving the digit string once at construction. |

`ICldrProvider` is 21 members, six of which still have no caller. The six are #3354, which says what each one needs; the four `Intl.DateTimeFormat` members only pay off together and want their own conformance run.

## Hot paths

Neither wiring lands on a per-element path. `GetCurrencyData` is read in `NumberFormatConstructor.Construct` — once per `new Intl.NumberFormat(...)`, and only for `style: "currency"`; the result is baked into the formatter's `NumberFormatInfo.CurrencySymbol`, which is what `format()` reads. `GetWeekInfo` is read once per `getWeekInfo()` call. Contrast `GetUnitPatterns`, `GetEraNames`, `GetListPatterns` and `GetRelativeTimePatterns`, which are already read per `format()` call and are untouched here.

## The calendar four-override problem

The issue's third point — adding an *unknown* non-ISO calendar needs four overrides, because `NonIsoCalendars` throws `NotSupportedException` for an identifier it has never seen — is filed separately as #3355. It is a different provider (`ICalendarProvider`, Temporal) from this one, two of the four overrides are semantically unavoidable, and what the other two should do instead is a design question, not a wiring. Folding it into a PR that has to hold test262 at an exact number buys nothing.

## Also here

- Every member of `DefaultCldrProvider` now carries `<inheritdoc />`, matching `DefaultCalendarProvider`. `UndocumentedPublicApi.txt` goes 658 → 635.
- The five API baselines lose three declarations each; `docs/v5-migration.md` gains three §2 rows and §4.21, and §5.2's "ten of twenty-three" prose is now true. (§4.19 and §4.20 were taken by #3356 and #3353 while this was in flight, so this one renumbered twice on rebase, per the guide's "numbering is assigned at merge" rule.)
- `README.md`'s provider table said `ICldrProvider` covers "plural rules", which it never did; and the paragraph below it still called `ICalendarProvider` "on the roadmap" long after it shipped.
- `WeekData.GetMinDays` and `WeekData.MinDays` are now unreferenced. Left in place deliberately: they are vendored CLDR data behind an `internal` type, and deleting an embedded data table is a separate call from trimming a public surface.

## Verification

- `dotnet build -c Release` clean.
- `Jint.Tests`: 10,668 passed on `net10.0` and `net8.0`, 7,316 on `net472`, 0 failed.
- `Jint.Tests.PublicInterface`: 2,961 passed on `net10.0`, 2,341 on `net472`, 0 failed.
- `Jint.Tests.Test262`: **102,495 passed, 0 failed**, 189 skipped, 102,684 total — the number `main` holds. `intl402` is generated and included, so this PR had real conformance exposure on both wirings.

  That number is from the run on an unloaded machine. Every run afterwards lost exactly one test, `staging/sm/expressions/short-circuit-compound-assignment.js`, to a bare `System.TimeoutException` out of `TimeConstraint.Check` at the engine's 30-second ceiling — 31 s to 42 s wall, nothing from this change on the stack, and the script does not mention `Intl` anywhere. Three pieces of evidence that it is machine load, not this PR:

  1. `--filter FullyQualifiedName~Sm_expressions` in isolation passes **75/75 in 808 ms** — the same test, a 40× slowdown under contention.
  2. The box was at 100% CPU with 38 concurrent `dotnet` processes throughout.
  3. **Plain `upstream/main` at `3ad9cd023`, built and run in the same worktree under the same load, fails the identical test at 32 s: `Failed: 1, Passed: 102494`.** Byte-for-byte the same result as this branch.
