### PR TITLE
ShadowRealm: a wrapper's eagerly built members are functions of the realm the wrapper belongs to

### DIFF
--- a/Jint.Tests.PublicInterface/ShadowRealmValueRealmTests.cs
+++ b/Jint.Tests.PublicInterface/ShadowRealmValueRealmTests.cs
@@ -126,4 +126,130 @@ public class ShadowRealmValueRealmTests
         shadowRealm.Evaluate("company instanceof PrincipalObject").Should().BeFalse();
         shadowRealm.Evaluate("company instanceof Object").Should().BeTrue();
     }
+
+    /// <summary>
+    /// The three members <see cref="Jint.Runtime.Interop.ObjectWrapper"/> builds eagerly in its constructor
+    /// — <c>Symbol.dispose</c>, <c>Symbol.asyncDispose</c> and <c>toJSON</c> — are functions like any other
+    /// and belong to the realm the object they hang off belongs to.
+    /// </summary>
+    /// <remarks>
+    /// They used to be built through the public <c>ClrFunction(Engine, string, …)</c> constructor, which pins
+    /// the engine's <em>original</em> intrinsics. That is right for a function a host wires up against an
+    /// engine (#2893, <c>HostClrFunctionRealmTests</c>) and wrong for one the engine builds for an object it
+    /// is creating, because the object's own prototype comes from the running realm. The two disagreed on the
+    /// same object: <c>handle.Dispose instanceof Function</c> was true while
+    /// <c>handle[Symbol.dispose] instanceof Function</c> was false (#3365).
+    /// </remarks>
+    [Test]
+    public void TheDisposeMemberOfAHostObjectBelongsToTheRealmItIsRegisteredOn()
+    {
+        var engine = new Engine();
+        var shadowRealm = engine.Intrinsics.ShadowRealm.Construct();
+
+        shadowRealm.SetValue("handle", new Handle());
+
+        // the lazily resolved member, which reads engine.Realm when it is materialized and was always right
+        shadowRealm.Evaluate("handle.Dispose instanceof Function").Should().BeTrue();
+
+        shadowRealm.Evaluate("typeof handle[Symbol.dispose]").Should().Be("function");
+        shadowRealm.Evaluate("handle[Symbol.dispose] instanceof Function").Should().BeTrue();
+        shadowRealm.Evaluate("Object.getPrototypeOf(handle[Symbol.dispose]) === Function.prototype").Should().BeTrue();
+    }
+
+#if !NETFRAMEWORK
+    [Test]
+    public void TheAsyncDisposeMemberOfAHostObjectBelongsToTheRealmItIsRegisteredOn()
+    {
+        var engine = new Engine();
+        var shadowRealm = engine.Intrinsics.ShadowRealm.Construct();
+
+        shadowRealm.SetValue("handle", new AsyncHandle());
+
+        shadowRealm.Evaluate("handle[Symbol.asyncDispose] instanceof Function").Should().BeTrue();
+        shadowRealm.Evaluate("Object.getPrototypeOf(handle[Symbol.asyncDispose]) === Function.prototype").Should().BeTrue();
+    }
+#endif
+
+    [Test]
+    public void TheToJsonMemberOfAHostObjectBelongsToTheRealmItIsRegisteredOn()
+    {
+        var engine = new Engine();
+        var shadowRealm = engine.Intrinsics.ShadowRealm.Construct();
+
+        shadowRealm.SetValue("payload", new Payload());
+
+        shadowRealm.Evaluate("payload.toJSON instanceof Function").Should().BeTrue();
+        shadowRealm.Evaluate("Object.getPrototypeOf(payload.toJSON) === Function.prototype").Should().BeTrue();
+        shadowRealm.Evaluate("JSON.stringify(payload)").Should().Be("\"acme\"");
+    }
+
+    /// <summary>
+    /// The negative half, stated against the very intrinsic the members used to inherit from.
+    /// </summary>
+    [Test]
+    public void AnEagerlyBuiltMemberIsNotAFunctionOfThePrincipalRealm()
+    {
+        var engine = new Engine();
+        var shadowRealm = engine.Intrinsics.ShadowRealm.Construct();
+
+        shadowRealm.SetValue("PrincipalFunction", (JsValue) engine.Intrinsics.Function);
+        shadowRealm.SetValue("handle", new Handle());
+
+        shadowRealm.Evaluate("handle[Symbol.dispose] instanceof PrincipalFunction").Should().BeFalse();
+        shadowRealm.Evaluate("handle[Symbol.dispose] instanceof Function").Should().BeTrue();
+    }
+
+    /// <summary>
+    /// The other half of the rule, and why the answer is "the realm the wrapper was created in" rather than a
+    /// realm stored on the wrapper: an object the host registers on the engine keeps the principal realm's
+    /// intrinsics, exactly as its own prototype does.
+    /// </summary>
+    [Test]
+    public void TheEagerlyBuiltMembersOfAnEngineRegistrationStayInThePrincipalRealm()
+    {
+        var engine = new Engine();
+        engine.Intrinsics.ShadowRealm.Construct();
+
+        engine.SetValue("handle", new Handle());
+
+        engine.Evaluate("handle[Symbol.dispose] instanceof Function").Should().BeTrue();
+        engine.Evaluate("Object.getPrototypeOf(handle[Symbol.dispose]) === Function.prototype").Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Disposal kept working throughout, because a call never consults the prototype — which is why the
+    /// defect was invisible to everything except a feature detection or a reach for <c>call</c>/<c>bind</c>.
+    /// </summary>
+    [Test]
+    public void ADisposableHostObjectIsStillDisposableInsideTheRealm()
+    {
+        var engine = new Engine();
+        var shadowRealm = engine.Intrinsics.ShadowRealm.Construct();
+
+        var handle = new Handle();
+        shadowRealm.SetValue("handle", handle);
+
+        shadowRealm.Evaluate("handle[Symbol.dispose].call(handle)");
+
+        handle.Disposed.Should().BeTrue();
+    }
+
+    public sealed class Handle : IDisposable
+    {
+        public bool Disposed { get; private set; }
+
+        public void Dispose() => Disposed = true;
+    }
+
+#if !NETFRAMEWORK
+    public sealed class AsyncHandle : IAsyncDisposable
+    {
+        public ValueTask DisposeAsync() => default;
+    }
+#endif
+
+    public sealed class Payload
+    {
+        public string toJSON() => "acme";
+    }
 }

