### PR TITLE
Options: a group materialized while the freeze is running ends up frozen, and a cloned registry carries the freeze

### DIFF
--- a/Jint.Tests.PublicInterface/HostOptionsReadOnlyTests.cs
+++ b/Jint.Tests.PublicInterface/HostOptionsReadOnlyTests.cs
@@ -364,6 +364,50 @@ public class HostOptionsReadOnlyTests
         Invoking(() => options.WebApi.Timers.MaxActiveTimers = 4)
             .Should().Throw<InvalidOperationException>();
     }
+
+    /// <summary>
+    /// The engine's private copy of the web-API subtree is frozen around registries that are frozen too.
+    /// </summary>
+    /// <remarks>
+    /// The only public door onto a group cloned from a frozen source. <c>WebApiOptions.Clone</c> copies each
+    /// sub-group with <c>MemberwiseClone</c>, which carries the frozen state, but a registry has to be a new
+    /// list or the copy would share the host's — and a new <see cref="OptionsList{T}"/> used to be born
+    /// writable, so this copy came back frozen around an <c>AllowedSchemes</c> that still accepted an
+    /// <c>Add</c>. The live door is for setting a value on the subtree, never for growing a registry on it,
+    /// and <see cref="TheLiveWebApiDoorSuspendsTheGuardForTheGroupItIsConfiguringAndNothingElse"/> pins the
+    /// same refusal for the sub-group nobody had materialized before the freeze — which reaches the copy
+    /// through the accessor rather than through the clone.
+    /// </remarks>
+    [Test]
+    public void TheEnginesPrivateWebApiCopyIsFrozenAroundFrozenRegistries()
+    {
+        var options = new Options();
+
+        // Materialized before the freeze, so the engine's copy of it comes from Clone rather than from the
+        // accessor that would have made it born frozen.
+        options.WebApi.Fetch.MaxRedirects = 5;
+
+        var engine = new Engine(options);
+        options.WebApi.Fetch.AllowedSchemes.IsReadOnly.Should().BeTrue();
+
+        Options.WebApiOptions? privateCopy = null;
+        engine.WebApi.Enable(WebApiFeatures.Timers, webApi =>
+        {
+            privateCopy = webApi;
+            webApi.Should().NotBeSameAs(options.WebApi);
+            webApi.Fetch.Should().NotBeSameAs(options.WebApi.Fetch);
+
+            webApi.Fetch.AllowedSchemes.IsReadOnly.Should().BeTrue(
+                "the copy is frozen, and a registry inside a frozen group is frozen too");
+            Invoking(() => webApi.Fetch.AllowedSchemes.Add("ftp"))
+                .Should().Throw<InvalidOperationException>();
+        });
+
+        privateCopy.Should().NotBeNull();
+
+        // And the host's own instance was not written to at all.
+        options.WebApi.Fetch.AllowedSchemes.Should().NotContain("ftp");
+    }
 #endif
 
     /// <summary>

--- a/Jint.Tests.PublicInterface/HostOptionsShapeTests.cs
+++ b/Jint.Tests.PublicInterface/HostOptionsShapeTests.cs
@@ -1,5 +1,6 @@
 #nullable enable
 
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Jint.Runtime;
@@ -127,5 +128,174 @@ public class HostOptionsShapeTests
         options.Constraints.RegexTimeout.Should().Be(TimeSpan.MaxValue);
         options.ValidateSecurityConfiguration().Diagnostics
             .Should().Contain(x => x.Code == SecurityDiagnosticCodes.RegexTimeoutExcessive);
