### PR TITLE
Tests: a timing assertion states its property, rather than measuring the machine it ran on

### DIFF
--- a/Jint.Tests.PublicInterface/WebApiWorkerTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiWorkerTests.cs
@@ -1,6 +1,7 @@
 #if NET8_0_OR_GREATER
 #nullable enable
 
+using System.Diagnostics;
 using System.Threading;
 using Jint;
 using Jint.Runtime;
@@ -360,10 +361,19 @@ public class WebApiWorkerTests
     /// <c>postMessage</c> round trip crosses it.
     /// </summary>
     /// <remarks>
-    /// Event-driven throughout, with a ten-second ceiling on every wait so that a loaded machine makes this
-    /// slower rather than redder. The worker's thread parks on its own reset event, which the parent's pump
-    /// wakes — the engine's own wait primitive is a separate change and this deliberately does not depend on
-    /// it.
+    /// <para>
+    /// Event-driven throughout, and every wait is a <see cref="TestBudgets.WedgeCeiling"/> rather than part
+    /// of the claim: nothing here asserts a duration, so a loaded machine has to make this slower rather than
+    /// redder. The worker's thread parks on its own reset event, which the parent's pump wakes — the engine's
+    /// own wait primitive is a separate change and this deliberately does not depend on it.
+    /// </para>
+    /// <para>
+    /// The ceiling has an assertion of its own, before the value is read, and #3297 is why: the loop used to
+    /// exit on a ten-second deadline straight into <c>AsString()</c>, so a machine slow enough to exhaust the
+    /// budget reported <i>"System.ArgumentException : Expected string but got Null"</i> from inside
+    /// <c>JsValue</c> — a message naming neither the worker, nor the round trip, nor the seconds that had
+    /// passed. A ceiling that ran out and a wrong value are different failures and now say so.
+    /// </para>
     /// </remarks>
     [Fact]
     public void AHostProviderThreadPerWorkerRoundTrips()
@@ -378,18 +388,32 @@ public class WebApiWorkerTests
             w.postMessage('ping');
             """);
 
-        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
-        while (DateTime.UtcNow < deadline && parent.Evaluate("got").IsNull())
+        var elapsed = Stopwatch.StartNew();
+        var got = parent.Evaluate("got");
+        while (got.IsNull() && elapsed.Elapsed < TestBudgets.WedgeCeiling)
         {
             parent.Tasks.ProcessTasks();
-            host.Answered.Wait(TimeSpan.FromMilliseconds(50));
+            // Bounded, so a wake this thread never sees costs one iteration rather than the whole budget.
+            host.Answered.Wait(PumpInterval);
+            got = parent.Evaluate("got");
         }
 
-        parent.Evaluate("got").AsString().Should().Be("pong:ping");
+        got.IsNull().Should().BeFalse(
+            $"the round trip must complete inside {TestBudgets.WedgeCeiling}; {elapsed.Elapsed} elapsed and the worker had "
+            + (host.Answered.IsSet ? "already answered, so the reply did not reach the parent's pump" : "not answered yet"));
+
+        got.AsString().Should().Be("pong:ping");
 
         parent.Execute("w.terminate();");
         host.WaitForPumpToLeave();
     }
+
+    /// <summary>
+    /// How long the parent parks between pumps while the worker has not answered. Not a budget anything
+    /// asserts — <see cref="ThreadPerWorkerHost.Answered"/> is what ends the park in the ordinary case, and
+    /// this only decides how long a lost wake would cost.
+    /// </summary>
+    private static readonly TimeSpan PumpInterval = TimeSpan.FromMilliseconds(50);
 
     /// <summary>
     /// A startup failure reaches the host through the connection alone — no sink, no listener, nothing wired.
@@ -635,7 +659,7 @@ public class WebApiWorkerTests
         }
 
         public void WaitForPumpToLeave()
-            => _left.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue("the loop observes IsEnded and leaves");
+            => _left.Wait(TestBudgets.WedgeCeiling).Should().BeTrue("the loop observes IsEnded and leaves");
 
         public void Dispose()
         {

--- a/Jint.Tests/Runtime/AsyncTests.cs
+++ b/Jint.Tests/Runtime/AsyncTests.cs
@@ -1027,7 +1027,7 @@ public class AsyncTests
         engine.SetValue("asyncWork", new Func<Task>(() => Task.Delay(100)));
 
         var result = engine.Evaluate("async function hello() {return await asyncTestMethod(async () =>{ await asyncWork(); })} hello();");
-        result = result.UnwrapIfPromise(TimeSpan.FromSeconds(30));
+        result = result.UnwrapIfPromise(TestBudgets.WedgeCeiling);
 
         result.Should().Be("Hello World");
     });
@@ -1044,7 +1044,7 @@ public class AsyncTests
         engine.SetValue("asyncWork", new Func<Task<string>>(async () => { await Task.Delay(100); return "Hello World"; }));
 
         var result = engine.Evaluate("async function hello() {return await asyncTestMethod(async () =>{ return await asyncWork(); })} hello();");
-        result = result.UnwrapIfPromise(TimeSpan.FromSeconds(30));
+        result = result.UnwrapIfPromise(TestBudgets.WedgeCeiling);
 
         result.Should().Be("Hello World");
     });
@@ -1152,23 +1152,47 @@ public class AsyncTests
 
         // A Task that never completes: the awaited promise stays pending forever unless cancellation breaks in.
         var neverCompletes = new TaskCompletionSource<int>();
-        engine.SetValue("hang", new Func<Task<int>>(() => neverCompletes.Task));
+        using var awaitReached = new ManualResetEventSlim();
+        engine.SetValue("hang", new Func<Task<int>>(() =>
+        {
+            awaitReached.Set();
+            return neverCompletes.Task;
+        }));
 
         engine.Modules.Add("main", """
             const x = await hang();
             export const answer = x;
             """);
 
-        // Cancel shortly after Import starts blocking on the drain (fires on a ThreadPool thread).
-        cts.CancelAfter(TimeSpan.FromMilliseconds(200));
+        // Started by the cancelling thread immediately before the cancel, so what is measured is the
+        // interval the assertion is about — how long the idle drain took to notice — and never how long the
+        // cancel itself took to be delivered. The cancel used to come from CancelAfter, whose callback the
+        // thread pool delivers whenever it gets round to it: #3369 measured a healthy 250 ms cancellation at
+        // 5.011 s that way, because a saturated pool grows at roughly one worker per 500 ms.
+        var elapsed = new System.Diagnostics.Stopwatch();
 
-        var sw = System.Diagnostics.Stopwatch.StartNew();
+        var canceller = DedicatedThread.RunAsync(() =>
+        {
+            // hang() has been called, so Import is on its way into the blocking drain; the settle lets it
+            // arrive. Both interleavings are correct — a cancel that beats the park is seen by the drain's
+            // own pre-check — so this only decides which of the two the run exercises.
+            awaitReached.Wait(TestBudgets.WedgeCeiling);
+            Thread.Sleep(TimeSpan.FromMilliseconds(200));
+            elapsed.Start();
+            cts.Cancel();
+        });
+
         Invoking(() => engine.Modules.Import("main")).Should().ThrowExactly<ExecutionCanceledException>();
-        sw.Stop();
+        elapsed.Stop();
 
-        // Prompt: nowhere near the multi-minute PromiseTimeout. A generous ceiling keeps this stable under CI load.
-        sw.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(10), $"Cancellation was not observed promptly: took {sw.Elapsed}.");
+        // Half of what the wrong answer costs, derived from it rather than written out again: a drain that
+        // never looked at the token sits out the whole PromiseTimeout, so the midpoint between the two is
+        // what separates "observed the cancellation" from "gave up on the budget".
+        elapsed.Elapsed.Should().BeLessThan(
+            TimeSpan.FromTicks(GenerousPromiseTimeout.Ticks / 2),
+            $"Cancellation was not observed promptly: took {elapsed.Elapsed} of a {GenerousPromiseTimeout} budget.");
 
+        canceller.GetAwaiter().GetResult();
         neverCompletes.TrySetCanceled();
     });
 
@@ -1197,7 +1221,13 @@ public class AsyncTests
         Invoking(() => engine.Modules.Import("main")).Should().ThrowExactly<InvalidOperationException>();
         sw.Stop();
 
-        sw.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(30), $"Never-settling await was not bounded: took {sw.Elapsed}.");
+        // Bounded rather than unbounded is the whole of what this half claims, and a wedge ceiling is
+        // therefore the honest number: the exception it accompanies says "did not return a fulfilled
+        // promise" and names no budget, so nothing here can tell a drain that gave up on the configured
+        // half-second from one that gave up on the ten-second default. Thirty seconds looked like a
+        // discriminator and was not — it is above both candidates — while being close enough to the
+        // half-second to be crossed by a stalled runner (#3379).
+        sw.Elapsed.Should().BeLessThan(TestBudgets.WedgeCeiling, $"Never-settling await was not bounded: took {sw.Elapsed}.");
 
         neverCompletes.TrySetCanceled();
     });
@@ -1216,7 +1246,7 @@ public class AsyncTests
         engine.SetValue("asyncWork", new Func<Task>(() => Task.Delay(100)));
         engine.SetValue("assert", new Action<bool>(static value => value.Should().BeTrue()));
         var result = engine.Evaluate("async function hello() {return await asyncTestMethod(async () =>{ await asyncWork(); })} hello();");
-        result = result.UnwrapIfPromise(TimeSpan.FromSeconds(30));
+        result = result.UnwrapIfPromise(TestBudgets.WedgeCeiling);
         result.Should().Be("Hello World");
     });
 
@@ -1232,7 +1262,7 @@ public class AsyncTests
         engine.SetValue("asyncWork", new Func<ValueTask<string>>(async () => { await Task.Delay(100); return "Hello World"; }));
         engine.SetValue("assert", new Action<bool>(static value => value.Should().BeTrue()));
         var result = engine.Evaluate("async function hello() {return await asyncTestMethod(async () =>{ return await asyncWork(); })} hello();");
-        result = result.UnwrapIfPromise(TimeSpan.FromSeconds(30));
+        result = result.UnwrapIfPromise(TestBudgets.WedgeCeiling);
         result.Should().Be("Hello World");
     });
 
@@ -1533,7 +1563,7 @@ public class AsyncTests
                         var val = result.GetValue("main").Call(testObj);
 
                         // Wait for the async function to complete (non-blocking async model)
-                        val = val.UnwrapIfPromise(TimeSpan.FromSeconds(30));
+                        val = val.UnwrapIfPromise(TestBudgets.WedgeCeiling);
                         val.AsInteger().Should().Be(1);
 
                         tasks[taskIdx].SetResult(null);
@@ -1559,15 +1589,22 @@ public class AsyncTests
         var engine = new Engine();
         var callbackExecuted = false;
 
-        engine.SetValue("setTimeout",
-            (Action action, int ms) =>
+        // The host timer never fires by itself: it hands its callback to this test and waits to be told.
+        // It used to be Task.Delay(ms).ContinueWith(...), which made both assertions below a statement about
+        // how long the Execute and the Evaluate took — a hundred milliseconds is not a margin a loaded
+        // runner respects, and a callback that had run reads as exactly the defect this test exists to catch
+        // (#3379). Nothing here is about latency: what is asserted is that calling f() without awaiting it
+        // returns before the awaited promise settles.
+        Action scheduled = null;
+        engine.SetValue("setTimeout", (Action action, int ms) =>
+        {
+            _ = ms;
+            scheduled = () =>
             {
-                Task.Delay(ms).ContinueWith(_ =>
-                {
-                    callbackExecuted = true;
-                    action();
-                });
-            });
+                callbackExecuted = true;
+                action();
+            };
+        });
 
         engine.Execute("""
             var x = '';
