### PR TITLE
Native AOT: the diagnostics an embedder pays go from 113 to 76, and the sixty-one pragmas that bought them nothing are gone

### DIFF
--- a/Jint.AotExample/AGENTS.md
+++ b/Jint.AotExample/AGENTS.md
@@ -13,21 +13,42 @@
 
 ### Native AOT: what is measured, what is annotated, and what is still suppressed
 
-`Jint.csproj` sets `<IsAotCompatible>` for net7.0+ and, in the same property group, suppresses eight IL
-codes — `IL3050` (*requires dynamic code*) plus `IL2060`, `IL2067`, `IL2069`, `IL2070`, `IL2072`,
-`IL2075`, `IL2080`. **The property is not evidence, and the suppressions are why.** What makes the
-claim checkable is that a CI leg publishes `Jint.AotExample` with `PublishAot=true` and *runs the
-native binary* (`aot` in `.github/workflows/pr.yml` and `build.yml`), because the run is the only thing
-that distinguishes a warning that matters from one that does not.
+`Jint.csproj` sets `<IsAotCompatible>` for net7.0+ and, in the same property group, `NoWarn`s nine IL
+codes. **The property is not evidence, and the `NoWarn` is why**: it is a property of Jint's own
+*compilation* and reaches nothing downstream, since ILC re-derives the whole set over the closed program
+— so **an embedder publishing Native AOT sees every diagnostic it hides**, attributed to Jint's files.
+What makes the claim checkable instead is the CI leg that publishes `Jint.AotExample` with
+`PublishAot=true` and *runs the native binary* (`aot` in `.github/workflows/pr.yml` and `build.yml`).
 
-Two facts about the suppressions are worth knowing before trusting either of them. Jint's `NoWarn` is a
-property of Jint's own *compilation* and reaches nothing downstream: ILC re-derives the whole set when
-it compiles the closed program, so **an embedder publishing Native AOT sees all of them**, attributed
-to Jint's files, in their build. And a source `#pragma warning disable IL3050` — `ObjectWrapper` has
-several — is Roslyn-only for the same reason; `[UnconditionalSuppressMessage]` is the one ILC honours,
-and is what to reach for when a suppression is genuinely justified. Paying the remaining 115 down is
-[#3305](https://github.com/sebastienros/jint/issues/3305), which carries the inventory by code and by
-file, why it is not one change, and a suggested order; `Jint.csproj`'s own comment says the same.
+**A source `#pragma warning disable IL....` is Roslyn-only for the same reason, and `Jint` now has
+none** — the sixty-one that sat at the tops of the interop files bought Jint a green build and an
+embedder nothing. `[UnconditionalSuppressMessage]` is what ILC honours; it asserts safety rather than
+requesting silence, so every one in the assembly names the invariant it stands on — the degradation a
+probe pins, the feature guard ILC folds, or the public entry point whose `[RequiresUnreferencedCode]`
+already states the requirement. **Do not write one whose justification is not literally true, and do not
+add a code back to `NoWarn` to quiet a new site.**
+
+[#3305](https://github.com/sebastienros/jint/issues/3305) took the published-and-run inventory from 113
+to 76 and carries what is left, grouped by what would close it. Four moves did most of it, and each is
+worth trying before a suppression is:
+
+* **Spell a constant type as `typeof(X)` at the reflection call.** That token is folded, so the lookup
+  *preserves* the member; the same lookup through a `static readonly Type` field loses the type's
+  identity on the way and merely reports. Six `IL2080` in `DefaultTypeConverter`'s static constructor
+  were exactly this.
+* **Do not reflect inside a cache lambda.** A lambda parameter cannot carry
+  `[DynamicallyAccessedMembers]`, so `GetOrAdd(type, static t => …reflect over t…)` drops at the closure
+  boundary what the caller had already promised. Hoist the resolution into the annotated method and
+  store through `GetOrAdd`'s *value* overload, which keeps the one-instance-per-key guarantee the
+  factory overload gave.
+* **Restate a feature guard in the method that makes the call.** Both analyzers reason one method at a
+  time, so a lane gated on `RuntimeFeature.IsDynamicCodeSupported` two frames up still reports
+  `IL3050`; an early return on the same property beside the `Expression.TryGetFuncType` call is a branch
+  they fold instead.
+* **Declare what the method reads, and no more.** `InteropHelper.IsAssignableToGenericType` demanded
+  every public member of *both* parameters while reading the interfaces of one and merely comparing the
+  other; no caller could satisfy the excess, so it propagated outwards as a diagnostic at every one of
+  them.
 
 #### What the leg proves
 
@@ -121,8 +142,8 @@ leaving its reflective one silent. **Annotate the pair, not the member** — and
 the same annotation twice, share the implementation instead. `JsValue.FromObject` is deliberately not among them: it is the engine's own
 conversion funnel with ~60 call sites inside Jint, the interpreter's operator-overloading path among
 them, so annotating it would either cascade `[RequiresUnreferencedCode]` across the interpreter or need
-a suppression per site. `Options.InteropOptions._defaultWrapObjectHandler` carries the one
-`[UnconditionalSuppressMessage]`, because it has to stay assignable to the public `WrapObjectDelegate`.
+a suppression per site. `Options.InteropOptions._defaultWrapObjectHandler` carries one of the
+`[UnconditionalSuppressMessage]`s, because it has to stay assignable to the public `WrapObjectDelegate`.
 
 #### Two costs that land in the embedder's project
 

--- a/Jint/Extensions/Polyfills.cs
+++ b/Jint/Extensions/Polyfills.cs
@@ -203,6 +203,21 @@ internal static class Polyfills
 #endif
 }
 
+internal static class TypePolyfills
+{
+#if NETFRAMEWORK || NETSTANDARD2_0
+    // Type.IsSZArray arrived in .NET Core 2.1 / netstandard2.1. The downlevel body is the type
+    // construction the call sites used to spell inline, and moving it here is why they can stop:
+    // Type.MakeArrayType is [RequiresDynamicCode], so asking "is this a plain T[]?" that way cost an
+    // IL3050 in every embedder's Native AOT publish - on frameworks where Native AOT does not exist at
+    // all. It also costs a Type construction per call, which the real property does not.
+    extension(Type type)
+    {
+        public bool IsSZArray => type.IsArray && type.GetArrayRank() == 1 && type == type.GetElementType()!.MakeArrayType();
+    }
+#endif
+}
+
 internal static class MemoryMarshalPolyfills
 {
     extension(MemoryMarshal)

--- a/Jint/Extensions/ReflectionExtensions.cs
+++ b/Jint/Extensions/ReflectionExtensions.cs
@@ -52,14 +52,22 @@ internal static class ReflectionExtensions
 
     internal static List<MethodInfo> GetOperatorOverloadMethods([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] this Type type)
     {
-        return _operatorOverloadMethodCache.GetOrAdd(type, static t =>
+        // The scan is written out here rather than in a GetOrAdd lambda because a lambda parameter cannot
+        // carry [DynamicallyAccessedMembers]: passing `type` through the closure dropped its annotation and
+        // reported the GetMethods call as unannotated in every trimming build, while the caller had already
+        // promised exactly what the scan needs.
+        if (_operatorOverloadMethodCache.TryGetValue(type, out var cached))
         {
-#pragma warning disable IL2070
-            return t.GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)
-                .Where(static m => m.IsSpecialName)
-                .ToList();
-#pragma warning restore IL2070
-        });
+            return cached;
+        }
+
+        var methods = type.GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)
+            .Where(static m => m.IsSpecialName)
+            .ToList();
+
+        // GetOrAdd's value overload rather than TryAdd, so that a race still hands every caller the same
+        // list the dictionary holds - which is what the factory overload guaranteed.
+        return _operatorOverloadMethodCache.GetOrAdd(type, methods);
     }
 
     private static bool IsExtensionMethod(this MethodBase methodInfo)

--- a/Jint/Jint.csproj
+++ b/Jint/Jint.csproj
@@ -25,30 +25,44 @@
     <NoWarn>$(NoWarn);JINT0001</NoWarn>
 
     <!--
