### PR TITLE
Intl: Intl.DurationFormat formats in the numbering system it reports

### DIFF
--- a/Jint.Tests/Runtime/IntlDurationFormatTests.cs
+++ b/Jint.Tests/Runtime/IntlDurationFormatTests.cs
@@ -1,0 +1,100 @@
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// <c>Intl.DurationFormat</c> resolves a numbering system and reports it from <c>resolvedOptions()</c>.
+/// https://tc39.es/ecma402/#sec-partitiondurationformatpattern step 4.h.iii.1, and the three numeric-style
+/// operations it delegates to, put that system into every <c>NumberFormat</c> the partition constructs — so
+/// the digits are the system's, in both lanes and in every style.
+/// </summary>
+public class IntlDurationFormatTests
+{
+    private readonly Engine _engine = new();
+
+    [Test]
+    public void TheResolvedNumberingSystemIsTheOneFormatWritesIn()
+    {
+        _engine.Evaluate("new Intl.DurationFormat('en', { numberingSystem: 'arab' }).resolvedOptions().numberingSystem")
+            .AsString().Should().Be("arab");
+        _engine.Evaluate("new Intl.DurationFormat('en', { numberingSystem: 'arab' }).format({ hours: 12, minutes: 30 })")
+            .AsString().Should().Be("١٢ hr, ٣٠ min");
+    }
+
+    /// <summary>
+    /// The digits come from the system and the unit names do not: a unit name is not a number, and
+    /// PartitionDurationFormatPattern only ever hands a value to a NumberFormat.
+    /// </summary>
+    [Test]
+    public void OnlyTheNumbersAreTransliterated()
+    {
+        var parts = _engine.Evaluate(
+            """
+            JSON.stringify(new Intl.DurationFormat('en', { numberingSystem: 'arab' })
+                .formatToParts({ hours: 12, minutes: 30 }))
+            """).AsString();
+
+        parts.Should().Be(
+            """
+            [{"type":"integer","value":"١٢","unit":"hour"},{"type":"literal","value":" ","unit":"hour"},{"type":"unit","value":"hr","unit":"hour"},{"type":"literal","value":", "},{"type":"integer","value":"٣٠","unit":"minute"},{"type":"literal","value":" ","unit":"minute"},{"type":"unit","value":"min","unit":"minute"}]
+            """);
+    }
+
+    /// <summary>
+    /// The numeric styles construct their own NumberFormats — FormatNumericHours, FormatNumericMinutes and
+    /// FormatNumericSeconds — and each is handed the same <c>[[NumberingSystem]]</c>. The fractional second
+    /// separator is the system's too.
+    /// </summary>
+    [Test]
+    public void TheNumericStylesWriteTheSameDigits()
+    {
+        _engine.Evaluate("new Intl.DurationFormat('en', { numberingSystem: 'arab', style: 'digital' }).format({ hours: 1, minutes: 2, seconds: 3 })")
+            .AsString().Should().Be("١:٠٢:٠٣");
+
+        _engine.Evaluate(
+            """
+            new Intl.DurationFormat('en', { numberingSystem: 'arab', style: 'digital', fractionalDigits: 3 })
+                .format({ hours: 1, minutes: 2, seconds: 3, milliseconds: 456 })
+            """).AsString().Should().Be("١:٠٢:٠٣٫٤٥٦");
+    }
+
+    /// <summary>
+    /// https://tc39.es/ecma402/#sec-Intl.DurationFormat.prototype.format steps 4-7 define <c>format</c> as
+    /// the concatenation of the very partition <c>formatToParts</c> returns, so the two can never disagree.
+    /// Jint writes them down separately — one transliterates the assembled string, the other transliterates
+    /// by part type — which is exactly why this is checked rather than assumed.
+    /// </summary>
+    [TestCase("{ hours: 12, minutes: 30 }", "short")]
+    [TestCase("{ years: 1234, months: 2 }", "long")]
+    [TestCase("{ hours: 1, minutes: 2, seconds: 3 }", "digital")]
+    [TestCase("{ days: 3, hours: 4 }", "narrow")]
+    [TestCase("{ hours: -1, minutes: -30 }", "digital")]
+    [TestCase("{ hours: -1, minutes: -30 }", "long")]
+    [TestCase("{ seconds: 3, milliseconds: 456 }", "digital")]
+    [TestCase("{ weeks: 2, days: 1, hours: 5, minutes: 6, seconds: 7 }", "short")]
+    public void PartsConcatenateToFormat(string duration, string style)
+    {
+        foreach (var numberingSystem in new[] { "latn", "arab", "beng", "deva" })
+        {
+            var script = $$"""
+                (function () {
+                    var df = new Intl.DurationFormat('en', { numberingSystem: '{{numberingSystem}}', style: '{{style}}' });
+                    var d = {{duration}};
+                    return df.formatToParts(d).map(function (p) { return p.value; }).join('') === df.format(d);
+                })()
+                """;
+
+            _engine.Evaluate(script).AsBoolean().Should().BeTrue($"{numberingSystem}/{style}/{duration}");
+        }
+    }
+
+    /// <summary>The Latin default writes what it always wrote, and pays nothing to find that out.</summary>
+    [Test]
+    public void TheLatinDefaultIsUnchanged()
+    {
+        _engine.Evaluate("new Intl.DurationFormat('en').format({ hours: 12, minutes: 30 })")
+            .AsString().Should().Be("12 hr, 30 min");
+        _engine.Evaluate("new Intl.DurationFormat('en', { numberingSystem: 'latn' }).format({ hours: 12, minutes: 30 })")
+            .AsString().Should().Be("12 hr, 30 min");
+        _engine.Evaluate("new Intl.DurationFormat('en', { style: 'digital' }).format({ hours: 1, minutes: 2, seconds: 3 })")
+            .AsString().Should().Be("1:02:03");
+    }
+}