@@ -1585,6 +1622,12 @@ public class AsyncTests
         // and NOT include "promise resolved -" yet
         x.Should().Be("f() called - ");
         callbackExecuted.Should().BeFalse("Promise callback should not have executed yet");
+
+        // ...and the other half of "not yet", which the wall clock could never state: once the host does run
+        // the timer, the continuation the async function was suspended on is the thing that lands.
+        scheduled.Should().NotBeNull("the script registered a timer");
+        scheduled();
+        engine.Evaluate("x").AsString().Should().Be("f() called - promise resolved - ");
     }
 
     [Fact]
@@ -2377,16 +2420,16 @@ public class AsyncTests
     [Fact]
     public async Task EvaluateAsyncTimeoutShouldFireDuringPendingClrTask()
     {
-        // Verify that the PromiseTimeout constraint works with the async wake path.
+        // Verify that the PromiseTimeout constraint works with the async wake path. The IO never completes at
+        // all, so the timeout is the only thing that can end the wait and no amount of load can let the IO
+        // win the race — where a five-second Task.Delay only had to beat the budget by a factor of fifty, on
+        // a pool that also has to deliver the budget's own CancelAfter callback.
+        var neverCompletes = new TaskCompletionSource<int>();
         var engine = new Engine(options =>
         {
             options.Constraints.PromiseTimeout = TimeSpan.FromMilliseconds(100);
         });
-        engine.SetValue("slowIO", new Func<Task<int>>(async () =>
-        {
-            await Task.Delay(5000);
-            return 999;
-        }));
+        engine.SetValue("slowIO", new Func<Task<int>>(() => neverCompletes.Task));
 
         await Awaiting(async () =>
         {
@@ -2397,6 +2440,8 @@ public class AsyncTests
                 main()
                 """);
         }).Should().ThrowExactlyAsync<PromiseRejectedException>();
+
+        neverCompletes.TrySetCanceled();
     }
 
     [Fact]
@@ -2487,10 +2532,18 @@ public class AsyncTests
         var engine = new Engine(options => options.Constraints.PromiseTimeout = GenerousPromiseTimeout);
         var ioStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
+        // The IO ends when this test says so, never on an interval — the same fix
+        // PromiseTests.UnwrapIfPromiseAsync_WithIOBoundTask_DoesNotBlockCallerThread took for its twin of
+        // this body. `await Task.Delay(200)` made the "still pending" assertion below a race this test could
+        // lose: on a loaded runner the two hundred milliseconds can be gone before this thread is scheduled
+        // again, and a completed evaluation then reads as exactly the defect the test exists to catch. A gate
+        // the test holds cannot complete early, so "in flight" is a fact rather than a hope.
+        var releaseIO = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
         engine.SetValue("simulateIO", new Func<Task<int>>(async () =>
         {
             ioStarted.TrySetResult(true);
-            await Task.Delay(200);
+            await releaseIO.Task.ConfigureAwait(false);
             return 42;
         }));
 
@@ -2507,6 +2560,8 @@ public class AsyncTests
 
         // The evalTask should not be completed yet — IO is in flight
         evalTask.IsCompleted.Should().BeFalse("EvaluateAsync should not block; task should still be pending during IO");
+
+        releaseIO.SetResult(true);
 
         // Now await the result
         var result = await evalTask;
@@ -2652,61 +2707,121 @@ public class AsyncTests
         // and the TCS in WaitForEventAsync gets cancelled (stale). The engine must
         // remain usable for subsequent calls — the stale TCS must be detected and
         // replaced on the next EvaluateAsync invocation.
-        //
-        // One budget for both halves, because the Options an engine was built from are read-only afterwards.
-        // It is generous enough that the recovery half asserts success rather than racing the machine, and
-        // the first half reaches it anyway because the slow IO never completes at all.
         var neverCompletes = new TaskCompletionSource<int>();
         var engine = new Engine(options =>
         {
-            options.Constraints.PromiseTimeout = TimeSpan.FromSeconds(1);
+            options.Constraints.PromiseTimeout = ReuseAfterTimeoutBudget;
         });
         engine.SetValue("slowIO", new Func<Task<int>>(() => neverCompletes.Task));
-        engine.SetValue("fastIO", new Func<Task<int>>(async () =>
+
+        // The recovery half's IO ends when a thread this test owns says so, never on an interval. It used to
+        // be `await Task.Delay(10)`, which is a pool timer whose continuation needs a pool worker, and on a
+        // saturated runner the pool grows at about one worker per 500 ms — so the ten milliseconds became
+        // seconds and the recovery failed as "Timeout of 00:00:01 reached", which says nothing about
+        // whether the engine was reusable. A dedicated thread that is already parked on the handshake below
+        // needs a core, not a worker.
+        using var recoveryIOStarted = new ManualResetEventSlim();
+        var recoveryIO = new TaskCompletionSource<int>();
+        engine.SetValue("fastIO", new Func<Task<int>>(() =>
         {
-            await Task.Delay(10);
-            return 42;
+            recoveryIOStarted.Set();
+            return recoveryIO.Task;
         }));
 
-        // First call should time out
-        await Awaiting(async () =>
+        var releaser = DedicatedThread.RunAsync(() =>
+        {
+            recoveryIOStarted.Wait(TestBudgets.WedgeCeiling);
+            recoveryIO.TrySetResult(42);
+        });
+
+        // First call should time out. Which budget it gave up on is stated by the rejection itself —
+        // AwaitPromiseSettlementAsync formats the very local it armed the timeout CTS from — so the size of
+        // that budget is not what this asserts and a slower machine cannot change the answer.
+        var rejection = await Awaiting(async () =>
         {
             await engine.EvaluateAsync("(async () => await slowIO())()");
         }).Should().ThrowExactlyAsync<PromiseRejectedException>();
 
+        rejection.Which.Message.Should().Contain(ReuseAfterTimeoutBudget.ToString());
+
         // Engine should still work
         var result = await engine.EvaluateAsync("(async () => await fastIO())()");
         result.AsInteger().Should().Be(42);
+
+        await releaser;
     }
+
+    /// <summary>
+    /// The one promise budget <see cref="EngineReusableAfterEvaluateAsyncTimeout"/> has for both of its
+    /// halves, because the <see cref="Options"/> an engine was built from are read-only afterwards and
+    /// <c>EvaluateAsync</c> takes no per-call timeout.
+    /// </summary>
+    /// <remarks>
+    /// It plays two roles, which is why it is named rather than written inline. The first half spends all of
+    /// it — the slow IO never completes — so it is the whole cost of the test, and it is deliberately not the
+    /// two-minute <see cref="TestBudgets.WedgeCeiling"/> the behaviour-only rows here use. The second half
+    /// gets all of it as margin, and that is the half a loaded runner used to take away at one second
+    /// (#3379): what the recovery has to fit inside is now a handshake and a context switch on a thread the
+    /// test already started, rather than a thread-pool timer and the pool's worker-injection rate.
+    /// <em>Which</em> budget fired is asserted from the rejection message rather than from this number, so
+    /// moving it changes what the test costs and never what it claims.
+    /// </remarks>
+    private static readonly TimeSpan ReuseAfterTimeoutBudget = TimeSpan.FromSeconds(5);
 
     [Fact]
     public async Task EngineReusableAfterEvaluateAsyncCancellation()
     {
         // CancellationToken fires during a pending EvaluateAsync. The TCS in
         // WaitForEventAsync gets cancelled. Verify the engine is still usable.
+        //
+        // Nothing here is on the wall clock, and nothing is released by the thread pool. The slow IO is a
+        // gate this test holds rather than a ten-second Task.Delay it had to outrun; the cancel comes from a
+        // thread the test owns rather than from CancelAfter, whose callback a saturated pool delivers
+        // whenever it gets round to it; and the recovery IO is completed by that same thread rather than by
+        // another pool timer. What is asserted is the exception type and the recovered value — never a
+        // duration — so GenerousPromiseTimeout is a wedge ceiling on all of it.
         var engine = new Engine(options => options.Constraints.PromiseTimeout = GenerousPromiseTimeout);
-        engine.SetValue("slowIO", new Func<Task<int>>(async () =>
+
+        var slowIO = new TaskCompletionSource<int>();
+        using var slowIOStarted = new ManualResetEventSlim();
+        engine.SetValue("slowIO", new Func<Task<int>>(() =>
         {
-            await Task.Delay(10_000);
-            return 999;
-        }));
-        engine.SetValue("fastIO", new Func<Task<int>>(async () =>
-        {
-            await Task.Delay(10);
-            return 7;
+            slowIOStarted.Set();
+            return slowIO.Task;
         }));
 
-        using (var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(50)))
+        var recoveryIO = new TaskCompletionSource<int>();
+        using var recoveryIOStarted = new ManualResetEventSlim();
+        engine.SetValue("fastIO", new Func<Task<int>>(() =>
         {
+            recoveryIOStarted.Set();
+            return recoveryIO.Task;
+        }));
+
+        using (var cts = new CancellationTokenSource())
+        {
+            var driver = DedicatedThread.RunAsync(() =>
+            {
+                slowIOStarted.Wait(TestBudgets.WedgeCeiling);
+                cts.Cancel();
+
+                recoveryIOStarted.Wait(TestBudgets.WedgeCeiling);
+                recoveryIO.TrySetResult(7);
+            });
+
             await Awaiting(async () =>
             {
                 await engine.EvaluateAsync("(async () => await slowIO())()", cancellationToken: cts.Token);
             }).Should().ThrowAsync<OperationCanceledException>();
+
+            // Engine must still be usable after cancellation
+            var result = await engine.EvaluateAsync("(async () => await fastIO())()");
+            result.AsInteger().Should().Be(7);
+
+            await driver;
         }
 
-        // Engine must still be usable after cancellation
-        var result = await engine.EvaluateAsync("(async () => await fastIO())()");
-        result.AsInteger().Should().Be(7);
+        slowIO.TrySetCanceled();
     }
 
     // ========================================================================
@@ -3196,7 +3311,7 @@ public class AsyncTests
         var engine = new Engine(options =>
         {
             options.Strict = true;
-            options.Constraints.PromiseTimeout = TimeSpan.FromSeconds(30);
+            options.Constraints.PromiseTimeout = TestBudgets.WedgeCeiling;
         });
 
         engine.SetValue("host", (Func<string, Task<string>>) (value => Task.FromResult(value)));
@@ -3350,7 +3465,9 @@ public class AsyncTests
 
         loop.Enqueue(static () => { });
 
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        // A wedge ceiling: what is asserted is that both waiters were signalled, never how quickly, and the
+        // completions are delivered by the thread pool.
+        using var cts = new CancellationTokenSource(TestBudgets.WedgeCeiling);
         await Task.WhenAll(waiter1, waiter2).WaitAsync(cts.Token);
 
         waiter1.IsCompletedSuccessfully.Should().BeTrue();

--- a/Jint.Tests/Runtime/AtomicsWaitAsyncPumpTests.cs
+++ b/Jint.Tests/Runtime/AtomicsWaitAsyncPumpTests.cs
@@ -160,7 +160,9 @@ public class AtomicsWaitAsyncPumpTests
         var engine = new Engine();
         var promise = engine.Evaluate(SharedInt32Array + "Atomics.waitAsync(i32a, 0, 0, 1).value");
 
-        promise.UnwrapIfPromise(TimeSpan.FromSeconds(10)).AsString().Should().Be("timed-out");
+        // The unwrap's own budget is a wedge ceiling here — what is asserted is the value the wait settled
+        // with, and a clamp that regressed never ends the wait at all, so no budget can be too generous.
+        promise.UnwrapIfPromise(TestBudgets.WedgeCeiling).AsString().Should().Be("timed-out");
     }
 
     [Fact]
@@ -211,14 +213,15 @@ public class AtomicsWaitAsyncPumpTests
 
     /// <summary>
     /// Pumps the engine on this thread until <paramref name="condition"/> holds, and answers which thread that
-    /// was. The bound exists so a broken engine fails the run rather than hanging it, and is three orders of
-    /// magnitude above the longest timeout any test here asks for — nothing is asserted about how long the
-    /// loop actually took, which is the property that keeps these tests off the wall clock.
+    /// was. The bound exists so a broken engine fails the run rather than hanging it — nothing is asserted
+    /// about how long the loop actually took, which is the property that keeps these tests off the wall
+    /// clock, and which makes <see cref="TestBudgets.WedgeCeiling"/> the right length for it rather than the
+    /// thirty seconds a loaded runner could reach on its own (#3379).
     /// </summary>
     private static int PumpUntil(Engine engine, string condition)
     {
         var elapsed = Stopwatch.StartNew();
-        while (elapsed.Elapsed < TimeSpan.FromSeconds(30))
+        while (elapsed.Elapsed < TestBudgets.WedgeCeiling)
         {
             engine.Tasks.ProcessTasks();
             if (engine.Evaluate(condition).AsBoolean())

--- a/Jint.Tests/Runtime/AtomicsWaitAsyncTests.cs
+++ b/Jint.Tests/Runtime/AtomicsWaitAsyncTests.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 namespace Jint.Tests.Runtime;
@@ -28,6 +29,10 @@ public class AtomicsWaitAsyncTests
         // the engine after that is the timeout timer, because there is nothing else left to hold it.
         var reference = WaitNotifyAndForget();
 
+        // Ten seconds is four hundred forced blocking gen-2 collections, and that is not a wall-clock margin:
+        // an object that is rooted does not stop being rooted because more time passed, so the budget only
+        // has to outlast the transient window the remarks on CollectUntilDead describe. Widening it would buy
+        // no reliability and would cost two minutes of full collections on a genuine regression.
         CollectUntilDead(reference, TimeSpan.FromSeconds(10))
             .Should().BeTrue("the timeout timer of a woken Atomics.waitAsync still pins the engine that owned it");
 
@@ -58,7 +63,7 @@ public class AtomicsWaitAsyncTests
             Atomics.waitAsync(i32a, 0, 0, 50).value.then(function (v) { outcome = v; });
             """);
 
-        DrainUntil(engine, "outcome !== 'pending'", TimeSpan.FromSeconds(10));
+        DrainUntil(engine, "outcome !== 'pending'");
 
         engine.Evaluate("outcome").AsString().Should().Be("timed-out");
     }
@@ -77,20 +82,35 @@ public class AtomicsWaitAsyncTests
 
         engine.Evaluate("notified").AsNumber().Should().Be(1);
 
-        DrainUntil(engine, "outcome !== 'pending'", TimeSpan.FromSeconds(10));
+        DrainUntil(engine, "outcome !== 'pending'");
 
         engine.Evaluate("outcome").AsString().Should().Be("ok");
     }
 
