### PR TITLE
Native AOT: a degraded array view still refuses a resize, and the value-type generic sites are eight, not five

### DIFF
--- a/Jint.AotExample/Jint.AotExample.csproj
+++ b/Jint.AotExample/Jint.AotExample.csproj
@@ -11,7 +11,7 @@
       Jint's own csproj suppresses eight IL warning codes (IL3050 and seven IL2xxx) so that Jint
       compiles clean. That NoWarn is a property of Jint's *compilation* and reaches nothing here: ILC
       re-derives the whole set when it compiles the closed program, and this project's publish is
-      where all 122 of them surface. Turning them into errors - which repository-wide
+      where all of them surface - the inventory #3305 tracks. Turning them into errors - which repository-wide
       TreatWarningsAsErrors would otherwise do, since IlcTreatWarningsAsErrors defaults to it - would
       make `dotnet publish` fail before it ever produced a binary, and the binary is the point: the
       warnings say what *might* break, the run says what *does*.

--- a/Jint.AotExample/Program.cs
+++ b/Jint.AotExample/Program.cs
@@ -15,12 +15,28 @@
 // Type.MakeGenericType + Activator.CreateInstance or MethodInfo.MakeGenericMethod. Reference-type
 // arguments share canonical code and work; value types need a specific instantiation the compiler
 // never saw. The sibling probe beside each gap pins that boundary rather than merely asserting it.
-// All five were https://github.com/sebastienros/jint/issues/3299; three of them now degrade to an
-// untyped wrapper instead of throwing, and their rows below are Probes rather than gaps. The two
-// that remain are the two with no non-generic answer to degrade TO: there is no way to produce a
-// Task<double> without Task.FromResult<double>, and declining a generic host method would report
-// "no matching overload" for a method that plainly exists. Both would trade a diagnosable throw for
-// a wrong answer, so both stay gaps.
+//
+// https://github.com/sebastienros/jint/issues/3299 is the enumeration of those sites. Eight exist, not
+// the five it was filed with - the T[] wrapper branch arrived later, and two more were never in the
+// list - and each is now either a Probe or a KnownAotGap below. The split is whether there is a
+// non-generic answer to degrade TO:
+//
+//   degrades, and the Probe checks the degradation is CORRECT and not merely quiet
+//     ArrayWrapperFactory<int> / GenericListWrapperFactory<int> -> ListWrapper
+//     ReadOnlyListWrapperFactory<double>                        -> plain ObjectWrapper
+//     EnumerableSnapshotFactory<int>                            -> object snapshot
+//   throws, because nothing non-generic satisfies the contract asked for
+//     Task.FromResult<double>              - nothing else produces a Task<double>
+//     hostMethod.MakeGenericMethod(double) - declining reports "no matching overload" for a method
+//                                            that plainly exists
+//     List<long> for an IEnumerable<long> parameter, and its Collection<short> sibling
+//     a closed generic type the SCRIPT named, constructed through importNamespace
+//
+// Each of the four that throw can be closed by the embedder rather than by Jint, by making the
+// instantiation reachable from their own code; docs/v5-migration.md section 6.2 says how. Jint cannot
+// do it for them: no signature anywhere in Jint predicts which value types a host's members and a
+// script's arguments will produce, and rooting a guessed set would cost every AOT consumer binary size
+// for instantiations they never use.
 
 using Jint;
 using Jint.Native;
