### PR TITLE
Intl: the calendar a locale defaults to is the CLDR provider's answer, not .NET's

### DIFF
--- a/Jint.Tests.PublicInterface/HostLocaleProviderTests.cs
+++ b/Jint.Tests.PublicInterface/HostLocaleProviderTests.cs
@@ -16,7 +16,7 @@ namespace Jint.Tests.PublicInterface;
 public class HostLocaleProviderTests
 {
     [Test]
-    public void OverridingOneCldrDatumLeavesTheOtherSeventeenMembersInherited()
+    public void OverridingOneCldrDatumLeavesTheOtherEighteenMembersInherited()
     {
         var engine = new Engine(options => options.Intl.CldrProvider = new OneCurrencyName());
 
@@ -127,6 +127,32 @@ public class HostLocaleProviderTests
         engine.Evaluate("Temporal.PlainDate.from({ year: 1445, monthCode: 'M08', day: 25, calendar: 'islamic-civil' }).toString()")
             .AsString().Should().Be(
                 stock.Evaluate("Temporal.PlainDate.from({ year: 1445, monthCode: 'M08', day: 25, calendar: 'islamic-civil' }).toString()").AsString());
+    }
+
+    /// <summary>
+    /// <c>ca</c> is a relevant extension key, and its locale default is a datum like any other: it used to be
+    /// read off <c>CultureInfo.Calendar</c>, where a host had no way to reach it.
+    /// </summary>
+    [Test]
+    public void OverridingTheDefaultCalendarReachesDateTimeFormat()
+    {
+        var engine = new Engine(options => options.Intl.CldrProvider = new HebrewByDefault());
+
+        // the one overridden member
+        engine.Evaluate("new Intl.DateTimeFormat('en-US').resolvedOptions().calendar")
+            .AsString().Should().Be("hebrew");
+
+        // …and the two things ResolveLocale lets outrank it still do
+        engine.Evaluate("new Intl.DateTimeFormat('en-US', { calendar: 'gregory' }).resolvedOptions().calendar")
+            .AsString().Should().Be("gregory");
+        engine.Evaluate("new Intl.DateTimeFormat('en-US-u-ca-buddhist').resolvedOptions().calendar")
+            .AsString().Should().Be("buddhist");
+
+        // …and every other member is the inherited data, delegated by nobody
+        engine.Evaluate("new Intl.NumberFormat('en', { style: 'unit', unit: 'meter' }).format(5)")
+            .AsString().Should().Be("5 m");
+        engine.Evaluate("new Intl.DisplayNames('en', { type: 'currency' }).of('USD')")
+            .AsString().Should().Be("US Dollar");
     }
 
     [Test]
@@ -379,6 +405,12 @@ file sealed class SundayIsTheWeekend : DefaultCldrProvider
 }
 
 /// <summary>One numbering system the engine has never heard of; every other one is inherited.</summary>
