### PR TITLE
Tests: the concurrency fixture gets the same regex wedge ceiling the SunSpider one already has

### DIFF
--- a/Jint.Tests.CommonScripts/ConcurrencyTest.cs
+++ b/Jint.Tests.CommonScripts/ConcurrencyTest.cs
@@ -11,7 +11,11 @@ public class ConcurrencyTest
 
         Parallel.ForEach(Enumerable.Range(0, 3), x =>
         {
-            new Engine()
+            // Same wedge ceiling as SunSpiderTests, and this fixture needs it more: it runs three engines
+            // over babel-standalone.js at once, and ParallelScope.Fixtures puts them alongside that
+            // fixture's twenty-eight. The engine's ten-second default was sized for one script on one
+            // machine, and a starved matcher reaches it long before a catastrophic pattern would.
+            new Engine(options => options.Constraints.RegexTimeout = SunSpiderTests.RegexWedgeCeiling)
                 .SetValue("assert", new Action<bool, string>((condition, message)=> { }))
                 .Evaluate(script);
         });

--- a/Jint.Tests.CommonScripts/SunSpiderTests.cs
+++ b/Jint.Tests.CommonScripts/SunSpiderTests.cs
@@ -7,10 +7,10 @@ namespace Jint.Tests.CommonScripts;
 public class SunSpiderTests
 {
     /// <summary>
-    /// What a single regular-expression match in these scripts is given.
+    /// What a single regular-expression match in this project's scripts is given, in either fixture.
     /// </summary>
     /// <remarks>
-    /// Nothing in this suite asserts anything about <c>Options.Constraints.RegexTimeout</c>; every test here
+    /// Nothing in this project asserts anything about <c>Options.Constraints.RegexTimeout</c>; every test here
     /// asserts that a real-world script produces the right answer. The engine's ten-second default is
     /// therefore a wedge ceiling, and it was one sized for a machine running a single script: this fixture is
     /// <c>[Parallelizable(ParallelScope.All)]</c>, so twenty-eight CPU-bound workloads share whatever cores
@@ -20,7 +20,7 @@ public class SunSpiderTests
     /// and a catastrophic one reported after a minute is still reported. It stays finite deliberately:
     /// <c>Regex.InfiniteMatchTimeout</c> would turn that failure into a hung run.
     /// </remarks>
-    private static readonly TimeSpan RegexWedgeCeiling = TimeSpan.FromMinutes(1);
+    internal static readonly TimeSpan RegexWedgeCeiling = TimeSpan.FromMinutes(1);
 
     private static void RunTest(string source)
     {


### PR DESCRIPTION
A docs-only PR (#3433) failed on the Windows leg with

```
System.AggregateException : One or more errors occurred. (The Regex engine has timed out while trying to match a pattern to an input string. ...)
   at assertVersion (<anonymous>:68285:11)
```

A pull request that changes two markdown files cannot break a regular expression, so this is CI noise — and it is the noise #3358 already diagnosed and fixed, in one of the two fixtures that needed it.

## What #3358 established

`SunSpiderTests` is `[Parallelizable(ParallelScope.All)]`, so twenty-eight CPU-bound scripts share whatever cores the runner has. A Windows leg was measured at **7 m 19 s** for the twenty-eight against ~20 s unloaded, with `RegexMatchTimeoutException` as the only symptom. The engine's ten-second default was sized for one script on one machine; a starved matcher reaches it long before a catastrophic pattern would. So that fixture got a one-minute wedge ceiling — finite on purpose, because `Regex.InfiniteMatchTimeout` turns the failure into a hung run.

## What it missed

`ConcurrencyTest.ConcurrentEnginesCanUseSameAst` constructs its engines with a bare `new Engine()`, so it kept the ten-second default. It needs the ceiling **more** than the fixture that got it:

- it runs `babel-standalone.js` — the largest script in the project — through `Parallel.ForEach` over three engines at once, and
- it is `[Parallelizable(ParallelScope.Fixtures)]`, so those three run *alongside* SunSpider's twenty-eight.

The stack confirms which test it was: `assertVersion` at `<anonymous>:68285` is babel-standalone, and the exception arrives wrapped in the `AggregateException` that only `Parallel.ForEach` produces.

## The change

`RegexWedgeCeiling` becomes `internal` and `ConcurrencyTest` uses it, so there is one number and one rationale rather than two that can drift. Its doc comment now says it governs the project rather than the one fixture.

Green locally on net472 and net10.0. No production code changes, and nothing here asserts anything about `Options.Constraints.RegexTimeout` — every test in this project asserts that a real-world script produces the right answer.
