### PR TITLE
Strings: a long `+` defers its copy, so `s = s + x` is linear like `s += x`

### DIFF
--- a/Jint.Benchmark/StringConcatLargeBenchmark.cs
+++ b/Jint.Benchmark/StringConcatLargeBenchmark.cs
@@ -16,6 +16,22 @@ namespace Jint.Benchmark;
 /// ChainLargeThree shows the win when the skipped intermediate is large, and ChainNumericThree
 /// guards the numeric fast lanes that must survive on chains that never become strings.
 /// </para>
+/// <para>
+/// The Assign* lanes are the shape the rest of the class was missing, and the reason a rope evaluated
+/// against it in July 2026 came out as a NO-GO: every accumulating lane above builds with
+/// <c>s += chunk</c>, which is already amortised linear, and ConcatLargePair rebuilds a <em>fresh</em>
+/// pair each iteration so its left operand never grows. Accumulating through the <c>+</c> operator —
+/// <c>s = s + x</c>, <c>s = x + s</c>, <c>s = s + x + y</c> — is a different code path, and was
+/// quadratic (<a href="https://github.com/sebastienros/jint/issues/3350">#3350</a>).
+/// </para>
+/// <para>
+/// Two pairings carry the reading. AssignAppendSmallChunks against <b>AppendSmallChunks</b> is the same
+/// 4,096 x 16 characters with one operator changed, so the difference between them is the whole cost of
+/// the <c>+</c> path. AssignAppendThenScan against <b>AssignAppendSmallChunks</b> is that same build
+/// plus a charAt scan of the result, so their difference is what reading the value back as text costs —
+/// the lane a deferred representation cannot cheat, since the other three finish on <c>s.length</c>,
+/// which such a value answers without ever producing the characters.
+/// </para>
 /// <para><b>Engine isolation.</b> Every row gets its own engine — built by <c>CreateEngine</c>, which
 /// re-runs <see cref="SetupSource"/> so each engine owns its own <c>chunk16</c>/<c>chunk4k</c>/
 /// <c>big64k</c> — and warmed with its own script and nothing else (see <see cref="IsolatedScript"/>).
@@ -38,6 +54,10 @@ public class StringConcatLargeBenchmark
     private IsolatedScript _chainSmallSix;
     private IsolatedScript _chainLargeThree;
     private IsolatedScript _chainNumericThree;
+    private IsolatedScript _assignAppendSmallChunks;
+    private IsolatedScript _assignPrependSmallChunks;
+    private IsolatedScript _assignChainThree;
+    private IsolatedScript _assignAppendThenScan;
 
     private const string SetupSource = """
         var chunk16 = 'abcdefghijklmnop';
@@ -156,6 +176,53 @@ public class StringConcatLargeBenchmark
             }
             g();
             """), CreateEngine);
+
+        // the same 4,096 x 16 chars -> 64 KB as AppendSmallChunks, accumulated through `+` instead of
+        // `+=`. Identical semantics, and until #3350 a different code path: this one copied the whole
+        // accumulator on every iteration. Read it paired with AppendSmallChunks.
+        _assignAppendSmallChunks = IsolatedScript.Warm(Engine.PrepareScript("""
+            function f() {
+                var s = '';
+                for (var i = 0; i < 4096; i++) { s = s + chunk16; }
+                return s.length;
+            }
+            f();
+            """), CreateEngine);
+
+        // prepending: the shape `+=` cannot express at all, so it has never had a fast path
+        _assignPrependSmallChunks = IsolatedScript.Warm(Engine.PrepareScript("""
+            function f() {
+                var s = '';
+                for (var i = 0; i < 4096; i++) { s = chunk16 + s; }
+                return s.length;
+            }
+            f();
+            """), CreateEngine);
+
+        // accumulating through a three-operand chain, which is one flattened node rather than two
+        // nested additions -- the same accumulator, reached by the other of the two '+' code paths
+        _assignChainThree = IsolatedScript.Warm(Engine.PrepareScript("""
+            function f() {
+                var s = '';
+                for (var i = 0; i < 2048; i++) { s = s + chunk16 + chunk16; }
+                return s.length;
+            }
+            f();
+            """), CreateEngine);
+
+        // AssignAppendSmallChunks plus a charAt scan of the result, so the difference between the two is
+        // what reading the built value back as text costs -- which for a representation that defers the
+        // copy is where it has to pay for it, over a tree one node deep per iteration.
+        _assignAppendThenScan = IsolatedScript.Warm(Engine.PrepareScript("""
+            function f() {
+                var s = '';
+                for (var i = 0; i < 4096; i++) { s = s + chunk16; }
+                var acc = 0;
+                for (var i = 0; i < s.length; i += 997) { acc += s.charCodeAt(i); }
+                return acc;
+            }
+            f();
+            """), CreateEngine);
     }
 
     [Benchmark]
@@ -181,4 +248,16 @@ public class StringConcatLargeBenchmark
 
     [Benchmark]
     public JsValue ChainNumericThree() => _chainNumericThree.Run();
+
+    [Benchmark]
+    public JsValue AssignAppendSmallChunks() => _assignAppendSmallChunks.Run();
+
+    [Benchmark]
+    public JsValue AssignPrependSmallChunks() => _assignPrependSmallChunks.Run();
+
+    [Benchmark]
+    public JsValue AssignChainThree() => _assignChainThree.Run();
+
+    [Benchmark]
+    public JsValue AssignAppendThenScan() => _assignAppendThenScan.Run();
 }