-    private static void DrainUntil(Engine engine, string condition, TimeSpan timeout)
+    /// <summary>
+    /// Pumps until <paramref name="condition"/> holds, or fails saying that it never did.
+    /// </summary>
+    /// <remarks>
+    /// The budget is a <see cref="TestBudgets.WedgeCeiling"/>: nothing here asserts how long the pump took —
+    /// the callers assert what the wait settled <em>with</em> — so widening it can hide nothing, and the ten
+    /// seconds it was could be reached by a runner slow enough without anything being wrong. Running out of
+    /// it now says so: this used to return silently, so an exhausted budget reported as
+    /// <c>outcome == "pending"</c>, which reads as a settlement defect rather than as the wedge it is.
+    /// </remarks>
+    private static void DrainUntil(Engine engine, string condition)
     {
-        var deadline = DateTime.UtcNow + timeout;
-        while (DateTime.UtcNow < deadline)
+        var elapsed = Stopwatch.StartNew();
+        while (true)
         {
             engine.Tasks.ProcessTasks();
             if (engine.Evaluate(condition).AsBoolean())
             {
                 return;
+            }
+
+            if (elapsed.Elapsed >= TestBudgets.WedgeCeiling)
+            {
+                Assert.Fail($"the engine never reached `{condition}` within {TestBudgets.WedgeCeiling}");
             }
 
             Thread.Sleep(5);

--- a/Jint.Tests/Runtime/AtomicsWaiterRegistryTests.cs
+++ b/Jint.Tests/Runtime/AtomicsWaiterRegistryTests.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Jint.Native;
 using Jint.Native.Atomics;
@@ -36,7 +37,12 @@ public class AtomicsWaiterRegistryTests
         };
         thread.Start();
 
-        var completedWithoutBlocking = thread.Join(TimeSpan.FromSeconds(2));
+        // "Rejected the wait" and "blocked on it" are separated by whether the thread ever finishes, not by
+        // how quickly, so this is a wedge ceiling: a regressed implementation blocks for ever and misses any
+        // budget, while a healthy one that a loaded runner has not scheduled yet is not a defect. Two seconds
+        // was a number the machine could decide (#3379); the cost of the wider one is paid only by a genuine
+        // regression, which now takes two minutes to be reported.
+        var completedWithoutBlocking = thread.Join(TestBudgets.WedgeCeiling);
         if (!completedWithoutBlocking)
         {
             var notifier = new Engine();
@@ -185,8 +191,11 @@ public class AtomicsWaiterRegistryTests
 
         engine.Evaluate("notified").AsNumber().Should().Be(1);
 
-        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
-        while (DateTime.UtcNow < deadline && engine.Evaluate("outcome").AsString() == "pending")
+        // A wedge ceiling: the assertion is what the wait settled with, never how many pumps it took. A wait
+        // the notify missed stays "pending" for its own three minutes, which no budget short of that could
+        // mistake for a slow runner.
+        var elapsed = Stopwatch.StartNew();
+        while (elapsed.Elapsed < TestBudgets.WedgeCeiling && engine.Evaluate("outcome").AsString() == "pending")
         {
             engine.Tasks.ProcessTasks();
             Thread.Sleep(5);

--- a/Jint.Tests/Runtime/ForLoopIterationEnvironmentAwaitTests.cs
+++ b/Jint.Tests/Runtime/ForLoopIterationEnvironmentAwaitTests.cs
@@ -66,9 +66,10 @@ public class ForLoopIterationEnvironmentAwaitTests
 
         DedicatedThread.Run(
             () => result = new Engine().Evaluate(script).UnwrapIfPromise(),
-            joinTimeout: TimeSpan.FromSeconds(30),
-            timeoutMessage: "evaluation did not complete within 30s — the lexical environment chain is most "
-                + "likely corrupt, leaving GetThisEnvironment() or an identifier walk spinning");
+            joinTimeout: TestBudgets.WedgeCeiling,
+            timeoutMessage: $"evaluation did not complete within {TestBudgets.WedgeCeiling} — the lexical "
+                + "environment chain is most likely corrupt, leaving GetThisEnvironment() or an identifier "
+                + "walk spinning");
 
         return result;
     }

--- a/Jint.Tests/Runtime/RegExpTests.cs
+++ b/Jint.Tests/Runtime/RegExpTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using System.Text.RegularExpressions;
+﻿using System.Text.RegularExpressions;
 using Jint.Native;
 using Jint.Runtime;
 
@@ -520,22 +519,62 @@ public class RegExpTests
             $"export default '{TestedValue}'.match(/{TestRegex}/)",
             options: preparationOptions);
 
