### PR TITLE
Verification: a value built for an engine another thread is using is a violation, and now it says so

### DIFF
--- a/Jint.Tests.PublicInterface/HostStackGuardThreadHopTests.cs
+++ b/Jint.Tests.PublicInterface/HostStackGuardThreadHopTests.cs
@@ -1,0 +1,196 @@
+#nullable enable
+
+using System.Collections.Generic;
+using Jint.Constraints;
+using Jint.Native;
+using Jint.Native.Json;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// <see cref="Options.ConstraintOptions.MaxExecutionStackCount"/> selects a lane that continues a deep call
+/// chain on a fresh thread-pool thread while the calling thread blocks. These pin that the hop is invisible
+/// to the host: engine ownership travels with it, so a host callback reached across it may re-enter the
+/// engine, and the memory-limit segment is charged on whichever thread is actually allocating.
+/// <para>
+/// Every test here runs on a deliberately small stack and asserts that the hop <em>happened</em> — that some
+/// engine work ran on a thread other than the one that entered. Without that assertion a machine with a
+/// roomier stack would pass them all without ever crossing the boundary they are about.
+/// </para>
+/// </summary>
+public class HostStackGuardThreadHopTests
+{
+    /// <summary>Smaller than the platform default, so the recursion below reliably crosses the hop.</summary>
+    private const int SmallStack = 1024 * 1024;
+
+    /// <summary>Deeper than a 1 MB stack holds, so the lane hops rather than throwing.</summary>
+    private const int DeepEnoughToHop = 2000;
+
+    /// <summary>High enough never to fire; this suite is about the hop, not about the limit.</summary>
+    private const int UnreachedStackCount = 1_000_000;
+
+    private const string RecurseThenProbe =
+        "function recurse(n) { return n === 0 ? probe(n) : recurse(n - 1) + 0; }";
+
+    [Fact]
+    public void AHostCallbackReachedAcrossTheHopCanReEnterTheEngine()
+    {
+        DedicatedThread.Run(
+            () =>
+            {
+                var engine = new Engine(options => options.Constraints.MaxExecutionStackCount = UnreachedStackCount);
+                var entryThread = Environment.CurrentManagedThreadId;
+                var probeThreads = new List<int>();
+                var failures = new List<string>();
+
+                engine.SetValue("probe", new Func<int, int>(depth =>
+                {
+                    probeThreads.Add(Environment.CurrentManagedThreadId);
+                    try
+                    {
+                        engine.Evaluate("1 + 1");
+                        JsValue.FromObject(engine, new { a = 1 });
+                        new JsonParser(engine).Parse("{\"a\":1}");
+                    }
+                    catch (Exception exception)
+                    {
+                        failures.Add($"{exception.GetType().Name}: {exception.Message}");
+                    }
+
+                    return depth;
+                }));
+
+                engine.Execute(RecurseThenProbe);
+                engine.Evaluate("recurse(0)");
+                engine.Evaluate($"recurse({DeepEnoughToHop})");
+
+                probeThreads.Should().HaveCount(2);
+                probeThreads[0].Should().Be(entryThread, "a shallow call never leaves the entry thread");
+                probeThreads[1].Should().NotBe(
+                    entryThread,
+                    "the deep call has to actually cross the guard's thread hop, or this test pins nothing");
+                failures.Should().BeEmpty("the host is single-threaded and the engine is running its script");
+            },
+            maxStackSize: SmallStack);
+    }
+
+    [Fact]
+    public void AMemoryLimitedScriptSurvivesTheHopWithNoHostCallbackAtAll()
+    {
+        DedicatedThread.Run(
+            () =>
+            {
+                var engine = new Engine(options =>
+                {
+                    options.Constraints.MaxExecutionStackCount = UnreachedStackCount;
+                    options.LimitMemory(200_000_000);
+                });
+
+                engine.Execute("function recurse(n) { return n === 0 ? 0 : recurse(n - 1) + 0; }");
+                engine.Evaluate("recurse(0)").AsNumber().Should().Be(0);
+                engine.Evaluate($"recurse({DeepEnoughToHop})").AsNumber().Should().Be(0);
+            },
+            maxStackSize: SmallStack);
+    }
+
+    [Fact]
+    public void TheMemoryOperationIsChargedOnBothSidesOfTheHop()
+    {
+        DedicatedThread.Run(
+            () =>
+            {
+                var engine = new Engine(options =>
+                {
+                    options.Constraints.MaxExecutionStackCount = UnreachedStackCount;
+                    options.LimitMemory(200_000_000);
+                });
+
+                var entryThread = Environment.CurrentManagedThreadId;
+                var probeThread = 0;
+                long observed = -1;
+                string? failure = null;
+
+                engine.SetValue("probe", new Func<int, int>(depth =>
+                {
+                    probeThread = Environment.CurrentManagedThreadId;
+                    try
+                    {
+                        observed = engine.Constraints.Find<MemoryLimitConstraint>()!.AllocatedBytes;
+                    }
+                    catch (Exception exception)
+                    {
+                        failure = $"{exception.GetType().Name}: {exception.Message}";
+                    }
+
+                    return depth;
+                }));
+
+                engine.Execute(RecurseThenProbe);
+                engine.Evaluate($"recurse({DeepEnoughToHop})");
+
+                probeThread.Should().NotBe(entryThread, "the probe has to run on the far side of the hop");
+                failure.Should().BeNull();
+                observed.Should().BePositive(
+                    "the allocations the recursion made before the hop are still charged to this operation");
+            },
+            maxStackSize: SmallStack);
+    }
+
+    [Fact]
+    public void AnUnrelatedThreadIsStillRefusedWhileTheHopHoldsTheEngine()
+    {
+        DedicatedThread.Run(
+            () =>
+            {
+                var engine = new Engine(options => options.Constraints.MaxExecutionStackCount = UnreachedStackCount);
+                var entryThread = Environment.CurrentManagedThreadId;
+                var probeThread = 0;
+                string? outcome = null;
+
+                using var insideTheHop = new ManualResetEventSlim(false);
+                using var unrelatedThreadAnswered = new ManualResetEventSlim(false);
+
+                engine.SetValue("probe", new Func<int, int>(depth =>
+                {
+                    probeThread = Environment.CurrentManagedThreadId;
+                    insideTheHop.Set();
+                    unrelatedThreadAnswered.Wait(TestBudgets.WedgeCeiling);
+                    return depth;
+                }));
+
+                var unrelated = new Thread(() =>
+                {
+                    insideTheHop.Wait(TestBudgets.WedgeCeiling);
+                    try
+                    {
+                        engine.Evaluate("1 + 1");
+                        outcome = "admitted";
+                    }
+                    catch (InvalidOperationException)
+                    {
+                        outcome = "refused";
+                    }
+                    catch (Exception exception)
+                    {
+                        outcome = exception.GetType().Name;
+                    }
+
+                    unrelatedThreadAnswered.Set();
+                })
+                {
+                    IsBackground = true,
+                };
+
+                unrelated.Start();
+                engine.Execute(RecurseThenProbe);
+                engine.Evaluate($"recurse({DeepEnoughToHop})");
+                unrelated.Join(TestBudgets.WedgeCeiling);
+
+                probeThread.Should().NotBe(entryThread, "the probe has to run on the far side of the hop");
+                outcome.Should().Be(
+                    "refused",
+                    "the hop transfers ownership rather than releasing it, so the engine is still in use");
+            },
+            maxStackSize: SmallStack);
+    }
+}

