### PR TITLE
Interop: an index on a host collection is one property, however script spelled it

### DIFF
--- a/Jint.Tests.PublicInterface/ClrWriteConfigurationTests.cs
+++ b/Jint.Tests.PublicInterface/ClrWriteConfigurationTests.cs
@@ -237,8 +237,6 @@ public class ClrWriteConfigurationTests
     [TestCase("Array.prototype.pop.call(list)")]
     [TestCase("Array.prototype.shift.call(list)")]
     [TestCase("Array.prototype.splice.call(list, 0, 1)")]
-    [TestCase("list['0'] = 9")]
-    [TestCase("Reflect.set(list, '0', 9)")]
     [TestCase("Object.assign(list, { 0: 9 })")]
     [TestCase("Object.getOwnPropertyDescriptor(list, '0').set.call(list, 9)")]
     public void ArrayGenericsCannotMutateFrozenClrListsWhenWritesAreEnabled(string script)
@@ -251,6 +249,45 @@ public class ClrWriteConfigurationTests
             .Should().Throw<JavaScriptException>().Which;
 
         exception.Error.Get("name").AsString().Should().Be("TypeError");
+        list.Should().Equal(1, 2);
+    }
+
+    /// <summary>
+    /// The other half of the refusal, and it is not a throw. A bare assignment to a frozen wrapper is an
+    /// ordinary <c>[[Set]]</c> returning <see langword="false"/> — silent outside strict mode — and
+    /// <c>Reflect.set</c> reports that <see langword="false"/> rather than raising. Both spellings of the
+    /// index answer the same way since #3384; before it, <c>list[0]</c> was silent and <c>list['0']</c>
+    /// threw, because only the second reached the reflected indexer's throwing descriptor.
+    /// </summary>
+    [TestCase("list[0] = 9")]
+    [TestCase("list['0'] = 9")]
+    public void AnAssignmentToAFrozenClrListIsRefusedSilentlyInSloppyModeAndThrowsInStrictMode(string script)
+    {
+        var list = new List<int> { 1, 2 };
+
+        var engine = new Engine(options => options.Interop.AllowWrite = true).SetValue("list", list);
+        engine.Execute("Object.freeze(list);");
+        engine.Execute(script);
+        list.Should().Equal(1, 2);
+
+        var strictEngine = new Engine(options => options.Interop.AllowWrite = true).SetValue("list", list);
+        strictEngine.Execute("Object.freeze(list);");
+        var exception = Invoking(() => strictEngine.Execute("'use strict';\n" + script))
+            .Should().Throw<JavaScriptException>().Which;
+
+        exception.Error.Get("name").AsString().Should().Be("TypeError");
+        list.Should().Equal(1, 2);
+    }
+
+    [TestCase("Reflect.set(list, 0, 9)")]
+    [TestCase("Reflect.set(list, '0', 9)")]
+    public void ReflectSetReportsAFrozenClrListsRefusalAsFalse(string script)
+    {
+        var list = new List<int> { 1, 2 };
+        var engine = new Engine(options => options.Interop.AllowWrite = true).SetValue("list", list);
+        engine.Execute("Object.freeze(list);");
+
+        engine.Evaluate(script).Should().BeFalse();
         list.Should().Equal(1, 2);
     }
 

