### PR TITLE
Interop: a collection exposed as IList<T> or IReadOnlyList<T> gets the wrapper that contract names

### DIFF
--- a/Jint.AotExample/Program.cs
+++ b/Jint.AotExample/Program.cs
@@ -157,13 +157,12 @@ Probe("IList<string> without IList (GenericListWrapperFactory<string>)", static 
 });
 
 // Same site, value-type argument, and the shape that reaches ArrayOperations.IndexWrappedOperations: a
-// wrapped CLR collection with an index to read but no IList to read it through. Under a JIT *this host*
-// gets the typed GenericListWrapper<int> and the lane is never entered, so Native AOT is what runs the
-// lane for this type - but not the only thing that runs the lane, which is what #3362 got wrong and #3394
-// corrected: exposing any host collection as IList<T> reaches it under a plain JIT, because
-// ResolveArrayLikeWrapperFactoryType scans the exposed type's interfaces and an interface is not among
-// its own. Jint.Tests.PublicInterface/HostExposedCollectionTypeTests.cs covers that route on every leg;
-// what this probe adds is the value-type degradation, which only a published native binary produces.
+// wrapped CLR collection with an index to read but no IList to read it through. Under a JIT this host
+// gets the typed GenericListWrapper<int> and the lane is never entered, so this probe is the only thing
+// that runs it - which is what makes it the boundary the row above is not. #3394 found a second route,
+// under a plain JIT, by exposing a host collection as IList<T>; that route was a defect in
+// ResolveArrayLikeWrapperFactoryType rather than a shape of the engine, and closing it (#3421) left this
+// probe once again the only coverage the lane has. Do not delete it for want of a sibling test.
 // Two bugs sat on the lane undetected until #3302 was fixed beside them: the reflection fallback passed
 // the WRAPPER to PropertyInfo.GetValue instead of the CLR target, a TargetException waiting for its first
 // read, and SetLength threw a bare NotSupportedException where the wrapper's read-only "length" owes

--- a/Jint.Tests.PublicInterface/HostExposedCollectionTypeTests.cs
+++ b/Jint.Tests.PublicInterface/HostExposedCollectionTypeTests.cs
@@ -1,138 +1,221 @@
 #nullable enable
 
 using System.Collections;
-using Jint.Native;
-using Jint.Native.Object;
 using Jint.Runtime;
 using Jint.Runtime.Interop;
 
 namespace Jint.Tests.PublicInterface;
 
 /// <summary>
-/// A host object exposed to script under a collection <em>interface</em> rather than under its own type.
-/// <c>ObjectWrapper.Create(engine, target, typeof(IList&lt;int&gt;))</c> is public API and is what a
-/// <see cref="Options.WrapObjectDelegate"/> writes, so everything below runs on every target framework and
-/// every leg — under a plain JIT, with no trimming and no Native AOT anywhere near it.
-///
-/// <para>
-/// The exposure matters because it decides which wrapper is built.
-/// <c>ResolveArrayLikeWrapperFactoryType</c> looks for <c>IList&lt;&gt;</c> among the exposed type's
-/// <c>GetInterfaces()</c>, and an interface is not among its own — <c>typeof(IList&lt;int&gt;)</c> yields
-/// <c>ICollection&lt;int&gt;</c>, <c>IEnumerable&lt;int&gt;</c> and <c>IEnumerable</c>. So no typed wrapper
-/// is built; the target is not a non-generic <see cref="IList"/> either, so there is no
-/// <c>ListWrapper</c> to fall back to; and the result is a plain <see cref="ObjectWrapper"/> whose type
-/// descriptor still reports an integer index, which is exactly what
-/// <c>ArrayOperations.IndexWrappedOperations</c> serves.
-/// </para>
-///
-/// <para>
-/// That lane was believed to be reachable only under Native AOT, where a value-type generic instantiation
-/// cannot be built (#3362, #3393). It is not, and the two bugs #3381 repaired on it — the reflection
-/// fallback handing <c>PropertyInfo.GetValue</c> the wrapper instead of the CLR target, and a
-/// <c>SetLength</c> that threw a bare <see cref="NotSupportedException"/> where a read-only <c>length</c>
-/// owes script a <c>TypeError</c> — were reachable by an embedder on any runtime. This file is the
-/// coverage that says so (#3394).
-/// </para>
+/// A host object exposed to script under a collection <em>contract</em> rather than under its own type.
+/// <c>ObjectWrapper.Create(engine, target, typeof(IList&lt;int&gt;))</c> is public API, is what a
+/// <see cref="Options.WrapObjectDelegate"/> writes, and is what the member lane hands over for a property
+/// whose <em>declared</em> type is a collection interface — so everything below runs on every target
+/// framework and every leg, under a plain JIT with no trimming and no Native AOT anywhere near it.
 /// </summary>
