### PR TITLE
[JsAccessible]: a decline points at a syntax tree, so .editorconfig can promote it

### DIFF
--- a/Jint.SourceGenerators.Interop/Jint.SourceGenerators.Interop.csproj
+++ b/Jint.SourceGenerators.Interop/Jint.SourceGenerators.Interop.csproj
@@ -29,11 +29,11 @@
   </ItemGroup>
 
   <!-- Shared with the other generator rather than copied: the incremental pipeline's value equality
-       depends on these types behaving identically in both. DiagnosticInfo is the equatable stand-in for a
-       Diagnostic, which is not equatable and would defeat the pipeline's caching if a model held one. -->
+       depends on this type behaving identically in both. Its DiagnosticInfo is deliberately NOT shared;
+       see the remark on AccessibleDiagnostic for why a location that has no SourceTree cannot be
+       promoted from an .editorconfig. -->
   <ItemGroup>
     <Compile Include="..\Jint.SourceGenerators\EquatableArray.cs" Link="EquatableArray.cs" />
-    <Compile Include="..\Jint.SourceGenerators\DiagnosticInfo.cs" Link="DiagnosticInfo.cs" />
   </ItemGroup>
 
   <!-- Inherited usings from the root Directory.Build.props target Jint runtime types we don't reference. -->

--- a/Jint.SourceGenerators.Interop/JsAccessibleDiagnostics.cs
+++ b/Jint.SourceGenerators.Interop/JsAccessibleDiagnostics.cs
@@ -3,6 +3,49 @@ using Microsoft.CodeAnalysis;
 namespace Jint.SourceGenerators.Interop;
 
 /// <summary>
+/// One reported decline, as the pipeline carries it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is deliberately <b>not</b> <c>Jint.SourceGenerators.DiagnosticInfo</c>, which the other generator
+/// uses. That type rebuilds its location from a file path and a span, through
+/// <c>Location.Create(string, TextSpan, LinePositionSpan)</c> — and the location that produces has no
+/// <c>SourceTree</c>. The compiler resolves an <c>.editorconfig</c> severity <em>per syntax tree</em>, so a
+/// tree-less diagnostic silently skips that lookup and keeps its default severity no matter what the
+/// consumer writes. It cost nothing there, where every descriptor is an error already. Here the whole
+/// point is that a host can promote one, so the real <see cref="Microsoft.CodeAnalysis.Location"/> is
+/// carried instead.
+/// </para>
+/// <para>
+/// A <c>Location</c> is not the value-equatable thing an incremental model wants, which is why
+/// <c>JsAccessibleGenerator</c> keeps the reporting output and the emitting output apart: the emitting one
+/// selects <c>AccessibleTypeDefinition</c>, which carries no location, so an edit that moves a declaration
+/// without changing what is generated still re-uses the cached source.
+/// </para>
+/// </remarks>
+internal sealed record class AccessibleDiagnostic(
+    DiagnosticDescriptor Descriptor,
+    Location? Location,
+    EquatableArray<string> MessageArgs)
+{
+    public AccessibleDiagnostic(DiagnosticDescriptor descriptor, Location? location, params string[] messageArgs)
+        : this(descriptor, location, messageArgs.ToEquatableArray())
+    {
+    }
+
+    public Diagnostic ToDiagnostic()
+    {
+        var args = new object[MessageArgs.Count];
+        for (var i = 0; i < MessageArgs.Count; i++)
+        {
+            args[i] = MessageArgs[i];
+        }
+
+        return Diagnostic.Create(Descriptor, Location, args);
+    }
+}
+
+/// <summary>
 /// What the <c>[JsAccessible]</c> generator could not take, and why. Every one of these says the same
 /// thing about behaviour — the member keeps the reflection path it had before the type was annotated, and
 /// nothing about it changes — so none of them is a defect and none defaults above

--- a/Jint.SourceGenerators.Interop/JsAccessibleGenerator.cs
+++ b/Jint.SourceGenerators.Interop/JsAccessibleGenerator.cs
@@ -32,8 +32,7 @@ public sealed class JsAccessibleGenerator : IIncrementalGenerator
                 JsAccessibleAttributeMetadataName,
                 predicate: static (node, _) => node is TypeDeclarationSyntax,
                 transform: static (ctx, ct) => AccessibleTypeResult.From(ctx, ct))
