### PR TITLE
Promise budget: the drain measures on the engine's clock, so a test can state the budget instead of racing it

### DIFF
--- a/Jint.Tests.PublicInterface/HostConstraintClockTests.cs
+++ b/Jint.Tests.PublicInterface/HostConstraintClockTests.cs
@@ -129,6 +129,12 @@ public class HostConstraintClockTests
             }))
             .Should().Throw<ArgumentException>().WithMessage("*TimestampFrequency*");
 
+        // ...and now with no time limit registered at all. The same clock bounds the blocking promise drain
+        // (docs/v5-migration.md 4.46), so it is resolved for every engine rather than only for one that
+        // happened to ask for an execution timeout.
+        Invoking(() => new Engine(o => o.Constraints.TimeProvider = new FrequencylessClock()))
+            .Should().Throw<ArgumentException>().WithMessage("*TimestampFrequency*");
+
         Invoking(() => new OperationDeadlineConstraint(new FrequencylessClock()))
             .Should().Throw<ArgumentException>().WithMessage("*TimestampFrequency*");
     }

--- a/Jint.Tests.PublicInterface/HostPromiseTimeoutTests.cs
+++ b/Jint.Tests.PublicInterface/HostPromiseTimeoutTests.cs
@@ -11,11 +11,23 @@ namespace Jint.Tests.PublicInterface;
 /// bound the blocking unwrap actually waits under.
 /// </summary>
 /// <remarks>
+/// <para>
 /// The argument-less <see cref="JsValueExtensions.UnwrapIfPromise(JsValue)"/> used to hard-code ten seconds.
 /// Its default happens to be ten seconds too, so a host that configured a shorter one was ignored in silence
 /// — nothing failed, the call simply waited twenty times longer than asked. The overloads taking an explicit
 /// <see cref="TimeSpan"/> or a <see cref="CancellationToken"/> were always honoured and still are, which is
 /// why both directions are pinned here.
+/// </para>
+/// <para>
+/// The claim has two halves, and they are asserted separately because they can fail separately. <em>Which</em>
+/// budget the wait resolved is stated by the rejection itself, on every target framework. <em>That the wait
+/// actually ended on it</em> is a property of the drain rather than of the resolution, and needs a clock the
+/// test controls — which is why that half is <c>net8.0</c> and later, where
+/// <c>Options.Constraints.TimeProvider</c> exists. It used to be a stopwatch race against the ten-second
+/// default, and since the wrong answer <em>is</em> that default, the margin could only ever sit at five
+/// seconds: not derivable from the budget under test, not wideable without asserting nothing, and duly
+/// failing an unrelated pull request at 47 s (sebastienros/jint#3406).
+/// </para>
 /// </remarks>
 public class HostPromiseTimeoutTests
 {
@@ -35,18 +47,18 @@ public class HostPromiseTimeoutTests
         => rejection.Message.Should().Contain(budget.ToString());
 
     /// <summary>
-    /// The other half of the same claim, and the half a clock is needed for: that the wait <em>ended</em> on
-    /// the budget it names rather than sitting out the longer one it should have ignored. The bound is half
-    /// of whatever the wrong answer would have spent, so it stays a midpoint between the two candidates
-    /// instead of an absolute number a loaded runner can walk past — #3358 saw a 200 ms wait measured at
-    /// 1 m 3 s against a fixed 5 s.
+    /// The other half of the same claim where the budget it discriminates against is far enough away for a
+    /// clock to answer it: the bound is half of whatever the wrong answer would have spent, so it stays a
+    /// midpoint between the two candidates instead of an absolute number a loaded runner can walk past.
+    /// Only the row whose wrong answer is minutes away uses it — the row whose wrong answer is the engine's
+    /// own ten-second default cannot, and asserts the property directly instead.
     /// </summary>
     private static void ShouldNotHaveSpentTheOtherBudget(Stopwatch elapsed, TimeSpan wrongBudget)
         => elapsed.Elapsed.Should().BeLessThan(TimeSpan.FromTicks(wrongBudget.Ticks / 2));
 
     /// <summary>
     /// A promise nobody settles, and a budget far below the ten-second default. Reading the default instead
-    /// of the configured value would name ten seconds and park for ten seconds, and both are asserted.
+    /// of the configured value would name ten seconds, and the rejection names what the drain was handed.
     /// </summary>
     [Test]
     public void TheArgumentLessUnwrapTakesTheConfiguredPromiseTimeout()
@@ -56,18 +68,19 @@ public class HostPromiseTimeoutTests
         using var engine = new Engine(options => options.Constraints.PromiseTimeout = configured);
         var manual = engine.Tasks.RegisterPromise();
 
-        var elapsed = Stopwatch.StartNew();
         var rejection = Assert.Throws<PromiseRejectedException>(() => manual.Promise.UnwrapIfPromise())!;
-        elapsed.Stop();
 
         ShouldNameTheBudgetItWaitedUnder(rejection, configured);
-        ShouldNotHaveSpentTheOtherBudget(elapsed, DefaultPromiseTimeout);
+        rejection.Message.Should().NotContain(
+            DefaultPromiseTimeout.ToString(),
+            "the default is the wrong answer this row exists to discriminate against");
     }
 
     /// <summary>
     /// The counterpart: a caller that names a bound gets exactly that bound, whatever the engine is
     /// configured with. Here the configured value is the longer of the two, so honouring it would be the