+/// <remarks>
+/// <para>
+/// The exposure decides which wrapper is built, and the wrapper is what decides what script may do: whether
+/// elements can be written, whether the collection can grow, and which lane <c>Array.prototype</c> takes.
+/// <c>ResolveArrayLikeWrapperFactoryType</c> looked for <c>IList&lt;&gt;</c> and <c>IReadOnlyList&lt;&gt;</c>
+/// among the exposed type's <c>GetInterfaces()</c> and nowhere else. An interface is not among its own —
+/// <c>typeof(IList&lt;int&gt;)</c> yields <c>ICollection&lt;int&gt;</c>, <c>IEnumerable&lt;int&gt;</c> and
+/// <c>IEnumerable</c> — so exposing a collection <em>as</em> one of the two contracts the method is written to
+/// recognize found nothing, and the engine fell back to a wrapper the exposure had not named: a plain
+/// <see cref="ObjectWrapper"/> when the target is not a non-generic <see cref="IList"/>, and a
+/// target-writable <c>ListWrapper</c> when it is (#3421).
+/// </para>
+/// </remarks>
 public class HostExposedCollectionTypeTests
 {
     /// <summary>
-    /// The exposure produces a plain wrapper, which is what routes the collection through the lane. Asserted
-    /// rather than assumed: if a future change gives this exposure a typed wrapper, every read below still
-    /// answers correctly from a different lane and this file would pin nothing.
+    /// Which wrapper each exposure produces. Asserted by name because the wrapper types are internal, and
+    /// asserted at all because it is the fact every behaviour below follows from: a matrix that only checked
+    /// answers would go on passing while the engine quietly served them from the wrong view.
     /// </summary>
-    [Test]
-    public void ExposingAHostCollectionAsAGenericInterfaceProducesAPlainWrapper()
+    [TestCase("IndexedItems", "IList<int>", "GenericListWrapper`1")]
+    [TestCase("IndexedItems", null, "GenericListWrapper`1")]
+    [TestCase("ReadOnlyItems", "IReadOnlyList<int>", "ReadOnlyListWrapper`1")]
+    [TestCase("ReadOnlyItems", null, "ReadOnlyListWrapper`1")]
+    [TestCase("List<int>", "IList<int>", "GenericListWrapper`1")]
+    [TestCase("List<int>", "IReadOnlyList<int>", "ReadOnlyListWrapper`1")]
+    [TestCase("int[]", "IReadOnlyList<int>", "ReadOnlyListWrapper`1")]
+    [TestCase("int[]", "IList<int>", "GenericListWrapper`1")]
+    [TestCase("int[]", null, "ArrayWrapper`1")]
+    public void TheExposedContractDecidesTheWrapper(string target, string? exposedAs, string expected)
     {
         var engine = new Engine(options => options.AllowClr());
 
-        var wrapper = ObjectWrapper.Create(engine, new IndexedItems(1, 2, 3), typeof(IList<int>));
+        var wrapper = ObjectWrapper.Create(engine, Target(target), ExposedType(exposedAs));
 
-        wrapper.GetType().Should().Be<ObjectWrapper>(
-            "the typed wrapper is not built for an exposed interface, and the target is not a non-generic IList either");
+        wrapper.GetType().Name.Should().Be(expected,
+            "{0} exposed as {1} names that contract, and the wrapper is what honours it", target, exposedAs ?? "its own type");
     }
 
     /// <summary>
-    /// The read repair. Every element an <c>Array.prototype</c> generic sees comes back through the lane's
-    /// reflection fallback — <c>PropertyInfo.GetValue</c> over <c>IList&lt;int&gt;.Item</c> — and the
-    /// receiver has to be the CLR collection. Passing the wrapper was a <see cref="TargetException"/>
-    /// waiting for its first caller.
+    /// A contract with no index in it names no view: <see cref="ICollection{T}"/> and
+    /// <see cref="IEnumerable{T}"/> are count-and-enumerate, so a target reachable only through them keeps the
+    /// plain wrapper. The check considers the exposed type itself, not every generic interface it can see.
+    /// </summary>
+    [TestCase("ICollection<int>")]
+    [TestCase("IEnumerable<int>")]
+    public void AContractWithNoIndexProducesNoView(string exposedAs)
+    {
+        var engine = new Engine(options => options.AllowClr());
+
+        var wrapper = ObjectWrapper.Create(engine, new IndexedItems(1, 2, 3), ExposedType(exposedAs));
+
+        wrapper.GetType().Should().Be<ObjectWrapper>();
+    }
+
+    /// <summary>
+    /// A host may hand <see cref="ObjectWrapper.Create(Engine, object, Type?)"/> a type its target does not
+    /// implement. Every typed wrapper casts the target to the contract the exposure named, and until the
+    /// exposed type itself was consulted such a factory could only be found by scanning the target's own
+    /// interfaces — so the cast could not fail. It keeps the answer it has always had rather than becoming an
+    /// <see cref="InvalidCastException"/> out of a wrapper creation.
+    /// </summary>
+    [Test]
+    public void AnExposedTypeTheTargetDoesNotImplementIsNotCastTo()
+    {
+        var engine = new Engine(options => options.AllowClr());
+
+        var wrapper = ObjectWrapper.Create(engine, new IndexedItems(1, 2, 3), typeof(IReadOnlyList<int>));
+
+        wrapper.GetType().Should().Be<ObjectWrapper>("IndexedItems is not an IReadOnlyList<int>");
+    }
+
+    /// <summary>
+    /// Every read an <c>Array.prototype</c> generic makes over the exposed collection, plus the element read
+    /// and the two iteration forms. These answered correctly before too — through the plain wrapper's
+    /// reflection lane — so they are the half that must not change.
     /// </summary>
     [TestCase("Array.prototype.join.call(host, '-')", "1-2-3")]
     [TestCase("Array.prototype.indexOf.call(host, 3)", 2d)]
     [TestCase("Array.prototype.filter.call(host, function (x) { return x > 1; }).join('-')", "2-3")]
     [TestCase("Array.prototype.map.call(host, function (x) { return x * 2; }).join('-')", "2-4-6")]
     [TestCase("Array.prototype.slice.call(host, 1).join('-')", "2-3")]
+    [TestCase("Array.from(host).join('-')", "1-2-3")]
+    [TestCase("[...host].join('-')", "1-2-3")]
     [TestCase("host.length", 3d)]
-    public void ArrayGenericsReadTheExposedCollectionThroughItsClrTarget(string script, object expected)
+    [TestCase("host[1]", 2d)]
+    [TestCase("JSON.stringify(host)", "[1,2,3]")]
+    public void ReadsThroughAnExposedContractAreUnchanged(string script, object expected)
     {
-        var engine = CreateEngine(new IndexedItems(1, 2, 3));
+        var engine = CreateEngine("IndexedItems", "IList<int>", out _);
 
         engine.Evaluate(script).ToObject().Should().Be(expected);
     }
 
     /// <summary>
-    /// The contrast that explains why the receiver bug survived: <c>host[1]</c> resolves the type's own
-    /// indexer through the ordinary member lane and never touches <c>IndexWrappedOperations</c>.
+    /// The element keys of the view now enumerate as an array's do. Through the plain wrapper the same object
+    /// reported its reflected CLR member names instead — <c>IndexOf</c>, <c>Insert</c>, <c>RemoveAt</c> — for
+    /// a target script sees as a list.
     /// </summary>
     [Test]
-    public void AnElementReadDoesNotUseTheSameLaneAsTheGenerics()
+    public void AnExposedCollectionEnumeratesItsPositions()
     {
-        var engine = CreateEngine(new IndexedItems(1, 2, 3));
+        var engine = CreateEngine("IndexedItems", "IList<int>", out _);
 
-        engine.Evaluate("host[1]").AsNumber().Should().Be(2);
+        engine.Evaluate("JSON.stringify(Object.keys(host))").AsString().Should().Be("[\"0\",\"1\",\"2\"]");
+        engine.Evaluate("JSON.stringify(Object.getOwnPropertyNames(host))").AsString().Should().Be("[\"0\",\"1\",\"2\"]");
     }
 
     /// <summary>
-    /// The write repair. <c>splice(0, 0)</c> is the shortest generic that reaches <c>SetLength</c> and
-    /// nothing else: a delete count of zero with no items performs no element write and no delete, just
-    /// <c>Set(O, "length", len, true)</c>. The wrapper has no <see cref="IList"/> to resize, so that write
-    /// meets its read-only <c>length</c> and owes script a <c>TypeError</c> — where a bare
-    /// <see cref="NotSupportedException"/> is invisible to a script <c>try</c>/<c>catch</c> and to a host
-    /// <c>catch (JavaScriptException)</c> alike.
+    /// <see cref="IList{T}"/> declares a settable indexer, <c>Add</c> and <c>RemoveAt</c>, so a collection
+    /// exposed under it is writable and growable — which is what the typed wrapper the contract names gives
+    /// it, and what the plain wrapper could not.
     /// </summary>
-    [TestCase("Array.prototype.splice.call(host, 0, 0)")]
-    [TestCase("Array.prototype.push.call(host, 4)")]
-    public void AGenericThatWouldResizeTheExposedCollectionThrowsACatchableTypeError(string script)
+    [Test]
+    public void AWritableExposedContractIsWritableAndGrowable()
     {
-        var items = new IndexedItems(1, 2, 3);
-        var engine = CreateEngine(items);
+        var engine = CreateEngine("IndexedItems", "IList<int>", out var items);
 
-        var thrown = Caught.Exception(() => engine.Execute(script));
+        engine.Execute("host[0] = 9");
+        items.Should().Equal(new[] { 9, 2, 3 }, "IList<int> has a settable indexer");
 
-        thrown.Should().BeOfType<JavaScriptException>();
-        ((JavaScriptException) thrown!).Error.Get("name").AsString().Should().Be("TypeError");
-        items.Should().Equal(1, 2, 3);
-    }
+        engine.Evaluate("Array.prototype.push.call(host, 4)").AsNumber().Should().Be(4);
+        items.Should().Equal(new[] { 9, 2, 3, 4 }, "IList<int> has Add");
 
-    [TestCase("Array.prototype.pop.call(host)")]
-    [TestCase("Array.prototype.shift.call(host)")]
-    [TestCase("Array.prototype.unshift.call(host, 0)")]
-    [TestCase("Array.prototype.fill.call(host, 9)")]
-    [TestCase("Array.prototype.reverse.call(host)")]
-    [TestCase("Array.prototype.sort.call(host, function (a, b) { return b - a; })")]
-    [TestCase("Array.prototype.splice.call(host, 0, 1)")]
-    [TestCase("Array.from(host).join('-')")]
-    [TestCase("[...host].join('-')")]
-    [TestCase("host.length = 5")]
-    [TestCase("delete host[3]")]
-    [TestCase("JSON.stringify(host)")]
-    public void NoOperationOnAnExposedCollectionLetsAClrExceptionPastScript(string script)
-    {
-        // A bare `host[3] = 9` is deliberately absent: it is not this lane but the plain wrapper's own
-        // reflected-indexer write, which still hands an out-of-range index to the collection. Fixing that
-        // is a decision about every indexed CLR type rather than about array-likes, so it is filed rather
-        // than widened into this change.
-        var engine = CreateEngine(new IndexedItems(1, 2, 3));
+        engine.Evaluate("Array.prototype.pop.call(host)").AsNumber().Should().Be(4);
+        items.Should().Equal(new[] { 9, 2, 3 }, "IList<int> has RemoveAt");
 
-        var thrown = Caught.Exception(() => engine.Execute(script));
-
-        thrown.Should().Match(e => e == null || e is JavaScriptException,
-            "{0} must answer script, not the CLR", script);
+        engine.Execute("host.length = 5");
+        items.Should().Equal(new[] { 9, 2, 3, 0, 0 });
     }
 
     /// <summary>
-    /// The same exposure through the hook an embedder actually configures, rather than through a hand-made
+    /// The other half. <see cref="IReadOnlyList{T}"/> declares a get-only indexer and no mutator at all, so a
+    /// <see cref="List{T}"/> handed to script under it must refuse every mutation — and refuse it as a
+    /// JavaScript error, not as a CLR exception. #3384 gave the refusal to a <c>ListWrapper</c> that took its
+    /// writability from the target; the exposure now gets the wrapper that says so from its type argument.
+    /// </summary>
+    [TestCase("Array.prototype.push.call(host, 4)")]
+    [TestCase("Array.prototype.pop.call(host)")]
+    [TestCase("Array.prototype.reverse.call(host)")]
+    [TestCase("Array.prototype.splice.call(host, 0, 0)")]
+    [TestCase("host.length = 5")]
+    public void AReadOnlyExposedContractRefusesMutationWithAJavaScriptError(string script)
+    {
+        var engine = CreateEngine("List<int>", "IReadOnlyList<int>", out var items);
+
+        Caught.Exception(() => engine.Execute(script)).Should().Match(e => e == null || e is JavaScriptException,
+            "{0} must answer script, not the CLR", script);
+        items.Should().Equal(new[] { 1, 2, 3 }, "the collection is untouched");
+    }
+
+    [Test]
+    public void AReadOnlyExposedContractStillReads()
+    {
+        var engine = CreateEngine("List<int>", "IReadOnlyList<int>", out _);
+
+        engine.Evaluate("host.length").AsNumber().Should().Be(3);
+        engine.Evaluate("host[1]").AsNumber().Should().Be(2);
+        engine.Evaluate("Array.prototype.join.call(host, '-')").AsString().Should().Be("1-2-3");
+        engine.Evaluate("host[3]").IsUndefined().Should().BeTrue();
+
+        engine.Execute("host[0] = 9");
+        engine.Evaluate("host[0]").AsNumber().Should().Be(1, "an element write through a read-only contract is refused");
+    }
+
+    /// <summary>
+    /// Whatever the exposure names, nothing script can do to the collection leaves a CLR exception to the
+    /// embedder. The two rows are the two contracts that name a view — a growable one and a read-only one —
+    /// so the same sixteen operations are answered from opposite ends of what the exposure permits.
+    /// </summary>
+    [TestCase("IndexedItems", "IList<int>")]
+    [TestCase("List<int>", "IReadOnlyList<int>")]
+    public void NoOperationOnAnExposedCollectionLetsAClrExceptionPastScript(string target, string exposedAs)
+    {
+        foreach (var script in new[]
+                 {
+                     "host[3] = 9",
+                     "host['3'] = 9",
+                     "host[-1] = 9",
+                     "Array.prototype.pop.call(host)",
+                     "Array.prototype.shift.call(host)",
+                     "Array.prototype.unshift.call(host, 0)",
+                     "Array.prototype.fill.call(host, 9)",
+                     "Array.prototype.reverse.call(host)",
+                     "Array.prototype.sort.call(host, function (a, b) { return b - a; })",
+                     "Array.prototype.splice.call(host, 0, 1)",
+                     "Array.prototype.push.call(host, 4)",
+                     "Array.from(host).join('-')",
+                     "[...host].join('-')",
+                     "host.length = 5",
+                     "delete host[3]",
+                     "JSON.stringify(host)",
+                 })
+        {
+            var engine = CreateEngine(target, exposedAs, out _);
+
+            Caught.Exception(() => engine.Execute(script)).Should().Match(e => e == null || e is JavaScriptException,
+                "{0} on a collection exposed as {1} must answer script, not the CLR", script, exposedAs);
+        }
+    }
+
+    /// <summary>
+    /// The same exposure through the hook an embedder actually configures rather than through a hand-made
     /// wrapper: <see cref="Options.WrapObjectDelegate"/> receives the target and returns the wrapper, and
     /// narrowing what script sees is the reason the hook exists.
     /// </summary>
@@ -142,36 +225,58 @@ public class HostExposedCollectionTypeTests
         var engine = new Engine(options =>
         {
             options.AllowClr();
-            options.Interop.WrapObjectHandler = static (e, target, _) => target is IndexedItems
-                ? ObjectWrapper.Create(e, target, typeof(IList<int>))
+            options.Interop.AllowWrite = true;
+            options.Interop.WrapObjectHandler = static (e, target, _) => target is List<int>
+                ? ObjectWrapper.Create(e, target, typeof(IReadOnlyList<int>))
                 : ObjectWrapper.Create(e, target);
         });
-        engine.SetValue("host", new IndexedItems(1, 2, 3));
+        engine.SetValue("host", new List<int> { 1, 2, 3 });
 
         engine.Evaluate("Array.prototype.join.call(host, '-')").AsString().Should().Be("1-2-3");
-        Caught.Exception(() => engine.Execute("Array.prototype.splice.call(host, 0, 0)"))
-            .Should().BeOfType<JavaScriptException>();
+        Caught.Exception(() => engine.Execute("Array.prototype.push.call(host, 4)"))
+            .Should().BeOfType<JavaScriptException>("the handler narrowed the exposure to a read-only contract");
     }
 
