### PR TITLE
Engine: a host can read back the configuration of an engine it was handed

### DIFF
--- a/Jint.Tests.PublicInterface/HostEngineConfigurationTests.cs
+++ b/Jint.Tests.PublicInterface/HostEngineConfigurationTests.cs
@@ -1,0 +1,253 @@
+#nullable enable
+
+using System.Globalization;
+using Jint.Constraints;
+using Jint.Runtime.Modules;
+#if NET8_0_OR_GREATER
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Jint.WebApi;
+#endif
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// A host can read back the configuration of an engine it was handed.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>Engine.Options</c> was internal through 4.16.x, so a component given nothing but an <see cref="Engine"/>
+/// had no supported way to answer "what is this engine allowed to do". The options are frozen once an engine
+/// has read them, so handing the instance back is a read and nothing else.
+/// </para>
+/// <para>
+/// This project has no <c>InternalsVisibleTo</c>, so everything asserted here is reachable by a third party.
+/// </para>
+/// </remarks>
+public class HostEngineConfigurationTests
+{
+    [Test]
+    public void AHostReadsBackWhatItConfigured()
+    {
+        var loader = new StubModuleLoader();
+        var limits = new ResultLimits(maxDepth: 7);
+
+        var options = new Options();
+        options.Strict = true;
+        options.Culture = CultureInfo.InvariantCulture;
+        options.TimeZone = TimeZoneInfo.Utc;
+        options.ResultLimits = limits;
+        options.Constraints.MaxRecursionDepth = 12;
+        options.Interop.Enabled = true;
+        options.Interop.AllowWrite = true;
+        options.Json.MaxParseDepth = 9;
+        options.UseModules(loader);
+        options.AddImmutableCrossing(typeof(Version));
+
+        var engine = new Engine(options);
+
+        engine.Options.Strict.Should().BeTrue();
+        engine.Options.Culture.Should().BeSameAs(CultureInfo.InvariantCulture);
+        engine.Options.TimeZone.Should().Be(TimeZoneInfo.Utc);
+        engine.Options.ResultLimits.Should().BeSameAs(limits);
+        engine.Options.Constraints.MaxRecursionDepth.Should().Be(12);
+        engine.Options.Interop.Enabled.Should().BeTrue();
+        engine.Options.Interop.AllowWrite.Should().BeTrue();
+        engine.Options.Json.MaxParseDepth.Should().Be(9);
+        engine.Options.Modules.ModuleLoader.Should().BeSameAs(loader);
+        engine.Options.Interop.ImmutableCrossingTypes.Should().ContainSingle().Which.Should().Be(typeof(Version));
+    }
+
+    /// <summary>
+    /// The engine keeps the caller's own instance rather than a copy, which is what makes reading it back the
+    /// same answer as reading the object the host still holds.
+    /// </summary>
+    [Test]
+    public void TheEngineHandsBackTheInstanceItWasBuiltFrom()
+    {
+        var options = new Options();
+        var engine = new Engine(options);
+
+        engine.Options.Should().BeSameAs(options);
+        engine.Options.IsReadOnly.Should().BeTrue();
+    }
+
+    [Test]
+    public void AConfigurationCallbackIsVisibleOnTheEngineItConfigured()
+    {
+        var engine = new Engine(options => options.Constraints.MaxArraySize = 1234);
+
+        engine.Options.Constraints.MaxArraySize.Should().Be(1234u);
+    }
+
+    [Test]
+    public void ASetterOnAReadBackInstanceThrows()
+    {
+        var engine = new Engine();
+
+        Invoking(() => engine.Options.Strict = true)
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage("Options.Strict cannot be changed*");
+
+        Invoking(() => engine.Options.Interop.AllowWrite = true)
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage("Options.Interop.AllowWrite cannot be changed*");
+
+        // Including the half of the configuration that grows.
+        Invoking(() => engine.Options.Interop.AllowedAssemblies.Add(typeof(string).Assembly))
+            .Should().Throw<InvalidOperationException>();
+        Invoking(() => engine.Options.AddLazyGlobal("x", static _ => Native.JsValue.Undefined))
+            .Should().Throw<InvalidOperationException>();
+    }
+
+    /// <summary>
+    /// Two engines built with a callback each configure their own instance, so what one is allowed to do says
+    /// nothing about what the other is.
+    /// </summary>
+    [Test]
+    public void TwoEnginesConfiguredByCallbackDoNotShareOneConfiguration()
+    {
+        var first = new Engine(options => options.Interop.Enabled = true);
+        var second = new Engine(options => options.Strict = true);
+
+        first.Options.Should().NotBeSameAs(second.Options);
+        first.Options.Interop.Enabled.Should().BeTrue();
+        first.Options.Strict.Should().BeFalse();
+        second.Options.Interop.Enabled.Should().BeFalse();
+        second.Options.Strict.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// <c>new Engine()</c> reads one process-wide instance of the defaults, which is now something a host can
+    /// see rather than something it has to infer.
+    /// </summary>
+    /// <remarks>
+    /// It is the sharing behind the cross-tenant leak in #3331. What that issue's fix closed is the writing —
+    /// the one door that configures a live engine takes it a copy of its own first — and not the sharing,
+    /// which carries nothing tenant-specific: the instance is frozen by the first engine built from it and
+    /// every setting on it is a default.
+    /// </remarks>
+    [Test]
+    public void TwoDefaultBuiltEnginesReadBackOneSharedConfigurationOfDefaults()
+    {
+        var first = new Engine();
+        var second = new Engine();
+
+        first.Options.Should().BeSameAs(second.Options);
+        first.Options.IsReadOnly.Should().BeTrue();
+        first.Options.Interop.Enabled.Should().BeFalse();
+        first.Options.Strict.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// A hardened engine keeps a private copy, so reading it back answers what the engine runs under rather
+    /// than what the host declared.
+    /// </summary>
+    [Test]
+    public void AnUntrustedProfileReadsBackAsTheEnginesOwnHardenedCopy()
+    {
+        var options = new Options();
+        options.Interop.Enabled = true;
+        options.ForUntrustedCode(new UntrustedCodeLimits(
+            timeoutInterval: TimeSpan.FromSeconds(5),
+            maxStatements: 500,
+            memoryLimit: 16_000_000,
+            maxRecursionDepth: 64,
+            maxArraySize: 10_000,
+            regexTimeout: TimeSpan.FromMilliseconds(100),
+            promiseTimeout: TimeSpan.FromMilliseconds(100),
+            maxOperationDuration: TimeSpan.FromSeconds(10)));
+
+        var engine = new Engine(options);
+
+        engine.Options.Should().NotBeSameAs(options);
+
+        // The grant the host declared is revoked on the engine's copy, and left alone on the host's.
+        engine.Options.Interop.Enabled.Should().BeFalse();
+        options.Interop.Enabled.Should().BeTrue();
+
+        // ... and what the profile imposed is readable, rather than only observable by tripping it.
+        engine.Options.Constraints.MaxRecursionDepth.Should().Be(64);
+        engine.Options.Constraints.MaxArraySize.Should().Be(10_000u);
+        engine.Options.Host.StringCompilationAllowed.Should().BeFalse();
+
+        // The copy is frozen too.
+        engine.Options.IsReadOnly.Should().BeTrue();
+        Invoking(() => engine.Options.Interop.Enabled = true).Should().Throw<InvalidOperationException>();
+    }
+
+    /// <summary>
+    /// A constraint reads back from where it was registered: an instance from the configuration, a factory
+    /// registration only from the engine that built one.
+    /// </summary>
+    [Test]
+    public void AConstraintReadsBackFromWhereItWasRegistered()
+    {
+        var instance = new NoopConstraint();
+
+        var options = new Options();
+        options.AddConstraint(instance);
+        options.LimitStatements(1000);
+
+        var engine = new Engine(options);
+
+        engine.Options.Constraints.Constraints.Should().ContainSingle().Which.Should().BeSameAs(instance);
+
+        // The budget was registered as a factory, so the instance enforcing it is the engine's own and the
+        // configuration never held one. engine.Constraints.Find<T>() is what answers for the live set, and
+        // the two questions stay different questions.
+        engine.Constraints.Find<MaxStatementsConstraint>().Should().NotBeNull();
+    }
+
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// The shape of #3331, read back rather than inferred: a live web-API configuration lands on the engine
+    /// that asked for it, and the sibling sharing the defaults is untouched.
+    /// </summary>
+    [Test]
+    public void ALiveWebApiConfigurationIsReadBackOnTheEngineThatAskedForItAndNoOther()
+    {
+        var tenant = new Engine();
+        var other = new Engine();
+
+        // They start out reading one instance...
+        tenant.Options.Should().BeSameAs(other.Options);
+
+        var client = new HttpClient(new StubHandler());
+        tenant.WebApi.Enable(WebApiFeatures.Fetch, webApi => webApi.Fetch.HttpClient = client);
+
+        // ... and the engine that was configured took a copy of its own.
+        tenant.Options.Should().NotBeSameAs(other.Options);
+        tenant.Options.WebApi.Fetch.HttpClient.Should().BeSameAs(client);
+        other.Options.WebApi.Fetch.HttpClient.Should().BeNull();
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+    }
+#endif
+
+    private sealed class NoopConstraint : Constraint
+    {
+        public override void Check()
+        {
+        }
+
+        public override void Reset()
+        {
+        }
+    }
+
+    private sealed class StubModuleLoader : IModuleLoader
+    {
+        public ResolvedSpecifier Resolve(string? referencingModuleLocation, ModuleRequest moduleRequest)
+            => throw new NotSupportedException();
+
+        public ModuleRecord LoadModule(Engine engine, ResolvedSpecifier resolved)
+            => throw new NotSupportedException();
+    }
+}

--- a/Jint.Tests.PublicInterface/HostOptionsReadOnlyTests.cs
+++ b/Jint.Tests.PublicInterface/HostOptionsReadOnlyTests.cs
@@ -189,6 +189,8 @@ public class HostOptionsReadOnlyTests
             { "CatchClrExceptions", static o => o.CatchClrExceptions() },
             { "ExposeDetailedErrors", static o => o.ExposeDetailedErrors() },
             { "ForUntrustedCode", static o => o.ForUntrustedCode(CreateLimits()) },
+            { "UseNodeBuiltinModules", static o => o.UseNodeBuiltinModules() },
+            { "UseNodeProcess", static o => o.UseNodeProcess() },
         };
 
 #if NET8_0_OR_GREATER
@@ -257,6 +259,12 @@ public class HostOptionsReadOnlyTests
         // The profile revoked the CLR grant on the engine's own copy, and left the caller's reading alone.
         engine.Evaluate("typeof importNamespace").AsString().Should().Be("undefined");
         options.Interop.Enabled.Should().BeTrue();
+
+        // The same thing said of the configuration rather than of its effect, which is only sayable because
+        // the engine hands its own copy back.
+        engine.Options.Should().NotBeSameAs(options);
+        engine.Options.Interop.Enabled.Should().BeFalse();
+        engine.Options.IsReadOnly.Should().BeTrue();
 
         // ... and the budget it registered is the engine's, not a value nobody enforces.
         Invoking(() => engine.Execute("for (let i = 0; i < 1000000; i++) {}"))

--- a/Jint.Tests.PublicInterface/HostOptionsShapeTests.cs
+++ b/Jint.Tests.PublicInterface/HostOptionsShapeTests.cs
@@ -54,6 +54,40 @@ public class HostOptionsShapeTests
         }
     }
 
