### PR TITLE
Tests: a timing assertion measures the property, not the machine it ran on

### DIFF
--- a/Jint.Tests.CommonScripts/SunSpiderTests.cs
+++ b/Jint.Tests.CommonScripts/SunSpiderTests.cs
@@ -6,9 +6,25 @@ namespace Jint.Tests.CommonScripts;
 [Parallelizable(ParallelScope.All)]
 public class SunSpiderTests
 {
+    /// <summary>
+    /// What a single regular-expression match in these scripts is given.
+    /// </summary>
+    /// <remarks>
+    /// Nothing in this suite asserts anything about <c>Options.Constraints.RegexTimeout</c>; every test here
+    /// asserts that a real-world script produces the right answer. The engine's ten-second default is
+    /// therefore a wedge ceiling, and it was one sized for a machine running a single script: this fixture is
+    /// <c>[Parallelizable(ParallelScope.All)]</c>, so twenty-eight CPU-bound workloads share whatever cores
+    /// the runner has, and a Windows leg has been observed taking 7 m 19 s for the twenty-eight against ~20 s
+    /// unloaded — with <c>RegexMatchTimeoutException</c> as the only symptom (#3358). A minute cannot be
+    /// reached by a starved matcher on a pattern these scripts contain, only by a genuinely catastrophic one,
+    /// and a catastrophic one reported after a minute is still reported. It stays finite deliberately:
+    /// <c>Regex.InfiniteMatchTimeout</c> would turn that failure into a hung run.
+    /// </remarks>
+    private static readonly TimeSpan RegexWedgeCeiling = TimeSpan.FromMinutes(1);
+
     private static void RunTest(string source)
     {
-        var engine = new Engine()
+        var engine = new Engine(options => options.Constraints.RegexTimeout = RegexWedgeCeiling)
             .SetValue("log", new Action<object>(Console.WriteLine))
             .SetValue("assert", new Action<bool, string>(static (condition, message) => condition.Should().BeTrue(message)));
 

--- a/Jint.Tests.PublicInterface/ConstraintReplacementTests.cs
+++ b/Jint.Tests.PublicInterface/ConstraintReplacementTests.cs
@@ -21,6 +21,15 @@ public class ConstraintReplacementTests
 {
     private const string LoopScript = "var n = 0; for (var i = 0; i < 200000; i++) { n += i; } n";
 
+    /// <summary>
+    /// The widened interval in the row below. It is not a duration the test is about: the discriminator is
+    /// the one-millisecond interval that must no longer be registered, which two hundred thousand iterations
+    /// pass by four orders of magnitude on any machine. What this number decides is only whether a healthy
+    /// run finishes inside it, so it is a wedge ceiling — thirty seconds was one on an idle box and not on a
+    /// runner that has been seen stalling a two-hundred-millisecond wait for a minute (#3358).
+    /// </summary>
+    private static readonly TimeSpan WidenedInterval = TimeSpan.FromMinutes(10);
+
     [Fact]
     public void TheLaterTimeoutIsTheOneEnforced()
     {
@@ -28,7 +37,7 @@ public class ConstraintReplacementTests
         // constraint is still registered alongside it
         var engine = new Engine(o => o
             .LimitExecutionTime(TimeSpan.FromMilliseconds(1))
-            .LimitExecutionTime(TimeSpan.FromSeconds(30)));
+            .LimitExecutionTime(WidenedInterval));
 
         engine.Evaluate(LoopScript).AsNumber().Should().BeGreaterThan(0);
     }

--- a/Jint.Tests.PublicInterface/HostPromiseTimeoutTests.cs
+++ b/Jint.Tests.PublicInterface/HostPromiseTimeoutTests.cs
@@ -20,8 +20,33 @@ namespace Jint.Tests.PublicInterface;
 public class HostPromiseTimeoutTests
 {
     /// <summary>
-    /// A promise nobody settles, and a budget far below the ten-second default. The elapsed time is the
-    /// assertion: reading the default instead of the configured value would park for ten seconds.
+    /// <c>Options.Constraints.PromiseTimeout</c>'s own default, and so what the wrong answer costs in each
+    /// row below where the engine's configured value is not the one asserted about.
+    /// </summary>
+    private static readonly TimeSpan DefaultPromiseTimeout = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Which budget the wait actually ran under, stated by the wait itself. <c>UnwrapIfPromiseCore</c>
+    /// resolves the effective timeout into one local, hands that local to the drain, and formats the very
+    /// same local into this message — so a wait that consulted the wrong budget cannot name the right one,
+    /// and this is a witness rather than a restatement of the configuration.
+    /// </summary>
+    private static void ShouldNameTheBudgetItWaitedUnder(PromiseRejectedException rejection, TimeSpan budget)
+        => rejection.Message.Should().Contain(budget.ToString());
+
+    /// <summary>
+    /// The other half of the same claim, and the half a clock is needed for: that the wait <em>ended</em> on
+    /// the budget it names rather than sitting out the longer one it should have ignored. The bound is half
+    /// of whatever the wrong answer would have spent, so it stays a midpoint between the two candidates
+    /// instead of an absolute number a loaded runner can walk past — #3358 saw a 200 ms wait measured at
+    /// 1 m 3 s against a fixed 5 s.
+    /// </summary>
+    private static void ShouldNotHaveSpentTheOtherBudget(Stopwatch elapsed, TimeSpan wrongBudget)
+        => elapsed.Elapsed.Should().BeLessThan(TimeSpan.FromTicks(wrongBudget.Ticks / 2));
+
+    /// <summary>
+    /// A promise nobody settles, and a budget far below the ten-second default. Reading the default instead
+    /// of the configured value would name ten seconds and park for ten seconds, and both are asserted.
     /// </summary>
     [Fact]
     public void TheArgumentLessUnwrapTakesTheConfiguredPromiseTimeout()
@@ -35,10 +60,8 @@ public class HostPromiseTimeoutTests
         var rejection = Assert.Throws<PromiseRejectedException>(() => manual.Promise.UnwrapIfPromise());
         elapsed.Stop();
 
-        // Generous against a loaded CI machine, and still an order of magnitude below the ten seconds the
-        // hard-coded default would have cost.
-        elapsed.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(5));
-        rejection.Message.Should().Contain(configured.ToString());
+        ShouldNameTheBudgetItWaitedUnder(rejection, configured);
+        ShouldNotHaveSpentTheOtherBudget(elapsed, DefaultPromiseTimeout);
     }
 
     /// <summary>
@@ -49,7 +72,8 @@ public class HostPromiseTimeoutTests
     [Fact]
     public void AnExplicitTimeoutStillWinsOverTheConfiguredOne()
     {
-        using var engine = new Engine(options => options.Constraints.PromiseTimeout = TimeSpan.FromMinutes(5));
+        var configured = TimeSpan.FromMinutes(5);
+        using var engine = new Engine(options => options.Constraints.PromiseTimeout = configured);
         var manual = engine.Tasks.RegisterPromise();
 
         var requested = TimeSpan.FromMilliseconds(200);
@@ -58,8 +82,8 @@ public class HostPromiseTimeoutTests
         var rejection = Assert.Throws<PromiseRejectedException>(() => manual.Promise.UnwrapIfPromise(requested));
         elapsed.Stop();
 
-        elapsed.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(5));
-        rejection.Message.Should().Contain(requested.ToString());
+        ShouldNameTheBudgetItWaitedUnder(rejection, requested);
+        ShouldNotHaveSpentTheOtherBudget(elapsed, configured);
     }
 
     /// <summary>

