### PR TITLE
Intl: a narrow date name is narrow, and a timeStyle day period is the locale's

### DIFF
--- a/Jint.Tests.PublicInterface/HostLocaleProviderTests.cs
+++ b/Jint.Tests.PublicInterface/HostLocaleProviderTests.cs
@@ -198,9 +198,44 @@ public class HostLocaleProviderTests
         engine.Evaluate("new Intl.DateTimeFormat('en', { hour: 'numeric', hour12: true, timeZone: 'UTC' }).formatToParts(Date.UTC(2024, 0, 15, 15, 30))[2].value")
             .AsString().Should().Be("EVE");
 
+        // …and the timeStyle lane, which wrote two English literals and reached no locale data at all
+        engine.Evaluate("new Intl.DateTimeFormat('en', { timeStyle: 'short', timeZone: 'UTC' }).format(Date.UTC(2024, 0, 15, 15, 30))")
+            .AsString().Should().Be("3:30 EVE");
+        engine.Evaluate("new Intl.DateTimeFormat('en', { timeStyle: 'medium', timeZone: 'UTC' }).formatToParts(Date.UTC(2024, 0, 15, 9, 5, 7))[6].value")
+            .AsString().Should().Be("MORN");
+
         // the months and weekdays are still the inherited data
         engine.Evaluate("new Intl.DateTimeFormat('en', { month: 'long', timeZone: 'UTC' }).format(Date.UTC(2024, 0, 15))")
             .AsString().Should().Be("January");
+    }
+
+    /// <summary>
+    /// The narrow styles are the two <see cref="ICldrProvider"/> members the engine never asked for, because
+    /// it wrote the abbreviated name for a narrow style and so had no narrow lane to feed.
+    /// </summary>
+    [Test]
+    public void OverridingTheNarrowNamesReachesDateTimeFormat()
+    {
+        var engine = new Engine(options => options.Intl.CldrProvider = new GreekInitials());
+
+        engine.Evaluate("new Intl.DateTimeFormat('en', { month: 'narrow', timeZone: 'UTC' }).format(Date.UTC(2024, 0, 15))")
+            .AsString().Should().Be("Ι");
+        engine.Evaluate("new Intl.DateTimeFormat('en', { weekday: 'narrow', timeZone: 'UTC' }).format(Date.UTC(2024, 0, 15))")
+            .AsString().Should().Be("Δ");
+        engine.Evaluate("new Intl.DateTimeFormat('en', { month: 'narrow', timeZone: 'UTC' }).formatToParts(Date.UTC(2024, 0, 15))[0].value")
+            .AsString().Should().Be("Ι");
+        engine.Evaluate("new Intl.DateTimeFormat('en', { weekday: 'narrow', month: 'narrow', day: 'numeric', timeZone: 'UTC' }).format(Date.UTC(2024, 0, 15))")
+            .AsString().Should().StartWith("Δ");
+
+        // the styles the subclass does not answer for are the inherited data
+        engine.Evaluate("new Intl.DateTimeFormat('en', { month: 'short', timeZone: 'UTC' }).format(Date.UTC(2024, 0, 15))")
+            .AsString().Should().Be("Jan");
+        engine.Evaluate("new Intl.DateTimeFormat('en', { month: 'long', timeZone: 'UTC' }).format(Date.UTC(2024, 0, 15))")
+            .AsString().Should().Be("January");
+        engine.Evaluate("new Intl.DateTimeFormat('en', { weekday: 'short', timeZone: 'UTC' }).format(Date.UTC(2024, 0, 15))")
+            .AsString().Should().Be("Mon");
+        engine.Evaluate("new Intl.DateTimeFormat('en', { weekday: 'long', timeZone: 'UTC' }).format(Date.UTC(2024, 0, 15))")
+            .AsString().Should().Be("Monday");
     }
 
     [Test]
@@ -323,6 +358,20 @@ file sealed class PlanetaryWeekdays : DefaultCldrProvider
     public override string[]? GetWeekdayNames(string locale, string style)
         => string.Equals(style, "long", StringComparison.Ordinal)
             ? ["Sunday", "Moonday", "Marsday", "Mercuryday", "Jupiterday", "Venusday", "Saturnday"]
+            : base.GetWeekdayNames(locale, style);
+}
+
+/// <summary>Only the narrow month and weekday names; the other styles are the inherited data.</summary>
+file sealed class GreekInitials : DefaultCldrProvider
+{
+    public override string[]? GetMonthNames(string locale, string style, string? calendar)
+        => string.Equals(style, "narrow", StringComparison.Ordinal)
+            ? ["Ι", "Φ", "Μ", "Α", "Μ", "Ι", "Ι", "Α", "Σ", "Ο", "Ν", "Δ"]
+            : base.GetMonthNames(locale, style, calendar);
+
+    public override string[]? GetWeekdayNames(string locale, string style)
+        => string.Equals(style, "narrow", StringComparison.Ordinal)
+            ? ["Κ", "Δ", "Τ", "Τ", "Π", "Π", "Σ"]
             : base.GetWeekdayNames(locale, style);
 }
 

--- a/Jint.Tests/Runtime/IntlTests.cs
+++ b/Jint.Tests/Runtime/IntlTests.cs
@@ -1423,4 +1423,174 @@ public class IntlTests
             }
         }
     }
