### PR TITLE
Intl: a locale's own numbering system is what DurationFormat and RelativeTimeFormat resolve to

### DIFF
--- a/Jint.Tests/Runtime/IntlNumberingSystemTests.cs
+++ b/Jint.Tests/Runtime/IntlNumberingSystemTests.cs
@@ -1,0 +1,225 @@
+#nullable enable
+
+using Jint.Native.Intl;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// The four formatters that carry a <c>[[NumberingSystem]]</c> answer one locale with one numbering
+/// system. https://tc39.es/ecma402/#sec-resolvelocale (9.2.7) step 13 starts <c>nu</c> at
+/// <c>keyLocaleData[0]</c> — the locale's own default, which
+/// <see cref="ICldrProvider.GetDefaultNumberingSystem"/> answers for — and lets the locale's
+/// <c>-u-nu-</c> extension and then the <c>numberingSystem</c> option overwrite it.
+/// </summary>
+/// <remarks>
+/// The shipped <see cref="DefaultCldrProvider"/> has no per-locale numbering data and answers null for
+/// every locale, so these tests install the answers ICU gives instead: that is the configuration in which
+/// the four constructors could disagree, and the one an embedder that installs a CLDR-backed provider is
+/// in.
+/// </remarks>
+public class IntlNumberingSystemTests
+{
+    private static readonly string[] Formatters = ["NumberFormat", "DateTimeFormat", "RelativeTimeFormat", "DurationFormat"];
+
+    private static Engine WithCldrDefaults() => new(options => options.Intl.CldrProvider = new CldrLocaleDefaults());
+
+    /// <summary>
+    /// The defect: two of the four asked the provider and two returned <c>"latn"</c> unconditionally, so
+    /// one engine gave one locale two answers to the same question.
+    /// </summary>
+    [Test]
+    public void EveryFormatterResolvesTheLocalesOwnNumberingSystem()
+    {
+        var engine = WithCldrDefaults();
+
+        foreach (var formatter in Formatters)
+        {
+            engine.Evaluate($"new Intl.{formatter}('ar-EG').resolvedOptions().numberingSystem")
+                .AsString().Should().Be("arab", $"Intl.{formatter} reads the locale's default");
+            engine.Evaluate($"new Intl.{formatter}('bn-BD').resolvedOptions().numberingSystem")
+                .AsString().Should().Be("beng", $"Intl.{formatter} reads the locale's default");
+
+            // …and a locale whose default is Latin is untouched
+            engine.Evaluate($"new Intl.{formatter}('en-US').resolvedOptions().numberingSystem")
+                .AsString().Should().Be("latn", $"Intl.{formatter} leaves a Latin locale alone");
+        }
+    }
+
+    /// <summary>
+    /// A resolved numbering system that nothing formats in is the defect #3420 fixed, wearing a new coat
+    /// of paint — so the digits are asserted, not only <c>resolvedOptions()</c>.
+    /// </summary>
+    [Test]
+    public void TheLocaleDefaultIsWrittenAndNotOnlyReported()
+    {
+        var engine = WithCldrDefaults();
+
+        // the digits, not the separators: which separator ar-EG groups with is .NET's answer and differs
+        // between .NET Framework and modern .NET, while the ten digits do not
+        ShouldWriteArabicIndicDigits(engine, "new Intl.NumberFormat('ar-EG').format(12)", "١٢");
+        ShouldWriteArabicIndicDigits(engine, "new Intl.NumberFormat('ar-EG').format(1234.5)", "٢٣٤");
+        ShouldWriteArabicIndicDigits(engine, "new Intl.DateTimeFormat('ar-EG', { year: 'numeric', timeZone: 'UTC' }).format(0)", "١٩٧٠");
+        ShouldWriteArabicIndicDigits(engine, "new Intl.RelativeTimeFormat('ar-EG').format(3, 'day')", "٣");
+        ShouldWriteArabicIndicDigits(engine, "new Intl.DurationFormat('ar-EG').format({ hours: 12, minutes: 30 })", "١٢");
+        ShouldWriteArabicIndicDigits(engine, "new Intl.DurationFormat('ar-EG', { style: 'digital' }).format({ hours: 12, minutes: 30 })", "١٢:٣٠");
+    }
+
+    /// <summary>
+    /// Step 13.e: a value the locale's own <c>-u-nu-</c> extension asked for overwrites the default.
+    /// </summary>
+    [Test]
+    public void TheUnicodeExtensionWinsOverTheLocaleDefault()
+    {
+        var engine = WithCldrDefaults();
+
+        foreach (var formatter in Formatters)
+        {
+            engine.Evaluate($"new Intl.{formatter}('ar-EG-u-nu-latn').resolvedOptions().numberingSystem")
+                .AsString().Should().Be("latn", $"Intl.{formatter} lets -u-nu- win");
+
+            // an extension naming some other non-Latin system wins just as much
+            engine.Evaluate($"new Intl.{formatter}('ar-EG-u-nu-beng').resolvedOptions().numberingSystem")
+                .AsString().Should().Be("beng", $"Intl.{formatter} lets -u-nu- win");
+        }
+
+        engine.Evaluate("new Intl.NumberFormat('ar-EG-u-nu-latn').format(1234.5)")
+            .AsString().Should().MatchRegex("[0-9]");
+        engine.Evaluate("new Intl.DurationFormat('ar-EG-u-nu-latn').format({ hours: 12 })")
+            .AsString().Should().MatchRegex("[0-9]");
+    }
+
+    /// <summary>
+    /// Step 13.f: the <c>numberingSystem</c> option overwrites both.
+    /// </summary>
+    [Test]
+    public void TheNumberingSystemOptionWinsOverTheLocaleDefault()
+    {
+        var engine = WithCldrDefaults();
+
+        foreach (var formatter in Formatters)
+        {
+            engine.Evaluate($"new Intl.{formatter}('ar-EG', {{ numberingSystem: 'latn' }}).resolvedOptions().numberingSystem")
+                .AsString().Should().Be("latn", $"Intl.{formatter} lets the option win");
+            engine.Evaluate($"new Intl.{formatter}('ar-EG-u-nu-beng', {{ numberingSystem: 'latn' }}).resolvedOptions().numberingSystem")
+                .AsString().Should().Be("latn", $"Intl.{formatter} lets the option win over the extension too");
+        }
+
+        engine.Evaluate("new Intl.NumberFormat('ar-EG', { numberingSystem: 'latn' }).format(1234.5)")
+            .AsString().Should().MatchRegex("[0-9]");
+        engine.Evaluate("new Intl.DurationFormat('ar-EG', { numberingSystem: 'latn' }).format({ hours: 12 })")
+            .AsString().Should().MatchRegex("[0-9]");
+    }
+
+    /// <summary>
+    /// Steps 13.e.iii.1 and 13.f.iv both ask whether <c>keyLocaleData</c> contains the requested value
+    /// before adopting it, and neither clears <c>value</c> when it does not — so a well-formed request for
+    /// a system nothing can write leaves the locale's default in place, rather than dropping to Latin.
+    /// </summary>
+    [Test]
+    public void AWellFormedButUnusableRequestFallsBackToTheLocaleDefault()
+    {
+        var engine = WithCldrDefaults();
+
+        foreach (var formatter in Formatters)
+        {
+            engine.Evaluate($"new Intl.{formatter}('ar-EG', {{ numberingSystem: 'abcdef' }}).resolvedOptions().numberingSystem")
+                .AsString().Should().Be("arab", $"Intl.{formatter} keeps the locale default");
+            engine.Evaluate($"new Intl.{formatter}('ar-EG-u-nu-abcdef').resolvedOptions().numberingSystem")
+                .AsString().Should().Be("arab", $"Intl.{formatter} keeps the locale default");
+        }
+    }
+
+    /// <summary>
+    /// The locale's default is a default, not a request, so it does not become a <c>-u-nu-</c> subtag of
+    /// the reported locale — while one the caller did ask for stays exactly where they put it.
+    /// </summary>
+    [Test]
+    public void TheLocaleDefaultDoesNotAppearInTheResolvedLocale()
+    {
+        var engine = WithCldrDefaults();
+
+        foreach (var formatter in Formatters)
+        {
+            engine.Evaluate($"new Intl.{formatter}('ar-EG').resolvedOptions().locale")
+                .AsString().Should().Be("ar-EG", $"Intl.{formatter} reports the locale it was given");
+            engine.Evaluate($"new Intl.{formatter}('ar-EG-u-nu-beng').resolvedOptions().locale")
+                .AsString().Should().Be("ar-EG-u-nu-beng", $"Intl.{formatter} keeps a requested extension");
+        }
+    }
+
+    /// <summary>
+    /// A system the provider names but cannot supply digits for is not in <c>keyLocaleData</c> at all, so
+    /// no formatter adopts it — a numbering system nothing could write in is exactly what must not be
+    /// reported.
+    /// </summary>
+    [Test]
+    public void ADefaultTheProviderCannotWriteIsNotAdopted()
+    {
+        var engine = new Engine(options => options.Intl.CldrProvider = new NamesASystemItCannotWrite());
+
+        foreach (var formatter in Formatters)
+        {
+            engine.Evaluate($"new Intl.{formatter}('ar-EG').resolvedOptions().numberingSystem")
+                .AsString().Should().Be("latn", $"Intl.{formatter} refuses a system with no digits");
+        }
+    }
+
+    /// <summary>
+    /// The shipped provider has no per-locale numbering data and says so by answering null, so an
+    /// unconfigured engine writes exactly what it wrote before.
+    /// </summary>
+    [Test]
+    public void TheShippedProviderStillWritesLatinDigitsEverywhere()
+    {
+        var engine = new Engine();
+
+        DefaultCldrProvider.Instance.GetDefaultNumberingSystem("ar-EG").Should().BeNull();
+
+        foreach (var formatter in Formatters)
+        {
+            engine.Evaluate($"new Intl.{formatter}('ar-EG').resolvedOptions().numberingSystem")
+                .AsString().Should().Be("latn");
+        }
+
+        engine.Evaluate("new Intl.NumberFormat('ar-EG').format(1234.5)").AsString().Should().MatchRegex("[0-9]");
+        engine.Evaluate("new Intl.DurationFormat('ar-EG').format({ hours: 12 })").AsString().Should().MatchRegex("[0-9]");
+    }
+
+    private static void ShouldWriteArabicIndicDigits(Engine engine, string expression, string expectedDigits)
+    {
+        var text = engine.Evaluate(expression).AsString();
+        text.Should().Contain(expectedDigits, $"{expression} writes in the system it resolved");
+        text.Should().NotMatchRegex("[0-9]", $"{expression} writes no Latin digit");
+    }
+}
+
+/// <summary>
+/// The answers ICU gives for two locales whose CLDR default is not Latin, and nothing else: everything
+/// the rest of the interface knows still comes from the inherited implementation.
+/// </summary>
+file sealed class CldrLocaleDefaults : DefaultCldrProvider
+{
+    public override string? GetDefaultNumberingSystem(string locale)
+    {
+        var separator = locale.IndexOf('-');
+        var language = separator < 0 ? locale : locale.Substring(0, separator);
+
+        if (string.Equals(language, "ar", StringComparison.OrdinalIgnoreCase))
+        {
+            return "arab";
+        }
+
+        if (string.Equals(language, "bn", StringComparison.OrdinalIgnoreCase))
+        {
+            return "beng";
+        }
+
+        return base.GetDefaultNumberingSystem(locale);
+    }
+}
+
+/// <summary>A provider naming a numbering system it has no digits for.</summary>
+file sealed class NamesASystemItCannotWrite : DefaultCldrProvider
+{
+    public override string? GetDefaultNumberingSystem(string locale) => "abcdef";
+}

