### PR TITLE
Temporal: a month difference past the calendar's range raises RangeError instead of spinning

### DIFF
--- a/Jint.Tests/DedicatedThread.cs
+++ b/Jint.Tests/DedicatedThread.cs
@@ -98,13 +98,8 @@ internal static class DedicatedThread
             },
             maxStackSize)
         {
-            // A thread that outlives its join must not keep the process alive...
+            // A thread that outlives its join must not keep the process alive.
             IsBackground = true,
-
-            // ...and must not compete with the rest of the run for a core while it does. Background
-            // only governs process exit; a spinning thread goes on burning CPU until then, which is
-            // exactly the condition the suite's known wall-clock flakes fail under.
-            Priority = ThreadPriority.Lowest,
         };
 
         thread.Start();
@@ -113,6 +108,12 @@ internal static class DedicatedThread
         {
             if (!thread.Join(timeout))
             {
+                // Only now is the body known to be a runaway, and only a runaway must be kept off the
+                // cores the rest of the run needs. Background governs process exit and nothing else; a
+                // spinning thread goes on burning CPU until then, which is exactly the condition the
+                // suite's known wall-clock flakes fail under.
+                Demote(thread);
+
                 throw new AssertionException(timeoutMessage ?? $"the test body did not complete within {timeout}");
             }
         }
@@ -122,5 +123,32 @@ internal static class DedicatedThread
         }
 
         exception?.Throw();
+    }
+
+    /// <summary>
+    /// Drops a runaway body to the lowest priority, once its join has timed out and not before.
+    /// </summary>
+    /// <remarks>
+    /// The priority a runaway deserves is not the priority a body that is going to finish deserves, and
+    /// this used to be set at construction so that every body got the runaway's. A thread at
+    /// <see cref="ThreadPriority.Lowest"/> is the last thing a saturated runner schedules, behind every
+    /// normal-priority NUnit worker beside it — measured on a two-core affinity mask with two busy
+    /// threads, a 0.1 ms body took 2.5 s at <c>Lowest</c> against 0.14 s at <c>Normal</c>. On a
+    /// four-core CI runner the first body in a fixture, which pays that fixture's cold JIT on top,
+    /// missed a 15-second budget doing ten microseconds of work.
+    /// <para>
+    /// The thread may have finished between the join timing out and this call, which the setter reports
+    /// as a <see cref="ThreadStateException"/>. Nothing is owed for a thread that is no longer running.
+    /// </para>
+    /// </remarks>
+    private static void Demote(Thread thread)
+    {
+        try
+        {
+            thread.Priority = ThreadPriority.Lowest;
+        }
+        catch (ThreadStateException)
+        {
+        }
     }
 }