+/// <summary>A host whose locales all keep the Hebrew calendar.</summary>
+file sealed class HebrewByDefault : DefaultCldrProvider
+{
+    public override string? GetDefaultCalendar(string locale) => "hebrew";
+}
+
 file sealed class AlphabetDigits : DefaultCldrProvider
 {
     public override string? GetNumberingSystemDigits(string numberingSystem)

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
@@ -1350,6 +1350,7 @@ namespace Jint.Native.Intl
         public virtual Jint.Native.Intl.CurrencyData? GetCurrencyData(string locale, string currencyCode) { }
         public virtual string? GetCurrencyDisplayName(string locale, string code) { }
         public virtual string[]? GetDayPeriods(string locale, string style, string? calendar) { }
+        public virtual string? GetDefaultCalendar(string locale) { }
         public virtual string? GetDefaultNumberingSystem(string locale) { }
         public virtual string[]? GetEraNames(string locale, string style, string? calendar) { }
         public virtual Jint.Native.Intl.ListPatterns? GetListPatterns(string locale, string type, string style) { }
@@ -1371,6 +1372,7 @@ namespace Jint.Native.Intl
         Jint.Native.Intl.CurrencyData? GetCurrencyData(string locale, string currencyCode);
         string? GetCurrencyDisplayName(string locale, string code);
         string[]? GetDayPeriods(string locale, string style, string? calendar);
+        string? GetDefaultCalendar(string locale);
         string? GetDefaultNumberingSystem(string locale);
         string[]? GetEraNames(string locale, string style, string? calendar);
         Jint.Native.Intl.ListPatterns? GetListPatterns(string locale, string type, string style);

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net472.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net472.verified.txt
@@ -1197,6 +1197,7 @@ namespace Jint.Native.Intl
         public virtual Jint.Native.Intl.CurrencyData? GetCurrencyData(string locale, string currencyCode) { }
         public virtual string? GetCurrencyDisplayName(string locale, string code) { }
         public virtual string[]? GetDayPeriods(string locale, string style, string? calendar) { }
+        public virtual string? GetDefaultCalendar(string locale) { }
         public virtual string? GetDefaultNumberingSystem(string locale) { }
         public virtual string[]? GetEraNames(string locale, string style, string? calendar) { }
         public virtual Jint.Native.Intl.ListPatterns? GetListPatterns(string locale, string type, string style) { }
@@ -1218,6 +1219,7 @@ namespace Jint.Native.Intl
         Jint.Native.Intl.CurrencyData? GetCurrencyData(string locale, string currencyCode);
         string? GetCurrencyDisplayName(string locale, string code);
         string[]? GetDayPeriods(string locale, string style, string? calendar);
+        string? GetDefaultCalendar(string locale);
         string? GetDefaultNumberingSystem(string locale);
         string[]? GetEraNames(string locale, string style, string? calendar);
         Jint.Native.Intl.ListPatterns? GetListPatterns(string locale, string type, string style);

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
@@ -1350,6 +1350,7 @@ namespace Jint.Native.Intl
         public virtual Jint.Native.Intl.CurrencyData? GetCurrencyData(string locale, string currencyCode) { }
         public virtual string? GetCurrencyDisplayName(string locale, string code) { }
         public virtual string[]? GetDayPeriods(string locale, string style, string? calendar) { }
+        public virtual string? GetDefaultCalendar(string locale) { }
         public virtual string? GetDefaultNumberingSystem(string locale) { }
         public virtual string[]? GetEraNames(string locale, string style, string? calendar) { }
         public virtual Jint.Native.Intl.ListPatterns? GetListPatterns(string locale, string type, string style) { }
@@ -1371,6 +1372,7 @@ namespace Jint.Native.Intl
         Jint.Native.Intl.CurrencyData? GetCurrencyData(string locale, string currencyCode);
         string? GetCurrencyDisplayName(string locale, string code);
         string[]? GetDayPeriods(string locale, string style, string? calendar);
+        string? GetDefaultCalendar(string locale);
         string? GetDefaultNumberingSystem(string locale);
         string[]? GetEraNames(string locale, string style, string? calendar);
         Jint.Native.Intl.ListPatterns? GetListPatterns(string locale, string type, string style);

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.0.verified.txt
@@ -1197,6 +1197,7 @@ namespace Jint.Native.Intl
         public virtual Jint.Native.Intl.CurrencyData? GetCurrencyData(string locale, string currencyCode) { }
         public virtual string? GetCurrencyDisplayName(string locale, string code) { }
         public virtual string[]? GetDayPeriods(string locale, string style, string? calendar) { }
+        public virtual string? GetDefaultCalendar(string locale) { }
         public virtual string? GetDefaultNumberingSystem(string locale) { }
         public virtual string[]? GetEraNames(string locale, string style, string? calendar) { }
         public virtual Jint.Native.Intl.ListPatterns? GetListPatterns(string locale, string type, string style) { }
@@ -1218,6 +1219,7 @@ namespace Jint.Native.Intl
         Jint.Native.Intl.CurrencyData? GetCurrencyData(string locale, string currencyCode);
         string? GetCurrencyDisplayName(string locale, string code);
         string[]? GetDayPeriods(string locale, string style, string? calendar);
+        string? GetDefaultCalendar(string locale);
         string? GetDefaultNumberingSystem(string locale);
         string[]? GetEraNames(string locale, string style, string? calendar);
         Jint.Native.Intl.ListPatterns? GetListPatterns(string locale, string type, string style);

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.1.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.1.verified.txt
@@ -1197,6 +1197,7 @@ namespace Jint.Native.Intl
         public virtual Jint.Native.Intl.CurrencyData? GetCurrencyData(string locale, string currencyCode) { }
         public virtual string? GetCurrencyDisplayName(string locale, string code) { }
         public virtual string[]? GetDayPeriods(string locale, string style, string? calendar) { }
+        public virtual string? GetDefaultCalendar(string locale) { }
         public virtual string? GetDefaultNumberingSystem(string locale) { }
         public virtual string[]? GetEraNames(string locale, string style, string? calendar) { }
         public virtual Jint.Native.Intl.ListPatterns? GetListPatterns(string locale, string type, string style) { }
@@ -1218,6 +1219,7 @@ namespace Jint.Native.Intl
         Jint.Native.Intl.CurrencyData? GetCurrencyData(string locale, string currencyCode);
         string? GetCurrencyDisplayName(string locale, string code);
         string[]? GetDayPeriods(string locale, string style, string? calendar);
+        string? GetDefaultCalendar(string locale);
         string? GetDefaultNumberingSystem(string locale);
         string[]? GetEraNames(string locale, string style, string? calendar);
         Jint.Native.Intl.ListPatterns? GetListPatterns(string locale, string type, string style);

--- a/Jint.Tests.Test262/IcuCldrProvider.cs
+++ b/Jint.Tests.Test262/IcuCldrProvider.cs
@@ -279,6 +279,11 @@ public sealed class IcuCldrProvider : ICldrProvider
     // Note: ICU4N doesn't have DateFormatSymbols ported yet, so we use the fallback provider
     // which uses .NET's CultureInfo for basic date/time data.
 
+    // The default provider reads CLDR's own calendarPreferenceData, which is the table ICU would answer
+    // from, so there is nothing ICU4N could add here.
+    public string? GetDefaultCalendar(string locale)
+        => _fallback.GetDefaultCalendar(locale);
+
     public string[]? GetMonthNames(string locale, string style, string? calendar)
         => _fallback.GetMonthNames(locale, style, calendar);
 

--- a/Jint.Tests/Runtime/IntlCalendarDefaultTests.cs
+++ b/Jint.Tests/Runtime/IntlCalendarDefaultTests.cs
@@ -1,0 +1,154 @@
+#nullable enable
+
+using Jint.Native.Intl;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// <c>ca</c> is a relevant extension key of <c>Intl.DateTimeFormat</c>, and its locale default is
+/// <c>keyLocaleData[0]</c> — https://tc39.es/ecma402/#sec-resolvelocale step 13.c — which
+/// <see cref="ICldrProvider.GetDefaultCalendar"/> answers for, the way
+/// <see cref="ICldrProvider.GetDefaultNumberingSystem"/> answers for <c>nu</c>.
+/// </summary>
+public class IntlCalendarDefaultTests
+{
+    private readonly Engine _engine = new();
+
+    /// <summary>
+    /// CLDR's <c>calendarPreferenceData</c> names four regions that prefer something other than
+    /// <c>gregory</c>, and every other region takes territory <c>001</c>'s answer.
+    /// </summary>
+    [TestCase("en-US", "gregory")]
+    [TestCase("de-DE", "gregory")]
+    [TestCase("ar-EG", "gregory")]
+    [TestCase("ja-JP", "gregory")]
+    [TestCase("ko-KR", "gregory")]
+    [TestCase("zh-TW", "gregory")]
+    [TestCase("he-IL", "gregory")]
+    [TestCase("th-TH", "buddhist")]
+    [TestCase("fa-IR", "persian")]
+    [TestCase("ps-AF", "persian")]
+    [TestCase("ar-SA", "islamic-umalqura")]
+    public void TheLocalesOwnCalendarIsTheDefault(string locale, string expected)
+    {
+        _engine.Evaluate($"new Intl.DateTimeFormat('{locale}').resolvedOptions().calendar")
+            .AsString().Should().Be(expected);
+    }
+
+    /// <summary>
+    /// The table is keyed by region, and a locale that names none still has one: <c>th</c> maximizes to
+    /// <c>th-Thai-TH</c>.
+    /// </summary>
+    [TestCase("th", "buddhist")]
+    [TestCase("fa", "persian")]
+    [TestCase("ps", "persian")]
+    [TestCase("ar", "gregory")]
+    [TestCase("en", "gregory")]
+    public void TheRegionIsFoundThroughLikelySubtags(string locale, string expected)
+    {
+        _engine.Evaluate($"new Intl.DateTimeFormat('{locale}').resolvedOptions().calendar")
+            .AsString().Should().Be(expected);
+    }
+
+    /// <summary>
+    /// The defect: <c>ar-SA</c> could name no calendar but <c>islamic</c>, because the answer came from
+    /// <c>CultureInfo.Calendar</c> and both of .NET's Hijri classes mapped to that one identifier — while
+    /// <c>islamic</c> is a calendar https://tc39.es/ecma402/#sec-createdatetimeformat step 9 says a formatter
+    /// must resolve away from, and <c>islamic-umalqura</c> was one an explicit option could already reach.
+    /// </summary>
+    [Test]
+    public void ArabicSaudiResolvesToUmmAlQuraAndFormatsInIt()
+    {
+        _engine.Evaluate("new Intl.DateTimeFormat('ar-SA').resolvedOptions().calendar")
+            .AsString().Should().Be("islamic-umalqura");
+
+        // …and the year it writes is that calendar's, where it used to be the Gregorian year beside a
+        // Hijri day and month — 2026-08-27 came out as "14/3/2026"
+        var script = """
+            (function () {
+                var d = new Date(Date.UTC(2026, 7, 27));
+                var hijri = new Intl.DateTimeFormat('ar-SA', { year: 'numeric', timeZone: 'UTC' }).format(d);
+                var gregorian = new Intl.DateTimeFormat('en-US', { year: 'numeric', timeZone: 'UTC' }).format(d);
+                return hijri !== gregorian;
+            })()
+            """;
+        _engine.Evaluate(script).AsBoolean().Should().BeTrue();
+    }
+
+    /// <summary>The two things ResolveLocale lets outrank the locale's own answer still do.</summary>
+    [Test]
+    public void AnExplicitRequestStillWins()
+    {
+        _engine.Evaluate("new Intl.DateTimeFormat('ar-SA-u-ca-gregory').resolvedOptions().calendar")
+            .AsString().Should().Be("gregory");
+        _engine.Evaluate("new Intl.DateTimeFormat('th-TH', { calendar: 'gregory' }).resolvedOptions().calendar")
+            .AsString().Should().Be("gregory");
+        _engine.Evaluate("new Intl.DateTimeFormat('en', { calendar: 'islamic-umalqura' }).resolvedOptions().calendar")
+            .AsString().Should().Be("islamic-umalqura");
+    }
+
+    /// <summary>A host provider's answer is the locale default, and it reaches what the formatter writes.</summary>
+    [Test]
+    public void AHostProviderAnswersForTheCalendarToo()
+    {
+        var engine = new Engine(options => options.Intl.CldrProvider = new EverywhereIsHebrew());
+
+        engine.Evaluate("new Intl.DateTimeFormat('en-US').resolvedOptions().calendar")
+            .AsString().Should().Be("hebrew");
+
+        // …and an explicit request still outranks it
+        engine.Evaluate("new Intl.DateTimeFormat('en-US', { calendar: 'gregory' }).resolvedOptions().calendar")
+            .AsString().Should().Be("gregory");
+    }
+
+    /// <summary>
+    /// <c>keyLocaleData</c> is built out of the calendars the implementation supports, so a provider naming
+    /// one outside that list has not named a candidate — it has named nothing.
+    /// </summary>
+    [Test]
+    public void ACalendarTheEngineCannotFormatIsNotAdopted()
+    {
+        var engine = new Engine(options => options.Intl.CldrProvider = new NamesACalendarNobodyHas());
+
+        engine.Evaluate("new Intl.DateTimeFormat('en-US').resolvedOptions().calendar")
+            .AsString().Should().Be("gregory");
+    }
+
+    /// <summary>A provider with no opinion is answered the way one with no numbering-system opinion is.</summary>
+    [Test]
+    public void AProviderWithNoOpinionFallsBackToGregory()
+    {
+        var engine = new Engine(options => options.Intl.CldrProvider = new NoOpinion());
+
+        engine.Evaluate("new Intl.DateTimeFormat('th-TH').resolvedOptions().calendar")
+            .AsString().Should().Be("gregory");
+    }
+
+    /// <summary>The shipped provider's own answers, read directly.</summary>
+    [Test]
+    public void TheShippedProviderReadsCldrsTable()
+    {
+        DefaultCldrProvider.Instance.GetDefaultCalendar("ar-SA").Should().Be("islamic-umalqura");
+        DefaultCldrProvider.Instance.GetDefaultCalendar("th-TH").Should().Be("buddhist");
+        DefaultCldrProvider.Instance.GetDefaultCalendar("fa-IR").Should().Be("persian");
+        DefaultCldrProvider.Instance.GetDefaultCalendar("en-US").Should().Be("gregory");
+    }
+}
+
+/// <summary>One datum, and the other eighteen members inherited.</summary>
+file sealed class EverywhereIsHebrew : DefaultCldrProvider
+{
+    public override string? GetDefaultCalendar(string locale) => "hebrew";
+}
+
+/// <summary>A provider naming a calendar this engine has no conversions for.</summary>
+file sealed class NamesACalendarNobodyHas : DefaultCldrProvider
+{
+    public override string? GetDefaultCalendar(string locale) => "mayan";
+}
+
+/// <summary>A provider that declines to answer.</summary>
+file sealed class NoOpinion : DefaultCldrProvider
+{
+    public override string? GetDefaultCalendar(string locale) => null;
+}

--- a/Jint/Native/Intl/Data/CalendarPreferenceData.cs
+++ b/Jint/Native/Intl/Data/CalendarPreferenceData.cs
@@ -1,0 +1,52 @@
+namespace Jint.Native.Intl.Data;
+
+/// <summary>
+/// CLDR's <c>calendarPreferenceData</c>, reduced to the one entry ECMA-402 reads: the calendar a region
+/// prefers first.
+/// </summary>
+/// <remarks>
+/// <para>
+/// https://tc39.es/ecma402/#sec-resolvelocale step 13.c starts the <c>ca</c> key at
+/// <c>keyLocaleData[0]</c>, and https://tc39.es/ecma402/#sec-internal-slots says that first element
+/// "provid[es] the default value for that key in the locale". CLDR keys the ordering by territory, and its
+/// world default — territory <c>001</c> — is <c>gregorian</c>, so only the territories that disagree are
+/// listed here; every other region falls through to <see cref="Default"/>.
+/// </para>
+/// <para>
+/// The identifiers are ECMA-402's rather than CLDR's, which differ for exactly one of them: CLDR writes
+/// <c>gregorian</c> where https://tc39.es/ecma402/#table-datetimeformat-components and the Unicode
+/// <c>-u-ca-</c> grammar write <c>gregory</c>.
+/// </para>
+/// <para>
+/// The rest of each region's ordering — <c>SA</c>'s is
+/// <c>islamic-umalqura gregorian islamic islamic-rgsa</c> — is what
+/// <c>Intl.Locale.prototype.getCalendars</c> would report, and that method does not read this table yet.
+/// </para>
+/// </remarks>
+internal static class CalendarPreferenceData
+{
+    /// <summary>CLDR territory <c>001</c>: what a region with no entry of its own prefers.</summary>
+    internal const string Default = "gregory";
+
+    private static readonly Dictionary<string, string> _firstPreference = new(4, StringComparer.OrdinalIgnoreCase)
+    {
+        ["AF"] = "persian",
+        ["IR"] = "persian",
+        ["SA"] = "islamic-umalqura",
+        ["TH"] = "buddhist",
+    };
+
+    /// <summary>
+    /// The calendar <paramref name="region"/> prefers first, or <see cref="Default"/> for a region CLDR has
+    /// no separate entry for — which is most of them.
+    /// </summary>
+    internal static string GetFirstPreference(string? region)
+    {
+        if (!string.IsNullOrEmpty(region) && _firstPreference.TryGetValue(region!, out var calendar))
+        {
+            return calendar;
+        }
+
+        return Default;
+    }
+}

--- a/Jint/Native/Intl/DateTimeFormatConstructor.cs
+++ b/Jint/Native/Intl/DateTimeFormatConstructor.cs
@@ -423,9 +423,11 @@ internal sealed partial class DateTimeFormatConstructor : Constructor
         // Get prototype from newTarget (for cross-realm construction)
         var proto = GetPrototypeFromConstructor(newTarget, static intrinsics => intrinsics.DateTimeFormat.PrototypeObject);
 
-        // Resolve default calendar from locale if not explicitly specified
-        // Per ECMA-402, the calendar is always resolved - defaults to "gregory" for most locales
-        calendar ??= GetDefaultCalendarForLocale(culture);
+        // https://tc39.es/ecma402/#sec-resolvelocale step 13.c: with no calendar option and no -u-ca-
+        // extension, the key starts at keyLocaleData[0] — the locale's own calendar, which the CLDR
+        // provider answers for. The calendar is always resolved, so an answer this engine cannot format
+        // in becomes "gregory" rather than a calendar nothing can write a date with.
+        calendar ??= GetDefaultCalendarForLocale(resolvedLocale);
 
         // https://tc39.es/ecma402/#sec-formatdatetimepattern — the month, weekday and day-period names a
         // pattern writes are locale data. Every one of them is produced by handing a .NET pattern to
@@ -850,23 +852,32 @@ internal sealed partial class DateTimeFormatConstructor : Constructor
     }
 
     /// <summary>
