### PR TITLE
Temporal: a rejected time zone identifier is not remembered, and costs no system scan

### DIFF
--- a/Jint.Tests/Runtime/TemporalTimeZoneCacheTests.cs
+++ b/Jint.Tests/Runtime/TemporalTimeZoneCacheTests.cs
@@ -1,0 +1,226 @@
+#nullable enable
+
+using Jint.Native.Temporal;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// <c>DefaultTimeZoneProvider.Instance</c> is the provider every unconfigured engine gets, so its resolution
+/// cache is process-wide in practice. These tests pin that a script cannot grow it without bound.
+/// </summary>
+/// <remarks>
+/// Non-parallelizable because the assertions are about a static shared by the whole test run: a fixture
+/// running beside this one would add its own zones to the same dictionary.
+/// </remarks>
+[NonParallelizable]
+public class TemporalTimeZoneCacheTests
+{
+    /// <summary>
+    /// <c>IsValidTimeZone</c> ends in the same resolution the working paths use, so validation used to
+    /// populate the cache and every <i>rejected</i> identifier became a permanent entry.
+    /// </summary>
+    [Test]
+    public void RejectedTimeZoneIdentifiersDoNotGrowTheProcessWideCache()
+    {
+        var engine = new Engine();
+        engine.Execute("""
+            for (var i = 0; i < 500; i++) {
+                try { Temporal.ZonedDateTime.from({ year: 2020, month: 1, day: 1, timeZone: 'A/' + i }); }
+                catch (e) { }
+            }
+            """);
+
+        DefaultTimeZoneProvider.Instance.TimeZoneCacheCount
+            .Should().BeLessThanOrEqualTo(DefaultTimeZoneProvider.TimeZoneCacheBound);
+    }
+
+    /// <summary>
+    /// The identifiers that <i>do</i> resolve are a large key space too, because an offset identifier
+    /// resolves to a zone the provider manufactures from the string.
+    /// </summary>
+    [Test]
+    public void OffsetTimeZoneIdentifiersDoNotGrowTheProcessWideCache()
+    {
+        var engine = new Engine();
+        engine.Execute("""
+            function pad(n) { return (n < 10 ? '0' : '') + n; }
+            for (var h = 0; h < 24; h++) {
+                for (var m = 0; m < 60; m++) {
+                    Temporal.ZonedDateTime
+                        .from({ year: 2020, month: 1, day: 1, timeZone: '+' + pad(h) + ':' + pad(m) })
+                        .getTimeZoneTransition('next');
+                }
+            }
+            """);
+
+        DefaultTimeZoneProvider.Instance.TimeZoneCacheCount
+            .Should().BeLessThanOrEqualTo(DefaultTimeZoneProvider.TimeZoneCacheBound);
+    }
+
+    /// <summary>
+    /// The bound is not allowed to become a correctness problem: a zone resolved after the cache overflowed
+    /// answers exactly as it did before, because the value is a total function of the identifier.
+    /// </summary>
+    [Test]
+    public void AnEvictedZoneAnswersExactlyAsItDidBefore()
+    {
+        var engine = new Engine();
+        const string Script = "Temporal.ZonedDateTime.from({ year: 2020, month: 6, day: 1, timeZone: 'Europe/Helsinki' }).offsetNanoseconds";
+
+        var before = engine.Evaluate(Script).AsNumber();
+
+        engine.Execute("""
+            function pad(n) { return (n < 10 ? '0' : '') + n; }
+            for (var h = 0; h < 24; h++) {
+                for (var m = 0; m < 60; m++) {
+                    Temporal.ZonedDateTime
+                        .from({ year: 2020, month: 1, day: 1, timeZone: '+' + pad(h) + ':' + pad(m) })
+                        .getTimeZoneTransition('next');
+                }
+            }
+            """);
+
+        engine.Evaluate(Script).AsNumber().Should().Be(before);
+    }
+
+    /// <summary>
+    /// The syntactic screen that answers an impossible identifier without a system lookup must never decline
+    /// an identifier the system can actually resolve, so every zone this machine has has to survive it.
+    /// </summary>
+    [Test]
+    public void EverySystemTimeZoneIdentifierSurvivesTheSyntacticScreen()
+    {
+        var provider = DefaultTimeZoneProvider.Instance;
+        var screened = 0;
+
+        foreach (var zone in TimeZoneInfo.GetSystemTimeZones())
+        {
+            if (!zone.Id.Contains('/'))
+            {
+                // Windows identifiers ("Eastern Standard Time") are declined by the IANA naming rule that
+                // predates this change, and the screen is not what decides them.
+                continue;
+            }
+
+            provider.IsValidTimeZone(zone.Id).Should().BeTrue(because: $"'{zone.Id}' is a zone this machine has");
+            screened++;
+        }
+
+        foreach (var id in provider.GetAvailableTimeZones())
+        {
+            if (id.Contains('/'))
+            {
+                provider.IsValidTimeZone(id).Should().BeTrue(because: $"'{id}' is reported as available");
+                screened++;
+            }
+        }
+
+#if !NETFRAMEWORK
+        // On Windows the first loop does nothing, because the system's zones are Windows identifiers. Ask
+        // .NET for the IANA name of each instead: that is the key space the screen actually has to survive,
+        // and it is a real check on the platform where the first loop is empty.
+        foreach (var zone in TimeZoneInfo.GetSystemTimeZones())
+        {
+            if (TimeZoneInfo.TryConvertWindowsIdToIanaId(zone.Id, out var ianaId))
+            {
+                DefaultTimeZoneProvider.IsPlausibleIanaName(ianaId)
+                    .Should().BeTrue(because: $"'{ianaId}' is what .NET calls '{zone.Id}'");
+                screened++;
+            }
+        }
+#endif
+
+        // never vacuous: Linux fills the first loop, Windows the second and third
+        screened.Should().BeGreaterThan(0);
+    }
+
+    /// <summary>
+    /// A rejection is not merely bounded, it is not remembered at all -- which is what stops a script that
+    /// invents plausible-looking identifiers from paying the cache in entries.
+    /// </summary>
+    [Test]
+    public void ARejectedIdentifierIsNotRemembered()
+    {
+        var provider = DefaultTimeZoneProvider.Instance;
+
+        // survives the syntactic screen, so it reaches the system lookup and is rejected there
+        var unknown = "Europe/Nowhere_" + Guid.NewGuid().ToString("N");
+        var before = provider.TimeZoneCacheCount;
+
+        provider.IsValidTimeZone(unknown).Should().BeFalse();
+
+        provider.TimeZoneCacheCount.Should().Be(before);
+    }
+
+    /// <summary>
+    /// Every shape the TZDB actually uses has to survive the screen, or it would decline an identifier the
+    /// system could resolve.
+    /// </summary>
+    [Test]
+    [TestCase("America/New_York")]
+    [TestCase("America/Argentina/Buenos_Aires")]
+    [TestCase("America/Port-au-Prince")]
+    [TestCase("Antarctica/DumontDUrville")]
+    [TestCase("Asia/Ho_Chi_Minh")]
+    [TestCase("Etc/GMT+5")]
+    [TestCase("Etc/GMT-14")]
+    [TestCase("Pacific/Chatham")]
+    [TestCase("US/Eastern")]
+    [TestCase("posix/America/New_York")]
+    [TestCase("right/UTC")]
+    public void TheSyntacticScreenAcceptsEveryTzdbNameShape(string id)
+    {
+        DefaultTimeZoneProvider.IsPlausibleIanaName(id).Should().BeTrue();
+    }
+
+    /// <summary>
+    /// And nothing that cannot be one, which is the half that costs an invented identifier nothing.
+    /// </summary>
+    [Test]
+    [TestCase("A/0")]
+    [TestCase("Europe/0London")]
+    [TestCase("Europe/")]
+    [TestCase("/Europe")]
+    [TestCase("Europe//London")]
+    [TestCase("Europe/Lond on")]
+    [TestCase("Europe/Lond*on")]
+    [TestCase("Europe/Lond\u00f6n")]
+    [TestCase("")]
+    public void TheSyntacticScreenDeclinesWhatCannotNameAZone(string id)
+    {
+        DefaultTimeZoneProvider.IsPlausibleIanaName(id).Should().BeFalse();
+    }
+
+    [Test]
+    public void TheSyntacticScreenDeclinesAnAbsurdlyLongIdentifier()
+    {
+        DefaultTimeZoneProvider.IsPlausibleIanaName("Europe/" + new string('a', 1_000_000)).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// A rejected identifier stays rejected and a valid one stays valid, whether or not the answer was
+    /// remembered.
+    /// </summary>
+    [Test]
+    [TestCase("A/0", false)]
+    [TestCase("Not A Zone", false)]
+    [TestCase("Europe/Nowhere", false)]
+    [TestCase("ACT", false)]
+    [TestCase("Europe/Helsinki", true)]
+    [TestCase("europe/helsinki", true)]
+    [TestCase("UTC", true)]
+    [TestCase("Etc/UTC", true)]
+    [TestCase("America/Argentina/Buenos_Aires", true)]
+    [TestCase("+01:00", true)]
+    [TestCase("-05:30", true)]
+    [TestCase("+0130", true)]
+    [TestCase("+01", true)]
+    [TestCase("+01:00:00", false)]
+    public void AnAnswerIsTheSameOnEveryAsking(string timeZoneId, bool expected)
+    {
+        var provider = DefaultTimeZoneProvider.Instance;
+
+        provider.IsValidTimeZone(timeZoneId).Should().Be(expected);
+        provider.IsValidTimeZone(timeZoneId).Should().Be(expected);
+    }
+}

--- a/Jint/Extensions/Polyfills.cs
+++ b/Jint/Extensions/Polyfills.cs
@@ -521,3 +521,37 @@ internal static class CharUnicodeInfoPolyfills
 #endif
     }
 }