+    /// <summary>
+    /// The clock is the one member on <see cref="Options"/> that memoizes into a backing field on read, so
+    /// the freeze resolves it: otherwise reading a frozen configuration would write to it, and threads
+    /// reading it would race for which clock the engines built from it get.
+    /// </summary>
+    [Test]
+    public async Task AFrozenConfigurationHasOneClockHoweverManyThreadsReadIt()
+    {
+        for (var attempt = 0; attempt < 300; attempt++)
+        {
+            var options = new Options();
+            options.MakeReadOnly();
+
+            using var start = new ManualResetEventSlim(false);
+            var seen = new ITimeSystem[8];
+
+            var readers = new Task[seen.Length];
+            for (var i = 0; i < readers.Length; i++)
+            {
+                var slot = i;
+                readers[slot] = Task.Run(() =>
+                {
+                    start.Wait();
+                    seen[slot] = options.TimeSystem;
+                });
+            }
+
+            start.Set();
+            await Task.WhenAll(readers);
+
+            seen.Should().OnlyContain(x => ReferenceEquals(x, options.TimeSystem));
+        }
+    }
+
     [Test]
     public void TheJsonGroupIsConfiguredThroughItsMembers()
     {

--- a/Jint.Tests.PublicInterface/HostWebApiOptionsIsolationTests.cs
+++ b/Jint.Tests.PublicInterface/HostWebApiOptionsIsolationTests.cs
@@ -23,9 +23,11 @@ namespace Jint.Tests.PublicInterface;
 /// both directions in time.
 /// </para>
 /// <para>
-/// This project has no <c>InternalsVisibleTo</c>, so every assertion here is one an embedder could write:
-/// the leak is observed through what a <i>second</i> engine's script does, not by reading the options back.
-/// Nothing opens a socket — each engine that fetches is given a handler that answers from memory.
+/// This project has no <c>InternalsVisibleTo</c>, so every assertion here is one an embedder could write.
+/// Each case observes the leak through what a <i>second</i> engine's script does, which is the assertion
+/// that still means something if the settings ever stop being read where they are read now; where reading
+/// the configuration back says more, <see cref="HostEngineConfigurationTests"/> says it. Nothing opens a
+/// socket — each engine that fetches is given a handler that answers from memory.
 /// </para>
 /// </remarks>
 public class HostWebApiOptionsIsolationTests
@@ -130,6 +132,12 @@ public class HostWebApiOptionsIsolationTests
             .UnwrapIfPromise().AsString().Should().Be("200");
 
         tenantHandler.Urls.Should().BeEmpty();
+
+        // The same statement about the configuration rather than about its effect: each engine took a copy of
+        // the subtree, and the instance the host still holds was written to by neither.
+        tenant.Options.Should().NotBeSameAs(other.Options);
+        tenant.Options.WebApi.Fetch.UrlFilter.Should().NotBeSameAs(other.Options.WebApi.Fetch.UrlFilter);
+        options.WebApi.Fetch.HttpClient.Should().BeNull();
     }
 
     /// <summary>

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
@@ -35,6 +35,7 @@ namespace Jint
         public object? HostDefined { get; set; }
         public Jint.Runtime.Intrinsics Intrinsics { get; }
         public Jint.Engine.ModuleOperations Modules { get; }
