### PR TITLE
Intl: the culture cache every engine shares is bounded, so invented locale tags cannot grow it

### DIFF
--- a/Jint.Tests/Runtime/IntlCultureCacheTests.cs
+++ b/Jint.Tests/Runtime/IntlCultureCacheTests.cs
@@ -1,0 +1,64 @@
+#nullable enable
+
+using Jint.Native.Intl;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// The process-wide <c>IntlUtilities</c> culture cache is keyed on a locale tag a script chose, and every
+/// engine in the process shares it. These tests pin that a script cannot grow it without bound.
+/// </summary>
+/// <remarks>
+/// Non-parallelizable because the assertions are about a static shared by the whole test run: a fixture
+/// running beside this one would add its own tags to the same dictionary.
+/// </remarks>
+[NonParallelizable]
+public class IntlCultureCacheTests
+{
+    /// <summary>
+    /// <c>toLocaleLowerCase</c> is core <c>String.prototype</c> -- no <c>Intl</c> opt-in, no WebApi, nothing --
+    /// and ECMA-402 requires a structurally valid but unknown tag to be accepted rather than rejected, so
+    /// every tag the loop invents used to become a permanent entry no engine's <c>LimitMemory</c> could see.
+    /// </summary>
+    [Test]
+    public void ScriptSuppliedLocaleTagsDoNotGrowTheProcessWideCultureCache()
+    {
+        var engine = new Engine();
+        engine.Execute("for (var i = 0; i < 2000; i++) { 'x'.toLocaleLowerCase('en-abcd' + i); }");
+
+        IntlUtilities.CultureCacheCount.Should().BeLessThanOrEqualTo(IntlUtilities.CultureCacheBound);
+    }
+
+    /// <summary>
+    /// The same key space reached through <c>Intl</c> itself, where <c>BestAvailableLocale</c> additionally
+    /// asks for every truncated prefix of the requested tag.
+    /// </summary>
+    [Test]
+    public void RequestedLocalesOfAnIntlFormatterDoNotGrowTheProcessWideCultureCache()
+    {
+        var engine = new Engine();
+        engine.Execute("for (var i = 0; i < 2000; i++) { new Intl.NumberFormat('en-abcd' + i + '-efgh' + i).format(1); }");
+
+        IntlUtilities.CultureCacheCount.Should().BeLessThanOrEqualTo(IntlUtilities.CultureCacheBound);
+    }
+
+    /// <summary>
+    /// The bound is not allowed to become a correctness problem: a tag resolved after the cache overflowed
+    /// answers exactly as it did before, because the value is a total function of the key.
+    /// </summary>
+    [Test]
+    public void AnEvictedTagResolvesToTheSameCultureItDidBefore()
+    {
+        var before = IntlUtilities.GetCultureInfo("de-DE");
+        before.Should().NotBeNull();
+
+        var engine = new Engine();
+        engine.Execute("for (var i = 0; i < 2000; i++) { 'x'.toLocaleLowerCase('en-abcd' + i); }");
+
+        var after = IntlUtilities.GetCultureInfo("de-DE");
+        after.Should().NotBeNull();
+        after!.Name.Should().Be(before!.Name);
+        after.IsReadOnly.Should().BeTrue();
+        after.NumberFormat.NumberDecimalSeparator.Should().Be(before.NumberFormat.NumberDecimalSeparator);
+    }
+}

--- a/Jint/Native/Intl/IntlUtilities.cs
+++ b/Jint/Native/Intl/IntlUtilities.cs
@@ -86,7 +86,26 @@ internal static class IntlUtilities
     // Cache for CultureInfo instances to avoid repeated allocations. The entries are shared by every engine
     // in the process, so CreateCultureInfo hands them out read-only rather than trusting every call site not
     // to write to one.
+    //
+    // The key is a locale tag a script chose. ECMA-402 requires CanonicalizeLocaleList to accept any
+    // structurally valid tag rather than reject an unknown one, so 'x'.toLocaleLowerCase('en-abcd' + i) --
+    // core String.prototype, on an engine that opted into nothing -- invents a distinct key on every
+    // iteration, and BestAvailableLocale asks again for every truncated prefix. The cache is therefore
+    // bounded the same way RegExpParseCache is: once it holds Capacity distinct tags it is cleared and
+    // refilled. Real scripts use a handful of locales and fill it once.
     private static readonly ConcurrentDictionary<string, CultureInfo?> _cultureCache = new(StringComparer.OrdinalIgnoreCase);
