### PR TITLE
Engine: WebApi.Enable's callback configures one engine, not every engine

### DIFF
--- a/Jint.Tests.PublicInterface/HostOptionsReadOnlyTests.cs
+++ b/Jint.Tests.PublicInterface/HostOptionsReadOnlyTests.cs
@@ -275,6 +275,11 @@ public class HostOptionsReadOnlyTests
     /// the suspension it opens is scoped to the group it is configuring — not to web-API groups at large, and
     /// not to the registries.
     /// </summary>
+    /// <remarks>
+    /// The group it hands the callback is the engine's own copy of the web-API subtree, so the host's own
+    /// instance is not written to at all; <see cref="HostWebApiOptionsIsolationTests"/> is where that is
+    /// pinned from the outside.
+    /// </remarks>
     [Fact]
     public void TheLiveWebApiDoorSuspendsTheGuardForTheGroupItIsConfiguringAndNothingElse()
     {
@@ -302,7 +307,13 @@ public class HostOptionsReadOnlyTests
         });
 
         ran.Should().BeTrue();
-        options.WebApi.Timers.MaxActiveTimers.Should().Be(3);
+
+        // The engine got the setting, on the copy of the subtree it took for itself...
+        engine.WebApi.Features.Should().HaveFlag(WebApiFeatures.Timers);
+
+        // ... and this instance, which the host may be sharing with any number of other engines, was not
+        // written to at all.
+        options.WebApi.Timers.MaxActiveTimers.Should().Be(1000);
 
         // ... and the suspension ends with the call.
         Invoking(() => options.WebApi.Timers.MaxActiveTimers = 4)