-    /// failure.
+    /// failure — and it is five minutes away, so the elapsed half of the claim still has a midpoint no
+    /// runner reaches.
     /// </summary>
     [Test]
     public void AnExplicitTimeoutStillWinsOverTheConfiguredOne()
@@ -99,4 +112,118 @@ public class HostPromiseTimeoutTests
 
         manual.Promise.UnwrapIfPromise().AsNumber().Should().Be(42);
     }
+
+#if NET8_0_OR_GREATER
+
+    /// <summary>
+    /// How long the wait is given to end when it must not. A "did not happen" bound, so a loaded runner can
+    /// only strengthen it: nothing about being slow turns a wait that stayed pending into one that returned.
+    /// It is long enough for the drain's ten-millisecond poll to have re-read the clock some twenty-five
+    /// times and found the budget still unspent.
+    /// </summary>
+    private static readonly TimeSpan StillWaitingProbe = TimeSpan.FromMilliseconds(250);
+
+    /// <summary>
+    /// The half a message cannot state: that the drain <em>ended</em> on the budget it named. Asserted
+    /// against a clock the test moves itself, so it is exact — the wait survives one tick short of the
+    /// configured budget and ends on the tick that reaches it, and no amount of real time on either side
+    /// changes either answer.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the row sebastienros/jint#3406 asked for, and the seam that makes it possible is not new
+    /// public API: <c>Options.Constraints.TimeProvider</c> already existed for
+    /// <c>LimitExecutionTime</c>, and the promise budget sits beside it on the same options group. What
+    /// changed is that the engine's blocking drain now reads its deadline off that clock instead of off
+    /// <c>DateTime.UtcNow</c> — monotonic like the pump's own ceiling has always been, and steerable like
+    /// every other Jint budget a test needs to be sure about.
+    /// </para>
+    /// <para>
+    /// The discrimination is positive rather than a margin. Had the drain consulted the ten-second default,
+    /// two hundred milliseconds of this clock would never reach it and the wait would still be pending when
+    /// the ceiling ran out — so the wrong answer is excluded by the test hanging, not by a number chosen to
+    /// sit between two candidates.
+    /// </para>
+    /// </remarks>
+    [Test]
+    public void TheArgumentLessUnwrapEndsExactlyWhenTheConfiguredBudgetElapsesOnTheEnginesClock()
+    {
+        var configured = TimeSpan.FromMilliseconds(200);
+
+        using var clock = new GatedClock();
+        using var engine = new Engine(options =>
+        {
+            options.Constraints.TimeProvider = clock;
+            options.Constraints.PromiseTimeout = configured;
+        });
+        var manual = engine.Tasks.RegisterPromise();
+
+        clock.Reads.Should().Be(
+            0,
+            "the deadline has to be anchored at a reading of this clock the drain itself takes");
+
+        Exception? failure = null;
+        var unwrap = DedicatedThread.RunAsync(
+            () => failure = Caught.Exception(() => manual.Promise.UnwrapIfPromise()));
+
+        clock.Armed.Wait(TestBudgets.WedgeCeiling).Should().BeTrue(
+            "the drain has to have armed its deadline before this thread may move the clock under it");
+
+        clock.Advance(configured - TimeSpan.FromTicks(1));
+        unwrap.Wait(StillWaitingProbe).Should().BeFalse(
+            "one tick short of the configured budget is inside it, whatever the machine is doing");
+
+        clock.Advance(TimeSpan.FromTicks(1));
+        unwrap.Wait(TestBudgets.WedgeCeiling).Should().BeTrue(
+            "the configured budget has now elapsed on the engine's own clock — the ten-second default never would");
+
+        var rejection = failure.Should().BeOfType<PromiseRejectedException>().Subject;
+        ShouldNameTheBudgetItWaitedUnder(rejection, configured);
+    }
+
+    /// <summary>
+    /// A clock the test moves itself, which says when it has been read often enough for the drain's
+    /// deadline to be anchored.
+    /// </summary>
+    /// <remarks>
+    /// Reports <see cref="TimeSpan.TicksPerSecond"/> so that a tick of this clock and a tick of a
+    /// <see cref="TimeSpan"/> are the same unit, exactly as <c>HostConstraintClockTests</c>'s does.
+    /// </remarks>
+    private sealed class GatedClock : TimeProvider, IDisposable
+    {
+        private long _timestamp;
+        private int _reads;
+
+        /// <summary>
+        /// Set once this clock has been read twice: the drain reads once to arm its deadline and again on
+        /// its first pass to ask what is left, so a second reading proves the first has already been turned
+        /// into a deadline. Advancing before that would move the origin the deadline is anchored at, which
+        /// is the one thing a test steering a clock must not do.
+        /// </summary>
+        internal ManualResetEventSlim Armed { get; } = new(false);
+
+        /// <summary>How many readings this clock has handed out.</summary>
+        internal int Reads => Volatile.Read(ref _reads);
+
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        public override long GetTimestamp()
+        {
+            // Read before the count is published, so a reading can never be attributed to a deadline that
+            // was armed from a later one.
+            var now = Interlocked.Read(ref _timestamp);
+            if (Interlocked.Increment(ref _reads) >= 2)
+            {
+                Armed.Set();
+            }
+
+            return now;
+        }
+
+        internal void Advance(TimeSpan amount) => Interlocked.Add(ref _timestamp, amount.Ticks);
+
+        public void Dispose() => Armed.Dispose();
+    }
+
+#endif
 }