+        public Jint.Options Options { get; }
         public Jint.Engine.TaskOperations Tasks { get; }
         public Jint.Runtime.Interop.ClrTypeConverter TypeConverter { get; }
         public Jint.Engine.WebApiOperations WebApi { get; }

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net472.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net472.verified.txt
@@ -35,6 +35,7 @@ namespace Jint
         public object? HostDefined { get; set; }
         public Jint.Runtime.Intrinsics Intrinsics { get; }
         public Jint.Engine.ModuleOperations Modules { get; }
+        public Jint.Options Options { get; }
         public Jint.Engine.TaskOperations Tasks { get; }
         public Jint.Runtime.Interop.ClrTypeConverter TypeConverter { get; }
         public void AddLazyGlobal(string name, System.Func<Jint.Engine, Jint.Native.JsValue> valueFactory, Jint.Runtime.Descriptors.PropertyFlag flags = 21) { }

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
@@ -35,6 +35,7 @@ namespace Jint
         public object? HostDefined { get; set; }
         public Jint.Runtime.Intrinsics Intrinsics { get; }
         public Jint.Engine.ModuleOperations Modules { get; }
+        public Jint.Options Options { get; }
         public Jint.Engine.TaskOperations Tasks { get; }
         public Jint.Runtime.Interop.ClrTypeConverter TypeConverter { get; }
         public Jint.Engine.WebApiOperations WebApi { get; }

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.0.verified.txt
@@ -35,6 +35,7 @@ namespace Jint
         public object? HostDefined { get; set; }
         public Jint.Runtime.Intrinsics Intrinsics { get; }
         public Jint.Engine.ModuleOperations Modules { get; }