--- a/Jint/Native/Intl/DateTimeFormatConstructor.cs
+++ b/Jint/Native/Intl/DateTimeFormatConstructor.cs
@@ -198,14 +198,7 @@ internal sealed partial class DateTimeFormatConstructor : Constructor
         // If no user-supplied numberingSystem and no Unicode extension, fall back to the locale's
         // default per CLDR (e.g. ar-EG → arab). The provider returns null when it has no opinion;
         // in that case we leave numberingSystem null and the formatter uses Latin digits.
-        if (numberingSystem is null)
-        {
-            var localeDefault = _engine.Options.Intl.CldrProvider.GetDefaultNumberingSystem(resolvedLocale);
-            if (localeDefault is not null && !string.Equals(localeDefault, "latn", StringComparison.OrdinalIgnoreCase))
-            {
-                numberingSystem = ResolveSupportedNumberingSystem(supported, localeDefault);
-            }
-        }
+        numberingSystem ??= IntlUtilities.GetLocaleDefaultNumberingSystem(_engine, resolvedLocale);
 
         // Step 13: Get hour12 option
         var hour12Value = optionsObj.Get("hour12");

--- a/Jint/Native/Intl/DurationFormatConstructor.cs
+++ b/Jint/Native/Intl/DurationFormatConstructor.cs
@@ -79,8 +79,8 @@ internal sealed partial class DurationFormatConstructor : Constructor
             extensionNu = ParseNumberingSystemExtension(requestedLocales[0]);
         }
 