@@ -156,6 +172,81 @@ Probe("Dictionary<string, int> crossing", static () =>
     var engine = new Engine(static cfg => cfg.AllowClr());
     engine.SetValue("map", new Dictionary<string, int> { ["a"] = 1 });
     Expect(1, engine.Evaluate("map.a"));
+});
+
+Probe("string[] live view (ArrayWrapperFactory<string>)", static () =>
+{
+    var engine = new Engine(static cfg => { cfg.AllowClr(); cfg.Interop.ArrayConversion = ArrayConversionMode.LiveView; cfg.Interop.AllowWrite = true; });
+    engine.SetValue("arr", new ArrayHolder());
+    Expect("a", engine.Evaluate("arr.strings[0]"));
+    Expect("z", engine.Evaluate("arr.strings[1] = 'z'; arr.strings[1]"));
+    Expect("TypeError", engine.Evaluate("try { arr.strings.push('z'); 'no throw' } catch (e) { e.constructor.name }"));
+});
+
+// ObjectWrapper.ResolveArrayLikeWrapperFactoryType, T[] branch: ArrayWrapperFactory<int> has no native
+// code, so the array degrades to the untyped ListWrapper. The degradation is only worth having if it
+// still answers the way the typed wrapper does, which is why this probe writes an element and attempts
+// a resize rather than only reading: ListWrapper served the write as a boxed double (InvalidCastException
+// into an int[]) and served the resize through IList.Add, which on an array raises the CLR's own
+// "Collection was of a fixed size" past script instead of the TypeError the JIT path gives (#3299).
+Probe("int[] live view (ListWrapper fallback under AOT)", static () =>
+{
+    var engine = new Engine(static cfg => { cfg.AllowClr(); cfg.Interop.ArrayConversion = ArrayConversionMode.LiveView; cfg.Interop.AllowWrite = true; });
+    engine.SetValue("arr", new ArrayHolder());
+    Expect(1, engine.Evaluate("arr.numbers[0]"));
+    Expect(9, engine.Evaluate("arr.numbers[1] = 9; arr.numbers[1]"));
+    Expect("TypeError", engine.Evaluate("try { arr.numbers.push(9); 'no throw' } catch (e) { e.constructor.name }"));
+});
+
+Probe("JS array -> IEnumerable<string> parameter", static () =>
+{
+    var engine = new Engine(static cfg => cfg.AllowClr());
+    engine.SetValue("taker", new ListTaker());
+    Expect("a,b", engine.Evaluate("taker.joinStrings(['a', 'b'])"));
+});
+
+// The parameter type is List<int> itself, so ILC compiled that instantiation for the signature and
+// MakeGenericType finds it. This is the boundary worth pinning beside the gap below: whether the site
+// works depends on whether the host's own signatures happen to name the closed type Jint asks for.
+Probe("JS array -> List<int> parameter", static () =>
+{
+    var engine = new Engine(static cfg => cfg.AllowClr());
+    engine.SetValue("taker", new ListTaker());
+    Expect(6, engine.Evaluate("taker.sumList([1, 2, 3])"));
+});
+
+// DefaultTypeConverter.TryConvertInternal: typeof(List<>).MakeGenericType(long). The parameter is an
+// interface, so nothing in the closed program names List<long> and there is no non-generic value that
+// satisfies IEnumerable<long> to degrade to - an array would need long[] to exist for the same reason,
+// and would hand a host that calls Add a fixed-size collection.
+KnownAotGap("JS array -> IEnumerable<long> parameter", static () =>
+{
+    var engine = new Engine(static cfg => cfg.AllowClr());
+    engine.SetValue("taker", new ListTaker());
+    Expect(6, engine.Evaluate("taker.sumEnumerable([1, 2, 3])"));
+});
+
+// The Collection<T> branch of the same method, which builds the inner List<short> the constructor takes.
+KnownAotGap("JS array -> Collection<short> parameter", static () =>
+{
+    var engine = new Engine(static cfg => cfg.AllowClr());
+    engine.SetValue("taker", new ListTaker());
+    Expect(2, engine.Evaluate("taker.countCollection([1, 2])"));
+});
+
+Probe("script-built generic CLR type, reference type argument", static () =>
+{
+    var engine = new Engine(static cfg => cfg.AllowClr(typeof(Company).Assembly, typeof(string).Assembly));
+    Expect("a", engine.Evaluate("var B = importNamespace('AotProbe').Box(System.String); new B('a').read()"));
+});
+
+// NamespaceReference.MakeGenericType, driven from script: the type arguments are named by the script, so
+// no signature anywhere in the closed program predicts them. The instantiation itself survives - it is
+// metadata, and Box<T> is rooted - and the failure lands where the code is needed, on construction.
+KnownAotGap("script-built generic CLR type, value type argument", static () =>
+{
+    var engine = new Engine(static cfg => cfg.AllowClr(typeof(Company).Assembly, typeof(string).Assembly));
+    Expect(3, engine.Evaluate("var B = importNamespace('AotProbe').Box(System.Int16); new B(3).read()"));
 });
 
 Probe("delegate crossing: JS function -> Func<int, int>", static () =>
@@ -360,6 +451,20 @@ public class GenericHost
     public T Identity<T>(T value) => value;
 }
 
+public class ArrayHolder
+{
+    public string[] Strings { get; } = ["a", "b"];
+    public int[] Numbers { get; } = [1, 2, 3];
+}
+
+public class ListTaker
+{
+    public string JoinStrings(IEnumerable<string> values) => string.Join(",", values);
+    public int SumList(List<int> values) { var sum = 0; foreach (var v in values) { sum += v; } return sum; }
+    public long SumEnumerable(IEnumerable<long> values) { long sum = 0; foreach (var v in values) { sum += v; } return sum; }
+    public int CountCollection(System.Collections.ObjectModel.Collection<short> values) => values.Count;
+}
+
 public sealed class ReadOnlyStrings : IReadOnlyList<string>
 {
     private readonly List<string> _items = ["x", "y"];
@@ -376,4 +481,14 @@ public sealed class ReadOnlyDoubles : IReadOnlyList<double>
     public int Count => _items.Count;
     public IEnumerator<double> GetEnumerator() => _items.GetEnumerator();
     System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => _items.GetEnumerator();
+}
+
+namespace AotProbe
+{
+    public class Box<T>
+    {
+        private readonly T _value;
+        public Box(T value) => _value = value;
+        public T Read() => _value;
+    }
 }

