### PR TITLE
[JsAccessible]: a registration invalidates the type it registered, not every type every engine resolved

### DIFF
--- a/Jint.Tests.PublicInterface/HostAccessorCacheInvalidationTests.cs
+++ b/Jint.Tests.PublicInterface/HostAccessorCacheInvalidationTests.cs
@@ -1,0 +1,100 @@
+#nullable enable
+
+using Jint.Native;
+using Jint.Runtime.Interop;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// Pins how far a <c>[JsAccessible]</c> registration reaches into the accessor cache a
+/// <see cref="TypeResolver"/> holds. <see cref="JsAccessibleRegistry"/> is process-wide and every registration
+/// bumps one process-wide counter, so the reach is a question about every engine in the process — including
+/// the ones using a resolver the caller constructed privately, which the counter does not distinguish.
+///
+/// <para>
+/// The answer is that a registration reaches exactly the registered type. Every consult of the registry is
+/// keyed on the exact target type — <c>TryGetMember</c>, and <c>TryGetAccessorForDeclaredMember</c>, which
+/// additionally requires the reflected member to be declared on that very type — so nothing else can resolve
+/// differently because of it. Dropping the whole cache instead was measurable from another test entirely:
+/// a <c>RegisterAll()</c> landing between two resolutions of an unrelated type made the second one
+/// re-resolve, and the assertions that count resolutions failed intermittently (#3368, and the two failures
+/// reported in #3363).
+/// </para>
+///
+/// <para>
+/// The probe is the resolver's own <see cref="TypeResolver.MemberFilter"/>, which is consulted only while a
+/// member is being resolved, so a zero says the cache answered.
+/// </para>
+/// </summary>
+public class HostAccessorCacheInvalidationTests
+{
+    private sealed class Unregistered
+    {
+        public int Value => 1;
+    }
+
+    private sealed class RegisteredElsewhere
+    {
+        public int Value => 1;
+    }
+
+    private sealed class RegisteredLate
+    {
+        public int Value => 1;
+    }
+
+    private static Engine CreateEngine(TypeResolver resolver, object host)
+    {
+        var engine = new Engine(options => options.Interop.TypeResolver = resolver);
+        engine.SetValue("host", host);
+        return engine;
+    }
+
+    /// <summary>
+    /// The row #3368 is about: one registration must not cost every other type in the process the
+    /// resolutions it already paid for. Deterministic — the registration happens between the two engines on
+    /// this thread — where the failure it stands for was an interleaving.
+    /// </summary>
+    [Fact]
+    public void RegisteringOneTypeKeepsWhatEveryOtherTypeResolved()
+    {
+        var calls = 0;
+        var resolver = new TypeResolver { MemberFilter = _ => { calls++; return true; } };
+
+        CreateEngine(resolver, new Unregistered()).Evaluate("host.Value").Should().Be(1);
+        calls.Should().BeGreaterThan(0, "the first engine has to resolve the member");
+
+        calls = 0;
+        JsAccessibleRegistry.Register(
+            typeof(RegisteredElsewhere),
+            builder => builder.AddMember("Value", typeof(int), static _ => JsNumber.Create(7), static _ => 7, null, null));
+
+        CreateEngine(resolver, new Unregistered()).Evaluate("host.Value").Should().Be(1);
+        calls.Should().Be(0, "a registration can only change how the registered type resolves");
+    }
+
+    /// <summary>
+    /// The other direction, which the narrowing must not lose: a registration landing after the type's
+    /// members were already resolved still takes effect, or a late <c>RegisterAll()</c> would be silently
+    /// ineffective rather than merely late (#3333).
+    /// </summary>
+    [Fact]
+    public void RegisteringATypeStillDropsWhatWasResolvedForIt()
+    {
+        var calls = 0;
+        var resolver = new TypeResolver { MemberFilter = _ => { calls++; return true; } };
+
+        CreateEngine(resolver, new RegisteredLate()).Evaluate("host.Value").Should().Be(1);
+        calls.Should().BeGreaterThan(0);
+
+        calls = 0;
+        JsAccessibleRegistry.Register(
+            typeof(RegisteredLate),
+            builder => builder.AddMember("Value", typeof(int), static _ => JsNumber.Create(42), static _ => 42, null, null));
+
+        // 42 rather than 1 is the whole assertion: the reflected accessor cached a moment ago would still
+        // have read the CLR property
+        CreateEngine(resolver, new RegisteredLate()).Evaluate("host.Value").Should().Be(42);
+        calls.Should().BeGreaterThan(0, "the registered type's entry had to be resolved again");
+    }
+}

