### PR TITLE
Intl: one list of calendars, and ICalendarProvider owns it

### DIFF
--- a/Jint.Tests.PublicInterface/HostLocaleProviderTests.cs
+++ b/Jint.Tests.PublicInterface/HostLocaleProviderTests.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 
 using System.Globalization;
 using System.Numerics;
@@ -16,7 +16,7 @@ namespace Jint.Tests.PublicInterface;
 public class HostLocaleProviderTests
 {
     [Test]
-    public void OverridingOneCldrDatumLeavesTheOtherEighteenMembersInherited()
+    public void OverridingOneCldrDatumLeavesTheOtherSeventeenMembersInherited()
     {
         var engine = new Engine(options => options.Intl.CldrProvider = new OneCurrencyName());
 
@@ -300,6 +300,36 @@ public class HostLocaleProviderTests
             .AsString().Should().Be(new Engine().Evaluate("Temporal.PlainDate.from('2024-03-05').withCalendar('hebrew').add({ months: 1 }).toString()").AsString());
     }
 
+    /// <summary>
+    /// The calendars an engine answers for are one list, so the calendar a host adds through
+    /// <see cref="ICalendarProvider"/> is a calendar <c>Intl</c> knows about too. Before this it existed for
+    /// <c>Temporal</c> alone: <c>Intl.supportedValuesOf</c> read a different provider's list, and
+    /// <c>Intl.DateTimeFormat</c> read a third that nothing could change.
+    /// </summary>
+    [Test]
+    public void ACalendarTheHostAddsIsOneIntlKnowsAbout()
+    {
+        var engine = new Engine(options => options.Temporal.CalendarProvider = new WithMayan());
+
+        engine.Evaluate("Intl.supportedValuesOf('calendar').indexOf('mayan') >= 0").AsBoolean().Should().BeTrue();
+        engine.Evaluate("new Intl.DateTimeFormat('en', { calendar: 'mayan' }).resolvedOptions().calendar")
+            .AsString().Should().Be("mayan");
+        engine.Evaluate("new Intl.DateTimeFormat('en-u-ca-mayan').resolvedOptions().calendar")
+            .AsString().Should().Be("mayan");
+
+        // …and a date in it can be formatted, in the calendar's own fields rather than the ISO ones
+        engine.Evaluate("new Intl.DateTimeFormat('en', { calendar: 'mayan', year: 'numeric', timeZone: 'UTC' }).format(Date.UTC(2024, 2, 5))")
+            .AsString().Should().Be("5138");
+        engine.Evaluate("Temporal.PlainDate.from('2024-03-05').withCalendar('mayan').toLocaleString('en', { calendar: 'mayan', year: 'numeric' })")
+            .AsString().Should().Be("5138");
+
+        // a stock engine answers for exactly the sixteen it always did, and no host calendar
+        var stock = new Engine();
+        stock.Evaluate("Intl.supportedValuesOf('calendar').indexOf('mayan') >= 0").AsBoolean().Should().BeFalse();
+        stock.Evaluate("new Intl.DateTimeFormat('en', { calendar: 'mayan' }).resolvedOptions().calendar")
+            .AsString().Should().Be("gregory");
+    }
+
     [Test]
     public void AnEngineThatConfiguresNothingStillReadsTheSharedSingletons()
     {
@@ -311,7 +341,7 @@ public class HostLocaleProviderTests
     }
 }
 
-/// <summary>One currency's display name; the other eighteen members are inherited.</summary>
+/// <summary>One currency's display name; the other seventeen members are inherited.</summary>
 file sealed class OneCurrencyName : DefaultCldrProvider
 {
     public override string? GetCurrencyDisplayName(string locale, string code)
@@ -381,7 +411,7 @@ file sealed class NauticalDayPeriods : DefaultCldrProvider
     public override string[]? GetDayPeriods(string locale, string style, string? calendar) => ["MORN", "EVE"];
 }
 