-    private static Engine CreateEngine(IndexedItems items)
+    private static Engine CreateEngine(string target, string? exposedAs, out IEnumerable<int> host)
     {
+        var instance = (IEnumerable<int>) Target(target);
+        host = instance;
         var engine = new Engine(options =>
         {
             options.AllowClr();
             options.Interop.AllowWrite = true;
         });
-        engine.SetValue("host", ObjectWrapper.Create(engine, items, typeof(IList<int>)));
+        engine.SetValue("host", ObjectWrapper.Create(engine, instance, ExposedType(exposedAs)));
         return engine;
     }
+
+    private static object Target(string target) => target switch
+    {
+        "IndexedItems" => new IndexedItems(1, 2, 3),
+        "ReadOnlyItems" => new ReadOnlyItems(1, 2, 3),
+        "List<int>" => new List<int> { 1, 2, 3 },
+        "int[]" => new[] { 1, 2, 3 },
+        _ => throw new ArgumentOutOfRangeException(nameof(target), target, "unknown target"),
+    };
+
+    private static Type? ExposedType(string? exposedAs) => exposedAs switch
+    {
+        null => null,
+        "IList<int>" => typeof(IList<int>),
+        "IReadOnlyList<int>" => typeof(IReadOnlyList<int>),
+        "ICollection<int>" => typeof(ICollection<int>),
+        "IEnumerable<int>" => typeof(IEnumerable<int>),
+        _ => throw new ArgumentOutOfRangeException(nameof(exposedAs), exposedAs, "unknown exposure"),
+    };
 
     /// <summary>
     /// A host collection that implements <see cref="IList{T}"/> and the non-generic <see cref="ICollection"/>
     /// but <em>not</em> the non-generic <see cref="IList"/>. Every part of that is load-bearing: the generic
     /// interface is what gives the type an index, the non-generic <see cref="ICollection"/> is where
     /// <c>ArrayOperations</c> reads the count, and the absence of the non-generic <see cref="IList"/> is what