--- a/Jint.Tests.PublicInterface/HostWebApiOptionsIsolationTests.cs
+++ b/Jint.Tests.PublicInterface/HostWebApiOptionsIsolationTests.cs
@@ -1,0 +1,206 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Jint.Native;
+using Jint.WebApi;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// What a host writes in <c>Engine.WebApi.Enable</c>'s configuration callback reaches the engine it
+/// called it on, and no other engine in the process.
+/// </summary>
+/// <remarks>
+/// <para>
+/// That callback is the one write to an engine's <see cref="Options"/> after construction, and the instance
+/// behind it is shared: with every engine built from it, and — for <c>new Engine()</c>, which is what a host
+/// writes when it has no options to give — with one instance Jint keeps process-wide. A per-tenant HTTP
+/// client or URL policy set through the callback therefore used to become every default-built engine's, in
+/// both directions in time.
+/// </para>
+/// <para>
+/// This project has no <c>InternalsVisibleTo</c>, so every assertion here is one an embedder could write:
+/// the leak is observed through what a <i>second</i> engine's script does, not by reading the options back.
+/// Nothing opens a socket — each engine that fetches is given a handler that answers from memory.
+/// </para>
+/// </remarks>
+public class HostWebApiOptionsIsolationTests
+{
+    /// <summary>Answers every request from memory, recording what it was asked for.</summary>
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        internal List<string> Urls { get; } = new();
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            lock (Urls)
+            {
+                Urls.Add(request.RequestUri!.ToString());
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("ok") });
+        }
+    }
+
+    /// <summary>Keeps every line a console wrote, so a leak shows up as another engine's output arriving.</summary>
+    private sealed class RecordingSink : ConsoleSink
+    {
+        internal List<string> Lines { get; } = new();
+
+        public override void Write(ConsoleLogLevel level, string message)
+        {
+            lock (Lines)
+            {
+                Lines.Add(message);
+            }
+        }
+    }
+
+    /// <summary>
+    /// The sample from the issue: two engines built by <c>new Engine()</c>, one of which configures a network
+    /// policy through the live door. The other must not be governed by it.
+    /// </summary>
+    /// <remarks>
+    /// The second engine is constructed <em>before</em> the first is configured and enables its own web APIs
+    /// <em>after</em>, so the assertion covers both directions in time across the shared instance.
+    /// </remarks>
+    [Fact]
+    public void APolicyConfiguredThroughTheLiveDoorDoesNotGovernAnotherDefaultBuiltEngine()
+    {
+        var tenantHandler = new RecordingHandler();
+        var otherHandler = new RecordingHandler();
+
+        var tenant = new Engine();
+        var other = new Engine();
+
+        tenant.WebApi.Enable(WebApiFeatures.Fetch, webApi =>
+        {
+            webApi.Fetch.HttpClient = new HttpClient(tenantHandler);
+            webApi.Fetch.UrlFilter = uri => uri.Host.Equals("tenant.example", StringComparison.OrdinalIgnoreCase);
+        });
+
+        other.WebApi.Enable(WebApiFeatures.Fetch, webApi => webApi.Fetch.HttpClient = new HttpClient(otherHandler));
+
+        // The other engine never asked for a URL policy, so it has none.
+        other.Evaluate("fetch('https://elsewhere.test/x').then(r => String(r.status), e => e.constructor.name)")
+            .UnwrapIfPromise().AsString().Should().Be("200");
+
+        otherHandler.Urls.Should().ContainSingle().Which.Should().Be("https://elsewhere.test/x");
+
+        // ... and its request never went through the tenant's client.
+        tenantHandler.Urls.Should().BeEmpty();
+
+        // The engine that did ask for the policy still has it.
+        tenant.Evaluate("fetch('https://elsewhere.test/x').then(() => 'resolved', e => e.constructor.name)")
+            .UnwrapIfPromise().AsString().Should().Be("TypeError");
+
+        tenant.Evaluate("fetch('https://tenant.example/x').then(r => r.status)")
+            .UnwrapIfPromise().AsNumber().Should().Be(200);
+
+        tenantHandler.Urls.Should().ContainSingle().Which.Should().Be("https://tenant.example/x");
+    }
+
+    /// <summary>
+    /// The same, for two engines a host deliberately built from one <see cref="Options"/> instance — the
+    /// pooled shape, where the sharing is written down and the leak is no more wanted for it.
+    /// </summary>
+    [Fact]
+    public void APolicyConfiguredThroughTheLiveDoorDoesNotGovernASiblingBuiltFromTheSameOptions()
+    {
+        var tenantHandler = new RecordingHandler();
+        var otherHandler = new RecordingHandler();
+
+        var options = new Options();
+        var tenant = new Engine(options);
+        var other = new Engine(options);
+
+        tenant.WebApi.Enable(WebApiFeatures.Fetch, webApi =>
+        {
+            webApi.Fetch.HttpClient = new HttpClient(tenantHandler);
+            webApi.Fetch.UrlFilter = uri => uri.Host.Equals("tenant.example", StringComparison.OrdinalIgnoreCase);
+        });
+
+        other.WebApi.Enable(WebApiFeatures.Fetch, webApi => webApi.Fetch.HttpClient = new HttpClient(otherHandler));
+
+        other.Evaluate("fetch('https://elsewhere.test/x').then(r => String(r.status), e => e.constructor.name)")
+            .UnwrapIfPromise().AsString().Should().Be("200");
+
+        tenantHandler.Urls.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// A setting read live rather than at enable time leaks the same way, and an engine that passed no
+    /// callback at all is enough to show it: its <c>console</c> output must not reach another engine's sink.
+    /// </summary>
+    [Fact]
+    public void AConsoleSinkConfiguredThroughTheLiveDoorDoesNotCaptureAnotherEnginesOutput()
+    {
+        var sink = new RecordingSink();
+
+        var tenant = new Engine();
+        tenant.WebApi.Enable(WebApiFeatures.Console, webApi => webApi.Console.Sink = sink);
+
+        var other = new Engine();
+        other.WebApi.Enable(WebApiFeatures.Console);
+        other.Execute("console.log('the other engine');");
+
+        sink.Lines.Should().BeEmpty();
+
+        tenant.Execute("console.log('the tenant');");
+        sink.Lines.Should().ContainSingle().Which.Should().Be("the tenant");
+    }
+
+    /// <summary>
+    /// The engine's copy starts as a copy: what the host configured on the options up front is still in force
+    /// after the live door has written one setting of its own.
+    /// </summary>
+    [Fact]
+    public void WhatTheHostConfiguredUpFrontSurvivesALiveConfiguration()
+    {
+        var handler = new RecordingHandler();
+
+        var options = new Options();
+        options.WebApi.Fetch.UrlFilter = uri => uri.Host.Equals("allowed.example", StringComparison.OrdinalIgnoreCase);
+
+        var engine = new Engine(options);
+        engine.WebApi.Enable(WebApiFeatures.Fetch, webApi => webApi.Fetch.HttpClient = new HttpClient(handler));
+
+        engine.Evaluate("fetch('https://denied.test/x').then(() => 'resolved', e => e.constructor.name)")
+            .UnwrapIfPromise().AsString().Should().Be("TypeError");
+
+        engine.Evaluate("fetch('https://allowed.example/x').then(r => r.status)")
+            .UnwrapIfPromise().AsNumber().Should().Be(200);
+
+        handler.Urls.Should().ContainSingle().Which.Should().Be("https://allowed.example/x");
+    }
+
+    /// <summary>
+    /// Two live configurations on the same engine accumulate, so the copy is the engine's from the first call
+    /// onwards rather than being taken afresh from the shared instance each time.
+    /// </summary>
+    [Fact]
+    public void ASecondLiveConfigurationSeesWhatTheFirstOneWrote()
+    {
+        var handler = new RecordingHandler();
+
+        var engine = new Engine();
+        engine.WebApi.Enable(WebApiFeatures.Fetch, webApi => webApi.Fetch.HttpClient = new HttpClient(handler));
+        engine.WebApi.Enable(
+            WebApiFeatures.EventSource,
+            webApi => webApi.Fetch.UrlFilter = uri => uri.Host.Equals("allowed.example", StringComparison.OrdinalIgnoreCase));
+
+        engine.Evaluate("fetch('https://denied.test/x').then(() => 'resolved', e => e.constructor.name)")
+            .UnwrapIfPromise().AsString().Should().Be("TypeError");
+
+        // The client the first call supplied is still the one in use.
+        engine.Evaluate("fetch('https://allowed.example/x').then(r => r.status)")
+            .UnwrapIfPromise().AsNumber().Should().Be(200);
+
+        handler.Urls.Should().ContainSingle().Which.Should().Be("https://allowed.example/x");
+    }
+}
+#endif