+        public Jint.Options Options { get; }
         public Jint.Engine.TaskOperations Tasks { get; }
         public Jint.Runtime.Interop.ClrTypeConverter TypeConverter { get; }
         public void AddLazyGlobal(string name, System.Func<Jint.Engine, Jint.Native.JsValue> valueFactory, Jint.Runtime.Descriptors.PropertyFlag flags = 21) { }

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.1.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.1.verified.txt
@@ -35,6 +35,7 @@ namespace Jint
         public object? HostDefined { get; set; }
         public Jint.Runtime.Intrinsics Intrinsics { get; }
         public Jint.Engine.ModuleOperations Modules { get; }
+        public Jint.Options Options { get; }
         public Jint.Engine.TaskOperations Tasks { get; }
         public Jint.Runtime.Interop.ClrTypeConverter TypeConverter { get; }
         public void AddLazyGlobal(string name, System.Func<Jint.Engine, Jint.Native.JsValue> valueFactory, Jint.Runtime.Descriptors.PropertyFlag flags = 21) { }

--- a/Jint/AGENTS.md
+++ b/Jint/AGENTS.md
@@ -75,9 +75,13 @@ untrusted-code profile's private snapshot from sharing state with the host's opt
 with `MakeReadOnly()`, which cascades to every group and registry; a group materialized later is born frozen,
 which is why `Materialize` takes the owner's state. So a new setting needs `ThrowIfReadOnly()` in its setter
 (`[CallerMemberName]` names it), a new registry is an `OptionsList<T>` rather than a `List<T>`, and a new
-group implements `IOptionsGroup` and joins the two cascades in `Options.ReadOnly.cs`. Nothing Jint writes to
-`Options` may happen after that line — the profile re-expansion and the host's `Configure` callbacks both run
-inside `Options.Apply`, well before it. The one sanctioned post-construction write is
+group implements `IOptionsGroup` and joins the two cascades in `Options.ReadOnly.cs`. A setting that
+*memoizes on read* resolves in `SetReadOnly` as well, ahead of the flag — `Engine.Options` hands the frozen
+instance to a host, so reading one of its members must never be a write to it (`Options.TimeSystem` was, and
+two threads reading it got a clock each); and a public method that writes a bare field rather than a guarded
+property refuses through a door of its own (`Options.SetNodeBuiltinModules`), or it is the one write nothing
+stops. Nothing Jint writes to `Options` may happen after that line — the profile re-expansion and the host's
+`Configure` callbacks both run inside `Options.Apply`, well before it. The one sanctioned post-construction write is
 `Engine.WebApi.Enable`'s callback, and it writes to a copy of the web-API subtree the engine takes for itself
 first (`Engine.TakePrivateWebApiOptions`) — an `Options` is shareable, and for `new Engine()` it is one Jint
 keeps process-wide, so a per-tenant client set there used to reach every default-built engine. The copy stays
@@ -112,6 +116,7 @@ being detailed. A compiler cannot find those, so the guide is the only place an 
 | `GlobalSnapshot` + `Engine.Advanced.CaptureGlobalSnapshot` / `RestoreGlobalSnapshot` / `WithRestoredGlobals` | `Jint/Engine.GlobalSnapshot.cs` |
 | `ResultLimits` + `ResultLimit` + `ResultLimitExceededException` + `Engine.ConvertResult` + bounded `JsonSerializer` / `JavaScriptException.GetJavaScriptErrorString` overloads | `Jint/ResultLimits.cs`, `Jint/Runtime/ResultLimitExceededException.cs`, `Jint/Engine.cs`, `Jint/Native/Json/JsonSerializer.cs`, `Jint/Runtime/JavaScriptException.cs` |
 | The `*Async` failure channel — which of the two ways out of an `*Async` entry a given failure takes | `Jint/Engine.Async.cs`, `Jint/Engine.Modules.cs`, `Jint/Engine.Pump.cs` |
+| `Engine.Options` — the frozen configuration the engine actually runs under, which for a hardened profile is the engine's private clone rather than the instance the host handed in, and which `Engine.WebApi.Enable` replaces with a copy of its own | `Jint/Engine.cs`, `Jint.Tests.PublicInterface/HostEngineConfigurationTests.cs` |
 | A `string` reaching an invocation entry — `Engine.Invoke`/`InvokeAsync` name **one property of the global object**, by that literal name, and nothing on `Engine` parses a name as source. `Call(string)`/`Construct(string)` did, and were deleted for it (#3289) | `Jint/Engine.cs`, `Jint.Tests.PublicInterface/HostCallableResolutionTests.cs` |
 
 **Five areas keep their own rows beside the code they govern**, on exactly these terms — the same rule, the

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -1821,7 +1821,29 @@ public sealed partial class Engine : IDisposable
 
     internal long CurrentMemoryUsage { get; private set; }
 
-    internal Options Options
+    /// <summary>
+    /// Gets the configuration this engine was built from, frozen: every setter on it throws.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// It is the instance the host handed to <see cref="Engine(Options)"/>, so engines built from one
+    /// <see cref="Options"/> read back one object, and <c>new Engine()</c> reads back a process-wide default.
+    /// </para>
+    /// <para>
+    /// An engine built through <see cref="OptionsExtensions.ForUntrustedCode"/> keeps a private hardened
+    /// copy, so this answers what the engine actually runs under rather than what the host declared.
+    /// </para>
+    /// <para>
+    /// <c>Engine.WebApi.Enable</c> replaces it with a copy owning its own web-API subtree, so read it again
+    /// after that call rather than caching the reference across one.
+    /// </para>
+    /// <para>
+    /// The freeze covers the settings, not the objects they name: a
+    /// <see cref="Jint.Runtime.Interop.TypeResolver"/>, a module loader or an <c>HttpClient</c> read back
+    /// here is still the host's own mutable object.
+    /// </para>
+    /// </remarks>
+    public Options Options
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get;

--- a/Jint/NodeCompat/NodeBuiltinModuleOptionsExtensions.cs
+++ b/Jint/NodeCompat/NodeBuiltinModuleOptionsExtensions.cs
@@ -76,8 +76,10 @@ public static class NodeBuiltinModuleOptionsExtensions
         configure?.Invoke(moduleOptions);
 
         // Snapshotted here rather than at engine build: the host owns what it configured and may go on
-        // changing it, and Options is meant to be shared by concurrently constructed engines.
-        options._nodeBuiltinModules = NodeBuiltinModuleConfiguration.Snapshot(moduleOptions);
+        // changing it, and Options is meant to be shared by concurrently constructed engines. Through the
+        // door on Options rather than the field, so that this refuses on a frozen instance the way every
+        // other registration does - a bare field assignment was the one public write that did not.
+        options.SetNodeBuiltinModules(NodeBuiltinModuleConfiguration.Snapshot(moduleOptions));
         return options;
     }
 }