-    /// Gets the default calendar for a locale. Per ECMA-402, most locales use "gregory".
-    /// Japanese locale uses "japanese", Thai uses "buddhist", etc.
+    /// The calendar a locale itself uses, as <see cref="ICldrProvider.GetDefaultCalendar"/> answers it.
     /// </summary>
-    private static string GetDefaultCalendarForLocale(CultureInfo culture)
+    /// <remarks>
+    /// <para>
+    /// It used to be read off <c>CultureInfo.Calendar</c> and mapped by .NET calendar class, which no host
+    /// could correct and which is coarser than the data: <see cref="System.Globalization.HijriCalendar"/> and
+    /// <see cref="System.Globalization.UmAlQuraCalendar"/> are one .NET type each and were both answered
+    /// <c>"islamic"</c>, so <c>ar-SA</c> could not resolve to the <c>islamic-umalqura</c> that CLDR's
+    /// <c>calendarPreferenceData</c> — and ICU — put first for <c>SA</c>, even though Jint knows that
+    /// calendar and an explicit option resolves to it.
+    /// </para>
+    /// <para>
+    /// An answer the engine does not answer for is discarded rather than resolved to: the specification
+    /// builds <c>keyLocaleData</c> out of the calendars the implementation supports, so a provider naming one
+    /// outside that list has named something that is not in the list at all.
+    /// </para>
+    /// </remarks>
+    private string GetDefaultCalendarForLocale(string locale)
     {
-        var calendarName = culture.Calendar.GetType().Name;
-        return calendarName switch
+        var preferred = _engine.Options.Intl.CldrProvider.GetDefaultCalendar(locale);
+        if (preferred is null)
         {
-            "JapaneseCalendar" => "japanese",
-            "ThaiBuddhistCalendar" => "buddhist",
-            "KoreanCalendar" => "korean",
-            "TaiwanCalendar" => "roc",
-            "HijriCalendar" or "UmAlQuraCalendar" => "islamic",
-            "HebrewCalendar" => "hebrew",
-            "PersianCalendar" => "persian",
-            _ => "gregory"
-        };
+            return "gregory";
+        }
+
+        return AvailableCalendars.ResolveForDateTimeFormat(_engine, preferred) ?? "gregory";
     }
 
     /// <summary>