-    /// leaves the wrapper with nothing to resize and nothing to read elements through but reflection.
+    /// left the exposure with no <c>ListWrapper</c> to fall back to and therefore no view at all.
     /// </summary>
-    private sealed class IndexedItems : IList<int>, ICollection, IEnumerable<int>
+    private sealed class IndexedItems : IList<int>, ICollection
     {
         private readonly List<int> _items;
 
@@ -208,5 +313,21 @@ public class HostExposedCollectionTypeTests
         object ICollection.SyncRoot => this;
 
         void ICollection.CopyTo(Array array, int index) => ((ICollection) _items).CopyTo(array, index);
+    }
+
+    /// <summary>The read-only sibling, reachable only through <see cref="IReadOnlyList{T}"/>.</summary>
+    private sealed class ReadOnlyItems : IReadOnlyList<int>
+    {
+        private readonly List<int> _items;
+
+        public ReadOnlyItems(params int[] items) => _items = [.. items];
+
+        public int this[int index] => _items[index];
+
+        public int Count => _items.Count;
+
+        public IEnumerator<int> GetEnumerator() => _items.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => _items.GetEnumerator();
     }
 }

--- a/Jint/Native/Array/ArrayOperations.cs
+++ b/Jint/Native/Array/ArrayOperations.cs
@@ -618,14 +618,15 @@ internal abstract class ArrayOperations : IEnumerable<JsValue>
         // integer indexer answers an element read. Every member below was already written for a null _list,
         // which is what says the hard cast this replaced was never the intent.
         //