--- a/Jint/Runtime/Interop/JsAccessibleRegistry.cs
+++ b/Jint/Runtime/Interop/JsAccessibleRegistry.cs
@@ -18,8 +18,9 @@ namespace Jint.Runtime.Interop;
 /// The registry is process-wide, which is what a <see cref="JsAccessibleAttribute"/> already implies: the
 /// members of a type do not vary by engine, and the lanes registered here close over nothing but the target
 /// instance handed to them. It composes with <see cref="TypeResolver"/>'s own process-wide accessor cache —
-/// registering a type after an engine has already resolved one of its members invalidates that cache, so a
-/// late <c>RegisterAll()</c> is merely late rather than silently ineffective.
+/// registering a type after an engine has already resolved one of its members invalidates that type's
+/// entries in that cache, so a late <c>RegisterAll()</c> is merely late rather than silently ineffective,
+/// and costs the types it did not name nothing.
 /// </para>
 /// <para>
 /// Registering the same type twice replaces its previous entry. Registering is safe from several threads;
@@ -39,12 +40,28 @@ public static class JsAccessibleRegistry
 
     /// <summary>
     /// Bumped by every <see cref="Register"/> call. <see cref="TypeResolver"/> compares the value it last
-    /// saw against this one and drops its accessor cache when they differ, so a member resolved before its
-    /// type was registered does not keep answering from the cache afterwards.
+    /// saw against this one and, when they differ, drops the accessor cache entries of the <b>registered
+    /// types</b>, so a member resolved before its type was registered does not keep answering from the cache
+    /// afterwards.
     /// </summary>
+    /// <remarks>
+    /// It is a counter and not a log of what changed, so the resolver cannot ask which type moved and asks
+    /// <see cref="IsRegistered"/> about each cached entry instead. That over-invalidates by the types
+    /// registered earlier and under-invalidates by nothing, where dropping the whole cache made one
+    /// registration cost every unrelated engine in the process everything it had resolved (#3368).
+    /// </remarks>
     private static int _generation;
 
     internal static int Generation => Volatile.Read(ref _generation);
+
+    /// <summary>
+    /// Whether <paramref name="type"/> has been registered, and therefore whether a cached accessor for it
+    /// may have been resolved before its registration. Every consult of this registry is keyed on the exact
+    /// target type — <see cref="TryGetMember"/>, and <see cref="TryGetAccessorForDeclaredMember"/>, which
+    /// additionally requires the reflected member to be declared on that very type — so no other type's
+    /// resolution can have changed.
+    /// </summary>
+    internal static bool IsRegistered(Type type) => _byType.ContainsKey(type);
 
     /// <summary>
     /// Declares the typed member lanes of one <see cref="JsAccessibleAttribute"/>-annotated type. Called by

--- a/Jint/Runtime/Interop/TypeResolver.cs
+++ b/Jint/Runtime/Interop/TypeResolver.cs
@@ -394,17 +394,40 @@ public sealed class TypeResolver
     }
 
     /// <summary>