--- a/Jint.Tests.PublicInterface/HostPumpWaitTests.cs
+++ b/Jint.Tests.PublicInterface/HostPumpWaitTests.cs
@@ -18,11 +18,20 @@ namespace Jint.Tests.PublicInterface;
 /// </remarks>
 public class HostPumpWaitTests
 {
-    private static readonly TimeSpan Ceiling = TimeSpan.FromSeconds(10);
+    /// <summary>
+    /// What the wait under test is given. Nothing should ever spend it, so its only job is to bound a wake
+    /// that never comes — which is why it is a minute rather than the ten seconds it was through #3301: the
+    /// ratio below is the assertion, and raising both together widens the margin without weakening it.
+    /// </summary>
+    private static readonly TimeSpan Ceiling = TimeSpan.FromSeconds(60);
 
-    private static readonly TimeSpan EarlyReturnMargin = TimeSpan.FromSeconds(5);
+    /// <summary>
+    /// The margin the wake has to beat, derived from the ceiling rather than written out again so the two
+    /// cannot drift. Half of it, which is what separates "woke on the post" from "ran out the ceiling".
+    /// </summary>
+    private static readonly TimeSpan EarlyReturnMargin = TimeSpan.FromTicks(Ceiling.Ticks / 2);
 
-    private static readonly TimeSpan WedgeCeiling = TimeSpan.FromMinutes(2);
+    private static readonly TimeSpan WedgeCeiling = TestBudgets.WedgeCeiling;
 
     /// <summary>
     /// The shape the wait exists for: one thread parked on this engine, another handing it work. A settled
@@ -50,11 +59,7 @@ public class HostPumpWaitTests
         var elapsed = new Stopwatch();
 
         engine.SetValue("hostWork", manual.Promise);
-        engine.SetValue("armProducer", new Action(() =>
-        {
-            elapsed.Start();
-            producerArmed.Set();
-        }));
+        engine.SetValue("armProducer", new Action(producerArmed.Set));
         engine.SetValue("park", new Func<bool>(() => engine.Tasks.WaitForScheduledWork(Ceiling)));
 
         var producer = DedicatedThread.RunAsync(() =>
@@ -64,6 +69,12 @@ public class HostPumpWaitTests
             // Lets the wait be reached before the settle lands, so the wake rather than the pre-check is what
             // ends it. Both are correct and both pass — see the remarks above.
             Thread.Sleep(TimeSpan.FromMilliseconds(250));
+
+            // Started here, on the producer, immediately before the post: what the margin below is about is
+            // the wake, and starting the clock back in armProducer() also charged it for this thread being
+            // scheduled and for the settle above. That is what produced the 12 s reading in #3358 on a wake
+            // that was not slow at all.
+            elapsed.Start();
             manual.Resolve(JsValue.Undefined);
         });
 

