### PR TITLE
Interop: a host operator that throws reports what it threw, not an exception nothing raised

### DIFF
--- a/Jint.Tests.PublicInterface/HostOperatorExceptionTests.cs
+++ b/Jint.Tests.PublicInterface/HostOperatorExceptionTests.cs
@@ -1,0 +1,92 @@
+#nullable enable
+
+using Jint.Runtime;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// A host <c>operator</c> that throws is a host method that throws, and the embedder has to receive the
+/// same exception from both.
+/// </summary>
+/// <remarks>
+/// Every other interop call site normalizes what it catches with
+/// <c>e as TargetInvocationException ?? new TargetInvocationException(e)</c>; the operator-overloading path
+/// wrapped <c>e.InnerException</c> instead, and by the time it catches, the invoke has already been
+/// unwrapped — so <c>InnerException</c> is the host exception's own cause, or nothing at all. The pairs
+/// below are the measurement: the same failure raised from an ordinary method and from an operator, which
+/// must arrive identically.
+/// </remarks>
+public class HostOperatorExceptionTests
+{
+    public sealed class Meter
+    {
+        public Meter(double value) => Value = value;
+
+        public double Value { get; }
+
+        /// <summary>A plain failure, with a message and no cause of its own.</summary>
+        public static Meter operator +(Meter left, Meter right) => throw new InvalidOperationException("HOST BOOM");
+
+        /// <summary>A failure that carries a cause, which is the half that got reported instead of it.</summary>
+        public static Meter operator -(Meter left, Meter right)
+            => throw new NotSupportedException("metres do not subtract", new ArgumentException("nested cause"));
+
+        public Meter Add(Meter other) => throw new InvalidOperationException("HOST BOOM");
+
+        public Meter Subtract(Meter other)
+            => throw new NotSupportedException("metres do not subtract", new ArgumentException("nested cause"));
+    }
+
+    private static Exception? Evaluate(string source)
+    {
+        var engine = new Engine(options => options.Interop.AllowOperatorOverloading = true);
+        engine.SetValue("a", new Meter(1));
+        engine.SetValue("b", new Meter(2));
+        return Caught.Exception(() => engine.Evaluate(source));
+    }
+
+    [Test]
+    public void AHostOperatorsFailureArrivesWithItsMessage()
+    {
+        var fromMethod = Evaluate("a.Add(b)");
+        var fromOperator = Evaluate("a + b");
+
+        fromMethod.Should().BeOfType<InvalidOperationException>().Which.Message.Should().Be("HOST BOOM");
+        fromOperator.Should().BeOfType<InvalidOperationException>().Which.Message.Should().Be("HOST BOOM");
+    }
+
+    [Test]
+    public void AHostOperatorsFailureArrivesRatherThanItsCause()
+    {
+        var fromMethod = Evaluate("a.Subtract(b)");
+        var fromOperator = Evaluate("a - b");
+
+        fromMethod.Should().BeOfType<NotSupportedException>().Which.Message.Should().Be("metres do not subtract");
+        fromOperator.Should().BeOfType<NotSupportedException>().Which.Message.Should().Be("metres do not subtract");
+    }
+
+    [Test]
+    public void TheSameHoldsWhenTheHostAsksForClrExceptionsToBeCaught()
+    {
+        // CatchClrExceptions builds the JavaScript error from the *meaningful* exception, so it reads the
+        // same value the two tests above assert on: the host exception is what TryGetClrException hands
+        // back, and what the message is drawn from once the host opts into detailed messages. Wrapping the
+        // wrong thing put a placeholder TargetInvocationException in both places.
+        var engine = new Engine(options =>
+        {
+            options.Interop.AllowOperatorOverloading = true;
+            options.Interop.ExposeDetailedExceptionMessages = true;
+            options.CatchClrExceptions();
+        });
+        engine.SetValue("a", new Meter(1));
+        engine.SetValue("b", new Meter(2));
+
+        var exception = Invoking(() => engine.Evaluate("a + b")).Should().Throw<JavaScriptException>().Which;
+
+        exception.Message.Should().Be("HOST BOOM");
+        JintException.TryGetClrException(exception, out var clrException).Should().BeTrue();
+        clrException.Should().BeOfType<InvalidOperationException>();
+
+        engine.Evaluate("try { a + b } catch (e) { e.message }").AsString().Should().Be("HOST BOOM");
+    }
+}