--- a/Jint.Tests/Runtime/InteropTests.ClrArrayLiveView.cs
+++ b/Jint.Tests/Runtime/InteropTests.ClrArrayLiveView.cs
@@ -712,6 +712,44 @@ public partial class InteropTests
         list[3].Should().Be(4);
     }
 
+    [Theory]
+    [InlineData("list.push(4)")]
+    [InlineData("list.pop()")]
+    [InlineData("list.splice(0, 1)")]
+    [InlineData("list.length = 1")]
+    [InlineData("list.length = 10")]
+    [InlineData("list[3] = 4")]
+    public void FixedSizeUntypedListRefusesResizeWithTypeError(string operation)
+    {
+        // ArrayList.FixedSize implements IList and no generic collection interface, so it resolves to the
+        // untyped ListWrapper - which is also what a T[] falls back to when its typed ArrayWrapper<T>
+        // cannot be instantiated (Native AOT over a value type, #3299). Until ListWrapper honoured
+        // IList.IsFixedSize, every length-changing operation reached IList.Add/RemoveAt and leaked the
+        // collection's own NotSupportedException past script instead of the TypeError the typed wrapper
+        // raises for the same operation.
+        var engine = CreateLiveViewEngine();
+        engine.SetValue("list", System.Collections.ArrayList.FixedSize(new System.Collections.ArrayList { 1, 2, 3 }));
+
+        var result = engine.Evaluate(
+            $"(function() {{ try {{ {operation}; return 'no-throw'; }} catch (e) {{ return e instanceof TypeError ? 'TypeError' : 'unexpected: ' + e; }} }})()");
+
+        result.AsString().Should().Be("TypeError");
+        engine.Evaluate("list.length").AsNumber().Should().Be(3);
+    }
+
+    [Fact]
+    public void GrowableUntypedListStillResizes()
+    {
+        var list = new System.Collections.ArrayList { 1, 2, 3 };
+        var engine = CreateLiveViewEngine();
+        engine.SetValue("list", list);
+
+        engine.Execute("list.push(4);");
+
+        list.Count.Should().Be(4);
+        list[3].Should().Be(4);
+    }
+
     private sealed class ReentrantCopyProbe
     {
     }

--- a/Jint/Runtime/Interop/AGENTS.md
+++ b/Jint/Runtime/Interop/AGENTS.md
@@ -145,35 +145,62 @@ file, why it is not one change, and a suggested order; `Jint.csproj`'s own comme
 #### What the leg proves
 
 An engine with `AllowClr()` reading properties, fields, indexers and methods off a host object works
-natively, as do `T[]`, `List<T>`, `IReadOnlyList<T>`, `IEnumerable<T>`, `Dictionary<,>`, delegates in
-both directions, extension methods, `TypeReference` construction, JSON, promises, and an
+natively, as do `T[]`, `List<T>`, `IReadOnlyList<T>`, `IEnumerable<T>`, `Dictionary<,>`, a CLR array as a
+live view under `ArrayConversionMode.LiveView` (its element writes and its resize refusals included),
+delegates in both directions, extension methods, `TypeReference` construction, JSON, promises, and an
 `Interop.Enabled = false` engine. What it proves does *not* work is one shape — **a generic
 instantiation over a value type built at run time**. Reference-type arguments share canonical code and
 are fine; `int`, `double` and friends need a specific instantiation ILC never saw.
 