-            .Where(static result => result is not null)
-            .Collect();
+            .Where(static result => result is not null);
 
         var rootNamespace = context.AnalyzerConfigOptionsProvider
             .Select(static (provider, _) =>
@@ -41,33 +40,24 @@ public sealed class JsAccessibleGenerator : IIncrementalGenerator
             .Combine(context.CompilationProvider.Select(static (compilation, _) => compilation.AssemblyName))
             .Select(static (pair, _) => SanitizeNamespace(pair.Left) ?? SanitizeNamespace(pair.Right) ?? string.Empty);
 
-        context.RegisterSourceOutput(types.Combine(rootNamespace), static (spc, pair) =>
+        // Two outputs, and the split is load-bearing rather than tidy. A reported decline carries a real
+        // Location, because that is the only kind an .editorconfig severity can reach — and a Location is
+        // not a value, so anything holding one re-runs on every edit. Selecting the definitions first, which
+        // carry no location at all, keeps emission on the cached path: an edit that moves an annotated
+        // declaration without changing what is generated re-runs the reporting and nothing else.
+        var definitions = types
+            .Select(static (result, _) => result!.Definition)
+            .Collect()
+            .Combine(rootNamespace);
+
+        context.RegisterSourceOutput(definitions, static (spc, pair) =>
         {
-            var results = Deduplicate(pair.Left!);
-
-            foreach (var result in results)
-            {
-                foreach (var diagnostic in result.Diagnostics)
-                {
-                    spc.ReportDiagnostic(diagnostic);
-                }
-            }
-
-            var definitions = ImmutableArray.CreateBuilder<AccessibleTypeDefinition>(results.Length);
-            foreach (var result in results)
-            {
-                if (result.Definition is not null)
-                {
-                    definitions.Add(result.Definition);
-                }
-            }
-
-            if (definitions.Count == 0)
+            var emitted = DeduplicateDefinitions(pair.Left);
+            if (emitted.Length == 0)
             {
                 return;
             }
 
-            var emitted = definitions.ToImmutable();
             foreach (var definition in emitted)
             {
                 spc.AddSource(definition.HintName, SourceText.From(JsAccessibleEmitter.EmitType(definition), Encoding.UTF8));
@@ -77,14 +67,43 @@ public sealed class JsAccessibleGenerator : IIncrementalGenerator
                 "JsAccessibleRegistration.g.cs",
                 SourceText.From(JsAccessibleEmitter.EmitRegistration(pair.Right, emitted), Encoding.UTF8));
         });
+
+        context.RegisterSourceOutput(types.Collect(), static (spc, results) =>
+        {
+            foreach (var result in DeduplicateResults(results))
+            {
+                foreach (var diagnostic in result.Diagnostics)
+                {
+                    spc.ReportDiagnostic(diagnostic);
+                }
+            }
+        });
     }
 
     /// <summary>
     /// One entry per annotated type, ordered by the path that names it so the emitted registration — and the
     /// order the diagnostics are reported in — is stable whatever order the compilation reported the
-    /// declarations in.
+    /// declarations in. Deduplicating is what makes a <c>partial class</c> carrying the attribute on two of
+    /// its parts produce one file and one set of diagnostics rather than two of each.
     /// </summary>
-    private static ImmutableArray<AccessibleTypeResult> Deduplicate(ImmutableArray<AccessibleTypeResult?> results)
+    private static ImmutableArray<AccessibleTypeDefinition> DeduplicateDefinitions(ImmutableArray<AccessibleTypeDefinition?> definitions)
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var unique = new List<AccessibleTypeDefinition>(definitions.Length);
+        foreach (var definition in definitions)
+        {
+            if (definition is not null && seen.Add(definition.MetadataPath))
+            {
+                unique.Add(definition);
+            }
+        }
+
+        unique.Sort(static (a, b) => string.CompareOrdinal(a.MetadataPath, b.MetadataPath));
+        return unique.ToImmutableArray();
+    }
+
+    /// <inheritdoc cref="DeduplicateDefinitions" />
+    private static ImmutableArray<AccessibleTypeResult> DeduplicateResults(ImmutableArray<AccessibleTypeResult?> results)
     {
         var seen = new HashSet<string>(StringComparer.Ordinal);
         var unique = new List<AccessibleTypeResult>(results.Length);

--- a/Jint.SourceGenerators.Interop/JsAccessibleModels.cs
+++ b/Jint.SourceGenerators.Interop/JsAccessibleModels.cs
@@ -66,7 +66,7 @@ internal sealed record class AccessibleMethod(
 internal sealed record class AccessibleTypeResult(
     string MetadataPath,
     AccessibleTypeDefinition? Definition,
-    EquatableArray<DiagnosticInfo> DiagnosticInfos)
+    EquatableArray<AccessibleDiagnostic> DiagnosticInfos)
 {
     public IEnumerable<Diagnostic> Diagnostics
     {
@@ -90,13 +90,13 @@ internal sealed record class AccessibleTypeResult(
             ? declaration.Identifier.GetLocation()
             : context.TargetNode.GetLocation();
 
-        var diagnostics = new List<DiagnosticInfo>();
+        var diagnostics = new List<AccessibleDiagnostic>();
         var metadataPath = MetadataPathOf(type);
 
         var ineligible = IneligibleTypeReason(type);
         if (ineligible is not null)
         {
-            diagnostics.Add(new DiagnosticInfo(
+            diagnostics.Add(new AccessibleDiagnostic(
                 JsAccessibleDiagnosticDescriptors.TypeCannotBeRegistered,
                 typeLocation,
                 type.Name,
@@ -138,7 +138,7 @@ internal sealed record class AccessibleTypeResult(
 
         if (members.Count == 0 && methods.Count == 0)
         {
-            diagnostics.Add(new DiagnosticInfo(
+            diagnostics.Add(new AccessibleDiagnostic(
                 JsAccessibleDiagnosticDescriptors.TypeRegistersNothing,
                 typeLocation,
                 type.Name));
@@ -247,14 +247,14 @@ internal sealed record class AccessibleTypeResult(
         INamedTypeSymbol type,
         IPropertySymbol property,
         ImmutableArray<AccessibleMember>.Builder members,
-        List<DiagnosticInfo> diagnostics)
+        List<AccessibleDiagnostic> diagnostics)
     {
         // Reported on its own rule: an indexer is not merely a member the generator declines, it is probed
         // ahead of the declared members, so every name it answers for resolves through it whatever the
         // registry holds.
         if (property.IsIndexer)
         {
-            diagnostics.Add(new DiagnosticInfo(
+            diagnostics.Add(new AccessibleDiagnostic(
                 JsAccessibleDiagnosticDescriptors.IndexerIsProbedFirst,
                 LocationOf(property),
                 property.Parameters.Length == 1 ? property.Parameters[0].Type.ToDisplayString() : "…",
@@ -326,7 +326,7 @@ internal sealed record class AccessibleTypeResult(
         INamedTypeSymbol type,
         IFieldSymbol field,
         ImmutableArray<AccessibleMember>.Builder members,
-        List<DiagnosticInfo> diagnostics)
+        List<AccessibleDiagnostic> diagnostics)
     {
         // Three silent declines, and none of them is a difference a host could act on. A backing field is
         // not something they wrote. A static field - and a constant, which is static - is not reported by
@@ -358,7 +358,7 @@ internal sealed record class AccessibleTypeResult(
         INamedTypeSymbol type,
         IMethodSymbol method,
         ImmutableArray<AccessibleMethod>.Builder methods,
-        List<DiagnosticInfo> diagnostics)
+        List<AccessibleDiagnostic> diagnostics)
     {
         // Property accessors, constructors, operators, finalizers and event accessors. Reflection does
         // resolve `get_Score` by name, so declining these is a real difference — but nobody annotated a type
@@ -403,7 +403,7 @@ internal sealed record class AccessibleTypeResult(
         var ambiguity = NameAmbiguityReason(type, method);
         if (ambiguity is not null)
         {
-            diagnostics.Add(new DiagnosticInfo(
+            diagnostics.Add(new AccessibleDiagnostic(
                 JsAccessibleDiagnosticDescriptors.MethodNameIsNotUnique,
                 LocationOf(method),
                 method.Name,
@@ -421,7 +421,7 @@ internal sealed record class AccessibleTypeResult(
             var problem = ParameterProblem(parameter);
             if (problem is not null)
             {
-                diagnostics.Add(new DiagnosticInfo(
+                diagnostics.Add(new AccessibleDiagnostic(
                     JsAccessibleDiagnosticDescriptors.MethodSignatureNotGenerated,
                     parameter.Locations.FirstOrDefault() ?? LocationOf(method),
                     method.Name,
@@ -436,7 +436,7 @@ internal sealed record class AccessibleTypeResult(
             var reason = InexpressibleReason(method.ReturnType);
             if (reason is not null)
             {
-                diagnostics.Add(new DiagnosticInfo(
+                diagnostics.Add(new AccessibleDiagnostic(
                     JsAccessibleDiagnosticDescriptors.MemberTypeCannotBeNamed,
                     LocationOf(method),
                     "Method",
@@ -516,24 +516,24 @@ internal sealed record class AccessibleTypeResult(
 
     /// <summary>JINT032 and JINT033 name the method directly, so their arguments are (name, type, reason).</summary>
     private static void ReportMethod(
-        List<DiagnosticInfo> diagnostics,
+        List<AccessibleDiagnostic> diagnostics,
         DiagnosticDescriptor descriptor,
         IMethodSymbol method,
         INamedTypeSymbol type,
         string reason)
-        => diagnostics.Add(new DiagnosticInfo(descriptor, LocationOf(method), method.Name, type.Name, reason));
+        => diagnostics.Add(new AccessibleDiagnostic(descriptor, LocationOf(method), method.Name, type.Name, reason));
 
     /// <summary>JINT034 and JINT035 cover more than one member kind, so they lead with the kind word.</summary>
     private static void ReportMember(
-        List<DiagnosticInfo> diagnostics,
+        List<AccessibleDiagnostic> diagnostics,
         DiagnosticDescriptor descriptor,
         ISymbol member,
         INamedTypeSymbol type,
         string reason)
-        => diagnostics.Add(new DiagnosticInfo(descriptor, LocationOf(member), KindWordOf(member), member.Name, type.Name, reason));
+        => diagnostics.Add(new AccessibleDiagnostic(descriptor, LocationOf(member), KindWordOf(member), member.Name, type.Name, reason));
 
     private static void ReportInexpressible(
-        List<DiagnosticInfo> diagnostics,
+        List<AccessibleDiagnostic> diagnostics,
         ISymbol member,
         INamedTypeSymbol type,
         ITypeSymbol memberType,
@@ -545,7 +545,7 @@ internal sealed record class AccessibleTypeResult(
             return;
         }
 
-        diagnostics.Add(new DiagnosticInfo(
+        diagnostics.Add(new AccessibleDiagnostic(
             JsAccessibleDiagnosticDescriptors.MemberTypeCannotBeNamed,
             LocationOf(member),
             KindWordOf(member),

--- a/Jint.Tests.SourceGenerators/JsAccessibleGeneratorTests.cs
+++ b/Jint.Tests.SourceGenerators/JsAccessibleGeneratorTests.cs
@@ -2,6 +2,8 @@ using static Jint.Tests.SourceGenerators.VerifyHelper;
 
 namespace Jint.Tests.SourceGenerators;
 
+#pragma warning disable NUnit2045 // the assertions describe one location each, and the first failure names it
+
 #pragma warning disable NUnit1032 // Verify is used as a static helper, not async-disposable infra
 
 /// <summary>
@@ -220,6 +222,63 @@ public class JsAccessibleGeneratorTests
                 public static int Score { get; set; }
             }
             """);
+    }
+
+    /// <summary>
+    /// Every reported decline has to point at a syntax tree the compilation actually holds, because that is
+    /// the one thing an <c>.editorconfig</c> severity depends on: the compiler resolves
+    /// <c>dotnet_diagnostic.JINT03x.severity</c> per tree, and falls back to the global configuration alone
+    /// when <c>Location.SourceTree</c> is <see langword="null"/>. A diagnostic whose location was rebuilt
+    /// from a file path — which is what <c>Location.Create(string, TextSpan, LinePositionSpan)</c> produces,
+    /// and what the sibling generator's <c>DiagnosticInfo</c> does — therefore keeps its default severity
+    /// whatever a host writes, silently. Nothing else in this suite would notice: the snapshots record the
+    /// line and column either way.
+    /// </summary>
+    [Test]
+    public void EveryDiagnosticPointsAtATreeTheCompilationHolds()
+    {
+        var (diagnostics, compilation) = VerifyHelper.RunJsAccessibleGeneratorFor("""
+            using Jint;
+            using Jint.Native;
+
+            namespace Sample;
+
+            [JsAccessible]
+            public sealed class Model
+            {
+                public int Kept { get; set; }
+                public int PrivateSetter { get; private set; }
+                public string Shout(string text) => text;
+                public static int StaticMethod() => 0;
+                public int this[string key] => 0;
+            }
+
+            [JsAccessible]
+            public abstract class Abstract
+            {
+                public int Score { get; set; }
+            }
+
+            [JsAccessible]
+            public sealed class Marker
+            {
+            }
+            """);
+
+        Assert.That(diagnostics, Is.Not.Empty);
+
+        foreach (var diagnostic in diagnostics)
+        {
+            Assert.That(
+                diagnostic.Location.SourceTree,
+                Is.Not.Null,
+                $"{diagnostic.Id} has no source tree, so no .editorconfig severity can reach it");
+
+            Assert.That(
+                compilation.SyntaxTrees,
+                Does.Contain(diagnostic.Location.SourceTree),
+                $"{diagnostic.Id} points at a tree the compilation does not hold");
+        }
     }
 
     [Test]

--- a/Jint.Tests.SourceGenerators/Snapshots/JsAccessibleGeneratorTests.AmbiguousMethodName_ProducesDiagnostic.verified.txt
+++ b/Jint.Tests.SourceGenerators/Snapshots/JsAccessibleGeneratorTests.AmbiguousMethodName_ProducesDiagnostic.verified.txt
@@ -1,7 +1,13 @@
 ﻿{
   Diagnostics: [
     {
-      Location: : (15,19)-(15,29),
+      Location: /*
+
+    public JsValue Overloaded(JsValue value) => value;
+                   ^^^^^^^^^^
+    public JsValue Overloaded(JsValue first, JsValue second) => first;
+*/
+ : (15,19)-(15,29),
       Message: Method 'Overloaded' on 'Model' is reached through reflection: 'Overloaded' is declared more than once on the type or a base type, and choosing between the candidates is what the reflected path exists for,
       Severity: Info,
       WarningLevel: 1,
@@ -15,7 +21,13 @@
       }
     },
     {
-      Location: : (16,19)-(16,29),
+      Location: /*
+    public JsValue Overloaded(JsValue value) => value;
+    public JsValue Overloaded(JsValue first, JsValue second) => first;
+                   ^^^^^^^^^^
+
+*/
+ : (16,19)-(16,29),
       Message: Method 'Overloaded' on 'Model' is reached through reflection: 'Overloaded' is declared more than once on the type or a base type, and choosing between the candidates is what the reflected path exists for,
       Severity: Info,
       WarningLevel: 1,
@@ -29,7 +41,13 @@
       }
     },
     {
-      Location: : (18,27)-(18,35),
+      Location: /*
+
+    public override string ToString() => "";
+                           ^^^^^^^^
+
+*/
+ : (18,27)-(18,35),
       Message: Method 'ToString' on 'Model' is reached through reflection: 'ToString' is declared more than once on the type or a base type, and choosing between the candidates is what the reflected path exists for,
       Severity: Info,
       WarningLevel: 1,
@@ -43,7 +61,13 @@
       }
     },
     {
-      Location: : (20,19)-(20,27),
+      Location: /*
+
+    public JsValue Describe(JsValue prefix) => prefix;
+                   ^^^^^^^^
+}
+*/
+ : (20,19)-(20,27),
       Message: Method 'Describe' on 'Model' is reached through reflection: 'Sample.INamed' also declares 'Describe', which resolves by name to the same accessor,
       Severity: Info,
       WarningLevel: 1,

--- a/Jint.Tests.SourceGenerators/Snapshots/JsAccessibleGeneratorTests.Indexer_ProducesDiagnostic.verified.txt
+++ b/Jint.Tests.SourceGenerators/Snapshots/JsAccessibleGeneratorTests.Indexer_ProducesDiagnostic.verified.txt
@@ -1,7 +1,13 @@
 ﻿{
   Diagnostics: [
     {
-      Location: : (9,18)-(9,22),
+      Location: /*
+
+    public string this[string key]
+                  ^^^^
+    {
+*/
+ : (9,18)-(9,22),
       Message: Indexer 'this[string]' on 'Model' is reached through reflection, and it is probed ahead of the declared members: every name the indexer answers for resolves through it, and the generated lane is not consulted for that name,
       Severity: Info,
       WarningLevel: 1,

--- a/Jint.Tests.SourceGenerators/Snapshots/JsAccessibleGeneratorTests.IneligibleType_ProducesDiagnostic.verified.txt
+++ b/Jint.Tests.SourceGenerators/Snapshots/JsAccessibleGeneratorTests.IneligibleType_ProducesDiagnostic.verified.txt
@@ -1,7 +1,13 @@
 ﻿{
   Diagnostics: [
     {
-      Location: : (5,22)-(5,30),
+      Location: /*
+[JsAccessible]
+public abstract class Abstract
+                      ^^^^^^^^
+{
+*/
+ : (5,22)-(5,30),
       Message: Type 'Abstract' is annotated with [JsAccessible] but cannot be registered, so every member of it is reached through reflection: it is abstract, so it is never the runtime type of a receiver,
       Severity: Info,
       WarningLevel: 1,
@@ -15,7 +21,13 @@
       }
     },
     {
-      Location: : (17,20)-(17,27),
+      Location: /*
+[JsAccessible]
+public sealed class Generic<T>
+                    ^^^^^^^
+{
+*/
+ : (17,20)-(17,27),
       Message: Type 'Generic' is annotated with [JsAccessible] but cannot be registered, so every member of it is reached through reflection: it is a generic type definition, and has no single runtime type to register under,
       Severity: Info,
       WarningLevel: 1,
@@ -29,7 +41,13 @@
       }
     },
     {
-      Location: : (31,25)-(31,31),
+      Location: /*
+    [JsAccessible]
+    private sealed class Hidden
+                         ^^^^^^
+    {
+*/
+ : (31,25)-(31,31),
       Message: Type 'Hidden' is annotated with [JsAccessible] but cannot be registered, so every member of it is reached through reflection: it, or a type containing it, is private or protected, and the generated registration cannot name it,
       Severity: Info,
       WarningLevel: 1,
@@ -43,7 +61,13 @@
       }
     },
     {
-      Location: : (23,21)-(23,29),
+      Location: /*
+[JsAccessible]
+public sealed record Recorded
+                     ^^^^^^^^
+{
+*/
+ : (23,21)-(23,29),
       Message: Type 'Recorded' is annotated with [JsAccessible] but cannot be registered, so every member of it is reached through reflection: it is a record, whose compiler-generated members the generator does not model,
       Severity: Info,
       WarningLevel: 1,
@@ -57,7 +81,13 @@
       }
     },
     {
-      Location: : (11,20)-(11,27),
+      Location: /*
+[JsAccessible]
+public static class Statics
+                    ^^^^^^^
+{
+*/
+ : (11,20)-(11,27),
       Message: Type 'Statics' is annotated with [JsAccessible] but cannot be registered, so every member of it is reached through reflection: it is a static class, so it is never the runtime type of a receiver,
       Severity: Info,
       WarningLevel: 1,

--- a/Jint.Tests.SourceGenerators/Snapshots/JsAccessibleGeneratorTests.MemberDeclaration_ProducesDiagnostic.verified.txt
+++ b/Jint.Tests.SourceGenerators/Snapshots/JsAccessibleGeneratorTests.MemberDeclaration_ProducesDiagnostic.verified.txt
@@ -1,7 +1,13 @@
 ﻿{
   Diagnostics: [
     {
-      Location: : (11,15)-(11,28),
+      Location: /*
+
+    public int PrivateSetter { get; private set; }
+               ^^^^^^^^^^^^^
+    public int PrivateGetter { private get; set; }
+*/
+ : (11,15)-(11,28),
       Message: Property 'PrivateSetter' on 'Model' is reached through reflection: its set accessor is not public, and generated code cannot call it,
       Severity: Info,
       WarningLevel: 1,
@@ -15,7 +21,13 @@
       }
     },
     {
-      Location: : (12,15)-(12,28),
+      Location: /*
+    public int PrivateSetter { get; private set; }
+    public int PrivateGetter { private get; set; }
+               ^^^^^^^^^^^^^
+    public int InitOnly { get; init; }
+*/
+ : (12,15)-(12,28),
       Message: Property 'PrivateGetter' on 'Model' is reached through reflection: its get accessor is not public, and generated code cannot call it,
       Severity: Info,
       WarningLevel: 1,
@@ -29,7 +41,13 @@
       }
     },
     {
-      Location: : (13,15)-(13,23),
+      Location: /*
+    public int PrivateGetter { private get; set; }
+    public int InitOnly { get; init; }
+               ^^^^^^^^
+    public ref int Slot => ref _slot;
+*/
+ : (13,15)-(13,23),
       Message: Property 'InitOnly' on 'Model' is reached through reflection: its setter is 'init', which only an object initializer or reflection can call,
       Severity: Info,
       WarningLevel: 1,
@@ -43,7 +61,13 @@
       }
     },
     {
-      Location: : (14,19)-(14,23),
+      Location: /*
+    public int InitOnly { get; init; }
+    public ref int Slot => ref _slot;
+                   ^^^^
+}
+*/
+ : (14,19)-(14,23),
       Message: Property 'Slot' on 'Model' is reached through reflection: it returns by reference,
       Severity: Info,
       WarningLevel: 1,

--- a/Jint.Tests.SourceGenerators/Snapshots/JsAccessibleGeneratorTests.MemberTypeCannotBeNamed_ProducesDiagnostic.verified.txt
+++ b/Jint.Tests.SourceGenerators/Snapshots/JsAccessibleGeneratorTests.MemberTypeCannotBeNamed_ProducesDiagnostic.verified.txt
@@ -1,7 +1,13 @@
 ﻿{
   Diagnostics: [
     {
-      Location: : (13,18)-(13,26),
+      Location: /*
+
+    public Handle Borrowed => default;
+                  ^^^^^^^^
+    public unsafe int* Address => null;
+*/
+ : (13,18)-(13,26),
       Message: Property 'Borrowed' on 'Model' is reached through reflection: its type 'Sample.Handle' is a ref struct, which generated code cannot box,
       Severity: Info,
       WarningLevel: 1,
@@ -15,7 +21,13 @@
       }
     },
     {
-      Location: : (14,23)-(14,30),
+      Location: /*
+    public Handle Borrowed => default;
+    public unsafe int* Address => null;
+                       ^^^^^^^
+    public Handle Borrow() => default;
+*/
+ : (14,23)-(14,30),
       Message: Property 'Address' on 'Model' is reached through reflection: its type 'int*' is a pointer type, which generated code cannot box,
       Severity: Info,
       WarningLevel: 1,
@@ -29,7 +41,13 @@
       }
     },
     {
-      Location: : (15,18)-(15,24),
+      Location: /*
+    public unsafe int* Address => null;
+    public Handle Borrow() => default;
+                  ^^^^^^
+}
+*/
+ : (15,18)-(15,24),
       Message: Method 'Borrow' on 'Model' is reached through reflection: its return type 'Sample.Handle' is a ref struct, which generated code cannot box,
       Severity: Info,
       WarningLevel: 1,

--- a/Jint.Tests.SourceGenerators/Snapshots/JsAccessibleGeneratorTests.MethodSignature_ProducesDiagnostic.verified.txt
+++ b/Jint.Tests.SourceGenerators/Snapshots/JsAccessibleGeneratorTests.MethodSignature_ProducesDiagnostic.verified.txt
@@ -1,7 +1,13 @@
 ﻿{
   Diagnostics: [
     {
-      Location: : (12,22)-(12,29),
+      Location: /*
+
+    public static int Utility() => 0;
+                      ^^^^^^^
+    public T Generic<T>(JsValue value) => default;
+*/
+ : (12,22)-(12,29),
       Message: Method 'Utility' on 'Model' is reached through reflection: it is static, and the generated read, write and invoke lanes are instance lanes,
       Severity: Info,
       WarningLevel: 1,
@@ -15,7 +21,13 @@
       }
     },
     {
-      Location: : (13,13)-(13,20),
+      Location: /*
+    public static int Utility() => 0;
+    public T Generic<T>(JsValue value) => default;
+             ^^^^^^^
+    public ref int Slot() => ref _slot;
+*/
+ : (13,13)-(13,20),
       Message: Method 'Generic' on 'Model' is reached through reflection: it is generic, and its type arguments are chosen per call,
       Severity: Info,
       WarningLevel: 1,
@@ -29,7 +41,13 @@
       }
     },
     {
-      Location: : (14,19)-(14,23),
+      Location: /*
+    public T Generic<T>(JsValue value) => default;
+    public ref int Slot() => ref _slot;
+                   ^^^^
+    public JsValue Coerced(string text) => text;
+*/
+ : (14,19)-(14,23),
       Message: Method 'Slot' on 'Model' is reached through reflection: it returns by reference,
       Severity: Info,
       WarningLevel: 1,
@@ -43,7 +61,13 @@
       }
     },
     {
-      Location: : (15,34)-(15,38),
+      Location: /*
+    public ref int Slot() => ref _slot;
+    public JsValue Coerced(string text) => text;
+                                  ^^^^
+    public JsValue Defaulted(JsValue value, JsValue other = null) => value;
+*/
+ : (15,34)-(15,38),
       Message: Method 'Coerced' on 'Model' is reached through reflection: parameter 'text' is typed 'string' rather than JsValue, so its reflected binding is a conversion chain steered by engine options,
       Severity: Info,
       WarningLevel: 1,
@@ -57,7 +81,13 @@
       }
     },
     {
-      Location: : (16,52)-(16,57),
+      Location: /*
+    public JsValue Coerced(string text) => text;
+    public JsValue Defaulted(JsValue value, JsValue other = null) => value;
+                                                    ^^^^^
+    public JsValue Spread(params JsValue[] values) => values[0];
+*/
+ : (16,52)-(16,57),
       Message: Method 'Defaulted' on 'Model' is reached through reflection: parameter 'other' is optional, and its default is applied by the reflected binder,
       Severity: Info,
       WarningLevel: 1,
@@ -71,7 +101,13 @@
       }
     },
     {
-      Location: : (17,43)-(17,49),
+      Location: /*
+    public JsValue Defaulted(JsValue value, JsValue other = null) => value;
+    public JsValue Spread(params JsValue[] values) => values[0];
+                                           ^^^^^^
+    public JsValue ByRef(ref JsValue value) => value;
+*/
+ : (17,43)-(17,49),
       Message: Method 'Spread' on 'Model' is reached through reflection: parameter 'values' is a params parameter, whose reflected binding spreads the remaining arguments,
       Severity: Info,
       WarningLevel: 1,
@@ -85,7 +121,13 @@
       }
     },
     {
-      Location: : (18,37)-(18,42),
+      Location: /*
+    public JsValue Spread(params JsValue[] values) => values[0];
+    public JsValue ByRef(ref JsValue value) => value;
+                                     ^^^^^
+}
+*/
+ : (18,37)-(18,42),
       Message: Method 'ByRef' on 'Model' is reached through reflection: parameter 'value' is passed by reference,
       Severity: Info,
       WarningLevel: 1,

--- a/Jint.Tests.SourceGenerators/Snapshots/JsAccessibleGeneratorTests.ShapesTheGeneratorDeclines.verified.txt
+++ b/Jint.Tests.SourceGenerators/Snapshots/JsAccessibleGeneratorTests.ShapesTheGeneratorDeclines.verified.txt
@@ -1,7 +1,13 @@
 ﻿{
   Diagnostics: [
     {
-      Location: : (12,15)-(12,28),
+      Location: /*
+    // reflection writes a non-public accessor; generated code cannot
+    public int PrivateSetter { get; private set; }
+               ^^^^^^^^^^^^^
+    public int PrivateGetter { private get; set; }
+*/
+ : (12,15)-(12,28),
       Message: Property 'PrivateSetter' on 'Model' is reached through reflection: its set accessor is not public, and generated code cannot call it,
       Severity: Info,
       WarningLevel: 1,
@@ -15,7 +21,13 @@
       }
     },
     {
-      Location: : (13,15)-(13,28),
+      Location: /*
+    public int PrivateSetter { get; private set; }
+    public int PrivateGetter { private get; set; }
+               ^^^^^^^^^^^^^
+    public int InitOnly { get; init; }
+*/
+ : (13,15)-(13,28),
       Message: Property 'PrivateGetter' on 'Model' is reached through reflection: its get accessor is not public, and generated code cannot call it,
       Severity: Info,
       WarningLevel: 1,
@@ -29,7 +41,13 @@
       }
     },
     {
-      Location: : (14,15)-(14,23),
+      Location: /*
+    public int PrivateGetter { private get; set; }
+    public int InitOnly { get; init; }
+               ^^^^^^^^
+
+*/
+ : (14,15)-(14,23),
       Message: Property 'InitOnly' on 'Model' is reached through reflection: its setter is 'init', which only an object initializer or reflection can call,
       Severity: Info,
       WarningLevel: 1,
@@ -43,7 +61,13 @@
       }
     },
     {
-      Location: : (17,15)-(17,25),
+      Location: /*
+    // resolved by MethodInfoFunction's overload scoring
+    public int Overloaded(int value) => value;
+               ^^^^^^^^^^
+    public int Overloaded(int first, int second) => first + second;
+*/
+ : (17,15)-(17,25),
       Message: Method 'Overloaded' on 'Model' is reached through reflection: 'Overloaded' is declared more than once on the type or a base type, and choosing between the candidates is what the reflected path exists for,
       Severity: Info,
       WarningLevel: 1,
@@ -57,7 +81,13 @@
       }
     },
     {
-      Location: : (18,15)-(18,25),
+      Location: /*
+    public int Overloaded(int value) => value;
+    public int Overloaded(int first, int second) => first + second;
+               ^^^^^^^^^^
+
+*/
+ : (18,15)-(18,25),
       Message: Method 'Overloaded' on 'Model' is reached through reflection: 'Overloaded' is declared more than once on the type or a base type, and choosing between the candidates is what the reflected path exists for,
       Severity: Info,
       WarningLevel: 1,
@@ -71,7 +101,13 @@
       }
     },
     {
-      Location: : (21,31)-(21,35),
+      Location: /*
+    // a parameter whose reflected binding is a conversion steered by engine options
+    public string Shout(string text) => text;
+                               ^^^^
+    public int Optional(JsValue value, JsValue other = null) => 0;
+*/
+ : (21,31)-(21,35),
       Message: Method 'Shout' on 'Model' is reached through reflection: parameter 'text' is typed 'string' rather than JsValue, so its reflected binding is a conversion chain steered by engine options,
       Severity: Info,
       WarningLevel: 1,
@@ -85,7 +121,13 @@
       }
     },
     {
-      Location: : (22,47)-(22,52),
+      Location: /*
+    public string Shout(string text) => text;
+    public int Optional(JsValue value, JsValue other = null) => 0;
+                                               ^^^^^
+    public int Params(params JsValue[] values) => 0;
+*/
+ : (22,47)-(22,52),
       Message: Method 'Optional' on 'Model' is reached through reflection: parameter 'other' is optional, and its default is applied by the reflected binder,
       Severity: Info,
       WarningLevel: 1,
@@ -99,7 +141,13 @@
       }
     },
     {
-      Location: : (23,39)-(23,45),
+      Location: /*
+    public int Optional(JsValue value, JsValue other = null) => 0;
+    public int Params(params JsValue[] values) => 0;
+                                       ^^^^^^
+    public T Generic<T>(JsValue value) => default;
+*/
+ : (23,39)-(23,45),
       Message: Method 'Params' on 'Model' is reached through reflection: parameter 'values' is a params parameter, whose reflected binding spreads the remaining arguments,
       Severity: Info,
       WarningLevel: 1,
@@ -113,7 +161,13 @@
       }
     },
     {
-      Location: : (24,13)-(24,20),
+      Location: /*
+    public int Params(params JsValue[] values) => 0;
+    public T Generic<T>(JsValue value) => default;
+             ^^^^^^^
+
+*/
+ : (24,13)-(24,20),
       Message: Method 'Generic' on 'Model' is reached through reflection: it is generic, and its type arguments are chosen per call,
       Severity: Info,
       WarningLevel: 1,
@@ -127,7 +181,13 @@
       }
     },
     {
-      Location: : (28,22)-(28,34),
+      Location: /*
+    public static int Static { get; set; }
+    public static int StaticMethod() => 0;
+                      ^^^^^^^^^^^^
+
+*/
+ : (28,22)-(28,34),
       Message: Method 'StaticMethod' on 'Model' is reached through reflection: it is static, and the generated read, write and invoke lanes are instance lanes,
       Severity: Info,
       WarningLevel: 1,
@@ -141,7 +201,13 @@
       }
     },
     {
-      Location: : (31,15)-(31,19),
+      Location: /*
+    // an indexer is served by IndexerAccessor
+    public int this[int index] => index;
+               ^^^^
+
+*/
+ : (31,15)-(31,19),
       Message: Indexer 'this[int]' on 'Model' is reached through reflection, and it is probed ahead of the declared members: every name the indexer answers for resolves through it, and the generated lane is not consulted for that name,
       Severity: Info,
       WarningLevel: 1,

--- a/Jint.Tests.SourceGenerators/Snapshots/JsAccessibleGeneratorTests.TypeRegistersNothing_ProducesDiagnostic.verified.txt
+++ b/Jint.Tests.SourceGenerators/Snapshots/JsAccessibleGeneratorTests.TypeRegistersNothing_ProducesDiagnostic.verified.txt
@@ -1,7 +1,13 @@
 ﻿{
   Diagnostics: [
     {
-      Location: : (5,20)-(5,26),
+      Location: /*
+[JsAccessible]
+public sealed class Marker
+                    ^^^^^^
+{
+*/
+ : (5,20)-(5,26),
       Message: Type 'Marker' is annotated with [JsAccessible] but no member of it can be generated, so the annotation registers nothing and every member is reached through reflection,
       Severity: Info,
       WarningLevel: 1,
@@ -15,7 +21,13 @@
       }
     },
     {
-      Location: : (10,20)-(10,31),
+      Location: /*
+[JsAccessible]
+public sealed class OnlyStatics
+                    ^^^^^^^^^^^
+{
+*/
+ : (10,20)-(10,31),
       Message: Type 'OnlyStatics' is annotated with [JsAccessible] but no member of it can be generated, so the annotation registers nothing and every member is reached through reflection,
       Severity: Info,
       WarningLevel: 1,

--- a/Jint.Tests.SourceGenerators/Snapshots/JsAccessibleGeneratorTests.TypesTheGeneratorDeclinesEntirely.verified.txt
+++ b/Jint.Tests.SourceGenerators/Snapshots/JsAccessibleGeneratorTests.TypesTheGeneratorDeclinesEntirely.verified.txt
@@ -1,7 +1,13 @@
 ﻿{
   Diagnostics: [
     {
-      Location: : (5,22)-(5,30),
+      Location: /*
+[JsAccessible]
+public abstract class Abstract
+                      ^^^^^^^^
+{
+*/
+ : (5,22)-(5,30),
       Message: Type 'Abstract' is annotated with [JsAccessible] but cannot be registered, so every member of it is reached through reflection: it is abstract, so it is never the runtime type of a receiver,
       Severity: Info,
       WarningLevel: 1,
@@ -15,7 +21,13 @@
       }
     },
     {
-      Location: : (11,20)-(11,27),
+      Location: /*
+[JsAccessible]
+public sealed class Generic<T>
+                    ^^^^^^^
+{
+*/
+ : (11,20)-(11,27),
       Message: Type 'Generic' is annotated with [JsAccessible] but cannot be registered, so every member of it is reached through reflection: it is a generic type definition, and has no single runtime type to register under,
       Severity: Info,
       WarningLevel: 1,
@@ -29,7 +41,13 @@
       }
     },
     {
-      Location: : (17,20)-(17,40),
+      Location: /*
+[JsAccessible]
+public sealed class NoExpressibleMembers
+                    ^^^^^^^^^^^^^^^^^^^^
+{
+*/
+ : (17,20)-(17,40),
       Message: Type 'NoExpressibleMembers' is annotated with [JsAccessible] but no member of it can be generated, so the annotation registers nothing and every member is reached through reflection,
       Severity: Info,
       WarningLevel: 1,

--- a/Jint.Tests.SourceGenerators/VerifyHelper.cs
+++ b/Jint.Tests.SourceGenerators/VerifyHelper.cs
@@ -26,28 +26,39 @@ internal static class VerifyHelper
     public static Task VerifyJsAccessibleGenerator(string[] sources, [System.Runtime.CompilerServices.CallerFilePath] string sourceFile = "")
         => Run(new Jint.SourceGenerators.Interop.JsAccessibleGenerator(), sources, sourceFile);
 
-    private static Task Run(IIncrementalGenerator generator, string[] sources, string sourceFile)
+    /// <summary>
+    /// The <c>[JsAccessible]</c> generator's diagnostics for one source, beside the compilation they were
+    /// reported against — which is the pair the tree-location invariant is about.
+    /// </summary>
+    public static (IReadOnlyList<Diagnostic> Diagnostics, Compilation Compilation) RunJsAccessibleGeneratorFor(string source)
     {
-        var parseOptions = new CSharpParseOptions(LanguageVersion.Latest);
+        var compilation = Compile([source], LanguageVersion.Latest);
+        var result = Drive(new Jint.SourceGenerators.Interop.JsAccessibleGenerator(), compilation).GetRunResult();
+        return (result.Diagnostics, compilation);
+    }
+
+    private static Task Run(IIncrementalGenerator generator, string[] sources, string sourceFile)
+        => Verifier
+            .Verify(Drive(generator, Compile(sources, LanguageVersion.Latest)), sourceFile: sourceFile)
+            .UseDirectory("Snapshots");
+
+    private static GeneratorDriver Drive(IIncrementalGenerator generator, Compilation compilation)
+        => CSharpGeneratorDriver.Create(generator).RunGenerators(compilation);
+
+    private static CSharpCompilation Compile(string[] sources, LanguageVersion languageVersion)
+    {
+        var parseOptions = new CSharpParseOptions(languageVersion);
         var syntaxTrees = new SyntaxTree[sources.Length];
         for (var i = 0; i < sources.Length; i++)
         {
             syntaxTrees[i] = CSharpSyntaxTree.ParseText(sources[i], parseOptions);
         }
 
-        var compilation = CSharpCompilation.Create(
+        return CSharpCompilation.Create(
             assemblyName: "JintSourceGenTests",
             syntaxTrees: syntaxTrees,
             references: _references,
             options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));
-
-        var driver = CSharpGeneratorDriver
-            .Create(generator)
-            .RunGenerators(compilation);
-
-        return Verifier
-            .Verify(driver, sourceFile: sourceFile)
-            .UseDirectory("Snapshots");
     }
 
     private static ImmutableArray<MetadataReference> BuildReferences()

--- a/Jint/Runtime/Interop/AGENTS.md
+++ b/Jint/Runtime/Interop/AGENTS.md
@@ -110,11 +110,19 @@ Six consequences worth knowing before touching any of it.
   nothing was lost. A public **static method** is reported, because the default method flags include
   `BindingFlags.Static` and reflection does serve it. Getting that wrong in the permissive direction is how
   a rule earns a blanket suppression and stops being read at all. There is deliberately **no attribute
-  property** promoting these: `dotnet_diagnostic.JINT033.severity = error` in an `.editorconfig` is
-  verified to reach a generator-reported diagnostic, it is per id rather than all-or-nothing, and it is a
-  property of the build rather than of one annotated type. A branch that cannot be reached is declined
-  silently and says so in a comment (an abstract method, a `ref` field) rather than carrying a message no
-  snapshot can pin.
+  property** promoting these: `dotnet_diagnostic.JINT033.severity = error` in an `.editorconfig` is what
+  promotes one, it is per id rather than all-or-nothing, and it is a property of the build rather than of
+  one annotated type. **That works only because each diagnostic carries a real `Location` with a
+  `SourceTree`**, which is why these do not use `Jint.SourceGenerators`' `DiagnosticInfo`: that type
+  rebuilds its location from a file path through `Location.Create(string, TextSpan, LinePositionSpan)`,
+  and the compiler resolves an `.editorconfig` severity *per syntax tree* — a tree-less diagnostic skips
+  that lookup and keeps its default severity whatever the host writes, with no error and nothing in a
+  snapshot to show it, since Verify records the line and column either way. It costs the other generator
+  nothing, every descriptor there being an error already. A `Location` is not a value, so
+  `JsAccessibleGenerator` keeps reporting and emitting as two outputs: the emitting one selects
+  `AccessibleTypeDefinition`, which carries no location, and stays on the cached path. A branch that
+  cannot be reached is declined silently and says so in a comment (an abstract method, a `ref` field)
+  rather than carrying a message no snapshot can pin.
 - **The generator lives in its own analyzer assembly, `Jint.SourceGenerators.Interop`, and that is not
   organisational.** `Jint.SourceGenerators` emits its attribute set through
   `RegisterPostInitializationOutput` unconditionally, and that source declares members typed


### PR DESCRIPTION
#3373 shipped seven `JINT03x` info diagnostics and an argument for how a host promotes one: not an
attribute property, but `dotnet_diagnostic.JINT033.severity = error` in an `.editorconfig`, because
whether a build tolerates a member falling back to reflection is a property of **the build** rather
than of one annotated type, and per-id beats all-or-nothing.

The argument stands. The mechanism did not work.

## What was wrong

Every reported decline was built through `Jint.SourceGenerators`' `DiagnosticInfo` — the standard
equatable stand-in for a `Diagnostic`, which rebuilds its location from a file path with
`Location.Create(string, TextSpan, LinePositionSpan)`. **That location has no `SourceTree`.** The
compiler resolves `dotnet_diagnostic.<id>.severity` *per syntax tree* and falls back to the global
configuration alone when there is none, so the `.editorconfig` entry was read, applied to nothing,
and said nothing: the diagnostic stayed at `Info`.

It costs the sibling generator nothing — every descriptor there is an error already — which is why
it had never mattered.

## Why nothing caught it

Verify records the line and column identically either way, so every one of the seven
`*_ProducesDiagnostic` snapshots passed against the broken version. It surfaced only when a real
consumer build was put in front of it.

## The fix

The interop generator carries its own `AccessibleDiagnostic` holding the real `Location`. A
`Location` is not a value, so reporting and emitting become **two outputs**: the emitting one
selects `AccessibleTypeDefinition`, which carries no location, so an edit that moves an annotated
declaration without changing what is generated re-runs the reporting and re-uses the cached source.

`EveryDiagnosticPointsAtATreeTheCompilationHolds` pins the invariant, because nothing else would.
Confirmed end to end as well: with `JINT033` promoted in `.editorconfig`,
`Jint.Tests.PublicInterface` now fails to build on its two declined methods, where before it built
clean.

The snapshot diffs are all the same shape — with a real tree, Verify now renders the source context
each diagnostic points at, which is strictly better output.

No behaviour change to the engine, no public API change, no change to any emitted `.g.cs`.
