### PR TITLE
Native AOT: six more diagnostics an embedder pays are internal hops or a lookup that reads more than it wants

### DIFF
--- a/Jint.AotExample/AGENTS.md
+++ b/Jint.AotExample/AGENTS.md
@@ -29,7 +29,7 @@ already states the requirement. **Do not write one whose justification is not li
 add a code back to `NoWarn` to quiet a new site.**
 
 [#3305](https://github.com/sebastienros/jint/issues/3305) took the published-and-run inventory from 113
-to 73 and carries what is left, grouped by what would close it. Five moves did most of it, and each is
+to 67 and carries what is left, grouped by what would close it. Five moves did most of it, and each is
 worth trying before a suppression is:
 
 * **Spell a constant type as `typeof(X)` at the reflection call.** That token is folded, so the lookup
@@ -71,6 +71,15 @@ the *embedder's own file* through the inherited `[RequiresDynamicCode] Enum.GetV
 `engine.SetValue("Env", typeof(Environment))` cost two. That is the `Delegate` trap of
 `docs/v5-migration.md` §6.4 a second time, and trading two diagnostics in Jint's files for an unbounded
 number in every host's was the wrong way round. **Do not close them by widening the constant.**
+
+**What is left is close to a floor, and the shape of it is one sentence:** 58 of the 67 are dataflow
+whose value is a `Type` produced at run time by something that cannot be annotated — `object.GetType()`
+(14, plus 8 more through `ObjectWrapper.ClrType` and `.Target`), an element of `Type.GetInterfaces()`
+(6, and `[DynamicallyAccessedMembers]` is not honoured on a `Type[]`), `ParameterInfo.ParameterType`
+(3, plus 3 through Jint's own `ParameterMetadata`), `Type.GetElementType()` (2). The remaining nine are
+the §6.2 gaps. **Annotating a Jint-owned property or field that merely carries one of those values is
+not a fix**: it collapses N reports into one and then has the analyzer *trust* a promise nothing keeps,
+downstream and silently. That is why `ObjectWrapper.ClrType` has no annotation and must not get one.
 
 #### What the leg proves
 

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -668,7 +668,10 @@ public sealed partial class Options
         AttachExtensionMethodsToPrototype(engine, engine.Realm.Intrinsics.String.PrototypeObject, typeof(string));
     }
 
-    private static void AttachExtensionMethodsToPrototype(Engine engine, ObjectInstance prototype, Type objectType)
+    private static void AttachExtensionMethodsToPrototype(
+        Engine engine,
+        ObjectInstance prototype,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type objectType)
     {
         if (!engine._extensionMethods.TryGetExtensionMethods(objectType, out var methods))
         {

--- a/Jint/Runtime/Interop/DefaultTypeConverter.cs
+++ b/Jint/Runtime/Interop/DefaultTypeConverter.cs
@@ -343,21 +343,34 @@ public class DefaultTypeConverter : ClrTypeConverter
             }
             else
             {
-                var members = type.GetMembers();
-                foreach (var member in members)
+                // The two lookups this loop actually wants, rather than GetMembers() filtered down to them.
+                // GetMembers() reports methods, constructors, events and nested types as well, so a trimmer
+                // read it as needing PublicNestedTypes of `type` - a requirement that propagated out to every
+                // annotated caller for members this loop skips - and every call materialized a MemberInfo for
+                // each of them only to discard it. Same public instance-and-static set.
+                foreach (var member in type.GetProperties())
                 {
-                    // only use fields and properties
-                    if (member.MemberType != MemberTypes.Property &&
-                        member.MemberType != MemberTypes.Field)
-                    {
-                        continue;
-                    }
+                    CopyDictionaryEntryToMember(this, typeDescriptor, value, obj, member, formatProvider);
+                }
 
+                foreach (var member in type.GetFields())
+                {
+                    CopyDictionaryEntryToMember(this, typeDescriptor, value, obj, member, formatProvider);
+                }
+
+                static void CopyDictionaryEntryToMember(
+                    DefaultTypeConverter converter,
+                    TypeDescriptor typeDescriptor,
+                    object value,
+                    object target,
+                    MemberInfo member,
+                    IFormatProvider formatProvider)
+                {
                     if (typeDescriptor.TryGetDictionaryValue(value, member.Name, out var val)
                         || typeDescriptor.TryGetDictionaryValue(value, member.Name.UpperToLowerCamelCase(), out val))
                     {
-                        var output = Convert(val, member.GetDefinedType(), formatProvider);
-                        member.SetValue(obj, output);
+                        var output = converter.Convert(val, member.GetDefinedType(), formatProvider);
+                        member.SetValue(target, output);
                     }
                 }
             }

--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -185,7 +185,7 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
     private static bool TryBuildArrayLikeWrapper(
         Engine engine,
         object target,
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type type,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces | DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicProperties)] Type type,
         [NotNullWhen(true)] out ArrayLikeWrapper? result)
     {
         result = null;

--- a/Jint/Runtime/Interop/Reflection/ExtensionMethodCache.cs
+++ b/Jint/Runtime/Interop/Reflection/ExtensionMethodCache.cs
@@ -142,7 +142,9 @@ internal sealed class ExtensionMethodCache
 
     public bool HasMethods => _allExtensionMethods.Count > 0;
 
-    public bool TryGetExtensionMethods(Type objectType, [NotNullWhen(true)] out MethodInfo[]? methods)
+    public bool TryGetExtensionMethods(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type objectType,
+        [NotNullWhen(true)] out MethodInfo[]? methods)
     {
         if (_allExtensionMethods.Count == 0)
         {
@@ -180,7 +182,8 @@ internal sealed class ExtensionMethodCache
         return methods.Length > 0;
     }
 
-    private static IEnumerable<Type> GetParentTypes(Type type)
+    private static IEnumerable<Type> GetParentTypes(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type type)
     {
         // is there any base type?
         if (type == null)

--- a/Jint/Runtime/Interop/TypeResolver.cs
+++ b/Jint/Runtime/Interop/TypeResolver.cs
@@ -222,7 +222,7 @@ public sealed class TypeResolver
 
     internal ReflectionAccessor GetAccessor(
         Engine engine,
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.Interfaces)] Type type,
+        [DynamicallyAccessedMembers(InteropHelper.DefaultDynamicallyAccessedMemberTypes | DynamicallyAccessedMemberTypes.PublicNestedTypes)] Type type,
         string member,
         MemberResolutionRequirement requirement,
         bool throwOnError = true,
@@ -495,7 +495,7 @@ public sealed class TypeResolver
 
     private ReflectionAccessor ResolvePropertyDescriptorFactory(
         Engine engine,
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.Interfaces)] Type type,
+        [DynamicallyAccessedMembers(InteropHelper.DefaultDynamicallyAccessedMemberTypes | DynamicallyAccessedMemberTypes.PublicNestedTypes)] Type type,
         string memberName,
         MemberResolutionRequirement requirement,
         bool throwOnError)

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -2968,7 +2968,7 @@ your code changes; the overload is picked automatically.
 **Expect some of Jint's own diagnostics in your build.** Jint's `NoWarn` is a property of Jint's
 compilation and reaches nothing downstream - ILC re-derives every diagnostic over the closed program -
 so an AOT publish reports Jint's remaining trim-analysis warnings against Jint's files in *your* build.