--- a/Jint.Tests.PublicInterface/HostStreamBridgeTests.cs
+++ b/Jint.Tests.PublicInterface/HostStreamBridgeTests.cs
@@ -24,12 +24,31 @@ namespace Jint.Tests.PublicInterface;
 /// asynchronous methods complete synchronously (see <see cref="RecordingStream"/>), so the whole copy runs on
 /// the engine's own turns and a bounded <c>ProcessTasks</c> loop is enough to drive it to completion. The one
 /// test that deliberately goes off-thread, <see cref="ReadsAStreamWhoseReadsCompleteOnAnotherThread"/>, waits
-/// for the outcome through the engine's own blocking drain rather than for an interval.
+/// for the outcome through the engine's own blocking drain rather than for an interval — under the wedge
+/// ceiling <see cref="OffThreadStreamEngine"/> configures, which is a bound on a hang and never an assertion.
 /// </para>
 /// </remarks>
 public class HostStreamBridgeTests
 {
     private static Engine StreamEngine() => new(options => options.UseWebApis(WebApiFeatures.Streams));
+
+    /// <summary>
+    /// The same engine for the one test whose chunks arrive from another thread, with the promise budget the
+    /// blocking drain runs under moved off the engine's ten-second default and onto
+    /// <see cref="TestBudgets.WedgeCeiling"/>.
+    /// </summary>
+    /// <remarks>
+    /// Nothing here asserts a duration — the assertion is the text that came out of the stream — so the
+    /// budget is a wedge ceiling and widening it can hide nothing. What it removes is the thread pool from
+    /// the set of things that decide the outcome: each chunk is delivered by a pool continuation, and on a
+    /// saturated runner the whole copy has been seen failing as <c>PromiseRejectedException: Timeout of
+    /// 00:00:10 reached</c> (#3358), which is a symptom of the machine rather than of the bridge.
+    /// </remarks>
+    private static Engine OffThreadStreamEngine() => new(options =>
+    {
+        options.UseWebApis(WebApiFeatures.Streams);
+        options.Constraints.PromiseTimeout = TestBudgets.WedgeCeiling;
+    });
 
     private static byte[] Utf8(string text) => Encoding.UTF8.GetBytes(text);
 
@@ -383,7 +402,7 @@ public class HostStreamBridgeTests
         // The cross-thread half: every chunk arrives as a generation-stamped event-loop job rather than
         // through the synchronous window. UnwrapIfPromise is the engine's own blocking drain, which wakes on
         // the work-arrived signal rather than on a poll interval.
-        var engine = StreamEngine();
+        var engine = OffThreadStreamEngine();
         engine.SetValue("input", engine.WebApi.CreateReadableStream(
             new OffThreadStream(Utf8("streamed off-thread")),
             new HostReadableStreamOptions { ChunkSize = 4 }));

--- a/Jint.Tests.PublicInterface/UntrustedCodeProfileTests.cs
+++ b/Jint.Tests.PublicInterface/UntrustedCodeProfileTests.cs
@@ -327,7 +327,15 @@ public class UntrustedCodeProfileTests
     [Fact]
     public async Task OperationScopeCannotEndWhileAsyncWorkOwnsTheEngine()
     {
-        var limits = CreateLimits();
+        // Every wall-clock limit here is a wedge ceiling rather than part of the claim: what is asserted is
+        // that a scope refuses to end while an evaluation is suspended, and then ends once it resumes. The
+        // profile's own five-second timeout interval and ten-second operation deadline are budgets an
+        // embedder would size for their own work, and leaving them at those defaults made this test fail on
+        // a loaded runner as a TimeoutException from the gate below rather than as anything about scopes.
+        var limits = CreateLimits(
+            timeoutInterval: TestBudgets.WedgeCeiling,
+            promiseTimeout: TestBudgets.WedgeCeiling,
+            maxOperationDuration: TestBudgets.WedgeCeiling);
         using var cancellation = new CancellationTokenSource();
         // TaskCompletionSource<bool> rather than the non-generic one, which only exists from .NET 5 and
         // this project also compiles for net472.

--- a/Jint.Tests/Runtime/AsyncTests.cs
+++ b/Jint.Tests/Runtime/AsyncTests.cs
@@ -965,7 +965,17 @@ public class AsyncTests
     public Task ShouldTaskAwaitCurrentStack() => DedicatedThread.RunAsync(() =>
     {
         //https://github.com/sebastienros/jint/issues/514#issuecomment-1507127509
-        Engine engine = new(options => options.ExperimentalFeatures = ExperimentalFeature.TaskInterop);
+
+        // What is asserted is the order the three appends landed in, never a duration, so the promise budget
+        // here is a wedge ceiling rather than part of the claim. The delays below add up to about 1.1 s of
+        // intended work, which the engine's ten-second default was sized for on an idle machine and not on a
+        // two-core runner whose pool grows at a worker per 500 ms: sebastienros/jint#3358 saw exactly this
+        // body fail on net472 with "Timeout of 00:00:10 reached", which says nothing about awaiting a stack.
+        Engine engine = new(options =>
+        {
+            options.ExperimentalFeatures = ExperimentalFeature.TaskInterop;
+            options.Constraints.PromiseTimeout = TestBudgets.WedgeCeiling;
+        });
         AsyncTestClass asyncTestClass = new();
 
         engine.SetValue("myAsyncMethod", new Func<Task>(async () =>
@@ -1284,7 +1294,11 @@ public class AsyncTests
     public Task ShouldValueTaskAwaitCurrentStack() => DedicatedThread.RunAsync(() =>
     {
         //https://github.com/sebastienros/jint/issues/514#issuecomment-1507127509
-        Engine engine = new();
+
+        // The ValueTask twin of ShouldTaskAwaitCurrentStack, and a wedge ceiling for the same reason: the
+        // assertion is the order, and a second of intended work inside a ten-second default is not a margin
+        // a two-core runner respects.
+        Engine engine = new(options => options.Constraints.PromiseTimeout = TestBudgets.WedgeCeiling);
         string log = "";
         engine.SetValue("myAsyncMethod", new Func<ValueTask>(async () =>
         {
@@ -1308,7 +1322,7 @@ public class AsyncTests
         Engine engine = new(options =>
         {
             options.ExperimentalFeatures = ExperimentalFeature.TaskInterop;
-            options.Constraints.PromiseTimeout = TimeSpan.FromMinutes(2);
+            options.Constraints.PromiseTimeout = TestBudgets.WedgeCeiling;
         });
         engine.SetValue("asyncTestClass", new AsyncTestClass());
         var result = engine.Evaluate("asyncTestClass.ReturnDelayedValueTaskAsync().then(x=>x)");

--- a/Jint.Tests/Runtime/PromiseTests.cs
+++ b/Jint.Tests/Runtime/PromiseTests.cs
@@ -704,10 +704,17 @@ return Promise.all(promiseArray);") // Returning and array through Promise.any()
         var engine = new Engine();
         var ioStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
+        // The IO ends when this test says so, never on an interval. `await Task.Delay(100)` used to stand in
+        // for it, which made the "still pending" assertion below a race the test could lose: on a loaded
+        // runner the hundred milliseconds can be gone before this thread is scheduled again, and a completed
+        // unwrap then reads as the defect this test exists to catch. A gate the test holds cannot complete
+        // early, so "in flight" is a fact rather than a hope.
+        var releaseIO = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
         engine.SetValue("simulateIO", new Func<Task<int>>(async () =>
         {
             ioStarted.TrySetResult(true);
-            await Task.Delay(100);
+            await releaseIO.Task.ConfigureAwait(false);
             return 99;
         }));
 
@@ -721,6 +728,8 @@ return Promise.all(promiseArray);") // Returning and array through Promise.any()
 
         // The unwrap task should still be pending while IO is in flight
         unwrapTask.IsCompleted.Should().BeFalse("UnwrapIfPromiseAsync should not block; task should still be pending during IO");
+
+        releaseIO.SetResult(true);
 
         var result = await unwrapTask;
         result.AsInteger().Should().Be(99);

--- a/Jint.Tests/Runtime/WaitForScheduledWorkTests.cs
+++ b/Jint.Tests/Runtime/WaitForScheduledWorkTests.cs
@@ -22,6 +22,16 @@ namespace Jint.Tests.Runtime;
 /// the far smaller bound an early return has to beat, and a failure means the wake did not happen at all
 /// rather than that it happened slowly.
 /// </para>
+/// <para>
+/// Two rules keep that true on a runner that is not idle, and both matter because #3301 was a healthy wake
+/// missing its discriminator by eleven milliseconds. First, a stopwatch is started by <em>the thread that
+/// releases the wait, immediately before it releases it</em>, so what is measured is the wake latency alone
+/// and never the scheduling of the releasing thread, its settle sleep, or the script that got the waiter
+/// there. Second, nothing here is released by a thread-pool timer: <c>CancellationTokenSource.CancelAfter</c>
+/// runs its callback on the pool, and a saturated pool grows at roughly one worker per 500 ms, so a timer is
+/// the one release whose latency the test cannot bound. Every release below comes from a
+/// <see cref="DedicatedThread"/> the test owns.
+/// </para>
 /// </remarks>
 public class WaitForScheduledWorkTests
 {
@@ -31,18 +41,26 @@ public class WaitForScheduledWorkTests
     /// <summary>
     /// What a wait under test is given. Nothing should ever spend it: it is the bound a broken wake runs into.
     /// </summary>
-    private static readonly TimeSpan Ceiling = TimeSpan.FromSeconds(10);
+    /// <remarks>
+    /// A minute rather than the ten seconds this was through #3301. The absolute number is what a loaded
+    /// runner crosses — a healthy 250 ms wake was measured at 5.011 s against a 5 s midpoint — while the
+    /// <em>ratio</em> is what the assertion is about, so moving both together is what widens the margin
+    /// without weakening anything. The cost is paid only by a genuine regression, which now takes a minute to
+    /// be reported instead of ten seconds.
+    /// </remarks>
+    private static readonly TimeSpan Ceiling = TimeSpan.FromSeconds(60);
 
     /// <summary>
-    /// The margin an early return has to beat. Half the ceiling, so the assertion separates "woke" from "ran
-    /// out the ceiling" and says nothing at all about latency.
+    /// The margin an early return has to beat. Half the ceiling — derived from it rather than written out
+    /// again, so the two cannot drift — which is what makes the assertion separate "woke" from "ran out the
+    /// ceiling" while saying nothing at all about latency.
     /// </summary>
-    private static readonly TimeSpan EarlyReturnMargin = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan EarlyReturnMargin = TimeSpan.FromTicks(Ceiling.Ticks / 2);
 
     /// <summary>
     /// Reached only by a genuine wedge — every handshake below is released by a thread the test owns.
     /// </summary>
-    private static readonly TimeSpan WedgeCeiling = TimeSpan.FromMinutes(2);
+    private static readonly TimeSpan WedgeCeiling = TestBudgets.WedgeCeiling;
 
     /// <summary>
     /// An engine with nothing queued and nothing scheduled has nothing to report, so the wait spends its whole
@@ -88,14 +106,18 @@ public class WaitForScheduledWorkTests
         using var engine = new Engine();
         using var waiterAboutToPark = new ManualResetEventSlim();
 
+        // Started by the producer immediately before the enqueue, so it measures the wake and nothing else —
+        // not this thread reaching the wait, not the producer being scheduled, not the settle sleep.
+        var elapsed = new Stopwatch();
+
         var producer = DedicatedThread.RunAsync(() =>
         {
             waiterAboutToPark.Wait(WedgeCeiling);
-            SettleBeforeEnqueueing();
+            SettleBeforeReleasingTheWait();
+            elapsed.Start();
             engine.AddToEventLoop(static () => { });
         });
 
-        var elapsed = Stopwatch.StartNew();
         waiterAboutToPark.Set();
         engine.Tasks.WaitForScheduledWork(Ceiling).Should().BeTrue();
         elapsed.Elapsed.Should().BeLessThan(EarlyReturnMargin);
@@ -107,8 +129,23 @@ public class WaitForScheduledWorkTests
     /// The token ends the wait, whether it was already cancelled when the wait started or fired while it was
     /// parked, and either way the engine is handed back usable.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The elapsed assertion is <b>not</b> redundant beside the <see cref="OperationCanceledException"/>, and
+    /// #3301 exists because deleting it is the tempting simplification: a wait that never looked at the token
+    /// and ran out its whole ceiling still ends up throwing on the way out, since the token is cancelled by
+    /// then. Separating "observed the token" from "noticed it at the end" is the whole claim, and only a clock
+    /// can make it.
+    /// </para>
+    /// <para>
+    /// So the clock stays and the two things it used to conflate are pulled apart instead. The cancel comes
+    /// from a thread the test owns rather than from <c>CancelAfter</c>, whose callback a saturated thread pool
+    /// delivers whenever it gets round to it; and the stopwatch starts on that thread immediately before the
+    /// cancel, so the only interval measured is the one being asserted about.
+    /// </para>
+    /// </remarks>
     [Fact]
-    public void ThrowsOperationCanceledOnTheToken()
+    public async Task ThrowsOperationCanceledOnTheToken()
     {
         using var engine = new Engine();
 
@@ -118,12 +155,23 @@ public class WaitForScheduledWorkTests
             .Should().Throw<OperationCanceledException>();
 
         using var cancelledWhileParked = new CancellationTokenSource();
-        cancelledWhileParked.CancelAfter(SettleInterval);
+        using var waiterAboutToPark = new ManualResetEventSlim();
+        var elapsed = new Stopwatch();
 
-        var elapsed = Stopwatch.StartNew();
+        var canceller = DedicatedThread.RunAsync(() =>
+        {
+            waiterAboutToPark.Wait(WedgeCeiling);
+            SettleBeforeReleasingTheWait();
+            elapsed.Start();
+            cancelledWhileParked.Cancel();
+        });
+
+        waiterAboutToPark.Set();
         Invoking(() => engine.Tasks.WaitForScheduledWork(Ceiling, cancelledWhileParked.Token))
             .Should().Throw<OperationCanceledException>();
         elapsed.Elapsed.Should().BeLessThan(EarlyReturnMargin);
+
+        await canceller;
 
         engine.Evaluate("1 + 1").AsNumber().Should().Be(2);
     }
@@ -248,14 +296,15 @@ public class WaitForScheduledWorkTests
         using var engine = new Engine();
 
         using var waiterAboutToPark = new ManualResetEventSlim();
+        var elapsed = new Stopwatch();
         var producer = DedicatedThread.RunAsync(() =>
         {
             waiterAboutToPark.Wait(WedgeCeiling);
-            SettleBeforeEnqueueing();
+            SettleBeforeReleasingTheWait();
+            elapsed.Start();
             engine.AddToEventLoop(static () => { });
         });
 
-        var elapsed = Stopwatch.StartNew();
         waiterAboutToPark.Set();
         (await engine.Tasks.WaitForScheduledWorkAsync(Ceiling)).Should().BeTrue();
         elapsed.Elapsed.Should().BeLessThan(EarlyReturnMargin);
@@ -264,24 +313,25 @@ public class WaitForScheduledWorkTests
     }
 
     /// <summary>
-    /// How long a producer lets the waiter settle after being told it is about to park.
+    /// How long a releasing thread lets the waiter settle after being told it is about to park.
     /// </summary>
     private static readonly TimeSpan SettleInterval = TimeSpan.FromMilliseconds(250);
 
     /// <summary>
-    /// Lets the waiter reach its park before the enqueue lands.
+    /// Lets the waiter reach its park before the release — an enqueue, or a cancel — lands.
     /// </summary>
     /// <remarks>
-    /// Not a poll, and not something an assertion rides on: <b>both</b> interleavings pass — an enqueue that
+    /// Not a poll, and not something an assertion rides on: <b>both</b> interleavings pass — a release that
     /// beats the wait is seen by the pre-check, and one that does not exercises the wake — so this only decides
     /// which of the two mechanisms the run measures. The waiter's next instruction after the signal is the
     /// interlocked claim inside the wait, so a quarter of a second is not a race anything can realistically
     /// lose; and if it did, the run would still be green, merely testing the weaker of the two paths. The
     /// engine cannot offer a signal here — it does not run script while it waits — and probing its ownership
     /// from this thread would have to <em>take</em> ownership, which is the one thing that could make the
-    /// waiter fail.
+    /// waiter fail. It is also why nothing measures this interval: the stopwatch each caller starts is started
+    /// <em>after</em> the sleep, immediately before the release it is timing.
     /// </remarks>
-    private static void SettleBeforeEnqueueing() => Thread.Sleep(SettleInterval);
+    private static void SettleBeforeReleasingTheWait() => Thread.Sleep(SettleInterval);
 
     /// <summary>
     /// Waits until <paramref name="running"/> is provably parked inside <c>block()</c>. Ends on the signal, on


### PR DESCRIPTION
Across a full day of v5 campaign work, **every single CI failure was environmental** — not one was a real
regression from the twenty-two pull requests that merged. The cost is not the re-run. It is that a genuine
regression now arrives looking exactly like the noise, and gets waved through.

This is the mechanism behind the repeat offenders. Nothing here deletes an assertion, and nothing here raises
a number until it stops failing. #3301 states the trap explicitly and it applies to all of them: a wait that
ignored its token and ran out its whole ceiling would still throw `OperationCanceledException`, so deleting
the elapsed check would let a real defect pass. Each row below is instead given a clock it can trust, a
handshake that removes the clock, or a margin expressed as a ratio to the ceiling it discriminates against.

## What changed, per test

### The stopwatch is started by the thread that releases the wait

`Jint.Tests/Runtime/WaitForScheduledWorkTests.cs`, `Jint.Tests.PublicInterface/HostPumpWaitTests.cs`

`WaitForScheduledWorkTests.ThrowsOperationCanceledOnTheToken` (#3301) missed its discriminator by 11 ms;
`HostPumpWaitTests.WaitForScheduledWorkWakesOnACrossThreadPost` reported 12 s against a 10 s ceiling it never
actually spent. Both were measuring far more than the wake: the clock started before the releasing thread had
even been scheduled, and ran through its quarter-second settle sleep.

It now starts **on that thread, immediately before the release**, so the only interval measured is the wake
latency — which is the thing the assertion is about. The property survives exactly: a wait that noticed the
release only when its ceiling ran out still fails, because that interval is measured from the release.

The cancellation row also stops releasing through `CancellationTokenSource.CancelAfter`. That callback is
delivered by the thread pool, and a saturated pool grows at roughly one worker per 500 ms, so it is the one
release whose latency the test cannot bound — a healthy 250 ms cancellation was measured at 5.011 s against a
5 s midpoint. It is now cancelled from a `DedicatedThread` the test owns, the same shape the enqueue rows
already used.

`Ceiling` moves from ten seconds to a minute in both files, with `EarlyReturnMargin` **derived** from it as a
half rather than written out again. #3301 asked for exactly this: the ratio is what the assertion is about,
so moving both together widens the margin without weakening it. A healthy run spends none of the ceiling; only
a genuine regression pays the extra fifty seconds before being reported.

### The witness that needs no clock is asserted first

`Jint.Tests.PublicInterface/HostPromiseTimeoutTests.cs`

`AnExplicitTimeoutStillWinsOverTheConfiguredOne` failed with *"Expected elapsed to be less than 5s, but found
1m 3s"* — a 200 ms wait, stalled by a factor of three hundred.

`UnwrapIfPromiseCore` resolves the effective timeout into one local, hands that local to the drain, and formats
the same local into the rejection message. The message is therefore a **witness of which budget the wait
actually ran under**, not a restatement of the configuration: a wait that consulted the wrong budget cannot
name the right one. That is asserted first, by a named helper.

The elapsed check stays as the other half of the claim — that the wait *ended* on the budget it names rather
than sitting out the longer one it should have ignored — but its bound is now **half of whatever the wrong
answer would have spent** instead of a fixed five seconds. For the explicit row the wrong answer is the
configured five minutes, so the midpoint moves to 2 m 30 s and a three-hundred-fold stall no longer reaches it.
For the argument-less row the wrong answer is the ten-second default, which this test cannot change, so its
midpoint stays at five seconds — that is the one residual, and it is now a deliberate, documented consequence
of the rule rather than a magic constant.

### The simulated IO ends when the test says so

`Jint.Tests/Runtime/PromiseTests.cs`

`UnwrapIfPromiseAsync_WithIOBoundTask_DoesNotBlockCallerThread` asserted that the unwrap task is still pending
while IO is in flight — with the IO being `await Task.Delay(100)`. On a loaded runner the hundred milliseconds
can be gone before the test thread is scheduled again, and a completed unwrap then reads as exactly the defect
the test exists to catch.

It now ends on a `TaskCompletionSource` the test holds. "In flight" becomes a fact rather than a hope, and the
assertion gets *stronger*: the unwrap task provably cannot have completed.

### Wedge ceilings on budgets nothing asserts

`TestBudgets.WedgeCeiling` already exists for this, and documents the distinction it turns on: a budget is
either part of what a test asserts, or it is a ceiling that exists only so a wedge is reported instead of a
hang. Five rows were sitting on budgets of the second kind, sized for an idle machine.

- `HostStreamBridgeTests.ReadsAStreamWhoseReadsCompleteOnAnotherThread` — every chunk arrives as a thread-pool
  continuation, and the whole copy was failing as `PromiseRejectedException: Timeout of 00:00:10 reached`. The
  assertion is the text that came out of the stream.
- `AsyncTests.ShouldTaskAwaitCurrentStack` (#3358, seen on net472) and its `ValueTask` twin
  `ShouldValueTaskAwaitCurrentStack` — about 1.1 s of intended work inside the ten-second default. The
  assertion is the order the three appends landed in.
- `UntrustedCodeProfileTests.OperationScopeCannotEndWhileAsyncWorkOwnsTheEngine` — the profile's five-second
  timeout interval and ten-second operation deadline are budgets an embedder sizes for their own work. The
  assertion is that a scope refuses to end while an evaluation is suspended, and ends once it resumes.
- `ConstraintReplacementTests.TheLaterTimeoutIsTheOneEnforced` — the discriminator is the one-millisecond
  interval that must no longer be registered, which two hundred thousand iterations pass by four orders of
  magnitude on any machine. The widened interval was never a duration the test is about; thirty seconds was a
  wedge ceiling sized for an idle box.
- `Jint.Tests.CommonScripts` — the fixture is `[Parallelizable(ParallelScope.All)]`, so twenty-eight CPU-bound
  real-world workloads share whatever cores the runner has, and a Windows leg was observed taking 7 m 19 s for
  the twenty-eight against ~20 s unloaded, with `RegexMatchTimeoutException` as the only symptom. Nothing here
  asserts anything about `RegexTimeout`. It stays finite deliberately — `Regex.InfiniteMatchTimeout` would turn
  a genuinely catastrophic pattern into a hung run.

## Evidence

A clean run on an idle box proves nothing here, so: a 32-core machine saturated with CPU-bound spinner
processes, the affected tests run in a loop on both `net10.0` and `net472`, before and after, same load and
same iteration count each time. "Before" is `upstream/main`'s copy of the nine files, built in the same tree.

| load | build | Jint.Tests net10.0 | Jint.Tests net472 | PublicInterface net10.0 | PublicInterface net472 | total |
| --- | --- | --- | --- | --- | --- | --- |
| 64 spinners (2×), 20 iterations | before | 20/20 | 20/20 | **19/20** | 20/20 | **79/80** |
| 64 spinners (2×), 20 iterations | after | 20/20 | 20/20 | 20/20 | 20/20 | **80/80** |
| 128 spinners (4×), 15 iterations | before | **13/15** | 15/15 | **14/15** | 15/15 | **57/60** |
| 128 spinners (4×), 15 iterations | after | 15/15 | 15/15 | 15/15 | 15/15 | **60/60** |

**136/140 before, 140/140 after.** All four baseline failures are named in this pull request, and both are
reproductions of the reported symptom rather than something new:

- `PromiseTests.UnwrapIfPromiseAsync_WithIOBoundTask_DoesNotBlockCallerThread` — twice, at 128 spinners:
  *"Expected unwrapTask.IsCompleted to be False … but found True"*. This is the `Task.Delay(100)` race,
  reproduced exactly.
- `UntrustedCodeProfileTests.OperationScopeCannotEndWhileAsyncWorkOwnsTheEngine` — once at each load:
  `PromiseRejectedException: Timeout of 00:00:00.1000000 reached`, the profile's 100 ms promise budget.

The remaining rows did not fire in 140 attempts, which is expected — #3301's own failure was one occurrence
on a shared runner and it took six CI attempts on one pull request to establish the last one of these. Their
change is reasoned from the mechanism rather than from a reproduction, and the reasoning is stated per row
above.

## #3358's third item is a different mechanism, and is not here

`html/webappapis/timers/negative-settimeout.any.js` was listed in #3358 with the issue's own caveat that it
should not be assumed to be a budget until someone looked. It was looked at, and it is neither a budget nor a
timer-ordering defect: the engine's clamp and ordering are deterministic and correct, and the driver simply
has no completion boundary for uncaught-callback reports while draining the event loop twice more after the
file is over. Upstream `testharness.js` has an explicit guard for exactly this. It is a WPT-driver change with
its own shim-symmetry tests and a worker-lane question to settle, so it is filed separately as #3366 — with
the full trace, upstream's guard quoted at the corpus pin, and the minimal fix — rather than folded in here.

## One more flake found on the way, also filed rather than folded in

`TypeConverterRegistrationTests.AnEngineWithACustomConverterSharesTheStockAccessorCache` fails about one run
in three on the `net472` leg under `JINT_HOST_CONTRACT_VERIFICATION=1`, and never when its class is run alone.
It is not a budget either: `JsAccessibleRegistry.Generation` is a process-wide counter and
`TypeResolver.SyncGeneratedMembers` drops the *whole* accessor cache when it moves, so any of the four
`RegisterAll()` calls elsewhere in the same two assemblies landing between that test's two engines makes its
`calls.Should().Be(0)` see a re-resolution. Filed with the mechanism and a fix direction as #3368.

## Notes

- No public surface is touched: nine test files and nothing under `Jint/`. `PublicApiTest` and
  `PublicApiDocumentationTest` both pass unchanged, and `UndocumentedPublicApi.txt` is untouched.
- `Jint.Tests.Test262` was not run: no engine code changed.
- `dotnet build -c Release` clean. `Jint.Tests` 7316/10668/10668 (net472/net8.0/net10.0),
  `Jint.Tests.PublicInterface` 2964/2339 (net10.0/net472), `Jint.Tests.CommonScripts` 28/28 on both — and the
  same two suites again with `JINT_HOST_CONTRACT_VERIFICATION=1`, whose only failure was #3368 above.

Fixes #3358.
Fixes #3301.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014W5mbjGhyvgAS4pivXoc4S
