### PR TITLE
Intl: the parts lane writes the numbering system's digits, and only the number is transliterated

### DIFF
--- a/Jint.Tests/Runtime/IntlNumberFormatPartsTests.cs
+++ b/Jint.Tests/Runtime/IntlNumberFormatPartsTests.cs
@@ -1,0 +1,293 @@
+#nullable enable
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// <c>Intl.NumberFormat</c>'s two lanes are one algorithm.
+/// https://tc39.es/ecma402/#sec-formatnumeric defines <c>format</c> as the concatenation of exactly the
+/// parts https://tc39.es/ecma402/#sec-formatnumerictoparts returns, both of them
+/// https://tc39.es/ecma402/#sec-partitionnumberpattern, so the digits, the separators and the pattern text
+/// are the same characters read two ways — including when <c>[[NumberingSystem]]</c> is not Latin.
+/// </summary>
+/// <remarks>
+/// The grids below compare each numbering system against <c>latn</c> rather than asserting the join outright:
+/// what is being pinned is that <b>asking for a numbering system introduces no disagreement</b>, so a
+/// combination whose Latin lanes already differ is skipped instead of being silently blessed. Four such
+/// combinations exist today, all of them about locale data rather than digits — a <c>ja-JP</c> long unit
+/// name, an <c>ar-EG</c> negative currency's directionality mark, <c>notation: "scientific"</c> of exactly
+/// zero, and a non-finite value under <c>style: "currency"</c> or <c>"unit"</c>.
+/// </remarks>
+public class IntlNumberFormatPartsTests
+{
+    private readonly Engine _engine = new();
+
+    private static readonly string[] NumberingSystems =
+    [
+        "arab", "arabext", "beng", "deva", "thai", "hanidec", "fullwide",
+        // ten digits outside the BMP, so a surrogate pair has to survive the rewrite
+        "mathbold"
+    ];
+
+    private static readonly string[] Locales = ["en", "en-US", "de-DE", "fr-FR", "pt-PT", "ar-EG", "ja-JP"];
+
+    private static readonly string[] OptionSets =
+    [
+        "{}",
+        "{ minimumFractionDigits: 2 }",
+        "{ useGrouping: false }",
+        "{ signDisplay: 'always' }",
+        "{ style: 'percent' }",
+        "{ style: 'currency', currency: 'USD' }",
+        "{ style: 'currency', currency: 'EUR', currencyDisplay: 'name' }",
+        "{ style: 'unit', unit: 'meter' }",
+        "{ style: 'unit', unit: 'kilometer-per-hour', unitDisplay: 'long' }",
+        "{ notation: 'scientific' }",
+        "{ notation: 'engineering' }",
+        "{ notation: 'compact' }",
+        "{ notation: 'compact', compactDisplay: 'long' }"
+    ];
+
+    private const string Values =
+        "[0, 1, -1, 0.5, 1234.5, -1234.5, 1234567.891, 12345678901234, NaN, Infinity, -Infinity]";
+
+    /// <summary>
+    /// The defect: <c>format</c> transliterated and <c>formatToParts</c> did not, so
+    /// <c>new Intl.NumberFormat('en', { numberingSystem: 'arab' })</c> wrote <c>"١,٢٣٤٫٥"</c> from one lane
+    /// and <c>"1,234.5"</c> from the other.
+    /// </summary>
+    [Test]
+    public void PartsConcatenateToFormat()
+    {
+        AssertNoMismatch(
+            $$"""
+            (function () {
+                var bad = [];
+                var locales = {{JsArrayOf(Locales)}};
+                var systems = {{JsArrayOf(NumberingSystems)}};
+                var optionSets = [{{string.Join(", ", OptionSets)}}];
+                var values = {{Values}};
+                function join(parts) { return parts.map(function (p) { return p.value; }).join(''); }
+                for (var l = 0; l < locales.length; l++) {
+                    for (var o = 0; o < optionSets.length; o++) {
+                        var latin = new Intl.NumberFormat(locales[l], optionSets[o]);
+                        for (var s = 0; s < systems.length; s++) {
+                            var options = Object.assign({ numberingSystem: systems[s] }, optionSets[o]);
+                            var nf = new Intl.NumberFormat(locales[l], options);
+                            for (var v = 0; v < values.length; v++) {
+                                if (join(latin.formatToParts(values[v])) !== latin.format(values[v])) {
+                                    continue;
+                                }
+                                var joined = join(nf.formatToParts(values[v]));
+                                var formatted = nf.format(values[v]);
+                                if (joined !== formatted) {
+                                    bad.push(locales[l] + '/' + systems[s] + '/' + o + '/' + values[v]
+                                        + ': format=' + formatted + ' parts=' + joined);
+                                }
+                            }
+                        }
+                    }
+                }
+                return JSON.stringify(bad);
+            })()
+            """);
+    }
+
+    /// <summary>
+    /// The range lanes are the same operation twice, plus the literal between them.
+    /// https://tc39.es/ecma402/#sec-formatnumericrange is the concatenation of
+    /// https://tc39.es/ecma402/#sec-formatnumericrangetoparts, so a range that is not collapsed has to join
+    /// back to the string.
+    /// </summary>
+    [Test]
+    public void RangePartsConcatenateToFormatRange()
+    {
+        AssertNoMismatch(
+            $$"""
+            (function () {
+                var bad = [];
+                var locales = {{JsArrayOf(Locales)}};
+                var systems = {{JsArrayOf(NumberingSystems)}};
+                var optionSets = [{}, { minimumFractionDigits: 2 }, { style: 'percent' },
+                                  { style: 'unit', unit: 'meter' }, { notation: 'compact' },
+                                  { style: 'currency', currency: 'USD' }];
+                var pairs = [[1, 5], [3, 3], [-5, -1], [0, 1000000], [1234.5, 2345.6]];
+                function join(parts) { return parts.map(function (p) { return p.value; }).join(''); }
+                for (var l = 0; l < locales.length; l++) {
+                    for (var o = 0; o < optionSets.length; o++) {
+                        var latin = new Intl.NumberFormat(locales[l], optionSets[o]);
+                        for (var s = 0; s < systems.length; s++) {
+                            var options = Object.assign({ numberingSystem: systems[s] }, optionSets[o]);
+                            var nf = new Intl.NumberFormat(locales[l], options);
+                            for (var p = 0; p < pairs.length; p++) {
+                                var a = pairs[p][0], b = pairs[p][1];
+                                if (join(latin.formatRangeToParts(a, b)) !== latin.formatRange(a, b)) {
+                                    continue;
+                                }
+                                var joined = join(nf.formatRangeToParts(a, b));
+                                var formatted = nf.formatRange(a, b);
+                                if (joined !== formatted) {
+                                    bad.push(locales[l] + '/' + systems[s] + '/' + o + '/' + pairs[p]
+                                        + ': formatRange=' + formatted + ' parts=' + joined);
+                                }
+                            }
+                        }
+                    }
+                }
+                return JSON.stringify(bad);
+            })()
+            """);
+    }
+
+    /// <summary>
+    /// <c>Intl.RelativeTimeFormat.prototype.formatToParts</c> copies <c>NumberFormat</c>'s parts
+    /// (https://tc39.es/ecma402/#sec-partitionrelativetimepattern step 8.b), so it inherited whichever digits
+    /// that lane wrote — and its own <c>format</c> transliterated the assembled string, pattern text and all.
+    /// </summary>
+    [Test]
+    public void RelativeTimePartsConcatenateToFormat()
+    {
+        AssertNoMismatch(
+            $$"""
+            (function () {
+                var bad = [];
+                var locales = {{JsArrayOf(Locales)}};
+                var systems = {{JsArrayOf(NumberingSystems)}};
+                var styles = ['long', 'short', 'narrow'];
+                var numerics = ['always', 'auto'];
+                var units = ['second', 'minute', 'hour', 'day', 'week', 'month', 'quarter', 'year'];
+                var values = [0, 1, -1, 3, -3, 1234.5];
+                function join(parts) { return parts.map(function (p) { return p.value; }).join(''); }
+                for (var l = 0; l < locales.length; l++) {
+                    for (var st = 0; st < styles.length; st++) {
+                        for (var n = 0; n < numerics.length; n++) {
+                            var latin = new Intl.RelativeTimeFormat(locales[l],
+                                { style: styles[st], numeric: numerics[n] });
+                            for (var s = 0; s < systems.length; s++) {
+                                var rtf = new Intl.RelativeTimeFormat(locales[l],
+                                    { numberingSystem: systems[s], style: styles[st], numeric: numerics[n] });
+                                for (var u = 0; u < units.length; u++) {
+                                    for (var v = 0; v < values.length; v++) {
+                                        if (join(latin.formatToParts(values[v], units[u]))
+                                            !== latin.format(values[v], units[u])) {
+                                            continue;
+                                        }
+                                        var joined = join(rtf.formatToParts(values[v], units[u]));
+                                        var formatted = rtf.format(values[v], units[u]);
+                                        if (joined !== formatted) {
+                                            bad.push(locales[l] + '/' + systems[s] + '/' + styles[st] + '/'
+                                                + numerics[n] + '/' + units[u] + '/' + values[v]
+                                                + ': format=' + formatted + ' parts=' + joined);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                return JSON.stringify(bad);
+            })()
+            """);
+    }
+
+    /// <summary>The reported issue, verbatim: the parts lane wrote Latin digits the string lane never did.</summary>
+    [Test]
+    public void TheResolvedNumberingSystemReachesTheParts()
+    {
+        _engine.Evaluate("new Intl.NumberFormat('en', { numberingSystem: 'arab' }).format(1234.5)")
+            .AsString().Should().Be("١,٢٣٤٫٥");
+        _engine.Evaluate(
+            "new Intl.NumberFormat('en', { numberingSystem: 'arab' }).formatToParts(1234.5).map(function (p) { return p.value; }).join('')")
+            .AsString().Should().Be("١,٢٣٤٫٥");
+
+        _engine.Evaluate("new Intl.RelativeTimeFormat('en', { numberingSystem: 'arab' }).format(3, 'day')")
+            .AsString().Should().Be("in ٣ days");
+        _engine.Evaluate(
+            "new Intl.RelativeTimeFormat('en', { numberingSystem: 'arab' }).formatToParts(3, 'day').map(function (p) { return p.value; }).join('')")
+            .AsString().Should().Be("in ٣ days");
+    }
+
+    /// <summary>
+    /// A currency symbol, a unit name and a literal are pattern text, and pattern text is not a number.
+    /// The full stop of a <c>style: "short"</c> abbreviation is the case that made
+    /// <c>Intl.RelativeTimeFormat</c> write <c>"in ٣ sec٫"</c>, where <c>٫</c> is U+066B, the Arabic decimal
+    /// separator that only a decimal point should ever have become.
+    /// </summary>
+    [Test]
+    public void OnlyTheNumberIsTransliterated()
+    {
+        _engine.Evaluate("new Intl.RelativeTimeFormat('en', { style: 'short', numberingSystem: 'arab' }).format(3, 'second')")
+            .AsString().Should().Be("in ٣ sec.");
+        _engine.Evaluate("new Intl.RelativeTimeFormat('en', { style: 'short', numberingSystem: 'arab' }).format(3, 'minute')")
+            .AsString().Should().Be("in ٣ min.");
+
+        _engine.Evaluate(
+            """
+            JSON.stringify(new Intl.NumberFormat('en', { numberingSystem: 'arab', style: 'unit', unit: 'meter' }).formatToParts(1.5))
+            """)
+            .AsString().Should().Be(
+                """
+                [{"type":"integer","value":"١"},{"type":"decimal","value":"٫"},{"type":"fraction","value":"٥"},{"type":"literal","value":" "},{"type":"unit","value":"m"}]
+                """);
+    }
+
+    /// <summary>
+    /// A full stop a locale does not use as its decimal separator is pattern text like any other.
+    /// German writes <c>1,2 Mio.</c>, and the comma is the number while the full stop is the abbreviation's.
+    /// </summary>
+    [Test]
+    public void ALocaleWhoseSeparatorIsACommaKeepsItsFullStops()
+    {
+        // the space between the two is .NET's, and is a non-breaking one on some platforms
+        var compact = _engine.Evaluate(
+            "new Intl.NumberFormat('de-DE', { numberingSystem: 'arab', notation: 'compact' }).format(1234567.891)").AsString();
+        compact.Should().StartWith("١٫٢").And.EndWith("Mio.");
+        _engine.Evaluate("new Intl.NumberFormat('de-DE', { numberingSystem: 'arab' }).format(1234.5)")
+            .AsString().Should().Be("١.٢٣٤٫٥");
+    }
+
+    /// <summary>
+    /// The separator between two range endpoints is the one the string lane writes: the locale's tight form
+    /// for a plain number, its spaced form for a currency. test262's
+    /// <c>NumberFormat/prototype/formatRange/en-US.js</c> pins <c>"987,654,321–987,654,322"</c> against
+    /// <c>formatRangeToParts/en-US.js</c>'s <c>{ type: "literal", value: " – " }</c> for a currency.
+    /// </summary>
+    [Test]
+    public void TheRangeSeparatorIsTheOneFormatRangeWrites()
+    {
+        _engine.Evaluate("new Intl.NumberFormat('en-US').formatRange(1, 5)").AsString().Should().Be("1–5");
+        _engine.Evaluate(
+            "new Intl.NumberFormat('en-US').formatRangeToParts(1, 5).map(function (p) { return p.value; }).join('')")
+            .AsString().Should().Be("1–5");
+
+        _engine.Evaluate(
+            "new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }).formatRange(3, 5)")
+            .AsString().Should().Be("$3 – $5");
+        _engine.Evaluate(
+            """
+            new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 })
+                .formatRangeToParts(3, 5).map(function (p) { return p.value; }).join('')
+            """)
+            .AsString().Should().Be("$3 – $5");
+    }
+
+    /// <summary>An engine that asks for no numbering system writes exactly what it always wrote.</summary>
+    [Test]
+    public void TheLatinDefaultIsUnchanged()
+    {
+        _engine.Evaluate("new Intl.NumberFormat('en').formatToParts(1234.5).map(function (p) { return p.value; }).join('')")
+            .AsString().Should().Be("1,234.5");
+        _engine.Evaluate("new Intl.NumberFormat('en').format(1234.5)").AsString().Should().Be("1,234.5");
+        _engine.Evaluate("new Intl.RelativeTimeFormat('en', { style: 'short' }).format(3, 'second')")
+            .AsString().Should().Be("in 3 sec.");
+        _engine.Evaluate("new Intl.RelativeTimeFormat('en', { numeric: 'auto' }).format(-1, 'day')")
+            .AsString().Should().Be("yesterday");
+    }
+
+    private void AssertNoMismatch(string script)
+    {
+        var mismatches = _engine.Evaluate(script).AsString();
+        mismatches.Should().Be("[]", "every part list joins back to the string the same formatter writes");
+    }
+
+    private static string JsArrayOf(string[] values) => "['" + string.Join("', '", values) + "']";
+}