--- a/Jint.Tests/Runtime/StringConcatenationTests.cs
+++ b/Jint.Tests/Runtime/StringConcatenationTests.cs
@@ -1,0 +1,307 @@
+using Jint.Native;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// <c>s += x</c> and <c>s = s + x</c> mean the same thing, and used to differ by an order of magnitude:
+/// the compound assignment builds into a <see cref="JsString.ConcatenatedString"/>, which is
+/// <see cref="System.Text.StringBuilder"/>-backed and amortised linear, while a plain <c>+</c> produced a
+/// flat string per operation and so copied the whole accumulated left operand on every iteration.
+/// Prepending (<c>s = x + s</c>) had no fast path at all, because the compound form cannot express it.
+/// <para>
+/// A plain <c>+</c> now produces <c>JsString.RopeString</c> once the result is long enough to be worth
+/// deferring — an <em>immutable</em> node holding the two operands, which is what makes it safe where the
+/// mutable builder is not: a <c>+</c> leaves both operands reachable from wherever they were read, so a
+/// representation it can share has to be one nobody can append into. These tests pin the two halves of
+/// that: the value is indistinguishable from the flat string it stands for, and building it is linear.
+/// </para>
+/// </summary>
+public class StringConcatenationTests
+{
+    private const string Chunk = "var chunk = '0123456789';";
+
+    private static Engine CreateEngine()
+    {
+        var engine = new Engine();
+        engine.Execute(Chunk);
+        return engine;
+    }
+
+    /// <summary>
+    /// The premise of everything below: an accumulator built with <c>+</c> is left as a deferred node
+    /// rather than copied. If the interpreter ever starts flattening this shape, these tests would keep
+    /// passing while covering nothing.
+    /// </summary>
+    [Fact]
+    public void AccumulatingWithPlusLeavesTheValueDeferred()
+    {
+        var value = CreateEngine().Evaluate("var s = ''; for (var i = 0; i < 200; i++) { s = s + chunk; } s;");
+
+        value.Should().BeOfType<JsString.RopeString>();
+        value.ToString().Length.Should().Be(2000);
+    }
+
+    [Fact]
+    public void PrependingWithPlusLeavesTheValueDeferred()
+    {
+        var value = CreateEngine().Evaluate("var s = ''; for (var i = 0; i < 200; i++) { s = chunk + s; } s;");
+
+        value.Should().BeOfType<JsString.RopeString>();
+        value.ToString().Length.Should().Be(2000);
+    }
+
+    /// <summary>
+    /// A short result is still allocated flat: below the deferral threshold a node costs more than the
+    /// copy it saves, and every consumer of the result would pay the flattening indirection for nothing.
+    /// </summary>
+    [Fact]
+    public void AShortConcatenationIsStillFlat()
+    {
+        var engine = CreateEngine();
+
+        engine.Evaluate("'a' + 'b'").Should().BeOfType<JsString>();
+        engine.Evaluate("'a' + 'b' + 'c'").Should().BeOfType<JsString>();
+        engine.Evaluate($"'x'.repeat({JsString.MinDeferredConcatenationLength - 2}) + 'y'").Should().BeOfType<JsString>();
+    }
+
+    /// <summary>
+    /// Every accumulation shape has to produce exactly what the compound assignment produces — including
+    /// the chain forms, which are evaluated as one flattened node rather than nested pairwise additions.
+    /// </summary>
+    [Theory]
+    [InlineData("s += chunk", 1000, 10000)]
+    [InlineData("s = s + chunk", 1000, 10000)]
+    [InlineData("s = chunk + s", 1000, 10000)]
+    [InlineData("s = s + chunk + chunk", 500, 10000)]
+    [InlineData("s = s + chunk + chunk + chunk", 400, 12000)]
+    [InlineData("s = s + chunk + chunk + chunk + chunk + chunk", 200, 10000)]
+    [InlineData("s = chunk + chunk + s", 500, 10000)]
+    public void EveryAccumulationShapeProducesTheSameCharacters(string body, int iterations, int expectedLength)
+    {
+        var engine = CreateEngine();
+
+        var built = engine
+            .Evaluate($"(function () {{ var s = ''; for (var i = 0; i < {iterations}; i++) {{ {body}; }} return s; }})()")
+            .AsString();
+
+        built.Length.Should().Be(expectedLength);
+        built.Should().Be(string.Concat(Enumerable.Repeat("0123456789", expectedLength / 10)));
+    }
+
+    /// <summary>
+    /// The row above uses one repeated piece, so it cannot see an operand swapped for its sibling.
+    /// These build from a piece that changes every iteration, and assert against the two orders
+    /// spelled out — the one thing a concatenation node can get wrong that a length check will not show.
+    /// </summary>
+    [Fact]
+    public void AppendAndPrependPutTheOperandsInTheRightOrder()
+    {
+        var engine = CreateEngine();
+
+        var appended = engine
+            .Evaluate("(function () { var s = ''; for (var i = 0; i < 400; i++) { s = s + ('[' + i + ']'); } return s; })()")
+            .AsString();
+        var prepended = engine
+            .Evaluate("(function () { var s = ''; for (var i = 0; i < 400; i++) { s = ('[' + i + ']') + s; } return s; })()")
+            .AsString();
+
+        var pieces = Enumerable.Range(0, 400).Select(i => "[" + i + "]").ToArray();
+        appended.Should().Be(string.Concat(pieces));
+        prepended.Should().Be(string.Concat(Enumerable.Reverse(pieces)));
+    }
+
+    /// <summary>
+    /// Every <c>String.prototype</c> method, and every engine path that needs characters, has to see the
+    /// deferred node as the string it stands for. Only the length is answered without flattening.
+    /// </summary>
+    [Theory]
+    [InlineData("s.length", "2000")]
+    [InlineData("s.charCodeAt(0)", "48")]
+    [InlineData("s.charCodeAt(1999)", "57")]
+    [InlineData("s.charAt(11)", "1")]
+    [InlineData("s[12]", "2")]
+    [InlineData("s.indexOf('789012')", "7")]
+    [InlineData("s.lastIndexOf('0123')", "1990")]
+    [InlineData("s.slice(5, 15)", "5678901234")]
+    [InlineData("s.substring(0, 4)", "0123")]
+    [InlineData("s.startsWith('01234')", "true")]
+    [InlineData("s.endsWith('56789')", "true")]
+    [InlineData("s.includes('456')", "true")]
+    [InlineData("s.split('0').length", "201")]
+    [InlineData("s.toUpperCase().length", "2000")]
+    [InlineData("JSON.stringify(s).length", "2002")]
+    [InlineData("(s === s + '')", "true")]
+    [InlineData("`${s}`.length", "2000")]
+    [InlineData("(+s.slice(0, 3))", "12")]
+    [InlineData("s.replace('012', 'zzz').slice(0, 5)", "zzz34")]
+    [InlineData("[...s].length", "2000")]
+    [InlineData("s.match(/9(0)/)[1]", "0")]
+    [InlineData("(s == s.valueOf())", "true")]
+    public void EveryStringOperationSeesTheFlatValue(string expression, string expected)
+    {
+        var engine = CreateEngine();
+        engine.Execute("var s = ''; for (var i = 0; i < 200; i++) { s = s + chunk; }");
+
+        engine.Evaluate("s").Should().BeOfType<JsString.RopeString>();
+        engine.Evaluate(expression).ToString().Should().Be(expected);
+    }
+
+    /// <summary>
+    /// The hazard the node's immutability exists to avoid, from the other side: an operand that is itself
+    /// a <see cref="JsString.ConcatenatedString"/> is still growable, and <c>+=</c> appends into it in
+    /// place. A node that simply held the reference would change content behind whoever read the
+    /// concatenation, so the operand is snapshotted on the way in.
+    /// </summary>
+    [Fact]
+    public void AppendingToAnOperandAfterwardsDoesNotChangeTheResult()
+    {
+        var engine = CreateEngine();
+        engine.Execute("""
+            var a = ['']; a[0] += chunk.repeat(60); a[0] += chunk.repeat(60);
+            """);
+        engine.Evaluate("a[0]").Should().BeOfType<JsString.ConcatenatedString>();
+
+        engine.Execute("var b = a[0] + '!';");
+        engine.Evaluate("b").Should().BeOfType<JsString.RopeString>();
+
+        engine.Execute("a[0] += 'MUTATED';");
+
+        engine.Evaluate("b.length").AsNumber().Should().Be(1201);
+        engine.Evaluate("b.indexOf('MUTATED')").AsNumber().Should().Be(-1);
+        engine.Evaluate("b === chunk.repeat(120) + '!'").AsBoolean().Should().BeTrue();
+        engine.Evaluate("a[0].length").AsNumber().Should().Be(1207);
+    }
+
+    /// <summary>
+    /// A deferred node has to hash and compare like the flat string it stands for, or it cannot be used
+    /// interchangeably as a property key or a collection key. Content, not representation, is the
+    /// identity of a string value.
+    /// </summary>
+    [Fact]
+    public void ADeferredNodeIsIndistinguishableFromTheFlatString()
+    {
+        var engine = CreateEngine();
+        var deferred = engine.Evaluate("var s = ''; for (var i = 0; i < 60; i++) { s = s + chunk; } s;");
+        deferred.Should().BeOfType<JsString.RopeString>();
+
+        var flat = new JsString(string.Concat(Enumerable.Repeat("0123456789", 60)));
+
+        deferred.Equals(flat).Should().BeTrue();
+        flat.Equals(deferred).Should().BeTrue();
+        deferred.GetHashCode().Should().Be(flat.GetHashCode());
+        deferred.ToString().Should().Be(flat.ToString());
+
+        // and the same after it has flattened, which replaces what the base bodies read
+        deferred.ToString();
+        deferred.Equals(flat).Should().BeTrue();
+        deferred.GetHashCode().Should().Be(flat.GetHashCode());
+    }
+
+    [Fact]
+    public void ADeferredNodeWorksAsAKeyOnBothSidesOfALookup()
+    {
+        var engine = CreateEngine();
+        engine.Execute("""
+            var deferred = ''; for (var i = 0; i < 60; i++) { deferred = deferred + chunk; }
+            var flat = ''; for (var i = 0; i < 60; i++) { flat += chunk; }
+            flat = flat.slice(0);
+            """);
+        engine.Evaluate("deferred").Should().BeOfType<JsString.RopeString>();
+
+        engine.Evaluate("new Map([[deferred, 1]]).get(flat)").AsNumber().Should().Be(1);
+        engine.Evaluate("new Map([[flat, 1]]).get(deferred)").AsNumber().Should().Be(1);
+        engine.Evaluate("new Set([deferred]).has(flat)").AsBoolean().Should().BeTrue();
+        engine.Evaluate("new Set([deferred, flat]).size").AsNumber().Should().Be(1);
+        engine.Evaluate("var o = {}; o[deferred] = 7; o[flat]").AsNumber().Should().Be(7);
+        engine.Evaluate("Object.keys(o)[0].length").AsNumber().Should().Be(600);
+    }
+
+    /// <summary>
+    /// A long loop builds a completely unbalanced tree — one node per iteration — and flattening it must
+    /// not put a frame on the CLR stack per node. Both leanings are covered because they are mirror
+    /// images: appending leans left, prepending leans right, and a walk that is cheap on one is the one
+    /// that has to keep an explicit stack for the other.
+    /// </summary>
+    [Theory]
+    [InlineData("s = s + 'ab'")]
+    [InlineData("s = 'ab' + s")]
+    public void AVeryDeepTreeFlattensWithoutRecursing(string body)
+    {
+        var engine = CreateEngine();
+
+        engine.Execute($"var s = ''; for (var i = 0; i < 200000; i++) {{ {body}; }}");
+
+        engine.Evaluate("s.length").AsNumber().Should().Be(400000);
+        engine.Evaluate("s.charCodeAt(0)").AsNumber().Should().Be('a');
+        engine.Evaluate("s.charCodeAt(399999)").AsNumber().Should().Be('b');
+        engine.Evaluate("s === 'ab'.repeat(200000)").AsBoolean().Should().BeTrue();
+    }
+
+    /// <summary>
+    /// A tree whose operands are shared — <c>s = s + s</c> doubles by referencing the same node twice, so
+    /// it is a DAG rather than a tree — flattens to the whole value, not to one copy per distinct node.
+    /// </summary>
+    [Fact]
+    public void SharedOperandsFlattenToTheWholeValue()
+    {
+        var engine = CreateEngine();
+
+        var value = engine.Evaluate("var s = chunk; for (var i = 0; i < 8; i++) { s = s + s; } s;");
+
+        value.Should().BeOfType<JsString.RopeString>();
+        value.AsString().Should().Be(string.Concat(Enumerable.Repeat("0123456789", 256)));
+    }
+
+    /// <summary>
+    /// The asymptotic claim, measured deterministically. Wall-clock is the obvious way to show a
+    /// quadratic is gone and the worst way to assert it in a test suite; allocated bytes say the same
+    /// thing without depending on what else the machine is doing, because the quadratic <em>is</em> the
+    /// copying — every iteration allocated a fresh string holding the whole accumulator.
+    /// <para>
+    /// Doubling the iteration count doubles the work, so linear building doubles the allocation and the
+    /// quadratic shape quadrupled it. The bound is deliberately loose: anything under 4 would have
+    /// failed before, and the absolute ceiling is 40× under what the quadratic shape allocated at this
+    /// size, so neither assertion is close enough to the truth to be fragile.
+    /// </para>
+    /// </summary>
+    [Theory]
+    [InlineData("s = s + chunk")]
+    [InlineData("s = chunk + s")]
+    [InlineData("s = s + chunk + chunk")]
+    public void AccumulatingWithPlusIsNoLongerQuadratic(string body)
+    {
+        if (!GCPolyfills.AllocatedBytesForCurrentThreadIsSupported)
+        {
+            // true on every runtime this suite executes on (.NET Framework 4.6+, .NET Core 2.0+); the
+            // guard is here so a trimmed or exotic host running the suite reports no result rather than
+            // a failure it cannot act on
+            return;
+        }
+
+        var small = AllocatedBytesAccumulating(body, 4_000);
+        var large = AllocatedBytesAccumulating(body, 8_000);
+
+        // 8,000 iterations of 10 characters copied in full every time is ~640 MB
+        large.Should().BeLessThan(16 * 1024 * 1024);
+        ((double) large / small).Should().BeLessThan(3.0);
+    }
+
+    private static long AllocatedBytesAccumulating(string body, int iterations)
+    {
+        var engine = CreateEngine();
+        var script = Engine.PrepareScript($"(function (n) {{ var s = ''; for (var i = 0; i < n; i++) {{ {body}; }} return s.length; }})(n)");
+
+        // warm the handler tree and the call-site caches, so what is measured is the loop and not the
+        // one-off cost of reaching it
+        engine.SetValue("n", 16);
+        engine.Evaluate(script);
+
+        engine.SetValue("n", iterations);
+        GC.Collect();
+        GCPolyfills.TryGetAllocatedBytesForCurrentThread(out var before);
+        engine.Evaluate(script);
+        GCPolyfills.TryGetAllocatedBytesForCurrentThread(out var after);
+
+        return after - before;
+    }
+}

