### PR TITLE
Intl: the date names and digits a host supplies now reach format(), and two members that could not carry their data are gone

### DIFF
--- a/Jint.Tests.PublicInterface/HostLocaleProviderTests.cs
+++ b/Jint.Tests.PublicInterface/HostLocaleProviderTests.cs
@@ -15,7 +15,7 @@ namespace Jint.Tests.PublicInterface;
 public class HostLocaleProviderTests
 {
     [Fact]
-    public void OverridingOneCldrDatumLeavesTheOtherTwentyMembersInherited()
+    public void OverridingOneCldrDatumLeavesTheOtherEighteenMembersInherited()
     {
         var engine = new Engine(options => options.Intl.CldrProvider = new OneCurrencyName());
 
@@ -129,6 +129,80 @@ public class HostLocaleProviderTests
     }
 
     [Fact]
+    public void OverridingOneNumberingSystemsDigitsMakesItUsable()
+    {
+        var engine = new Engine(options => options.Intl.CldrProvider = new AlphabetDigits());
+
+        // a numbering system the engine has never heard of: the provider is the only thing that can
+        // say it exists, and the only thing that can transliterate it
+        engine.Evaluate("new Intl.NumberFormat('en', { numberingSystem: 'lettera' }).format(1024)")
+            .AsString().Should().Be("B,ACE");
+        engine.Evaluate("new Intl.NumberFormat('en', { numberingSystem: 'lettera' }).resolvedOptions().numberingSystem")
+            .AsString().Should().Be("lettera");
+        engine.Evaluate("new Intl.RelativeTimeFormat('en', { numberingSystem: 'lettera' }).format(3, 'day')")
+            .AsString().Should().Be("in D days");
+
+        // …and every system the subclass does not claim still reads the inherited digit table
+        engine.Evaluate("new Intl.NumberFormat('en', { numberingSystem: 'arab' }).format(123)")
+            .AsString().Should().Be("١٢٣");
+        engine.Evaluate("new Intl.NumberFormat('en').format(123)")
+            .AsString().Should().Be("123");
+    }
+
+    [Fact]
+    public void OverridingOneMonthNameReachesDateTimeFormat()
+    {
+        var engine = new Engine(options => options.Intl.CldrProvider = new RevolutionaryMonths());
+
+        engine.Evaluate("new Intl.DateTimeFormat('en', { month: 'long', timeZone: 'UTC' }).format(Date.UTC(2024, 0, 15))")
+            .AsString().Should().Be("Nivose");
+        engine.Evaluate("new Intl.DateTimeFormat('en', { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' }).format(Date.UTC(2024, 6, 4))")
+            .AsString().Should().Be("Messidor 4, 2024");
+        engine.Evaluate("new Intl.DateTimeFormat('en', { month: 'long', timeZone: 'UTC' }).formatToParts(Date.UTC(2024, 0, 15))[0].value")
+            .AsString().Should().Be("Nivose");
+
+        // the style the subclass does not answer for, and every other member, are the inherited data
+        engine.Evaluate("new Intl.DateTimeFormat('en', { month: 'short', timeZone: 'UTC' }).format(Date.UTC(2024, 0, 15))")
+            .AsString().Should().Be("Jan");
+        engine.Evaluate("new Intl.DateTimeFormat('en', { weekday: 'long', timeZone: 'UTC' }).format(Date.UTC(2024, 0, 15))")
+            .AsString().Should().Be("Monday");
+    }
+
+    [Fact]
+    public void OverridingOneWeekdayNameReachesDateTimeFormat()
+    {
+        var engine = new Engine(options => options.Intl.CldrProvider = new PlanetaryWeekdays());
+
+        engine.Evaluate("new Intl.DateTimeFormat('en', { weekday: 'long', timeZone: 'UTC' }).format(Date.UTC(2024, 0, 15))")
+            .AsString().Should().Be("Moonday");
+        engine.Evaluate("new Intl.DateTimeFormat('en', { weekday: 'long', timeZone: 'UTC' }).formatToParts(Date.UTC(2024, 0, 14))[0].value")
+            .AsString().Should().Be("Sunday");
+
+        // the abbreviated names, and the months, are the inherited data
+        engine.Evaluate("new Intl.DateTimeFormat('en', { weekday: 'short', timeZone: 'UTC' }).format(Date.UTC(2024, 0, 15))")
+            .AsString().Should().Be("Mon");
+        engine.Evaluate("new Intl.DateTimeFormat('en', { month: 'long', timeZone: 'UTC' }).format(Date.UTC(2024, 0, 15))")
+            .AsString().Should().Be("January");
+    }
+
+    [Fact]
+    public void OverridingOneDayPeriodReachesDateTimeFormat()
+    {
+        var engine = new Engine(options => options.Intl.CldrProvider = new NauticalDayPeriods());
+
+        engine.Evaluate("new Intl.DateTimeFormat('en', { hour: 'numeric', hour12: true, timeZone: 'UTC' }).format(Date.UTC(2024, 0, 15, 15, 30))")
+            .AsString().Should().Be("3 EVE");
+        engine.Evaluate("new Intl.DateTimeFormat('en', { hour: 'numeric', hour12: true, timeZone: 'UTC' }).format(Date.UTC(2024, 0, 15, 9, 30))")
+            .AsString().Should().Be("9 MORN");
+        engine.Evaluate("new Intl.DateTimeFormat('en', { hour: 'numeric', hour12: true, timeZone: 'UTC' }).formatToParts(Date.UTC(2024, 0, 15, 15, 30))[2].value")
+            .AsString().Should().Be("EVE");
+
+        // the months and weekdays are still the inherited data
+        engine.Evaluate("new Intl.DateTimeFormat('en', { month: 'long', timeZone: 'UTC' }).format(Date.UTC(2024, 0, 15))")
+            .AsString().Should().Be("January");
+    }
+
+    [Fact]
     public void AnEngineThatConfiguresNothingStillReadsTheSharedSingletons()
     {
         var options = new Options();
@@ -139,7 +213,7 @@ public class HostLocaleProviderTests
     }
 }
 
-/// <summary>One currency's display name; the other twenty members are inherited.</summary>
+/// <summary>One currency's display name; the other eighteen members are inherited.</summary>
 file sealed class OneCurrencyName : DefaultCldrProvider
 {
     public override string? GetCurrencyDisplayName(string locale, string code)
@@ -162,7 +236,40 @@ file sealed class SundayIsTheWeekend : DefaultCldrProvider
         => new WeekInfo { FirstDay = DayOfWeek.Wednesday, Weekend = [DayOfWeek.Sunday] };
 }
 
-/// <summary>One list-pattern set; the other twenty members are inherited.</summary>
+/// <summary>One numbering system the engine has never heard of; every other one is inherited.</summary>
+file sealed class AlphabetDigits : DefaultCldrProvider
+{
+    public override string? GetNumberingSystemDigits(string numberingSystem)
+        => string.Equals(numberingSystem, "lettera", StringComparison.OrdinalIgnoreCase)
+            ? "ABCDEFGHIJ"
+            : base.GetNumberingSystemDigits(numberingSystem);
+}
+
+/// <summary>One month-name style; every other name the formatter needs is inherited.</summary>
+file sealed class RevolutionaryMonths : DefaultCldrProvider
+{
+    public override string[]? GetMonthNames(string locale, string style, string? calendar)
+        => string.Equals(style, "long", StringComparison.Ordinal)
+            ? ["Nivose", "Pluviose", "Ventose", "Germinal", "Floreal", "Prairial", "Messidor", "Thermidor", "Fructidor", "Vendemiaire", "Brumaire", "Frimaire"]
+            : base.GetMonthNames(locale, style, calendar);
+}
+
+/// <summary>One weekday-name style; every other name the formatter needs is inherited.</summary>
+file sealed class PlanetaryWeekdays : DefaultCldrProvider
+{
+    public override string[]? GetWeekdayNames(string locale, string style)
+        => string.Equals(style, "long", StringComparison.Ordinal)
+            ? ["Sunday", "Moonday", "Marsday", "Mercuryday", "Jupiterday", "Venusday", "Saturnday"]
+            : base.GetWeekdayNames(locale, style);
+}
+
+/// <summary>One pair of day periods; every other name the formatter needs is inherited.</summary>
+file sealed class NauticalDayPeriods : DefaultCldrProvider
+{
+    public override string[]? GetDayPeriods(string locale, string style, string? calendar) => ["MORN", "EVE"];
+}
+
+/// <summary>One list-pattern set; the other eighteen members are inherited.</summary>
 file sealed class GermanLists : DefaultCldrProvider
 {
     public override ListPatterns? GetListPatterns(string locale, string type, string style)
@@ -188,8 +295,7 @@ file sealed class ShiftedHebrewEra : DefaultCalendarProvider
 }
 
 /// <summary>