-/// <summary>One list-pattern set; the other eighteen members are inherited.</summary>
+/// <summary>One list-pattern set; the other seventeen members are inherited.</summary>
 file sealed class GermanLists : DefaultCldrProvider
 {
     public override ListPatterns? GetListPatterns(string locale, string type, string style)
@@ -447,7 +477,7 @@ file sealed class WithMayan : DefaultCalendarProvider
 
 /// <summary>
 /// Present only to be compiled: a host reaching a member the engine never consults still has to be able
-/// to override it, and the compiler is the only thing that checks that all twenty-one are virtual.
+/// to override it, and the compiler is the only thing that checks that all twenty are virtual.
 /// </summary>
 file sealed class EveryCldrMemberOverridden : DefaultCldrProvider
 {
@@ -464,7 +494,6 @@ file sealed class EveryCldrMemberOverridden : DefaultCldrProvider
     public override string[]? GetEraNames(string locale, string style, string? calendar) => base.GetEraNames(locale, style, calendar);
     public override string? GetCurrencyDisplayName(string locale, string code) => base.GetCurrencyDisplayName(locale, code);
     public override WeekInfo? GetWeekInfo(string locale) => base.GetWeekInfo(locale);
-    public override IReadOnlyCollection<string> GetSupportedCalendars() => base.GetSupportedCalendars();
     public override IReadOnlyCollection<string> GetSupportedCollations() => base.GetSupportedCollations();
     public override IReadOnlyCollection<string> GetSupportedCurrencies() => base.GetSupportedCurrencies();
     public override IReadOnlyCollection<string> GetSupportedNumberingSystems() => base.GetSupportedNumberingSystems();

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
@@ -1361,7 +1361,6 @@ namespace Jint.Native.Intl
         public virtual string? GetNumberingSystemDigits(string numberingSystem) { }
         public virtual Jint.Native.Intl.RelativeTimePatterns? GetRelativeTimePatterns(string locale, string unit, string style) { }
         public virtual string? GetRelativeTimeSpecialPhrase(string locale, string unit, int value, bool past, string style) { }
-        public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCalendars() { }
         public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCollations() { }
         public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCurrencies() { }
         public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedNumberingSystems() { }
@@ -1383,7 +1382,6 @@ namespace Jint.Native.Intl
         string? GetNumberingSystemDigits(string numberingSystem);
         Jint.Native.Intl.RelativeTimePatterns? GetRelativeTimePatterns(string locale, string unit, string style);
         string? GetRelativeTimeSpecialPhrase(string locale, string unit, int value, bool past, string style);
-        System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCalendars();
         System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCollations();
         System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCurrencies();
         System.Collections.Generic.IReadOnlyCollection<string> GetSupportedNumberingSystems();

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net472.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net472.verified.txt
@@ -1208,7 +1208,6 @@ namespace Jint.Native.Intl
         public virtual string? GetNumberingSystemDigits(string numberingSystem) { }
         public virtual Jint.Native.Intl.RelativeTimePatterns? GetRelativeTimePatterns(string locale, string unit, string style) { }
         public virtual string? GetRelativeTimeSpecialPhrase(string locale, string unit, int value, bool past, string style) { }
-        public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCalendars() { }
         public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCollations() { }
         public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCurrencies() { }
         public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedNumberingSystems() { }
@@ -1230,7 +1229,6 @@ namespace Jint.Native.Intl
         string? GetNumberingSystemDigits(string numberingSystem);
         Jint.Native.Intl.RelativeTimePatterns? GetRelativeTimePatterns(string locale, string unit, string style);
         string? GetRelativeTimeSpecialPhrase(string locale, string unit, int value, bool past, string style);
-        System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCalendars();
         System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCollations();
         System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCurrencies();
         System.Collections.Generic.IReadOnlyCollection<string> GetSupportedNumberingSystems();

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
@@ -1361,7 +1361,6 @@ namespace Jint.Native.Intl
         public virtual string? GetNumberingSystemDigits(string numberingSystem) { }
         public virtual Jint.Native.Intl.RelativeTimePatterns? GetRelativeTimePatterns(string locale, string unit, string style) { }
         public virtual string? GetRelativeTimeSpecialPhrase(string locale, string unit, int value, bool past, string style) { }
-        public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCalendars() { }
         public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCollations() { }
         public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCurrencies() { }
         public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedNumberingSystems() { }
@@ -1383,7 +1382,6 @@ namespace Jint.Native.Intl
         string? GetNumberingSystemDigits(string numberingSystem);
         Jint.Native.Intl.RelativeTimePatterns? GetRelativeTimePatterns(string locale, string unit, string style);
         string? GetRelativeTimeSpecialPhrase(string locale, string unit, int value, bool past, string style);
-        System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCalendars();
         System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCollations();
         System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCurrencies();
         System.Collections.Generic.IReadOnlyCollection<string> GetSupportedNumberingSystems();

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.0.verified.txt
@@ -1208,7 +1208,6 @@ namespace Jint.Native.Intl
         public virtual string? GetNumberingSystemDigits(string numberingSystem) { }
         public virtual Jint.Native.Intl.RelativeTimePatterns? GetRelativeTimePatterns(string locale, string unit, string style) { }
         public virtual string? GetRelativeTimeSpecialPhrase(string locale, string unit, int value, bool past, string style) { }
-        public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCalendars() { }
         public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCollations() { }
         public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCurrencies() { }
         public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedNumberingSystems() { }
@@ -1230,7 +1229,6 @@ namespace Jint.Native.Intl
         string? GetNumberingSystemDigits(string numberingSystem);
         Jint.Native.Intl.RelativeTimePatterns? GetRelativeTimePatterns(string locale, string unit, string style);
         string? GetRelativeTimeSpecialPhrase(string locale, string unit, int value, bool past, string style);
-        System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCalendars();
         System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCollations();
         System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCurrencies();
         System.Collections.Generic.IReadOnlyCollection<string> GetSupportedNumberingSystems();

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.1.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.1.verified.txt
@@ -1208,7 +1208,6 @@ namespace Jint.Native.Intl
         public virtual string? GetNumberingSystemDigits(string numberingSystem) { }
         public virtual Jint.Native.Intl.RelativeTimePatterns? GetRelativeTimePatterns(string locale, string unit, string style) { }
         public virtual string? GetRelativeTimeSpecialPhrase(string locale, string unit, int value, bool past, string style) { }
-        public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCalendars() { }
         public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCollations() { }
         public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCurrencies() { }
         public virtual System.Collections.Generic.IReadOnlyCollection<string> GetSupportedNumberingSystems() { }
@@ -1230,7 +1229,6 @@ namespace Jint.Native.Intl
         string? GetNumberingSystemDigits(string numberingSystem);
         Jint.Native.Intl.RelativeTimePatterns? GetRelativeTimePatterns(string locale, string unit, string style);
         string? GetRelativeTimeSpecialPhrase(string locale, string unit, int value, bool past, string style);
-        System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCalendars();
         System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCollations();
         System.Collections.Generic.IReadOnlyCollection<string> GetSupportedCurrencies();
         System.Collections.Generic.IReadOnlyCollection<string> GetSupportedNumberingSystems();

--- a/Jint.Tests.Test262/IcuCldrProvider.cs
+++ b/Jint.Tests.Test262/IcuCldrProvider.cs
@@ -303,9 +303,6 @@ public sealed class IcuCldrProvider : ICldrProvider
 
     // === Supported Values ===
 
-    public IReadOnlyCollection<string> GetSupportedCalendars()
-        => _fallback.GetSupportedCalendars();
-
     public IReadOnlyCollection<string> GetSupportedCollations()
         => _fallback.GetSupportedCollations();
 

--- a/Jint.Tests/Runtime/IntlTests.cs
+++ b/Jint.Tests/Runtime/IntlTests.cs
@@ -1624,4 +1624,70 @@ public class IntlTests
         _engine.Evaluate("new Intl.DateTimeFormat('en', { timeStyle: 'medium', timeZone: 'UTC' }).format(Date.UTC(2024, 0, 15, 9, 5, 7))")
             .AsString().Should().Be("9:05:07 AM");
     }
+
+    /// <summary>
+    /// https://tc39.es/ecma402/#sec-availablecalendars is one list, and three places used to carry their own
+    /// copy of it. This is the entry-by-entry statement of what an unconfigured engine answers, so that
+    /// collapsing the three cannot quietly change it.
+    /// </summary>
+    [Test]
+    public void TheAvailableCalendarsOfADefaultEngineAreTheSixteen()
+    {
+        _engine.Evaluate("JSON.stringify(Intl.supportedValuesOf('calendar'))").AsString().Should().Be(
+            """
+            ["buddhist","chinese","coptic","dangi","ethioaa","ethiopic","gregory","hebrew","indian","islamic-civil","islamic-tbla","islamic-umalqura","iso8601","japanese","persian","roc"]
+            """);
+    }
+
+    /// <summary>
+    /// The three sites now read one list and one alias table, so they answer the same question the same way.
+    /// The two deprecated identifiers are the one place they part, and they part because the two
+    /// specifications ask for different things:
+    /// https://tc39.es/ecma402/#sec-createdatetimeformat step 9 makes a formatter asking for one resolve to
+    /// another available calendar, and <c>Temporal</c> refuses them outright.
+    /// </summary>
+    [TestCase("islamicc", "islamic-civil")]
+    [TestCase("ethiopic-amete-alem", "ethioaa")]
+    [TestCase("ISO8601", "iso8601")]
+    [TestCase("Gregory", "gregory")]
+    [TestCase("islamic", "islamic-civil")]
+    [TestCase("islamic-rgsa", "islamic-civil")]
+    public void TheCalendarOptionResolvesThroughTheOneAliasTable(string requested, string resolved)
+    {
+        _engine.Evaluate($"new Intl.DateTimeFormat('en', {{ calendar: '{requested}' }}).resolvedOptions().calendar")
+            .AsString().Should().Be(resolved);
+    }
+
+    /// <summary>
+    /// A grammatically valid identifier this engine does not answer for is not an error — ResolveLocale keeps
+    /// the locale's own calendar and the option is dropped — while an ill-formed one is a RangeError however
+    /// the locale would have resolved a well-formed one.
+    /// </summary>
+    [Test]
+    public void ACalendarNobodyAnswersForFallsBackAndAnIllFormedOneThrows()
+    {
+        _engine.Evaluate("new Intl.DateTimeFormat('en', { calendar: 'mayan' }).resolvedOptions().calendar")
+            .AsString().Should().Be("gregory");
+        _engine.Evaluate("new Intl.DateTimeFormat('en-u-ca-mayan').resolvedOptions().calendar")
+            .AsString().Should().Be("gregory");
+
+        Assert.Throws<JavaScriptException>(() => _engine.Evaluate("new Intl.DateTimeFormat('en', { calendar: 'no' })"));
+        Assert.Throws<JavaScriptException>(() => _engine.Evaluate("new Intl.DateTimeFormat('en', { calendar: 'İSO8601' })"));
+    }
+
+    /// <summary>
+    /// <c>Intl.DisplayNames</c> reads the same list, which is what its own comment said it was for: it named
+    /// a calendar exactly when <c>Intl.supportedValuesOf('calendar')</c> did, through a second membership
+    /// scan and a hand-written <c>gregorian</c> special case.
+    /// </summary>
+    [Test]
+    public void DisplayNamesOffersANameForExactlyTheAvailableCalendars()
+    {
+        _engine.Evaluate("new Intl.DisplayNames('en', { type: 'calendar' }).of('gregory')")
+            .AsString().Should().Be("Gregorian Calendar");
+        _engine.Evaluate("new Intl.DisplayNames('en', { type: 'calendar' }).of('islamicc')")
+            .AsString().Should().Be("Islamic (civil) Calendar");
+        _engine.Evaluate("new Intl.DisplayNames('en', { type: 'calendar' }).of('mayan')")
+            .AsString().Should().Be("mayan");
+    }
 }