--- a/Jint.Tests/Runtime/StringLengthLimitTests.cs
+++ b/Jint.Tests/Runtime/StringLengthLimitTests.cs
@@ -21,11 +21,17 @@ namespace Jint.Tests.Runtime;
 /// Every row below is a path whose limit is decided from small inputs — a repeat count, a pad length,
 /// a replacement pattern's expansion factor, an array's <c>length</c> — so the throw happens before
 /// anything of that size is allocated and the test costs a few megabytes. The remaining guarded paths
-/// (<c>+</c>/<c>+=</c>, template literals, <c>concat</c>, <c>join</c>, <c>toLocaleString</c>,
+/// (<c>+=</c>, template literals, <c>concat</c>, <c>join</c>, <c>toLocaleString</c>,
 /// <c>String.raw</c>, the accumulators inside <c>replace</c>/<c>replaceAll</c> and the element-by-element
 /// half of <c>JSON.stringify</c>) accumulate their result one piece at a time, so their guard can only
 /// fire once roughly half a billion characters are already in hand; a test for those would have to
 /// allocate the gigabyte the guard exists to prevent, and there is no cheaper input that reaches them.
+/// </para>
+/// <para>
+/// <c>+</c> used to be in that second list and no longer is: it defers a long result into an immutable
+/// node rather than materializing it, so <c>s = s + s</c> doubles the length by referencing the same
+/// value twice and reaches the limit through 29 nodes and no characters at all. The guard is checked
+/// on the summed lengths, before the node is built, which is why it still fires there.
 /// </para>
 /// </summary>
 public class StringLengthLimitTests
@@ -71,6 +77,30 @@ public class StringLengthLimitTests
     {
         Caught($"'x'.padEnd({JsString.MaxLength + 1L}, 'ab')").Should().Be(InvalidStringLength);
         _engine.Evaluate("'x'.padEnd(3, 'ab')").AsString().Should().Be("xab");
+    }
+
+    /// <summary>
+    /// Repeated doubling with <c>+</c>: each step references the previous value twice, so the length
+    /// doubles while the representation grows by one node. The limit is therefore reached with nothing
+    /// of that size allocated, which is exactly where the guard has to fire — on the summed lengths,
+    /// before the result is built.
+    /// </summary>
+    [Fact]
+    public void ConcatenationPastTheLimitIsACatchableRangeError()
+    {
+        _engine.Execute("var s = 'x'; for (var i = 0; i < 28; i++) { s = s + s; }");
+        _engine.Evaluate("s.length").AsNumber().Should().Be(268_435_456);
+        _engine.Evaluate($"s.length <= {JsString.MaxLength}").AsBoolean().Should().BeTrue();
+
+        // one more character fits and is refused nothing; one more doubling does not
+        _engine.Evaluate("(s + 'y').length").AsNumber().Should().Be(268_435_457);
+        Caught("s + s").Should().Be(InvalidStringLength);
+        Caught("s + s + s").Should().Be(InvalidStringLength);
+        Caught("'y' + s + s").Should().Be(InvalidStringLength);
+
+        // deliberately not `s += s`: the compound form coerces its right operand to text first, so it
+        // would flatten the half-gigabyte this row exists to avoid allocating. Its guard is the one the
+        // paragraph above describes, and it stays untested for the reason given there.
     }
 
     /// <summary>