--- a/Jint/Constraints/AGENTS.md
+++ b/Jint/Constraints/AGENTS.md
@@ -23,6 +23,7 @@ when it breaks nothing at compile time — and the engine-wide rows are in
 | `Constraint` + `IsAmortizable` | `Jint/Constraint.cs` |
 | `OperationDeadlineConstraint` — public sealed, host-armed `Begin`/`End` budget spanning a whole multi-entry host operation, which the per-entry constraint reset deliberately never rewinds | `Jint/Constraints/OperationDeadlineConstraint.cs` |
 | `MemoryLimitConstraint` + `MemoryLimitAccuracy` — per-operation managed-allocation accounting carried across async thread hops, with host-armed `Begin`/`End` for a multi-entry operation | `Jint/Constraints/MemoryLimitConstraint.cs` |
+| `Options.Constraints.TimeProvider` (`net8.0`+) — the clock **both** of the engine's own time budgets measure against: `LimitExecutionTime`'s constraint, and `PromiseTimeout`'s blocking drain since [#3406](https://github.com/sebastienros/jint/issues/3406). A frozen clock therefore keeps a blocking `UnwrapIfPromise` or synchronous `Modules.Import` pending until the host advances it, and any new engine-bounded wait takes its deadline from `Engine.GetWaitTimestamp` rather than from `DateTime.UtcNow`. The web-API timers are *not* on it — they have their own `Options.WebApi.Timers.TimeProvider`, being a WHATWG feature rather than a budget | `Jint/Options.cs`, `Jint/Constraints/ConstraintClock.cs`, `Jint/Engine.cs` |
 
 ### Bounding a host-driven sequence
 