--- a/Jint/AGENTS.md
+++ b/Jint/AGENTS.md
@@ -78,9 +78,10 @@ which is why `Materialize` takes the owner's state. So a new setting needs `Thro
 group implements `IOptionsGroup` and joins the two cascades in `Options.ReadOnly.cs`. Nothing Jint writes to
 `Options` may happen after that line — the profile re-expansion and the host's `Configure` callbacks both run
 inside `Options.Apply`, well before it. The one sanctioned post-construction write is
-`Engine.WebApi.Enable`'s callback, which suspends the guard for the web-API groups on the calling
-thread alone; toggling a group's flag instead would open it to every thread, since the `Options` may be one
-other engines are being built from right now.
+`Engine.WebApi.Enable`'s callback, and it writes to a copy of the web-API subtree the engine takes for itself
+first (`Engine.TakePrivateWebApiOptions`) — an `Options` is shareable, and for `new Engine()` it is one Jint
+keeps process-wide, so a per-tenant client set there used to reach every default-built engine. The copy stays
+frozen; the guard is suspended for it on the calling thread alone.
 
 ### Type co-location
 

--- a/Jint/Engine.WebApi.Operations.cs
+++ b/Jint/Engine.WebApi.Operations.cs
@@ -150,10 +150,12 @@ public partial class Engine
         /// prevented, but a read already in flight may have resolved the old binding.
         /// </para>
         /// <para>
-        /// <b><paramref name="configure"/> writes to the engine's own <see cref="Options"/> instance</b>, which
-        /// is read-only from construction onwards and is unfrozen here and nowhere else. That instance is
-        /// shared with every engine built from it, and for an engine built by <c>new Engine()</c> it is one
-        /// Jint keeps process-wide — so give an engine its own <see cref="Options"/> before configuring it here.
+        /// <b><paramref name="configure"/> writes where only this engine reads.</b> An <see cref="Options"/>
+        /// instance is shared with every engine built from it, and for an engine built by <c>new Engine()</c>
+        /// it is one Jint keeps process-wide, so before the callback runs the engine takes a copy of the
+        /// web-API settings for itself. The copy starts as a copy — whatever the host configured up front is
+        /// still in force — and what the callback adds reaches this engine and nothing else. Shared
+        /// configuration is still expressed by configuring the <see cref="Options"/> before building.
         /// </para>
         /// </remarks>
         /// <example>
@@ -178,13 +180,11 @@ public partial class Engine
         /// </param>
         /// <param name="configure">
         /// Optional configuration of the per-feature settings, run once — before anything is installed, and
-        /// only when this call is actually enabling something. It is handed this engine's own
-        /// <c>Options.WebApi</c> group, which is the group the engine reads its settings from; <b>an
-        /// <see cref="Options"/> instance shared with other engines is shared here too</b>, exactly as it
-        /// already is at options time, so give an engine its own <see cref="Options"/> when its network policy
-        /// has to be its own. Assigning <c>Features</c> inside the delegate does not enable anything for this
-        /// call — <paramref name="features"/> is what this call enables — and only affects engines built from
-        /// those options later.
+        /// only when this call is actually enabling something. It is handed <b>this engine's own copy</b> of
+        /// the <c>Options.WebApi</c> group, which from that moment is the group the engine reads its settings
+        /// from, so a network policy set here is this engine's and no sibling's. Assigning <c>Features</c>
+        /// inside the delegate does not enable anything — <paramref name="features"/> is what this call
+        /// enables — and, since the copy belongs to this engine, it no longer reaches engines built later.
         /// </param>
         /// <returns>
         /// The features this call actually added, after closure expansion, or

--- a/Jint/Engine.WebApi.cs
+++ b/Jint/Engine.WebApi.cs
@@ -106,6 +106,56 @@ public partial class Engine
     internal WebApiFeatures _webApiFeatures;
 
     /// <summary>