+
+    // Cleared (not LRU-evicted) on overflow: cheap, thread-safe, allocates nothing on the hit path and is
+    // self-healing when the working set shifts. Dropping an entry can only cost one re-resolution and never
+    // a different answer -- the value is a total function of the tag, and the instance handed out is
+    // read-only, so an engine still holding one keeps a culture equal to whatever the next lookup produces.
+    private const int CultureCacheCapacity = 256;
+
+    /// <summary>Number of cached locale tags. Exists so the growth test can assert on the bound.</summary>
+    internal static int CultureCacheCount => _cultureCache.Count;
+
+    /// <summary>The bound <see cref="CultureCacheCount"/> can never exceed for long.</summary>
+    internal static int CultureCacheBound => CultureCacheCapacity;
     // BCP 47 language tag pattern (permissive to accept Unicode extensions)
     // Accepts: language[-script][-region][-variant]*[-extension]*[-privateuse]
     // Extensions use single-character singletons like -u- for Unicode extensions
@@ -1824,7 +1843,21 @@ internal static class IntlUtilities
             return null;
         }
 
-        return _cultureCache.GetOrAdd(locale, static key => CreateCultureInfo(key));
+        if (_cultureCache.TryGetValue(locale, out var cached))
+        {
+            return cached;
+        }
+
+        var culture = CreateCultureInfo(locale);
+
+        if (_cultureCache.Count >= CultureCacheCapacity)
+        {
+            _cultureCache.Clear();
+        }
+
+        // GetOrAdd rather than the indexer: another thread may already have published an instance for this
+        // tag, and a caller holding that one has to keep matching what the next lookup returns.
+        return _cultureCache.GetOrAdd(locale, culture);
     }
 
     private static CultureInfo? CreateCultureInfo(string locale)


### PR DESCRIPTION
Part of #3438 — the growth half. [#3448](https://github.com/sebastienros/jint/pull/3448) closed the mutability half.

`IntlUtilities` caches one `CultureInfo` per locale tag in a process-wide `ConcurrentDictionary` shared by every engine, and nothing ever evicted. The key is a string a script chose: ECMA-402 requires `CanonicalizeLocaleList` to accept a structurally valid but *unknown* tag rather than reject it, and `GetCultureInfo` is keyed on the raw tag on three paths — one of which is core `String.prototype`.

```js
for (var i = 0; i < 2000; i++) { 'x'.toLocaleLowerCase('en-abcd' + i); }
```

On a `new Engine()` — no `Intl` opt-in, no WebApi, nothing — that left **4001** permanent entries behind (2000 tags plus the likely-subtags expansion of each, plus `en`), attributable to no engine's `LimitMemory` and outliving every engine that created them.

## The bound

A capacity of 256 distinct tags, cleared and refilled on overflow — the rule `RegExpParseCache` already uses in this repository, and `EvalFunction` / `FunctionInstance.Dynamic` use at 32.

**What a hit costs: exactly what it cost before.** One `ConcurrentDictionary.TryGetValue` and nothing else — no recency list, no timestamp, no counter, no allocation. Clearing rather than LRU-evicting is what buys that: the bookkeeping an LRU needs would land on the hit path, which is the path real scripts are on. It is also thread-safe without a lock and self-healing when the working set shifts. Real scripts use a handful of locales and fill the cache once; 256 is far above any of them and far below the key space a loop can invent.

**Eviction cannot become a correctness problem here.** The value is a total function of the key — `Options.Culture` never reaches `Intl`, so nothing engine-specific is in it — and since #3448 the instance handed out is read-only, so an engine still holding an evicted culture keeps one equal to whatever the next lookup produces. `AnEvictedTagResolvesToTheSameCultureItDidBefore` pins that by resolving `de-DE`, overflowing the cache, and re-resolving it.

`GetOrAdd(locale, culture)` rather than the indexer on the add, so a concurrent creator's instance stays the one everybody sees.

## Tests

`IntlCultureCacheTests`, `[NonParallelizable]` because the assertions are about a static shared by the whole run. Against the unbounded code, with the accessor in place but not the bound:

```
Failed RequestedLocalesOfAnIntlFormatterDoNotGrowTheProcessWideCultureCache
   Expected IntlUtilities.CultureCacheCount to be less than or equal to 256, but found 4001 (difference of 3745).
Failed ScriptSuppliedLocaleTagsDoNotGrowTheProcessWideCultureCache
   Expected IntlUtilities.CultureCacheCount to be less than or equal to 256, but found 4001 (difference of 3745).
```

Both assert on the cache's own `Count`, never on process memory. With the bound: `Intl` 261/261, and the full suite green — `Jint.Tests` 10835 (net8.0/net10.0), 7459 (net472), `Jint.Tests.PublicInterface` 3241/3231/2609, test262 **102495 passed / 0 failed / 189 skipped**.

## No migration row

`IntlUtilities` is `internal`, no public signature changes, and no script-visible answer changes — a locale that resolved to a culture still resolves to an equal one. Nothing for `docs/v5-migration.md`.

## How it was found

The #3426 audit of process-wide caches. The sibling shape it found beside this one is #3439, fixed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014W5mbjGhyvgAS4pivXoc4S