--- a/Jint/Native/Intl/AvailableCalendars.cs
+++ b/Jint/Native/Intl/AvailableCalendars.cs
@@ -1,0 +1,150 @@
+using System.Buffers;
+using Jint.Native.Temporal;
+
+namespace Jint.Native.Intl;
+
+/// <summary>
+/// https://tc39.es/ecma402/#sec-availablecalendars — the calendar identifiers this engine answers for.
+/// </summary>
+/// <remarks>
+/// <para>
+/// ECMA-402 has one such list, not three, and defines it as the calendars "for which the implementation
+/// provides the functionality of <c>Intl.DateTimeFormat</c> objects". Three places consume it, and each used
+/// to carry its own copy: <c>Intl.supportedValuesOf('calendar')</c>
+/// (https://tc39.es/ecma402/#sec-intl.supportedvaluesof step 2), the <c>calendar</c> option of
+/// <see cref="DateTimeFormatConstructor"/>, and — through
+/// https://tc39.es/proposal-temporal/#sec-temporal-canonicalizecalendar, whose first step is this very
+/// operation — every <c>Temporal</c> entry point. The three agreed on the sixteen for a default engine and
+/// on nothing else: they had different alias tables, and only one of them could be extended.
+/// </para>
+/// <para>
+/// Extending it is <see cref="ICalendarProvider.GetSupportedCalendars"/>, which after #3405 is what makes a
+/// non-ISO calendar exist. So a host adds a calendar once, and it is a calendar everywhere — including in
+/// <c>Intl.supportedValuesOf</c> and as an <c>Intl.DateTimeFormat</c> <c>calendar</c> option, neither of
+/// which could see it before. The sixteen are named here rather than asked of the provider, so an
+/// unconfigured engine answers from a lookup and never constructs one.
+/// </para>
+/// <para>
+/// Two identifiers are accepted and never available. <c>islamic</c> and <c>islamic-rgsa</c> name
+/// observation-based calendars whose data Jint does not have:
+/// https://tc39.es/ecma402/#sec-createdatetimeformat step 9 requires a formatter asking for one to resolve to
+/// some other available calendar instead — which is what test262's
+/// <c>DateTimeFormat/constructor-options-calendar-islamic-fallback.js</c> asserts, with a list of exactly
+/// these sixteen — and <c>Temporal</c> refuses them outright in <c>RejectTemporalUnsupportedCalendar</c>.
+/// That is the one place the two services differ, and it is about data rather than about membership: a host
+/// provider that claims either has the observation tables, and then it is available like any other.
+/// </para>
+/// </remarks>
+internal static class AvailableCalendars
+{
+    /// <summary>
+    /// The identifiers a default engine answers for, in lexicographic code-unit order — the order
+    /// <c>Intl.supportedValuesOf</c> reports and the order this array is read in.
+    /// </summary>
+    private static readonly string[] Builtin =
+    [
+        "buddhist", "chinese", "coptic", "dangi", "ethioaa", "ethiopic",
+        "gregory", "hebrew", "indian", "islamic-civil", "islamic-tbla",
+        "islamic-umalqura", "iso8601", "japanese", "persian", "roc"
+    ];
+
+    private static readonly StringSearchValues BuiltinLookup = new(Builtin, StringComparison.Ordinal);
+
+    /// <summary>
+    /// A legacy spelling of <c>gregory</c> that predates the Unicode <c>type</c> grammar and cannot appear in
+    /// a <c>-u-ca-</c> extension, being nine characters where the grammar allows eight. It is here because
+    /// <c>Temporal</c> has always accepted it as a <c>calendar</c> field value.
+    /// </summary>
+    private const string LegacyGregorian = "gregorian";
+
+    /// <summary>The two deprecated identifiers of the remark above: legal to ask for, never resolved to.</summary>
+    private static bool IsDeprecated(string canonical)
+        => string.Equals(canonical, "islamic", StringComparison.Ordinal)
+        || string.Equals(canonical, "islamic-rgsa", StringComparison.Ordinal);
+
+    /// <summary>
+    /// Whether <paramref name="canonical"/> — already through <see cref="Canonicalize"/> — is one of the
+    /// calendars this engine can convert dates for.
+    /// </summary>
+    internal static bool Contains(Engine? engine, string canonical)
+    {
+        if (BuiltinLookup.Contains(canonical))
+        {
+            return true;
+        }
+
+        // Only a host provider can answer for anything else, and the shared singleton is skipped by identity
+        // because the sixteen above are everything it claims. It is asked for a well-formed Unicode calendar
+        // type only, so nothing it claims can produce an identifier that would not round-trip through a
+        // [u-ca=…] annotation.
+        var provider = engine?.Options.Temporal.CalendarProvider;
+        return provider is not null
+            && !ReferenceEquals(provider, DefaultCalendarProvider.Instance)
+            && IntlUtilities.IsValidUnicodeExtensionValue(canonical)
+            && provider.IsSupported(canonical);
+    }
+
+    /// <summary>
+    /// https://tc39.es/ecma402/#sec-canonicalizeuvalue applied to a calendar identifier, then checked against
+    /// the list. Returns null for an identifier this engine does not answer for, which is the caller's cue to
+    /// throw a <c>RangeError</c> (<c>Temporal</c>) or to fall back to the locale's calendar (<c>Intl</c>).
+    /// </summary>
+    /// <remarks>
+    /// The two deprecated identifiers come back as themselves rather than as null: they are legal option and
+    /// annotation values, and each consumer decides what to do with one.
+    /// </remarks>
+    internal static string? Canonicalize(Engine? engine, string identifier)
+    {
+        var canonical = IntlUtilities.CanonicalizeUValue("ca", identifier);
+
+        if (string.Equals(canonical, LegacyGregorian, StringComparison.Ordinal))
+        {
+            return "gregory";
+        }
+
+        return Contains(engine, canonical) || IsDeprecated(canonical) ? canonical : null;
+    }
+
+    /// <summary>
+    /// The calendar an <c>Intl.DateTimeFormat</c> resolves to for a requested identifier, or null when the
+    /// request is not one this engine answers for and the caller should fall back to the locale's own
+    /// calendar. https://tc39.es/ecma402/#sec-createdatetimeformat step 9 is the deprecated-identifier
+    /// substitution; the tabular civil calendar is the closest thing Jint has to either of them.
+    /// </summary>
+    internal static string? ResolveForDateTimeFormat(Engine engine, string identifier)
+    {
+        var canonical = Canonicalize(engine, identifier);
+        if (canonical is null)
+        {
+            return null;
+        }
+
+        return IsDeprecated(canonical) && !Contains(engine, canonical) ? "islamic-civil" : canonical;
+    }
+
+    /// <summary>
+    /// What <c>Intl.supportedValuesOf('calendar')</c> reports: the available list, with the deprecated
+    /// identifiers left out because they are never a resolved calendar. The caller sorts.
+    /// </summary>
+    internal static string[] SupportedValues(Engine engine)
+    {
+        var provider = engine.Options.Temporal.CalendarProvider;
+        if (ReferenceEquals(provider, DefaultCalendarProvider.Instance))
+        {
+            return (string[]) Builtin.Clone();
+        }
+
+        var result = new List<string>(Builtin.Length + 4);
+        result.AddRange(Builtin);
+
+        foreach (var calendar in provider.GetSupportedCalendars())
+        {
+            if (!IsDeprecated(calendar) && !result.Contains(calendar))
+            {
+                result.Add(calendar);
+            }
+        }
+
+        return result.ToArray();
+    }
+}