-        // A null _list is not the Native AOT case alone, which is what this comment used to say and what
-        // #3362 assumed. It is reached under a plain JIT whenever a host object is *exposed* as IList<T> —
-        // ObjectWrapper.Create(engine, target, typeof(IList<int>)), which is public API and is what a
-        // WrapObjectDelegate writes. ResolveArrayLikeWrapperFactoryType looks for IList<> among the exposed
-        // type's GetInterfaces(), and an interface is not among its own, so no typed wrapper is built; a
-        // target that is not a non-generic IList has no ListWrapper to fall back to either; and the plain
-        // ObjectWrapper that results still reports an integer index, which is what admits it here.
-        // Jint.Tests.PublicInterface/HostExposedCollectionTypeTests.cs covers that route on every leg (#3394).
+        // A null _list is the Native AOT case: a runtime with no code for the typed factory's value-type
+        // instantiation degrades to a plain ObjectWrapper when the target is not a non-generic IList, and
+        // Jint.AotExample's IList<int> probe is what pins the lane, on a published native binary.
+        //
+        // It was briefly also a JIT case, and that was itself a defect rather than a route: exposing a host
+        // collection as IList<T> found no typed factory, because ResolveArrayLikeWrapperFactoryType scanned
+        // the exposed type's GetInterfaces() and an interface is not among its own (#3394 documented the
+        // route, #3421 closed it). Under a JIT every exposure that reports an integer index now gets the
+        // typed wrapper its own contract names, so nothing reaches this lane.
         public IndexWrappedOperations(ObjectWrapper wrapper)
         {
             _target = wrapper;

--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -219,7 +219,13 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
             factory = _arrayLikeWrapperResolution.GetOrAdd(type, factory);
         }
 