--- a/Jint/Options.NodeCompat.cs
+++ b/Jint/Options.NodeCompat.cs
@@ -1,4 +1,6 @@
+using System.Runtime.CompilerServices;
 using Jint.NodeCompat;
+using Jint.Runtime;
 
 namespace Jint;
 
@@ -18,4 +20,23 @@ public sealed partial class Options
     /// <c>UseModules</c> stops mattering.
     /// </remarks>
     internal NodeBuiltinModuleConfiguration? _nodeBuiltinModules;
+
+    /// <summary>
+    /// The one door onto <see cref="_nodeBuiltinModules"/>, so that <c>UseNodeBuiltinModules</c> refuses after
+    /// the freeze exactly as an assignment does.
+    /// </summary>
+    /// <param name="configuration">The snapshot of what the host configured.</param>
+    /// <param name="verb">
+    /// Filled in by the compiler with the extension method the host actually called, so that the refusal names
+    /// that rather than this private door.
+    /// </param>
+    internal void SetNodeBuiltinModules(NodeBuiltinModuleConfiguration configuration, [CallerMemberName] string? verb = null)
+    {
+        if (_readOnly)
+        {
+            Throw.OptionsReadOnlyCall("Options." + verb);
+        }
+
+        _nodeBuiltinModules = configuration;
+    }
 }

--- a/Jint/Options.ReadOnly.cs
+++ b/Jint/Options.ReadOnly.cs
@@ -50,8 +50,20 @@ public sealed partial class Options
     /// Cascades the read-only state to every materialized group. Thawing is used in exactly one place —
     /// <see cref="CreateEngineOptions"/>, whose private clone has to be hardened before the engine reads it.
     /// </summary>