+
+    /// <summary>
+    /// https://tc39.es/ecma402/#table-datetimeformat-components lists <c>"narrow"</c> as a value of
+    /// <c>weekday</c> and of <c>month</c> in its own right, beside <c>"short"</c>. Both used to render the
+    /// abbreviated .NET pattern letter, so a narrow format was an abbreviated one.
+    /// </summary>
+    [Test]
+    public void NarrowMonthAndWeekdayAreNotTheAbbreviatedName()
+    {
+        // 2024-01-15 is a Monday
+        const string Date = "Date.UTC(2024, 0, 15)";
+
+        _engine.Evaluate($"new Intl.DateTimeFormat('en', {{ month: 'narrow', timeZone: 'UTC' }}).format({Date})")
+            .AsString().Should().Be("J");
+        _engine.Evaluate($"new Intl.DateTimeFormat('en', {{ weekday: 'narrow', timeZone: 'UTC' }}).format({Date})")
+            .AsString().Should().Be("M");
+
+        // the parts lane and the string lane are the same names
+        _engine.Evaluate($"new Intl.DateTimeFormat('en', {{ month: 'narrow', timeZone: 'UTC' }}).formatToParts({Date})[0].value")
+            .AsString().Should().Be("J");
+        _engine.Evaluate($"new Intl.DateTimeFormat('en', {{ weekday: 'narrow', timeZone: 'UTC' }}).formatToParts({Date})[0].value")
+            .AsString().Should().Be("M");
+
+        // …and the two styles beside it are untouched
+        _engine.Evaluate($"new Intl.DateTimeFormat('en', {{ month: 'short', timeZone: 'UTC' }}).format({Date})")
+            .AsString().Should().Be("Jan");
+        _engine.Evaluate($"new Intl.DateTimeFormat('en', {{ month: 'long', timeZone: 'UTC' }}).format({Date})")
+            .AsString().Should().Be("January");
+        _engine.Evaluate($"new Intl.DateTimeFormat('en', {{ weekday: 'short', timeZone: 'UTC' }}).format({Date})")
+            .AsString().Should().Be("Mon");
+        _engine.Evaluate($"new Intl.DateTimeFormat('en', {{ weekday: 'long', timeZone: 'UTC' }}).format({Date})")
+            .AsString().Should().Be("Monday");
+    }
+
+    /// <summary>
+    /// All seven narrow weekday names, against the values every browser writes, so that the seeding is
+    /// reading a whole array and not one entry of it by luck.
+    /// </summary>
+    /// <remarks>
+    /// Literal values rather than a comparison against <c>ShortestDayNames</c>, because that array is where
+    /// the two platforms disagree: it holds CLDR's narrow names on Windows and its short ones — <c>Su</c>,
+    /// <c>Mo</c> — on Linux, and what this asserts is that <c>Intl</c> writes the same seven either way.
+    /// </remarks>
+    [Test]
+    public void EveryNarrowWeekdayIsTheSameOnEveryPlatform()
+    {
+        string[] expected = ["S", "M", "T", "W", "T", "F", "S"];
+
+        // 2024-01-14 is a Sunday
+        for (var i = 0; i < 7; i++)
+        {
+            _engine.Evaluate($"new Intl.DateTimeFormat('en-US', {{ weekday: 'narrow', timeZone: 'UTC' }}).format(Date.UTC(2024, 0, {14 + i}))")
+                .AsString().Should().Be(expected[i]);
+        }
+    }
+
+    /// <summary>
+    /// .NET has narrow weekday names and no narrow month names, so <c>DefaultCldrProvider</c> reads the one
+    /// and derives the other. This is the guard on that derivation: it walks every culture the machine has and
+    /// compares entry by entry, so a change to either half fails here rather than in one spot-checked locale.
+    /// </summary>
+    [Test]
+    public void TheDefaultCldrProviderDerivesNarrowNamesFromDotNetsOwnData()
+    {
+        var provider = DefaultCldrProvider.Instance;
+        var compared = 0;
+
+        foreach (var culture in CultureInfo.GetCultures(CultureTypes.SpecificCultures))
+        {
+            var name = culture.Name;
+            if (name.Length == 0)
+            {
+                continue;
+            }
+
+            CultureInfo resolved;
+            try
+            {
+                resolved = new CultureInfo(name, false);
+            }
+            catch (CultureNotFoundException)
+            {
+                continue;
+            }
+
+            var dtfi = resolved.DateTimeFormat;
+
+            var narrowMonths = provider.GetMonthNames(name, "narrow", null);
+            narrowMonths.Should().NotBeNull();
+            narrowMonths!.Should().HaveCount(12);
+            for (var i = 0; i < 12; i++)
+            {
+                narrowMonths[i].Should().Be(Narrow(resolved, dtfi.AbbreviatedMonthNames[i]), $"narrow month {i + 1} of '{name}'");
+            }
+
+            var narrowWeekdays = provider.GetWeekdayNames(name, "narrow");
+            narrowWeekdays.Should().NotBeNull();
+            narrowWeekdays!.Should().HaveCount(7);
+
+            // Already narrow when any entry is a single text element; narrowed entry by entry when none is.
+            var shortest = dtfi.ShortestDayNames;
+            var alreadyNarrow = shortest.Any(d => d.Length == 0 || StringInfo.GetNextTextElement(d, 0).Length == d.Length);
+            for (var i = 0; i < 7; i++)
+            {
+                var expected = alreadyNarrow ? shortest[i] : Narrow(resolved, shortest[i]);
+                narrowWeekdays[i].Should().Be(expected, $"narrow weekday {i} of '{name}'");
+            }
+
+            compared++;
+        }
+
+        compared.Should().BeGreaterThan(100);
+    }
+
+    /// <summary>The narrowing the provider applies, written once so the test states the rule rather than copying it.</summary>
+    private static string Narrow(CultureInfo culture, string name)
+        => name.Length == 0 ? name : culture.TextInfo.ToUpper(StringInfo.GetNextTextElement(name, 0));
+
+    /// <summary>
+    /// https://tc39.es/ecma402/#sec-formatdatetimepattern step 15.g makes the <c>ampm</c> a pattern writes an
+    /// ILD String, so the two lanes that can write one — <c>timeStyle</c> and <c>hour</c> with
+    /// <c>hour12</c> — have to write the same locale's designators. The <c>timeStyle</c> lane used to write
+    /// two English literals.
+    /// </summary>
+    [TestCase("en")]
+    [TestCase("ar")]
+    [TestCase("zh")]
+    [TestCase("ja")]
+    [TestCase("ko")]
+    [TestCase("el")]
+    [TestCase("tr")]
+    [TestCase("he")]
+    [TestCase("th")]
+    public void TheTimeStyleLaneWritesTheSameDayPeriodAsTheComponentLane(string locale)
+    {
+        var expected = new CultureInfo(locale, false).DateTimeFormat.PMDesignator;
+
+        var script = $$"""
+            new Intl.DateTimeFormat('{{locale}}', { timeStyle: 'short', hour12: true, timeZone: 'UTC', numberingSystem: 'latn' })
+                .formatToParts(Date.UTC(2024, 0, 15, 15, 30))
+                .filter(function (p) { return p.type === 'dayPeriod'; })
+                .map(function (p) { return p.value; })
+                .join('');
+            """;
+
+        _engine.Evaluate(script).AsString().Should().Be(expected);
+
+        var componentScript = $$"""
+            new Intl.DateTimeFormat('{{locale}}', { hour: 'numeric', hour12: true, timeZone: 'UTC', numberingSystem: 'latn' })
+                .formatToParts(Date.UTC(2024, 0, 15, 15, 30))
+                .filter(function (p) { return p.type === 'dayPeriod'; })
+                .map(function (p) { return p.value; })
+                .join('');
+            """;
+
+        _engine.Evaluate(componentScript).AsString().Should().Be(expected);
+    }
+
+    /// <summary>
+    /// The English designators are still the English ones: the fix is where the two letters come from, not
+    /// what they are for a locale that spells them that way.
+    /// </summary>
+    [Test]
+    public void TheEnglishTimeStyleStillWritesAmAndPm()
+    {
+        _engine.Evaluate("new Intl.DateTimeFormat('en', { timeStyle: 'short', timeZone: 'UTC' }).format(Date.UTC(2024, 0, 15, 15, 30))")
+            .AsString().Should().Be("3:30 PM");
+        _engine.Evaluate("new Intl.DateTimeFormat('en', { timeStyle: 'medium', timeZone: 'UTC' }).format(Date.UTC(2024, 0, 15, 9, 5, 7))")
+            .AsString().Should().Be("9:05:07 AM");
+    }
 }