-        if (factory is not null)
+        // IsInstanceOfType is what keeps the factory's cast honest. Every factory casts the target to the
+        // contract the exposed type named - (T[]), (IList<T>), (IReadOnlyList<T>) - and until the exposed
+        // type itself was considered (#3421) a factory could only be found by scanning the target's own
+        // interface set, so the cast could not fail. A host is free to hand Create a type its target does
+        // not implement, and that exposure keeps the answer it has always had rather than becoming an
+        // InvalidCastException out of a wrapper creation.
+        if (factory is not null && type.IsInstanceOfType(target))
         {
             result = factory.Create(engine, target, type);
         }
@@ -280,25 +286,62 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
             return typeof(ArrayWrapperFactory<>).MakeGenericType(elementType);
         }
 
+        // The exposed type itself, ahead of its interfaces. An interface is not among its own
+        // GetInterfaces() - typeof(IList<int>) yields ICollection<int>, IEnumerable<int> and IEnumerable,
+        // and never IList<int> - so exposing a collection *as* one of the two contracts this method is
+        // written to recognize found nothing at all, and the caller fell back to a wrapper the exposure had
+        // not named: a plain ObjectWrapper for a target that is not an IList, and a target-writable
+        // ListWrapper for one that is. Both are exposures a WrapObjectDelegate writes and the member lane
+        // produces for a declared IList<T> / IReadOnlyList<T> property (#3421).
+        var ownContract = TypedFactoryTypeFor(t);
+        if (ownContract is not null)
+        {
+            return ownContract;
+        }
+
         // check for generic interfaces
         foreach (var i in t.GetInterfaces())
         {
-            if (!i.IsGenericType)
+            var factoryType = TypedFactoryTypeFor(i);
+            if (factoryType is not null)
             {
-                continue;
+                return factoryType;
             }
+        }
 
-            var arrayItemType = i.GenericTypeArguments[0];
+        return null;
+    }
 