-There are 73 of them, down from 113 ([#3305](https://github.com/sebastienros/jint/issues/3305)), and
+There are 67 of them, down from 113 ([#3305](https://github.com/sebastienros/jint/issues/3305)), and
 they now divide into two kinds:
 
 * **Nine are the gaps in [§6.2](#62-the-one-thing-that-does-not-a-generic-instantiation-over-a-value-type)**


### PR DESCRIPTION
Part of #3305. **Stacked on #3473** — review the second commit; the first is that PR.

### Re-measured first

The number in the issue title is three moves out of date. On today's `main` a
`dotnet publish Jint.AotExample -c Release` reports **77**, not 115 and not the 76 §6.4 records —
#3395 was measured before six interop changes landed on top of it. #3473 takes it to 73. **This takes
it to 67.**

| | |
| --- | --- |
| issue title | 115 |
| after #3395 | 76 (113 → 76) |
| today's `main` | **77** |
| after #3473 | 73 |
| after this | **67** |

All internal. No public API change, no baseline movement, no change to the probe run
(**28 probes, 5 known AOT gaps**), test262 **102,495 / 0 / 189**.

### The six

**`TypeResolver.GetAccessor` and `ResolvePropertyDescriptorFactory` — 3 × `IL2067`.** Each declared
less than the method it hands the type to, so three diagnostics were reporting a promise lost between
two internal frames. Both now declare what they pass on. All seven callers of `GetAccessor` already
carry the diagnostic saying the type came from `ObjectWrapper.ClrType` or `object.GetType()`, so
nothing new appears above.

**`ObjectWrapper.TryBuildArrayLikeWrapper` — 1 × `IL2067`.** Declared `Interfaces`, and passes the
type to `TypeDescriptor.Get`, which reads public methods and properties too. Its one caller is
`ObjectWrapper.Create`, whose `[RequiresUnreferencedCode]` already states the requirement.

**`ExtensionMethodCache.GetParentTypes` — 1 × `IL2070`.** Reads `Type.GetInterfaces()` with nothing
declaring `Interfaces`. The chain is three frames and **ends in constants**: `TryGetExtensionMethods`,
then `Options.AttachExtensionMethodsToPrototype`, whose call sites pass `typeof(Array)`,
`typeof(string)` and friends. `TypeResolver`'s two call sites already carry `Interfaces`.

**`DefaultTypeConverter`'s dictionary-to-POCO conversion — 1 × `IL2070`, removed by narrowing rather
than annotating.** It walked `type.GetMembers()` and `continue`d past everything that was not a
property or a field. `GetMembers()` reports nested types as well, so a trimmer read it as needing
`PublicNestedTypes` of the exposed type — propagated out to every annotated caller, for members the
loop never used — and every conversion materialized a `MemberInfo` for each method, constructor and
event only to discard it. Two lookups instead: same public instance-and-static set, no filter, less
allocation.

### The floor, and why it is one

**58 of the remaining 67 are dataflow whose value is a `Type` produced at run time by something no
annotation can describe.**

| root | count | why it cannot be annotated |
| --- | --- | --- |
| `object.GetType()` | 14 | the runtime type of a host object; there is no signature to put it on |
| `ObjectWrapper.ClrType` / `.Target` | 8 | Jint-owned, but filled from `object.GetType()` |
| an element of `Type.GetInterfaces()` | 6 | `[DynamicallyAccessedMembers]` is not honoured on a `Type[]` |
| `ParameterInfo.ParameterType` (+ Jint's `ParameterMetadata`) | 6 | the BCL does not annotate it |
| `Type.GetElementType()` | 2 | same |
| `TypeReference.ReferenceType`, `ListWrapper.ElementTypeOf`, `_memberType`, `_valueType`, `GetDefinedType` | 6 | the two decisions in #3473, and three more fed from unannotated BCL reflection |
| `TypeResolver`'s three host-flag lookups | 3 | the flags are `Options.Interop.ObjectWrapperReported*BindingFlags`; see #3473 |
| everything else, moving-only | 13 | annotating relocates the diagnostic one frame, onto one of the roots above |

The other **nine are the §6.2 generic-instantiation gaps** — six `IL3050` and their three `IL2060`
twins — which are true, are what the native run confirms does not work, and are deliberately not
suppressed.

**The one move that would make the number smaller is the one that must not be made.** Annotating a
Jint-owned property or field that merely *carries* one of those values — `ObjectWrapper.ClrType` is
the tempting one, worth 7 on its own — collapses N reports into one and then has the analyzer **trust**
a promise nothing keeps, downstream and silently. `Jint.AotExample/AGENTS.md` now says so by name.

Two things are genuinely expressible and were left alone, both deliberately:

* `ClrTypeConverter.Convert`/`TryConvert`'s `Type` parameter declares `PublicConstructors |
  PublicFields` while `DefaultTypeConverter` reads more. Widening it closes 2 and opens 1 (on
  `ArrayLikeWrapper.ItemType`) for a **public API change** and five baselines — net −1. Say the word
  and it is a separate PR.
* `CompiledDelegateInvoker.For` reflects inside a `GetOrAdd` lambda, which is the documented move.
  Hoisting it moves the `IL2070` to an `IL2072` in `DelegateWrapper` on `d.GetType()`: net zero, and
  the honest place for it is where it already is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014W5mbjGhyvgAS4pivXoc4S
