### PR TITLE
fetch: the request goes out as the header list says, and a HEAD response has no body

### DIFF
--- a/Jint.Tests.PublicInterface/WebApiFetchTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiFetchTests.cs
@@ -388,6 +388,65 @@ public class WebApiFetchTests
         engine.Evaluate("typeof fetch").AsString().Should().Be("function");
     });
 
+    /// <summary>
+    /// What a host's own <c>HttpClient</c> — or the <c>DelegatingHandler</c> in front of it — sees of a
+    /// request the engine composed.
+    /// </summary>
+    [Fact]
+    public void AHostsHandlerSeesTheStandardsAcceptAndABodilessRequestsContentHeaders()
+    {
+        var handler = new RecordingHandler();
+        var engine = WebEngine(handler);
+
+        engine.Evaluate("fetch('https://example.org/a', { headers: { 'Content-Language': 'en-US' } }).then(r => r.status)")
+            .UnwrapIfPromise(TransportSignalCeiling).AsNumber().Should().Be(200);
+
+        var request = handler.Requests.Should().ContainSingle().Subject;
+
+        // https://fetch.spec.whatwg.org/#concept-fetch step 12 — appended by the engine, not by the script,
+        // and not by HttpClient either: SocketsHttpHandler adds no Accept of its own.
+        request.Accept.Should().Be("*/*");
+
+        // The Fetch header list is one list; the BCL's is two, and Content-Language lives in the half that
+        // belongs to the content — so a request with no body is given an empty one to carry it. A handler
+        // that reads Content on a GET will find it, and it reads as the zero bytes it is.
+        request.HasContent.Should().BeTrue();
+        request.ContentLanguage.Should().Be("en-US");
+
+        // No length, because the standard appends Content-Length only for a body or for a bodiless POST or
+        // PUT — this is what decides the framing HttpClient writes.
+        request.ContentLength.Should().BeNull();
+    }
+
+    private sealed record RecordedRequest(string? Accept, string? ContentLanguage, bool HasContent, long? ContentLength);
+
+    /// <summary>
+    /// Records the few facts about a request that outlive it — the message and its content are disposed as
+    /// soon as the transport has its answer.
+    /// </summary>
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        internal List<RecordedRequest> Requests { get; } = new();
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Requests.Add(new RecordedRequest(
+                First(request.Headers, "accept"),
+                request.Content is { } content ? First(content.Headers, "content-language") : null,
+                request.Content is not null,
+                request.Content?.Headers.ContentLength));
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("ok") });
+        }
+
+        /// <remarks>
+        /// Through <c>NonValidated</c>, which answers the bytes that will go out rather than
+        /// <see cref="HttpClient"/>'s re-serialization of its parsed form.
+        /// </remarks>
+        private static string? First(System.Net.Http.Headers.HttpHeaders headers, string name)
+            => headers.NonValidated.TryGetValues(name, out var values) ? values.ToString() : null;
+    }
+
     [Fact]
     public Task AnEngineCancellationSettlesNothingAtAll() => DedicatedThread.RunAsync(() =>
     {

--- a/Jint.Tests/Runtime/WebApi/FetchTests.cs
+++ b/Jint.Tests/Runtime/WebApi/FetchTests.cs
@@ -40,7 +40,14 @@ public class FetchTests
     /// through <c>NonValidated</c>, which answers the raw value rather than <see cref="HttpClient"/>'s
     /// re-serialization of its parsed form.
     /// </remarks>
-    private sealed record RecordedRequest(string Method, string Url, Dictionary<string, string> Headers, string? Body)
+    /// <param name="ContentLength">
+    /// What the request's content answered for its own length, which is not the same question as whether a
+    /// <c>Content-Length</c> header was in <paramref name="Headers"/>: this is the value
+    /// <see cref="HttpClient"/> frames the request with — a number writes <c>Content-Length</c> and
+    /// <see langword="null"/> writes <c>Transfer-Encoding: chunked</c> — and a message that never reaches a
+    /// socket is the only place it can be read.
+    /// </param>
+    private sealed record RecordedRequest(string Method, string Url, Dictionary<string, string> Headers, string? Body, long? ContentLength)
     {
         internal string? Header(string name) => Headers.TryGetValue(name, out var value) ? value : null;
     }
@@ -76,13 +83,18 @@ public class FetchTests
             Collect(headers, request.Headers);
 
             string? body = null;
+            long? contentLength = null;
             if (request.Content is { } content)
             {
                 Collect(headers, content.Headers);
+
+                // After the collection, deliberately: reading the length is what computes it, and a content
+                // that computed one here would look to every other test like a header the engine had set.
+                contentLength = content.Headers.ContentLength;
                 body = await content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
             }
 
-            return new RecordedRequest(request.Method.Method, request.RequestUri!.ToString(), headers, body);
+            return new RecordedRequest(request.Method.Method, request.RequestUri!.ToString(), headers, body, contentLength);
         }
 
         private static void Collect(Dictionary<string, string> headers, System.Net.Http.Headers.HttpHeaders source)
@@ -475,6 +487,151 @@ public class FetchTests
         // A null body is never disturbed, so it reads as often as the script likes.
         engine.Evaluate("r.bodyUsed").AsBoolean().Should().BeFalse();
         engine.Evaluate("r.text()").UnwrapIfPromise().AsString().Should().Be("");
+    }
+
+    /// <summary>
+    /// https://fetch.spec.whatwg.org/#concept-fetch step 12 — the <c>Accept</c> a request that named none of
+    /// its own is given, and <c>*/*</c> is the value for every destination but the handful a browser knows.
+    /// </summary>
+    [Fact]
+    public void SendsTheDefaultAcceptAndLeavesAScriptSetOneAlone()
+    {
+        var handler = new StubHandler();
+        Fetch(handler, "fetch('https://example.org/a').then(r => r.status)");
+        handler.Requests.Should().ContainSingle().Which.Header("accept").Should().Be("*/*");
+
+        // Step 13, the Accept-Language beside it, applies only "if request's client is non-null" and reports
+        // a user's language preferences. There is neither here, so nothing is sent.
+        handler.Requests[0].Header("accept-language").Should().BeNull();
+
+        var named = new StubHandler();
+        Fetch(named, "fetch('https://example.org/a', { headers: { accept: 'custom/*' } }).then(r => r.status)");
+        named.Requests.Should().ContainSingle().Which.Header("accept").Should().Be("custom/*");
+    }
+
+    [Fact]
+    public void TheDefaultAcceptIsNotVisibleOnTheRequestTheScriptHolds()
+    {
+        // The step appends to the header list fetch is working with, which is a copy: a browser sends
+        // Accept: */* while the script's own Request still answers null for it.
+        Fetch(new StubHandler(), "(() => { const r = new Request('https://example.org/a'); return fetch(r).then(() => String(r.headers.get('accept'))); })()")
+            .AsString().Should().Be("null");
+    }
+
+    /// <summary>
+    /// https://fetch.spec.whatwg.org/#concept-header-list is one list, so a content header a script set
+    /// reaches the wire whether or not the request has a body — which is what the BCL's split of the same
+    /// list into request headers and content headers stood in the way of.
+    /// </summary>
+    [Fact]
+    public void CarriesContentHeadersOnARequestThatHasNoBody()
+    {
+        var handler = new StubHandler();
+
+        Fetch(handler, @"fetch('https://example.org/a', {
+            method: 'GET',
+            headers: { 'Content-Encoding': 'Identity', 'Content-Language': 'en-US', 'Content-Location': 'foo' },
+        }).then(r => r.status)");
+
+        var request = handler.Requests.Should().ContainSingle().Subject;
+        request.Header("content-encoding").Should().Be("Identity");
+        request.Header("content-language").Should().Be("en-US");
+        request.Header("content-location").Should().Be("foo");
+
+        // https://fetch.spec.whatwg.org/#concept-http-network-or-cache-fetch step 8 appends Content-Length
+        // only for a body, or for a bodiless POST or PUT — so the content this GET had to be given to carry
+        // those three headers must not announce a length of its own, and it sends nothing.
+        request.ContentLength.Should().BeNull();
+        request.Body.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ABodilessPostStillAnnouncesTheZeroLengthTheStandardGivesIt()
+    {
+        var handler = new StubHandler();
+
+        Fetch(handler, "fetch('https://example.org/a', { method: 'POST', headers: { 'content-type': 'application/json' } }).then(r => r.status)");
+
+        var request = handler.Requests.Should().ContainSingle().Subject;
+        request.Header("content-type").Should().Be("application/json");
+
+        // "If httpRequest's body is null and httpRequest's method is `POST` or `PUT`, then set
+        // contentLengthHeaderValue to `0`" — which is also what a bodiless POST sent before it had anywhere
+        // to put a Content-Type.
+        request.ContentLength.Should().Be(0);
+    }
+
+    [Fact]
+    public void ARequestWithNoBodyDoesNotCarryAScriptSetContentLength()
+    {
+        var handler = new StubHandler();
+
+        // Content-Length is what a request body is framed with, and this request has none. Browsers refuse
+        // the name outright as a forbidden request-header; Jint declines to enforce that list (see
+        // HeadersGuard) and drops the value at the wire instead, exactly as it did before the header list
+        // had any content of its own to be carried on.
+        Fetch(handler, "fetch('https://example.org/a', { headers: { 'Content-Language': 'en-US', 'Content-Length': '99' } }).then(r => r.status)");
+
+        var request = handler.Requests.Should().ContainSingle().Subject;
+        request.Header("content-language").Should().Be("en-US");
+        request.Header("content-length").Should().BeNull();
+        request.ContentLength.Should().BeNull();
+    }
+
+    [Fact]
+    public void AResponseToHeadCarriesNoBody()
+    {
+        // https://fetch.spec.whatwg.org/#concept-main-fetch step 22: "If response is not a network error and
+        // either request's method is `HEAD` or `CONNECT`, or internalResponse's status is a null body status,
+        // set internalResponse's body to null and disregard any enqueuing toward it (if any)." A server that
+        // answers HEAD with bytes is what the step exists to standardise the handling of.
+        var handler = new StubHandler
+        {
+            Responder = _ => new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("hello-world") },
+        };
+
+        var engine = WebEngine(handler);
+        engine.Execute("var r; fetch('https://example.org/', { method: 'HEAD' }).then(x => r = x);");
+        engine.Tasks.ProcessTasks();
+
+        engine.Evaluate("r.status").AsNumber().Should().Be(200);
+        engine.Evaluate("r.body === null").AsBoolean().Should().BeTrue();
+        engine.Evaluate("r.text()").UnwrapIfPromise().AsString().Should().Be("");
+
+        // Nothing was disturbed, so it reads as often as the script likes — the same property a 204 has.
+        engine.Evaluate("r.bodyUsed").AsBoolean().Should().BeFalse();
+        engine.Evaluate("r.text()").UnwrapIfPromise().AsString().Should().Be("");
+
+        // The headers stay as they came: a HEAD answers the length of the representation it describes, and
+        // that it describes bytes it does not send is the whole point of asking with HEAD.
+        engine.Evaluate("r.headers.get('content-length')").AsString().Should().Be("11");
+    }
+
+    [Fact]
+    public void AHeadOfSomethingLargerThanTheCapIsNotRefused()
+    {
+        // The cap bounds what a response spends, and a HEAD spends nothing: refusing one for the length it
+        // reports would fail the one request that is asking precisely so as not to transfer it.
+        var handler = new StubHandler
+        {
+            Responder = _ =>
+            {
+                var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("") };
+                response.Content.Headers.ContentLength = 5_000_000;
+                return response;
+            },
+        };
+
+        var engine = WebEngine(handler, fetch => fetch.MaxResponseBytes = 1024);
+        engine.Execute("var r; fetch('https://example.org/', { method: 'HEAD' }).then(x => r = x, e => r = e);");
+        engine.Tasks.ProcessTasks();
+
+        engine.Evaluate("r.status").AsNumber().Should().Be(200);
+        engine.Evaluate("r.headers.get('content-length')").AsString().Should().Be("5000000");
+
+        // The same length on a GET is still refused before the promise settles.
+        Fetch(handler, "fetch('https://example.org/').then(() => 'resolved', e => e.constructor.name)", fetch => fetch.MaxResponseBytes = 1024)
+            .AsString().Should().Be("TypeError");
     }
 
     [Fact]