+
+internal static class TimeZoneInfoPolyfills
+{
+    extension(TimeZoneInfo)
+    {
+#if !NET8_0_OR_GREATER
+        // TimeZoneInfo.TryFindSystemTimeZoneById arrived in .NET 8, so net472, netstandard2.0 and
+        // netstandard2.1 all need it. Downlevel there is no way to ask without a throw, so this is the
+        // catch the call site would otherwise write -- what it buys is that the call site reads as the
+        // question it is on every target framework, and that net8 and net10, which have the real method,
+        // answer it without an exception at all. Both exceptions the real method reports as "no" are
+        // caught, so the polyfill answers what .NET 8 answers rather than what one call site happened to
+        // catch.
+        public static bool TryFindSystemTimeZoneById(string id, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out TimeZoneInfo? timeZoneInfo)
+        {
+            try
+            {
+                timeZoneInfo = TimeZoneInfo.FindSystemTimeZoneById(id);
+                return true;
+            }
+            catch (TimeZoneNotFoundException)
+            {
+                timeZoneInfo = null;
+                return false;
+            }
+            catch (InvalidTimeZoneException)
+            {
+                timeZoneInfo = null;
+                return false;
+            }
+        }
+#endif
+    }
+}

--- a/Jint/Native/Temporal/DefaultTimeZoneProvider.cs
+++ b/Jint/Native/Temporal/DefaultTimeZoneProvider.cs
@@ -56,8 +56,31 @@ public class DefaultTimeZoneProvider : ITimeZoneProvider
     // Unix epoch in .NET ticks
     private static readonly long UnixEpochTicks = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).Ticks;
 