--- a/Jint.Tests.PublicInterface/HostValueConstructionThreadTests.cs
+++ b/Jint.Tests.PublicInterface/HostValueConstructionThreadTests.cs
@@ -1,0 +1,185 @@
+#nullable enable
+
+using System.Collections.Generic;
+using Jint.Native;
+using Jint.Native.Json;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// Jint guards <em>operations</em> against concurrent use and does not guard <em>value construction</em>.
+/// These pin where that line is: which public APIs taking an <see cref="Engine"/> refuse a second thread and
+/// which build the value anyway, and that turning host-contract verification on catches the second kind
+/// without an always-on check on a bulk path.
+/// </summary>
+public class HostValueConstructionThreadTests
+{
+    private static readonly JsObjectLayout Layout = new("id", "name");
+
+    /// <summary>
+    /// Runs <paramref name="build"/> on a second thread while the engine is inside a host call on this one,
+    /// and reports what happened. The rendezvous is a two-way handshake rather than a sleep: the host call
+    /// signals that it is running, the second thread answers, and only then does the host call return.
+    /// </summary>
+    private static string OutcomeOnASecondThread(Action<Engine> build)
+    {
+        var engine = new Engine();
+        var outcome = "the second thread never ran";
+
+        using var insideTheHostCall = new ManualResetEventSlim(false);
+        using var secondThreadAnswered = new ManualResetEventSlim(false);
+
+        engine.SetValue("block", new Action(() =>
+        {
+            insideTheHostCall.Set();
+            secondThreadAnswered.Wait(TestBudgets.WedgeCeiling);
+        }));
+
+        var second = new Thread(() =>
+        {
+            insideTheHostCall.Wait(TestBudgets.WedgeCeiling);
+            try
+            {
+                build(engine);
+                outcome = "built";
+            }
+            catch (Exception exception)
+            {
+                outcome = exception.GetType().Name;
+            }
+
+            secondThreadAnswered.Set();
+        })
+        {
+            IsBackground = true,
+        };
+
+        second.Start();
+        engine.Evaluate("block()");
+        second.Join(TestBudgets.WedgeCeiling);
+        return outcome;
+    }
+
+    private static Action<Engine> Builder(string api) => api switch
+    {
+        "JsArray" => static engine => _ = new JsArray(engine, 4),
+        "JsObject.Create" => static engine => _ = JsObject.Create(engine, Layout, new JsValue?[] { 1, "a" }),
+        "JsObject.CreateFromEntries" => static engine => _ = JsObject.CreateFromEntries(
+            engine,
+            new[] { new KeyValuePair<string, JsValue>("a", 1) }),
+        _ => throw new ArgumentOutOfRangeException(nameof(api), api, "unknown construction API"),
+    };
+
+    [Theory]
+    [InlineData("JsArray")]
+    [InlineData("JsObject.Create")]
+    [InlineData("JsObject.CreateFromEntries")]
+    public void ConstructionIsOutsideTheConcurrencyGuardAndVerificationIsWhatCatchesIt(string api)
+    {
+        var outcome = OutcomeOnASecondThread(Builder(api));
+
+        if (HostContractVerificationSwitch.Enabled)
+        {
+            outcome.Should().Be(
+                "InvalidOperationException",
+                "host-contract verification is where this class of violation is reported");
+        }
+        else
+        {
+            outcome.Should().Be(
+                "built",
+                "construction takes no reservation, which is the line this test exists to write down");
+        }
+    }
+
+    [Theory]
+    [InlineData("Engine.Evaluate")]
+    [InlineData("JsValue.FromObject")]
+    [InlineData("JsonSerializer.Serialize")]
+    [InlineData("JsonParser.Parse")]
+    public void TheseEntriesRefuseASecondThreadWhicheverWayVerificationIsSet(string api)
+    {
+        Action<Engine> enter = api switch
+        {
+            "Engine.Evaluate" => static engine => engine.Evaluate("1 + 1"),
+            "JsValue.FromObject" => static engine => JsValue.FromObject(engine, new { a = 1 }),
+            "JsonSerializer.Serialize" => static engine => new JsonSerializer(engine).Serialize(JsValue.Null),
+            "JsonParser.Parse" => static engine => new JsonParser(engine).Parse("{\"a\":1}"),
+            _ => throw new ArgumentOutOfRangeException(nameof(api), api, "unknown entry"),
+        };
+
+        OutcomeOnASecondThread(enter).Should().Be("InvalidOperationException");
+    }
+
+    [Fact]
+    public void TheVerifierNamesTheTypeThatWasBuilt()
+    {
+        Assert.SkipUnless(HostContractVerificationSwitch.Enabled, "host-contract verification is off");
+
+        var engine = new Engine();
+        Exception? captured = null;
+
+        using var insideTheHostCall = new ManualResetEventSlim(false);
+        using var secondThreadAnswered = new ManualResetEventSlim(false);
+
+        engine.SetValue("block", new Action(() =>
+        {
+            insideTheHostCall.Set();
+            secondThreadAnswered.Wait(TestBudgets.WedgeCeiling);
+        }));
+
+        var second = new Thread(() =>
+        {
+            insideTheHostCall.Wait(TestBudgets.WedgeCeiling);
+            captured = Record.Exception(() => new JsArray(engine, 4));
+            secondThreadAnswered.Set();
+        })
+        {
+            IsBackground = true,
+        };
+
+        second.Start();
+        engine.Evaluate("block()");
+        second.Join(TestBudgets.WedgeCeiling);
+
+        captured.Should().BeOfType<InvalidOperationException>();
+        captured!.Message.Should().Contain("JsArray").And.Contain("was using that engine");
+    }
+
+    [Fact]
+    public void AnIdleEngineAcceptsAValueBuiltOnAnyThread()
+    {
+        var engine = new Engine();
+        JsValue? built = null;
+        Exception? captured = null;
+
+        var other = new Thread(() => captured = Record.Exception(
+            () => built = JsObject.CreateFromEntries(engine, new[] { new KeyValuePair<string, JsValue>("a", 1) })))
+        {
+            IsBackground = true,
+        };
+
+        other.Start();
+        other.Join(TestBudgets.WedgeCeiling);
+
+        captured.Should().BeNull("a host building a value between turns is the legitimate case");
+        engine.SetValue("row", built!);
+        engine.Evaluate("row.a").AsNumber().Should().Be(1);
+    }
+
+    [Fact]
+    public void TheOwningThreadMayBuildValuesFromInsideAHostCallback()
+    {
+        var engine = new Engine();
+        Exception? captured = null;
+
+        engine.SetValue("build", new Action(() => captured = Record.Exception(() =>
+        {
+            _ = new JsArray(engine, 4);
+            _ = JsObject.Create(engine, Layout, new JsValue?[] { 1, "a" });
+        })));
+
+        engine.Evaluate("build()");
+        captured.Should().BeNull("the thread inside the engine is the thread that may build for it");
+    }
+}

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -344,6 +344,117 @@ public sealed partial class Engine : IDisposable
         return true;
     }
 
