### PR TITLE
Tests: the source-text saving is measured per phase, not as a difference of two whole-process heaps

### DIFF
--- a/Jint.Tests/Runtime/GarbageCollectionTests.cs
+++ b/Jint.Tests/Runtime/GarbageCollectionTests.cs
@@ -71,15 +71,32 @@ public class GarbageCollectionTests
         var retained = MeasurePreparedHeap(count, commentChars, retainSourceText: true);
         var notRetained = MeasurePreparedHeap(count, commentChars, retainSourceText: false);
 
-        // Theoretical savings ≈ count * commentChars * 2 (UTF-16). Assert at least half to absorb noise.
-        var minimumSavings = (long) count * commentChars; // bytes; conservative lower bound (< chars * 2)
+        // Each phase reports what its own prepared scripts hold, so the two are independent statements
+        // rather than a difference of two whole-process heap sizes — see MeasurePreparedHeap.
+        var sourceBytes = (long) count * commentChars * 2; // UTF-16
         var actualSavings = retained - notRetained;
-        actualSavings.Should().BeGreaterThan(minimumSavings, $"""
+
+        // The retaining variant keeps the source text: it must hold most of it.
+        retained.Should().BeGreaterThan(sourceBytes / 2, $"""
+                          RetainFunctionSourceText did not keep the source text alive, so this test is
+                          no longer measuring what it claims to measure.
+                          Retained  : {BytesToString(retained)}
+                          Source    : {BytesToString(sourceBytes)}
+                          """);
+
+        // The default must keep the ASTs and essentially nothing else.
+        notRetained.Should().BeLessThan(sourceBytes / 4, $"""
+                          The default retained a substantial share of the source text.
+                          Not retained : {BytesToString(notRetained)}
+                          Source       : {BytesToString(sourceBytes)}
+                          """);
+
+        actualSavings.Should().BeGreaterThan(sourceBytes / 2, $"""
                           Disabling RetainFunctionSourceText did not free the expected source text.
                           Retained     : {BytesToString(retained)}
                           Not retained : {BytesToString(notRetained)}
                           Savings      : {BytesToString(actualSavings)}
-                          Expected     : > {BytesToString(minimumSavings)}
+                          Expected     : > {BytesToString(sourceBytes / 2)}
                           """);
 
         static long MeasurePreparedHeap(int count, int commentChars, bool retainSourceText)
@@ -88,6 +105,15 @@ public class GarbageCollectionTests
             {
                 ParsingOptions = new ScriptParsingOptions { RetainFunctionSourceText = retainSourceText },
             };
+
+            // Measured against a baseline taken inside the phase rather than as an absolute heap size.
+            // The two phases run back to back in one process, so an absolute reading makes the second
+            // one carry whatever the first left behind and the difference under-reports the saving by
+            // exactly that much. That is how this failed on a macOS runner reporting 8.1 MB of a ~20 MB
+            // theoretical saving while Windows reported 19.2 MB on the same commit. A per-phase baseline
+            // cancels the residue instead of racing it, and makes each phase's number mean something on
+            // its own: ~20.0 MB held with retention on, ~0.8 MB with it off.
+            var baseline = CurrentlyUsedMemory();
 
             var prepared = new List<Prepared<Script>>(count);
             for (var i = 0; i < count; i++)
@@ -99,7 +125,7 @@ public class GarbageCollectionTests
 
             var used = CurrentlyUsedMemory();
             GC.KeepAlive(prepared);
-            return used;
+            return used - baseline;
         }
 
         static string BuildLargeScript(int seed, int commentChars)


### PR DESCRIPTION
`PreparedScriptsDoNotRetainSourceTextByDefault` failed on the macOS leg of #3425 with

```
Expected actualSavings to be greater than 10000000L because Disabling RetainFunctionSourceText did not free the expected source text.
Expected     : >    9.5 MB, but found 8102296L (difference of -1897704).
```

on a commit that touches interop and nothing anywhere near prepared scripts. That is the signature of a measurement problem, so this is the measurement.

## What was wrong

`MeasurePreparedHeap` returned an **absolute** `GC.GetTotalMemory` reading, and the test subtracted one phase's absolute from the other's. The two phases run back to back in one process, so anything the first phase leaves behind is still counted in the second phase's absolute, and the difference under-reports the saving by exactly that much. The test was measuring *the saving minus the residue* and calling the result the saving.

Instrumented on Windows / net10.0, three consecutive runs:

| phase | absolute |
| --- | --- |
| `retain=True` | 36,300,024 |
| `retain=False` | 17,097,952 |

→ 19.2 MB of saving against a theoretical `25 * 400,000 * 2` = 20 MB. macOS reported **8.1 MB of the same 20 MB**, i.e. roughly 12 MB of residue — not a regression in retention.

## What changed

Each phase now takes its own baseline immediately before it allocates and returns what *its* prepared scripts hold, so residue appears in both the baseline and the reading and cancels. The same three runs then give:

| phase | held | expected |
| --- | --- | --- |
| `retain=True` | 20,040,280 | 20,000,000 of source text |
| `retain=False` | 837,400 | the ASTs — stable to the byte across runs |

which is what the test claims to be measuring.

Because each number now means something on its own, the assertion says so instead of resting on one subtraction:

- the retaining variant must hold **more than half** the source text — otherwise the test is no longer measuring retention at all, and would pass vacuously if retention silently stopped working;
- the default must hold **less than a quarter** of it — this is the #2560 invariant stated directly;
- the saving must still exceed half.

All three have roughly 2× headroom locally on net472, net8.0 and net10.0; the whole `GarbageCollectionTests` fixture is green on all three.

## Honest limits

The residue explanation is inferred from the Windows numbers and the structure of the measurement. I did not reproduce it on macOS — I do not have a macOS runner — so what this PR guarantees is that the two phases are no longer coupled, not that macOS's 12 MB is now accounted for line by line. If it recurs after this, the next reading will at least say which phase moved.

No production code changes.