### PR TITLE
CI: a testhost that starts slowly is not a failing test run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,13 @@ on:
 env:
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
+  # vstest gives a testhost 90 seconds to connect back, and aborts the whole run when it does not.
+  # These jobs run four test assemblies at once on a four-core runner, and the net472 host is the one
+  # that loses that race: it has the slowest start and goes last. The abort reads as a red leg with no
+  # failing test in it -- every assembly reports "Passed!" and the step still exits 1 -- so it costs a
+  # diagnosis every time. Five minutes is startup contention rather than a hang; anything genuinely
+  # stuck is caught by the suite's own per-test budgets, not by this.
+  VSTEST_CONNECTION_TIMEOUT: 300
 
 jobs:
   build:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,6 +12,13 @@ on:
 env:
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
+  # vstest gives a testhost 90 seconds to connect back, and aborts the whole run when it does not.
+  # These jobs run four test assemblies at once on a four-core runner, and the net472 host is the one
+  # that loses that race: it has the slowest start and goes last. The abort reads as a red leg with no
+  # failing test in it -- every assembly reports "Passed!" and the step still exits 1 -- so it costs a
+  # diagnosis every time. Five minutes is startup contention rather than a hang; anything genuinely
+  # stuck is caught by the suite's own per-test budgets, not by this.
+  VSTEST_CONNECTION_TIMEOUT: 300
 
 concurrency:
   group: ${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,13 @@ on:
 env:
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
+  # vstest gives a testhost 90 seconds to connect back, and aborts the whole run when it does not.
+  # These jobs run four test assemblies at once on a four-core runner, and the net472 host is the one
+  # that loses that race: it has the slowest start and goes last. The abort reads as a red leg with no
+  # failing test in it -- every assembly reports "Passed!" and the step still exits 1 -- so it costs a
+  # diagnosis every time. Five minutes is startup contention rather than a hang; anything genuinely
+  # stuck is caught by the suite's own per-test budgets, not by this.
+  VSTEST_CONNECTION_TIMEOUT: 300
 
 permissions:
   contents: read


### PR DESCRIPTION
#3453's Windows leg was red with every assembly reporting `Passed!`:

```
Passed!  - Failed: 0, Passed: 10784, Skipped: 4 ... Jint.Tests.dll (net8.0)
Passed!  - Failed: 0, Passed: 10784, Skipped: 4 ... Jint.Tests.dll (net10.0)
Passed!  - Failed: 0, Passed: 3133, Skipped: 21 ... Jint.Tests.PublicInterface.dll (net10.0)
Passed!  - Failed: 0, Passed: 102495, Skipped: 189 ... Jint.Tests.Test262.dll (net10.0)
##[error]Process completed with exit code 1.
```

`Jint.Tests.dll (net472)` is absent from that list, because its run never started:

```
vstest.console process failed to connect to testhost process after 90 seconds.
This may occur due to machine slowness, please set environment variable
VSTEST_CONNECTION_TIMEOUT to increase timeout.
Test Run Aborted.
```

**No test failed.** vstest gives a testhost 90 seconds to connect back and aborts the whole run when it does not. These jobs run four test assemblies at once on a four-core runner, and the net472 host is the one that loses that race — slowest start, and it goes last.

## Why this is worth a change rather than a re-run

The cost is not the retry, it is that **the failure carries no information**. A red leg whose log says every assembly passed sends whoever reads it looking for a failing test that does not exist. That happened twice in one session, on changes that could not possibly have caused it — a `Volatile.Write` in `Options` and a test-only file.

So the three workflows set `VSTEST_CONNECTION_TIMEOUT: 300`.

Five minutes is startup contention rather than a hang. Nothing about this weakens the suite's ability to report a hang: **anything genuinely stuck is caught by the per-test budgets**, which is where a hang should be reported and where the report names the test. This setting governs only how long the runner waits for a *process to start*.

## Related, same root cause

#3452 found that every test body ran at `ThreadPriority.Lowest` — measured at 2.5 s against 0.14 s for a 0.1 ms body with only two competitors on two cores. Both findings are the same oversubscribed-runner story from different angles: one starved the bodies, this one starved process startup.

No production code, no tests, no baselines, no migration row.
