### PR TITLE
Interop: a read-only host collection refuses script with a JavaScript error, not the CLR's own

### DIFF
--- a/Jint.Tests.PublicInterface/HostReadOnlyCollectionTests.cs
+++ b/Jint.Tests.PublicInterface/HostReadOnlyCollectionTests.cs
@@ -1,0 +1,306 @@
+#nullable enable
+
+using System.Collections;
+using System.Collections.Immutable;
+using System.Collections.ObjectModel;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// Pins what a wrapped CLR collection that declares itself read-only owes script when it is asked to
+/// change: a JavaScript error the script can catch, never the CLR's own
+/// <see cref="NotSupportedException"/> escaping <c>Evaluate</c>.
+///
+/// <para>
+/// Which JavaScript answer depends on the operation, not on the collection. <c>push</c>, <c>pop</c>,
+/// <c>splice</c>, <c>sort</c> and <c>reverse</c> are specified in terms of <c>Set(O, k, v, true)</c> and
+/// <c>DeletePropertyOrThrow</c>, so a refusal is a <c>TypeError</c> in either mode. A bare assignment —
+/// <c>host[0] = 9</c>, <c>host.length = 5</c>, <c>delete host[0]</c> — is an ordinary <c>[[Set]]</c> or
+/// <c>[[Delete]]</c> returning <see langword="false"/>, which is a <c>TypeError</c> in strict mode and
+/// silent in sloppy mode. Both halves are asserted below, because "make everything throw" would be wrong
+/// in the second one.
+/// </para>
+///
+/// <para>
+/// The contrast case is a collection that is fixed-size rather than read-only, which refuses the same
+/// length changes and still accepts element writes. <see cref="ArraySegment{T}"/> is the shape that makes
+/// the distinction load-bearing: it reports <see cref="ICollection{T}.IsReadOnly"/> as
+/// <see langword="true"/> meaning only that it cannot grow, exactly as <c>T[]</c> does.
+/// </para>
+/// </summary>
+public class HostReadOnlyCollectionTests
+{
+    private static Engine CreateEngine(object host, bool strict = false)
+    {
+        var engine = new Engine(options =>
+        {
+            options.Strict = strict;
+            options.Interop.AllowWrite = true;
+        });
+        engine.SetValue("host", host);
+        return engine;
+    }
+
+    /// <summary>
+    /// Every shape an embedder reaches for when it wants to hand script a collection it may read but not
+    /// change. They resolve to two different wrappers — <c>ReadOnlyCollection&lt;T&gt;</c> and a host
+    /// <see cref="IList{T}"/> to the generic list view, the rest to the read-only list view — and before
+    /// #3382 the two disagreed about which of them leaked which CLR exception.
+    /// </summary>
+    private static readonly string[] _readOnlyShapes =
+    [
+        nameof(ReadOnlyCollection<int>),
+        nameof(ImmutableList),
+        nameof(ImmutableArray),
+        nameof(HostReadOnlyList),
+        nameof(HostReadOnlySequence),
+        nameof(ArrayList),
+    ];
+
+    public static TheoryData<string> ReadOnlyShapes
+    {
+        get
+        {
+            var data = new TheoryData<string>();
+            foreach (var shape in _readOnlyShapes)
+            {
+                data.Add(shape);
+            }
+
+            return data;
+        }
+    }
+
+    private static (object Host, Func<IReadOnlyList<int>> Read) CreateReadOnlyShape(string kind)
+    {
+        switch (kind)
+        {
+            case nameof(ReadOnlyCollection<int>):
+            {
+                var items = new List<int> { 1, 2, 3 };
+                return (new ReadOnlyCollection<int>(items), () => items);
+            }
+            case nameof(ImmutableList):
+            {
+                var items = ImmutableList.Create(1, 2, 3);
+                return (items, () => items);
+            }
+            case nameof(ImmutableArray):
+            {
+                var items = ImmutableArray.Create(1, 2, 3);
+                return (items, () => items);
+            }
+            case nameof(HostReadOnlyList):
+            {
+                var items = new List<int> { 1, 2, 3 };
+                return (new HostReadOnlyList(items), () => items);
+            }
+            case nameof(HostReadOnlySequence):
+            {
+                var items = new List<int> { 1, 2, 3 };
+                return (new HostReadOnlySequence(items), () => items);
+            }
+            case nameof(ArrayList):
+            {
+                var items = ArrayList.ReadOnly(new ArrayList { 1, 2, 3 });
+                return (items, () => items.Cast<int>().ToList());
+            }
+            default:
+                throw new ArgumentOutOfRangeException(nameof(kind), kind, "unknown shape");
+        }
+    }
+
+    /// <summary>
+    /// The five <c>Array.prototype</c> generics that change a length. <c>sort</c> and <c>reverse</c> are
+    /// spelled through <c>Array.prototype</c> deliberately: several of these shapes carry a CLR
+    /// <c>Sort</c>/<c>Reverse</c> member of their own, and a wrapped member wins over the prototype, so
+    /// <c>host.sort(…)</c> would measure member resolution rather than the refusal.
+    /// </summary>
+    public static TheoryData<string, string> ThrowingOperations
+    {
+        get
+        {
+            var data = new TheoryData<string, string>();
+            foreach (var shape in _readOnlyShapes)
+            {
+                data.Add(shape, "host.push(4)");
+                data.Add(shape, "host.pop()");
+                data.Add(shape, "host.splice(0, 1)");
+                data.Add(shape, "Array.prototype.sort.call(host, function (a, b) { return b - a; })");
+                data.Add(shape, "Array.prototype.reverse.call(host)");
+            }
+
+            return data;
+        }
+    }
+
+    /// <summary>
+    /// The assignments, which the specification refuses differently: silently in sloppy mode.
+    /// </summary>
+    public static TheoryData<string, string> AssigningOperations
+    {
+        get
+        {
+            var data = new TheoryData<string, string>();
+            foreach (var shape in _readOnlyShapes)
+            {
+                data.Add(shape, "host[0] = 9");
+                data.Add(shape, "host[3] = 9");
+                data.Add(shape, "host.length = 5");
+                data.Add(shape, "host.length = 1");
+                data.Add(shape, "delete host[0]");
+            }
+
+            return data;
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(ThrowingOperations))]
+    public void AnArrayGenericThatMustGrowAReadOnlyCollectionThrowsACatchableTypeError(string shape, string operation)
+    {
+        var (host, read) = CreateReadOnlyShape(shape);
+
+        foreach (var strict in new[] { false, true })
+        {
+            var engine = CreateEngine(host, strict);
+
+            // the catch is script-side on purpose: a CLR NotSupportedException escaping Evaluate is
+            // invisible to it, which is the whole defect (#3382)
+            var outcome = engine.Evaluate(Probe(operation, strict)).AsString();
+
+            outcome.Should().Be("TypeError", "{0} on a read-only {1} is Set(O, k, v, true)", operation, shape);
+            read().Should().Equal(1, 2, 3);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(AssigningOperations))]
+    public void AnAssignmentToAReadOnlyCollectionIsRefusedSilentlyInSloppyModeAndThrowsInStrictMode(string shape, string operation)
+    {
+        var (host, read) = CreateReadOnlyShape(shape);
+
+        CreateEngine(host).Evaluate(Probe(operation, strict: false)).AsString()
+            .Should().Be("no-throw", "a failed [[Set]] is silent outside strict mode");
+        read().Should().Equal(1, 2, 3);
+
+        CreateEngine(host, strict: true).Evaluate(Probe(operation, strict: true)).AsString()
+            .Should().Be("TypeError", "a failed [[Set]] is a TypeError in strict mode");
+        read().Should().Equal(1, 2, 3);
+    }
+
+    /// <summary>
+    /// The refusal an embedder actually reads is the ordinary one a frozen JavaScript array gives — the
+    /// element write is what fails, and it names the property. Nothing here invents an interop-specific
+    /// message, which is the point: the refusal happens in <c>[[Set]]</c>, before the collection is
+    /// reached at all.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ReadOnlyShapes))]
+    public void TheRefusalIsTheOrdinaryReadOnlyPropertyTypeError(string shape)
+    {
+        var (host, _) = CreateReadOnlyShape(shape);
+        var engine = CreateEngine(host);
+
+        var message = engine.Evaluate("(function () { try { host.push(4); return ''; } catch (e) { return e.message; } })()").AsString();
+
+        message.Should().Contain("read only property '3'");
+    }
+
+    [Fact]
+    public void AGrowableListStillGrows()
+    {
+        // the control: nothing above may be bought by refusing writes that were always legitimate
+        var items = new List<int> { 1, 2, 3 };
+        var engine = CreateEngine(items);
+
+        engine.Execute("host.push(4); host[0] = 9; host.length = 6;");
+
+        items.Should().Equal(9, 2, 3, 4, 0, 0);
+    }
+
+    /// <summary>
+    /// <see cref="ArraySegment{T}"/> reports <see cref="ICollection{T}.IsReadOnly"/> as
+    /// <see langword="true"/> to mean it cannot grow, the same lie <c>T[]</c> tells through the same
+    /// interface, so it must be treated as fixed-size and keep its element writes.
+    /// </summary>
+    [Fact]
+    public void AnArraySegmentIsFixedSizeRatherThanReadOnly()
+    {
+        var array = new[] { 1, 2, 3 };
+        var engine = CreateEngine(new ArraySegment<int>(array));
+
+        engine.Evaluate(Probe("host.push(4)", strict: false)).AsString().Should().Be("TypeError");
+        engine.Evaluate(Probe("host[0] = 9", strict: false)).AsString().Should().Be("no-throw");
+
+        array.Should().Equal(9, 2, 3);
+    }
+
+    private static string Probe(string operation, bool strict)
+    {
+        var prologue = strict ? "'use strict';\n" : "";
+        return prologue
+            + "(function () { try { " + operation + "; return 'no-throw'; } "
+            + "catch (e) { return e instanceof TypeError ? 'TypeError' : 'unexpected: ' + e; } })()";
+    }
+
+    /// <summary>
+    /// A host list that declares itself read-only through <see cref="ICollection{T}.IsReadOnly"/> and
+    /// throws from every mutator, which is what the interface's contract asks of an implementer.
+    /// </summary>
+    private sealed class HostReadOnlyList : IList<int>
+    {
+        private readonly List<int> _items;
+
+        public HostReadOnlyList(List<int> items) => _items = items;
+
+        public int Count => _items.Count;
+
+        public bool IsReadOnly => true;
+
+        public int this[int index]
+        {
+            get => _items[index];
+            set => throw new NotSupportedException("Collection is read-only.");
+        }
+
+        public void Add(int item) => throw new NotSupportedException("Collection is read-only.");
+
+        public void Clear() => throw new NotSupportedException("Collection is read-only.");
+
+        public bool Contains(int item) => _items.Contains(item);
+
+        public void CopyTo(int[] array, int arrayIndex) => _items.CopyTo(array, arrayIndex);
+
+        public IEnumerator<int> GetEnumerator() => _items.GetEnumerator();
+
+        public int IndexOf(int item) => _items.IndexOf(item);
+
+        public void Insert(int index, int item) => throw new NotSupportedException("Collection is read-only.");
+
+        public bool Remove(int item) => throw new NotSupportedException("Collection is read-only.");
+
+        public void RemoveAt(int index) => throw new NotSupportedException("Collection is read-only.");
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    /// <summary>
+    /// The other half of the read-only surface: a type that offers no write at all, so the wrapper's
+    /// refusal cannot come from the target and has to come from the engine.
+    /// </summary>
+    private sealed class HostReadOnlySequence : IReadOnlyList<int>
+    {
+        private readonly List<int> _items;
+
+        public HostReadOnlySequence(List<int> items) => _items = items;
+
+        public int Count => _items.Count;
+
+        public int this[int index] => _items[index];
+
+        public IEnumerator<int> GetEnumerator() => _items.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -1033,10 +1033,11 @@ public partial class InteropTests : IDisposable
     [Fact]
     public void ReadOnlyCollectionWrapper_RejectsIndexWriteCleanly()
     {
-        // A runtime read-only IList<T> (e.g. List<T>.AsReadOnly()) is wrapped as a writable
-        // GenericListWrapper, but its backing indexer throws. The element write must be rejected
-        // through the normal [[Set]] path (TypeError in strict, silent no-op in non-strict), NOT
-        // surface a raw NotSupportedException from the underlying collection.
+        // A runtime read-only IList<T> (e.g. List<T>.AsReadOnly()) reaches GenericListWrapper, whose
+        // backing indexer throws. The element write must be rejected through the normal [[Set]] path
+        // (TypeError in strict, silent no-op in non-strict), NOT surface a raw NotSupportedException
+        // from the underlying collection. This engine has AllowWrite off, so CanWrite refuses either
+        // way; the wrapper's own ICollection<T>.IsReadOnly refuses it with AllowWrite on (#3382).
         var readOnly = new List<int> { 1, 2 }.AsReadOnly();
 
         var strict = new Engine(x => x.Strict = true);

--- a/Jint/Native/Array/ArrayOperations.cs
+++ b/Jint/Native/Array/ArrayOperations.cs
@@ -842,7 +842,12 @@ internal abstract class ArrayOperations : IEnumerable<JsValue>
 
         public override void Set(ulong index, JsValue value, bool updateLength = false, bool throwOnError = true)
         {
-            if (_target.Engine.Options.Interop.AllowWrite && _target.Extensible)
+            // CanWrite, not Options.Interop.AllowWrite: a wrapper over a target that declared itself
+            // read-only refuses the write, and the refusal it owes an Array.prototype generic is the
+            // TypeError Set(O, k, v, true) raises on a false [[Set]] - which is what routing through the
+            // wrapper produces, where SetAt would reach the collection and let its NotSupportedException
+            // past script (#3382).
+            if (_target.CanWrite && _target.Extensible)
             {
                 _target.SetAt((int) index, value);
             }

--- a/Jint/Runtime/Interop/ObjectWrapper.Specialized.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.Specialized.cs
@@ -171,7 +171,7 @@ internal abstract class ArrayLikeWrapper : ObjectWrapper
 
     public sealed override bool Delete(JsValue property)
     {
-        if (!_engine.Options.Interop.AllowWrite || !Extensible)
+        if (!CanWrite || !Extensible)
         {
             if (property is JsString dictionaryKey
                 && _typeDescriptor.IsStringKeyedGenericDictionary
@@ -404,13 +404,27 @@ internal abstract class ArrayLikeWrapper : ObjectWrapper
         return base.Set(property, value, receiver);
     }
 
-    protected virtual bool CanWrite => _engine.Options.Interop.AllowWrite;
+    /// <summary>
+    /// Whether an element of this view may be written at all: the engine must be configured for writes
+    /// and the target must not have declared itself read-only. Consulted by <see cref="Set"/>,
+    /// <see cref="Delete"/> and by <c>ArrayOperations</c>' array-like lane, so that a refusal is the
+    /// ordinary <c>[[Set]]</c>/<c>[[Delete]]</c> <see langword="false"/> — a <c>TypeError</c> in strict
+    /// mode, silent in sloppy — rather than a CLR exception from the collection.
+    /// </summary>
+    internal bool CanWrite => _engine.Options.Interop.AllowWrite && !IsReadOnly;
 
     /// <summary>
     /// Whether the underlying collection cannot change its length (CLR arrays). Enables the direct
     /// integral-index write lane in <see cref="Set"/>.
     /// </summary>
     protected virtual bool IsFixedSize => false;
+
+    /// <summary>
+    /// Whether the underlying collection refuses every mutation, elements included — what
+    /// <see cref="ICollection{T}.IsReadOnly"/> and <see cref="IList.IsReadOnly"/> declare. Strictly
+    /// stronger than <see cref="IsFixedSize"/>, which forbids only the length change.
+    /// </summary>
+    protected virtual bool IsReadOnly => false;
 
     /// <summary>
     /// The refusal every length-changing operation on a fixed-size target owes script: a
@@ -421,9 +435,37 @@ internal abstract class ArrayLikeWrapper : ObjectWrapper
     [DoesNotReturn]
     protected void ThrowFixedSize() => Throw.TypeError(_engine.Realm, "Cannot resize a fixed-size CLR array");
 
+    /// <summary>
+    /// The backstop for a read-only target, and deliberately unreachable: <see cref="CanWrite"/> is false
+    /// for one, so every lane refuses before a mutator is called and script gets the ordinary
+    /// <c>[[Set]]</c>/<c>[[Delete]]</c> refusal a frozen JavaScript array gives. It exists so that a lane
+    /// added later cannot reach <c>Add</c>/<c>RemoveAt</c> and leak the collection's own
+    /// <see cref="NotSupportedException"/> past script the way three of them did until #3382.
+    /// </summary>
+    [DoesNotReturn]
+    protected void ThrowReadOnly() => Throw.TypeError(_engine.Realm, "Cannot modify a read-only CLR collection");
+
+    /// <summary>
+    /// Guard at the head of every length-changing operation of a wrapper that takes its two facts from
+    /// the target rather than from its type argument. Read-only is answered first because it is the
+    /// stronger claim: a collection can be both (<c>ArrayList.ReadOnly</c>), and only one message is right.
+    /// </summary>
+    protected void ThrowIfLengthCannotChange()
+    {
+        if (IsReadOnly)
+        {
+            ThrowReadOnly();
+        }
+
+        if (IsFixedSize)
+        {
+            ThrowFixedSize();
+        }
+    }
+
     public void SetAt(int index, JsValue value)
     {
-        if (_engine.Options.Interop.AllowWrite)
+        if (CanWrite)
         {
             EnsureCapacity(index + 1);
             DoSetAt(index, ConvertToItemType(value));
@@ -479,12 +521,14 @@ internal sealed class ListWrapper : ArrayLikeWrapper
 {
     private readonly IList? _list;
     private readonly bool _fixedSize;
+    private readonly bool _readOnly;
 
     internal ListWrapper(Engine engine, IList target, Type type)
         : base(engine, target, ElementTypeOf(target), type, elementAccessMayRunHostCode: target is not (Array or ArrayList))
     {
         _list = target;
         _fixedSize = target.IsFixedSize;
+        _readOnly = target.IsReadOnly;
     }
 
     /// <summary>
@@ -505,6 +549,14 @@ internal sealed class ListWrapper : ArrayLikeWrapper
     /// <see cref="NotSupportedException"/> past script instead of raising a catchable <c>TypeError</c>.
     /// </summary>
     protected override bool IsFixedSize => _fixedSize;
+
+    /// <summary>
+    /// Read from the target for the same reason as <see cref="IsFixedSize"/>, and separately from it
+    /// because the non-generic <see cref="IList"/> asks the two questions separately:
+    /// <c>ArrayList.FixedSize</c> is fixed-size and writable, <c>ArrayList.ReadOnly</c> is both, and an
+    /// embedder's own read-only <see cref="IList"/> may be neither fixed-size nor writable.
+    /// </summary>
+    protected override bool IsReadOnly => _readOnly;
 
     public override int Length => _list?.Count ?? 0;
 
@@ -528,41 +580,29 @@ internal sealed class ListWrapper : ArrayLikeWrapper
 
     public override void AddDefault()
     {
-        if (_fixedSize)
-        {
-            ThrowFixedSize();
-        }
-
+        ThrowIfLengthCannotChange();
         _list?.Add(null);
     }
 
     public override void Add(JsValue value)
     {
-        if (_fixedSize)
-        {
-            ThrowFixedSize();
-        }
-
+        ThrowIfLengthCannotChange();
         _list?.Add(ConvertToItemType(value));
     }
 
     public override void RemoveAt(int index)
     {
-        if (_fixedSize)
-        {
-            ThrowFixedSize();
-        }
-
+        ThrowIfLengthCannotChange();
         _list?.RemoveAt(index);
     }
 
     public override void EnsureCapacity(int capacity)
     {
-        if (_fixedSize)
+        if (_fixedSize || _readOnly)
         {
             if (capacity > Length)
             {
-                ThrowFixedSize();
+                ThrowIfLengthCannotChange();
             }
 
             return;
@@ -575,12 +615,36 @@ internal sealed class ListWrapper : ArrayLikeWrapper
 internal class GenericListWrapper<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicFields)] T> : ArrayLikeWrapper
 {
     private readonly IList<T> _list;
+    private readonly bool _fixedSize;
+    private readonly bool _readOnly;
 
     public GenericListWrapper(Engine engine, IList<T> target, Type? type)
         : base(engine, target, typeof(T), type, elementAccessMayRunHostCode: target is not (T[] or List<T>))
     {
         _list = target;
+        _fixedSize = IsFixedSizeArray(target);
+        _readOnly = !_fixedSize && target.IsReadOnly;
     }
+
+    /// <summary>
+    /// The two shapes whose <see cref="ICollection{T}.IsReadOnly"/> means <em>cannot grow</em> rather
+    /// than <em>cannot be written</em>, which is the one place the generic interface's single flag
+    /// disagrees with the non-generic <see cref="IList"/>'s two. Both accept element writes and refuse
+    /// every length change, so they are fixed-size here and not read-only. A <c>T[]</c> reaches this
+    /// wrapper when the exposed type is a declared <see cref="IList{T}"/> rather than the array type,
+    /// which <see cref="ObjectWrapper.Create(Engine, object, Type?)"/> and <c>clrHelper</c> both allow.
+    /// </summary>
+    private static bool IsFixedSizeArray(IList<T> target) => target is T[] or ArraySegment<T>;
+
+    protected override bool IsFixedSize => _fixedSize;
+
+    /// <summary>
+    /// Taken from the target's own <see cref="ICollection{T}.IsReadOnly"/>: a
+    /// <c>ReadOnlyCollection&lt;T&gt;</c>, an immutable collection and a host list that declares itself
+    /// read-only all raise <see cref="NotSupportedException"/> from <c>Add</c>/<c>RemoveAt</c> and from
+    /// the indexer setter, which script cannot catch (#3382).
+    /// </summary>
+    protected override bool IsReadOnly => _readOnly;
 
     public override int Length => _list.Count;
 
@@ -608,15 +672,34 @@ internal class GenericListWrapper<[DynamicallyAccessedMembers(DynamicallyAccesse
 
     protected override void DoSetAt(int index, object? value) => _list[index] = (T) value!;
 
-    public override void AddDefault() => _list.Add(default!);
+    public override void AddDefault()
+    {
+        ThrowIfLengthCannotChange();
+        _list.Add(default!);
+    }
 
     public override void Add(JsValue value)
     {
+        ThrowIfLengthCannotChange();
         var converted = ConvertToItemType(value);
         _list.Add((T) converted!);
     }
 
-    public override void RemoveAt(int index) => _list.RemoveAt(index);
+    public override void RemoveAt(int index)
+    {
+        ThrowIfLengthCannotChange();
+        _list.RemoveAt(index);
+    }
+
+    public override void EnsureCapacity(int capacity)
+    {
+        if (capacity > Length)
+        {
+            ThrowIfLengthCannotChange();
+        }
+
+        base.EnsureCapacity(capacity);
+    }
 }
 
 /// <summary>
@@ -724,15 +807,20 @@ internal sealed class ReadOnlyListWrapper<[DynamicallyAccessedMembers(Dynamicall
         return Undefined;
     }
 
-    protected override bool CanWrite => false;
+    /// <summary>
+    /// An <see cref="IReadOnlyList{T}"/> exposes no write of any kind, so this view is read-only in the
+    /// full sense. It replaces the <c>CanWrite</c> override this class used to carry, which said the same
+    /// thing about element writes alone and left <c>Array.prototype</c>'s length-changing generics
+    /// reaching the mutators below — where they raised the CLR's own
+    /// <see cref="NotSupportedException"/> past script (#3382).
+    /// </summary>
+    protected override bool IsReadOnly => true;
 
-    public override void AddDefault() => Throw.NotSupportedException();
+    public override void AddDefault() => ThrowReadOnly();
 
-    protected override void DoSetAt(int index, object? value) => Throw.NotSupportedException();
+    protected override void DoSetAt(int index, object? value) => ThrowReadOnly();
 
-    public override void Add(JsValue value) => Throw.NotSupportedException();
+    public override void Add(JsValue value) => ThrowReadOnly();
 
-    public override void RemoveAt(int index) => Throw.NotSupportedException();
-
-    public override void EnsureCapacity(int capacity) => Throw.NotSupportedException();
+    public override void RemoveAt(int index) => ThrowReadOnly();
 }

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -1560,6 +1560,48 @@ might notice:
 - The result keeps its two operands alive until something reads its text. A host that concatenates a large
   string and holds only the result, expecting the operands to become collectable immediately, gets that back
   by reading the result once (`AsString()` is enough) — the node then drops both references.
+### 4.28 A read-only host collection refuses script with a JavaScript error ([#3382](https://github.com/sebastienros/jint/issues/3382))
+
+A wrapped collection that declares itself read-only — `ReadOnlyCollection<T>`, `ImmutableList<T>`,
+`ImmutableArray<T>`, `ArrayList.ReadOnly(…)`, a host `IList<T>` whose `IsReadOnly` is `true`, or anything
+reaching the engine as `IReadOnlyList<T>` — raised the CLR's own `NotSupportedException` out of
+`Engine.Evaluate` when script tried to change it. Not a `JavaScriptException`, so neither a script
+`try`/`catch` nor a host `catch (JavaScriptException)` could see it:
+
+```js
+// 4.16.x, for engine.SetValue("ro", new ReadOnlyCollection<int>([1, 2, 3]))
+//         with options.Interop.AllowWrite = true
+ro.push(4)        // NotSupportedException: Collection is read-only.
+ro.pop()          // NotSupportedException
+ro.length = 5     // NotSupportedException
+delete ro[0]      // NotSupportedException
+```
+
+Each of those now gets the answer the specification gives for the same operation on a frozen array-like,
+which is not the same answer for all of them. `push`, `pop`, `splice`, `sort` and `reverse` are specified in
+terms of `Set(O, k, v, true)` and `DeletePropertyOrThrow`, so they raise a `TypeError` in either mode; a bare
+assignment is an ordinary `[[Set]]` returning `false`, which is a `TypeError` only in strict mode:
+
+```js
+// 5.x
+ro.push(4)        // TypeError: Cannot assign to read only property '3' of object '#<Object>'
+ro.length = 5     // sloppy: silently ignored;  strict: TypeError
+ro[0] = 9         // sloppy: silently ignored;  strict: TypeError
+delete ro[0]      // sloppy: false;             strict: TypeError
+```
+
+The collection is left untouched in every case, which it was not before: `pop` and `splice` reached the
+target and mutated it part-way before the CLR refused.
+
+`ArraySegment<T>` moves in the same change and to a different place. It reports
+`ICollection<T>.IsReadOnly` as `true` to mean *cannot grow* — the same thing `T[]` reports through that
+interface — so it is treated as **fixed-size**: length changes are refused with the `TypeError` a `T[]` live
+view already gave, and element writes keep working.
+
+**What could break:** a `catch (NotSupportedException)` around `Evaluate` written to absorb this no longer
+fires. Script that relied on a length change silently succeeding never existed — it threw. Nothing changes
+for a growable collection, for `Options.Interop.AllowWrite = false` (which refused these writes already), or
+for a `T[]` exposed under `ArrayConversionMode.LiveView`.
 
 ## 5. New in v5
 


### PR DESCRIPTION
Fixes #3382.

A wrapped collection that refuses to change because it is **read-only** raised the CLR's own
`NotSupportedException` out of `Engine.Evaluate`, where the collection that refuses because it is
**fixed-size** answers with a `TypeError` — which #3381 had just finished making true for the last of the
fixed-size shapes. Neither a script `try`/`catch` nor a host `catch (JavaScriptException)` can see the CLR
one, so the two halves of one operation were not merely inconsistent: only one of them was catchable at all.

## Reproduction, before the change

Measured on `main`, `net10.0`, Release, from a program that does nothing but `engine.SetValue("x", …)` and
`Evaluate`, with `Interop.AllowWrite = true` and `ArrayConversion = LiveView`. Every collection holds
`1, 2, 3`. Cells that differ by mode are written `sloppy → strict`; everything else is the same in both.
**NSE** is `System.NotSupportedException`, **AOORE** is `System.ArgumentOutOfRangeException`, both escaping
`Evaluate`.

| | `List<int>` | `ReadOnlyCollection<int>` | host `IReadOnlyList<int>` | `ImmutableList<int>` | `ImmutableArray<int>` | host `IList<int>` `IsReadOnly` | host `ICollection<int>` `IsReadOnly` | `ArraySegment<int>` | `int[]` |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| wrapper | `GenericListWrapper` | `GenericListWrapper` | `ReadOnlyListWrapper` | `ReadOnlyListWrapper` | `ReadOnlyListWrapper` | `GenericListWrapper` | `ObjectWrapper` | `GenericListWrapper` | `ArrayWrapper` |
| `x.push(4)` | grows | **NSE** | **NSE** | **NSE** | **NSE** | **NSE** | TypeError | **NSE** | TypeError |
| `x.pop()` | shrinks | **NSE** | **NSE** | **NSE** | **NSE** | **NSE** | TypeError | **NSE**, *already truncated* | TypeError |
| `x[3] = 9` | **AOORE** | no-op → TypeError | no-op → TypeError | no-op → TypeError | no-op → TypeError | **NSE** | no-op | **AOORE** | TypeError |
| `x[0] = 9` | writes | no-op → TypeError | no-op → TypeError | no-op → TypeError | no-op → TypeError | **NSE** | no-op | writes | writes |
| `delete x[0]` | zeroes the slot | **NSE** | no-op → TypeError | **NSE** | **NSE** | **NSE** | no-op | zeroes the slot | no-op → TypeError |
| `x.length = 5` | grows | **NSE** | no-op → TypeError | no-op → TypeError | no-op → TypeError | **NSE** | no-op → TypeError | **NSE** | TypeError |
| `x.length = 1` | shrinks | **NSE** | no-op → TypeError | no-op → TypeError | no-op → TypeError | **NSE** | no-op → TypeError | **NSE** | TypeError |
| `%sort%.call(x, cmp)` | sorts | **NSE** | **NSE** | **NSE** | **NSE** | **NSE** | no-op | sorts | sorts |
| `%reverse%.call(x)` | reverses | **NSE** | **NSE** | **NSE** | **NSE** | **NSE** | no-op | reverses | reverses |
| `x.splice(0, 1)` | removes | **NSE** | **NSE** | **NSE** | **NSE** | **NSE** | TypeError | **NSE**, *already shifted* | TypeError, *already shifted* |

`%sort%` and `%reverse%` are `Array.prototype.sort`/`reverse` spelled through `.call`, deliberately: `x.sort(…)`
on a `List<T>`, an `ImmutableList<T>` or an `ImmutableArray<T>` resolves to the **CLR** `Sort` member, which
wins over the prototype. Writing `x.sort(…)` in the table would have measured member resolution instead of
the refusal, and would have shown `ImmutableList<int>` silently "succeeding" — it calls
`ImmutableList<T>.Sort()`, whose new list is discarded.

Four things the table says that the issue did not.

1. **It is six shapes, not one.** `ReadOnlyCollection<T>` and a host `IList<T>` reach it through
   `GenericListWrapper<T>`, whose growth paths call straight through to `IList<T>`; `ImmutableList<T>`,
   `ImmutableArray<T>` and anything reaching the engine as `IReadOnlyList<T>` reach it through
   `ReadOnlyListWrapper<T>`, whose mutators were literally `Throw.NotSupportedException()`; and
   `ArrayList.ReadOnly(…)` reaches it through the untyped `ListWrapper`. The issue's suspicion that
   `ReadOnlyListWrapper<T>`'s `CanWrite => false` "blocks element writes but not the length-changing
   generics" is exactly right, and the table is what says so.
2. **A host `IList<T>` that declares `IsReadOnly` leaked on element writes too**, where
   `ReadOnlyCollection<T>` did not. That difference is an accident of reflection rather than a rule:
   `ReadOnlyCollection<T>`'s public indexer is get-only, so the reflected member write was refused before
   the collection was reached, while a host type whose indexer setter throws was not.
3. **`pop` and `splice` mutated the target before refusing.** The element moves succeeded and the CLR
   refused at the end, so a caught-and-ignored `NotSupportedException` left the collection shifted.
4. **`ArraySegment<T>` is in it, and belongs somewhere else.** It reports `ICollection<T>.IsReadOnly` as
   `true` and its element writes work — see below.

The `host ICollection<int>` column is the one that was already right, and it is the #3356 shape: a
collection with a `Count` and no index, whose `Array.prototype` generics honour the length and find nothing
at each index. It is unchanged by this PR and carried as the contrast.

## What each shape should do, from the specification

The wrapper is an ordinary object carrying `Array.prototype`, so the answer is per *operation*, not per
collection, and it is not the same answer for all of them:

* `push`, `pop`, `splice`, `sort` and `reverse` are specified in terms of `Set(O, k, v, true)` and
  `DeletePropertyOrThrow`, which raise a **`TypeError`** on a `false` `[[Set]]`/`[[Delete]]` in either mode.
* `x[0] = 9`, `x[3] = 9`, `x.length = n` and `delete x[0]` are a bare `[[Set]]`/`[[Delete]]` returning
  `false`: a **`TypeError` in strict mode and silent in sloppy mode**. Making these throw as well would have
  been wrong — it is what `Object.freeze([1,2,3])` gives, and five rows of the table are that shape.
* A **fixed-size** collection still accepts an in-range element write, which is why `int[]`'s `x[0] = 9` and
  `sort` keep working and only the length changes are refused.
* `splice` on something whose length cannot change leaves the elements shifted and *then* throws, because
  the element moves are in-range `Set`s and only the final length write fails. That is what
  `Array.prototype.splice.call` gives for any array-like with a non-writable `length`, so the `2,3,3` cells
  stay.

## Reproduction, after the change

Only the cells that moved; every other cell above is byte-identical, the `List<int>` and
`host ICollection<int>` columns included.

| | `ReadOnlyCollection<int>` | host `IReadOnlyList<int>` | `ImmutableList<int>` | `ImmutableArray<int>` | host `IList<int>` `IsReadOnly` | `ArraySegment<int>` |
| --- | --- | --- | --- | --- | --- | --- |
| `x.push(4)` | TypeError | TypeError | TypeError | TypeError | TypeError | TypeError |
| `x.pop()` | TypeError | TypeError | TypeError | TypeError | TypeError | TypeError, *untouched* |
| `x[3] = 9` | — | — | — | — | no-op → TypeError | TypeError |
| `x[0] = 9` | — | — | — | — | no-op → TypeError | writes (unchanged) |
| `delete x[0]` | no-op → TypeError | — | no-op → TypeError | no-op → TypeError | no-op → TypeError | no-op → TypeError |
| `x.length = 5` | no-op → TypeError | — | — | — | no-op → TypeError | TypeError |
| `x.length = 1` | no-op → TypeError | — | — | — | no-op → TypeError | TypeError |
| `%sort%.call(x, cmp)` | TypeError | TypeError | TypeError | TypeError | TypeError | sorts (unchanged) |
| `%reverse%.call(x)` | TypeError | TypeError | TypeError | TypeError | TypeError | reverses (unchanged) |
| `x.splice(0, 1)` | TypeError | TypeError | TypeError | TypeError | TypeError | TypeError, *shifted* |

The `TypeError` an embedder actually reads is the ordinary one — *Cannot assign to read only property '3'
of object '#&lt;Object&gt;'* — because the refusal now happens in `[[Set]]`, before the collection is reached
at all. Nothing invents an interop-specific message for it.

## What changed

One fact, taken from the target the way #3381 took `IsFixedSize` from it:

* `ArrayLikeWrapper` gains `IsReadOnly`, and `CanWrite` becomes `AllowWrite && !IsReadOnly` and stops being
  virtual. `ReadOnlyListWrapper<T>`'s `CanWrite => false` override becomes `IsReadOnly => true`, which is the
  same statement about element writes plus the one it was missing about the length.
* `ListWrapper` reads `IList.IsReadOnly` beside the `IList.IsFixedSize` it already read;
  `GenericListWrapper<T>` reads `ICollection<T>.IsReadOnly`.
* The three lanes that consulted `Options.Interop.AllowWrite` **directly** rather than through `CanWrite` now
  consult `CanWrite`: `ArrayLikeWrapper.Delete`, `ArrayLikeWrapper.SetAt`, and `ArrayOperations`'
  `ArrayLikeOperations.Set`. Those three are precisely what made the mutators reachable for a read-only
  target, which is why the fix is three call sites and not a rewrite of the mutators.
* Because of that, the mutators are now **unreachable** for a read-only wrapper. Their bodies still refuse —
  `ThrowReadOnly()` instead of `Throw.NotSupportedException()` — as a documented backstop, so that a lane
  added later cannot re-open the same hole. The XML doc says it is unreachable rather than implying
  otherwise; nothing asserts its message, because nothing can reach it.

### The one carve-out, and why it is exactly two types

`ICollection<T>.IsReadOnly` cannot be taken at face value. `System.Array` and `ArraySegment<T>` both report
`true` through it to mean *cannot grow*, and both accept element writes — the non-generic `IList` asks
`IsReadOnly` and `IsFixedSize` separately and the generic interface collapsed them into one flag.
`GenericListWrapper<T>` therefore treats a `T[]` or an `ArraySegment<T>` target as **fixed-size** and
everything else's declaration as the truth.

That reclassifies `ArraySegment<T>`, which is the point rather than a side effect: it leaked
`NotSupportedException` from `push`/`pop`/`splice`/a `length` write and `ArgumentOutOfRangeException` from a
write past the end, and now answers exactly as an `int[]` live view does while keeping `x[0] = 9`. The `T[]`
half of the carve-out is not hypothetical either — a `T[]` reaches `GenericListWrapper<T>` whenever the
exposed type is a declared `IList<T>` rather than the array type, which `ObjectWrapper.Create(engine, target,
type)` and `clrHelper.toInterface` both allow.

## What is deliberately not in this PR

**A growable `List<int>` refuses `list[3] = 9` with a raw `ArgumentOutOfRangeException`**, while
`list.length = 5` on the same list grows it — visible in the `List<int>` column, unchanged before and after.
It is the same defect class and a different cause (an index write past the end defers to the reflected
indexer instead of growing, as the `length` lane does), so it is filed as its own issue rather than widened
into this one.

Two smaller pre-existing divergences the table also shows, both unchanged: a **fixed-size** `length` write
throws in sloppy mode too, where the specification would have it silent — deliberate, and pinned by
`InteropTests.ClrArrayLiveView.LiveViewArrayResizeAttemptsThrowTypeError`; and a plain `ObjectWrapper`'s
strict-mode `x[3] = 9` is silent where a failed `[[Set]]` should throw.

## Tests

`Jint.Tests.PublicInterface/HostReadOnlyCollectionTests.cs` pins the whole matrix from the embedder's side —
the only suite without `InternalsVisibleTo`, which is what makes "an embedder cannot catch this" a statement
the test can make. Six shapes × ten operations × both modes, plus the growable control, the message, and the
`ArraySegment<T>` reclassification.

**Failing first**, on unmodified `upstream/main` with only the test file added:

```
Failed!  - Failed:    49, Passed:    19, Skipped:     0, Total:    68 - Jint.Tests.PublicInterface.dll (net10.0)

  Failed …HostReadOnlyCollectionTests.TheRefusalIsTheOrdinaryReadOnlyPropertyTypeError(shape: "ReadOnlyCollection")
   System.NotSupportedException : Collection is read-only.
  Failed …HostReadOnlyCollectionTests.TheRefusalIsTheOrdinaryReadOnlyPropertyTypeError(shape: "ImmutableList")
   System.NotSupportedException : Specified method is not supported.
  Failed …AnAssignmentToAReadOnlyCollectionIsRefusedSilentlyInSloppyModeAndThrowsInStrictMode(shape: "ArrayList", operation: "host.length = 5")
   Expected … to be the same string because a failed [[Set]] is silent outside strict mode, but they differ at index 0
  Failed …AnArraySegmentIsFixedSizeRatherThanReadOnly
   System.NotSupportedException : Specified method is not supported.
```

The 19 that pass are the assignments `ReadOnlyCollection<T>`'s get-only indexer already refused by accident,
and the `IReadOnlyList<T>` length writes `CanWrite => false` already refused.

## Verification

* `dotnet build -c Release` — 0 warnings, 0 errors.
* `Jint.Tests` — 10,699 passed on `net10.0` and on `net8.0`, 7,323 on `net472`, 0 failed.
* `Jint.Tests.PublicInterface` — 3,066 passed on `net10.0`, 2,437 on `net472`, 0 failed.
* Both again with `JINT_HOST_CONTRACT_VERIFICATION=1` — 0 failed.
* `Jint.Tests.Test262` — 102,495 passed, 0 failed, 189 skipped (102,684 total). The first run of it on this shared machine lost one `StagingTests.Sm_expressions` case to load; that theory passes 75/75 on its own and the repeated full run is the number above.
* No public API baseline moved and `UndocumentedPublicApi.txt` is unchanged: `CanWrite`, `IsReadOnly` and the
  two refusals are all members of an `internal` type.
* `docs/v5-migration.md` §4.27 carries the embedder-facing form. No benchmark: the read path
  (`Get`/`GetJsValueAt`) is untouched, and the write path trades one virtual `CanWrite` call for one virtual
  `IsReadOnly` call.