--- a/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
@@ -785,7 +785,12 @@ internal abstract class JintBinaryExpression : JintExpression
                 }
                 catch (Exception e)
                 {
-                    Throw.MeaningfulException(context.Engine, new TargetInvocationException(e.InnerException));
+                    // The same normalization every other interop call site uses. Wrapping e.InnerException
+                    // instead reported the wrong exception twice over: MethodDescriptor.Call has already
+                    // unwrapped the invoke, so `e` is the host's own exception and its InnerException is
+                    // that exception's cause - null for the common case, which left MeaningfulException
+                    // with a contentless TargetInvocationException to report.
+                    Throw.MeaningfulException(context.Engine, e as TargetInvocationException ?? new TargetInvocationException(e));
                     result = null;
                     return false;
                 }

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -1717,6 +1717,40 @@ This is a catchable *failure*, not a raised ceiling: how deep a graph an engine 
 the thread's stack rather than by `MaxModuleGraphDepth`. Making the two algorithms iterative, the way loading
 already is, is tracked in [#3401](https://github.com/sebastienros/jint/issues/3401).
 
+### 4.32 A host operator that throws reports what it threw ([#3408](https://github.com/sebastienros/jint/issues/3408))
+
+With `Options.Interop.AllowOperatorOverloading = true`, an exception raised inside a host `operator` reached
+the embedder as something else. Every other interop call site normalizes what it catches with
+`e as TargetInvocationException ?? new TargetInvocationException(e)`; the operator path wrapped
+`e.InnerException`, and by the time it catches, the invoke has already been unwrapped — so it reported the
+host exception's *cause*, or, when there was none, an empty `TargetInvocationException`:
+
+```csharp
+// 4.16.x, for a host type whose operator+ throws InvalidOperationException("HOST BOOM")
+//         and whose operator- throws NotSupportedException("…", new ArgumentException("nested cause"))
+engine.Evaluate("a.Add(b)");   // InvalidOperationException: HOST BOOM
+engine.Evaluate("a + b");      // TargetInvocationException: Exception has been thrown by the
+                               //                            target of an invocation.  ← message gone
+engine.Evaluate("a.Sub(b)");   // NotSupportedException: metres do not subtract
+engine.Evaluate("a - b");      // ArgumentException: nested cause                       ← the cause, not the error
+```
+
+```csharp
+// 5.x — the operator and the ordinary method are the same exception
+engine.Evaluate("a + b");      // InvalidOperationException: HOST BOOM
+engine.Evaluate("a - b");      // NotSupportedException: metres do not subtract
+```
+
+`Options.CatchClrExceptions()` moves with it: the `JavaScriptException` is now built from the host
+exception, so `JintException.TryGetClrException` hands back that exception rather than a placeholder, and
+`Options.Interop.ExposeDetailedExceptionMessages = true` shows the host's message rather than the
+placeholder's.
+
+**What could break:** a `catch` written around `Evaluate` to absorb the placeholder — `catch
+(TargetInvocationException)`, or a `catch` for the exception type that happened to be the host exception's
+`InnerException`. Catch the exception the host actually raises instead. There is no option to restore the
+old shape; the old shape reported an exception nothing threw.
+
 ## 5. New in v5
 
 Everything in the table below is opt-in: nothing in it is installed unless the host asks for it, so


### PR DESCRIPTION
Fixes #3408

`JintBinaryExpression.TryOperatorOverloading` was the only site in the assembly building
`new TargetInvocationException(e.InnerException)`. The four comparable sites — `DelegateWrapper`,
`CompilableMemberAccessor`, `GeneratedMemberAccessor` and `MethodInfoFunction` — all spell it
`e as TargetInvocationException ?? new TargetInvocationException(e)`, and the difference is not cosmetic.

By the time that catch runs, `MethodDescriptor.Call` has already caught the invoke's
`TargetInvocationException` and rethrown the host exception itself through `Throw.MeaningfulException`. So
`e` **is** the host exception, and `e.InnerException` is that exception's own cause.

### Measured, each against the identical exception from an ordinary host method

`operator +` throws `InvalidOperationException("HOST BOOM")`:

| what the script does | what the embedder catches, before | after |
| --- | --- | --- |
| `a.Add(b)` | `InvalidOperationException: HOST BOOM` | unchanged |
| `a + b` | `TargetInvocationException: Exception has been thrown by the target of an invocation.` | `InvalidOperationException: HOST BOOM` |

`operator -` throws `NotSupportedException("metres do not subtract", new ArgumentException("nested cause"))`:

| what the script does | what the embedder catches, before | after |
| --- | --- | --- |
| `a.Subtract(b)` | `NotSupportedException: metres do not subtract` | unchanged |
| `a - b` | `ArgumentException: nested cause` | `NotSupportedException: metres do not subtract` |

The first is the more common shape and the worse one: a host exception with no cause of its own becomes a
`TargetInvocationException` whose `InnerException` is `null` — an exception nothing threw. Under
`Options.CatchClrExceptions()` that same `null` reached `FromClrException`, so the JavaScript error was
built over the placeholder; and where the host exception was itself a `JavaScriptException`, the error was
rebuilt over its own wrapper, one layer deeper each time. `JintException.TryGetClrException` now hands back
the host exception in both cases.

### Why this lands first

That contentless exception is also why #3410 has been green since #1011 in 2021 **without its assertion ever
being reached**: xUnit's unwrapper resolved a `TargetInvocationException` to its inner exception, which was
`null`, and recorded no failure at all. That test stays `[Ignore]`d here — what it asserts is #3407 — but
until this lands, any failure in that area reports the wrong exception, so this is what makes the next change
diagnosable. The repository is on NUnit now (#3409), which does not unwrap, so a regression here cannot hide
again.

### Tests

`Jint.Tests.PublicInterface/HostOperatorExceptionTests.cs` — the embedder's view, no `InternalsVisibleTo`.
The three tests fail on `main` with exactly the shapes in the tables above.

`docs/v5-migration.md` gains §4.32 (rebased onto #3415, which took §4.31; re-check at merge).