-      Trim and AOT analysis, suppressed so that Jint's own build is green. Read this before assuming it
-      means anything to a consumer: NoWarn is a property of THIS compilation and reaches nothing
-      downstream. ILC re-derives every diagnostic when it compiles the closed program, so an embedder
-      publishing Native AOT sees all 115 of them attributed to Jint's files in their own build. The
-      same is true of a source `#pragma warning disable IL....`, which reaches Roslyn and not ILC;
-      [UnconditionalSuppressMessage] is the form ILC honours, and it asserts safety, so it needs a
-      justification that is true.
+      Trim and AOT analysis. Read this before assuming it means anything to a consumer: NoWarn is a
+      property of THIS compilation and reaches nothing downstream. ILC re-derives every diagnostic when
+      it compiles the closed program, so an embedder publishing Native AOT sees the remaining ones
+      attributed to Jint's files in their own build. The same is true of a source
+      `#pragma warning disable IL....`, which reaches Roslyn and not ILC - the reason this assembly no
+      longer has any. [UnconditionalSuppressMessage] is the form ILC honours, and it asserts safety, so
+      it needs a justification that is true; every one in the assembly names the invariant it relies on.
 
       What actually substantiates the IsAotCompatible property below is the `aot` CI leg, which
       publishes Jint.AotExample with PublishAot=true and RUNS the native binary. The warnings say what
       might break; the run says what does.
 
-      Paying these down is https://github.com/sebastienros/jint/issues/3305, which carries the
-      inventory by code and by file and a suggested order. Almost all of them are dataflow - a Type
-      reaching a call that demands [DynamicallyAccessedMembers] - so each one is fixed by propagating
-      the annotation back to whoever produced the Type, and the propagation only terminates at a public
-      API. That is why removing this line is not one change: it turns ~104 diagnostics into build errors
-      at once, TreatWarningsAsErrors being on repository-wide.
+      What is left, and why each code is still here (https://github.com/sebastienros/jint/issues/3305):
+
+        IL3050, IL2060  The eight sites that build a generic instantiation over a type only known at run
+                        time - Task.FromResult<T>, MethodInfo.MakeGenericMethod, List<T>/Collection<T>
+                        for a generic-collection parameter, the closed type a script names through
+                        importNamespace, and the two Array.CreateInstance calls that bind a params array.
+                        These are REAL: docs/v5-migration.md section 6.2 documents them as the one shape
+                        that does not work natively, and Jint.AotExample pins five of them as
+                        KnownAotGaps. They are not suppressed because they are not safe, and they do not
+                        get [RequiresDynamicCode] because no signature in Jint predicts the type
+                        argument - it comes from the host's members and the script's arguments.
+
+        IL2062, IL2067  Dataflow: a Type reaching a call that demands [DynamicallyAccessedMembers]
+        IL2069, IL2070  without carrying it. Almost all of these root at one value - the runtime type of
+        IL2072, IL2075  a host object, obtained through object.GetType(), which no annotation can
+        IL2077          describe. The requirement is stated where a host can act on it instead:
+                        [RequiresUnreferencedCode] on Options.AllowClr, Engine.SetValue(string, object?),
+                        ObjectWrapper.Create and ClrHelper.Wrap/Unwrap, plus section 6.4's "root the host
+                        types Jint reaches only by reflection".
 
       Do not resolve one of these by annotating an API the measured run shows to work. An embedder who
       learns to suppress [RequiresDynamicCode] on the APIs that are fine will suppress it on the ones
-      that are not.
+      that are not. And do not add a code back to this line to silence a NEW site: fix it, or say at the
+      site why it is safe.
     -->
-    <NoWarn>$(NoWarn);IL3050;IL2080;IL2075;IL2072;IL2070;IL2069;IL2067;IL2060;</NoWarn>
+    <NoWarn>$(NoWarn);IL3050;IL2077;IL2075;IL2072;IL2070;IL2069;IL2067;IL2062;IL2060;</NoWarn>
 
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
 

--- a/Jint/Native/JsValue.cs
+++ b/Jint/Native/JsValue.cs
@@ -180,9 +180,25 @@ public abstract partial class JsValue : IEquatable<JsValue>
     /// <summary>
     /// Cached reflection lookups for Task interop to avoid repeated GetMethod/GetProperty calls.
     /// </summary>
+    /// <remarks>
+    /// Both lookups are keyed on a <em>constructed</em> generic type that only exists at run time, which is
+    /// why neither can carry <c>[DynamicallyAccessedMembers]</c> - and why both used to warn in every
+    /// trimming build without preserving anything. The member asked for belongs to the generic
+    /// <em>definition</em> in both cases, so a dependency on the definition covers every instantiation and
+    /// is expressible; see the attributes on the two methods below. What that fixes is not the diagnostic:
+    /// a trimmed-away <c>Task&lt;T&gt;.Result</c> made an awaited host value resolve to <c>undefined</c>,
+    /// silently.
+    /// </remarks>
     private static readonly ConcurrentDictionary<Type, PropertyInfo?> _taskResultPropertyCache = new();
     private static readonly ConcurrentDictionary<Type, MethodInfo?> _valueTaskAsTaskMethodCache = new();
 
+#if !NETFRAMEWORK && !NETSTANDARD2_0
+    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicMethods, typeof(ValueTask<>))]
+    [UnconditionalSuppressMessage("Trimming", "IL2070:UnrecognizedReflectionPattern",
+        Justification = "The lookup is reached only for a ValueTask<T> - every other awaitable shape is " +
+                        "handled above it - and AsTask is declared on ValueTask<>, whose public methods the " +
+                        "DynamicDependency preserves for every instantiation.")]
+#endif
     internal static JsValue ConvertAwaitableToPromise(Engine engine, object obj)
     {
         if (obj is Task task)
@@ -208,6 +224,11 @@ public abstract partial class JsValue : IEquatable<JsValue>
         return FromObject(engine, JsValue.Undefined);
     }
 
+    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicProperties, typeof(Task<>))]
+    [UnconditionalSuppressMessage("Trimming", "IL2070:UnrecognizedReflectionPattern",
+        Justification = "The lookup is reached only for the runtime type of a Task, so the only type that can " +
+                        "carry a Result property is a Task<T>, and Task<>'s public properties are preserved by " +
+                        "the DynamicDependency. A non-generic Task answers null, which the caller handles.")]
     internal static JsValue ConvertTaskToPromise(Engine engine, Task task)
     {
         // The settle functions convert on the engine's thread, not on the background thread that completes

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -498,6 +498,13 @@ public sealed partial class Options
     /// Called by the <see cref="Engine"/> instance that loads this <see cref="Options" />
     /// once it is loaded.
     /// </summary>
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+        Justification = "The three reflection-dependent registrations below - System, importNamespace and " +
+                        "clrHelper - are installed only when the host set Interop.Enabled, which is the gate " +
+                        "they belong to. The setter cannot carry [RequiresUnreferencedCode] (it would warn on " +
+                        "= false as well), so docs/v5-migration.md section 6.3 states the requirement and " +
+                        "Options.AllowClr, the way a host normally opens the gate, carries the attribute. " +
+                        "Warning here as well would report Jint's own file for a decision made in the host's.")]
     internal void Apply(Engine engine)
     {
         // Modules must exist before the configuration callbacks run: a host's
@@ -526,7 +533,6 @@ public sealed partial class Options
         // add missing bits if needed
         if (Interop.Enabled)
         {
-#pragma warning disable IL2026
             var typeResolutionPolicy = new ClrTypeResolutionPolicy(Interop);
 
             engine.Realm.GlobalObject.SetProperty("System", new PropertyDescriptor(new NamespaceReference(engine, "System", typeResolutionPolicy), PropertyFlag.AllForbidden));
@@ -541,8 +547,6 @@ public sealed partial class Options
                 PropertyFlag.AllForbidden));
 
             engine.Realm.GlobalObject.SetProperty("clrHelper", new PropertyDescriptor(ObjectWrapper.Create(engine, new ClrHelper(Interop, typeResolutionPolicy)), PropertyFlag.AllForbidden));
-
-#pragma warning restore IL2026
         }
 
 #if NET8_0_OR_GREATER

--- a/Jint/Runtime/Interop/ClrHelper.cs
+++ b/Jint/Runtime/Interop/ClrHelper.cs
@@ -4,8 +4,6 @@ using Jint.Native;
 
 namespace Jint.Runtime.Interop;
 