+    /// <summary>
+    /// The engine state that has to travel with <see cref="Runtime.CallStack.StackGuard"/>'s thread hop:
+    /// which thread owns the engine, and where the memory-limit segment currently being charged left off.
+    /// </summary>
+    [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Auto)]
+    internal readonly record struct StackGuardHandoff(
+        int OwnerThreadId,
+        MemoryLimitConstraint.OperationState? MemoryState,
+        MemoryLimitConstraint.SegmentToken SuspendedSegment,
+        bool HasSuspendedSegment);
+
+    /// <summary>
+    /// Hands this evaluation over to the thread <see cref="Runtime.CallStack.StackGuard"/> is about to
+    /// continue it on, and is called on the thread that will then block for the whole of that hop.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is a transfer rather than a release: <see cref="_ownerThreadId"/> is never written back to zero,
+    /// so a third thread reaching a public entry during the hop is refused exactly as it was before the hop
+    /// started. The operation is still in progress; only the thread running it changed.
+    /// </para>
+    /// <para>
+    /// <see cref="_ownerDepth"/>, <see cref="_ownerToken"/> and <see cref="_hostEntryDepth"/> deliberately do
+    /// not travel, because they do not change: the hop continues one entry rather than starting another, so
+    /// a callback authorized under the outer frame still matches and the outer run's constraints still apply.
+    /// </para>
+    /// <para>
+    /// The memory-limit segment does travel, and has to: it is charged from the runtime's per-thread
+    /// allocation counter, so a segment opened here and accumulated over there would either mis-bill one
+    /// thread's allocations to another or trip the constraint's own changed-thread guard.
+    /// </para>
+    /// </remarks>
+    internal StackGuardHandoff BeginStackGuardHandoff()
+    {
+        MemoryLimitConstraint.OperationState? memoryState = null;
+        MemoryLimitConstraint.SegmentToken suspendedSegment = default;
+        var hasSuspendedSegment = _memoryLimitConstraint?.TrySuspendActiveSegment(
+            out memoryState,
+            out suspendedSegment) == true;
+
+        return new StackGuardHandoff(
+            Volatile.Read(ref _ownerThreadId),
+            memoryState,
+            suspendedSegment,
+            hasSuspendedSegment);
+    }
+
+    /// <summary>
+    /// Claims the engine on the thread <see cref="Runtime.CallStack.StackGuard"/> continued the evaluation
+    /// on, for as long as the returned scope is alive.
+    /// </summary>
+    internal StackGuardClaim ClaimStackGuardHandoff(in StackGuardHandoff handoff)
+    {
+        Volatile.Write(ref _ownerThreadId, System.Environment.CurrentManagedThreadId);
+        if (!handoff.HasSuspendedSegment)
+        {
+            return new StackGuardClaim(this, default, hasMemorySegment: false);
+        }
+
+        var segment = _memoryLimitConstraint!.BeginSegment(handoff.MemoryState);
+        return new StackGuardClaim(this, segment, hasMemorySegment: true);
+    }
+
+    /// <summary>
+    /// Takes the evaluation back once <see cref="Runtime.CallStack.StackGuard"/>'s hop has finished, on the
+    /// thread that blocked for it.
+    /// </summary>
+    /// <remarks>
+    /// Ownership is restored here rather than in <see cref="StackGuardClaim"/>'s disposal so that a hop which
+    /// failed before it could claim, or after it claimed and before it released, still leaves
+    /// <see cref="_ownerThreadId"/> naming the thread that is about to resume. Nothing can observe the gap:
+    /// the only other thread that could is this one, and it is inside this call.
+    /// </remarks>
+    internal void EndStackGuardHandoff(in StackGuardHandoff handoff)
+    {
+        Volatile.Write(ref _ownerThreadId, handoff.OwnerThreadId);
+        if (handoff.HasSuspendedSegment)
+        {
+            var suspendedSegment = handoff.SuspendedSegment;
+            _memoryLimitConstraint!.EndSegment(in suspendedSegment);
+        }
+    }
+
+    /// <summary>
+    /// One thread's turn at a <see cref="StackGuardHandoff"/>, released when the hop's continuation returns.
+    /// </summary>
+    internal readonly struct StackGuardClaim : IDisposable
+    {
+        private readonly Engine _engine;
+        private readonly MemoryLimitConstraint.SegmentToken _memorySegment;
+        private readonly bool _hasMemorySegment;
+
+        internal StackGuardClaim(
+            Engine engine,
+            MemoryLimitConstraint.SegmentToken memorySegment,
+            bool hasMemorySegment)
+        {
+            _engine = engine;
+            _memorySegment = memorySegment;
+            _hasMemorySegment = hasMemorySegment;
+        }
+
+        public void Dispose()
+        {
+            if (_hasMemorySegment)
+            {
+                _engine._memoryLimitConstraint!.EndSegment(in _memorySegment);
+            }
+        }
+    }
+
     private void AcquireHostCall(int threadId)
     {
         var spinWait = new SpinWait();

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -186,6 +186,46 @@ public sealed partial class Engine : IDisposable
     internal HostCallScope EnterHostCallback()
         => EnterHostCall();
 
+    /// <summary>
+    /// The host-contract verifier for <b>thread affinity</b>: reports engine-affine state built on a thread
+    /// while a <em>different</em> thread is inside this engine.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Jint guards <em>operations</em> against concurrent use and does not guard <em>value construction</em>:
+    /// <see cref="Native.JsObject.Create(Engine, Native.JsObjectLayout, ReadOnlySpan{JsValue})"/>,
+    /// <see cref="Native.JsObject.CreateFromEntries(Engine, ReadOnlySpan{KeyValuePair{string, JsValue}})"/>
+    /// and the <see cref="Native.JsArray"/> constructors are per-object APIs on a bulk path, and an always-on
+    /// <see cref="EnterHostCall"/> there would be paid by every host that never got this wrong. This check is
+    /// where that line is enforced instead — folded out entirely in a process that never set the switch, and
+    /// exact in one that did.
+    /// </para>
+    /// <para>
+    /// It is deliberately the narrowest question that has no false positives: <em>another thread owns this
+    /// engine right now, and it is not me</em>. An idle engine answers no, because a host building values
+    /// between turns is the legitimate case this must never flag. A reserved-but-unclaimed engine — an
+    /// outstanding <c>*Async</c> operation between continuations — answers no for the same reason: there is
+    /// no thread to name, so there is nothing to report that is not a guess.
+    /// </para>
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    internal void VerifyValueConstructedOnOwningThread(Type constructedType)
+    {
+        var owner = Volatile.Read(ref _ownerThreadId);
+        var current = System.Environment.CurrentManagedThreadId;
+        if (owner == 0 || owner == current)
+        {
+            return;
+        }
+
+        HostContractVerification.Fail(
+            $"{constructedType} was built for an Engine on managed thread {current} while managed thread {owner} "
+            + "was using that engine. Value construction is outside the concurrency guard that rejects a "
+            + "concurrent Evaluate or Invoke, so nothing refused this and the object is now sharing an engine "
+            + "and a realm with another thread's work. Build the value on the thread that owns the engine, or "
+            + "while no thread does.");
+    }
+
     internal HostCallScope EnterTransferredHostCallback(object? expectedAuthorization)
     {
         if (expectedAuthorization is not HostCallbackAuthorization authorization)

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -80,6 +80,14 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
         InternalTypes type = InternalTypes.Object)
         : base(type)
     {
+        if (HostContractVerification.Enabled)
+        {
+            // Every engine-affine object begins here, whichever public API built it, so this is the one
+            // place the thread-affinity check has to be. GetType() in a base constructor is the
+            // most-derived runtime type, which is what names the object a host would go looking for.
+            engine.VerifyValueConstructedOnOwningThread(GetType());
+        }
+
         _engine = engine;
         _class = objectClass;
         // if engine is ready, we can take default prototype for object

--- a/Jint/Runtime/CallStack/StackGuard.cs
+++ b/Jint/Runtime/CallStack/StackGuard.cs
@@ -124,16 +124,46 @@ internal sealed class StackGuard
         return false;
     }
 
-    public static TR RunOnEmptyStack<T1, TR>(Func<T1, TR> action, T1 arg1)
+    /// <summary>
+    /// Continues the evaluation on a fresh thread-pool thread, with the calling thread blocked for the whole
+    /// of it, and hands engine ownership over for the duration.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The hand-over is what makes the hop invisible to a host. Without it <c>Engine._ownerThreadId</c> goes
+    /// on naming the thread parked below, so every public entry made from the continuation — a host callback
+    /// calling <c>Evaluate</c>, <c>JsValue.FromObject</c>, <c>JsonParser.Parse</c>, or the memory
+    /// constraint's own <c>Check</c> — took the wrong-owner path and threw
+    /// <see cref="InvalidOperationException"/> on a single-threaded host running single-threaded script
+    /// (sebastienros/jint#3343).
+    /// </para>
+    /// <para>
+    /// It is a transfer and not a release: ownership is never handed back to nobody, so a genuinely
+    /// unrelated thread reaching a public entry mid-hop is refused exactly as it was before the hop started.
+    /// </para>
+    /// </remarks>
+    public TR RunOnEmptyStack<T1, TR>(Func<T1, TR> action, T1 arg1)
     {
-        // ValueTuple rather than Tuple, so the state box is one allocation of a struct rather than a
-        // reference type. Every target framework carries it: net472 has it in mscorlib (it arrived in
-        // .NET Framework 4.7), and the netstandard targets get it from the reference assemblies.
-        return RunOnEmptyStackCore(static s =>
+        var engine = _engine;
+        var handoff = engine.BeginStackGuardHandoff();
+        try
         {
-            var t = ((Func<T1, TR>, T1)) s;
-            return t.Item1(t.Item2);
-        }, (action, arg1));
+            // ValueTuple rather than Tuple, so the state box is one allocation of a struct rather than a
+            // reference type. Every target framework carries it: net472 has it in mscorlib (it arrived in
+            // .NET Framework 4.7), and the netstandard targets get it from the reference assemblies.
+            return RunOnEmptyStackCore(static s =>
+            {
+                var t = ((Engine, Engine.StackGuardHandoff, Func<T1, TR>, T1)) s;
+                using (t.Item1.ClaimStackGuardHandoff(in t.Item2))
+                {
+                    return t.Item3(t.Item4);
+                }
+            }, (engine, handoff, action, arg1));
+        }
+        finally
+        {
+            engine.EndStackGuardHandoff(in handoff);
+        }
     }
 
     private static R RunOnEmptyStackCore<R>(Func<object, R> action, object state)