-Five sites had that shape ([#3299](https://github.com/sebastienros/jint/issues/3299)). Three now
-degrade; two still throw, and that is the interesting half:
+**Eight sites have that shape, not the five
+[#3299](https://github.com/sebastienros/jint/issues/3299) was filed with** — `MakeGenericType` and
+`MakeGenericMethod` are the whole inventory, and `grep` for those two names is how to re-derive it after
+this area moves again. Four degrade, four throw, and the split is the same question every time: *is
+there a non-generic value that satisfies what was asked for?*
 
 | site | shape | today |
 | --- | --- | --- |
-| `ObjectWrapper.TryBuildArrayLikeWrapper` | `GenericListWrapperFactory<int>` | degrades to `ListWrapper` |
+| `ObjectWrapper.ResolveArrayLikeWrapperFactoryType`, `T[]` branch | `ArrayWrapperFactory<int>` | degrades to `ListWrapper` |
+| same site, `IList<>` branch | `GenericListWrapperFactory<int>` | degrades to `ListWrapper` |
 | same site, `IReadOnlyList<>` branch | `ReadOnlyListWrapperFactory<double>` | degrades to a plain `ObjectWrapper` (loses array-likeness, keeps the indexer) |
 | `ObjectWrapper.ResolveEnumerableSnapshotFactory` | `EnumerableSnapshotFactory<int>` | degrades to `ObjectEnumerableSnapshotFactory` |
 | `DefaultTypeConverter.GetFromResultMethod` | `Task.FromResult<double>` | throws `NotSupportedException` |
 | `MethodInfoFunction.ResolveMethod` | `methodInfo.MakeGenericMethod(double)` | throws `NotSupportedException` |
+| `DefaultTypeConverter.TryConvertInternal`, ×2 | `List<long>` for an `IEnumerable<long>` parameter, and the inner list a `Collection<short>` takes | throws `NotSupportedException` |
+| `NamespaceReference.MakeGenericType` → `TypeReference` | a closed generic type the *script* named | throws `NotSupportedException`, on construction |
 
-The three that degrade do so through `ObjectWrapper.IsMissingGenericInstantiation`, which catches
+The four that degrade do so through `ObjectWrapper.IsMissingGenericInstantiation`, which catches
 `NotSupportedException` as well as the `MissingMethodException` the original `catch` named. **The
 original never fired**: Native AOT raises `NotSupportedException` from `Activator.CreateInstance`, so
 the fallback beside it was dead code exactly where it was needed. Do not add another such fallback
 without checking which exception the runtime actually throws.
 
-**The last two are not oversights, and must not be "fixed" by widening a `catch`.** Neither has a
-non-generic answer to degrade *to*: nothing produces a `Task<double>` without `Task.FromResult<double>`,
-and `ResolveMethod` returning `null` means *this candidate does not apply*, so swallowing the failure
-would report "no matching overload" for a method that plainly exists. Both would trade a diagnosable
-throw for a wrong answer, which is why `ResolveMethod`'s `catch (ArgumentException)` carries a comment
-saying it is deliberately not `NotSupportedException`.
+**A fallback only counts if it answers the way the wrapper it replaced does, and the `T[]` row is what
+proves that is a separate question from whether it throws.** `ArrayWrapper<T>` carries two facts in its
+type argument that `ListWrapper` used to take from nobody — the element type, and that the length is
+fixed — so the degradation read correctly while writing a boxed `double` into an `int[]`
+(`InvalidCastException`) and serving `push` through `IList.Add`, which raises the CLR's own *Collection
+was of a fixed size* past script where the typed wrapper raises a `TypeError`. `ListWrapper` now takes
+both from the target (`Array.GetType().GetElementType()`, `IList.IsFixedSize`), which also closes the
+same hole for a genuinely fixed-size `IList` under a JIT. **Probe the degraded path's writes and
+resizes, not only its reads.**
+
+**The four that throw are not oversights, and must not be "fixed" by widening a `catch`.** None has a
+non-generic answer to degrade *to*: nothing produces a `Task<double>` without `Task.FromResult<double>`;
+`ResolveMethod` returning `null` means *this candidate does not apply*, so swallowing the failure would
+report "no matching overload" for a method that plainly exists (which is why its `catch (ArgumentException)`
+carries a comment saying it is deliberately not `NotSupportedException`); and nothing but a `T`-typed
+value satisfies an `IEnumerable<T>` parameter or a `Box<short>` the script asked for. Nor may Jint root
+a guessed set of value types: every closed generic rooted costs binary size for every AOT consumer,
+including the ones that never touch that path, and no signature in Jint predicts which value types a
+host's members and a script's arguments will produce. **The embedder can close all four and Jint cannot**,
+which is what `docs/v5-migration.md` §6.2 now tells them — verified on a published binary, including the
+asymmetry that makes the recipe worth writing down: a compiled reference in the host's own
+`TrimmerRootAssembly` closes three of them, and does *not* close `Task.FromResult<double>`, because that
+one lives in an assembly the host has not rooted and Jint reaches it reflectively. Rooting it takes the
+same expression Jint evaluates —
+`typeof(Task).GetMethod(nameof(Task.FromResult)).MakeGenericMethod(typeof(double))` — which ILC folds
+because both tokens are constants.
 
 #### The rule for new work here
 

--- a/Jint/Runtime/Interop/ObjectWrapper.Specialized.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.Specialized.cs
@@ -412,6 +412,15 @@ internal abstract class ArrayLikeWrapper : ObjectWrapper
     /// </summary>
     protected virtual bool IsFixedSize => false;
 
+    /// <summary>
+    /// The refusal every length-changing operation on a fixed-size target owes script: a
+    /// <c>TypeError</c> it can catch, never the CLR <see cref="NotSupportedException"/> the underlying
+    /// collection would raise. Shared by <see cref="ArrayWrapper{T}"/> and by <see cref="ListWrapper"/>,
+    /// which is what a <c>T[]</c> falls back to when the typed wrapper cannot be built (#3299).
+    /// </summary>
+    [DoesNotReturn]
+    protected void ThrowFixedSize() => Throw.TypeError(_engine.Realm, "Cannot resize a fixed-size CLR array");
+
     public void SetAt(int index, JsValue value)
     {
         if (_engine.Options.Interop.AllowWrite)
@@ -458,15 +467,44 @@ internal abstract class ArrayLikeWrapper : ObjectWrapper
     }
 }
 
+/// <summary>
+/// The untyped view over anything that is an <see cref="IList"/>. It is the least specific of the
+/// array-like wrappers and also the one a <c>T[]</c> or an <c>IList&lt;T&gt;</c> degrades to when its typed
+/// factory cannot be instantiated — Native AOT has no code for
+/// <c>ArrayWrapperFactory&lt;int&gt;</c> and friends (#3299) — so it takes the two facts the typed wrapper
+/// carried in its type argument from the target instead: the element type, and whether the length can
+/// change.
+/// </summary>
 internal sealed class ListWrapper : ArrayLikeWrapper
 {
     private readonly IList? _list;
+    private readonly bool _fixedSize;
 
     internal ListWrapper(Engine engine, IList target, Type type)
-        : base(engine, target, typeof(object), type, elementAccessMayRunHostCode: target is not (Array or ArrayList))
+        : base(engine, target, ElementTypeOf(target), type, elementAccessMayRunHostCode: target is not (Array or ArrayList))
     {
         _list = target;
+        _fixedSize = target.IsFixedSize;
     }
+
+    /// <summary>
+    /// A <see cref="ListWrapper"/> over an array must coerce element writes to the array's element type,
+    /// exactly as <see cref="ArrayWrapper{T}"/> does from its type argument: <c>object</c> would hand
+    /// <c>IList.this[int]</c> the boxed <c>double</c> a JS number converts to and raise
+    /// <see cref="InvalidCastException"/> out of the assignment. Everything else keeps <c>object</c>,
+    /// which is all a non-generic <see cref="IList"/> promises.
+    /// </summary>
+    private static Type ElementTypeOf(IList target)
+        => target is Array array ? array.GetType().GetElementType() ?? typeof(object) : typeof(object);
+
+    /// <summary>
+    /// Read from the target rather than declared, because this wrapper serves both the growable case and
+    /// the fixed-size one: <c>System.Array</c> reaches it through <see cref="IList"/> whenever
+    /// <see cref="ArrayWrapper{T}"/> could not be built, and <c>ArrayList.FixedSize</c> reaches it always.
+    /// Without this every length-changing operation reached <c>IList.Add</c> and leaked that collection's
+    /// <see cref="NotSupportedException"/> past script instead of raising a catchable <c>TypeError</c>.
+    /// </summary>
+    protected override bool IsFixedSize => _fixedSize;
 
     public override int Length => _list?.Count ?? 0;
 
@@ -488,11 +526,50 @@ internal sealed class ListWrapper : ArrayLikeWrapper
         }
     }
 
-    public override void AddDefault() => _list?.Add(null);
+    public override void AddDefault()
+    {
+        if (_fixedSize)
+        {
+            ThrowFixedSize();
+        }
 
-    public override void Add(JsValue value) => _list?.Add(ConvertToItemType(value));
+        _list?.Add(null);
+    }
 
-    public override void RemoveAt(int index) => _list?.RemoveAt(index);
+    public override void Add(JsValue value)
+    {
+        if (_fixedSize)
+        {
+            ThrowFixedSize();
+        }
+
+        _list?.Add(ConvertToItemType(value));
+    }
+
+    public override void RemoveAt(int index)
+    {
+        if (_fixedSize)
+        {
+            ThrowFixedSize();
+        }
+
+        _list?.RemoveAt(index);
+    }
+
+    public override void EnsureCapacity(int capacity)
+    {
+        if (_fixedSize)
+        {
+            if (capacity > Length)
+            {
+                ThrowFixedSize();
+            }
+
+            return;
+        }
+
+        base.EnsureCapacity(capacity);
+    }
 }
 
 internal class GenericListWrapper<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicFields)] T> : ArrayLikeWrapper