+    /// Whether <see cref="Options"/> is a copy this engine took for itself, whose web-API subtree therefore
+    /// no other engine reads.
+    /// </summary>
+    private bool _ownsWebApiOptions;
+
+    /// <summary>
+    /// Gives this engine an <see cref="Jint.Options"/> instance whose web-API subtree nothing else reads, and
+    /// returns it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>WebApiRegistration.ApplyLive</c> is the only caller and calls it immediately before running the
+    /// host's configuration callback, because that callback is the one write to an engine's options after
+    /// construction and the instance it would otherwise write to is shared: with every other engine built
+    /// from it, and for <c>new Engine()</c> with an instance Jint keeps process-wide.
+    /// </para>
+    /// <para>
+    /// Swapping the whole instance rather than the group is what makes the copy stick, since every reader
+    /// — <c>console</c>'s sink, a later live enable — reaches the group through <see cref="Options"/>. Only
+    /// the web-API subtree is copied; every other group is shared by reference and frozen, so the swap
+    /// changes no answer this engine was already giving.
+    /// </para>
+    /// <para>
+    /// It happens once. A second copy would orphan the network settings <see cref="WebApiEngineState"/> is
+    /// holding, so the settings a live enable wrote would stop being the ones a fetch reads — which is why
+    /// the one copy re-points that binding at the group it made.
+    /// </para>
+    /// </remarks>
+    internal Options TakePrivateWebApiOptions()
+    {
+        if (_ownsWebApiOptions)
+        {
+            return Options;
+        }
+
+        var privateOptions = Options.CloneWithPrivateWebApiOptions();
+        Options = privateOptions;
+        _ownsWebApiOptions = true;
+
+        // The only group an engine holds by reference rather than reading through Options. A state that has
+        // one is reading the group this copy just replaced.
+        if (_webApi?.FetchOptions is not null)
+        {
+            _webApi.RebindFetchOptions(privateOptions.WebApi.Fetch);
+        }
+
+        return privateOptions;
+    }
+
+    /// <summary>
     /// Whether the event loop still has jobs queued behind the one running now. Only the web-API scheduler
     /// reads it, to keep a task from overtaking the microtasks of the turn it was posted in — see
     /// <see cref="Runtime.EventLoop.HasPendingJobs"/>.
@@ -550,6 +600,21 @@ internal sealed class WebApiEngineState
     internal void AttachFetchOptions(Options.FetchOptions fetchOptions)
     {
         Debug.Assert(FetchOptions is null, "the network settings must never be replaced on a live engine");
+        FetchOptions = fetchOptions;
+    }
+
+    /// <summary>
+    /// Re-points the network settings at the copy <see cref="Engine.TakePrivateWebApiOptions"/> made of the
+    /// group this state was reading.
+    /// </summary>
+    /// <remarks>
+    /// The one sanctioned replacement, and not a contradiction of <see cref="AttachFetchOptions"/>: the group
+    /// arriving here holds exactly what the one it replaces holds, and differs only in that no other engine
+    /// reads it. Without it the copy would be written and the original would still be read.
+    /// </remarks>
+    internal void RebindFetchOptions(Options.FetchOptions fetchOptions)
+    {
+        Debug.Assert(FetchOptions is not null, "there is nothing to re-point before the settings are attached");
         FetchOptions = fetchOptions;
     }
 

--- a/Jint/Options.ReadOnly.cs
+++ b/Jint/Options.ReadOnly.cs
@@ -263,12 +263,10 @@ public sealed partial class Options
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Thread-local rather than a flag toggled on the group, deliberately. The callback is handed the engine's
-    /// own <c>WebApi</c> group, and that group may belong to an <see cref="Options"/> instance other engines
-    /// are being built from at the same moment — including the process-wide instance a parameterless
-    /// <c>new Engine()</c> uses. Clearing the group's own read-only flag for the duration would open it to
-    /// every thread and let a concurrent engine build close it again mid-callback; suspending the guard on
-    /// the calling thread cannot be seen or disturbed by either.
+    /// Thread-local rather than a flag toggled on the group, deliberately. The group is the engine's own copy
+    /// of the web-API subtree — <c>Engine.TakePrivateWebApiOptions</c> takes it before the callback runs, so
+    /// nothing the host writes here reaches another engine — and it stays frozen throughout: what is suspended
+    /// is the guard, on one thread and for the length of one callback, rather than the group's own state.
     /// </para>
     /// <para>
     /// It holds the group being configured rather than a depth count, so the suspension is scoped to one

--- a/Jint/Options.WebApi.cs
+++ b/Jint/Options.WebApi.cs
@@ -31,6 +31,42 @@ public sealed partial class Options
     private WebApiOptions? _webApi;
 
     /// <summary>