-        // Resolve numbering system: option overrides extension; validate both
-        var numberingSystem = ResolveNumberingSystem(numberingSystemOption, extensionNu);
+        // Resolve numbering system: option overrides extension, and the locale's own default is below both
+        var numberingSystem = ResolveNumberingSystem(numberingSystemOption, extensionNu, resolved.Locale);
 
         // Build resolved locale: include -u-nu- extension when resolved value matches extension value
         var resolvedLocale = resolved.Locale;
@@ -312,7 +312,13 @@ internal sealed partial class DurationFormatConstructor : Constructor
         return null;
     }
 
-    private string ResolveNumberingSystem(string? optionValue, string? extensionValue)
+    /// <summary>
+    /// https://tc39.es/ecma402/#sec-resolvelocale (9.2.7) step 13 for <c>nu</c>, which
+    /// https://tc39.es/proposal-intl-duration-format/#sec-Intl.DurationFormat-internal-slots lists as a
+    /// relevant extension key: the option wins, then the locale's <c>-u-nu-</c> extension, then the
+    /// locale's own default.
+    /// </summary>
+    private string ResolveNumberingSystem(string? optionValue, string? extensionValue, string locale)
     {
         // Options override extension. A system is supported when the provider can supply its digits —
         // the embedded table is the default provider's answer, not the engine's own.
@@ -327,8 +333,8 @@ internal sealed partial class DurationFormatConstructor : Constructor
             return extensionValue;
         }
 
