### PR TITLE
Temporal: a calendar the provider claims is a calendar Temporal accepts, and adding one is three overrides

### DIFF
--- a/Jint.Tests.PublicInterface/HostLocaleProviderTests.cs
+++ b/Jint.Tests.PublicInterface/HostLocaleProviderTests.cs
@@ -1,5 +1,6 @@
 #nullable enable
 
+using System.Globalization;
 using System.Numerics;
 using Jint.Native.Intl;
 using Jint.Native.Temporal;
@@ -203,6 +204,68 @@ public class HostLocaleProviderTests
     }
 
     [Fact]
+    public void AddingACalendarTheEngineHasNeverSeenIsThreeOverrides()
+    {
+        var engine = new Engine(options => options.Temporal.CalendarProvider = new WithMayan());
+
+        // the identifier is valid everywhere a calendar identifier can appear
+        engine.Evaluate("Temporal.PlainDate.from('2024-03-05').withCalendar('mayan').year").AsNumber().Should().Be(5138);
+        engine.Evaluate("Temporal.PlainDate.from('2024-03-05').withCalendar('mayan').toString()")
+            .AsString().Should().Be("2024-03-05[u-ca=mayan]");
+        engine.Evaluate("Temporal.PlainDate.from({ year: 5138, monthCode: 'M03', day: 5, calendar: 'mayan' }).toString()")
+            .AsString().Should().Be("2024-03-05[u-ca=mayan]");
+        engine.Evaluate("Temporal.PlainDate.from('2024-03-05[u-ca=mayan]').year").AsNumber().Should().Be(5138);
+        engine.Evaluate("Temporal.PlainDateTime.from('2024-03-05T12:00[u-ca=mayan]').year").AsNumber().Should().Be(5138);
+        engine.Evaluate("Temporal.ZonedDateTime.from('2024-03-05T12:00[UTC][u-ca=mayan]').year").AsNumber().Should().Be(5138);
+
+        // …and every field accessor reads it through the two conversions
+        engine.Evaluate("Temporal.PlainDate.from('2024-03-05').withCalendar('mayan').monthCode").AsString().Should().Be("M03");
+        engine.Evaluate("Temporal.PlainDate.from('2024-03-05').withCalendar('mayan').daysInMonth").AsNumber().Should().Be(31);
+        engine.Evaluate("Temporal.PlainDate.from('2024-03-05').withCalendar('mayan').inLeapYear").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Temporal.PlainDate.from('2024-03-05').withCalendar('mayan').with({ day: 10 }).toString()")
+            .AsString().Should().Be("2024-03-10[u-ca=mayan]");
+        engine.Evaluate("Temporal.PlainYearMonth.from({ year: 5138, monthCode: 'M03', calendar: 'mayan' }).toString()")
+            .AsString().Should().Be("2024-03-01[u-ca=mayan]");
+        engine.Evaluate("Temporal.PlainMonthDay.from({ monthCode: 'M03', day: 5, calendar: 'mayan' }).toString()")
+            .AsString().Should().Be("1972-03-05[u-ca=mayan]");
+
+        // every calendar the subclass does not claim still reads the inherited BCL-backed arithmetic
+        var stock = new Engine();
+        foreach (var calendar in new[] { "islamic-civil", "coptic", "persian", "indian", "hebrew" })
+        {
+            var script = $"Temporal.PlainDate.from('2024-03-05').withCalendar('{calendar}').toString()";
+            engine.Evaluate(script).AsString().Should().Be(stock.Evaluate(script).AsString());
+        }
+    }
+
+    /// <summary>
+    /// Calendar arithmetic is implemented per calendar inside the engine and is not routed through
+    /// <see cref="ICalendarProvider"/>, so a calendar a host added has none. What this pins is that the
+    /// refusal is a <c>RangeError</c> a script can catch, rather than a <see cref="NotSupportedException"/>
+    /// escaping <c>Engine.Evaluate</c> as it did before.
+    /// </summary>
+    [Fact]
+    public void AHostCalendarHasNoArithmeticAndSaysSoInJavaScript()
+    {
+        var engine = new Engine(options => options.Temporal.CalendarProvider = new WithMayan());
+
+        foreach (var script in new[]
+        {
+            "Temporal.PlainDate.from('2024-03-05').withCalendar('mayan').add({ days: 1 })",
+            "Temporal.PlainDate.from('2024-03-05').withCalendar('mayan').subtract({ months: 1 })",
+            "Temporal.PlainDate.from('2024-03-05').withCalendar('mayan').until(Temporal.PlainDate.from('2024-05-05').withCalendar('mayan'))",
+        })
+        {
+            engine.Evaluate($"(function () {{ try {{ {script}; return 'no error'; }} catch (e) {{ return e.constructor.name + ': ' + e.message; }} }})()")
+                .AsString().Should().Be("RangeError: Calendar arithmetic is not implemented for 'mayan'");
+        }
+
+        // the calendars the engine implements itself are unaffected
+        engine.Evaluate("Temporal.PlainDate.from('2024-03-05').withCalendar('hebrew').add({ months: 1 }).toString()")
+            .AsString().Should().Be(new Engine().Evaluate("Temporal.PlainDate.from('2024-03-05').withCalendar('hebrew').add({ months: 1 }).toString()").AsString());
+    }
+
+    [Fact]
     public void AnEngineThatConfiguresNothingStillReadsTheSharedSingletons()
     {
         var options = new Options();
@@ -296,6 +359,46 @@ file sealed class ShiftedHebrewEra : DefaultCalendarProvider
 
 /// <summary>
 /// Present only to be compiled: the compiler is the only thing that checks that all nineteen are virtual.
+/// A calendar Jint has never heard of, defined as ISO shifted by the Mayan Long Count epoch so the
+/// arithmetic is checkable by eye. The two conversions are the whole subclass: nobody but the host can
+/// convert a calendar the engine does not know, and everything else about it is inherited.
+/// </summary>
+file sealed class WithMayan : DefaultCalendarProvider
+{
+    private const int EpochOffset = 3114;
+
+    public override IReadOnlyCollection<string> GetSupportedCalendars()
+        => [.. base.GetSupportedCalendars(), "mayan"];
+
+    public override CalendarFields IsoToCalendarFields(string calendar, int isoYear, int isoMonth, int isoDay)
+    {
+        if (!string.Equals(calendar, "mayan", StringComparison.Ordinal))
+        {
+            return base.IsoToCalendarFields(calendar, isoYear, isoMonth, isoDay);
+        }
+
+        var leap = DateTime.IsLeapYear(isoYear);
+        return new CalendarFields(
+            isoYear + EpochOffset, isoMonth, $"M{isoMonth:D2}", isoDay,
+            IsLeapMonth: false, MonthsInYear: 12, DaysInMonth: DateTime.DaysInMonth(isoYear, isoMonth),
+            DaysInYear: leap ? 366 : 365, InLeapYear: leap);
+    }
+
+    public override IsoDateFields? CalendarFieldsToIso(string calendar, int year, string? monthCode, int month, int day, string overflow)
+    {
+        if (!string.Equals(calendar, "mayan", StringComparison.Ordinal))
+        {
+            return base.CalendarFieldsToIso(calendar, year, monthCode, month, day, overflow);
+        }
+
+        var resolved = monthCode is not null ? int.Parse(monthCode.Substring(1), CultureInfo.InvariantCulture) : month;
+        return new IsoDateFields(year - EpochOffset, resolved, day);
+    }
+}
+
+/// <summary>
+/// Present only to be compiled: a host reaching a member the engine never consults still has to be able
+/// to override it, and the compiler is the only thing that checks that all twenty-one are virtual.
 /// </summary>
 file sealed class EveryCldrMemberOverridden : DefaultCldrProvider
 {

--- a/Jint.Tests/Runtime/TemporalCalendarProviderTests.cs
+++ b/Jint.Tests/Runtime/TemporalCalendarProviderTests.cs
@@ -1,0 +1,75 @@
+using Jint.Native.Temporal;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// <c>Temporal</c> now puts a calendar identifier its own table does not name to
+/// <see cref="ICalendarProvider.IsSupported"/>, and <see cref="DefaultCalendarProvider.IsSupported"/> answers
+/// from <see cref="DefaultCalendarProvider.GetSupportedCalendars"/> rather than from a second hardcoded list.
+/// Both are only reachable once a host installs a provider of its own, and both have to leave an
+/// unconfigured engine exactly where it was — which is what these check, identifier by identifier.
+/// </summary>
+public class TemporalCalendarProviderTests
+{
+    private static readonly string[] TheElevenNonIsoCalendars =
+    [
+        "chinese", "dangi", "hebrew", "persian",
+        "coptic", "ethiopic", "ethioaa", "indian",
+        "islamic-umalqura", "islamic-civil", "islamic-tbla",
+    ];
+
+    /// <summary>
+    /// The list-backed <c>IsSupported</c> replaced a switch over these same eleven identifiers. Equal sets
+    /// is the whole reason the replacement is invisible, so the two are compared entry by entry rather than
+    /// spot-checked.
+    /// </summary>
+    [Fact]
+    public void TheDefaultProviderClaimsExactlyTheElevenCalendarsTheEngineImplements()
+    {
+        var provider = DefaultCalendarProvider.Instance;
+
+        provider.GetSupportedCalendars().Should().BeEquivalentTo(TheElevenNonIsoCalendars);
+
+        foreach (var calendar in TheElevenNonIsoCalendars)
+        {
+            provider.IsSupported(calendar).Should().BeTrue(calendar);
+        }
+
+        foreach (var other in new[]
+        {
+            "iso8601", "gregory", "buddhist", "japanese", "roc", "islamic", "islamic-rgsa",
+            "ethiopic-amete-alem", "islamicc", "gregorian", "mayan", "", "CHINESE",
+        })
+        {
+            provider.IsSupported(other).Should().BeFalse(other);
+        }
+    }
+
+    /// <summary>
+    /// The provider is consulted for an identifier only when the host installed one of its own; an engine
+    /// that configures nothing keeps the fixed table, so a calendar nobody implements is still a RangeError.
+    /// </summary>
+    [Fact]
+    public void AnUnconfiguredEngineStillRefusesACalendarNobodyImplements()
+    {
+        var engine = new Engine();
+
+        foreach (var script in new[]
+        {
+            "Temporal.PlainDate.from('2024-03-05').withCalendar('mayan')",
+            "Temporal.PlainDate.from({ year: 2024, month: 3, day: 5, calendar: 'mayan' })",
+            "Temporal.PlainDate.from('2024-03-05[u-ca=mayan]')",
+        })
+        {
+            engine.Evaluate($"(function () {{ try {{ {script}; return 'no error'; }} catch (e) {{ return e.constructor.name; }} }})()")
+                .AsString().Should().Be("RangeError", script);
+        }
+
+        // and the two the specification lists but Temporal refuses are still refused
+        foreach (var calendar in new[] { "islamic", "islamic-rgsa" })
+        {
+            engine.Evaluate($"(function () {{ try {{ Temporal.PlainDate.from({{ year: 2024, month: 3, day: 5, calendar: '{calendar}' }}); return 'no error'; }} catch (e) {{ return e.constructor.name; }} }})()")
+                .AsString().Should().Be("RangeError", calendar);
+        }
+    }
+}

--- a/Jint/Native/Temporal/DefaultCalendarProvider.cs
+++ b/Jint/Native/Temporal/DefaultCalendarProvider.cs
@@ -14,13 +14,25 @@ namespace Jint.Native.Temporal;
 /// property alone keeps <see cref="Instance"/>, which the engine recognizes by identity and answers inline.
 /// </para>
 /// <para>
-/// Range-limited per the underlying BCL calendars. Adding a calendar Jint does not know is not a
-/// one-member job: <see cref="IsSupported"/>, <see cref="GetSupportedCalendars"/> and both conversions
-/// all have to answer for it, or the inherited conversion throws on an identifier it has never seen.
+/// Range-limited per the underlying BCL calendars. <em>Adding</em> a calendar Jint does not know is three
+/// overrides, and no fewer: <see cref="GetSupportedCalendars"/>, which is what makes the identifier valid
+/// anywhere in <c>Temporal</c>, and both conversions, which nobody but the host can perform for a calendar
+/// the engine has never heard of. The inherited <see cref="IsSupported"/> reads the list, so the two answer
+/// consistently without the host keeping them in step; override it as well only to make the membership test
+/// cheaper than a scan of the list.
+/// </para>
+/// <para>
+/// A calendar added this way reaches construction from fields and from a <c>[u-ca=…]</c> annotation, every
+/// field accessor, <c>with</c>, <c>toString</c> and the <c>PlainYearMonth</c> / <c>PlainMonthDay</c>
+/// conversions. It does not reach calendar arithmetic — <c>add</c>, <c>subtract</c>, <c>until</c>,
+/// <c>since</c> — which is implemented per calendar inside the engine and raises a <c>RangeError</c> for a
+/// calendar it does not implement; nor <c>Intl.DateTimeFormat</c>, which has its own calendar list, so
+/// <c>toLocaleString</c> on such a date raises a <c>RangeError</c> too.
 /// </para>
 /// </remarks>
 /// <example>
 /// <code>
+/// // Correcting a calendar Jint already knows: one override.
 /// sealed class AstronomicalPersian : DefaultCalendarProvider
 /// {
 ///     public override IsoDateFields? CalendarFieldsToIso(
@@ -29,6 +41,14 @@ namespace Jint.Native.Temporal;
 /// }
 ///
 /// options.Temporal.CalendarProvider = new AstronomicalPersian();
+///
+/// // Adding one it does not know: the list, plus the two conversions.
+/// sealed class WithMayan : DefaultCalendarProvider
+/// {
+///     public override IReadOnlyCollection&lt;string&gt; GetSupportedCalendars() => [.. base.GetSupportedCalendars(), "mayan"];
+///     public override CalendarFields IsoToCalendarFields(string calendar, int isoYear, int isoMonth, int isoDay) => …;
+///     public override IsoDateFields? CalendarFieldsToIso(string calendar, int year, string? monthCode, int month, int day, string overflow) => …;
+/// }
 /// </code>
 /// </example>
 public class DefaultCalendarProvider : ICalendarProvider
@@ -49,7 +69,40 @@ public class DefaultCalendarProvider : ICalendarProvider
     protected DefaultCalendarProvider() { }
 
     /// <inheritdoc />
-    public virtual bool IsSupported(string calendar) => NonIsoCalendars.IsNonIsoCalendar(calendar);
+    /// <remarks>
+    /// Answered from <see cref="GetSupportedCalendars"/>, so a derived provider that adds a calendar to the
+    /// list does not also have to remember to claim it here. That means the list is read on a Temporal
+    /// validation path: return a cached collection from <see cref="GetSupportedCalendars"/>, and override
+    /// this member too if the list is long enough that scanning it matters.
+    /// </remarks>
+    public virtual bool IsSupported(string calendar)
+    {
+        var supported = GetSupportedCalendars();
+
+        // The default is a string[], which iterates without allocating an enumerator.
+        if (supported is string[] array)
+        {
+            foreach (var candidate in array)
+            {
+                if (string.Equals(candidate, calendar, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        foreach (var candidate in supported)
+        {
+            if (string.Equals(candidate, calendar, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     /// <inheritdoc />
     public virtual IReadOnlyCollection<string> GetSupportedCalendars() => SupportedCalendars;

--- a/Jint/Native/Temporal/ICalendarProvider.cs
+++ b/Jint/Native/Temporal/ICalendarProvider.cs
@@ -17,9 +17,21 @@ namespace Jint.Native.Temporal;
 public interface ICalendarProvider
 {
     /// <summary>Returns true if this provider can handle the given calendar identifier.</summary>
+    /// <remarks>
+    /// Asked on every non-ISO calendar operation, so keep it cheap. <see cref="DefaultCalendarProvider"/>
+    /// answers it from <see cref="GetSupportedCalendars"/>, which is what keeps the two consistent.
+    /// </remarks>
     bool IsSupported(string calendar);
 
     /// <summary>Returns all calendar identifiers this provider supports.</summary>
+    /// <remarks>
+    /// This list is what makes an identifier <c>Temporal</c> does not implement itself a valid one: a
+    /// calendar named here is accepted by <c>Temporal.PlainDate.from</c>, <c>withCalendar</c> and a
+    /// <c>[u-ca=…]</c> annotation, and its conversions are then asked of this provider. It is read on a
+    /// validation path — return a cached collection rather than building one per call.
+    /// It does not feed <c>Intl.supportedValuesOf('calendar')</c>, which is
+    /// <see cref="Intl.ICldrProvider.GetSupportedCalendars"/>'s answer.
+    /// </remarks>
     IReadOnlyCollection<string> GetSupportedCalendars();
 
     /// <summary>

--- a/Jint/Native/Temporal/NonIsoCalendars.cs
+++ b/Jint/Native/Temporal/NonIsoCalendars.cs
@@ -1,5 +1,7 @@
-﻿using System.Globalization;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Runtime.InteropServices;
+using Jint.Runtime;
 
 namespace Jint.Native.Temporal;
 
@@ -66,12 +68,37 @@ internal static class NonIsoCalendars
         bool InLeapYear);
 
     /// <summary>
-    /// Returns true if the calendar is a non-ISO calendar supported by this adapter.
+    /// The failure of a provider that names a calendar in <see cref="ICalendarProvider.GetSupportedCalendars"/>
+    /// and then hands its conversion back to the base class, which has never heard of it. Reported as a
+    /// <c>RangeError</c> naming the member the host still owes, so it arrives as a JavaScript error rather
+    /// than as a <see cref="NotSupportedException"/> escaping the engine.
     /// </summary>
-    internal static bool IsNonIsoCalendar(string calendar)
-        => calendar is "chinese" or "dangi" or "hebrew" or "persian"
+    [DoesNotReturn]
+    private static void ThrowUnclaimedByProvider(Engine engine, string calendar, string member)
+    {
+        Throw.RangeError(
+            engine.Realm,
+            $"Calendar '{calendar}' is claimed by the configured {nameof(ICalendarProvider)} but its {member} does not answer for it");
+    }
+
+    /// <summary>
+    /// Returns true if the calendar is a non-ISO calendar this adapter can convert — the eleven it
+    /// implements itself, plus any a host <see cref="ICalendarProvider"/> claims when one is installed.
+    /// </summary>
+    internal static bool IsNonIsoCalendar(string calendar, Engine? engine = null)
+    {
+        if (calendar is "chinese" or "dangi" or "hebrew" or "persian"
             or "coptic" or "ethiopic" or "ethioaa" or "indian"
-            or "islamic-umalqura" or "islamic-civil" or "islamic-tbla";
+            or "islamic-umalqura" or "islamic-civil" or "islamic-tbla")
+        {
+            return true;
+        }
+
+        var provider = engine?.Options.Temporal.CalendarProvider;
+        return provider is not null
+            && !ReferenceEquals(provider, DefaultCalendarProvider.Instance)
+            && provider.IsSupported(calendar);
+    }
 
     /// <summary>
     /// Converts an ISO date to calendar-specific fields.
@@ -83,7 +110,20 @@ internal static class NonIsoCalendars
         var provider = engine?.Options.Temporal.CalendarProvider;
         if (provider is not null && provider != DefaultCalendarProvider.Instance && provider.IsSupported(calendar))
         {
-            var fields = provider.IsoToCalendarFields(calendar, isoDate.Year, isoDate.Month, isoDate.Day);
+            CalendarFields fields;
+            try
+            {
+                fields = provider.IsoToCalendarFields(calendar, isoDate.Year, isoDate.Month, isoDate.Day);
+            }
+            catch (NotSupportedException)
+            {
+                // The provider claims the calendar and then delegates it to an inherited conversion that
+                // has never heard of it. That is the host's contract broken, not the script's mistake, but
+                // a CLR exception crossing out of a Temporal call is nobody's idea of a diagnosis.
+                ThrowUnclaimedByProvider(engine!, calendar, nameof(ICalendarProvider.IsoToCalendarFields));
+                return default;
+            }
+
             return new CalendarDate(
                 fields.Year, fields.Month, fields.MonthCode, fields.Day,
                 fields.IsLeapMonth, fields.MonthsInYear, fields.DaysInMonth,
@@ -128,7 +168,17 @@ internal static class NonIsoCalendars
         var provider = engine?.Options.Temporal.CalendarProvider;
         if (provider is not null && provider != DefaultCalendarProvider.Instance && provider.IsSupported(calendar))
         {
-            var iso = provider.CalendarFieldsToIso(calendar, year, monthCode, month, day, overflow);
+            IsoDateFields? iso;
+            try
+            {
+                iso = provider.CalendarFieldsToIso(calendar, year, monthCode, month, day, overflow);
+            }
+            catch (NotSupportedException)
+            {
+                ThrowUnclaimedByProvider(engine!, calendar, nameof(ICalendarProvider.CalendarFieldsToIso));
+                return null;
+            }
+
             return iso is null ? null : new IsoDate(iso.Value.Year, iso.Value.Month, iso.Value.Day);
         }
 
@@ -799,11 +849,48 @@ internal static class NonIsoCalendars
     }
 
     /// <summary>
+    /// The same "latest calendar year whose (monthCode, day) still lands on or before the ISO reference
+    /// year" search as below, expressed only in terms of the two conversions an
+    /// <see cref="ICalendarProvider"/> supplies, for a calendar the engine itself does not implement.
+    /// </summary>
+    private static int FindProviderReferenceYear(string calendar, int isoReferenceYear, string monthCode, int day, Engine engine)
+    {
+        var anchor = IsoToCalendarDate(calendar, new IsoDate(isoReferenceYear, 12, 31), engine).Year;
+        var bestYear = anchor;
+        var bestDay = long.MinValue;
+
+        for (var year = anchor - 12; year <= anchor + 12; year++)
+        {
+            var iso = CalendarDateToIso(calendar, year, monthCode, 0, day, "reject", engine);
+            if (iso is null || iso.Value.Year > isoReferenceYear)
+            {
+                continue;
+            }
+
+            var epochDay = IsoToJulianDay(iso.Value.Year, iso.Value.Month, iso.Value.Day);
+            if (epochDay > bestDay)
+            {
+                bestDay = epochDay;
+                bestYear = year;
+            }
+        }
+
+        return bestYear;
+    }
+
+    /// <summary>
     /// Finds a calendar year where (year, monthCode, day) converts to an ISO date
     /// with the given ISO reference year. Used for PlainMonthDay without explicit year.
     /// </summary>
-    internal static int FindCalendarReferenceYear(string calendar, int isoReferenceYear, string monthCode, int day)
+    internal static int FindCalendarReferenceYear(string calendar, int isoReferenceYear, string monthCode, int day, Engine? engine = null)
     {
+        // A calendar only a host provider knows has no BCL calendar behind it, so the search below cannot
+        // run. The provider's own two conversions are enough to do it generically.
+        if (engine is not null && !IsNonIsoCalendar(calendar))
+        {
+            return FindProviderReferenceYear(calendar, isoReferenceYear, monthCode, day, engine);
+        }
+
         // For calendars that don't use .NET Calendar class
         if (calendar is "coptic" or "ethiopic" or "ethioaa")
         {

--- a/Jint/Native/Temporal/PlainDate/PlainDateConstructor.cs
+++ b/Jint/Native/Temporal/PlainDate/PlainDateConstructor.cs
@@ -88,10 +88,10 @@ internal sealed partial class PlainDateConstructor : Constructor
         {
             // Use ToTemporalCalendarIdentifier for spec-compliant conversion
             // This handles Temporal objects (fast path) and string calendars
-            calendar = TemporalHelpers.ToTemporalCalendarIdentifier(_realm, calendarValue);
+            calendar = TemporalHelpers.ToTemporalCalendarIdentifier(_engine, _realm, calendarValue);
         }
 
-        TemporalHelpers.RejectTemporalUnsupportedCalendar(_realm, calendar);
+        TemporalHelpers.RejectTemporalUnsupportedCalendar(_engine, _realm, calendar);
 
         // 2. day - read and convert immediately
         var dayValue = obj.Get("day");
@@ -186,7 +186,7 @@ internal sealed partial class PlainDateConstructor : Constructor
         // (TypeError) checks per CalendarResolveFields error ordering.
         month = TemporalHelpers.ValidateMonthAndMonthCode(_realm, calendar, year, month, monthCodeStr, monthFromCode);
 
-        var date = TemporalHelpers.CalendarDateToISO(_realm, calendar, year, month, day, overflow, monthCodeStr);
+        var date = TemporalHelpers.CalendarDateToISO(_engine, _realm, calendar, year, month, day, overflow, monthCodeStr);
         if (date is null)
         {
             Throw.RangeError(_realm, "Invalid date");
@@ -242,7 +242,7 @@ internal sealed partial class PlainDateConstructor : Constructor
 
             // Use ToTemporalCalendarIdentifier for spec-compliant conversion
             // This handles Temporal objects (fast path) and string calendars
-            calendar = TemporalHelpers.ToTemporalCalendarIdentifier(_realm, calendarArg);
+            calendar = TemporalHelpers.ToTemporalCalendarIdentifier(_engine, _realm, calendarArg);
         }
 
         var date = TemporalHelpers.RegulateIsoDate(year, month, day, "reject");
@@ -320,7 +320,7 @@ internal sealed partial class PlainDateConstructor : Constructor
         {
             // Use ToTemporalCalendarIdentifier for spec-compliant conversion
             // This handles Temporal objects (fast path) and string calendars
-            calendar = TemporalHelpers.ToTemporalCalendarIdentifier(_realm, calendarValue);
+            calendar = TemporalHelpers.ToTemporalCalendarIdentifier(_engine, _realm, calendarValue);
         }
 
         // 2. day - read and convert immediately
@@ -427,7 +427,7 @@ internal sealed partial class PlainDateConstructor : Constructor
             month = monthFromCode.Value;
         }
 
-        var date = TemporalHelpers.CalendarDateToISO(_realm, calendar, year, month, day, overflow);
+        var date = TemporalHelpers.CalendarDateToISO(_engine, _realm, calendar, year, month, day, overflow);
         if (date is null)
         {
             Throw.RangeError(_realm, "Invalid date");
@@ -436,7 +436,7 @@ internal sealed partial class PlainDateConstructor : Constructor
         return Construct(date.Value, calendar);
     }
 
-    private static ParsedDateResult? ParseDateString(string input)
+    private ParsedDateResult? ParseDateString(string input)
     {
         // Empty strings are invalid
         if (string.IsNullOrEmpty(input))
@@ -445,7 +445,7 @@ internal sealed partial class PlainDateConstructor : Constructor
         }
 
         // Strip annotations and extract calendar if present
-        var error = TemporalHelpers.StripAnnotations(input, out var coreString, out var calendar);
+        var error = TemporalHelpers.StripAnnotations(_engine, input, out var coreString, out var calendar);
         if (error is not null)
         {
             // Annotation parsing error - return null to let caller throw the error

--- a/Jint/Native/Temporal/PlainDate/PlainDatePrototype.cs
+++ b/Jint/Native/Temporal/PlainDate/PlainDatePrototype.cs
@@ -244,7 +244,7 @@ internal sealed partial class PlainDatePrototype : Prototype
         var overflow = TemporalHelpers.GetOverflowOption(_realm, (JsValue?) resolvedOptions ?? JsValue.Undefined);
 
         // Handle non-ISO calendars
-        if (NonIsoCalendars.IsNonIsoCalendar(plainDate.Calendar))
+        if (NonIsoCalendars.IsNonIsoCalendar(plainDate.Calendar, _engine))
         {
             // Get current calendar fields
             var calDate = NonIsoCalendars.IsoToCalendarDate(plainDate.Calendar, plainDate.IsoDate, _engine);
@@ -286,7 +286,7 @@ internal sealed partial class PlainDatePrototype : Prototype
                 finalMonthCode = calDate.MonthCode;
             }
 
-            var date = TemporalHelpers.CalendarDateToISO(_realm, plainDate.Calendar, finalCalYear,
+            var date = TemporalHelpers.CalendarDateToISO(_engine, _realm, plainDate.Calendar, finalCalYear,
                 month ?? 0, finalCalDay, overflow, finalMonthCode);
             if (date is null)
             {
@@ -324,7 +324,7 @@ internal sealed partial class PlainDatePrototype : Prototype
                 calMonth = mc.Value;
             }
 
-            var date2 = TemporalHelpers.CalendarDateToISO(_realm, plainDate.Calendar, calYear, calMonth, calDay, overflow);
+            var date2 = TemporalHelpers.CalendarDateToISO(_engine, _realm, plainDate.Calendar, calYear, calMonth, calDay, overflow);
             if (date2 is null)
             {
                 Throw.RangeError(_realm, "Invalid date");
@@ -526,7 +526,7 @@ internal sealed partial class PlainDatePrototype : Prototype
         }
 
         // Step 6: Get date difference using calendar
-        var dateDifference = TemporalHelpers.CalendarDateUntil(temporalDate.Calendar, temporalDate.IsoDate, other.IsoDate, largestUnit);
+        var dateDifference = TemporalHelpers.CalendarDateUntil(temporalDate.Calendar, temporalDate.IsoDate, other.IsoDate, largestUnit, _realm);
 
         // Step 7-10: If rounding needed, use RoundRelativeDuration
         DurationRecord result;
@@ -765,8 +765,8 @@ internal sealed partial class PlainDatePrototype : Prototype
                 }
             }
 
-            var canonicalYear = TemporalHelpers.FindCalendarReferenceYear(plainDate.Calendar, 1972, calFields.Month, day, monthCode);
-            var anchored = TemporalHelpers.CalendarDateToISO(_realm, plainDate.Calendar, canonicalYear, calFields.Month, day, "constrain", monthCode);
+            var canonicalYear = TemporalHelpers.FindCalendarReferenceYear(plainDate.Calendar, 1972, calFields.Month, day, monthCode, _engine);
+            var anchored = TemporalHelpers.CalendarDateToISO(_engine, _realm, plainDate.Calendar, canonicalYear, calFields.Month, day, "constrain", monthCode);
             if (anchored is not null)
             {
                 return new JsPlainMonthDay(_engine, _realm.Intrinsics.TemporalPlainMonthDay.PrototypeObject,
@@ -933,7 +933,7 @@ internal sealed partial class PlainDatePrototype : Prototype
         }
 
         // Use the shared ToTemporalCalendarIdentifier which handles ISO string parsing
-        return TemporalHelpers.ToTemporalCalendarIdentifier(_realm, value);
+        return TemporalHelpers.ToTemporalCalendarIdentifier(_engine, _realm, value);
     }
 
     /// <summary>

--- a/Jint/Native/Temporal/PlainDateTime/PlainDateTimeConstructor.cs
+++ b/Jint/Native/Temporal/PlainDateTime/PlainDateTimeConstructor.cs
@@ -128,7 +128,7 @@ internal sealed partial class PlainDateTimeConstructor : Constructor
                 Throw.RangeError(_realm, $"Unsupported calendar: {calendarStr}");
             }
 
-            var canonical = TemporalHelpers.CanonicalizeCalendar(calendarStr);
+            var canonical = TemporalHelpers.CanonicalizeCalendar(_engine, calendarStr);
             if (canonical is null)
             {
                 Throw.RangeError(_realm, $"Unsupported calendar: {calendarStr}");
@@ -212,7 +212,7 @@ internal sealed partial class PlainDateTimeConstructor : Constructor
                 Throw.RangeError(_realm, "Invalid date-time string");
             }
 
-            return Construct(parsed.DateTime.Value, TemporalHelpers.ExtractCalendarIdentifierFromString(str));
+            return Construct(parsed.DateTime.Value, TemporalHelpers.ExtractCalendarIdentifierFromString(_engine, str));
         }
 
         if (item.IsObject())
@@ -239,10 +239,10 @@ internal sealed partial class PlainDateTimeConstructor : Constructor
         {
             // Use ToTemporalCalendarIdentifier for spec-compliant conversion
             // This handles Temporal objects (fast path) and string calendars
-            calendar = TemporalHelpers.ToTemporalCalendarIdentifier(_realm, calendarProp);
+            calendar = TemporalHelpers.ToTemporalCalendarIdentifier(_engine, _realm, calendarProp);
         }
 
-        TemporalHelpers.RejectTemporalUnsupportedCalendar(_realm, calendar);
+        TemporalHelpers.RejectTemporalUnsupportedCalendar(_engine, _realm, calendar);
 
         // 2. day - read and convert immediately
         var dayValue = obj.Get("day");
@@ -362,7 +362,7 @@ internal sealed partial class PlainDateTimeConstructor : Constructor
             Throw.RangeError(_realm, "Date is outside valid range");
         }
 
-        var date = TemporalHelpers.CalendarDateToISO(_realm, calendar, year, month, day, overflow, monthCodeStr);
+        var date = TemporalHelpers.CalendarDateToISO(_engine, _realm, calendar, year, month, day, overflow, monthCodeStr);
         if (date is null)
         {
             Throw.RangeError(_realm, "Invalid date");

--- a/Jint/Native/Temporal/PlainDateTime/PlainDateTimePrototype.cs
+++ b/Jint/Native/Temporal/PlainDateTime/PlainDateTimePrototype.cs
@@ -372,7 +372,7 @@ internal sealed partial class PlainDateTimePrototype : Prototype
         IsoDate? date;
         if (isNonIso8601)
         {
-            date = TemporalHelpers.CalendarDateToISO(_realm, plainDateTime.Calendar, year, month, day, overflow, monthCode);
+            date = TemporalHelpers.CalendarDateToISO(_engine, _realm, plainDateTime.Calendar, year, month, day, overflow, monthCode);
         }
         else
         {
@@ -423,7 +423,7 @@ internal sealed partial class PlainDateTimePrototype : Prototype
         // https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.withcalendar
         var plainDateTime = ValidatePlainDateTime(thisObject);
         // Use ToTemporalCalendarIdentifier for spec-compliant conversion (handles Temporal objects)
-        var calendar = TemporalHelpers.ToTemporalCalendarIdentifier(_realm, calendarArg);
+        var calendar = TemporalHelpers.ToTemporalCalendarIdentifier(_engine, _realm, calendarArg);
 
         return _constructor.Construct(plainDateTime.IsoDateTime, calendar);
     }

--- a/Jint/Native/Temporal/PlainMonthDay/PlainMonthDayConstructor.cs
+++ b/Jint/Native/Temporal/PlainMonthDay/PlainMonthDayConstructor.cs
@@ -111,7 +111,7 @@ internal sealed partial class PlainMonthDayConstructor : Constructor
             }
 
             // Use ToTemporalCalendarIdentifier for spec-compliant conversion
-            calendar = TemporalHelpers.ToTemporalCalendarIdentifier(_realm, calendarArg);
+            calendar = TemporalHelpers.ToTemporalCalendarIdentifier(_engine, _realm, calendarArg);
         }
 
         // Use a reference year - 1972 is a leap year so Feb 29 is valid
@@ -182,10 +182,10 @@ internal sealed partial class PlainMonthDayConstructor : Constructor
         {
             // Calendar must be a string, not other types
             // Use ToTemporalCalendarIdentifier for spec-compliant conversion
-            calendar = TemporalHelpers.ToTemporalCalendarIdentifier(_realm, calendarValue);
+            calendar = TemporalHelpers.ToTemporalCalendarIdentifier(_engine, _realm, calendarValue);
         }
 
-        TemporalHelpers.RejectTemporalUnsupportedCalendar(_realm, calendar);
+        TemporalHelpers.RejectTemporalUnsupportedCalendar(_engine, _realm, calendar);
 
         // 2. day - read and convert immediately
         var dayValue = obj.Get("day");
@@ -278,7 +278,7 @@ internal sealed partial class PlainMonthDayConstructor : Constructor
 
         // For non-ISO calendars, when an explicit ordinal `month` is supplied, year is needed
         // because the ordinal-to-monthCode mapping is year-dependent (leap months shift it).
-        if (NonIsoCalendars.IsNonIsoCalendar(calendar) && month != 0 && !yearExplicitlyProvided)
+        if (NonIsoCalendars.IsNonIsoCalendar(calendar, _engine) && month != 0 && !yearExplicitlyProvided)
         {
             Throw.TypeError(_realm, "year is required when month is provided for a non-ISO calendar");
         }
@@ -290,7 +290,7 @@ internal sealed partial class PlainMonthDayConstructor : Constructor
 
         // Fundamental monthCode validity for non-ISO calendars: out-of-range display number,
         // or leap variant on a calendar without leap months → RangeError regardless of overflow.
-        if (monthCodeStr is not null && NonIsoCalendars.IsNonIsoCalendar(calendar)
+        if (monthCodeStr is not null && NonIsoCalendars.IsNonIsoCalendar(calendar, _engine)
             && !NonIsoCalendars.TryValidateMonthCode(calendar, monthCodeStr, out var displayMonth))
         {
             var max = NonIsoCalendars.MaxDisplayMonth(calendar) ?? 12;
@@ -327,7 +327,7 @@ internal sealed partial class PlainMonthDayConstructor : Constructor
             string? effectiveMonthCode = monthCodeStr;
             if (yearExplicitlyProvided)
             {
-                var validated = TemporalHelpers.CalendarDateToISO(_realm, calendar, year, month, day, overflow, monthCodeStr);
+                var validated = TemporalHelpers.CalendarDateToISO(_engine, _realm, calendar, year, month, day, overflow, monthCodeStr);
                 if (validated is null)
                 {
                     Throw.RangeError(_realm, "Invalid month-day");
@@ -387,9 +387,9 @@ internal sealed partial class PlainMonthDayConstructor : Constructor
                 }
             }
 
-            var calendarYear = TemporalHelpers.FindCalendarReferenceYear(calendar, 1972, month, actualDay, effectiveMonthCode);
+            var calendarYear = TemporalHelpers.FindCalendarReferenceYear(calendar, 1972, month, actualDay, effectiveMonthCode, _engine);
 
-            var calDate = TemporalHelpers.CalendarDateToISO(_realm, calendar, calendarYear, month, actualDay, finalOverflow, effectiveMonthCode);
+            var calDate = TemporalHelpers.CalendarDateToISO(_engine, _realm, calendar, calendarYear, month, actualDay, finalOverflow, effectiveMonthCode);
             if (calDate is null)
             {
                 Throw.RangeError(_realm, "Invalid month-day");
@@ -424,7 +424,7 @@ internal sealed partial class PlainMonthDayConstructor : Constructor
         }
 
         // Strip annotations and extract calendar if present
-        var error = TemporalHelpers.StripAnnotations(input, out var coreString, out var calendar);
+        var error = TemporalHelpers.StripAnnotations(engine, input, out var coreString, out var calendar);
         if (error is not null)
         {
             // Annotation parsing error
@@ -434,7 +434,7 @@ internal sealed partial class PlainMonthDayConstructor : Constructor
         var hasNonIsoCalendar = false;
         if (calendar is not null)
         {
-            var canonical = TemporalHelpers.CanonicalizeCalendar(calendar);
+            var canonical = TemporalHelpers.CanonicalizeCalendar(engine, calendar);
             if (canonical is null)
             {
                 return null; // Invalid calendar
@@ -588,7 +588,7 @@ internal sealed partial class PlainMonthDayConstructor : Constructor
                 // (Tevet 14 of 5732), so simply replacing the year flips the calendar day.
                 var calFields = NonIsoCalendars.IsoToCalendarDate(calendar, parsed.Value, engine);
                 var canonicalYear = TemporalHelpers.FindCalendarReferenceYear(calendar, 1972, calFields.Month, calFields.Day, calFields.MonthCode);
-                var anchored = TemporalHelpers.CalendarDateToISO(null!, calendar, canonicalYear, calFields.Month, calFields.Day, "constrain", calFields.MonthCode);
+                var anchored = TemporalHelpers.CalendarDateToISO(null, null!, calendar, canonicalYear, calFields.Month, calFields.Day, "constrain", calFields.MonthCode);
                 if (anchored is not null)
                 {
                     return anchored.Value;

--- a/Jint/Native/Temporal/PlainMonthDay/PlainMonthDayPrototype.cs
+++ b/Jint/Native/Temporal/PlainMonthDay/PlainMonthDayPrototype.cs
@@ -93,7 +93,7 @@ internal sealed partial class PlainMonthDayPrototype : Prototype
         }
 
         // Read and convert properties in strict alphabetical order per spec: day, month, monthCode, year
-        var isNonIso = NonIsoCalendars.IsNonIsoCalendar(md.Calendar);
+        var isNonIso = NonIsoCalendars.IsNonIsoCalendar(md.Calendar, _engine);
 
         // 1. day
         var dayProp = obj.Get("day");
@@ -188,7 +188,7 @@ internal sealed partial class PlainMonthDayPrototype : Prototype
             var calYear = isNonIso && yearProp.IsUndefined()
                 ? TemporalHelpers.CalendarYear(md.Calendar, md.IsoDate, _engine)
                 : year;
-            var calDate = TemporalHelpers.CalendarDateToISO(_realm, md.Calendar, calYear,
+            var calDate = TemporalHelpers.CalendarDateToISO(_engine, _realm, md.Calendar, calYear,
                 monthProp.IsUndefined() ? 0 : month, day, overflow, monthCode);
             if (calDate is null)
             {

--- a/Jint/Native/Temporal/PlainYearMonth/PlainYearMonthConstructor.cs
+++ b/Jint/Native/Temporal/PlainYearMonth/PlainYearMonthConstructor.cs
@@ -134,7 +134,7 @@ internal sealed partial class PlainYearMonthConstructor : Constructor
             }
 
             // Use ToTemporalCalendarIdentifier for spec-compliant conversion
-            calendar = TemporalHelpers.ToTemporalCalendarIdentifier(_realm, calendarArg);
+            calendar = TemporalHelpers.ToTemporalCalendarIdentifier(_engine, _realm, calendarArg);
         }
 
         var day = referenceDay.IsUndefined() ? 1 : TemporalHelpers.ToIntegerWithTruncationAsInt(_realm, referenceDay);
@@ -221,10 +221,10 @@ internal sealed partial class PlainYearMonthConstructor : Constructor
         else
         {
             // Use ToTemporalCalendarIdentifier for spec-compliant conversion
-            calendar = TemporalHelpers.ToTemporalCalendarIdentifier(_realm, calendarValue);
+            calendar = TemporalHelpers.ToTemporalCalendarIdentifier(_engine, _realm, calendarValue);
         }
 
-        TemporalHelpers.RejectTemporalUnsupportedCalendar(_realm, calendar);
+        TemporalHelpers.RejectTemporalUnsupportedCalendar(_engine, _realm, calendar);
 
         // 2. era/eraYear - read for era-supporting calendars (alphabetically between calendar and month)
         var eraYear = TemporalHelpers.ReadEraFields(_realm, obj, calendar);
@@ -307,7 +307,7 @@ internal sealed partial class PlainYearMonthConstructor : Constructor
         // For non-ISO/non-gregory calendars, convert calendar year/month to ISO via CalendarDateToISO
         if (calendar is not "iso8601" and not "gregory")
         {
-            var date = TemporalHelpers.CalendarDateToISO(_realm, calendar, year, month, 1, overflow, monthCodeStr);
+            var date = TemporalHelpers.CalendarDateToISO(_engine, _realm, calendar, year, month, 1, overflow, monthCodeStr);
             if (date is null)
             {
                 Throw.RangeError(_realm, "Invalid year-month");
@@ -353,7 +353,7 @@ internal sealed partial class PlainYearMonthConstructor : Constructor
         else
         {
             // Use ToTemporalCalendarIdentifier for spec-compliant conversion
-            calendar = TemporalHelpers.ToTemporalCalendarIdentifier(_realm, calendarValue);
+            calendar = TemporalHelpers.ToTemporalCalendarIdentifier(_engine, _realm, calendarValue);
         }
 
         // 2. era/eraYear - read for era-supporting calendars (alphabetically between calendar and month)
@@ -436,7 +436,7 @@ internal sealed partial class PlainYearMonthConstructor : Constructor
         // For non-ISO/non-gregory calendars, convert calendar year/month to ISO via CalendarDateToISO
         if (calendar is not "iso8601" and not "gregory")
         {
-            var date = TemporalHelpers.CalendarDateToISO(_realm, calendar, year, month, 1, overflow, monthCodeStr);
+            var date = TemporalHelpers.CalendarDateToISO(_engine, _realm, calendar, year, month, 1, overflow, monthCodeStr);
             if (date is null)
             {
                 Throw.RangeError(_realm, "Invalid year-month");
@@ -467,7 +467,7 @@ internal sealed partial class PlainYearMonthConstructor : Constructor
         return Construct(new IsoDate(year, month, 1), calendar);
     }
 
-    private static IsoDate? ParseYearMonthString(string input, out string parsedCalendar)
+    private IsoDate? ParseYearMonthString(string input, out string parsedCalendar)
     {
         parsedCalendar = "iso8601";
 
@@ -478,7 +478,7 @@ internal sealed partial class PlainYearMonthConstructor : Constructor
         }
 
         // Strip annotations and extract calendar if present
-        var error = TemporalHelpers.StripAnnotations(input, out var coreString, out var calendar);
+        var error = TemporalHelpers.StripAnnotations(_engine, input, out var coreString, out var calendar);
         if (error is not null)
         {
             // Annotation parsing error
@@ -488,7 +488,7 @@ internal sealed partial class PlainYearMonthConstructor : Constructor
         // Canonicalize calendar annotation if present
         if (calendar is not null)
         {
-            var canonical = TemporalHelpers.CanonicalizeCalendar(calendar);
+            var canonical = TemporalHelpers.CanonicalizeCalendar(_engine, calendar);
             if (canonical is null)
             {
                 return null; // Invalid calendar

--- a/Jint/Native/Temporal/PlainYearMonth/PlainYearMonthPrototype.cs
+++ b/Jint/Native/Temporal/PlainYearMonth/PlainYearMonthPrototype.cs
@@ -279,7 +279,7 @@ internal sealed partial class PlainYearMonthPrototype : Prototype
                 }
             }
 
-            var date = TemporalHelpers.CalendarDateToISO(_realm, ym.Calendar, year, month, 1, overflow, monthCode);
+            var date = TemporalHelpers.CalendarDateToISO(_engine, _realm, ym.Calendar, year, month, 1, overflow, monthCode);
             if (date is null)
             {
                 Throw.RangeError(_realm, "Invalid year-month");
@@ -489,7 +489,7 @@ internal sealed partial class PlainYearMonthPrototype : Prototype
         TemporalHelpers.CheckISODaysRange(_realm, otherDate);
 
         // Step 11: Get date difference using calendar
-        var dateDifference = TemporalHelpers.CalendarDateUntil(ym1.Calendar, thisDate, otherDate, largestUnit);
+        var dateDifference = TemporalHelpers.CalendarDateUntil(ym1.Calendar, thisDate, otherDate, largestUnit, _realm);
 
         // Step 12: AdjustDateDurationRecord - zero out weeks and days (PlainYearMonth only has years/months)
         var yearsMonthsDifference = new DurationRecord(
@@ -689,13 +689,13 @@ internal sealed partial class PlainYearMonthPrototype : Prototype
         var day = TemporalHelpers.ToPositiveIntegerWithTruncation(_realm, dayProp);
 
         IsoDate? date;
-        if (NonIsoCalendars.IsNonIsoCalendar(ym.Calendar))
+        if (NonIsoCalendars.IsNonIsoCalendar(ym.Calendar, _engine))
         {
             // For non-ISO calendars, get the calendar year/month and combine with the provided day
             var calYear = TemporalHelpers.CalendarYear(ym.Calendar, ym.IsoDate, _engine);
             var calMonth = TemporalHelpers.CalendarMonth(ym.Calendar, ym.IsoDate, _engine);
             var calMonthCode = TemporalHelpers.CalendarMonthCode(ym.Calendar, ym.IsoDate, _engine);
-            date = TemporalHelpers.CalendarDateToISO(_realm, ym.Calendar, calYear, calMonth, day, "constrain", calMonthCode);
+            date = TemporalHelpers.CalendarDateToISO(_engine, _realm, ym.Calendar, calYear, calMonth, day, "constrain", calMonthCode);
         }
         else
         {

--- a/Jint/Native/Temporal/TemporalHelpers.cs
+++ b/Jint/Native/Temporal/TemporalHelpers.cs
@@ -1,4 +1,5 @@
-﻿using System.Globalization;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -481,7 +482,7 @@ internal static class TemporalHelpers
     /// Handles: [u-ca=calendar], [timezone], [!u-ca=calendar], etc.
     /// Returns error message if annotations are invalid, null if valid.
     /// </summary>
-    public static string? StripAnnotations(string input, out string coreString, out string? calendar)
+    public static string? StripAnnotations(Engine? engine, string input, out string coreString, out string? calendar)
     {
         // Reject non-ASCII minus sign (U+2212)
         if (ContainsInvalidMinusSign(input))
@@ -593,7 +594,7 @@ internal static class TemporalHelpers
                         var calendarId = annotation.Substring(5); // Extract calendar name after "u-ca="
 
                         // Validate the calendar ID
-                        var canonical = CanonicalizeCalendar(calendarId);
+                        var canonical = CanonicalizeCalendar(engine, calendarId);
                         if (canonical is null)
                         {
                             coreString = input;
@@ -1573,7 +1574,15 @@ internal static class TemporalHelpers
     /// Canonicalizes a calendar identifier (case-insensitive matching).
     /// https://tc39.es/proposal-temporal/#sec-temporal-canonicalizetemporalcalendaridentifier
     /// </summary>
-    public static string? CanonicalizeCalendar(string calendar)
+    /// <remarks>
+    /// The switch below is Jint's own <c>AvailableCalendars</c>. An identifier it does not name is put to the
+    /// engine's <see cref="ICalendarProvider"/>, which is the only thing that could implement a calendar
+    /// Jint does not: without this, a host provider's <c>IsSupported</c> is never reached for a new
+    /// identifier, because every Temporal entry point canonicalizes before it consults a provider.
+    /// A host is answered only for a well-formed Unicode calendar type, so nothing it claims can produce an
+    /// identifier that would not round-trip through a <c>[u-ca=…]</c> annotation.
+    /// </remarks>
+    public static string? CanonicalizeCalendar(Engine? engine, string calendar)
     {
         // Must use ASCII case-folding only (not Turkish İ)
         // Check if it's a valid calendar ID and return canonical form
@@ -1602,20 +1611,46 @@ internal static class TemporalHelpers
             "japanese" => "japanese",
             "persian" => "persian",
             "roc" => "roc",
-            _ => null // Unsupported calendar
+            _ => AskCalendarProvider(engine, lower)
         };
+    }
+
+    /// <summary>
+    /// The last word on an identifier Jint's own table does not name: a host provider that claims it, or null.
+    /// </summary>
+    private static string? AskCalendarProvider(Engine? engine, string lowered)
+    {
+        var provider = engine?.Options.Temporal.CalendarProvider;
+        if (provider is null || ReferenceEquals(provider, DefaultCalendarProvider.Instance))
+        {
+            return null;
+        }
+
+        return Intl.IntlUtilities.IsValidUnicodeExtensionValue(lowered) && provider.IsSupported(lowered)
+            ? lowered
+            : null;
     }
 
     /// <summary>
     /// Throws RangeError for observation-based calendars that cannot be used in Temporal.
     /// "islamic" and "islamic-rgsa" are only valid for Intl.DateTimeFormat, not Temporal.
     /// </summary>
-    internal static void RejectTemporalUnsupportedCalendar(Realm realm, string calendar)
+    internal static void RejectTemporalUnsupportedCalendar(Engine engine, Realm realm, string calendar)
     {
-        if (calendar is "islamic" or "islamic-rgsa")
+        if (calendar is not ("islamic" or "islamic-rgsa"))
         {
-            Throw.RangeError(realm, $"Calendar '{calendar}' is not supported for Temporal operations");
+            return;
         }
+
+        // A host that installs its own provider and claims one of these has the observation data
+        // Jint lacks, which is the only reason these two are refused.
+        var provider = engine.Options.Temporal.CalendarProvider;
+        if (!ReferenceEquals(provider, DefaultCalendarProvider.Instance) && provider.IsSupported(calendar))
+        {
+            return;
+        }
+
+        Throw.RangeError(realm, $"Calendar '{calendar}' is not supported for Temporal operations");
     }
 
     /// <summary>
@@ -1697,7 +1732,7 @@ internal static class TemporalHelpers
     /// For non-ISO calendars, the input fields are in the calendar's system
     /// and need to be converted to the proleptic Gregorian (ISO 8601) calendar.
     /// </summary>
-    public static IsoDate? CalendarDateToISO(Realm realm, string calendar, int year, int month, int day, string overflow, string? monthCode = null)
+    public static IsoDate? CalendarDateToISO(Engine? engine, Realm realm, string calendar, int year, int month, int day, string overflow, string? monthCode = null)
     {
         // Observation-based calendars cannot be used for Temporal arithmetic
         if (calendar is "islamic" or "islamic-rgsa")
@@ -1729,9 +1764,9 @@ internal static class TemporalHelpers
             return RegulateIsoDate(year, month, day, overflow);
         }
 
-        if (NonIsoCalendars.IsNonIsoCalendar(calendar))
+        if (NonIsoCalendars.IsNonIsoCalendar(calendar, engine))
         {
-            return NonIsoCalendars.CalendarDateToIso(calendar, year, monthCode, month, day, overflow);
+            return NonIsoCalendars.CalendarDateToIso(calendar, year, monthCode, month, day, overflow, engine);
         }
 
         // For other calendars, fall back to treating fields as ISO (best effort)
@@ -1743,11 +1778,11 @@ internal static class TemporalHelpers
     /// converting (calendarYear, month, day) to ISO produces an ISO date with the given
     /// ISO reference year (typically 1972).
     /// </summary>
-    internal static int FindCalendarReferenceYear(string calendar, int isoReferenceYear, int month, int day, string? monthCode = null)
+    internal static int FindCalendarReferenceYear(string calendar, int isoReferenceYear, int month, int day, string? monthCode = null, Engine? engine = null)
     {
-        if (NonIsoCalendars.IsNonIsoCalendar(calendar) && monthCode is not null)
+        if (NonIsoCalendars.IsNonIsoCalendar(calendar, engine) && monthCode is not null)
         {
-            return NonIsoCalendars.FindCalendarReferenceYear(calendar, isoReferenceYear, monthCode, day);
+            return NonIsoCalendars.FindCalendarReferenceYear(calendar, isoReferenceYear, monthCode, day, engine);
         }
 
         if (calendar is "buddhist")
@@ -1768,7 +1803,7 @@ internal static class TemporalHelpers
             // Try years around the approximation to find one mapping to the ISO reference year
             for (var y = approxYear - 1; y <= approxYear + 1; y++)
             {
-                var isoDate = CalendarDateToISO(null!, calendar, y, month, day, "constrain");
+                var isoDate = CalendarDateToISO(null, null!, calendar, y, month, day, "constrain");
                 if (isoDate?.Year == isoReferenceYear)
                 {
                     return y;
@@ -1882,7 +1917,7 @@ internal static class TemporalHelpers
             return CalendarYear(calendar, isoDate.Year);
         }
 
-        if (NonIsoCalendars.IsNonIsoCalendar(calendar))
+        if (NonIsoCalendars.IsNonIsoCalendar(calendar, engine))
         {
             return NonIsoCalendars.IsoToCalendarDate(calendar, in isoDate, engine).Year;
         }
@@ -1900,7 +1935,7 @@ internal static class TemporalHelpers
             return isoDate.Month;
         }
 
-        if (NonIsoCalendars.IsNonIsoCalendar(calendar))
+        if (NonIsoCalendars.IsNonIsoCalendar(calendar, engine))
         {
             return NonIsoCalendars.IsoToCalendarDate(calendar, in isoDate, engine).Month;
         }
@@ -1918,7 +1953,7 @@ internal static class TemporalHelpers
             return $"M{isoDate.Month:D2}";
         }
 
-        if (NonIsoCalendars.IsNonIsoCalendar(calendar))
+        if (NonIsoCalendars.IsNonIsoCalendar(calendar, engine))
         {
             return NonIsoCalendars.IsoToCalendarDate(calendar, in isoDate, engine).MonthCode;
         }
@@ -1936,7 +1971,7 @@ internal static class TemporalHelpers
             return isoDate.Day;
         }
 
-        if (NonIsoCalendars.IsNonIsoCalendar(calendar))
+        if (NonIsoCalendars.IsNonIsoCalendar(calendar, engine))
         {
             return NonIsoCalendars.IsoToCalendarDate(calendar, in isoDate, engine).Day;
         }
@@ -1958,7 +1993,7 @@ internal static class TemporalHelpers
             return new IsoDate(isoDate.Year, isoDate.Month, 1);
         }
 
-        if (NonIsoCalendars.IsNonIsoCalendar(calendar))
+        if (NonIsoCalendars.IsNonIsoCalendar(calendar, engine))
         {
             var calDate = NonIsoCalendars.IsoToCalendarDate(calendar, in isoDate, engine);
             var firstOfMonth = NonIsoCalendars.CalendarDateToIso(calendar, calDate.Year, calDate.MonthCode, calDate.Month, 1, "constrain", engine);
@@ -1985,7 +2020,7 @@ internal static class TemporalHelpers
             return isoDate.DayOfYear();
         }
 
-        if (NonIsoCalendars.IsNonIsoCalendar(calendar))
+        if (NonIsoCalendars.IsNonIsoCalendar(calendar, engine))
         {
             var calDate = NonIsoCalendars.IsoToCalendarDate(calendar, in isoDate, engine);
             // Find the first day of the calendar year
@@ -2011,7 +2046,7 @@ internal static class TemporalHelpers
             return isoDate.DaysInMonth();
         }
 
-        if (NonIsoCalendars.IsNonIsoCalendar(calendar))
+        if (NonIsoCalendars.IsNonIsoCalendar(calendar, engine))
         {
             return NonIsoCalendars.IsoToCalendarDate(calendar, in isoDate, engine).DaysInMonth;
         }
@@ -2029,7 +2064,7 @@ internal static class TemporalHelpers
             return isoDate.DaysInYear();
         }
 
-        if (NonIsoCalendars.IsNonIsoCalendar(calendar))
+        if (NonIsoCalendars.IsNonIsoCalendar(calendar, engine))
         {
             return NonIsoCalendars.IsoToCalendarDate(calendar, in isoDate, engine).DaysInYear;
         }
@@ -2047,7 +2082,7 @@ internal static class TemporalHelpers
             return 12;
         }
 
-        if (NonIsoCalendars.IsNonIsoCalendar(calendar))
+        if (NonIsoCalendars.IsNonIsoCalendar(calendar, engine))
         {
             return NonIsoCalendars.IsoToCalendarDate(calendar, in isoDate, engine).MonthsInYear;
         }
@@ -2065,7 +2100,7 @@ internal static class TemporalHelpers
             return IsoDate.IsLeapYear(isoDate.Year);
         }
 
-        if (NonIsoCalendars.IsNonIsoCalendar(calendar))
+        if (NonIsoCalendars.IsNonIsoCalendar(calendar, engine))
         {
             return NonIsoCalendars.IsoToCalendarDate(calendar, in isoDate, engine).InLeapYear;
         }
@@ -2488,12 +2523,12 @@ internal static class TemporalHelpers
     /// <summary>
     /// Extracts and canonicalizes the calendar from a string, defaulting to "iso8601".
     /// </summary>
-    internal static string ExtractCalendarIdentifierFromString(string input)
+    internal static string ExtractCalendarIdentifierFromString(Engine? engine, string input)
     {
         var extracted = ExtractCalendarFromIsoString(input);
         if (extracted is not null)
         {
-            var canonical = CanonicalizeCalendar(extracted);
+            var canonical = CanonicalizeCalendar(engine, extracted);
             if (canonical is not null)
             {
                 return canonical;
@@ -2631,8 +2666,27 @@ internal static class TemporalHelpers
         }
         else
         {
-            throw new NotSupportedException($"Calendar '{calendar}' not yet supported");
+            ThrowCalendarArithmeticUnavailable(realm, calendar);
+            return default;
         }
+    }
+
+    /// <summary>
+    /// Calendar arithmetic — <c>add</c>, <c>subtract</c>, <c>until</c>, <c>since</c> — is implemented per
+    /// calendar in <see cref="NonIsoCalendars"/> and is not routed through
+    /// <see cref="ICalendarProvider"/>, so a calendar a host provider added has no arithmetic. Reported as
+    /// a <c>RangeError</c> wherever a realm is at hand, rather than as a <see cref="NotSupportedException"/>
+    /// escaping <c>Engine.Evaluate</c>.
+    /// </summary>
+    [DoesNotReturn]
+    private static void ThrowCalendarArithmeticUnavailable(Realm? realm, string calendar)
+    {
+        if (realm is not null)
+        {
+            Throw.RangeError(realm, $"Calendar arithmetic is not implemented for '{calendar}'");
+        }
+
+        throw new NotSupportedException($"Calendar '{calendar}' not yet supported");
     }
 
     /// <summary>
@@ -3915,7 +3969,7 @@ internal static class TemporalHelpers
     /// Converts a value to a calendar identifier string.
     /// https://tc39.es/proposal-temporal/#sec-temporal-totemporalcalendaridentifier (calendar.html:666-686)
     /// </summary>
-    public static string ToTemporalCalendarIdentifier(Realm realm, JsValue calendarLike)
+    public static string ToTemporalCalendarIdentifier(Engine engine, Realm realm, JsValue calendarLike)
     {
         // Step 1: If temporalCalendarLike is an Object
         if (calendarLike.IsObject())
@@ -3964,7 +4018,7 @@ internal static class TemporalHelpers
         var calendar = calendarLike.ToString();
 
         // First try as a plain calendar identifier
-        var canonical = CanonicalizeCalendar(calendar);
+        var canonical = CanonicalizeCalendar(engine, calendar);
         if (canonical is not null)
         {
             return canonical;
@@ -3981,7 +4035,7 @@ internal static class TemporalHelpers
 
             // If annotation found, canonicalize it; if no annotation, default to iso8601
             var calendarId = extractedCalendar ?? "iso8601";
-            canonical = CanonicalizeCalendar(calendarId);
+            canonical = CanonicalizeCalendar(engine, calendarId);
             if (canonical is not null)
             {
                 return canonical;
@@ -4366,7 +4420,7 @@ internal static class TemporalHelpers
 
                 // Build a simple object with just the fields PlainDate needs
                 // We already read all fields in order, so this won't cause additional reads
-                var resultPlainDate = CreatePlainDateFromFields(realm, fields);
+                var resultPlainDate = CreatePlainDateFromFields(engine, realm, fields);
                 return new RelativeToResult(resultPlainDate, null);
             }
             else
@@ -4424,7 +4478,7 @@ internal static class TemporalHelpers
         string calendar = "iso8601";
         if (!calendarProp.IsUndefined())
         {
-            calendar = ToTemporalCalendarIdentifier(realm, calendarProp);
+            calendar = ToTemporalCalendarIdentifier(engine, realm, calendarProp);
         }
 
         // Step 2: Read all other fields in alphabetical order
@@ -4552,7 +4606,7 @@ internal static class TemporalHelpers
     /// <summary>
     /// Helper to create PlainDate from RelativeToFields.
     /// </summary>
-    private static JsPlainDate CreatePlainDateFromFields(Realm realm, RelativeToFields fields)
+    private static JsPlainDate CreatePlainDateFromFields(Engine engine, Realm realm, RelativeToFields fields)
     {
         // Required fields: year, day, and (month or monthCode)
         if (!fields.Year.HasValue)
@@ -4568,7 +4622,7 @@ internal static class TemporalHelpers
         // Determine month from either month or monthCode
         int month;
         string? monthCode = null;
-        var isNonIso = NonIsoCalendars.IsNonIsoCalendar(fields.Calendar);
+        var isNonIso = NonIsoCalendars.IsNonIsoCalendar(fields.Calendar, engine);
         if (fields.Month.HasValue && !string.IsNullOrEmpty(fields.MonthCode))
         {
             // Both provided - verify they match (ISO only - non-ISO ordinal ≠ display)
@@ -4600,7 +4654,7 @@ internal static class TemporalHelpers
         IsoDate? isoDate;
         if (isNonIso)
         {
-            isoDate = CalendarDateToISO(realm, fields.Calendar, fields.Year.Value, month, fields.Day.Value, "constrain", monthCode);
+            isoDate = CalendarDateToISO(engine, realm, fields.Calendar, fields.Year.Value, month, fields.Day.Value, "constrain", monthCode);
         }
         else
         {
@@ -4640,7 +4694,7 @@ internal static class TemporalHelpers
         // Determine month
         int month;
         string? monthCode = null;
-        var isNonIso = NonIsoCalendars.IsNonIsoCalendar(fields.Calendar);
+        var isNonIso = NonIsoCalendars.IsNonIsoCalendar(fields.Calendar, engine);
         if (fields.Month.HasValue && !string.IsNullOrEmpty(fields.MonthCode))
         {
             var parsedMonthCode = ParseMonthCode(realm, fields.MonthCode!);
@@ -4671,7 +4725,7 @@ internal static class TemporalHelpers
         IsoDate? isoDate;
         if (isNonIso)
         {
-            isoDate = CalendarDateToISO(realm, fields.Calendar, fields.Year.Value, month, fields.Day.Value, "constrain", monthCode);
+            isoDate = CalendarDateToISO(engine, realm, fields.Calendar, fields.Year.Value, month, fields.Day.Value, "constrain", monthCode);
         }
         else
         {
@@ -6127,7 +6181,7 @@ internal static class TemporalHelpers
             var weeksEnd = AddDaysToISODate(weeksStart, (int) duration.Days);
 
             // Step 4: Calculate weeks between weeksStart and weeksEnd
-            var untilResult = CalendarDateUntil(calendar, weeksStart, weeksEnd, "week");
+            var untilResult = CalendarDateUntil(calendar, weeksStart, weeksEnd, "week", realm);
 
             // Step 5: Round total weeks (original weeks + calculated weeks from days)
             var weeks = RoundNumberToIncrement(duration.Weeks + untilResult.Weeks, increment, "trunc");
@@ -6693,7 +6747,7 @@ internal static class TemporalHelpers
     /// ISODateSurpasses algorithm (calendar.html:632-661) but uses direct arithmetic
     /// for O(1) performance on years/days instead of O(n) iteration.
     /// </summary>
-    internal static DurationRecord CalendarDateUntil(string calendar, IsoDate one, IsoDate two, string largestUnit)
+    internal static DurationRecord CalendarDateUntil(string calendar, IsoDate one, IsoDate two, string largestUnit, Realm? realm = null)
     {
         // Step 1: Get sign
         var sign = CompareIsoDates(one, two);
@@ -6712,7 +6766,7 @@ internal static class TemporalHelpers
                 return NonIsoCalendars.CalendarDateUntil(calendar, in one, in two, largestUnit);
             }
 
-            throw new NotSupportedException($"Calendar '{calendar}' not yet supported");
+            ThrowCalendarArithmeticUnavailable(realm, calendar);
         }
 
         // Step 3.1: Negate sign per spec (line 637)

--- a/Jint/Native/Temporal/ZonedDateTime/ZonedDateTimeConstructor.cs
+++ b/Jint/Native/Temporal/ZonedDateTime/ZonedDateTimeConstructor.cs
@@ -92,7 +92,7 @@ internal sealed partial class ZonedDateTimeConstructor : Constructor
         }
         else if (calendarArg.IsString())
         {
-            var canonical = TemporalHelpers.CanonicalizeCalendar(calendarArg.ToString());
+            var canonical = TemporalHelpers.CanonicalizeCalendar(_engine, calendarArg.ToString());
             if (canonical is null)
             {
                 Throw.RangeError(_realm, $"Invalid calendar: {calendarArg}");
@@ -180,10 +180,10 @@ internal sealed partial class ZonedDateTimeConstructor : Constructor
         if (!calendarProp.IsUndefined())
         {
             // Use ToTemporalCalendarIdentifier for spec-compliant conversion (handles Temporal objects)
-            calendar = TemporalHelpers.ToTemporalCalendarIdentifier(_realm, calendarProp);
+            calendar = TemporalHelpers.ToTemporalCalendarIdentifier(_engine, _realm, calendarProp);
         }
 
-        TemporalHelpers.RejectTemporalUnsupportedCalendar(_realm, calendar);
+        TemporalHelpers.RejectTemporalUnsupportedCalendar(_engine, _realm, calendar);
 
         // 2. day - read and convert immediately
         var dayValue = obj.Get("day");
@@ -321,7 +321,7 @@ internal sealed partial class ZonedDateTimeConstructor : Constructor
         month = TemporalHelpers.ValidateMonthAndMonthCode(_realm, calendar, year, month, monthCodeStr, monthFromCode);
 
         // Regulate date (with calendar conversion for non-ISO calendars)
-        var date = TemporalHelpers.CalendarDateToISO(_realm, calendar, year, month, day, overflow, monthCodeStr);
+        var date = TemporalHelpers.CalendarDateToISO(_engine, _realm, calendar, year, month, day, overflow, monthCodeStr);
         if (date is null)
         {
             Throw.RangeError(_realm, "Invalid date");
@@ -449,7 +449,7 @@ internal sealed partial class ZonedDateTimeConstructor : Constructor
         }
 
         var calendarId = result.Calendar ?? "iso8601";
-        var canonicalCalendar = TemporalHelpers.CanonicalizeCalendar(calendarId);
+        var canonicalCalendar = TemporalHelpers.CanonicalizeCalendar(_engine, calendarId);
         if (canonicalCalendar is null)
         {
             // A syntactically valid but not-yet-adopted calendar annotation (e.g. "bangla") must be rejected.

--- a/Jint/Native/Temporal/ZonedDateTime/ZonedDateTimePrototype.cs
+++ b/Jint/Native/Temporal/ZonedDateTime/ZonedDateTimePrototype.cs
@@ -494,7 +494,7 @@ internal sealed partial class ZonedDateTimePrototype : Prototype
         IsoDate? date;
         if (isNonIso8601)
         {
-            date = TemporalHelpers.CalendarDateToISO(_realm, zdt.Calendar, year, month, day, overflow, monthCode);
+            date = TemporalHelpers.CalendarDateToISO(_engine, _realm, zdt.Calendar, year, month, day, overflow, monthCode);
         }
         else
         {
@@ -573,7 +573,7 @@ internal sealed partial class ZonedDateTimePrototype : Prototype
         // Step 1-2: Validate this value
         var zdt = ValidateZonedDateTime(thisObject);
         // Step 3: Let calendar be ? ToTemporalCalendarIdentifier(calendarLike)
-        var calendar = TemporalHelpers.ToTemporalCalendarIdentifier(_realm, calendarLike);
+        var calendar = TemporalHelpers.ToTemporalCalendarIdentifier(_engine, _realm, calendarLike);
 
         // Step 4: Return ! CreateTemporalZonedDateTime(zonedDateTime.[[EpochNanoseconds]], zonedDateTime.[[TimeZone]], calendar)
         return _constructor.Construct(zdt.EpochNanoseconds, zdt.TimeZone, calendar);

--- a/README.md
+++ b/README.md
@@ -2837,9 +2837,28 @@ var engine = new Engine(options =>
 
 `Options.Temporal.CalendarProvider` (`ICalendarProvider`) is the third of these, for non-ISO
 calendar arithmetic. Its default, `DefaultCalendarProvider`, is backed by
-`System.Globalization.Calendar` subclasses, which constrains some date ranges — derive from it and
-override one conversion to correct a calendar (see
+`System.Globalization.Calendar` subclasses, which constrains some date ranges (see
 [`Jint/Native/Temporal/NonIsoCalendars.cs`](Jint/Native/Temporal/NonIsoCalendars.cs)).
+
+*Correcting* one of the eleven non-ISO calendars Jint implements is one override — the conversion that
+gets it wrong, with `base` answering for the other ten:
+
+```c#
+sealed class AstronomicalPersian : DefaultCalendarProvider
+{
+    public override IsoDateFields? CalendarFieldsToIso(
+        string calendar, int year, string? monthCode, int month, int day, string overflow)
+        => calendar == "persian"
+            ? MyTables.ToIso(year, month, day)
+            : base.CalendarFieldsToIso(calendar, year, monthCode, month, day, overflow);
+}
+```
+
+*Adding* a calendar Jint does not know is three: `GetSupportedCalendars`, which is what makes the
+identifier valid anywhere in `Temporal`, and both conversions, which nobody but you can perform. The
+inherited `IsSupported` reads the list, so it does not need overriding as well. Such a calendar reaches
+construction, every field accessor, `with` and `toString`; it does not reach `add`/`subtract`/`until`/`since`
+or `toLocaleString`, both of which raise a `RangeError` for a calendar the engine does not implement itself.
 
 ## Running untrusted code
 

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -1605,7 +1605,7 @@ fires. Script that relied on a length change silently succeeding never existed �
 for a growable collection, for `Options.Interop.AllowWrite = false` (which refused these writes already), or
 for a `T[]` exposed under `ArrayConversionMode.LiveView`.
 
-### 4.28 `Intl` reads the CLDR provider for date names and numbering-system digits ([#3354](https://github.com/sebastienros/jint/issues/3354))
+### 4.29 `Intl` reads the CLDR provider for date names and numbering-system digits ([#3354](https://github.com/sebastienros/jint/issues/3354))
 
 `Intl.DateTimeFormat` took its month, weekday and day-period names straight from .NET's `CultureInfo`, and
 every formatter transliterated digits by looking the numbering system up in an embedded table. Both now go
@@ -1644,6 +1644,47 @@ months keeps .NET's abbreviated ones. Two lanes stay out of reach and are the en
 the interface's — `month: "narrow"` and `weekday: "narrow"`, which the formatter renders with the
 abbreviated pattern letter, and `timeStyle`, which writes English `AM`/`PM` regardless of any locale data,
 .NET's included.
+
+### 4.30 A calendar `ICalendarProvider` claims is a calendar `Temporal` accepts ([#3355](https://github.com/sebastienros/jint/issues/3355))
+
+`ICalendarProvider` could correct one of the eleven non-ISO calendars Jint implements, and nothing more.
+*Adding* one was documented as four overrides and was in fact impossible at any number: every `Temporal`
+entry point canonicalizes the identifier through a fixed table of eighteen before a provider is consulted,
+so `withCalendar('mayan')` was a `RangeError` that no provider could prevent. `ICalendarProvider.GetSupportedCalendars`
+had no caller at all — `Intl.supportedValuesOf('calendar')` reads `ICldrProvider.GetSupportedCalendars`,
+which is a different provider.
+
+Three things changed, none of which an unconfigured engine can observe:
+
+- **Canonicalization asks the provider.** An identifier Jint's own table does not name, that is a
+  well-formed Unicode calendar type and that the configured provider claims, is now a valid calendar
+  identifier — in `withCalendar`, in a `calendar` field and in a `[u-ca=…]` annotation.
+- **`DefaultCalendarProvider.IsSupported` answers from `GetSupportedCalendars()`** instead of from its own
+  hardcoded list, so the two cannot disagree and adding a calendar is three overrides rather than four. The
+  two lists held exactly the same eleven identifiers, so the answer is unchanged for every input.
+- **An unknown calendar reaching a conversion is a `RangeError`, not a `NotSupportedException`.** That
+  applies to a provider that names a calendar and then hands its conversion back to the base class, and to
+  calendar arithmetic — `add`, `subtract`, `until`, `since` — which is implemented per calendar inside the
+  engine and is not routed through the provider. Both used to throw a CLR exception out of
+  `Engine.Evaluate`, where neither script nor an embedder's `catch (JintException)` could see it.
+
+```c#
+// 5.x — three overrides, and Temporal accepts the identifier everywhere
+sealed class WithMayan : DefaultCalendarProvider
+{
+    public override IReadOnlyCollection<string> GetSupportedCalendars() => [.. base.GetSupportedCalendars(), "mayan"];
+    public override CalendarFields IsoToCalendarFields(string calendar, int isoYear, int isoMonth, int isoDay) => …;
+    public override IsoDateFields? CalendarFieldsToIso(string calendar, int year, string? monthCode, int month, int day, string overflow) => …;
+}
+```
+
+**What could break:** a provider whose `IsSupported` and `GetSupportedCalendars` disagreed. `IsSupported` is
+now the list's answer for anything deriving from `DefaultCalendarProvider` without overriding it, and it is
+the question the engine asks — so a calendar in the list is now claimed, and one absent from it is not.
+A provider implementing `ICalendarProvider` from scratch is unaffected: both members are still its own.
+Second, a host calendar reaches construction, the field accessors, `with`, `toString` and the
+`PlainYearMonth`/`PlainMonthDay` conversions, but not arithmetic and not `Intl.DateTimeFormat`; both refuse
+it with a `RangeError`.
 
 ## 5. New in v5
 
@@ -1790,11 +1831,11 @@ var engine = new Engine(options => options.Intl.CldrProvider = new MyCldr());
 
 `ICldrProvider` is now nineteen members and every one of them has a caller, so whatever a derived class
 answers is what `Intl` shows — see [4.22](#422-intl-reads-the-cldr-provider-for-currency-symbols-and-week-info)
-and [4.28](#428-intl-reads-the-cldr-provider-for-date-names-and-numbering-system-digits) for the two changes
+and [4.29](#429-intl-reads-the-cldr-provider-for-date-names-and-numbering-system-digits) for the two changes
 that closed the gap, and section [2](#2-removed-api) for the two members that went instead of being wired.
 On the calendar side, *correcting* a calendar Jint already knows is one override, while *adding* one it does
-not know is four: `IsSupported`, `GetSupportedCalendars` and both conversions all have to answer for the new
-identifier.
+not know is three — `GetSupportedCalendars` and both conversions — per
+[4.30](#430-a-calendar-icalendarprovider-claims-is-a-calendar-temporal-accepts).
 
 ### 5.3 Host objects: one hook set for named properties ([#3338](https://github.com/sebastienros/jint/pull/3338))
 


### PR DESCRIPTION
Fixes #3355.

## The count was not four — it was infinity

The issue asks whether adding a calendar `ICalendarProvider` has never seen can be fewer than four overrides. Before answering that, the four-override claim had to be checked, and it does not hold: **adding a calendar was impossible at any number of overrides.**

Every Temporal entry point canonicalizes a calendar identifier through `TemporalHelpers.CanonicalizeCalendar`, a fixed switch over eighteen identifiers, *before* anything consults a provider. A host that overrides all four members and installs the provider gets:

```
  Failed Jint.Tests.PublicInterface.HostLocaleProviderTests.AddingACalendarTheEngineHasNeverSeen [199 ms]
  Error Message:
   Jint.Runtime.JavaScriptException : Invalid calendar: mayan
  ...
   at Jint.Tests.PublicInterface.HostLocaleProviderTests.AddingACalendarTheEngineHasNeverSeen()
----- Inner Stack Trace -----
    at withCalendar (<anonymous>:1:1)
```

Two more findings while confirming that:

- **`ICalendarProvider.GetSupportedCalendars` had no caller inside Jint at all.** A grep of `Jint/` finds `IsSupported` twice (both in `NonIsoCalendars`) and `GetSupportedCalendars` nowhere. The issue's "or `supportedValuesOf` omits it" refers to `Intl.supportedValuesOf('calendar')`, which reads `ICldrProvider.GetSupportedCalendars` — a different provider.
- **`IsSupported` and the list could disagree**, because each was its own hardcoded set.

## The answer: three overrides, and here is why not two

The two conversions are unavoidable — nobody but the host can convert a calendar the engine has never heard of. The third is **the list**, because something has to make the identifier valid before any conversion is reached, and a list is the only shape that also answers `IsSupported` and can be inherited. So:

- **Canonicalization asks the provider.** An identifier Jint's own table does not name, that is a well-formed [Unicode calendar type](https://tc39.es/ecma402/#sec-canonicalizeunicodelocaleid) and that a *non-default* provider claims, is now a valid calendar identifier — in `withCalendar`, in a `calendar` field and in a `[u-ca=…]` annotation.
- **`DefaultCalendarProvider.IsSupported` answers from `GetSupportedCalendars()`.** The two can no longer disagree, and a host adding a calendar does not have to remember to claim it twice. It stays `virtual`, so a provider with a long list can still make the membership test O(1); the doc comment says so, and says to return a cached collection because the list is now read on a validation path.

It is *not* two, and the reason is worth writing down: making `IsSupported` alone sufficient would leave `GetSupportedCalendars` with no caller again, and a "not mine" return on the conversions (the issue's second bullet) cannot help — the identifier has to be validated *before* a conversion runs, at `from`/`withCalendar`/annotation time, when there is no date to convert yet.

## What a host calendar can and cannot do

Measured, not assumed — a `WithMayan` provider (ISO shifted by the Long Count epoch, so the arithmetic is checkable by eye) run over the surface:

| Works | Does not |
| --- | --- |
| `withCalendar`, `from({fields})`, `from('…[u-ca=mayan]')` | `add` / `subtract` / `until` / `since` |
| `PlainDateTime`, `ZonedDateTime`, `PlainYearMonth`, `PlainMonthDay` | `toLocaleString` |
| `year`, `month`, `monthCode`, `day`, `dayOfWeek`, `dayOfYear`, `daysInMonth`, `daysInYear`, `monthsInYear`, `inLeapYear`, `era` | `new Intl.DateTimeFormat(…, { calendar })` |
| `with`, `toString`, `toPlainYearMonth`, `toPlainMonthDay` | `Intl.supportedValuesOf('calendar')` |

Calendar arithmetic is implemented per calendar inside `NonIsoCalendars` and is not routed through the provider — the `CalendarDateAdd` doc comment has said so since it was written. `Intl.DateTimeFormat` has its own calendar list, and this is the Temporal provider. Both limits are stated in `DefaultCalendarProvider`'s class docs, in the README and in the migration guide, and both are filed: #3403 and #3404.

## The third question: `NotSupportedException`

The issue asks whether it is the right exception out of a `Temporal` call. It is not — it is not a `JintException`, so it escapes `Engine.Evaluate` past both a script's `catch` and an embedder's. Two places produced it and both now raise a `RangeError`:

- A provider that names a calendar in its list and then hands the conversion back to `base`, which has never heard of it. The message names the member the host still owes: `Calendar 'mayan' is claimed by the configured ICalendarProvider but its IsoToCalendarFields does not answer for it`.
- Calendar arithmetic for a calendar the engine does not implement: `RangeError: Calendar arithmetic is not implemented for 'mayan'`.

The second is pinned by `AHostCalendarHasNoArithmeticAndSaysSoInJavaScript`, which asserts the *constructor name and message* from inside script — a `NotSupportedException` could not satisfy it.

## Also here

- The membership test is threaded down to the twelve calendar field accessors, `CalendarDateToISO`, and the `PlainMonthDay` reference-year search. That last one had no generic form, so `PlainMonthDay.from({ monthCode: 'M03', day: 5, calendar: 'mayan' })` produced `-001142-03-05` — silently wrong rather than refused. It now has one, written only in terms of the two conversions, and produces `1972-03-05`.
- `RejectTemporalUnsupportedCalendar` stops refusing `islamic` and `islamic-rgsa` when a provider claims them. Those two are in the specification's calendar list and are refused only because Jint has no sighting data; a host with ICU4N does, and this is the most realistic reason to reach for the extension point.

## Default-engine behaviour is unchanged

Not asserted — checked:

- **Every new arm is gated on `!ReferenceEquals(provider, DefaultCalendarProvider.Instance)`**, which is the same identity test `NonIsoCalendars` already used. An engine that configures nothing cannot reach any of them.
- **The list `IsSupported` now reads holds exactly the eleven identifiers the switch it replaced named** — `chinese`, `dangi`, `hebrew`, `persian`, `coptic`, `ethiopic`, `ethioaa`, `indian`, `islamic-umalqura`, `islamic-civil`, `islamic-tbla`. The new `TemporalCalendarProviderTests.TheDefaultProviderClaimsExactlyTheElevenCalendarsTheEngineImplements` compares them entry by entry, and checks thirteen identifiers that must stay unclaimed, including `islamic`, `islamic-rgsa`, `gregory` and `CHINESE`.
- `AnUnconfiguredEngineStillRefusesACalendarNobodyImplements` pins that `mayan` is still a `RangeError` through all three entry points on a stock engine, and that `islamic` / `islamic-rgsa` are still refused.

No public signature changed: `TemporalHelpers` is `internal`, and `ICalendarProvider` / `DefaultCalendarProvider` keep their four members. The five API baselines and `UndocumentedPublicApi.txt` are untouched, and both pass.

## Verification

- `dotnet build -c Release` clean, 0 warnings.
- `Jint.Tests`: 10,747 passed on `net10.0` and `net8.0`, 7,371 on `net472`, 0 failed.
- `Jint.Tests.PublicInterface`: 3,000 passed on `net10.0`, 2,371 on `net472`, 0 failed.
- `Jint.Tests.Test262`: **102,495 passed, 0 failed**, 189 skipped, 102,684 total — the number `main` holds. `intl402` is generated and included, and `intl402/Temporal` is where this change is exposed.

  An earlier run of the same tree lost `staging/sm/Array/toSpliced-dense.js` (both strict legs) to a bare `System.TimeoutException` out of `TimeConstraint.Check` at the engine's 30-second ceiling. That file mentions neither `Temporal` nor a calendar; `--filter FullyQualifiedName~Sm_Array` in isolation passes **182/182 in 3 seconds**, a 10× slowdown under contention, and the re-run on an unloaded machine is the number above.

## A note for whoever merges this and #3397

Both add a `§4.28` to `docs/v5-migration.md` and both rewrite the same paragraph in `§5.2`. Numbering is assigned at merge, so the second one in renumbers and re-merges that paragraph.