--- a/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
@@ -121,7 +121,7 @@ internal sealed class JintCallExpression : JintExpression
 
         if (!context.Engine._stackGuard.TryEnterOnCurrentStack())
         {
-            return StackGuard.RunOnEmptyStack(EvaluateInternal, context);
+            return context.Engine._stackGuard.RunOnEmptyStack(EvaluateInternal, context);
         }
 
         if (_calleeIsSuper)

--- a/README.md
+++ b/README.md
@@ -2193,10 +2193,13 @@ receiver gets no own-property inline caching — every own read reaches your `Ge
   named-projection hooks against each other — `HasName` and `NameAt` against `TryGetNamedValue`, a
   `writable: true` name against having a `TrySetNamedValue` override to accept it (and the reverse), and a
   `TryDeleteName` that answered `true` for a name still readable — a `LazyJsString`'s declared
-  length against the text it eventually produces, and an
+  length against the text it eventually produces, an
   `ObjectConverter` registered with `AddObjectConverter(converter, handledTypes)` converting a type it did not
-  declare. Turn it on in a test or staging host, never in production: the checks deliberately redo the work the
-  hooks exist to avoid. A Debug build of Jint has them on already and needs no switch.
+  declare, and — the one check that is about your *threading* rather than your property model — an
+  engine-affine object built on one thread while a different thread is inside that engine, which is the
+  violation the `Engine` entry-point check cannot see (see **Thread-safety**). Turn it on in a test or staging
+  host, never in production: the checks deliberately redo the work the hooks exist to avoid. A Debug build of
+  Jint has them on already and needs no switch.
 
 **Lazy values.** `PropertyFlag.CustomJsValue` is the supported hook for a property whose value is *computed on
 every read*: a `PropertyDescriptor` subclass overriding `CustomValue` keeps working under the read inline
@@ -2543,6 +2546,21 @@ engine to the pool. Direct mutation through engine-owned objects such as `engine
 the same contract and cannot be guarded by the `Engine` entry-point check. `Dispose` also fails fast while
 an operation owns the engine; await or finish that operation before disposing. This is observable during
 exception unwinding too, so a `using` scope must not outlive an async engine operation.