--- a/Jint.Tests/Runtime/NonIsoCalendarRangeTests.cs
+++ b/Jint.Tests/Runtime/NonIsoCalendarRangeTests.cs
@@ -1,0 +1,216 @@
+#nullable enable
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Jint reckons the eleven non-ISO calendars with <c>System.Globalization.Calendar</c> classes and with
+/// fixed-epoch arithmetic, and several of those classes cover far less than Temporal's own date range —
+/// <c>ChineseLunisolarCalendar</c> spans ISO 1901-02-19 to 2101-01-28. These pin what happens at the
+/// boundary: a bounded, catchable <c>RangeError</c>, and never a walk that does not end.
+/// </summary>
+/// <remarks>
+/// The failure these replace is the worst one an engine has. <c>CalendarDateUntil</c> walks a month at a
+/// time towards its target and stops when a step passes it; a conversion that answered with the
+/// calendar's boundary date made every further step land on that same date, so no step ever passed and
+/// the loop had no other exit. It is a CLR loop inside one interpreter step, so it crosses no statement
+/// boundary and no execution constraint can interrupt it: <c>LimitStatements</c> never counts,
+/// <c>LimitExecutionTime</c> never gets a check, and a <c>CancellationToken</c> is never observed. That
+/// is why every case here runs on a dedicated thread with a join timeout — a regression has to fail the
+/// run rather than wedge it. See <see href="https://github.com/sebastienros/jint/issues/3428"/>.
+/// </remarks>
+public class NonIsoCalendarRangeTests
+{
+    /// <summary>
+    /// Generous next to the milliseconds every case below actually takes, and unreachable for a walk
+    /// that does not terminate at all — which is the only distinction this has to make.
+    /// </summary>
+    private static readonly TimeSpan Budget = TimeSpan.FromSeconds(15);
+
+    private static readonly string[] TheElevenNonIsoCalendars =
+    [
+        "chinese", "dangi", "hebrew", "persian",
+        "coptic", "ethiopic", "ethioaa", "indian",
+        "islamic-umalqura", "islamic-civil", "islamic-tbla",
+    ];
+
+    /// <summary>
+    /// Runs <paramref name="body"/> on a dedicated thread, failing the test if it has not finished inside
+    /// <see cref="Budget"/>. Nothing in this fixture may evaluate on the runner's own thread: the defect
+    /// under test is a non-terminating one, so a regression evaluated inline wedges the whole run instead
+    /// of reporting it.
+    /// </summary>
+    private static void Guarded(string what, Action body) => DedicatedThread.Run(
+        body,
+        joinTimeout: Budget,
+        timeoutMessage: $"did not finish within {Budget}: {what}",
+        maxStackSize: DedicatedThread.DefaultStackSize);
+
+    /// <summary>
+    /// Evaluates <paramref name="expression"/>, answering with its string value or with the constructor
+    /// name of the JavaScript error it raised.
+    /// </summary>
+    private static string Evaluate(string expression)
+    {
+        var result = "";
+
+        Guarded(expression, () =>
+        {
+            var engine = new Engine();
+            result = engine.Evaluate(
+                $"(function () {{ try {{ return String({expression}); }} catch (e) {{ return e.constructor.name; }} }})()").AsString();
+        });
+
+        return result;
+    }
+
+    /// <summary>
+    /// The report from the issue, verbatim. Before the fix this never returned.
+    /// </summary>
+    [Test]
+    public void TheReportedMonthDifferencePastTheChineseRangeRaisesRangeError()
+    {
+        Evaluate(
+            "Temporal.PlainDate.from('1910-01-01').withCalendar('chinese')" +
+            ".until(Temporal.PlainDate.from('1900-01-03').withCalendar('chinese'), { largestUnit: 'year' })")
+            .Should().Be("RangeError");
+    }
+
+    /// <summary>
+    /// A difference is a sequence of additions, so every direction of walk and every largest unit that
+    /// walks has to be bounded — not only the one the report happened to name.
+    /// </summary>
+    [TestCase("chinese", "1910-01-01", "1900-01-03", TestName = "chinese below its 1901 floor")]
+    [TestCase("chinese", "2050-01-01", "2300-01-03", TestName = "chinese above its 2101 ceiling")]
+    [TestCase("dangi", "2050-01-01", "2300-01-03", TestName = "dangi above its 2051 ceiling")]
+    [TestCase("hebrew", "1990-01-01", "1000-01-03", TestName = "hebrew below its 1583 floor")]
+    [TestCase("hebrew", "2050-01-01", "2300-01-03", TestName = "hebrew above its 2239 ceiling")]
+    [TestCase("persian", "0700-01-01", "0300-01-03", TestName = "persian below its 622 floor")]
+    public void ADifferencePastACalendarRangeRaisesRangeErrorInsteadOfSpinning(string calendar, string one, string two)
+    {
+        foreach (var largestUnit in new[] { "year", "month" })
+        {
+            foreach (var op in new[] { "until", "since" })
+            {
+                Evaluate(
+                    $"Temporal.PlainDate.from('{one}').withCalendar('{calendar}')" +
+                    $".{op}(Temporal.PlainDate.from('{two}').withCalendar('{calendar}'), {{ largestUnit: '{largestUnit}' }})")
+                    .Should().Be("RangeError", $"{calendar}.{op} by {largestUnit}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// The same walk backs <c>until</c> and <c>since</c> on every type that carries a calendar, and
+    /// <c>Duration</c>'s <c>round</c>/<c>total</c> reach it through <c>relativeTo</c>. Each of these was
+    /// its own way to lose the thread, so each is named rather than left to the one the report used.
+    /// </summary>
+    [Test]
+    public void EveryDifferenceSurfaceThatWalksMonthsIsBounded()
+    {
+        const string Chinese = "withCalendar('chinese')";
+
+        Evaluate($"Temporal.PlainDateTime.from('1910-01-01T00:00').{Chinese}.until(Temporal.PlainDateTime.from('1900-01-03T00:00').{Chinese}, {{ largestUnit: 'year' }})")
+            .Should().Be("RangeError");
+
+        Evaluate($"Temporal.ZonedDateTime.from('1910-01-01T00:00[UTC]').{Chinese}.since(Temporal.ZonedDateTime.from('1900-01-03T00:00[UTC]').{Chinese}, {{ largestUnit: 'year' }})")
+            .Should().Be("RangeError");
+
+        Evaluate($"Temporal.PlainDate.from('1910-01-01').{Chinese}.toPlainYearMonth().until(Temporal.PlainDate.from('1900-01-03').{Chinese}.toPlainYearMonth(), {{ largestUnit: 'year' }})")
+            .Should().Be("RangeError");
+
+        Evaluate($"new Temporal.Duration(0, 0, 0, 200000).total({{ unit: 'year', relativeTo: Temporal.PlainDate.from('1990-01-01').{Chinese} }})")
+            .Should().Be("RangeError");
+
+        // round reaches the walk through a ZonedDateTime relativeTo. It does not reach it through a
+        // PlainDate one, because that arm reckons in "iso8601" whatever calendar the relativeTo carries
+        // -- a separate defect with its own issue, and the reason round answered where total refused
+        // even before this change.
+        Evaluate($"new Temporal.Duration(200).round({{ largestUnit: 'year', relativeTo: Temporal.ZonedDateTime.from('1990-01-01T00:00[UTC]').{Chinese} }})")
+            .Should().Be("RangeError");
+    }
+
+    /// <summary>
+    /// The other half of the same defect, and the one that answered rather than hanging: the boundary
+    /// date handed back was the calendar's <em>maximum</em> whichever end had been overrun, so
+    /// subtracting a century from a 1950 Chinese date moved it a century and a half forward, to
+    /// 2101-01-28, and reported success.
+    /// </summary>
+    [TestCase("chinese", "1950-01-01", "subtract({ years: 100 })")]
+    [TestCase("chinese", "2050-01-01", "add({ years: 100 })")]
+    [TestCase("chinese", "2050-01-01", "add({ months: 1200 })")]
+    [TestCase("dangi", "2050-01-01", "add({ years: 100 })")]
+    [TestCase("hebrew", "2050-01-01", "add({ years: 500 })")]
+    [TestCase("persian", "0700-01-01", "subtract({ years: 200 })")]
+    public void ArithmeticPastACalendarRangeRaisesRangeErrorInsteadOfAnsweringWithTheBoundary(string calendar, string from, string call)
+    {
+        Evaluate($"Temporal.PlainDate.from('{from}').withCalendar('{calendar}').{call}")
+            .Should().Be("RangeError");
+    }
+
+    /// <summary>
+    /// A <c>RangeError</c> is only an improvement on a hang if a script can act on it, which means it has
+    /// to be a JavaScript error and not a CLR exception on its way out of <c>Engine.Evaluate</c>.
+    /// </summary>
+    [Test]
+    public void TheRefusalIsAJavaScriptErrorAScriptCanCatch()
+    {
+        var caught = "";
+
+        Guarded(nameof(TheRefusalIsAJavaScriptErrorAScriptCanCatch), () => caught = new Engine().Evaluate(
+            @"(function () {
+                try {
+                    Temporal.PlainDate.from('1910-01-01').withCalendar('chinese')
+                        .until(Temporal.PlainDate.from('1900-01-03').withCalendar('chinese'), { largestUnit: 'year' });
+                    return 'no error';
+                } catch (e) {
+                    return (e instanceof RangeError) + '|' + (e.message.length > 0);
+                }
+            })()").AsString());
+
+        caught.Should().Be("true|true");
+    }
+
+    /// <summary>
+    /// The refusal is a boundary, not a new ceiling on ordinary arithmetic: every calendar still measures
+    /// and still adds inside the range it supports, and the two still agree with each other.
+    /// </summary>
+    [Test]
+    public void ArithmeticInsideEveryCalendarRangeIsUnchanged()
+    {
+        foreach (var calendar in TheElevenNonIsoCalendars)
+        {
+            Evaluate($"Temporal.PlainDate.from('1990-03-05').withCalendar('{calendar}').until(Temporal.PlainDate.from('2020-07-11').withCalendar('{calendar}'), {{ largestUnit: 'year' }})")
+                .Should().NotBe("RangeError", calendar);
+
+            Evaluate($"Temporal.PlainDate.from('1990-03-05').withCalendar('{calendar}').add({{ years: 5, months: 3, days: 2 }})")
+                .Should().NotBe("RangeError", calendar);
+
+            // add and until are the same reckoning read in opposite directions, so a date plus the
+            // difference to another date is that other date.
+            Evaluate(
+                $@"(function () {{
+                     var a = Temporal.PlainDate.from('1990-03-05').withCalendar('{calendar}');
+                     var b = Temporal.PlainDate.from('2020-07-11').withCalendar('{calendar}');
+                     return a.add(a.until(b, {{ largestUnit: 'year' }})).equals(b);
+                   }})()")
+                .Should().Be("true", calendar);
+        }
+    }
+
+    /// <summary>
+    /// The six calendars with no <c>System.Globalization.Calendar</c> behind them reckon by epoch-day
+    /// arithmetic and have no boundary to hit, which is why they answer where the BCL-backed ones refuse.
+    /// Pinned so that giving one of them a BCL implementation cannot quietly narrow it.
+    /// </summary>
+    [TestCase("coptic")]
+    [TestCase("ethiopic")]
+    [TestCase("ethioaa")]
+    [TestCase("indian")]
+    [TestCase("islamic-civil")]
+    [TestCase("islamic-tbla")]
+    public void ACalendarReckonedByArithmeticStillMeasuresAcrossTheWholeTemporalRange(string calendar)
+    {
+        Evaluate($"Temporal.PlainDate.from('1950-01-01').withCalendar('{calendar}').until(Temporal.PlainDate.from('-100000-01-03').withCalendar('{calendar}'), {{ largestUnit: 'year' }})")
+            .Should().StartWith("-P", calendar);
+    }
+}

--- a/Jint/Native/Temporal/CalendarRangeException.cs
+++ b/Jint/Native/Temporal/CalendarRangeException.cs
@@ -1,0 +1,26 @@
+namespace Jint.Native.Temporal;
+
+/// <summary>
+/// Signals that non-ISO calendar arithmetic left the range the calendar's implementation can represent.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Jint reckons the eleven non-ISO calendars with <see cref="System.Globalization.Calendar"/> classes and
+/// with fixed-epoch arithmetic, and several of those classes cover far less than Temporal's own date
+/// range: <c>ChineseLunisolarCalendar</c> spans ISO 1901-02-19 to 2101-01-28, <c>HebrewCalendar</c>
+/// 1583-01-01 to 2239-09-29. A step past either end has no date to answer with.
+/// </para>
+/// <para>
+/// What used to be answered there was the calendar's <em>maximum</em> supported date, whichever end had
+/// been overrun, which made <c>subtract</c> move forward and made <c>until</c>'s one-month-at-a-time walk
+/// stand still forever. <see cref="TemporalHelpers"/> catches this at the two calendar entry points and
+/// raises the <c>RangeError</c> that <c>CalendarDateAdd</c> raises for a result it cannot represent.
+/// </para>
+/// </remarks>
+internal sealed class CalendarRangeException : Exception
+{
+    internal CalendarRangeException(string calendar)
+        : base($"Date is outside the range supported by the '{calendar}' calendar")
+    {
+    }
+}

--- a/Jint/Native/Temporal/NonIsoCalendars.cs
+++ b/Jint/Native/Temporal/NonIsoCalendars.cs
@@ -332,13 +332,20 @@ internal static class NonIsoCalendars
         }
         catch (ArgumentOutOfRangeException)
         {
-            if (string.Equals(overflow, "reject", StringComparison.Ordinal))
-            {
-                throw new InvalidOperationException("reject");
-            }
-
-            // Fallback: clamp to calendar's valid range
-            return ClampToCalendarRange(cal, newYear, newOrdinalMonth, newDay);
+            // The result lies outside the range the backing System.Globalization.Calendar represents.
+            // That is not the month-or-day overflow "constrain" is allowed to clamp -- there is no
+            // nearby valid date to clamp to, only the calendar's own boundary -- so both overflow modes
+            // report it. NonISODateAdd is implementation-defined and may throw
+            // (https://tc39.es/proposal-temporal/#sec-temporal-nonisodateadd), and CalendarDateAdd
+            // raises a RangeError for a result it cannot represent
+            // (https://tc39.es/proposal-temporal/#sec-temporal-calendardateadd).
+            //
+            // The clamp this replaced answered with the calendar's MaxSupportedDateTime for an
+            // underflow as well as an overflow, so subtracting a century from a chinese date moved it
+            // forward to 2101-01-28 -- and, since every further step landed on that same date,
+            // CalendarDateUntil's month walk below never passed its target and never returned
+            // (https://github.com/sebastienros/jint/issues/3428).
+            throw new CalendarRangeException(calendar);
         }
     }
 