--- a/Jint/Native/Intl/Data/NumberingSystemData.cs
+++ b/Jint/Native/Intl/Data/NumberingSystemData.cs
@@ -32,13 +32,33 @@ internal readonly record struct ResolvedNumberingSystem(string Name, string? Dig
         return new ResolvedNumberingSystem(name, digits, NumberingSystemData.GetDecimalSeparator(name));
     }
 
-    /// <summary>True when <see cref="Transliterate"/> can change anything; false for Latin.</summary>
+    /// <summary>True when <see cref="Transliterate(string)"/> can change anything; false for Latin.</summary>
     public bool RewritesDigits => Digits is not null;
+
+    /// <summary>True when this system writes a decimal separator of its own, rather than a full stop.</summary>
+    public bool RewritesDecimalSeparator => DecimalSeparator != '.';
 
     /// <summary>
     /// Rewrites the ASCII digits and the decimal point of an already-formatted string in this system.
     /// </summary>
-    public string Transliterate(string input) => NumberingSystemData.TransliterateDigits(input, Digits, DecimalSeparator);
+    public string Transliterate(string input) => NumberingSystemData.TransliterateDigits(input, Digits, '.', DecimalSeparator);
+
+    /// <summary>
+    /// Rewrites the ASCII digits of an already-formatted string, and the one character its writer used as a
+    /// decimal separator — leaving every other separator and every character of pattern text alone.
+    /// </summary>
+    /// <remarks>
+    /// Assuming that character is a full stop is what turns the abbreviation of a locale whose separator is a
+    /// comma — German's <c>"1,2 Mio."</c> — into <c>"1,2 Mio٫"</c>.
+    /// </remarks>
+    public string Transliterate(string input, char sourceDecimalSeparator)
+        => NumberingSystemData.TransliterateDigits(input, Digits, sourceDecimalSeparator, DecimalSeparator);
+
+    /// <summary>
+    /// Rewrites the ASCII digits of an already-formatted string and nothing else, leaving every separator
+    /// and every character of pattern text as the pattern wrote it.
+    /// </summary>
+    public string TransliterateDigitsOnly(string input) => NumberingSystemData.TransliterateDigits(input, Digits, '.', '.');
 }
 
 /// <summary>