--- a/Jint.Tests.PublicInterface/HostCollectionIndexWriteTests.cs
+++ b/Jint.Tests.PublicInterface/HostCollectionIndexWriteTests.cs
@@ -1,0 +1,452 @@
+#nullable enable
+
+using System.Collections;
+using System.Collections.ObjectModel;
+using Jint.Runtime;
+using Jint.Runtime.Interop;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// Pins what an index names on a wrapped CLR collection: the same position whichever way script spelled it,
+/// and never an index the collection is left to reject.
+///
+/// <para>
+/// <c>x[3]</c> and <c>x["3"]</c> are one property key — <c>ToPropertyKey</c> makes both the String
+/// <c>"3"</c> — so they must be one answer. Until #3384 they were two: a number key was answered by the
+/// array-like view, and a string key by the reflected indexer, which took whatever index it parsed out of
+/// the key straight to the collection and let its <see cref="ArgumentOutOfRangeException"/> past script.
+/// </para>
+///
+/// <para>
+/// The growable half is the other question the issue asks. A wrapped <see cref="List{T}"/> answers
+/// <c>x.length = 5</c> by growing, so <c>x[3] = 9</c> — the same request, spelled the way a script author
+/// spells it — grows too: the view is an extensible ordinary object and the position can exist, so
+/// <c>CreateDataProperty</c> succeeds. A fixed-size or read-only target keeps the refusal #3381 and #3385
+/// gave it.
+/// </para>
+/// </summary>
+public class HostCollectionIndexWriteTests
+{
+    private static readonly string[] _growableShapes =
+    [
+        nameof(List<int>),
+        "ListOfString",
+        nameof(Collection<int>),
+        nameof(HostList),
+        nameof(ArrayList),
+        nameof(HostUntypedList),
+    ];
+
+    public static TestCases<string> GrowableShapes => new(_growableShapes);
+
+    /// <summary>
+    /// Both spellings of every index-shaped key, so that a row cannot pass because the test happened to
+    /// write the one the engine already answered.
+    /// </summary>
+    public static TestCases<string, string> GrowableShapesAndIndexSpellings
+    {
+        get
+        {
+            var data = new TestCases<string, string>();
+            foreach (var shape in _growableShapes)
+            {
+                data.Add(shape, "3");
+                data.Add(shape, "'3'");
+            }
+
+            return data;
+        }
+    }
+
+    private static (object Host, Func<IReadOnlyList<string>> Read) CreateGrowableShape(string kind)
+    {
+        switch (kind)
+        {
+            case nameof(List<int>):
+            {
+                var items = new List<int> { 1, 2, 3 };
+                return (items, () => Render(items));
+            }
+            case "ListOfString":
+            {
+                // a reference item type, whose grown slots are null rather than a zero
+                var items = new List<string?> { "1", "2", "3" };
+                return (items, () => Render(items));
+            }
+            case nameof(Collection<int>):
+            {
+                var items = new Collection<int> { 1, 2, 3 };
+                return (items, () => Render(items));
+            }
+            case nameof(HostList):
+            {
+                var items = new List<int> { 1, 2, 3 };
+                return (new HostList(items), () => Render(items));
+            }
+            case nameof(ArrayList):
+            {
+                var items = new ArrayList { 1, 2, 3 };
+                return (items, () => Render(items.Cast<object?>()));
+            }
+            case nameof(HostUntypedList):
+            {
+                var items = new List<int> { 1, 2, 3 };
+                return (new HostUntypedList(items), () => Render(items));
+            }
+            default:
+                throw new ArgumentOutOfRangeException(nameof(kind), kind, "unknown shape");
+        }
+    }
+
+    private static IReadOnlyList<string> Render<T>(IEnumerable<T> items)
+        => items.Select(i => i?.ToString() ?? "null").ToList();
+
+    private static Engine CreateEngine(object host, bool strict = false)
+    {
+        var engine = new Engine(options =>
+        {
+            options.Strict = strict;
+            options.Interop.AllowWrite = true;
+        });
+        engine.SetValue("x", host);
+        return engine;
+    }
+
+    /// <summary>
+    /// The reported defect: an index write at the end of a growable list raised the CLR's own
+    /// <see cref="ArgumentOutOfRangeException"/> out of <c>Evaluate</c>, where a <c>length</c> write of the
+    /// same size grew the list.
+    /// </summary>
+    [TestCaseSource(nameof(GrowableShapesAndIndexSpellings))]
+    public void AnIndexWriteAtTheEndOfAGrowableCollectionAppends(string shape, string index)
+    {
+        var (host, read) = CreateGrowableShape(shape);
+        var engine = CreateEngine(host);
+
+        engine.Execute("x[" + index + "] = 9");
+
+        read().Should().Equal("1", "2", "3", "9");
+        engine.Evaluate("x.length").AsNumber().Should().Be(4);
+    }
+
+    /// <summary>
+    /// An index past the end makes room the way the <c>length</c> write does, so the two agree cell for
+    /// cell — which is the whole point of the change, and what a JavaScript array's <c>a[5] = 9</c> means.
+    /// </summary>
+    [TestCaseSource(nameof(GrowableShapesAndIndexSpellings))]
+    public void AnIndexWritePastTheEndGrowsExactlyAsTheLengthWriteDoes(string shape, string index)
+    {
+        var key = index == "3" ? "5" : "'5'";
+
+        var (throughIndex, readIndex) = CreateGrowableShape(shape);
+        CreateEngine(throughIndex).Execute("x[" + key + "] = 9");
+
+        var (throughLength, readLength) = CreateGrowableShape(shape);
+        CreateEngine(throughLength).Execute("x.length = 6; x[" + key + "] = 9");
+
+        readIndex().Should().Equal(readLength(), "growing through an index and growing through length are one request");
+        readIndex().Should().HaveCount(6);
+        readIndex()[5].Should().Be("9");
+    }
+
+    /// <summary>
+    /// The ordinary ways a script copies into a host list. Both are specified as <c>Set(O, k, v, true)</c>
+    /// over string keys, so both used to reach the reflected indexer and raise a CLR exception.
+    /// </summary>
+    [TestCaseSource(nameof(GrowableShapes))]
+    public void CopyingIntoAGrowableCollectionGrowsIt(string shape)
+    {
+        var (host, read) = CreateGrowableShape(shape);
+        CreateEngine(host).Execute("Object.assign(x, { 3: 9 })");
+        read().Should().Equal("1", "2", "3", "9");
+
+        var (spreadHost, spreadRead) = CreateGrowableShape(shape);
+        CreateEngine(spreadHost).Execute("var src = { 3: 9 }; for (var k in src) { x[k] = src[k]; }");
+        spreadRead().Should().Equal("1", "2", "3", "9");
+    }
+
+    /// <summary>
+    /// A key that is index-shaped but can never be a position of the view: negative, non-canonical, or past
+    /// what the target can address. Each one used to be parsed by the reflected indexer and handed to the
+    /// collection; the view owes script the ordinary <c>[[Set]]</c> refusal instead — silent outside strict
+    /// mode, a <c>TypeError</c> inside it — because <c>x[-1]</c> reads <c>undefined</c> and <c>-1 in x</c>
+    /// is <see langword="false"/>, so a position it could be read back from does not exist.
+    /// </summary>
+    [TestCase("x[-1] = 9")]
+    [TestCase("x['-1'] = 9")]
+    [TestCase("x['08'] = 9")]
+    [TestCase("x['+3'] = 9")]
+    [TestCase("x[2147483648] = 9")]
+    public void AnIndexTheViewCannotHoldIsRefusedRatherThanHandedToTheCollection(string operation)
+    {
+        var (host, read) = CreateGrowableShape(nameof(List<int>));
+
+        CreateEngine(host).Evaluate(Probe(operation, strict: false)).AsString().Should().Be("no-throw");
+        read().Should().Equal("1", "2", "3");
+
+        CreateEngine(host, strict: true).Evaluate(Probe(operation, strict: true)).AsString().Should().Be("TypeError");
+        read().Should().Equal("1", "2", "3");
+    }
+
+    /// <summary>
+    /// The read side of the same key. <c>x["3"]</c> raised <see cref="ArgumentOutOfRangeException"/> out of
+    /// <c>Evaluate</c> where <c>x[3]</c> read <c>undefined</c> — a plain read of an absent index, on every
+    /// array-like wrapper including the read-only ones.
+    /// </summary>
+    [TestCaseSource(nameof(GrowableShapes))]
+    public void ReadingAnAbsentIndexIsUndefinedInEitherSpelling(string shape)
+    {
+        var (host, _) = CreateGrowableShape(shape);
+        var engine = CreateEngine(host);
+
+        foreach (var key in new[] { "3", "'3'", "-1", "'-1'", "'08'" })
+        {
+            engine.Evaluate("x[" + key + "] === undefined").AsBoolean()
+                .Should().BeTrue("reading x[{0}] of a three-element view is a hole", key);
+        }
+    }
+
+    /// <summary>
+    /// <c>delete</c> of a position that is not there is a no-op that succeeds, and of one that is there
+    /// resets the slot. Both spellings agree; before, the number spelling reached the collection with an
+    /// out-of-range index and the string spelling refused an in-range one.
+    /// </summary>
+    [TestCaseSource(nameof(GrowableShapes))]
+    public void DeletingAnIndexAnswersFromTheViewInEitherSpelling(string shape)
+    {
+        var (absentHost, absentRead) = CreateGrowableShape(shape);
+        var absent = CreateEngine(absentHost);
+        absent.Evaluate("delete x[3]").AsBoolean().Should().BeTrue();
+        absent.Evaluate("delete x['3']").AsBoolean().Should().BeTrue();
+        absent.Evaluate("delete x[-1]").AsBoolean().Should().BeTrue();
+        absentRead().Should().Equal("1", "2", "3");
+
+        var (presentHost, presentRead) = CreateGrowableShape(shape);
+        CreateEngine(presentHost).Evaluate("delete x['0']").AsBoolean().Should().BeTrue();
+        presentRead().Should().HaveCount(3);
+        presentRead()[0].Should().NotBe("1", "an in-range delete resets the slot, whichever way the index is spelled");
+    }
+
+    /// <summary>
+    /// The refusals a growable collection keeps. Neither is about the index: one is the engine's write
+    /// switch and the other is the object's own extensibility, and both are checked before the position is.
+    /// </summary>
+    [TestCase("3")]
+    [TestCase("'3'")]
+    public void GrowthStillNeedsWritesEnabledAndAnExtensibleView(string index)
+    {
+        var items = new List<int> { 1, 2, 3 };
+        var noWrites = new Engine().SetValue("x", items);
+        noWrites.Execute("x[" + index + "] = 9");
+        items.Should().Equal(1, 2, 3);
+
+        var frozen = CreateEngine(items);
+        frozen.Execute("Object.preventExtensions(x); x[" + index + "] = 9");
+        items.Should().Equal(1, 2, 3);
+    }
+
+    /// <summary>
+    /// The fixed-size half, unchanged by the growth lane and now answering the string spelling too: an
+    /// in-range element write works and anything outside the bounds is the <c>TypeError</c> #3381 gave it.
+    /// A <c>T[]</c> live view used to raise <see cref="IndexOutOfRangeException"/> for
+    /// <c>x['3'] = 9</c> and, worse, <see cref="ArgumentException"/> for the perfectly ordinary
+    /// <c>x['2'] = 9</c> — the reflected indexer for a <c>T[]</c> is the object-typed
+    /// <see cref="IList"/> one, so the write bypassed item-type coercion.
+    /// </summary>
+    [Test]
+    public void AFixedSizeViewAnswersBothSpellingsOfAnIndex()
+    {
+        var array = new[] { 1, 2, 3 };
+
+        var writable = LiveViewEngine(array);
+        writable.Execute("x['2'] = 9");
+        array.Should().Equal(1, 2, 9);
+
+        LiveViewEngine(array).Evaluate(Probe("x['3'] = 9", strict: false)).AsString().Should().Be("TypeError");
+        LiveViewEngine(array).Evaluate(Probe("x[3] = 9", strict: false)).AsString().Should().Be("TypeError");
+        array.Should().Equal(1, 2, 9);
+    }
+
+    private static Engine LiveViewEngine(object host)
+    {
+        var engine = new Engine(options =>
+        {
+            options.Interop.AllowWrite = true;
+            options.Interop.ArrayConversion = ArrayConversionMode.LiveView;
+        });
+        engine.SetValue("x", host);
+        return engine;
+    }
+
+    /// <summary>
+    /// An array or list handed to script under a read-only contract must refuse element writes in either
+    /// spelling. It used to refuse only the string one, and by accident: the reflected indexer of
+    /// <see cref="IReadOnlyList{T}"/> is get-only, while the view took its writability from the target.
+    /// </summary>
+    [TestCase("x[0] = 9")]
+    [TestCase("x['0'] = 9")]
+    [TestCase("x[3] = 9")]
+    [TestCase("x['3'] = 9")]
+    [TestCase("x.length = 5")]
+    public void AnExposedReadOnlyContractRefusesElementWritesInEitherSpelling(string operation)
+    {
+        var array = new[] { 1, 2, 3 };
+
+        ExposedReadOnly(array, strict: false).Evaluate(Probe(operation, strict: false)).AsString()
+            .Should().Be("no-throw", "a failed [[Set]] is silent outside strict mode");
+        array.Should().Equal(1, 2, 3);
+
+        ExposedReadOnly(array, strict: true).Evaluate(Probe(operation, strict: true)).AsString()
+            .Should().Be("TypeError", "a failed [[Set]] is a TypeError in strict mode");
+        array.Should().Equal(1, 2, 3);
+    }
+
+    [TestCase("x.push(9)")]
+    [TestCase("Object.assign(x, { 3: 9 })")]
+    public void AnExposedReadOnlyContractRefusesAGrowingGenericWithATypeError(string operation)
+    {
+        var array = new[] { 1, 2, 3 };
+
+        ExposedReadOnly(array, strict: false).Evaluate(Probe(operation, strict: false)).AsString()
+            .Should().Be("TypeError", "{0} is Set(O, k, v, true)", operation);
+        array.Should().Equal(1, 2, 3);
+    }
+
+    private static Engine ExposedReadOnly(int[] array, bool strict)
+    {
+        var engine = new Engine(options =>
+        {
+            options.Strict = strict;
+            options.Interop.AllowWrite = true;
+        });
+        engine.SetValue("x", ObjectWrapper.Create(engine, array, typeof(IReadOnlyList<int>)));
+        return engine;
+    }
+
+    /// <summary>
+    /// The blanket statement the three issues in this family are all about: whatever the shape and however
+    /// the index is spelled, what leaves <c>Evaluate</c> is a JavaScript error or nothing at all.
+    /// </summary>
+    [TestCaseSource(nameof(GrowableShapes))]
+    public void NoIndexOperationLetsAClrExceptionPastScript(string shape)
+    {
+        string[] operations =
+        [
+            "x[3] = 9", "x['3'] = 9", "x[5] = 9", "x['5'] = 9", "x[-1] = 9", "x['-1'] = 9", "x['08'] = 9",
+            "x[2147483648] = 9", "x[3]", "x['3']", "x[-1]", "x['-1']", "delete x[3]", "delete x['3']",
+            "delete x[-1]", "Object.assign(x, { 4: 9 })",
+        ];
+
+        foreach (var operation in operations)
+        {
+            foreach (var strict in new[] { false, true })
+            {
+                var (host, _) = CreateGrowableShape(shape);
+                var engine = CreateEngine(host, strict);
+
+                var thrown = Caught.Exception(() => engine.Execute(operation));
+
+                thrown.Should().Match(e => e == null || e is JavaScriptException,
+                    "{0} on {1} must answer script, not the CLR", operation, shape);
+            }
+        }
+    }
+
+    private static string Probe(string operation, bool strict)
+    {
+        var prologue = strict ? "'use strict';\n" : "";
+        return prologue
+            + "(function () { try { " + operation + "; return 'no-throw'; } "
+            + "catch (e) { return e instanceof TypeError ? 'TypeError' : 'unexpected: ' + e; } })()";
+    }
+
+    /// <summary>
+    /// A growable host list reaching the engine through the generic interface only.
+    /// </summary>
+    private sealed class HostList : IList<int>
+    {
+        private readonly List<int> _items;
+
+        public HostList(List<int> items) => _items = items;
+
+        public int Count => _items.Count;
+
+        public bool IsReadOnly => false;
+
+        public int this[int index]
+        {
+            get => _items[index];
+            set => _items[index] = value;
+        }
+
+        public void Add(int item) => _items.Add(item);
+
+        public void Clear() => _items.Clear();
+
+        public bool Contains(int item) => _items.Contains(item);
+
+        public void CopyTo(int[] array, int arrayIndex) => _items.CopyTo(array, arrayIndex);
+
+        public IEnumerator<int> GetEnumerator() => _items.GetEnumerator();
+
+        public int IndexOf(int item) => _items.IndexOf(item);
+
+        public void Insert(int index, int item) => _items.Insert(index, item);
+
+        public bool Remove(int item) => _items.Remove(item);
+
+        public void RemoveAt(int index) => _items.RemoveAt(index);
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    /// <summary>
+    /// A growable host list reaching the engine through the non-generic interface only, which is the
+    /// untyped view every typed one degrades to under Native AOT.
+    /// </summary>
+    private sealed class HostUntypedList : IList
+    {
+        private readonly List<int> _items;
+
+        public HostUntypedList(List<int> items) => _items = items;
+
+        public int Count => _items.Count;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => false;
+
+        public bool IsSynchronized => false;
+
+        public object SyncRoot => this;
+
+        public object? this[int index]
+        {
+            get => _items[index];
+            set => _items[index] = Convert.ToInt32(value, System.Globalization.CultureInfo.InvariantCulture);
+        }
+
+        public int Add(object? value)
+        {
+            _items.Add(Convert.ToInt32(value, System.Globalization.CultureInfo.InvariantCulture));
+            return _items.Count - 1;
+        }
+
+        public void Clear() => _items.Clear();
+
+        public bool Contains(object? value) => _items.Contains(Convert.ToInt32(value, System.Globalization.CultureInfo.InvariantCulture));
+
+        public void CopyTo(Array array, int index) => ((ICollection) _items).CopyTo(array, index);
+
+        public IEnumerator GetEnumerator() => _items.GetEnumerator();
+
+        public int IndexOf(object? value) => _items.IndexOf(Convert.ToInt32(value, System.Globalization.CultureInfo.InvariantCulture));
+
+        public void Insert(int index, object? value) => _items.Insert(index, Convert.ToInt32(value, System.Globalization.CultureInfo.InvariantCulture));
+
+        public void Remove(object? value) => _items.Remove(Convert.ToInt32(value, System.Globalization.CultureInfo.InvariantCulture));
+
+        public void RemoveAt(int index) => _items.RemoveAt(index);
+    }
+}

--- a/Jint/Runtime/Interop/ObjectWrapper.Specialized.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.Specialized.cs
@@ -107,22 +107,112 @@ internal abstract class ArrayLikeWrapper : ObjectWrapper
     // type descriptor does not recognize as integer-indexed
     internal sealed override bool HasIndexedElements => true;
 
-    public sealed override JsValue Get(JsValue property, JsValue receiver)
+    /// <summary>
+    /// What a property key names on this view. Every element lane below is keyed on the <em>index</em>
+    /// rather than on how script spelled it: <c>x[3]</c> and <c>x["3"]</c> are one property key, because
+    /// <see href="https://tc39.es/ecma262/#sec-topropertykey">ToPropertyKey</see> turns both into the
+    /// String <c>"3"</c>. Answering the two spellings from different lanes is answering one question
+    /// twice, and the lane that used to serve the string spelling was the reflected indexer, which reaches
+    /// the collection with whatever index it parses out of the key (#3384).
+    /// </summary>
+    private enum ElementKey
     {
-        if (property.IsInteger())
+        /// <summary>Not a position of this view: a member name, a symbol, a fractional number, or any string key of a dictionary-shaped target.</summary>
+        None,
+
+        /// <summary>A position the target could address. May be at or past <see cref="Length"/>.</summary>
+        Position,
+
+        /// <summary>Index-shaped but never a position of this view: negative, non-canonical (<c>"08"</c>, <c>"+3"</c>), or past what the target can address.</summary>
+        OutOfBand,
+    }
+
+    /// <summary>
+    /// The highest position an element lane will address, one below <see cref="int.MaxValue"/> so that
+    /// growing to <c>index + 1</c> cannot overflow.
+    /// </summary>
+    private const int MaxPosition = int.MaxValue - 1;
+
+    private ElementKey ClassifyElementKey(JsValue property, out int index)
+    {
+        index = 0;
+
+        if (property is JsNumber number)
         {
-            var index = property.AsInteger();
-            if ((uint) index < (uint) Length)
+            var value = number._value;
+            if (!TypeConverter.IsIntegralNumber(value))
             {
-                var result = GetJsValueAt(index);
-                if (_elementAccessMayRunHostCode)
-                {
-                    _engine.CheckAmortizedConstraintsAtHostBoundary();
-                }
-                return result;
+                return ElementKey.None;
             }
 
-            // out-of-range and negative indices read like JS array holes
+            if (value < 0 || value > MaxPosition)
+            {
+                return ElementKey.OutOfBand;
+            }
+
+            index = (int) value;
+            return ElementKey.Position;
+        }
+
+        // a symbol names no position, and a dictionary-shaped target (e.g. Newtonsoft's JObject: both
+        // IDictionary<string,_> and IList<_>) answers a string key from its own keys rather than by index
+        if (property is not JsString jsString || _typeDescriptor.IsDictionary)
+        {
+            return ElementKey.None;
+        }
+
+        var member = jsString.ToString();
+        var parsed = ArrayInstance.ParseArrayIndex(member);
+        if (parsed != uint.MaxValue)
+        {
+            if (parsed > MaxPosition)
+            {
+                return ElementKey.OutOfBand;
+            }
+
+            index = (int) parsed;
+            return ElementKey.Position;
+        }
+
+        // One character rules out every ordinary member name that reaches this view — "length", "Count",
+        // "push" — which would otherwise pay a whole long.TryParse only to be rejected by it.
+        if (member.Length == 0 || !IsIntegerShapedStart(member[0]))
+        {
+            return ElementKey.None;
+        }
+
+        // an integer-shaped but non-canonical key ("-1", "08") is not a position of the view either, and
+        // must not fall through to the reflected indexer, which parses one out of it and reaches the
+        // collection with an index the collection rejects
+        return long.TryParse(member, NumberStyles.Integer, CultureInfo.InvariantCulture, out _)
+            ? ElementKey.OutOfBand
+            : ElementKey.None;
+    }
+
+    /// <summary>
+    /// Whether <paramref name="c"/> can begin something <see cref="NumberStyles.Integer"/> parses: a digit,
+    /// a sign, or the leading white space it tolerates.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsIntegerShapedStart(char c)
+        => (uint) (c - '0') <= 9 || c == '-' || c == '+' || char.IsWhiteSpace(c);
+
+    public sealed override JsValue Get(JsValue property, JsValue receiver)
+    {
+        var key = ClassifyElementKey(property, out var index);
+        if (key == ElementKey.Position && (uint) index < (uint) Length)
+        {
+            var result = GetJsValueAt(index);
+            if (_elementAccessMayRunHostCode)
+            {
+                _engine.CheckAmortizedConstraintsAtHostBoundary();
+            }
+            return result;
+        }
+
+        if (key != ElementKey.None)
+        {
+            // out-of-range, negative and non-canonical indices read like JS array holes
             return Undefined;
         }
 
@@ -138,32 +228,18 @@ internal abstract class ArrayLikeWrapper : ObjectWrapper
             return base.HasProperty(property);
         }
 
-        if (property.IsNumber())
+        // membership of an array-like view is exactly the index range [0, Length); falling through would
+        // consult the reflected indexer, which reports presence for any parseable index (so e.g.
+        // "-1 in view" would be true)
+        var key = ClassifyElementKey(property, out var index);
+        if (key == ElementKey.Position)
         {
-            var value = ((JsNumber) property)._value;
-            if (TypeConverter.IsIntegralNumber(value))
-            {
-                // numeric membership of an array-like view is exactly the index range [0, Length);
-                // falling through would consult the reflected indexer, which reports presence for
-                // any parseable index (so e.g. "-1 in view" would be true). Compare as double so a
-                // negative or out-of-int-range index can never alias into range.
-                return value >= 0 && value < Length;
-            }
+            return (uint) index < (uint) Length;
         }
-        else if (property is JsString jsString)
+
+        if (key == ElementKey.OutOfBand)
         {
-            var str = jsString.ToString();
-            var index = ArrayInstance.ParseArrayIndex(str);
-            if (index != uint.MaxValue)
-            {
-                return index < (uint) Length;
-            }
-            // an integer-shaped but non-canonical key ("-1", "08") is not a member of the view
-            // either, and must not fall through to the reflected indexer's presence-only answer
-            if (long.TryParse(str, NumberStyles.Integer, CultureInfo.InvariantCulture, out _))
-            {
-                return false;
-            }
+            return false;
         }
 
         return base.HasProperty(property);
@@ -190,53 +266,55 @@ internal abstract class ArrayLikeWrapper : ObjectWrapper
                 }
             }
 
