### PR TITLE
WPT driver: a callback that runs after done() is the browser's business, not a harness error

### DIFF
--- a/Jint.Tests/Wpt/AGENTS.md
+++ b/Jint.Tests/Wpt/AGENTS.md
@@ -61,7 +61,12 @@ rather than erupt from the pump — the environment the corpus was written for, 
 `DiagnosticsSink.Null` on purpose: before it existed such an exception erupted and the driver reported a
 harness error for the whole file, so `WptHarness` turns any recorded uncaught callback error into that same
 harness error unless the file declared `setup({allow_uncaught_exception: true})` — which is upstream's own
-rule, and the second and last member of the properties bag the shim acts on.
+rule, and the second and last member of the properties bag the shim acts on. That rule stops at the file's
+own completion boundary, which is upstream's too: once a `setup({single_test: true})` file's one test has a
+result (`tests.tests[0].phase >= HAS_RESULT` upstream, `__wpt.fileTestComplete` here) a callback that throws
+afterwards is ignored, because the four such files arm a guard timer a browser lets fire. The predicate is
+"the file's one test has a result" and never "nothing is outstanding" — the latter would silence a file whose
+tests are all synchronous, which has an empty outstanding list from its first line.
 
 A seventh thing is worth knowing because it decides *where* a divergence gets recorded. The driver's unit of
 report is a test, so a file that cannot produce one — a throw at file scope, a run that **stalls**, or a file

--- a/Jint.Tests/Wpt/Prelude/testharness-shim.js
+++ b/Jint.Tests/Wpt/Prelude/testharness-shim.js
@@ -15,6 +15,9 @@
 //   __wpt.allowUncaughtException — whether the file declared `setup({allow_uncaught_exception: true})`, which
 //                       is what tells the driver that a failure escaping an engine-invoked callback is the
 //                       point of the file rather than a defect. See `setup` below.
+//   __wpt.fileTestComplete — whether a `setup({single_test: true})` file's one test has a result, which is
+//                       upstream's `tests.tests[0].phase >= HAS_RESULT` guard and is the boundary after which
+//                       a callback that throws is no longer this file's business. See `Test.prototype.done`.
 // The driver supplies `__wptReadResource(path)` before this file runs; nothing else crosses the boundary.
 //
 // Deliberate divergences from upstream testharness.js, all of them recorded in Jint.Tests/Wpt/Vendor/README.md:
@@ -733,6 +736,19 @@
         if (this.isAsync) {
             stopWaitingFor(this);
         }
+        // The completion boundary, published for the driver to read. Upstream's global error handler opens
+        // with `if (tests.file_is_test) { var test = tests.tests[0]; if (test.phase >= test.phases.HAS_RESULT)
+        // return; }` — a browser lets a `single_test` file's late timer fire and reach `window.onerror`, and
+        // the harness ignores it because the file's one test already has a result. Upstream reaches
+        // HAS_RESULT through this very method (`done()` -> `cleanup()` sets CLEANING, which is greater), and
+        // this shim's `phase === 'complete'` is the same state under its own two-phase vocabulary.
+        //
+        // `done()` rather than `complete()` because it is the only route the file's one test takes, and it
+        // takes it whichever way the test finished: the file calling `done()`, or a step throwing, which is
+        // `fail()` followed by `done()`. See WptHarness.WptDiagnosticsSink for the half that reads this.
+        if (this === fileTest) {
+            global.__wpt.fileTestComplete = true;
+        }
     };
 
     function test(func, name) {
@@ -1106,6 +1122,7 @@
     global.__wpt = {
         results: results,
         outstanding: outstanding,
-        allowUncaughtException: false
+        allowUncaughtException: false,
+        fileTestComplete: false
     };
 })(globalThis);

--- a/Jint.Tests/Wpt/Vendor/README.md
+++ b/Jint.Tests/Wpt/Vendor/README.md
@@ -702,6 +702,29 @@ callback error the file did not declare itself ready for into the same harness e
 Nothing else in the corpus moved: the sink changed no assertion's outcome anywhere, which the exclusion table
 proves for itself, since a row that stopped matching a failing test would fail its suite.
 