--- a/Jint.Tests/Runtime/StringRepresentationKeyTests.cs
+++ b/Jint.Tests/Runtime/StringRepresentationKeyTests.cs
@@ -4,7 +4,8 @@ namespace Jint.Tests.Runtime;
 
 /// <summary>
 /// <see cref="JsString"/> has more than one internal representation: a flat value, a lazily
-/// materialized view over a larger string, and a growable buffer built up by repeated concatenation.
+/// materialized view over a larger string, a growable buffer built up by repeated <c>+=</c>, and an
+/// immutable two-operand node produced by a long <c>+</c>.
 /// All of them must be usable interchangeably as a key, which means each one has to hash its
 /// <em>content</em> — the same hash a plain <see cref="JsString"/> with those characters produces.
 /// Hashing anything else (buffer identity, for instance) breaks the equals/hash-code contract:
@@ -285,5 +286,50 @@ public class StringRepresentationKeyTests
             .AsNumber().Should().Be(1);
         engine.Evaluate(Source + " var flat = big.split('').slice(0, 1500).join(''); new Map([[big.substring(0, 1500), 1]]).get(flat)")
             .AsNumber().Should().Be(1);
+    }
+
+    /// <summary>
+    /// Builds "abc…" through <c>+</c> rather than <c>+=</c>, which past a threshold produces the
+    /// immutable two-operand node — the fourth representation, and the one a <c>+</c> is free to hand
+    /// out because nobody can append into it.
+    /// </summary>
+    private const string DeferredConcatenation = "var d = ''; for (var i = 0; i < 200; i++) { d = d + 'abc'; }";
+
+    [Fact]
+    public void DeferredConcatenationIsLeftUnflattened()
+    {
+        // guards the premise of the two rows below, exactly as the first test in this file does for the
+        // growable-buffer representation
+        var engine = CreateEngine();
+
+        var value = engine.Evaluate(DeferredConcatenation + " d");
+
+        value.Should().BeOfType<JsString.RopeString>();
+        value.ToString().Should().Be(string.Concat(Enumerable.Repeat("abc", 200)));
+    }
+
+    [Fact]
+    public void DeferredConcatenationHashesLikeTheEquivalentFlatString()
+    {
+        var engine = CreateEngine();
+
+        var deferred = engine.Evaluate(DeferredConcatenation + " d");
+        var flat = new JsString(string.Concat(Enumerable.Repeat("abc", 200)));
+
+        deferred.Equals(flat).Should().BeTrue();
+        deferred.GetHashCode().Should().Be(flat.GetHashCode());
+    }
+
+    [Fact]
+    public void DeferredConcatenationIsUsableAsACollectionKey()
+    {
+        var engine = CreateEngine();
+
+        engine.Evaluate(DeferredConcatenation + " var flat = ''; for (var i = 0; i < 200; i++) { flat += 'abc'; } flat = flat.split('').join('');"
+            + " new Set([d, flat]).size").AsNumber().Should().Be(1);
+        engine.Evaluate(DeferredConcatenation + " var flat = ''; for (var i = 0; i < 200; i++) { flat += 'abc'; } flat = flat.split('').join('');"
+            + " new Map([[d, 1]]).get(flat)").AsNumber().Should().Be(1);
+        engine.Evaluate(DeferredConcatenation + " var flat = ''; for (var i = 0; i < 200; i++) { flat += 'abc'; } flat = flat.split('').join('');"
+            + " var o = {}; o[d] = 5; o[flat]").AsNumber().Should().Be(5);
     }
 }

--- a/Jint/Native/JsString.cs
+++ b/Jint/Native/JsString.cs
@@ -31,9 +31,10 @@ namespace Jint.Native;
 /// <para>
 /// <b>Subclassing this class directly.</b> Passing a <see langword="null"/> backing value to
 /// <see cref="JsString(string)"/> still works and is how a lazy host string was written before
-/// <see cref="LazyJsString"/> existed; Jint's own sliced and concatenated representations are built on
-/// the same mechanism. It is the harder path — the parameter is typed <see cref="string"/>, so the
-/// <see langword="null"/> is a suppression against a contract that lives only in prose, and the
+/// <see cref="LazyJsString"/> existed; Jint's own sliced, concatenated and deferred-concatenation
+/// representations are built on the same mechanism. It is the harder path — the parameter is typed
+/// <see cref="string"/>, so the <see langword="null"/> is a suppression against a contract that lives
+/// only in prose, and the
 /// subclass owns its own memoization. A subclass that does it <b>must</b> override every member that
 /// would otherwise observe the backing value:
 /// <list type="bullet">
@@ -355,6 +356,67 @@ public class JsString : JsValue, IEquatable<JsString>, IEquatable<string>
         }
 
         return CreateSliced(source.ToString(), start, length);
+    }
+
+    /// <summary>
+    /// The shortest concatenation result that is worth deferring instead of copying. Below it a
+    /// <see cref="RopeString"/> would cost a second object for a copy that is already cheaper than the
+    /// allocation, and every consumer of the result would pay the flattening indirection for nothing.
+    /// </summary>
+    /// <remarks>
+    /// Only the asymptotic behaviour above this line matters, and the exact value does not change it: a
+    /// loop that accumulates in <c>n</c>-character pieces copies for the first
+    /// <c>MinDeferredConcatenationLength / n</c> iterations and defers from then on, so the whole
+    /// quadratic term is bounded by <c>MinDeferredConcatenationLength²</c> characters however long the
+    /// loop runs. It is a knob for the small-string case, not for the fix.
+    /// </remarks>
+    internal const int MinDeferredConcatenationLength = 512;
+
+    /// <summary>
+    /// Concatenates two strings, deferring the copy into a <see cref="RopeString"/> once the result is
+    /// long enough to be worth a node. This is what <c>a + b</c> produces; it is deliberately not what
+    /// <c>a += b</c> produces, which stays on <see cref="ConcatenatedString"/>'s builder.
+    /// </summary>
+    /// <remarks>
+    /// The caller has already refused a result longer than <see cref="MaxLength"/> — it holds both
+    /// lengths for the sum it just checked, so re-reading them here would be two virtual dispatches for
+    /// a number it already has. That check is what lets the addition below be a plain <see cref="int"/>.
+    /// </remarks>
+    internal static JsString Concat(JsString left, JsString right)
+    {
+        var leftLength = left.Length;
+        var rightLength = right.Length;
+        Debug.Assert((long) leftLength + rightLength <= MaxLength, "the caller must refuse an over-long result before building it");
+
+        var length = leftLength + rightLength;
+        if (length < MinDeferredConcatenationLength)
+        {
+            return Create(string.Concat(left.ToString(), right.ToString()));
+        }
+
+        if (leftLength == 0)
+        {
+            return Immutable(right);
+        }
+
+        if (rightLength == 0)
+        {
+            return Immutable(left);
+        }
+
+        return new RopeString(Immutable(left), Immutable(right), length);
+    }
+
+    /// <summary>
+    /// A value that is safe to hold on to. <see cref="ConcatenatedString"/> is mutated in place by
+    /// <c>+=</c>, so a node that kept one would change content behind whoever else is still reading it;
+    /// everything else <see cref="JsString"/> produces is immutable and is returned as it is. The
+    /// snapshot is a wrapper around the string the builder has already flattened, not a character copy.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static JsString Immutable(JsString value)
+    {
+        return (value._type & InternalTypes.RequiresCloning) == InternalTypes.Empty ? value : new JsString(value.ToString());
     }
 
     internal static JsString Create(int value)