--- a/Jint/Native/Intl/DateTimeFormatConstructor.cs
+++ b/Jint/Native/Intl/DateTimeFormatConstructor.cs
@@ -480,8 +480,24 @@ internal sealed partial class DateTimeFormatConstructor : Constructor
         // agree is not assumed — IntlTests.TheDefaultCldrProviderAnswersWithDotNetsOwnDateNames walks every
         // culture on the machine and compares all five arrays entry by entry.
         var cldrProvider = _engine.Options.Intl.CldrProvider;
-        if (!ReferenceEquals(cldrProvider, DefaultCldrProvider.Instance)
-            && ApplyProviderNames(cldrProvider, dateTimeFormatInfo, culture.DateTimeFormat, resolvedLocale, calendar))
+        var namesChanged = !ReferenceEquals(cldrProvider, DefaultCldrProvider.Instance)
+            && ApplyProviderNames(cldrProvider, dateTimeFormatInfo, culture.DateTimeFormat, resolvedLocale, calendar);
+
+        // https://tc39.es/ecma402/#table-datetimeformat-components — "narrow" is a value of weekday and of
+        // month in its own right, and there is no .NET pattern letter for it. The narrow name goes into the
+        // abbreviated slot of this formatter's own DateTimeFormatInfo, so MMM and ddd write it and all three
+        // of format(), formatToParts() and formatRange() agree without any of them learning a new lane.
+        // One formatter reads at most one of the two slots per name group, so nothing is overwritten that
+        // the same formatter still needs: month and weekday have separate arrays, and a formatter carrying
+        // dateStyle or timeStyle has neither option set.
+        //
+        // Unlike the block above this asks the shared singleton too, and the guard is the option rather than
+        // the provider's identity: it is asked only when a narrow style is actually requested, so a default
+        // construction is untouched, and asking it there teaches something — .NET's narrow weekday names live
+        // in a slot no pattern letter reaches, and it has no narrow month names at all.
+        namesChanged |= ApplyNarrowNames(cldrProvider, dateTimeFormatInfo, resolvedLocale, calendar, month, weekday);
+
+        if (namesChanged)
         {
             culture = (CultureInfo) culture.Clone();
             culture.DateTimeFormat = dateTimeFormatInfo;
@@ -546,8 +562,8 @@ internal sealed partial class DateTimeFormatConstructor : Constructor
     /// wrong length.
     /// </para>
     /// <para>
-    /// The narrow styles are deliberately not read. The formatter emits the abbreviated pattern letter
-    /// (<c>MMM</c>, <c>ddd</c>) for <c>narrow</c>, so it has no narrow lane for a provider to feed.
+    /// The narrow styles are not read here. <see cref="ApplyNarrowNames"/> reads them instead, from every
+    /// provider and only for the formatter that asked for one.
     /// </para>
     /// </remarks>
     private static bool ApplyProviderNames(
@@ -598,6 +614,49 @@ internal sealed partial class DateTimeFormatConstructor : Constructor
             target.AMDesignator = dayPeriods[0];
             target.PMDesignator = dayPeriods[1];
             changed = true;
+        }
+
+        return changed;
+    }
+
+    /// <summary>
+    /// Puts the narrow month or weekday names into the abbreviated slots of one formatter's
+    /// <see cref="DateTimeFormatInfo"/>, so that <c>MMM</c> and <c>ddd</c> write the narrow form. Called only
+    /// when <c>month</c> or <c>weekday</c> is <c>"narrow"</c>, and reports whether it wrote anything.
+    /// </summary>
+    /// <remarks>
+    /// An answer of the wrong length, or none at all, leaves the abbreviated names in place — which is the
+    /// behaviour every release before this one had for a narrow style.
+    /// </remarks>
+    private static bool ApplyNarrowNames(
+        ICldrProvider provider,
+        DateTimeFormatInfo target,
+        string locale,
+        string? calendar,
+        string? month,
+        string? weekday)
+    {
+        var changed = false;
+
+        if (string.Equals(month, "narrow", StringComparison.Ordinal))
+        {
+            var narrowMonths = provider.GetMonthNames(locale, "narrow", calendar);
+            if (narrowMonths is { Length: 12 })
+            {
+                target.AbbreviatedMonthNames = WithTrailingEmpty(narrowMonths);
+                target.AbbreviatedMonthGenitiveNames = WithTrailingEmpty(narrowMonths);
+                changed = true;
+            }
+        }
+
+        if (string.Equals(weekday, "narrow", StringComparison.Ordinal))
+        {
+            var narrowWeekdays = provider.GetWeekdayNames(locale, "narrow");
+            if (narrowWeekdays is { Length: 7 })
+            {
+                target.AbbreviatedDayNames = (string[]) narrowWeekdays.Clone();
+                changed = true;
+            }
         }
 
         return changed;

--- a/Jint/Native/Intl/DefaultCldrProvider.cs
+++ b/Jint/Native/Intl/DefaultCldrProvider.cs
@@ -19,11 +19,14 @@ namespace Jint.Native.Intl;
 /// </para>
 /// <para>
 /// Every member has a caller: whatever this class answers is what <c>Intl</c> shows, and whatever a derived
-/// class answers displaces it. Two narrow gaps are worth knowing about, both of them the engine's rather
-/// than the interface's: <see cref="GetMonthNames"/> and <see cref="GetWeekdayNames"/> are not asked for
-/// <c>"narrow"</c>, because <c>Intl.DateTimeFormat</c> writes the abbreviated name for a narrow style; and
-/// <see cref="GetDayPeriods"/> reaches the component lane (<c>hour</c> with <c>hour12</c>) but not
-/// <c>timeStyle</c>, which writes English AM/PM regardless of any locale data, .NET's included.
+/// class answers displaces it. Two answers here are derived rather than read, because .NET has nowhere to
+/// read them from. <see cref="DateTimeFormatInfo"/> has no narrow month slot at all, so
+/// <see cref="GetMonthNames"/> answers <c>"narrow"</c> with the first text element of the abbreviated name,
+/// upper-cased; and its narrowest weekday slot, <c>ShortestDayNames</c>, holds CLDR's narrow names on Windows
+/// and its short ones on Linux, so <see cref="GetWeekdayNames"/> narrows that array the same way when the
+/// platform handed it the short one. Both reproduce CLDR for locales whose narrow form is an initial — Latin,
+/// Cyrillic and Greek — and neither does for the locales where it is not, such as the numeric narrow months of
+/// <c>ja</c>, <c>ko</c>, <c>cs</c> and <c>he</c>. A host that needs them exactly overrides the one member.
 /// </para>
 /// </remarks>
 /// <example>
@@ -411,11 +414,71 @@ public class DefaultCldrProvider : ICldrProvider
             {
                 "long" => culture.DateTimeFormat.MonthNames.Take(12).ToArray(),
                 "short" => culture.DateTimeFormat.AbbreviatedMonthNames.Take(12).ToArray(),
-                "narrow" => culture.DateTimeFormat.AbbreviatedMonthNames.Take(12).Select(m => m.Length > 0 ? m[0].ToString() : m).ToArray(),
+                "narrow" => NarrowMonths(culture),
                 _ => null
             };
         });
     }
