### PR TITLE
Docs: the migration guide's numbering rule fails a test run instead of being stated

### DIFF
--- a/Jint.Tests/MigrationGuideTests.cs
+++ b/Jint.Tests/MigrationGuideTests.cs
@@ -1,0 +1,136 @@
+#nullable enable
+
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace Jint.Tests;
+
+/// <summary>
+/// <c>docs/v5-migration.md</c> held to the numbering rule it states for itself.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why a test.</b> The guide's own "Keeping this document current" section already says numbering is
+/// assigned at merge rather than at authoring, and explains exactly why: several pull requests are in flight
+/// at once, each picks what looked like the next free subsection when it was written, and because two of them
+/// append to different parts of one file <b>git merges them cleanly</b>. The duplicate exists only in the
+/// rendered document, so nothing on the way in reports it — not the compiler, not the reviewer reading a diff
+/// that shows one added section, not the merge. Stating the rule in prose was not enough: during the v5
+/// campaign collisions were caught by hand roughly ten times and twice reached <c>main</c>, needing
+/// <see href="https://github.com/sebastienros/jint/pull/3344">#3344</see> and
+/// <see href="https://github.com/sebastienros/jint/pull/3347">#3347</see> to clean up after them.
+/// </para>
+/// <para>
+/// <b>What it does not check.</b> Gaps are legitimate and common — a merged section can sit at 4.37 while
+/// 4.36 is still in an open pull request — so only duplication and ordering are asserted, never contiguity.
+/// </para>
+/// </remarks>
+[Parallelizable(ParallelScope.All)]
+public class MigrationGuideTests
+{
+    private static readonly Regex ChapterHeading = new(@"^## (\d+)\. ", RegexOptions.Compiled);
+    private static readonly Regex SectionHeading = new(@"^### (\d+)\.(\d+) ", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Two sections cannot claim one number: that is the collision git merges without noticing.
+    /// </summary>
+    [Test]
+    public void NoTwoSectionsShareANumber()
+    {
+        var duplicates = ReadSections()
+            .GroupBy(static section => (section.Chapter, section.Number))
+            .Where(static group => group.Count() > 1)
+            .Select(static group =>
+                $"§{group.Key.Chapter}.{group.Key.Number} is claimed by "
+                + string.Join(" and ", group.Select(static s => $"line {s.Line} (\"{s.Title}\")")))
+            .ToList();
+
+        duplicates.Should().BeEmpty(
+            "two pull requests each picked this number while in flight, and git merged both cleanly. "
+            + "Whoever merges second renumbers, and repoints any [§x.y](#xy-...) link to the section — "
+            + "see \"Keeping this document current\" at the end of the guide");
+    }
+
+    /// <summary>
+    /// A section numbered <c>4.x</c> belongs under chapter 4, because the chapter is what the number means.
+    /// </summary>
+    [Test]
+    public void EverySectionSitsUnderItsOwnChapter()
+    {
+        var misplaced = ReadSections()
+            .Where(static section => section.Chapter != section.EnclosingChapter)
+            .Select(static section =>
+                $"line {section.Line}: \"### {section.Chapter}.{section.Number} {section.Title}\" "
+                + $"sits under \"## {section.EnclosingChapter}.\"")
+            .ToList();
+
+        misplaced.Should().BeEmpty(
+            "the chapter decides what the section number means, so a section renumbered into another "
+            + "chapter has to move with its number");
+    }
+
+    /// <summary>
+    /// Section numbers ascend in document order, so a renumbering that resolves a collision cannot leave the
+    /// new entry sitting above the one it was numbered after. Gaps are fine — an open pull request holds them.
+    /// </summary>
+    [Test]
+    public void SectionNumbersAscendInDocumentOrder()
+    {
+        var previous = new Dictionary<int, Section>();
+        var outOfOrder = new List<string>();
+
+        foreach (var section in ReadSections())
+        {
+            if (previous.TryGetValue(section.Chapter, out var earlier) && section.Number <= earlier.Number)
+            {
+                outOfOrder.Add(
+                    $"line {section.Line}: §{section.Chapter}.{section.Number} follows "
+                    + $"§{earlier.Chapter}.{earlier.Number} at line {earlier.Line}");
+            }
+
+            previous[section.Chapter] = section;
+        }
+
+        outOfOrder.Should().BeEmpty("a reader scanning for §4.12 reads downwards and stops when the numbers pass it");
+    }
+
+    private readonly record struct Section(int Chapter, int Number, string Title, int Line, int EnclosingChapter);
+
+    private static List<Section> ReadSections()
+    {
+        var path = Path.Combine(AgentInstructionFiles.RepositoryRoot, "docs", "v5-migration.md");
+        File.Exists(path).Should().BeTrue($"the migration guide is expected at {path}");
+
+        var sections = new List<Section>();
+        var enclosingChapter = 0;
+        var lineNumber = 0;
+
+        foreach (var line in File.ReadLines(path))
+        {
+            lineNumber++;
+
+            var chapter = ChapterHeading.Match(line);
+            if (chapter.Success)
+            {
+                enclosingChapter = int.Parse(chapter.Groups[1].Value, CultureInfo.InvariantCulture);
+                continue;
+            }
+
+            var section = SectionHeading.Match(line);
+            if (!section.Success)
+            {
+                continue;
+            }
+
+            sections.Add(new Section(
+                int.Parse(section.Groups[1].Value, CultureInfo.InvariantCulture),
+                int.Parse(section.Groups[2].Value, CultureInfo.InvariantCulture),
+                line[section.Length..].Trim(),
+                lineNumber,
+                enclosingChapter));
+        }
+
+        sections.Should().NotBeEmpty("the guide is numbered by section, and finding none means this test stopped testing anything");
+        return sections;
+    }
+}

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -1884,7 +1884,7 @@ Both are `Set(O, k, v, true)` over a position the view cannot hold, so both are 
 longer fires. Nothing changes for a target exposed under its own type or under a type that implements
 `IList<T>` (both get a typed, growable wrapper), for reads, or for any generic that stays inside the
 collection's bounds.
-### 4.40 One list of calendars, and `ICalendarProvider` owns it ([#3404](https://github.com/sebastienros/jint/issues/3404))
+### 4.38 One list of calendars, and `ICalendarProvider` owns it ([#3404](https://github.com/sebastienros/jint/issues/3404))
 
 Jint held the calendar identifiers in three places — `TemporalHelpers.CanonicalizeCalendar`,
 `DateTimeFormatConstructor`'s own table and alias map, and `DefaultCldrProvider.GetSupportedCalendars` —
@@ -1917,7 +1917,7 @@ Nothing an unconfigured engine does changes: the sixteen, the two deprecated ide
 behave exactly as the four tables made them behave.
 
 **What could break:** a host overriding `ICldrProvider.GetSupportedCalendars`. See [2. Removed API](#2-removed-api).
-### 4.38 A host object's `Symbol.dispose`, `Symbol.asyncDispose` and `toJSON` belong to its own realm ([#3365](https://github.com/sebastienros/jint/issues/3365))
+### 4.39 A host object's `Symbol.dispose`, `Symbol.asyncDispose` and `toJSON` belong to its own realm ([#3365](https://github.com/sebastienros/jint/issues/3365))
 
 `ObjectWrapper` builds three members eagerly — `Symbol.dispose` for an `IDisposable` target,
 `Symbol.asyncDispose` for an `IAsyncDisposable` one, and `toJSON` for a type that has one — and built them
@@ -1939,7 +1939,7 @@ from, and the one `ShadowRealm.SetValue` enters deliberately ([§4.23](#423-a-va
 (`x instanceof Function`), a reach for `call`/`apply`/`bind`, or an `Object.getPrototypeOf` inside a shadow
 realm now gets the answer the realm's own intrinsics give. A host function the embedder builds itself
 through `new ClrFunction(engine, …)` is unaffected and still belongs to the principal realm.
-### 4.36 An index on a host collection is one property, however it is spelled ([#3384](https://github.com/sebastienros/jint/issues/3384))
+### 4.40 An index on a host collection is one property, however it is spelled ([#3384](https://github.com/sebastienros/jint/issues/3384))
 
 `x[3]` and `x["3"]` are one property key, and a wrapped CLR collection answered them from two different
 places: a number key went to the array-like view, a string key to the reflected indexer, which took whatever


### PR DESCRIPTION
The guide's **Keeping this document current** section already states the rule, and explains exactly why it is needed:

> **Numbering is assigned at merge, not at authoring.** Several pull requests are usually in flight at once, each picking what looked like the next free subsection number when it was written […] and because two of them edit different parts of this file, git merges them cleanly and the duplicate only shows up in the rendered document.

Nothing on the way in reports that. Not the compiler, not a reviewer reading a diff that shows one added section, not the merge itself. During the v5 campaign collisions have been caught by hand roughly **ten times**, and twice reached `main` — #3344 and #3347 exist only to clean up after them.

It happened again while I was writing this. #3443 was authored at §4.41; #3447 merged §4.41 first; rebasing #3443 onto that `main` succeeded **without a conflict** and produced a document with two §4.41s. A rule that is only prose does not survive that.

## The three assertions

- **`NoTwoSectionsShareANumber`** — the collision git merges silently.
- **`EverySectionSitsUnderItsOwnChapter`** — a section numbered `4.x` belongs under `## 4.`, because the chapter is what the number means; a renumbering that crosses chapters has to move the section too.
- **`SectionNumbersAscendInDocumentOrder`** — so resolving a collision cannot leave the new entry sitting above the one it was numbered after.

**Contiguity is deliberately not asserted.** Gaps are legitimate and constant during a campaign: a merged section sits at §4.37 while §4.36 is still in an open pull request. Asserting contiguity would fail on `main` today and would push authors toward reusing numbers, which is the defect.

## Verification

Each failure was injected into the real document and the matching assertion watched to fail, naming the offending line numbers and titles. The exact #3443/#3447 collision trips two of the three:

```
§4.41 is claimed by line 1794 ("A narrow date name is narrow, and a `timeStyle` day period is the locale's …")
   and line 1887 ("Two holes in the freeze, closed (#3360)")

line 1842: §4.35 follows §4.41 at line 1794
```

and a section moved across chapters:

```
line 1794: "### 5.9 A narrow date name is narrow, …" sits under "## 4."
```

Green on net472, net8.0 and net10.0 against the unmodified guide (3/3 each). Test-only; no production code, no baselines, no migration row.