@@ -436,6 +443,19 @@ internal static class NonIsoCalendars
             var prevMonths = months;
             months += sign;
             var nextIso = CalendarDateAdd(calendar, in one, years, months, "constrain");
+
+            // The loop's only exit is "this step passed two", so a step that does not move the date
+            // never takes it: one more month of a walk that stands still is still standing still,
+            // however many are taken. Every conversion that used to saturate now raises
+            // CalendarRangeException rather than answering with a boundary date, which is what makes
+            // this a structural guarantee rather than a live path -- and it stays here so that a future
+            // calendar, or a host-supplied one, cannot reintroduce the hang of issue #3428 by adding a
+            // clamp somewhere below.
+            if (nextIso == currentIso)
+            {
+                throw new CalendarRangeException(calendar);
+            }
+
             var nextCal = IsoToCalendarDate(calendar, in nextIso);
             // Un-constrain the day in calendar-field space: if AddCalendar forced day down
             // to fit the target month, we still want to consider "next" as standing at the
@@ -1400,15 +1420,6 @@ internal static class NonIsoCalendars
         {
             return 30; // fallback
         }
-    }
-
-    /// <summary>
-    /// Clamps a date to the calendar's supported range.
-    /// </summary>
-    private static IsoDate ClampToCalendarRange(Calendar cal, int year, int month, int day)
-    {
-        var dt = cal.MaxSupportedDateTime;
-        return new IsoDate(dt.Year, dt.Month, dt.Day);
     }
 
     #endregion