-        // Engine is set to a long timeout so a regression that drops the prepare-time
-        // timeout on the floor falls through to ~EngineRegexTimeoutSeconds rather than
-        // the modest default — keeping a clear gap above the assertion threshold even
-        // on slow Windows CI runners where cancellation lag can be several seconds.
-        var engine = new Engine(o => o.Constraints.RegexTimeout = TimeSpan.FromSeconds(EngineRegexTimeoutSeconds));
+        // Engine is set to a long timeout so a regression that drops the prepare-time timeout on the floor
+        // falls through to EngineRegexTimeout rather than to the modest default — see
+        // ShouldHaveRunUnderThePrepareTimeBudget for why that is the wrong answer this test discriminates
+        // against, and why it no longer needs a clock to do it.
+        var engine = new Engine(o => o.Constraints.RegexTimeout = EngineRegexTimeout);
         engine.Modules.Add("__main__", x => x.AddModule(preparedModule));
 
-        var sw = Stopwatch.StartNew();
-        Invoking(() => engine.Modules.Import("__main__")).Should().ThrowExactly<RegexMatchTimeoutException>();
-        sw.Stop();
+        var timedOut = Invoking(() => engine.Modules.Import("__main__"))
+            .Should().ThrowExactly<RegexMatchTimeoutException>().Which;
 