@@ -156,7 +176,15 @@ internal static class NumberingSystemData
     /// <see cref="ResolvedNumberingSystem"/> carries. Null digits — Latin, or a system the provider does not
     /// answer for — leave the string alone.
     /// </summary>
-    public static string TransliterateDigits(string input, string? targetDigits, char decimalSeparator)
+    /// <param name="input">The already-formatted string.</param>
+    /// <param name="targetDigits">The ten digits to write, or null to leave the string alone.</param>
+    /// <param name="sourceDecimalSeparator">The character the string's writer used as a decimal separator.</param>
+    /// <param name="targetDecimalSeparator">The character to write instead; equal to the source means leave it.</param>
+    public static string TransliterateDigits(
+        string input,
+        string? targetDigits,
+        char sourceDecimalSeparator,
+        char targetDecimalSeparator)
     {
         if (targetDigits is null)
         {
@@ -176,10 +204,10 @@ internal static class NumberingSystemData
                 var digitStr = GetDigitAtIndex(targetDigits, digitIndex);
                 sb.Append(digitStr);
             }
-            else if (c == '.' && decimalSeparator != '.')
+            else if (c == sourceDecimalSeparator && targetDecimalSeparator != sourceDecimalSeparator)
             {
-                // Replace Latin decimal separator with target numbering system's separator
-                sb.Append(decimalSeparator);
+                // Replace the writer's decimal separator with the target numbering system's
+                sb.Append(targetDecimalSeparator);
             }
             else
             {

--- a/Jint/Native/Intl/JsNumberFormat.cs
+++ b/Jint/Native/Intl/JsNumberFormat.cs
@@ -165,10 +165,52 @@ internal sealed class JsNumberFormat : ObjectInstance
     /// </summary>
     internal string Format(double value)
     {
-        var result = FormatCore(value);
+        return Transliterate(FormatCore(value));
+    }
 
-        // Apply numbering system digit transliteration
-        return _numberingSystem.Transliterate(result);
+    /// <summary>
+    /// Rewrites an assembled result in <c>[[NumberingSystem]]</c>: the digits wherever they stand, and the
+    /// one character this formatter writes as its decimal separator.
+    /// </summary>
+    /// <remarks>
+    /// Rewriting every full stop instead — which is what the shared
+    /// <see cref="Data.ResolvedNumberingSystem.Transliterate(string)"/> does — reaches the full stops a pattern owns
+    /// as well as the one the number owns, and a locale whose own separator is a comma has both:
+    /// <c>de-DE</c> compact writes <c>"1,2 Mio."</c>, where the comma is the number's and the full stop
+    /// belongs to the abbreviation. https://tc39.es/ecma402/#sec-partitionnumberpattern puts the two in
+    /// different parts — <c>decimal</c> and <c>compact</c> — and only the first is a number.
+    /// </remarks>
+    private string Transliterate(string result)
+    {
+        if (!_numberingSystem.RewritesDigits)
+        {
+            return result;
+        }
+
+        var separator = DecimalSeparator;
+        if (_numberingSystem.RewritesDecimalSeparator && separator.Length == 1)
+        {
+            return _numberingSystem.Transliterate(result, separator[0]);
+        }
+
+        return _numberingSystem.TransliterateDigitsOnly(result);
+    }
+
+    /// <summary>
+    /// The decimal separator this formatter's own lanes write, which is the currency one for a currency and
+    /// the number one for everything else.
+    /// </summary>
+    private string DecimalSeparator
+    {
+        get
+        {
+            if (string.Equals(Style, "currency", StringComparison.Ordinal))
+            {
+                return NumberFormatInfo.CurrencyDecimalSeparator;
+            }
+
+            return NumberFormatInfo.NumberDecimalSeparator;
+        }
     }
 
     private string FormatCore(double value)
@@ -902,7 +944,7 @@ internal sealed class JsNumberFormat : ObjectInstance
             result = NumberFormatInfo.NegativeSign + result;
         }
 
-        return _numberingSystem.Transliterate(result);
+        return Transliterate(result);
     }
 
     /// <summary>