+    }
+
+    /// <summary>
+    /// A group materialized on one thread while another freezes the options ends up frozen either way.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="Options"/> is documented as safe to share between engines being constructed concurrently,
+    /// so the two threads below are an ordinary embedding rather than a contrivance: one host thread finishes
+    /// with the instance and publishes it, another is still touching a group. The accessor reads the owner's
+    /// frozen state, allocates, and only then publishes — so a freeze landing inside those few nanoseconds
+    /// sets the flag, finds the backing field still null, cascades over nothing, and the accessor publishes an
+    /// <b>unfrozen</b> group onto a frozen <see cref="Options"/>. It stays writable for the life of the
+    /// process, and the engine reads <c>Intl</c> and <c>Temporal</c> lazily, long after construction, so a
+    /// write to one of those still lands on a live engine.
+    /// </para>
+    /// <para>
+    /// The window cannot be held open from outside the assembly: nothing host-supplied runs between the state
+    /// read and the publication, so there is no seam a <see cref="ManualResetEventSlim"/> could be wedged
+    /// into. This is therefore a bounded sweep rather than a gate — two threads released from one
+    /// <see cref="Barrier"/>, the materializing one walking the groups in the order <c>MakeReadOnly</c>
+    /// cascades in, so that the freeze falls inside the first group's window as often as the scheduler
+    /// allows. Every escape is collected rather than only the first, so a failure says how often it happened.
+    /// </para>
+    /// </remarks>
+    [Test]
+    public void AGroupMaterializedWhileTheOptionsAreBeingFrozenIsStillFrozen()
+    {
+        const int Attempts = 1000;
+
+        var groups = EveryGroupInCascadeOrder();
+        var escapes = new List<string>();
+        var workerFailure = new StrongBox<Exception?>(null);
+        Options current = null!;
+
+        using var barrier = new Barrier(participantCount: 3);
+
+        var materializer = StartRounds("group-materializer", barrier, Attempts, workerFailure, () =>
+        {
+            var options = current;
+            foreach (var group in groups)
+            {
+                group.Read(options);
+            }
+        });
+
+        var freezer = StartRounds("options-freezer", barrier, Attempts, workerFailure, () => current.MakeReadOnly());
+
+        for (var attempt = 0; attempt < Attempts; attempt++)
+        {
+            var options = new Options();
+
+            // The freezing thread has to arrive at the freeze with nothing else to do first, and freezing
+            // resolves the default clock. Reading it here means the round measures the publication order the
+            // test is about rather than one thread's head start building a DefaultTimeSystem.
+            _ = options.TimeSystem;
+
+            current = options;
+
+            barrier.SignalAndWait();
+            barrier.SignalAndWait();
+
+            // Collected rather than asserted, so that nothing throws while two threads are still parked on
+            // the barrier this method's `using` is about to dispose.
+            if (!options.IsReadOnly)
+            {
+                escapes.Add($"attempt {attempt}: MakeReadOnly did not take");
+            }
+
+            foreach (var group in groups)
+            {
+                var refusal = Caught.Exception(() => group.Write(options));
+                if (refusal is null)
+                {
+                    escapes.Add($"attempt {attempt}: {group.Name} accepted a write on a frozen Options");
+                }
+                else if (refusal is not InvalidOperationException)
+                {
+                    escapes.Add($"attempt {attempt}: {group.Name} refused with {refusal.GetType()}");
+                }
+            }
+        }
+
+        materializer.Join();
+        freezer.Join();
+
+        workerFailure.Value.Should().BeNull();
+        escapes.Should().BeEmpty(
+            "a group materialized while MakeReadOnly runs must end up frozen, and {0} of {1} attempts published a writable one",
+            escapes.Count,
+            Attempts);
+    }
+
+    /// <summary>
+    /// Runs <paramref name="round"/> once per attempt on a thread of its own, bracketed by the two
+    /// rendezvous the caller drives.
+    /// </summary>
+    /// <remarks>
+    /// The inner catch is what keeps a round's failure from turning into a deadlock: the thread still reaches
+    /// its second <c>SignalAndWait</c>, so the other two participants are released. The outer one covers the
+    /// barrier itself — an unhandled exception on either of these threads would take the whole test run down
+    /// rather than fail this test.
+    /// </remarks>
+    private static Thread StartRounds(
+        string name,
+        Barrier barrier,
+        int attempts,
+        StrongBox<Exception?> failure,
+        Action round)
+    {
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                for (var attempt = 0; attempt < attempts; attempt++)
+                {
+                    barrier.SignalAndWait();
+                    try
+                    {
+                        round();
+                    }
+                    catch (Exception e)
+                    {
+                        Interlocked.CompareExchange(ref failure.Value, e, null);
+                    }
+
+                    barrier.SignalAndWait();
+                }
+            }
+            catch (Exception e)
+            {
+                Interlocked.CompareExchange(ref failure.Value, e, null);
+            }
+        })
+        {
+            IsBackground = true,
+            Name = name,
+        };
+
+        thread.Start();
+        return thread;
+    }
+
+    /// <summary>
+    /// Every group, in the order <c>Options.SetReadOnly</c> cascades over them, with a read that materializes
+    /// it and a value setting whose refusal is the only way a host can see that it is frozen.
+    /// </summary>
+    private static (string Name, Action<Options> Read, Action<Options> Write)[] EveryGroupInCascadeOrder()
+    {
+        var groups = new List<(string, Action<Options>, Action<Options>)>
+        {
+            ("Options.Constraints", static o => _ = o.Constraints, static o => o.Constraints.MaxRecursionDepth = 8),
+            ("Options.Parsing", static o => _ = o.Parsing, static o => o.Parsing.MaxNodeCount = 8),
+            ("Options.Interop", static o => _ = o.Interop, static o => o.Interop.Enabled = true),
+            ("Options.Debugger", static o => _ = o.Debugger, static o => o.Debugger.Enabled = true),
+            ("Options.Coverage", static o => _ = o.Coverage, static o => o.Coverage.Enabled = true),
+            ("Options.Host", static o => _ = o.Host, static o => o.Host.StringCompilationAllowed = false),
+            ("Options.Modules", static o => _ = o.Modules, static o => o.Modules.RegisterRequire = true),
+            ("Options.Intl", static o => _ = o.Intl, static o => o.Intl.CldrProvider = null!),
+            ("Options.Temporal", static o => _ = o.Temporal, static o => o.Temporal.TimeZoneProvider = null!),
+            ("Options.Json", static o => _ = o.Json, static o => o.Json.MaxParseDepth = 8),
+            ("Options.Profiling", static o => _ = o.Profiling, static o => o.Profiling.Enabled = true),
+        };
+
+#if NET8_0_OR_GREATER
+        groups.Add(("Options.WebApi", static o => _ = o.WebApi, static o => o.WebApi.Features = WebApiFeatures.Console));
+#endif
+
+        return groups.ToArray();
     }
 }