-    // Cache for resolved time zones
-    private readonly ConcurrentDictionary<string, TimeZoneInfo?> _timeZoneCache = new(StringComparer.OrdinalIgnoreCase);
+    // Cache of resolved time zones. The field is instance-scoped, which is right, but the instance that
+    // matters is Instance, the singleton every unconfigured engine gets from Options.Temporal.TimeZoneProvider,
+    // so in practice it is process-wide and outlives the engine that filled it.
+    //
+    // Only a resolution that *succeeded* is stored. A rejected identifier is never remembered: the identifier
+    // is a string a script chose and there is no bound on how many distinct ones it can invent, so a negative
+    // cache is unbounded growth no engine's LimitMemory can see. CreateTimeZone answers an identifier that
+    // cannot name a zone from the string alone, which makes recomputing a rejection cheaper than the
+    // dictionary write that would remember it.
+    //
+    // The successes need a bound of their own, because an offset identifier resolves to a zone this provider
+    // manufactures rather than to one the system has: getTimeZoneTransition on a ZonedDateTime built with
+    // '+HH:MM' reaches here, and there are 1440 of those. Once the cache holds Capacity entries it is cleared
+    // and refilled -- the rule RegExpParseCache uses: cheap, thread-safe, nothing on the hit path and
+    // self-healing when the working set shifts. A dropped entry costs one re-resolution and never a different
+    // answer, since the value is a total function of the identifier and TimeZoneInfo is immutable.
+    private const int TimeZoneCacheCapacity = 256;
+
+    private readonly ConcurrentDictionary<string, TimeZoneInfo> _timeZoneCache = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Number of cached time zones. Exists so the growth test can assert on the bound.</summary>
+    internal int TimeZoneCacheCount => _timeZoneCache.Count;
+
+    /// <summary>The bound <see cref="TimeZoneCacheCount"/> can never exceed for long.</summary>
+    internal static int TimeZoneCacheBound => TimeZoneCacheCapacity;
 
     // Common IANA to Windows mappings (subset for common cases)
     private static readonly Dictionary<string, string> IanaToWindows = new(StringComparer.OrdinalIgnoreCase)