-#pragma warning disable IL2072
-
 internal sealed class ClrHelper
 {
     // Snapshot, like every other engine-visible reading of this option: it is settled once the engine's

--- a/Jint/Runtime/Interop/CompiledDelegateInvoker.cs
+++ b/Jint/Runtime/Interop/CompiledDelegateInvoker.cs
@@ -8,10 +8,8 @@ using Expression = System.Linq.Expressions.Expression;
 
 // The invoker is compiled with System.Linq.Expressions and only ever binds publicly visible types
 // (guarded below), so the generated dynamic method needs no reflection-visibility relaxation.
-// IL2075/IL3050 cover the reflection + dynamic-code use, which is gated behind
-// RuntimeFeature.IsDynamicCodeCompiled before anything is built.
-#pragma warning disable IL2075
-#pragma warning disable IL3050
+// The reflection and dynamic-code use is gated behind RuntimeFeature.IsDynamicCodeCompiled before
+// anything is built.
 
 namespace Jint.Runtime.Interop;
 

--- a/Jint/Runtime/Interop/CompiledMethodInvoker.cs
+++ b/Jint/Runtime/Interop/CompiledMethodInvoker.cs
@@ -2,16 +2,16 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Jint.Native;
 using Expression = System.Linq.Expressions.Expression;
 using ConditionalExpression = System.Linq.Expressions.ConditionalExpression;
 
 // The delegate is compiled with System.Linq.Expressions; every member it references is public
 // (JsValue implicit operators, JsValueExtensions accessors, JsValue.Null) so the generated
-// dynamic method needs no reflection-visibility relaxation. IL2075/IL3050 cover the reflection +
-// dynamic-code use, which is gated behind RuntimeFeature.IsDynamicCodeCompiled at the call site.
-#pragma warning disable IL2075
-#pragma warning disable IL3050
+// dynamic method needs no reflection-visibility relaxation. The lane is gated on
+// RuntimeFeature.IsDynamicCodeCompiled at the call site in MethodDescriptor and on
+// IsDynamicCodeSupported again in TryCreateInvocationDelegate, which is what an AOT publish can see.
 
 namespace Jint.Runtime.Interop;
 
@@ -207,6 +207,15 @@ internal static class CompiledMethodInvoker
     {
         invocationDelegate = null;
         delegateType = null;
+
+        // Expression.TryGetFuncType / TryGetActionType close Func<> and Action<> over the signature, which
+        // is [RequiresDynamicCode]. MethodDescriptor already declines this lane when the runtime will not
+        // JIT, but the guard has to be restated HERE for an AOT publish to see it: the analyzer and ILC
+        // reason one method at a time, and IsDynamicCodeSupported is a feature guard they fold.
+        if (!RuntimeFeature.IsDynamicCodeSupported)
+        {
+            return false;
+        }
 
         var isVoid = returnType == typeof(void);
         var instanceSlot = method.IsStatic ? 0 : 1;

--- a/Jint/Runtime/Interop/DefaultObjectConverter.cs
+++ b/Jint/Runtime/Interop/DefaultObjectConverter.cs
@@ -213,17 +213,46 @@ internal static class DefaultObjectConverter
             System.Text.Json.JsonValueKind.Object => JsValue.FromObject(engine, value),
             System.Text.Json.JsonValueKind.Array => JsValue.FromObject(engine, value),
             System.Text.Json.JsonValueKind.String => JsString.Create(value.ToString()),
-#pragma warning disable IL2026, IL3050
-            System.Text.Json.JsonValueKind.Number => ((System.Text.Json.Nodes.JsonValue) value).TryGetValue<int>(out var intValue)
-                ? JsNumber.Create(intValue)
-                : System.Text.Json.JsonSerializer.Deserialize<double>(value),
-#pragma warning restore IL2026, IL3050
+            System.Text.Json.JsonValueKind.Number => ConvertSystemTextJsonNumber((System.Text.Json.Nodes.JsonValue) value),
             System.Text.Json.JsonValueKind.True => JsBoolean.True,
             System.Text.Json.JsonValueKind.False => JsBoolean.False,
             System.Text.Json.JsonValueKind.Undefined => JsValue.Undefined,
             System.Text.Json.JsonValueKind.Null => JsValue.Null,
             _ => null,
         };
+    }
+
+    /// <summary>
+    /// A JSON number as the nearest JavaScript number, asked of the node itself rather than of the
+    /// serializer.
+    /// </summary>
+    /// <remarks>
+    /// This used to fall through to <c>JsonSerializer.Deserialize&lt;double&gt;</c>, which is both
+    /// <c>[RequiresUnreferencedCode]</c> and <c>[RequiresDynamicCode]</c> - it goes through the whole
+    /// converter machinery, and reported so in every embedder's trimming and Native AOT build - to read a
+    /// number out of a node that is already parsed and already answers the question directly. The
+    /// <see cref="int"/> attempt above it always did.
+    /// </remarks>
+    private static JsNumber ConvertSystemTextJsonNumber(System.Text.Json.Nodes.JsonValue value)
+    {
+        if (value.TryGetValue<int>(out var intValue))
+        {
+            return JsNumber.Create(intValue);
+        }
+
+        if (value.TryGetValue<double>(out var doubleValue))
+        {
+            return JsNumber.Create(doubleValue);
+        }
+
+        // A JsonValue built around a CLR number the double conversion declines (a decimal, say) still
+        // renders as its JSON text, which is what a number literal in a script would have been read from.
+        if (double.TryParse(value.ToString(), System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out doubleValue))
+        {
+            return JsNumber.Create(doubleValue);
+        }
+
+        return JsNumber.DoubleNaN;
     }
 #endif
 
