### PR TITLE
Temporal: calendar arithmetic is answered by whoever answers for the calendar

### DIFF
--- a/Jint.Tests.PublicInterface/HostLocaleProviderTests.cs
+++ b/Jint.Tests.PublicInterface/HostLocaleProviderTests.cs
@@ -274,26 +274,40 @@ public class HostLocaleProviderTests
     }
 
     /// <summary>
-    /// Calendar arithmetic is implemented per calendar inside the engine and is not routed through
-    /// <see cref="ICalendarProvider"/>, so a calendar a host added has none. What this pins is that the
-    /// refusal is a <c>RangeError</c> a script can catch, rather than a <see cref="NotSupportedException"/>
-    /// escaping <c>Engine.Evaluate</c> as it did before.
+    /// The two conversions are the whole of what a host writes, and arithmetic is now walked in terms of
+    /// them — so a calendar the host added moves, and moves where its own conversions say. Adding a calendar
+    /// is still the three overrides <see cref="WithMayan"/> makes; none of them is an <c>add</c>.
     /// </summary>
     [Test]
-    public void AHostCalendarHasNoArithmeticAndSaysSoInJavaScript()
+    public void AHostCalendarGetsItsArithmeticFromItsOwnConversions()
     {
         var engine = new Engine(options => options.Temporal.CalendarProvider = new WithMayan());
 
-        foreach (var script in new[]
+        foreach (var (script, expected) in new[]
         {
-            "Temporal.PlainDate.from('2024-03-05').withCalendar('mayan').add({ days: 1 })",
-            "Temporal.PlainDate.from('2024-03-05').withCalendar('mayan').subtract({ months: 1 })",
-            "Temporal.PlainDate.from('2024-03-05').withCalendar('mayan').until(Temporal.PlainDate.from('2024-05-05').withCalendar('mayan'))",
+            ("Temporal.PlainDate.from('2024-03-05').withCalendar('mayan').add({ days: 1 }).toString()", "2024-03-06[u-ca=mayan]"),
+            ("Temporal.PlainDate.from('2024-03-05').withCalendar('mayan').add({ months: 1 }).toString()", "2024-04-05[u-ca=mayan]"),
+            ("Temporal.PlainDate.from('2024-03-05').withCalendar('mayan').add({ years: 1, months: 2 }).toString()", "2025-05-05[u-ca=mayan]"),
+            ("Temporal.PlainDate.from('2024-03-05').withCalendar('mayan').subtract({ months: 1 }).toString()", "2024-02-05[u-ca=mayan]"),
+            ("Temporal.PlainDate.from('2024-03-05').withCalendar('mayan').until(Temporal.PlainDate.from('2024-05-05').withCalendar('mayan')).toString()", "P61D"),
+            ("Temporal.PlainDate.from('2024-03-05').withCalendar('mayan').until(Temporal.PlainDate.from('2025-07-19').withCalendar('mayan'), { largestUnit: 'month' }).toString()", "P16M14D"),
         })
         {
-            engine.Evaluate($"(function () {{ try {{ {script}; return 'no error'; }} catch (e) {{ return e.constructor.name + ': ' + e.message; }} }})()")
-                .AsString().Should().Be("RangeError: Calendar arithmetic is not implemented for 'mayan'");
+            engine.Evaluate(script).AsString().Should().Be(expected, script);
         }
+
+        // the day is clamped against the month length the provider itself reported, and "reject" refuses
+        engine.Evaluate("Temporal.PlainDate.from('2024-01-31').withCalendar('mayan').add({ months: 1 }).toString()")
+            .AsString().Should().Be("2024-02-29[u-ca=mayan]");
+        engine.Evaluate(
+            """
+            (function () {
+                try {
+                    Temporal.PlainDate.from('2024-01-31').withCalendar('mayan').add({ months: 1 }, { overflow: 'reject' });
+                    return 'no error';
+                } catch (e) { return e.constructor.name; }
+            })()
+            """).AsString().Should().Be("RangeError");
 
         // the calendars the engine implements itself are unaffected
         engine.Evaluate("Temporal.PlainDate.from('2024-03-05').withCalendar('hebrew').add({ months: 1 }).toString()")

--- a/Jint.Tests/Runtime/TemporalCalendarArithmeticTests.cs
+++ b/Jint.Tests/Runtime/TemporalCalendarArithmeticTests.cs
@@ -1,0 +1,519 @@
+#nullable enable
+
+using System.Globalization;
+using Jint.Native.Temporal;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Calendar arithmetic — <c>add</c>, <c>subtract</c>, <c>until</c>, <c>since</c> — used to be implemented
+/// per calendar inside the engine and nowhere else, while <see cref="ICalendarProvider"/> was consulted only
+/// for the two conversions. A host that corrected a calendar therefore corrected its field accessors and
+/// left its arithmetic reading the BCL, and a host that added a calendar got a <c>RangeError</c> the moment
+/// a date in it was moved. The arithmetic now walks the provider's own conversions for every calendar the
+/// provider answers for.
+/// <para>
+/// Half of these check that. The other half check the thing that made the change worth measuring: an engine
+/// that configures no provider still reaches the same per-calendar implementation it always did, and so does
+/// a calendar under a provider that only meant to change something else. Every expected string here was
+/// captured from the build before the change.
+/// </para>
+/// </summary>
+public class TemporalCalendarArithmeticTests
+{
+    /// <summary>Every non-ISO calendar the engine implements itself, and one date well inside all eleven ranges.</summary>
+    private const string Base = "2024-03-05";
+
+    private const string Other = "2025-07-19";
+
+    private static readonly (string Calendar, string Operation, string Expected)[] AdditionBaseline =
+    [
+        ("chinese", "add({ years: 1 })", "2025-02-22"),
+        ("chinese", "add({ months: 1 })", "2024-04-03"),
+        ("chinese", "add({ months: 13 })", "2025-03-24"),
+        ("chinese", "subtract({ months: 1 })", "2024-02-04"),
+        ("chinese", "subtract({ years: 2 })", "2022-02-25"),
+        ("chinese", "add({ years: 1, months: 2, weeks: 1, days: 3 })", "2025-05-02"),
+        ("dangi", "add({ years: 1 })", "2025-02-22"),
+        ("dangi", "add({ months: 1 })", "2024-04-03"),
+        ("dangi", "add({ months: 13 })", "2025-03-24"),
+        ("dangi", "subtract({ months: 1 })", "2024-02-04"),
+        ("dangi", "subtract({ years: 2 })", "2022-02-25"),
+        ("dangi", "add({ years: 1, months: 2, weeks: 1, days: 3 })", "2025-05-02"),
+        ("hebrew", "add({ years: 1 })", "2025-03-25"),
+        ("hebrew", "add({ months: 1 })", "2024-04-04"),
+        ("hebrew", "add({ months: 13 })", "2025-03-25"),
+        ("hebrew", "subtract({ months: 1 })", "2024-02-04"),
+        ("hebrew", "subtract({ years: 2 })", "2022-02-26"),
+        ("hebrew", "add({ years: 1, months: 2, weeks: 1, days: 3 })", "2025-06-02"),
+        ("persian", "add({ years: 1 })", "2025-03-05"),
+        ("persian", "add({ months: 1 })", "2024-04-03"),
+        ("persian", "add({ months: 13 })", "2025-04-04"),
+        ("persian", "subtract({ months: 1 })", "2024-02-04"),
+        ("persian", "subtract({ years: 2 })", "2022-03-06"),
+        ("persian", "add({ years: 1, months: 2, weeks: 1, days: 3 })", "2025-05-15"),
+        ("coptic", "add({ years: 1 })", "2025-03-05"),
+        ("coptic", "add({ months: 1 })", "2024-04-04"),
+        ("coptic", "add({ months: 13 })", "2025-03-05"),
+        ("coptic", "subtract({ months: 1 })", "2024-02-04"),
+        ("coptic", "subtract({ years: 2 })", "2022-03-05"),
+        ("coptic", "add({ years: 1, months: 2, weeks: 1, days: 3 })", "2025-05-14"),
+        ("ethiopic", "add({ years: 1 })", "2025-03-05"),
+        ("ethiopic", "add({ months: 1 })", "2024-04-04"),
+        ("ethiopic", "add({ months: 13 })", "2025-03-05"),
+        ("ethiopic", "subtract({ months: 1 })", "2024-02-04"),
+        ("ethiopic", "subtract({ years: 2 })", "2022-03-05"),
+        ("ethiopic", "add({ years: 1, months: 2, weeks: 1, days: 3 })", "2025-05-14"),
+        ("ethioaa", "add({ years: 1 })", "2025-03-05"),
+        ("ethioaa", "add({ months: 1 })", "2024-04-04"),
+        ("ethioaa", "add({ months: 13 })", "2025-03-05"),
+        ("ethioaa", "subtract({ months: 1 })", "2024-02-04"),
+        ("ethioaa", "subtract({ years: 2 })", "2022-03-05"),
+        ("ethioaa", "add({ years: 1, months: 2, weeks: 1, days: 3 })", "2025-05-14"),
+        ("indian", "add({ years: 1 })", "2025-03-06"),
+        ("indian", "add({ months: 1 })", "2024-04-04"),
+        ("indian", "add({ months: 13 })", "2025-04-05"),
+        ("indian", "subtract({ months: 1 })", "2024-02-04"),
+        ("indian", "subtract({ years: 2 })", "2022-03-06"),
+        ("indian", "add({ years: 1, months: 2, weeks: 1, days: 3 })", "2025-05-15"),
+        ("islamic-umalqura", "add({ years: 1 })", "2025-02-23"),
+        ("islamic-umalqura", "add({ months: 1 })", "2024-04-03"),
+        ("islamic-umalqura", "add({ months: 13 })", "2025-03-24"),
+        ("islamic-umalqura", "subtract({ months: 1 })", "2024-02-05"),
+        ("islamic-umalqura", "subtract({ years: 2 })", "2022-03-27"),
+        ("islamic-umalqura", "add({ years: 1, months: 2, weeks: 1, days: 3 })", "2025-05-02"),
+        ("islamic-civil", "add({ years: 1 })", "2025-02-23"),
+        ("islamic-civil", "add({ months: 1 })", "2024-04-03"),
+        ("islamic-civil", "add({ months: 13 })", "2025-03-24"),
+        ("islamic-civil", "subtract({ months: 1 })", "2024-02-04"),
+        ("islamic-civil", "subtract({ years: 2 })", "2022-03-28"),
+        ("islamic-civil", "add({ years: 1, months: 2, weeks: 1, days: 3 })", "2025-05-03"),
+        ("islamic-tbla", "add({ years: 1 })", "2025-02-23"),
+        ("islamic-tbla", "add({ months: 1 })", "2024-04-03"),
+        ("islamic-tbla", "add({ months: 13 })", "2025-03-24"),
+        ("islamic-tbla", "subtract({ months: 1 })", "2024-02-04"),
+        ("islamic-tbla", "subtract({ years: 2 })", "2022-03-28"),
+        ("islamic-tbla", "add({ years: 1, months: 2, weeks: 1, days: 3 })", "2025-05-03"),
+    ];
+
+    private static readonly (string Calendar, string LargestUnit, string Until, string Since)[] DifferenceBaseline =
+    [
+        ("chinese", "year", "P1Y5M", "P1Y5M"),
+        ("chinese", "month", "P17M", "P17M"),
+        ("dangi", "year", "P1Y5M", "P1Y5M"),
+        ("dangi", "month", "P17M", "P17M"),
+        ("hebrew", "year", "P1Y3M28D", "P1Y4M28D"),
+        ("hebrew", "month", "P16M28D", "P16M28D"),
+        ("persian", "year", "P1Y4M13D", "P1Y4M13D"),
+        ("persian", "month", "P16M13D", "P16M13D"),
+        ("coptic", "year", "P1Y4M16D", "P1Y4M16D"),
+        ("coptic", "month", "P17M16D", "P17M16D"),
+        ("ethiopic", "year", "P1Y4M16D", "P1Y4M16D"),
+        ("ethiopic", "month", "P17M16D", "P17M16D"),
+        ("ethioaa", "year", "P1Y4M16D", "P1Y4M16D"),
+        ("ethioaa", "month", "P17M16D", "P17M16D"),
+        ("indian", "year", "P1Y4M13D", "P1Y4M13D"),
+        ("indian", "month", "P16M13D", "P16M13D"),
+        ("islamic-umalqura", "year", "P1Y5M", "P1Y5M"),
+        ("islamic-umalqura", "month", "P17M", "P17M"),
+        ("islamic-civil", "year", "P1Y4M28D", "P1Y4M28D"),
+        ("islamic-civil", "month", "P16M28D", "P16M28D"),
+        ("islamic-tbla", "year", "P1Y4M28D", "P1Y4M28D"),
+        ("islamic-tbla", "month", "P16M28D", "P16M28D"),
+    ];
+
+    private static string AddScript(string calendar, string operation)
+        => $"Temporal.PlainDate.from('{Base}').withCalendar('{calendar}').{operation}.toString()";
+
+    private static string UntilScript(string calendar, string largestUnit)
+        => $"Temporal.PlainDate.from('{Base}').withCalendar('{calendar}').until(Temporal.PlainDate.from('{Other}').withCalendar('{calendar}'), {{ largestUnit: '{largestUnit}' }}).toString()";
+
+    private static string SinceScript(string calendar, string largestUnit)
+        => $"Temporal.PlainDate.from('{Other}').withCalendar('{calendar}').since(Temporal.PlainDate.from('{Base}').withCalendar('{calendar}'), {{ largestUnit: '{largestUnit}' }}).toString()";
+
+    /// <summary>
+    /// The failing half of the issue: a calendar a host added reached every field accessor and no arithmetic
+    /// at all, on any of the four types that have some. The provider's two conversions are still the whole
+    /// subclass — nothing here teaches the engine how a Mayan month works.
+    /// </summary>
+    [Test]
+    public void AHostAddedCalendarNowAddsSubtractsAndDiffers()
+    {
+        var engine = new Engine(options => options.Temporal.CalendarProvider = new WithMayan());
+
+        engine.Evaluate("Temporal.PlainDate.from('2024-03-05').withCalendar('mayan').add({ months: 1 }).toString()")
+            .AsString().Should().Be("2024-04-05[u-ca=mayan]");
+        engine.Evaluate("Temporal.PlainDate.from('2024-03-05').withCalendar('mayan').add({ years: 1, months: 2 }).toString()")
+            .AsString().Should().Be("2025-05-05[u-ca=mayan]");
+        engine.Evaluate("Temporal.PlainDate.from('2024-03-05').withCalendar('mayan').subtract({ months: 1 }).toString()")
+            .AsString().Should().Be("2024-02-05[u-ca=mayan]");
+        engine.Evaluate("Temporal.PlainDate.from('2024-03-05').withCalendar('mayan').add({ days: 1 }).toString()")
+            .AsString().Should().Be("2024-03-06[u-ca=mayan]");
+
+        // a day that does not exist in the month landed on is constrained into it, from the length the
+        // provider itself reported for that month
+        engine.Evaluate("Temporal.PlainDate.from('2024-01-31').withCalendar('mayan').add({ months: 1 }).toString()")
+            .AsString().Should().Be("2024-02-29[u-ca=mayan]");
+        engine.Evaluate("(function () { try { Temporal.PlainDate.from('2024-01-31').withCalendar('mayan').add({ months: 1 }, { overflow: 'reject' }); return 'no error'; } catch (e) { return e.constructor.name; } })()")
+            .AsString().Should().Be("RangeError");
+
+        engine.Evaluate($"Temporal.PlainDate.from('{Base}').withCalendar('mayan').until(Temporal.PlainDate.from('{Other}').withCalendar('mayan'), {{ largestUnit: 'month' }}).toString()")
+            .AsString().Should().Be("P16M14D");
+        engine.Evaluate($"Temporal.PlainDate.from('{Other}').withCalendar('mayan').since(Temporal.PlainDate.from('{Base}').withCalendar('mayan')).toString()")
+            .AsString().Should().Be("P501D");
+
+        engine.Evaluate("Temporal.PlainDateTime.from('2024-03-05T12:30[u-ca=mayan]').add({ months: 2 }).toString()")
+            .AsString().Should().Be("2024-05-05T12:30:00[u-ca=mayan]");
+        engine.Evaluate("Temporal.PlainDateTime.from('2024-03-05T12:30[u-ca=mayan]').subtract({ years: 1 }).toString()")
+            .AsString().Should().Be("2023-03-05T12:30:00[u-ca=mayan]");
+        engine.Evaluate("Temporal.PlainDateTime.from('2024-03-05T12:30[u-ca=mayan]').until(Temporal.PlainDateTime.from('2025-07-19T04:00[u-ca=mayan]'), { largestUnit: 'year' }).toString()")
+            .AsString().Should().Be("P1Y4M13DT15H30M");
+        engine.Evaluate("Temporal.PlainDateTime.from('2025-07-19T04:00[u-ca=mayan]').since(Temporal.PlainDateTime.from('2024-03-05T12:30[u-ca=mayan]'), { largestUnit: 'year' }).toString()")
+            .AsString().Should().Be("P1Y4M13DT15H30M");
+
+        engine.Evaluate("Temporal.PlainYearMonth.from({ year: 5138, monthCode: 'M03', calendar: 'mayan' }).add({ months: 2 }).toString()")
+            .AsString().Should().Be("2024-05-01[u-ca=mayan]");
+        engine.Evaluate("Temporal.ZonedDateTime.from('2024-03-05T12:00[UTC][u-ca=mayan]').add({ months: 1 }).toString()")
+            .AsString().Should().Be("2024-04-05T12:00:00+00:00[UTC][u-ca=mayan]");
+    }
+
+    /// <summary>
+    /// The headline of the issue: a provider that <em>corrects</em> a calendar used to be obeyed by the field
+    /// accessors and ignored by the arithmetic, so a date could be moved by a month and land where the
+    /// corrected reckoning has no such month. Here the correction is a persian of twelve thirty-day months,
+    /// which the BCL <c>PersianCalendar</c> agrees with nowhere: it puts <c>add({ months: 1 })</c> exactly
+    /// thirty days out, one day past where the stock arithmetic lands, and the shift is only visible if the
+    /// arithmetic went through the provider.
+    /// </summary>
+    [Test]
+    public void ACorrectedCalendarMovesInTheFieldsItWasCorrectedTo()
+    {
+        var stock = new Engine();
+        var engine = new Engine(options => options.Temporal.CalendarProvider = new ThirtyDayPersian());
+
+        // the correction is visible in the fields, as it always was
+        stock.Evaluate($"Temporal.PlainDate.from('{Base}').withCalendar('persian').year").AsNumber().Should().Be(1402);
+        engine.Evaluate($"Temporal.PlainDate.from('{Base}').withCalendar('persian').year").AsNumber().Should().Be(25);
+        engine.Evaluate($"Temporal.PlainDate.from('{Base}').withCalendar('persian').monthCode").AsString().Should().Be("M07");
+        engine.Evaluate($"Temporal.PlainDate.from('{Base}').withCalendar('persian').day").AsNumber().Should().Be(11);
+
+        // …and now in the arithmetic, which lands one day past where the BCL reckoning puts it
+        stock.Evaluate($"Temporal.PlainDate.from('{Base}').withCalendar('persian').add({{ months: 1 }}).toString()")
+            .AsString().Should().Be("2024-04-03[u-ca=persian]");
+        engine.Evaluate($"Temporal.PlainDate.from('{Base}').withCalendar('persian').add({{ months: 1 }}).toString()")
+            .AsString().Should().Be("2024-04-04[u-ca=persian]");
+
+        // the property the issue is really about: reading the moved date's fields, and building a date from
+        // those same fields, have to agree — one month on from (25, M07, 11) is (25, M08, 11) and nowhere else
+        engine.Evaluate($"Temporal.PlainDate.from('{Base}').withCalendar('persian').add({{ months: 1 }}).year").AsNumber().Should().Be(25);
+        engine.Evaluate($"Temporal.PlainDate.from('{Base}').withCalendar('persian').add({{ months: 1 }}).monthCode").AsString().Should().Be("M08");
+        engine.Evaluate($"Temporal.PlainDate.from('{Base}').withCalendar('persian').add({{ months: 1 }}).day").AsNumber().Should().Be(11);
+        engine.Evaluate("Temporal.PlainDate.from({ calendar: 'persian', year: 25, monthCode: 'M08', day: 11 }).toString()")
+            .AsString().Should().Be("2024-04-04[u-ca=persian]");
+
+        // a year is twelve of those months and nothing else, and thirteen months crosses into the next year
+        engine.Evaluate($"Temporal.PlainDate.from('{Base}').withCalendar('persian').add({{ years: 1 }}).toString()")
+            .AsString().Should().Be("2025-02-28[u-ca=persian]");
+        engine.Evaluate($"Temporal.PlainDate.from('{Base}').withCalendar('persian').add({{ months: 13 }}).toString()")
+            .AsString().Should().Be("2025-03-30[u-ca=persian]");
+
+        // and the difference is measured in the corrected fields too
+        stock.Evaluate(UntilScript("persian", "month")).AsString().Should().Be("P16M13D");
+        engine.Evaluate(UntilScript("persian", "month")).AsString().Should().Be("P16M21D");
+    }
+
+    /// <summary>
+    /// The regression baseline: every expected string below was captured from the build before calendar
+    /// arithmetic learned about the provider, and an engine that configures none must still produce it.
+    /// </summary>
+    [Test]
+    public void ArithmeticOnTheElevenBuiltInCalendarsIsUnchangedOnAnUnconfiguredEngine()
+    {
+        var engine = new Engine();
+
+        foreach (var (calendar, operation, expected) in AdditionBaseline)
+        {
+            engine.Evaluate(AddScript(calendar, operation))
+                .AsString().Should().Be($"{expected}[u-ca={calendar}]", $"{calendar}.{operation}");
+        }
+
+        foreach (var (calendar, largestUnit, until, since) in DifferenceBaseline)
+        {
+            engine.Evaluate(UntilScript(calendar, largestUnit)).AsString().Should().Be(until, $"{calendar} until largestUnit={largestUnit}");
+            engine.Evaluate(SinceScript(calendar, largestUnit)).AsString().Should().Be(since, $"{calendar} since largestUnit={largestUnit}");
+        }
+    }
+
+    /// <summary>
+    /// A provider is installed for one calendar and inherits the rest, so it claims all eleven and the
+    /// arithmetic asks it about all eleven — which is the point, since the field accessors already did. What
+    /// has to hold is that asking it changes no answer: the inherited conversions are the same BCL data the
+    /// per-calendar implementations read, and the generic walk over them lands on the same dates.
+    /// </summary>
+    [Test]
+    public void AProviderInstalledForOneCalendarLeavesTheOtherElevenWhereTheyWere()
+    {
+        var engine = new Engine(options => options.Temporal.CalendarProvider = new WithMayan());
+
+        foreach (var (calendar, operation, expected) in AdditionBaseline)
+        {
+            engine.Evaluate(AddScript(calendar, operation))
+                .AsString().Should().Be($"{expected}[u-ca={calendar}]", $"{calendar}.{operation}");
+        }
+
+        foreach (var (calendar, largestUnit, until, since) in DifferenceBaseline)
+        {
+            engine.Evaluate(UntilScript(calendar, largestUnit)).AsString().Should().Be(until, $"{calendar} until largestUnit={largestUnit}");
+            engine.Evaluate(SinceScript(calendar, largestUnit)).AsString().Should().Be(since, $"{calendar} since largestUnit={largestUnit}");
+        }
+    }
+
+    /// <summary>
+    /// Weeks and days are ISO days on every calendar — the calendar reckoning covers years and months only,
+    /// and the day count is added to the ISO date afterwards. True before the change, and unchanged by it,
+    /// including for a calendar the host added.
+    /// </summary>
+    [Test]
+    public void WeeksAndDaysAreAddedAsIsoDaysOnEveryCalendar()
+    {
+        var engine = new Engine();
+
+        foreach (var calendar in new[]
+        {
+            "chinese", "dangi", "hebrew", "persian", "coptic", "ethiopic", "ethioaa",
+            "indian", "islamic-umalqura", "islamic-civil", "islamic-tbla",
+        })
+        {
+            engine.Evaluate($"Temporal.PlainDate.from('{Base}').withCalendar('{calendar}').add({{ weeks: 2, days: 3 }}).toString()")
+                .AsString().Should().Be($"2024-03-22[u-ca={calendar}]", calendar);
+        }
+
+        var withMayan = new Engine(options => options.Temporal.CalendarProvider = new WithMayan());
+        withMayan.Evaluate($"Temporal.PlainDate.from('{Base}').withCalendar('mayan').add({{ weeks: 2, days: 3 }}).toString()")
+            .AsString().Should().Be("2024-03-22[u-ca=mayan]");
+    }
+
+    /// <summary>
+    /// The month walk that measures a difference steps one month at a time towards the target and stops when
+    /// a step passes it, so a step that does not move the date never stops it. Inside the engine that can no
+    /// longer happen — every conversion that used to saturate raises instead, which is what
+    /// <see cref="NonIsoCalendarRangeTests"/> pins for the eleven built-in calendars — but the walk is written
+    /// in whichever two conversions answer for the calendar, and a host provider is free to clamp where the
+    /// engine no longer does. This is that crossing: a provider whose calendar cannot represent the target
+    /// and answers with its own boundary date every time. The walk has to end, and it has to end as a
+    /// <c>RangeError</c> a script can catch rather than as a CLR exception leaving <c>Engine.Evaluate</c>.
+    /// </summary>
+    /// <remarks>
+    /// It runs on a dedicated thread because the failure it guards against is a non-terminating one: the
+    /// loop is in the engine's own code and crosses no statement boundary, so no execution constraint
+    /// interrupts it and a regression evaluated inline wedges the whole run instead of reporting it.
+    /// </remarks>
+    [Test]
+    public void ADifferencePastAHostCalendarsRangeRaisesRangeErrorInsteadOfSpinning()
+    {
+        DedicatedThread.Run(
+            () =>
+            {
+                var engine = new Engine(options => options.Temporal.CalendarProvider = new ClampingMayan());
+
+                // inside the window the provider can represent, the walk measures exactly what the same
+                // calendar measures under a provider that clamps nowhere
+                engine.Evaluate(MayanDifference("until", Base, Other, "month") + ".toString()")
+                    .AsString().Should().Be("P16M14D");
+
+                // and past either end of it the walk stands still, so it has to stop and say so. The walk
+                // starts at the receiver for both operations -- `since` is `until` read backwards, not
+                // walked backwards -- so aiming the receiver's walk at a date the provider cannot place is
+                // what stands still, at each end of the window and for each largest unit that walks months.
+                foreach (var largestUnit in new[] { "year", "month" })
+                {
+                    foreach (var operation in new[] { "until", "since" })
+                    {
+                        foreach (var two in new[] { PastTheCeiling, PastTheFloor })
+                        {
+                            engine.Evaluate(CaughtErrorOf(MayanDifference(operation, InsideTheWindow, two, largestUnit)))
+                                .AsString().Should().Be("true|true", $"{operation} {two} by {largestUnit}");
+                        }
+                    }
+                }
+            },
+            TestBudgets.WedgeCeiling,
+            "the calendar difference walk did not terminate for a host-supplied calendar",
+            DedicatedThread.DefaultStackSize);
+    }
+
+    /// <summary>A date <see cref="ClampingMayan"/> places exactly, and two it clamps at one end or the other.</summary>
+    private const string InsideTheWindow = "2024-03-05";
+
+    private const string PastTheCeiling = "2050-07-19";
+
+    private const string PastTheFloor = "1900-01-03";
+
+    private static string MayanDifference(string operation, string one, string two, string largestUnit)
+        => $"Temporal.PlainDate.from('{one}').withCalendar('mayan').{operation}("
+            + $"Temporal.PlainDate.from('{two}').withCalendar('mayan'), {{ largestUnit: '{largestUnit}' }})";
+
+    /// <summary>
+    /// Wraps <paramref name="expression"/> so it answers <c>"true|true"</c> for a <c>RangeError</c> carrying a
+    /// message. A CLR exception leaving the engine is not caught here and fails the evaluation instead, which
+    /// is the second half of what the test asserts.
+    /// </summary>
+    private static string CaughtErrorOf(string expression)
+        => "(function () { try { " + expression
+            + "; return 'no error'; } catch (e) { return (e instanceof RangeError) + '|' + (e.message.length > 0); } })()";
+}
+
+/// <summary>
+/// A calendar Jint has never heard of, defined as ISO shifted by the Mayan Long Count epoch so its
+/// arithmetic is checkable by eye. The two conversions are the whole subclass: nobody but the host can
+/// convert a calendar the engine does not know, and everything else about it — including, now, how a date in
+/// it moves — is inherited.
+/// </summary>
+file sealed class WithMayan : DefaultCalendarProvider
+{
+    private const int EpochOffset = 3114;
+
+    public override IReadOnlyCollection<string> GetSupportedCalendars()
+        => [.. base.GetSupportedCalendars(), "mayan"];
+
+    public override CalendarFields IsoToCalendarFields(string calendar, int isoYear, int isoMonth, int isoDay)
+    {
+        if (!string.Equals(calendar, "mayan", StringComparison.Ordinal))
+        {
+            return base.IsoToCalendarFields(calendar, isoYear, isoMonth, isoDay);
+        }
+
+        var leap = DateTime.IsLeapYear(isoYear);
+        return new CalendarFields(
+            isoYear + EpochOffset, isoMonth, $"M{isoMonth:D2}", isoDay,
+            IsLeapMonth: false, MonthsInYear: 12, DaysInMonth: DateTime.DaysInMonth(isoYear, isoMonth),
+            DaysInYear: leap ? 366 : 365, InLeapYear: leap);
+    }
+
+    public override IsoDateFields? CalendarFieldsToIso(string calendar, int year, string? monthCode, int month, int day, string overflow)
+    {
+        if (!string.Equals(calendar, "mayan", StringComparison.Ordinal))
+        {
+            return base.CalendarFieldsToIso(calendar, year, monthCode, month, day, overflow);
+        }
+
+        var resolved = monthCode is not null ? int.Parse(monthCode.Substring(1), CultureInfo.InvariantCulture) : month;
+        return new IsoDateFields(year - EpochOffset, resolved, day);
+    }
+}
+
+/// <summary>
+/// A persian the host disagrees with the BCL about: twelve months of thirty days counted from 2000-01-01,
+/// which shares no month boundary with <see cref="System.Globalization.PersianCalendar"/>. Correcting a
+/// calendar the engine already implements is what the second override is for, and the two together are the
+/// whole reckoning — the arithmetic asks for nothing else.
+/// </summary>
+file sealed class ThirtyDayPersian : DefaultCalendarProvider
+{
+    private const int MonthsPerYear = 12;
+    private const int DaysPerMonth = 30;
+    private const int DaysPerYear = MonthsPerYear * DaysPerMonth;
+
+    private static readonly long Epoch = new DateTime(2000, 1, 1).Ticks / TimeSpan.TicksPerDay;
+
+    public override CalendarFields IsoToCalendarFields(string calendar, int isoYear, int isoMonth, int isoDay)
+    {
+        if (!string.Equals(calendar, "persian", StringComparison.Ordinal))
+        {
+            return base.IsoToCalendarFields(calendar, isoYear, isoMonth, isoDay);
+        }
+
+        var index = new DateTime(isoYear, isoMonth, isoDay).Ticks / TimeSpan.TicksPerDay - Epoch;
+        var year = (int) Math.Floor(index / (double) DaysPerYear) + 1;
+        var rest = (int) (index - (long) (year - 1) * DaysPerYear);
+        var month = rest / DaysPerMonth + 1;
+        var day = rest % DaysPerMonth + 1;
+        return new CalendarFields(
+            year, month, $"M{month:D2}", day,
+            IsLeapMonth: false, MonthsInYear: MonthsPerYear, DaysInMonth: DaysPerMonth,
+            DaysInYear: DaysPerYear, InLeapYear: false);
+    }
+
+    public override IsoDateFields? CalendarFieldsToIso(string calendar, int year, string? monthCode, int month, int day, string overflow)
+    {
+        if (!string.Equals(calendar, "persian", StringComparison.Ordinal))
+        {
+            return base.CalendarFieldsToIso(calendar, year, monthCode, month, day, overflow);
+        }
+
+        var resolved = monthCode is not null ? int.Parse(monthCode.Substring(1, 2), CultureInfo.InvariantCulture) : month;
+        var leapMonthAsked = monthCode is not null && monthCode.Length != 3;
+        if (leapMonthAsked || resolved < 1 || resolved > MonthsPerYear || day < 1 || day > DaysPerMonth)
+        {
+            if (leapMonthAsked || string.Equals(overflow, "reject", StringComparison.Ordinal))
+            {
+                return null;
+            }
+
+            resolved = resolved < 1 ? 1 : (resolved > MonthsPerYear ? MonthsPerYear : resolved);
+            day = day < 1 ? 1 : (day > DaysPerMonth ? DaysPerMonth : day);
+        }
+
+        var index = Epoch + (long) (year - 1) * DaysPerYear + (resolved - 1) * DaysPerMonth + (day - 1);
+        var iso = new DateTime(index * TimeSpan.TicksPerDay);
+        return new IsoDateFields(iso.Year, iso.Month, iso.Day);
+    }
+}
+
+/// <summary>
+/// <see cref="WithMayan"/>'s calendar, given the one property the engine's own conversions no longer have: a
+/// range, and a clamp at each end of it instead of a refusal. That is what the eleven built-in calendars
+/// used to do — answer with a boundary date for anything past their end — and it is the shape that made the
+/// month walk stand still forever, every step past the boundary landing on the boundary so that no step ever
+/// passed the target. A host provider can still be written this way, which is why the walk keeps a
+/// no-progress guard of its own.
+/// </summary>
+file sealed class ClampingMayan : DefaultCalendarProvider
+{
+    private const int EpochOffset = 3114;
+
+    private const int FloorIsoYear = 2000;
+    private const int CeilingIsoYear = 2030;
+
+    public override IReadOnlyCollection<string> GetSupportedCalendars()
+        => [.. base.GetSupportedCalendars(), "mayan"];
+
+    public override CalendarFields IsoToCalendarFields(string calendar, int isoYear, int isoMonth, int isoDay)
+    {
+        if (!string.Equals(calendar, "mayan", StringComparison.Ordinal))
+        {
+            return base.IsoToCalendarFields(calendar, isoYear, isoMonth, isoDay);
+        }
+
+        var leap = DateTime.IsLeapYear(isoYear);
+        return new CalendarFields(
+            isoYear + EpochOffset, isoMonth, $"M{isoMonth:D2}", isoDay,
+            IsLeapMonth: false, MonthsInYear: 12, DaysInMonth: DateTime.DaysInMonth(isoYear, isoMonth),
+            DaysInYear: leap ? 366 : 365, InLeapYear: leap);
+    }
+
+    public override IsoDateFields? CalendarFieldsToIso(string calendar, int year, string? monthCode, int month, int day, string overflow)
+    {
+        if (!string.Equals(calendar, "mayan", StringComparison.Ordinal))
+        {
+            return base.CalendarFieldsToIso(calendar, year, monthCode, month, day, overflow);
+        }
+
+        var isoYear = year - EpochOffset;
+
+        // the clamp: a date this calendar cannot place answers with the nearer end of what it can, and that
+        // answer does not move however many further months are added to it
+        if (isoYear < FloorIsoYear)
+        {
+            return new IsoDateFields(FloorIsoYear, 1, 1);
+        }
+
+        if (isoYear > CeilingIsoYear)
+        {
+            return new IsoDateFields(CeilingIsoYear, 12, 31);
+        }
+
+        var resolved = monthCode is not null ? int.Parse(monthCode.Substring(1), CultureInfo.InvariantCulture) : month;
+        return new IsoDateFields(isoYear, resolved, day);
+    }
+}

--- a/Jint/Native/Temporal/DefaultCalendarProvider.cs
+++ b/Jint/Native/Temporal/DefaultCalendarProvider.cs
@@ -23,11 +23,19 @@ namespace Jint.Native.Temporal;
 /// </para>
 /// <para>
 /// A calendar added this way reaches construction from fields and from a <c>[u-ca=…]</c> annotation, every
-/// field accessor, <c>with</c>, <c>toString</c> and the <c>PlainYearMonth</c> / <c>PlainMonthDay</c>
-/// conversions. It does not reach calendar arithmetic — <c>add</c>, <c>subtract</c>, <c>until</c>,
-/// <c>since</c> — which is implemented per calendar inside the engine and raises a <c>RangeError</c> for a
-/// calendar it does not implement; nor <c>Intl.DateTimeFormat</c>, which has its own calendar list, so
-/// <c>toLocaleString</c> on such a date raises a <c>RangeError</c> too.
+/// field accessor, <c>with</c>, <c>toString</c>, the <c>PlainYearMonth</c> / <c>PlainMonthDay</c>
+/// conversions, and calendar arithmetic — <c>add</c>, <c>subtract</c>, <c>until</c>, <c>since</c> — which
+/// walks the two conversions below rather than any table of its own, so a year is however many months the
+/// provider says that year holds and a month is however many days it says that month holds. The one thing
+/// it does not reach is <c>Intl.DateTimeFormat</c>, which has its own calendar list, so
+/// <c>toLocaleString</c> on such a date raises a <c>RangeError</c>.
+/// </para>
+/// <para>
+/// The same walk answers for a calendar this class already implements once a derived provider is installed,
+/// because the inherited <see cref="GetSupportedCalendars"/> claims all eleven and the conversions are what
+/// the field accessors were already reading. That is deliberate: a host that corrects one calendar gets the
+/// correction in its arithmetic too, and one that corrects none gets the same dates either way, since the
+/// inherited conversions are the same data the per-calendar implementations read.
 /// </para>
 /// </remarks>
 /// <example>

--- a/Jint/Native/Temporal/Duration/DurationConstructor.cs
+++ b/Jint/Native/Temporal/Duration/DurationConstructor.cs
@@ -85,8 +85,8 @@ internal sealed partial class DurationConstructor : Constructor
             var timeZone = zonedRelativeTo.TimeZone;
             var calendar = zonedRelativeTo.Calendar;
             var provider = _engine.Options.Temporal.TimeZoneProvider;
-            var after1 = TemporalHelpers.AddZonedDateTime(_realm, provider, zonedRelativeTo.EpochNanoseconds, timeZone, calendar, d1, "constrain");
-            var after2 = TemporalHelpers.AddZonedDateTime(_realm, provider, zonedRelativeTo.EpochNanoseconds, timeZone, calendar, d2, "constrain");
+            var after1 = TemporalHelpers.AddZonedDateTime(_engine, _realm, provider, zonedRelativeTo.EpochNanoseconds, timeZone, calendar, d1, "constrain");
+            var after2 = TemporalHelpers.AddZonedDateTime(_engine, _realm, provider, zonedRelativeTo.EpochNanoseconds, timeZone, calendar, d2, "constrain");
             return JsNumber.Create(after1.CompareTo(after2));
         }
 
@@ -142,7 +142,7 @@ internal sealed partial class DurationConstructor : Constructor
         }
 
         // Add years/months/weeks to get the later date