@@ -678,82 +701,109 @@ public class DefaultTimeZoneProvider : ITimeZoneProvider
 
     private TimeZoneInfo? ResolveTimeZone(string timeZoneId)
     {
-        return _timeZoneCache.GetOrAdd(timeZoneId, id =>
+        if (_timeZoneCache.TryGetValue(timeZoneId, out var cached))
         {
-            // Handle UTC
-            if (id.Equals("UTC", StringComparison.OrdinalIgnoreCase) ||
-                id.Equals("Etc/UTC", StringComparison.OrdinalIgnoreCase))
-            {
-                return TimeZoneInfo.Utc;
-            }
+            return cached;
+        }
 
-            // Handle offset strings (e.g., +01:00, -05:30, +01:30:00)
-            var offset = ParseOffsetString(id);
-            if (offset.HasValue)
-            {
-                // .NET TimeZoneInfo only supports whole minute offsets, but we need to allow
-                // seconds precision for Temporal. We'll create a custom TimeZoneInfo with
-                // the offset rounded to minutes, but GetOffsetNanosecondsFor will return the exact offset.
-                //
-                // IMPORTANT: TimeZoneInfo.CreateCustomTimeZone only accepts offsets within ±14 hours,
-                // but ISO 8601/Temporal allows ±23:59. We clamp to ±14 hours for the TimeZoneInfo,
-                // but GetOffsetNanosecondsFor will still return the actual parsed offset.
-                var totalMinutes = (int) offset.Value.TotalMinutes;
-                const int MaxOffsetMinutes = 14 * 60; // ±14 hours
-                if (totalMinutes > MaxOffsetMinutes)
-                    totalMinutes = MaxOffsetMinutes;
-                else if (totalMinutes < -MaxOffsetMinutes)
-                    totalMinutes = -MaxOffsetMinutes;
+        var resolved = CreateTimeZone(timeZoneId);
+        if (resolved is null)
+        {
+            // Deliberately not remembered -- see the note on _timeZoneCache. IsValidTimeZone ends here, so a
+            // negative entry would be one per rejected identifier, and a script chooses those.
+            return null;
+        }
 
-                var roundedOffset = TimeSpan.FromMinutes(totalMinutes);
-                return TimeZoneInfo.CreateCustomTimeZone(id, roundedOffset, id, id);
-            }
+        if (_timeZoneCache.Count >= TimeZoneCacheCapacity)
+        {
+            _timeZoneCache.Clear();
+        }
 
-            // On Windows, .NET resolves non-IANA identifiers (Java abbreviations like ACT, BST, etc.)
-            // Reject identifiers that don't follow IANA naming conventions
-            if (!IsValidIanaIdentifier(id))
-            {
-                return null;
-            }
+        // GetOrAdd rather than the indexer: another thread may already have published an instance for this
+        // identifier, and a caller holding that one has to keep matching what the next lookup returns.
+        return _timeZoneCache.GetOrAdd(timeZoneId, resolved);
+    }
 
-            // Try direct lookup first
-            try
-            {
-                return TimeZoneInfo.FindSystemTimeZoneById(id);
-            }
-            catch (TimeZoneNotFoundException)
-            {
-                // Continue to mapping
-            }
+    private static TimeZoneInfo? CreateTimeZone(string id)
+    {
+        // Handle UTC
+        if (id.Equals("UTC", StringComparison.OrdinalIgnoreCase) ||
+            id.Equals("Etc/UTC", StringComparison.OrdinalIgnoreCase))
+        {
+            return TimeZoneInfo.Utc;
+        }
 
-            // Try IANA to Windows mapping (case-insensitive via dictionary comparer)
-            if (IsWindowsPlatform() &&
-                IanaToWindows.TryGetValue(id, out var windowsId))
-            {
-                try
-                {
-                    return TimeZoneInfo.FindSystemTimeZoneById(windowsId);
-                }
-                catch (TimeZoneNotFoundException)
-                {
-                    // Continue
-                }
-            }
+        // Handle offset strings (e.g., +01:00, -05:30, +01:30:00)
+        var offset = ParseOffsetString(id);
+        if (offset.HasValue)
+        {
+            // .NET TimeZoneInfo only supports whole minute offsets, but we need to allow
+            // seconds precision for Temporal. We'll create a custom TimeZoneInfo with
+            // the offset rounded to minutes, but GetOffsetNanosecondsFor will return the exact offset.
+            //
+            // IMPORTANT: TimeZoneInfo.CreateCustomTimeZone only accepts offsets within ±14 hours,
+            // but ISO 8601/Temporal allows ±23:59. We clamp to ±14 hours for the TimeZoneInfo,
+            // but GetOffsetNanosecondsFor will still return the actual parsed offset.
+            var totalMinutes = (int) offset.Value.TotalMinutes;
+            const int MaxOffsetMinutes = 14 * 60; // ±14 hours
+            if (totalMinutes > MaxOffsetMinutes)
+                totalMinutes = MaxOffsetMinutes;
+            else if (totalMinutes < -MaxOffsetMinutes)
+                totalMinutes = -MaxOffsetMinutes;
+
+            var roundedOffset = TimeSpan.FromMinutes(totalMinutes);
+            return TimeZoneInfo.CreateCustomTimeZone(id, roundedOffset, id, id);
+        }
+
+        // On Windows, .NET resolves non-IANA identifiers (Java abbreviations like ACT, BST, etc.)
+        // Reject identifiers that don't follow IANA naming conventions. This is the screen that answers an
+        // identifier a script invented -- 'A/0', 'A/1', ... -- from the string alone: no system lookup, no
+        // exception, nothing retained.
+        if (!IsValidIanaIdentifier(id))
+        {
+            return null;
+        }
+
+        // Try direct lookup first. TryFindSystemTimeZoneById rather than FindSystemTimeZoneById in a catch:
+        // on net8 and net10 an identifier the system does not have is answered without a throw at all, and
+        // below that the polyfill is the same catch written once.
+        if (TimeZoneInfo.TryFindSystemTimeZoneById(id, out var direct))
+        {
+            return direct;
+        }
+
+        // Try IANA to Windows mapping (case-insensitive via dictionary comparer)
+        if (IsWindowsPlatform() &&
+            IanaToWindows.TryGetValue(id, out var windowsId) &&
+            TimeZoneInfo.TryFindSystemTimeZoneById(windowsId, out var mapped))
+        {
+            return mapped;
+        }
 
 #if NET8_0_OR_GREATER
-            // Case-insensitive fallback: try all system timezones
-            foreach (var systemTz in TimeZoneInfo.GetSystemTimeZones())
-            {
-                if (string.Equals(systemTz.Id, id, StringComparison.OrdinalIgnoreCase))
-                {
-                    return systemTz;
-                }
-            }
+        // Case-insensitive fallback over the system's zones, answered from a dictionary built once rather
+        // than by re-scanning every zone the machine has on each unresolved identifier.
+        return SystemTimeZonesByIdIgnoreCase.Value.TryGetValue(id, out var systemTz) ? systemTz : null;
+#else
+        return null;
 #endif
-
-            return null;
-        });
     }