@@ -611,9 +688,6 @@ internal sealed class ArrayWrapper<[DynamicallyAccessedMembers(DynamicallyAccess
             ThrowFixedSize();
         }
     }
-
-    [DoesNotReturn]
-    private void ThrowFixedSize() => Throw.TypeError(_engine.Realm, "Cannot resize a fixed-size CLR array");
 }
 
 internal sealed class ReadOnlyListWrapper<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicFields)] T> : ArrayLikeWrapper

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -1818,6 +1818,7 @@ the part that was never certain:
 | --- | --- |
 | properties, fields, indexers, methods on a host object | works |
 | `T[]`, `List<T>`, `IReadOnlyList<T>`, `IEnumerable<T>`, `Dictionary<K,V>` | works |
+| a CLR array as a live view (`ArrayConversionMode.LiveView`) - reads, element writes, and the `TypeError` a resize attempt owes script | works |
 | delegates in both directions (`Func<int, int>` to and from script) | works |
 | extension methods, `TypeReference` construction from script | works |
 | generic host methods with a **reference-type** argument | works |
@@ -1826,25 +1827,55 @@ the part that was never certain:
 ### 6.2 The one thing that does not: a generic instantiation over a value type
 
 Native AOT shares one compiled body across every reference-type argument, so `Identity<string>` works.