@@ -953,7 +995,7 @@ internal sealed class JsNumberFormat : ObjectInstance
         };
 
         // Apply numbering system digit transliteration
-        return _numberingSystem.Transliterate(result);
+        return Transliterate(result);
     }
 
     /// <summary>
@@ -2163,7 +2205,63 @@ internal sealed class JsNumberFormat : ObjectInstance
     /// Formats a number and returns an array of parts.
     /// https://tc39.es/ecma402/#sec-partitionnumberpattern
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// https://tc39.es/ecma402/#sec-formatnumeric is defined as the concatenation of exactly the parts
+    /// https://tc39.es/ecma402/#sec-formatnumerictoparts returns, so both lanes write
+    /// <c>[[NumberingSystem]]</c>'s digits or neither does. <see cref="Format(double)"/> transliterates the
+    /// assembled string; this lane transliterates the parts a number's digits went into, which is the same
+    /// rewrite applied one part at a time. <c>IntlNumberFormatPartsTests.PartsConcatenateToFormat</c> walks a grid
+    /// of locales, numbering systems and styles and asserts the two agree, rather than assuming it.
+    /// </para>
+    /// </remarks>
     internal List<NumberFormatPart> FormatToParts(double value)
+    {
+        var parts = FormatToPartsCore(value);
+
+        if (_numberingSystem.RewritesDigits)
+        {
+            for (var i = 0; i < parts.Count; i++)
+            {
+                var part = parts[i];
+                var transliterated = TransliterateNumericPart(part.Type, part.Value);
+                if (!ReferenceEquals(transliterated, part.Value))
+                {
+                    parts[i] = new NumberFormatPart(part.Type, transliterated);
+                }
+            }
+        }
+
+        return parts;
+    }
+
+    /// <summary>
+    /// Rewrites one part's value in this formatter's numbering system, for the part types
+    /// https://tc39.es/ecma402/#sec-partitionnumberpattern fills from the number's own digits. A currency
+    /// symbol, a unit name and a literal are pattern text, not a number, and keep the characters the pattern
+    /// gave them.
+    /// </summary>
+    /// <remarks>
+    /// <c>decimal</c> is a separator rather than a digit, and is here because a numbering system can carry
+    /// one of its own — <c>arab</c> writes U+066B — which is the same rewrite
+    /// <see cref="Transliterate(string)"/> applies to the assembled string. <c>group</c> is a separator the
+    /// system has no opinion about, and keeps the locale's.
+    /// </remarks>
+    private string TransliterateNumericPart(string type, string value)
+    {
+        if (string.Equals(type, "decimal", StringComparison.Ordinal))
+        {
+            return _numberingSystem.RewritesDecimalSeparator ? _numberingSystem.DecimalSeparator.ToString() : value;
+        }
+
+        return type switch
+        {
+            "integer" or "fraction" or "exponentInteger" => _numberingSystem.TransliterateDigitsOnly(value),
+            _ => value
+        };
+    }
+
+    private List<NumberFormatPart> FormatToPartsCore(double value)
     {
         var parts = new List<NumberFormatPart>();
 

--- a/Jint/Native/Intl/JsRelativeTimeFormat.cs
+++ b/Jint/Native/Intl/JsRelativeTimeFormat.cs
@@ -68,6 +68,16 @@ internal sealed class JsRelativeTimeFormat : ObjectInstance
     /// <summary>
     /// Formats a relative time value.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// https://tc39.es/ecma402/#sec-partitionrelativetimepattern substitutes one number — through
+    /// PartitionNumberPattern, which is where <c>[[NumberingSystem]]</c> is written — into a pattern whose
+    /// every other character is a literal. So the digits arrive already transliterated, in
+    /// <see cref="NumberFormat"/>'s output, and the pattern text around them is never a number: a
+    /// <c>style: "short"</c> abbreviation ending in a full stop keeps that full stop rather than acquiring
+    /// the numbering system's decimal separator.
+    /// </para>
+    /// </remarks>
     internal string Format(double value, string unit)
     {
         var absValue = System.Math.Abs(value);
@@ -124,8 +134,7 @@ internal sealed class JsRelativeTimeFormat : ObjectInstance
                     : (plural ? patterns.FuturePlural : patterns.Future);
             }
 
-            var result = pattern.Replace("{0}", formattedNumber);
-            return _numberingSystem.Transliterate(result);
+            return pattern.Replace("{0}", formattedNumber);
         }
 
         // Fallback to hardcoded patterns