+    /// Returns a copy of these options whose web-API subtree is shared with nothing, so that a host callback
+    /// writing to it reaches the one engine that asked for it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>Engine.WebApi.Enable</c> is the only caller, and it takes this copy before it runs the
+    /// host's configuration callback. Every other group stays shared by reference: they are frozen, nothing
+    /// this door can reach writes to them, and copying them would cost an engine build's worth of allocations
+    /// to change nothing.
+    /// </para>
+    /// <para>
+    /// A null <see cref="_webApi"/> is left null rather than materialized — the copy's own accessor will
+    /// create it, born frozen, exactly as any other post-freeze group access does.
+    /// </para>
+    /// </remarks>
+    internal Options CloneWithPrivateWebApiOptions()
+    {
+        var clone = (Options) MemberwiseClone();
+
+        // TimeSystem materializes inside its own getter, so a null field here would let the copy and the
+        // original each build one and hand two engines two different clocks. Reading it materializes the
+        // original's and MemberwiseClone has already shared whatever that produced.
+        clone._timeSystem = TimeSystem;
+
+        var webApi = _webApi?.Clone();
+
+        // Clone gives FetchOptions.AllowedSchemes a fresh OptionsList, and a fresh one is born writable;
+        // every group otherwise carries the source's frozen state through MemberwiseClone. Re-freezing the
+        // subtree is what keeps the live door to setting a value rather than growing a registry.
+        SetReadOnly(webApi, _readOnly);
+        clone._webApi = webApi;
+
+        return clone;
+    }
+
+    /// <summary>
     /// Configuration for the opt-in web platform APIs. Requires .NET 8 or higher.
     /// </summary>
     /// <remarks>
@@ -192,8 +228,8 @@ public sealed partial class Options
         /// <remarks>
         /// <para>
         /// A worker needs a thread and a pump, and Jint never starts either, so there is no default provider
-        /// and there cannot be one. See <see cref="WorkerProvider"/> for what a provider owes and for the
-        /// pooled-host warning about setting this through the live <c>Engine.WebApi.Enable</c> door.
+        /// and there cannot be one. See <see cref="WorkerProvider"/> for what a provider owes and for how a
+        /// pooled host reaches per-request policy from one.
         /// </para>
         /// <para>
         /// Read once, when the engine is built.