+
+#if NET8_0_OR_GREATER
+    // Built once from the same TimeZoneInfo.GetSystemTimeZones() the linear scan used to walk, in the same
+    // order, so first-wins here is the first match that scan returned.
+    private static readonly Lazy<Dictionary<string, TimeZoneInfo>> SystemTimeZonesByIdIgnoreCase = new(static () =>
+    {
+        var zones = TimeZoneInfo.GetSystemTimeZones();
+        var map = new Dictionary<string, TimeZoneInfo>(zones.Count, StringComparer.OrdinalIgnoreCase);
+        foreach (var zone in zones)
+        {
+            map.TryAdd(zone.Id, zone);
+        }
+
+        return map;
+    });
+#endif
 
     /// <summary>
     /// Parses an offset string like "+01:00" or "-05:30" to a TimeSpan.
@@ -917,15 +967,72 @@ public class DefaultTimeZoneProvider : ITimeZoneProvider
     /// </summary>
     private static bool IsValidIanaIdentifier(string id)
     {
-        // IDs containing '/' are Area/Location format (always valid IANA)
+        // IDs containing '/' are Area/Location format, valid IANA as long as every component could be a TZDB
+        // name at all. That second half is what keeps an identifier a script invented from reaching a system
+        // lookup: it is answered from the string, and it only ever declines what the lookup would decline.
         if (id.Contains('/'))
         {
-            return true;
+            return IsPlausibleIanaName(id);
         }
 
         // IDs containing digits with letters (like EST5EDT, CST6CDT) are IANA compound TZ names
         // Known single-word IANA identifiers (Zone and Link names from TZDB)
         return s_validSingleWordIanaIds.Contains(id);
+    }
+
+    // No TZDB name comes close; the longest the database has is America/Argentina/ComodRivadavia at 32, and
+    // the posix/ and right/ prefixes .NET exposes on Unix add six. The bound exists so that hashing a
+    // megabyte of script-supplied text is not the cost of asking whether it names a time zone.
+    private const int MaxIanaIdentifierLength = 128;
+
+    /// <summary>
+    /// Whether <paramref name="id"/> has the shape of a TZDB Zone or Link name: '/'-separated components,
+    /// each beginning with an ASCII letter and continuing with letters, digits, '.', '_', '+' or '-'.
+    /// </summary>
+    /// <remarks>
+    /// Every name in the database fits -- <c>Etc/GMT+5</c>, <c>America/Port-au-Prince</c>,
+    /// <c>America/Argentina/Buenos_Aires</c>, and the <c>posix/</c> and <c>right/</c> prefixes .NET exposes
+    /// on Unix -- so declining anything else costs no identifier a system lookup could have resolved. That
+    /// is what <c>EverySystemTimeZoneIdentifierSurvivesTheSyntacticScreen</c> pins, against whatever zones
+    /// the machine running the tests happens to have.
+    /// </remarks>
+    internal static bool IsPlausibleIanaName(string id)
+    {
+        if (id.Length == 0 || id.Length > MaxIanaIdentifierLength)
+        {
+            return false;
+        }
+
+        var atComponentStart = true;
+        for (var i = 0; i < id.Length; i++)
+        {
+            var c = id[i];
+
+            if (atComponentStart)
+            {
+                if (!char.IsAsciiLetter(c))
+                {
+                    return false;
+                }
+
+                atComponentStart = false;
+                continue;
+            }
+
+            if (c == '/')
+            {
+                atComponentStart = true;
+                continue;
+            }
+
+            if (!char.IsAsciiLetterOrDigit(c) && c != '.' && c != '_' && c != '+' && c != '-')
+            {
+                return false;
+            }
+        }
+
+        // a trailing '/' leaves an empty component
+        return !atComponentStart;
     }
 
     private static readonly HashSet<string> s_validSingleWordIanaIds = new(StringComparer.OrdinalIgnoreCase)