@@ -136,17 +145,17 @@ internal sealed class JsRelativeTimeFormat : ObjectInstance
         {
             if (isPast)
             {
-                return _numberingSystem.Transliterate($"{formattedNumber} {unitName} ago");
+                return $"{formattedNumber} {unitName} ago";
             }
-            return _numberingSystem.Transliterate($"in {formattedNumber} {unitName}");
+            return $"in {formattedNumber} {unitName}";
         }
 
         // For non-English, use a simple format
         if (isPast)
         {
-            return _numberingSystem.Transliterate($"-{formattedNumber} {unitName}");
+            return $"-{formattedNumber} {unitName}";
         }
-        return _numberingSystem.Transliterate($"+{formattedNumber} {unitName}");
+        return $"+{formattedNumber} {unitName}";
     }
 
     /// <summary>

--- a/Jint/Native/Intl/NumberFormatPrototype.cs
+++ b/Jint/Native/Intl/NumberFormatPrototype.cs
@@ -436,6 +436,22 @@ internal sealed partial class NumberFormatPrototype : Prototype
         return startFormatted + sepTight + endFormatted;
     }
 
+    /// <summary>
+    /// The literal <c>formatRange</c> puts between two endpoints it did not collapse, which is what
+    /// <c>formatRangeToParts</c> writes as its shared <c>literal</c> part.
+    /// </summary>
+    /// <remarks>
+    /// The one shape this does not reproduce is a currency range whose two ends share a sign and a symbol
+    /// (<c>signDisplay: "always"</c>): <see cref="CollapseFormattedRange"/> drops the duplicate from the end
+    /// and tightens the separator, and the parts lane has no way to say that an endpoint's own parts were
+    /// elided. test262 asserts the two shapes below and not that one.
+    /// </remarks>
+    private static string RangeSeparator(JsNumberFormat numberFormat)
+    {
+        GetRangeSeparators(numberFormat.Locale, out var tight, out var loose);
+        return string.Equals(numberFormat.Style, "currency", StringComparison.Ordinal) ? loose : tight;
+    }
+
     // TODO: read range patterns from CLDR (e.g. via Options.Intl.CldrProvider) instead of
     // hard-coding language detection here. Other locales (fr, ja, …) have their own pattern
     // shapes and will silently fall through to the en-style default until that data path