-            if (!_typeDescriptor.IsDictionary && property.IsNumber())
+            if (!_typeDescriptor.IsDictionary)
             {
-                var value = ((JsNumber) property)._value;
-                if (TypeConverter.IsIntegralNumber(value))
+                var frozenKey = ClassifyElementKey(property, out var frozenIndex);
+                if (frozenKey == ElementKey.Position)
                 {
-                    return value < 0 || value >= Length;
+                    return (uint) frozenIndex >= (uint) Length;
                 }
-            }
-            else if (!_typeDescriptor.IsDictionary && property is JsString jsString)
-            {
-                var index = ArrayInstance.ParseArrayIndex(jsString.ToString());
-                if (index != uint.MaxValue)
+
+                if (frozenKey == ElementKey.OutOfBand)
                 {
-                    return index >= (uint) Length;
+                    return true;
                 }
             }
 
             return ProbeOwnPropertyChecked(property) == OwnPropertyProbe.Missing;
         }
 
-        if (property.IsNumber())
+        var key = ClassifyElementKey(property, out var index);
+        if (key != ElementKey.None)
         {
-            var value = ((JsNumber) property)._value;
-            if (TypeConverter.IsIntegralNumber(value))
+            if (key == ElementKey.OutOfBand || (uint) index >= (uint) Length)
             {
-                if (IsFixedSize)
-                {
-                    // elements of a fixed-size CLR array view cannot be removed (and resetting them to a
-                    // default value on delete would let Array.prototype.pop/shift/splice silently zero
-                    // slots before their length write throws). Mirror integer-indexed exotic object
-                    // semantics instead: false for an in-range index, true for anything out of range.
-                    return value < 0 || value >= Length;
-                }
-
-                var defaultValue = default(object);
-                if (typeof(JsValue).IsAssignableFrom(ItemType))
-                {
-                    defaultValue = JsValue.Undefined;
-                }
-                else if (ItemType.IsValueType)
-                {
-                    defaultValue = Activator.CreateInstance(ItemType);
-                }
-
-                DoSetAt((int) value, defaultValue);
+                // there is no such position, so there is nothing to delete: OrdinaryDelete returns true
+                // for a property that is not there. Reaching the collection with the index instead is
+                // what raised the CLR's own ArgumentOutOfRangeException out of Evaluate (#3384).
                 return true;
             }
+
+            if (IsFixedSize)
+            {
+                // elements of a fixed-size CLR array view cannot be removed (and resetting them to a
+                // default value on delete would let Array.prototype.pop/shift/splice silently zero
+                // slots before their length write throws). Mirror integer-indexed exotic object
+                // semantics instead: false for an in-range index, true for anything out of range.
+                return false;
+            }
+
+            var defaultValue = default(object);
+            if (typeof(JsValue).IsAssignableFrom(ItemType))
+            {
+                defaultValue = JsValue.Undefined;
+            }
+            else if (ItemType.IsValueType)
+            {
+                defaultValue = Activator.CreateInstance(ItemType);
+            }
+
+            DoSetAt(index, defaultValue);
+            return true;
         }
 
         return base.Delete(property);