--- a/Jint/Native/Intl/DefaultCldrProvider.cs
+++ b/Jint/Native/Intl/DefaultCldrProvider.cs
@@ -549,6 +549,19 @@ public class DefaultCldrProvider : ICldrProvider
         return _currencyDisplayNames.Value.TryGetValue(upperCode, out var name) ? name : null;
     }
 
+    /// <inheritdoc />
+    /// <remarks>
+    /// Read out of CLDR's <c>calendarPreferenceData</c>, which keys the answer by region, so a locale that
+    /// names none is maximized first — <c>"th"</c> is <c>"th-Thai-TH"</c> and therefore <c>"buddhist"</c>.
+    /// Four regions prefer something other than <c>"gregory"</c>: <c>AF</c> and <c>IR</c>, <c>SA</c>, and
+    /// <c>TH</c>.
+    /// </remarks>
+    public virtual string? GetDefaultCalendar(string locale)
+    {
+        var region = ExtractRegion(locale) ?? ExtractRegion(LikelySubtags.AddLikelySubtags(locale));
+        return CalendarPreferenceData.GetFirstPreference(region);
+    }
+
     // === Locale Data ===
 
     /// <inheritdoc />

--- a/Jint/Native/Intl/ICldrProvider.cs
+++ b/Jint/Native/Intl/ICldrProvider.cs
@@ -81,6 +81,20 @@ public interface ICldrProvider
     // === Date/Time Formatting (DateTimeFormat) ===
 
     /// <summary>