-A value-type argument needs a specific instantiation the compiler had to have seen, and two places in
-Jint build one at run time:
+A value-type argument needs a specific instantiation the compiler had to have seen, and eight places in
+Jint build one at run time. Four have a non-generic answer to fall back on and take it; the other four
+throw `NotSupportedException`, because nothing non-generic satisfies what was asked for and a wrong
+answer is worse than a diagnosable throw:
 
-| shape | script that reaches it | what you get |
-| --- | --- | --- |
-| a JS function converted to `Func<double, Task<double>>` (any `Task<T>` / `ValueTask<T>` over a value type) | calling a host method that takes such a delegate | `NotSupportedException` |
-| a generic host method called with a number | `host.identity(7)` - `host.identity('hi')` is fine | `NotSupportedException` |
+| what throws | what to know |
+| --- | --- |
+| a host method taking `Func<double, Task<double>>` — any `Task<T>` / `ValueTask<T>` over a value type — called with a JS function | nothing but `Task.FromResult<double>` produces a `Task<double>` |
+| a generic host method called with a number: `host.identity(7)` | `host.identity('hi')` is fine; declining instead would report *no matching overload* for a method that plainly exists |
+| a host method taking `IEnumerable<long>`, `IList<short>`, `Collection<short>`, … called with a JS array | it works when the *closed* type appears in one of your own signatures, because that is what makes ILC compile it: a `List<int>` parameter is fine, an `IEnumerable<int>` parameter is not |
+| a closed generic type the **script** names: `importNamespace('MyApp').Box(System.Int16)` | the type resolves; the failure lands on construction |
 
-Both throw rather than degrade, deliberately: there is no non-generic way to produce a `Task<double>`,
-and declining the generic method would report *no matching overload* for a method that plainly exists.
-A wrong answer is worse than a diagnosable throw. If you need either shape under Native AOT, give the
-host method a non-generic overload, or take `Task<object>` and box.
+**Only you can close these, and you can close all four.** The type argument comes from your members and
+your scripts, so no signature in Jint predicts it, and rooting a guessed set of value types would cost
+every AOT consumer binary size for instantiations they never use. Make each instantiation reachable from
+code ILC compiles, and Jint's run-time lookup then finds it:
 