@@ -362,42 +440,49 @@ internal abstract class ArrayLikeWrapper : ObjectWrapper
             Throw.TypeError(_engine.Realm, "Invalid array length");
         }
 
-        if (ReferenceEquals(receiver, this) && property.IsNumber())
+        if (ReferenceEquals(receiver, this))
         {
-            // An element write to a read-only or non-extensible (frozen) wrapper must be refused:
-            // base.SetSlow would otherwise materialize a throwaway descriptor and return true, silently
-            // "succeeding" (#2541), or reach an indexer with an out-of-range growth write. Everything else —
-            // writable in-range writes, growth, negative and non-integral indices — defers to base.Set, which
-            // writes through and already
-            // rejects runtime read-only collections (e.g. ReadOnlyCollection<T>) cleanly. Wrappers don't
-            // track per-element writability, so a non-extensible wrapper blocks existing-element writes too
-            // — a deliberate, contained interop divergence from the spec.
-            var numValue = ((JsNumber) property)._value;
-            if (TypeConverter.IsIntegralNumber(numValue) && numValue >= 0
-                && (!CanWrite || !Extensible))
+            // Every index write is answered here rather than through the reflection indexer base.Set would
+            // resolve. That indexer takes the index straight to the collection, so it leaked the CLR's own
+            // ArgumentOutOfRangeException for anything outside [0, Count) and, for a T[], found the
+            // non-generic IList.Item (object-typed) overload, whose writes bypass item-type coercion (#3384).
+            var key = ClassifyElementKey(property, out var index);
+            if (key != ElementKey.None)
             {
-                return false;
-            }
-
-            // Fixed-size targets (CLR arrays) handle integral index writes here: in-range writes go
-            // straight to the backing store and anything else is a TypeError. The base.Set slow path
-            // below resolves the element writer through the reflection indexer, which for T[] finds
-            // the non-generic IList.Item (object-typed) indexer — element values would bypass item
-            // type coercion and out-of-range writes would leak CLR exceptions.
-            if (IsFixedSize && TypeConverter.IsIntegralNumber(numValue))
-            {
+                // An element write to a read-only or non-extensible (frozen) wrapper is refused as an
+                // ordinary [[Set]] false — silent in sloppy mode, a TypeError in strict — rather than by
+                // materializing a throwaway descriptor and returning true (#2541). Wrappers don't track
+                // per-element writability, so a non-extensible wrapper blocks existing-element writes too
+                // — a deliberate, contained interop divergence from the spec.
                 if (!CanWrite || !Extensible)
                 {
                     return false;
                 }
 
-                if (numValue >= 0 && numValue < Length)
+                if (key == ElementKey.Position && (uint) index < (uint) Length)
                 {
-                    SetAt((int) numValue, value);
+                    SetAt(index, value);
                     return true;
                 }
 
-                Throw.TypeError(_engine.Realm, "Cannot write outside the bounds of a fixed-size CLR array");
+                if (IsFixedSize)
+                {
+                    Throw.TypeError(_engine.Realm, "Cannot write outside the bounds of a fixed-size CLR array");
+                }
+
+                if (key == ElementKey.OutOfBand)
+                {
+                    // a negative, non-canonical or unaddressable index is a position this view can never
+                    // have — Get answers undefined for it and HasProperty answers false — so the write is
+                    // the ordinary [[Set]] refusal rather than something the collection has to reject
+                    return false;
+                }
+
+                // At or past the end of a growable target. The view is an extensible ordinary object and
+                // the position can exist, so CreateDataProperty succeeds: make room and write, which is
+                // exactly what a "length" write of index + 1 does through the lane above.
+                SetAt(index, value);
+                return true;
             }
         }
 