@@ -539,10 +555,12 @@ internal sealed partial class NumberFormatPrototype : Prototype
                 result.SetIndexValue(index++, partObj, updateLength: true);
             }
 
-            // Add separator
+            // Add separator — the one CollapseFormattedRange would have written between the same two
+            // endpoints, so the parts join back to what formatRange() returns. A currency range keeps both
+            // ends in full and takes the spaced separator; every other style takes the locale's tight one.
             var separator = ObjectInstance.OrdinaryObjectCreate(Engine, Engine.Realm.Intrinsics.Object.PrototypeObject);
             separator.CreateDataPropertyOrThrow("type", "literal");
-            separator.CreateDataPropertyOrThrow("value", " – ");
+            separator.CreateDataPropertyOrThrow("value", RangeSeparator(numberFormat));
             separator.CreateDataPropertyOrThrow("source", "shared");
             result.SetIndexValue(index++, separator, updateLength: true);
 

--- a/Jint/Native/Intl/RelativeTimeFormatConstructor.cs
+++ b/Jint/Native/Intl/RelativeTimeFormatConstructor.cs
@@ -157,9 +157,15 @@ internal sealed partial class RelativeTimeFormatConstructor : Constructor
         // Get prototype from newTarget (for cross-realm construction)
         var proto = GetPrototypeFromConstructor(newTarget, static intrinsics => intrinsics.RelativeTimeFormat.PrototypeObject);
 
-        // Per ECMA-402 17.1.1 step 24: Create NumberFormat for number formatting
+        // https://tc39.es/ecma402/#sec-InitializeRelativeTimeFormat steps 25-27: the NumberFormat this
+        // formatter substitutes into its patterns is constructed with [[NumberingSystem]] written into its
+        // options, not left to re-derive it from the locale. It has to be told: the resolved locale drops the
+        // -u-nu- subtag whenever the numberingSystem option overrode one, so a NumberFormat built from the
+        // locale alone would write the locale's digits where this formatter reports another system's.
         var numberFormatConstructor = (NumberFormatConstructor) _realm.Intrinsics.NumberFormat;