@@ -528,8 +557,7 @@ internal static class DefaultObjectConverter
     /// </summary>
     private static bool TryConvertArrayLiveView(Engine e, object v, Type arrayType, [NotNullWhen(true)] out JsValue? result)
     {
-        if (arrayType.GetElementType() is not { } elementType
-            || arrayType != elementType.MakeArrayType())
+        if (!arrayType.IsSZArray)
         {
             result = null;
             return false;

--- a/Jint/Runtime/Interop/DefaultTypeConverter.cs
+++ b/Jint/Runtime/Interop/DefaultTypeConverter.cs
@@ -12,13 +12,6 @@ using Jint.Native.Function;
 using Jint.Native.Object;
 using Expression = System.Linq.Expressions.Expression;
 
-#pragma warning disable IL2026
-#pragma warning disable IL2062
-#pragma warning disable IL2067
-#pragma warning disable IL2070
-#pragma warning disable IL2072
-#pragma warning disable IL3050
-
 namespace Jint.Runtime.Interop;
 
 public class DefaultTypeConverter : ClrTypeConverter
@@ -34,24 +27,36 @@ public class DefaultTypeConverter : ClrTypeConverter
     private static readonly Type iCallableType = typeof(JsCallDelegate);
     private static readonly Type jsValueType = typeof(JsValue);
     private static readonly Type objectType = typeof(object);
-    private static readonly Type engineType = typeof(Engine);
     private static readonly Type taskType = typeof(Task);
     private static readonly Type genTaskType = typeof(Task<>);
-    private static readonly MethodInfo taskFromResultInfo = taskType.GetMethod("FromResult")!;
 #if !NETFRAMEWORK && !NETSTANDARD2_0
     private static readonly Type valueTaskType = typeof(ValueTask);
     private static readonly Type genValueTaskType = typeof(ValueTask<>);
-    private static readonly MethodInfo valueTaskFromResultInfo = valueTaskType.GetMethod("FromResult")!;
+#endif
+
+    // Every lookup below spells its receiver as `typeof(X)` rather than reading one of the Type fields
+    // above, and that is not a style choice. A `typeof` token is a constant the trim analyzer folds, so
+    // it both PRESERVES the member being looked up and reports nothing; the same lookup through a field
+    // read loses the type's identity on the way and was six IL2080 in every embedder's publish. Keep new
+    // lookups in this shape - the fields exist for the identity comparisons further down, not for
+    // reflection.
+    private static readonly MethodInfo taskFromResultInfo = typeof(Task).GetMethod("FromResult")!;
+#if !NETFRAMEWORK && !NETSTANDARD2_0
+    private static readonly MethodInfo valueTaskFromResultInfo = typeof(ValueTask).GetMethod("FromResult")!;
 #endif
 
     private static readonly MethodInfo changeTypeIfConvertible = typeof(DefaultTypeConverter).GetMethod(
         nameof(ChangeTypeOnlyIfConvertible), BindingFlags.NonPublic | BindingFlags.Static)!;
-    private static readonly MethodInfo jsValueFromObject = jsValueType.GetMethod(nameof(JsValue.FromObject))!;
-    private static readonly MethodInfo enterHostCallback = engineType.GetMethod(nameof(Engine.EnterTransferredHostCallback), BindingFlags.Instance | BindingFlags.NonPublic)!;
-    private static readonly MethodInfo getHostCallbackOwner = engineType.GetMethod(nameof(Engine.GetHostCallbackAuthorization), BindingFlags.Instance | BindingFlags.NonPublic)!;
+    private static readonly MethodInfo jsValueFromObject = typeof(JsValue).GetMethod(nameof(JsValue.FromObject))!;
+    private static readonly MethodInfo enterHostCallback = typeof(Engine).GetMethod(nameof(Engine.EnterTransferredHostCallback), BindingFlags.Instance | BindingFlags.NonPublic)!;
+    private static readonly MethodInfo getHostCallbackOwner = typeof(Engine).GetMethod(nameof(Engine.GetHostCallbackAuthorization), BindingFlags.Instance | BindingFlags.NonPublic)!;
     private static readonly MethodInfo exitHostCallback = typeof(Engine.HostCallScope).GetMethod(nameof(IDisposable.Dispose))!;
-    private static readonly MethodInfo jsValueToObject = jsValueType.GetMethod(nameof(JsValue.ToObject))!;
+    private static readonly MethodInfo jsValueToObject = typeof(JsValue).GetMethod(nameof(JsValue.ToObject))!;
 
+    // Expression.Property(Expression, string) resolves the property by NAME and is [RequiresUnreferencedCode]
+    // for it. The declaring type here is a constant and so is the name, so the PropertyInfo overload says the
+    // same thing while preserving the property instead of warning about it.
+    private static readonly PropertyInfo objectInstanceEngine = typeof(ObjectInstance).GetProperty(nameof(ObjectInstance.Engine))!;
 
     public DefaultTypeConverter(Engine engine)
     {
@@ -462,6 +467,12 @@ public class DefaultTypeConverter : ClrTypeConverter
     internal static bool IsHostCallback(object? value)
         => value is Delegate callback && _hostCallbackDelegates.TryGetValue(callback, out _);
 
+    [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
+        Justification = "Expression.NewArrayInit is [RequiresDynamicCode] because the array type may have to " +
+                        "be constructed at run time. The element type here is always typeof(JsValue), and " +
+                        "JsValue[] is used throughout this assembly, so the array type is already in any image " +
+                        "that contains Jint. Jint.AotExample's 'JS function -> Func<int, int>' probe runs this " +
+                        "path on a published native binary.")]
     private static LambdaExpression BuildDelegate(
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type type,
         JsCallDelegate function,
@@ -479,7 +490,7 @@ public class DefaultTypeConverter : ClrTypeConverter
         var initializers = new List<MethodCallExpression>(parameters.Length);
         var targetEngine = Expression.Property(
             Expression.Convert(targetExpression, typeof(ObjectInstance)),
-            nameof(ObjectInstance.Engine));
+            objectInstanceEngine);
 
         for (var i = 0; i < parameters.Length; i++)
         {
@@ -496,7 +507,9 @@ public class DefaultTypeConverter : ClrTypeConverter
                 for (var j = 0; j < instance.GetLength(); j++)
                 {
                     var returnLabel = Expression.Label(typeof(object));
-                    var checkIndex = Expression.GreaterThanOrEqual(Expression.Property(param, nameof(Array.Length)), Expression.Constant(j));
+                    // ArrayLength rather than Expression.Property(param, "Length"), which resolves by name
+                    // and is [RequiresUnreferencedCode] for it; the node produced is the same ldlen.
+                    var checkIndex = Expression.GreaterThanOrEqual(Expression.ArrayLength(param), Expression.Constant(j));
                     var condition = Expression.IfThen(checkIndex, Expression.Return(returnLabel, Expression.ArrayAccess(param, Expression.Constant(j))));
                     var block = Expression.Block(condition, Expression.Label(returnLabel, Expression.Constant(JsValue.Undefined)));
 

--- a/Jint/Runtime/Interop/DelegateWrapper.cs
+++ b/Jint/Runtime/Interop/DelegateWrapper.cs
@@ -8,9 +8,6 @@ using Jint.Extensions;
 using Jint.Native;
 using Jint.Native.Function;
 
-#pragma warning disable IL2072
-#pragma warning disable IL3050
-
 namespace Jint.Runtime.Interop;
 
 /// <summary>

--- a/Jint/Runtime/Interop/InteropHelper.cs
+++ b/Jint/Runtime/Interop/InteropHelper.cs
@@ -6,8 +6,6 @@ using Jint.Native;
 
 namespace Jint.Runtime.Interop;
 
-#pragma warning disable IL2072
-
 internal sealed class InteropHelper
 {
     internal const DynamicallyAccessedMemberTypes DefaultDynamicallyAccessedMemberTypes = DynamicallyAccessedMemberTypes.PublicConstructors
@@ -31,10 +29,29 @@ internal sealed class InteropHelper
     /// and array handling - i.e.
     /// GetElementType()
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The two parameters are annotated asymmetrically on purpose, and the asymmetry is what each one
+    /// actually reads. <paramref name="givenType"/> is asked for its interfaces, so it declares
+    /// <see cref="DynamicallyAccessedMemberTypes.Interfaces"/> and nothing else. <paramref name="genericType"/>
+    /// is only ever compared - <c>IsConstructedGenericType</c>, <c>IsGenericType</c>,
+    /// <c>GetGenericTypeDefinition</c> - none of which reads a member, so it declares nothing at all. The
+    /// pair used to demand every public member of both, which no caller could satisfy: the types arrive as
+    /// a parameter's type or a value's <c>GetType()</c>, so the excess propagated outwards as a trim
+    /// diagnostic at every call site rather than preserving anything.
+    /// </para>
+    /// <para>
+    /// The base-type walk is a loop rather than the recursion it used to be for the same reason.
+    /// <see cref="Type.GetInterfaces"/> already returns the transitive closure, so a base type's interfaces
+    /// were re-scanned having already been scanned here, and the recursive call demanded
+    /// <c>Interfaces</c> of a <see cref="Type.BaseType"/> that cannot carry it. What is left in the loop -
+    /// the constructed-generic-definition test - reads no members, so it needs no annotation. Same answer,
+    /// including which type a miss reports (the last one in the chain).
+    /// </para>
+    /// </remarks>
     internal static AssignableResult IsAssignableToGenericType(
-        [DynamicallyAccessedMembers(DefaultDynamicallyAccessedMemberTypes | DynamicallyAccessedMemberTypes.Interfaces)]
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
         Type givenType,
-        [DynamicallyAccessedMembers(DefaultDynamicallyAccessedMemberTypes | DynamicallyAccessedMemberTypes.Interfaces)]
         Type genericType)
     {
         if (givenType is null)
@@ -69,18 +86,22 @@ internal sealed class InteropHelper
             }
         }
 
-        if (givenType.IsGenericType && givenType.GetGenericTypeDefinition() == genericType)
+        var current = givenType;
+        while (true)
         {
-            return new AssignableResult(0, givenType);
-        }
+            if (current.IsGenericType && current.GetGenericTypeDefinition() == genericType)
+            {
+                return new AssignableResult(0, current);
+            }
 
-        var baseType = givenType.BaseType;
-        if (baseType == null)
-        {
-            return new AssignableResult(-1, givenType);
-        }
+            var baseType = current.BaseType;
+            if (baseType is null)
+            {
+                return new AssignableResult(-1, current);
+            }
 
-        return IsAssignableToGenericType(baseType, genericType);
+            current = baseType;
+        }
     }
 
     /// <summary>

--- a/Jint/Runtime/Interop/MethodDescriptor.cs
+++ b/Jint/Runtime/Interop/MethodDescriptor.cs
@@ -5,8 +5,6 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using Jint.Extensions;
 
-#pragma warning disable IL2072
-
 namespace Jint.Runtime.Interop;
 
 internal sealed class MethodDescriptor

--- a/Jint/Runtime/Interop/MethodInfoFunction.cs
+++ b/Jint/Runtime/Interop/MethodInfoFunction.cs
@@ -7,10 +7,6 @@ using Jint.Native;
 using Jint.Native.Function;
 using Jint.Native.Object;
 
-#pragma warning disable IL2067
-#pragma warning disable IL2072
-#pragma warning disable IL3050
-
 namespace Jint.Runtime.Interop;
 
 internal sealed class MethodInfoFunction : Function

--- a/Jint/Runtime/Interop/NamespaceReference.cs
+++ b/Jint/Runtime/Interop/NamespaceReference.cs
@@ -6,8 +6,6 @@ using Jint.Native;
 using Jint.Native.Object;
 using Jint.Runtime.Descriptors;
 
-#pragma warning disable IL3050
-
 namespace Jint.Runtime.Interop;
 
 /// <summary>

--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -12,10 +12,6 @@ using Jint.Runtime.Descriptors;
 using Jint.Runtime.Descriptors.Specialized;
 using Jint.Runtime.Interop.Reflection;
 
-#pragma warning disable IL2067
-#pragma warning disable IL2072
-#pragma warning disable IL2075
-
 namespace Jint.Runtime.Interop;
 
 /// <summary>
@@ -181,21 +177,31 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
 
         // resolved once per exposed type: reflection (interface scan + generic instantiation +
         // Activator) runs only on the first sighting, every later wrapper creation is a single
-        // virtual call into the cached factory
-        var factory = _arrayLikeWrapperResolution.GetOrAdd(type, static t =>
+        // virtual call into the cached factory.
+        //
+        // Deliberately not GetOrAdd with a lambda: a lambda parameter carries no
+        // [DynamicallyAccessedMembers], so `type`'s annotation is lost at the closure boundary and the
+        // interface scan inside reads as unannotated in every trimming build. Resolving in this method
+        // keeps the annotated parameter in scope. A cached miss is stored as null and TryGetValue reports
+        // it, so a type that is not array-like is resolved once and not once per crossing.
+        if (!_arrayLikeWrapperResolution.TryGetValue(type, out var factory))
         {
             try
             {
-                var factoryType = ResolveArrayLikeWrapperFactoryType(t);
-                return factoryType is null ? null : (ArrayLikeWrapperFactory) Activator.CreateInstance(factoryType)!;
+                var factoryType = ResolveArrayLikeWrapperFactoryType(type);
+                factory = factoryType is null ? null : (ArrayLikeWrapperFactory) Activator.CreateInstance(factoryType)!;
             }
             catch (Exception e) when (IsMissingGenericInstantiation(e))
             {
                 // no typed factory on this runtime; the caller degrades to the non-generic ListWrapper,
                 // or to a plain ObjectWrapper when the target is not even an IList
-                return null;
+                factory = null;
             }
-        });
+
+            // GetOrAdd's value overload rather than TryAdd, so that a race still hands every caller the
+            // same factory the dictionary holds - which is what the factory overload guaranteed.
+            factory = _arrayLikeWrapperResolution.GetOrAdd(type, factory);
+        }
 
         if (factory is not null)
         {
@@ -232,19 +238,28 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
     /// <c>try</c>: both are ways of asking for a generic instantiation, and either can be the one a runtime
     /// declines.
     /// </summary>
+    [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
+        Justification = "The sole caller wraps this call and the activation of its result in a catch that " +
+                        "degrades to the non-generic ListWrapper, or to a plain ObjectWrapper when the target " +
+                        "is not an IList. Jint.AotExample's List<int>, int[] and IReadOnlyList<double> probes " +
+                        "assert the degraded answers on a published native binary, so a runtime with no code " +
+                        "for the instantiation is handled rather than merely tolerated. See " +
+                        "IsMissingGenericInstantiation.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2055:MakeGenericType",
+        Justification = "The three factories are Jint's own internal sealed types, so the only instantiation a " +
+                        "trimmer can remove is one over an element type it also removed; Activator.CreateInstance " +
+                        "then raises MissingMethodException, which the same catch degrades. See " +
+                        "IsMissingGenericInstantiation.")]
+    [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
     private static Type? ResolveArrayLikeWrapperFactoryType(
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type t)
     {
-#pragma warning disable IL2055
-#pragma warning disable IL2070
-#pragma warning disable IL3050
-
         // single-rank zero-based CLR arrays (T[]) get a fixed-size live wrapper; T[] implements
         // IList<T> and would otherwise flow into GenericListWrapper<T> below, whose growth paths
         // call IList<T>.Add and would leak NotSupportedException from the underlying array.
-        // The MakeArrayType equality intentionally excludes multi-rank (T[,]) and non-zero-based
-        // (T[*]) arrays, which keep their previous handling.
-        if (t.IsArray && t.GetElementType() is { } elementType && t == elementType.MakeArrayType())
+        // IsSZArray intentionally excludes multi-rank (T[,]) and non-zero-based (T[*]) arrays, which keep
+        // their previous handling.
+        if (t.IsSZArray && t.GetElementType() is { } elementType)
         {
             return typeof(ArrayWrapperFactory<>).MakeGenericType(elementType);
         }
@@ -269,10 +284,6 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
                 return typeof(ReadOnlyListWrapperFactory<>).MakeGenericType(arrayItemType);
             }
         }
-
-#pragma warning restore IL3050
-#pragma warning restore IL2070
-#pragma warning restore IL2055
 
         return null;
     }