--- a/Jint.Tests/Runtime/OptionsCloneReadOnlyTests.cs
+++ b/Jint.Tests/Runtime/OptionsCloneReadOnlyTests.cs
@@ -1,0 +1,86 @@
+#nullable enable
+
+using System;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// A group cloned from a frozen <see cref="Options"/> comes back frozen, registries included.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every group's own <c>Clone</c> is <c>MemberwiseClone</c>, which carries the group's frozen state for
+/// nothing. A registry cannot be copied that way — its list has to be a new one, or the copy would go on
+/// sharing the source's — so <see cref="OptionsList{T}"/> has a hand-written <c>Clone</c>, and a freshly
+/// constructed registry used to be born writable. That left a frozen group wrapping writable registries:
+/// <c>IsReadOnly</c> answering <see langword="true"/> on <c>Options.Interop</c> and <see langword="false"/>
+/// on <c>Interop.ObjectConverters</c> beside it.
+/// </para>
+/// <para>
+/// Nothing shipped was broken by it, because the two callers each compensated — <c>CloneWithPrivateWebApiOptions</c>
+/// re-froze the subtree it had just copied, and <c>CreateEngineOptions</c> thaws the whole clone immediately.
+/// This is what makes those compensations unnecessary rather than load-bearing, so that a third caller of
+/// <c>InteropOptions.Clone</c> or <c>ConstraintOptions.Clone</c> — a future per-engine copy, a profile that
+/// snapshots one group — gets the state the source had instead of having to know to repair it.
+/// </para>
+/// </remarks>
+public class OptionsCloneReadOnlyTests
+{
+    [Test]
+    public void AGroupClonedFromFrozenOptionsIsFrozenAroundItsRegistriesToo()
+    {
+        var options = new Options();
+        options.Interop.ExtensionMethodTypes.Add(typeof(string));
+        options.MakeReadOnly();
+
+        // The two groups the issue names, because neither caller of theirs compensates for the asymmetry.
+        var interop = options.Interop.Clone();
+        var constraints = options.Constraints.Clone();
+
+        const string Because = "a clone of a frozen group must not be frozen around a writable registry";
+
+        interop.ExtensionMethodTypes.IsReadOnly.Should().BeTrue(Because);
+        interop.ObjectConverters.IsReadOnly.Should().BeTrue(Because);
+        interop.ImmutableCrossingTypes.IsReadOnly.Should().BeTrue(Because);
+        interop.AllowedAssemblies.IsReadOnly.Should().BeTrue(Because);
+        constraints.Constraints.IsReadOnly.Should().BeTrue(Because);
+        constraints.ConstraintFactories.IsReadOnly.Should().BeTrue(Because);
+
+        Invoking(() => interop.ExtensionMethodTypes.Add(typeof(int)))
+            .Should().Throw<InvalidOperationException>();
+        Invoking(() => constraints.Constraints.Clear())
+            .Should().Throw<InvalidOperationException>();
+
+        // It is still a copy rather than the source's own list: freezing it must not have made it shared.
+        interop.ExtensionMethodTypes.Should().ContainSingle().Which.Should().Be(typeof(string));
+        interop.ExtensionMethodTypes.Should().NotBeSameAs(options.Interop.ExtensionMethodTypes);
+    }
+
+    /// <summary>
+    /// The other half: the one caller that wants a writable copy asks for it, and gets it all the way down.
+    /// </summary>
+    [Test]
+    public void TheUntrustedProfilesPrivateCopyIsThawedThroughout()
+    {
+        var options = new Options();
+        options.Interop.ExtensionMethodTypes.Add(typeof(string));
+        options.ForUntrustedCode(new UntrustedCodeLimits(
+            timeoutInterval: TimeSpan.FromSeconds(5),
+            maxStatements: 100_000,
+            memoryLimit: 16_000_000,
+            maxRecursionDepth: 64,
+            maxArraySize: 10_000,
+            regexTimeout: TimeSpan.FromMilliseconds(100),
+            promiseTimeout: TimeSpan.FromMilliseconds(100),
+            maxOperationDuration: TimeSpan.FromSeconds(10)));
+        options.MakeReadOnly();
+
+        var forEngine = options.CreateEngineOptions();
+
+        forEngine.Should().NotBeSameAs(options);
+        forEngine.IsReadOnly.Should().BeFalse();
+        forEngine.Interop.ExtensionMethodTypes.IsReadOnly.Should().BeFalse();
+        forEngine.Constraints.Constraints.IsReadOnly.Should().BeFalse();
+        forEngine.Constraints.ConstraintFactories.IsReadOnly.Should().BeFalse();
+    }
+}

--- a/Jint/AGENTS.md
+++ b/Jint/AGENTS.md
@@ -73,7 +73,12 @@ untrusted-code profile's private snapshot from sharing state with the host's opt
 
 **`Options` is configuration until an engine reads it, and frozen afterwards.** The `Engine` constructor ends
 with `MakeReadOnly()`, which cascades to every group and registry; a group materialized later is born frozen,
-which is why `Materialize` takes the owner's state. So a new setting needs `ThrowIfReadOnly()` in its setter
+which is why `Materialize` takes the owner's state — **by reference, and read a second time after the
+interlocked publication**, because the freeze sets the flag and *then* cascades over the backing fields,
+so a group materialized inside that window used to be missed by both halves and stay writable on a frozen
+`Options` for the life of the process. `SetReadOnly` publishes the flag with a full barrier for the same
+handshake, and `OptionsList<T>.Clone` carries it the way a group's `MemberwiseClone` does, so no caller of
+a `Clone` has to re-freeze what it copied. A new setting needs `ThrowIfReadOnly()` in its setter
 (`[CallerMemberName]` names it), a new registry is an `OptionsList<T>` rather than a `List<T>`, and a new
 group implements `IOptionsGroup` and joins the two cascades in `Options.ReadOnly.cs`. A setting that
 *memoizes on read* resolves in `SetReadOnly` as well, ahead of the flag — `Engine.Options` hands the frozen

