### PR TITLE
Temporal: Duration.prototype.round reckons in the calendar its relativeTo carries

### DIFF
--- a/Jint.Tests/Runtime/DurationRoundCalendarTests.cs
+++ b/Jint.Tests/Runtime/DurationRoundCalendarTests.cs
@@ -1,0 +1,193 @@
+#nullable enable
+
+using System.Text;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// <c>Temporal.Duration.prototype.round</c> reckons in the calendar of the <c>relativeTo</c> it was given,
+/// which is what makes it agree with <c>until</c>, <c>add</c> and <c>total</c> about the same two dates.
+/// </summary>
+/// <remarks>
+/// The defect these pin read the calendar off a <c>PlainDate</c> <c>relativeTo</c> and then wrote
+/// <c>"iso8601"</c> into both calendar operations it performs, so every rounding with a non-ISO
+/// <c>relativeTo</c> counted ISO years and ISO months under that calendar's name — and past a calendar's
+/// range it answered where <c>total</c> and <c>add</c> refused. See
+/// <see href="https://github.com/sebastienros/jint/issues/3450"/>, and
+/// <see href="https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.round"/> step 443, which
+/// is <c>CalendarDateAdd(calendar, …)</c> for the calendar the <c>relativeTo</c> carries.
+/// </remarks>
+public class DurationRoundCalendarTests
+{
+    private static readonly string[] EveryCalendarTemporalReckonsIn =
+    [
+        "iso8601",
+        "chinese", "dangi", "hebrew", "persian",
+        "coptic", "ethiopic", "ethioaa", "indian",
+        "islamic-umalqura", "islamic-civil", "islamic-tbla",
+    ];
+
+    /// <summary>Day counts short and long enough to cross months, leap months and years.</summary>
+    private static readonly int[] DayCounts = [1, 30, 60, 365, 400, 1000, 3000, 10000, 20000];
+
+    private static string Evaluate(string expression)
+    {
+        var engine = new Engine();
+        return engine.Evaluate(
+            $"(function () {{ try {{ return String({expression}); }} catch (e) {{ return e.constructor.name; }} }})()").AsString();
+    }
+
+    /// <summary>
+    /// Rounding a duration of days with <c>largestUnit: 'year'</c> and a <c>relativeTo</c> is the same
+    /// question <c>until</c> answers between the same two dates, so the two have to give the same duration.
+    /// </summary>
+    [TestCaseSource(nameof(EveryCalendarTemporalReckonsIn))]
+    public void RoundingDaysToYearsIsTheDifferenceTheSameCalendarMeasures(string calendar)
+    {
+        var failures = new StringBuilder();
+
+        foreach (var days in DayCounts)
+        {
+            var rounded = Evaluate(
+                $"new Temporal.Duration(0, 0, 0, {days})" +
+                $".round({{ largestUnit: 'year', relativeTo: Temporal.PlainDate.from('1990-01-01').withCalendar('{calendar}') }})");
+
+            var measured = Evaluate(
+                $"(function () {{ var r = Temporal.PlainDate.from('1990-01-01').withCalendar('{calendar}');" +
+                $" return r.until(r.add({{ days: {days} }}), {{ largestUnit: 'year' }}); }})()");
+
+            if (!string.Equals(rounded, measured, StringComparison.Ordinal))
+            {
+                failures.Append(calendar).Append(", ").Append(days).Append(" days: round said ")
+                    .Append(rounded).Append(", until said ").Append(measured).AppendLine();
+            }
+        }
+
+        failures.ToString().Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// The whole-year part of a rounding and the integer part of a total are the same count of the same
+    /// calendar's years. <c>total</c> already reckoned in the <c>relativeTo</c>'s calendar, so this is the
+    /// disagreement the issue leads with, stated as an invariant.
+    /// </summary>
+    [TestCaseSource(nameof(EveryCalendarTemporalReckonsIn))]
+    public void TheYearsRoundingTruncatesToAreTheYearsTotalCounts(string calendar)
+    {
+        var failures = new StringBuilder();
+
+        foreach (var days in DayCounts)
+        {
+            var relativeTo = $"Temporal.PlainDate.from('1990-01-01').withCalendar('{calendar}')";
+
+            var rounded = Evaluate(
+                $"new Temporal.Duration(0, 0, 0, {days}).round(" +
+                $"{{ largestUnit: 'year', smallestUnit: 'year', roundingMode: 'trunc', relativeTo: {relativeTo} }}).years");
+
+            var totalled = Evaluate(
+                $"Math.trunc(new Temporal.Duration(0, 0, 0, {days}).total({{ unit: 'year', relativeTo: {relativeTo} }}))");
+
+            if (!string.Equals(rounded, totalled, StringComparison.Ordinal))
+            {
+                failures.Append(calendar).Append(", ").Append(days).Append(" days: round said ")
+                    .Append(rounded).Append(" years, total said ").Append(totalled).AppendLine();
+            }
+        }
+
+        failures.ToString().Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// A <c>ZonedDateTime</c> <c>relativeTo</c> always passed its own calendar through, which is why the
+    /// same rounding gave two answers depending on which kind of <c>relativeTo</c> it was handed.
+    /// </summary>
+    [TestCase("chinese")]
+    [TestCase("hebrew")]
+    [TestCase("islamic-civil")]
+    public void APlainRelativeToAndAZonedOneInTheSameCalendarRoundAlike(string calendar)
+    {
+        var plain = Evaluate(
+            "new Temporal.Duration(0, 0, 0, 10000).round({ largestUnit: 'year', relativeTo: " +
+            $"Temporal.PlainDate.from('1990-01-01').withCalendar('{calendar}') }})");
+
+        var zoned = Evaluate(
+            "new Temporal.Duration(0, 0, 0, 10000).round({ largestUnit: 'year', relativeTo: " +
+            $"Temporal.ZonedDateTime.from('1990-01-01T00:00:00[UTC][u-ca={calendar}]') }})");
+
+        plain.Should().Be(zoned);
+    }
+
+    /// <summary>
+    /// Thirteen months is a whole year in a lunisolar leap year and a year and a month in the ISO
+    /// calendar, so a rounding that counts ISO months answers the wrong one under the calendar's name.
+    /// </summary>
+    /// <remarks>
+    /// 2023-01-22 is day 1 of the first month of the Chinese year 2023, which carries a leap month and
+    /// therefore thirteen months in all — <c>monthsInYear</c> reports 13 for it.
+    /// </remarks>
+    [Test]
+    public void ThirteenMonthsIsAWholeYearInALunisolarLeapYear()
+    {
+        Evaluate("Temporal.PlainDate.from('2023-01-22').withCalendar('chinese').monthsInYear")
+            .Should().Be("13");
+
+        Evaluate(
+            "new Temporal.Duration(0, 13).round({ largestUnit: 'year', relativeTo: " +
+            "Temporal.PlainDate.from('2023-01-22').withCalendar('chinese') })")
+            .Should().Be("P1Y");
+
+        // The same thirteen months against an ISO relativeTo, which is what the defect answered for both.
+        Evaluate("new Temporal.Duration(0, 13).round({ largestUnit: 'year', relativeTo: '2023-01-22' })")
+            .Should().Be("P1Y1M");
+    }
+
+    /// <summary>
+    /// The report from the issue. A span that leaves the Chinese calendar's range has no answer in it, and
+    /// the three members that reckon in the calendar have to say so together.
+    /// </summary>
+    /// <remarks>
+    /// This asserts that they <em>agree</em>, not which way: whichever range the engine can reckon the
+    /// calendar over, a span past its end is refused by all three or answered by all three. The
+    /// <c>add</c> arm adds <em>years</em>, because that is the component
+    /// <see href="https://tc39.es/proposal-temporal/#sec-temporal-calendardateadd">CalendarDateAdd</see>
+    /// reckons in the calendar — days and weeks are ISO days whatever the calendar is, and
+    /// <c>add({ days: 200000 })</c> therefore never asks it anything.
+    /// </remarks>
+    [Test]
+    public void ASpanPastTheCalendarsRangeIsRefusedByRoundExactlyWhenItIsRefusedByTotalAndAdd()
+    {
+        const string RelativeTo = "Temporal.PlainDate.from('1990-01-01').withCalendar('chinese')";
+
+        var rounded = Evaluate(
+            $"new Temporal.Duration(0, 0, 0, 200000).round({{ largestUnit: 'year', relativeTo: {RelativeTo} }})");
+        var totalled = Evaluate(
+            $"new Temporal.Duration(0, 0, 0, 200000).total({{ unit: 'year', relativeTo: {RelativeTo} }})");
+        var added = Evaluate($"{RelativeTo}.add({{ years: 547 }})");
+
+        var kinds = new[] { rounded, totalled, added }
+            .Select(r => string.Equals(r, "RangeError", StringComparison.Ordinal))
+            .Distinct()
+            .Count();
+
+        kinds.Should().Be(
+            1,
+            "round, total and add reckon in the same calendar over the same span, but round said {0}, total said {1} and add said {2}",
+            rounded,
+            totalled,
+            added);
+    }
+
+    /// <summary>
+    /// An ISO <c>relativeTo</c> is the case the hardcoded calendar happened to be right for, and nothing
+    /// about it moves.
+    /// </summary>
+    [Test]
+    public void AnIsoRelativeToRoundsExactlyAsItDid()
+    {
+        Evaluate("new Temporal.Duration(0, 0, 0, 10000).round({ largestUnit: 'year', relativeTo: '1990-01-01' })")
+            .Should().Be("P27Y4M18D");
+
+        Evaluate("new Temporal.Duration(0, 0, 0, 10000).total({ unit: 'year', relativeTo: '1990-01-01' })")
+            .Should().Be("27.378082191780823");
+    }
+}

--- a/Jint/Native/Temporal/Duration/DurationPrototype.cs
+++ b/Jint/Native/Temporal/Duration/DurationPrototype.cs
@@ -459,6 +459,10 @@ internal sealed partial class DurationPrototype : Prototype
 
         var relativeDateStart = plainRelativeTo.IsoDate;
 
+        // Step 438: calendar = plainRelativeTo.[[Calendar]]. Every calendar operation below reckons in it;
+        // the ZonedDateTime arm does the same with zonedRelativeTo.[[Calendar]].
+        var calendar = plainRelativeTo.Calendar;
+
         // Step 439: Convert to internal duration with 24-hour days
         // ToInternalDurationRecordWith24HourDays moves duration.Days into the time nanoseconds
         var timeDuration = TemporalHelpers.TimeDurationFromComponents(duration);
@@ -491,7 +495,7 @@ internal sealed partial class DurationPrototype : Prototype
 
         // Step 443: targetDate = CalendarDateAdd(calendar, relativeTo, dateDuration)
         var adjustedDuration = new DurationRecord(duration.Years, duration.Months, duration.Weeks, adjustedDays, 0, 0, 0, 0, 0, 0);
-        var targetDate = TemporalHelpers.CalendarDateAdd(engine, realm, "iso8601", relativeDateStart, adjustedDuration, "constrain");
+        var targetDate = TemporalHelpers.CalendarDateAdd(engine, realm, calendar, relativeDateStart, adjustedDuration, "constrain");
 
         // Step 444-445: Combine isoDateTime and targetDateTime
         var isoDateTime = new IsoDateTime(relativeDateStart, IsoTime.Midnight);
@@ -509,7 +513,7 @@ internal sealed partial class DurationPrototype : Prototype
             realm,
             isoDateTime,
             targetDateTime,
-            "iso8601", // calendar
+            calendar,
             largestUnit,
             (int) roundingIncrement,
             smallestUnit,

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -2466,6 +2466,39 @@ else. A host implementing `ICldrProvider` **from scratch** rather than deriving 
 has one more member to write; deriving costs nothing, and [5.2](#52-changing-one-locale-datum-is-one-override)
 is why that is the shape the interface is documented for.
 
+### 4.49 `Duration.prototype.round` reckons in the calendar its `relativeTo` carries ([#3450](https://github.com/sebastienros/jint/issues/3450))
+
+`round` read the calendar off a `PlainDate` `relativeTo` and then wrote `"iso8601"` into both calendar
+operations it performs, so every rounding with a non-ISO `relativeTo` counted ISO years and ISO months under
+that calendar's name. It now passes `relativeTo.[[Calendar]]`, which is what
+[step 443](https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.round) says and what the
+`ZonedDateTime` arm of the same method always did.
+
+```js
+const chinese = Temporal.PlainDate.from('1990-01-01').withCalendar('chinese');
+
+new Temporal.Duration(0, 0, 0, 10000).round({ largestUnit: 'year', relativeTo: chinese }).toString();
+// 5.0: "P27Y4M18D" — the ISO answer, which is also what round said for every other calendar
+// 5.x: "P27Y4M19D" — what chinese.until(chinese.add({ days: 10000 }), { largestUnit: 'year' }) says
+
+// thirteen months is a whole year in a lunisolar leap year, and the Chinese year 2023 is one
+const leapYear = Temporal.PlainDate.from('2023-01-22').withCalendar('chinese'); // monthsInYear === 13
+new Temporal.Duration(0, 13).round({ largestUnit: 'year', relativeTo: leapYear }).toString();
+// 5.0: "P1Y1M"   5.x: "P1Y"
+```
+
+Past the end of a calendar's range it also stopped answering where its neighbours refuse:
+`new Temporal.Duration(0, 0, 0, 200000).round({ largestUnit: 'year', relativeTo: chinese })` was `P547Y7M`
+while `total` and `chinese.add({ years: 547 })` both raised
+`RangeError: Date is outside the range supported by the 'chinese' calendar`. All three now say the same
+thing, because all three now ask the same calendar.
+
+**What could break:** any rounding of a duration against a non-ISO `relativeTo`. `round` was the only member
+of `Temporal` still reckoning in ISO with another calendar's name attached — `until`, `since`, `add`,
+`subtract` and `total` all already reckoned in the calendar — so a value that changes here was disagreeing
+with all of them. An ISO `relativeTo` is unaffected, and so is a duration rounded without one: nothing
+outside the calendar path moves.
+
 ## 5. New in v5
 
 Everything in the table below is opt-in: nothing in it is installed unless the host asks for it, so


### PR DESCRIPTION
Fixes #3450.

## What was wrong

`DurationPrototype.RoundDurationWithPlainDate` takes a `plainRelativeTo` and then writes `"iso8601"` into
both calendar operations it performs — the `CalendarDateAdd` of step 443 and the
`DifferencePlainDateTimeWithRounding` of step 446 — so `plainRelativeTo.Calendar` was read nowhere in the
method.

[Step 443](https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.round) is
`CalendarDateAdd(calendar, …)` where `calendar` is `relativeTo.[[Calendar]]`, and the sibling arm for a
`ZonedDateTime` `relativeTo` already passed `zonedRelativeTo.Calendar`. So the same rounding gave two
different answers depending on which kind of `relativeTo` it was handed:

```js
const chinese = Temporal.PlainDate.from('1990-01-01').withCalendar('chinese');
const zoned   = Temporal.ZonedDateTime.from('1990-01-01T00:00:00[UTC][u-ca=chinese]');
const d       = new Temporal.Duration(0, 0, 0, 10000);

d.round({ largestUnit: 'year', relativeTo: chinese }).toString();  // before: P27Y4M18D
d.round({ largestUnit: 'year', relativeTo: zoned   }).toString();  // before: P27Y4M19D
```

`P27Y4M18D` is the ISO answer. `P27Y4M19D` is what the Chinese calendar says, and it is what
`chinese.until(chinese.add({ days: 10000 }), { largestUnit: 'year' })` and
`chinese.total({ unit: 'year', … })` already said. `round` was the one member of `Temporal` still reckoning
in ISO with another calendar's name attached.

The visible consequence is not only the boundary the issue leads with. A Hebrew leap year has thirteen
months and a Chinese one can too, so "how many years is this many months" has a different answer in those
calendars:

```js
const leapYear = Temporal.PlainDate.from('2023-01-22').withCalendar('chinese'); // monthsInYear === 13
new Temporal.Duration(0, 13).round({ largestUnit: 'year', relativeTo: leapYear }).toString();
// before: "P1Y1M"   after: "P1Y"   (and until() said "P1Y" all along)
```

And past the end of a calendar's range it answered where its neighbours refuse — the report from the issue:

```js
new Temporal.Duration(0, 0, 0, 200000).round({ largestUnit: 'year', relativeTo: chinese }); // P547Y7M
new Temporal.Duration(0, 0, 0, 200000).total({ unit: 'year', relativeTo: chinese });        // RangeError
chinese.add({ years: 547 });                                                                // RangeError
```

That is why the `round` half of #3428 never hung: it was not reaching the month walk at all.

## What changed

`RoundDurationWithPlainDate` reads `plainRelativeTo.Calendar` once and passes it to both operations.
Six lines, no public API change, nothing else touched.

## Failing-test evidence

`Jint.Tests/Runtime/DurationRoundCalendarTests.cs` states the agreement as an invariant rather than pinning
values: rounding a duration of days to years with a `relativeTo` is the same question `until` answers
between the same two dates, and the whole-year part of a rounding is the integer part of a `total`. Against
**unfixed `main`**:

```
Failed!  - Failed: 21, Passed: 9, Total: 30
```

All eleven non-ISO calendars fail the `until` agreement, `iso8601` passes:

```
Failed RoundingDaysToYearsIsTheDifferenceTheSameCalendarMeasures("chinese")
  chinese, 30 days:    round said P30D,       until said P1M
  chinese, 365 days:   round said P1Y,        until said P12M11D
  chinese, 400 days:   round said P1Y1M4D,    until said P1Y16D
  chinese, 3000 days:  round said P8Y2M19D,   until said P8Y2M17D
  chinese, 10000 days: round said P27Y4M18D,  until said P27Y4M19D
  chinese, 20000 days: round said P54Y9M3D,   until said P54Y9M9D
… and the same for dangi, hebrew, persian, coptic, ethiopic, ethioaa, indian,
  islamic-umalqura, islamic-civil, islamic-tbla

Failed TheYearsRoundingTruncatesToAreTheYearsTotalCounts("islamic-civil")
  islamic-civil, 10000 days: round said 27 years, total said 28

Failed APlainRelativeToAndAZonedOneInTheSameCalendarRoundAlike("chinese"|"hebrew"|"islamic-civil")

Failed ASpanPastTheCalendarsRangeIsRefusedByRoundExactlyWhenItIsRefusedByTotalAndAdd
  round said P547Y7M, total said RangeError and add said RangeError

Failed ThirteenMonthsIsAWholeYearInALunisolarLeapYear
```

With the fix, **30 passed / 0 failed** on `net472`, `net8.0` and `net10.0`. A 108-case sweep
(12 calendars × 9 day counts) has zero disagreements with either `until` or `total`, where unfixed `main`
disagrees on both.

The boundary case asserts that the three **agree**, not which way they agree: whichever range the engine
can reckon a calendar over, a span past its end is refused by all three or answered by all three. That
keeps the test honest against a future widening of a calendar's range.

The `add` arm of that test adds **years**, not days, because years and months are the components
[`CalendarDateAdd`](https://tc39.es/proposal-temporal/#sec-temporal-calendardateadd) reckons in the
calendar — days and weeks are ISO days whatever the calendar is, so `add({ days: 200000 })` never asks the
calendar anything.

## Test results

- `Jint.Tests`: **10,913 passed / 0 failed** on `net8.0` and `net10.0`, **7,537 / 0** on `net472`.
- `Jint.Tests.Test262`: **102,495 passed / 0 failed / 189 skipped** — unchanged from `main`. (Two
  `intl402` cases timed out on the first run under concurrent load and pass in three seconds on
  re-run; neither is Temporal.)

Migration guide: **§4.49**.