+    /// Gets the calendar a locale itself uses (e.g. <c>"th-TH"</c> → <c>"buddhist"</c>), for a formatter
+    /// constructed without an explicit <c>calendar</c> option or Unicode extension.
+    /// </summary>
+    /// <param name="locale">The locale identifier.</param>
+    /// <returns>The calendar identifier, or null if the provider has no opinion (caller falls back to "gregory").</returns>
+    /// <remarks>
+    /// This is <c>keyLocaleData[0]</c> for <c>ca</c> — https://tc39.es/ecma402/#sec-resolvelocale step 13.c —
+    /// so it sits below the locale's <c>-u-ca-</c> extension and below the <c>calendar</c> option, both of
+    /// which the same step lets overwrite it. A calendar this engine does not answer for is not in
+    /// <c>keyLocaleData</c> at all, and is ignored rather than becoming a calendar nothing can format in.
+    /// </remarks>
+    string? GetDefaultCalendar(string locale);
+
+    /// <summary>
     /// Gets month names for a locale.
     /// </summary>
     /// <param name="locale">The locale identifier.</param>

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -2418,6 +2418,53 @@ it wrote before, and `latn` is what an unconfigured engine resolves for every lo
 formatter that asked for another numbering system, or for an embedder whose `ICldrProvider` gives a locale a
 non-Latin default: the parts lane gains that system's digits, a pattern's own punctuation stops acquiring
 them, and a locale whose decimal separator is a comma keeps its group separator as the full stop it is.
