### PR TITLE
Interop: hasOwnProperty and 'in' give one answer about an index on a wrapped collection

### DIFF
--- a/Jint.Tests.PublicInterface/HostCollectionIndexAgreementTests.cs
+++ b/Jint.Tests.PublicInterface/HostCollectionIndexAgreementTests.cs
@@ -1,0 +1,296 @@
+#nullable enable
+
+using System.Collections;
+using Jint.Runtime;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// One question — <em>does this index exist?</em> — asked of a wrapped CLR collection through every lane an
+/// embedder's script can reach it: <c>in</c>, <c>hasOwnProperty</c>, the indexed read,
+/// <c>Object.getOwnPropertyDescriptor</c>, <c>propertyIsEnumerable</c> and <c>Object.getOwnPropertyNames</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// They have to give one answer. <see href="https://tc39.es/ecma262/#sec-ordinaryhasproperty">OrdinaryHasProperty</see>
+/// is defined in terms of <c>[[GetOwnProperty]]</c>, so <c>3 in list</c> being <see langword="false"/> while
+/// <c>list.hasOwnProperty(3)</c> is <see langword="true"/> on the same object is not a divergence between two
+/// lanes an implementation may choose — it is a contradiction. It was the state of every array-like wrapper
+/// until #3423: the view owned <c>Get</c>, <c>Set</c>, <c>HasProperty</c>, <c>Delete</c> and the key
+/// enumerations, and left <c>[[GetOwnProperty]]</c> to <see cref="Jint.Runtime.Interop.ObjectWrapper"/>, which
+/// resolves the reflected indexer and reports a descriptor for <em>any</em> parseable index.
+/// </para>
+/// <para>
+/// Every shape below is an ordinary embedder exposure and every one of them reaches a different wrapper, which
+/// is the point: the contradiction was in the shared base and so was in all of them.
+/// </para>
+/// </remarks>
+public class HostCollectionIndexAgreementTests
+{
+    /// <summary>Every wrapper an array-like CLR target reaches, named by the exposure that produces it.</summary>
+    public static IEnumerable<string> Shapes =>
+    [
+        "List<int>",
+        "int[]",
+        "IReadOnlyList<int>",
+        "IList<int>",
+        "ArrayList",
+    ];
+
+    /// <summary>
+    /// Keys that name no position of a three-element view: past the end, far past it, negative, and the two
+    /// integer-shaped spellings that are not canonical array indices.
+    /// </summary>
+    public static IEnumerable<string> AbsentIndices => ["3", "10", "-1", "'3.5'", "'08'", "'+3'"];
+
+    /// <summary>Both spellings of every position the view does have — <c>x[1]</c> and <c>x['1']</c> are one key.</summary>
+    public static IEnumerable<string> PresentIndices => ["0", "1", "2", "'0'", "'2'"];
+
+    private const string AllAbsent = "false,false,false,false,false,false";
+    private const string AllPresent = "true,true,true,true,true,true";
+
+    [TestCaseSource(nameof(Shapes))]
+    public void EveryLaneAgreesThatAnAbsentIndexIsAbsent(string shape)
+    {
+        foreach (var key in AbsentIndices)
+        {
+            var engine = CreateEngine(shape);
+
+            Lanes(engine, key).Should().Be(AllAbsent,
+                "{0}[{1}] is not a position of the view, so no lane may report it as one", shape, key);
+        }
+    }
+
+    [TestCaseSource(nameof(Shapes))]
+    public void EveryLaneAgreesThatAPresentIndexIsPresent(string shape)
+    {
+        foreach (var key in PresentIndices)
+        {
+            var engine = CreateEngine(shape);
+
+            Lanes(engine, key).Should().Be(AllPresent,
+                "{0}[{1}] is a position of the view, so every lane reports it", shape, key);
+        }
+    }
+
+    /// <summary>
+    /// The descriptor lane resolved the reflected indexer and cached what it built, so a position that had been
+    /// asked about once went on being reported after the collection shrank past it. Reading the range first is
+    /// what makes the cached descriptor unreachable.
+    /// </summary>
+    [Test]
+    public void AnIndexStopsExistingWhenTheCollectionShrinksPastIt()
+    {
+        var engine = CreateEngine("List<int>");
+
+        engine.Evaluate("x.hasOwnProperty(2)").AsBoolean().Should().BeTrue();
+
+        engine.Execute("x.length = 1");
+
+        Lanes(engine, "2").Should().Be(AllAbsent, "the third element is gone, and the cached descriptor for it is not the answer");
+    }
+
+    /// <summary>
+    /// A position the view does not have cannot be defined into one either, or it would exist for
+    /// <c>[[GetOwnProperty]]</c> and not for anything else. The refusal is what script already saw — the
+    /// reflected indexer's descriptor was non-configurable — so this pins the answer, not a new one.
+    /// </summary>
+    [TestCaseSource(nameof(Shapes))]
+    public void DefiningAnAbsentIndexIsRefused(string shape)
+    {
+        var engine = CreateEngine(shape);
+
+        engine.Evaluate("Reflect.defineProperty(x, 5, { value: 42 })").AsBoolean().Should().BeFalse();
+        Caught.Exception(() => engine.Execute("Object.defineProperty(x, 5, { value: 42 })"))
+            .Should().BeOfType<JavaScriptException>();
+        Lanes(engine, "5").Should().Be(AllAbsent, "nothing was defined");
+    }
+
+    /// <summary>
+    /// The one target shape that answers a string key from its own keys rather than by index — Newtonsoft's
+    /// <c>JObject</c> is both an <c>IDictionary&lt;string, _&gt;</c> and an <c>IList&lt;_&gt;</c> — is stood in for
+    /// here by a type with the same two interfaces. Its index-shaped keys are dictionary keys and must keep
+    /// answering as such.
+    /// </summary>
+    [Test]
+    public void ADictionaryShapedArrayLikeStillAnswersFromItsKeys()
+    {
+        var engine = new Engine(options => options.AllowClr());
+        engine.SetValue("x", new KeyedList { { "3", 42 } });
+
+        engine.Evaluate("'3' in x").AsBoolean().Should().BeTrue();
+        engine.Evaluate("x.hasOwnProperty('3')").AsBoolean().Should().BeTrue();
+        engine.Evaluate("x['3']").AsNumber().Should().Be(42);
+    }
+
+    /// <summary>
+    /// Named CLR members are not positions and were never part of the disagreement; asserted so that reading
+    /// the index range first cannot be mistaken for owning every key.
+    /// </summary>
+    [Test]
+    public void ANamedMemberIsUnaffected()
+    {
+        var engine = CreateEngine("List<int>");
+
+        engine.Evaluate("x.hasOwnProperty('Count')").AsBoolean().Should().BeTrue();
+        engine.Evaluate("x.Count").AsNumber().Should().Be(3);
+        engine.Evaluate("x.hasOwnProperty('NoSuchMember')").AsBoolean().Should().BeFalse();
+    }
+
+    /// <summary>
+    /// The six answers, in the order <see cref="AllAbsent"/> and <see cref="AllPresent"/> spell them, joined so
+    /// that a failure names every lane that disagreed instead of stopping at the first.
+    /// </summary>
+    private static string Lanes(Engine engine, string key) => engine.Evaluate($$"""
+        [
+            ({{key}} in x),
+            x.hasOwnProperty({{key}}),
+            x[{{key}}] !== undefined,
+            Object.getOwnPropertyDescriptor(x, {{key}}) !== undefined,
+            x.propertyIsEnumerable({{key}}),
+            Object.getOwnPropertyNames(x).indexOf(String({{key}})) >= 0
+        ].join(',')
+        """).AsString();
+
+    private static Engine CreateEngine(string shape)
+    {
+        var engine = new Engine(options =>
+        {
+            options.AllowClr();
+            options.Interop.AllowWrite = true;
+            options.Interop.ArrayConversion = ArrayConversionMode.LiveView;
+        });
+
+        engine.SetValue("x", Target(shape));
+        return engine;
+    }
+
+    private static object Target(string shape) => shape switch
+    {
+        "List<int>" => new List<int> { 1, 2, 3 },
+        "int[]" => new[] { 1, 2, 3 },
+        "IReadOnlyList<int>" => new ReadOnlyItems(1, 2, 3),
+        "IList<int>" => new IndexedItems(1, 2, 3),
+        "ArrayList" => new ArrayList { 1, 2, 3 },
+        _ => throw new ArgumentOutOfRangeException(nameof(shape), shape, "unknown shape"),
+    };
+
+    /// <summary>A host collection reachable only through <see cref="IReadOnlyList{T}"/>.</summary>
+    private sealed class ReadOnlyItems : IReadOnlyList<int>
+    {
+        private readonly List<int> _items;
+
+        public ReadOnlyItems(params int[] items) => _items = [.. items];
+
+        public int this[int index] => _items[index];
+
+        public int Count => _items.Count;
+
+        public IEnumerator<int> GetEnumerator() => _items.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => _items.GetEnumerator();
+    }
+
+    /// <summary>
+    /// A host collection that implements <see cref="IList{T}"/> and the non-generic <see cref="ICollection"/>
+    /// but not the non-generic <see cref="IList"/>.
+    /// </summary>
+    private sealed class IndexedItems : IList<int>, ICollection
+    {
+        private readonly List<int> _items;
+
+        public IndexedItems(params int[] items) => _items = [.. items];
+
+        public int this[int index] { get => _items[index]; set => _items[index] = value; }
+
+        public int Count => _items.Count;
+
+        public bool IsReadOnly => false;
+
+        public void Add(int item) => _items.Add(item);
+
+        public void Clear() => _items.Clear();
+
+        public bool Contains(int item) => _items.Contains(item);
+
+        public void CopyTo(int[] array, int arrayIndex) => _items.CopyTo(array, arrayIndex);
+
+        public int IndexOf(int item) => _items.IndexOf(item);
+
+        public void Insert(int index, int item) => _items.Insert(index, item);
+
+        public bool Remove(int item) => _items.Remove(item);
+
+        public void RemoveAt(int index) => _items.RemoveAt(index);
+
+        public IEnumerator<int> GetEnumerator() => _items.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => _items.GetEnumerator();
+
+        bool ICollection.IsSynchronized => false;
+
+        object ICollection.SyncRoot => this;
+
+        void ICollection.CopyTo(Array array, int index) => ((ICollection) _items).CopyTo(array, index);
+    }
+
+    /// <summary>
+    /// Both an <c>IDictionary&lt;string, int&gt;</c> and an <c>IList&lt;int&gt;</c>, the way Newtonsoft's
+    /// <c>JObject</c> is: its index-shaped keys are dictionary keys.
+    /// </summary>
+    private sealed class KeyedList : IDictionary<string, int>, IList<int>
+    {
+        private readonly Dictionary<string, int> _byKey = new(StringComparer.Ordinal);
+
+        public int this[string key] { get => _byKey[key]; set => _byKey[key] = value; }
+
+        public int this[int index] { get => _byKey.Values.ElementAt(index); set => throw new NotSupportedException(); }
+
+        public ICollection<string> Keys => _byKey.Keys;
+
+        public ICollection<int> Values => _byKey.Values;
+
+        public int Count => _byKey.Count;
+
+        public bool IsReadOnly => false;
+
+        public void Add(string key, int value) => _byKey.Add(key, value);
+
+        public void Add(KeyValuePair<string, int> item) => _byKey.Add(item.Key, item.Value);
+
+        public void Add(int item) => throw new NotSupportedException();
+
+        public void Clear() => _byKey.Clear();
+
+        public bool Contains(KeyValuePair<string, int> item) => _byKey.Contains(item);
+
+        public bool Contains(int item) => _byKey.ContainsValue(item);
+
+        public bool ContainsKey(string key) => _byKey.ContainsKey(key);
+
+        public void CopyTo(KeyValuePair<string, int>[] array, int arrayIndex)
+            => ((ICollection<KeyValuePair<string, int>>) _byKey).CopyTo(array, arrayIndex);
+
+        public void CopyTo(int[] array, int arrayIndex) => _byKey.Values.CopyTo(array, arrayIndex);
+
+        public int IndexOf(int item) => throw new NotSupportedException();
+
+        public void Insert(int index, int item) => throw new NotSupportedException();
+
+        public bool Remove(string key) => _byKey.Remove(key);
+
+        public bool Remove(KeyValuePair<string, int> item) => _byKey.Remove(item.Key);
+
+        public bool Remove(int item) => throw new NotSupportedException();
+
+        public void RemoveAt(int index) => throw new NotSupportedException();
+
+        public bool TryGetValue(string key, out int value) => _byKey.TryGetValue(key, out value);
+
+        IEnumerator<KeyValuePair<string, int>> IEnumerable<KeyValuePair<string, int>>.GetEnumerator() => _byKey.GetEnumerator();
+
+        IEnumerator<int> IEnumerable<int>.GetEnumerator() => _byKey.Values.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => _byKey.GetEnumerator();
+    }
+}