-    /// Drops the accessor cache when something has been registered with <see cref="JsAccessibleRegistry"/>
-    /// since the last resolution. Costs one volatile read per resolution and nothing else while no host has
-    /// registered anything.
+    /// Drops the accessor cache entries a <see cref="JsAccessibleRegistry"/> registration can have changed,
+    /// when something has been registered since the last resolution. Costs one volatile read per resolution
+    /// and nothing else while no host has registered anything.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The entries of registered types only, because a registration reaches nothing else: every consult of
+    /// the registry is keyed on the exact target type, and the substitution additionally requires the
+    /// reflected member to be declared on it. Dropping the whole cache instead was measurable from an
+    /// unrelated engine — one <c>RegisterAll()</c> made every other type re-resolve, in every engine sharing
+    /// any resolver, including a privately constructed one (#3368).
+    /// </para>
+    /// <para>
+    /// The static accessors and the constructors are not touched at all. Everything registered is a public
+    /// <em>instance</em> member, and the static lane passes its own binding flags — which is exactly what
+    /// excludes it from the substitution in <see cref="TryFindMemberAccessor"/>.
+    /// </para>
+    /// </remarks>
     private void SyncGeneratedMembers()
     {
         var generation = JsAccessibleRegistry.Generation;
-        if (_generatedMembersGeneration != generation)
+        if (_generatedMembersGeneration == generation)
         {
-            _generatedMembersGeneration = generation;
-            InvalidateResolvedAccessors();
+            return;
+        }
+
+        _generatedMembersGeneration = generation;
+
+        foreach (var entry in _reflectionAccessors)
+        {
+            if (JsAccessibleRegistry.IsRegistered(entry.Key.Type))
+            {
+                _reflectionAccessors.TryRemove(entry.Key, out _);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #3368.
Fixes #3363.

## Which of the two this fixes: the design

The issue offers the choice, and says of the design that it is "not a product bug: dropping the cache on a
registration is exactly what `JsAccessibleRegistry.Generation`'s doc comment says it is for, and a host
registers once at startup." Two things make that the wrong half to accept.

**A registration cannot change how any other type resolves, so dropping any other type's entries is not
"what the counter is for" — it is what a counter cannot express.** Every consult of the registry is keyed on
the exact target type: `TryGetMember` looks the type up directly, and `TryGetAccessorForDeclaredMember`
additionally requires the reflected member's `DeclaringType` to be that same type ("Members are resolved for
this exact type, never for a subclass" is the registry's own documented contract). Neither a subclass of a
registered type nor a type holding one can resolve differently because of it. `SyncGeneratedMembers` was
nonetheless calling `InvalidateResolvedAccessors()`, which clears `_reflectionAccessors`, `_staticAccessors`
**and** `_constructors` — on every resolver in the process, including one a host constructed privately and
handed to one engine.

**And "a host registers once at startup" is exactly what #3333 stopped being true.** Late registration was
made to work on purpose — a plugin assembly loading, a generated `RegisterAll()` called after the first
request — and `HostGeneratedInteropTests.ALateRegistrationDropsWhatWasResolvedBeforeIt` pins it. A host that
takes the feature up on that offer currently pays for it with every engine's entire resolved member set, and
nothing says so. That is the same shape of invisible cost the registry's own doc warns about in the other
direction.

So the fix is the invalidation, and the flaky test needs no change at all: the interference it was exposed
to no longer exists.

## #3363 is the same bug

#3363 reports a different test failing on each run on `net472` and suspects "shared process-wide resolution
state leaking between tests". Both of the failures it names are the same probe as #3368's — a counting
`MemberFilter` on a privately constructed `TypeResolver`, asserting that a second engine resolves nothing —
and a privately constructed resolver has exactly one channel by which another test can empty it: the
process-wide generation.

Forcing a registration into the middle of each of the three, which is the interleaving that happens by
chance under parallel collections, fails all three **deterministically** on unmodified `upstream/main`:

```
Failed  TypeConverterRegistrationTests.AnEngineWithACustomConverterSharesTheStockAccessorCache
  Expected calls to be 0 because the converter is no longer part of what partitions the cache, but found 19.
Failed  TypeConverterRegistrationTests.AConverterThatCouldKeyAnIndexerDifferentlyResolvesItsOwn
  Expected calls to be 0 because this converter cannot produce a string key, …, but found 6.
Failed  HostMemberResolutionTests.AssigningTheSameSettingBackKeepsWhatWasResolved
  Expected … to be 0, but found 2.

Failed!  - Failed:     3, Passed:     0, Skipped:     0, Total:     3 - net10.0
```

and passes all three with this change:

```
Passed!  - Failed:     0, Passed:     3, Skipped:     0, Total:     3 - net10.0
```

The forced bump is a measurement, not a shipped edit — a one-line
`JsAccessibleRegistry.Register(typeof(StringBuilder), _ => { })` between the two engines of each test, backed
out afterwards. `net472` being where #3363 saw it is timing, not mechanism: the generation is not `#if`-ed,
and #3368 reproduced the same assertion failing on the default leg.

If a *fourth* test in that family starts failing after this lands, it is a different bug, because this
channel is closed.

## The change

`SyncGeneratedMembers` removes the entries of registered types and leaves the rest:

```csharp
_generatedMembersGeneration = generation;

foreach (var entry in _reflectionAccessors)
{
    if (JsAccessibleRegistry.IsRegistered(entry.Key.Type))
    {
        _reflectionAccessors.TryRemove(entry.Key, out _);
    }
}
```

* The fast path is untouched: one volatile read and an `int` compare per member resolution, and the scan
  runs only when the generation actually moved. `ConcurrentDictionary` enumeration is safe against the
  concurrent removal, and a resolution in flight on another thread can still land a stale entry afterwards —
  which was already true of `InvalidateResolvedAccessors` and is documented there.
* `_staticAccessors` and `_constructors` are no longer touched **at all**, and that is provable rather than
  hopeful: everything registered is a public *instance* member, and the static lane passes its own binding
  flags to `TryFindMemberAccessor`, whose `maySubstituteGenerated` requires `bindingFlags is null`. The
  registry holds no constructors.
* It over-invalidates by the types registered earlier — a counter cannot say which type moved, and the
  alternative is a log of registrations that must be kept for as long as the furthest-behind resolver — and
  under-invalidates by nothing. In the ordinary shape, where every `RegisterAll()` runs before any engine
  resolves anything, there is nothing cached to drop.
* `JsAccessibleRegistry` gains one `internal static bool IsRegistered(Type)`. No public surface moves, so no
  baseline and no `UndocumentedPublicApi.txt` line changes, and no `docs/v5-migration.md` row: nothing an
  embedder can observe behaves differently — a late registration still takes over from what was resolved
  before it, which is the only thing the counter promised.

## Tests

`Jint.Tests.PublicInterface/HostAccessorCacheInvalidationTests.cs`, in the suite without
`InternalsVisibleTo` because `JsAccessibleRegistry.Register` and `JsAccessibleTypeBuilder` are the public API
a host's generated code calls. Two rows, one per direction:

* `RegisteringOneTypeKeepsWhatEveryOtherTypeResolved` — the row #3368 is about, distilled to the mechanism
  and made deterministic: the registration happens between the two engines, on this thread.
* `RegisteringATypeStillDropsWhatWasResolvedForIt` — the narrowing must not lose what the counter exists
  for. It resolves a member reflectively, registers *that* type with a generated lane answering `42` where
  the CLR property answers `1`, and reads `42`. An invalidation that dropped nothing would read `1`.

**Failing first**, with only the test file added to unmodified `upstream/main` — deterministic on both legs:

```
  Failed …HostAccessorCacheInvalidationTests.RegisteringOneTypeKeepsWhatEveryOtherTypeResolved
   Expected calls to be 0 because a registration can only change how the registered type resolves,
   but found 2 (difference of 2).

Failed!  - Failed:     1, Passed:     1, Skipped:     0, Total:     2 - Jint.Tests.PublicInterface.dll (net10.0)
Failed!  - Failed:     1, Passed:     1, Skipped:     0, Total:     2 - Jint.Tests.PublicInterface.exe (net472)
```

The second row passes on `main` too, which is the point of it — it is the regression guard on the narrowing,
not on the bug.

### Why not an xUnit collection

The issue suggests serialising every test that registers against every test that depends on the cache
surviving. That makes the flake go away by removing the interleaving rather than the interference, so the
product keeps the blunt invalidation — and, worse, it would hide a regression of *this* change just as
effectively: put those tests in one collection and narrowing the invalidation becomes untestable from the
suite that cares about it.

## Verification

* `dotnet build -c Release` — 0 warnings, 0 errors.
* `Jint.Tests` — 10,699 passed on `net10.0` and `net8.0`, 7,323 on `net472`, 0 failed.
* `Jint.Tests.PublicInterface` — 3,000 passed on `net10.0`, 2,371 on `net472`, 0 failed.
* Both again with `JINT_HOST_CONTRACT_VERIFICATION=1` — 0 failed (3,013 / 2,384 and 10,699 / 7,323).
* `Jint.Tests.Test262` — 102,495 passed, 0 failed, 189 skipped.