-        sw.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(MaxAcceptableTimeoutSeconds), $"Expected RegexMatchTimeoutException within {MaxAcceptableTimeoutSeconds}s, took {sw.Elapsed.TotalSeconds:F1}s");
+        ShouldHaveRunUnderThePrepareTimeBudget(timedOut);
     }
 
-    private const int EngineRegexTimeoutSeconds = 30;
-    private const int MaxAcceptableTimeoutSeconds = 15;
+    /// <summary>
+    /// The budget the match that failed was actually running under — <b>not</b> a restatement of the
+    /// configuration.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>RegExpPrototype.ExecuteWithTimeout</c> resolves the effective timeout into one local
+    /// (<c>GetCustomEngineTimeout</c>: the prepared script's, falling back to the engine's), hands that local
+    /// to the interpreter as its deadline, and constructs the <see cref="RegexMatchTimeoutException"/> from
+    /// the very same local. So <see cref="RegexMatchTimeoutException.MatchTimeout"/> is a witness of which of
+    /// the two budgets fired, thrown by the matcher that fired it — a regression that drops the prepare-time
+    /// timeout reports <see cref="EngineRegexTimeout"/> here and fails, and there is no way to report
+    /// <see cref="PrepareTimeRegexTimeout"/> while having actually waited out the other one.
+    /// </para>
+    /// <para>
+    /// This replaces a wall-clock bound (#3379). That bound asked the same question — did this fire on one
+    /// second or on thirty? — through a proxy, and the proxy does not survive a loaded runner: .NET and
+    /// Jint's interpreter both check a regex deadline every <i>N</i> steps rather than continuously, so the
+    /// overshoot scales with the machine and a one-second budget was measured reporting at 16.7 s against a
+    /// 15 s bound on a contended Windows leg. Expressing the bound as a ratio of the thirty seconds would not
+    /// have helped either, because the wrong answer's overshoot scales by the same factor — both candidates
+    /// move together, so no fixed fraction separates them. The exception's own field does, exactly, and
+    /// without measuring anything.
+    /// </para>
+    /// <para>
+    /// It is also strictly narrower than the type check it accompanies:
+    /// <c>RegExpInterpreter</c> raises the same exception type for a backtracking stack overflow, which
+    /// carries no match timeout at all and used to satisfy <c>ThrowExactly</c>.
+    /// </para>
+    /// </remarks>
+    private static void ShouldHaveRunUnderThePrepareTimeBudget(RegexMatchTimeoutException timedOut)
+        => timedOut.MatchTimeout.Should().Be(
+            PrepareTimeRegexTimeout,
+            "the match must have run under the prepared script's own regex timeout rather than falling through to the engine's {0}",
+            EngineRegexTimeout);
+
+    /// <summary>
+    /// The wrong answer. Deliberately far from <see cref="PrepareTimeRegexTimeout"/> so that a regression is
+    /// unmistakable in the witness above, and finite so that a regression which dropped <em>both</em> budgets
+    /// is reported rather than hanging the run.
+    /// </summary>
+    private static readonly TimeSpan EngineRegexTimeout = TimeSpan.FromSeconds(30);
+
     private static readonly TimeSpan PrepareTimeRegexTimeout = TimeSpan.FromSeconds(1);
 
     private static void AssertPrepareTimeRegexTimeoutFires(string script)
@@ -550,17 +589,15 @@ public class RegExpTests
 
         var preparedScript = Engine.PrepareScript(script, options: preparationOptions);
 
-        // Engine is set to a long timeout so a regression that drops the prepare-time
-        // timeout on the floor falls through to ~EngineRegexTimeoutSeconds rather than
-        // the modest default — keeping a clear gap above the assertion threshold even
-        // on slow Windows CI runners where cancellation lag can be several seconds.
-        var engine = new Engine(o => o.Constraints.RegexTimeout = TimeSpan.FromSeconds(EngineRegexTimeoutSeconds));
+        // Engine is set to a long timeout so a regression that drops the prepare-time timeout on the floor
+        // falls through to EngineRegexTimeout rather than to the modest default — see
+        // ShouldHaveRunUnderThePrepareTimeBudget.
+        var engine = new Engine(o => o.Constraints.RegexTimeout = EngineRegexTimeout);
 
-        var sw = Stopwatch.StartNew();
-        Invoking(() => engine.Execute(preparedScript)).Should().ThrowExactly<RegexMatchTimeoutException>();
-        sw.Stop();
+        var timedOut = Invoking(() => engine.Execute(preparedScript))
+            .Should().ThrowExactly<RegexMatchTimeoutException>().Which;
 
-        sw.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(MaxAcceptableTimeoutSeconds), $"Expected RegexMatchTimeoutException within {MaxAcceptableTimeoutSeconds}s, took {sw.Elapsed.TotalSeconds:F1}s");
+        ShouldHaveRunUnderThePrepareTimeBudget(timedOut);
     }
 
     // ---- host-supplied .NET Regex (RegExpConstructor.Construct(Regex, ...)) ----

--- a/Jint.Tests/Runtime/Test262AgentManagerTests.cs
+++ b/Jint.Tests/Runtime/Test262AgentManagerTests.cs
@@ -1,5 +1,6 @@
 #nullable enable
 
+using System.Diagnostics;
 using Jint.Native;
 using Jint.Runtime;
 