--- a/Jint/Native/Intl/DateTimeFormatConstructor.cs
+++ b/Jint/Native/Intl/DateTimeFormatConstructor.cs
@@ -43,14 +43,6 @@ internal sealed partial class DateTimeFormatConstructor : Constructor
     private static readonly StringSearchValues DateStyleValues = new(["full", "long", "medium", "short"], StringComparison.Ordinal);
     private static readonly StringSearchValues TimeStyleValues = new(["full", "long", "medium", "short"], StringComparison.Ordinal);
 
-    // Supported calendars per ECMA-402 and Unicode CLDR
-    private static readonly StringSearchValues SupportedCalendars = new(
-    [
-        "buddhist", "chinese", "coptic", "dangi", "ethioaa", "ethiopic",
-        "gregory", "hebrew", "indian", "islamic", "islamic-civil", "islamic-rgsa",
-        "islamic-tbla", "islamic-umalqura", "iso8601", "japanese", "persian", "roc"
-    ], StringComparison.Ordinal);
-
     public DateTimeFormatConstructor(
         Engine engine,
         Realm realm,
@@ -131,46 +123,21 @@ internal sealed partial class DateTimeFormatConstructor : Constructor
         var calendarOption = GetUnicodeExtensionOption(optionsObj, "calendar");
         string? calendar;
 
-        if (calendarOption != null)
+        // https://tc39.es/ecma402/#sec-createdatetimeformat steps 7-9. An identifier this engine does not
+        // answer for is not an error: ResolveLocale simply keeps the locale's own calendar, and the option
+        // is dropped. AvailableCalendars is the one list all of that is decided against.
+        var resolvedExtCalendar = extCalendar != null ? AvailableCalendars.ResolveForDateTimeFormat(_engine, extCalendar) : null;
+        calendar = calendarOption != null ? AvailableCalendars.ResolveForDateTimeFormat(_engine, calendarOption) : null;
+
+        if (calendar != null)
         {
-            // Option provided - validate and canonicalize
-            var canonicalizedOption = CanonicalizeCalendar(calendarOption);
-            if (IsValidCalendar(canonicalizedOption))
-            {
-                // Valid option - it overrides extension
-                calendar = canonicalizedOption;
-                // If option matches extension, preserve the extension
-                preserveCalendarExt = extCalendar != null && string.Equals(calendar, CanonicalizeCalendar(extCalendar), StringComparison.Ordinal);
-            }
-            else if (extCalendar != null && IsValidCalendar(CanonicalizeCalendar(extCalendar)))
-            {
-                // Invalid option, but valid extension - use extension
-                calendar = CanonicalizeCalendar(extCalendar);
-                preserveCalendarExt = true;
-            }
-            else
-            {
-                // Both invalid - use default
-                calendar = null;
-            }
+            // The extension is preserved in the resolved locale only when it asked for the same calendar.
+            preserveCalendarExt = resolvedExtCalendar != null && string.Equals(calendar, resolvedExtCalendar, StringComparison.Ordinal);
         }
-        else if (extCalendar != null)
+        else if (resolvedExtCalendar != null)
         {
-            // No option, check if extension is valid
-            var canonicalizedExt = CanonicalizeCalendar(extCalendar);
-            if (IsValidCalendar(canonicalizedExt))
-            {
-                calendar = canonicalizedExt;
-                preserveCalendarExt = true;
-            }
-            else
-            {
-                calendar = null;
-            }
-        }
-        else
-        {
-            calendar = null;
+            calendar = resolvedExtCalendar;
+            preserveCalendarExt = true;
         }
 
         // Step 10: Get numberingSystem option
@@ -910,14 +877,6 @@ internal sealed partial class DateTimeFormatConstructor : Constructor
     }
 
     /// <summary>