@@ -824,6 +886,141 @@ public class JsString : JsValue, IEquatable<JsString>, IEquatable<string>
         {
             // same hash as the equivalent flat string instance
             return string.GetHashCode(AsSpan(), StringComparison.Ordinal);
+        }
+    }
+
+    /// <summary>
+    /// An immutable binary concatenation node: the result of an <c>a + b</c> whose operands are long
+    /// enough that copying them is worth deferring. It holds the two operands and the total length; the
+    /// flat text is produced once, on the first read that actually needs characters, and memoized.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Why not <see cref="ConcatenatedString"/>.</b> That one is a mutable builder, and <c>s += t</c>
+    /// may append into it only because the assignment replaces the receiver. A non-assignment <c>+</c>
+    /// has no such guarantee — both operands stay reachable from wherever they were read — so the
+    /// deferred form it can use has to be immutable. Same reason an operand that <em>is</em> a
+    /// <see cref="ConcatenatedString"/> is snapshotted on the way in (<see cref="Immutable"/>): a later
+    /// <c>+=</c> on it appends in place, and a node holding it would change content behind its reader.
+    /// </para>
+    /// <para>
+    /// <b>Only the length is answered from the node.</b> <see cref="Length"/> — and therefore
+    /// truthiness, and the length comparison <see cref="JsString.Equals(JsString)"/> performs first — is
+    /// free. Everything else flattens, including <see cref="this[int]"/>, which does so deliberately
+    /// rather than descending the tree: descending is O(depth), so a <c>charCodeAt</c> scan over a
+    /// freshly accumulated value would become a new quadratic — the very shape this class exists to
+    /// remove. Flattening costs one copy, which is what the old code performed on every concatenation
+    /// anyway, and the memo makes every later read O(1). The base <see cref="JsString"/> bodies for
+    /// equality and hashing are correct as they stand: they read <c>_value</c> only when it is either
+    /// <see langword="null"/> or the exact flat text, which is the invariant this class keeps.
+    /// </para>
+    /// <para>
+    /// <b>Depth is not capped, and that is the design.</b> Flushing the tree at a depth bound would
+    /// re-copy the whole accumulated value every N concatenations — the quadratic behaviour again, with
+    /// a smaller constant, which is the thing being fixed. The hazard a cap would have addressed, a
+    /// recursive flatten overflowing the CLR stack on the unbalanced tree a long loop produces, is
+    /// removed at its source instead: <see cref="CopyInto"/> walks iteratively with an explicit,
+    /// heap-allocated stack, so depth costs 8 bytes per pending node — against the ~40 the node itself
+    /// already costs — and no stack frames at all. The walk descends right-first, so the append shape
+    /// (<c>s = s + x</c>, a left-leaning spine) never has more than one node pending; the prepend shape
+    /// (<c>s = x + s</c>) is the one that pays for the array.
+    /// </para>
+    /// </remarks>
+    internal sealed class RopeString : JsString
+    {
+        /// <summary>
+        /// Where the pending-node stack starts. A tree that never leans right stays inside one entry, so
+        /// this is only ever reached by prepend-shaped or genuinely bushy trees, which then double.
+        /// </summary>
+        private const int InitialPendingCapacity = 16;
+
+        // Not readonly, and released once the flat value is memoized: a flattened rope must stop
+        // retaining the tree it was built from, which for an accumulator loop is one node per iteration.
+        private JsString? _left;
+        private JsString? _right;
+
+        private readonly int _length;
+
+        internal RopeString(JsString left, JsString right, int length) : base(null!, InternalTypes.String)
+        {
+            _left = left;
+            _right = right;
+            _length = length;
+        }
+
+        public override int Length => _length;
+
+        public override string ToString() => _value ?? Flatten();
+
+        // Flattens rather than descending; see the class remarks for why.
+        public override char this[int index] => ToString()[index];
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private string Flatten()
+        {
+            // Not routed through a polyfill, unlike the rest of the assembly's downlevel gaps: what
+            // net472 and netstandard2.0 lack is not string.Create but System.Buffers.SpanAction<T, TArg>,
+            // its callback type, and a "polyfill" that declared a delegate of its own would be inventing
+            // API rather than backfilling it. The downlevel form fills an array and copies it into the
+            // string, which is the extra copy those targets already pay everywhere a string is built
+            // from parts; the modern form writes the characters into the string as it is allocated, and
+            // that single copy is what keeps a flattened concatenation no more expensive than the
+            // string.Concat it replaced.
+#if NETFRAMEWORK || NETSTANDARD2_0
+            var buffer = new char[_length];
+            CopyInto(buffer);
+            var value = new string(buffer);
+#else
+            var value = string.Create(_length, this, static (span, rope) => rope.CopyInto(span));
+#endif
+
+            _value = value;
+            _left = null;
+            _right = null;
+
+            return value;
+        }
+
+        /// <summary>
+        /// Writes the whole tree into <paramref name="destination"/>, filling it from the back so that a
+        /// left-leaning spine — the <c>s = s + x</c> accumulator — keeps at most one node pending.
+        /// </summary>
+        private void CopyInto(Span<char> destination)
+        {
+            var pending = System.Array.Empty<JsString>();
+            var pendingCount = 0;
+            var node = (JsString) this;
+            var position = _length;
+
+            while (true)
+            {
+                // A node that has already memoized its own flat value is a leaf as far as this walk is
+                // concerned: ToString() below hands back the memo without touching the (released) children.
+                if (node is RopeString { _value: null } rope)
+                {
+                    if (pendingCount == pending.Length)
+                    {
+                        System.Array.Resize(ref pending, pendingCount == 0 ? InitialPendingCapacity : pendingCount * 2);
+                    }
+
+                    pending[pendingCount++] = rope._left!;
+                    node = rope._right!;
+                    continue;
+                }
+
+                var text = node.ToString();
+                position -= text.Length;
+                text.AsSpan().CopyTo(destination.Slice(position));
+
+                if (pendingCount == 0)
+                {
+                    break;
+                }
+
+                node = pending[--pendingCount];
+            }
+
+            Debug.Assert(position == 0, "the node's length must be the sum of its operands' lengths");
         }
     }
 }

--- a/Jint/Native/JsValueExtensions.cs
+++ b/Jint/Native/JsValueExtensions.cs
@@ -141,8 +141,9 @@ public static class JsValueExtensions
 
     /// <summary>
     /// Reinterprets a value the caller has already proven to be a string with <see cref="JsValue.IsString"/>.