-        // Default
-        return "latn";
+        // keyLocaleData[0] — the locale's own default, which is Latin only when the provider says so
+        return IntlUtilities.GetLocaleDefaultNumberingSystem(_engine, locale) ?? "latn";
     }
 
     /// <summary>

--- a/Jint/Native/Intl/IntlUtilities.cs
+++ b/Jint/Native/Intl/IntlUtilities.cs
@@ -868,6 +868,35 @@ internal static class IntlUtilities
         => engine.Options.Intl.CldrProvider.GetNumberingSystemDigits(numberingSystem) is not null;
 
     /// <summary>
+    /// The numbering system a locale itself defaults to, or null when Latin digits are what it asks for.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// https://tc39.es/ecma402/#sec-resolvelocale (9.2.7) step 13.c starts a relevant extension key at
+    /// <c>keyLocaleData[0]</c>, and https://tc39.es/ecma402/#sec-internal-slots (9.1) says that first
+    /// element "provid[es] the default value for that key in the locale". For <c>nu</c> that element is
+    /// what <see cref="ICldrProvider.GetDefaultNumberingSystem"/> answers, so this is the last rung of the
+    /// ladder in all four constructors that carry a <c>[[NumberingSystem]]</c> — below the locale's own
+    /// <c>-u-nu-</c> extension and below the <c>numberingSystem</c> option, both of which the same step
+    /// lets overwrite it.
+    /// </para>
+    /// <para>
+    /// A system the provider names but cannot supply digits for is not in <c>keyLocaleData</c> at all, and
+    /// is answered as null rather than becoming a system nothing could format in.
+    /// </para>
+    /// </remarks>
+    internal static string? GetLocaleDefaultNumberingSystem(Engine engine, string locale)
+    {
+        var localeDefault = engine.Options.Intl.CldrProvider.GetDefaultNumberingSystem(locale);
+        if (localeDefault is null || string.Equals(localeDefault, "latn", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        return IsSupportedNumberingSystem(engine, localeDefault) ? CanonicalizeUValue("nu", localeDefault) : null;
+    }
+
+    /// <summary>
     /// Validates that a string matches the Unicode extension value pattern: (3*8alphanum) *("-" (3*8alphanum))
     /// Only ASCII alphanumeric characters are allowed.
     /// </summary>

--- a/Jint/Native/Intl/NumberFormatConstructor.cs
+++ b/Jint/Native/Intl/NumberFormatConstructor.cs
@@ -100,17 +100,6 @@ internal sealed partial class NumberFormatConstructor : Constructor
         var availableLocales = IntlUtilities.GetAvailableLocales();
         var resolvedLocale = ResolveNumberFormatLocale(_engine, availableLocales, requestedLocales, localeMatcher);
 
-        // If no user-supplied numberingSystem, fall back to the locale's CLDR default
-        // (e.g. ar-EG → arab). Provider returning null means "no opinion" → use Latin.
-        if (numberingSystem is null)
-        {
-            var localeDefault = _engine.Options.Intl.CldrProvider.GetDefaultNumberingSystem(resolvedLocale);
-            if (localeDefault is not null && !string.Equals(localeDefault, "latn", StringComparison.OrdinalIgnoreCase))
-            {
-                numberingSystem = localeDefault;
-            }
-        }
-
         // SetNumberFormatUnitOptions - read style, currency, currencyDisplay, currencySign, unit, unitDisplay
         var style = GetStringOption(optionsObj, "style", StyleValues, "decimal");
 
@@ -289,10 +278,11 @@ internal sealed partial class NumberFormatConstructor : Constructor
             };
         }
 