--- a/Jint/Runtime/Interop/ObjectWrapper.Specialized.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.Specialized.cs
@@ -6,6 +6,7 @@ using Jint.Extensions;
 using Jint.Native;
 using Jint.Native.Array;
 using Jint.Native.Object;
+using Jint.Runtime.Descriptors;
 
 namespace Jint.Runtime.Interop;
 
@@ -210,6 +211,64 @@ internal abstract class ArrayLikeWrapper : ObjectWrapper
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool IsIntegerShapedStart(char c)
         => (uint) (c - '0') <= 9 || c == '-' || c == '+' || char.IsWhiteSpace(c);
+
+    /// <summary>
+    /// Whether <paramref name="property"/> spells a position this view does not have — index-shaped, and
+    /// either outside <c>[0, Length)</c> or never addressable at all (negative, non-canonical, past what the
+    /// target can hold).
+    /// </summary>
+    /// <remarks>
+    /// This is the single question every lane that answers <em>whether an index exists</em> has to answer the
+    /// same way. <see cref="Get"/>, <see cref="HasProperty"/> and <c>GetOwnPropertyKeys</c> already did;
+    /// <c>[[GetOwnProperty]]</c> did not, because it was left to <see cref="ObjectWrapper"/>, which resolves the
+    /// reflected indexer and reports a descriptor for <em>any</em> parseable index. So <c>3 in list</c> was
+    /// <see langword="false"/> while <c>list.hasOwnProperty(3)</c> was <see langword="true"/> on the same object,
+    /// which is not a divergence an implementation may choose:
+    /// <see href="https://tc39.es/ecma262/#sec-ordinaryhasproperty">OrdinaryHasProperty</see> is defined in terms
+    /// of <c>[[GetOwnProperty]]</c> (#3423).
+    /// <para>
+    /// A dictionary-shaped target (Newtonsoft's <c>JObject</c> is both <c>IDictionary&lt;string,_&gt;</c> and
+    /// <c>IList&lt;_&gt;</c>) answers a string key from its own keys, exactly as <see cref="HasProperty"/>
+    /// defers for it.
+    /// </para>
+    /// </remarks>
+    private bool NamesAbsentPosition(JsValue property)
+    {
+        if (_typeDescriptor.IsDictionary)
+        {
+            return false;
+        }
+
+        var key = ClassifyElementKey(property, out var index);
+        return key == ElementKey.OutOfBand
+               || (key == ElementKey.Position && (uint) index >= (uint) Length);
+    }
+
+    /// <summary>
+    /// The descriptor lane, answered from the view's index range before the reflected indexer is consulted.
+    /// Reached by <c>Object.getOwnPropertyDescriptor</c>, <c>Reflect.getOwnPropertyDescriptor</c>,
+    /// <c>hasOwnProperty</c>, <c>propertyIsEnumerable</c> and — through the default
+    /// <see cref="ObjectInstance.ProbeOwnProperty"/> — everything that asks whether a key exists.
+    /// </summary>
+    public sealed override PropertyDescriptor GetOwnProperty(JsValue property)
+        => NamesAbsentPosition(property) ? PropertyDescriptor.Undefined : base.GetOwnProperty(property);
+
+    /// <summary>
+    /// The existence probe, kept in step with <see cref="GetOwnProperty"/> by construction rather than by
+    /// deriving it: an absent position is answered without resolving an accessor or building a descriptor.
+    /// </summary>
+    protected internal sealed override OwnPropertyProbe ProbeOwnProperty(JsValue property)
+        => NamesAbsentPosition(property) ? OwnPropertyProbe.Missing : base.ProbeOwnProperty(property);
+
+    /// <summary>
+    /// A position this view does not have cannot be defined into existence either. Without this,
+    /// <c>Object.defineProperty(view, 5, …)</c> would store a descriptor in the wrapper's own property bag for
+    /// a key <see cref="GetOwnProperty"/> then denies — a property that both exists and does not. The refusal
+    /// is what script already saw (the reflected indexer's descriptor is non-configurable, so the redefinition
+    /// was rejected); it is now a property of the view rather than an accident of reflection.
+    /// </summary>
+    public sealed override bool DefineOwnProperty(JsValue property, PropertyDescriptor desc)
+        => !NamesAbsentPosition(property) && base.DefineOwnProperty(property, desc);
 
     public sealed override JsValue Get(JsValue property, JsValue receiver)
     {

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -2492,7 +2492,6 @@ consequences, none of which changes a signature:
   rather than only when `LimitExecutionTime` happens to be registered. It was always rejected by
   `ConstraintClock.Resolve` with a named `ArgumentException`; that clock is now resolved for every engine, so
   the diagnostic arrives where the clock was supplied instead of at whichever budget first tried to use it.
-
 ### 4.49 `Duration.prototype.round` reckons in the calendar its `relativeTo` carries ([#3450](https://github.com/sebastienros/jint/issues/3450))
 
 `round` read the calendar off a `PlainDate` `relativeTo` and then wrote `"iso8601"` into both calendar
@@ -2616,6 +2615,49 @@ these patterns and still does not — it bounds script-supplied regular expressi
 caught `RegexMatchTimeoutException` around `Engine.Evaluate` to absorb this can drop that handler; a host
 that treated it as a signal the script was hostile was reading a scheduling artefact.
 
+### 4.55 An index a wrapped collection does not have does not exist, in every lane ([#3423](https://github.com/sebastienros/jint/issues/3423))
+
+On every array-like CLR wrapper, `[[HasProperty]]` and `[[GetOwnProperty]]` gave different answers for an
+index outside the collection:
+
+```js
+// 4.16.x, for engine.SetValue("x", new List<int> { 1, 2, 3 })
+3 in x                          // false
+x[3]                            // undefined
+x.hasOwnProperty(3)             // true
+x.hasOwnProperty("3")           // true
+x.hasOwnProperty(-1)            // true
+x.propertyIsEnumerable("3")     // true
+Object.getOwnPropertyDescriptor(x, 3)   // a descriptor
+Object.getOwnPropertyNames(x)   // ["0","1","2"]
+```
+
+That is not a divergence between two lanes an implementation may choose.
+[OrdinaryHasProperty](https://tc39.es/ecma262/#sec-ordinaryhasproperty) is defined in terms of
+`[[GetOwnProperty]]`, so `3 in x` being `false` while `x.hasOwnProperty(3)` is `true` on the same object is a
+contradiction. The cause: the view owned `Get`, `Set`, `HasProperty`, `Delete` and both key enumerations, and
+left `[[GetOwnProperty]]` to `ObjectWrapper`, which resolves the reflected indexer and reports a descriptor
+for **any** parseable index — including a negative or non-canonical one.
+
+In 5.x the descriptor lane reads the same index range as the rest, so all four of `in`, `hasOwnProperty`, the
+indexed read and `Object.getOwnPropertyNames` agree, and `hasOwnProperty`, `propertyIsEnumerable` and
+`Object.getOwnPropertyDescriptor` answer `false`/`undefined` for `3`, `10`, `-1`, `"08"` and `"+3"` alike.
+Positions the view **does** have are unchanged, in both spellings.
+
+Two consequences worth naming:
+
+- **A cached descriptor is no longer the answer after the collection shrinks.** Asking about an index stored
+  the reflected indexer's descriptor on the wrapper, so `x.hasOwnProperty(2)` went on being `true` after
+  `x.length = 1`. The range is read first, so it cannot be.
+- **`Object.defineProperty(x, 5, …)` for a position the view does not have is refused** rather than storing a
+  descriptor the other lanes then deny. That is the answer script already got — the reflected indexer's
+  descriptor was non-configurable, so the redefinition was rejected — now given by the view itself.
+  `Reflect.defineProperty` returns `false`, `Object.defineProperty` raises a `TypeError`.
+
+**What could break:** a host or script relying on `hasOwnProperty` / `propertyIsEnumerable` /
+`Object.getOwnPropertyDescriptor` reporting an out-of-range index as present. Nothing changes for in-range
+indices, for named CLR members, or for a dictionary-shaped target such as Newtonsoft's `JObject`, whose
+index-shaped string keys are dictionary keys and still answer from its own key set.
 ## 5. New in v5
 
 Everything in the table below is opt-in: nothing in it is installed unless the host asks for it, so


### PR DESCRIPTION
Fixes #3423.

`3 in x` was `false` while `x.hasOwnProperty(3)` was `true`, on the same wrapped `List<int>`. That is not a
divergence between two lanes an implementation may choose:
[OrdinaryHasProperty](https://tc39.es/ecma262/#sec-ordinaryhasproperty) is defined in terms of
`[[GetOwnProperty]]`, so the two cannot answer differently.

```js
// main, for engine.SetValue("x", new List<int> { 1, 2, 3 })
3 in x                                  // false
x[3]                                    // undefined
Object.getOwnPropertyNames(x)           // ["0","1","2"]
x.hasOwnProperty(3)                     // true      <- contradiction
x.hasOwnProperty("3")                   // true
x.hasOwnProperty(-1)                    // true
x.propertyIsEnumerable("3")             // true
Object.getOwnPropertyDescriptor(x, 3)   // a descriptor
```

`ArrayLikeWrapper` owned `Get`, `Set`, `HasProperty`, `Delete` and both key enumerations, and left
`[[GetOwnProperty]]` to `ObjectWrapper` — which resolves the reflected indexer and reports a descriptor for
**any** parseable index, a negative or non-canonical one included. So the four lanes that answer *does this
index exist* split three-to-one, and `Object.keys`, `for..in` and `JSON.stringify` agreed with `in` only
because they read `GetOwnPropertyKeys`, which the view does own.

The view now answers the descriptor lane from the same index range as the rest: `NamesAbsentPosition` is one
classification of the key (the one #3384 introduced), consulted by a sealed `GetOwnProperty`,
`ProbeOwnProperty` and `DefineOwnProperty`. Positions the view does have are unchanged, in both spellings.

Two things fall out of reading the range first.

* **A cached descriptor is no longer the answer after the collection shrinks.** Asking about an index stored
  the reflected indexer's descriptor on the wrapper, so `x.hasOwnProperty(2)` stayed `true` after
  `x.length = 1`.
* **`Object.defineProperty(x, 5, …)` for a position the view does not have is refused**, rather than storing a
  descriptor the other lanes then deny. That is the answer script already got — the reflected descriptor is
  non-configurable, so the redefinition was rejected — now given by the view rather than by an accident of
  reflection.

### The four-way agreement, proved

`Jint.Tests.PublicInterface/HostCollectionIndexAgreementTests.cs` asks all six lanes — `in`,
`hasOwnProperty`, the indexed read, `Object.getOwnPropertyDescriptor`, `propertyIsEnumerable` and
`Object.getOwnPropertyNames` — one question per key and joins the answers, so a failure names every lane that
disagreed. It runs over the five exposures that reach five different wrappers (`List<int>` → `ListWrapper`,
`int[]` under `LiveView` → `ArrayWrapper<T>`, an `IReadOnlyList<int>` → `ReadOnlyListWrapper<T>`, an
`IList<int>`+`ICollection` → `GenericListWrapper<T>`, `ArrayList` → `ListWrapper`), because the contradiction
was in the shared base and therefore in all of them.

Against unmodified `main`, 11 of its 18 cases fail, every one of them the same way:

```
Failed EveryLaneAgreesThatAnAbsentIndexIsAbsent("List<int>")
   Expected string to be the same string because List<int>[3] is not a position of the view,
   so no lane may report it as one, but they differ at index 6:
  "false,true,false,true,true,false"     <- actual
  "false,false,false,false,false,false"  <- expected

Failed EveryLaneAgreesThatAnAbsentIndexIsAbsent("int[]")
Failed EveryLaneAgreesThatAnAbsentIndexIsAbsent("IReadOnlyList<int>")
Failed EveryLaneAgreesThatAnAbsentIndexIsAbsent("IList<int>")
Failed EveryLaneAgreesThatAnAbsentIndexIsAbsent("ArrayList")
Failed DefiningAnAbsentIndexIsRefused(<all five shapes>)
Failed AnIndexStopsExistingWhenTheCollectionShrinksPastIt
```

`EveryLaneAgreesThatAPresentIndexIsPresent` passes on `main` and still passes, which is what says this
narrows nothing that was right.

A dictionary-shaped array-like — Newtonsoft's `JObject` is both an `IDictionary<string, _>` and an
`IList<_>` — answers a string key from its own keys, and `ADictionaryShapedArrayLikeStillAnswersFromItsKeys`
pins that the range check defers for it exactly as `HasProperty` already did.

`docs/v5-migration.md` §4.49 carries the embedder-facing form.