-        var later = TemporalHelpers.CalendarDateAdd(_realm, plainRelativeTo.Calendar, plainRelativeTo.IsoDate, yearsMonthsWeeksDuration, "constrain");
+        var later = TemporalHelpers.CalendarDateAdd(_engine, _realm, plainRelativeTo.Calendar, plainRelativeTo.IsoDate, yearsMonthsWeeksDuration, "constrain");
 
         // Compute epoch days difference
         var epochDays1 = TemporalHelpers.IsoDateToDays(plainRelativeTo.IsoDate.Year, plainRelativeTo.IsoDate.Month, plainRelativeTo.IsoDate.Day);

--- a/Jint/Native/Temporal/Duration/DurationPrototype.cs
+++ b/Jint/Native/Temporal/Duration/DurationPrototype.cs
@@ -424,7 +424,7 @@ internal sealed partial class DurationPrototype : Prototype
     {
         if (relativeTo.PlainRelativeTo is not null)
         {
-            return RoundDurationWithPlainDate(realm, duration, smallestUnit, largestUnit, roundingIncrement, roundingMode, relativeTo.PlainRelativeTo);
+            return RoundDurationWithPlainDate(engine, realm, duration, smallestUnit, largestUnit, roundingIncrement, roundingMode, relativeTo.PlainRelativeTo);
         }
 
         if (relativeTo.ZonedRelativeTo is not null)
@@ -437,6 +437,7 @@ internal sealed partial class DurationPrototype : Prototype
     }
 
     private static DurationRecord RoundDurationWithPlainDate(
+        Engine engine,
         Realm realm,
         DurationRecord duration,
         string smallestUnit,
@@ -490,7 +491,7 @@ internal sealed partial class DurationPrototype : Prototype
 
         // Step 443: targetDate = CalendarDateAdd(calendar, relativeTo, dateDuration)
         var adjustedDuration = new DurationRecord(duration.Years, duration.Months, duration.Weeks, adjustedDays, 0, 0, 0, 0, 0, 0);
-        var targetDate = TemporalHelpers.CalendarDateAdd(realm, "iso8601", relativeDateStart, adjustedDuration, "constrain");
+        var targetDate = TemporalHelpers.CalendarDateAdd(engine, realm, "iso8601", relativeDateStart, adjustedDuration, "constrain");
 
         // Step 444-445: Combine isoDateTime and targetDateTime
         var isoDateTime = new IsoDateTime(relativeDateStart, IsoTime.Midnight);
@@ -504,6 +505,7 @@ internal sealed partial class DurationPrototype : Prototype
 
         // Step 446: Call DifferencePlainDateTimeWithRounding
         return TemporalHelpers.DifferencePlainDateTimeWithRounding(
+            engine,
             realm,
             isoDateTime,
             targetDateTime,
@@ -537,6 +539,7 @@ internal sealed partial class DurationPrototype : Prototype
 
         // Step 434: AddZonedDateTime to get target epoch nanoseconds
         var targetEpochNs = TemporalHelpers.AddZonedDateTime(
+            engine,
             realm,
             provider,
             relativeEpochNs,
@@ -547,6 +550,7 @@ internal sealed partial class DurationPrototype : Prototype
 
         // Step 435: DifferenceZonedDateTimeWithRounding
         return TemporalHelpers.DifferenceZonedDateTimeWithRounding(
+            engine,
             realm,
             provider,
             relativeEpochNs,
@@ -924,7 +928,7 @@ internal sealed partial class DurationPrototype : Prototype
     {
         if (relativeTo.PlainRelativeTo is not null)
         {
-            return TotalDurationWithPlainDate(realm, duration, unit, relativeTo.PlainRelativeTo);
+            return TotalDurationWithPlainDate(engine, realm, duration, unit, relativeTo.PlainRelativeTo);
         }
 
         if (relativeTo.ZonedRelativeTo is not null)
@@ -936,6 +940,7 @@ internal sealed partial class DurationPrototype : Prototype
     }
 
     private static double TotalDurationWithPlainDate(
+        Engine engine,
         Realm realm,
         DurationRecord duration,
         string unit,
@@ -967,7 +972,7 @@ internal sealed partial class DurationPrototype : Prototype
 
         // Step 494: CalendarDateAdd to get targetDate
         var calendar = plainRelativeTo.Calendar;
-        var targetDate = TemporalHelpers.CalendarDateAdd(realm, calendar, plainRelativeTo.IsoDate, adjustedDuration, "constrain");
+        var targetDate = TemporalHelpers.CalendarDateAdd(engine, realm, calendar, plainRelativeTo.IsoDate, adjustedDuration, "constrain");
 
         // Step 495-496: Combine start and target as IsoDateTime
         var isoDateTime = new IsoDateTime(plainRelativeTo.IsoDate, IsoTime.Midnight);
@@ -981,6 +986,7 @@ internal sealed partial class DurationPrototype : Prototype
 
         // Step 497: Call DifferencePlainDateTimeWithTotal
         return TemporalHelpers.DifferencePlainDateTimeWithTotal(
+            engine,
             realm,
             isoDateTime,
             targetDateTime,
@@ -1009,6 +1015,7 @@ internal sealed partial class DurationPrototype : Prototype
         // Step 487: Add duration to get target epoch nanoseconds
         // Uses AddZonedDateTime which handles calendar-aware date addition + timezone-aware time addition
         var ns2 = TemporalHelpers.AddZonedDateTime(
+            engine,
             realm,
             provider,
             ns1,
@@ -1020,6 +1027,7 @@ internal sealed partial class DurationPrototype : Prototype
         // Step 488: Compute total using DifferenceZonedDateTimeWithTotal
         // This operation handles both calendar units and time units correctly
         return TemporalHelpers.DifferenceZonedDateTimeWithTotal(
+            engine,
             realm,
             provider,
             ns1,
@@ -1331,7 +1339,7 @@ internal sealed partial class DurationPrototype : Prototype
         // Per spec step 20: If plainRelativeTo is not undefined, ALWAYS use PlainDate path
         if (relativeToResult.PlainRelativeTo != null)
         {
-            var total = TotalDurationWithPlainDate(_realm, d, unit, relativeToResult.PlainRelativeTo);
+            var total = TotalDurationWithPlainDate(_engine, _realm, d, unit, relativeToResult.PlainRelativeTo);
             return JsNumber.Create(total);
         }
 

--- a/Jint/Native/Temporal/ICalendarProvider.cs
+++ b/Jint/Native/Temporal/ICalendarProvider.cs
@@ -13,6 +13,14 @@ namespace Jint.Native.Temporal;
 /// The provider is consulted only for calendars where <see cref="IsSupported"/> returns
 /// true. ISO/Gregorian calendars are handled directly in TemporalHelpers and never
 /// reach the provider.
+/// <para>
+/// The two conversions are also the whole of what calendar arithmetic — <c>add</c>, <c>subtract</c>,
+/// <c>until</c>, <c>since</c> — asks for: a year is however many months
+/// <see cref="CalendarFields.MonthsInYear"/> reports for it, a month however many days
+/// <see cref="CalendarFields.DaysInMonth"/> reports, and a monthCode carried from one year into the next is
+/// whatever <see cref="CalendarFieldsToIso"/> places there. A provider that answers those two consistently
+/// therefore needs nothing else to make a date in its calendar movable.
+/// </para>
 /// </remarks>
 public interface ICalendarProvider
 {

--- a/Jint/Native/Temporal/NonIsoCalendars.cs
+++ b/Jint/Native/Temporal/NonIsoCalendars.cs
@@ -222,19 +222,161 @@ internal static class NonIsoCalendars
     }
 
     /// <summary>
+    /// Whether the engine's <see cref="ICalendarProvider"/> is the one that answers for this calendar.
+    /// It is the same identity-then-membership test <see cref="IsoToCalendarDate"/> and
+    /// <see cref="CalendarDateToIso"/> already make, asked once here so that a date's arithmetic and its
+    /// field accessors are never answered by two different reckonings.
+    /// </summary>
+    private static bool AnsweredByProvider(string calendar, [NotNullWhen(true)] Engine? engine)
+    {
+        var provider = engine?.Options.Temporal.CalendarProvider;
+        return provider is not null
+            && !ReferenceEquals(provider, DefaultCalendarProvider.Instance)
+            && provider.IsSupported(calendar);
+    }
+
+    /// <summary>
+    /// The calendar fields of the first of (<paramref name="year"/>, <paramref name="ordinalMonth"/>), or
+    /// null when the conversion cannot place that month. Everything the walk below needs to know about a
+    /// month it has not landed on yet — how long it is, how many months its year holds — is read back off
+    /// a trip out to ISO and straight back in, because those two conversions are all an
+    /// <see cref="ICalendarProvider"/> supplies.
+    /// </summary>
+    private static CalendarDate? ProviderProbeMonth(string calendar, int year, int ordinalMonth, Engine engine)
+    {
+        var iso = CalendarDateToIso(calendar, year, null, ordinalMonth, 1, "constrain", engine);
+        return iso is null ? null : IsoToCalendarDate(calendar, iso.Value, engine);
+    }
+
+    /// <summary>
+    /// The number of months in a calendar year, read off the same probe. A year the provider cannot place
+    /// at all has no month count, and answering zero would leave the month-stepping loop below turning
+    /// forever, so it raises the "reject" signal the caller already reports as a <c>RangeError</c>.
+    /// </summary>
+    private static int ProviderMonthsInYear(string calendar, int year, Engine engine)
+    {
+        var probe = ProviderProbeMonth(calendar, year, 1, engine);
+        if (probe is null || probe.Value.MonthsInYear < 1)
+        {
+            throw new InvalidOperationException("reject");
+        }
+
+        return probe.Value.MonthsInYear;
+    }
+
+    /// <summary>
+    /// The same year-then-month-then-day walk the per-calendar implementations below make, expressed only
+    /// in terms of the two conversions an <see cref="ICalendarProvider"/> supplies, for a calendar whose
+    /// reckoning nobody but the provider knows. Every conversion here can decline to answer; each one that
+    /// does ends in the "reject" signal an out-of-range date already raises and the caller already turns
+    /// into a <c>RangeError</c>, so no null is dereferenced and no CLR exception leaves the engine.
+    /// </summary>
+    private static IsoDate ProviderCalendarDateAdd(string calendar, in IsoDate isoDate, int years, int months, string overflow, Engine engine)
+    {
+        var reject = string.Equals(overflow, "reject", StringComparison.Ordinal);
+        var calDate = IsoToCalendarDate(calendar, in isoDate, engine);
+        var newYear = calDate.Year + years;
+        int newOrdinalMonth;
+
+        if (years != 0)
+        {
+            // Years move by monthCode, never by ordinal: a lunisolar year need not hold as many months as
+            // the one beside it, so the fourth month of one year is not the fourth month of the next.
+            // Asking the provider to place the same monthCode in the target year is what carries the
+            // meaning across, and a rejected placement is how it says that code does not occur there.
+            var placed = CalendarDateToIso(calendar, newYear, calDate.MonthCode, 0, 1, "reject", engine);
+            if (placed is not null)
+            {
+                newOrdinalMonth = IsoToCalendarDate(calendar, placed.Value, engine).Month;
+            }
+            else
+            {
+                // A leap month landing in a year that has no such leap month. Constraining moves to the
+                // calendar's own non-leap equivalent, which is the rule the per-calendar paths apply too;
+                // if even that will not place, the ordinal it started from is the last thing left to try.
+                if (reject)
+                {
+                    throw new InvalidOperationException("reject");
+                }
+
+                var fallbackCode = NonLeapEquivalentMonthCode(calendar, calDate.MonthCode);
+                var fallback = CalendarDateToIso(calendar, newYear, fallbackCode, 0, 1, "constrain", engine);
+                newOrdinalMonth = fallback is null
+                    ? calDate.Month
+                    : IsoToCalendarDate(calendar, fallback.Value, engine).Month;
+            }
+        }
+        else
+        {
+            newOrdinalMonth = calDate.Month;
+        }
+
+        if (months != 0)
+        {
+            newOrdinalMonth += months;
+            var monthsInYear = ProviderMonthsInYear(calendar, newYear, engine);
+            while (newOrdinalMonth > monthsInYear)
+            {
+                newOrdinalMonth -= monthsInYear;
+                newYear++;
+                monthsInYear = ProviderMonthsInYear(calendar, newYear, engine);
+            }
+
+            while (newOrdinalMonth < 1)
+            {
+                newYear--;
+                newOrdinalMonth += ProviderMonthsInYear(calendar, newYear, engine);
+            }
+        }
+
+        // The length of the month landed on stays the provider's to state, so the day is clamped against a
+        // probe of that month rather than against anything computed here.
+        var target = ProviderProbeMonth(calendar, newYear, newOrdinalMonth, engine);
+        if (target is null)
+        {
+            throw new InvalidOperationException("reject");
+        }
+
+        var newDay = calDate.Day;
+        if (newDay > target.Value.DaysInMonth)
+        {
+            if (reject)
+            {
+                throw new InvalidOperationException("reject");
+            }
+
+            newDay = target.Value.DaysInMonth;
+        }
+
+        var result = CalendarDateToIso(calendar, newYear, null, newOrdinalMonth, newDay, "constrain", engine);
+        if (result is null)
+        {
+            throw new InvalidOperationException("reject");
+        }
+
+        return result.Value;
+    }
+
+    /// <summary>
     /// Adds years and months to an ISO date using calendar-specific reckoning.
     /// Years are added preserving monthCode semantics (not ordinal month).
     /// Months are added as ordinal month steps.
     /// </summary>
     /// <remarks>
-    /// Note: <see cref="ICalendarProvider"/> is consulted only for IsoToCalendarFields /
-    /// CalendarFieldsToIso. Higher-level calendar arithmetic (this method, CalendarDateUntil,
-    /// MaxDaysForChineseLeapMonth, etc.) currently uses the BCL/inline implementations
-    /// regardless of the registered provider. A custom provider that needs different
-    /// add/until semantics will need this helper threaded through too.
+    /// A calendar a host <see cref="ICalendarProvider"/> answers for is walked by
+    /// <see cref="ProviderCalendarDateAdd"/>, through the provider's own two conversions — which is what
+    /// gives a calendar the host added arithmetic at all, and what keeps a calendar the host corrected
+    /// from being corrected in its field accessors and not in its arithmetic. The per-calendar
+    /// implementations below answer for every calendar the provider leaves to the engine, so an engine
+    /// that configures nothing reaches exactly the same one it always did.
     /// </remarks>
-    internal static IsoDate CalendarDateAdd(string calendar, in IsoDate isoDate, int years, int months, string overflow)
+    internal static IsoDate CalendarDateAdd(string calendar, in IsoDate isoDate, int years, int months, string overflow, Engine? engine = null)
     {
+        if (AnsweredByProvider(calendar, engine))
+        {
+            return ProviderCalendarDateAdd(calendar, in isoDate, years, months, overflow, engine);
+        }
+
         // For calendars that use epoch-day arithmetic (coptic/ethiopic/ethioaa)
         // or Indian calendar, handle them directly
         if (calendar is "coptic" or "ethiopic" or "ethioaa")
@@ -253,7 +395,7 @@ internal static class NonIsoCalendars
         }
 
         var cal = GetCalendar(calendar);
-        var calDate = IsoToCalendarDate(calendar, in isoDate);
+        var calDate = IsoToCalendarDate(calendar, in isoDate, engine);
         var newYear = calDate.Year + years;
         int newOrdinalMonth;
 
@@ -350,6 +492,31 @@ internal static class NonIsoCalendars
     }
 
     /// <summary>
+    /// Whether stepping <paramref name="months"/> months out from <paramref name="one"/> lands past
+    /// <paramref name="calTwo"/>, and where that step landed. The comparison is made in calendar-field
+    /// space with the day left un-constrained: a day the step had to force down to fit a shorter target
+    /// month still counts from where it started, which is the "would the original day exist there?"
+    /// criterion the specification's ISODateSurpasses states and the polyfill implements.
+    /// </summary>
+    private static bool MonthStepSurpasses(
+        string calendar,
+        in IsoDate one,
+        in CalendarDate calOne,
+        in CalendarDate calTwo,
+        int years,
+        int months,
+        int sign,
+        Engine? engine,
+        out IsoDate stepped)
+    {
+        stepped = CalendarDateAdd(calendar, in one, years, months, "constrain", engine);
+        var steppedCal = IsoToCalendarDate(calendar, in stepped, engine);
+        var notionalDay = steppedCal.Day != calOne.Day ? calOne.Day : steppedCal.Day;
+        var ccd = CompareCalendarFields(calTwo.Year, calTwo.MonthCode, calTwo.Day, steppedCal.Year, steppedCal.MonthCode, notionalDay);
+        return ccd * sign < 0;
+    }
+
+    /// <summary>
     /// Computes the difference between two ISO dates using calendar-specific reckoning.
     /// Mirrors the temporal-polyfill HelperBase.untilCalendar algorithm:
     /// (1) compute years from a "diffInYearSign" formula based on monthCode/day position,
@@ -358,7 +525,13 @@ internal static class NonIsoCalendars
     ///     un-constrained (so a day forced down by AddCalendar still counts as "past target"),
     /// (4) measure remaining days as ISO epoch-day diff.
     /// </summary>
-    internal static DurationRecord CalendarDateUntil(string calendar, in IsoDate one, in IsoDate two, string largestUnit)
+    /// <remarks>
+    /// Every calendar-specific step here is one of <see cref="IsoToCalendarDate"/> or
+    /// <see cref="CalendarDateAdd"/>, so threading <paramref name="engine"/> through is the whole of what a
+    /// calendar a host <see cref="ICalendarProvider"/> answers for needs: the difference is then measured
+    /// in the provider's own fields, the way its <c>add</c> already moves in them.
+    /// </remarks>
+    internal static DurationRecord CalendarDateUntil(string calendar, in IsoDate one, in IsoDate two, string largestUnit, Engine? engine = null)
     {
         var rawSign = TemporalHelpers.CompareIsoDates(one, two);
         if (rawSign == 0)
@@ -386,8 +559,8 @@ internal static class NonIsoCalendars
         // Spec convention: sign = +1 if two > one (forward), -1 if backward.
         var sign = -rawSign;
 
-        var calOne = IsoToCalendarDate(calendar, in one);
-        var calTwo = IsoToCalendarDate(calendar, in two);
+        var calOne = IsoToCalendarDate(calendar, in one, engine);
+        var calTwo = IsoToCalendarDate(calendar, in two, engine);
 
         var years = 0;
         var diffYears = calTwo.Year - calOne.Year;
@@ -410,8 +583,8 @@ internal static class NonIsoCalendars
             // day-overflow within the same year boundary all flow through this check.
             if (years != 0)
             {
-                var check = CalendarDateAdd(calendar, in one, years, 0, "constrain");
-                var checkCal = IsoToCalendarDate(calendar, in check);
+                var check = CalendarDateAdd(calendar, in one, years, 0, "constrain", engine);
+                var checkCal = IsoToCalendarDate(calendar, in check, engine);
                 var notional = checkCal.Day != calOne.Day ? calOne.Day : checkCal.Day;
                 var ccd = CompareCalendarFields(calTwo.Year, calTwo.MonthCode, calTwo.Day, checkCal.Year, checkCal.MonthCode, notional);
                 if (ccd * sign < 0)
@@ -426,49 +599,57 @@ internal static class NonIsoCalendars
         {
             if (years != 0)
             {
-                // Whole-year skip estimate. The iteration loop below corrects for
-                // year-length variation in lunisolar calendars (Hebrew/Chinese/Dangi).
-                var monthsPerCycle = calendar is "coptic" or "ethiopic" or "ethioaa" ? 13 : 12;
-                months = years * monthsPerCycle;
+                // Whole-year skip estimate. How many months a year holds is the calendar's own answer, and
+                // for one only a provider knows nothing else here can give it, so the count the conversion
+                // already reported for the starting date's year is the guess — a guess, because the year
+                // beside it may hold one more or one fewer in a lunisolar calendar.
+                months = years * System.Math.Max(calOne.MonthsInYear, 1);
             }
             years = 0;
         }
 
+        // The iteration below only ever steps in the direction of sign, so an estimate that has already
+        // reached past two would be returned as it stands and the overshoot would come back as a negative
+        // day count. Walk it back a month at a time until it is short of two again; an estimate that was
+        // never past it leaves this loop untouched.
+        while (months != 0 && MonthStepSurpasses(calendar, in one, in calOne, in calTwo, years, months, sign, engine, out _))
+        {
+            months -= sign;
+        }
+
         var currentIso = years != 0 || months != 0
-            ? CalendarDateAdd(calendar, in one, years, months, "constrain")
+            ? CalendarDateAdd(calendar, in one, years, months, "constrain", engine)
             : one;
 
         while (true)
         {
             var prevMonths = months;
             months += sign;
-            var nextIso = CalendarDateAdd(calendar, in one, years, months, "constrain");
 
-            // The loop's only exit is "this step passed two", so a step that does not move the date
-            // never takes it: one more month of a walk that stands still is still standing still,
-            // however many are taken. Every conversion that used to saturate now raises
-            // CalendarRangeException rather than answering with a boundary date, which is what makes
-            // this a structural guarantee rather than a live path -- and it stays here so that a future
-            // calendar, or a host-supplied one, cannot reintroduce the hang of issue #3428 by adding a
-            // clamp somewhere below.
-            if (nextIso == currentIso)
-            {
-                throw new CalendarRangeException(calendar);
-            }
-
-            var nextCal = IsoToCalendarDate(calendar, in nextIso);
-            // Un-constrain the day in calendar-field space: if AddCalendar forced day down
-            // to fit the target month, we still want to consider "next" as standing at the
-            // source's original day for comparison (matches polyfill behavior).
-            var notionalDay = nextCal.Day != calOne.Day ? calOne.Day : nextCal.Day;
-
-            var ccd = CompareCalendarFields(calTwo.Year, calTwo.MonthCode, calTwo.Day, nextCal.Year, nextCal.MonthCode, notionalDay);
-
-            // Continue while ccd * sign >= 0 (next has not yet passed two).
-            if (ccd * sign < 0)
+            // Continue while the step has not yet passed two.
+            if (MonthStepSurpasses(calendar, in one, in calOne, in calTwo, years, months, sign, engine, out var nextIso))
             {
                 months = prevMonths;
                 break;
+            }
+
+            // The loop's only exit above is "this step passed two", so a step that does not move the
+            // date never takes it: one more month of a walk that stands still is still standing still,
+            // however many are taken. Without this the loop turns forever — a script asking a Chinese
+            // date for its distance to a date before 1901 never returned, and no execution constraint
+            // interrupts a CLR loop that crosses no statement boundary
+            // (https://github.com/sebastienros/jint/issues/3428).
+            //
+            // For the eleven calendars the engine reckons itself this is now a structural guarantee
+            // rather than a live path: every conversion that used to saturate raises
+            // CalendarRangeException instead of answering with a boundary date. It stays because the
+            // walk above is written in whichever two conversions answer for the calendar, and a host
+            // ICalendarProvider is free to clamp where the engine no longer does. Either way a walk
+            // that cannot reach its target is a difference the calendar cannot represent, and that is
+            // the RangeError CalendarDateAdd raises — not a degraded answer that never reached two.
+            if (nextIso == currentIso)
+            {
+                throw new CalendarRangeException(calendar);
             }
 
             currentIso = nextIso;

--- a/Jint/Native/Temporal/PlainDate/PlainDatePrototype.cs
+++ b/Jint/Native/Temporal/PlainDate/PlainDatePrototype.cs
@@ -417,7 +417,7 @@ internal sealed partial class PlainDatePrototype : Prototype
             duration.Days + balancedDays, 0, 0, 0, 0, 0, 0);
 
         // Use calendar-aware date addition
-        var newDate = TemporalHelpers.CalendarDateAdd(_realm, plainDate.Calendar, plainDate.IsoDate, dateDuration, overflow);
+        var newDate = TemporalHelpers.CalendarDateAdd(_engine, _realm, plainDate.Calendar, plainDate.IsoDate, dateDuration, overflow);
 
         // Validate the result is within Temporal's representable range
         if (!TemporalHelpers.IsValidIsoDateTime(newDate.Year, newDate.Month, newDate.Day))
@@ -526,7 +526,7 @@ internal sealed partial class PlainDatePrototype : Prototype
         }
 
         // Step 6: Get date difference using calendar
-        var dateDifference = TemporalHelpers.CalendarDateUntil(temporalDate.Calendar, temporalDate.IsoDate, other.IsoDate, largestUnit, _realm);
+        var dateDifference = TemporalHelpers.CalendarDateUntil(_engine, _realm, temporalDate.Calendar, temporalDate.IsoDate, other.IsoDate, largestUnit);
 
         // Step 7-10: If rounding needed, use RoundRelativeDuration
         DurationRecord result;
@@ -545,6 +545,7 @@ internal sealed partial class PlainDatePrototype : Prototype
 
             // Round the duration
             var roundedDuration = TemporalHelpers.RoundRelativeDuration(
+                _engine,
                 _realm,
                 null, // timeZoneProvider = null for PlainDate
                 duration,

--- a/Jint/Native/Temporal/PlainDateTime/PlainDateTimePrototype.cs
+++ b/Jint/Native/Temporal/PlainDateTime/PlainDateTimePrototype.cs
@@ -482,7 +482,7 @@ internal sealed partial class PlainDateTimePrototype : Prototype
         var adjustedDuration = new DurationRecord(
             duration.Years, duration.Months, duration.Weeks,
             duration.Days + (long) dayOverflow, 0, 0, 0, 0, 0, 0);
-        var regulated = TemporalHelpers.CalendarDateAdd(_realm, plainDateTime.Calendar, plainDateTime.IsoDateTime.Date, adjustedDuration, overflow);
+        var regulated = TemporalHelpers.CalendarDateAdd(_engine, _realm, plainDateTime.Calendar, plainDateTime.IsoDateTime.Date, adjustedDuration, overflow);
 
         // Step 6: Construct validates ISODateTimeWithinLimits
         var newTime = IsoTime.FromNanoseconds((long) timeNs);
@@ -584,6 +584,7 @@ internal sealed partial class PlainDateTimePrototype : Prototype
         // Step 6: Get rounded difference
         // DifferencePlainDateTimeWithRounding returns an already-balanced DurationRecord
         var result = TemporalHelpers.DifferencePlainDateTimeWithRounding(
+            _engine,
             _realm,
             dateTime.IsoDateTime,
             other.IsoDateTime,

--- a/Jint/Native/Temporal/PlainYearMonth/PlainYearMonthPrototype.cs
+++ b/Jint/Native/Temporal/PlainYearMonth/PlainYearMonthPrototype.cs
@@ -373,7 +373,7 @@ internal sealed partial class PlainYearMonthPrototype : Prototype
 
         // Use calendar-aware date addition
         var yearMonthDuration = new DurationRecord(duration.Years, duration.Months, 0, 0, 0, 0, 0, 0, 0, 0);
-        var resultDate = TemporalHelpers.CalendarDateAdd(_realm, ym.Calendar, intermediateDate, yearMonthDuration, overflow);
+        var resultDate = TemporalHelpers.CalendarDateAdd(_engine, _realm, ym.Calendar, intermediateDate, yearMonthDuration, overflow);
 
         // Validate the result is within Temporal's representable range
         if (!TemporalHelpers.ISOYearMonthWithinLimits(resultDate.Year, resultDate.Month))
@@ -489,7 +489,7 @@ internal sealed partial class PlainYearMonthPrototype : Prototype
         TemporalHelpers.CheckISODaysRange(_realm, otherDate);
 
         // Step 11: Get date difference using calendar
-        var dateDifference = TemporalHelpers.CalendarDateUntil(ym1.Calendar, thisDate, otherDate, largestUnit, _realm);
+        var dateDifference = TemporalHelpers.CalendarDateUntil(_engine, _realm, ym1.Calendar, thisDate, otherDate, largestUnit);
 
         // Step 12: AdjustDateDurationRecord - zero out weeks and days (PlainYearMonth only has years/months)
         var yearsMonthsDifference = new DurationRecord(
@@ -514,6 +514,7 @@ internal sealed partial class PlainYearMonthPrototype : Prototype
 
             // Round the duration
             var roundedDuration = TemporalHelpers.RoundRelativeDuration(
+                _engine,
                 _realm,
                 null, // timeZoneProvider = null for PlainYearMonth
                 duration,

--- a/Jint/Native/Temporal/TemporalHelpers.cs
+++ b/Jint/Native/Temporal/TemporalHelpers.cs
@@ -2562,7 +2562,12 @@ internal static class TemporalHelpers
     /// https://tc39.es/proposal-temporal/#sec-temporal-calendardateadd
     /// Adds a duration to a date using calendar-specific reckoning.
     /// </summary>
-    public static IsoDate CalendarDateAdd(Realm? realm, string calendar, IsoDate isoDate, DurationRecord duration, string overflow)
+    /// <remarks>
+    /// <paramref name="engine"/> is what carries the host's <see cref="ICalendarProvider"/> down to the
+    /// arithmetic: without it a calendar only the provider knows is not even recognised as a calendar here,
+    /// and one the provider corrects is corrected in its field accessors and nowhere else.
+    /// </remarks>
+    public static IsoDate CalendarDateAdd(Engine? engine, Realm? realm, string calendar, IsoDate isoDate, DurationRecord duration, string overflow)
     {
         // For ISO calendar and Gregorian-based calendars (they share the same arithmetic)
         if (IsGregorianBasedCalendar(calendar))
@@ -2593,12 +2598,12 @@ internal static class TemporalHelpers
             // Range validation happens at the caller (e.g., CreateTemporalDate, GetEpochNanosecondsFor).
             return result;
         }
-        else if (NonIsoCalendars.IsNonIsoCalendar(calendar))
+        else if (NonIsoCalendars.IsNonIsoCalendar(calendar, engine))
         {
             try
             {
                 // Add years and months using calendar-specific reckoning
-                var result = NonIsoCalendars.CalendarDateAdd(calendar, in isoDate, (int) duration.Years, (int) duration.Months, overflow);
+                var result = NonIsoCalendars.CalendarDateAdd(calendar, in isoDate, (int) duration.Years, (int) duration.Months, overflow, engine);
 
                 // Add weeks and days using ISO arithmetic
                 var days = duration.Days + 7 * duration.Weeks;
@@ -2631,11 +2636,10 @@ internal static class TemporalHelpers
     }
 
     /// <summary>
-    /// Calendar arithmetic — <c>add</c>, <c>subtract</c>, <c>until</c>, <c>since</c> — is implemented per
-    /// calendar in <see cref="NonIsoCalendars"/> and is not routed through
-    /// <see cref="ICalendarProvider"/>, so a calendar a host provider added has no arithmetic. Reported as
-    /// a <c>RangeError</c> wherever a realm is at hand, rather than as a <see cref="NotSupportedException"/>
-    /// escaping <c>Engine.Evaluate</c>.
+    /// The calendar is neither Gregorian-based, nor one of the eleven <see cref="NonIsoCalendars"/>
+    /// implements, nor one the host's <see cref="ICalendarProvider"/> claims — so nothing on this engine
+    /// knows how to move a date in it. Reported as a <c>RangeError</c> wherever a realm is at hand, rather
+    /// than as a <see cref="NotSupportedException"/> escaping <c>Engine.Evaluate</c>.
     /// </summary>
     [DoesNotReturn]
     private static void ThrowCalendarArithmeticUnavailable(Realm? realm, string calendar)
@@ -5350,6 +5354,7 @@ internal static class TemporalHelpers
     /// https://tc39.es/proposal-temporal/#sec-temporal-roundrelativeduration
     /// </summary>
     public static DurationRecord RoundRelativeDuration(
+        Engine? engine,
         Realm realm,
         ITimeZoneProvider? timeZoneProvider,
         DurationRecord duration,
@@ -5381,13 +5386,13 @@ internal static class TemporalHelpers
         if (irregularLengthUnit)
         {
             // Calendar units (year/month/week) or day with timezone - use NudgeToCalendarUnit
-            var result = NudgeToCalendarUnit(realm, sign, duration, originEpochNs, destEpochNs, isoDateTime, timeZone, timeZoneProvider, calendar, increment, smallestUnit, roundingMode);
+            var result = NudgeToCalendarUnit(engine, realm, sign, duration, originEpochNs, destEpochNs, isoDateTime, timeZone, timeZoneProvider, calendar, increment, smallestUnit, roundingMode);
             nudgeResult = result.NudgeResult;
         }
         else if (timeZone != null)
         {
             // Time units with timezone - use NudgeToZonedTime
-            nudgeResult = NudgeToZonedTime(realm, timeZoneProvider!, sign, duration, isoDateTime, timeZone, calendar, (long) increment, smallestUnit, roundingMode);
+            nudgeResult = NudgeToZonedTime(engine, realm, timeZoneProvider!, sign, duration, isoDateTime, timeZone, calendar, (long) increment, smallestUnit, roundingMode);
         }
         else
         {
@@ -5402,7 +5407,7 @@ internal static class TemporalHelpers
         if (nudgeResult.DidExpandCalendarUnit && !string.Equals(smallestUnit, "week", StringComparison.Ordinal))
         {
             var startUnit = LargerOfTwoTemporalUnits(smallestUnit, "day");
-            resultDuration = BubbleRelativeDuration(realm, sign, resultDuration, nudgeResult.NudgedEpochNs, isoDateTime, calendar, largestUnit, startUnit);
+            resultDuration = BubbleRelativeDuration(engine, realm, sign, resultDuration, nudgeResult.NudgedEpochNs, isoDateTime, calendar, largestUnit, startUnit);
         }
 
         return resultDuration;
@@ -5691,6 +5696,7 @@ internal static class TemporalHelpers
     /// Based on spec but simplified for initial implementation.
     /// </summary>
     private static DurationRecord DifferenceZonedDateTime(
+        Engine? engine,
         Realm realm,
         ITimeZoneProvider timeZoneProvider,
         BigInteger ns1,
@@ -5710,11 +5716,11 @@ internal static class TemporalHelpers
         var endDateTime = GetISODateTimeFor(timeZoneProvider, timeZone, ns2);
 
         // Step 4: Get initial difference - only use the date portion
-        var diff = DifferenceISODateTime(realm, startDateTime, endDateTime, calendar, largestUnit);
+        var diff = DifferenceISODateTime(engine, realm, startDateTime, endDateTime, calendar, largestUnit);
         var dateDifference = new DurationRecord(diff.Years, diff.Months, diff.Weeks, diff.Days, 0, 0, 0, 0, 0, 0);
 
         // Step 5: Create intermediate datetime by adding date portion to start
-        var intermediateDate = CalendarDateAdd(realm, calendar, startDateTime.Date, dateDifference, "constrain");
+        var intermediateDate = CalendarDateAdd(engine, realm, calendar, startDateTime.Date, dateDifference, "constrain");
         var intermediateDateTime = new IsoDateTime(intermediateDate, startDateTime.Time);
 
         // Step 6: Get epoch nanoseconds for intermediate
@@ -5740,7 +5746,7 @@ internal static class TemporalHelpers
             dateDifference = AdjustDateDurationRecord(dateDifference, timeSign);
 
             // Step 10b: Recompute intermediate
-            intermediateDate = CalendarDateAdd(realm, calendar, startDateTime.Date, dateDifference, "constrain");
+            intermediateDate = CalendarDateAdd(engine, realm, calendar, startDateTime.Date, dateDifference, "constrain");
             intermediateDateTime = new IsoDateTime(intermediateDate, startDateTime.Time);
 
             // Step 10c: Recompute intermediate epoch ns
@@ -5798,6 +5804,7 @@ internal static class TemporalHelpers
     /// Computes the rounded difference between two zoned datetimes.
     /// </summary>
     public static DurationRecord DifferenceZonedDateTimeWithRounding(
+        Engine? engine,
         Realm realm,
         ITimeZoneProvider timeZoneProvider,
         BigInteger ns1,
@@ -5817,7 +5824,7 @@ internal static class TemporalHelpers
         }
 
         // Step 2: Get unrounded difference (for calendar units: year/month/week/day)
-        var difference = DifferenceZonedDateTime(realm, timeZoneProvider, ns1, ns2, timeZone, calendar, largestUnit);
+        var difference = DifferenceZonedDateTime(engine, realm, timeZoneProvider, ns1, ns2, timeZone, calendar, largestUnit);
 
         // Step 3: If no rounding needed, return
         if (string.Equals(smallestUnit, "nanosecond", StringComparison.Ordinal) && roundingIncrement == 1)
@@ -5829,7 +5836,7 @@ internal static class TemporalHelpers
         var dateTime = GetISODateTimeFor(timeZoneProvider, timeZone, ns1);
 
         // Step 5: Round the difference
-        return RoundRelativeDuration(realm, timeZoneProvider, difference, ns1, ns2, dateTime, timeZone, calendar, largestUnit, roundingIncrement, smallestUnit, roundingMode);
+        return RoundRelativeDuration(engine, realm, timeZoneProvider, difference, ns1, ns2, dateTime, timeZone, calendar, largestUnit, roundingIncrement, smallestUnit, roundingMode);
     }
 
     /// <summary>
@@ -5838,6 +5845,7 @@ internal static class TemporalHelpers
     /// Returns the total number of units in duration, relative to isoDateTime.
     /// </summary>
     public static double TotalRelativeDuration(
+        Engine? engine,
         Realm realm,
         DurationRecord duration,
         BigInteger originEpochNs,
@@ -5855,7 +5863,7 @@ internal static class TemporalHelpers
             var sign = InternalDurationSign(duration) < 0 ? -1 : 1;
 
             // Step 1b: Call NudgeToCalendarUnit with increment=1 and roundingMode=trunc
-            var record = NudgeToCalendarUnit(realm, sign, duration, originEpochNs, destEpochNs, isoDateTime, timeZone, timeZoneProvider, calendar, 1, unit, "trunc");
+            var record = NudgeToCalendarUnit(engine, realm, sign, duration, originEpochNs, destEpochNs, isoDateTime, timeZone, timeZoneProvider, calendar, 1, unit, "trunc");
 
             // Step 1c: Return the total
             return record.Total;
@@ -5875,6 +5883,7 @@ internal static class TemporalHelpers
     /// Computes the total difference between two zoned datetimes in the given unit.
     /// </summary>
     public static double DifferenceZonedDateTimeWithTotal(
+        Engine? engine,
         Realm realm,
         ITimeZoneProvider timeZoneProvider,
         BigInteger ns1,
@@ -5895,13 +5904,13 @@ internal static class TemporalHelpers
         }
 
         // Step 2: Get unrounded difference
-        var difference = DifferenceZonedDateTime(realm, timeZoneProvider, ns1, ns2, timeZone, calendar, unit);
+        var difference = DifferenceZonedDateTime(engine, realm, timeZoneProvider, ns1, ns2, timeZone, calendar, unit);
 
         // Step 3: Get ISO datetime for ns1
         var dateTime = GetISODateTimeFor(timeZoneProvider, timeZone, ns1);
 
         // Step 4: Call TotalRelativeDuration
-        return TotalRelativeDuration(realm, difference, ns1, ns2, dateTime, timeZone, timeZoneProvider, calendar, unit);
+        return TotalRelativeDuration(engine, realm, difference, ns1, ns2, dateTime, timeZone, timeZoneProvider, calendar, unit);
     }
 
     /// <summary>
@@ -5930,6 +5939,7 @@ internal static class TemporalHelpers
     /// Adds a duration to zoned datetime epoch nanoseconds, accounting for timezone and calendar.
     /// </summary>
     public static BigInteger AddZonedDateTime(
+        Engine? engine,
         Realm realm,
         ITimeZoneProvider timeZoneProvider,
         BigInteger epochNanoseconds,
@@ -5953,7 +5963,7 @@ internal static class TemporalHelpers
 
         // Step 3: Add date portion only using CalendarDateAdd (time components are handled in step 7)
         var dateDuration = new DurationRecord(duration.Years, duration.Months, duration.Weeks, duration.Days, 0, 0, 0, 0, 0, 0);
-        var addedDate = CalendarDateAdd(realm, calendar, isoDateTime.Date, dateDuration, overflow);
+        var addedDate = CalendarDateAdd(engine, realm, calendar, isoDateTime.Date, dateDuration, overflow);
 
         // Step 4: Combine with original time
         var intermediateDateTime = new IsoDateTime(addedDate, isoDateTime.Time);
@@ -5971,6 +5981,7 @@ internal static class TemporalHelpers
     /// Computes the total difference between two plain datetimes in the given unit.
     /// </summary>
     public static double DifferencePlainDateTimeWithTotal(
+        Engine? engine,
         Realm realm,
         IsoDateTime isoDateTime1,
         IsoDateTime isoDateTime2,
@@ -5990,7 +6001,7 @@ internal static class TemporalHelpers
         }
 
         // Step 3: DifferenceISODateTime to get the diff
-        var diff = DifferenceISODateTime(realm, isoDateTime1, isoDateTime2, calendar, unit);
+        var diff = DifferenceISODateTime(engine, realm, isoDateTime1, isoDateTime2, calendar, unit);
 
         // Step 4: If unit is nanosecond, return diff time duration directly
         if (string.Equals(unit, "nanosecond", StringComparison.Ordinal))
@@ -6004,7 +6015,7 @@ internal static class TemporalHelpers
         var destEpochNs = GetUTCEpochNanoseconds(isoDateTime2);
 
         // Step 6: Call TotalRelativeDuration with timeZone=null (unset)
-        return TotalRelativeDuration(realm, diff, originEpochNs, destEpochNs, isoDateTime1, null, null, calendar, unit);
+        return TotalRelativeDuration(engine, realm, diff, originEpochNs, destEpochNs, isoDateTime1, null, null, calendar, unit);
     }
 
     /// <summary>
@@ -6111,6 +6122,7 @@ internal static class TemporalHelpers
     /// duration.html:1569-1641
     /// </summary>
     private static NudgeWindowResult ComputeNudgeWindow(
+        Engine? engine,
         Realm realm,
         int sign,
         DurationRecord duration,
@@ -6150,13 +6162,13 @@ internal static class TemporalHelpers
             var yearsMonths = new DurationRecord(duration.Years, duration.Months, 0, 0, 0, 0, 0, 0, 0, 0);
 
             // Step 2: Add yearsMonths to start date
-            var weeksStart = CalendarDateAdd(realm, calendar, isoDateTime.Date, yearsMonths, "constrain");
+            var weeksStart = CalendarDateAdd(engine, realm, calendar, isoDateTime.Date, yearsMonths, "constrain");
 
             // Step 3: Add days to get end of the period
             var weeksEnd = AddDaysToISODate(weeksStart, (int) duration.Days);
 
             // Step 4: Calculate weeks between weeksStart and weeksEnd
-            var untilResult = CalendarDateUntil(calendar, weeksStart, weeksEnd, "week", realm);
+            var untilResult = CalendarDateUntil(engine, realm, calendar, weeksStart, weeksEnd, "week");
 
             // Step 5: Round total weeks (original weeks + calculated weeks from days)
             var weeks = RoundNumberToIncrement(duration.Weeks + untilResult.Weeks, increment, "trunc");
@@ -6187,7 +6199,7 @@ internal static class TemporalHelpers
         }
         else
         {
-            var start = CalendarDateAdd(realm, calendar, isoDateTime.Date, startDuration, "constrain");
+            var start = CalendarDateAdd(engine, realm, calendar, isoDateTime.Date, startDuration, "constrain");
             var startDateTime = new IsoDateTime(start, isoDateTime.Time);
 
             if (timeZone != null)
@@ -6200,7 +6212,7 @@ internal static class TemporalHelpers
             }
         }
 
-        var end = CalendarDateAdd(realm, calendar, isoDateTime.Date, endDuration, "constrain");
+        var end = CalendarDateAdd(engine, realm, calendar, isoDateTime.Date, endDuration, "constrain");
         var endDateTime = new IsoDateTime(end, isoDateTime.Time);
 
         if (timeZone != null)
@@ -6229,6 +6241,7 @@ internal static class TemporalHelpers
     /// duration.html:1644-1717
     /// </summary>
     private static CalendarNudgeResult NudgeToCalendarUnit(
+        Engine? engine,
         Realm realm,
         int sign,
         DurationRecord duration,
@@ -6245,7 +6258,7 @@ internal static class TemporalHelpers
         bool didExpandCalendarUnit = false;
 
         // Step 2: Compute nudge window (without additional shift) - spec line 1667
-        var nudgeWindow = ComputeNudgeWindow(realm, sign, duration, originEpochNs, isoDateTime, timeZone, timeZoneProvider, calendar, increment, unit, false);
+        var nudgeWindow = ComputeNudgeWindow(engine, realm, sign, duration, originEpochNs, isoDateTime, timeZone, timeZoneProvider, calendar, increment, unit, false);
 
         var startEpochNs = nudgeWindow.StartEpochNs;
         var endEpochNs = nudgeWindow.EndEpochNs;
@@ -6256,7 +6269,7 @@ internal static class TemporalHelpers
             if (!(startEpochNs <= destEpochNs && destEpochNs <= endEpochNs))
             {
                 // Spec line 1672
-                nudgeWindow = ComputeNudgeWindow(realm, sign, duration, originEpochNs, isoDateTime, timeZone, timeZoneProvider, calendar, increment, unit, true);
+                nudgeWindow = ComputeNudgeWindow(engine, realm, sign, duration, originEpochNs, isoDateTime, timeZone, timeZoneProvider, calendar, increment, unit, true);
                 startEpochNs = nudgeWindow.StartEpochNs;
                 endEpochNs = nudgeWindow.EndEpochNs;
                 didExpandCalendarUnit = true;
@@ -6267,7 +6280,7 @@ internal static class TemporalHelpers
             if (!(endEpochNs <= destEpochNs && destEpochNs <= startEpochNs))
             {
                 // Spec line 1677
-                nudgeWindow = ComputeNudgeWindow(realm, sign, duration, originEpochNs, isoDateTime, timeZone, timeZoneProvider, calendar, increment, unit, true);
+                nudgeWindow = ComputeNudgeWindow(engine, realm, sign, duration, originEpochNs, isoDateTime, timeZone, timeZoneProvider, calendar, increment, unit, true);
                 startEpochNs = nudgeWindow.StartEpochNs;
                 endEpochNs = nudgeWindow.EndEpochNs;
                 didExpandCalendarUnit = true;
@@ -6334,6 +6347,7 @@ internal static class TemporalHelpers
     /// It implements rounding a duration to an increment of a time unit, relative to a ZonedDateTime starting point.
     /// </summary>
     private static DurationNudgeResult NudgeToZonedTime(
+        Engine? engine,
         Realm realm,
         ITimeZoneProvider timeZoneProvider,
         int sign,
@@ -6347,7 +6361,7 @@ internal static class TemporalHelpers
     {
         // Step 1: Let start be ? CalendarDateAdd(calendar, isoDateTime.[[ISODate]], duration.[[Date]], constrain)
         var datePart = new DurationRecord(duration.Years, duration.Months, duration.Weeks, duration.Days, 0, 0, 0, 0, 0, 0);
-        var start = CalendarDateAdd(realm, calendar, isoDateTime.Date, datePart, "constrain");
+        var start = CalendarDateAdd(engine, realm, calendar, isoDateTime.Date, datePart, "constrain");
 
         // Step 2: Let startDateTime be CombineISODateAndTimeRecord(start, isoDateTime.[[Time]])
         var startDateTime = new IsoDateTime(start, isoDateTime.Time);
@@ -6443,6 +6457,7 @@ internal static class TemporalHelpers
     /// Simplified version for PlainDate (no timezone).
     /// </summary>
     private static DurationRecord BubbleRelativeDuration(
+        Engine? engine,
         Realm realm,
         int sign,
         DurationRecord duration,
@@ -6492,7 +6507,7 @@ internal static class TemporalHelpers
                 }
 
                 // Step 5.1.4-7: Calculate epoch for this duration
-                var end = CalendarDateAdd(realm, calendar, isoDateTime.Date, endDuration, "constrain");
+                var end = CalendarDateAdd(engine, realm, calendar, isoDateTime.Date, endDuration, "constrain");
                 var endDateTime = new IsoDateTime(end, isoDateTime.Time);
                 var endEpochNs = GetUTCEpochNanoseconds(endDateTime);
 
@@ -6579,6 +6594,7 @@ internal static class TemporalHelpers
     /// https://tc39.es/proposal-temporal/#sec-temporal-differenceisodatetime
     /// </summary>
     private static DurationRecord DifferenceISODateTime(
+        Engine? engine,
         Realm? realm,
         IsoDateTime isoDateTime1,
         IsoDateTime isoDateTime2,
@@ -6609,7 +6625,7 @@ internal static class TemporalHelpers
         var dateLargestUnit = LargerOfTwoTemporalUnits("day", largestUnit);
 
         // Step 9: Compute date difference using calendar
-        var dateDifference = CalendarDateUntil(calendar, isoDateTime1.Date, adjustedDate, dateLargestUnit, realm);
+        var dateDifference = CalendarDateUntil(engine, realm, calendar, isoDateTime1.Date, adjustedDate, dateLargestUnit);
 
         // Step 10-11: If largestUnit is smaller than day, add days to time
         if (!string.Equals(dateLargestUnit, largestUnit, StringComparison.Ordinal))
@@ -6723,7 +6739,13 @@ internal static class TemporalHelpers
     /// ISODateSurpasses algorithm (calendar.html:632-661) but uses direct arithmetic
     /// for O(1) performance on years/days instead of O(n) iteration.
     /// </summary>
-    internal static DurationRecord CalendarDateUntil(string calendar, IsoDate one, IsoDate two, string largestUnit, Realm? realm)
+    /// <remarks>
+    /// <paramref name="engine"/> carries the host's <see cref="ICalendarProvider"/> down the same way
+    /// <see cref="CalendarDateAdd(Engine?, Realm?, string, IsoDate, DurationRecord, string)"/> does; every
+    /// caller that has one owes it here, or the difference between two dates is measured in a reckoning the
+    /// host already replaced.
+    /// </remarks>
+    internal static DurationRecord CalendarDateUntil(Engine? engine, Realm? realm, string calendar, IsoDate one, IsoDate two, string largestUnit)
     {
         // Step 1: Get sign
         var sign = CompareIsoDates(one, two);
@@ -6737,11 +6759,11 @@ internal static class TemporalHelpers
         // Step 3: For ISO and Gregorian-based calendars (same arithmetic)
         if (!IsGregorianBasedCalendar(calendar))
         {
-            if (NonIsoCalendars.IsNonIsoCalendar(calendar))
+            if (NonIsoCalendars.IsNonIsoCalendar(calendar, engine))
             {
                 try
                 {
-                    return NonIsoCalendars.CalendarDateUntil(calendar, in one, in two, largestUnit);
+                    return NonIsoCalendars.CalendarDateUntil(calendar, in one, in two, largestUnit, engine);
                 }
                 catch (CalendarRangeException ex)
                 {
@@ -6750,6 +6772,20 @@ internal static class TemporalHelpers
                     // RangeError the addition itself raises -- rather than as the non-terminating walk
                     // of issue #3428.
                     ThrowCalendarRange(realm, ex);
+                }
+                catch (InvalidOperationException ex) when (string.Equals(ex.Message, "reject", StringComparison.Ordinal))
+                {
+                    // The walk adds months to `one` to find the difference, and a conversion along the way
+                    // can decline to answer — a year past the end of a calendar's tables, or a provider that
+                    // will not place one. That is the same refusal an out-of-range `add` raises, and it
+                    // belongs in script as the same RangeError rather than as a CLR exception escaping
+                    // Engine.Evaluate.
+                    if (realm != null)
+                    {
+                        Throw.RangeError(realm, "Invalid date while computing calendar difference");
+                    }
+
+                    throw new ArgumentException("Invalid date while computing calendar difference", nameof(two), ex);
                 }
             }
 
@@ -6869,6 +6905,7 @@ internal static class TemporalHelpers
     /// https://tc39.es/proposal-temporal/#sec-temporal-differenceplaindatetimewithrounding
     /// </summary>
     public static DurationRecord DifferencePlainDateTimeWithRounding(
+        Engine? engine,
         Realm realm,
         IsoDateTime isoDateTime1,
         IsoDateTime isoDateTime2,
@@ -6891,7 +6928,7 @@ internal static class TemporalHelpers
         }
 
         // Step 3: Get unrounded difference
-        var diff = DifferenceISODateTime(realm, isoDateTime1, isoDateTime2, calendar, largestUnit);
+        var diff = DifferenceISODateTime(engine, realm, isoDateTime1, isoDateTime2, calendar, largestUnit);
 
         // Step 4: If no rounding needed, return
         if (string.Equals(smallestUnit, "nanosecond", StringComparison.Ordinal) && roundingIncrement == 1)
@@ -6904,7 +6941,7 @@ internal static class TemporalHelpers
         var destEpochNs = GetUTCEpochNanoseconds(isoDateTime2);
 
         // timeZone is ~unset~ for PlainDateTime
-        return RoundRelativeDuration(realm, null, diff, originEpochNs, destEpochNs, isoDateTime1, null, calendar, largestUnit, roundingIncrement, smallestUnit, roundingMode);
+        return RoundRelativeDuration(engine, realm, null, diff, originEpochNs, destEpochNs, isoDateTime1, null, calendar, largestUnit, roundingIncrement, smallestUnit, roundingMode);
     }
 
     /// <summary>

--- a/Jint/Native/Temporal/ZonedDateTime/ZonedDateTimePrototype.cs
+++ b/Jint/Native/Temporal/ZonedDateTime/ZonedDateTimePrototype.cs
@@ -1194,7 +1194,7 @@ internal sealed partial class ZonedDateTimePrototype : Prototype
     private BigInteger AddDurationToZonedDateTime(JsZonedDateTime zdt, DurationRecord duration, string overflow)
     {
         var provider = _engine.Options.Temporal.TimeZoneProvider;
-        return TemporalHelpers.AddZonedDateTime(_realm, provider, zdt.EpochNanoseconds, zdt.TimeZone, zdt.Calendar, duration, overflow);
+        return TemporalHelpers.AddZonedDateTime(_engine, _realm, provider, zdt.EpochNanoseconds, zdt.TimeZone, zdt.Calendar, duration, overflow);
     }
 
     /// <summary>
@@ -1276,6 +1276,7 @@ internal sealed partial class ZonedDateTimePrototype : Prototype
         // Step 16: Call DifferenceZonedDateTimeWithRounding for calendar-aware difference
         var timeZoneProvider = _engine.Options.Temporal.TimeZoneProvider;
         var finalResult = TemporalHelpers.DifferenceZonedDateTimeWithRounding(
+            _engine,
             _realm,
             timeZoneProvider,
             zonedDateTime.EpochNanoseconds,

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -1682,8 +1682,10 @@ now the list's answer for anything deriving from `DefaultCalendarProvider` witho
 the question the engine asks — so a calendar in the list is now claimed, and one absent from it is not.
 A provider implementing `ICalendarProvider` from scratch is unaffected: both members are still its own.
 Second, a host calendar reaches construction, the field accessors, `with`, `toString` and the
-`PlainYearMonth`/`PlainMonthDay` conversions, but not arithmetic and not `Intl.DateTimeFormat`; both refused
-it with a `RangeError` when this shipped. 4.35 gives it arithmetic and 4.36 gives it `Intl`.
+`PlainYearMonth`/`PlainMonthDay` conversions, but neither arithmetic nor `Intl.DateTimeFormat`; both refused
+it with a `RangeError` when this shipped.
+[§4.40](#440-one-list-of-calendars-and-icalendarprovider-owns-it-3404) gives it `Intl`, and
+[§4.44](#444-calendar-arithmetic-is-answered-by-whoever-answers-for-the-calendar-3403) gives it arithmetic.
 
 ### 4.31 A module graph too deep to link raises an error instead of ending the process ([#3401](https://github.com/sebastienros/jint/issues/3401))
 
@@ -2099,6 +2101,57 @@ exactly what it wrote before. It moves for an embedder who has installed a CLDR-
 `ICldrProvider` — `Intl.RelativeTimeFormat` and `Intl.DurationFormat` now write that provider's digits for a
 locale whose default is not Latin, the way `Intl.NumberFormat` and `Intl.DateTimeFormat` already did. To keep
 Latin digits for such a locale, ask for them: `{ numberingSystem: 'latn' }`, or a `-u-nu-latn` subtag.
+
+### 4.44 Calendar arithmetic is answered by whoever answers for the calendar ([#3403](https://github.com/sebastienros/jint/issues/3403))
+
+`ICalendarProvider` supplies two conversions, ISO ↔ calendar fields, and the engine consulted them for the
+field accessors, `from`, `with`, `toString` and the `PlainYearMonth`/`PlainMonthDay` conversions — but not
+for `add`, `subtract`, `until` or `since`, which were written per calendar against the BCL. So a host that
+**corrected** a calendar corrected half of it, and the two halves disagreed about the same date; a host that
+**added** one got `RangeError: Calendar arithmetic is not implemented for 'mayan'`.
+
+For a calendar the configured provider answers for, the year-and-month walk is now expressed in the two
+conversions themselves: the same monthCode placed in the target year, ordinal months stepped across year
+boundaries by the month count the conversion reports, and the day clamped to the month length it reports.
+Weeks and days were always ISO days and still are.
+
+```js
+// with a provider that adds "mayan" — 5.0 raised RangeError for all of these
+Temporal.PlainDate.from('2024-03-05').withCalendar('mayan').add({ months: 1 }).toString(); // "2024-04-05[u-ca=mayan]"
+Temporal.PlainDate.from('2024-01-31').withCalendar('mayan').add({ months: 1 }).toString(); // "2024-02-29[u-ca=mayan]"
+Temporal.PlainDate.from('2024-03-05').withCalendar('mayan')
+    .until(Temporal.PlainDate.from('2025-07-19').withCalendar('mayan'), { largestUnit: 'month' }).toString(); // "P16M14D"
+```
+
+An engine that configures no provider reaches the per-calendar implementation it always did — proved, not
+asserted: 774,158 `CalendarDateAdd` results over the eleven built-in calendars are byte-identical before and
+after.
+
+**What could break:** an engine that installs a provider for one calendar and relies on the engine's own
+arithmetic for another. The provider is asked for every calendar it claims, and a derived
+`DefaultCalendarProvider` claims all eleven by inheritance — which is the point, since its inherited
+conversions are already what every field accessor reads. Over the same 774,158-case sweep the two paths
+agree on 100.000% of cases within the BCL calendars' ranges. The 1.7% that differ are all `chinese` and
+`dangi` dates whose arithmetic leaves `ChineseLunisolarCalendar`'s 1901–2101 or `KoreanLunisolarCalendar`'s
+2051 ceiling, and out there the two now part in kind rather than in detail:
+[#3452](https://github.com/sebastienros/jint/pull/3452) made the engine's own arithmetic **refuse** a result
+it cannot represent, while the provider path goes on answering — because `IsoToCalendarFields` and
+`CalendarFieldsToIso` fall back to ISO-like fields past the end of a BCL calendar, and always did, which is
+what every field accessor on such a date has always read. So
+`Temporal.PlainDate.from('1950-01-01').withCalendar('chinese').subtract({ years: 100 })` is a `RangeError`
+on a default engine and `1849-11-13` under any provider that claims `chinese`. Both terminate, and neither
+is the Chinese calendar. To keep a calendar on the engine's own arithmetic, do not claim it: override
+`IsSupported` to return `false` for it, or drop it from `GetSupportedCalendars`.
+
+A host provider is also free to clamp where the engine no longer does, and a conversion that answers with
+its own boundary date every time is what made the month walk stand still forever. The walk keeps a
+no-progress guard for that: a step that adds a month and does not move the date raises the same `RangeError`
+an out-of-range addition raises, so a difference measured in a calendar the host supplied cannot hang the
+engine either.
+
+Two refusals that used to escape as CLR exceptions are now `RangeError`s a script can catch:
+`DifferenceISODateTime` reached `CalendarDateUntil` with no realm to report against, and an out-of-range
+difference threw out of `Engine.Evaluate`.
 
 ## 5. New in v5
 


### PR DESCRIPTION
`ICalendarProvider` supplies two conversions, ISO ↔ calendar fields, and the engine consults them for the
field accessors, `from`, `with`, `toString` and the `PlainYearMonth`/`PlainMonthDay` conversions. It did not
consult them for arithmetic, and the doc comment on `NonIsoCalendars.CalendarDateAdd` said so:

> Note: `ICalendarProvider` is consulted only for IsoToCalendarFields / CalendarFieldsToIso. Higher-level
> calendar arithmetic (this method, CalendarDateUntil, MaxDaysForChineseLeapMonth, etc.) currently uses the
> BCL/inline implementations regardless of the registered provider.

Two consequences, and the first is the one that matters. A host that **corrected** one of the eleven non-ISO
calendars got its correction in the field accessors and not in `add`/`subtract`/`until`/`since` — so the two
disagreed about the same date, and a calendar that disagrees with itself is worse than one that is simply
wrong. A host that **added** a calendar got no arithmetic at all: a `RangeError` reading
`Calendar arithmetic is not implemented for 'mayan'`.

## What changed

For a calendar the configured provider answers for, the year-and-month walk is now expressed in the two
conversions themselves — the same monthCode placed in the target year, ordinal months stepped across year
boundaries by the month count the conversion reports, the day clamped to the month length it reports, and
back out to ISO. Every one of those conversions may decline to answer, and each declining one ends in the
`"reject"` signal an out-of-range date already raises and the caller already turns into a `RangeError`, so no
null is dereferenced and no CLR exception leaves the engine.

`CalendarDateUntil` needed almost nothing: it was already written in calendar-field terms, over
`IsoToCalendarDate` and `CalendarDateAdd`, so threading the engine through it was most of the change.

```js
// with a provider that adds "mayan" (three overrides, per #3405)
// every one of these was RangeError: Calendar arithmetic is not implemented for 'mayan'

Temporal.PlainDate.from('2024-03-05').withCalendar('mayan').add({ days: 1 }).toString();        // "2024-03-06[u-ca=mayan]"
Temporal.PlainDate.from('2024-03-05').withCalendar('mayan').add({ months: 1 }).toString();      // "2024-04-05[u-ca=mayan]"
Temporal.PlainDate.from('2024-03-05').withCalendar('mayan').add({ years: 1, months: 2 }).toString(); // "2025-05-05[u-ca=mayan]"
Temporal.PlainDate.from('2024-03-05').withCalendar('mayan').subtract({ months: 1 }).toString(); // "2024-02-05[u-ca=mayan]"
Temporal.PlainDate.from('2024-03-05').withCalendar('mayan')
    .until(Temporal.PlainDate.from('2024-05-05').withCalendar('mayan')).toString();             // "P61D"
Temporal.PlainDate.from('2024-03-05').withCalendar('mayan')
    .until(Temporal.PlainDate.from('2025-07-19').withCalendar('mayan'), { largestUnit: 'month' }).toString(); // "P16M14D"

// the day is clamped to the month length the provider itself reported, and "reject" refuses
Temporal.PlainDate.from('2024-01-31').withCalendar('mayan').add({ months: 1 }).toString();      // "2024-02-29[u-ca=mayan]"
```

And the half the issue leads with — a calendar that disagreed with itself. Against a provider whose
`persian` is twelve 30-day months:

```js
Temporal.PlainDate.from('2024-03-05').withCalendar('persian').add({ months: 1 }).toString();
// 5.0: "2024-04-03" — the BCL's Persian months, while the field accessors read the provider's
// 5.x: "2024-04-04" — year 25, monthCode M08, day 11, which is exactly the date
//      PlainDate.from({ calendar: 'persian', year: 25, monthCode: 'M08', day: 11 }) builds
```

## Where the split between calendar and ISO arithmetic actually falls

Worth naming, because it is not where one might guess and this does not move it:
[CalendarDateAdd](https://tc39.es/proposal-temporal/#sec-temporal-calendardateadd) adds **years and months**
in calendar terms and **weeks and days** as ISO days, and
[CalendarDateUntil](https://tc39.es/proposal-temporal/#sec-temporal-calendardateuntil) is the mirror — a
`largestUnit` of `"week"` or smaller never touches the calendar at all. So the calendar is consulted by
`add`/`subtract` only for the year and month components, and by `until`/`since` only when `largestUnit` is
`"year"` or `"month"`. `Temporal.Duration.prototype.round` and `.total` reach the same two operations through
`relativeTo`; `Duration.prototype.add` never does, because it rejects a calendar `largestUnit` outright.

## The dispatch, and the measurement that chose it

The generic walk runs when the engine's `ICalendarProvider` is **not** `DefaultCalendarProvider.Instance`
**and** `IsSupported(calendar)` — the same identity-then-membership test `IsoToCalendarDate` and
`CalendarDateToIso` already make. Asking it once, in one place, is what keeps a date's arithmetic and its
field accessors from being answered by two different reckonings, which is the defect.

That is a real decision and it was measured rather than assumed, because a derived `DefaultCalendarProvider`
claims all eleven built-in calendars by inheritance — so an engine that installs a provider to correct
`hebrew` gets the generic walk for `chinese` too. Comparing the per-calendar `CalendarDateAdd` against the
generic one run over the default provider's own conversions, across 11 calendars × 457 ISO dates × 7 year
deltas × 11 month deltas × 2 overflow modes:

| calendar | comparisons | disagree | % |
| --- | ---: | ---: | ---: |
| chinese | 70,378 | 4,867 | 6.916% |
| dangi | 70,378 | 8,491 | 12.065% |
| hebrew, persian, coptic, ethiopic, ethioaa, indian, islamic-umalqura, islamic-civil, islamic-tbla | 70,378 each | **0** | 0.000% |
| **total** | **774,158** | **13,358** | **1.725%** |

Every disagreement is at a BCL range edge and nowhere else — `chinese` from source years 1901 and 2099,
`dangi` from 2050 and 2099. `ChineseLunisolarCalendar` spans ISO 1901-02-19…2101-01-28 and
`KoreanLunisolarCalendar` ends 2051-02-10, and ±3 years of arithmetic from those years leaves the table.
**Excluding those four (calendar, year) buckets: 734,118 comparisons, 0 disagreements.**

Where they differ, both paths are degraded, differently: the per-calendar one catches the BCL's
`ArgumentOutOfRangeException` and clamps to the calendar's *maximum* date even when the arithmetic was going
backwards — `1901-01-01 − 3y − 25m` gives `2101-01-28` — while the generic one falls into the existing
"treat the calendar fields as ISO" fallback and returns `1895-12-01`. Neither is right. `until` tells the
same story: 160,864 comparisons, 496 disagreements (0.308%), all `chinese` and `dangi`, all
`largestUnit: "month"`, all with an endpoint past the calendar's range.

A host that wants the old arithmetic for a calendar it did not mean to touch declines to claim it —
`IsSupported` returning false for it, or dropping it from `GetSupportedCalendars`.

## Three things that came out of writing it down

**The whole-year month estimate in `CalendarDateUntil` was a hardcoded 12 or 13.** It is now the count the
conversion reports for the starting year, which is the only source for a calendar only a provider knows.
That needed a back-off loop: the forward walk only ever steps in the direction of the difference, so an
estimate that had already passed the target was returned as it stood and the overshoot came back as a
negative day count. `12` was a safe floor for the eleven; a reported count is not.

**`DifferenceISODateTime` reached `CalendarDateUntil` with no realm**, so an out-of-range difference threw a
raw `NotSupportedException` out of `Engine.Evaluate`, where neither script nor an embedder's
`catch (JintException)` could see it. It is a `RangeError` now.

**The month walk never terminated when a conversion saturated** — [#3428](https://github.com/sebastienros/jint/issues/3428), now fixed on `main` by [#3452](https://github.com/sebastienros/jint/pull/3452).

```js
Temporal.PlainDate.from('1910-01-01').withCalendar('chinese')
    .until(Temporal.PlainDate.from('1900-01-03').withCalendar('chinese'), { largestUnit: 'year' });
// before #3452: never returns, and no execution constraint can interrupt it
```

Every step landed on the calendar's boundary date, never passed the target, and the loop had no other exit.
It is a CLR loop inside one interpreter step, so it crosses no statement boundary: `LimitStatements` never
counts, `LimitExecutionTime` never gets a check, a `CancellationToken` is never observed.

This branch reached the same defect from the other side and the rebase merged the two deliberately, rather
than taking either wholesale. #3452 removed the clamp that produced the boundary date at all, so the engine's
own arithmetic now **refuses** a result it cannot represent; that is what the eleven built-in calendars do
here, unchanged by this branch, and `NonIsoCalendarRangeTests` is its pin. What this branch adds is the
reason the walk's own no-progress guard has to stay: the walk is now written in whichever two conversions
answer for the calendar, and a host `ICalendarProvider` is free to clamp where the engine no longer does. So
the guard raises `CalendarRangeException` — the same `RangeError` an out-of-range addition raises — rather
than answering with a degraded difference. For a built-in calendar it is unreachable, which is exactly the
shape #3452 wanted it to have: `NonIsoCalendarRangeTests` passes in full with the guard deleted. For a host
calendar it is live, and the new `TemporalCalendarArithmeticTests` case — a provider that clamps at each end
of its range — does not return at all without it.

## What is unchanged

An engine that configures no provider reaches the per-calendar implementation it always did. Proved rather
than asserted: the per-calendar `CalendarDateAdd` column of the 774,158-case sweep, captured from the build
*before* this change, is byte-identical to the same column captured after.

- `dotnet build -c Release` on the solution: clean.
- `dotnet test -c Release` on the solution, all three target frameworks: green. `Jint.Tests` 10,819 passed /
  0 failed on `net8.0` and `net10.0`, 7,443 on `net472`; `Jint.Tests.PublicInterface` 3,208 / 3,218 / 2,587,
  including the public-API and documentation baselines — the surface does not move, only two doc comments
  that stated the old contract.
- `Jint.Tests.Test262` — 102,495 passed, 0 failed, 189 skipped, which is the figure `main` gives.

`HostLocaleProviderTests.AHostCalendarHasNoArithmeticAndSaysSoInJavaScript` is inverted rather than deleted:
it pinned the refusal, and now pins the six results and the clamping, because that is the behaviour a third
party can reach.

Fixes #3403