### PR DESCRIPTION
Fixes #3439.

`DefaultTimeZoneProvider.Instance` is the provider every unconfigured engine gets from `Options.Temporal.TimeZoneProvider`, so its `_timeZoneCache` is instance-scoped in name and process-wide in practice. `IsValidTimeZone` ends in the same `ResolveTimeZone` the working paths use, and `TemporalHelpers.ValidateTimeZoneId` calls it for every user-supplied zone — so a **rejected** identifier got a permanent `null` entry keyed on a string the script chose, and on net8+ each one cost a full linear scan of `TimeZoneInfo.GetSystemTimeZones()` to establish.

```js
for (var i = 0; i < 500; i++) {
    try { Temporal.ZonedDateTime.from({ year: 2020, month: 1, day: 1, timeZone: 'A/' + i }); }
    catch (e) { }
}
```

## Rejections are not cached at all

A negative cache is the sharper half of this: it is the one an attacker or a careless script can fill for free, and unlike the positive side it buys nothing a correct program wants. So the answer here is not to bound it but to remove it — which is only defensible if a miss is cheap, and three changes make it so.

**The syntactic screen decides the flood shape for free.** `IsValidIanaIdentifier` treated *anything* containing `/` as a valid IANA name, so `A/0` went to `FindSystemTimeZoneById`, then to the IANA→Windows map, then to the full scan. It now also checks that every `/`-separated component could be a TZDB name at all: non-empty, beginning with an ASCII letter, continuing with letters, digits, `.`, `_`, `+` or `-`, within a generous total length bound. `A/0`, `Europe/`, `Europe//London`, `Europe/Lond*on` and a megabyte of text are answered from the string, with no `TimeZoneInfo` call and nothing retained.