+
+    /// <summary>
+    /// Derives narrow month names from the abbreviated ones, because <see cref="DateTimeFormatInfo"/> has no
+    /// narrow month slot to read at all.
+    /// </summary>
+    private static string[] NarrowMonths(CultureInfo culture)
+    {
+        var abbreviated = culture.DateTimeFormat.AbbreviatedMonthNames;
+        var result = new string[12];
+        for (var i = 0; i < 12; i++)
+        {
+            result[i] = Narrow(culture, abbreviated[i]);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// .NET's narrowest weekday names, narrowed further when the platform filled that slot with CLDR's
+    /// <em>short</em> names rather than its <em>narrow</em> ones.
+    /// </summary>
+    /// <remarks>
+    /// Which of the two <c>ShortestDayNames</c> holds is a platform difference rather than a locale one: for
+    /// <c>en</c> it is <c>S,M,T,W,T,F,S</c> on Windows and <c>Su,Mo,Tu,We,Th,Fr,Sa</c> on Linux. An array in
+    /// which no entry is a single text element is one of the latter, and narrowing each entry recovers the
+    /// CLDR narrow name for every locale whose narrow form is an initial. An array that already has a
+    /// single-element entry is left alone, so the locales whose narrow names are genuinely two characters
+    /// long — <c>th</c>'s <c>อา</c>, <c>hi</c>'s <c>सो</c> — keep them.
+    /// </remarks>
+    private static string[] NarrowWeekdays(CultureInfo culture)
+    {
+        var shortest = culture.DateTimeFormat.ShortestDayNames;
+
+        foreach (var name in shortest)
+        {
+            if (name.Length == 0 || StringInfo.GetNextTextElement(name, 0).Length == name.Length)
+            {
+                return shortest;
+            }
+        }
+
+        var result = new string[shortest.Length];
+        for (var i = 0; i < shortest.Length; i++)
+        {
+            result[i] = Narrow(culture, shortest[i]);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// One name reduced to its narrow form: the first text element, upper-cased in the locale's own casing
+    /// rules.
+    /// </summary>
+    /// <remarks>
+    /// A text element rather than a <c>char</c>, so a surrogate pair or a base letter carrying a combining
+    /// mark stays whole. The locale's own casing, so Turkish dotted and dotless I are not anglicised.
+    /// </remarks>
+    private static string Narrow(CultureInfo culture, string name)
+        => name.Length == 0 ? name : culture.TextInfo.ToUpper(StringInfo.GetNextTextElement(name, 0));
 
     /// <inheritdoc />
     public virtual string[]? GetWeekdayNames(string locale, string style)
@@ -433,7 +496,7 @@ public class DefaultCldrProvider : ICldrProvider
             {
                 "long" => culture.DateTimeFormat.DayNames,
                 "short" => culture.DateTimeFormat.AbbreviatedDayNames,
-                "narrow" => culture.DateTimeFormat.ShortestDayNames,
+                "narrow" => NarrowWeekdays(culture),
                 _ => null
             };
         });

--- a/Jint/Native/Intl/JsDateTimeFormat.cs
+++ b/Jint/Native/Intl/JsDateTimeFormat.cs
@@ -953,7 +953,8 @@ internal sealed class JsDateTimeFormat : ObjectInstance
 
         var minuteStr = dateTime.Minute.ToString("D2", CultureInfo.InvariantCulture);
         var secondStr = dateTime.Second.ToString("D2", CultureInfo.InvariantCulture);
-        var dayPeriod = use12Hour ? " " + GetDayPeriod(dateTime.Hour) : "";
+        var dayPeriodName = use12Hour ? GetDayPeriod(dateTime.Hour) : "";
+        var dayPeriod = dayPeriodName.Length > 0 ? " " + dayPeriodName : "";
 
         return TimeStyle switch
         {
@@ -965,9 +966,17 @@ internal sealed class JsDateTimeFormat : ObjectInstance
         };
     }
 
-    private static string GetDayPeriod(int hour)
+    /// <summary>
+    /// https://tc39.es/ecma402/#sec-formatdatetimepattern step 15.g — the <c>ampm</c> field of a pattern is
+    /// "an ILD String representing post meridiem / ante meridiem", not those words, and Annex A lists
+    /// "am/pm indicators" among the implementation- and locale-dependent behaviours. This is the same data the
+    /// component lane's <c>tt</c> pattern letter renders through: the designators on this formatter's own
+    /// <see cref="DateTimeFormatInfo"/>, which a host <see cref="ICldrProvider.GetDayPeriods"/> has already
+    /// had its say over.
+    /// </summary>
+    private string GetDayPeriod(int hour)
     {
-        return hour < 12 ? "AM" : "PM";
+        return hour < 12 ? DateTimeFormatInfo.AMDesignator : DateTimeFormatInfo.PMDesignator;
     }
 
     private string FormatWithComponents(DateTime dateTime, int? originalYear = null)
@@ -1076,8 +1085,10 @@ internal sealed class JsDateTimeFormat : ObjectInstance
         }
 
         // Day period (AM/PM) - only add "tt" if using 12-hour format with hour specified