--- a/Jint/Constraints/ConstraintClock.cs
+++ b/Jint/Constraints/ConstraintClock.cs
@@ -40,6 +40,23 @@ internal static class ConstraintClock
         return ticks >= long.MaxValue / 2.0 ? long.MaxValue / 2 : (long) ticks;
     }
 
+    /// <summary>
+    /// The inverse of <see cref="ToTimestampTicks"/>: how long <paramref name="timestampTicks"/> of a clock
+    /// running at <paramref name="frequency"/> is, saturating at <see cref="TimeSpan.MaxValue"/> rather than
+    /// overflowing.
+    /// </summary>
+    /// <remarks>
+    /// The saturation is reachable in one direction only and is harmless there: the callers use the answer
+    /// to shorten an idle wait, never to lengthen one, so a saturated value simply leaves the wait at
+    /// whatever bound it already had. Overflowing instead would produce a <em>negative</em> span and end a
+    /// wait that has barely started, which is the failure this exists to rule out.
+    /// </remarks>
+    internal static TimeSpan ToTimeSpan(long timestampTicks, long frequency)
+    {
+        var ticks = timestampTicks * ((double) TimeSpan.TicksPerSecond / frequency);
+        return ticks >= long.MaxValue ? TimeSpan.MaxValue : TimeSpan.FromTicks((long) ticks);
+    }
+
 #if NET8_0_OR_GREATER
     /// <summary>
     /// The provider a constraint should store, or <see langword="null"/> for "read

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -1373,6 +1373,15 @@ public sealed partial class Engine : IDisposable
 
     internal readonly Constraint[] _constraints;
 
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// The clock the engine's own bounded <em>waits</em> measure against — <c>Options.Constraints.TimeProvider</c>
+    /// put through <see cref="ConstraintClock.Resolve"/>, so <see langword="null"/> means
+    /// <see cref="Stopwatch"/>, which is what every engine that named no clock carries.
+    /// </summary>
+    private readonly TimeProvider? _waitClock;
+#endif
+
     // _constraints partitioned once at construction (the set is fixed for the engine's lifetime):
     // exact constraints must run before every statement, amortized ones every N statements.
     // See Engine.Constraints.cs for the partitioning rationale.
@@ -1612,6 +1621,13 @@ public sealed partial class Engine : IDisposable
         _objectConverterTypeFilter = ObjectConverterTypeFilter.Create(_objectConverters);
         _immutableCrossingFilter = ImmutableCrossingTypeFilter.Create(Options.Interop.ImmutableCrossingTypes);
         _enumsAsStrings = Options.Interop.EnumConversion == EnumConversionMode.String;
+
+#if NET8_0_OR_GREATER
+        // Resolved once, here, rather than at each wait: Resolve is what rejects a clock that cannot measure
+        // anything, and a named error at engine construction beats a promise budget that expires the instant
+        // it is armed. Reading it costs nothing on an engine that named no clock — the fold hands back null.
+        _waitClock = ConstraintClock.Resolve(Options.Constraints.TimeProvider);
+#endif
 
         _constraints = BuildConstraints(Options.Constraints);
         var partitionedConstraints = PartitionConstraints(_constraints);
@@ -2711,6 +2727,43 @@ public sealed partial class Engine : IDisposable
     internal bool DrainEventLoopUntilSettled(JsPromise promise, TimeSpan timeout, System.Threading.CancellationToken cancellationToken = default)
         => DrainEventLoopUntil(static state => ((JsPromise) state).State != PromiseState.Pending, promise, promise.CompletedEvent, timeout, cancellationToken);
 