@@ -306,39 +317,51 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
 
     private static readonly ConcurrentDictionary<Type, EnumerableSnapshotFactory> _enumerableSnapshotResolution = new();
 
+    [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
+        Justification = "MakeGenericType and the activation beside it are both under a catch that degrades to " +
+                        "ObjectEnumerableSnapshotFactory when the runtime has no code for the instantiation, and " +
+                        "Jint.AotExample's IEnumerable<int> snapshot probe asserts that degraded answer on a " +
+                        "published native binary. See IsMissingGenericInstantiation.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2055:MakeGenericType",
+        Justification = "EnumerableSnapshotFactory<> is Jint's own internal sealed type, so the only instantiation " +
+                        "a trimmer can remove is one over an element type it also removed; Activator.CreateInstance " +
+                        "then raises MissingMethodException, which the same catch degrades. See " +
+                        "IsMissingGenericInstantiation.")]
     private static EnumerableSnapshotFactory ResolveEnumerableSnapshotFactory(
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type type)
     {
-        return _enumerableSnapshotResolution.GetOrAdd(type, static t =>
+        // resolved out of the lambda for the reason TryBuildArrayLikeWrapper's is: an annotated Type does
+        // not survive the closure boundary, so the interface scan below read as unannotated.
+        if (_enumerableSnapshotResolution.TryGetValue(type, out var cached))
         {
-#pragma warning disable IL2055
-#pragma warning disable IL2070
-#pragma warning disable IL3050
-            foreach (var i in t.GetInterfaces())
-            {
-                if (i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IEnumerable<>))
-                {
-                    try
-                    {
-                        var factoryType = typeof(EnumerableSnapshotFactory<>).MakeGenericType(i.GenericTypeArguments[0]);
-                        return (EnumerableSnapshotFactory) Activator.CreateInstance(factoryType)!;
-                    }
-                    catch (Exception e) when (IsMissingGenericInstantiation(e))
-                    {
-                        // trimmed, or Native AOT with no code for this instantiation: snapshot as
-                        // objects instead. See IsMissingGenericInstantiation for why both exceptions.
-                        break;
-                    }
-                }
-            }
-#pragma warning restore IL3050
-#pragma warning restore IL2070
-#pragma warning restore IL2055
+            return cached;
+        }
 
-            // a type implementing IEnumerable<T> more than once takes the first one, the same arbitrary
-            // choice every other interface scan on this path makes
-            return ObjectEnumerableSnapshotFactory.Instance;
-        });
+        EnumerableSnapshotFactory factory = ObjectEnumerableSnapshotFactory.Instance;
+        foreach (var i in type.GetInterfaces())
+        {
+            if (i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+            {
+                try
+                {
+                    var factoryType = typeof(EnumerableSnapshotFactory<>).MakeGenericType(i.GenericTypeArguments[0]);
+                    factory = (EnumerableSnapshotFactory) Activator.CreateInstance(factoryType)!;
+                }
+                catch (Exception e) when (IsMissingGenericInstantiation(e))
+                {
+                    // trimmed, or Native AOT with no code for this instantiation: snapshot as
+                    // objects instead. See IsMissingGenericInstantiation for why both exceptions.
+                }
+
+                // a type implementing IEnumerable<T> more than once takes the first one, the same arbitrary
+                // choice every other interface scan on this path makes
+                break;
+            }
+        }
+
+        // GetOrAdd's value overload rather than TryAdd, so that a race still hands every caller the same
+        // factory the dictionary holds - which is what the factory overload guaranteed.
+        return _enumerableSnapshotResolution.GetOrAdd(type, factory);
     }
 
     public object Target { get; }