-        // Resolve numbering system with proper fallback logic
+        // Resolve numbering system per https://tc39.es/ecma402/#sec-resolvelocale (9.2.7) step 13 for the
+        // relevant extension key "nu":
         // 1. If options.numberingSystem is a supported system, use it
         // 2. Otherwise, fall back to locale extension if supported
-        // 3. Otherwise, use default "latn"
+        // 3. Otherwise, use the locale's own default, and Latin only when that has no opinion either
         string? localeNumberingSystem = null;
         foreach (var loc in requestedLocales)
         {
@@ -319,8 +309,8 @@ internal sealed partial class NumberFormatConstructor : Constructor
         }
         else
         {
-            // Default to "latn"
-            resolvedNumberingSystem = "latn";
+            // keyLocaleData[0] — the locale's own default, which is Latin only when the provider says so
+            resolvedNumberingSystem = IntlUtilities.GetLocaleDefaultNumberingSystem(_engine, resolvedLocale) ?? "latn";
         }
 
         // Adjust the resolved locale based on numbering system source

--- a/Jint/Native/Intl/RelativeTimeFormatConstructor.cs
+++ b/Jint/Native/Intl/RelativeTimeFormatConstructor.cs
@@ -87,7 +87,9 @@ internal sealed partial class RelativeTimeFormatConstructor : Constructor
         var availableLocales = IntlUtilities.GetAvailableLocales();
         var resolvedLocale = ResolveRelativeTimeFormatLocale(_engine, availableLocales, requestedLocales, localeMatcher);
 