--- a/Jint/Options.Profiling.cs
+++ b/Jint/Options.Profiling.cs
@@ -10,7 +10,7 @@ public sealed partial class Options
     /// before this existed.
     /// </summary>
     /// <seealso cref="Engine.DiagnosticOperations.StartProfiling"/>
-    public ProfilingOptions Profiling => Materialize(ref _profiling, _readOnly);
+    public ProfilingOptions Profiling => Materialize(ref _profiling, ref _readOnly);
 
     private ProfilingOptions? _profiling;
 

--- a/Jint/Options.ReadOnly.cs
+++ b/Jint/Options.ReadOnly.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using Jint.Runtime;
 
 namespace Jint;
@@ -18,6 +19,18 @@ internal interface IOptionsGroup
 
 public sealed partial class Options
 {
+    /// <summary>
+    /// The freeze flag, read and written through <see cref="Volatile"/> rather than declared
+    /// <see langword="volatile"/> only because <see cref="Materialize{T}"/> takes it by reference.
+    /// </summary>
+    /// <remarks>
+    /// This flag and <c>WebApiOptions._readOnly</c> are the two that gate a <i>publication</i>, which is why
+    /// they are the two published with a barrier. A stale read of any other group's flag costs one
+    /// setter that should have been refused — the same thing that happens when a setter passes
+    /// <c>ThrowIfReadOnly</c> a moment before the freeze starts, and not something a barrier can prevent,
+    /// because the freeze is a state change rather than a lock. A stale read of one of these two costs an
+    /// object: the group it publishes is writable for as long as the <see cref="Options"/> lives.
+    /// </remarks>
     private bool _readOnly;
 
     /// <summary>
@@ -27,7 +40,7 @@ public sealed partial class Options
     /// Modelled on <c>JsonSerializerOptions.IsReadOnly</c>, and true for the same reason: a component has
     /// taken this instance as its configuration and reads it live.
     /// </remarks>
-    public bool IsReadOnly => _readOnly;
+    public bool IsReadOnly => Volatile.Read(ref _readOnly);
 
     /// <summary>
     /// Freezes this configuration, so that a later write throws instead of reaching an engine that already read it.
@@ -64,7 +77,16 @@ public sealed partial class Options
             _ = TimeSystem;
         }
 
-        _readOnly = value;
+        // The flag is published before the cascade reads the backing fields, and with a full fence rather
+        // than only the release write: a group being materialized on another thread has to either see this
+        // write and be born frozen, or have published itself in time for the cascade below to find it. A
+        // release write orders the stores before it and not the loads after it, so without the barrier both
+        // halves can miss at once — this cascade reading a field the accessor has not published yet, while
+        // that accessor reads a flag still sitting in this thread's store buffer — and the group it goes on
+        // to publish accepts writes on a frozen Options for the life of the process.
+        Volatile.Write(ref _readOnly, value);
+        Thread.MemoryBarrier();
+
         SetReadOnly(_constraints, value);
         SetReadOnly(_parsing, value);
         SetReadOnly(_interop, value);