@@ -2578,7 +2589,11 @@ internal static class NonIsoCalendars
         }
 
         var result = IndianDateToIso(newYear, null, newMonth, newDay, overflow);
-        return result ?? isoDate; // fallback to input if conversion fails
+
+        // Answering with the input date when the conversion cannot be made -- which is what this did --
+        // is a no-progress answer: `add` reports that adding a year changed nothing, and the month walk
+        // in CalendarDateUntil takes the same step forever. See CalendarRangeException.
+        return result ?? throw new CalendarRangeException("indian");
     }
 
     /// <summary>
@@ -3057,7 +3072,10 @@ internal static class NonIsoCalendars
 
         // Convert back to ISO using the appropriate calendar
         var result = CalendarDateToIso(calendar, newYear, null, newMonth, newDay, overflow);
-        return result ?? isoDate;
+
+        // Same no-progress hazard as the Indian arm above: the input date is not an answer to
+        // "add a year to this", and a step that stands still is one CalendarDateUntil never gets past.
+        return result ?? throw new CalendarRangeException(calendar);
     }
 
     /// <summary>

--- a/Jint/Native/Temporal/TemporalHelpers.cs
+++ b/Jint/Native/Temporal/TemporalHelpers.cs
@@ -2655,6 +2655,11 @@ internal static class TemporalHelpers
 
                 return result;
             }