@@ -24,7 +25,12 @@ public class Test262AgentManagerTests
             `);
             """);
 
-        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        // A wedge ceiling — nothing here asserts how long the spawned agent took, only what it reported — and
+        // its exhaustion is stated before the value is read. The five seconds it was ran straight into
+        // AsString() on a JS null, so a runner too slow to start a thread inside the budget reported
+        // "Expected string but got Null" from inside JsValue: a message about neither the agent nor the
+        // budget, which is the diagnosis cost #3297 is about.
+        var elapsed = Stopwatch.StartNew();
         JsValue report;
         do
         {
@@ -33,8 +39,9 @@ public class Test262AgentManagerTests
             {
                 Thread.Sleep(10);
             }
-        } while (report.IsNull() && DateTime.UtcNow < deadline);
+        } while (report.IsNull() && elapsed.Elapsed < TestBudgets.WedgeCeiling);
 
+        report.IsNull().Should().BeFalse($"the spawned agent must report within {TestBudgets.WedgeCeiling}; {elapsed.Elapsed} elapsed");
         report.AsString().Should().Be("timed-out");
     }
 }

--- a/Jint.Tests/Runtime/WebApi/PumpWaitTests.cs
+++ b/Jint.Tests/Runtime/WebApi/PumpWaitTests.cs
@@ -18,27 +18,61 @@ namespace Jint.Tests.Runtime.WebApi;
 public class PumpWaitTests
 {
     /// <summary>
+    /// What the wait under test is given. Nothing should ever spend it: it is the bound a wait that ignored
+    /// the engine's own schedule runs into. A minute rather than the ten seconds this was, for the reason
+    /// #3369 gives — the absolute number is what a loaded runner crosses, the ratio below is what the
+    /// assertion is about, and raising both together widens the margin without weakening it.
+    /// </summary>
+    private static readonly TimeSpan Ceiling = TimeSpan.FromSeconds(60);
+
+    /// <summary>
+    /// The margin the clamped return has to beat. Half the ceiling — derived from it rather than written out
+    /// again, so the two cannot drift — which is what makes the assertion separate "woke on the engine's own
+    /// due time" from "ran out the ceiling" while saying nothing at all about latency.
+    /// </summary>
+    private static readonly TimeSpan EarlyReturnMargin = TimeSpan.FromTicks(Ceiling.Ticks / 2);
+
+    /// <summary>
     /// The wait is bounded internally by the engine's own next due time, not only by the ceiling the caller
-    /// passed: a <c>setTimeout</c> due in 50 ms wakes a wait that was given ten seconds. Without that clamp
+    /// passed: a <c>setTimeout</c> due in 50 ms wakes a wait that was given a minute. Without that clamp
     /// nothing would end the wait — a timer coming due enqueues nothing, and so wakes nobody — and a host
     /// pumping on a ceiling would run every timer at its own cadence instead of at the script's.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The timer's effect is observed through a host-side flag rather than through a script global, and that
+    /// is what keeps this off the wall clock (#3379). Probing with <c>Evaluate("fired")</c> put a second
+    /// engine entry between the arming and the wait, and <c>RunAvailableContinuations</c> promotes one due
+    /// timer whenever the job queue runs dry — so on a runner that took more than fifty milliseconds to get
+    /// from the <c>Execute</c> to the probe, <b>the probe ran the timer</b>. The probe's own assertion still
+    /// passed, because the value is read before that entry's drain; what failed was the wait below, which
+    /// then had nothing left to clamp to, spent its whole ceiling and returned <see langword="false"/>.
+    /// Reading a <c>bool</c> enters no engine and drains nothing, so between arming the timer and asking the
+    /// wait about it there is now no drain at all.
+    /// </para>
+    /// <para>
+    /// The clock has to stay real here: a fake one would never make the timer due, and the due time is the
+    /// very thing the wait is supposed to clamp to.
+    /// </para>
+    /// </remarks>
     [Fact]
     public void ClampsToTheEnginesOwnSchedule()
     {
         using var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Timers));
-        engine.Execute("globalThis.fired = false; setTimeout(function () { globalThis.fired = true; }, 50);");
 
-        // Nothing has run it yet: Execute drains the loop, but a timer 50 ms out is not due.
-        engine.Evaluate("fired").AsBoolean().Should().BeFalse();
+        var fired = false;
+        engine.SetValue("mark", new Action(() => fired = true));
+        engine.Execute("setTimeout(mark, 50);");
+
+        fired.Should().BeFalse("nothing has entered the engine since the timer was armed, so nothing can have run it");
 
         var elapsed = Stopwatch.StartNew();
-        engine.Tasks.WaitForScheduledWork(TimeSpan.FromSeconds(10)).Should().BeTrue();
-        elapsed.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(5));
+        engine.Tasks.WaitForScheduledWork(Ceiling).Should().BeTrue();
+        elapsed.Elapsed.Should().BeLessThan(EarlyReturnMargin);
 
         // The wait reports work; the pump is what runs it. That division is the whole contract.
         engine.Tasks.ProcessTasks();
-        engine.Evaluate("fired").AsBoolean().Should().BeTrue();
+        fired.Should().BeTrue();
     }
 }
 #endif

--- a/Jint.Tests/Runtime/WebApi/SchedulerTests.cs
+++ b/Jint.Tests/Runtime/WebApi/SchedulerTests.cs
@@ -1,7 +1,6 @@
 #if NET8_0_OR_GREATER
 #nullable enable
 
-using System.Diagnostics;
 using Jint.Native;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
@@ -1001,28 +1000,36 @@ public class SchedulerTests
         result.AsString().Should().Be("ab");
     }
 
+    /// <summary>
+    /// Nothing but a pump the host calls itself runs a task: Jint starts no thread and arms no background
+    /// timer, so a delayed task that is due sits there until <c>ProcessTasks</c> is called.
+    /// </summary>
+    /// <remarks>
+    /// On the same manual clock as the rest of this class, which is what makes each of the three states below
+    /// a fact rather than a race (#3372). The first assertion used to be a statement about how long the
+    /// enclosing <c>Execute</c> took: the outer background task runs during that call's own drain and posts
+    /// the inner one with a twenty-millisecond delay, so on a machine where the drain outlived twenty
+    /// milliseconds of <em>wall</em> clock the inner task came due inside the same <c>Execute</c> and
+    /// <c>done</c> was already true. A clock that only this test moves cannot be outlived, and it buys the
+    /// middle state as well — due, and still not run, which is the actual claim and which no amount of
+    /// polling could have asserted.
+    /// </remarks>
     [Fact]
     public void AHostsOwnPumpRunsTheTasks()
     {
-        var engine = new Engine(options => options.UseWebApis());
+        var (engine, clock) = SchedulerEngine();
 
         var done = false;
         engine.SetValue("done", new Action(() => done = true));
 
-        // Nothing drains here: Evaluate returns as soon as the script has run, and the delayed task is still
-        // waiting on the clock.
         engine.Execute("scheduler.postTask(() => scheduler.postTask(done, { delay: 20 }), { priority: 'background' });");
-        done.Should().BeFalse();
+        done.Should().BeFalse("the clock has not moved, so the inner task is not due");
 
-        var deadline = Stopwatch.StartNew();
-        while (!done && deadline.Elapsed < TimeSpan.FromSeconds(5))
-        {
-            // Nothing but the host's own pump: no engine thread, no background timer.
-            engine.Tasks.ProcessTasks();
-            Thread.Sleep(5);
-        }
+        clock.Advance(20);
+        done.Should().BeFalse("being due is not enough — only a pump the host calls may run it");
 
-        done.Should().BeTrue();
+        engine.Tasks.ProcessTasks();
+        done.Should().BeTrue("the host's own pump is what runs it");
     }
 }
 #endif

--- a/Jint.Tests/Runtime/WebApi/TimerTests.cs
+++ b/Jint.Tests/Runtime/WebApi/TimerTests.cs
@@ -566,8 +566,11 @@ public class TimerTests
 
         engine.Execute("(async () => { await new Promise(r => setTimeout(r, 50)); markDone(); })();");
 
-        var deadline = Stopwatch.StartNew();
-        while (!done && deadline.Elapsed < TimeSpan.FromSeconds(5))
+        // A wedge ceiling: what is asserted is that the host's own pump is enough, never how many passes it
+        // took. A timer nothing runs is never run at all, so no budget here can be too generous — while the
+        // five seconds this was is a number a loaded runner can reach on a healthy engine (#3379).
+        var elapsed = Stopwatch.StartNew();
+        while (!done && elapsed.Elapsed < TestBudgets.WedgeCeiling)
         {
             // Nothing but the host's own pump: no engine thread, no background timer.
             engine.Tasks.ProcessTasks();

--- a/Jint.Tests/Runtime/WebApi/WorkerMechanismTests.cs
+++ b/Jint.Tests/Runtime/WebApi/WorkerMechanismTests.cs
@@ -31,8 +31,14 @@ public class WorkerMechanismTests
 {
     private const string Specifier = "./worker.js";
 
-    /// <summary>Ten seconds: long enough that a loaded machine is slow rather than red.</summary>
-    private static readonly TimeSpan Ceiling = TimeSpan.FromSeconds(10);
+    /// <summary>
+    /// Long enough that a loaded machine is slow rather than red. Every use is a <c>Wait</c> or a
+    /// <c>Join</c> on a thread this class started, and nothing asserts how long either took — the assertions
+    /// are that the handshake happened and that the thread left — so this is a wedge ceiling and
+    /// <see cref="TestBudgets.WedgeCeiling"/> is what the suite calls one. Ten seconds was that number sized
+    /// for an idle box (#3379).
+    /// </summary>
+    private static readonly TimeSpan Ceiling = TestBudgets.WedgeCeiling;
 
     // -------------------------------------------------------------------------------------------------------
     // Construction and refusals

--- a/Jint.Tests/Runtime/WebApi/WorkerTests.cs
+++ b/Jint.Tests/Runtime/WebApi/WorkerTests.cs
@@ -422,7 +422,10 @@ public class WorkerTests
 
         foreach (var thread in threads)
         {
-            thread.Join(TimeSpan.FromSeconds(60)).Should().BeTrue("End() never blocks its caller");
+            // A wedge ceiling: what is claimed is that End() never blocks its caller, and a call that blocks
+            // blocks for ever on a Barrier nobody else will reach — so the budget separates "finished" from
+            // "wedged" and never "fast" from "slow", however many racers the runner has cores for.
+            thread.Join(TestBudgets.WedgeCeiling).Should().BeTrue("End() never blocks its caller");
         }
 
         for (var round = 0; round < Rounds; round++)


### PR DESCRIPTION
Every timing assertion in `Jint.Tests` that decided its outcome by measuring the machine, rather than by
stating the property it exists for. #3369 did this for `Jint.Tests.PublicInterface`; this is the same rules
applied to the other suite, plus the two open flakes that live there and the one in `PublicInterface` that
reports the wrong cause.

Nothing here deletes an assertion and nothing raises a number until it stops failing. #3301's trap applies
throughout: a wait that ignored its budget entirely would still throw the right exception, so the check that
looks redundant is the one carrying the claim. Each row below gets a deterministic handshake, a clock only
the test can move, an exact witness the failure already carries, or — where a budget is genuinely a bound on
a hang and nothing asserts it — `TestBudgets.WedgeCeiling`, the suite's existing name for that.

## The three issues

### `RegExpTests.PreparedScriptHonorsRegexTimeoutForCustomEngine` — the clock was a proxy for a fact (#3379)

*"Expected time to be less than 15s ... took 16.7s"*, on a PR that could not reach the regex engine.

The 15 s was already a ratio — half the 30 s engine timeout the test discriminates against — and the ratio is
what does not work here. Both .NET's `Regex` and Jint's own interpreter check a match deadline every *N*
steps rather than continuously, so the overshoot is **multiplicative in the machine**: a 16× slower runner
turns the 1 s prepare-time budget into 16.7 s and would turn the 30 s engine budget into eight minutes. Both
candidates move together, so no fixed fraction separates them.

They are separated exactly, and without a clock, by
`RegexMatchTimeoutException.MatchTimeout`. `RegExpPrototype.ExecuteWithTimeout` resolves the effective
timeout into one local (`GetCustomEngineTimeout`: the prepared script's, falling back to the engine's), hands
that local to the interpreter as its deadline, and constructs the exception from the very same local — so the
field is a **witness thrown by the matcher that fired**, not a restatement of the configuration. The
stopwatch is gone; `MatchTimeout.Should().Be(PrepareTimeRegexTimeout)` replaces it.

It is also strictly narrower than the `ThrowExactly` it accompanies: `RegExpInterpreter` raises the same
exception type for a backtracking stack overflow, which carries no match timeout and used to satisfy the
type check.

**Proof the property survives.** `GetCustomEngineTimeout` was temporarily changed to ignore the prepared
script's timeout, and every row failed:

```
Expected 1s because the match must have run under the prepared script's own regex timeout
rather than falling through to the engine's 00:00:30, but found 30s.
```

### `SchedulerTests.AHostsOwnPumpRunsTheTasks` — the first assertion (#3372)

`done.Should().BeFalse()` was a statement about how long the enclosing `Execute` took: the outer background
task runs during that call's own drain and posts the inner one with a 20 ms delay, so a drain that outlived
20 ms of wall clock ran it inside the same `Execute`.

The class already has a `ManualClock` wired through `Options.WebApi.Timers.TimeProvider`, and a
`scheduler.postTask` delay rides the very timer queue that provider drives — the seam reaches. The test now
uses it, which is issue #3372's own preferred option, and it buys a **third** state the wall clock could
never assert:

```csharp
done.Should().BeFalse("the clock has not moved, so the inner task is not due");
clock.Advance(20);
done.Should().BeFalse("being due is not enough — only a pump the host calls may run it");
engine.Tasks.ProcessTasks();
done.Should().BeTrue("the host's own pump is what runs it");
```

That middle line is what the test is actually named for, and it was not being asserted at all.

### `WebApiWorkerTests.AHostProviderThreadPerWorkerRoundTrips` — the message (#3297)

The loop exited on a ten-second deadline straight into `AsString()` on a JS `null`, so an exhausted budget
reported `System.ArgumentException : Expected string but got Null` — a message naming neither the worker, nor
the round trip, nor the seconds that had passed.

The ceiling now has an assertion of its own before the value is read, and is a `WedgeCeiling`: nothing here
asserts a duration, and the 50 ms poll already bounds a missed wake to one iteration, so the budget was the
part sized for an idle box. The issue asked whether the ten seconds were genuinely insufficient or whether
there was a lost wakeup; the new assertion reports which, because it names whether `Answered` was ever
signalled.

**Proof.** The same round trip with the ceiling widened to zero, before and after:

```
before:  System.ArgumentException : Expected string but got Null
after:   Expected got.IsNull() to be False because the round trip must complete inside 00:00:00;
         00:00:00.0104485 elapsed and the worker had not answered yet, but found True.