-        var numberFormat = (JsNumberFormat) numberFormatConstructor.Construct([new JsString(finalResolvedLocale), Undefined], numberFormatConstructor);
+        var numberFormatOptions = OrdinaryObjectCreate(_engine, null);
+        numberFormatOptions.CreateDataPropertyOrThrow("numberingSystem", resolvedNumberingSystem);
+        var numberFormat = (JsNumberFormat) numberFormatConstructor.Construct([new JsString(finalResolvedLocale), numberFormatOptions], numberFormatConstructor);
 
         return new JsRelativeTimeFormat(
             _engine,

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -2368,6 +2368,57 @@ Two smaller consequences of the same derivation, both debugger-only:
 - A `with` scope over a host object whose properties live outside the engine's tables is no longer reported as
   an empty scope and dropped from `DebugInformation.CurrentScopeChain`.
 
+### 4.46 `Intl` writes the numbering system's digits in the parts lane, and only in the number ([#3455](https://github.com/sebastienros/jint/issues/3455), [#3456](https://github.com/sebastienros/jint/issues/3456))
+
+[FormatNumeric](https://tc39.es/ecma402/#sec-formatnumeric) is defined as the concatenation of exactly the
+parts [FormatNumericToParts](https://tc39.es/ecma402/#sec-formatnumerictoparts) returns — both of them
+[PartitionNumberPattern](https://tc39.es/ecma402/#sec-partitionnumberpattern) — so the two lanes cannot
+legally disagree. `format` transliterated into `[[NumberingSystem]]` and `formatToParts` did not, and
+`Intl.RelativeTimeFormat.prototype.formatToParts` inherited the Latin digits by copying those parts:
+
+```js
+const nf = new Intl.NumberFormat('en', { numberingSystem: 'arab' });
+// 4.16.x / earlier 5.0
+nf.format(1234.5);                                       // "١,٢٣٤٫٥"
+nf.formatToParts(1234.5).map(p => p.value).join('');     // "1,234.5"
+nf.formatRangeToParts(1, 5).map(p => p.value).join('');  // "1 - 5", against formatRange's "١-٥"
+
+// 5.x — one number, one set of digits
+nf.formatToParts(1234.5).map(p => p.value).join('');     // "١,٢٣٤٫٥"
+nf.formatRangeToParts(1, 5).map(p => p.value).join('');  // "١-٥"
+```
+
+The same rewrite now applies to the number and not to the pattern it sits in.
+`Intl.RelativeTimeFormat.prototype.format` transliterated its assembled string, so a `style: "short"`
+abbreviation's full stop became the numbering system's decimal separator, and `Intl.NumberFormat.prototype.format`
+did the same to a compact suffix in any locale whose own separator is not a full stop:
+
+```js
+// 4.16.x / earlier 5.0
+new Intl.RelativeTimeFormat('en', { style: 'short', numberingSystem: 'arab' }).format(3, 'second');
+// "in ٣ sec٫"  - U+066B ARABIC DECIMAL SEPARATOR, where the abbreviation's full stop belongs
+new Intl.NumberFormat('de-DE', { numberingSystem: 'arab', notation: 'compact' }).format(1234567.891);
+// "١,٢ Mio٫"
+
+// 5.x
+new Intl.RelativeTimeFormat('en', { style: 'short', numberingSystem: 'arab' }).format(3, 'second');  // "in ٣ sec."
+new Intl.NumberFormat('de-DE', { numberingSystem: 'arab', notation: 'compact' }).format(1234567.891); // "١٫٢ Mio."
+```
+
+Two smaller things move with it. The `NumberFormat` an `Intl.RelativeTimeFormat` substitutes into its
+patterns is now constructed with `[[NumberingSystem]]` in its options, as
+[InitializeRelativeTimeFormat](https://tc39.es/ecma402/#sec-InitializeRelativeTimeFormat) requires — it had
+been left to re-derive the system from a resolved locale the `numberingSystem` option had just stripped the
+`-u-nu-` subtag from. And `formatRangeToParts` writes the separator `formatRange` writes rather than a fixed
+`" - "`: the locale's tight form for a plain number, its spaced form for a currency, which is what test262's
+`formatRange/en-US.js` and `formatRangeToParts/en-US.js` assert against each other.
+
+**What could break:** nothing on a default engine — every formatter that resolves `latn` writes exactly what
+it wrote before, and `latn` is what an unconfigured engine resolves for every locale. Output moves for a
+formatter that asked for another numbering system, or for an embedder whose `ICldrProvider` gives a locale a
+non-Latin default: the parts lane gains that system's digits, a pattern's own punctuation stops acquiring
+them, and a locale whose decimal separator is a comma keeps its group separator as the full stop it is.
+
 ## 5. New in v5
 
 Everything in the table below is opt-in: nothing in it is installed unless the host asks for it, so


### PR DESCRIPTION
Fixes #3455. Fixes #3456.

One fix, because they are one defect seen from two sides: transliteration applied at the wrong granularity.
[FormatNumeric](https://tc39.es/ecma402/#sec-formatnumeric) is defined as the concatenation of exactly the
parts [FormatNumericToParts](https://tc39.es/ecma402/#sec-formatnumerictoparts) returns — both of them
[PartitionNumberPattern](https://tc39.es/ecma402/#sec-partitionnumberpattern) — so the two lanes cannot
legally disagree, and the rewrite that makes them agree is the one that applies to *a number's parts* rather
than to the assembled string.

## The defect, before the fix

```
nf.format(1234.5)          => ١,٢٣٤٫٥
nf.formatToParts join      => 1,234.5
nf.formatRange(1,5)        => ١–٥
nf.formatRangeToParts join => 1 – 5
rtf.format(3,day)          => in ٣ days
rtf.formatToParts join     => in 3 days
rtf short format(3,second) => in ٣ sec٫      <- #3456: U+066B where the abbreviation's full stop belongs
rtf short parts join       => in 3 sec.
```

(`nf` is `new Intl.NumberFormat('en', { numberingSystem: 'arab' })`, `rtf` the matching
`Intl.RelativeTimeFormat`.)

`Intl.NumberFormat.prototype.format` had the same #3456 defect one style over, in any locale whose own
decimal separator is not a full stop — the blanket `'.'` rewrite reached a compact suffix's own full stop:

```js
new Intl.NumberFormat('de-DE', { numberingSystem: 'arab', notation: 'compact' }).format(1234567.891);
// before: "١,٢ Mio٫"     after: "١٫٢ Mio."
```

## What changed

- **`JsNumberFormat.FormatToParts`** transliterates by part type — `integer`, `fraction`, `exponentInteger`
  and the `decimal` separator — the way `JsDurationFormat` has since #3420. A `currency`, `unit`, `compact`
  or `literal` part is pattern text and keeps the characters the pattern gave it.
- **`JsNumberFormat.Format`** rewrites the digits plus the one character *this formatter* writes as a
  decimal separator, instead of every full stop in the string. `ResolvedNumberingSystem.Transliterate` takes
  the source separator, so it is still one pass.
- **`JsRelativeTimeFormat.Format`** no longer transliterates its assembled string at all — the digits arrive
  already transliterated, in the substituted number, and everything around them is a literal.
- **`RelativeTimeFormatConstructor`** constructs its inner `NumberFormat` with `[[NumberingSystem]]` in its
  options, as [InitializeRelativeTimeFormat](https://tc39.es/ecma402/#sec-InitializeRelativeTimeFormat)
  requires. It had been left to re-derive the system from a resolved locale the `numberingSystem` option had
  just stripped the `-u-nu-` subtag from, which is why the blanket rewrite was load-bearing and could not
  simply be deleted.
- **`NumberFormatPrototype.FormatRangeToParts`** writes the separator `formatRange` writes rather than a
  fixed `" – "`: the locale's tight form for a plain number, its spaced form for a currency. That is exactly
  what test262 asserts across the two files — `formatRange/en-US.js` expects
  `"987,654,321–987,654,322"`, `formatRangeToParts/en-US.js` expects `{ type: "literal", value: " – " }` for
  a currency — and both keep passing.

## The invariant, and how it is pinned

`Jint.Tests/Runtime/IntlNumberFormatPartsTests.cs` walks a grid — 7 locales × 8 non-Latin numbering systems
(including `mathbold`, whose digits are surrogate pairs) × 13 option sets × 8 values for `NumberFormat`, plus
grids for `formatRange` and for `RelativeTimeFormat` — and asserts that
`parts.map(p => p.value).join('') === format(x)`.

It states that as *"asking for a numbering system introduces no disagreement Latin did not already have"*,
comparing each system against the same formatter in `latn`, so the four places where Jint's two lanes already
differ for reasons that have nothing to do with digits are skipped rather than silently blessed. Those four
are now filed as #3465, and the test's remark names them; closing that issue is what lets this assertion be
tightened to the outright equality the specification states.

**Verified failing first.** Against `upstream/main` at b7fed7a03, with only the test file added:

```
Failed ALocaleWhoseSeparatorIsACommaKeepsItsFullStops
Failed OnlyTheNumberIsTransliterated
Failed PartsConcatenateToFormat            ["en/arab/0/0: format=٠ parts=0", …]
Failed RangePartsConcatenateToFormatRange  ["en/arab/0/3,3: formatRange=~٣ parts=~3", …]
Failed RelativeTimePartsConcatenateToFormat ["en/arab/long/always/second/0: format=in ٠ seconds parts=in …
Failed TheRangeSeparatorIsTheOneFormatRangeWrites
Failed TheResolvedNumberingSystemReachesTheParts
Failed!  - Failed: 7, Passed: 1, Total: 8
```

The one that passes is `TheLatinDefaultIsUnchanged`, which is the point: an unconfigured engine resolves
`latn` for every locale and writes exactly what it wrote before.

## Verification

| | |
| --- | --- |
| `dotnet build -c Release` (solution) | 0 warnings, 0 errors |
| `Jint.Tests` | 10,840 passed / 0 failed (net8.0, net10.0), 7,464 (net472) |
| `Jint.Tests.PublicInterface` | 3,242 / 3,231 / 2,609 passed, 0 failed |
| **test262** | **102,495 passed / 0 failed / 189 skipped — the control, unmoved. Run twice; both identical** |

No public API change, so no baselines to regenerate. Migration guide: **§4.46**.

Related follow-ups found by the grid and filed rather than folded in: #3465 (four lane disagreements that
are not about digits), #3466 (`formatRangeToParts` and the collapsed currency range), #3468 (the same
#3456 defect in `Intl.DateTimeFormat`), #3469 (`formatToParts` builds a `dateStyle` pattern the locale does
not use).