@@ -85,7 +107,7 @@ public sealed partial class Options
 
     private void ThrowIfReadOnly([CallerMemberName] string? setting = null)
     {
-        if (_readOnly)
+        if (Volatile.Read(ref _readOnly))
         {
             Throw.OptionsReadOnly("Options." + setting);
         }
@@ -322,11 +344,16 @@ public sealed partial class Options
 
     public sealed partial class WebApiOptions : IOptionsGroup
     {
+        /// <inheritdoc cref="Options._readOnly"/>
         private bool _readOnly;
 
         void IOptionsGroup.SetReadOnly(bool value)
         {
-            _readOnly = value;
+            // Published with a barrier for the reason Options.SetReadOnly states: the eight accessors below
+            // read this flag before they publish, and this cascade reads their fields after it.
+            Volatile.Write(ref _readOnly, value);
+            Thread.MemoryBarrier();
+
             Options.SetReadOnly(_console, value);
             Options.SetReadOnly(_timers, value);
             Options.SetReadOnly(_fetch, value);
@@ -353,7 +380,7 @@ public sealed partial class Options
 
         private void ThrowIfReadOnly([CallerMemberName] string? setting = null)
         {
-            if (_readOnly && !IsConfiguringWebApisLive(this))
+            if (Volatile.Read(ref _readOnly) && !IsConfiguringWebApisLive(this))
             {
                 Throw.OptionsReadOnly("Options.WebApi." + setting);
             }
@@ -512,7 +539,21 @@ public sealed class OptionsList<T> : IList<T>, IReadOnlyList<T>
         _items = items;
     }
 
-    internal OptionsList<T> Clone() => new(_name, new List<T>(_items));
+    /// <summary>
+    /// A copy of this registry, carrying its read-only state.
+    /// </summary>
+    /// <remarks>
+    /// A group's own <c>Clone</c> is <c>MemberwiseClone</c> and so carries the group's frozen state; a fresh
+    /// registry would be born writable, which used to make the registries of a clone taken from a frozen
+    /// source the one part of it that still accepted an <c>Add</c>. The caller that wants a writable copy is
+    /// <see cref="Options.CreateEngineOptions"/>, and it thaws the whole clone deliberately.
+    /// </remarks>
+    internal OptionsList<T> Clone()
+    {
+        var clone = new OptionsList<T>(_name, new List<T>(_items));
+        clone._readOnly = _readOnly;
+        return clone;
+    }
 
     internal void SetReadOnly(bool value) => _readOnly = value;
 

--- a/Jint/Options.WebApi.cs
+++ b/Jint/Options.WebApi.cs
@@ -26,7 +26,7 @@ public sealed partial class Options
     /// never does it.
     /// </para>
     /// </remarks>
-    public WebApiOptions WebApi => Materialize(ref _webApi, _readOnly);
+    public WebApiOptions WebApi => Materialize(ref _webApi, ref _readOnly);
 
     private WebApiOptions? _webApi;
 
@@ -56,13 +56,10 @@ public sealed partial class Options
         // invariant is the copy's, not the freeze's.
         clone._timeSystem = TimeSystem;
 
-        var webApi = _webApi?.Clone();
-
-        // Clone gives FetchOptions.AllowedSchemes a fresh OptionsList, and a fresh one is born writable;
-        // every group otherwise carries the source's frozen state through MemberwiseClone. Re-freezing the
-        // subtree is what keeps the live door to setting a value rather than growing a registry.
-        SetReadOnly(webApi, _readOnly);
-        clone._webApi = webApi;
+        // Every part of the copy carries the source's frozen state on its own: the groups through
+        // MemberwiseClone, and the registries through OptionsList<T>.Clone. That is what keeps the live door
+        // to setting a value rather than growing a registry.
+        clone._webApi = _webApi?.Clone();
 
         return clone;
     }
@@ -94,7 +91,7 @@ public sealed partial class Options
         /// Settings for the <c>console</c> object, installed when <see cref="Features"/> contains
         /// <see cref="WebApiFeatures.Console"/>.
         /// </summary>
-        public ConsoleOptions Console => Materialize(ref _console, _readOnly);
+        public ConsoleOptions Console => Materialize(ref _console, ref _readOnly);
 
         private ConsoleOptions? _console;
 
@@ -102,7 +99,7 @@ public sealed partial class Options
         /// Settings for the timer functions, installed when <see cref="Features"/> contains
         /// <see cref="WebApiFeatures.Timers"/>.
         /// </summary>
-        public TimerOptions Timers => Materialize(ref _timers, _readOnly);
+        public TimerOptions Timers => Materialize(ref _timers, ref _readOnly);
 
         private TimerOptions? _timers;
 
@@ -110,7 +107,7 @@ public sealed partial class Options
         /// Settings for <c>fetch</c>, installed when <see cref="Features"/> contains
         /// <see cref="WebApiFeatures.Fetch"/> — which <see cref="WebApiFeatures.Default"/> never does.
         /// </summary>
-        public FetchOptions Fetch => Materialize(ref _fetch, _readOnly);
+        public FetchOptions Fetch => Materialize(ref _fetch, ref _readOnly);
 
         private FetchOptions? _fetch;
 
@@ -120,7 +117,7 @@ public sealed partial class Options
         /// itself, and <see cref="WebApiFeatures.Reporting"/> additionally gives script the
         /// <c>reportError</c> function that feeds it.
         /// </summary>
-        public DiagnosticsOptions Diagnostics => Materialize(ref _diagnostics, _readOnly);
+        public DiagnosticsOptions Diagnostics => Materialize(ref _diagnostics, ref _readOnly);
 
         private DiagnosticsOptions? _diagnostics;
 
@@ -128,7 +125,7 @@ public sealed partial class Options
         /// Settings for <c>localStorage</c> and <c>sessionStorage</c>, installed when <see cref="Features"/>
         /// contains <see cref="WebApiFeatures.Storage"/>.
         /// </summary>
-        public StorageOptions Storage => Materialize(ref _storage, _readOnly);
+        public StorageOptions Storage => Materialize(ref _storage, ref _readOnly);
 
         private StorageOptions? _storage;
 
@@ -136,7 +133,7 @@ public sealed partial class Options
         /// Settings for the <c>caches</c> object, installed when <see cref="Features"/> contains
         /// <see cref="WebApiFeatures.CacheApi"/> — which <see cref="WebApiFeatures.Default"/> never does.
         /// </summary>
-        public CacheOptions Cache => Materialize(ref _cache, _readOnly);
+        public CacheOptions Cache => Materialize(ref _cache, ref _readOnly);
 
         private CacheOptions? _cache;
 
@@ -144,7 +141,7 @@ public sealed partial class Options
         /// Settings for channel messaging, installed when <see cref="Features"/> contains
         /// <see cref="WebApiFeatures.Messaging"/>.
         /// </summary>
-        public MessagingOptions Messaging => Materialize(ref _messaging, _readOnly);
+        public MessagingOptions Messaging => Materialize(ref _messaging, ref _readOnly);
 
         private MessagingOptions? _messaging;
 
@@ -153,7 +150,7 @@ public sealed partial class Options
         /// <see cref="WebApiFeatures.Workers"/> — which <see cref="WebApiFeatures.Default"/> never does — and
         /// <see cref="Options.WorkerOptions.Provider"/> names a provider.
         /// </summary>
-        public WorkerOptions Workers => Materialize(ref _workers, _readOnly);
+        public WorkerOptions Workers => Materialize(ref _workers, ref _readOnly);
 
         private WorkerOptions? _workers;
 

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -39,7 +39,7 @@ public sealed partial class Options
     /// </param>
     internal void AddConfiguration(EngineConfiguration configuration, [CallerMemberName] string? verb = null)
     {
-        if (_readOnly)
+        if (Volatile.Read(ref _readOnly))
         {
             Throw.OptionsReadOnlyCall("Options." + verb);
         }
@@ -94,8 +94,17 @@ public sealed partial class Options
     /// and mutable by the very host write that was supposed to be refused, and the engine reads those groups
     /// lazily, so the write would land.
     /// </para>
+    /// <para>
+    /// It is taken by reference and read <b>again after the publication</b>, because one read taken before the
+    /// allocation cannot cover a freeze running on another thread. <c>SetReadOnly</c> sets the flag and then
+    /// cascades over the backing fields, so an accessor that read the flag first and published second is
+    /// missed by both halves — and the group it publishes stays writable on a frozen <see cref="Options"/> for
+    /// the life of the process. The second read means one of the two always catches it: either the cascade
+    /// finds a published group, or this finds the flag. Freezing a group that is already frozen is a no-op, so
+    /// it does not matter which. <c>SetReadOnly</c>'s barrier is the other half of that argument.
+    /// </para>
     /// </remarks>
-    private static T Materialize<T>(ref T? field, bool readOnly) where T : class, IOptionsGroup, new()
+    private static T Materialize<T>(ref T? field, ref bool readOnly) where T : class, IOptionsGroup, new()
     {
         var existing = field;
         if (existing is not null)
@@ -104,74 +113,83 @@ public sealed partial class Options
         }
 
         var created = new T();
-        if (readOnly)
+        if (Volatile.Read(ref readOnly))
         {
             created.SetReadOnly(true);
         }
 
-        return Interlocked.CompareExchange(ref field, created, null) ?? created;
+        var published = Interlocked.CompareExchange(ref field, created, null) ?? created;
+
+        // The publication above is a full fence, so a freeze that has already set the flag is visible here
+        // whether or not its cascade reached this field in time to see the group.
+        if (Volatile.Read(ref readOnly))
+        {
+            published.SetReadOnly(true);
+        }
+
+        return published;
     }
 
     /// <summary>
     /// Execution constraints for the engine.
     /// </summary>
-    public ConstraintOptions Constraints => Materialize(ref _constraints, _readOnly);
+    public ConstraintOptions Constraints => Materialize(ref _constraints, ref _readOnly);
 
     private ConstraintOptions? _constraints;
 
     /// <summary>
     /// Resource limits applied while parsing scripts and modules.
     /// </summary>
-    public ParsingOptions Parsing => Materialize(ref _parsing, _readOnly);
+    public ParsingOptions Parsing => Materialize(ref _parsing, ref _readOnly);
 
     private ParsingOptions? _parsing;
 
     /// <summary>
     /// CLR interop related options.
     /// </summary>
-    public InteropOptions Interop => Materialize(ref _interop, _readOnly);
+    public InteropOptions Interop => Materialize(ref _interop, ref _readOnly);
 
     private InteropOptions? _interop;
 
     /// <summary>
     /// Debugger configuration.
     /// </summary>
-    public DebuggerOptions Debugger => Materialize(ref _debugger, _readOnly);
+    public DebuggerOptions Debugger => Materialize(ref _debugger, ref _readOnly);
 
     private DebuggerOptions? _debugger;
 
     /// <summary>
     /// Script code coverage configuration. Off by default.
     /// </summary>
-    public CoverageOptions Coverage => Materialize(ref _coverage, _readOnly);
+    public CoverageOptions Coverage => Materialize(ref _coverage, ref _readOnly);
 
     private CoverageOptions? _coverage;
 
     /// <summary>
     /// Host options.
     /// </summary>
-    public HostOptions Host => Materialize(ref _host, _readOnly);
+    public HostOptions Host => Materialize(ref _host, ref _readOnly);
 
     private HostOptions? _host;
 
     /// <summary>
     /// Module options
     /// </summary>
-    public ModuleOptions Modules => Materialize(ref _modules, _readOnly);
+    public ModuleOptions Modules => Materialize(ref _modules, ref _readOnly);
 
     private ModuleOptions? _modules;
 
     /// <summary>
     /// Internationalization (Intl) options.
     /// </summary>
-    public IntlOptions Intl => Materialize(ref _intl, _readOnly);
+    public IntlOptions Intl => Materialize(ref _intl, ref _readOnly);
 
     private IntlOptions? _intl;
 
     /// <summary>
     /// Temporal API options.
     /// </summary>
-    public TemporalOptions Temporal => Materialize(ref _temporal, _readOnly);
+    public TemporalOptions Temporal => Materialize(ref _temporal, ref _readOnly);
 
     private TemporalOptions? _temporal;
 
@@ -280,7 +298,7 @@ public sealed partial class Options
     /// Options for the built-in JSON (de)serializer which
     /// gets used using <c>JSON.parse</c> or <c>JSON.stringify</c>
     /// </summary>
-    public JsonOptions Json => Materialize(ref _json, _readOnly);
+    public JsonOptions Json => Materialize(ref _json, ref _readOnly);
 
     private JsonOptions? _json;
 


### PR DESCRIPTION
Closes #3444. Closes #3445.

## Two fixes, not one

They share a file and an invariant — *everything reachable from a frozen `Options` is frozen* — and nothing
else. #3444 is a publication-ordering defect between two threads that is reachable today; #3445 is a
single-threaded asymmetry in cloning that is currently unreachable because both callers compensate for it.
They travel together only because a second PR in `Jint/Options.ReadOnly.cs` would have to be rebased onto
this one anyway. The reasoning for each is below, separately.

## #3444: the interleaving, as proved

Every group accessor was `public IntlOptions Intl => Materialize(ref _intl, _readOnly);`, so the owner's
frozen state was read **at the call site**, before `Materialize` allocated and published. `MakeReadOnly`
sets the flag and then cascades over the twelve backing fields. Both halves can therefore miss the same
group:

1. Thread A reads `_readOnly == false` and enters `Materialize`.
2. Thread B sets `_readOnly = true`, then reads `_intl` — still `null`, so the cascade covers nothing.
3. Thread A publishes with the `Interlocked.CompareExchange`, **unfrozen**, onto a frozen `Options`.

It stays writable for the life of the process, and the engine reads `Intl` and `Temporal` lazily long after
construction, so a write to one of them still lands on a live engine. `Options` is documented as safe to
share between engines being constructed concurrently, so this is an ordinary embedding — one host thread
finishing with an instance while another is still touching a group — not a contrivance.

`Jint.Tests.PublicInterface/HostOptionsShapeTests.AGroupMaterializedWhileTheOptionsAreBeingFrozenIsStillFrozen`
runs two threads released from one `Barrier`, one materializing every group in the order the cascade walks
them and one calling `MakeReadOnly()`, and then asserts that every group refuses a write. Against
unmodified `main`, first run:

```
Failed AGroupMaterializedWhileTheOptionsAreBeingFrozenIsStillFrozen [271 ms]
  Expected collection to be empty because a group materialized while MakeReadOnly runs must end up frozen,
  and 109 of 1000 attempts published a writable one, but found at least one item
  {"attempt 0: Options.Constraints accepted a write on a frozen Options"}.
```

**It is a bounded sweep rather than a deterministic gate, and that is a real limitation of the seam.** The
window is the few nanoseconds between the accessor's state read and its publication, and nothing
host-supplied runs inside it — no callback, no host object's constructor — so there is nothing outside the
assembly a `ManualResetEventSlim` could be wedged into. What makes the sweep sharp rather than a guess is
alignment, not load: two threads and one barrier, the materializing one walking the groups in the cascade's
own order so that the freeze falls inside the *first* group's window as often as the scheduler allows, and
the clock resolved before the round starts so the freezing thread arrives at the freeze with nothing else to
do first. Measured against the unfixed engine, four runs of a thousand attempts each: **109, 62, 105 and 77
escapes**, the earliest on attempt 0. It collects every escape and reports the count rather than stopping at
the first. After the fix, 20 000 attempts produce none.

### The fix

- `Materialize` takes the flag **by reference** and reads it **again after the interlocked publication**,
  freezing the winner if it is set. `Interlocked.CompareExchange` is a full fence, so a freeze that has
  already set the flag is visible to that second read whether or not its cascade saw the field.
- `SetReadOnly` publishes the flag with `Volatile.Write` **plus `Thread.MemoryBarrier()`** before it reads
  the fields. It already set the flag first; what it lacked was the fence. A release write orders the
  stores before it and *not* the loads after it, so without a StoreLoad barrier the two halves can still
  miss simultaneously — the cascade reading a field the accessor has not published yet, while the accessor
  reads a flag still sitting in the freezing thread's store buffer. That is Dekker's, and it is real on x86
  as well as on ARM.

Between them one of the two always catches the group: the cascade finds it published, or the accessor finds
the flag. Freezing an already-frozen group is a no-op, so it does not matter which. `Options._readOnly` and
`WebApiOptions._readOnly` are the two flags that gate a *publication* and so the two that get the barrier;
the other eighteen group flags gate value setters only, where a stale read costs one write that should have
been refused — which is what happens anyway when a setter passes `ThrowIfReadOnly` a moment before the
freeze begins, and is not something a barrier can prevent. That distinction is written down on the field.

### What it costs

Nothing that is not cold, and no lock.

| path | before | after |
| --- | --- | --- |
| accessor **hit** (group already exists) | load `_readOnly`, pass by value | pass `ref _readOnly`; the flag is not read at all |
| accessor **miss** (once per group per `Options`) | one branch | one extra acquire read + one predictable branch, and on a frozen owner one redundant `SetReadOnly` cascade of at most eight null checks |
| `MakeReadOnly()` | — | one `Thread.MemoryBarrier()`, i.e. one `lock or [rsp], 0` on x64 with the line already hot |
| `ThrowIfReadOnly` / `IsReadOnly` / `AddConfiguration` | plain load | acquire load (a plain `mov` on x64, `ldar` on ARM64) — host-side setters only, never an execution path |

The engine constructor calls `MakeReadOnly()` twice (`Options` and `sourceOptions`, usually the same
object), so an engine build gains two barriers, plus one more if it materializes `WebApi`. I have not run
BenchmarkDotNet for it and would rather say so than quote a number I have not measured — say the word if you
want the construction row measured rather than argued. The one thing worth noting in the other direction:
the flag read moved off the accessor's hit path, and `Options.Interop` is read on hot interop paths.

## #3445: a cloned registry carries the freeze

`OptionsList<T>.Clone()` was `new(_name, new List<T>(_items))`, and a fresh registry is born with
`_readOnly == false`. Every group's own `Clone()` is `MemberwiseClone()` and therefore *does* carry the
source's frozen state, so a group cloned from a frozen source came back frozen around writable registries —
`IsReadOnly` answering `true` on `Options.Interop` and `false` on `Interop.ObjectConverters` beside it.

Nothing shipped was broken by it because both callers compensated: `CloneWithPrivateWebApiOptions` re-froze
the subtree it had just copied, and `CreateEngineOptions` thaws the whole clone immediately. `Clone()` now
carries the flag, which makes the first of those **unnecessary rather than load-bearing** — the explicit
re-freeze and the comment naming the asymmetry are both gone, since a comment describing something that is
no longer true is worse than none.

Two tests, because the defect is reachable from two distances:

- `Jint.Tests/Runtime/OptionsCloneReadOnlyTests` goes at `InteropOptions.Clone` and `ConstraintOptions.Clone`
  directly — the two the issue names, because neither of their callers compensates. This is the clean red,
  needing no other change:

  ```
  Failed AGroupClonedFromFrozenOptionsIsFrozenAroundItsRegistriesToo
    Expected boolean to be True because a clone of a frozen group must not be frozen around a writable
    registry, but found False.
  ```

  Its sibling `TheUntrustedProfilesPrivateCopyIsThawedThroughout` is the other half: the one caller that
  wants a writable copy asks for it, and still gets it all the way down to the registries.

- `HostOptionsReadOnlyTests.TheEnginesPrivateWebApiCopyIsFrozenAroundFrozenRegistries` is the embedder's
  view, through the only public door onto a cloned group — `Engine.WebApi.Enable`'s callback, with `Fetch`
  materialized *before* the freeze so the copy comes from `Clone` rather than from the accessor. It is red
  once the compensation is removed, which is precisely the claim that the compensation was load-bearing:

  ```
  Failed TheEnginesPrivateWebApiCopyIsFrozenAroundFrozenRegistries
    Expected webApi.Fetch.AllowedSchemes.IsReadOnly to be True because the copy is frozen, and a registry
    inside a frozen group is frozen too, but found False.
  ```

  Beside it, the existing `TheLiveWebApiDoorSuspendsTheGuardForTheGroupItIsConfiguringAndNothingElse` stayed
  green in that same run — worth stating, because it asserts the same refusal for a sub-group nobody had
  materialized before the freeze, which reaches the copy through `Materialize` rather than through `Clone`.
  Two paths, and only the clone one was broken.

## The sibling audit

`Materialize` is not the only lazy publish on `Options`, so every field written on read and every place a
`_readOnly` value is captured before the work it guards:

| site | verdict |
| --- | --- |
| the twelve `Options` group accessors + the eight on `WebApiOptions` | the defect — fixed |
| `Options.TimeSystem`'s `_timeSystem ??=` | the same shape, **left alone deliberately**: #3447 was already replacing it with an `Interlocked.CompareExchange` and resolving it at freeze time, and has since merged. Fixing it here would have been a second edit to the same lines |
| `Options.ResultLimits`, `ProfilingOptions.MaxEvents` | plain getters over a backing field; nothing is written on read |
| `Options._nodeBuiltinModules` | written by `UseNodeBuiltinModules`, never on a read (and #3447 has since put a guard on that door) |
| `AddConfiguration` — `if (_readOnly) throw; _configurations.Add(...)` | check-then-act, but it publishes no object: the worst case is one appended configuration, the accepted "the freeze is a state change, not a lock" property. Now an acquire read for consistency within the class |
| every `ThrowIfReadOnly()`-then-write setter (about ninety-five of them) | same, and the same verdict — the issue says so itself |
| `CloneWithPrivateWebApiOptions`'s `SetReadOnly(webApi, _readOnly)` | captured the flag after cloning; removed, because the clone now carries it |
| the other eighteen group `_readOnly` flags | plain, deliberately — see the paragraph above |

## Composition with #3447

#3447 merged while this was being written, so this branch is **rebased onto it** rather than composed with
it. The two touched one hunk in common and it was textual rather than semantic: #3447 added
`if (value) { _ = TimeSystem; }` to the top of `SetReadOnly`, this PR replaced the `_readOnly = value` below
it with the volatile write and the barrier. Resolved by keeping both in that order — resolve `TimeSystem`
first, then publish the flag with the fence, then cascade — and everything else (`Options.cs`,
`Options.WebApi.cs`, `AGENTS.md`, both test files) auto-merged. The full suite and test262 were re-run on the
rebased tree; the numbers below are from that run.

## Not a public API change

`Materialize` is private, `OptionsList<T>.Clone` and `SetReadOnly` are internal, and both `_readOnly` fields
stayed private. The five baselines are unchanged (the `net10.0` leg that verifies them is green), so there is
no `docs/v5-migration.md` row and no baseline regeneration here.

## Verification

On the rebased tree:

- `dotnet build -c Release` (solution) and `dotnet test -c Release` (solution) green, exit 0.
- `Jint.Tests` 10 783 passed on `net8.0` and `net10.0`, 7 407 on `net472`; `Jint.Tests.PublicInterface`
  3 132 / 3 122 / 2 501 on `net10.0` / `net8.0` / `net472`; `Jint.Tests.CommonScripts` 28;
  `Jint.Tests.SourceGenerators` 71.
- `Jint.Tests.PublicInterface` green again on all three target frameworks with
  `JINT_HOST_CONTRACT_VERIFICATION=1` (3 145 / 3 135 / 2 514).
- test262: **102 495 passed, 0 failed, 189 skipped** — unchanged.
- The race test at 20 000 attempts: no escapes. At its shipped 1 000 attempts it costs ~200 ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014W5mbjGhyvgAS4pivXoc4S