@@ -528,7 +613,15 @@ internal sealed class ListWrapper : ArrayLikeWrapper
     {
         _list = target;
         _fixedSize = target.IsFixedSize;
-        _readOnly = target.IsReadOnly;
+
+        // Two ways this view is read-only: the target says so, or the exposed contract offers no writable
+        // indexer. The second half is what a T[] or a List<T> reaching the engine as IReadOnlyList<T>
+        // needs. ReadOnlyListWrapper<T> says read-only from its type argument, but an interface is not
+        // among its own GetInterfaces(), so ResolveArrayLikeWrapperFactoryType finds no typed factory for
+        // that exposure and it degrades to here. Until #3384 the element lane read the target's writability
+        // and wrote straight through a contract that had promised script it could only read; the refusal
+        // came from the reflected indexer instead, and therefore only for a string-spelled index.
+        _readOnly = target.IsReadOnly || !_typeDescriptor.IsIntegerIndexed;
     }
 
     /// <summary>

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -1939,6 +1939,67 @@ from, and the one `ShadowRealm.SetValue` enters deliberately ([§4.23](#423-a-va
 (`x instanceof Function`), a reach for `call`/`apply`/`bind`, or an `Object.getPrototypeOf` inside a shadow
 realm now gets the answer the realm's own intrinsics give. A host function the embedder builds itself
 through `new ClrFunction(engine, …)` is unaffected and still belongs to the principal realm.
+### 4.36 An index on a host collection is one property, however it is spelled ([#3384](https://github.com/sebastienros/jint/issues/3384))
+
+`x[3]` and `x["3"]` are one property key, and a wrapped CLR collection answered them from two different
+places: a number key went to the array-like view, a string key to the reflected indexer, which took whatever
+index it parsed out of the key straight to the collection. So on a `List<int>` of three elements:
+
+```js
+// 4.16.x, for engine.SetValue("x", new List<int> { 1, 2, 3 })
+//         with options.Interop.AllowWrite = true
+x[3] = 9                    // ArgumentOutOfRangeException out of Evaluate
+x["3"] = 9                  // ArgumentOutOfRangeException
+x["3"]                      // ArgumentOutOfRangeException — a read
+Object.assign(x, { 3: 9 })  // ArgumentOutOfRangeException
+delete x[3]                 // ArgumentOutOfRangeException
+x[-1] = 9                   // ArgumentOutOfRangeException
+x.length = 5                // grows the list to 1,2,3,0,0
+```
+
+None of those is a `JavaScriptException`, so neither a script `try`/`catch` nor a host
+`catch (JavaScriptException)` could see them. The view now answers every index-shaped key itself:
+
+```js
+// 5.x
+x[3] = 9                    // 1,2,3,9  — what x.length = 4 already did
+x["3"] = 9                  // 1,2,3,9
+x[5] = 9                    // 1,2,3,0,0,9 — exactly what x.length = 6; x[5] = 9 gives
+x["3"]                      // undefined
+Object.assign(x, { 3: 9 })  // 1,2,3,9
+delete x[3]                 // true, list untouched
+x[-1] = 9                   // sloppy: silently ignored;  strict: TypeError
+```
+
+**A growable collection grows.** An index at or past the end is `CreateDataProperty` on an extensible
+ordinary object, so it succeeds and makes room the way the `length` write does — including the default-valued
+slots in between. A **fixed-size** target (`T[]` under `ArrayConversionMode.LiveView`, `ArraySegment<T>`,
+`ArrayList.FixedSize`) keeps the `TypeError` #3381 gave it, and a **read-only** one keeps the refusal #3382
+gave it.
+
+**An index the view can never hold is refused, not handed to the collection.** A negative index, a
+non-canonical one (`"08"`, `"+3"`), and one past what the target can address are all ordinary `[[Set]]`
+refusals: silent outside strict mode, a `TypeError` inside it. `x[-1]` already read `undefined` and
+`-1 in x` was already `false`, so there was no position to write to.
+
+**A read-only exposed contract is now honoured by the view itself.** An array or list handed to script as
+`IReadOnlyList<T>` refused element writes only when the index was string-spelled, because the refusal came
+from that interface's get-only indexer rather than from the wrapper. It now refuses both spellings.
+
+**What could break**, in each case only where the two spellings used to disagree:
+
+- a `catch (ArgumentOutOfRangeException)` around `Evaluate` written to absorb an out-of-range index write no
+  longer fires — the write succeeds on a growable collection and is refused on any other;
+- `Object.freeze(list); list["0"] = 9` outside strict mode was a `TypeError` and is now silent, which is what
+  `list[0] = 9` always did and what a frozen JavaScript array gives. `Reflect.set(list, "0", 9)` returns
+  `false` instead of throwing, which is what `Reflect.set` is specified to do;
+- `delete list["0"]` resets the slot instead of being refused, matching `delete list[0]`;
+- a `T[]` live view accepts `x["2"] = 9`, which used to raise `ArgumentException` because the reflected
+  indexer for an array is the `object`-typed `IList` one and bypassed item-type coercion.
+
+Nothing changes for `Options.Interop.AllowWrite = false`, for a non-extensible or frozen wrapper, for a
+dictionary-shaped target such as `JObject` (string keys still answer from its own keys), or for the
+`Array.prototype` generics, which reached the view rather than the indexer already.
 
 ### 4.41 Two holes in the freeze, closed ([#3360](https://github.com/sebastienros/jint/issues/3360))
 


### PR DESCRIPTION
Fixes #3384.

A wrapped growable `List<int>` answers `list.length = 5` by growing and answered `list[3] = 9` with the
CLR's own `ArgumentOutOfRangeException` out of `Engine.Evaluate`. Building the matrix the issue asks for
showed the reported cell is one of forty-four, and that the cause is not "growth is missing" but something
narrower and worse: **an array-like view owned only the number spelling of an index.**

`x[3]` and `x["3"]` are one property key — `ToPropertyKey` makes both the String `"3"` — and they were
answered from two different places. A number key went to the view, which knows its own length. A string key
went to the reflected indexer, which parsed an index out of the key and handed it to the collection. So the
same request, written the two ways a script writes it, gave two different answers on almost every row, and
one of the two was a CLR exception no `catch` on either side of the boundary can see.

## Reproduction, before the change

Measured on `main`, `net10.0`, Release, JIT, from a program that does nothing but `engine.SetValue("x", …)`
and `Execute`, with `Interop.AllowWrite = true` and `ArrayConversion = LiveView`. Every collection holds
`1, 2, 3`. A cell is `outcome + collection afterwards`; where sloppy and strict differ it is written
`sloppy → strict`. **AOORE** is `System.ArgumentOutOfRangeException`, **IOORE**
`System.IndexOutOfRangeException`, **AE** `System.ArgumentException`, all escaping `Execute`.

The six growable shapes — `List<int>`, `List<string>`, `Collection<int>`, a host `IList<int>`, `ArrayList`
and a host non-generic `IList` — are **byte-identical on every row** apart from the default element a grown
slot gets (`0` for `int`, `null` for `string` and for the untyped lists), so they are one column here. The
six span all three wrappers: the first four reach `GenericListWrapper<T>`, the last two `ListWrapper`.

| | growable (6 shapes) | `int[]` LiveView | `ArraySegment<int>` | `ReadOnlyCollection<int>` |
| --- | --- | --- | --- | --- |
| wrapper | `GenericListWrapper` / `ListWrapper` | `ArrayWrapper` | `GenericListWrapper` | `GenericListWrapper` |
| `x[2] = 9` | writes | writes | writes | no-op → TypeError |
| `x["2"] = 9` | writes | **AE** | writes | no-op → TypeError |
| `x[3] = 9` | **AOORE** | TypeError | TypeError | no-op → TypeError |
| `x["3"] = 9` | **AOORE** | **IOORE** | **AOORE** | no-op → TypeError |
| `x[5] = 9` | **AOORE** | TypeError | TypeError | no-op → TypeError |
| `x[100000] = 9` | **AOORE** | TypeError | TypeError | no-op → TypeError |
| `x[-1] = 9` | **AOORE** | TypeError | TypeError | no-op → TypeError |
| `x["-1"] = 9` | **AOORE** | **IOORE** | **AOORE** | no-op → TypeError |
| `x["08"] = 9` | **AOORE** | **IOORE** | **AOORE** | no-op → TypeError |
| `x[3.5] = 9` | no-op | no-op | no-op | no-op |
| `x[2**31] = 9` | no-op | no-op | no-op | no-op |
| `delete x[0]` | resets the slot | no-op → TypeError | no-op → TypeError | no-op → TypeError |
| `delete x["0"]` | no-op → TypeError | no-op → TypeError | no-op → TypeError | no-op → TypeError |
| `delete x[3]` | **AOORE** | true | true | true |
| `delete x["3"]` | no-op → TypeError | no-op → TypeError | no-op → TypeError | true |
| `delete x[-1]` | **AOORE** | true | true | true |
| `x.length = 5` | grows | TypeError | TypeError | no-op → TypeError |
| `x.push(9)` | grows | TypeError | TypeError | TypeError |
| `x.foo = 1` | expando | expando | expando | expando |
| `x[3] = 9`, `AllowWrite = false` | no-op → TypeError | no-op → TypeError | no-op → TypeError | no-op → TypeError |
| `preventExtensions(x); x[3] = 9` | no-op → TypeError | no-op → TypeError | no-op → TypeError | no-op → TypeError |

And the read side, which the issue did not mention at all and which is the same split:

| | growable (6 shapes) | `int[]` LiveView | `ArraySegment<int>` | `ReadOnlyCollection<int>` |
| --- | --- | --- | --- | --- |
| `x[2]` / `x["2"]` | `3` / `3` | `3` / `3` | `3` / `3` | `3` / `3` |
| `x[3]` | `undefined` | `undefined` | `undefined` | `undefined` |
| `x["3"]` | **AOORE** | **IOORE** | **AOORE** | **AOORE** |
| `x["-1"]`, `x["08"]` | **AOORE** | **IOORE** | **AOORE** | **AOORE** |
| `Object.assign(x, {3: 9})` | **AOORE** | **IOORE** | **AOORE** | TypeError |
| `3 in x`, `"3" in x`, `Object.keys(x)`, `for..in`, `JSON.stringify(x)` | correct | correct | correct | correct |

`Object.assign` is the row that says this is not a curiosity: it is the ordinary way a script copies into a
host list, it is specified over string keys, and it was a CLR exception on **every** array-like wrapper,
read-only ones included.

## What each row should do, from the specification

The wrapper is an ordinary object carrying `Array.prototype`, so the answer is per operation and per
position, never per spelling.

* **One key.** `[[Set]]`, `[[Get]]`, `[[Delete]]` and `[[HasProperty]]` all take a property *key*, and
  `ToPropertyKey` has already turned `3` into `"3"` by the time any of them runs. Two lanes for one key is
  two answers to one question.
* **An index at or past the end of a growable target succeeds.** The view is extensible and there is no
  own non-writable property there, so `OrdinarySetWithOwnDescriptor` reaches `CreateDataProperty` and it
  succeeds — which for this object means making room, exactly what a `length` write of `index + 1` already
  did. `a[a.length] = v` appends on a JavaScript array for the same reason.
* **A fixed-size or read-only target keeps its refusal.** #3381's `TypeError` for a write outside a
  `T[]`'s bounds and #3382's `[[Set]]` `false` for a read-only collection are unchanged; they now answer
  the string spelling too.
* **An index the view can never hold is an ordinary refusal, not an exception.** `x[-1]` already read
  `undefined` and `-1 in x` was already `false`, so there is no position to create and none to read a
  written value back from. A `false` from `[[Set]]` is silent outside strict mode and a `TypeError` inside
  it — the same rule #3385 established, and "make everything throw" would be as wrong here as it was there.
* **`delete` of an absent position returns `true`.** `OrdinaryDelete` returns `true` when the descriptor is
  undefined, which is what an out-of-range or negative index is on this view.

## Reproduction, after the change

Only the cells that moved; every other cell above is unchanged.

| | growable (6 shapes) | `int[]` LiveView | `ArraySegment<int>` |
| --- | --- | --- | --- |
| `x["2"] = 9` | — | writes | — |
| `x[3] = 9` | grows: `1,2,3,9` | — | — |
| `x["3"] = 9` | grows: `1,2,3,9` | TypeError | TypeError |
| `x[5] = 9` | grows: `1,2,3,0,0,9` | — | — |
| `x[100000] = 9` | grows to 100001 | — | — |
| `x[-1] = 9` | no-op → TypeError | — | — |
| `x["-1"] = 9`, `x["08"] = 9` | no-op → TypeError | TypeError | TypeError |
| `x[2**31] = 9` | no-op → TypeError | TypeError | TypeError |
| `delete x["0"]` | resets the slot | — | — |
| `delete x[3]`, `delete x[-1]` | true, untouched | — | — |
| `delete x["3"]` | true, untouched | true | true |
| `x["3"]` (read) | `undefined` | `undefined` | `undefined` |
| `Object.assign(x, {3: 9})` | grows: `1,2,3,9` | TypeError | TypeError |

Two rows are worth calling out because they are not about growth at all. A `T[]` live view refused
`x["2"] = 9` — a perfectly ordinary in-range element write — with `ArgumentException`, because the reflected
indexer for an array is the `object`-typed `IList` one and the write bypassed item-type coercion; the source
comment on the fixed-size lane predicted exactly that and the lane only covered number keys. And
`delete x["0"]` was refused where `delete x[0]` reset the slot.

## What changed

`ArrayLikeWrapper` classifies a property key **once** — `ClassifyElementKey` — and `Get`, `Set`,
`HasProperty` and `Delete` all read that answer instead of each re-deriving a different one. Three outcomes:
a `Position` the target could address, an `OutOfBand` key that is index-shaped but can never be a position
(negative, non-canonical, past `int`), and `None` for everything else, which falls through to `base` exactly
as before. The `"08"`/`"-1"` guard and the dictionary-shaped carve-out are not new — `HasProperty` already
had both, and this makes them the rule for the other three.

`Set` then grows for a `Position` at or past the end of a target that is not fixed-size, which is `SetAt`,
which is `EnsureCapacity` + write — the same two calls `x.length = n` and `x.push(v)` already make.

One further fact the matrix forced, and the only part of this that is not the classifier. `ListWrapper` took
its writability from the *target*, so an `int[]` handed to script as `IReadOnlyList<T>` produced a writable
view; the refusal came from that interface's get-only indexer, and therefore only for a string-spelled
index. It now also treats an exposed contract with no writable indexer as read-only — which is what the
typed `ReadOnlyListWrapper<T>` says from its type argument, and what
`InteropTests.LiveViewHonorsNonArrayDeclaredType` has always asserted. `ListWrapper` is what such an
exposure degrades to because `ResolveArrayLikeWrapperFactoryType` scans the exposed type's `GetInterfaces()`
and an interface is not among its own; that gap is filed separately rather than closed here, because closing
it changes which wrapper several exposures get and deserves its own matrix.

## Tests

`Jint.Tests.PublicInterface/HostCollectionIndexWriteTests.cs` — the only suite without
`InternalsVisibleTo`, which is what makes "an embedder cannot catch this" a statement a test can make. Six
growable shapes, both spellings of every index-shaped key, the growth-equals-`length` equivalence, the
fixed-size and exposed-read-only contrasts, and a blanket row asserting that what leaves `Execute` is a
JavaScript error or nothing.

**Failing first**, on unmodified `upstream/main` with only the new test file added:

```
Failed!  - Failed:    55, Passed:     8, Skipped:     0, Total:    63 - Jint.Tests.PublicInterface.dll (net10.0)

  Failed AnIndexWriteAtTheEndOfAGrowableCollectionAppends("List","3")
   System.ArgumentOutOfRangeException : Index was out of range. …
  Failed CopyingIntoAGrowableCollectionGrowsIt("ArrayList")
   System.ArgumentOutOfRangeException : Index was out of range. …
  Failed ReadingAnAbsentIndexIsUndefinedInEitherSpelling("List")
   System.ArgumentOutOfRangeException : Index was out of range. …
  Failed AFixedSizeViewAnswersBothSpellingsOfAnIndex
   System.ArgumentException : Cannot widen from source type to target type …
  Failed AnExposedReadOnlyContractRefusesElementWritesInEitherSpelling("x.length = 5")
   Expected … to be "no-throw" because a failed [[Set]] is silent outside strict mode, but …
```

The 8 that pass are the in-range writes, and the exposed-`IReadOnlyList<T>` element writes the get-only
indexer already refused by accident.

Two rows of `ClrWriteConfigurationTests.ArrayGenericsCannotMutateFrozenClrListsWhenWritesAreEnabled` were
asserting the string spelling's answer and move: `Object.freeze(list); list["0"] = 9` outside strict mode is
now silent, as `list[0] = 9` always was and as a frozen JavaScript array is, and
`Reflect.set(list, "0", 9)` returns `false` rather than throwing, which is what `Reflect.set` is specified
to do. Both are now pinned in both spellings, in two tests named for what they assert.

## Verification

* `dotnet build -c Release` — 0 warnings, 0 errors.
* `Jint.Tests` — 10,752 passed on `net10.0` and `net8.0`, 7,376 on `net472`, 0 failed.
* `Jint.Tests.PublicInterface` — 3,145 passed on `net10.0`, 3,135 on `net8.0`, 2,516 on `net472`, 0 failed.
* Both again with `JINT_HOST_CONTRACT_VERIFICATION=1` — 0 failed.
* `Jint.Tests.Test262` — 102,495 passed, 0 failed, 189 skipped (102,684 total).
* No public API baseline moved and `UndocumentedPublicApi.txt` is unchanged: everything touched is a member
  of an `internal` type.
* `docs/v5-migration.md` §4.33 carries the embedder-facing form. No benchmark: the read path gains one
  branch for a key that is not a `JsNumber` and loses the reflected-indexer resolution it used to take, and
  the write path replaces one type test with one classification.