-    /// Checks if the given calendar is supported.
-    /// </summary>
-    private static bool IsValidCalendar(string? calendar)
-    {
-        return calendar != null && SupportedCalendars.Contains(calendar);
-    }
-
-    /// <summary>
     /// Builds the resolved locale string, including only the unicode extensions that should be preserved.
     /// </summary>
     private static string BuildResolvedLocale(string baseLocale, string requestedLocale,
@@ -952,32 +911,6 @@ internal sealed partial class DateTimeFormatConstructor : Constructor
         }
 
         return $"{baseLocale}-u-{string.Join('-', extensions)}";
-    }
-
-    /// <summary>
-    /// Canonicalizes calendar names per ECMA-402.
-    /// Converts deprecated/alias names to their canonical forms.
-    /// Per ECMA-402, "islamic" and "islamic-rgsa" should fallback to a valid calendar
-    /// from AvailableCalendars (like "islamic-civil").
-    /// </summary>
-    private static string? CanonicalizeCalendar(string? calendar)
-    {
-        if (calendar == null)
-        {
-            return null;
-        }
-
-        // Calendar alias and fallback mappings per Unicode CLDR and ECMA-402
-        return calendar.ToLowerInvariant() switch
-        {
-            "ethiopic-amete-alem" => "ethioaa",
-            "islamicc" => "islamic-civil",
-            // Per ECMA-402 §11.1.2, "islamic" and "islamic-rgsa" are deprecated
-            // and should fallback to a valid calendar from AvailableCalendars
-            "islamic" => "islamic-civil",
-            "islamic-rgsa" => "islamic-civil",
-            _ => calendar.ToLowerInvariant()
-        };
     }
 
     /// <summary>

--- a/Jint/Native/Intl/DefaultCldrProvider.cs
+++ b/Jint/Native/Intl/DefaultCldrProvider.cs
@@ -593,21 +593,6 @@ public class DefaultCldrProvider : ICldrProvider
     // === Supported Values ===
 
     /// <inheritdoc />
-    public virtual IReadOnlyCollection<string> GetSupportedCalendars()
-    {
-        // Only return calendars that are fully supported per ECMA-402 and Intl.Era-monthcode spec
-        // Note: "islamic" and "islamic-rgsa" are excluded because they require specific
-        // DateTimeFormat support that maps them back correctly (not aliased to islamic-civil)
-        return new[]
-        {
-            "buddhist", "chinese", "coptic", "dangi", "ethioaa", "ethiopic",
-            "gregory", "hebrew", "indian", "islamic-civil",
-            "islamic-tbla", "islamic-umalqura", "iso8601",
-            "japanese", "persian", "roc"
-        };
-    }
-
-    /// <inheritdoc />
     public virtual IReadOnlyCollection<string> GetSupportedCollations()
     {
         // https://tc39.es/ecma402/#sec-availablecanonicalcollations wants the collations the

--- a/Jint/Native/Intl/ICldrProvider.cs
+++ b/Jint/Native/Intl/ICldrProvider.cs
@@ -141,11 +141,6 @@ public interface ICldrProvider
     // === Supported Values ===
 
     /// <summary>
-    /// Gets all supported calendar identifiers.
-    /// </summary>
-    IReadOnlyCollection<string> GetSupportedCalendars();
-
-    /// <summary>
     /// Gets all supported collation identifiers.
     /// </summary>
     IReadOnlyCollection<string> GetSupportedCollations();

--- a/Jint/Native/Intl/IntlInstance.cs
+++ b/Jint/Native/Intl/IntlInstance.cs
@@ -103,18 +103,12 @@ internal sealed partial class IntlInstance : ObjectInstance
         return result;
     }
 