--- a/Jint/Native/Intl/DurationFormatConstructor.cs
+++ b/Jint/Native/Intl/DurationFormatConstructor.cs
@@ -209,7 +209,7 @@ internal sealed partial class DurationFormatConstructor : Constructor
             proto,
             resolvedLocale,
             style,
-            numberingSystem,
+            Data.ResolvedNumberingSystem.Resolve(_engine, numberingSystem),
             culture,
             yearsStyle,
             monthsStyle,

--- a/Jint/Native/Intl/JsDurationFormat.cs
+++ b/Jint/Native/Intl/JsDurationFormat.cs
@@ -15,7 +15,7 @@ internal sealed class JsDurationFormat : ObjectInstance
         ObjectInstance prototype,
         string locale,
         string style,
-        string numberingSystem,
+        in Data.ResolvedNumberingSystem numberingSystem,
         CultureInfo cultureInfo,
         string yearsStyle,
         string monthsStyle,
@@ -42,7 +42,7 @@ internal sealed class JsDurationFormat : ObjectInstance
         _prototype = prototype;
         Locale = locale;
         Style = style;
-        NumberingSystem = numberingSystem;
+        _numberingSystem = numberingSystem;
         CultureInfo = cultureInfo;
 
         YearsStyle = yearsStyle;
@@ -85,10 +85,12 @@ internal sealed class JsDurationFormat : ObjectInstance
     /// </summary>
     internal string Style { get; }
 
+    private readonly Data.ResolvedNumberingSystem _numberingSystem;
+
     /// <summary>
-    /// The numbering system.
+    /// The numbering system, as <c>resolvedOptions()</c> reports it.
     /// </summary>
-    internal string NumberingSystem { get; }
+    internal string NumberingSystem => _numberingSystem.Name;
 
     /// <summary>
     /// The .NET CultureInfo for locale-specific formatting.
@@ -125,16 +127,32 @@ internal sealed class JsDurationFormat : ObjectInstance
     /// <summary>
     /// Formats a duration object.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// https://tc39.es/ecma402/#sec-partitiondurationformatpattern step 4.h.iii.1 writes
+    /// <c>[[NumberingSystem]]</c> into the options of the <c>NumberFormat</c> it then constructs for the
+    /// unit's value, and the three numeric-style operations it delegates to —
+    /// https://tc39.es/ecma402/#sec-formatnumerichours,
+    /// https://tc39.es/ecma402/#sec-formatnumericminutes and
+    /// https://tc39.es/ecma402/#sec-formatnumericseconds — each do the same for their own. All four sites
+    /// mean one thing: every digit a duration writes is that system's.
+    /// </para>
+    /// <para>
+    /// Jint assembles the string first and transliterates it once, which reaches all four: the CLDR unit
+    /// names for the ten duration units carry no ASCII digit in any locale, so there is nothing else in the
+    /// string for this to touch. That this agrees with the parts lane, which transliterates by part type, is
+    /// what https://tc39.es/ecma402/#sec-Intl.DurationFormat.prototype.format steps 4-7 require — format() is
+    /// the concatenation of the same partition formatToParts() returns — and it is pinned by
+    /// IntlTests.DurationFormatPartsConcatenateToFormat rather than assumed.
+    /// </para>
+    /// </remarks>
     internal string Format(DurationRecord duration)
     {
         var isDigital = string.Equals(Style, "digital", StringComparison.Ordinal);
 
-        if (isDigital)
-        {
-            return FormatDigital(duration);
-        }
+        var formatted = isDigital ? FormatDigital(duration) : FormatNonDigital(duration);
 
-        return FormatNonDigital(duration);
+        return _numberingSystem.RewritesDigits ? _numberingSystem.Transliterate(formatted) : formatted;
     }
 
     private string FormatDigital(DurationRecord duration)