+    // CA1822: on the target frameworks without TimeProvider these two read no instance state. They stay
+    // instance members on every one of them so that the wait loop can call them unconditionally and keep
+    // conditional compilation out of it - the rule Engine.Pump.cs states once for the same reason.
+#pragma warning disable CA1822
+
+    /// <summary>
+    /// A reading of the clock <see cref="DrainEventLoopUntil"/> bounds itself by. Declared on every target
+    /// framework with the conditional compilation inside, the way every pump hook is, so the wait loop needs
+    /// none of its own.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal long GetWaitTimestamp()
+    {
+#if NET8_0_OR_GREATER
+        return _waitClock is null ? Stopwatch.GetTimestamp() : _waitClock.GetTimestamp();
+#else
+        return Stopwatch.GetTimestamp();
+#endif
+    }
+
+    /// <summary>
+    /// The tick frequency <see cref="GetWaitTimestamp"/>'s readings are expressed in.
+    /// </summary>
+    internal long WaitTimestampFrequency
+    {
+        get
+        {
+#if NET8_0_OR_GREATER
+            return ConstraintClock.FrequencyOf(_waitClock);
+#else
+            return Stopwatch.Frequency;
+#endif
+        }
+    }
+
+#pragma warning restore CA1822
+
     /// <summary>
     /// The general form of <see cref="DrainEventLoopUntilSettled"/>: drives the event loop until
     /// <paramref name="isSettled"/> holds for <paramref name="state"/>. Used by the module load phase, where