-    private string[] GetSupportedCalendars()
-    {
-        // Use CLDR provider for supported calendars
-        var calendars = CldrProvider.GetSupportedCalendars();
-        var result = new string[calendars.Count];
-        var i = 0;
-        foreach (var calendar in calendars)
-        {
-            result[i++] = calendar;
-        }
-        return result;
-    }
+    /// <summary>
+    /// https://tc39.es/ecma402/#sec-intl.supportedvaluesof step 2 — the calendars this engine answers for,
+    /// which is one list rather than this one's own. Extending it is <c>ICalendarProvider</c>: a calendar
+    /// needs conversions before it needs names, and a host that adds one adds it once.
+    /// </summary>
+    private string[] GetSupportedCalendars() => AvailableCalendars.SupportedValues(_engine);
 
     private string[] GetSupportedCollations()
     {

--- a/Jint/Native/Intl/JsDateTimeFormat.cs
+++ b/Jint/Native/Intl/JsDateTimeFormat.cs
@@ -654,8 +654,10 @@ internal sealed class JsDateTimeFormat : ObjectInstance
         // Other non-ISO calendars go through the full IsoToCalendarDate machinery.
         try
         {
+            // With the engine, so a calendar a host ICalendarProvider added is converted by the provider that
+            // knows it rather than falling through to the catch below and printing the underlying ISO date.
             var isoDate = new IsoDate(originalYear ?? dateTime.Year, dateTime.Month, dateTime.Day);
-            var calDate = NonIsoCalendars.IsoToCalendarDate(Calendar, in isoDate);
+            var calDate = NonIsoCalendars.IsoToCalendarDate(Calendar, in isoDate, _engine);
             year = calDate.Year;
             month = calDate.Month;
             day = calDate.Day;

--- a/Jint/Native/Intl/JsDisplayNames.cs
+++ b/Jint/Native/Intl/JsDisplayNames.cs
@@ -171,26 +171,16 @@ internal sealed class JsDisplayNames : ObjectInstance
 
     private string? GetCalendarDisplayName(string code)
     {
-        var normalizedCode = code.ToLowerInvariant();
-
-        // Only return display names for calendars we actually support
-        // This ensures consistency with Intl.supportedValuesOf("calendar")
-        var supportedCalendars = _engine.Options.Intl.CldrProvider.GetSupportedCalendars();
-        var isSupported = false;
-        foreach (var supported in supportedCalendars)
-        {
-            if (string.Equals(supported, normalizedCode, StringComparison.OrdinalIgnoreCase) ||
-                (string.Equals(normalizedCode, "gregorian", StringComparison.Ordinal) && string.Equals(supported, "gregory", StringComparison.Ordinal)))
-            {
-                isSupported = true;
-                break;
-            }
-        }
-
-        if (!isSupported)
+        // A display name is offered for exactly the calendars this engine answers for, which is the one
+        // AvailableCalendars list rather than a second opinion about it — the alias handling comes with it,
+        // and a calendar a host ICalendarProvider added is one this can now be asked about.
+        var canonical = AvailableCalendars.Canonicalize(_engine, code);
+        if (canonical is null || !AvailableCalendars.Contains(_engine, canonical))
         {
             return GetFallbackValue(code);
         }
+
+        var normalizedCode = canonical;
 
         var name = normalizedCode switch
         {

--- a/Jint/Native/Temporal/ICalendarProvider.cs
+++ b/Jint/Native/Temporal/ICalendarProvider.cs
@@ -25,12 +25,12 @@ public interface ICalendarProvider
 
     /// <summary>Returns all calendar identifiers this provider supports.</summary>
     /// <remarks>
-    /// This list is what makes an identifier <c>Temporal</c> does not implement itself a valid one: a
-    /// calendar named here is accepted by <c>Temporal.PlainDate.from</c>, <c>withCalendar</c> and a
-    /// <c>[u-ca=…]</c> annotation, and its conversions are then asked of this provider. It is read on a
-    /// validation path — return a cached collection rather than building one per call.
-    /// It does not feed <c>Intl.supportedValuesOf('calendar')</c>, which is
-    /// <see cref="Intl.ICldrProvider.GetSupportedCalendars"/>'s answer.
+    /// This list is what makes an identifier the engine does not implement itself a valid one, everywhere a
+    /// calendar identifier can appear: a calendar named here is accepted by <c>Temporal.PlainDate.from</c>,
+    /// <c>withCalendar</c> and a <c>[u-ca=…]</c> annotation, is reported by
+    /// <c>Intl.supportedValuesOf('calendar')</c>, and is a valid <c>calendar</c> option of
+    /// <c>Intl.DateTimeFormat</c> — one list, because a calendar needs conversions before it needs names.
+    /// It is read on a validation path — return a cached collection rather than building one per call.
     /// </remarks>
     IReadOnlyCollection<string> GetSupportedCalendars();
 

--- a/Jint/Native/Temporal/TemporalHelpers.cs
+++ b/Jint/Native/Temporal/TemporalHelpers.cs
@@ -1575,60 +1575,14 @@ internal static class TemporalHelpers
     /// https://tc39.es/proposal-temporal/#sec-temporal-canonicalizetemporalcalendaridentifier
     /// </summary>
     /// <remarks>
-    /// The switch below is Jint's own <c>AvailableCalendars</c>. An identifier it does not name is put to the
-    /// engine's <see cref="ICalendarProvider"/>, which is the only thing that could implement a calendar
-    /// Jint does not: without this, a host provider's <c>IsSupported</c> is never reached for a new
-    /// identifier, because every Temporal entry point canonicalizes before it consults a provider.
-    /// A host is answered only for a well-formed Unicode calendar type, so nothing it claims can produce an
-    /// identifier that would not round-trip through a <c>[u-ca=…]</c> annotation.
+    /// Step 1 of that operation is <c>AvailableCalendars()</c>, and
+    /// <see cref="Intl.AvailableCalendars"/> is it — the same list, the same alias table and the same
+    /// provider question that <c>Intl.supportedValuesOf('calendar')</c> and <c>Intl.DateTimeFormat</c>'s
+    /// <c>calendar</c> option read. This method used to carry its own copy of all three.
     /// </remarks>
     public static string? CanonicalizeCalendar(Engine? engine, string calendar)
     {
-        // Must use ASCII case-folding only (not Turkish İ)
-        // Check if it's a valid calendar ID and return canonical form
-        var lower = ToAsciiLowerCase(calendar);
-
-        // Map of known calendar identifiers to their canonical forms
-        // https://tc39.es/ecma402/#sec-availablecalendars
-        return lower switch
-        {
-            "iso8601" => "iso8601",
-            "gregory" or "gregorian" => "gregory",
-            "buddhist" => "buddhist",
-            "chinese" => "chinese",
-            "coptic" => "coptic",
-            "dangi" => "dangi",
-            "ethioaa" or "ethiopic-amete-alem" => "ethioaa",
-            "ethiopic" => "ethiopic",
-            "hebrew" => "hebrew",
-            "indian" => "indian",
-            "islamic" => "islamic",
-            "islamic-civil" => "islamic-civil",
-            "islamic-rgsa" => "islamic-rgsa",
-            "islamic-tbla" => "islamic-tbla",
-            "islamic-umalqura" => "islamic-umalqura",
-            "islamicc" => "islamic-civil",
-            "japanese" => "japanese",
-            "persian" => "persian",
-            "roc" => "roc",
-            _ => AskCalendarProvider(engine, lower)
-        };
-    }
-
-    /// <summary>
-    /// The last word on an identifier Jint's own table does not name: a host provider that claims it, or null.
-    /// </summary>
-    private static string? AskCalendarProvider(Engine? engine, string lowered)
-    {
-        var provider = engine?.Options.Temporal.CalendarProvider;
-        if (provider is null || ReferenceEquals(provider, DefaultCalendarProvider.Instance))
-        {
-            return null;
-        }
-
-        return Intl.IntlUtilities.IsValidUnicodeExtensionValue(lowered) && provider.IsSupported(lowered)
-            ? lowered
-            : null;
+        return Intl.AvailableCalendars.Canonicalize(engine, calendar);
     }
 
     /// <summary>

--- a/README.md
+++ b/README.md
@@ -2855,10 +2855,13 @@ sealed class AstronomicalPersian : DefaultCalendarProvider
 ```
 
 *Adding* a calendar Jint does not know is three: `GetSupportedCalendars`, which is what makes the
-identifier valid anywhere in `Temporal`, and both conversions, which nobody but you can perform. The
-inherited `IsSupported` reads the list, so it does not need overriding as well. Such a calendar reaches
-construction, every field accessor, `with` and `toString`; it does not reach `add`/`subtract`/`until`/`since`
-or `toLocaleString`, both of which raise a `RangeError` for a calendar the engine does not implement itself.
+identifier valid, and both conversions, which nobody but you can perform. The inherited `IsSupported` reads
+the list, so it does not need overriding as well. That list is the engine's only list of calendars, so such
+a calendar reaches construction, every field accessor, `with`, `toString`, `add`/`subtract`/`until`/`since`
+— the arithmetic is walked through your two conversions — and `Intl`: it is reported by
+`Intl.supportedValuesOf('calendar')`, is a valid `calendar` option of `Intl.DateTimeFormat`, and formats
+through `toLocaleString`. Month, weekday and era *names* for it are `ICldrProvider`'s to supply; without
+them the fields are written numerically.
 
 ## Running untrusted code
 

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -69,6 +69,7 @@ This table is filled by the pull request that removes the member. A member that 
 | `WeekInfo.MinimalDays` | nothing. ECMA-402 removed `minimalDays` from `getWeekInfo()`'s result, and test262 asserts the keys are exactly `firstDay` and `weekend`, so no caller could ever have reached it | [#3336](https://github.com/sebastienros/jint/issues/3336) |
 | `ICldrProvider.GetCompactPatterns` and the `CompactPatterns` type (with `DefaultCldrProvider`'s override) | nothing. `CompactPatterns` is a magnitude-to-pattern map with no plural dimension and no digit count, so it cannot express what compact notation actually needs: CLDR keys these patterns by plural category as well as by power of ten (`ru` long is `0 тысяча` / `0 тысячи` / `0 тысяч`), and the zero count in a CLDR pattern (`00 Tsd.`) is the rounding. Compact suffixes come from the engine's embedded table | [#3354](https://github.com/sebastienros/jint/issues/3354) |
 | `ICldrProvider.GetDateTimePatterns` and the `DateTimePatterns` type (with `DefaultCldrProvider`'s override) | nothing. It never had an implementation — the only one in the tree returned `null` unconditionally — so the syntax of its three pattern strings was never fixed, and .NET custom format strings and LDML skeletons disagree on the letters that matter (`yyyy` vs `y`, `tt` vs `a`, `ddd` vs `E`). Wiring it would have meant inventing that contract, and for the `dateStyle`/`timeStyle` pair alone: ECMA-402 resolves both out of the same `availableFormats` skeleton data the component options use, which three strings cannot carry | [#3354](https://github.com/sebastienros/jint/issues/3354) |
+| `ICldrProvider.GetSupportedCalendars` (and `DefaultCldrProvider`'s override) | `ICalendarProvider.GetSupportedCalendars`. ECMA-402 has one list of calendars, not two, and defines it as the calendars the implementation can format — which in Jint means the ones it can *convert*, because that is what formatting a non-ISO calendar goes through. A calendar with conversions and no names still formats numerically; one with names and no conversions cannot be formatted at all. Adding a calendar was already three overrides on `ICalendarProvider`, and it now reaches `Intl` as well as `Temporal` | [#3404](https://github.com/sebastienros/jint/issues/3404) |
 
 ### 2.1 Sealed types
 
@@ -1681,8 +1682,8 @@ now the list's answer for anything deriving from `DefaultCalendarProvider` witho
 the question the engine asks — so a calendar in the list is now claimed, and one absent from it is not.
 A provider implementing `ICalendarProvider` from scratch is unaffected: both members are still its own.
 Second, a host calendar reaches construction, the field accessors, `with`, `toString` and the
-`PlainYearMonth`/`PlainMonthDay` conversions, but not arithmetic and not `Intl.DateTimeFormat`; both refuse
-it with a `RangeError`.
+`PlainYearMonth`/`PlainMonthDay` conversions, but not arithmetic and not `Intl.DateTimeFormat`; both refused
+it with a `RangeError` when this shipped. 4.35 gives it arithmetic and 4.36 gives it `Intl`.
 
 ### 4.31 A module graph too deep to link raises an error instead of ending the process ([#3401](https://github.com/sebastienros/jint/issues/3401))
 
@@ -1883,6 +1884,39 @@ Both are `Set(O, k, v, true)` over a position the view cannot hold, so both are 
 longer fires. Nothing changes for a target exposed under its own type or under a type that implements
 `IList<T>` (both get a typed, growable wrapper), for reads, or for any generic that stays inside the
 collection's bounds.
+### 4.40 One list of calendars, and `ICalendarProvider` owns it ([#3404](https://github.com/sebastienros/jint/issues/3404))
+
+Jint held the calendar identifiers in three places — `TemporalHelpers.CanonicalizeCalendar`,
+`DateTimeFormatConstructor`'s own table and alias map, and `DefaultCldrProvider.GetSupportedCalendars` —
+plus a fourth membership scan inside `Intl.DisplayNames`. They agreed on the sixteen for a default engine
+and on nothing else: two different alias tables, and only one of them could be extended, so a calendar a
+host added existed for `Temporal` and was invisible to `Intl`.
+
+[AvailableCalendars](https://tc39.es/ecma402/#sec-availablecalendars) is one list, defined as the calendars
+the implementation can format, and read by `Intl.supportedValuesOf('calendar')`, by `Intl.DateTimeFormat`'s
+`calendar` option and — as its literal first step — by
+[Temporal's `CanonicalizeCalendar`](https://tc39.es/proposal-temporal/#sec-temporal-canonicalizecalendar).
+All four sites now read one internal `AvailableCalendars`, whose alias handling is the engine's existing
+`CanonicalizeUValue("ca", …)` and whose extension point is `ICalendarProvider.GetSupportedCalendars`.
+
+```js
+// with a provider that adds "mayan" — 5.0 answered "gregory", false, and "gregory"
+new Intl.DateTimeFormat('en', { calendar: 'mayan' }).resolvedOptions().calendar; // "mayan"
+Intl.supportedValuesOf('calendar').includes('mayan');                            // true
+new Intl.DateTimeFormat('en', { calendar: 'mayan', year: 'numeric', timeZone: 'UTC' })
+    .format(Date.UTC(2024, 2, 5));                                               // "5138"
+```
+
+`islamic` and `islamic-rgsa` are the one place the two services still part, and they part because the two
+specifications ask for different things: [CreateDateTimeFormat](https://tc39.es/ecma402/#sec-createdatetimeformat)
+step 9 requires a formatter asking for one to resolve to another available calendar, and `Temporal` refuses
+them outright. That is now stated once, beside the list, instead of being an accident of two switches
+disagreeing.
+
+Nothing an unconfigured engine does changes: the sixteen, the two deprecated identifiers and the aliases all
+behave exactly as the four tables made them behave.
+
+**What could break:** a host overriding `ICldrProvider.GetSupportedCalendars`. See [2. Removed API](#2-removed-api).
 
 ### 4.41 Two holes in the freeze, closed ([#3360](https://github.com/sebastienros/jint/issues/3360))
 
@@ -2065,7 +2099,7 @@ sealed class MyCldr : DefaultCldrProvider
 var engine = new Engine(options => options.Intl.CldrProvider = new MyCldr());
 ```
 
-`ICldrProvider` is now nineteen members and every one of them has a caller, so whatever a derived class
+`ICldrProvider` is now eighteen members and every one of them has a caller, so whatever a derived class
 answers is what `Intl` shows — see [4.22](#422-intl-reads-the-cldr-provider-for-currency-symbols-and-week-info)
 and [4.29](#429-intl-reads-the-cldr-provider-for-date-names-and-numbering-system-digits) for the two changes
 that closed the gap, and section [2](#2-removed-api) for the two members that went instead of being wired.


### PR DESCRIPTION
Jint held the list of calendar identifiers in four places, and only one of them could be extended. The
fourth's own comment says what it was for: "Only return display names for calendars we actually support.
This ensures consistency with `Intl.supportedValuesOf("calendar")`."

| Where | What it answered | Who could change it |
| --- | --- | --- |
| `TemporalHelpers.CanonicalizeCalendar` | an 18-arm switch with its own alias table | a host `ICalendarProvider`, since #3405 |
| `DateTimeFormatConstructor.SupportedCalendars` + its own `CanonicalizeCalendar` | 18 identifiers and a *different* alias table | nobody |
| `DefaultCldrProvider.GetSupportedCalendars()` | the 16 `Intl.supportedValuesOf('calendar')` reports | a host `ICldrProvider` |
| `JsDisplayNames.GetCalendarDisplayName` | a fourth membership scan, plus a hand-written `gregorian` case | nobody |

## What each of the three actually governs, and whether they should be one

They should be one, and the specification says so in as many words.
[AvailableCalendars](https://tc39.es/ecma402/#sec-availablecalendars) (§6.9.1 — renamed from
`AvailableCanonicalCalendars` in 2024, the old anchor now only an `oldids` shim) is defined as the calendars
"for which the implementation provides the functionality of `Intl.DateTimeFormat` objects", and it is
consumed by [`Intl.supportedValuesOf`](https://tc39.es/ecma402/#sec-intl.supportedvaluesof) step 2, by
`CalendarsOfLocale`, and — as its literal first step — by
[Temporal's `CanonicalizeCalendar`](https://tc39.es/proposal-temporal/#sec-temporal-canonicalizecalendar).
There is no room for `Temporal` to accept a calendar `Intl` cannot format: the one list is *defined* by what
`Intl` can format, and `Temporal` reads it.

So the three collapse. `AvailableCalendars` is one internal type, and the three sites read it:

- **`Intl.supportedValuesOf('calendar')`** reports it.
- **`Intl.DateTimeFormat`'s `calendar` option** resolves against it, with one alias table instead of two —
  `IntlUtilities.CanonicalizeUValue("ca", …)`, which is what
  [CanonicalizeCalendar step 3](https://tc39.es/proposal-temporal/#sec-temporal-canonicalizecalendar) says
  and which the engine already had, carrying CLDR's bcp47 aliases.
- **`Temporal`'s `CanonicalizeCalendar`** delegates to it.

**Extending it is `ICalendarProvider`**, not `ICldrProvider`. A calendar needs conversions before it needs
names: `Intl.DateTimeFormat`'s non-ISO lane goes through the same `NonIsoCalendars` conversions `Temporal`
does, and a calendar with names but no conversions cannot be formatted at all, while one with conversions
and no names formats numerically. That is also where #3405 already put the question.
`ICldrProvider.GetSupportedCalendars` is therefore **removed**: it answered a question that is not `Intl`'s,
and it was the reason a host-added calendar was invisible to `Intl`.

## The one difference that stays, on purpose

`islamic` and `islamic-rgsa` name observation-based calendars whose data Jint does not have. They are
accepted as an identifier and are never an *available* calendar, and the two services do different things
with them because the two specifications ask for different things:
[CreateDateTimeFormat step 9](https://tc39.es/ecma402/#sec-createdatetimeformat) requires a formatter asking
for one to resolve to some other available calendar — test262's
`DateTimeFormat/constructor-options-calendar-islamic-fallback.js` asserts exactly that, against a list of
exactly these sixteen — and `Temporal` refuses them outright. That is now written down in one place, beside
the list, rather than being an accident of two switches disagreeing. A host provider that claims either has
the observation tables, and then it is available like any other.

## What this fixes

```js
// with a provider that adds "mayan" (three overrides, per #3405)

// before
Temporal.PlainDate.from('2024-03-05').withCalendar('mayan').year;               // 5138
new Intl.DateTimeFormat('en', { calendar: 'mayan' }).resolvedOptions().calendar; // "gregory"
Intl.supportedValuesOf('calendar').includes('mayan');                            // false

// after
new Intl.DateTimeFormat('en', { calendar: 'mayan' }).resolvedOptions().calendar; // "mayan"
Intl.supportedValuesOf('calendar').includes('mayan');                            // true
Temporal.PlainDate.from('2024-03-05').withCalendar('mayan').toLocaleString('en', { calendar: 'mayan' });
```

## What is unchanged

Nothing an unconfigured engine does. The sixteen are named in one array in the new type, the two deprecated
identifiers behave exactly as the two switches made them behave, and the alias table the surviving path uses
is the one `Intl.DateTimeFormat` already used — `islamicc` → `islamic-civil`,
`ethiopic-amete-alem` → `ethioaa` — plus `Temporal`'s legacy `gregorian` → `gregory`, which the Unicode
`type` grammar cannot express anyway (nine characters where eight are allowed) and which therefore only ever
reached a `calendar` field. Proved entry by entry rather than asserted:

- `Intl.supportedValuesOf('calendar')` reports the same sixteen, in the same order, pinned as a literal in
  `IntlTests.TheAvailableCalendarsOfADefaultEngineAreTheSixteen`.
- Every alias resolves as it did: `islamicc` -> `islamic-civil`, `ethiopic-amete-alem` -> `ethioaa`,
  `ISO8601` -> `iso8601`, `islamic` and `islamic-rgsa` -> `islamic-civil`; a grammatically valid identifier
  nobody answers for still falls back to the locale's calendar rather than throwing, and an ill-formed one
  still throws.
- 10,752 `Jint.Tests` and 3,081 `Jint.Tests.PublicInterface` pass, the latter including the five public-API
  baselines, which move by exactly the two removed lines and nothing else.

**What could break:** a host overriding `ICldrProvider.GetSupportedCalendars`. The member is gone; adding a
calendar is `ICalendarProvider.GetSupportedCalendars`, which is the same three overrides #3405 documented and
now reaches `Intl` as well as `Temporal`.

Fixes #3404