-        // Resolve numbering system with proper fallback logic
+        // Resolve numbering system per https://tc39.es/ecma402/#sec-resolvelocale (9.2.7) step 13 for the
+        // relevant extension key "nu": the option wins, then the locale's -u-nu- extension, then the
+        // locale's own default.
         string? localeNumberingSystem = null;
         foreach (var loc in requestedLocales)
         {
@@ -111,8 +113,8 @@ internal sealed partial class RelativeTimeFormatConstructor : Constructor
         }
         else
         {
-            // Default to "latn"
-            resolvedNumberingSystem = "latn";
+            // keyLocaleData[0] — the locale's own default, which is Latin only when the provider says so
+            resolvedNumberingSystem = IntlUtilities.GetLocaleDefaultNumberingSystem(_engine, resolvedLocale) ?? "latn";
         }
 
         // Adjust the resolved locale based on numbering system source

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -2065,6 +2065,40 @@ budget the engine was configured with, so an engine with a deliberately short `R
 `Constraints.RegexTimeout`, or set `RegexTimeout` on the parsing options of the script in question, which
 still outranks the constraint. A prepared script keeps carrying its own prepare-time value and now applies
 it to the regexes it builds as well as the ones it declares.
+### 4.43 A locale's own numbering system is what every `Intl` formatter resolves to ([#3418](https://github.com/sebastienros/jint/issues/3418))
+
+Four formatters carry a `[[NumberingSystem]]`. Two of them asked `ICldrProvider.GetDefaultNumberingSystem`
+when the caller named no system, and two returned `"latn"` unconditionally — so one engine gave one locale
+two answers to the same question. All four now ask, through one helper, and the locale's default sits below
+the locale's `-u-nu-` extension and below the `numberingSystem` option, where
+[ResolveLocale](https://tc39.es/ecma402/#sec-resolvelocale) step 13 puts it.
+
+```js
+// 5.0 — with a CLDR-backed provider installed
+new Intl.NumberFormat('ar-EG').resolvedOptions().numberingSystem;       // "arab"
+new Intl.DurationFormat('ar-EG').resolvedOptions().numberingSystem;     // "latn"
+new Intl.DurationFormat('ar-EG').format({ hours: 12 });                 // "12 hr"
+new Intl.NumberFormat('ar-EG-u-nu-latn').resolvedOptions().numberingSystem;      // "arab"
+new Intl.NumberFormat('ar-EG', { numberingSystem: 'nope' }).resolvedOptions().numberingSystem; // "latn"
+
+// 5.x
+new Intl.DurationFormat('ar-EG').resolvedOptions().numberingSystem;     // "arab"
+new Intl.DurationFormat('ar-EG').format({ hours: 12 });                 // "١٢ hr"
+new Intl.NumberFormat('ar-EG-u-nu-latn').resolvedOptions().numberingSystem;      // "latn"
+new Intl.NumberFormat('ar-EG', { numberingSystem: 'nope' }).resolvedOptions().numberingSystem; // "arab"
+```
+
+The last two lines are `Intl.NumberFormat`'s half of the same defect: it read the locale's default into the
+slot the `numberingSystem` option had just been read into, so the default outranked the `-u-nu-` extension
+that must beat it, and a well-formed request for a system nothing can write dropped to Latin instead of
+leaving the locale's default in place.
+
+**What could break:** nothing on a default engine. The shipped `DefaultCldrProvider` has no per-locale
+numbering data and answers `null` for every locale, so every formatter still resolves to `latn` and writes
+exactly what it wrote before. It moves for an embedder who has installed a CLDR-backed
+`ICldrProvider` — `Intl.RelativeTimeFormat` and `Intl.DurationFormat` now write that provider's digits for a
+locale whose default is not Latin, the way `Intl.NumberFormat` and `Intl.DateTimeFormat` already did. To keep
+Latin digits for such a locale, ask for them: `{ numberingSystem: 'latn' }`, or a `-u-nu-latn` subtag.
 
 ## 5. New in v5
 


### PR DESCRIPTION
Fixes #3418.

Four formatters carry a `[[NumberingSystem]]`. `Intl.NumberFormat` and `Intl.DateTimeFormat` asked
`ICldrProvider.GetDefaultNumberingSystem` when neither a `numberingSystem` option nor a `-u-nu-` extension
was supplied. `Intl.RelativeTimeFormat` and `Intl.DurationFormat` ended their resolution in a hardcoded
`return "latn"`. So one engine gave one locale two answers to the same question.

[ResolveLocale](https://tc39.es/ecma402/#sec-resolvelocale) step 13.c starts a relevant extension key at
`keyLocaleData[0]`, and [§9.1](https://tc39.es/ecma402/#sec-internal-slots) says that first element
"provid[es] the default value for that key in the locale". `nu` is a relevant extension key for all four, so
`"latn"` unconditionally is wrong wherever the locale says otherwise.

## The tests, before the fix

`Jint.Tests/Runtime/IntlNumberingSystemTests.cs` installs the answers ICU gives — `ar` → `arab`, `bn` →
`beng` — because the shipped `DefaultCldrProvider` has no per-locale numbering data at all and answers
`null` for every locale. Five of its eight tests fail against unmodified `main`:

```
Failed EveryFormatterResolvesTheLocalesOwnNumberingSystem
  ...because Intl.RelativeTimeFormat reads the locale's default, but they differ at index 0