@@ -2787,8 +2840,17 @@ public sealed partial class Engine : IDisposable
 
         try
         {
+            // Monotonic, and on the clock the host named. Two things follow, and the second is the point of
+            // the first. A deadline read off DateTime.UtcNow - which this was - is cut short by an NTP step
+            // forwards and stretched by one backwards, which is exactly the reason the pump's own ceiling
+            // has always been measured on Stopwatch instead (see Engine.Pump.ElapsedSince). And once the
+            // reading goes through the engine's clock, Options.Constraints.TimeProvider reaches the promise
+            // budget that sits beside it on the same options group, so "the wait ended on the budget it
+            // names" is a claim a test can make exactly rather than by racing a stopwatch against the
+            // ten-second default (sebastienros/jint#3406).
             var hasTimeout = timeout > TimeSpan.Zero;
-            var deadline = hasTimeout ? DateTime.UtcNow + timeout : DateTime.MaxValue;
+            var frequency = WaitTimestampFrequency;
+            var deadline = hasTimeout ? GetWaitTimestamp() + ConstraintClock.ToTimestampTicks(timeout, frequency) : 0;
             var pollInterval = TimeSpan.FromMilliseconds(10);
 
             while (!isSettled(state))
@@ -2808,12 +2870,13 @@ public sealed partial class Engine : IDisposable
                 var waitInterval = pollInterval;
                 if (hasTimeout)
                 {
-                    var remaining = deadline - DateTime.UtcNow;
-                    if (remaining <= TimeSpan.Zero)
+                    var remainingTicks = deadline - GetWaitTimestamp();
+                    if (remainingTicks <= 0)
                     {
                         break;
                     }
 
+                    var remaining = ConstraintClock.ToTimeSpan(remainingTicks, frequency);
                     if (remaining < waitInterval)
                     {
                         waitInterval = remaining;

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -1358,22 +1358,29 @@ public sealed partial class Options
 
 #if NET8_0_OR_GREATER
         /// <summary>
-        /// The clock <see cref="ConstraintsOptionsExtensions.LimitExecutionTime"/>'s constraint measures against.
-        /// Defaults to <see cref="TimeProvider.System"/>; a fake one makes a timeout test exact instead of a
-        /// race against the machine it runs on.
+        /// The clock this engine's own time budgets measure against — <see cref="ConstraintsOptionsExtensions.LimitExecutionTime"/>'s
+        /// constraint and <see cref="PromiseTimeout"/>. Defaults to <see cref="TimeProvider.System"/>; a fake
+        /// one makes a timeout test exact instead of a race against the machine it runs on.
         /// </summary>
         /// <remarks>
         /// <para>
         /// Only <see cref="TimeProvider.GetTimestamp"/> and <see cref="TimeProvider.TimestampFrequency"/> are
-        /// ever called. <see cref="TimeProvider.CreateTimer"/> deliberately is not: the constraint schedules
-        /// nothing, it compares an inline deadline on the thread already running the script, which is what
+        /// ever called. <see cref="TimeProvider.CreateTimer"/> deliberately is not: neither budget schedules
+        /// anything, each compares an inline deadline on the thread already doing the work, which is what
         /// bounds detection by the timeout rather than by the thread pool.
         /// </para>
         /// <para>
-        /// Read when the engine builds its constraints, so it may be set in any order relative to
-        /// <see cref="ConstraintsOptionsExtensions.LimitExecutionTime"/>.
+        /// Read when the engine is built, so it may be set in any order relative to
+        /// <see cref="ConstraintsOptionsExtensions.LimitExecutionTime"/> or <see cref="PromiseTimeout"/>.
         /// Leaving it at <see cref="TimeProvider.System"/> costs exactly what it cost
         /// before this property existed — see <c>ConstraintClock</c> for the fold that makes that true.
+        /// </para>
+        /// <para>
+        /// The blocking promise drain it governs is what <see cref="Native.JsValue.UnwrapIfPromise()"/>
+        /// and a synchronous module import wait in, so a frozen clock keeps such a wait pending until the
+        /// host moves it. What it does <em>not</em> govern is the web-API timers, which have a clock of their
+        /// own in <c>Options.WebApi.Timers.TimeProvider</c> because they are a WHATWG feature rather than an
+        /// execution budget.
         /// </para>
         /// <para>
         /// It governs the constraint the engine registers. <see cref="Constraints.OperationDeadlineConstraint"/>

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -2465,6 +2465,28 @@ locale reports exactly what it reported before, `.NET`'s answer and CLDR's havin
 else. A host implementing `ICldrProvider` **from scratch** rather than deriving from `DefaultCldrProvider`
 has one more member to write; deriving costs nothing, and [5.2](#52-changing-one-locale-datum-is-one-override)
 is why that is the shape the interface is documented for.
+### 4.48 The blocking promise drain is bounded on the engine's clock, not on the wall clock ([#3406](https://github.com/sebastienros/jint/issues/3406))
+
+`Engine.DrainEventLoopUntil` — what `UnwrapIfPromise` blocks in, and what a synchronous `Modules.Import`
+waits in — used to arm its deadline from `DateTime.UtcNow`. It now arms it from a monotonic timestamp, read
+through `Options.Constraints.TimeProvider` on `net8.0` and later and from `Stopwatch` everywhere else. Three
+consequences, none of which changes a signature:
+
+- **A system-clock step no longer moves a promise budget.** An NTP correction forwards used to cut a
+  `PromiseTimeout` short and one backwards used to stretch it; neither does now. This is the rule the pump's
+  own ceiling has always followed (`Engine.Pump.ElapsedSince`), and the drain was the one wait that did not.
+- **`Options.Constraints.TimeProvider` now governs `Options.Constraints.PromiseTimeout` as well as
+  `LimitExecutionTime`.** A host that supplied a clock to make its execution-timeout tests exact will find
+  the promise budget measured against the same clock — so a *frozen* clock now keeps a blocking unwrap
+  pending until the host advances it, where before it timed out on real time. If that is not wanted, leave
+  `TimeProvider` at `TimeProvider.System` (the default) and register `OperationDeadlineConstraint` with its
+  own clock instead; it takes one through its own constructor. The web-API timers are unaffected — they keep
+  their own clock in `Options.WebApi.Timers.TimeProvider`, because they are a WHATWG feature rather than an
+  execution budget.
+- **A `TimeProvider` reporting a non-positive `TimestampFrequency` is rejected when the engine is built**,
+  rather than only when `LimitExecutionTime` happens to be registered. It was always rejected by
+  `ConstraintClock.Resolve` with a named `ArgumentException`; that clock is now resolved for every engine, so
+  the diagnostic arrives where the clock was supplied instead of at whichever budget first tried to use it.
 
 ## 5. New in v5
 


### PR DESCRIPTION
`HostPromiseTimeoutTests.TheArgumentLessUnwrapTakesTheConfiguredPromiseTimeout` is the one assertion #3369 identified as unfixable without weakening it, and it said why: the wrong answer it discriminates against is the engine's own ten-second `PromiseTimeout` **default**, so the midpoint has to sit at five seconds and the test cannot move the thing it is discriminating against. Widening past ten seconds does not make it robust — it makes it assert nothing. It duly failed an unrelated pull request at 47 s.

## What the message can and cannot witness

The message half already worked: `UnwrapIfPromiseCore` resolves one local, hands it to the drain and formats the same local into the rejection, so a wait that consulted the wrong budget cannot name the right one. What no message can state is the other half — that the drain **ended** on the budget it named. That is a property of the wait, not of the resolution, and it needs a clock the test controls.

## The seam is one the host already owns

`DrainEventLoopUntil` armed its deadline from `DateTime.UtcNow`. It now arms it from a monotonic timestamp read through `Options.Constraints.TimeProvider`.

That is **not new public API** — the property has existed for `LimitExecutionTime` since #3232, and `PromiseTimeout` sits beside it on the same options group — and it fixes something on its own account: a wall-clock deadline is cut short by an NTP step forwards and stretched by one backwards, which is exactly why the pump's own ceiling has always been measured on `Stopwatch` instead (`Engine.Pump.ElapsedSince`). The drain was the one wait that was not.

## The assertion is now exact, and positive

The new row survives one tick short of the configured budget and ends on the tick that reaches it. No amount of real time on either side changes either answer, and the wrong answer is excluded **by construction** rather than by a chosen midpoint: two hundred milliseconds of this clock never reach a ten-second deadline, so a drain reading the default leaves the wait pending until the ceiling.

Both directions were verified against builds carrying each regression:

| Regression | Result |
| --- | --- |
| `UnwrapIfPromiseCore` hard-codes the ten-second default | new row **fails** (hangs to the ceiling) **and** the message row fails |
| the drain put back on `DateTime.UtcNow` | new row **fails** at its clock handshake — "the drain never read the clock I gave it" |

The target frameworks the clock cannot reach (`TimeProvider` is .NET 8+) keep the witness they had: the message, asserted on every one of them, now also asserting that it does *not* name the default.

## Host-visible consequences

`docs/v5-migration.md` §4.46 carries all three, including the one a host has to act on — a **frozen** clock now keeps a blocking unwrap pending until the host advances it — and the third: a `TimeProvider` reporting a non-positive `TimestampFrequency` is now refused when the engine is built rather than only when a time limit happens to be registered, since the clock is resolved for every engine. The web-API timers are unaffected; they keep their own clock in `Options.WebApi.Timers.TimeProvider`.

No signature changes, so no baseline regeneration.

## Verification

- `dotnet build -c Release` (solution) and `dotnet test -c Release` green: `Jint.Tests` 10,832 / 10,832 / 7,456 (net8.0 / net10.0 / net472), `Jint.Tests.PublicInterface` 3,232 / 3,242 / 2,609, CommonScripts 28, SourceGenerators 71.
- **Test262: 102,495 passed / 0 failed / 189 skipped** — the control exactly.
- 20 consecutive runs of `HostPromiseTimeoutTests` + `HostConstraintClockTests` green.
- `MigrationGuideTests` green.

Fixes #3406.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014W5mbjGhyvgAS4pivXoc4S