--- a/Jint.Tests/Wpt/AGENTS.md
+++ b/Jint.Tests/Wpt/AGENTS.md
@@ -21,14 +21,16 @@ Six things to know before touching it. **The exclusion table is the artefact**: 
 named in `WptTestRunner._exclusions` with a `WptDivergence` category, and an entry must match at least one
 failing test and no passing one — so a fix, a rename, or a corpus bump makes the run fail until the table is
 brought back in line, and a `*` glob can never widen into a blanket. A test *name* may itself contain a `*`,
-which is what the `\*` escape is for; without it there is no pattern at all that names
-`fetch/api/basic/accept-header.any.js`'s failing `…with value '*/*'` row and not its passing sibling
-`…with value 'custom/*'`. **`NeedsTriage` is the debt**: those are genuine defects the harness found, recorded
+which is what the `\*` escape is for; without it there was no pattern at all that named
+`fetch/api/basic/accept-header.any.js`'s then-failing `…with value '*/*'` row and not its passing sibling
+`…with value 'custom/*'` — both pass now, so the escape's only user today is `WptCorpusTests`.
+**`NeedsTriage` is the debt**: those are genuine defects the harness found, recorded
 rather than fixed so that the change which first ran a suite is not also the change that moved the engine — a
 non-zero count there means the corpus has found something and somebody still owes the engine a fix. It was
