### PR TITLE
Timer tests: a timer outlives the unwrap because its clock says so, not because the machine was quick enough

### DIFF
--- a/Jint.Tests.PublicInterface/WebApiTimerTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiTimerTests.cs
@@ -200,10 +200,28 @@ public class WebApiTimerTests
         done.Should().BeTrue();
     }
 
+    /// <summary>
+    /// A blocking unwrap runs the timers it finds due, so a timer that is <em>not</em> due leaves the
+    /// unwrap's own bound as the only thing that can end the wait — which is what makes the rejection the
+    /// design and not a lost race.
+    /// </summary>
+    /// <remarks>
+    /// The clock is the test's own and is never advanced, so "outlives the timeout" is a fact about the
+    /// timer rather than a bet on how long this thread takes to reach the next statement. It used to be a
+    /// bet: a five-second timer registered inside <see cref="Engine.Evaluate(string, string?)"/> against
+    /// the system clock is already due if the machine spends five seconds between that call returning and
+    /// the unwrap starting, and the first thing the unwrap does is run the continuations it finds — so the
+    /// promise <em>fulfils</em> and nothing is thrown. That is not a hypothetical: sleeping 5.1 s between
+    /// those two statements reproduces the CI failure exactly, "Expected: &lt;PromiseRejectedException&gt;
+    /// But was: null", and a runner whose test bodies all run at <see cref="ThreadPriority.Lowest"/> under
+    /// three concurrent legs has spent far longer than that on far less (sebastienros/jint#3452, and the
+    /// 200 ms budget measured at 47 s in sebastienros/jint#3406).
+    /// </remarks>
     [Test]
     public void ATimerOutlivingTheUnwrapTimeoutTimesOutByDesign()
     {
-        var engine = new Engine(options => options.UseWebApis());
+        var clock = new ManualClock();
+        var engine = new Engine(options => options.UseWebApis(webApi => webApi.Timers.TimeProvider = clock));
 
         var pending = engine.Evaluate("new Promise(r => setTimeout(r, 5000))");
 


### PR DESCRIPTION
`WebApiTimerTests.ATimerOutlivingTheUnwrapTimeoutTimesOutByDesign` failed once on windows/net8.0 with

```
Expected: <Jint.Runtime.PromiseRejectedException>
But was:  null
```

— a 200 ms `UnwrapIfPromise` returning **without throwing** against a five-second timer. A 25× margin does not close through runner load in that direction, so it looked like a real race in the unwrap-timeout path. It is not. It is the same wall-clock assumption #3369 and #3388 spent a campaign removing, wearing a margin big enough to look safe.

## What the five seconds actually bound

Not the unwrap. They bound the gap between the `setTimeout` call *inside* `Evaluate` and the unwrap starting on the next line, both measured against the system clock:

```csharp
var pending = engine.Evaluate("new Promise(r => setTimeout(r, 5000))");   // timer armed here
Assert.Throws<PromiseRejectedException>(() => pending.UnwrapIfPromise(TimeSpan.FromMilliseconds(200)));
```

Spend five seconds in that gap and the timer is **already due** when the unwrap begins — and the first thing `DrainEventLoopUntil` does is run the continuations it finds. The timer fires, `r` is called, the promise **fulfils**, and nothing is thrown.

That is not a hypothetical. Sleeping 5.1 s between those two statements reproduces the reported failure exactly, message for message:

```
  Error Message:
     Assert.That(caughtException, expression)
  Expected: <Jint.Runtime.PromiseRejectedException>
  But was:  null
```

A runner whose test bodies all run at `ThreadPriority.Lowest` (#3452) under three concurrent legs has spent longer than that on less — the same suite had a 200 ms budget measured at 47 s in #3406.

## The fix

The one this file already uses four tests above: a `ManualClock` the test owns and never advances, so the timer can never be due and the unwrap's own bound is the only thing that can end the wait. No margin, no clock to lose a race against.

## Verification

With the 5.1 s widening still in place the test now passes. Without it: **20 consecutive runs** of `WebApiTimerTests` green, and the full `Jint.Tests.PublicInterface` suite green on net8.0 / net10.0 / net472.

Test-only change; no public API, no migration-guide row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014W5mbjGhyvgAS4pivXoc4S