-        // and DayPeriod is not explicitly specified (DayPeriod uses extended periods)
-        var needsAmPm = Hour != null && hourUse12Hour && DayPeriod == null;
+        // and DayPeriod is not explicitly specified (DayPeriod uses extended periods). An empty designator
+        // takes its separator with it, so this lane and the parts lane cannot disagree for a host that
+        // supplies one; no culture on any machine has one.
+        var needsAmPm = Hour != null && hourUse12Hour && DayPeriod == null && GetDayPeriod(dateTime.Hour).Length > 0;
         if (needsAmPm)
         {
             parts.Add("tt");
@@ -1609,11 +1620,15 @@ internal sealed class JsDateTimeFormat : ObjectInstance
             result.Add(new DateTimePart("second", dateTime.Second.ToString("D2", CultureInfo)));
         }
 
-        // Day period (AM/PM) for 12-hour format
+        // Day period (AM/PM) for 12-hour format, from the same locale data the component lane's "tt" reads
         if (use12Hour)
         {
-            result.Add(new DateTimePart("literal", " "));
-            result.Add(new DateTimePart("dayPeriod", dateTime.Hour < 12 ? "AM" : "PM"));
+            var dayPeriodName = GetDayPeriod(dateTime.Hour);
+            if (dayPeriodName.Length > 0)
+            {
+                result.Add(new DateTimePart("literal", " "));
+                result.Add(new DateTimePart("dayPeriod", dayPeriodName));
+            }
         }
 
         // Time zone name (for long and full) - omit for plain Temporal types