+            catch (CalendarRangeException ex)
+            {
+                ThrowCalendarRange(realm, ex);
+                return default;
+            }
             catch (InvalidOperationException ex) when (string.Equals(ex.Message, "reject", StringComparison.Ordinal))
             {
                 if (realm != null)
@@ -2687,6 +2692,22 @@ internal static class TemporalHelpers
         }
 
         throw new NotSupportedException($"Calendar '{calendar}' not yet supported");
+    }
+
+    /// <summary>
+    /// Reports arithmetic that left the range a non-ISO calendar's implementation can represent as the
+    /// <c>RangeError</c> <see href="https://tc39.es/proposal-temporal/#sec-temporal-calendardateadd">CalendarDateAdd</see>
+    /// raises for a result it cannot produce.
+    /// </summary>
+    [DoesNotReturn]
+    private static void ThrowCalendarRange(Realm? realm, CalendarRangeException ex)
+    {
+        if (realm is not null)
+        {
+            Throw.RangeError(realm, ex.Message);
+        }
+
+        throw ex;
     }
 
     /// <summary>
@@ -5735,7 +5756,7 @@ internal static class TemporalHelpers
         var endDateTime = GetISODateTimeFor(timeZoneProvider, timeZone, ns2);
 
         // Step 4: Get initial difference - only use the date portion
-        var diff = DifferenceISODateTime(startDateTime, endDateTime, calendar, largestUnit);
+        var diff = DifferenceISODateTime(realm, startDateTime, endDateTime, calendar, largestUnit);
         var dateDifference = new DurationRecord(diff.Years, diff.Months, diff.Weeks, diff.Days, 0, 0, 0, 0, 0, 0);
 
         // Step 5: Create intermediate datetime by adding date portion to start
@@ -6015,7 +6036,7 @@ internal static class TemporalHelpers
         }
 
         // Step 3: DifferenceISODateTime to get the diff
-        var diff = DifferenceISODateTime(isoDateTime1, isoDateTime2, calendar, unit);
+        var diff = DifferenceISODateTime(realm, isoDateTime1, isoDateTime2, calendar, unit);
 
         // Step 4: If unit is nanosecond, return diff time duration directly
         if (string.Equals(unit, "nanosecond", StringComparison.Ordinal))