--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -77,19 +77,34 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
             }
         }
 
+        // The three members below are the only ones this constructor builds eagerly, and each is a function
+        // of the realm this wrapper is being created in — the same realm ObjectInstance's constructor just
+        // took this object's own prototype from, and the one ArrayLikeWrapper takes Array.prototype from a
+        // few lines above. That is what an ObjectWrapper answers with: not a realm of its own, but whichever
+        // one is running when it is built, which ShadowRealm.SetValue brackets deliberately (#3367).
+        //
+        // The public ClrFunction(Engine, string, …) constructor is the wrong one here, and not by accident:
+        // it pins engine._originalIntrinsics so that a function a *host* wires up against an engine belongs
+        // to the principal realm whatever was constructed since (#2893, HostClrFunctionRealmTests). Used
+        // here it made these three principal-realm functions hanging off a shadow-realm object, so
+        // `handle.Dispose instanceof Function` was true while `handle[Symbol.dispose] instanceof Function`
+        // was false on the same object — every lazily resolved member reads engine.Realm at materialization
+        // and was already right (#3365).
+        var realm = engine.Realm;
+
         if (_typeDescriptor.IsDisposable)
         {
-            SetProperty(GlobalSymbolRegistry.Dispose, new PropertyDescriptor(new ClrFunction(engine, "dispose", static (thisObject, _) =>
+            SetProperty(GlobalSymbolRegistry.Dispose, new PropertyDescriptor(new ClrFunction(engine, realm, "dispose", static (thisObject, _) =>
             {
                 ((thisObject as ObjectWrapper)?.Target as IDisposable)?.Dispose();
                 return Undefined;
-            }), PropertyFlag.NonEnumerable));
+            }, 0), PropertyFlag.NonEnumerable));
         }
 
 #if SUPPORTS_ASYNC_DISPOSE
         if (_typeDescriptor.IsAsyncDisposable)
         {
-            SetProperty(GlobalSymbolRegistry.AsyncDispose, new PropertyDescriptor(new ClrFunction(engine, "asyncDispose", (thisObject, _) =>
+            SetProperty(GlobalSymbolRegistry.AsyncDispose, new PropertyDescriptor(new ClrFunction(engine, realm, "asyncDispose", (thisObject, _) =>
             {
                 var target = ((thisObject as ObjectWrapper)?.Target as IAsyncDisposable)?.DisposeAsync();
                 if (target is not null)
@@ -97,14 +112,14 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
                     return ConvertAwaitableToPromise(engine, target);
                 }
                 return Undefined;
-            }), PropertyFlag.NonEnumerable));
+            }, 0), PropertyFlag.NonEnumerable));
         }
 #endif
 
         if (_typeDescriptor.ToJsonMethod is not null)
         {
             // Wrap the toJSON method in a ClrFunction with the expected signature for JSON.stringify
-            var toJsonFunction = new ClrFunction(engine, "toJSON", (thisObject, arguments) =>
+            var toJsonFunction = new ClrFunction(engine, realm, "toJSON", (thisObject, arguments) =>
             {
                 var wrapper = thisObject as ObjectWrapper;
                 if (wrapper is null)
@@ -123,7 +138,7 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
                     Throw.MeaningfulException(engine, exception);
                     return Undefined;
                 }
-            });
+            }, 0);
 
             // toJSON should be writable, configurable, and non-enumerable to match JavaScript standard
             // (e.g., Date.prototype.toJSON has these same flags)

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -1917,6 +1917,28 @@ Nothing an unconfigured engine does changes: the sixteen, the two deprecated ide
 behave exactly as the four tables made them behave.
 
 **What could break:** a host overriding `ICldrProvider.GetSupportedCalendars`. See [2. Removed API](#2-removed-api).
+### 4.38 A host object's `Symbol.dispose`, `Symbol.asyncDispose` and `toJSON` belong to its own realm ([#3365](https://github.com/sebastienros/jint/issues/3365))
+
+`ObjectWrapper` builds three members eagerly — `Symbol.dispose` for an `IDisposable` target,
+`Symbol.asyncDispose` for an `IAsyncDisposable` one, and `toJSON` for a type that has one — and built them
+as functions of the engine's **principal** realm. Every other member of the same object is resolved lazily
+and takes the realm that is running, so inside a `ShadowRealm` the two disagreed on the same object:
+
+```js
+// 4.16.x, for shadowRealm.SetValue("handle", new Handle())  — a sealed class : IDisposable
+handle.Dispose instanceof Function            // true
+typeof handle[Symbol.dispose]                 // "function"
+handle[Symbol.dispose] instanceof Function    // false
+```
+
+All three are now functions of the realm the wrapper is created in — the same realm its own prototype comes
+from, and the one `ShadowRealm.SetValue` enters deliberately ([§4.23](#423-a-value-registered-on-a-shadowrealm-belongs-to-that-realm-3325)).
+
+**What could break:** nothing that worked. Calling the member never consulted its prototype, so `using` and
+`JSON.stringify` behaved correctly throughout; what changes is that a feature detection
+(`x instanceof Function`), a reach for `call`/`apply`/`bind`, or an `Object.getPrototypeOf` inside a shadow
+realm now gets the answer the realm's own intrinsics give. A host function the embedder builds itself
+through `new ClrFunction(engine, …)` is unaffected and still belongs to the principal realm.
 
 ### 4.41 Two holes in the freeze, closed ([#3360](https://github.com/sebastienros/jint/issues/3360))
 


### PR DESCRIPTION
Fixes #3365.

`ObjectWrapper`'s constructor builds three members eagerly — `Symbol.dispose` for an `IDisposable` target,
`Symbol.asyncDispose` for an `IAsyncDisposable` one, and `toJSON` for a type that has one — and built each
through the public `ClrFunction(Engine, string, …)` constructor. That constructor pins
`engine._originalIntrinsics.Function.PrototypeObject`, which is the **principal** realm's, so inside a
`ShadowRealm` one object answered two ways at once:

```csharp
var shadowRealm = engine.Intrinsics.ShadowRealm.Construct();
shadowRealm.SetValue("handle", new Handle());   // sealed class Handle : IDisposable
```

```js
handle.Dispose instanceof Function            // true   — resolved lazily, reads engine.Realm
typeof handle[Symbol.dispose]                 // "function"
handle[Symbol.dispose] instanceof Function    // false  — a Function of a realm this script cannot reach
```

`using` and `JSON.stringify` kept working throughout, because a call never consults the prototype. What did
not work is anything that asks *what the member is*: a feature detection, `Object.getPrototypeOf`, or a
reach for `call`/`apply`/`bind`.

## The question the issue asks, and why the answer needs no new field

> What has to be decided first is which realm an `ObjectWrapper` answers with: it has no `_realm` field
> today, only `_engine`, and adding one means saying whether a wrapper is pinned to the realm it was created
> in or resolves late like its reflected members do.

It is already decided, two constructors up. `ObjectInstance`'s constructor sets
`_prototype = engine.Realm.Intrinsics?.Object?.PrototypeObject`, and `ArrayLikeWrapper`'s sets
`Prototype = engine.Intrinsics.Array.PrototypeObject` — both the **running** realm, which for a host
registration is the realm being registered on, because `ShadowRealm.SetValue` enters it
(#3367). So an `ObjectWrapper` is already pinned to the realm it was created in, by its own `[[Prototype]]`,
and there is nothing for a `_realm` field to say that the prototype does not say already. The three members
simply have to agree with it, which is what this changes: each now uses the internal
`ClrFunction(Engine, Realm, string, JsCallDelegate, int, PropertyFlag)` constructor — the one whose own doc
comment names this exact case — with `engine.Realm`.

That also answers the issue's second half. `ArrayLikeWrapper`'s `engine.Intrinsics.Array.PrototypeObject` is
not a second question with a second answer; it is the precedent, and it is already correct.

## What is deliberately untouched

`ClrFunction(Engine, …)`, `HostFunction` and `Constructor(Engine, string)` keep pinning
`engine._originalIntrinsics`. That is #2893's fix and it is about a different function: one a **host** wires
up against an engine, which must belong to the realm the surrounding script can reach whatever realm
happened to be current when it was built — a lazily registered global materializing after a script has
constructed a shadow realm is the reachable shape. `HostClrFunctionRealmTests` pins it and still passes.

The distinction the two constructors draw is now the whole rule: *the host's function belongs to the host's
realm; the engine's function belongs to the object's.*

## Tests

Five more facts in `Jint.Tests.PublicInterface/ShadowRealmValueRealmTests.cs`, beside the ones #3367 added —
one per eagerly built member, the negative half measured against the principal `Function` handed into the
realm through the overload that installs a `JsValue` untouched, the other direction (an engine registration
keeps the principal realm, which is what says the answer is "the realm it was created in" rather than
"always the shadow one"), and the control that disposal itself still works.

**Failing first**, on unmodified `upstream/main` with only the tests added:

```
Failed!  - Failed:     4, Passed:     9, Skipped:     0, Total:    13 - Jint.Tests.PublicInterface.dll (net10.0)

  Failed TheDisposeMemberOfAHostObjectBelongsToTheRealmItIsRegisteredOn
   Expected value to be "true (Boolean)", but found "false (Boolean)".
  Failed TheAsyncDisposeMemberOfAHostObjectBelongsToTheRealmItIsRegisteredOn
   Expected value to be "true (Boolean)", but found "false (Boolean)".
  Failed TheToJsonMemberOfAHostObjectBelongsToTheRealmItIsRegisteredOn
   Expected value to be "true (Boolean)", but found "false (Boolean)".
  Failed AnEagerlyBuiltMemberIsNotAFunctionOfThePrincipalRealm
   Expected value to be "false (Boolean)", but found "true (Boolean)".
```

The `Symbol.asyncDispose` pair is `#if !NETFRAMEWORK`, matching Jint's own `SUPPORTS_ASYNC_DISPOSE`, which is
off for `net472` and `netstandard2.0`.

## Verification

* `dotnet build -c Release` — 0 warnings, 0 errors.
* `Jint.Tests` — 10,752 passed on `net10.0` and `net8.0`, 7,376 on `net472`, 0 failed.
* `Jint.Tests.PublicInterface` — 3,083 passed on `net10.0`, 3,073 on `net8.0`, 2,453 on `net472`, 0 failed.
* Both again with `JINT_HOST_CONTRACT_VERIFICATION=1` — 0 failed.
* `Jint.Tests.Test262` — 102,495 passed, 0 failed, 189 skipped (102,684 total).
* No public API baseline moved and `UndocumentedPublicApi.txt` is unchanged: the constructor being called
  instead is `internal` and already existed.
* `docs/v5-migration.md` §4.33 carries the embedder-facing form. No benchmark: the change is which of two
  already-resolved prototype references three constructor-time allocations read.