--- a/Jint/Runtime/Interop/Reflection/CompiledKeyedAccessor.cs
+++ b/Jint/Runtime/Interop/Reflection/CompiledKeyedAccessor.cs
@@ -9,10 +9,8 @@ using Expression = System.Linq.Expressions.Expression;
 #endif
 
 // The delegates are compiled with System.Linq.Expressions and only reference the reflected declaring
-// type, whose visibility is checked before anything is emitted. IL2075/IL3050 cover the reflection +
-// dynamic-code use, which is gated behind RuntimeFeature.IsDynamicCodeCompiled.
-#pragma warning disable IL2075
-#pragma warning disable IL3050
+// type, whose visibility is checked before anything is emitted. The reflection and dynamic-code use is
+// gated behind RuntimeFeature.IsDynamicCodeCompiled.
 
 namespace Jint.Runtime.Interop.Reflection;
 

--- a/Jint/Runtime/Interop/Reflection/CompiledMemberAccessor.cs
+++ b/Jint/Runtime/Interop/Reflection/CompiledMemberAccessor.cs
@@ -12,10 +12,9 @@ using ConditionalExpression = System.Linq.Expressions.ConditionalExpression;
 
 // The delegates are compiled with System.Linq.Expressions; every member they reference is public
 // (JsValue implicit operators, JsValueExtensions accessors, JsValue.Null, Math.Floor) so the
-// generated dynamic methods need no reflection-visibility relaxation. IL2075/IL3050 cover the
-// reflection + dynamic-code use, which is gated behind RuntimeFeature.IsDynamicCodeCompiled.
-#pragma warning disable IL2075
-#pragma warning disable IL3050
+// generated dynamic methods need no reflection-visibility relaxation. The lane is gated on
+// RuntimeFeature.IsDynamicCodeCompiled in CanCompile and on IsDynamicCodeSupported again in
+// TryCreateOpenDelegate, which is what an AOT publish can actually see.
 
 namespace Jint.Runtime.Interop.Reflection;
 
@@ -391,6 +390,17 @@ internal static class CompiledMemberAccessor
     {
         accessorDelegate = null;
         delegateType = null;
+
+        // Expression.TryGetFuncType / TryGetActionType close Func<> and Action<> over the argument types,
+        // which is [RequiresDynamicCode]. The lane as a whole already declines when the runtime will not
+        // JIT (CanCompile above), but the guard has to be repeated HERE for it to mean anything to an AOT
+        // publish: the trim analyzer and ILC reason one method at a time, and IsDynamicCodeSupported is a
+        // feature guard they fold, so restating it turns two IL3050 in every embedder's build into a
+        // branch the compiler removes.
+        if (!RuntimeFeature.IsDynamicCodeSupported)
+        {
+            return false;
+        }
 
         if (returnType is null)
         {

--- a/Jint/Runtime/Interop/Reflection/DynamicObjectAccessor.cs
+++ b/Jint/Runtime/Interop/Reflection/DynamicObjectAccessor.cs
@@ -1,7 +1,6 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Dynamic;
 using Jint.Native;
-
-#pragma warning disable IL2092
 
 namespace Jint.Runtime.Interop.Reflection;
 
@@ -45,6 +44,18 @@ internal sealed class DynamicObjectAccessor : ReflectionAccessor
         };
     }
 
+    /// <remarks>
+    /// The two binders below are never installed in a <see cref="System.Runtime.CompilerServices.CallSite"/>.
+    /// They are handed straight to <see cref="DynamicObject.TryGetMember"/> /
+    /// <see cref="DynamicObject.TrySetMember"/>, which dispatches to the host's own override — which is why
+    /// their <c>Fallback*</c> members throw: reaching one would mean the DLR was driving, and it never is.
+    /// The <c>[RequiresDynamicCode]</c> on the base constructors is about that call-site path
+    /// ("Creating a call site may require dynamic code generation"), so it does not describe this use, and
+    /// the suppression says so rather than the csproj silencing it for everyone.
+    /// </remarks>
+    [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
+        Justification = "The binder is only ever passed to DynamicObject.TryGetMember, never used to build a " +
+                        "CallSite, which is what the base constructor's attribute is about.")]
     private sealed class JintGetMemberBinder : GetMemberBinder
     {
         public JintGetMemberBinder(string name, bool ignoreCase) : base(name, ignoreCase)
@@ -57,6 +68,9 @@ internal sealed class DynamicObjectAccessor : ReflectionAccessor
         }
     }
 
+    [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
+        Justification = "The binder is only ever passed to DynamicObject.TrySetMember, never used to build a " +
+                        "CallSite, which is what the base constructor's attribute is about.")]
     private sealed class JintSetMemberBinder : SetMemberBinder
     {
         public JintSetMemberBinder(string name, bool ignoreCase) : base(name, ignoreCase)

--- a/Jint/Runtime/Interop/Reflection/ExtensionMethodCache.cs
+++ b/Jint/Runtime/Interop/Reflection/ExtensionMethodCache.cs
@@ -6,9 +6,6 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using Jint.Extensions;
 
-#pragma warning disable IL2067
-#pragma warning disable IL2070
-
 namespace Jint.Runtime.Interop.Reflection;
 
 /// <summary>
@@ -55,6 +52,20 @@ internal sealed class ExtensionMethodCache
         return _builtCaches.GetOrAdd(key, static k => BuildCore(k.Types));
     }
 