-Three shapes that used to throw here now degrade instead
-([#3299](https://github.com/sebastienros/jint/issues/3299)): `List<int>`, `IReadOnlyList<double>` and
-an `IEnumerable<int>` under `EnumerableConversionMode.Snapshot` fall back to an untyped wrapper and
-answer correctly. The only loss is that a collection reached through the last-resort fallback is not
-array-*like*: `IReadOnlyList<double>` keeps `ro[0]` but loses `ro.length` and the `Array.prototype`
-generics unless the type also implements `IList`.
+```csharp
+// Never called. It only has to be compiled, so put it in a method your program calls or - simpler -
+// anywhere in the assembly you already root with TrimmerRootAssembly (§6.4).
+internal static void RootAotInstantiations()
+{
+    _ = new MyHost().Identity(0d);   // one line per value type a script passes to a generic host method
+    _ = new List<long>();            // for an IEnumerable<long> / IList<long> / Collection<long> parameter
+    _ = new Box<short>(default);     // for a closed generic type a script names
+
+    // Task.FromResult<double>, for Func<double, Task<double>>. A plain `Task.FromResult(0d)` is NOT
+    // enough: it compiles the body, but Jint reaches the method through reflection and `Task` lives in an
+    // assembly you have not rooted, so there is nothing to invoke. Naming it the way Jint does works,
+    // because both tokens are constants and ILC folds the expression at compile time.
+    _ = typeof(Task).GetMethod(nameof(Task.FromResult))!.MakeGenericMethod(typeof(double));
+}
+```
+
+The asymmetry is the rule to carry away: for **your own** types a compiled reference is enough, because
+`TrimmerRootAssembly` keeps their metadata; for a **framework** type reached by reflection, root it the
+way it will be looked up. Or avoid the shape entirely — give the host method a non-generic overload, take
+`Task<object>` and box, or declare the parameter as the closed `List<T>` rather than as an interface
+over it.
+
+**Four shapes that used to throw here degrade instead**
+([#3299](https://github.com/sebastienros/jint/issues/3299)): `int[]` under
+`ArrayConversionMode.LiveView`, `List<int>`, `IReadOnlyList<double>` and an `IEnumerable<int>` under
+`EnumerableConversionMode.Snapshot` fall back to an untyped wrapper and answer correctly — element
+writes coerce to the element type, and a resize attempt on a fixed-size target raises the same
+`TypeError` the typed wrapper raises rather than the collection's own `NotSupportedException`. The only
+loss is that a collection reached through the last-resort fallback is not array-*like*:
+`IReadOnlyList<double>` keeps `ro[0]` but loses `ro.length` and the `Array.prototype` generics unless
+the type also implements `IList`.
 
 ### 6.3 APIs that now warn
 
@@ -1920,7 +1951,7 @@ your code changes; the overload is picked automatically.
 **Expect Jint's own diagnostics in your build.** Jint's `NoWarn` is a property of Jint's compilation
 and reaches nothing downstream - ILC re-derives every diagnostic over the closed program - so an AOT
 publish reports the remaining trim-analysis warnings against Jint's files in *your* build. They are
-tracked in [#3299](https://github.com/sebastienros/jint/issues/3299); until they are paid down, set
+tracked in [#3305](https://github.com/sebastienros/jint/issues/3305); until they are paid down, set
 `<IlcTreatWarningsAsErrors>false</IlcTreatWarningsAsErrors>` or `NoWarn` the codes, and treat the run
 as the evidence rather than the warning count.
 


### PR DESCRIPTION
Fixes #3299.

#3299 is the list of interop shapes that throw `NotSupportedException` under Native AOT, all of them one
shape: **a generic instantiation over a value type built at run time**. This re-derives the list from
source, fixes the one degradation that was answering wrongly, pins every site with a probe on the
published native binary, and writes down the remedy an embedder — and only an embedder — can apply.

## The list is eight, not five

`MakeGenericType` and `MakeGenericMethod` are the whole inventory, and grepping for those two names is how
to re-derive it after this area moves again. The `T[]` branch arrived after the issue was filed (#3356),
and two sites were never in it.

| site | shape | verdict |
| --- | --- | --- |
| `ObjectWrapper.ResolveArrayLikeWrapperFactoryType`, `T[]` branch | `ArrayWrapperFactory<int>` | degrades — **and the degradation was wrong; fixed here** |
| same site, `IList<>` branch | `GenericListWrapperFactory<int>` | degrades to `ListWrapper` |
| same site, `IReadOnlyList<>` branch | `ReadOnlyListWrapperFactory<double>` | degrades to a plain `ObjectWrapper` |
| `ObjectWrapper.ResolveEnumerableSnapshotFactory` | `EnumerableSnapshotFactory<int>` | degrades to the object snapshot |
| `DefaultTypeConverter.GetFromResultMethod` | `Task.FromResult<double>` | unsupportable |
| `MethodInfoFunction.ResolveMethod` | `hostMethod.MakeGenericMethod(double)` | unsupportable |
| `DefaultTypeConverter.TryConvertInternal`, ×2 | `List<long>` for an `IEnumerable<long>` parameter; the inner list a `Collection<short>` takes | **new** — unsupportable |
| `NamespaceReference.MakeGenericType` → `TypeReference` | a closed generic type the *script* named | **new** — unsupportable |

## The `T[]` degradation read correctly and did everything else wrong

`ArrayWrapper<T>` carries two facts in its type argument that `ListWrapper` took from nobody: the element
type, and that the length is fixed. So under Native AOT an `int[]` exposed as a live view

* answered `arr[0]` correctly,
* stored a **boxed `double`** into an `int[]` on `arr[0] = 9` (`InvalidCastException`), and
* served `arr.push(9)` through `IList.Add`, which on an array raises the CLR's own *Collection was of a
  fixed size* **past script** — where the same script under a JIT gets the `TypeError`
  `LiveViewArrayResizeAttemptsThrowTypeError` already pins.

Nothing covered it, because the row's probe only read. `ListWrapper` now takes both facts from the target
(`Array.GetType().GetElementType()`, `IList.IsFixedSize`), and `ThrowFixedSize` moves up to
`ArrayLikeWrapper` so both wrappers refuse with one message.

**The same hole existed under a JIT**, for a genuinely fixed-size `IList`: `ArrayList.FixedSize(...)`
resolves to `ListWrapper` on every runtime and leaked `NotSupportedException` there too. The new theory in
`InteropTests.ClrArrayLiveView.cs` asserts it — all six of its cases fail without the change, and the
growable control passes either way.

## Why the other four stay throwing

The same question each time, and the same answer: **nothing non-generic satisfies what was asked for**, so
degrading would trade a diagnosable throw for a wrong answer.

* Nothing but `Task.FromResult<double>` produces a `Task<double>`.
* Declining a generic host method reports *no matching overload* for a method that plainly exists — which
  is why `ResolveMethod`'s `catch (ArgumentException)` already carries a comment saying it is deliberately
  not `NotSupportedException`.
* Nothing but a `T`-typed value satisfies an `IEnumerable<long>` parameter. An array would need `long[]` to
  exist for exactly the same reason, and would hand a host that calls `Add` a fixed-size collection.
* A `Box<short>` the script asked for is a `Box<short>`.

Nothing gets `[RequiresDynamicCode]` either, and that is a deliberate verdict rather than an omission: the
type argument comes from the **host's members** and the **script's arguments**, so no signature anywhere in
Jint predicts it. Annotating `SetValue` or `AllowClr` would warn on the overwhelming majority of uses that
work. Nor may Jint root a guessed set of value types — every closed generic rooted costs binary size for
every AOT consumer, including the ones that never touch that path.

## What Jint *can* do: say who can close them, and how

The embedder can close all four, and this was verified on a published native binary rather than reasoned
about. A compiled reference from an assembly they already root with `TrimmerRootAssembly` closes three:

```csharp
_ = new MyHost().Identity(0d);
_ = new List<long>();
_ = new Box<short>(default);
```

It does **not** close `Task.FromResult<double>`. A plain `Task.FromResult(0d)` compiles the body, but Jint
reaches the method reflectively and `Task` lives in an assembly the host has not rooted, so there is
nothing to invoke. Naming it the way Jint names it does close it, because both tokens are constants and ILC
folds the expression:

```csharp
_ = typeof(Task).GetMethod(nameof(Task.FromResult))!.MakeGenericMethod(typeof(double));
```

That asymmetry is the part worth writing down, and `docs/v5-migration.md` §6.2 now carries it, along with
the corrected enumeration. §6.4's pointer for the trim-analysis inventory moves from #3299 to #3305, which
is the issue that actually tracks it.

## The probe file

`Jint.AotExample` goes from 20 probes / 2 gaps to **25 probes / 5 gaps**. Five new probes — a `string[]`
and an `int[]` live view *including their element writes and resize refusals*, a JS array reaching
`IEnumerable<string>` and `List<int>` parameters, and a script-built generic type over a reference type —
and three new gaps, one per newly enumerated site.

The `List<int>` row is there because it is the boundary: that site works when the host's own signature
names the closed type, which is what makes ILC compile it. An `IEnumerable<int>` parameter does not.

## Verification

| | |
| --- | --- |
| `dotnet build -c Release` | clean (the one `MSB3277` is a pre-existing `System.Memory` conflict in `Jint.Tests.CommonScripts` on `net472`) |
| `dotnet publish Jint.AotExample -c Release`, **binary run natively** | `ALL PROBES PASSED (25 probes, 5 known AOT gaps)`; before: 20 probes / 2 gaps, and 4 of the new rows failed as raw `NotSupportedException` |
| trim/AOT analysis diagnostics | 113 before, 113 after — the change adds none, and none is attributed to the example |
| `Jint.Tests` | 7323 (net472), 10684 (net8.0), 10684 (net10.0), 0 failed |
| `Jint.Tests.PublicInterface` | 2356 (net472), 2985 (net10.0), 0 failed |
| `Jint.Tests.Test262` | **102495 passed, 0 failed** |
| public API | unchanged — everything touched is `internal`, so no `Verify` snapshot and no `UndocumentedPublicApi.txt` movement |

## Deferred

A read-only collection refuses to grow with the CLR's own `NotSupportedException` where a fixed-size one
now refuses with a `TypeError` — `new ReadOnlyCollection<int>(...)` then `ro.push(4)` escapes `Evaluate`
uncatchable. It is a real disagreement between two wrappers and it is not an AOT problem, so it is filed
as #3382 rather than folded in here.