@@ -1925,8 +1940,12 @@ internal sealed class JsDateTimeFormat : ObjectInstance
         }
         else if (Hour != null && hourUse12Hour)
         {
-            result.Add(new DateTimePart("literal", " "));
-            result.Add(new DateTimePart("dayPeriod", dateTime.ToString("tt", CultureInfo)));
+            var dayPeriodName = dateTime.ToString("tt", CultureInfo);
+            if (dayPeriodName.Length > 0)
+            {
+                result.Add(new DateTimePart("literal", " "));
+                result.Add(new DateTimePart("dayPeriod", dayPeriodName));
+            }
         }
 
         // Time zone name
@@ -1986,12 +2005,12 @@ internal sealed class JsDateTimeFormat : ObjectInstance
                     >= 18 and < 21 => "in the evening",
                     _ => "at night"
                 },
-                _ => hour < 12 ? "AM" : "PM"
+                _ => GetDayPeriod(hour)
             };
         }
 
-        // Default: use AM/PM
-        return hour < 12 ? "AM" : "PM";
+        // No extended day-period data for this locale: fall back to its own AM/PM designators.
+        return GetDayPeriod(hour);
     }
 
     internal readonly record struct DateTimePart(string Type, string Value);

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -1640,10 +1640,8 @@ nothing at all.
 `DefaultCldrProvider`. Its `GetMonthNames`, `GetWeekdayNames`, `GetDayPeriods` and
 `GetNumberingSystemDigits` were dead code and are now read. The fallback is per member and per style:
 `null`, or an array of the wrong length, keeps .NET's data, so a provider that answers only for `"long"`
-months keeps .NET's abbreviated ones. Two lanes stay out of reach and are the engine's own gaps rather than
-the interface's — `month: "narrow"` and `weekday: "narrow"`, which the formatter renders with the
-abbreviated pattern letter, and `timeStyle`, which writes English `AM`/`PM` regardless of any locale data,
-.NET's included.
+months keeps .NET's abbreviated ones. Two lanes stayed out of reach when this shipped and are reached in
+4.33: `month: "narrow"` / `weekday: "narrow"`, and the day period a `timeStyle` writes.
 
 ### 4.30 A calendar `ICalendarProvider` claims is a calendar `Temporal` accepts ([#3355](https://github.com/sebastienros/jint/issues/3355))
 
@@ -1793,6 +1791,54 @@ it declined, so a hopeless candidate was proposed and then rejected. It is no lo
 longer fires — catch `JavaScriptException`, or stop writing the expression that threw. A host relying on
 `'s' + v` throwing as a type check has to test explicitly instead. Nothing changes for
 `AllowOperatorOverloading = false`, which took the concatenating path already.