That screen must not narrow what resolves, so it is pinned rather than argued: `EverySystemTimeZoneIdentifierSurvivesTheSyntacticScreen` walks every zone the machine running the tests has (and, on Windows where those are Windows identifiers, the IANA name .NET gives for each) and asserts the screen accepts it, with a counter so the test can never pass vacuously. `Etc/GMT+5`, `America/Port-au-Prince`, `America/Argentina/Buenos_Aires` and the `posix/` and `right/` prefixes .NET exposes on Unix are covered by name as well.

**On the shipping asset, a plausible-but-unknown identifier no longer costs a throw.** The direct lookup uses `TimeZoneInfo.TryFindSystemTimeZoneById`, which on net8 and net10 answers without an exception at all. It arrived only in .NET 8, so `Polyfills.cs` backfills it for net472/netstandard2.0/netstandard2.1 — there the throw remains, because downlevel there is no other way to ask; what the polyfill buys on those targets is that the call site reads as the question it is, and that both exceptions the real method reports as "no" are caught rather than only the one the old call site happened to catch.

**And the scan is gone.** The case-insensitive fallback reads a dictionary built once from `GetSystemTimeZones()`, in the same order, so first-wins there is the first match the scan returned.

## The successes are bounded

They need a bound of their own, and this is the part the issue did not have: an *offset* identifier resolves to a zone the provider manufactures rather than one the system has, and `getTimeZoneTransition` on a `ZonedDateTime` reaches `ResolveTimeZone` without pre-parsing the offset — 1440 distinct `+HH:MM` spellings, all valid, all cached. So the cache is capped at 256 entries, cleared and refilled on overflow: the rule `RegExpParseCache` already uses here.

**What a hit costs: exactly what it cost before** — one `ConcurrentDictionary.TryGetValue`, no recency list, no timestamp, no allocation. That is what clearing rather than LRU-evicting buys; an LRU's bookkeeping would land on the hit path, which is where real scripts are. Eviction can only cost time, never a different answer: the value is a total function of the identifier and `TimeZoneInfo` is immutable, which `AnEvictedZoneAnswersExactlyAsItDidBefore` pins by reading an offset before and after an overflow.

## Evidence

`TemporalTimeZoneCacheTests`, `[NonParallelizable]` because the assertions are about a static shared by the whole run, and always about the cache's own `Count` rather than process memory. Against unmodified `main` with the accessor in place but no fix:

```
Failed OffsetTimeZoneIdentifiersDoNotGrowTheProcessWideCache
   Expected DefaultTimeZoneProvider.Instance.TimeZoneCacheCount to be less than or equal to 256, but found 1489 (difference of 1233).
Failed RejectedTimeZoneIdentifiersDoNotGrowTheProcessWideCache
   Expected DefaultTimeZoneProvider.Instance.TimeZoneCacheCount to be less than or equal to 256, but found 1988 (difference of 1732).
```

With the fix, `ARejectedIdentifierIsNotRemembered` additionally asserts the stronger property — a rejection changes `Count` by zero, not merely by less than the bound.

Green: `Jint.Tests` 10872 (net8.0/net10.0), 7496 (net472); `Jint.Tests.PublicInterface` 3231/3241/2609; `Jint.Tests.CommonScripts` 28/28; test262 **102495 passed / 0 failed / 189 skipped**, the control figure exactly.

## No migration row

`DefaultTimeZoneProvider` is public, but no signature and no answer changes — `IsValidTimeZone`, `CanonicalizeTimeZone` and the offset and transition members all return what they returned. What changes is what is retained and what a miss costs. Nothing for `docs/v5-migration.md`.

## How it was found

The #3426 audit of process-wide caches, alongside the `Intl` sibling in #3438 (fixed by #3462). The two are independent and touch no common file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014W5mbjGhyvgAS4pivXoc4S