-/// Present only to be compiled: a host reaching a member the engine never consults still has to be able
-/// to override it, and the compiler is the only thing that checks that all twenty-one are virtual.
+/// Present only to be compiled: the compiler is the only thing that checks that all nineteen are virtual.
 /// </summary>
 file sealed class EveryCldrMemberOverridden : DefaultCldrProvider
 {
@@ -198,10 +304,8 @@ file sealed class EveryCldrMemberOverridden : DefaultCldrProvider
     public override string? GetRelativeTimeSpecialPhrase(string locale, string unit, int value, bool past, string style) => base.GetRelativeTimeSpecialPhrase(locale, unit, value, past, style);
     public override string? GetNumberingSystemDigits(string numberingSystem) => base.GetNumberingSystemDigits(numberingSystem);
     public override string? GetDefaultNumberingSystem(string locale) => base.GetDefaultNumberingSystem(locale);
-    public override CompactPatterns? GetCompactPatterns(string locale, string style) => base.GetCompactPatterns(locale, style);
     public override CurrencyData? GetCurrencyData(string locale, string currencyCode) => base.GetCurrencyData(locale, currencyCode);
     public override UnitPatterns? GetUnitPatterns(string locale, string unit, string style) => base.GetUnitPatterns(locale, unit, style);
-    public override DateTimePatterns? GetDateTimePatterns(string locale, string? dateStyle, string? timeStyle) => base.GetDateTimePatterns(locale, dateStyle, timeStyle);
     public override string[]? GetMonthNames(string locale, string style, string? calendar) => base.GetMonthNames(locale, style, calendar);
     public override string[]? GetWeekdayNames(string locale, string style) => base.GetWeekdayNames(locale, style);
     public override string[]? GetDayPeriods(string locale, string style, string? calendar) => base.GetDayPeriods(locale, style, calendar);

--- a/Jint.Tests.PublicInterface/UndocumentedPublicApi.txt
+++ b/Jint.Tests.PublicInterface/UndocumentedPublicApi.txt
@@ -12,7 +12,7 @@
 #
 # The names are ISO documentation comment ids, which is what the compiler writes into Jint.xml.
 #
-undocumented: 634
+undocumented: 632
 F:Jint.ModuleParsingOptions.Default
 F:Jint.ModulePreparationOptions.Default
 F:Jint.Native.Function.Function._length
@@ -172,9 +172,7 @@ M:Jint.Native.Array.ArrayInstance.ToArray
 M:Jint.Native.Array.ArrayPrototype.Pop(Jint.Native.JsValue)
 M:Jint.Native.Constructor.Construct(Jint.Native.JsValue[],Jint.Native.JsValue)
 M:Jint.Native.Error.ErrorConstructor.Construct(System.String)
-M:Jint.Native.Intl.CompactPatterns.#ctor
 M:Jint.Native.Intl.CurrencyData.#ctor
-M:Jint.Native.Intl.DateTimePatterns.#ctor
 M:Jint.Native.Intl.ListPatterns.#ctor
 M:Jint.Native.Intl.RelativeTimePatterns.#ctor
 M:Jint.Native.Intl.UnitPatterns.#ctor

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
@@ -1339,11 +1339,6 @@ namespace Jint.Native.Global
 }
 namespace Jint.Native.Intl
 {
-    public sealed class CompactPatterns
-    {
-        public CompactPatterns() { }
-        public required System.Collections.Generic.Dictionary<int, string> Patterns { get; init; }
-    }
     public sealed class CurrencyData
     {
         public CurrencyData() { }
@@ -1351,21 +1346,12 @@ namespace Jint.Native.Intl
         public string? NarrowSymbol { get; init; }
         public required string Symbol { get; init; }
     }
-    public sealed class DateTimePatterns
-    {
-        public DateTimePatterns() { }
-        public string? DatePattern { get; init; }
-        public string? DateTimePattern { get; init; }
-        public string? TimePattern { get; init; }
-    }
     public class DefaultCldrProvider : Jint.Native.Intl.ICldrProvider
     {
         public static readonly Jint.Native.Intl.DefaultCldrProvider Instance;
         protected DefaultCldrProvider() { }
-        public virtual Jint.Native.Intl.CompactPatterns? GetCompactPatterns(string locale, string style) { }
         public virtual Jint.Native.Intl.CurrencyData? GetCurrencyData(string locale, string currencyCode) { }
         public virtual string? GetCurrencyDisplayName(string locale, string code) { }
-        public virtual Jint.Native.Intl.DateTimePatterns? GetDateTimePatterns(string locale, string? dateStyle, string? timeStyle) { }
         public virtual string[]? GetDayPeriods(string locale, string style, string? calendar) { }
         public virtual string? GetDefaultNumberingSystem(string locale) { }
         public virtual string[]? GetEraNames(string locale, string style, string? calendar) { }
@@ -1386,10 +1372,8 @@ namespace Jint.Native.Intl
     }
     public interface ICldrProvider
     {
-        Jint.Native.Intl.CompactPatterns? GetCompactPatterns(string locale, string style);
         Jint.Native.Intl.CurrencyData? GetCurrencyData(string locale, string currencyCode);
         string? GetCurrencyDisplayName(string locale, string code);
-        Jint.Native.Intl.DateTimePatterns? GetDateTimePatterns(string locale, string? dateStyle, string? timeStyle);
         string[]? GetDayPeriods(string locale, string style, string? calendar);
         string? GetDefaultNumberingSystem(string locale);
         string[]? GetEraNames(string locale, string style, string? calendar);

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net472.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net472.verified.txt
@@ -1186,11 +1186,6 @@ namespace Jint.Native.Global
 }
 namespace Jint.Native.Intl
 {
-    public sealed class CompactPatterns
-    {
-        public CompactPatterns() { }
-        public required System.Collections.Generic.Dictionary<int, string> Patterns { get; init; }
-    }
     public sealed class CurrencyData
     {
         public CurrencyData() { }
@@ -1198,21 +1193,12 @@ namespace Jint.Native.Intl
         public string? NarrowSymbol { get; init; }
         public required string Symbol { get; init; }
     }
-    public sealed class DateTimePatterns
-    {
-        public DateTimePatterns() { }
-        public string? DatePattern { get; init; }
-        public string? DateTimePattern { get; init; }
-        public string? TimePattern { get; init; }
-    }
     public class DefaultCldrProvider : Jint.Native.Intl.ICldrProvider
     {
         public static readonly Jint.Native.Intl.DefaultCldrProvider Instance;
         protected DefaultCldrProvider() { }
-        public virtual Jint.Native.Intl.CompactPatterns? GetCompactPatterns(string locale, string style) { }
         public virtual Jint.Native.Intl.CurrencyData? GetCurrencyData(string locale, string currencyCode) { }
         public virtual string? GetCurrencyDisplayName(string locale, string code) { }
-        public virtual Jint.Native.Intl.DateTimePatterns? GetDateTimePatterns(string locale, string? dateStyle, string? timeStyle) { }
         public virtual string[]? GetDayPeriods(string locale, string style, string? calendar) { }
         public virtual string? GetDefaultNumberingSystem(string locale) { }
         public virtual string[]? GetEraNames(string locale, string style, string? calendar) { }
@@ -1233,10 +1219,8 @@ namespace Jint.Native.Intl
     }
     public interface ICldrProvider
     {
-        Jint.Native.Intl.CompactPatterns? GetCompactPatterns(string locale, string style);
         Jint.Native.Intl.CurrencyData? GetCurrencyData(string locale, string currencyCode);
         string? GetCurrencyDisplayName(string locale, string code);
-        Jint.Native.Intl.DateTimePatterns? GetDateTimePatterns(string locale, string? dateStyle, string? timeStyle);
         string[]? GetDayPeriods(string locale, string style, string? calendar);
         string? GetDefaultNumberingSystem(string locale);
         string[]? GetEraNames(string locale, string style, string? calendar);

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
@@ -1339,11 +1339,6 @@ namespace Jint.Native.Global
 }
 namespace Jint.Native.Intl
 {
-    public sealed class CompactPatterns
-    {
-        public CompactPatterns() { }
-        public required System.Collections.Generic.Dictionary<int, string> Patterns { get; init; }
-    }
     public sealed class CurrencyData
     {
         public CurrencyData() { }
@@ -1351,21 +1346,12 @@ namespace Jint.Native.Intl
         public string? NarrowSymbol { get; init; }
         public required string Symbol { get; init; }
     }
-    public sealed class DateTimePatterns
-    {
-        public DateTimePatterns() { }
-        public string? DatePattern { get; init; }
-        public string? DateTimePattern { get; init; }
-        public string? TimePattern { get; init; }
-    }
     public class DefaultCldrProvider : Jint.Native.Intl.ICldrProvider
     {
         public static readonly Jint.Native.Intl.DefaultCldrProvider Instance;
         protected DefaultCldrProvider() { }
-        public virtual Jint.Native.Intl.CompactPatterns? GetCompactPatterns(string locale, string style) { }
         public virtual Jint.Native.Intl.CurrencyData? GetCurrencyData(string locale, string currencyCode) { }
         public virtual string? GetCurrencyDisplayName(string locale, string code) { }
-        public virtual Jint.Native.Intl.DateTimePatterns? GetDateTimePatterns(string locale, string? dateStyle, string? timeStyle) { }
         public virtual string[]? GetDayPeriods(string locale, string style, string? calendar) { }
         public virtual string? GetDefaultNumberingSystem(string locale) { }
         public virtual string[]? GetEraNames(string locale, string style, string? calendar) { }
@@ -1386,10 +1372,8 @@ namespace Jint.Native.Intl
     }
     public interface ICldrProvider
     {
-        Jint.Native.Intl.CompactPatterns? GetCompactPatterns(string locale, string style);
         Jint.Native.Intl.CurrencyData? GetCurrencyData(string locale, string currencyCode);
         string? GetCurrencyDisplayName(string locale, string code);
-        Jint.Native.Intl.DateTimePatterns? GetDateTimePatterns(string locale, string? dateStyle, string? timeStyle);
         string[]? GetDayPeriods(string locale, string style, string? calendar);
         string? GetDefaultNumberingSystem(string locale);
         string[]? GetEraNames(string locale, string style, string? calendar);

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.0.verified.txt
@@ -1186,11 +1186,6 @@ namespace Jint.Native.Global
 }
 namespace Jint.Native.Intl
 {
-    public sealed class CompactPatterns
-    {
-        public CompactPatterns() { }
-        public required System.Collections.Generic.Dictionary<int, string> Patterns { get; init; }
-    }
     public sealed class CurrencyData
     {
         public CurrencyData() { }
@@ -1198,21 +1193,12 @@ namespace Jint.Native.Intl
         public string? NarrowSymbol { get; init; }
         public required string Symbol { get; init; }
     }
-    public sealed class DateTimePatterns
-    {
-        public DateTimePatterns() { }
-        public string? DatePattern { get; init; }
-        public string? DateTimePattern { get; init; }
-        public string? TimePattern { get; init; }
-    }
     public class DefaultCldrProvider : Jint.Native.Intl.ICldrProvider
     {
         public static readonly Jint.Native.Intl.DefaultCldrProvider Instance;
         protected DefaultCldrProvider() { }
-        public virtual Jint.Native.Intl.CompactPatterns? GetCompactPatterns(string locale, string style) { }
         public virtual Jint.Native.Intl.CurrencyData? GetCurrencyData(string locale, string currencyCode) { }
         public virtual string? GetCurrencyDisplayName(string locale, string code) { }
-        public virtual Jint.Native.Intl.DateTimePatterns? GetDateTimePatterns(string locale, string? dateStyle, string? timeStyle) { }
         public virtual string[]? GetDayPeriods(string locale, string style, string? calendar) { }
         public virtual string? GetDefaultNumberingSystem(string locale) { }
         public virtual string[]? GetEraNames(string locale, string style, string? calendar) { }
@@ -1233,10 +1219,8 @@ namespace Jint.Native.Intl
     }
     public interface ICldrProvider
     {
-        Jint.Native.Intl.CompactPatterns? GetCompactPatterns(string locale, string style);
         Jint.Native.Intl.CurrencyData? GetCurrencyData(string locale, string currencyCode);
         string? GetCurrencyDisplayName(string locale, string code);
-        Jint.Native.Intl.DateTimePatterns? GetDateTimePatterns(string locale, string? dateStyle, string? timeStyle);
         string[]? GetDayPeriods(string locale, string style, string? calendar);
         string? GetDefaultNumberingSystem(string locale);
         string[]? GetEraNames(string locale, string style, string? calendar);

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.1.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.1.verified.txt
@@ -1186,11 +1186,6 @@ namespace Jint.Native.Global
 }
 namespace Jint.Native.Intl
 {
-    public sealed class CompactPatterns
-    {
-        public CompactPatterns() { }
-        public required System.Collections.Generic.Dictionary<int, string> Patterns { get; init; }
-    }
     public sealed class CurrencyData
     {
         public CurrencyData() { }
@@ -1198,21 +1193,12 @@ namespace Jint.Native.Intl
         public string? NarrowSymbol { get; init; }
         public required string Symbol { get; init; }
     }
-    public sealed class DateTimePatterns
-    {
-        public DateTimePatterns() { }
-        public string? DatePattern { get; init; }
-        public string? DateTimePattern { get; init; }
-        public string? TimePattern { get; init; }
-    }
     public class DefaultCldrProvider : Jint.Native.Intl.ICldrProvider
     {
         public static readonly Jint.Native.Intl.DefaultCldrProvider Instance;
         protected DefaultCldrProvider() { }
-        public virtual Jint.Native.Intl.CompactPatterns? GetCompactPatterns(string locale, string style) { }
         public virtual Jint.Native.Intl.CurrencyData? GetCurrencyData(string locale, string currencyCode) { }
         public virtual string? GetCurrencyDisplayName(string locale, string code) { }
-        public virtual Jint.Native.Intl.DateTimePatterns? GetDateTimePatterns(string locale, string? dateStyle, string? timeStyle) { }
         public virtual string[]? GetDayPeriods(string locale, string style, string? calendar) { }
         public virtual string? GetDefaultNumberingSystem(string locale) { }
         public virtual string[]? GetEraNames(string locale, string style, string? calendar) { }
@@ -1233,10 +1219,8 @@ namespace Jint.Native.Intl
     }
     public interface ICldrProvider
     {
-        Jint.Native.Intl.CompactPatterns? GetCompactPatterns(string locale, string style);
         Jint.Native.Intl.CurrencyData? GetCurrencyData(string locale, string currencyCode);
         string? GetCurrencyDisplayName(string locale, string code);
-        Jint.Native.Intl.DateTimePatterns? GetDateTimePatterns(string locale, string? dateStyle, string? timeStyle);
         string[]? GetDayPeriods(string locale, string style, string? calendar);
         string? GetDefaultNumberingSystem(string locale);
         string[]? GetEraNames(string locale, string style, string? calendar);

--- a/Jint.Tests.Test262/IcuCldrProvider.cs
+++ b/Jint.Tests.Test262/IcuCldrProvider.cs
@@ -173,9 +173,6 @@ public sealed class IcuCldrProvider : ICldrProvider
         }
     }
 
-    public CompactPatterns? GetCompactPatterns(string locale, string style)
-        => _fallback.GetCompactPatterns(locale, style);
-
     public Jint.Native.Intl.CurrencyData? GetCurrencyData(string locale, string currencyCode)
         => _fallback.GetCurrencyData(locale, currencyCode);
 
@@ -281,9 +278,6 @@ public sealed class IcuCldrProvider : ICldrProvider
     // === Date/Time Formatting ===
     // Note: ICU4N doesn't have DateFormatSymbols ported yet, so we use the fallback provider
     // which uses .NET's CultureInfo for basic date/time data.
-
-    public DateTimePatterns? GetDateTimePatterns(string locale, string? dateStyle, string? timeStyle)
-        => _fallback.GetDateTimePatterns(locale, dateStyle, timeStyle);
 
     public string[]? GetMonthNames(string locale, string style, string? calendar)
         => _fallback.GetMonthNames(locale, style, calendar);

--- a/Jint.Tests/Runtime/IntlTests.cs
+++ b/Jint.Tests/Runtime/IntlTests.cs
@@ -1,4 +1,6 @@
-﻿using Jint.Runtime;
+﻿using System.Globalization;
+using Jint.Native.Intl;
+using Jint.Runtime;
 
 namespace Jint.Tests.Runtime;
 
@@ -1365,5 +1367,74 @@ public class IntlTests
             """;
 
         _engine.Evaluate(script).AsNumber().Should().Be(1);
+    }
+
+    /// <summary>
+    /// <c>Intl.DateTimeFormat</c> seeds each formatter's <c>DateTimeFormatInfo</c> from
+    /// <c>Options.Intl.CldrProvider</c>, and writes only a name group that differs from what .NET already
+    /// held. <c>DefaultCldrProvider</c> reads those names out of the very same <c>CultureInfo</c>, so on an
+    /// unconfigured engine the seeding writes nothing at all and the formatter keeps the culture instance it
+    /// always had. This walks every culture the machine has and checks that entry by entry, rather than
+    /// asserting it for one locale.
+    /// </summary>
+    [Fact]
+    public void TheDefaultCldrProviderAnswersWithDotNetsOwnDateNames()
+    {
+        var provider = DefaultCldrProvider.Instance;
+        var compared = 0;
+
+        foreach (var culture in CultureInfo.GetCultures(CultureTypes.SpecificCultures))
+        {
+            var name = culture.Name;
+            if (name.Length == 0)
+            {
+                continue;
+            }
+
+            DateTimeFormatInfo dtfi;
+            try
+            {
+                dtfi = new CultureInfo(name, false).DateTimeFormat;
+            }
+            catch (CultureNotFoundException)
+            {
+                continue;
+            }
+
+            provider.GetMonthNames(name, "long", null).Should().Equal(dtfi.MonthNames.Take(12));
+            provider.GetMonthNames(name, "short", null).Should().Equal(dtfi.AbbreviatedMonthNames.Take(12));
+            provider.GetWeekdayNames(name, "long").Should().Equal(dtfi.DayNames);
+            provider.GetWeekdayNames(name, "short").Should().Equal(dtfi.AbbreviatedDayNames);
+            provider.GetDayPeriods(name, "short", null).Should().Equal(new[] { dtfi.AMDesignator, dtfi.PMDesignator });
+            compared++;
+        }
+
+        compared.Should().BeGreaterThan(100);
+    }
+
+    /// <summary>
+    /// The digits <c>Intl</c> transliterates with are the ones <c>ICldrProvider.GetNumberingSystemDigits</c>
+    /// answers with, and the set a formatter accepts is exactly the set that member answers for. On an
+    /// unconfigured engine that has to be the same set <c>Intl.supportedValuesOf('numberingSystem')</c>
+    /// reports, or a host can be told about a system no constructor will take.
+    /// </summary>
+    [Fact]
+    public void EveryAdvertisedNumberingSystemHasDigitsAndIsAccepted()
+    {
+        var provider = DefaultCldrProvider.Instance;
+        var advertised = provider.GetSupportedNumberingSystems();
+
+        advertised.Should().NotBeEmpty();
+
+        foreach (var system in advertised)
+        {
+            provider.GetNumberingSystemDigits(system).Should().NotBeNull($"'{system}' is advertised");
+
+            foreach (var constructor in new[] { "NumberFormat", "DateTimeFormat", "RelativeTimeFormat", "DurationFormat" })
+            {
+                _engine.Evaluate($"new Intl.{constructor}('en', {{ numberingSystem: '{system}' }}).resolvedOptions().numberingSystem")
+                    .AsString().Should().Be(system, $"Intl.{constructor} should accept '{system}'");
+            }
+        }
     }
 }

--- a/Jint.Tests/Runtime/IntlTests.cs
+++ b/Jint.Tests/Runtime/IntlTests.cs
@@ -1371,12 +1371,17 @@ public class IntlTests
 
     /// <summary>
     /// <c>Intl.DateTimeFormat</c> seeds each formatter's <c>DateTimeFormatInfo</c> from
-    /// <c>Options.Intl.CldrProvider</c>, and writes only a name group that differs from what .NET already
-    /// held. <c>DefaultCldrProvider</c> reads those names out of the very same <c>CultureInfo</c>, so on an
-    /// unconfigured engine the seeding writes nothing at all and the formatter keeps the culture instance it
-    /// always had. This walks every culture the machine has and checks that entry by entry, rather than
-    /// asserting it for one locale.
+    /// <c>Options.Intl.CldrProvider</c>, and skips the shared <c>DefaultCldrProvider.Instance</c> by identity
+    /// rather than asking it and comparing — because it reads those names out of the very same
+    /// <c>CultureInfo</c> the formatter would otherwise have used, so it can only answer with what is
+    /// already there.
     /// </summary>
+    /// <remarks>
+    /// This is what makes that shortcut sound, so it is the guard on it: it walks every culture the machine
+    /// has and compares all five arrays the seeding reads, entry by entry, against the
+    /// <c>DateTimeFormatInfo</c> behind them. Should the default provider ever start answering with names of
+    /// its own, this fails, and the identity check in <c>DateTimeFormatConstructor</c> is then wrong.
+    /// </remarks>
     [Fact]
     public void TheDefaultCldrProviderAnswersWithDotNetsOwnDateNames()
     {

--- a/Jint/Native/Intl/CldrDataTypes.cs
+++ b/Jint/Native/Intl/CldrDataTypes.cs
@@ -139,39 +139,6 @@ public sealed class UnitPatterns
 }
 
 /// <summary>
-/// Compact number formatting patterns from CLDR.
-/// </summary>
-public sealed class CompactPatterns
-{
-    /// <summary>
-    /// Patterns keyed by magnitude (3 for thousands, 6 for millions, etc.).
-    /// Value is the pattern, e.g., "{0}K" or "{0} thousand".
-    /// </summary>
-    public required Dictionary<int, string> Patterns { get; init; }
-}
-
-/// <summary>
-/// Date/time formatting patterns from CLDR.
-/// </summary>
-public sealed class DateTimePatterns
-{
-    /// <summary>
-    /// Date pattern component.
-    /// </summary>
-    public string? DatePattern { get; init; }
-
-    /// <summary>
-    /// Time pattern component.
-    /// </summary>
-    public string? TimePattern { get; init; }
-
-    /// <summary>
-    /// Combined date/time pattern.
-    /// </summary>
-    public string? DateTimePattern { get; init; }
-}
-
-/// <summary>
 /// Week information from CLDR.
 /// </summary>
 public sealed class WeekInfo

--- a/Jint/Native/Intl/Data/NumberingSystemData.cs
+++ b/Jint/Native/Intl/Data/NumberingSystemData.cs
@@ -1,4 +1,45 @@
+using System.Runtime.InteropServices;
+
 namespace Jint.Native.Intl.Data;
+
+/// <summary>
+/// A numbering system resolved against <see cref="ICldrProvider.GetNumberingSystemDigits"/> once, while a
+/// formatter is being constructed, so that <c>format()</c> never asks the provider again.
+/// </summary>
+/// <param name="Name">The resolved numbering system, as <c>resolvedOptions()</c> reports it.</param>
+/// <param name="Digits">The ten digits, or null for Latin and for a system the provider does not answer for.</param>
+/// <param name="DecimalSeparator">The separator this system writes, which is '.' unless CLDR says otherwise.</param>
+[StructLayout(LayoutKind.Auto)]
+internal readonly record struct ResolvedNumberingSystem(string Name, string? Digits, char DecimalSeparator)
+{
+    /// <summary>The Latin digits every formatter falls back to; null digits mean "write the string as it is".</summary>
+    public static ResolvedNumberingSystem Latin { get; } = new("latn", Digits: null, DecimalSeparator: '.');
+
+    /// <summary>
+    /// Asks the engine's <see cref="ICldrProvider"/> for the system's digits. Latin is answered inline:
+    /// its digits are the ones the formatter already wrote, so there is nothing to transliterate.
+    /// </summary>
+    public static ResolvedNumberingSystem Resolve(Engine engine, string? numberingSystem)
+    {
+        if (string.IsNullOrEmpty(numberingSystem)
+            || string.Equals(numberingSystem, "latn", StringComparison.OrdinalIgnoreCase))
+        {
+            return Latin;
+        }
+
+        var name = numberingSystem!;
+        var digits = engine.Options.Intl.CldrProvider.GetNumberingSystemDigits(name);
+        return new ResolvedNumberingSystem(name, digits, NumberingSystemData.GetDecimalSeparator(name));
+    }
+
+    /// <summary>True when <see cref="Transliterate"/> can change anything; false for Latin.</summary>
+    public bool RewritesDigits => Digits is not null;
+
+    /// <summary>
+    /// Rewrites the ASCII digits and the decimal point of an already-formatted string in this system.
+    /// </summary>
+    public string Transliterate(string input) => NumberingSystemData.TransliterateDigits(input, Digits, DecimalSeparator);
+}
 
 /// <summary>
 /// Provides digit mappings for numbering systems.
@@ -111,24 +152,16 @@ internal static class NumberingSystemData
     }
 
     /// <summary>
-    /// Transliterates Latin digits (0-9) and decimal separator in the input string to the specified numbering system.
+    /// Transliterates Latin digits (0-9) and the decimal separator in the input string into the digits a
+    /// <see cref="ResolvedNumberingSystem"/> carries. Null digits — Latin, or a system the provider does not
+    /// answer for — leave the string alone.
     /// </summary>
-    public static string TransliterateDigits(string input, string numberingSystem)
+    public static string TransliterateDigits(string input, string? targetDigits, char decimalSeparator)
     {
-        // "latn" is the default - no transliteration needed
-        if (string.Equals(numberingSystem, "latn", StringComparison.OrdinalIgnoreCase))
+        if (targetDigits is null)
         {
             return input;
         }
-
-        if (!Digits.TryGetValue(numberingSystem, out var targetDigits))
-        {
-            // Unknown numbering system - return as-is
-            return input;
-        }
-
-        // Get the decimal separator for this numbering system
-        var decimalSeparator = GetDecimalSeparator(numberingSystem);
 
         // Use a StringBuilder for efficient character replacement
         var sb = new System.Text.StringBuilder(input.Length * 2); // Extra space for surrogate pairs

--- a/Jint/Native/Intl/DateTimeFormatConstructor.cs
+++ b/Jint/Native/Intl/DateTimeFormatConstructor.cs
@@ -186,15 +186,7 @@ internal sealed partial class DateTimeFormatConstructor : Constructor
                 Throw.RangeError(_realm, $"Invalid value '{nsOptionStr}' for option 'numberingSystem'");
             }
             // Validate against supported numbering systems
-            string? validatedOption = null;
-            foreach (var ns in supported)
-            {
-                if (string.Equals(ns, nsOptionStr, StringComparison.OrdinalIgnoreCase))
-                {
-                    validatedOption = ns;
-                    break;
-                }
-            }
+            var validatedOption = ResolveSupportedNumberingSystem(supported, nsOptionStr);
 
             if (validatedOption != null)
             {
@@ -207,15 +199,7 @@ internal sealed partial class DateTimeFormatConstructor : Constructor
             else if (extNumberingSystem != null)
             {
                 // Invalid option, check if extension is valid
-                string? validatedExt = null;
-                foreach (var ns in supported)
-                {
-                    if (string.Equals(ns, extNumberingSystem, StringComparison.OrdinalIgnoreCase))
-                    {
-                        validatedExt = ns;
-                        break;
-                    }
-                }
+                var validatedExt = ResolveSupportedNumberingSystem(supported, extNumberingSystem);
                 if (validatedExt != null)
                 {
                     numberingSystem = validatedExt;
@@ -236,16 +220,8 @@ internal sealed partial class DateTimeFormatConstructor : Constructor
         else if (extNumberingSystem != null)
         {
             // No option, use extension value if supported
-            numberingSystem = null;
-            foreach (var ns in supported)
-            {
-                if (string.Equals(ns, extNumberingSystem, StringComparison.OrdinalIgnoreCase))
-                {
-                    numberingSystem = ns;
-                    preserveNumberingSystemExt = true;
-                    break;
-                }
-            }
+            numberingSystem = ResolveSupportedNumberingSystem(supported, extNumberingSystem);
+            preserveNumberingSystemExt = numberingSystem != null;
         }
         else
         {
@@ -260,14 +236,7 @@ internal sealed partial class DateTimeFormatConstructor : Constructor
             var localeDefault = _engine.Options.Intl.CldrProvider.GetDefaultNumberingSystem(resolvedLocale);
             if (localeDefault is not null && !string.Equals(localeDefault, "latn", StringComparison.OrdinalIgnoreCase))
             {
-                foreach (var ns in supported)
-                {
-                    if (string.Equals(ns, localeDefault, StringComparison.OrdinalIgnoreCase))
-                    {
-                        numberingSystem = ns;
-                        break;
-                    }
-                }
+                numberingSystem = ResolveSupportedNumberingSystem(supported, localeDefault);
             }
         }
 
@@ -498,12 +467,23 @@ internal sealed partial class DateTimeFormatConstructor : Constructor
         // Per ECMA-402, the calendar is always resolved - defaults to "gregory" for most locales
         calendar ??= GetDefaultCalendarForLocale(culture);
 
+        // https://tc39.es/ecma402/#sec-formatdatetimepattern — the month, weekday and day-period names a
+        // pattern writes are locale data. Every one of them is produced by handing a .NET pattern to
+        // this culture, so seeding the culture's own tables is the one place a host's names reach all of
+        // format(), formatToParts() and formatRange() at once, and it happens here, once per formatter,
+        // rather than on the per-format() path.
+        if (ApplyProviderNames(dateTimeFormatInfo, culture.DateTimeFormat, resolvedLocale, calendar))
+        {
+            culture = (CultureInfo) culture.Clone();
+            culture.DateTimeFormat = dateTimeFormatInfo;
+        }
+
         return new JsDateTimeFormat(
             _engine,
             proto,
             resolvedLocale,
             calendar,
-            numberingSystem,
+            Data.ResolvedNumberingSystem.Resolve(_engine, numberingSystem),
             timeZone,
             hourCycle,
             dateStyle,
@@ -522,6 +502,123 @@ internal sealed partial class DateTimeFormatConstructor : Constructor
             hasExplicitFormatComponents,
             dateTimeFormatInfo,
             culture);
+    }
+
+    /// <summary>
+    /// https://tc39.es/ecma402/#table-numbering-system-digits
+    /// Resolves one candidate numbering system to the spelling <c>resolvedOptions()</c> reports, or null
+    /// when nothing can format in it. The advertised list is scanned first because it carries the
+    /// canonical spelling; a system the provider has digits for but does not advertise is still accepted,
+    /// because digits are what formatting actually needs.
+    /// </summary>
+    private string? ResolveSupportedNumberingSystem(IReadOnlyCollection<string> supported, string candidate)
+    {
+        foreach (var ns in supported)
+        {
+            if (string.Equals(ns, candidate, StringComparison.OrdinalIgnoreCase))
+            {
+                return ns;
+            }
+        }
+
+        return IntlUtilities.IsSupportedNumberingSystem(_engine, candidate) ? candidate.ToLowerInvariant() : null;
+    }
+
+    /// <summary>
+    /// Seeds one formatter's <see cref="DateTimeFormatInfo"/> with the month, weekday and day-period names
+    /// the engine's <see cref="ICldrProvider"/> answers with, and reports whether any of them differed from
+    /// what .NET already held. A provider answering with .NET's own names writes nothing — which is exactly
+    /// what <see cref="DefaultCldrProvider"/> does, since it reads them out of this same culture.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The fallback is per group and per style: a host overriding only <see cref="ICldrProvider.GetMonthNames"/>,
+    /// or answering only for <c>"long"</c>, keeps .NET's data for everything else, and so does an answer of the
+    /// wrong length.
+    /// </para>
+    /// <para>
+    /// The narrow styles are deliberately not read. The formatter emits the abbreviated pattern letter
+    /// (<c>MMM</c>, <c>ddd</c>) for <c>narrow</c>, so it has no narrow lane for a provider to feed.
+    /// </para>
+    /// </remarks>
+    private bool ApplyProviderNames(
+        DateTimeFormatInfo target,
+        DateTimeFormatInfo original,
+        string locale,
+        string? calendar)
+    {
+        var provider = _engine.Options.Intl.CldrProvider;
+        var changed = false;
+
+        var longMonths = provider.GetMonthNames(locale, "long", calendar);
+        if (DiffersFrom(longMonths, original.MonthNames, 12))
+        {
+            target.MonthNames = WithTrailingEmpty(longMonths!);
+            target.MonthGenitiveNames = WithTrailingEmpty(longMonths!);
+            changed = true;
+        }
+
+        var shortMonths = provider.GetMonthNames(locale, "short", calendar);
+        if (DiffersFrom(shortMonths, original.AbbreviatedMonthNames, 12))
+        {
+            target.AbbreviatedMonthNames = WithTrailingEmpty(shortMonths!);
+            target.AbbreviatedMonthGenitiveNames = WithTrailingEmpty(shortMonths!);
+            changed = true;
+        }
+
+        var longWeekdays = provider.GetWeekdayNames(locale, "long");
+        if (DiffersFrom(longWeekdays, original.DayNames, 7))
+        {
+            target.DayNames = (string[]) longWeekdays!.Clone();
+            changed = true;
+        }
+
+        var shortWeekdays = provider.GetWeekdayNames(locale, "short");
+        if (DiffersFrom(shortWeekdays, original.AbbreviatedDayNames, 7))
+        {
+            target.AbbreviatedDayNames = (string[]) shortWeekdays!.Clone();
+            changed = true;
+        }
+
+        // The pattern letter is "tt", whose CLDR counterpart is the abbreviated day period.
+        var dayPeriods = provider.GetDayPeriods(locale, "short", calendar);
+        if (dayPeriods is { Length: 2 }
+            && (!string.Equals(dayPeriods[0], original.AMDesignator, StringComparison.Ordinal)
+                || !string.Equals(dayPeriods[1], original.PMDesignator, StringComparison.Ordinal)))
+        {
+            target.AMDesignator = dayPeriods[0];
+            target.PMDesignator = dayPeriods[1];
+            changed = true;
+        }
+
+        return changed;
+    }
+
+    private static bool DiffersFrom(string[]? provided, string[] current, int length)
+    {
+        if (provided is null || provided.Length != length || current.Length < length)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < length; i++)
+        {
+            if (!string.Equals(provided[i], current[i], StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary><see cref="DateTimeFormatInfo"/> month arrays carry thirteen entries, the last one empty.</summary>
+    private static string[] WithTrailingEmpty(string[] months)
+    {
+        var result = new string[13];
+        System.Array.Copy(months, result, 12);
+        result[12] = "";
+        return result;
     }
 
     private string? GetStringOption(ObjectInstance options, string property, in StringSearchValues values, string? fallback)

--- a/Jint/Native/Intl/DateTimeFormatConstructor.cs
+++ b/Jint/Native/Intl/DateTimeFormatConstructor.cs
@@ -472,7 +472,16 @@ internal sealed partial class DateTimeFormatConstructor : Constructor
         // this culture, so seeding the culture's own tables is the one place a host's names reach all of
         // format(), formatToParts() and formatRange() at once, and it happens here, once per formatter,
         // rather than on the per-format() path.
-        if (ApplyProviderNames(dateTimeFormatInfo, culture.DateTimeFormat, resolvedLocale, calendar))
+        //
+        // The shared singleton is recognized by identity and skipped, the way the engine already treats
+        // DefaultCalendarProvider.Instance: it reads these very names out of this very culture, so it can
+        // only ever answer with what is already there, and asking it would cost five provider calls, five
+        // cache-key allocations and four cloned DateTimeFormatInfo arrays to learn nothing. That the two
+        // agree is not assumed — IntlTests.TheDefaultCldrProviderAnswersWithDotNetsOwnDateNames walks every
+        // culture on the machine and compares all five arrays entry by entry.
+        var cldrProvider = _engine.Options.Intl.CldrProvider;
+        if (!ReferenceEquals(cldrProvider, DefaultCldrProvider.Instance)
+            && ApplyProviderNames(cldrProvider, dateTimeFormatInfo, culture.DateTimeFormat, resolvedLocale, calendar))
         {
             culture = (CultureInfo) culture.Clone();
             culture.DateTimeFormat = dateTimeFormatInfo;
@@ -526,9 +535,9 @@ internal sealed partial class DateTimeFormatConstructor : Constructor
 
     /// <summary>
     /// Seeds one formatter's <see cref="DateTimeFormatInfo"/> with the month, weekday and day-period names
-    /// the engine's <see cref="ICldrProvider"/> answers with, and reports whether any of them differed from
-    /// what .NET already held. A provider answering with .NET's own names writes nothing — which is exactly
-    /// what <see cref="DefaultCldrProvider"/> does, since it reads them out of this same culture.
+    /// a host <see cref="ICldrProvider"/> answers with, and reports whether any of them differed from what
+    /// .NET already held. Reached only for a provider the host installed: <see cref="DefaultCldrProvider"/>'s
+    /// shared singleton reads these names out of this same culture, so the caller skips it by identity.
     /// </summary>
     /// <remarks>
     /// <para>
@@ -541,13 +550,13 @@ internal sealed partial class DateTimeFormatConstructor : Constructor
     /// (<c>MMM</c>, <c>ddd</c>) for <c>narrow</c>, so it has no narrow lane for a provider to feed.
     /// </para>
     /// </remarks>
-    private bool ApplyProviderNames(
+    private static bool ApplyProviderNames(
+        ICldrProvider provider,
         DateTimeFormatInfo target,
         DateTimeFormatInfo original,
         string locale,
         string? calendar)
     {
-        var provider = _engine.Options.Intl.CldrProvider;
         var changed = false;
 
         var longMonths = provider.GetMonthNames(locale, "long", calendar);

--- a/Jint/Native/Intl/DateTimeFormatPrototype.cs
+++ b/Jint/Native/Intl/DateTimeFormatPrototype.cs
@@ -299,7 +299,7 @@ internal sealed partial class DateTimeFormatPrototype : Prototype
                 }
 
                 return new JsDateTimeFormat(
-                    _engine, dtf._prototype!, dtf.Locale, dtf.Calendar, dtf.NumberingSystem,
+                    _engine, dtf._prototype!, dtf.Locale, dtf.Calendar, dtf.ResolvedNumberingSystem,
                     dtf.TimeZone, dtf.HourCycle, null, null,
                     null, null, year, month, day, null, null, null, null, null,
                     null, false, dtf.DateTimeFormatInfo, dtf.CultureInfo);
@@ -310,7 +310,7 @@ internal sealed partial class DateTimeFormatPrototype : Prototype
                 || !string.Equals(effectiveTimeStyle, dtf.TimeStyle, StringComparison.Ordinal))
             {
                 return new JsDateTimeFormat(
-                    _engine, dtf._prototype!, dtf.Locale, dtf.Calendar, dtf.NumberingSystem,
+                    _engine, dtf._prototype!, dtf.Locale, dtf.Calendar, dtf.ResolvedNumberingSystem,
                     dtf.TimeZone, dtf.HourCycle, effectiveDateStyle, effectiveTimeStyle,
                     dtf.Weekday, dtf.Era, dtf.Year, dtf.Month, dtf.Day, dtf.DayPeriod,
                     dtf.Hour, dtf.Minute, dtf.Second, dtf.FractionalSecondDigits,
@@ -371,7 +371,7 @@ internal sealed partial class DateTimeFormatPrototype : Prototype
             }
 
             return new JsDateTimeFormat(
-                _engine, dtf._prototype!, dtf.Locale, dtf.Calendar, dtf.NumberingSystem,
+                _engine, dtf._prototype!, dtf.Locale, dtf.Calendar, dtf.ResolvedNumberingSystem,
                 dtf.TimeZone, dtf.HourCycle, null, null,
                 null, era, year, month, day, null, hour, minute, second, null,
                 timeZoneName, false, dtf.DateTimeFormatInfo, dtf.CultureInfo);
@@ -421,7 +421,7 @@ internal sealed partial class DateTimeFormatPrototype : Prototype
         }
 
         return new JsDateTimeFormat(
-            _engine, dtf._prototype!, dtf.Locale, dtf.Calendar, dtf.NumberingSystem,
+            _engine, dtf._prototype!, dtf.Locale, dtf.Calendar, dtf.ResolvedNumberingSystem,
             dtf.TimeZone, dtf.HourCycle, null, null,
             fWeekday, era, fYear, fMonth, fDay, fDayPeriod, fHour, fMinute, fSecond, fFractionalSecondDigits,
             fTimeZoneName, true, dtf.DateTimeFormatInfo, dtf.CultureInfo);
@@ -741,7 +741,7 @@ internal sealed partial class DateTimeFormatPrototype : Prototype
 
         result.CreateDataPropertyOrThrow("calendar", dateTimeFormat.Calendar ?? "gregory");
 
-        result.CreateDataPropertyOrThrow("numberingSystem", dateTimeFormat.NumberingSystem ?? "latn");
+        result.CreateDataPropertyOrThrow("numberingSystem", dateTimeFormat.NumberingSystem);
 
         // timeZone is always present - use local timezone if not specified
         // Convert Windows timezone IDs to IANA format per ECMA-402

--- a/Jint/Native/Intl/DefaultCldrProvider.cs
+++ b/Jint/Native/Intl/DefaultCldrProvider.cs
@@ -11,16 +11,19 @@ namespace Jint.Native.Intl;
 /// <remarks>
 /// <para>
 /// Every member is <c>virtual</c>, so changing one datum means deriving from this class and overriding
-/// that one member. The other twenty are inherited, and nothing has to be delegated by hand.
+/// that one member. The other eighteen are inherited, and nothing has to be delegated by hand.
 /// </para>
 /// <para>
 /// Install the derived instance on <see cref="Options.IntlOptions.CldrProvider"/>; leaving that property
 /// alone keeps <see cref="Instance"/>, the shared singleton every unconfigured engine reads.
 /// </para>
 /// <para>
-/// Overriding a member is not the same as adding data the engine never asks for: six still have no caller
-/// inside Jint — the four that answer for <c>Intl.DateTimeFormat</c>, plus <see cref="GetCompactPatterns"/>
-/// and <see cref="GetNumberingSystemDigits"/> — so overriding one of those changes nothing script can see.
+/// Every member has a caller: whatever this class answers is what <c>Intl</c> shows, and whatever a derived
+/// class answers displaces it. Two narrow gaps are worth knowing about, both of them the engine's rather
+/// than the interface's: <see cref="GetMonthNames"/> and <see cref="GetWeekdayNames"/> are not asked for
+/// <c>"narrow"</c>, because <c>Intl.DateTimeFormat</c> writes the abbreviated name for a narrow style; and
+/// <see cref="GetDayPeriods"/> reaches the component lane (<c>hour</c> with <c>hour12</c>) but not
+/// <c>timeStyle</c>, which writes English AM/PM regardless of any locale data, .NET's included.
 /// </para>
 /// </remarks>
 /// <example>
@@ -218,47 +221,6 @@ public class DefaultCldrProvider : ICldrProvider
     }
 
     /// <inheritdoc />
-    public virtual CompactPatterns? GetCompactPatterns(string locale, string style)
-    {
-        // Use existing CompactPatterns data
-        // The default provider returns English patterns only
-        if (!IsEnglish(locale))
-        {
-            return null;
-        }
-
-        if (string.Equals(style, "short", StringComparison.Ordinal))
-        {
-            return new CompactPatterns
-            {
-                Patterns = new Dictionary<int, string>
-                {
-                    [3] = "{0}K",
-                    [6] = "{0}M",
-                    [9] = "{0}B",
-                    [12] = "{0}T"
-                }
-            };
-        }
-
-        if (string.Equals(style, "long", StringComparison.Ordinal))
-        {
-            return new CompactPatterns
-            {
-                Patterns = new Dictionary<int, string>
-                {
-                    [3] = "{0} thousand",
-                    [6] = "{0} million",
-                    [9] = "{0} billion",
-                    [12] = "{0} trillion"
-                }
-            };
-        }
-
-        return null;
-    }
-
-    /// <inheritdoc />
     public virtual CurrencyData? GetCurrencyData(string locale, string currencyCode)
     {
         return new CurrencyData
@@ -432,13 +394,6 @@ public class DefaultCldrProvider : ICldrProvider
     }
 
     // === Date/Time Formatting ===
-
-    /// <inheritdoc />
-    public virtual DateTimePatterns? GetDateTimePatterns(string locale, string? dateStyle, string? timeStyle)
-    {
-        // Default provider delegates to .NET's DateTimeFormatInfo
-        return null;
-    }
 
     /// <inheritdoc />
     public virtual string[]? GetMonthNames(string locale, string style, string? calendar)

--- a/Jint/Native/Intl/DurationFormatConstructor.cs
+++ b/Jint/Native/Intl/DurationFormatConstructor.cs
@@ -1,6 +1,5 @@
 using System.Globalization;
 using Jint.Native.Function;
-using Jint.Native.Intl.Data;
 using Jint.Native.Object;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
@@ -283,7 +282,7 @@ internal sealed partial class DurationFormatConstructor : Constructor
             Throw.RangeError(_realm, $"Invalid numbering system: {stringValue}");
         }
 
-        // 9.2.7 step 10. ResolveNumberingSystem below probes NumberingSystemData.Digits, which is keyed
+        // 9.2.7 step 10. ResolveNumberingSystem below asks the provider, whose default answers
         // OrdinalIgnoreCase, so an uncanonicalized 'LATN' was accepted and then reported back verbatim
         // from resolvedOptions() as a numbering system identifier that does not exist.
         return IntlUtilities.CanonicalizeUValue("nu", stringValue);
@@ -313,16 +312,17 @@ internal sealed partial class DurationFormatConstructor : Constructor
         return null;
     }
 
-    private static string ResolveNumberingSystem(string? optionValue, string? extensionValue)
+    private string ResolveNumberingSystem(string? optionValue, string? extensionValue)
     {
-        // Options override extension
-        if (optionValue != null && NumberingSystemData.Digits.ContainsKey(optionValue))
+        // Options override extension. A system is supported when the provider can supply its digits —
+        // the embedded table is the default provider's answer, not the engine's own.
+        if (optionValue != null && IntlUtilities.IsSupportedNumberingSystem(_engine, optionValue))
         {
             return optionValue;
         }
 
         // Extension fallback
-        if (extensionValue != null && NumberingSystemData.Digits.ContainsKey(extensionValue))
+        if (extensionValue != null && IntlUtilities.IsSupportedNumberingSystem(_engine, extensionValue))
         {
             return extensionValue;
         }

--- a/Jint/Native/Intl/ICldrProvider.cs
+++ b/Jint/Native/Intl/ICldrProvider.cs
@@ -57,14 +57,6 @@ public interface ICldrProvider
     string? GetDefaultNumberingSystem(string locale);
 
     /// <summary>
-    /// Gets compact number patterns for a locale.
-    /// </summary>
-    /// <param name="locale">The locale identifier.</param>
-    /// <param name="style">Compact display style: "short" or "long".</param>
-    /// <returns>Compact patterns or null if not available.</returns>
-    CompactPatterns? GetCompactPatterns(string locale, string style);
-
-    /// <summary>
     /// Gets the symbols and name <c>Intl.NumberFormat</c> writes beside an amount in this currency.
     /// </summary>
     /// <param name="locale">The locale identifier.</param>
@@ -87,15 +79,6 @@ public interface ICldrProvider
     UnitPatterns? GetUnitPatterns(string locale, string unit, string style);
 
     // === Date/Time Formatting (DateTimeFormat) ===
-
-    /// <summary>
-    /// Gets date/time formatting patterns for a locale.
-    /// </summary>
-    /// <param name="locale">The locale identifier.</param>
-    /// <param name="dateStyle">Date style: "full", "long", "medium", "short", or null.</param>
-    /// <param name="timeStyle">Time style: "full", "long", "medium", "short", or null.</param>
-    /// <returns>DateTime patterns or null if not available.</returns>
-    DateTimePatterns? GetDateTimePatterns(string locale, string? dateStyle, string? timeStyle);
 
     /// <summary>
     /// Gets month names for a locale.

--- a/Jint/Native/Intl/IntlUtilities.cs
+++ b/Jint/Native/Intl/IntlUtilities.cs
@@ -858,6 +858,15 @@ internal static class IntlUtilities
     }
 
     /// <summary>
+    /// https://tc39.es/ecma402/#table-numbering-system-digits
+    /// A numbering system is usable when the engine's <see cref="ICldrProvider"/> can supply its ten digits.
+    /// The embedded table is only what the default provider answers with, so a host that adds a system by
+    /// overriding <see cref="ICldrProvider.GetNumberingSystemDigits"/> gets it accepted here as well.
+    /// </summary>
+    internal static bool IsSupportedNumberingSystem(Engine engine, string numberingSystem)
+        => engine.Options.Intl.CldrProvider.GetNumberingSystemDigits(numberingSystem) is not null;
+
+    /// <summary>
     /// Validates that a string matches the Unicode extension value pattern: (3*8alphanum) *("-" (3*8alphanum))
     /// Only ASCII alphanumeric characters are allowed.
     /// </summary>

--- a/Jint/Native/Intl/JsDateTimeFormat.cs
+++ b/Jint/Native/Intl/JsDateTimeFormat.cs
@@ -16,7 +16,7 @@ internal sealed class JsDateTimeFormat : ObjectInstance
         ObjectInstance prototype,
         string locale,
         string? calendar,
-        string? numberingSystem,
+        in Data.ResolvedNumberingSystem numberingSystem,
         string? timeZone,
         string? hourCycle,
         string? dateStyle,
@@ -39,7 +39,7 @@ internal sealed class JsDateTimeFormat : ObjectInstance
         _prototype = prototype;
         Locale = locale;
         Calendar = calendar;
-        NumberingSystem = numberingSystem;
+        _numberingSystem = numberingSystem;
         TimeZone = timeZone;
         HourCycle = hourCycle;
         DateStyle = dateStyle;
@@ -60,9 +60,14 @@ internal sealed class JsDateTimeFormat : ObjectInstance
         CultureInfo = cultureInfo;
     }
 
+    private readonly Data.ResolvedNumberingSystem _numberingSystem;
+
     internal string Locale { get; }
     internal string? Calendar { get; }
-    internal string? NumberingSystem { get; }
+    internal string NumberingSystem => _numberingSystem.Name;
+
+    /// <summary>The numbering system resolved once at construction, digits and all.</summary>
+    internal Data.ResolvedNumberingSystem ResolvedNumberingSystem => _numberingSystem;
     internal string? TimeZone { get; }
     internal string? HourCycle { get; }
     internal string? DateStyle { get; }
@@ -162,9 +167,9 @@ internal sealed class JsDateTimeFormat : ObjectInstance
         }
 
         // Apply numbering system transliteration if not using Latin digits
-        if (NumberingSystem != null && !string.Equals(NumberingSystem, "latn", StringComparison.OrdinalIgnoreCase))
+        if (_numberingSystem.RewritesDigits)
         {
-            result = Data.NumberingSystemData.TransliterateDigits(result, NumberingSystem);
+            result = _numberingSystem.Transliterate(result);
         }
 
         return result;
@@ -1427,12 +1432,12 @@ internal sealed class JsDateTimeFormat : ObjectInstance
         }
 
         // Apply numbering system transliteration if not using Latin digits
-        if (NumberingSystem != null && !string.Equals(NumberingSystem, "latn", StringComparison.OrdinalIgnoreCase))
+        if (_numberingSystem.RewritesDigits)
         {
             for (var i = 0; i < result.Count; i++)
             {
                 var part = result[i];
-                var transliterated = Data.NumberingSystemData.TransliterateDigits(part.Value, NumberingSystem);
+                var transliterated = _numberingSystem.Transliterate(part.Value);
                 if (!ReferenceEquals(transliterated, part.Value))
                 {
                     result[i] = new DateTimePart(part.Type, transliterated);
@@ -1901,9 +1906,7 @@ internal sealed class JsDateTimeFormat : ObjectInstance
         if (FractionalSecondDigits.HasValue && FractionalSecondDigits.Value > 0)
         {
             // Use the decimal separator for the numbering system (e.g., ٫ for Arabic)
-            var decimalSeparator = NumberingSystem != null
-                ? Data.NumberingSystemData.GetDecimalSeparator(NumberingSystem).ToString()
-                : ".";
+            var decimalSeparator = _numberingSystem.DecimalSeparator.ToString();
             result.Add(new DateTimePart("literal", decimalSeparator));
             // Use % prefix for single-character format to prevent it being interpreted as standard format
             var format = FractionalSecondDigits.Value == 1 ? "%f" : new string('f', FractionalSecondDigits.Value);

--- a/Jint/Native/Intl/JsNumberFormat.cs
+++ b/Jint/Native/Intl/JsNumberFormat.cs
@@ -19,7 +19,7 @@ internal sealed class JsNumberFormat : ObjectInstance
         Engine engine,
         ObjectInstance prototype,
         string locale,
-        string numberingSystem,
+        in Data.ResolvedNumberingSystem numberingSystem,
         string style,
         string? currency,
         string? currencyDisplay,
@@ -46,7 +46,7 @@ internal sealed class JsNumberFormat : ObjectInstance
     {
         _prototype = prototype;
         Locale = locale;
-        NumberingSystem = numberingSystem;
+        _numberingSystem = numberingSystem;
         Style = style;
         Currency = currency;
         CurrencyDisplay = currencyDisplay;
@@ -72,8 +72,10 @@ internal sealed class JsNumberFormat : ObjectInstance
         CultureInfo = cultureInfo;
     }
 
+    private readonly Data.ResolvedNumberingSystem _numberingSystem;
+
     internal string Locale { get; }
-    internal string NumberingSystem { get; }
+    internal string NumberingSystem => _numberingSystem.Name;
     internal string Style { get; }
     internal string? Currency { get; }
     internal string? CurrencyDisplay { get; }
@@ -166,7 +168,7 @@ internal sealed class JsNumberFormat : ObjectInstance
         var result = FormatCore(value);
 
         // Apply numbering system digit transliteration
-        return Data.NumberingSystemData.TransliterateDigits(result, NumberingSystem);
+        return _numberingSystem.Transliterate(result);
     }
 
     private string FormatCore(double value)
@@ -900,7 +902,7 @@ internal sealed class JsNumberFormat : ObjectInstance
             result = NumberFormatInfo.NegativeSign + result;
         }
 
-        return Data.NumberingSystemData.TransliterateDigits(result, NumberingSystem);
+        return _numberingSystem.Transliterate(result);
     }
 
     /// <summary>
@@ -951,7 +953,7 @@ internal sealed class JsNumberFormat : ObjectInstance
         };
 
         // Apply numbering system digit transliteration
-        return Data.NumberingSystemData.TransliterateDigits(result, NumberingSystem);
+        return _numberingSystem.Transliterate(result);
     }
 
     /// <summary>

--- a/Jint/Native/Intl/JsRelativeTimeFormat.cs
+++ b/Jint/Native/Intl/JsRelativeTimeFormat.cs
@@ -13,7 +13,7 @@ internal sealed class JsRelativeTimeFormat : ObjectInstance
         Engine engine,
         ObjectInstance prototype,
         string locale,
-        string numberingSystem,
+        in Data.ResolvedNumberingSystem numberingSystem,
         string style,
         string numeric,
         CultureInfo cultureInfo,
@@ -21,7 +21,7 @@ internal sealed class JsRelativeTimeFormat : ObjectInstance
     {
         _prototype = prototype;
         Locale = locale;
-        NumberingSystem = numberingSystem;
+        _numberingSystem = numberingSystem;
         Style = style;
         Numeric = numeric;
         CultureInfo = cultureInfo;
@@ -33,10 +33,12 @@ internal sealed class JsRelativeTimeFormat : ObjectInstance
     /// </summary>
     internal string Locale { get; }
 
+    private readonly Data.ResolvedNumberingSystem _numberingSystem;
+
     /// <summary>
     /// The numbering system used for formatting digits.
     /// </summary>
-    internal string NumberingSystem { get; }
+    internal string NumberingSystem => _numberingSystem.Name;
 
     /// <summary>
     /// The style: "long", "short", or "narrow".
@@ -123,7 +125,7 @@ internal sealed class JsRelativeTimeFormat : ObjectInstance
             }
 
             var result = pattern.Replace("{0}", formattedNumber);
-            return Data.NumberingSystemData.TransliterateDigits(result, NumberingSystem);
+            return _numberingSystem.Transliterate(result);
         }
 
         // Fallback to hardcoded patterns
@@ -134,17 +136,17 @@ internal sealed class JsRelativeTimeFormat : ObjectInstance
         {
             if (isPast)
             {
-                return Data.NumberingSystemData.TransliterateDigits($"{formattedNumber} {unitName} ago", NumberingSystem);
+                return _numberingSystem.Transliterate($"{formattedNumber} {unitName} ago");
             }
-            return Data.NumberingSystemData.TransliterateDigits($"in {formattedNumber} {unitName}", NumberingSystem);
+            return _numberingSystem.Transliterate($"in {formattedNumber} {unitName}");
         }
 
         // For non-English, use a simple format
         if (isPast)
         {
-            return Data.NumberingSystemData.TransliterateDigits($"-{formattedNumber} {unitName}", NumberingSystem);
+            return _numberingSystem.Transliterate($"-{formattedNumber} {unitName}");
         }
-        return Data.NumberingSystemData.TransliterateDigits($"+{formattedNumber} {unitName}", NumberingSystem);
+        return _numberingSystem.Transliterate($"+{formattedNumber} {unitName}");
     }
 
     /// <summary>

--- a/Jint/Native/Intl/NumberFormatConstructor.cs
+++ b/Jint/Native/Intl/NumberFormatConstructor.cs
@@ -351,7 +351,7 @@ internal sealed partial class NumberFormatConstructor : Constructor
             _engine,
             proto,
             finalResolvedLocale,
-            resolvedNumberingSystem,
+            Data.ResolvedNumberingSystem.Resolve(_engine, resolvedNumberingSystem),
             style,
             currency,
             currencyDisplay,
@@ -452,10 +452,11 @@ internal sealed partial class NumberFormatConstructor : Constructor
         return null;
     }
 
-    private static bool IsSupportedNumberingSystem(string numberingSystem)
+    private bool IsSupportedNumberingSystem(string numberingSystem)
     {
-        // Check if the numbering system is actually supported (has digit mappings)
-        return Data.NumberingSystemData.Digits.ContainsKey(numberingSystem);
+        // A system is supported when the provider can supply its digits — the embedded table is the
+        // default provider's answer, not the engine's own, so a host that adds a system is honoured here.
+        return IntlUtilities.IsSupportedNumberingSystem(_engine, numberingSystem);
     }
 
     private static string RemoveNumberingSystemFromLocale(string locale)

--- a/Jint/Native/Intl/RelativeTimeFormatConstructor.cs
+++ b/Jint/Native/Intl/RelativeTimeFormatConstructor.cs
@@ -71,8 +71,8 @@ internal sealed partial class RelativeTimeFormatConstructor : Constructor
                 Throw.RangeError(_realm, $"Invalid numberingSystem: {numberingSystem}");
             }
 
-            // 9.2.7 step 10. IsSupportedNumberingSystem below is an OrdinalIgnoreCase dictionary probe,
-            // so 'LATN' was accepted and then reported verbatim from resolvedOptions().
+            // 9.2.7 step 10. IsSupportedNumberingSystem below asks the provider, whose default answers
+            // OrdinalIgnoreCase, so 'LATN' was accepted and then reported verbatim from resolvedOptions().
             numberingSystem = IntlUtilities.CanonicalizeUValue("nu", numberingSystem);
         }
 
@@ -163,7 +163,7 @@ internal sealed partial class RelativeTimeFormatConstructor : Constructor
             _engine,
             proto,
             finalResolvedLocale,
-            resolvedNumberingSystem,
+            Data.ResolvedNumberingSystem.Resolve(_engine, resolvedNumberingSystem),
             style,
             numeric,
             culture,
@@ -198,10 +198,11 @@ internal sealed partial class RelativeTimeFormatConstructor : Constructor
         return null;
     }
 
-    private static bool IsSupportedNumberingSystem(string numberingSystem)
+    private bool IsSupportedNumberingSystem(string numberingSystem)
     {
-        // Check if the numbering system is actually supported (has digit mappings)
-        return Data.NumberingSystemData.Digits.ContainsKey(numberingSystem);
+        // A system is supported when the provider can supply its digits — the embedded table is the
+        // default provider's answer, not the engine's own, so a host that adds a system is honoured here.
+        return IntlUtilities.IsSupportedNumberingSystem(_engine, numberingSystem);
     }
 
     private static string RemoveNumberingSystemFromLocale(string locale)

--- a/README.md
+++ b/README.md
@@ -2818,7 +2818,7 @@ data and full IANA timezone DST history are reachable via two pluggable provider
 | Extension point | Default | What it covers | Reusable example |
 | --- | --- | --- | --- |
 | `Options.Temporal.TimeZoneProvider` (`ITimeZoneProvider`) | `DefaultTimeZoneProvider` (BCL `TimeZoneInfo` + Windows↔IANA mapping) | UTC offsets, DST transitions, IANA canonicalization | [`NodaTimeZoneProvider.cs`](Jint.Tests.Test262/NodaTimeZoneProvider.cs) — uses NodaTime TZDB for full historical accuracy |
-| `Options.Intl.CldrProvider` (`ICldrProvider`) | `DefaultCldrProvider` (English + .NET `CultureInfo`) | currency symbols and names, unit patterns, list and relative-time patterns, era names, week info, and the `Intl.supportedValuesOf` lists | [`IcuCldrProvider.cs`](Jint.Tests.Test262/IcuCldrProvider.cs) — uses ICU4N for full CLDR coverage |
+| `Options.Intl.CldrProvider` (`ICldrProvider`) | `DefaultCldrProvider` (English + .NET `CultureInfo`) | currency symbols and names, unit patterns, list and relative-time patterns, month, weekday, day-period and era names, numbering-system digits, week info, and the `Intl.supportedValuesOf` lists | [`IcuCldrProvider.cs`](Jint.Tests.Test262/IcuCldrProvider.cs) — uses ICU4N for full CLDR coverage |
 
 The provider files in `Jint.Tests.Test262/` are **MIT-licensed copy-and-modify templates**,
 not a stable API contract. They are also exactly how the test suite reaches its current

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -67,6 +67,8 @@ This table is filled by the pull request that removes the member. A member that 
 | `ICldrProvider.SelectPluralCategory` (and `DefaultCldrProvider`'s override) | nothing. It took a `double`, which cannot carry the CLDR plural operands — `1` and `1.00` are different categories in most languages and the same `double` — so it could not implement plural selection correctly even if the engine had asked. `Intl.PluralRules`, `Intl.NumberFormat`, `Intl.RelativeTimeFormat` and `Intl.DurationFormat` all use the engine's own operand-aware rules | [#3336](https://github.com/sebastienros/jint/issues/3336) |
 | `ICldrProvider.GetLikelySubtags` (and `DefaultCldrProvider`'s override) | nothing. It expressed only the *maximize* half of the Unicode Add/Remove Likely Subtags algorithm, and `Intl.Locale.prototype.minimize` needs both halves plus subtag-level lookups the signature has no room for. The table is a Unicode constant, not a locale opinion | [#3336](https://github.com/sebastienros/jint/issues/3336) |
 | `WeekInfo.MinimalDays` | nothing. ECMA-402 removed `minimalDays` from `getWeekInfo()`'s result, and test262 asserts the keys are exactly `firstDay` and `weekend`, so no caller could ever have reached it | [#3336](https://github.com/sebastienros/jint/issues/3336) |
+| `ICldrProvider.GetCompactPatterns` and the `CompactPatterns` type (with `DefaultCldrProvider`'s override) | nothing. `CompactPatterns` is a magnitude-to-pattern map with no plural dimension and no digit count, so it cannot express what compact notation actually needs: CLDR keys these patterns by plural category as well as by power of ten (`ru` long is `0 тысяча` / `0 тысячи` / `0 тысяч`), and the zero count in a CLDR pattern (`00 Tsd.`) is the rounding. Compact suffixes come from the engine's embedded table | [#3354](https://github.com/sebastienros/jint/issues/3354) |
+| `ICldrProvider.GetDateTimePatterns` and the `DateTimePatterns` type (with `DefaultCldrProvider`'s override) | nothing. It never had an implementation — the only one in the tree returned `null` unconditionally — so the syntax of its three pattern strings was never fixed, and .NET custom format strings and LDML skeletons disagree on the letters that matter (`yyyy` vs `y`, `tt` vs `a`, `ddd` vs `E`). Wiring it would have meant inventing that contract, and for the `dateStyle`/`timeStyle` pair alone: ECMA-402 resolves both out of the same `availableFormats` skeleton data the component options use, which three strings cannot carry | [#3354](https://github.com/sebastienros/jint/issues/3354) |
 
 ### 2.1 Sealed types
 
@@ -1561,6 +1563,46 @@ might notice:
   string and holds only the result, expecting the operands to become collectable immediately, gets that back
   by reading the result once (`AsString()` is enough) — the node then drops both references.
 
+### 4.28 `Intl` reads the CLDR provider for date names and numbering-system digits ([#3354](https://github.com/sebastienros/jint/issues/3354))
+
+`Intl.DateTimeFormat` took its month, weekday and day-period names straight from .NET's `CultureInfo`, and
+every formatter transliterated digits by looking the numbering system up in an embedded table. Both now go
+through `Options.Intl.CldrProvider` — `GetMonthNames`, `GetWeekdayNames`, `GetDayPeriods` and
+`GetNumberingSystemDigits` — so overriding any of them reaches script:
+
+```c#
+// 5.x — one override, and Intl.DateTimeFormat().format() shows it
+sealed class MyMonths : DefaultCldrProvider
+{
+    public override string[]? GetMonthNames(string locale, string style, string? calendar)
+        => style == "long" && locale.StartsWith("fr")
+            ? ["Nivose", "Pluviose", "Ventose", "Germinal", "Floreal", "Prairial",
+               "Messidor", "Thermidor", "Fructidor", "Vendemiaire", "Brumaire", "Frimaire"]
+            : base.GetMonthNames(locale, style, calendar);
+}
+```
+
+`GetNumberingSystemDigits` is now also what makes a numbering system *usable*: `Intl.NumberFormat`,
+`Intl.RelativeTimeFormat` and `Intl.DurationFormat` accept exactly the systems it answers for, and
+`Intl.DateTimeFormat` accepts those plus whatever `GetSupportedNumberingSystems` advertises. Before this,
+a host could advertise a system through `Intl.supportedValuesOf('numberingSystem')` that every constructor
+then rejected, with nothing able to transliterate it. The provider is asked once, while the formatter is
+being constructed; `format()` reads the resolved digits and never calls the provider.
+
+An engine that configures no provider — or one whose provider derives from `DefaultCldrProvider` — formats
+exactly as it did before. The names `DefaultCldrProvider` answers with are read out of the same
+`CultureInfo` the formatter would otherwise have used, and a provider whose names match .NET's writes
+nothing at all.
+
+**What could break:** a host implementing `ICldrProvider` from scratch rather than deriving from
+`DefaultCldrProvider`. Its `GetMonthNames`, `GetWeekdayNames`, `GetDayPeriods` and
+`GetNumberingSystemDigits` were dead code and are now read. The fallback is per member and per style:
+`null`, or an array of the wrong length, keeps .NET's data, so a provider that answers only for `"long"`
+months keeps .NET's abbreviated ones. Two lanes stay out of reach and are the engine's own gaps rather than
+the interface's — `month: "narrow"` and `weekday: "narrow"`, which the formatter renders with the
+abbreviated pattern letter, and `timeStyle`, which writes English `AM`/`PM` regardless of any locale data,
+.NET's included.
+
 ## 5. New in v5
 
 Everything in the table below is opt-in: nothing in it is installed unless the host asks for it, so
@@ -1685,7 +1727,7 @@ which is at least a failure you can see. It does nothing to a project that annot
 
 `DefaultCldrProvider`, `DefaultTimeZoneProvider` and `DefaultCalendarProvider` were `sealed`, so a host that
 disagreed with one currency name, one time zone alias or one calendar had to implement the whole interface —
-21, 9 and 4 members — and hand-delegate every member it did not care about to the singleton. Miss one and the
+19, 9 and 4 members — and hand-delegate every member it did not care about to the singleton. Miss one and the
 engine silently loses a datum it used to have.
 
 All three are now unsealed with `virtual` members, matching `DefaultTimeSystem`, which has always had that
@@ -1694,7 +1736,7 @@ shape. Nothing about an unconfigured engine changed: the `Options` properties st
 and answers inline rather than going through the interface.
 
 ```c#
-// 5.x — the other twenty members are inherited
+// 5.x — the other eighteen members are inherited
 sealed class MyCldr : DefaultCldrProvider
 {
     public override string? GetCurrencyDisplayName(string locale, string code)
@@ -1704,14 +1746,13 @@ sealed class MyCldr : DefaultCldrProvider
 var engine = new Engine(options => options.Intl.CldrProvider = new MyCldr());
 ```
 
-Two limits are worth knowing before reaching for this. Six of `ICldrProvider`'s twenty-one members have no
-caller inside Jint today — `GetMonthNames`, `GetWeekdayNames`, `GetDayPeriods`, `GetDateTimePatterns`,
-`GetCompactPatterns` and `GetNumberingSystemDigits` — so overriding one of those changes nothing script can
-observe until the engine starts consulting it; [#3336](https://github.com/sebastienros/jint/issues/3336)
-tracks the remaining six, and wired `GetCurrencyData` and `GetWeekInfo` on the way, per
-[4.21](#422-intl-reads-the-cldr-provider-for-currency-symbols-and-week-info). And on the calendar side, *correcting* a calendar Jint already
-knows is one override, while *adding* one it does not know is four: `IsSupported`, `GetSupportedCalendars` and
-both conversions all have to answer for the new identifier.
+`ICldrProvider` is now nineteen members and every one of them has a caller, so whatever a derived class
+answers is what `Intl` shows — see [4.22](#422-intl-reads-the-cldr-provider-for-currency-symbols-and-week-info)
+and [4.28](#428-intl-reads-the-cldr-provider-for-date-names-and-numbering-system-digits) for the two changes
+that closed the gap, and section [2](#2-removed-api) for the two members that went instead of being wired.
+On the calendar side, *correcting* a calendar Jint already knows is one override, while *adding* one it does
+not know is four: `IsSupported`, `GetSupportedCalendars` and both conversions all have to answer for the new
+identifier.
 
 ### 5.3 Host objects: one hook set for named properties ([#3338](https://github.com/sebastienros/jint/pull/3338))
 


### PR DESCRIPTION
Fixes #3354.

`ICldrProvider` had six members with no caller inside Jint. Four are wired here and two are removed; nothing is left deferred.

## The failing tests, first

`Jint.Tests.PublicInterface/HostLocaleProviderTests.cs` gains four host providers, each overriding exactly one of the four members and nothing else. Against `main`:

```
  Failed Jint.Tests.PublicInterface.HostLocaleProviderTests.OverridingOneNumberingSystemsDigitsMakesItUsable [1 ms]
   Expected engine.Evaluate("new Intl.NumberFormat('en', { numberingSystem: 'lettera' }).format(1024)").AsString() to be the same string, but they differ at index 0:
   ↓ (actual)
  "1,024"
  "B,ACE"
   ↑ (expected).

  Failed Jint.Tests.PublicInterface.HostLocaleProviderTests.OverridingOneMonthNameReachesDateTimeFormat [1 ms]
   Expected engine.Evaluate("new Intl.DateTimeFormat('en', { month: 'long', timeZone: 'UTC' }).format(Date.UTC(2024, 0, 15))").AsString() to be the same string, but they differ at index 0:
   ↓ (actual)
  "January"
  "Nivose"
   ↑ (expected).

  Failed Jint.Tests.PublicInterface.HostLocaleProviderTests.OverridingOneWeekdayNameReachesDateTimeFormat [1 ms]
   Expected engine.Evaluate("new Intl.DateTimeFormat('en', { weekday: 'long', timeZone: 'UTC' }).format(Date.UTC(2024, 0, 15))").AsString() to be the same string, but they differ at index 2:
     ↓ (actual)
  "Monday"
  "Moonday"
     ↑ (expected).

  Failed Jint.Tests.PublicInterface.HostLocaleProviderTests.OverridingOneDayPeriodReachesDateTimeFormat [215 ms]
   Expected engine.Evaluate("new Intl.DateTimeFormat('en', { hour: 'numeric', hour12: true, timeZone: 'UTC' }).format(Date.UTC(2024, 0, 15, 15, 30))").AsString() to be the same string, but they differ at index 2:
     ↓ (actual)
  "3 PM"
  "3 EVE"
     ↑ (expected).
```

## The six, member by member

| Member | Verdict | Reason |
| --- | --- | --- |
| `GetNumberingSystemDigits` | **wired** | It is now what makes a numbering system *usable*, not merely what spells it. See below. |
| `GetMonthNames` | **wired** | Seeds the formatter's `DateTimeFormatInfo.MonthNames` / `AbbreviatedMonthNames` (and their genitive twins) at construction. |
| `GetWeekdayNames` | **wired** | Seeds `DayNames` / `AbbreviatedDayNames`. |
| `GetDayPeriods` | **wired** | Seeds `AMDesignator` / `PMDesignator`. |
| `GetCompactPatterns` (and the `CompactPatterns` type) | **removed** | `CompactPatterns` is a magnitude-to-pattern map with no plural dimension and no digit count, so it cannot carry what compact notation needs. CLDR keys these patterns by plural category as well as by power of ten — `ru` long is `0 тысяча` / `0 тысячи` / `0 тысяч` at the same magnitude — and the zero count in a CLDR pattern (`00 Tsd.`) *is* the rounding, which a `{0}` placeholder erases. It is the same shape of argument #3357 made for `SelectPluralCategory`. |
| `GetDateTimePatterns` (and the `DateTimePatterns` type) | **removed** | It never had an implementation: the only one in the tree returned `null` unconditionally, so the syntax of its three pattern strings was never fixed, and .NET custom format strings and LDML skeletons disagree on the letters that matter (`yyyy` vs `y`, `tt` vs `a`, `ddd` vs `E`). Wiring it would mean inventing that contract, and for the `dateStyle`/`timeStyle` pair alone — [ECMA-402 §11.1.2](https://tc39.es/ecma402/#sec-initializedatetimeformat) resolves both out of the same `availableFormats` skeleton data the component options use, which three strings cannot carry. |

## `GetNumberingSystemDigits`

`GetSupportedNumberingSystems` was already wired, so a host could list a system through `Intl.supportedValuesOf('numberingSystem')` that `new Intl.NumberFormat('en', { numberingSystem: 'x' })` then rejected — `IsSupportedNumberingSystem` probed the embedded `NumberingSystemData.Digits`, not the provider — and that nothing could have transliterated even if it had been accepted.

The rule now is that **digits are what a numbering system is**. `Intl.NumberFormat`, `Intl.RelativeTimeFormat` and `Intl.DurationFormat` accept exactly the systems `GetNumberingSystemDigits` answers for. `Intl.DateTimeFormat` scans `GetSupportedNumberingSystems()` first — that list carries the canonical spelling `resolvedOptions().numberingSystem` reports — and falls back to a digits probe for a system the provider has digits for but does not advertise.

The digits and the decimal separator are resolved into a `ResolvedNumberingSystem` **once, in the constructor**, and the formatter carries it; `format()` reads the resolved string and never calls the provider. `NumberingSystemData.TransliterateDigits` now takes the digits rather than the system's name.

## The three `Intl.DateTimeFormat` name groups

Everything `JsDateTimeFormat` writes — the string lane, the parts lane, `dateStyle`'s `"D"` pattern, `formatRange` — is produced by `dateTime.ToString(<pattern>, CultureInfo)`. That culture is the one seam every name passes through, so the provider seeds it in `DateTimeFormatConstructor`, once per formatter, and the ten name-producing sites need no changes at all.

**The fallback rule: per member and per style, never all-or-nothing.** Each group is asked for separately; a `null` answer, or an array of the wrong length, leaves .NET's value in place. So a host that overrides only `GetMonthNames`, or answers only for `"long"`, keeps .NET's data for everything else. And a group is written *only when it differs* from what .NET already held, so a provider agreeing with .NET writes nothing and the `CultureInfo` is not even cloned.

Two lanes stay out of reach, and both are the engine's own gaps rather than the interface's. They are stated in `DefaultCldrProvider`'s class docs and in the migration guide, and each is filed:

- `month: "narrow"` and `weekday: "narrow"` render with the *abbreviated* pattern letter (`MMM`, `ddd`), so there is no narrow lane for a provider to feed. Wiring the provider into it would have changed default output (`"Jan"` → `"J"`), which is a conformance fix that wants its own change (#3398).
- `timeStyle` writes English `AM`/`PM` from two hardcoded literals, ignoring .NET's designators as much as the provider's (#3399).

## Default-engine output is unchanged

Not asserted — checked, and in two of the three cases it is an identity rather than a comparison.

- **Numbering systems.** `DefaultCldrProvider.GetSupportedNumberingSystems()` is `NumberingSystemData.Digits.Keys` and `GetNumberingSystemDigits` is `NumberingSystemData.Digits.TryGetValue`, against the same `OrdinalIgnoreCase` dictionary. The acceptance test is therefore the same predicate over the same 85 keys, and `Intl.DateTimeFormat`'s new fallback arm is reachable only for a candidate absent from that key set — which is exactly the set the digits probe answers `null` for, so on a default engine that arm is dead by construction. The new `EveryAdvertisedNumberingSystemHasDigitsAndIsAccepted` walks all 85 and asserts each has digits and is accepted by all four constructors.
- **Date names.** The new `TheDefaultCldrProviderAnswersWithDotNetsOwnDateNames` walks **605 specific cultures** the machine has and compares, entry by entry, all five arrays the seeding reads (12 long months, 12 abbreviated months, 7 long weekdays, 7 abbreviated weekdays, 2 day periods) against the `DateTimeFormatInfo` the formatter would otherwise have used. Every one matches, which is what makes the seeding a no-op: nothing is written, so the formatter keeps the very `CultureInfo` instance it held before.
- **Compact patterns.** The removed `DefaultCldrProvider.GetCompactPatterns` had no caller, so nothing read it. The compact suffixes `Intl.NumberFormat` writes come from `Jint/Native/Intl/Data/CompactPatterns.cs`, which is untouched.

## Hot paths, and what a default construction pays

Nothing lands on a per-`format()` path. Both wirings are read in a constructor, and the transliteration that used to do a dictionary probe per `format()` call now reads a field.

The first revision of this branch asked the provider for five name groups on *every* `Intl.DateTimeFormat` construction and compared each against .NET's, writing only what differed. Writing nothing is cheap; asking was not — five cache-key string concatenations, five `ConcurrentDictionary` probes each allocating a closure, and four `DateTimeFormatInfo` array getters, every one of which clones. Measured with `GC.GetAllocatedBytesForCurrentThread` (deterministic, unlike wall clock on a shared machine), 200,000 constructions per row, best of three:

| `new Intl.…` | `main` | asking the default provider | skipping it by identity |
| --- | ---: | ---: | ---: |
| `DateTimeFormat('en')` | 2,624 B | 3,408 B (**+29.9%**) | **2,640 B (+0.6%)** |
| `DateTimeFormat('en', {y,m,d})` | 2,624 B | 3,408 B (+29.9%) | 2,640 B (+0.6%) |
| `DateTimeFormat('de-DE')` | 2,872 B | 3,696 B (+28.7%) | 2,888 B (+0.6%) |
| `NumberFormat('en')` | 1,920 B | 1,936 B | 1,936 B (+0.8%) |
| `RelativeTimeFormat('en')` | 2,912 B | 2,944 B | 2,944 B (+1.1%) |
| `Collator('en')` — control | 1,056 B | 1,056 B | 1,056 B (0) |
| `ListFormat('en')` — control | 872 B | 872 B | 872 B (0) |

So `DefaultCldrProvider.Instance` is now **recognized by identity and skipped**, exactly as the engine already treats `DefaultCalendarProvider.Instance`: it reads those names out of the very culture the formatter would otherwise have used, so it cannot answer with anything else. That is not assumed — `TheDefaultCldrProviderAnswersWithDotNetsOwnDateNames` walks all 605 cultures on the machine and compares the five arrays entry by entry, and its doc comment now says it is the guard on this shortcut.

The default path is a single reference comparison. What is left is **+16 bytes per formatter**: the `ResolvedNumberingSystem` struct replacing a `string?` field on `JsNumberFormat`, `JsDateTimeFormat` and `JsRelativeTimeFormat` — which is what buys the removal of a dictionary probe from every `format()` call. `RelativeTimeFormat` pays 32 because it builds a `NumberFormat` of its own. The two controls, which this branch does not touch, are byte-identical.

A host that installs its own provider still pays the comparison; that is the feature working, and it is the configuration the conformance suite runs in.

Wall clock says nothing useful about any of this on a shared box: across three alternating branch/`main` pairs, the untouched `Collator` and `ListFormat` controls swung −11% and +19%, an envelope that swamps every touched row. Which is also the answer to the `intl402/constructors-string-and-single-element-array.js` timeout: that file makes **468 construction attempts, of which 132 succeed**. At the per-construction cost measured here, 30 seconds would require ~64 ms each, three orders of magnitude above anything either side does.

`GetUnitPatterns`, `GetEraNames`, `GetListPatterns` and `GetRelativeTimePatterns` are still the four that are read per `format()` call, and are untouched.

## Also here

- `Jint.Tests.Test262/IcuCldrProvider.cs` loses the same two members. Its `GetMonthNames`/`GetWeekdayNames`/`GetDayPeriods` delegate to `DefaultCldrProvider`, so the seeding is a no-op there too; its `GetNumberingSystemDigits` goes through ICU, which is now what the conformance run's formatters transliterate with.
- `ICldrProvider` is 19 members, and every one of them has a caller.
- The five API baselines lose 12 declarations each; `UndocumentedPublicApi.txt` goes 634 → 632.
- `docs/v5-migration.md` gains two §2 rows and §4.28, and §5.2's "six have no caller" paragraph is now false and says so instead. README's provider table now names the date data and the digits.
- `Intl.DurationFormat` still does not transliterate at all — its `numberingSystem` reaches `resolvedOptions()` and nothing else. Pre-existing and unchanged here; filed as #3400.

## Verification

- `dotnet build -c Release` clean, 0 warnings.
- `Jint.Tests`: 10,747 passed on `net10.0` and `net8.0`, 7,371 on `net472`, 0 failed.
- `Jint.Tests.PublicInterface`: 3,002 passed on `net10.0`, 2,373 on `net472`, 0 failed.
- `Jint.Tests.Test262`: **102,495 passed, 0 failed**, 189 skipped, 102,684 total — the number `main` holds, re-run after the identity shortcut. `intl402` is generated and included, and this change is squarely in it (6,592 of those passes are `intl402`); `intl402/constructors-string-and-single-element-array.js` is among them.