Failed TheLocaleDefaultIsWrittenAndNotOnlyReported
  Expected string "12 hour, 30 minute" to contain "١٢"
Failed TheUnicodeExtensionWinsOverTheLocaleDefault
  ...because Intl.NumberFormat lets -u-nu- win, but they differ at index 0
Failed AWellFormedButUnusableRequestFallsBackToTheLocaleDefault
  ...because Intl.NumberFormat keeps the locale default, but they differ at index 0
Failed TheLocaleDefaultDoesNotAppearInTheResolvedLocale
  ...because Intl.NumberFormat keeps a requested extension, but they differ at index 5
Failed!  - Failed: 5, Passed: 3
```

The three that pass before and after are the guards: an explicit option already won, a provider naming a
system it has no digits for is still refused, and an unconfigured engine still writes Latin digits
everywhere.

## `ar-EG`, before and after

With a CLDR-backed `ICldrProvider` installed:

| | 5.0 | this PR |
| --- | --- | --- |
| `new Intl.NumberFormat('ar-EG').resolvedOptions().numberingSystem` | `"arab"` | `"arab"` |
| `new Intl.DateTimeFormat('ar-EG').resolvedOptions().numberingSystem` | `"arab"` | `"arab"` |
| `new Intl.RelativeTimeFormat('ar-EG').resolvedOptions().numberingSystem` | `"latn"` | `"arab"` |
| `new Intl.DurationFormat('ar-EG').resolvedOptions().numberingSystem` | `"latn"` | `"arab"` |
| `new Intl.DurationFormat('ar-EG').format({ hours: 12, minutes: 30 })` | `"12 hour, 30 minute"` | `"١٢ hour, ٣٠ minute"` |
| `new Intl.DurationFormat('ar-EG', { style: 'digital' }).format({ hours: 12, minutes: 30 })` | `"12:30:00"` | `"١٢:٣٠:٠٠"` |
| `new Intl.NumberFormat('ar-EG').format(12)` | `"١٢"` | `"١٢"` |
| `new Intl.DateTimeFormat('ar-EG', { year: 'numeric' }).format(0)` | `"١٩٧٠"` | `"١٩٧٠"` |

`Intl.RelativeTimeFormat`'s *output* does not move: it already wrote `"in ٣ days"` for `ar-EG` while
reporting `latn`, because its inner `NumberFormat` resolved the locale default on its own. What moves is
that it now says so. `Intl.DurationFormat`'s output does move, and it is what #3420 makes possible — that PR
wired the resolved system into every `NumberFormat` `PartitionDurationFormatPattern` constructs, so
resolving `arab` and then writing Latin digits is no longer a thing this constructor can do.

## One lookup, not four

`IntlUtilities.GetLocaleDefaultNumberingSystem` is the single spelling, and all four constructors call it as
the last rung of the same ladder — below the locale's `-u-nu-` extension, below the `numberingSystem`
option, which is the order step 13 puts them in. A system the provider *names* but has no digits for is not
in `keyLocaleData` at all, so it is answered as `null` rather than becoming a system nothing could format
in.

`Intl.DateTimeFormat` and `Intl.RelativeTimeFormat` were call-site substitutions. `Intl.NumberFormat` was
not, because extracting the helper exposed its half of the same defect: it read the locale default into the
variable the `numberingSystem` **option** had just been read into, two hundred lines above the ladder that
consumes it. Two things followed from that, both visible in the failing tests above —

```js
// 5.0
new Intl.NumberFormat('ar-EG-u-nu-latn').resolvedOptions().numberingSystem;                    // "arab"
new Intl.NumberFormat('ar-EG', { numberingSystem: 'nope' }).resolvedOptions().numberingSystem; // "latn"