+    /// <remarks>
+    /// The container types arrive as a <see cref="Type"/> array, and
+    /// <c>[DynamicallyAccessedMembers]</c> is honoured on a <see cref="Type"/> or a <see cref="string"/>
+    /// only — never on an array of them. So nothing this call site can write would preserve the methods
+    /// being scanned for. The requirement is stated where a host can act on it instead:
+    /// <c>Options.AddExtensionMethods(params Type[])</c> carries <c>[RequiresUnreferencedCode]</c> saying
+    /// exactly this and naming the fix (root the declaring types), and
+    /// <c>docs/v5-migration.md</c> §6.3 repeats it. Suppressed rather than left to the csproj's
+    /// <c>NoWarn</c>, which reaches Jint's own compilation and no embedder's.
+    /// </remarks>
+    [UnconditionalSuppressMessage("Trimming", "IL2067:UnrecognizedReflectionPattern",
+        Justification = "The registered container types cannot carry DynamicallyAccessedMembers - the parameter " +
+                        "that accepts them is an array - and Options.AddExtensionMethods is annotated " +
+                        "[RequiresUnreferencedCode] to say so at the call site the host controls.")]
     private static ExtensionMethodCache BuildCore(Type[] extensionMethodContainerTypes)
     {
         static Type GetTypeDefinition(Type type)

--- a/Jint/Runtime/Interop/Reflection/IndexerAccessor.cs
+++ b/Jint/Runtime/Interop/Reflection/IndexerAccessor.cs
@@ -6,8 +6,6 @@ using Jint.Native;
 using Jint.Runtime.Descriptors;
 using Jint.Runtime.Descriptors.Specialized;
 
-#pragma warning disable IL2067
-
 namespace Jint.Runtime.Interop.Reflection;
 
 internal sealed class IndexerAccessor : ReflectionAccessor

--- a/Jint/Runtime/Interop/Reflection/ReflectionAccessor.cs
+++ b/Jint/Runtime/Interop/Reflection/ReflectionAccessor.cs
@@ -6,10 +6,6 @@ using Jint.Native;
 using Jint.Runtime.Descriptors;
 using Jint.Runtime.Descriptors.Specialized;
 
-#pragma warning disable IL2098
-#pragma warning disable IL2072
-#pragma warning disable IL2077
-
 namespace Jint.Runtime.Interop.Reflection;
 
 /// <summary>

--- a/Jint/Runtime/Interop/TypeDescriptor.cs
+++ b/Jint/Runtime/Interop/TypeDescriptor.cs
@@ -4,10 +4,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Jint.Runtime.Interop.Reflection;
 
-#pragma warning disable IL2067
-#pragma warning disable IL2075
-#pragma warning disable IL2077
-
 namespace Jint.Runtime.Interop;
 
 internal sealed class TypeDescriptor
@@ -129,7 +125,17 @@ internal sealed class TypeDescriptor
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.Interfaces)]
         Type type)
     {
-        return _cache.GetOrAdd(type, t => new TypeDescriptor(t));
+        // Built here rather than in a GetOrAdd lambda: a lambda parameter carries no
+        // [DynamicallyAccessedMembers], so the caller's promise about `type` was dropped at the closure
+        // boundary and the whole analysis below read as unannotated in every trimming build.
+        if (_cache.TryGetValue(type, out var cached))
+        {
+            return cached;
+        }
+
+        // GetOrAdd's value overload rather than TryAdd, so that a race still hands every caller the same
+        // descriptor instance the dictionary holds - which is what the factory overload guaranteed.
+        return _cache.GetOrAdd(type, new TypeDescriptor(type));
     }
 
     private static void Analyze(
@@ -167,7 +173,6 @@ internal sealed class TypeDescriptor
 
         foreach (var t in type.GetInterfaces())
         {
-#pragma warning disable IL2072
             AnalyzeType(
                 t,
                 out var isCollectionForSubType,
@@ -183,7 +188,6 @@ internal sealed class TypeDescriptor
                 out var genericContainsKeyMethodForSubType,
                 out var genericIndexerSetMethodForSubType,
                 out var genericRemoveMethodForSubType);
-#pragma warning restore IL2072
 
             isCollection |= isCollectionForSubType;
             isEnumerable |= isEnumerableForSubType;

--- a/Jint/Runtime/Interop/TypeReference.cs
+++ b/Jint/Runtime/Interop/TypeReference.cs
@@ -6,8 +6,6 @@ using Jint.Native.Symbol;
 using Jint.Runtime.Descriptors;
 using Jint.Runtime.Interop.Reflection;
 
-#pragma warning disable IL2072
-
 namespace Jint.Runtime.Interop;
 
 /// <summary>

--- a/Jint/Runtime/Interop/TypeResolver.cs
+++ b/Jint/Runtime/Interop/TypeResolver.cs
@@ -6,11 +6,6 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using Jint.Runtime.Interop.Reflection;
 
-#pragma warning disable IL2067
-#pragma warning disable IL2070
-#pragma warning disable IL2072
-#pragma warning disable IL2075
-
 namespace Jint.Runtime.Interop;
 
 /// <summary>
@@ -324,14 +319,20 @@ public sealed class TypeResolver
         Engine engine,
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
     {
-        return _constructors.GetOrAdd(
-            type,
-            t =>
-            {
-                List<ConstructorInfo> constructors = [.. t.GetConstructors(BindingFlags.Public | BindingFlags.Instance)];
-                constructors.RemoveAll(x => !Filter(engine, t, x));
-                return MethodDescriptor.Build(constructors);
-            });
+        // Resolved here rather than in a GetOrAdd lambda: a lambda parameter carries no
+        // [DynamicallyAccessedMembers], so the caller's promise about `type` was dropped at the closure
+        // boundary and the GetConstructors call read as unannotated in every trimming build.
+        if (_constructors.TryGetValue(type, out var cached))
+        {
+            return cached;
+        }
+
+        List<ConstructorInfo> constructors = [.. type.GetConstructors(BindingFlags.Public | BindingFlags.Instance)];
+        constructors.RemoveAll(x => !Filter(engine, type, x));
+
+        // GetOrAdd's value overload rather than TryAdd, so that a race still hands every caller the same
+        // array the dictionary holds - which is what the factory overload guaranteed.
+        return _constructors.GetOrAdd(type, MethodDescriptor.Build(constructors));
     }
 
     private ReflectionAccessor ResolveStaticAccessor(

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -2025,12 +2025,26 @@ a real trimming bug: `SetValue("items", companies)` used to preserve the public 
 `System.Array`, never `Company`'s, so `companies[0].name` was the one thing not preserved. Nothing in
 your code changes; the overload is picked automatically.
 
-**Expect Jint's own diagnostics in your build.** Jint's `NoWarn` is a property of Jint's compilation
-and reaches nothing downstream - ILC re-derives every diagnostic over the closed program - so an AOT
-publish reports the remaining trim-analysis warnings against Jint's files in *your* build. They are
-tracked in [#3305](https://github.com/sebastienros/jint/issues/3305); until they are paid down, set
-`<IlcTreatWarningsAsErrors>false</IlcTreatWarningsAsErrors>` or `NoWarn` the codes, and treat the run
-as the evidence rather than the warning count.
+**Expect some of Jint's own diagnostics in your build.** Jint's `NoWarn` is a property of Jint's
+compilation and reaches nothing downstream - ILC re-derives every diagnostic over the closed program -
+so an AOT publish reports Jint's remaining trim-analysis warnings against Jint's files in *your* build.
+There are 76 of them, down from 113 ([#3305](https://github.com/sebastienros/jint/issues/3305)), and
+they now divide into two kinds:
+
+* **Nine are the gaps in [§6.2](#62-the-one-thing-that-does-not-a-generic-instantiation-over-a-value-type)**
+  - six `IL3050` and their three `IL2060` twins, one per site that builds a generic instantiation over a
+  type only known at run time. These are true, they are the shapes the native run confirms do not work,
+  and they are not suppressed for exactly that reason. If your script never reaches one, the diagnostic
+  costs you nothing; if it does, §6.2 says what to write instead.
+* **The rest are dataflow**, and almost all root at one value: the runtime type of a host object,
+  obtained through `object.GetType()`. No annotation can describe it, which is why the requirement is
+  stated at the entry points instead ([§6.3](#63-apis-that-now-warn)) and why the answer is the rooting
+  above rather than anything in the diagnostic.
+
+Neither kind is actionable at the file it names, so set
+`<IlcTreatWarningsAsErrors>false</IlcTreatWarningsAsErrors>` or `NoWarn` the codes, and treat the run as
+the evidence rather than the warning count. What *is* actionable is any diagnostic pointing at **your**
+files: those are the ones §6.3 and this section are about.
 
 ### 6.5 The AOT-safe subset
 


### PR DESCRIPTION
`Jint.csproj` suppressed eight IL codes and twenty-two interop files carried sixty-one
`#pragma warning disable IL....` lines between them. Neither reaches an embedder: `NoWarn` is a property
of Jint's own compilation and a pragma is Roslyn-only, while ILC re-derives every diagnostic over the
closed program. So the whole apparatus bought Jint a green build and an embedder publishing Native AOT
the full inventory, attributed to Jint's files, in *their* build.

Measured with `dotnet publish Jint.AotExample -c Release` (SDK 10.0.400), the inventory was **113**. It
is now **76**, and `ALL PROBES PASSED (25 probes, 5 known AOT gaps)` on the published native binary,
unchanged.

| code | before | after | | code | before | after |
| --- | --- | --- | --- | --- | --- | --- |
| `IL2072` | 36 | 33 | | `IL2062` | 4 | 4 |
| `IL3050` | 20 | **6** | | `IL2060` | 3 | 3 |
| `IL2067` | 20 | 13 | | `IL2055` | 3 | **0** |
| `IL2070` | 12 | 7 | | `IL2077` | 2 | 2 |
| `IL2080` | 6 | **0** | | `IL2076` | 1 | 1 |
| `IL2075` | 6 | 6 | | `IL2069` | 1 | 1 |
| | | | | **total** | **113** | **76** |

`IL2080` and `IL2055` are gone entirely; `IL3050` is down by 14 to the six that are true. **All sixty-one
pragmas are gone**, and `NoWarn` drops `IL2080` while gaining `IL2062` and `IL2077` — the two codes the
pragmas were hiding from it. What it now carries is nine codes with a comment saying, per code, what is
left and why.

## What closed, and how

**Six `IL2080` — a constant type laundered through a `static readonly Type` field.**
`DefaultTypeConverter`'s static constructor looked up `Task.FromResult`, `ValueTask.FromResult`,
`JsValue.FromObject`/`ToObject` and two non-public `Engine` methods through fields holding `typeof(Task)`
and friends. A `typeof` token is a constant the analyzer folds; a field read is not, so the identity was
lost on the way and six diagnostics came back. Spelling the receiver `typeof(X)` at the lookup both
silences them and *preserves* the members, which the field form never did.

**Four `IL3050` — a feature guard the analyzer could not see.** `CompiledMemberAccessor` and
`CompiledMethodInvoker` already decline entirely when `RuntimeFeature.IsDynamicCodeCompiled` is false,
which is exactly the case `Expression.TryGetFuncType`/`TryGetActionType` are `[RequiresDynamicCode]` for.
But both analyzers reason one method at a time, and the guard was two frames up. Restating it as an early
return in the method that makes the call turns the diagnostic into a branch the compiler removes — no
suppression, and the guard is now visible where it matters.

**Three `IL3050` + one `IL2026` — reflection that was not needed.**
`JsonSerializer.Deserialize<double>(JsonNode)` went through the whole converter machinery to read a
number out of a node that answers `TryGetValue<double>` directly (the `int` attempt beside it always
did). And two sites asked "is this a plain `T[]`?" as `t == t.GetElementType().MakeArrayType()`, building
a `Type` per call to compare it away; `Type.IsSZArray` says the same thing, and is polyfilled downwards
for `net472`/`netstandard2.0` where Native AOT does not exist.

**Two `IL2026` — `Expression.Property(expr, string)` on constants.** Both call sites name a compile-time
type and a `nameof` member. One becomes the `PropertyInfo` overload (preserving `ObjectInstance.Engine`
instead of warning about it), the other becomes `Expression.ArrayLength`, which emits the same `ldlen`.

**Five dataflow diagnostics — an annotation dropped at a closure boundary.** A lambda parameter cannot
carry `[DynamicallyAccessedMembers]`, so `dict.GetOrAdd(type, static t => …reflect over t…)` discards
what the caller had already promised. Five caches did this — the array-like wrapper factory, the
enumerable-snapshot factory, `TypeDescriptor.Get`, `TypeResolver.GetConstructors` and the
operator-overload cache. Each resolution moves into the annotated method and stores through `GetOrAdd`'s
*value* overload, which keeps the one-instance-per-key guarantee the factory overload gave.

**Five dataflow diagnostics — a requirement larger than what the method reads.**
`InteropHelper.IsAssignableToGenericType` demanded every public member of *both* parameters while reading
the interfaces of one and merely comparing the other. No caller could satisfy the excess, so it
propagated outwards as a diagnostic at each of them. `givenType` now declares `Interfaces` and
`genericType` declares nothing; the base-chain recursion becomes a loop, because `GetInterfaces()` already
returns the transitive closure and the only test left in the walk reads no members. Same answers,
including which type a miss reports.

**Two `IL2070` — and a real trimming bug behind them.** `Task<T>.Result` and `ValueTask<T>.AsTask` are
looked up on a constructed generic type that only exists at run time. The member belongs to the generic
*definition*, though, so `[DynamicDependency(…, typeof(Task<>))]` expresses what no annotation on the
lookup could — and preserves it. Without that, a trimmed-away `Task<T>.Result` made an awaited host value
resolve to `undefined`, silently.

**Nine more through six `[UnconditionalSuppressMessage]`s**, each stating the invariant it stands on
rather than asking for quiet:

* the two generic-factory resolvers in `ObjectWrapper` (`IL3050`, `IL2055`) — both callers sit under the
  `catch` that degrades to `ListWrapper` / a plain `ObjectWrapper` / the object snapshot, and
  `Jint.AotExample`'s `List<int>`, `int[]`, `IReadOnlyList<double>` and `IEnumerable<int>` probes assert
  those degraded answers on a published native binary;
* `DefaultTypeConverter.BuildDelegate`'s `Expression.NewArrayInit` (`IL3050`) — the element type is always
  `typeof(JsValue)`, and `JsValue[]` is in any image that contains Jint; the *JS function →
  `Func<int, int>`* probe runs the path natively;
* the two DLR binders in `DynamicObjectAccessor` (`IL3050`) — they are never installed in a `CallSite`,
  which is what the base constructors' attribute is about; they go straight to `DynamicObject.TryGetMember`,
  which is why their `Fallback*` members throw;
* `ExtensionMethodCache.BuildCore` (`IL2067`) and `Options.Apply` (`IL2026`) — the requirement cannot be
  expressed here (a `Type[]` cannot carry `[DynamicallyAccessedMembers]`; a `bool` setter cannot carry
  `[RequiresUnreferencedCode]` without warning on `= false`), and it is already stated where a host can
  act on it: `Options.AddExtensionMethods` and `Options.AllowClr`.

## What is left, and why it is left

**Nine are the documented gaps** — six `IL3050` and their three `IL2060` twins, one per site that builds a
generic instantiation over a type only known at run time: `Task.FromResult<T>`, `MakeGenericMethod`,
`List<T>`/`Collection<T>` for a generic-collection parameter, and the closed type a script names through
`importNamespace`. These map one-to-one onto §6.2 of the migration guide and the five `KnownAotGap`s in
`Jint.AotExample`. They are true, so they are **not** suppressed, and they do not get
`[RequiresDynamicCode]` because no signature in Jint predicts the type argument — it comes from the host's
members and the script's arguments (#3381).

**The other 66 (of 75 distinct; ILC prints one twice) are dataflow**, and almost all root at one value: the runtime type of a host object,
obtained through `object.GetType()` or read back off a wrapper. No annotation can describe it — the
propagation only terminates at a public API, and the ones it terminates at either already carry
`[RequiresUnreferencedCode]` or would have to widen what every AOT consumer preserves. #3305 stays open
with that grouping.

## Verification

* `dotnet build -c Release` clean, all five target frameworks, `TreatWarningsAsErrors` on.
* `dotnet publish Jint.AotExample -c Release`: **113 → 76** diagnostics, table above.
* The published native binary: `ALL PROBES PASSED (25 probes, 5 known AOT gaps)`, before and after.
* `Jint.Tests`: 10,745 passed on net10.0 and net8.0, 7,369 on net472, 0 failed.
* `Jint.Tests.PublicInterface`: 2,998 passed on net10.0, 2,369 on net472, 0 failed.
* `Jint.Tests.Test262`: 102,495 passed, 0 failed, 189 skipped.

* `Jint.Tests/AgentInstructionFileTests.cs` (#3391): 4/4 green. `Jint.AotExample/AGENTS.md` 13,892 bytes
  (18,876 headroom), `Jint/Runtime/Interop/AGENTS.md` byte-identical to `main`.

No public signature changes, so no `docs/v5-migration.md` §2/§3/§4 row and no `UndocumentedPublicApi.txt`
movement. §6.4 is updated, because the count and the shape of what an embedder sees is what it describes.

Rebased onto #3391, which moved the Native AOT instruction section verbatim out of
`Jint/Runtime/Interop/AGENTS.md` into `Jint.AotExample/AGENTS.md`. The revisions this PR makes to that
section land in the new file; `Jint/Runtime/Interop/AGENTS.md` is left exactly as #3391 wrote it. Two of
the five edits are **not** re-applied on purpose — they were byte-budget compressions of #3381's prose,
made only because the interop file was over its 32 KiB cap. With the section relocated there is 18 KiB of
headroom, so that prose stays as its author wrote it, and the four-move list is restored to its full
form.