+**The rule needed its other half, and that took a second change.** Upstream's global error handler does not
+record everything it is told about: it opens with `if (tests.file_is_test) { var test = tests.tests[0]; if
+(test.phase >= test.phases.HAS_RESULT) return; }`, so once a `setup({single_test: true})` file's one test has
+a result, a callback that throws afterwards is ignored. That matters here because three of the four such
+files arm a guard timer they expect never to matter — `setTimeout(assert_unreached, 10)` in
+`negative-settimeout.any.js`, `100` in the two `type-long-` files, `1000` in `negative-setinterval.any.js` —
+and a browser lets those fire. The driver had no such boundary and kept reaching the engine after `done()`,
+because `Engine.Execute` drains the event loop on its way out and `ReadResults` used to add a whole
+`engine.Evaluate` behind it. A guard timer that came due inside that window was recorded as an uncaught
+callback error and became a harness error for a file that had already passed — a green test reported red, at
+whatever rate the machine's scheduler happened to produce it
+([#3366](https://github.com/sebastienros/jint/issues/3366)). The shim now publishes
+`__wpt.fileTestComplete` when the file's one test reaches a result, `WptDiagnosticsSink` asks each engine it
+watches for that flag at report time — upstream's guard, evaluated where upstream evaluates it — and
+`ReadResults` reads `__wpt.results` through the object model like everything else the driver reads, which
+closes the widest of the windows outright. Nothing is weakened: a callback that throws *before* the file's
+test has a result is still a harness error, a file with no `single_test` declaration has no file test and is
+forgiven nothing, and `WptHarnessTests` pins all three directions. Measured on a saturated 32-core box, 500
+runs of each of the four files: `negative-settimeout` 498/500 before and 500/500 after, the other three
+500/500 in both — and with the post-`done()` window widened deliberately past every guard margin, 0/40 before
+and 40/40 after, which is what makes this latent in all four rather than specific to the one with the
+thinnest margin.
+
 ## Encoding, the single-byte half
 
 The two files that used to sit in the not-vendored table for

--- a/Jint.Tests/Wpt/WptHarness.cs
+++ b/Jint.Tests/Wpt/WptHarness.cs
@@ -65,6 +65,18 @@ internal sealed record WptRunOutcome(IReadOnlyList<WptTestResult> Results, strin
 /// <see cref="DiagnosticEventKind.UncaughtCallbackError"/> this sink has already been told about directly.
 /// </para>
 /// <para>
+/// <b>And what it must not do is keep counting after the file is over.</b> A
+/// <c>setup({single_test: true})</c> file is one test finished by <c>done()</c>, and three of the four in the
+/// corpus arm a guard timer — <c>setTimeout(assert_unreached, 10)</c> — that a browser lets fire. Upstream's
+/// own handler opens by ignoring it: <c>if (tests.file_is_test) { var test = tests.tests[0]; if (test.phase >=
+/// test.phases.HAS_RESULT) return; }</c>, because the file's one test already has a result and there is
+/// nothing left for a failure to be attributed to. Without that boundary the driver kept reaching the engine
+/// after <c>done()</c> — <c>Engine.Execute</c> drains the event loop on its way out — and a guard timer that
+/// came due inside that window became a harness error for a file that had passed. So
+/// <see cref="Report"/> asks the same question upstream asks, at the same moment: see
+/// <see cref="Watch"/>.
+/// </para>
+/// <para>
 /// It needs no synchronization even though the worker lane shares one instance between two engines:
 /// <see cref="WptWorkerProvider"/> is the cooperative provider, so the parent and every worker are pumped in
 /// turn on the test's own thread and nothing here is ever reached from a second one.
@@ -73,16 +85,62 @@ internal sealed record WptRunOutcome(IReadOnlyList<WptTestResult> Results, strin
 internal sealed class WptDiagnosticsSink : DiagnosticsSink
 {
     private readonly List<string> _uncaught = [];
+    private readonly List<Engine> _watched = [];
 
     /// <summary>What escaped a callback the engine invoked, as text, in report order.</summary>
     internal IReadOnlyList<string> UncaughtCallbackErrors => _uncaught;
 
+    /// <summary>
+    /// Watches an engine for the shim's completion boundary, so that a report arriving after the file is over
+    /// is ignored the way a browser ignores it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>The engine rather than its <c>__wpt</c>, so that the question is asked when the answer is wanted.</b>
+    /// A <see cref="DiagnosticEvent"/> says nothing about which engine raised it, and this sink is shared —
+    /// the worker lane hands the same instance to the parent and to every worker. Holding one flag set from
+    /// whichever shim published last would be a guess; holding the engines and reading each one's own
+    /// <c>__wpt.fileTestComplete</c> at report time is upstream's guard, evaluated where upstream evaluates
+    /// it. Registering the engine at the moment it is built also removes every ordering question: the worker
+    /// lane's shim does not run until the worker's module evaluates, long after this.
+    /// </para>
+    /// <para>
+    /// <b>At most one watched engine can ever answer yes</b>, so scanning them is exact rather than a
+    /// widening. A run installs the shim in exactly one engine: the top-level lane's own, or — for a
+    /// <c>// META: global=worker</c> file — the worker's, whose parent runs nothing but
+    /// <c>new Worker(…)</c>. The one lane with several engines is
+    /// <c>workers/modules/dedicated-worker-import.any.js</c>, whose workers run vendored corpus modules and
+    /// never see this file at all.
+    /// </para>
+    /// </remarks>
+    internal void Watch(Engine engine) => _watched.Add(engine);
+
     public override void Report(DiagnosticEvent report)
     {
-        if (report.Kind == DiagnosticEventKind.UncaughtCallbackError)
+        if (report.Kind == DiagnosticEventKind.UncaughtCallbackError && !FileTestComplete())
         {
             _uncaught.Add($"{report.CallbackSource}: {report.Exception?.Message}");
         }
+    }
+
+    /// <summary>
+    /// Upstream's <c>tests.tests[0].phase &gt;= HAS_RESULT</c>, read off the shim. False for every file that
+    /// did not declare <c>setup({single_test: true})</c>, which is what keeps this from becoming
+    /// "<c>outstanding</c> is empty" — a file whose tests are all synchronous has an empty outstanding list
+    /// from its first line, and a callback throwing there is still a harness error.
+    /// </summary>
+    private bool FileTestComplete()
+    {
+        foreach (var engine in _watched)
+        {
+            if (engine.GetValue("__wpt") is ObjectInstance wpt
+                && TypeConverter.ToBoolean(wpt.Get("fileTestComplete")))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 }
 
@@ -681,6 +739,10 @@ internal static class WptHarness
         WebApiRegistration.InstallFetchModel(engine);
         InstallResourceReader(engine, directory);
 
+        // Before anything can report, so the sink never has to reason about when the shim arrived — see
+        // WptDiagnosticsSink.Watch.
+        sink.Watch(engine);
+
         return engine;
     }
 
@@ -834,6 +896,7 @@ internal static class WptHarness
     /// <c>JSON.stringify</c>.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// JSON is the obvious way to move a list of records across and it is the wrong one here: the URL corpus
     /// names tests after their input, several of those inputs are lone surrogates, and a well-formed
     /// <c>JSON.stringify</c> escapes those as <c>\udXXX</c> — which
@@ -841,12 +904,23 @@ internal static class WptHarness
     /// JSON text as string with missing low surrogate"). A .NET string holds an unpaired surrogate perfectly
     /// well, so reading the values straight off the objects loses nothing and needs no encoding both sides
     /// have to agree on.
+    /// </para>
+    /// <para>
+    /// <b>Through the object model, never by evaluating a script</b>, which is the same rule
+    /// <see cref="Pump"/> is written to and for the same reason: <c>Engine.Evaluate</c> ends in
+    /// <c>ScriptEvaluation</c>, which drains the event loop on its way out and promotes a further due timer
+    /// while doing it. This used to read <c>engine.Evaluate("typeof __wpt === 'object' ? __wpt.results :
+    /// null")</c>, and that one line was the widest of the windows in which a finished
+    /// <c>setup({single_test: true})</c> file's guard timer could still fire — parsing and running a script,
+    /// after the run was already over. The completion boundary above makes the late timer harmless; this
+    /// stops the driver opening the window in the first place.
+    /// </para>
     /// </remarks>
     private static List<WptTestResult> ReadResults(Engine engine)
     {
         var results = new List<WptTestResult>();
 
-        if (engine.Evaluate("typeof __wpt === 'object' ? __wpt.results : null") is not ObjectInstance array)
+        if (engine.GetValue("__wpt") is not ObjectInstance wpt || wpt.Get("results") is not ObjectInstance array)
         {
             return results;
         }

--- a/Jint.Tests/Wpt/WptHarnessTests.cs
+++ b/Jint.Tests/Wpt/WptHarnessTests.cs
@@ -989,6 +989,63 @@ public class WptHarnessTests
     }
 
     [Fact]
+    public void ACallbackThatThrowsAfterASingleTestFileIsDoneIsNotAHarnessError()
+    {
+        // Upstream's completion boundary, and the reason the four `single_test` timer files are deterministic:
+        // `testharness.js`'s global error handler returns without recording anything once the file's one test
+        // has a result (`tests.tests[0].phase >= HAS_RESULT`). Three of those four arm a guard timer —
+        // `setTimeout(assert_unreached, 10)` in negative-settimeout.any.js — that a browser lets fire and
+        // ignores, and that the driver used to turn into a harness error for a file that had passed.
+        //
+        // Deterministic by ordering rather than by timing, which is the rule this whole class is written to:
+        // `done()` runs at file scope, so the file's one test has its result before the timer is even armed,
+        // and a zero delay is due the moment it is — so the drain on the way out of `Engine.Execute` runs it
+        // every time, which is window 1 of the three the driver used to leave open.
+        var outcome = Run("""
+            setup({ single_test: true });
+            done();
+            setTimeout(() => { throw new Error('late'); }, 0);
+            """);
+
+        outcome.HarnessError.Should().BeNull();
+        outcome.Results.Should().HaveCount(1);
+        outcome.Results[0].Status.Should().Be("PASS", outcome.Results[0].Message);
+    }
+
+    [Fact]
+    public void ACallbackThatThrowsBeforeASingleTestFileIsDoneStillIsAHarnessError()
+    {
+        // The other half, and what stops the boundary above from being a way to go quiet. The predicate is
+        // upstream's "the file's one test has a result" and never "nothing is outstanding" — the latter would
+        // also silence AnExceptionEscapingACallbackIsAHarnessErrorForTheWholeFile above, whose file has an
+        // empty outstanding list from its first line.
+        var outcome = Run("""
+            setup({ single_test: true });
+            setTimeout(() => { throw new Error('early'); }, 0);
+            setTimeout(done, 0);
+            """);
+
+        outcome.HarnessError.Should().NotBeNull();
+        outcome.HarnessError.Should().Contain("allow_uncaught_exception");
+        outcome.HarnessError.Should().Contain("early");
+    }
+
+    [Fact]
+    public void TheCompletionBoundaryIsPerFileRatherThanPerRun()
+    {
+        // A file that never declared `single_test` has no file test to have a result, so nothing about it is
+        // forgiven however finished it looks. This is the same rule as the test above stated from the other
+        // end, and it is what a flag reset per run rather than per report would get wrong.
+        var outcome = Run("""
+            test(() => {}, 'row');
+            setTimeout(() => { throw new Error('late'); }, 0);
+            """);
+
+        outcome.HarnessError.Should().NotBeNull();
+        outcome.HarnessError.Should().Contain("late");
+    }
+
+    [Fact]
     public void ASynchronousXmlHttpRequestReadsAVendoredResource()
     {
         var outcome = WptHarness.RunInline("""

--- a/Jint.Tests/Wpt/WptWorkerProvider.cs
+++ b/Jint.Tests/Wpt/WptWorkerProvider.cs
@@ -112,6 +112,13 @@ internal sealed class WptWorkerProvider : WorkerProvider
         WptHarness.InstallResourceReader(engine, _directory);
         engine.SetValue("__wptTestFile", request.Specifier);
 
+        // A worker-scoped file is where `setup({single_test: true})` would be declared in this lane, so the
+        // sink has to be able to ask *this* engine whether the file's one test has a result — see
+        // WptDiagnosticsSink.Watch. Registered now, before the worker's module has evaluated and therefore
+        // before the shim it installs exists, which is exactly why the sink watches the engine and not its
+        // `__wpt`.
+        _sink.Watch(engine);
+
         return engine;
     }
 


### PR DESCRIPTION
`setup({single_test: true})` makes a file one test that `done()` finishes, and three of the four such files in the corpus arm a guard timer they expect never to matter — `setTimeout(assert_unreached, 10)` in `negative-settimeout.any.js`, `100` in the two `type-long-` files, `1000` in `negative-setinterval.any.js`. A browser lets those fire and ignores them. Upstream `testharness.js`'s global error handler opens with the guard:

```js
var error_handler = function(error, message, stack) {
    if (tests.file_is_test) {
        var test = tests.tests[0];
        if (test.phase >= test.phases.HAS_RESULT) {
            return;
        }
```

The file's one test already has a result, so there is nothing left for a failure to be attributed to. Upstream does not cancel the file's pending timers either — the late one fires and reaches `window.onerror` exactly as it does here.

## What went wrong

The driver had no such boundary, and it kept reaching the engine after `done()`. `Engine.Execute` ends in `ScriptEvaluation`, which drains the event loop and promotes a further due timer on the way out; `ReadResults` then added a whole `engine.Evaluate` behind it — parsing and running a one-line script, after the run was already over, and in contradiction of the rule `Pump`'s own remarks state ("read through the object model, never by evaluating a script, because the window that opens is exactly the one a due timer settles in"). A guard timer that came due inside that window ran, threw, reached the `DiagnosticsSink`, and `UndeclaredCallbackErrors` turned it into a harness error for a file that had already passed.

The engine was right throughout: `TimerFunctions` clamps, `TimerQueue.Arm` orders by due time with a monotonic sequence tiebreak, and `done` can never be dequeued second. It was simply not fast enough for a margin the file hard-codes — which is not something the file is entitled to ask of a loaded machine, and not something a browser makes it ask.

## The fix

Port the guard rather than approximate it.

* **`Prelude/testharness-shim.js`** publishes `__wpt.fileTestComplete` when the file's one test reaches a result. It is set in `Test.prototype.done`, which is the only route that test takes and takes it whichever way the test finished — the file calling `done()`, or a step throwing, which is `fail()` followed by `done()`. Upstream reaches `HAS_RESULT` through the same method (`done()` → `cleanup()` sets `CLEANING`, which is greater), and this shim's `phase === 'complete'` is that state in its own two-phase vocabulary.
* **`WptDiagnosticsSink.Report`** asks the same question at the same moment. It watches the **engine** rather than its `__wpt`: a `DiagnosticEvent` says nothing about which engine raised it and the worker lane shares one sink between the parent and every worker, so a single flag set by whichever shim published last would be a guess. Registering each engine as it is built removes every ordering question — the worker lane's shim does not exist until its module evaluates — and at most one watched engine can ever have a file test, because a run installs the shim in exactly one of them.
* **`ReadResults`** now reads `__wpt.results` through the object model like everything else the driver reads, which closes the widest of the three windows outright rather than relying on the guard to forgive it.

## Why this does not weaken anything

It reproduces the browser bit for bit. A callback that throws **before** the file's one test has a result is still a harness error; a file that never declared `single_test` has no file test and is forgiven nothing. The predicate is upstream's "the file's one test has a result" and deliberately **not** "`outstanding` is empty" — the latter would also silence `AnExceptionEscapingACallbackIsAHarnessErrorForTheWholeFile`, whose file has an empty outstanding list from its first line. `WptHarnessTests` pins all three directions, and the new after-`done()` case fails on `main` with exactly the reported symptom (`Timer: late`).

If the engine ever got the ordering wrong, `done()` would not have run when the guard timer throws, the flag would be false, and the run would fail exactly as it does today; if `done()` never runs at all, `Pump` still reports the file stalled.

## Evidence

Under load — 256 spinners on a 32-core box, `\Processor(_Total)\% Processor Time` pegged at 100 — 500 runs of each of the four `single_test` files:

| file | guard margin | before | after |
| --- | --- | --- | --- |
| `negative-settimeout.any.js` | 10 ms | **498 / 500** | 500 / 500 |
| `type-long-settimeout.any.js` | 100 ms | 500 / 500 | 500 / 500 |
| `type-long-setinterval.any.js` | 100 ms | 500 / 500 | 500 / 500 |
| `negative-setinterval.any.js` | 1000 ms | 500 / 500 | 500 / 500 |

The two failures both reported `Timer: reached unreachable code`. A clean run proves nothing on its own, though, and the other three rows are not evidence that they are sound — only that this box did not stall for 100 ms in the right place. So the window was also widened deliberately, past every guard margin, and drained: 1.2 s between `Pump` returning and the results being read, which is what a scheduler preemption does by accident.

| file | before | after |
| --- | --- | --- |
| `negative-settimeout.any.js` | 0 / 10 | 10 / 10 |
| `type-long-settimeout.any.js` | 0 / 10 | 10 / 10 |
| `type-long-setinterval.any.js` | 0 / 10 | 10 / 10 |
| `negative-setinterval.any.js` | 0 / 10 | 10 / 10 |

That is what makes this latent in **all four** rather than specific to the two that have been observed failing. `negative-settimeout`'s 10 ms margin is simply the thinnest, which is why it flaked first.

## Scope

No exclusion moves and **`NeedsTriage` stays empty** — 0 before, 0 after. The census is unchanged (`JINT_WPT_CENSUS=1` passes against the committed table): these files were recording `PASS` all along, and it was the whole-file harness error that failed the run, which is why this never showed up in the "Not passing" column. No engine code is touched, so no test262 run was needed; `Jint.Tests` is green on all three target frameworks, including `PublicApiTest` and `PublicApiDocumentationTest`.

Fixes #3366

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014W5mbjGhyvgAS4pivXoc4S