+
+**The fail-fast check guards operations, not value construction, and that line is drawn deliberately.** The
+APIs that *build* a value for an engine — `JsObject.Create`, `JsObject.CreateFromEntries` and the `JsArray`
+constructors, the ones **Projecting host data** above recommends — take no reservation. They are per-object
+APIs on a bulk path, and an always-on claim there would be paid by every host that projects a batch of rows.
+Building one of them on a second thread while another thread is inside the engine is therefore the host's own
+responsibility, and it does not fail where it is built: an engine-affine object built during another thread's
+work fails later, somewhere else, as a torn shape table or a lost property. **Host-contract verification is
+how you find one** — turn the switch on in a test or staging host (see **Projecting host data**) and the
+construction throws, naming the type, instead of succeeding quietly. `JsValue.FromObject` is on the guarded
+side, but because it can run host converters and reference resolvers, not because construction generally is.
+
+The rule that follows from the two paragraphs together: build values for an engine on the thread that owns
+it, or while no thread does. An idle engine accepts construction from any thread, which is what makes
+preparing values between turns — and pooling engines — work.
 
 ## Examples
 

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -1494,6 +1494,7 @@ none of it changes an engine that does not.
 | The three shipped locale-data providers are extensible — one datum is one override | derive from `DefaultCldrProvider` / `DefaultTimeZoneProvider` / `DefaultCalendarProvider` and assign the instance to the matching `Options` property | [5.2](#52-changing-one-locale-datum-is-one-override) |
 | Writable named projections, and named members on an `ArrayLikeObject` | `IsNameWritable` / `TrySetNamedValue` / `TryDeleteName`, and the same `NameCount` / `NameAt` / `TryGetNamedValue` triple on both classes | [§5.3](#53-host-objects-one-hook-set-for-named-properties-3338) |
 | `HostFunction` — one base class for a host-defined callable, the function sibling of `ArrayLikeObject` and `NamedPropertyObject` | derive from it and override `Invoke` | [§5.5](#55-a-host-function-is-a-class-you-can-derive-3345) |
+| Host-contract verification catches a value built for an engine another thread is using | `AppContext.SetSwitch("Jint.EnableHostContractVerification", true)` | [§5.6](#56-host-contract-verification-also-checks-thread-affinity-3332) |
 | `LazyJsString` — one base class for a host string whose text is expensive to produce | `class Field : LazyJsString { public Field(int len) : base(len) {} protected override string Materialize() => … }` | [Lazy strings](../README.md#embedding-performance) |
 
 The last row is the only one that replaces an existing spelling rather than adding a capability, so it is
@@ -1765,6 +1766,34 @@ Four things decided deliberately:
 
 Reach for `ClrFunction` when the body is a lambda, and for `HostFunction` when the callable has state,
 wants a name a stack trace can show, or belongs to a family that shares a base.
+
+### 5.6 Host-contract verification also checks thread affinity ([#3332](https://github.com/sebastienros/jint/issues/3332))
+
+Jint guards *operations* against concurrent use and does not guard *value construction*. `Engine.Evaluate`,
+`JsValue.FromObject`, `JsonSerializer.Serialize` and `JsonParser.Parse` all reject a second thread while the
+engine is in use; `JsObject.Create`, `JsObject.CreateFromEntries` and the `JsArray` constructors — the ones
+README's **Projecting host data** recommends in preference to subclassing `ObjectInstance` — build the value
+anyway. They are per-object APIs on a bulk path, so an always-on claim there would be paid by every host that
+never got this wrong.
+
+That line has not moved, and construction stays as cheap as it was. What is new is that the violation is now
+*visible*: with host-contract verification on, an engine-affine object built on one thread while a different
+thread is inside that engine throws `InvalidOperationException` naming the type, at the point of construction:
+
+```csharp
+// once, before the first use of any Jint type — a [ModuleInitializer] in the test assembly is the usual place
+AppContext.SetSwitch("Jint.EnableHostContractVerification", true);
+```
+
+The check is the narrowest question with no false positives — *another thread owns this engine right now, and
+it is not me*. An **idle** engine answers no, so a host preparing values between turns, or building them
+before handing an engine out of a pool, is never flagged. It costs a production build nothing: the gate is a
+`static readonly bool` read once at type initialization, so the JIT folds the check and the branch out of a
+process that never set the switch.
+
+This is worth turning on precisely because the failure it catches is not local. An object built for an engine
+another thread is using does not fail where it was built; it fails later, somewhere else, as a torn shape
+table or a lost property, and the host sees a nondeterministic script result.
 
 ## 6. AOT and trimming
 

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -1446,6 +1446,37 @@ one, and a `LimitMemory` that had never applied to it now does. A host relying o
 unaccounted — parsing a document larger than its own `LimitMemory` between evaluations — has to raise the
 limit or bracket the parse in a `MemoryLimitConstraint.Begin`/`End` window of its own.
 
+### 4.26 A deep recursion no longer refuses the host that started it ([#3343](https://github.com/sebastienros/jint/issues/3343))
+
+`Options.Constraints.MaxExecutionStackCount` selects a lane that continues a deep call chain on a fresh
+thread-pool thread while the calling thread blocks. That hop did not transfer engine ownership, so
+`Engine._ownerThreadId` went on naming the thread parked below it and every public entry made from the far
+side took the wrong-owner path:
+
+```csharp
+var engine = new Engine(o => o.Constraints.MaxExecutionStackCount = 1_000_000);
+engine.SetValue("probe", new Func<int, int>(d => { engine.Evaluate("1 + 1"); return d; }));
+engine.Execute("function recurse(n) { return n === 0 ? probe(n) : recurse(n - 1) + 0; }");
+
+engine.Evaluate("recurse(10)");    // 4.16.x: fine
+engine.Evaluate("recurse(2000)");  // 4.16.x: InvalidOperationException, "already in use by another thread"
+```
+
+One host thread, one script, no concurrency — the engine refused itself, and the exception escaped the
+callback and killed the evaluation. `JsValue.FromObject`, `JsonParser.Parse` and anything else behind the
+ownership check failed the same way. Combining the setting with `LimitMemory` was worse still: the memory
+constraint checks ownership on every statement, so a *plain* script with no host callback at all died at the
+first hop.
+
+The hop now hands ownership over for its duration and takes it back afterwards, carrying the memory-limit
+segment with it so allocations are charged to the thread that makes them. It is a transfer, not a release: an
+unrelated thread reaching a public entry mid-hop is refused exactly as it was before the hop started.
+
+**What could break:** nothing an embedder configured. A test asserting that the exception is thrown was
+asserting the bug. An engine left at the default `MaxExecutionStackCount` (`-1`) never took this lane and is
+unaffected — `Options.Constraints.StackOverflowGuard`, the default, throws a `RangeError` without hopping
+threads.
+
 ## 5. New in v5
 
 Everything in the table below is opt-in: nothing in it is installed unless the host asks for it, so


### PR DESCRIPTION
Fixes #3332.

Jint guards *operations* against concurrent use and does not guard *value construction*. That is a reasonable line to draw for performance — but it was drawn silently, and the two APIs on the wrong side of it are the two README's **Projecting host data** tells hosts to use.

Measured on `main`, a second thread acting while the engine thread is inside a host call:

| public API taking an `Engine` | before | after, verification **off** | after, verification **on** |
| --- | --- | --- | --- |
| `engine.Evaluate` (control) | `InvalidOperationException` | `InvalidOperationException` | `InvalidOperationException` |
| `JsValue.FromObject` | `InvalidOperationException` | `InvalidOperationException` | `InvalidOperationException` |
| `new JsonSerializer(e).Serialize(v)` | `InvalidOperationException` | `InvalidOperationException` | `InvalidOperationException` |
| `new JsonParser(e).Parse(json)` | `InvalidOperationException` (#3330) | `InvalidOperationException` | `InvalidOperationException` |
| `new JsArray(engine, 4)` | **ran concurrently** | ran concurrently | **`InvalidOperationException`** |
| `JsObject.Create(...)` | **ran concurrently** | ran concurrently | **`InvalidOperationException`** |
| `JsObject.CreateFromEntries(...)` | **ran concurrently** | ran concurrently | **`InvalidOperationException`** |

## Why the verifier and not a guard

The issue's own argument, and I did not find a reason to depart from it. `JsObject.Create` / `CreateFromEntries` and the `JsArray` constructors are **per-object APIs on a bulk path** — a host projecting ten thousand rows calls them ten thousand times. An always-on `EnterHostCall` there would be paid by every host that never got this wrong, to catch a mistake made by a few. `HostContractVerification` exists for exactly this class of problem: a contract the engine trusts, cannot afford to re-check on the hot path, and whose violation is otherwise silent. Its gate is a `static readonly bool` read once at type initialization, so `if (HostContractVerification.Enabled)` and the block it guards are **folded out entirely** in a Release process that never set the switch.

## Where the check went

`ObjectInstance`'s internal constructor — the one both public constructors funnel through, and where every engine-affine object begins, whichever public API built it. That covers `JsObject`, `JsArray`, every intrinsic and every host subclass, rather than a list of factories that a future one could be added beside without noticing.

The check is the narrowest question that has no false positives, which is what the issue specified: *another thread owns this engine right now, and it is not me*.

- An **idle** engine answers no. A host preparing values between turns, and a host building values before handing an engine out of a pool, are the legitimate cases and are never flagged.
- A **reserved-but-unclaimed** engine — an outstanding `*Async` operation between continuations — also answers no, deliberately. There is no thread to name there, so anything it reported would be a guess rather than a violation. `EnterHostCall` refuses that case because it is about to *claim*; this check claims nothing.

The obvious objection to putting anything in that constructor is that it is the hottest allocation site in the engine, and that a larger constructor body could cost an inlining decision even where the branch folds. Measured rather than assumed: `Jint.Tests` `net10.0`, five full runs of each tree against six busy cores, this branch **1 m 32 s – 1 m 41 s** and `main` **1 m 35 s – 1 m 39 s**. No separable difference.

## Blocked on #3361

The verifier's premise is that `_ownerThreadId` names the thread actually inside the engine. Until #3361 (#3343) that was false during `StackGuard`'s thread hop, and the verifier reported Jint's own hop as a host violation in three tests. This PR is stacked on it; with it, the whole suite is clean with verification on.

## Documentation

`README.md`'s **Thread-safety** section now states the line — one paragraph saying that construction APIs taking an `Engine` are the host's own responsibility, that verification is how you find a violation, that `JsValue.FromObject` is guarded because it can run host converters rather than because construction generally is, and the rule that follows: build values on the thread that owns the engine, or while no thread does. The verifier checklist under **Projecting host data** gains the new check, flagged as the one that is about threading rather than the property model.

`docs/v5-migration.md` §5.6 and a row in the §5 opt-in table.

## Tests

`Jint.Tests.PublicInterface/HostValueConstructionThreadTests.cs`, 10 tests. Four fail against a tree without the check, with verification on:

```
Failed ConstructionIsOutsideTheConcurrencyGuardAndVerificationIsWhatCatchesIt(api: "JsArray")
  Expected outcome to be the same string because host-contract verification is where this class of
  violation is reported, but they differ at index 0:
  ↓ (actual)
  "built"
  "InvalidOperationException"
Failed ConstructionIsOutsideTheConcurrencyGuardAndVerificationIsWhatCatchesIt(api: "JsObject.CreateFromEntries")   (same)
Failed ConstructionIsOutsideTheConcurrencyGuardAndVerificationIsWhatCatchesIt(api: "JsObject.Create")             (same)
Failed TheVerifierNamesTheTypeThatWasBuilt
  Expected captured to be System.InvalidOperationException, but found <null>.
Failed!  - Failed: 4, Passed: 6, Skipped: 0, Total: 10
```

They follow this project's established verification pattern — a branch on `HostContractVerificationSwitch.Enabled` rather than a skip — so both legs assert something: with the switch off the tests pin that **construction still takes no reservation**, which is the line itself written down.

**On determinism.** No sleeps. `OutcomeOnASecondThread` is a two-way handshake: a host call signals that the engine is busy, the second thread acts and answers, and only then does the host call return, so the second thread provably acts while the engine is owned. The waits are bounded by `TestBudgets.WedgeCeiling`, which is a wedge ceiling and never an assertion.

The four tests that are *not* about the violation are the ones that keep the check honest: the guarded entries refuse either way, an idle engine accepts construction from any thread (and the object it produced works), and the owning thread may build from inside a host callback.

## Verification

Re-run after rebasing onto #3361 over `main` at `63459e223`:

- `dotnet build -c Release` clean across five target frameworks, `TreatWarningsAsErrors` on.
- `Jint.Tests`: 10,677 / 10,677 / 7,316 passed on `net10.0` / `net8.0` / `net472`, 0 failed.
- `Jint.Tests.PublicInterface`: 2,997 on `net10.0`, 2,368 on `net472`, 0 failed.
- Both again with `JINT_HOST_CONTRACT_VERIFICATION=1`, which is the configuration this PR is about: 10,677 / 10,677 / 7,316 and 3,010 / 2,381, 0 failed — and the new check found nothing anywhere in either suite.
- `Jint.Tests.Test262`: 102,495 passed, 0 failed.
- No public surface change — the verifier method is `internal` — so the five API baselines and the documentation register are untouched.

One note on the suite: `SchedulerTests.AHostsOwnPumpRunsTheTasks` fails roughly one full leg in five, on **pristine `main`** with nothing else in the tree. It is a race in that test's first assertion, unrelated to this change — filed as #3372 with the measurements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014W5mbjGhyvgAS4pivXoc4S