+    /// <remarks>
+    /// Freezing resolves <see cref="TimeSystem"/> first. It is the one member that memoizes into a backing
+    /// field on read, so leaving it unresolved would make reading a frozen <see cref="Options"/> a write to
+    /// it — benign while the value is equal by construction, and not something a readable
+    /// <see cref="Engine.Options"/> should rest on. Every other lazy member is a group, and
+    /// <see cref="Materialize{T}"/> already publishes those with the owner's frozen state.
+    /// </remarks>
     internal void SetReadOnly(bool value)
     {
+        if (value)
+        {
+            _ = TimeSystem;
+        }
+
         _readOnly = value;
         SetReadOnly(_constraints, value);
         SetReadOnly(_parsing, value);

--- a/Jint/Options.WebApi.cs
+++ b/Jint/Options.WebApi.cs
@@ -50,9 +50,10 @@ public sealed partial class Options
     {
         var clone = (Options) MemberwiseClone();
 
-        // TimeSystem materializes inside its own getter, so a null field here would let the copy and the
-        // original each build one and hand two engines two different clocks. Reading it materializes the
-        // original's and MemberwiseClone has already shared whatever that produced.
+        // TimeSystem memoizes inside its own getter, so a null field here would let the copy and the
+        // original each build one and hand two engines two different clocks. Freezing resolves it and this
+        // only ever runs on an engine's own frozen options, so the read is a read; it stays because the
+        // invariant is the copy's, not the freeze's.
         clone._timeSystem = TimeSystem;
 
         var webApi = _webApi?.Clone();

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -199,11 +199,31 @@ public sealed partial class Options
     public CultureInfo Culture { get; set { ThrowIfReadOnly(); field = value; } } = _defaultCulture;
 
     /// <summary>
-    /// Configures a time system to use. Defaults to DefaultTimeSystem using local time.
+    /// Gets or sets the clock and date parser the engine runs on. Defaults to a
+    /// <see cref="DefaultTimeSystem"/> over <see cref="TimeZone"/> and <see cref="Culture"/>.
     /// </summary>
+    /// <remarks>
+    /// The default is built from <see cref="TimeZone"/> and <see cref="Culture"/> as they stand when it is
+    /// first read, or when <see cref="MakeReadOnly"/> freezes these options, whichever comes first. Setting
+    /// either afterwards does not rebuild it.
+    /// </remarks>
     public ITimeSystem TimeSystem
     {
-        get => _timeSystem ??= new DefaultTimeSystem(TimeZone, Culture);
+        get
+        {
+            var timeSystem = _timeSystem;
+            if (timeSystem is not null)
+            {
+                return timeSystem;
+            }
+
+            // Never reached on a frozen instance: MakeReadOnly resolves the field before it sets the flag, so
+            // that reading a member of a frozen Options is not a write to it. Interlocked for the same reason
+            // Materialize is - Options is documented as shareable between engines being constructed
+            // concurrently, and two racing builds must see one clock rather than one each.
+            var created = new DefaultTimeSystem(TimeZone, Culture);
+            return Interlocked.CompareExchange(ref _timeSystem, created, null) ?? created;
+        }
         set
         {
             ThrowIfReadOnly();

--- a/README.md
+++ b/README.md
@@ -3002,7 +3002,9 @@ need host-specific review (for example a custom module loader); they remain in t
 `EnsureSecurityConfiguration` throw. Treat a validated `Options` as immutable and pass it directly to
 `Engine(Options)`. Public engine-construction callbacks registered by `Configure`, `SetTypeConverter`, or
 `UseHostFactory` produce `JINTSEC031`; inspect `engine.Diagnostics.ValidateSecurityConfiguration()` after
-construction to validate their final effects without replaying them. Custom constraint factories remain
+construction to validate their final effects without replaying them. `engine.Options` reads the settings
+themselves back — for an engine built with `ForUntrustedCode` that is the engine's own hardened copy rather
+than the instance you handed in, and every setter on it throws. Custom constraint factories remain
 supported under their existing contract and are invoked only by engine construction, never by diagnostics.
 
 | Codes | Coverage |

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -1794,6 +1794,44 @@ longer fires — catch `JavaScriptException`, or stop writing the expression tha
 `'s' + v` throwing as a type check has to test explicitly instead. Nothing changes for
 `AllowOperatorOverloading = false`, which took the concatenating path already.
 
+### 4.41 Two holes in the freeze, closed ([#3360](https://github.com/sebastienros/jint/issues/3360))
+
+[§4.16](#416-options-is-configuration-until-an-engine-reads-it-and-frozen-afterwards-3327) says an `Options`
+stops accepting changes once an engine has read it. Two things did not obey that, and both matter more now
+that [§5.7](#57-a-host-can-read-back-the-configuration-of-an-engine-it-was-handed-3360) hands the frozen
+instance to a host.
+
+**`UseNodeBuiltinModules` on a frozen `Options` used to succeed silently.** It was the only public
+configuration method that wrote a bare field rather than a guarded property, so it neither reached the engine
+that already existed nor said so — while still changing every engine built from that instance afterwards,
+including the process-wide instance behind `new Engine()`. It now throws
+`InvalidOperationException` reading `Options.UseNodeBuiltinModules cannot be called…`, exactly as
+`UseModules`, `AddLazyGlobal` and the rest already did.
+
+**`Options.TimeSystem` memoized after the freeze.** The default `ITimeSystem` — a `DefaultTimeSystem` over
+`Options.TimeZone` and `Options.Culture` — was built by the property's own getter and memoized into its
+backing field with a plain `??=`. The engine's first read of it comes from `DateConstructor`, which is built
+the first time a script touches `Date`, so the memoization landed *after* `MakeReadOnly`: reading a member of
+a frozen `Options` wrote to it, and threads racing that read could be handed a clock each.
+
+`MakeReadOnly()` now resolves it before it sets the flag, and the getter publishes with
+`Interlocked.CompareExchange` for the unfrozen case. A frozen `Options` therefore has exactly one clock, and
+reading it is a read — which is what makes §5.7 handing the instance back safe. Both instances were equal by
+construction, so what `Date`, `Temporal.Now` and `Intl.DateTimeFormat` answer is unchanged.
+
+**What could break:** code that called `UseNodeBuiltinModules` after building an engine now gets an exception
+where it used to get silence — move the call before the first `new Engine(options)`. And freezing an
+`Options`, which every engine build does, now allocates one `DefaultTimeSystem` even when nothing ever asks
+for the clock, once per instance rather than once per engine; the default is built from `TimeZone` and
+`Culture` as they stand at the freeze rather than at the first read, which on a frozen instance is the same
+pair. Assigning `TimeSystem = null` before the freeze still gets the default back on the next read, as before.
+
+**What is *not* closed, and is not a hole:** the freeze covers this object's settings, not the objects they
+name. A `TypeResolver` (whose `Default` is a process-wide singleton with unguarded `MemberFilter`), a
+`CultureInfo`, a module loader, an `HttpClient`, a storage or worker provider, and a `Constraint` instance the
+host registered are all still the host's own mutable objects, reachable exactly as they were before they were
+handed to Jint.
+
 ## 5. New in v5
 
 Everything in the table below is opt-in: nothing in it is installed unless the host asks for it, so
@@ -2108,6 +2146,41 @@ process that never set the switch.
 This is worth turning on precisely because the failure it catches is not local. An object built for an engine
 another thread is using does not fail where it was built; it fails later, somewhere else, as a torn shape
 table or a lost property, and the host sees a nondeterministic script result.
+
+### 5.7 A host can read back the configuration of an engine it was handed ([#3360](https://github.com/sebastienros/jint/issues/3360))
+
+`Engine.Options` was internal, so a component handed nothing but an `Engine` had no supported way to answer
+"what is this engine allowed to do". It is now a public get-only property returning the frozen instance.
+
+```csharp
+static void Audit(Engine engine)
+{
+    if (engine.Options.Interop.Enabled && engine.Options.Interop.AllowWrite)
+    {
+        throw new InvalidOperationException("this engine may write to host objects");
+    }
+}
+```
+
+What it answers is what the engine actually runs under, which is not always what the host declared:
+
+| built by | what `engine.Options` is |
+| --- | --- |
+| `new Engine(options)` | that very instance — reference-equal to the object the host still holds |
+| `new Engine(options => …)` | a fresh instance per engine, carrying what the callback wrote |
+| `new Engine()` | one process-wide instance of the defaults, shared by every engine built that way |
+| `options.ForUntrustedCode(…)` | the engine's **private hardened copy**, so the grants the profile revoked read back revoked while the host's own object still reads back as the host wrote it |
+
+`Engine.WebApi.Enable` replaces the instance with a copy owning its own web-API subtree
+([§4.21](#421-webapienables-callback-configures-one-engine-not-every-engine-3359)), so read the property again
+after that call rather than caching the reference across one.
+
+**It is a read, not a second configuration channel.** The options are frozen once an engine has read them
+([§4.16](#416-options-is-configuration-until-an-engine-reads-it-and-frozen-afterwards-3327)), so every setter
+and every registry reached through this property throws — including the two that used not to
+([§4.41](#441-two-holes-in-the-freeze-closed-3360)). What the freeze covers is the settings, not the objects
+they name: a `TypeResolver`, a `CultureInfo`, a module loader, a provider or an `HttpClient` read back here is
+still the host's own mutable object, exactly as it was before it was handed to Jint.
 
 ## 6. AOT and trimming
 


### PR DESCRIPTION
Closes #3360.

`Engine.Options` was internal, so a component handed nothing but an `Engine` had no supported way to answer *what is this engine allowed to do*. Two pieces of v5 work hit that separately: #3327's freeze tests had to assert behaviour rather than configuration, and #3359 found it was much of why the cross-tenant leak in #3331 was invisible — there was no supported way to see that two engines shared one `Options`, or that a live configure had landed on a sibling.

## The decision

**`Engine.Options` is public and get-only, returning the frozen instance.** Not a new `EngineConfigurationReport`.

The one-line diff in all five baselines:

```diff
+        public Jint.Options Options { get; }
```

Three reasons, in the order the issue asks them:

1. **The instance is genuinely immutable.** Since #3327 every setter throws once an engine has taken it, so handing it out no longer hands out a mutation channel. That was the only real objection before v5 — and this PR closes the two remaining holes in it (below).
2. **A narrower report would be a second vocabulary for the same facts.** `Options` already names every setting; a report would name a subset again, differently. #3309 and #3310 set the precedent against that.
3. **Exposing a registered delegate grants no capability the caller did not already have** — see the next section, which is where I tried hardest to find a counter-example.

What it answers is what the engine actually runs under, which is not always what the host declared:

| built by | what `engine.Options` is |
| --- | --- |
| `new Engine(options)` | that very instance |
| `new Engine(options => …)` | a fresh instance per engine |
| `new Engine()` | one process-wide instance of the defaults |
| `options.ForUntrustedCode(…)` | the engine's **private hardened copy** |

## Point 3, tested rather than assumed

I went through every reference-typed member reachable from the tree and asked whether a host holding only the `Engine` could already reach or invoke it. **No delegate is a counter-example.** Every one of the thirteen — `WrapObjectHandler`, `MemberAccessor`, `ExceptionHandler`, the two error decorators, `BuildCallStackHandler`, `SerializeToJson`, `CreateClrObject`, `CreateTypeReferenceObject`, `ObjectWrapperReportedPropertyKeys`, `FunctionToStringHandler`, `Fetch.UrlFilter`, `Fetch.HttpClientFactory` — runs on a script action the `Engine` holder can cause.

The nearest thing to a counter-example is not a delegate but a **capability object read back below the gate the engine applies around it**:

- `WebApi.Fetch.HttpClient` — `AllowedSchemes` and `UrlFilter` are enforced in `FetchOperation`/`FetchTransport`, not by the client, so the client used directly is unfiltered (and carries whatever `DefaultRequestHeaders` the host put on it).
- `WebApi.Workers.Provider` — `MaxWorkers` is enforced in `WorkerConstructor`, not by the provider.
- `WebApi.Storage.*Provider`, `Cache.Provider`, `Messaging.Broker`, `Console.Sink`, `Diagnostics.Sink` — live stores and egress, though script can reach each of them through the API they back, so those are strictly equal.

I do not think that changes the shape, for one reason that decides it: **every one of those gates bounds _script_, and the reader of `Engine.Options` is host CLR code, which they never bounded.** In-process CLR code could already read the internal property by reflection, mutate `TypeResolver.Default` (a `public static readonly` singleton), or simply `new HttpClient()`. `internal` was never a boundary here. If a reviewer disagrees, the narrowest change is to project `FetchOptions` rather than to abandon the shape.

## Two holes in the freeze, closed

Both are in `§4.41` of the migration guide, and both matter more once a host reads the instance back.

**`Options.TimeSystem` memoized after the freeze** (the issue's question 2). The default `ITimeSystem` was `_timeSystem ??= new DefaultTimeSystem(TimeZone, Culture)`, and the engine's first read of it comes from `DateConstructor`, built the first time a script touches `Date`. So the memoization landed *after* `MakeReadOnly`: reading a member of a frozen `Options` wrote to it, and threads racing that read got a clock each. `MakeReadOnly()` now resolves it before it sets the flag, and the getter publishes with `Interlocked.CompareExchange` for the unfrozen case.

**`UseNodeBuiltinModules` on a frozen `Options` succeeded silently.** Found by the audit below. It was the only public configuration method writing a bare field rather than a guarded property, so it neither reached the engine that already existed nor said so — while still changing every engine built from that instance afterwards, including the process-wide instance behind `new Engine()`. It now goes through a door on `Options` and throws like every other registration. Its sibling `UseNodeProcess` was already safe (it routes through `Configure`), and the new test row proves that too.

## The frozen-object audit

The freeze cascade itself is complete: all twelve group fields, all eight web-API sub-groups and all seven `OptionsList<T>` registries are reached, and all ~95 property setters call `ThrowIfReadOnly()` first. Beyond the two fixed above, what the audit turned up, none of it changed here:

| finding | verdict |
| --- | --- |
| A group materialized *concurrently with* the freeze can be published writable (`_readOnly` is read at the call site, and is non-volatile) | real, pre-existing, needs a host writing configuration during an engine build — filed as #3444 |
| `OptionsList<T>.Clone()` is born writable while its owning group's clone is born frozen | latent; both current callers compensate — filed as #3445 |
| `ConstraintFactories` is constructed with `Constraints`' name, so a refused `LimitStatements` names the wrong registry | filed as #3446 |
| `Options.Interop.TypeResolver` has three unguarded setters on a process-wide singleton | by design and already public as `TypeResolver.Default` |
| `Options.Constraints.Constraints` hands out the engine's live `Constraint` instances (`MaxStatementsConstraint.MaxStatements` is settable) | already reachable through `engine.Constraints.Find<T>()` |
| `Options.Culture` is a mutable `CultureInfo`, shared process-wide as the default | the host's own object |
| the web-API providers, sinks, brokers and `HttpClient` above | the host's own objects |
| `Options._configurations` is a raw `List<T>`, and three `internal static readonly string[]` | internal reach only; the public door (`AddConfiguration`) is guarded |

The rule this leaves behind is in `Jint/AGENTS.md` and in the guide: **the freeze covers this object's settings, not the objects they name.**

## One thing I could not write the test the issue implies

The brief asked for a test that two `new Engine()` instances do not share one `Options`. **They do share one** — `Engine._defaultEngineOptions` is a `private static readonly Options` and `CreateEngineOptions()` returns `this` for the unprofiled case, so every default-built engine in the process reads one instance. That is the sharing behind #3331; what #3359 closed is the *writing*, not the sharing.

So the suite pins the truth instead, in three tests: default-built engines read back one shared instance of the defaults (and it is frozen, and every setting on it is a default); callback-built engines do **not** share; and a live `WebApi.Enable` gives the engine that asked a copy of its own, which is the #3331 shape read back rather than inferred. Undoing the sharing is an allocation per engine to change nothing observable, so I did not — say the word if you want it anyway.

## Tests

New `Jint.Tests.PublicInterface/HostEngineConfigurationTests.cs` (the only suite without `InternalsVisibleTo`): a host reads back what it configured; the engine hands back the instance it was built from; a setter and a registry `Add` on a read-back instance throw; callback-built engines do not share; default-built engines do; an untrusted profile reads back as the engine's own hardened copy; a constraint reads back from where it was registered; and the live-`Enable` isolation above.

Tightened where reading the configuration says *more* than the behaviour already asserted — never as a replacement:

- `HostOptionsReadOnlyTests.AnUntrustedProfileStillAppliesAndBothInstancesEndUpReadOnly` keeps its `typeof importNamespace` assertions and adds the three about the copy.
- `HostWebApiOptionsIsolationTests` keeps observing the leak through a second engine's script and adds the identity assertions after it.
- `HostOptionsShapeTests.AFrozenConfigurationHasOneClockHoweverManyThreadsReadIt` is new.
- Two rows added to `EveryRegistryRefusesAChange`.

### Failing against unfixed code

Every new assertion was run against the tree without the fix first.

`HostEngineConfigurationTests` does not compile at all — which is the point of it being in that project:

```
HostEngineConfigurationTests.cs(101,31): error CS1061: 'Engine' does not contain a definition for
'Options' and no accessible extension method 'Options' accepting a first argument of type 'Engine'
could be found
```

The clock test, with the `??=` restored and the freeze-time resolution removed, four runs out of four:

```
Failed AFrozenConfigurationHasOneClockHoweverManyThreadsReadIt
Expected seen to contain only items matching ReferenceEquals(x, options.TimeSystem), but ...
```

The `UseNodeBuiltinModules` row, with that guard removed — exactly one of the thirty-three rows, and `UseNodeProcess` green beside it:

```
Failed EveryRegistryRefusesAChange("UseNodeBuiltinModules",System.Action`1[Jint.Options])
Expected a <System.InvalidOperationException> to be thrown because UseNodeBuiltinModules changes a
frozen Options, but no exception was thrown.
```

## Verification

- `dotnet build -c Release` (solution) and `dotnet test -c Release` (solution) green.
- `Jint.Tests.PublicInterface` green on `net472`, `net8.0` and `net10.0`, and green again with `JINT_HOST_CONTRACT_VERIFICATION=1`.
- test262: **102,495 passed, 0 failed, 189 skipped** — unchanged.
- All five TFM baselines regenerated; the diff is the one line above in each.
- One allocation is added to every `Options` freeze: a `DefaultTimeSystem` for options whose engine never touches `Date`. It is two field writes on the engine-construction path and is called out in the guide; say the word if you want it measured rather than argued.