@@ -6604,6 +6625,7 @@ internal static class TemporalHelpers
     /// https://tc39.es/proposal-temporal/#sec-temporal-differenceisodatetime
     /// </summary>
     private static DurationRecord DifferenceISODateTime(
+        Realm? realm,
         IsoDateTime isoDateTime1,
         IsoDateTime isoDateTime2,
         string calendar,
@@ -6633,7 +6655,7 @@ internal static class TemporalHelpers
         var dateLargestUnit = LargerOfTwoTemporalUnits("day", largestUnit);
 
         // Step 9: Compute date difference using calendar
-        var dateDifference = CalendarDateUntil(calendar, isoDateTime1.Date, adjustedDate, dateLargestUnit);
+        var dateDifference = CalendarDateUntil(calendar, isoDateTime1.Date, adjustedDate, dateLargestUnit, realm);
 
         // Step 10-11: If largestUnit is smaller than day, add days to time
         if (!string.Equals(dateLargestUnit, largestUnit, StringComparison.Ordinal))
@@ -6747,7 +6769,7 @@ internal static class TemporalHelpers
     /// ISODateSurpasses algorithm (calendar.html:632-661) but uses direct arithmetic
     /// for O(1) performance on years/days instead of O(n) iteration.
     /// </summary>
-    internal static DurationRecord CalendarDateUntil(string calendar, IsoDate one, IsoDate two, string largestUnit, Realm? realm = null)
+    internal static DurationRecord CalendarDateUntil(string calendar, IsoDate one, IsoDate two, string largestUnit, Realm? realm)
     {
         // Step 1: Get sign
         var sign = CompareIsoDates(one, two);
@@ -6763,7 +6785,18 @@ internal static class TemporalHelpers
         {
             if (NonIsoCalendars.IsNonIsoCalendar(calendar))
             {
-                return NonIsoCalendars.CalendarDateUntil(calendar, in one, in two, largestUnit);
+                try
+                {
+                    return NonIsoCalendars.CalendarDateUntil(calendar, in one, in two, largestUnit);
+                }
+                catch (CalendarRangeException ex)
+                {
+                    // The walk that measures the difference is a sequence of NonISODateAdd steps, so a
+                    // difference reaching past what the calendar can represent surfaces as the same
+                    // RangeError the addition itself raises -- rather than as the non-terminating walk
+                    // of issue #3428.
+                    ThrowCalendarRange(realm, ex);
+                }
             }
 
             ThrowCalendarArithmeticUnavailable(realm, calendar);
@@ -6904,7 +6937,7 @@ internal static class TemporalHelpers
         }
 
         // Step 3: Get unrounded difference
-        var diff = DifferenceISODateTime(isoDateTime1, isoDateTime2, calendar, largestUnit);
+        var diff = DifferenceISODateTime(realm, isoDateTime1, isoDateTime2, calendar, largestUnit);
 
         // Step 4: If no rounding needed, return
         if (string.Equals(smallestUnit, "nanosecond", StringComparison.Ordinal) && roundingIncrement == 1)


### PR DESCRIPTION
Fixes #3428.

## What was wrong

`NonIsoCalendars.CalendarDateUntil` measures a difference by walking one month at a time from the source
towards the target, and its only exit is "this step passed the target". `NonIsoCalendars.CalendarDateAdd`
takes those steps, and when the conversion back to ISO left the range of the backing
`System.Globalization.Calendar` it did not report that — it answered with `ClampToCalendarRange`, which
ignored its year, month and day arguments entirely and returned `cal.MaxSupportedDateTime`:

```csharp
private static IsoDate ClampToCalendarRange(Calendar cal, int year, int month, int day)
{
    var dt = cal.MaxSupportedDateTime;
    return new IsoDate(dt.Year, dt.Month, dt.Day);
}
```

The calendar's *maximum*, whichever end had been overrun. So every further step of a backwards walk landed
on that same date, no step ever passed the target, and the loop had no other exit.

```js
Temporal.PlainDate.from('1910-01-01').withCalendar('chinese')
    .until(Temporal.PlainDate.from('1900-01-03').withCalendar('chinese'), { largestUnit: 'year' });
// never returned
```

`ChineseLunisolarCalendar` spans ISO 1901-02-19 to 2101-01-28, so the target is outside it.

## What an embedder saw

The thread, and nothing else. It is a CLR loop inside one interpreter step, so it crosses no statement
boundary: `LimitStatements` never counted, `LimitExecutionTime` never got a check, and a
`CancellationToken` was never observed. `Jint.Constraints.OperationDeadlineConstraint` does not help
either, for the same reason. A host that bounded untrusted script the documented way still lost the
thread, and the only way back was to end the process.

Reachable from any script that can name a `chinese`, `dangi`, `hebrew` or `persian` date, through `until`,
`since` and `total` on `PlainDate`, `PlainDateTime`, `PlainYearMonth`, `ZonedDateTime` and `Duration`.
Present in every released version; nothing recent introduced it.

The same clamp was also answering, rather than hanging, on the addition side — with the wrong date, and
with no signal that it was wrong:

```js
Temporal.PlainDate.from('1950-01-01').withCalendar('chinese').subtract({ years: 100 });
// 2101-01-28[u-ca=chinese]   -- subtracting a century moved it a century and a half forward
Temporal.PlainDate.from('2050-01-01').withCalendar('hebrew').add({ years: 500 });
// 2239-09-29[u-ca=hebrew]
```

## What changed

Out-of-range calendar arithmetic reports itself instead of clamping. `NonISODateAdd` is
implementation-defined and is declared as returning "either a normal completion containing an ISO Date
Record or a throw completion"
([spec](https://tc39.es/proposal-temporal/#sec-temporal-nonisodateadd)), and `CalendarDateAdd` raises a
`RangeError` for a result it cannot represent
([spec](https://tc39.es/proposal-temporal/#sec-temporal-calendardateadd)), so that is what the two
`TemporalHelpers` entry points now do with it. Both `overflow` modes report it: leaving the calendar's
range is not the month-or-day overflow `constrain` is allowed to clamp, because there is no nearby valid
date to clamp to — only the calendar's own boundary.

- `NonIsoCalendars.CalendarDateAdd` — `ClampToCalendarRange` is gone; the `ArgumentOutOfRangeException`
  from `cal.ToDateTime` becomes a `CalendarRangeException`.
- `NonIsoCalendars.IndianCalendarDateAdd` and `IslamicTabularCalendarDateAdd` — both answered
  `result ?? isoDate`, handing back their **input** date when the conversion failed. That is the same
  no-progress answer by a different route: `add` reports that adding a year changed nothing, and the walk
  takes the same step forever. Both now report instead.
- `NonIsoCalendars.CalendarDateUntil` — the walk keeps a no-progress guard of its own. A step that does
  not move the date can never pass the target however many more are taken, so it is a `RangeError` too.
  With the three fixes above it is unreachable today; it stays as the structural guarantee that this loop
  terminates, so a clamp reintroduced anywhere below it cannot become a hang again.
- `TemporalHelpers.CalendarDateAdd` / `CalendarDateUntil` map it to `Throw.RangeError`. `realm` is now
  threaded through `DifferenceISODateTime` (all three of its callers already had one) and is no longer
  optional on `CalendarDateUntil`, so no call site can lose it and turn a script-visible `RangeError` into
  a CLR exception escaping `Engine.Evaluate`.

All internal; no public API change.

### Siblings checked and found sound

- **`CalendarDateUntil`'s other units.** `week`, `day` and smaller are closed-form ISO epoch-day
  arithmetic with no loop; the year count is arithmetic plus a single overshoot check. Only the month walk
  loops, and with `largestUnit: 'year'` it takes at most ~13 steps whatever the span.
- **`FixedEpochCalendarDateAdd`** (coptic/ethiopic/ethioaa) is pure epoch-day arithmetic with no backing
  BCL calendar and no clamp, so it always progresses. Same for `IndianToCalendarDate`,
  `IslamicCivilToCalendarDate` and the `IsoToCalendarDate` arms behind them. Those six calendars still
  measure across the whole Temporal range, which a test now pins.
- **The month-wrap loops** in the four `*CalendarDateAdd` variants (`while (newMonth > 12/13)`,
  `while (newMonth < 1)`) are bounded by a months-in-year that every arm documents as never below 12.
- **The year-estimate correction loops** — `HebrewAlgorithmicFromIso`, `PersianToCalendarDate`,
  `EpochDaysToFixedEpoch` — correct a bounded estimate against a monotone year-start function.
- **The reference-year searches** (`MaxDaysForChineseLeapMonth`, `FindFixedEpochReferenceYear`,
  `FindIndianReferenceYear`, …) are bounded `for` loops over fixed windows.
- **`TemporalHelpers.CalendarDateUntil`'s Gregorian-based path** counts years and months by direct
  arithmetic and has no unbounded loop.

## Failing-test evidence

`Jint.Tests/Runtime/NonIsoCalendarRangeTests.cs` runs every case on a dedicated thread with a 15-second
join, so a regression fails the run rather than wedging it. Against **unfixed `main`**, the same file:

```
Failed chinese below its 1901 floor [15 s]
  did not finish within 00:00:15: Temporal.PlainDate.from('1910-01-01').withCalendar('chinese').until(…)
Failed chinese above its 2101 ceiling [15 s]
Failed dangi above its 2051 ceiling [15 s]
Failed hebrew below its 1583 floor [15 s]
Failed hebrew above its 2239 ceiling [15 s]
Failed persian below its 622 floor [15 s]
Failed EveryDifferenceSurfaceThatWalksMonthsIsBounded [15 s]
Failed TheReportedMonthDifferencePastTheChineseRangeRaisesRangeError [15 s]
Failed TheRefusalIsAJavaScriptErrorAScriptCanCatch [15 s]
Failed ArithmeticPastACalendarRangeRaisesRangeError…("chinese","1950-01-01","subtract({ years: 100 })")
  Expected … "RangeError", but was "2101-01-28[u-ca=chinese]"
… and five more of the same

Failed!  - Failed: 15, Passed: 7, Skipped: 0, Total: 22, Duration: 2 m 15 s
```

Nine of those fifteen are the hang; six are the boundary date answered as if it were the result. With the
fix: **22 passed / 0 failed** on `net472`, `net8.0` and `net10.0`.

## Follow-up: the `net472` red leg on the first push, diagnosed

The first push's Windows leg failed one of the new tests on `net472` only:

```
did not finish within 00:00:15: Temporal.PlainDate.from('1950-01-01').withCalendar('coptic')
  .until(Temporal.PlainDate.from('-100000-01-03').withCalendar('coptic'), { largestUnit: 'year' })
```

**It is not the walk.** Measured on `net472`, calling the walk directly:

```
coptic          cold=0.114ms  warm=0.0102ms/call  years=-101947 months=-11 days=-24
ethiopic        cold=0.011ms  warm=0.0100ms/call  years=-101947 months=-11 days=-24
ethioaa         cold=0.016ms  warm=0.0096ms/call  years=-101947 months=-11 days=-24
indian          cold=0.010ms  warm=0.0073ms/call  years=-101949 months=-11 days=-28
islamic-civil   cold=0.012ms  warm=0.0110ms/call  years=-105078 months=-11 days=-6
islamic-tbla    cold=0.020ms  warm=0.0154ms/call  years=-105078 months=-11 days=-6
```

Ten microseconds, with the right answer. It could not be an exception-type or range divergence in the
netfx BCL either: `coptic`, `ethiopic` and `ethioaa` have no `System.Globalization.Calendar` behind them
at all — `CalendarDateAdd` routes them to `FixedEpochCalendarDateAdd`, which is pure epoch-day arithmetic,
so no `catch` and no BCL range is involved on any target framework.

**The 15 seconds was thread scheduling.** `DedicatedThread.Run` started every body at
`ThreadPriority.Lowest`. Pinning the test process to a two-core affinity mask and running two
normal-priority busy threads — a small CI runner reproduced without saturating a 32-core box — the *same
warm 0.1 ms evaluation*:

```
round 0: Lowest=2462ms   Normal=144ms
round 1: Lowest=2554ms   Normal=159ms
round 2: Lowest=2488ms   Normal=128ms
```

A 17× penalty from two competitors. The CI job is far harsher: its log shows four test assemblies in
flight at once on a four-core `windows-latest` runner —

```
01:39:47  Jint.Tests.dll (net472)                  1 m 28 s   <- the failure
01:39:54  Jint.Tests.PublicInterface.dll (net8.0)  1 m 43 s
01:41:33  Jint.Tests.dll (net8.0)                  3 m 15 s
01:41:34  Jint.Tests.dll (net10.0)                 3 m 15 s
```

— each with `[assembly: Parallelizable(ParallelScope.Fixtures)]` and `LevelOfParallelism` defaulting to
the core count, so roughly sixteen normal-priority workers over four cores. The `net472` assembly alone
took 1 m 28 s there against 19 s uncontended locally, a 4.6× inflation *at normal priority*; a `Lowest`
thread inside that fares far worse. And the body was cold: the first Temporal script in a `net472` process
pays the intrinsic graph plus JIT, measured at 547 ms of CPU against 0.1 ms for every one after it — and
`ACalendarReckonedByArithmeticStillMeasuresAcrossTheWholeTemporalRange` sorts first among the fixture's
methods, so it is the body that absorbs that warmup, on the starved thread.

### The fix, and it is not a bigger budget

`Jint.Tests/DedicatedThread.cs` now starts a body at normal priority and demotes the thread to `Lowest`
only once its join has timed out — at which point it is known to be a runaway that must be kept off the
cores the rest of the run needs. The helper's comment already said what the demotion is for; only its
timing moves. The priority a runaway deserves is not the priority a body that is going to finish deserves,
and every caller of the helper was paying the former.

Verified by reproducing the CI failure locally and then removing it — same machine, same two-core affinity
mask, same full `net472` assembly, one line of difference:

| `DedicatedThread` | `net472` result |
| --- | --- |
| start at `Lowest` (main's) | **Failed: 1** — `ACalendarReckoned…("coptic")`, `did not finish within 00:00:15` [20 s], 7426 passed |
| demote on timeout (this PR) | **Passed: 7427, Failed: 0**, 4 skipped |

The 15-second budget is untouched. Under the two-core reproduction the body completes in ~0.14 s against
it, a 100× margin.

## Test suites

Rebased onto `c39396fd4`. One `dotnet test -c Release` run, everything green:

```
Jint.Tests.dll (net472)                  7427 passed,     0 failed,   4 skipped
Jint.Tests.dll (net8.0)                 10803 passed,     0 failed,   5 skipped
Jint.Tests.dll (net10.0)                10803 passed,     0 failed,   5 skipped
Jint.Tests.PublicInterface.dll (net472)  2501 passed,     0 failed,  21 skipped
Jint.Tests.PublicInterface.dll (net8.0)  3121 passed,     0 failed,  21 skipped
Jint.Tests.PublicInterface.dll (net10.0) 3131 passed,     0 failed,  21 skipped
Jint.Tests.CommonScripts.dll (net472)      28 passed,     0 failed
Jint.Tests.CommonScripts.dll (net10.0)     28 passed,     0 failed
Jint.Tests.SourceGenerators.dll            71 passed,     0 failed
Jint.Tests.Test262.dll                 102495 passed,     0 failed, 189 skipped
```

**test262: 102,495 / 0 / 189** — the control number. `dotnet build -c Release`: 0 errors, no new warnings.

## Two siblings found but not fixed here

Both are wrong answers rather than hangs, with their own blast radius, so they are filed separately:

- #3450 — `Temporal.Duration.prototype.round` reads the calendar off a `PlainDate` `relativeTo` and then
  reckons in `iso8601`. It is why the `round` half of the report never hung: it was not reaching the walk
  that did.
- #3451 — a date outside a non-ISO calendar's implementation range reports ISO fields under that
  calendar's name (`Temporal.PlainDate.from('1800-01-01').withCalendar('chinese').monthCode` is `'M01'`).
  Now that the arithmetic refuses at the boundary, the field accessors are the remaining place where the
  engine answers something it does not know.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014W5mbjGhyvgAS4pivXoc4S
