### PR TITLE
Options: a refused constraint-factory registration names its own registry

### DIFF
--- a/Jint.Tests.PublicInterface/HostOptionsReadOnlyTests.cs
+++ b/Jint.Tests.PublicInterface/HostOptionsReadOnlyTests.cs
@@ -84,6 +84,45 @@ public class HostOptionsReadOnlyTests
             .WithMessage($"{name} cannot be changed*");
     }
 
+    /// <summary>
+    /// Two registries sit side by side on <c>Options.Constraints</c>: the public <c>Constraints</c> list of
+    /// live instances, and the internal factory list that <c>AddConstraint(Func&lt;Constraint&gt;)</c> writes
+    /// to. They were constructed with the same name string, so a refused factory registration named the
+    /// registry the host had not touched.
+    /// </summary>
+    /// <remarks>
+    /// The <c>Limit*</c> methods do not reach this: each begins with <c>RemoveConstraints</c>, which is
+    /// refused first and names the live-instances list correctly. <c>AddConstraint</c> with a factory is
+    /// the only way to the second registry, and so the only way to observe the collision.
+    /// </remarks>
+    [Test]
+    public void ARefusedConstraintFactoryNamesItsOwnRegistry()
+    {
+        var options = new Options();
+        _ = new Engine(options);
+
+        Invoking(() => options.AddConstraint(static () => new InertConstraint()))
+            .Should().Throw<InvalidOperationException>("the options are frozen")
+            .WithMessage("*cannot be changed*")
+            .And.Message.Should().NotContain(
+                "Options.Constraints.Constraints",
+                "the factory registry is not the list of live instances, and naming that one sends the host to a line it never wrote");
+    }
+
+    /// <summary>
+    /// A constraint that bounds nothing: this fixture only cares which registry refuses the registration.
+    /// </summary>
+    private sealed class InertConstraint : Constraint
+    {
+        public override void Check()
+        {
+        }
+
+        public override void Reset()
+        {
+        }
+    }
+
     public static TestCases<string, Action<Options>> EveryGroup()
     {
         var data = new TestCases<string, Action<Options>>

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -1167,7 +1167,14 @@ public sealed partial class Options
         /// exactly once while constructing, so the constraints — and the per-execution state they carry —
         /// belong to that engine alone.
         /// </summary>
-        internal OptionsList<Func<Constraint>> ConstraintFactories { get; private set; } = new("Options.Constraints.Constraints");
+        /// <remarks>
+        /// The registry is internal, so its name here is what a refusal shows a host that called
+        /// <see cref="OptionsExtensions.AddConstraint(Options, Func{Constraint})"/> or one of the
+        /// <c>Limit*</c> methods that route through it. It must not be
+        /// <c>Options.Constraints.Constraints</c>, which is the registry beside it that the host did
+        /// not touch.
+        /// </remarks>
+        internal OptionsList<Func<Constraint>> ConstraintFactories { get; private set; } = new("Options.Constraints constraint factories");
 
         internal int? RequestedMaxStatements { get; set { ThrowIfReadOnly(); field = value; } }
 


### PR DESCRIPTION
`Options.ConstraintOptions` declares two registries and constructed both with the same name string:

```csharp
public   OptionsList<Constraint>       Constraints         = new("Options.Constraints.Constraints");
internal OptionsList<Func<Constraint>> ConstraintFactories = new("Options.Constraints.Constraints");
```

That string is what `OptionsList<T>.ThrowIfReadOnly` puts in the refusal, so registering a **factory** on a frozen `Options` reported a registry the host never touched. The refusal was correct; the name in it was not — and the per-registry names exist precisely so a host can find the line it has to move.

The factory registry is now named for itself. It is `internal`, so nothing in the baseline changes and there is no migration row.

## A correction to the issue

#3446 said `options.LimitStatements(100)` was the way to observe this. It is not, and I only found that out by writing the test first and watching it fail *with* the fix applied:

```
Options.Constraints.Constraints cannot be changed: these options are read-only ...
```

Every `Limit*` method begins with `options.RemoveConstraints(...)`, which is refused **first** and names the live-instances list entirely correctly. `AddConstraint(Func<Constraint>)` is the only route to the second registry, and so the only way to observe the collision at all. The test uses that.

It also uses a host's own `Constraint` subclass rather than `MaxStatementsConstraint`, whose constructor is `internal` — `Jint.Tests.PublicInterface` is the one project without `InternalsVisibleTo`, which is the whole reason a test there means anything.

## Verification

The new assertion is red before the fix on net10.0 with the message quoted above, and the fixture is green after on net472, net8.0 and net10.0 (72 / 72 / 59). Solution builds clean in Release.

Closes #3446