-    /// <see cref="InternalTypes.String"/> is set only by <see cref="JsString"/> and its two nested
-    /// subclasses (ConcatenatedString, SlicedString), all of which are <see cref="JsString"/>.
+    /// <see cref="InternalTypes.String"/> is set only by <see cref="JsString"/>, its three nested
+    /// subclasses (ConcatenatedString, SlicedString, RopeString) and <see cref="LazyJsString"/>, all of
+    /// which are <see cref="JsString"/>.
     /// </summary>
     [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Jint/Native/LazyJsString.cs
+++ b/Jint/Native/LazyJsString.cs
@@ -133,10 +133,10 @@ public abstract class LazyJsString : JsString
         if (HostContractVerification.Enabled)
         {
             // No out-of-assembly gate: nothing in Jint derives from this class - its own lazy strings
-            // (SlicedString, ConcatenatedString) predate it and answer their lengths from their own
-            // fields - so every instance reaching here is a host type by construction. The check is one
-            // integer comparison on the path that just did the expensive part, so there is nothing to
-            // save by narrowing it further.
+            // (SlicedString, ConcatenatedString, RopeString) are built on JsString directly and answer
+            // their lengths from their own fields - so every instance reaching here is a host type by
+            // construction. The check is one integer comparison on the path that just did the expensive
+            // part, so there is nothing to save by narrowing it further.
             VerifyDeclaredLength(value);
         }
 

--- a/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
@@ -1495,17 +1495,20 @@ internal abstract class JintBinaryExpression : JintExpression
     {
         if (lprim.IsString() || rprim.IsString())
         {
-            var left = TypeConverter.ToString(lprim);
-            var right = TypeConverter.ToString(rprim);
+            // ToJsString rather than ToString: the operands keep their own representation, so a large
+            // left operand is not materialized just to be copied. JsString.Concat then decides whether
+            // the result is worth deferring - which is what keeps `s = s + x` in a loop linear.
+            var left = TypeConverter.ToJsString(lprim);
+            var right = TypeConverter.ToJsString(rprim);
 
-            // Checked before string.Concat allocates the result. The realm is resolved only inside
+            // Checked before the result is built, deferred or not. The realm is resolved only inside
             // the cold branch, so the warm path pays one widened add and one compare.
             if ((long) left.Length + right.Length > JsString.MaxLength)
             {
                 Throw.RangeError(context.Engine.Realm, "Invalid string length");
             }
 
-            return JsString.Create(string.Concat(left, right));
+            return JsString.Concat(left, right);
         }
 
         if (AreNonBigIntOperands(lprim, rprim))
@@ -1524,10 +1527,16 @@ internal abstract class JintBinaryExpression : JintExpression
     /// <para>
     /// Left-associativity means that once the first operation yields a string, every later '+' in the
     /// chain is also a string concatenation. So the chain's kind can be decided once, from the first
-    /// two primitives: if either is a string the whole chain is concatenated in a single pass and the
-    /// result is allocated exactly once. The nested <see cref="PlusBinaryExpression"/> form instead
-    /// materializes one intermediate string per '+' — for a 3-operand chain of large strings that is
-    /// about twice the result's bytes (measured 250 KB per concat against a 125 KB result).
+    /// two primitives: if either is a string, the whole chain is coerced in a single pass. A short
+    /// result is then allocated exactly once, where the nested <see cref="PlusBinaryExpression"/> form
+    /// materializes one intermediate string per '+' — for a 3-operand chain that is one extra copy of
+    /// the first two operands.
+    /// </para>
+    /// <para>
+    /// A long result is instead folded through <see cref="JsString.Concat"/>, which defers the copy into
+    /// an immutable node, so a chain that accumulates (<c>s = s + a + b</c>) never copies its
+    /// accumulator. This is the same decision the two-operand form makes; deciding it here as well is
+    /// what keeps the flattened chain from being the one shape that stayed quadratic.
     /// </para>
     /// <para>
     /// Evaluation order matches ApplyStringOrNumericBinaryOperator exactly: evaluate operand 0,
@@ -1721,7 +1730,7 @@ internal abstract class JintBinaryExpression : JintExpression
                     nextFold++;
                 }
 
-                return accumulator ?? JsString.Create(ConcatAll(context, buffer, count));
+                return accumulator ?? ConcatAll(context, buffer, count);
             }
             finally
             {
@@ -1771,46 +1780,111 @@ internal abstract class JintBinaryExpression : JintExpression
             }
 
             _kind = ChainKind.String;
-            var s0 = TypeConverter.ToString(p0);
-            var s1 = TypeConverter.ToString(p1);
+            var s0 = TypeConverter.ToJsString(p0);
+            var s1 = TypeConverter.ToJsString(p1);
 
             if (count == 3)
             {
-                var s2 = NextOperandAsString(context, operands[2]);
-                CheckConcatenationLength(context, (long) s0.Length + s1.Length + s2.Length);
-                return JsString.Create(string.Concat(s0, s1, s2));
+                var s2 = NextOperandAsJsString(context, operands[2]);
+                return ConcatThree(context, s0, s1, s2);
             }
 
             if (count == 4)
             {
-                var s2 = NextOperandAsString(context, operands[2]);
-                var s3 = NextOperandAsString(context, operands[3]);
-                CheckConcatenationLength(context, (long) s0.Length + s1.Length + s2.Length + s3.Length);
-                return JsString.Create(string.Concat(s0, s1, s2, s3));
+                var s2 = NextOperandAsJsString(context, operands[2]);
+                var s3 = NextOperandAsJsString(context, operands[3]);
+                return ConcatFour(context, s0, s1, s2, s3);
             }
 
-            var strings = new string[count];
-            strings[0] = s0;
-            strings[1] = s1;
+            var parts = new JsString[count];
+            parts[0] = s0;
+            parts[1] = s1;
             long total = s0.Length + (long) s1.Length;
             for (var i = 2; i < count; i++)
             {
-                var next = NextOperandAsString(context, operands[i]);
-                strings[i] = next;
+                var next = NextOperandAsJsString(context, operands[i]);
+                parts[i] = next;
                 total += next.Length;
             }
 
             CheckConcatenationLength(context, total);
-            return JsString.Create(string.Concat(strings));
+            return ConcatMany(parts, total);
         }
 
         /// <summary>
         /// Evaluates one trailing operand and coerces it, in that order — past the opening pair each
         /// operand is coerced before the next one is evaluated.
         /// </summary>
+        /// <remarks>
+        /// <see cref="TypeConverter.ToJsString"/> rather than <see cref="TypeConverter.ToString(JsValue)"/>:
+        /// the two produce the same characters, but this one leaves a string operand in whatever
+        /// representation it already has, so a large one is not materialized just to be copied.
+        /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static string NextOperandAsString(EvaluationContext context, JintExpression operand)
-            => TypeConverter.ToString(TypeConverter.ToPrimitive(operand.GetValue(context)));
+        private static JsString NextOperandAsJsString(EvaluationContext context, JintExpression operand)
+            => TypeConverter.ToJsString(TypeConverter.ToPrimitive(operand.GetValue(context)));
+
+        /// <summary>
+        /// The chain's whole result, in the two shapes it can take: a short one is concatenated in the
+        /// single allocation the flattened chain exists to produce, and a long one is folded
+        /// left-to-right through <see cref="JsString.Concat"/>, which defers the copy — so a chain that
+        /// accumulates (<c>s = s + a + b</c>) never copies its accumulator, exactly as the two-operand
+        /// form does not. Both callers — the direct path and the resumed one — share these, so the
+        /// decision cannot drift between them.
+        /// </summary>
+        private static JsString ConcatThree(EvaluationContext context, JsString s0, JsString s1, JsString s2)
+        {
+            var total = (long) s0.Length + s1.Length + s2.Length;
+            CheckConcatenationLength(context, total);
+
+            if (total >= JsString.MinDeferredConcatenationLength)
+            {
+                return JsString.Concat(JsString.Concat(s0, s1), s2);
+            }
+
+            return JsString.Create(string.Concat(s0.ToString(), s1.ToString(), s2.ToString()));
+        }
+
+        /// <inheritdoc cref="ConcatThree"/>
+        private static JsString ConcatFour(EvaluationContext context, JsString s0, JsString s1, JsString s2, JsString s3)
+        {
+            var total = (long) s0.Length + s1.Length + s2.Length + s3.Length;
+            CheckConcatenationLength(context, total);
+
+            if (total >= JsString.MinDeferredConcatenationLength)
+            {
+                return JsString.Concat(JsString.Concat(JsString.Concat(s0, s1), s2), s3);
+            }
+
+            return JsString.Create(string.Concat(s0.ToString(), s1.ToString(), s2.ToString(), s3.ToString()));
+        }
+
+        /// <inheritdoc cref="ConcatThree"/>
+        /// <remarks>
+        /// The five-or-more form, whose caller has already summed and checked the total — the 3- and
+        /// 4-operand ones exist to keep the <see cref="string"/>[]-free <c>string.Concat</c> overloads.
+        /// </remarks>
+        private static JsString ConcatMany(JsString[] parts, long total)
+        {
+            if (total >= JsString.MinDeferredConcatenationLength)
+            {
+                var accumulator = JsString.Concat(parts[0], parts[1]);
+                for (var i = 2; i < parts.Length; i++)
+                {
+                    accumulator = JsString.Concat(accumulator, parts[i]);
+                }
+
+                return accumulator;
+            }
+
+            var strings = new string[parts.Length];
+            for (var i = 0; i < parts.Length; i++)
+            {
+                strings[i] = parts[i].ToString();
+            }
+
+            return JsString.Create(string.Concat(strings));
+        }
 
         /// <summary>
         /// Refuses a concatenation whose result would exceed <see cref="JsString.MaxLength"/>, before