-            if (i.GetGenericTypeDefinition() == typeof(IList<>))
-            {
-                return typeof(GenericListWrapperFactory<>).MakeGenericType(arrayItemType);
-            }
+    /// <summary>
+    /// The closed factory type for one contract, or <see langword="null"/> when it names neither of the two
+    /// the typed wrappers are written for. Shared by the exposed type and its interfaces, which is what
+    /// makes the two answer identically.
+    /// </summary>
+    [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
+        Justification = "Reached only from ResolveArrayLikeWrapperFactoryType, whose caller wraps it and the " +
+                        "activation of its result in a catch that degrades. See IsMissingGenericInstantiation.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2055:MakeGenericType",
+        Justification = "The two factories are Jint's own internal sealed types, so the only instantiation a " +
+                        "trimmer can remove is one over an element type it also removed; Activator.CreateInstance " +
+                        "then raises MissingMethodException, which the caller's catch degrades.")]
+    [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+    private static Type? TypedFactoryTypeFor(Type contract)
+    {
+        if (!contract.IsGenericType)
+        {
+            return null;
+        }
 
-            if (i.GetGenericTypeDefinition() == typeof(IReadOnlyList<>))
-            {
-                return typeof(ReadOnlyListWrapperFactory<>).MakeGenericType(arrayItemType);
-            }
+        var definition = contract.GetGenericTypeDefinition();
+
+        if (definition == typeof(IList<>))
+        {
+            return typeof(GenericListWrapperFactory<>).MakeGenericType(contract.GenericTypeArguments[0]);
+        }
+
+        if (definition == typeof(IReadOnlyList<>))
+        {
+            return typeof(ReadOnlyListWrapperFactory<>).MakeGenericType(contract.GenericTypeArguments[0]);
         }
 
         return null;

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -2691,6 +2691,53 @@ out-of-range index on such a target no longer fires — the read is `undefined` 
 reading `n in x` or `x.hasOwnProperty(n)` as "the indexer would accept `n`" gets `false` for out-of-range `n`
 instead of `true`.
 
+### 4.57 A collection exposed as `IList<T>` or `IReadOnlyList<T>` gets the wrapper that contract names ([#3421](https://github.com/sebastienros/jint/issues/3421))
+
+The type a host object is *exposed* under decides which wrapper the engine builds, and the wrapper decides
+what script may do with it — whether elements are writable, whether the collection can grow, and which lane
+`Array.prototype` takes. That exposure is public API (`ObjectWrapper.Create(engine, target, type)`), it is
+what a `WrapObjectDelegate` supplies, and it is what the member lane passes for a property whose **declared**
+type is a collection interface.
+
+The resolution scanned the exposed type's `GetInterfaces()` for `IList<>` and `IReadOnlyList<>` and nowhere
+else. An interface is not among its own — `typeof(IList<int>).GetInterfaces()` yields `ICollection<int>`,
+`IEnumerable<int>` and `IEnumerable` — so exposing a collection *as* one of the two contracts the code is
+written to recognize found nothing, and the engine fell back to a wrapper the exposure had not named:
+
+| exposure | 4.16.x | 5.x |
+| --- | --- | --- |
+| a host `IList<T>` (not a non-generic `IList`) as `IList<T>` | plain `ObjectWrapper` — no `Array.prototype`, member names for keys, a read-only `length` | the typed writable, growable view |
+| a `List<T>` as `IList<T>` | untyped `ListWrapper` (element type `object`) | the typed view, with `T`-typed element writes |
+| a `List<T>` or `T[]` as `IReadOnlyList<T>` | `ListWrapper`, taking its writability from the target | the typed read-only view |
+| a host `IReadOnlyList<T>` (not an `IList`) as `IReadOnlyList<T>` | plain `ObjectWrapper` | the typed read-only view |
+
+What that changes for the first row, which is the one an embedder is most likely to have:
+
+```js
+// engine.SetValue("host", ObjectWrapper.Create(engine, items, typeof(IList<int>)))
+Object.keys(host)                     // 4.16.x: ["IndexOf","Insert","RemoveAt"]   5.x: ["0","1","2"]
+host[3] = 9                           // 4.16.x: ArgumentOutOfRangeException        5.x: grows to 1,2,3,9
+Array.prototype.push.call(host, 4)    // 4.16.x: TypeError (§4.37)                  5.x: 4
+Array.prototype.pop.call(host)        // 4.16.x: TypeError                          5.x: removes the last element
+```
+
+Reads are unchanged in every row: `host.length`, `host[1]`, the `Array.prototype` generics, `Array.from`,
+spread and `JSON.stringify` all answered correctly before, through the plain wrapper's reflection lane.
+
+**What could break.** An exposure under `IList<T>` becomes writable and growable — the contract says so, but a
+host that was relying on the accidental refusal should expose the collection as `IReadOnlyList<T>` instead,
+which now produces a view that refuses every mutation as a catchable JavaScript error. An exposure under
+`IReadOnlyList<T>` gains `Array.prototype`, index-keyed enumeration and a `length` where the fallback wrapper
+had given it the target's members. A contract with no index in it — `ICollection<T>`, `IEnumerable<T>` — names
+no view and is unchanged. A type the target does **not** implement is not cast to: that exposure keeps the
+plain wrapper it has always had rather than raising `InvalidCastException`.
+
+[§4.37](#437-a-host-collection-exposed-as-ilistt-refuses-a-growing-generic-with-a-typeerror-3394) is narrowed
+by this: the `ArrayOperations.IndexWrappedOperations` lane it describes is no longer reachable under a JIT,
+because the exposure that reached it now gets a typed wrapper. The refusal it added is still what a runtime
+with no code for the typed factory's instantiation gives — Native AOT over a value-type element — and
+`Jint.AotExample` is what pins it there.
+
 `Engine.DrainEventLoopUntil` — what `UnwrapIfPromise` blocks in, and what a synchronous `Modules.Import`
 waits in — used to arm its deadline from `DateTime.UtcNow`. It now arms it from a monotonic timestamp, read
 through `Options.Constraints.TimeProvider` on `net8.0` and later and from `Stopwatch` everywhere else. Three
@@ -2711,7 +2758,6 @@ consequences, none of which changes a signature:
   rather than only when `LimitExecutionTime` happens to be registered. It was always rejected by
   `ConstraintClock.Resolve` with a named `ArgumentException`; that clock is now resolved for every engine, so
   the diagnostic arrives where the clock was supplied instead of at whichever budget first tried to use it.
-
 ## 5. New in v5
 
 Everything in the table below is opt-in: nothing in it is installed unless the host asks for it, so


### PR DESCRIPTION
Fixes #3421.

`ResolveArrayLikeWrapperFactoryType` decides which wrapper an exposed type gets by scanning
`t.GetInterfaces()` for `IList<>` and `IReadOnlyList<>`. **An interface is not among its own
`GetInterfaces()`**, so when `t` *is* one of those two the scan finds nothing:

```csharp
typeof(IList<int>).GetInterfaces()          // ICollection<int>, IEnumerable<int>, IEnumerable
typeof(IReadOnlyList<int>).GetInterfaces()  // IReadOnlyCollection<int>, IEnumerable<int>, IEnumerable
```

Exposing a collection *as* one of the two contracts the method is written to recognize therefore found
nothing, and the engine fell back to a wrapper the exposure had not named. That exposure is public API
(`ObjectWrapper.Create(engine, target, type)`), it is what a `WrapObjectDelegate` supplies, and it is what the
member lane passes for a property whose **declared** type is a collection interface — so it is reachable under
a plain JIT, with no trimming and no Native AOT anywhere near it.

| exposure | `main` | this PR |
| --- | --- | --- |
| a host `IList<T>` (not a non-generic `IList`) as `IList<T>` | plain `ObjectWrapper` | `GenericListWrapper<T>` |
| a `List<T>` as `IList<T>` | untyped `ListWrapper` (element type `object`) | `GenericListWrapper<T>` |
| a `List<T>` or `T[]` as `IReadOnlyList<T>` | `ListWrapper`, writability read from the target | `ReadOnlyListWrapper<T>` |
| a host `IReadOnlyList<T>` (not an `IList`) as `IReadOnlyList<T>` | plain `ObjectWrapper` | `ReadOnlyListWrapper<T>` |
| as `ICollection<T>` / `IEnumerable<T>` | plain `ObjectWrapper` | unchanged — those contracts name no view |

What the first row means for an embedder:

```js
// engine.SetValue("host", ObjectWrapper.Create(engine, items, typeof(IList<int>)))
Object.keys(host)                     // main: ["IndexOf","Insert","RemoveAt"]   here: ["0","1","2"]
host[3] = 9                           // main: ArgumentOutOfRangeException        here: grows to 1,2,3,9
Array.prototype.push.call(host, 4)    // main: TypeError (§4.37)                  here: 4
Array.prototype.pop.call(host)        // main: TypeError                          here: removes the last
```

Reads are unchanged in every row — `host.length`, `host[1]`, the generics, `Array.from`, spread and
`JSON.stringify` all answered correctly through the plain wrapper's reflection lane already, and
`ReadsThroughAnExposedContractAreUnchanged` is the ten rows that say so.

**One guard comes with it.** Every typed factory casts the target to the contract the exposure named, and
until the exposed type itself was consulted a factory could only be found by scanning the *target's* own
interfaces — so the cast could not fail. `TryBuildArrayLikeWrapper` now requires `type.IsInstanceOfType(target)`
before using the factory, so a host handing `Create` a type its target does not implement keeps the answer it
has always had rather than getting an `InvalidCastException` out of a wrapper creation.

### Proof

`Jint.Tests.PublicInterface/HostExposedCollectionTypeTests.cs` — the file #3425 added for this exposure — is
rewritten around the contract rather than around the wrapper it accidentally got. Against unmodified `main`,
**9 of its 33 cases fail**:

```
Failed TheExposedContractDecidesTheWrapper("IndexedItems","IList<int>","GenericListWrapper`1")
Failed TheExposedContractDecidesTheWrapper("List<int>","IList<int>","GenericListWrapper`1")
Failed TheExposedContractDecidesTheWrapper("int[]","IList<int>","GenericListWrapper`1")
Failed TheExposedContractDecidesTheWrapper("ReadOnlyItems","IReadOnlyList<int>","ReadOnlyListWrapper`1")
Failed TheExposedContractDecidesTheWrapper("List<int>","IReadOnlyList<int>","ReadOnlyListWrapper`1")
Failed TheExposedContractDecidesTheWrapper("int[]","IReadOnlyList<int>","ReadOnlyListWrapper`1")

Failed AnExposedCollectionEnumeratesItsPositions
   Expected string to be the same string, but they differ at index 1
   (["IndexOf","Insert","RemoveAt"] for a target script sees as a list)

Failed AWritableExposedContractIsWritableAndGrowable
   Jint.Runtime.JavaScriptException : Cannot assign to read only property '3' of object '#<Object>'

Failed NoOperationOnAnExposedCollectionLetsAClrExceptionPastScript("IndexedItems","IList<int>")
   ... but found System.ArgumentOutOfRangeException: Index was out of range.

Failed!  - Failed: 9, Passed: 24, Skipped: 0, Total: 33
```

The contrast cases pass on `main` and still pass: the exposures under `ICollection<T>` / `IEnumerable<T>` that
must stay plain, the ten read rows, and the exposed type the target does not implement.

### What this narrows

`ArrayOperations.IndexWrappedOperations` is once again reachable only under Native AOT. The plain-JIT route
[#3394](https://github.com/sebastienros/jint/issues/3394) found — and that
[§4.37](https://github.com/sebastienros/jint/blob/main/docs/v5-migration.md) documents — *was this defect*,
not a shape of the engine: the exposure that reached the lane now gets a typed wrapper. The refusal #3425
added to that lane is still what a runtime with no code for the typed factory's value-type instantiation
gives, and `Jint.AotExample`'s `IList<int>` probe is again the only coverage it has — the comments in
`ArrayOperations.cs` and `Jint.AotExample/Program.cs` say so, and the latter says not to delete the probe for
want of a sibling test.

`docs/v5-migration.md` §4.57 carries the embedder-facing form and narrows §4.37.

**Merge last of the three** (#3464, #3472, then this): all three touch `Jint/Runtime/Interop/ObjectWrapper*.cs`
and `docs/v5-migration.md`, and this one is the behaviour change the other two should be in place for.