-empty until [#3260](https://github.com/sebastienros/jint/issues/3260) gave the fetch corpus a server; the five
-things it found the moment it could make a real request are filed as #3279–#3283 and named there with their
-citations. A row that turns out not to be a defect at all leaves for `AssertsWhatNothingRequires`, the
+empty until [#3260](https://github.com/sebastienros/jint/issues/3260) gave the fetch corpus a server, which
+found five things the moment it could make a real request; they were filed as #3279–#3283, they are all fixed,
+and the category is **empty again**, which is the state that makes the next non-zero count mean something.
+A row that turns out not to be a defect at all leaves for `AssertsWhatNothingRequires`, the
 analogue of test262's `PERMANENT EXCLUSIONS` banner, earned the same way: a normative citation and an argued
 decision, never a to-do. **The engine supplies its own `setTimeout`** — unlike the test262 harness, which has no web APIs to
 enable and shims one onto the event loop, this driver enables

--- a/Jint.Tests/Wpt/Vendor/README.md
+++ b/Jint.Tests/Wpt/Vendor/README.md
@@ -185,11 +185,14 @@ is answering a request the corpus itself composed.
 
 **What it cost and what it bought.** The lane added 20 files and 326 assertions, and cost about **5 s**:
 medians of five `--filter Jint.Tests.Wpt` runs each side on one Windows machine, 68 s before and 73 s after,
-with the count identical on every run of both. Of those 326 assertions 233 pass; the 93 that do not are named
-in the exclusion table under five categories, four of which are engine defects filed separately (see
-`WptDivergence.NeedsTriage`) and the fifth of which is not an engine matter at all — the .NET HTTP stack does
-not carry a header value above ASCII, which
+with the count identical on every run of both. Of those 326 assertions 233 passed the day the lane landed;
+the 93 that did not were named in the exclusion table under five categories, four of which were engine defects
+filed separately (see `WptDivergence.NeedsTriage`) and the fifth of which is not an engine matter at all — the
+.NET HTTP stack does not carry a header value above ASCII, which
 `WptServerTests.AHeaderValueAboveAsciiDoesNotSurviveTheHttpStack` measures with no engine in the picture.
+**Every one of those defects is now fixed**, so 257 assertions pass and the 69 that do not are decisions and
+that transport limit — see [what the fetch *network* corpus says](#what-the-fetch-network-corpus-says-about-this-engine)
+below for the arithmetic.
 
 ## Deliberately not vendored
 
@@ -967,34 +970,53 @@ citation and an argued decision, never a to-do — and the rule that age alone n
 
 ## What the fetch *network* corpus says about this engine
 
-326 assertions across the twenty files [the server lane](#the-server-lane) added, of which **93 do not pass**.
-Unlike the object-model half above, most of these are not decisions — the corpus was making a real request for
-the first time, and it found five things. Each was filed as its own issue and deliberately **not** fixed by the
-change that first ran the suite: the change that first runs a suite must not also be the change that moves the
-engine, or nobody can tell which of the two a number came from. The four still open are the whole of
-`WptDivergence.NeedsTriage`, which was empty before. The fifth is fixed — a fetched response's `Headers` now
-carry the *immutable* guard ([#3281](https://github.com/sebastienros/jint/issues/3281)), so
-`response/response-headers-guard.any.js` passes whole.
+326 assertions across the twenty files [the server lane](#the-server-lane) added, of which **69 do not pass**,
+and every one of those 69 is a decision or the environment rather than a defect. It did not start that way.
+Unlike the object-model half above, most of what the lane first found were not decisions — the corpus was
+making a real request for the first time, and five things it asserts turned out not to hold. Each was filed as
+its own issue and deliberately **not** fixed by the change that first ran the suite: the change that first runs
+a suite must not also be the change that moves the engine, or nobody can tell which of the two a number came
+from. All five are fixed, and `WptDivergence.NeedsTriage` is empty again — which is the state that makes a
+future non-zero count in it mean something.
 
-1. **No `Accept: */*` is appended** ([#3279](https://github.com/sebastienros/jint/issues/3279)). Step 8 of
-   [HTTP-network-or-cache fetch](https://fetch.spec.whatwg.org/#concept-http-network-or-cache-fetch) says to
-   append it when the header list has no `Accept`, and nothing does. One row of `basic/accept-header.any.js`;
-   the row that sets `Accept` explicitly passes, which is what says the header list itself is fine.
-2. **A `HEAD` response carries a body stream** ([#3280](https://github.com/sebastienros/jint/issues/3280)).
-   [HTTP-network fetch](https://fetch.spec.whatwg.org/#concept-http-network-fetch) gives it a null body, and
-   `response.body` is a `ReadableStream` here. One row of `basic/response-null-body.any.js`; the nine
-   null-body-status rows (204, 205, 304) all pass, so it is the method half alone.
-3. **`Content-Encoding`, `Content-Language` and `Content-Location` never leave a bodiless request**
+1. **No `Accept: */*` was appended** ([#3279](https://github.com/sebastienros/jint/issues/3279)). Step 12 of
+   [fetch](https://fetch.spec.whatwg.org/#concept-fetch) says to append it when the header list has no
+   `Accept`, and nothing did. One row of `basic/accept-header.any.js`; the row that sets `Accept` explicitly
+   always passed, which is what said the header list itself was fine. `FetchTransport` appends it to the
+   transport's own copy of the list, so the header goes out and the `Request` the script holds still answers
+   null for it, exactly as in a browser. The `Accept-Language` step beside it stays unimplemented on purpose:
+   it applies only "if request's client is non-null" and reports a user's preferences, and there is no user
+   here — the two steps sitting in one algorithm is what makes that line a decision rather than an oversight.
+2. **A `HEAD` response carried a body stream** ([#3280](https://github.com/sebastienros/jint/issues/3280)).
+   Step 22 of [main fetch](https://fetch.spec.whatwg.org/#concept-main-fetch) sets the body to null for a
+   `HEAD` or `CONNECT` request as well as for a null body status — "this standardizes the error handling for
+   servers that violate HTTP" — and only the status half was consulted. One row of
+   `basic/response-null-body.any.js`; the nine null-body-status rows (204, 205, 304) always passed, so it was
+   the method half alone. The response's own headers are untouched by it: a `HEAD` still answers the
+   `Content-Length` of the representation it describes, and that length no longer counts against
+   `MaxResponseBytes`, since nothing is going to be transferred.
+3. **`Content-Encoding`, `Content-Language` and `Content-Location` never left a bodiless request**
    ([#3282](https://github.com/sebastienros/jint/issues/3282)). The BCL
-   files those three as *content* headers, so a GET or HEAD — which has no `HttpContent` to hang them on —
-   drops them silently, where Fetch has no such category and they are ordinary request headers. Eight rows of
-   `redirect/redirect-method.any.js`; its POST rows pass, which is what localises it.
-4. **`clone()` hands both bodies the same buffer** ([#3283](https://github.com/sebastienros/jint/issues/3283)).
+   files those three as *content* headers, so a GET or HEAD — which had no `HttpContent` to hang them on —
+   dropped them silently, where Fetch has no such category and they are ordinary request headers. Eight rows of
+   `redirect/redirect-method.any.js`; its POST rows always passed, which is what localised it. Such a request
+   is now given an empty `HttpContent` to carry them, and the framing that costs is the interesting half: the
+   BCL frames any message that has content, so `FetchTransport.CreateHeaderCarrier` keeps the length for a
+   `POST` or `PUT` — where step 8 of
+   [HTTP-network-or-cache fetch](https://fetch.spec.whatwg.org/#concept-http-network-or-cache-fetch) appends
+   `Content-Length: 0` itself — and suppresses it for every other method, where the standard appends nothing
+   and the same file asserts its absence. What the BCL writes instead there is `Transfer-Encoding: chunked`,
+   an HTTP/1.1 transfer artefact that is in no header list and does not exist in HTTP/2, which is the cheaper
+   of the two divergences the stack leaves available.
+4. **`clone()` handed both bodies the same buffer** ([#3283](https://github.com/sebastienros/jint/issues/3283)).
    [Body clone](https://fetch.spec.whatwg.org/#concept-body-clone) tees the stream, and the chunks the two
    branches deliver must be structured clones of one another rather than the same object. Fourteen rows of
    `response/response-clone.any.js`, one per typed-array kind.
+5. **A fetched response's `Headers` were mutable** ([#3281](https://github.com/sebastienros/jint/issues/3281)),
+   where [the fetch method](https://fetch.spec.whatwg.org/#dom-global-fetch) creates the `Response` object with
+   the *immutable* guard. `response/response-headers-guard.any.js` passes whole.
 
-The other 69 are decisions or environment, in five groups that add up exactly: 35 + 21 + 10 + 2 + 1.
+The 69 that remain are decisions or environment, in five groups that add up exactly: 35 + 21 + 10 + 2 + 1.
 
 * **35 `NeedsXmlHttpRequest`.** Both `header-values*` files run their whole table twice, once through
   `XMLHttpRequest.setRequestHeader` and once through `fetch`, and the driver's XHR is a corpus reader that
@@ -1020,9 +1042,15 @@ from the corpus and fails when the README disagrees — see [Taking the census](
 the two halves of that check and the one command that rewrites the table.
 
 Measured at this pin, on Windows, with the driver's exclusion table in force. "Not passing" is every result
-the shim did not record `PASS`, which is exactly the set the table names. The last change to move a row is
-[#3281](https://github.com/sebastienros/jint/issues/3281), which gave a fetched response's `Headers` the
-*immutable* guard and moved Fetch's not-passing count alone, 169 to 168. Before it,
+the shim did not record `PASS`, which is exactly the set the table names. The last change to move a row is the
+one that fixed the server lane's three remaining defects at once —
+[#3279](https://github.com/sebastienros/jint/issues/3279),
+[#3280](https://github.com/sebastienros/jint/issues/3280) and
+[#3282](https://github.com/sebastienros/jint/issues/3282) — and moved Fetch's not-passing count alone, 154 to
+144: one `Accept` row, one `HEAD` row and the eight GET and HEAD rows of `redirect-method.any.js`. Before it
+[#3283](https://github.com/sebastienros/jint/issues/3283) took the same row 168 to 154 by structured-cloning
+the chunks `clone()` tees, and [#3281](https://github.com/sebastienros/jint/issues/3281) took it 169 to 168 by
+giving a fetched response's `Headers` the *immutable* guard. Before all three,
 [#3260](https://github.com/sebastienros/jint/issues/3260) moved exactly one row: Fetch, from 29 files /
 388 assertions / 75 not passing to 49 / 714 / 169 — [the server lane](#the-server-lane)'s twenty files, 326
 assertions, 232 of them passing at the time. Every other row was re-derived in the same run and had not moved. The census
@@ -1044,8 +1072,8 @@ their exclusions without revisiting this table.
 | HTML — workers | `workers/` ×4 | 12 | 24 | 8 |
 | HTML — timers, microtasks, structured clone | `html/webappapis/` ×3 | 11 | 154 | 3 |
 | DOM | `dom/` ×2 | 13 | 76 | 0 |
-| Fetch | `fetch/api/` ×5 | 49 | 714 | 154 |
-| **total** | **38** | **293** | **40,983** | **2,968** |
+| Fetch | `fetch/api/` ×5 | 49 | 714 | 144 |
+| **total** | **38** | **293** | **40,983** | **2,958** |
 
 Re-censused whole rather than adjusted row by row, because several rows had gone stale between the changes
 that moved them: before [#3195](https://github.com/sebastienros/jint/issues/3195) the true figures were

--- a/Jint.Tests/Wpt/WptCorpusTests.cs
+++ b/Jint.Tests/Wpt/WptCorpusTests.cs
@@ -58,6 +58,13 @@ public class WptCorpusTests
     // because the driver still refuses it if any test in that file passes.
     [InlineData("*", "anything", true)]
     [InlineData("*", "", true)]
+    // \* is a literal asterisk, for the names that contain one. No entry spells it today — the pair it was
+    // introduced for is accept-header.any.js's, and both rows pass since
+    // https://github.com/sebastienros/jint/issues/3279 — so this is what keeps the escape honest.
+    [InlineData(@"Request through fetch should have 'accept' header with value '\*/\*'",
+        "Request through fetch should have 'accept' header with value '*/*'", true)]
+    [InlineData(@"Request through fetch should have 'accept' header with value '\*/\*'",
+        "Request through fetch should have 'accept' header with value 'custom/*'", false)]
     public void AnExclusionMatchesExactlyWhatItsPatternSays(string pattern, string testName, bool expected)
         => WptExclusion.MatchesPattern(pattern, testName).Should().Be(expected);
 }

--- a/Jint.Tests/Wpt/WptExclusions.cs
+++ b/Jint.Tests/Wpt/WptExclusions.cs
@@ -367,9 +367,11 @@ internal enum WptDivergence
     /// state — <c>Accept-Language</c> from the user's language preferences, and the <c>Referer</c> family
     /// from the document that made the request. An embedded engine has neither, and inventing a value would
     /// be inventing a fact about a user who does not exist. Deliberately not the same row as a header the
-    /// <i>standard</i> requires of every client: <c>Accept: */*</c> is step 8 of
-    /// https://fetch.spec.whatwg.org/#concept-http-network-or-cache-fetch and is owed by anyone implementing
-    /// fetch, so its row is a defect and lives in <see cref="NeedsTriage"/>.
+    /// <i>standard</i> requires of every client: <c>Accept: */*</c> is step 12 of
+    /// https://fetch.spec.whatwg.org/#concept-fetch and is owed by anyone implementing fetch, so its row was a
+    /// defect (https://github.com/sebastienros/jint/issues/3279) rather than an entry here, and it passes. The
+    /// two steps sit next to each other in the same algorithm, and the condition on the second — "and
+    /// request's client is non-null" — is precisely the line between them.
     /// </summary>
     NeedsBrowserRequestHeaders,
 
@@ -495,28 +497,31 @@ internal enum WptDivergence
     /// <see cref="AssertsWhatNothingRequires"/> rather than earning a longer explanation under this one.
     /// </para>
     /// <para>
-    /// <b>It is not empty any more, and that is the mechanism working.</b> Standing
-    /// <see cref="WptServer"/> up (https://github.com/sebastienros/jint/issues/3260) let the fetch corpus
-    /// make a real request for the first time, and five things it asserts turned out not to hold. Each is
-    /// filed as its own issue and deliberately left unfixed here, for the reason the paragraphs above give:
-    /// the change that first ran a suite must not also be the change that moves the engine, or nobody can
-    /// tell which of the two a number came from.
+    /// <b>It went non-empty once, and the whole cycle is what the mechanism looks like when it works.</b>
+    /// Standing <see cref="WptServer"/> up (https://github.com/sebastienros/jint/issues/3260) let the fetch
+    /// corpus make a real request for the first time, and five things it asserts turned out not to hold. Each
+    /// was filed as its own issue and deliberately left unfixed there, for the reason the paragraphs above
+    /// give: the change that first runs a suite must not also be the change that moves the engine, or nobody
+    /// can tell which of the two a number came from. All five are now fixed — the response <c>Headers</c>
+    /// guard (https://github.com/sebastienros/jint/issues/3281) and <c>clone()</c>'s shared buffer
+    /// (https://github.com/sebastienros/jint/issues/3283) first, then the three the request and response
+    /// plumbing owed, which left this category empty again:
     /// <list type="bullet">
     /// <item><description>
     /// https://github.com/sebastienros/jint/issues/3279 — <c>basic/accept-header.any.js</c>: no
-    /// <c>Accept: */*</c> is appended, which is step 8 of
-    /// https://fetch.spec.whatwg.org/#concept-http-network-or-cache-fetch.
+    /// <c>Accept: */*</c> was appended, which is step 12 of https://fetch.spec.whatwg.org/#concept-fetch.
     /// </description></item>
     /// <item><description>
     /// https://github.com/sebastienros/jint/issues/3280 — <c>basic/response-null-body.any.js</c>: a
-    /// <c>HEAD</c> response carries a body stream where
-    /// https://fetch.spec.whatwg.org/#concept-http-network-fetch gives it a null body.
+    /// <c>HEAD</c> response carried a body stream where step 22 of
+    /// https://fetch.spec.whatwg.org/#concept-main-fetch gives it a null body.
     /// </description></item>
     /// <item><description>
     /// https://github.com/sebastienros/jint/issues/3282 — <c>redirect/redirect-method.any.js</c>:
     /// <c>Content-Encoding</c>, <c>Content-Language</c> and <c>Content-Location</c> set on a bodiless request
-    /// never reach the wire, because the BCL files them as content headers and a GET has no content to hang
-    /// them on.
+    /// never reached the wire, because the BCL files them as content headers and a GET has no content to hang
+    /// them on. It has one now, and <c>FetchTransport.CreateHeaderCarrier</c> is where the framing that costs
+    /// is argued.
     /// </description></item>
     /// </list>
     /// </para>
@@ -626,6 +631,10 @@ internal sealed record WptExclusion(
     /// not the second — every literal segment of the one is a segment of the other, so the wildcard reading
     /// makes them indistinguishable and the two-sided rule (match a failing test, match no passing one) can
     /// never be satisfied. No other escape is recognized, and a lone backslash is a lone backslash.
+    /// <b>No entry spells it today</b>: that pair is exactly the case
+    /// https://github.com/sebastienros/jint/issues/3279 fixed, so both rows pass and the exclusion that
+    /// needed the escape is gone. <c>WptCorpusTests.AnExclusionMatchesExactlyWhatItsPatternSays</c> holds the
+    /// escape instead, so it stays correct for the next name that carries a star.
     /// </para>
     /// </remarks>
     internal static bool MatchesPattern(string pattern, string value)

--- a/Jint.Tests/Wpt/WptTestRunner.cs
+++ b/Jint.Tests/Wpt/WptTestRunner.cs
@@ -1065,23 +1065,14 @@ public class WptTestRunner
 
         // ---- what the server lane found. WptServer (issue #3260) is what let these files make a real
         // request for the first time; WptHarness._serverBackedFiles is the list of the files it runs.
-
-        // The five defects the lane turned up, each filed and deliberately not fixed here — see
-        // WptDivergence.NeedsTriage for the citation behind every one and why the change that first ran a
-        // suite must not also be the change that moves the engine.
         //
-        // The first entry's stars are escaped because they are part of the test's *name* — its sibling row is
-        // "…with value 'custom/*'" and passes, so an unescaped pattern would cover a passing test. See
-        // WptExclusion.MatchesPattern.
-        new("fetch/api/basic/accept-header.any.js",
-            @"Request through fetch should have 'accept' header with value '\*/\*'", WptDivergence.NeedsTriage),
-        new("fetch/api/basic/response-null-body.any.js",
-            "Response.body is null for responses with method=HEAD", WptDivergence.NeedsTriage),
-        new("fetch/api/redirect/redirect-method.any.js", "Redirect 30* with GET", WptDivergence.NeedsTriage),
-        new("fetch/api/redirect/redirect-method.any.js", "Redirect 30* with HEAD", WptDivergence.NeedsTriage),
+        // The five defects it turned up were all filed rather than fixed there, and all five are now fixed:
+        // #3281 and #3283 first, then #3279, #3280 and #3282 together, which is what emptied
+        // WptDivergence.NeedsTriage again. The entries below are the lane's *decisions*, which no fix moves.
 
         // The other half of accept-header.any.js, and not a defect: Accept-Language is a browser reporting
-        // the user's language preferences, and there is no user here.
+        // the user's language preferences, and there is no user here. Its sibling rows — the Accept the
+        // standard gives every client, whether the script named one or not — pass since #3279.
         new("fetch/api/basic/accept-header.any.js",
             "Request through fetch should have a 'accept-language' header", WptDivergence.NeedsBrowserRequestHeaders),
 

--- a/Jint/Options.WebApi.cs
+++ b/Jint/Options.WebApi.cs
@@ -509,6 +509,11 @@ public sealed partial class Options
         /// response's body stream</i> instead, and every consumer of that body reports it.
         /// </para>
         /// <para>
+        /// <b>A response with no body to read is never refused for its length</b> — a <c>HEAD</c>, or one of
+        /// the null body statuses. There the <c>Content-Length</c> describes a representation the response is
+        /// not transferring, and asking with <c>HEAD</c> precisely so as not to transfer it is the point.
+        /// </para>
+        /// <para>
         /// <b><see cref="long.MaxValue"/> means unlimited</b>, and zero or less refuses every body. This is
         /// deliberately unlike the execution constraints' saturated sentinels, where
         /// <c>LimitMemory(long.MaxValue)</c> removes the constraint: there is no constraint to remove here, and

--- a/Jint/WebApi/Fetch/FetchTransport.cs
+++ b/Jint/WebApi/Fetch/FetchTransport.cs
@@ -148,6 +148,12 @@ internal sealed class FetchExchange : IDisposable
 {
     internal required HttpResponseMessage Response { get; init; }
 
+    /// <summary>
+    /// The method the last hop was made with, which is not always the one the request started with: a
+    /// redirect rewrites <c>POST</c> to <c>GET</c>. What answers whether the response has a body at all.
+    /// </summary>
+    internal required string Method { get; init; }
+
     /// <summary>The URL that produced this response, i.e. the last hop of the redirect chain.</summary>
     internal required UrlRecord Url { get; init; }
 
@@ -169,8 +175,9 @@ internal sealed class FetchResponseSnapshot
     internal required List<HeaderEntry> Headers { get; init; }
 
     /// <summary>
-    /// The body still on the wire, or <see langword="null"/> for a status the standard gives no body —
-    /// https://fetch.spec.whatwg.org/#null-body-status. The connection is <b>still open</b> when this
+    /// The body still on the wire, or <see langword="null"/> for the two answers the standard gives no body:
+    /// a null body status (https://fetch.spec.whatwg.org/#null-body-status) and a response to
+    /// <c>HEAD</c>. The connection is <b>still open</b> when this
     /// reaches the engine thread: <see cref="FetchBodyStream.Attach"/> is what starts reading it, and
     /// <see cref="FetchBodyStream.Dispose"/> is what lets it go if nothing ever will.
     /// </summary>
@@ -290,7 +297,7 @@ internal static class FetchTransport
         var handedOver = false;
         try
         {
-            var snapshot = await BeginResponseAsync(exchange.Response, exchange.Url, exchange.Redirected, policy, cancellationToken).ConfigureAwait(false);
+            var snapshot = await BeginResponseAsync(exchange.Response, exchange.Method, exchange.Url, exchange.Redirected, policy, cancellationToken).ConfigureAwait(false);
             handedOver = snapshot.Body is not null;
             return snapshot;
         }
@@ -325,6 +332,7 @@ internal static class FetchTransport
         var body = request.Body;
         var content = request.BodyContent;
         var headers = new List<HeaderEntry>(request.Headers);
+        AppendDefaultAccept(headers);
         var redirectCount = 0;
 
         while (true)
@@ -363,7 +371,7 @@ internal static class FetchTransport
                     || string.Equals(request.Redirect, JsRequest.RedirectManual, StringComparison.Ordinal))
                 {
                     handedOver = true;
-                    return new FetchExchange { Response = response, Url = url, Redirected = redirectCount > 0 };
+                    return new FetchExchange { Response = response, Method = method, Url = url, Redirected = redirectCount > 0 };
                 }
 
                 if (string.Equals(request.Redirect, JsRequest.RedirectError, StringComparison.Ordinal))
@@ -377,7 +385,7 @@ internal static class FetchTransport
                 if (location is null)
                 {
                     handedOver = true;
-                    return new FetchExchange { Response = response, Url = url, Redirected = redirectCount > 0 };
+                    return new FetchExchange { Response = response, Method = method, Url = url, Redirected = redirectCount > 0 };
                 }
 
                 // https://fetch.spec.whatwg.org/#http-redirect-fetch step 12: "If internalResponse's status
@@ -409,6 +417,38 @@ internal static class FetchTransport
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// https://fetch.spec.whatwg.org/#concept-fetch step 12: a request whose header list does not contain
+    /// <c>Accept</c> is given one, and <c>*/*</c> is the value for everything but the few destinations a
+    /// browser knows — a document, an image, a stylesheet. A request made here has no destination, so the
+    /// general value is the only one that applies.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The list this appends to is the transport's copy, which is what makes it invisible to the script: a
+    /// browser sends <c>Accept: */*</c> while the <c>Request</c> the script holds still answers null for it,
+    /// and so does this. Every hop of a redirect carries it for the same reason the script's own headers do.
+    /// </para>
+    /// <para>
+    /// <b>Step 13, the <c>Accept-Language</c> beside it, is deliberately not implemented.</b> It applies only
+    /// "if request's client is non-null" and its value is the user's language preferences; an embedded engine
+    /// has neither a client nor a user, so there is nothing to report and a made-up value would be worse than
+    /// the absence.
+    /// </para>
+    /// </remarks>
+    private static void AppendDefaultAccept(List<HeaderEntry> headers)
+    {
+        foreach (var header in headers)
+        {
+            if (string.Equals(header.LowerName, "accept", StringComparison.Ordinal))
+            {
+                return;
+            }
+        }
+
+        headers.Add(new HeaderEntry("accept", "*/*"));
     }
 
     /// <summary>
@@ -531,19 +571,86 @@ internal static class FetchTransport
             message.Content.Headers.ContentType = null;
         }
 
+        var bodiless = message.Content is null;
+
         foreach (var header in headers)
         {
             // A content header belongs on the content, and the request-header collection refuses it. Both
             // calls are TryAddWithoutValidation: the header list has already been validated against the
             // Fetch Standard's own grammar, which is what a script is entitled to be measured against.
-            if (!message.Headers.TryAddWithoutValidation(header.LowerName, header.Value))
+            if (message.Headers.TryAddWithoutValidation(header.LowerName, header.Value))
             {
-                message.Content?.Headers.TryAddWithoutValidation(header.LowerName, header.Value);
+                continue;
             }
+
+            // Content-Length is the one content header a carrier does not take: there is no body, and a
+            // length is what the transport frames one with, so a script that set one would have this request
+            // announce bytes it is never going to send.
+            if (bodiless && string.Equals(header.LowerName, "content-length", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            message.Content ??= CreateHeaderCarrier(method);
+            message.Content.Headers.TryAddWithoutValidation(header.LowerName, header.Value);
         }
 
         return message;
     }
+
+    /// <summary>
+    /// The empty <see cref="HttpContent"/> a request with no body is given so that a content header the
+    /// script set can leave at all.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// https://fetch.spec.whatwg.org/#concept-header-list is <i>one</i> list, and the only names it treats
+    /// specially on a request are the forbidden request-headers, which these are not. The BCL splits that one
+    /// list in two: <c>Content-Encoding</c>, <c>Content-Language</c>, <c>Content-Location</c>,
+    /// <c>Content-Type</c> and the rest belong to <see cref="HttpContent.Headers"/> and are refused by
+    /// <see cref="HttpRequestMessage.Headers"/> — so a <c>GET</c> or a <c>HEAD</c> carrying one had nowhere to
+    /// put it and dropped it on the floor.
+    /// </para>
+    /// <para>
+    /// <b>The framing it costs.</b> A message with content is framed, and the BCL offers exactly two shapes:
+    /// a known length writes <c>Content-Length</c>, an unknown one writes <c>Transfer-Encoding: chunked</c>
+    /// and an empty chunked body. For <c>POST</c> and <c>PUT</c> the first is what the standard appends
+    /// itself — https://fetch.spec.whatwg.org/#concept-http-network-or-cache-fetch step 8, "If httpRequest's
+    /// body is null and httpRequest's method is `POST` or `PUT`, then set contentLengthHeaderValue to `0`" —
+    /// and what a bodiless request of those methods already sends, so the carrier keeps its length;
+    /// <c>PATCH</c> joins them because a body is expected of it too and <see cref="HttpClient"/> already sends
+    /// <c>Content-Length: 0</c> for a bodiless one. For every other method the standard appends no
+    /// <c>Content-Length</c> at all, so the
+    /// length is suppressed and the chunked framing is taken instead: a transfer encoding is an HTTP/1.1
+    /// artefact that no header list contains and that HTTP/2 does not have, where an invented
+    /// <c>Content-Length: 0</c> would be a header the server reads out of the very list the standard decides.
+    /// </para>
+    /// </remarks>
+    private static ByteArrayContent CreateHeaderCarrier(string method)
+    {
+        var carrier = new ByteArrayContent([]);
+        if (!MustHaveRequestBody(method))
+        {
+            carrier.Headers.ContentLength = null;
+        }
+
+        return carrier;
+    }
+
+    /// <summary>
+    /// The methods a request body is expected of, and so the ones a bodiless request already announces a
+    /// length for: the two the standard names, plus the one <see cref="HttpClient"/> adds.
+    /// </summary>
+    /// <remarks>
+    /// Case-insensitively, unlike the ordinal comparisons elsewhere here, because
+    /// https://fetch.spec.whatwg.org/#concept-method-normalize uppercases six methods and leaves
+    /// <c>patch</c> alone — and which of the two spellings a script wrote is no reason to frame its request
+    /// differently.
+    /// </remarks>
+    private static bool MustHaveRequestBody(string method)
+        => method.Equals("POST", StringComparison.OrdinalIgnoreCase)
+        || method.Equals("PUT", StringComparison.OrdinalIgnoreCase)
+        || method.Equals("PATCH", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// Collects the headers and hands the still-open body over to a <see cref="FetchBodyStream"/>, which the
@@ -565,16 +672,16 @@ internal static class FetchTransport
     /// </remarks>
     private static async Task<FetchResponseSnapshot> BeginResponseAsync(
         HttpResponseMessage response,
+        string method,
         UrlRecord url,
         bool redirected,
         FetchPolicy policy,
         CancellationToken cancellationToken)
     {
+        // Read before the headers are collected, and not only for the cap below: a response a host's own
+        // handler built in memory computes its length on first access and only then carries the header, so
+        // this read is also what puts Content-Length in the list.
         var declaredLength = response.Content.Headers.ContentLength;
-        if (declaredLength is { } length && length > policy.MaxResponseBytes)
-        {
-            throw TooLarge(policy);
-        }
 
         var headers = new List<HeaderEntry>();
         Collect(headers, response.Headers);
@@ -582,8 +689,24 @@ internal static class FetchTransport
 
         var status = (int) response.StatusCode;
 
+        // https://fetch.spec.whatwg.org/#concept-main-fetch step 22: "If response is not a network error and
+        // either request's method is `HEAD` or `CONNECT`, or internalResponse's status is a null body status,
+        // set internalResponse's body to null and disregard any enqueuing toward it (if any)." The method half
+        // is the one a server cannot be trusted on: a HEAD response carries the headers the GET would have
+        // had — Content-Length among them — and none of the bytes they describe. CONNECT never reaches here,
+        // being a forbidden method (see FetchValues.IsForbiddenMethod).
+        var hasBody = !FetchValues.IsNullBodyStatus(status) && !string.Equals(method, "HEAD", StringComparison.Ordinal);
+
+        // Only a body that will be read is measured against the cap. A HEAD answers the length of the
+        // representation it is describing rather than of anything it is about to send, so refusing it as too
+        // large would fail a request that transfers nothing — which is the whole point of asking with HEAD.
+        if (hasBody && declaredLength is { } length && length > policy.MaxResponseBytes)
+        {
+            throw TooLarge(policy);
+        }
+
         FetchBodyStream? body = null;
-        if (!FetchValues.IsNullBodyStatus(status))
+        if (hasBody)
         {
             Stream content;
             try

--- a/README.md
+++ b/README.md
@@ -1209,7 +1209,9 @@ delivered as generation-stamped event-loop jobs, exactly like every other cross-
 so nothing about a body arrives on a thread the host did not pump. `MaxResponseBytes` is enforced on the
 running total per chunk; because the promise has already resolved by the time a body byte is read, a body
 that breaks the cap **errors the stream** rather than rejecting the `fetch` promise (a `Content-Length` that
-already exceeds it is still refused before the promise settles).
+already exceeds it is still refused before the promise settles — unless the response has no body to read at
+all, a `HEAD` or a 204/205/304, where that header describes a representation rather than a transfer and
+`response.body` is `null`).
 
 The `Body` mixin sits on top of that and is unchanged in behaviour: `text()`, `json()`, `arrayBuffer()`,
 `bytes()` and `blob()` read the stream to the end and answer with the whole body, `bodyUsed` is the stream's


### PR DESCRIPTION
Three divergences the web-platform-tests server lane ([#3260](https://github.com/sebastienros/jint/issues/3260)) found the first time `fetch/api/` could make a real request. They are one pull request because they are three deviations in the same request/response plumbing — `FetchTransport` — and each is small; splitting them would have tripled the WPT churn for no reviewer benefit.

Fixes #3279.
Fixes #3280.
Fixes #3282.

## 1. `Accept: */*` (#3279)

**Spec:** [fetch](https://fetch.spec.whatwg.org/#concept-fetch) **step 12** — "If request's header list does not contain \`Accept\`, then: let *value* be \`*/*\` … append (\`Accept\`, *value*) to request's header list." The per-destination values in that step ("image", "style", …) are a browser's; a request made here has no destination, so the general value is the only one that applies.

*The issue cites step 8 of HTTP-network-or-cache fetch, which is where this used to live.* The step has since moved into the `fetch` algorithm itself, next to `Accept-Language` — which is the useful part of the move for us, because it is what puts the two side by side with the condition that separates them: `Accept-Language` applies only "if request's client is non-null" and reports a *user's* preferences, so it stays unimplemented and its row stays in `NeedsBrowserRequestHeaders`.

It is appended to the transport's own copy of the header list, so the header goes out while the `Request` the script holds still answers `null` for it — which is what a browser does, and is pinned by a test.

**Before** — `fetch/api/basic/accept-header.any.js`:

```
[FAIL] Request through fetch should have 'accept' header with value '*/*': expected "*/*" but got null (Request has accept header with value '*/*')
```

**After:** the file's four rows report, three pass and the fourth is the `accept-language` row that has always been a documented decision.

## 2. A `HEAD` response has no body (#3280)

**Spec:** [main fetch](https://fetch.spec.whatwg.org/#concept-main-fetch) **step 22** — "If response is not a network error and either request's method is \`HEAD\` or \`CONNECT\`, or internalResponse's status is a null body status, set internalResponse's body to null and disregard any enqueuing toward it (if any)." The note under it says why the method half exists at all: *"This standardizes the error handling for servers that violate HTTP."* Only the status half was consulted. `CONNECT` never reaches the transport — it is a forbidden method.

The response's headers are untouched, so a `HEAD` still answers the `Content-Length` of the representation it describes. One consequence follows from that and is part of this change: that length no longer counts against `MaxResponseBytes`, because nothing is going to be transferred — refusing a `HEAD` for the size of a body it will never fetch fails the one request that is asking precisely so as not to fetch it.

**Before** — `fetch/api/basic/response-null-body.any.js`:

```
[FAIL] Response.body is null for responses with method=HEAD: expected null but got object "ReadableStream" (the body should be null)
```

**After:** all eleven rows pass.

## 3. Content headers on a bodiless request (#3282)

**Spec:** [header list](https://fetch.spec.whatwg.org/#concept-header-list) is *one* list, and the only names it treats specially on a request are the [forbidden request-headers](https://fetch.spec.whatwg.org/#forbidden-request-header), which these are not (and which Jint deliberately does not enforce — `HeadersGuard` documents that). The BCL splits the same list in two and files `Content-Encoding`, `Content-Language`, `Content-Location` and `Content-Type` on `HttpContent`, so a `GET` or `HEAD` had nowhere to hang one and dropped it.

Such a request is now given an empty `HttpContent` to carry them. **The framing that costs is the part worth reviewing**, and it is where the spec and the corpus agree on something the BCL cannot express. `HttpClient` frames any message that has content, and offers exactly two shapes — measured, not assumed, against a raw `TcpListener`:

| carrier | wire |
| --- | --- |
| `new ByteArrayContent([])` | `Content-Length: 0` |
| the same with `Headers.ContentLength = null` | `Transfer-Encoding: chunked` + `0\r\n\r\n` |

There is no third shape: `TransferEncodingChunked = false` and a content that computes no length both still produce chunked, and only `Content == null` produces no framing header at all. So the choice is which of the two to be wrong with, per method:

* **`POST`, `PUT`** (and `PATCH`) keep the length, because that is what the standard appends itself — [HTTP-network-or-cache fetch](https://fetch.spec.whatwg.org/#concept-http-network-or-cache-fetch) step 8: "If httpRequest's body is null and httpRequest's method is \`POST\` or \`PUT\`, then set *contentLengthHeaderValue* to \`0\`" — and what a bodiless request of those methods already sent. A bodiless `POST` that names a `Content-Type` is the common shape here, and it now sends the header it was given plus the `Content-Length: 0` it always sent.
* **Every other method** suppresses the length, because the standard appends no `Content-Length` at all for a bodiless `GET` — and `redirect-method.any.js` asserts its absence, `x-request-content-length` having to read `"NO"` on every GET and HEAD row. What the BCL writes instead is `Transfer-Encoding: chunked`, which is the cheaper divergence: a transfer encoding is an HTTP/1.1 framing artefact that appears in no header list and does not exist in HTTP/2, where an invented `Content-Length: 0` would be a header the server reads out of the very list the standard decides.

A script-set `Content-Length` is still dropped on a bodiless request rather than put on the carrier, since it would frame bytes that are never sent.

**Before** — `fetch/api/redirect/redirect-method.any.js`, eight rows:

```
[FAIL] Redirect 301 with GET: expected "Identity" but got "NO" (Request Content-Encoding after redirection is Identity)
[FAIL] Redirect 301 with HEAD: expected "Identity" but got "NO" (Request Content-Encoding after redirection is Identity)
[FAIL] Redirect 302 with GET / HEAD, 303 with GET / HEAD, 307 with GET / HEAD: the same
```

**After:** all fifteen rows pass.

## Where spec and corpus meet

Nowhere did the two disagree — the corpus asserts exactly what the algorithms say. What they *jointly* ask for in the third case is a wire form the .NET HTTP stack cannot produce (a request carrying content headers and no framing header), which is why that fix argues its framing rather than simply obeying. The argument is on `FetchTransport.CreateHeaderCarrier` so it is next to the code rather than only in this description.

## The exclusion table

Four `NeedsTriage` entries deleted, and the category is **empty again** — the state that makes the next non-zero count mean something. It has held nothing else since [#3281](https://github.com/sebastienros/jint/issues/3281) and [#3283](https://github.com/sebastienros/jint/issues/3283), the other two things the lane found, so `NeedsTriage` goes **4 → 0**.

* `accept-header.any.js` "…with value '\*/\*'" — the last entry that needed the `\*` escape, so `WptCorpusTests` now holds the escape instead of an exclusion doing it.
* `response-null-body.any.js` "Response.body is null for responses with method=HEAD"
* `redirect-method.any.js` "Redirect 30\* with GET" and "…with HEAD"

The census table in `Vendor/README.md` was regenerated on Windows with `JINT_WPT_CENSUS=update`, as its first line requires: **Fetch 154 → 144 not passing, total 2,968 → 2,958** — the ten rows above. The lane's own 326 assertions are now 257 passing and 69 not, and all 69 are the five decision/environment categories that already added up: 35 + 21 + 10 + 2 + 1.

## Verification

All of it on `main` as of a0fcd372a.

* `dotnet build -c Release` for the solution: clean.
* `Jint.Tests`: 10,677 passed on `net10.0` and on `net8.0`, 7,316 on `net472`, 0 failed. `Jint.Tests.PublicInterface`: 2,965 and 2,339, 0 failed — the public surface itself does not move, so no baseline or documentation-register regeneration; the one new test there is a third party's `HttpMessageHandler` reading what the engine composed.
* `Jint.Tests.Wpt` with `JINT_WPT_CENSUS=1`: 460 passed, 0 failed, census enforced.
* test262: **102,495 passed / 0 failed**, 189 skipped, 102,684 total, on the rebased tree.
  Three earlier runs on this shared build machine came back 102,494 / 1, 102,494 / 1 and 102,493 / 2, and
  every one of those failures was a staging case running into the runner's 30-second default while eight
  other `dotnet` processes were on the box — `staging/sm/expressions/short-circuit-compound-assignment.js`
  at 32 s and 33 s, `staging/sm/Array/toSpliced-dense.js` at 30 s — each of which passes in isolation (the
  whole `Sm_expressions` theory is 75 passed in 915 ms, `Sm_Array` 182 in 2 s). Nothing in this change is
  reachable from test262 in any case: it lives inside `#if NET8_0_OR_GREATER` `Jint/WebApi/Fetch/`, which no
  engine without `WebApiFeatures.Fetch` loads.

`docs/v5-migration.md` gets no row: it is "the running record of every change a 4.16.x embedder has to react to", and `fetch` does not exist in 4.16.x — the behaviour changed here is inside a feature that is itself new in v5, so there is no upgrade step for anyone to take. `README.md`'s fetch section gains one clause, because it claimed a `Content-Length` above the cap is refused before the promise settles without saying that a response with no body to read is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014W5mbjGhyvgAS4pivXoc4S