@@ -1828,42 +1902,42 @@ internal abstract class JintBinaryExpression : JintExpression
         }
 
         /// <summary>
-        /// Joins every operand's string form with a single allocation for the result. The 3- and
-        /// 4-operand overloads avoid the intermediate <see cref="string"/>[] that the general
-        /// <see cref="string.Concat(string[])"/> path needs.
+        /// Joins every operand of a chain that suspended at least once. The buffer already holds each
+        /// operand's coerced <see cref="JsString"/>, so this only has to make the same call the direct
+        /// path makes, through the same three helpers.
         /// </summary>
-        private static string ConcatAll(EvaluationContext context, JsValue[] buffer, int count)
+        private static JsString ConcatAll(EvaluationContext context, JsValue[] buffer, int count)
         {
             if (count == 3)
             {
-                var s0 = TypeConverter.ToString(buffer[0]);
-                var s1 = TypeConverter.ToString(buffer[1]);
-                var s2 = TypeConverter.ToString(buffer[2]);
-                CheckConcatenationLength(context, (long) s0.Length + s1.Length + s2.Length);
-                return string.Concat(s0, s1, s2);
+                return ConcatThree(
+                    context,
+                    TypeConverter.ToJsString(buffer[0]),
+                    TypeConverter.ToJsString(buffer[1]),
+                    TypeConverter.ToJsString(buffer[2]));
             }
 
             if (count == 4)
             {
-                var s0 = TypeConverter.ToString(buffer[0]);
-                var s1 = TypeConverter.ToString(buffer[1]);
-                var s2 = TypeConverter.ToString(buffer[2]);
-                var s3 = TypeConverter.ToString(buffer[3]);
-                CheckConcatenationLength(context, (long) s0.Length + s1.Length + s2.Length + s3.Length);
-                return string.Concat(s0, s1, s2, s3);
+                return ConcatFour(
+                    context,
+                    TypeConverter.ToJsString(buffer[0]),
+                    TypeConverter.ToJsString(buffer[1]),
+                    TypeConverter.ToJsString(buffer[2]),
+                    TypeConverter.ToJsString(buffer[3]));
             }
 
-            var strings = new string[count];
+            var parts = new JsString[count];
             long total = 0;
             for (var i = 0; i < count; i++)
             {
-                var next = TypeConverter.ToString(buffer[i]);
-                strings[i] = next;
+                var next = TypeConverter.ToJsString(buffer[i]);
+                parts[i] = next;
                 total += next.Length;
             }
 
             CheckConcatenationLength(context, total);
-            return string.Concat(strings);
+            return ConcatMany(parts, total);
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -2246,8 +2246,11 @@ memoization cannot be bypassed — and it never runs at all for anything the dec
 against a 40 KB value costs nothing. Override `this[int index]` as well when your store can produce one
 character without decoding the whole value, and character access joins that list. Everything else does need
 the characters, including the one that surprises: a property key is a string plus its ordinal hash, so
-`obj[field]`, `field in obj` and a computed key all materialize, as do `JSON.stringify`, concatenation and
-the `String.prototype` methods.
+`obj[field]`, `field in obj` and a computed key all materialize, as do `JSON.stringify` and the
+`String.prototype` methods. Concatenation is the exception it used to be part of: `field + x` defers the
+result once it is long enough to be worth deferring, holding your value as one of the two operands, so
+measuring or further concatenating that result still costs nothing. A short concatenation, and any read of
+the finished text, materializes as before.
 
 The length you declare is what all of those shortcuts answer from, so it has to be the length you produce;
 with **host-contract verification** on (above) a disagreement throws at the moment both answers exist,

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -1542,6 +1542,25 @@ asserting the bug. An engine left at the default `MaxExecutionStackCount` (`-1`)
 unaffected — `Options.Constraints.StackOverflowGuard`, the default, throws a `RangeError` without hopping
 threads.
 
+### 4.27 A long `+` returns a deferred string ([#3350](https://github.com/sebastienros/jint/issues/3350))
+
+`s += x` and `s = s + x` mean the same thing and did not cost the same thing: the compound form builds into a
+`StringBuilder`-backed value and is amortised linear, while a plain `+` produced a flat string per operation
+and so copied the whole accumulated left operand on every iteration. Prepending (`s = x + s`) had no fast
+path at all. From v5 a `+` whose result is at least 512 characters returns an *immutable* two-operand node
+instead, and materializes the text on the first read that needs characters.
+
+**What could break:** nothing a script can see — the value is the string it stands for, for equality,
+hashing, property keys, `length`, every `String.prototype` method and `JSON.stringify`. Two things a host
+might notice:
+
+- `engine.Evaluate("a + b")` may hand back a `JsString` **subclass**. It always could — `+=` has returned one
+  since long before v5 — so `is JsString`, `AsString()`, `ToString()` and `ToObject()` are unaffected, but an
+  exact-type test (`result.GetType() == typeof(JsString)`) now fails for one more shape.
+- The result keeps its two operands alive until something reads its text. A host that concatenates a large
+  string and holds only the result, expecting the operands to become collectable immediately, gets that back
+  by reading the result once (`AsString()` is enough) — the node then drops both references.
+
 ## 5. New in v5
 
 Everything in the table below is opt-in: nothing in it is installed unless the host asks for it, so


### PR DESCRIPTION
`s += x` and `s = s + x` mean the same thing and did not cost the same thing. The compound form builds into `JsString.ConcatenatedString`, which is `StringBuilder`-backed and amortised linear; a plain `+` went through `ApplyAdditionToPrimitives`, which coerced both operands to `string` and returned `JsString.Create(string.Concat(left, right))`, so every iteration of an accumulator loop copied the whole left operand. Prepending (`s = x + s`) had no fast path at all, because `+=` cannot express it.

Fixes #3350.

## The node

`+` cannot simply reuse `ConcatenatedString`: it is mutated in place, and `+=` may do that only because the assignment replaces the receiver. A non-assignment `+` leaves both operands reachable from wherever they were read, so the deferred form it can use has to be **immutable** — which is also the property that makes it work for prepend, the shape `+=` can never reach. `JsString.RopeString` (internal, nested beside `ConcatenatedString` and `SlicedString`) is that form: two `JsString` operands and a total length.

`JsString.Concat` builds one once the result reaches **512 characters** and concatenates flat below that. The threshold is a knob for the small-string case, not for the fix: a loop accumulating in *n*-character pieces copies for the first `512/n` iterations and defers from then on, so the entire quadratic term is bounded by 512² characters however long the loop runs.

The five things that are ways to get this wrong:

| Hazard | How it is handled |
| --- | --- |
| **`Length` without flattening; `ToString()` flattening once** | `Length` is a stored field, so `str.length`, truthiness and the length comparison `Equals(JsString)` performs first are all free. `ToString()` is `_value ?? Flatten()`, and `Flatten` memoizes into `_value` **and releases both child references**, so a flattened value stops retaining the tree it was built from — one node per iteration, for an accumulator loop. |
| **Equality and `GetHashCode` consistent with the flat forms** | Not overridden, deliberately. The base bodies read `_value` only when it is either `null` or the exact flat text, which is precisely the invariant this class keeps (the one `ConcatenatedString` does *not*, which is why it has to override them). Pinned both before and after flattening, and as a `Map`/`Set`/property key on both sides of a lookup. |
| **Members that do not route through `ToString()`** | `Length` and `this[int]` are the only two the class declares. `this[int]` **flattens** rather than descending: descending is O(depth), so a `charCodeAt` scan over a freshly accumulated value would be a *new* quadratic — the very shape being removed. Flattening costs the one copy the old code performed on every concatenation anyway, and the memo makes every later read O(1). `Contains`, `IndexOf`, `StartsWith`, `EndsWith`, `Substring`, `Equals(string)`, `TryGetIterator`, `Append`, `EnsureCapacity` and `ToObject` all route through `ToString()` already and are correct unchanged. |
| **A depth bound** | **There is no cap on construction, and that is the design.** Flushing at a depth bound re-copies the whole accumulator every N operations — the quadratic again, with a smaller constant, i.e. the thing being fixed. The hazard a cap would have addressed (a recursive flatten overflowing the CLR stack on the unbalanced tree a long loop produces) is removed at its source: the flatten walk is **iterative over an explicit heap array**, so depth costs 8 bytes per pending node against the ~40 the node already costs, and no stack frames at all. It descends right-first, so the append shape (`s = s + x`, a left-leaning spine) never holds more than **one** pending entry; the prepend shape is the one that pays for the array. Tested at 200,000 nodes in both leanings. |
| **`MaxLength` enforcement** | Unchanged in position: the check is on the summed operand lengths, before the result is built — now *before* rather than *after* a large operand is materialized. That check is also what lets the node's `int` length arithmetic be unchecked. |

One more hazard the issue did not name, and the reason `Immutable` exists: an operand may itself be a `ConcatenatedString`, which a later `+=` grows **in place**. A node that merely held the reference would change content behind whoever read the concatenation, so such an operand is snapshotted on the way in — a wrapper around the string the builder has already flattened, not a character copy. `AppendingToAnOperandAfterwardsDoesNotChangeTheResult` pins it.

The flattened `a + b + c` chain (`AdditionChainExpression`) gets the same decision, through three helpers shared by the direct and the resumed paths, so `s = s + a + b` is linear too — otherwise it would have been the one shape that stayed quadratic. Below the threshold it still concatenates in the single allocation that node exists to produce, and the coercion moved from `TypeConverter.ToString` to `TypeConverter.ToJsString`, which produces the same characters without materializing an operand's representation.

**`+=` is untouched.** Not one line of `JintAssignmentExpression` changed, and `Append`/`EnsureCapacity` are not overridden on the node — a `+=` against a deferred value flattens once and lands back on the builder lane, which is what keeps repeated small appends on the representation that is best for them.

## Evidence

**Asymptotics, measured by allocation rather than wall-clock** — the quadratic *is* the copying, so allocated bytes say the same thing as a stopwatch without depending on what else the machine is doing. `AccumulatingWithPlusIsNoLongerQuadratic` builds at 4,000 and 8,000 iterations of a 10-character chunk and asserts the ratio is under 3 (linear ≈ 2, quadratic ≈ 4) plus an absolute 16 MB ceiling. Measured on this branch against the same test with the deferral threshold set to `int.MaxValue`, which is exactly the old behaviour:

| shape | 8,000 iterations, before | after |
| --- | --- | --- |
| `s = s + x` | 640,600,272 B | 478,848 B |
| `s = x + s` | 640,805,928 B | 478,848 B |
| `s = s + x + y` | 1,280,612,824 B | 913,448 B |

Every other new test also fails against that same disabled-threshold build, so none of them is asserting a tautology.

`Jint.Repl`, Release, the issue's own repro (indicative only — REPL timings, not gate-quality numbers): `s = s + x` went 463 ms → 10 ms at 20,000 iterations and 1,626 ms → 20 ms at 40,000, i.e. from 3.5× for 2× the work to 2.0×. `s = x + s` and `s = s + x + y` scale the same way.

A side effect worth its own row: `s = s + s` now doubles the length by referencing the same value twice, so the `MaxLength` guard for `+` is reachable through 29 nodes and no characters at all. That path used to need the half gigabyte it exists to prevent, and `StringLengthLimitTests` said so in prose; it now has a real test.

## Benchmarks — added, not run

Four lanes in `StringConcatLargeBenchmark`, which had none of this shape (every accumulating lane there uses `s += chunk`, and `ConcatLargePair` rebuilds a fresh pair each iteration so its left operand never grows — which is why the July 2026 rope evaluation came out a NO-GO for what it measured):

- `AssignAppendSmallChunks` — `s = s + chunk16` × 4,096
- `AssignPrependSmallChunks` — `s = chunk16 + s` × 4,096
- `AssignChainThree` — `s = s + chunk16 + chunk16` × 2,048
- `AssignAppendThenScan` — the first one plus a `charCodeAt` scan of the result

**Measurement is outstanding.** This machine runs agents concurrently, so nothing here was benchmarked and no timing figure in this PR comes from BenchmarkDotNet. `JINT_BENCH_MODE=gate` on an idle machine, run serially, paired against `main`:

```
JINT_BENCH_MODE=gate dotnet run -c Release --project Jint.Benchmark -- --filter "*StringConcatLargeBenchmark*"
```

The pairings that carry the reading:

1. **`AssignAppendSmallChunks` vs `AppendSmallChunks`** — the same 4,096 × 16 characters with one operator changed. This is the headline: the difference between them is the whole remaining cost of the `+` path.
2. **`AssignAppendThenScan` vs `AssignAppendSmallChunks`** — the same build plus a read-back, so their difference is what flattening costs. The other three lanes finish on `s.length`, which a deferred value answers without ever producing characters, so this is the one a deferred representation cannot cheat.
3. **`ChainSmallThree` and `ChainSmallSix`, branch vs `main`** — the guard rows. Short chains take the flat path and must not get slower; the only change they see is that the operand lengths are now read through a virtual `Length` rather than off the coerced `string`.
4. **`AppendSmallChunks`, `AppendLargeChunks`, `BuildLargeThenScan`, branch vs `main`** — the `+=` rows. They must be flat: no code on their path changed, but they now share `JsString.Length` / `ToString()` call sites with one more subclass, and a lost guarded devirtualization would show up here or nowhere.
5. `ConcatLargePair` and `ChainLargeThree` should improve outright (`big64k + big64k` followed by `.length` no longer copies 128 KB); they are the least interesting rows here.

## Verification

- `dotnet build -c Release` — clean, 0 warnings, all five target frameworks.
- `Jint.Tests` — 10,745 passed on net10.0 and net8.0, 7,369 on net472 (which is what exercises the `#if NETFRAMEWORK` half of the flatten), 0 failed. Also green with `JINT_HOST_CONTRACT_VERIFICATION=1`.
- `Jint.Tests.PublicInterface` — 2,998 passed on net10.0, 2,369 on net472, 0 failed. No public API added, so `UndocumentedPublicApi.txt` (634) is untouched; `RopeString` is `internal` and nested, like its two siblings.
- `Jint.Tests.CommonScripts` — 28/28 on both frameworks.
- **`Jint.Tests.Test262` — 102,495 passed, 0 failed, 189 skipped.** Unchanged.

## Documentation

- `docs/v5-migration.md` §4.27 — a `+` may now hand a host a `JsString` **subclass** (it always could, for `+=`, so only an exact-type test is affected), and the result keeps its operands alive until something reads its text.
- `README.md` — the `LazyJsString` section listed concatenation among the operations that materialize a lazy host string. A long one no longer does; it holds the value as an operand.
- `Jint.Benchmark/StringConcatLargeBenchmark.cs`, `Jint.Tests/Runtime/StringRepresentationKeyTests.cs` and `Jint.Tests/Runtime/StringLengthLimitTests.cs` all carried prose that this change makes wrong; each is corrected in place rather than left to mislead the next reader.

## Nothing dropped

One judgement call worth flagging for review: `Flatten()` carries a `#if NETFRAMEWORK || NETSTANDARD2_0` block rather than a `Polyfills.cs` entry, against the repository's polyfill-downwards rule. What those targets lack is not `string.Create` but `System.Buffers.SpanAction<T, TArg>`, its callback type — a "polyfill" declaring a delegate of its own would be inventing API rather than backfilling it. The downlevel arm fills a `char[]` and copies it into the string; the modern arm writes the characters into the string as it is allocated, and that single copy is what keeps a flattened concatenation no more expensive than the `string.Concat` it replaced.