// this PR
new Intl.NumberFormat('ar-EG-u-nu-latn').resolvedOptions().numberingSystem;                    // "latn"
new Intl.NumberFormat('ar-EG', { numberingSystem: 'nope' }).resolvedOptions().numberingSystem; // "arab"
```

— the locale default outranked the `-u-nu-` extension that step 13.e lets beat it, and a well-formed request
for a system nothing can write dropped to Latin, where neither step 13.e.iii.1 nor step 13.f.iv clears
`value` when `keyLocaleData` does not contain the request. The lookup moved to where its three siblings do
it; nothing else in that constructor changed.

## Precedence, pinned

The tests assert, for all four constructors uniformly:

- `ar-EG-u-nu-latn` and `ar-EG-u-nu-beng` → the extension's system, not the locale's;
- `{ numberingSystem: 'latn' }` → the option's system, over the locale default *and* over a conflicting
  `-u-nu-beng`;
- `{ numberingSystem: 'abcdef' }` and `-u-nu-abcdef` → the locale default, which is what `keyLocaleData`
  not containing the request leaves in place — not Latin;
- `resolvedOptions().locale` stays `ar-EG`, because a default is not a request and does not become a
  `-u-nu-` subtag, while a requested `-u-nu-beng` stays exactly where the caller put it.

## Test262

**102,495 passed / 0 failed / 189 skipped** — identical to `main`. Solution build clean, whole solution
green on net472 / net8.0 / net10.0.

## Migration

`docs/v5-migration.md` **§4.42**. No public API changed, so the five `Verify` baselines are untouched and
`Jint.Tests.PublicInterface` is green as-is.

## Found along the way, filed separately

- #3455 — `Intl.NumberFormat`'s `formatToParts` / `formatRangeToParts` never transliterate, so they disagree
  with `format` about the same number, and `Intl.RelativeTimeFormat.formatToParts` inherits it.
- #3456 — `Intl.RelativeTimeFormat.format` transliterates the assembled string, so `style: 'short'` turns
  `"sec."` into `"sec٫"`.
- #3457 — `Intl.DateTimeFormat`'s `ca` default is read from `CultureInfo.Calendar` rather than from
  `ICldrProvider`, so a host cannot correct it and `ar-SA` resolves to `"islamic"` where CLDR says
  `"islamic-umalqura"`.

`nu` is the only relevant extension key `Intl.RelativeTimeFormat` and `Intl.DurationFormat` have — neither
reports a `calendar`, an `hourCycle` or a `collation` from `resolvedOptions()` — so there is no second key
with this shape in either constructor. `Intl.Collator`'s hardcoded `"default"` for `co` was checked and is
correct: ECMA-402 10.2.3 requires `null` as the first element of every `[[co]]` list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014W5mbjGhyvgAS4pivXoc4S