```

## The rest of the sweep

`Jint.Tests` and `Jint.Tests.CommonScripts` were enumerated for three shapes: an assertion comparing measured
elapsed wall clock against a fixed `TimeSpan`; a polling loop on a fixed budget whose exhaustion feeds an
assertion; and an assertion that something has *not* happened yet with no handshake enforcing it. The list is
bounded, and knowing that is worth as much as the fixes.

### Fixed

| Test | Was | Now |
| --- | --- | --- |
| `RegExpTests.Prepared{Script,Module}HonorsRegexTimeoutForCustomEngine` | `elapsed < 15 s` | `RegexMatchTimeoutException.MatchTimeout == PrepareTimeRegexTimeout` — exact, no clock |
| `SchedulerTests.AHostsOwnPumpRunsTheTasks` | 20 ms real timer vs `Execute`'s drain; 5 s poll | `ManualClock`; three states, all facts |
| `PumpWaitTests.ClampsToTheEnginesOwnSchedule` | script-global probe between arming and wait; `elapsed < 5 s` of a 10 s ceiling | host-side flag (no drain at all between them); `Ceiling` 60 s with `EarlyReturnMargin` derived as half |
| `AsyncTests.EngineReusableAfterEvaluateAsyncTimeout` | recovery on `Task.Delay(10)` inside a 1 s budget | recovery released by a thread the test owns; budget named, and *which* budget fired asserted from the rejection message |
| `AsyncTests.EngineReusableAfterEvaluateAsyncCancellation` | `CancelAfter(50 ms)` on the pool vs a 10 s `Task.Delay` | gates the test holds; cancel from a dedicated thread |
| `AsyncTests.ShouldObserveCancellationDuringTopLevelAwait…` | `CancelAfter` on the pool; `elapsed < 10 s` fixed | cancel from a dedicated thread, stopwatch started on it immediately before the cancel; bound derived as half the wrong answer |
| `AsyncTests.ShouldTimeOutTopLevelAwait…WithoutCancellation` | `elapsed < 30 s` | `WedgeCeiling` — see the residual below |
| `AsyncTests.AsyncFunctionShouldNotBlockWhenCalledWithoutAwait` | `Task.Delay(100).ContinueWith` racing the assertions | the host timer hands its callback to the test; the "and then it does run" half is now asserted too |
| `AsyncTests.EvaluateAsyncShouldNotBlockCallerThread` | `await Task.Delay(200)` | a `TaskCompletionSource` gate — the same fix its twin in `PromiseTests` already had |
| `AsyncTests.EvaluateAsyncTimeoutShouldFireDuringPendingClrTask` | 100 ms budget vs a 5 s `Task.Delay` | an IO that never completes, so the timeout cannot lose |
| `AsyncTests` × 5 `UnwrapIfPromise(30 s)`, `EventLoopShouldSignalAllConcurrentWaiters` (5 s), one 30 s `PromiseTimeout` | budgets nothing asserts, sized for an idle box | `TestBudgets.WedgeCeiling` |
| `TimerTests.AHostPollingLoopIsEnoughToRunTimers` | 5 s poll ceiling | `WedgeCeiling` |
| `AtomicsWaitAsyncTests.DrainUntil` | 10 s, **returned silently** on exhaustion | `WedgeCeiling`, and says so — an exhausted budget used to report as `outcome == "pending"` |
| `AtomicsWaitAsyncPumpTests.PumpUntil`, `TheBlockingUnwrapCompletesAShortTimeout` | 30 s / 10 s | `WedgeCeiling` |
| `AtomicsWaiterRegistryTests` × 2 | 2 s join deciding the assertion; 10 s poll | `WedgeCeiling` — "blocked for ever" misses any budget |
| `Test262AgentManagerTests.SpawnedAgentsCanUseSynchronousWait` | 5 s, then `AsString()` on a JS null | `WedgeCeiling` + the exhaustion asserted first (#3297's shape, second instance) |
| `WorkerMechanismTests` (8 waits/joins), `WorkerTests` End() racers (60 s), `ForLoopIterationEnvironmentAwaitTests` (30 s join) | fixed ceilings nothing asserts | `WedgeCeiling` |
| `WebApiWorkerTests.AHostProviderThreadPerWorkerRoundTrips`, `WaitForPumpToLeave` | 10 s each | `WedgeCeiling` + an honest exhaustion assertion |

### Examined and left alone, with the reason

- **`TimerTests.ABlockingUnwrapWaitsOutARealTimer`** — `elapsed >= 80 ms` against a 100 ms timer. A *lower*
  bound is monotone in load: a slow machine only makes it larger, and the engine's timer rides
  `TimeProvider.GetTimestamp`, so it cannot come due early. Not a hazard.
- **`TimerTests.ATimerLongerThanTheUnwrapTimeoutTimesOutByDesign`** — the file's own comment describes the
  race that *used* to be there; the timer already rides a `ManualClock` nobody advances, so it can never come
  due and the 200 ms unwrap budget always wins.
- **`AtomicsWaitAsyncPumpTests`'s `PumpFor(100)` / `PumpFor(200)` and `Thread.Sleep(250)`** — these give the
  engine *every opportunity* to do the thing the test says it must not do. Extra elapsed time only
  strengthens them.
- **`AtomicsWaitAsyncTests.CollectUntilDead(10 s)`** — 400 forced blocking gen-2 collections. Not a
  wall-clock margin: a rooted object does not become unrooted with time. Widening buys nothing and costs two
  minutes of full GCs on a regression.
- **`ParseOnlyPreparationRaceTests.StartGate.Arrive(200 ms)`** — no assertion rides it; missing the race
  degrades to a plain correctness run, which the file documents.
- **`WaitForScheduledWorkTests`, `TopLevelPark`, `EngineConcurrencyTests`, `EventSourceTests`,
  `FetchStreamTests`, `WebSocketTests`** — already on `WedgeCeiling`/two-minute transport ceilings, and the
  `WaitForScheduledWorkTests` stopwatches are already started by the releasing thread (#3369).
- **The ~25 `UnwrapIfPromise(1 s | 5 s)` sites over pure-JS promise chains** — `Promise.resolve()`,
  `Promise.reject()`, `Task.FromResult`. Nothing external settles them, so the drain returns on its first
  pass and the budget is never consulted.
- **`Jint.Tests.CommonScripts`** — zero hits. #3369 already gave `SunSpiderTests` its `RegexWedgeCeiling`,
  and `ConcurrencyTest` has no timing at all.

### Assertions that silently weaken rather than flake, recorded not fixed

- **`AtomicsWaitAsyncPumpTests.ManyWaitsOnOneIndexAllTimeOutInDeadlineOrder`** gates its strict-order
  assertion on a wall-clock reading taken inside the script (`regMillis < 10`), so on a loaded runner the
  interesting half quietly does not run. It fails *permissively*, so it is not a flake — but it is a test
  that reports green while asserting less than it says.
- **`EventSourceTests`' five fixed "settle windows"** (20 × `Thread.Sleep(2)`) before a "nothing further
  arrived" assertion, over a real `HttpMessageHandler` on pool continuations. Also permissive.

Both would need a different mechanism rather than a different number, and neither has ever been seen red.

## Evidence

A clean run on an idle box proves nothing, and neither does a green run on a loaded one. So each race was
**widened deliberately** — the #3380 form of proof, which shows the defect is latent rather than merely
reachable when the machine happens to stall in the right place. Every pair below is the body as it stands on
`main` and the body this branch ships, under the *same* widening, run twenty times each on an idle box:

| Widened race | Widening | before | after |
| --- | --- | ---: | ---: |
| `AHostsOwnPumpRunsTheTasks` | 200 ms of busy work inside `Execute`'s own drain, after the inner task is posted | **0/20** | **20/20** |
| `ClampsToTheEnginesOwnSchedule` | 200 ms stall between arming the timer and the probe | **0/20** | **20/20** |
| `EngineReusableAfterEvaluateAsyncTimeout` | budget squeezed from 1 s to 5 ms (200×) | **0/20** | **20/20** |
| `AsyncFunctionShouldNotBlockWhenCalledWithoutAwait` | 200 ms stall before the assertions | **0/20** | **20/20** |
| `EvaluateAsyncShouldNotBlockCallerThread` | 500 ms stall after the IO provably started | **0/20** | **20/20** |

The `ClampsToTheEnginesOwnSchedule` row is worth reading, because the widening found a different mechanism
than the inventory expected. The probe's own `Should().BeFalse()` still *passes* when the timer has already
come due — `Evaluate("fired")` reads the value before that entry's drain runs. What fails is
`WaitForScheduledWork(...).Should().BeTrue()` two lines later, because the probe's drain promoted and ran the
one due timer and left the wait nothing to clamp to. That is why the fix is "no engine entry between the
arming and the wait" rather than "a bigger margin".

Two more, proved the same way but by inspection of the message rather than by a count:

- **`RegExpTests`** — `GetCustomEngineTimeout` was temporarily patched to ignore the prepared script's
  timeout. All five `PreparedScript…` rows and the `PreparedModule…` row failed, each naming exactly what
  went wrong (`Expected 1s … but found 30s`). The engine patch was reverted; **no engine code is in this
  PR.**
- **`WebApiWorkerTests`** — the before/after messages quoted above, from the same round trip with the ceiling
  set to zero.

### What was *not* demonstrated, and why

I did **not** run a saturated before/after sweep. An earlier attempt at one pinned all 32 logical cores of a
shared machine and had to be killed; that was the wrong tool for this, and the widened windows above are
better evidence anyway. What I ran instead was a light-contention sanity check — six `Idle`-priority spinners,
eight iterations of the affected classes on `net10.0`, `before` and `after`:

| | iterations | passed |
| --- | ---: | ---: |
| `before` (upstream/main's copies of the twelve files, built in this tree) | 8 | 8/8 |
| `after` | 8 | 8/8 |

That is an honest null result and is reported as one: six low-priority spinners do not reproduce these races,
which is precisely why the deliberate widening is the evidence and not the load run. The one thing the light
run does establish is that nothing in this branch regressed at that level of perturbation.

## Verification

`dotnet build -c Release` clean (`TreatWarningsAsErrors` on; the only warning in the solution is the
pre-existing `MSB3277` System.Memory unification in `Jint.Tests.CommonScripts` on `net472`).

| Suite | Result |
| --- | --- |
| `Jint.Tests` `net472` | 7323 passed, 0 failed |
| `Jint.Tests` `net8.0` | 10699 passed, 0 failed |
| `Jint.Tests` `net10.0` | 10699 passed, 0 failed |
| `Jint.Tests.PublicInterface` `net10.0` | 2998 passed, 0 failed |
| `Jint.Tests.PublicInterface` `net472` | 2369 passed, 0 failed |
| `Jint.Tests.CommonScripts` `net10.0` / `net472` | 28 / 28 passed |
| `JINT_HOST_CONTRACT_VERIFICATION=1`, both suites, both target frameworks | green — see the note below |

`PublicApiTest` and `PublicApiDocumentationTest` pass unchanged; there is no public-surface change here, and
no engine source in the diff at all, so `Jint.Tests.Test262` was not run and does not apply.

**One note on the verification leg.** Two runs of the `net472` verification leg tripped
`InteropAccessorCacheSharingTests` — a different test each time
(`SharingCoversMethodsAndWrites`, then `AnEngineWithACustomTypeConverterStillSharesOrdinaryMembers`). That is
**#3368**: `JsAccessibleRegistry.Generation` is a single process-wide counter, and a `Register` call from any
concurrently running test drops the accessor cache of a resolver another test constructed privately, so the
"resolved nothing" counts become order-dependent. It is a cross-test coupling through static state, not a
wall-clock budget, which is why it is filed separately and not fixed here. Measured for the record:
**12/12 clean on `upstream/main`** and **12/12 clean on this branch** in back-to-back samples, with the two
failures landing outside those samples on both a warm and a cold build. Nothing in this diff touches the
interop path; the only way it can reach that class is by shifting which tests run beside it.

Fixes #3379
Fixes #3372
Fixes #3297