--- a/Jint/WebApi/WebApiRegistration.cs
+++ b/Jint/WebApi/WebApiRegistration.cs
@@ -106,11 +106,18 @@ internal static class WebApiRegistration
         var options = engine.Options;
         if (configure is not null)
         {
-            // The engine froze its options when it was built, and this callback is documented to configure
-            // the very group the engine reads its web-API settings from — the one sanctioned write to an
-            // engine's own options after construction. The suspension is scoped to this group's subtree and
-            // to this thread; see Options.BeginLiveWebApiConfiguration for why the group's own flag is the
-            // wrong thing to toggle when the Options may be shared with engines being built right now.
+            // The callback is about to write settings only this engine should read, and the instance it would
+            // otherwise write to is shared — with every engine built from it, and for `new Engine()` with one
+            // Jint keeps process-wide. So the engine takes a private copy of the web-API subtree first, and
+            // the callback configures that. Everything already on the shared group is copied across, so a
+            // host that configured its options up front still gets those settings; what the callback adds
+            // reaches this engine and nothing else.
+            options = engine.TakePrivateWebApiOptions();
+
+            // The engine froze its options when it was built, and the copy inherits that, so this callback is
+            // still writing to a frozen group — the one sanctioned write to an engine's own options after
+            // construction. The suspension is scoped to this group's subtree and to this thread; see
+            // Options.BeginLiveWebApiConfiguration for why the group's own flag is the wrong thing to toggle.
             var webApi = options.WebApi;
             var previous = Options.BeginLiveWebApiConfiguration(webApi);
             try

--- a/Jint/WebApi/Workers/WorkerProvider.cs
+++ b/Jint/WebApi/Workers/WorkerProvider.cs
@@ -31,10 +31,10 @@ namespace Jint.WebApi;
 /// normally the same object for every engine in a pool; everything that varies per request — tenant, loader
 /// root, budget — is read inside <see cref="CreateWorkerEngine"/> from
 /// <c>request.Parent.HostDefined</c>, which is per engine, never read by the engine, and survives
-/// <c>RestoreGlobalSnapshot</c>. Do <b>not</b> set the provider through
-/// <c>engine.WebApi.Enable(…, w =&gt; w.Workers.Provider = …)</c> on a pooled host: that callback is
-/// handed the engine's own <c>Options.WebApi</c> group, and a shared <see cref="Options"/> instance is shared
-/// there too — the write would reach every tenant.
+/// <c>RestoreGlobalSnapshot</c>. Setting the provider through
+/// <c>engine.WebApi.Enable(…, w =&gt; w.Workers.Provider = …)</c> reaches that one engine and no other —
+/// the callback is handed a copy of the web-API settings that the engine takes for itself — so it is a way
+/// to give one rented engine a provider of its own, not a way to configure the pool.
 /// </para>
 /// <para>
 /// <b>Thread-safety.</b> A provider is called from the parent's thread

--- a/README.md
+++ b/README.md
@@ -539,12 +539,12 @@ built. Four things are worth knowing:
 * **Network access is still only ever granted by name.** No feature closure pulls in `Fetch`, `EventSource`
   or `WebSocket`; asking for `WebApiFeatures.Default` here grants exactly what it grants on the options.
 * **Settings come from this engine's `Options`, read at the moment of the call**, with the same read-once
-  semantics they have at construction. The delegate is handed that same group — which, exactly as at options
-  time, is shared with every other engine built from the same `Options` instance, so give an engine its own
-  `Options` when its network policy has to be its own. Two settings are deliberately *not* re-read for an
-  engine that already has web-API state: `Timers.TimeProvider`, because the timers, `performance.now()` and
-  the time origin have to stay on one clock for the engine's life, and `Diagnostics.Sink`, which also decides
-  whether a callback's exception erupts.
+  semantics they have at construction. The delegate is handed a copy of the web-API settings that the engine
+  takes for itself first — it starts as a copy, so whatever you configured on the `Options` up front is still
+  in force, and a network policy you set here is this engine's and no sibling's. Two settings are deliberately
+  *not* re-read for an engine that already has web-API state: `Timers.TimeProvider`, because the timers,
+  `performance.now()` and the time origin have to stay on one clock for the engine's life, and
+  `Diagnostics.Sink`, which also decides whether a callback's exception erupts.
 * **`RestoreGlobalSnapshot` removes globals installed after the capture**, exactly as it does for
   `AddLazyGlobal` and `SetFetchHandler` — and it does *not* revert the engine's feature record, so the engine
   is left knowing about an API whose globals script can no longer name, and re-calling `engine.WebApi.Enable` is a

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -1162,9 +1162,9 @@ Three details worth knowing:
   write to an engine's own options after construction, and it is the only place the freeze is suspended. The
   suspension covers that engine's own web-API group and its sub-groups, on the calling thread, for the
   duration of the callback — no other `Options` instance, no other group, and not the registries: a live
-  enable sets a value, it never grows an `OptionsList<T>`. Note that the instance it writes to is shared with
-  every engine built from it, and for an engine built by `new Engine()` it is one Jint keeps process-wide, so
-  give an engine its own `Options` before configuring it there.
+  enable sets a value, it never grows an `OptionsList<T>`. What it writes to is a copy of the web-API settings
+  the engine takes for itself, so nothing the callback writes reaches another engine — see
+  [§4.19](#421-webapienables-callback-configures-one-engine-not-every-engine-3359).
 - **A group is allocated on first touch, and one materialized after the freeze is born frozen.** So
   `options.Intl.CldrProvider = …` on an engine's options throws even though nothing had ever touched
   `Intl`.
@@ -1251,6 +1251,33 @@ fires, and script that reached one of these generics now gets an answer where it
 destructuring of a `HashSet<T>` changes too — `var [...r] = set` yielded `[undefined, undefined, undefined]`
 while `[...set]` yielded the elements, and both now yield the elements. Destructuring is *GetIterator* in
 the specification, so an index-reading fast path may only stand in for the iterator where the two agree.
+
+### 4.21 `WebApi.Enable`'s callback configures one engine, not every engine ([#3359](https://github.com/sebastienros/jint/pull/3359))
+
+`Engine.WebApi.Enable(features, configure)` used to hand the callback the very `Options`
+instance the engine was built from. That instance is shared with every other engine built from it,
+and an engine built by `new Engine()` shares one Jint keeps process-wide — so this, the sample from
+the method's own documentation, set the tenant's client on every default-built engine in the process,
+those built before the call included:
+
+```csharp
+var engine = new Engine();
+engine.WebApi.Enable(WebApiFeatures.Fetch, w => w.Fetch.HttpClient = tenantClient);
+```
+
+The engine now takes a copy of the web-API settings for itself before the callback runs. The copy
+starts as a copy, so whatever the host configured on the options up front is still in force, and what
+the callback writes reaches that one engine.
+
+**What could break:** a host that used the callback to configure a *pool* — writing through one
+engine and expecting its siblings to pick the setting up — and a host reading a setting back off its
+own `Options` afterwards, which now answers what the host put there rather than what the callback
+wrote. Shared configuration is spelled by configuring the options before building:
+
+```csharp
+var options = new Options().UseWebApis(WebApiFeatures.Fetch);
+options.WebApi.Fetch.HttpClient = sharedClient;   // every engine built from this
+```
 
 ## 5. New in v5
 


### PR DESCRIPTION
Fixes #3331.

```csharp
var engine = new Engine();
engine.WebApi.Enable(WebApiFeatures.Fetch, w => w.Fetch.HttpClient = tenantClient);
```

That is the sample from `WebApi.Enable`'s own documentation, and until this change it set `tenantClient` on every
other engine in the process built with `new Engine()` — the ones built before the call included. `Options` is
shared, `new Engine()` shares one instance Jint keeps process-wide, and the callback was handed that instance.

## Which of the three candidates, and why

The issue offered three. **The callback now writes to a copy the engine takes for itself** — candidate 2 — and
the other two were measured or reasoned out of the running rather than waved away.

### Candidate 1 — `new Engine()` allocates its own `Options` — does not close the hole, and is not free

Two findings, and the first is the decisive one.

**It fixes the accidental sharing and leaves the deliberate sharing.** `Options` is documented as shareable, the
`AddLazyGlobal` docs say "one `Options`, any number of engines", and a pool handing one configured instance to
every rented engine is the exact multi-tenant shape the issue is about. Give each `new Engine()` its own
`Options` and `new Engine(sharedOptions)` + `WebApi.Enable(…, configure)` still publishes to every sibling. The
second test in the new file is that case, and it fails today for the same reason the first one does.

**And the static is not saving nothing.** Measured on `net10.0`, Release, from allocation counters rather than
BenchmarkDotNet:

| | bytes/op | ns/op |
| --- | ---: | ---: |
| `new Engine()` | 9,280 | 1,087 |
| `new Engine(new Options())` | 10,440 | 1,255 |
| **the difference a private `Options` costs** | **+1,160 (+12.5%)** | **+168 (+15.5%)** |

`new Options()` alone is 224 bytes; the other ~936 is the **seven groups a default engine build materializes**
— `Constraints`, `Parsing`, `Interop`, `Debugger`, `Coverage`, `Host`, `Modules`. That is what the static
actually saves, and it is more than "one object plus its lazily-created groups": with the static those seven
exist once per process, without it they exist once per engine. The byte figures are exact and reproducible
(`GC.GetAllocatedBytesForCurrentThread`); the nanoseconds are a best-of-7 `Stopwatch` reading on a shared
machine, so treat them as an order of magnitude. **If a maintainer wants the static gone anyway, that is a
benchmark-gated call and I have not made it here.**

The reason it is defensible to keep is worth stating explicitly: **after this change nothing can write to the
process-wide default at all.** #3327 froze `Options` at the end of the engine constructor, and the only
`ThrowIfReadOnly` in the tree with an escape hatch is the web-API family's `!IsConfiguringWebApisLive(this)`.
That hatch is the door this PR closes. The two tests the issue mentions
(`_engine.Options.Modules.ExposeDetailedLoadErrors = true` on a default-built engine) already throw. So the
static becomes an unobservable construction-time detail rather than shared mutable state.

### Candidate 3 — refuse the callback when the instance is the process-wide default

Breaks a working, documented pattern, and only the `new Engine()` half of it: it would still accept the call on
a shared `Options` a pool handed out, which is the worse case.

### What the copy means for an `Options` other engines already read

The issue asks this directly. The copy is a `MemberwiseClone` plus `WebApiOptions.Clone()`, so:

- **Every other group stays shared by reference.** They are frozen and an `Action<WebApiOptions>` cannot reach
  them, so copying them would cost an engine build's worth of allocations to change no answer.
- **The copy starts as a copy.** Settings the host put on the options up front are still in force — pinned by
  `WhatTheHostConfiguredUpFrontSurvivesALiveConfiguration`.
- **It stays frozen.** `WebApiOptions.Clone()` gives `FetchOptions.AllowedSchemes` a fresh, writable
  `OptionsList`, so the subtree is re-frozen after cloning; the existing
  `TheLiveWebApiDoorSuspendsTheGuardForTheGroupItIsConfiguringAndNothingElse` catches the alternative, because a
  live enable is still allowed to set a value and never to grow a registry.
- **It composes with #3327 rather than replacing it.** The `[ThreadStatic]` suspension is untouched and now
  targets the copy's group. Its stated rationale changed (the group can no longer belong to an instance another
  thread is building from) and the doc comment says so.
- **It happens once per engine.** A second copy would orphan the one option group an engine holds by reference
  rather than reading through `Options` — `WebApiEngineState.FetchOptions` — so the copy re-points that binding,
  and `ASecondLiveConfigurationSeesWhatTheFirstOneWrote` pins the accumulation.
- **`Engine.Options` is swapped, not just the group**, because every reader reaches the group through it —
  `ConsoleInstance` re-reads `_engine.Options.WebApi.Console.Sink` on every record, which is how the sink test
  below leaks without the second engine passing a callback at all.

## The failing-first test

`Jint.Tests.PublicInterface/HostWebApiOptionsIsolationTests.cs` — the project without `InternalsVisibleTo`, so
every assertion is one an embedder could write: the leak is observed through what a *second* engine's script
does, never by reading the options back. Nothing opens a socket.

Against `main` (the fix's one line commented out), 3 of the 5 fail:

```
  Failed HostWebApiOptionsIsolationTests.APolicyConfiguredThroughTheLiveDoorDoesNotGovernAnotherDefaultBuiltEngine
  Error Message:
   Expected string to be the same string, but they differ at index 0:
   ↓ (actual)
  "TypeError"
  "200"
   ↑ (expected).

  Failed HostWebApiOptionsIsolationTests.APolicyConfiguredThroughTheLiveDoorDoesNotGovernASiblingBuiltFromTheSameOptions
  Error Message:
   Expected string to be the same string, but they differ at index 0:
   ↓ (actual)
  "TypeError"
  "200"
   ↑ (expected).

  Failed HostWebApiOptionsIsolationTests.AConsoleSinkConfiguredThroughTheLiveDoorDoesNotCaptureAnotherEnginesOutput
  Error Message:
   Expected collection to be empty, but found at least one item {"the other engine"}.

Failed!  - Failed: 3, Passed: 2, Skipped: 0, Total: 5
```

The first two: one engine's tenant URL filter governed the other engine's `fetch`, which is why it saw a
`TypeError` instead of a 200. The third is the sharpest — the second engine calls
`WebApi.Enable(WebApiFeatures.Console)` with **no callback at all** and its `console.log` still lands in the
first engine's sink, because `Console.Sink` is read live off `engine.Options` on every record.

The other two pass on `main` by construction: they pin what the copy must *not* break.

One existing test changed with the behaviour. `HostOptionsReadOnlyTests`'
`TheLiveWebApiDoorSuspendsTheGuardForTheGroupItIsConfiguringAndNothingElse` asserted
`options.WebApi.Timers.MaxActiveTimers.Should().Be(3)` — that the callback's write landed on the host's own
instance. It now asserts the opposite, plus that the engine got the feature.

## Verification

- `dotnet build -c Release` clean, `TreatWarningsAsErrors` on.
- `Jint.Tests`: 10,673 on `net10.0` and `net8.0`, 7,320 on `net472`. One `net10.0` failure on the full run,
  `PromiseTests.UnwrapIfPromiseAsync_WithIOBoundTask_DoesNotBlockCallerThread` — a thread-pool timing assertion
  under load on a shared machine; it passes on `net8.0` in the same run and passes in isolation.
- `Jint.Tests.PublicInterface`: 2,928 on `net10.0`, 2,303 on `net472`, 0 failed. `PublicApiTest` and
  `PublicApiDocumentationTest` are among them and are green: nothing here is public, so no baseline and no
  register moved.
- `Jint.Tests.Test262`: **102,495 passed, 0 failed** (189 skipped, 102,684 total), one run at the end.
- Rebased onto `main` after #3351 renamed `Engine.Advanced.EnableWebApis` to `Engine.WebApi.Enable`; every
  reference here uses the new name.
- `docs/v5-migration.md` §4.19, README's "Enabling web APIs on an engine that already exists", and the
  `WorkerProvider` warning that told pooled hosts not to use this door — it is now a supported way to give one
  rented engine a provider of its own.

## Found and left alone

- **`Engine.Options` is entirely `internal`.** A host handed an engine cannot read back the configuration it is
  running under, which is a large part of why this leak was invisible: there is no supported way to observe that
  two engines share one `Options`, or that a live configure landed somewhere other than where the caller meant.
  Worth its own issue; deliberately not widened here, because a read-only projection of a frozen `Options` is a
  public-surface decision and not a bug fix.
- **`Jint/AGENTS.md` is 33,923 bytes**, over the 32 KiB budget its own root file sets. This PR's edit to it is
  size-neutral; the overflow is pre-existing.
- **`Options.TimeSystem`'s getter memoizes into `_timeSystem` on a frozen instance** with a plain `??=`, so two
  threads building engines from one `Options` can each construct a `DefaultTimeSystem`. Benign — they are equal
  by construction — but it is the one field on `Options` that is written after the freeze. The new copy reads
  the property before cloning so the copy and the original cannot end up on two clocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014W5mbjGhyvgAS4pivXoc4S
