### PR TITLE
Intl: the culture every engine shares is handed out read-only

### DIFF
--- a/Jint.Tests/Runtime/IntlTests.cs
+++ b/Jint.Tests/Runtime/IntlTests.cs
@@ -1363,6 +1363,37 @@ public class IntlTests
     /// <c>DateTimeFormatInfo</c> behind them. Should the default provider ever start answering with names of
     /// its own, this fails, and the identity check in <c>DateTimeFormatConstructor</c> is then wrong.
     /// </remarks>
+    /// <summary>
+    /// The <c>CultureInfo</c> instances <c>IntlUtilities</c> caches are process-wide: one per locale tag,
+    /// shared by every engine, never evicted. A <c>CultureInfo</c> is writable unless it is explicitly made
+    /// read-only — <c>useUserOverride: false</c> only suppresses the Windows user regional overrides — so
+    /// without this the two places that adjust a format for one formatter could instead have adjusted it for
+    /// every engine in the process, and nothing would have reported it.
+    /// </summary>
+    /// <remarks>
+    /// Both of those places clone before writing (<c>DateTimeFormatConstructor</c> clones the culture and its
+    /// <c>DateTimeFormatInfo</c>, <c>NumberFormatConstructor</c> clones the <c>NumberFormatInfo</c>) and a
+    /// clone of a read-only instance is writable, which is why the whole <c>Intl</c> suite is the other half
+    /// of this test: it exercises both of those paths on every construction.
+    /// </remarks>
+    [Test]
+    [TestCase("en-US")]
+    [TestCase("de-DE")]
+    [TestCase("ar-SA")]
+    public void ACachedCultureIsReadOnly(string locale)
+    {
+        var culture = IntlUtilities.GetCultureInfo(locale);
+
+        culture.Should().NotBeNull();
+        culture!.IsReadOnly.Should().BeTrue();
+        IntlUtilities.GetCultureInfo(locale).Should().BeSameAs(culture);
+
+        // what the two format-adjusting call sites do, and what has to keep working
+        ((CultureInfo) culture.Clone()).IsReadOnly.Should().BeFalse();
+        ((DateTimeFormatInfo) culture.DateTimeFormat.Clone()).IsReadOnly.Should().BeFalse();
+        ((NumberFormatInfo) culture.NumberFormat.Clone()).IsReadOnly.Should().BeFalse();
+    }
+
     [Test]
     public void TheDefaultCldrProviderAnswersWithDotNetsOwnDateNames()
     {

--- a/Jint/Native/Intl/IntlUtilities.cs
+++ b/Jint/Native/Intl/IntlUtilities.cs
@@ -83,8 +83,9 @@ internal static class IntlUtilities
 
         return thisObject;
     }
-    // Cache for CultureInfo instances to avoid repeated allocations.
-    // CultureInfo with useUserOverride:false is immutable, safe to cache and share.
+    // Cache for CultureInfo instances to avoid repeated allocations. The entries are shared by every engine
+    // in the process, so CreateCultureInfo hands them out read-only rather than trusting every call site not
+    // to write to one.
     private static readonly ConcurrentDictionary<string, CultureInfo?> _cultureCache = new(StringComparer.OrdinalIgnoreCase);
     // BCP 47 language tag pattern (permissive to accept Unicode extensions)
     // Accepts: language[-script][-region][-variant]*[-extension]*[-privateuse]
@@ -1807,7 +1808,15 @@ internal static class IntlUtilities
             // data. GetCultureInfo returns a cached read-only culture that may have different
             // NumberFormatInfo patterns (e.g., CurrencyNegativePattern).
             // useUserOverride: false ensures consistent behavior regardless of Windows regional settings.
-            return new CultureInfo(cultureTag, false);
+            //
+            // Read-only because the instance is cached process-wide and handed to every engine: a write to
+            // its DateTimeFormat or NumberFormat would be one engine's setting becoming another engine's
+            // formatting, with nothing to report it. useUserOverride:false does not make a CultureInfo
+            // read-only - only CultureInfo.ReadOnly does - and wrapping does not undo the line above,
+            // because it marks the instance it is given rather than re-resolving the culture. Both places
+            // that adjust a format (DateTimeFormatConstructor, NumberFormatConstructor) clone first, and a
+            // clone of a read-only culture or format is writable.
+            return CultureInfo.ReadOnly(new CultureInfo(cultureTag, false));
         }
         catch (CultureNotFoundException)
         {


### PR DESCRIPTION
Part of #3438 — the mutability half. The unbounded-growth half stays open there.

`IntlUtilities` caches one `CultureInfo` per locale tag in a process-wide `ConcurrentDictionary`, shared by every engine, never evicted. The comment above the field said:

```csharp
// CultureInfo with useUserOverride:false is immutable, safe to cache and share.
```

`useUserOverride: false` suppresses the Windows user regional overrides. It does **not** set `IsReadOnly` — that is what `CultureInfo.GetCultureInfo` does, and the comment inside `CreateCultureInfo` explains why *that* API was deliberately avoided (it resolves different `NumberFormatInfo` patterns). So the cached instance was writable, and it is handed straight out to `StringPrototype`, `CollatorConstructor`, `ListFormatConstructor`, `SegmenterConstructor`, `PluralRulesConstructor`, `DisplayNamesConstructor`, `DurationFormatConstructor`, `RelativeTimeFormatConstructor`, `LocaleConstructor`, `NumberFormatConstructor` and `DateTimeFormatConstructor`.

No live defect: the only two places that adjust a format clone first — `DateTimeFormatConstructor` clones the culture *and* its `DateTimeFormatInfo`, `NumberFormatConstructor` clones the `NumberFormatInfo`. But one future `culture.NumberFormat.CurrencySymbol = …` on any of those hand-out sites would be one engine's write becoming another engine's formatting, with nothing to report it — #3331 in miniature, on state that outlives every engine that touched it.

## The change

```csharp
return CultureInfo.ReadOnly(new CultureInfo(cultureTag, false));
```

`CultureInfo.ReadOnly` marks the instance it is given rather than re-resolving the culture, so the reason `new CultureInfo(...)` is used instead of `CultureInfo.GetCultureInfo(...)` is untouched — the data is the same data, it just cannot be written to any more. And a clone of a read-only culture (or of a read-only `DateTimeFormatInfo`/`NumberFormatInfo`) is writable, which is what keeps the two adjusting call sites working unchanged.

The field comment is corrected to say what is actually true and why.

## Tests

`IntlTests.ACachedCultureIsReadOnly` asserts `IsReadOnly`, that the cache really is returning one shared instance, and that all three clones a caller needs come back writable. Against unmodified `main`:

```
Failed ACachedCultureIsReadOnly("en-US")   Expected culture!.IsReadOnly to be True, but found False.
Failed ACachedCultureIsReadOnly("de-DE")   Expected culture!.IsReadOnly to be True, but found False.
Failed ACachedCultureIsReadOnly("ar-SA")   Expected culture!.IsReadOnly to be True, but found False.
```

The other half of the evidence is the existing suite, which is what proves the clones really are writable rather than merely documented to be: `Intl` 261/261, `Jint.Tests` 10775/10775.

No public API change — `IntlUtilities` is internal and nothing an embedder can reach hands out one of these instances — so no baselines and no migration row.

## How it was found

The #3426 audit of process-wide caches. The cache's *key* covers its value (`locale → CultureInfo` is a total function of the tag, and `Options.Culture` never reaches Intl), so it is not that issue's shape; this is what the sweep found beside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014W5mbjGhyvgAS4pivXoc4S