+### 4.34 A narrow date name is narrow, and a `timeStyle` day period is the locale's ([#3398](https://github.com/sebastienros/jint/issues/3398), [#3399](https://github.com/sebastienros/jint/issues/3399))
+
+Two lanes of `Intl.DateTimeFormat` wrote something other than the locale data the specification names, and
+both are the ones 4.29 could not reach.
+
+**`month: "narrow"` and `weekday: "narrow"` rendered the abbreviated name.** Both options mapped onto the
+abbreviated .NET pattern letter — `MMM`, `ddd` — because .NET has no narrow one. The narrow names now go
+into that formatter's own `DateTimeFormatInfo`, so the same pattern letter writes them:
+
+```js
+// 5.0
+new Intl.DateTimeFormat('en', { month: 'narrow' }).format(Date.UTC(2024, 0, 15));   // "Jan"
+new Intl.DateTimeFormat('en', { weekday: 'narrow' }).format(Date.UTC(2024, 0, 15)); // "Mon"
+
+// 5.x — what every browser writes
+new Intl.DateTimeFormat('en', { month: 'narrow' }).format(Date.UTC(2024, 0, 15));   // "J"
+new Intl.DateTimeFormat('en', { weekday: 'narrow' }).format(Date.UTC(2024, 0, 15)); // "M"
+```
+
+`ICldrProvider.GetMonthNames` and `GetWeekdayNames` are asked for `"narrow"` for the first time, and unlike
+the other styles the shared `DefaultCldrProvider.Instance` is asked too, because .NET has nowhere to read
+either answer from directly. Narrow **weekdays** start from `ShortestDayNames`, a slot no pattern letter
+reaches and whose contents are a *platform* difference rather than a locale one: for `en` it holds CLDR's
+narrow names on Windows (`S`, `M`, `T`, …) and its short ones on Linux (`Su`, `Mo`, `Tu`, …), so an array in
+which no entry is a single text element is narrowed entry by entry and `Intl` writes the same seven either
+way. Narrow **months** .NET does not carry at all, so they are derived the same way, from the first text
+element of the abbreviated name, upper-cased in the locale's own casing rules. Both reproduce CLDR for
+locales whose narrow form is an initial — Latin, Cyrillic and Greek — and neither does where it is not, such
+as the numeric narrow months of `ja`, `ko`, `cs` and `he`; a host that needs those exactly overrides the one
+member.
+
+**`timeStyle` wrote English `AM`/`PM`.** The component lane (`hour` with `hour12`) rendered the locale's
+designators and the `timeStyle` lane wrote two literals, so one formatter's two lanes disagreed:
+
+```js
+// 5.0
+new Intl.DateTimeFormat('ar', { timeStyle: 'short' }).format(Date.UTC(2024, 0, 15, 15, 30));            // "3:30 PM"
+new Intl.DateTimeFormat('ar', { hour: 'numeric', hour12: true }).format(Date.UTC(2024, 0, 15, 15, 30)); // "3 م"
+
+// 5.x — both lanes, one source
+new Intl.DateTimeFormat('ar', { timeStyle: 'short' }).format(Date.UTC(2024, 0, 15, 15, 30));            // "3:30 م"
+```
+
+**What could break:** any output containing a narrow month or weekday, and any `timeStyle` output in a
+12-hour locale whose designators are not `AM`/`PM`. `en` is unchanged in both: its designators are those two
+letters, and its narrow names are what the derivation produces. Formatting that asks for neither a narrow
+style nor a day period is untouched, and so is the cost of constructing it — the narrow names are read only
+when a narrow style was actually requested.
 
 ## 5. New in v5
 


### PR DESCRIPTION
`Intl.DateTimeFormat` had two lanes that wrote something other than the locale data the specification
names, and both are the ones #3397 could not reach — its own doc comment on `DefaultCldrProvider` named
them in a single paragraph, which is why they are one pull request.

## `month: "narrow"` and `weekday: "narrow"` rendered the abbreviated name