+### 4.47 `Intl.DateTimeFormat`'s calendar default comes from the CLDR provider ([#3457](https://github.com/sebastienros/jint/issues/3457))
+
+`ca` is a relevant extension key, and with no `calendar` option and no `-u-ca-` subtag its value is
+`keyLocaleData[0]` — [ResolveLocale](https://tc39.es/ecma402/#sec-resolvelocale) step 13.c, the locale's own
+calendar. That answer was read off `CultureInfo.Calendar` and mapped by .NET calendar *class*, which no host
+could reach and which is coarser than the data: `HijriCalendar` and `UmAlQuraCalendar` are one .NET type each
+and both answered `"islamic"`.
+
+`ICldrProvider` gains a nineteenth member, `GetDefaultCalendar(string locale)`, and `DefaultCldrProvider`
+answers it from CLDR's `calendarPreferenceData` — keyed by region, so a locale naming none is maximized
+first. Four regions prefer something other than `gregory`: `AF` and `IR` (`persian`), `SA`
+(`islamic-umalqura`) and `TH` (`buddhist`).
+
+```js
+// 4.16.x / earlier 5.0
+new Intl.DateTimeFormat('ar-SA').resolvedOptions().calendar;             // "islamic"
+new Intl.DateTimeFormat('ar-SA').format(new Date(Date.UTC(2026, 7, 27))); // "14/3/2026" - a Hijri day and month beside a Gregorian year
+
+// 5.x
+new Intl.DateTimeFormat('ar-SA').resolvedOptions().calendar;             // "islamic-umalqura"
+new Intl.DateTimeFormat('ar-SA').format(new Date(Date.UTC(2026, 7, 27))); // "14/3/1448"
+```
+
+`islamic-umalqura` was never out of reach — it is in the supported list and an explicit
+`{ calendar: 'islamic-umalqura' }` always resolved to it. It was only the *default* that could not name it,
+and `islamic` is an identifier
+[CreateDateTimeFormat](https://tc39.es/ecma402/#sec-createdatetimeformat) step 9 requires a formatter to
+resolve away from rather than to.
+
+Correcting the calendar a locale defaults to is now one override, the way correcting its numbering system is:
+
+```c#
+sealed class HebrewByDefault : DefaultCldrProvider
+{
+    public override string? GetDefaultCalendar(string locale) => "hebrew";
+}
+```
+
+An answer the engine has no calendar for is discarded rather than resolved to — `keyLocaleData` is built from
+the calendars the implementation supports — so a provider naming `"mayan"` gets `gregory`, as does one
+answering `null`.
+
+**What could break:** `ar-SA` and its region-mates now report and format in `islamic-umalqura`. Every other
+locale reports exactly what it reported before, `.NET`'s answer and CLDR's having already agreed everywhere
+else. A host implementing `ICldrProvider` **from scratch** rather than deriving from `DefaultCldrProvider`
+has one more member to write; deriving costs nothing, and [5.2](#52-changing-one-locale-datum-is-one-override)
+is why that is the shape the interface is documented for.
 
 ## 5. New in v5
 
@@ -2562,7 +2609,7 @@ sealed class MyCldr : DefaultCldrProvider
 var engine = new Engine(options => options.Intl.CldrProvider = new MyCldr());
 ```
 
-`ICldrProvider` is now eighteen members and every one of them has a caller, so whatever a derived class
+`ICldrProvider` is now nineteen members and every one of them has a caller, so whatever a derived class
 answers is what `Intl` shows — see [4.22](#422-intl-reads-the-cldr-provider-for-currency-symbols-and-week-info)
 and [4.29](#429-intl-reads-the-cldr-provider-for-date-names-and-numbering-system-digits) for the two changes
 that closed the gap, and section [2](#2-removed-api) for the two members that went instead of being wired.


### PR DESCRIPTION
Fixes #3457.

Its own PR because it changes public API: `ICldrProvider` gains a nineteenth member.

`ca` is a relevant extension key of `Intl.DateTimeFormat`, and with no `calendar` option and no `-u-ca-`
subtag its value is `keyLocaleData[0]` — [ResolveLocale](https://tc39.es/ecma402/#sec-resolvelocale)
step 13.c, the locale's own calendar. That answer was read off `CultureInfo.Calendar` and mapped by .NET
calendar **class**, which had two consequences: no host could correct it, and the mapping is coarser than the
data — `HijriCalendar` and `UmAlQuraCalendar` are one .NET type each and both answered `"islamic"`.

## The defect, before the fix

```
ar-SA -> islamic  |  14‏/3‏/2026
```

A Hijri day and month beside a **Gregorian year**, because `islamic` is not one of the calendars the
formatter can convert dates for. After:

```
ar-SA -> islamic-umalqura  |  14‏/3‏/1448
```

`islamic-umalqura` was never out of reach — it is in `AvailableCalendars` and
`{ calendar: 'islamic-umalqura' }` always resolved to it. Only the *default* could not name it. And
`islamic` is an identifier [CreateDateTimeFormat](https://tc39.es/ecma402/#sec-createdatetimeformat) step 9
requires a formatter to resolve *away from*, which is exactly what the deprecated-identifier substitution in
`AvailableCalendars.ResolveForDateTimeFormat` (from #3430) already does — the default lane simply never went
through it.

## The shape of the seam, and why

**`string? GetDefaultCalendar(string locale)` on `ICldrProvider`, with a `virtual` implementation on
`DefaultCldrProvider`.** That is the shape every other locale datum has, and it is deliberately the same one
`GetDefaultNumberingSystem` has for `nu` — the sibling key of the same ResolveLocale step, which #3418
routed through the provider. A host correcting the calendar a locale defaults to writes the same three lines
it writes to correct its numbering system:

```c#
sealed class HebrewByDefault : DefaultCldrProvider
{
    public override string? GetDefaultCalendar(string locale) => "hebrew";
}
```

The alternative considered was a **separate optional interface** (`provider as ICldrCalendarDefaults`), which
breaks no implementer at all. It was rejected on two grounds. First, the documented seam is the class, not
the interface: since #3335 all three shipped providers are unsealed with `virtual` members precisely so that
one datum is one override, and §5.2 of the migration guide says so — a host that derives is unaffected by
this change, and a host that does not is the case the guide already tells to derive. Second, an optional
side interface makes `ca` the one relevant extension key answered somewhere other than where the other
eighteen data live, which is the inconsistency #3430 and #3404 were about removing rather than adding. Two
members have been *removed* from this interface during v5 (#3336, #3354) and two more replaced (#3404), all
with the same "what could break: a host implementing it from scratch" note, so this is the established
tariff rather than a new one.

## What `DefaultCldrProvider` answers

CLDR's `calendarPreferenceData`, keyed by region, with a locale that names none maximized through likely
subtags first (`"th"` is `"th-Thai-TH"`, hence `buddhist`). Four regions prefer something other than
`gregory` — `AF` and `IR` (`persian`), `SA` (`islamic-umalqura`), `TH` (`buddhist`) — and territory `001`
answers `gregory` for everything else. That matches ICU, and therefore Node.

An answer the engine has no calendar for is discarded rather than resolved to (`keyLocaleData` is built from
the calendars the implementation supports), so a provider naming `"mayan"` gets `gregory`, as does one
answering `null`.

Nothing else moves. A probe of sixteen locales against `upstream/main` and against this branch differs on
`ar-SA` and nowhere else — .NET's per-culture default and CLDR's region preference already agreed for
`en-US`, `de-DE`, `ar-EG`, `th-TH`, `ja-JP`, `ko-KR`, `zh-TW`, `zh-CN`, `fa-IR`, `he-IL`, `hi-IN`, `am-ET`,
`ps-AF`, `ur-PK`, `sa-IN`, `dz-BT`. The old switch's `"korean"` arm could in principle have produced an
identifier that is not an ECMA-402 calendar at all; nothing on this machine reached it.

## Verification

`Jint.Tests/Runtime/IntlCalendarDefaultTests.cs` (22 cases) and one host test in
`Jint.Tests.PublicInterface/HostLocaleProviderTests.cs` that overrides the one member and delegates nothing.
The new test file does not compile against `main` — the member it calls does not exist there — which is the
API half of the defect stated as a build error; the behaviour half is the probe above.

| | |
| --- | --- |
| `dotnet build -c Release` (solution) | 0 warnings, 0 errors |
| `Jint.Tests` | 10,854 passed / 0 failed (net8.0, net10.0), 7,478 (net472) |
| `Jint.Tests.PublicInterface` | 3,242 / 3,232 / 2,610 passed, 0 failed |
| **test262** | **102,495 passed / 0 failed / 189 skipped — the control, unmoved** |

Public API baselines regenerated for all five TFMs (two added lines each). Migration guide: **§4.47**, plus
one word in §5.2 ("eighteen members" → "nineteen").

Two neighbours the issue checked and found fine needed no work: `hc` is derived from the culture and its
answers are right, and `Intl.Collator`'s hardcoded `"default"` for `co` is what ECMA-402 10.2.3 asks for.

Found while fixing this: #3467 — the mirror defect, an *explicit* `calendar` option not reaching the
formatter for a locale whose .NET culture calendar is not Gregorian. Filed rather than folded in.