@@ -773,6 +791,25 @@ internal sealed class JsDurationFormat : ObjectInstance
     }
 
     /// <summary>
+    /// Rewrites one part's value in this formatter's numbering system, for the part types a NumberFormat
+    /// would have produced under https://tc39.es/ecma402/#sec-partitiondurationformatpattern. A unit name and
+    /// a literal are not numbers and keep their own digits, whatever they turn out to be.
+    /// </summary>
+    private string TransliterateNumericPart(string type, string value)
+    {
+        if (!_numberingSystem.RewritesDigits)
+        {
+            return value;
+        }
+
+        return type switch
+        {
+            "integer" or "fraction" or "decimal" or "group" => _numberingSystem.Transliterate(value),
+            _ => value
+        };
+    }
+
+    /// <summary>
     /// Formats a duration object and returns parts.
     /// </summary>
     internal JsArray FormatToParts(Engine engine, DurationRecord duration)
@@ -821,7 +858,7 @@ internal sealed class JsDurationFormat : ObjectInstance
         {
             var part = OrdinaryObjectCreate(engine, engine.Realm.Intrinsics.Object.PrototypeObject);
             part.Set("type", type);
-            part.Set("value", value);
+            part.Set("value", TransliterateNumericPart(type, value));
             if (unit != null)
             {
                 part.Set("unit", unit);
@@ -974,7 +1011,7 @@ internal sealed class JsDurationFormat : ObjectInstance
         {
             var part = OrdinaryObjectCreate(engine, engine.Realm.Intrinsics.Object.PrototypeObject);
             part.Set("type", type);
-            part.Set("value", value);
+            part.Set("value", TransliterateNumericPart(type, value));
             if (unit != null)
             {
                 part.Set("unit", unit);

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -1839,6 +1839,29 @@ new Intl.DateTimeFormat('ar', { timeStyle: 'short' }).format(Date.UTC(2024, 0, 1
 letters, and its narrow names are what the derivation produces. Formatting that asks for neither a narrow
 style nor a day period is untouched, and so is the cost of constructing it — the narrow names are read only
 when a narrow style was actually requested.
+### 4.35 `Intl.DurationFormat` formats in the numbering system it reports ([#3400](https://github.com/sebastienros/jint/issues/3400))
+
+`Intl.DurationFormat` resolved a numbering system, reported it from `resolvedOptions()`, and then wrote
+Latin digits anyway. Its three siblings — `Intl.NumberFormat`, `Intl.DateTimeFormat`,
+`Intl.RelativeTimeFormat` — all transliterated their output; this one stored the value and nothing read it.
+
+```js
+// 5.0
+new Intl.DurationFormat('en', { numberingSystem: 'arab' }).resolvedOptions().numberingSystem; // "arab"
+new Intl.DurationFormat('en', { numberingSystem: 'arab' }).format({ hours: 12, minutes: 30 }); // "12 hr, 30 min"
+
+// 5.x
+new Intl.DurationFormat('en', { numberingSystem: 'arab' }).format({ hours: 12, minutes: 30 }); // "١٢ hr, ٣٠ min"
+new Intl.DurationFormat('en', { numberingSystem: 'arab', style: 'digital' }).format({ hours: 1, minutes: 2, seconds: 3 }); // "١:٠٢:٠٣"
+```
+
+Digits only: a unit name is not a number, so `hr` and `min` keep their own characters, which is what
+`formatToParts` already said by giving them a `unit` type rather than an `integer` one. `format()` and
+`formatToParts()` agree, because the specification defines the first as the concatenation of the second.
+
+**What could break:** a duration formatted with an explicit `numberingSystem`, or a `-u-nu-` extension, that
+is not `latn`. Nothing else moves — a formatter that resolves to `latn`, which is every formatter that does
+not ask for something else, writes exactly what it wrote before.
 
 ## 5. New in v5
 


### PR DESCRIPTION
`Intl.DurationFormat` resolved a numbering system, reported it from `resolvedOptions()`, and then wrote
Latin digits anyway. Its three siblings all transliterate — `JsNumberFormat.Format`,
`JsDateTimeFormat.Format`, `JsRelativeTimeFormat.Format` — and this one stored `NumberingSystem` where
nothing read it.

```js
new Intl.DurationFormat('en', { numberingSystem: 'arab' }).resolvedOptions().numberingSystem;
// "arab"

// before
new Intl.DurationFormat('en', { numberingSystem: 'arab' }).format({ hours: 12, minutes: 30 });
// "12 hr, 30 min"
new Intl.DurationFormat('en', { numberingSystem: 'arab', style: 'digital' }).format({ hours: 1, minutes: 2, seconds: 3 });
// "1:02:03"

// after — character for character what Node 24's ICU writes
// "١٢ hr, ٣٠ min"
// "١:٠٢:٠٣"
```

## It is a formatting gap, not a reporting one

The specification is explicit about which of the two it is.
[PartitionDurationFormatPattern](https://tc39.es/ecma402/#sec-partitiondurationformatpattern) step 4.h.iii.1
writes `durationFormat.[[NumberingSystem]]` into the options of the `NumberFormat` it constructs for the
unit's value at step 4.h.iii.7 — so the digits are the system's by construction, and `resolvedOptions()`
was telling the truth about a value the formatter simply never used.

There are **four** such construction sites, not one: the non-numeric branch above, plus
[FormatNumericHours](https://tc39.es/ecma402/#sec-formatnumerichours),
[FormatNumericMinutes](https://tc39.es/ecma402/#sec-formatnumericminutes) and
[FormatNumericSeconds](https://tc39.es/ecma402/#sec-formatnumericseconds), each of which builds its own
`NumberFormat` and passes `[[NumberingSystem]]` independently. A fix that only reached the non-numeric
branch would still write Latin digits for the `digital` style, which is the shape most people use.

`JsDurationFormat` now carries a `ResolvedNumberingSystem` — the same record the other three formatters
took in #3397, resolved once at construction through `ICldrProvider.GetNumberingSystemDigits`, so
`format()` never asks the provider. Digits only: a unit name is not a number, so `hr` and `min` keep their
own characters, which is what `formatToParts` already said by giving them a `unit` type rather than an
`integer` one. ICU agrees:

```js
new Intl.DurationFormat('en', { numberingSystem: 'arab' }).formatToParts({ hours: 12, minutes: 30 });
// [{"type":"integer","value":"١٢","unit":"hour"},{"type":"literal","value":" ","unit":"hour"},
//  {"type":"unit","value":"hr","unit":"hour"}, … ]
```

## The two lanes

[`Intl.DurationFormat.prototype.format`](https://tc39.es/ecma402/#sec-Intl.DurationFormat.prototype.format)
steps 4–7 define the string as the concatenation of the very partition `formatToParts` returns, so the two
can never disagree. Jint writes them down separately, so this is checked rather than assumed:
`IntlDurationFormatTests.PartsConcatenateToFormat` runs seven duration shapes × four styles × four
numbering systems and asserts the identity for all 112.

The parts lane transliterates by part type — `integer`, `fraction`, `decimal`, `group` — and the string
lane transliterates the assembled string once. They reach the same characters because the CLDR unit names
for the ten duration units carry no ASCII digit in any locale, and the test is what says so rather than
the argument.

The fractional-second separator comes along for free, because `ResolvedNumberingSystem.Transliterate`
already rewrites `.` as the system's separator:
`{ style: 'digital', fractionalDigits: 3 }` on 1:02:03.456 gives `١:٠٢:٠٣٫٤٥٦`, which is ICU's answer too.

## What is unchanged

Every formatter that resolves to `latn` — which is every formatter that does not ask for something else —
writes exactly what it wrote before. Proved entry by entry rather than asserted.

**44,771 entries, zero changed.** That is the whole matrix, not only the duration half: 605 cultures × 4
styles × 5 duration shapes for `Intl.DurationFormat`, and 605 cultures × 27 option sets × 2 instants for
`Intl.DateTimeFormat` alongside it, formatted on `main` and on this branch and diffed line by line. Nothing
in it resolves to a system other than `latn`, so nothing in it moves.

## Deferred

`Intl.DurationFormat` and `Intl.RelativeTimeFormat` never ask `ICldrProvider.GetDefaultNumberingSystem`,
so `new Intl.DurationFormat('ar-EG').resolvedOptions().numberingSystem` is `"latn"` where
`Intl.NumberFormat` on the same locale answers `"arab"`.
[ResolveLocale](https://tc39.es/ecma402/#sec-resolvelocale) step 13.c makes the default the locale's own
first entry, so `"latn"` unconditionally is wrong — but it is a separate observable change, on a different
member, in two more formatters, and it belongs in its own pull request. Filed as #3418.

Fixes #3400