[Table 16](https://tc39.es/ecma402/#table-datetimeformat-components) lists `"narrow"` as a value of
`weekday` and of `month` in its own right, beside `"short"`, and
[FormatDateTimePattern](https://tc39.es/ecma402/#sec-formatdatetimepattern) step 15.f.x.1 makes each of the
three "an ILD String representing value in the form given by fieldFormat". Both narrow options mapped onto
the abbreviated .NET pattern letter, because .NET has no narrow one:

```c#
"long" => "MMMM", "short" => "MMM", "narrow" => "MMM",
```

Before:

```
en month narrow   => Jan
en weekday narrow => Mon
de month narrow   => Jan
de weekday narrow => Mo
```

After — and this is what every browser writes, checked against Node 24's ICU for 22 locales:

```
en month narrow   => J
en weekday narrow => M
de month narrow   => J
de weekday narrow => M
```

The fix is one place: the narrow names go into the **abbreviated slots** of that formatter's own
`DateTimeFormatInfo`, so `MMM` and `ddd` write them and `format()`, `formatToParts()` and `formatRange()`
agree without any of them learning a new lane. One formatter reads at most one of the two slots per name
group — month and weekday have separate arrays, and a formatter carrying `dateStyle` or `timeStyle` has
neither option set — so nothing is overwritten that the same formatter still needs.

`ICldrProvider.GetMonthNames` and `GetWeekdayNames` are asked for `"narrow"` for the first time. Unlike the
long/short seeding, **the shared `DefaultCldrProvider.Instance` is asked too**, and the guard is the option
rather than the provider's identity: it is asked only when a narrow style was actually requested, so a
default construction is untouched, and asking it there teaches something the culture cannot be read for
directly.

- narrow **weekdays** start from .NET's `ShortestDayNames`, a slot no pattern letter reaches — and whose
  contents are a **platform** difference rather than a locale one, which is what the first CI run on this
  branch caught. For `en` it holds CLDR's *narrow* names on Windows (`S,M,T,W,T,F,S`) and its *short* ones on
  Linux (`Su,Mo,Tu,We,Th,Fr,Sa`), so taking it verbatim would have made `weekday: 'narrow'` render `Mo` on
  the platform most people deploy to. An array in which no entry is a single text element is one of the
  latter and is narrowed entry by entry; one that already has a single-element entry is left alone, so the
  locales whose narrow names are genuinely two characters — `th`'s `อา`, `hi`'s `सो` — keep them. Either way
  `Intl` writes the same seven, and they are CLDR's: `en` `S,M,T,W,T,F,S`, `de` `S,M,D,M,D,F,S`,
  `fr` `D,L,M,M,J,V,S`, `ar` `ح,ن,ث,ر,خ,ج,س` — entry for entry with ICU on all fifteen locales checked.
- narrow **months** .NET does not carry at all, so `DefaultCldrProvider` derives them: the first *text
  element* of the abbreviated name (a text element, so a surrogate pair or a base letter carrying a
  combining mark stays whole), upper-cased in the locale's own casing rules. That reproduces CLDR exactly
  for Latin, Cyrillic and Greek locales — `es E,F,M,A,M,J,J,A,S,O,N,D`, `it G,F,M,A,M,G,L,A,S,O,N,D`,
  `ru Я,Ф,М,А,М,И,И,А,С,О,Н,Д`, `pl S,L,M,K,M,C,L,S,W,P,L,G`, `fi T,H,M,H,T,K,H,E,S,L,M,J`,
  `tr O,Ş,M,N,M,H,T,A,E,E,K,A` — and does not for locales whose narrow months are numeric (`ja`, `ko`,
  `cs`, `he`). A host that needs those exactly overrides `GetMonthNames`, which is now the member that
  answers. The derivation is documented on `DefaultCldrProvider` rather than left to be discovered.

## `timeStyle` wrote English `AM`/`PM`

[FormatDateTimePattern](https://tc39.es/ecma402/#sec-formatdatetimepattern) step 15.g says the `ampm` field
is "an ILD String representing *post meridiem*" — not those words — and Annex A lists "am/pm indicators"
among the implementation- and locale-dependent behaviours. The component lane already did that: `hour` with
`hour12` adds a `tt` token and renders through `AMDesignator`/`PMDesignator`. The `timeStyle` lane wrote two
literals, in `FormatTimeStyle` and again inline in `FormatTimeStyleToParts`, so one formatter's two lanes
disagreed for any 12-hour locale whose designators are not English:

```
                      before                  after
ar timeStyle short    3:30 PM                 3:30 م
ar component hour12   3 م                     3 م
zh timeStyle short    3:30 PM                 3:30 下午
zh component hour12   3 下午                   3 下午
en timeStyle short    3:30 PM                 3:30 PM
```

ICU writes `م` for `ar` too. Both sites now read this formatter's own `DateTimeFormatInfo`, which is the
seam #3397 already seeds from `ICldrProvider.GetDayPeriods` — so a host that supplies day periods sees them
in both lanes, which `HostLocaleProviderTests.OverridingOneDayPeriodReachesDateTimeFormat` now asserts. The
extended-day-period fallbacks for a locale with no CLDR phrase data went the same way; they were the same
two literals.

An empty designator now drops its separator with it, in both lanes, so the two cannot disagree for a host
that supplies one. No culture on the machine has one — that guard exists for a provider, not for .NET.

## What is unchanged

`en` is unchanged in both halves: its designators are those two letters, and its narrow names are what the
derivation produces. Proved entry by entry rather than asserted — 605 specific cultures × 27 option sets ×
2 instants, formatted on `main` and on this branch and diffed:

| option set | entries | changed |
| --- | ---: | ---: |
| `month: narrow` | 1210 | 1193 |
| `weekday: narrow` | 1210 | 1191 |
| `weekday+month narrow, day, year` | 1210 | 1210 |
| `timeStyle: short` | 1210 | 708 |
| `timeStyle: medium` | 1210 | 708 |
| `timeStyle: short, hour12: true` | 1210 | 814 |
| `dateStyle+timeStyle: medium` | 1210 | 708 |
| `dayPeriod: long` | 1210 | 626 |
| **the other 19 sets** — `year`/`month`/`day` in every style, `weekday` short and long, `hour` with and without `hour12`, all four `dateStyle`s, `timeStyle` with `hour12: false`, `era` | **22,990** | **0** |

`en-US` moved in the three narrow rows and nowhere else — its designators *are* `AM`/`PM`, and its narrow
names are what the derivation produces:

```
- en-US|m-narrow|Jan            + en-US|m-narrow|J
- en-US|wd-narrow|Mon           + en-US|wd-narrow|M
- en-US|narrow-combo|Mon Jan 15, 2024   + en-US|narrow-combo|M J 15, 2024
```

and the locales that moved in a `timeStyle` row moved onto the designator their own component lane was
already writing:

```
- en-GB|ts-short|3:30 PM        + en-GB|ts-short|3:30 pm
- ar-EG|ts-short|3:30 PM        + ar-EG|ts-short|3:30 م
- ar-EG|ts-short|9:05 AM        + ar-EG|ts-short|9:05 ص
```

The `DefaultCldrProvider.Instance` fast path still short-circuits: the long/short/day-period seeding is
still skipped by identity, and the narrow lane is entered only by a formatter that asked for a narrow
style, so nothing about constructing an ordinary formatter changed. No work was added to any `format()`
path — the names are resolved once, at construction.

Fixes #3398
Fixes #3399
