### PR TITLE
Temporal: a date past a lunisolar calendar's table is still reckoned in that calendar

### DIFF
--- a/Jint.Tests/Runtime/LunisolarAstronomyTests.cs
+++ b/Jint.Tests/Runtime/LunisolarAstronomyTests.cs
@@ -1,0 +1,215 @@
+#nullable enable
+
+using System.Globalization;
+using System.Text;
+using Jint.Native.Temporal;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// The astronomical lunisolar reckoning, checked against the two BCL tables it takes over from.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Outside <c>ChineseLunisolarCalendar</c>'s ISO 1901-02-19 to 2101-01-28 and
+/// <c>KoreanLunisolarCalendar</c>'s 918-02-19 to 2051-02-10 there is nothing to check an answer against.
+/// What these do instead is run the reckoning across the whole of each table and require it to reproduce
+/// it: an algorithm that reproduces two independently compiled tables day for day is the same algorithm
+/// outside them, which is the only claim that can be made about the years past their ends.
+/// </para>
+/// <para>
+/// The tables reach back further than the calendar they tabulate does. China's present rules — true
+/// solar terms rather than mean ones — date from the Shixian reform of 1645, and Korea reckoned the
+/// Chinese calendar, in Chinese time, until 1912. Before those dates the tables record a different
+/// calendar, which no modern algorithm reproduces and none should.
+/// </para>
+/// <para>
+/// The tables also do not agree with each other across target frameworks, which is why only one window
+/// below is asserted exactly. See the remarks on
+/// <see cref="TheReckoningTracksTheRestOfBothTables"/> for what differs where.
+/// </para>
+/// </remarks>
+public class LunisolarAstronomyTests
+{
+    private static readonly string[] TheTwoTables = ["chinese", "dangi"];
+
+    private static EastAsianLunisolarCalendar TableFor(string calendar) => calendar switch
+    {
+        "chinese" => new ChineseLunisolarCalendar(),
+        _ => new KoreanLunisolarCalendar(),
+    };
+
+    private static LunisolarRegion RegionFor(string calendar) => calendar switch
+    {
+        "chinese" => LunisolarRegion.China,
+        _ => LunisolarRegion.Korea,
+    };
+
+    /// <summary>
+    /// Every day of 1912 to 2051, read twice — once by <c>KoreanLunisolarCalendar</c> and once by the
+    /// reckoning — with no allowance at all, and on every target framework.
+    /// </summary>
+    /// <remarks>
+    /// 1912 is when Korea began reckoning its own calendar rather than China's, so those 50,811 days are
+    /// the whole of what that table has to say about the calendar this implements. Reproducing them
+    /// exactly is the strongest statement available about the years past the table's end, and it is the
+    /// end of the table that matters: 2051-02-10 is where the reckoning takes over.
+    /// </remarks>
+    [Test]
+    public void TheReckoningReproducesTheKoreanTableExactlyFrom1912()
+    {
+        var (compared, disagreements, report) = Compare("dangi", 1912);
+
+        compared.Should().BeGreaterThan(50_000);
+        report.Should().BeEmpty($"{disagreements} of {compared} days disagree");
+    }
+
+    /// <summary>
+    /// The rest of both tables, bounded rather than exact.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Three things put days on this side of the line, and only the first is about the reckoning. A new
+    /// moon falling within minutes of local midnight lands on either side of it, which moves one month
+    /// boundary by a day and so 30 days at a time. The centuries before China's Shixian reform of 1645
+    /// are a different calendar — mean solar terms rather than true ones — which no modern algorithm
+    /// reproduces and none should.
+    /// </para>
+    /// <para>
+    /// And the tables do not agree with each other. <c>ChineseLunisolarCalendar</c> reads 2057-09-28 as
+    /// 2057/9/1 on .NET 8 and as 2057/8/30 on .NET Framework 4.8 and .NET 10;
+    /// <c>KoreanLunisolarCalendar</c> on .NET Framework starts five days earlier than its .NET Core
+    /// counterpart and reads 1500-06-15 as 1500/5/19 where .NET Core reads 1500/5/9. So the measurement
+    /// is per runtime: <c>chinese</c> from 1901 is 30, 60 and 120 days of 73,027 on .NET 8, .NET 10 and
+    /// .NET Framework; <c>dangi</c> from 1654 is 2,218, 2,218 and 2,750 of 145,042. The allowances are
+    /// the largest of those with room.
+    /// </para>
+    /// </remarks>
+    [TestCase("chinese", 1901, 0.005)]
+    [TestCase("dangi", 1654, 0.030)]
+    public void TheReckoningTracksTheRestOfBothTables(string name, int fromIsoYear, double allowed)
+    {
+        var (compared, disagreements, _) = Compare(name, fromIsoYear);
+
+        compared.Should().BeGreaterThan(70_000);
+        ((double) disagreements / compared).Should().BeLessThan(
+            allowed,
+            "{0} of {1} days disagree",
+            disagreements,
+            compared);
+    }
+
+    private static (int Compared, int Disagreements, string Report) Compare(string name, int fromIsoYear)
+    {
+        var calendar = TableFor(name);
+        var region = RegionFor(name);
+
+        var first = new DateTime(fromIsoYear, 1, 1);
+        if (first < calendar.MinSupportedDateTime)
+        {
+            first = calendar.MinSupportedDateTime.Date.AddDays(1);
+        }
+
+        var last = calendar.MaxSupportedDateTime.Date;
+
+        var report = new StringBuilder();
+        var compared = 0;
+        var disagreements = 0;
+
+        for (var date = first; date <= last; date = date.AddDays(1))
+        {
+            compared++;
+
+            var days = (long) (date - new DateTime(1970, 1, 1)).TotalDays;
+            var year = LunisolarAstronomy.ForFixed(days, region);
+
+            var ordinal = 1;
+            while (ordinal < year.MonthCount && year.MonthStarts[ordinal] <= days)
+            {
+                ordinal++;
+            }
+
+            var day = (int) (days - year.MonthStarts[ordinal - 1]) + 1;
+            var leapOrdinal = year.LeapIndex + 1;
+
+            var tableYear = calendar.GetYear(date);
+            var tableMonth = calendar.GetMonth(date);
+            var tableDay = calendar.GetDayOfMonth(date);
+            var tableLeap = calendar.GetLeapMonth(tableYear);
+
+            if (year.Year == tableYear && ordinal == tableMonth && day == tableDay && leapOrdinal == tableLeap)
+            {
+                continue;
+            }
+
+            disagreements++;
+            if (disagreements <= 20)
+            {
+                report
+                    .Append(date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture))
+                    .Append(": table said ")
+                    .Append(tableYear).Append('/').Append(tableMonth).Append('/').Append(tableDay)
+                    .Append(" leap=").Append(tableLeap)
+                    .Append(", reckoning said ")
+                    .Append(year.Year).Append('/').Append(ordinal).Append('/').Append(day)
+                    .Append(" leap=").Append(leapOrdinal)
+                    .AppendLine();
+            }
+        }
+
+        return (compared, disagreements, report.ToString());
+    }
+
+    /// <summary>
+    /// The two directions have to be each other's inverse, or a date read out of a calendar cannot be put
+    /// back into it — which is what <c>with</c>, <c>from</c> and every <c>PlainYearMonth</c> operation do.
+    /// </summary>
+    /// <remarks>
+    /// The sweep runs a hundred thousand years each way, far outside either table, so it is also what
+    /// exercises the bounded searches: the series stop being monotone out there, and a correction loop
+    /// that assumed otherwise would not return from this at all.
+    /// </remarks>
+    [TestCaseSource(nameof(TheTwoTables))]
+    public void ReadingAYearAndAskingForItByNumberFindTheSameYear(string name)
+    {
+        var region = RegionFor(name);
+
+        var failures = new StringBuilder();
+        var checkedDates = 0;
+
+        for (var isoYear = -100_000; isoYear <= 100_000; isoYear += 997)
+        {
+            for (var isoMonth = 1; isoMonth <= 12; isoMonth += 5)
+            {
+                checkedDates++;
+
+                var days = TemporalHelpers.IsoDateToDays(isoYear, isoMonth, 15);
+                var year = LunisolarAstronomy.ForFixed(days, region);
+
+                if (days < year.Start || days >= year.MonthStarts[year.MonthCount])
+                {
+                    failures.Append(isoYear).Append('-').Append(isoMonth)
+                        .AppendLine(": the year found does not contain the date");
+                    continue;
+                }
+
+                if (year.MonthCount is not (12 or 13))
+                {
+                    failures.Append(isoYear).Append('-').Append(isoMonth)
+                        .Append(": month count is ").Append(year.MonthCount).AppendLine();
+                    continue;
+                }
+
+                var byNumber = LunisolarAstronomy.ForYear(year.Year, region);
+                if (byNumber is null || byNumber.Start != year.Start)
+                {
+                    failures.Append(isoYear).Append('-').Append(isoMonth)
+                        .Append(": year ").Append(year.Year).AppendLine(" does not resolve back to the same start");
+                }
+            }
+        }
+
+        checkedDates.Should().BeGreaterThan(500);
+        failures.ToString().Should().BeEmpty();
+    }
+}

--- a/Jint.Tests/Runtime/NonIsoCalendarOutOfRangeFieldTests.cs
+++ b/Jint.Tests/Runtime/NonIsoCalendarOutOfRangeFieldTests.cs
@@ -1,0 +1,381 @@
+#nullable enable
+
+using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions;
+using AwesomeAssertions.Execution;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// A date outside a non-ISO calendar's implementation range still reports that calendar's fields.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>ChineseLunisolarCalendar</c> spans ISO 1901-02-19 to 2101-01-28 and <c>KoreanLunisolarCalendar</c>
+/// 918-02-19 to 2051-02-10, while <c>Temporal.PlainDate</c> spans a quarter of a million years each way.
+/// Outside those two tables the engine used to answer with the ISO year, <c>M{isoMonth}</c>, the ISO
+/// days-in-month and twelve months a year — Gregorian fields wearing a lunisolar label, with nothing
+/// downstream able to tell them from real ones
+/// (<see href="https://github.com/sebastienros/jint/issues/3451"/>).
+/// </para>
+/// <para>
+/// Refusing instead is not open to the engine.
+/// <see href="https://tc39.es/proposal-temporal/#sec-temporal-nonisocalendarisotodate">NonISOCalendarISOToDate</see>
+/// is declared as returning <em>a Calendar Date Record</em> and not "either a normal completion … or a
+/// throw completion" — the phrasing its neighbour
+/// <see href="https://tc39.es/proposal-temporal/#sec-temporal-nonisodateadd">NonISODateAdd</see> does
+/// carry, which is what let the arithmetic refuse in
+/// <see href="https://github.com/sebastienros/jint/pull/3452">#3452</see> — and
+/// <c>get PlainDate.prototype.monthCode</c> reads it without <c>?</c>. So the accessors have to answer.
+/// </para>
+/// </remarks>
+public class NonIsoCalendarOutOfRangeFieldTests
+{
+    /// <summary>
+    /// A month code is <c>M</c> plus the month's zero-padded position in a common year of its calendar,
+    /// with an <c>L</c> for a leap month — so <c>M13</c> is well formed for the thirteen-month Coptic and
+    /// Ethiopic calendars and nothing above it ever is.
+    /// </summary>
+    private static readonly Regex WellFormedMonthCode = new(@"^M(0[1-9]|1[0-3])L?$", RegexOptions.Compiled);
+
+    /// <summary>A lunisolar display month never reaches thirteen: the thirteenth is a leap month.</summary>
+    private static readonly Regex WellFormedLunisolarMonthCode = new(@"^M(0[1-9]|1[0-2])L?$", RegexOptions.Compiled);
+
+    private static string Evaluate(string expression)
+    {
+        var engine = new Engine();
+        return engine.Evaluate(
+            $"(function () {{ try {{ return String({expression}); }} catch (e) {{ return e.constructor.name; }} }})()").AsString();
+    }
+
+    private static string Fields(string isoDate, string calendar) => Evaluate(
+        $"(function () {{ var d = Temporal.PlainDate.from('{isoDate}').withCalendar('{calendar}');" +
+        " return [d.year, d.month, d.day, d.monthCode, d.monthsInYear, d.daysInMonth, d.daysInYear," +
+        " d.dayOfYear, d.inLeapYear].join('|'); })()");
+
+    /// <summary>
+    /// The report from the issue. 1800-01-01 is not in the Chinese year 1800, it is not day 1 of a month
+    /// coded <c>M01</c>, and the year it is in has twelve months because that year has twelve — not
+    /// because twelve is what an ISO year has.
+    /// </summary>
+    [Test]
+    public void TheReportedDatePastTheChineseRangeReportsChineseFields()
+    {
+        Fields("1800-01-01", "chinese").Should().Be("1799|12|7|M12|12|30|354|331|false");
+    }
+
+    /// <summary>
+    /// 1800-01-01 is past the end of <c>ChineseLunisolarCalendar</c> and well inside
+    /// <c>KoreanLunisolarCalendar</c>, and Korea reckoned the Chinese calendar until 1912. So the Korean
+    /// table is an independent check on the reckoning that took over where the Chinese table stopped, and
+    /// it says the same thing.
+    /// </summary>
+    /// <remarks>
+    /// One date rather than a sweep, because .NET Framework's copy of the Korean table is not .NET Core's
+    /// — it starts five days earlier and reads 1500-06-15 as 1500/5/19 where .NET Core reads 1500/5/9.
+    /// The systematic form of this comparison, measured per runtime, is in
+    /// <c>LunisolarAstronomyTests</c>.
+    /// </remarks>
+    [Test]
+    public void ThePastDateTheKoreanTableAlsoCoversReadsTheSameInBoth()
+    {
+        Fields("1800-01-01", "chinese").Should().Be(Fields("1800-01-01", "dangi"));
+    }
+
+    /// <summary>
+    /// The day before a table's first day and the day after its last: the reckoning that takes over has
+    /// to leave the calendar where the table left it, or the boundary is a visible seam.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Stated structurally rather than as dates, because the tables themselves differ between target
+    /// frameworks. Both end on a year's last day, so what has to hold there is that the two sides make
+    /// one continuous calendar: the day after the table's last is day 1 of the following year.
+    /// </para>
+    /// <para>
+    /// The start of the table is asserted for <c>chinese</c> only. .NET Framework's
+    /// <c>KoreanLunisolarCalendar</c> begins on 918-02-14 and calls it day 1 of the Korean year 918,
+    /// while .NET Core's begins on 918-02-19 and calls that day 1 — so on .NET Framework there is no year
+    /// boundary at the table's start for the reckoning to join to, and the seam there is that table's,
+    /// not this one's.
+    /// </para>
+    /// </remarks>
+    [TestCase("chinese", true)]
+    [TestCase("dangi", false)]
+    public void TheReckoningJoinsTheTableWithoutASeam(string calendar, bool tableStartsOnANewYear)
+    {
+        var table = calendar switch
+        {
+            "chinese" => (EastAsianLunisolarCalendar) new ChineseLunisolarCalendar(),
+            _ => new KoreanLunisolarCalendar(),
+        };
+
+        var firstDay = table.MinSupportedDateTime.Date;
+        var lastDay = table.MaxSupportedDateTime.Date;
+
+        using var _ = new AssertionScope();
+
+        if (tableStartsOnANewYear)
+        {
+            var beforeFirst = Read(firstDay.AddDays(-1), calendar);
+            var first = Read(firstDay, calendar);
+
+            first.Month.Should().Be(1, "the table starts on a new year's day");
+            first.Day.Should().Be(1);
+            first.DayOfYear.Should().Be(1);
+
+            beforeFirst.Year.Should().Be(first.Year - 1, "the day before is in the preceding year");
+            beforeFirst.Month.Should().Be(beforeFirst.MonthsInYear, "and is in that year's last month");
+            beforeFirst.Day.Should().Be(beforeFirst.DaysInMonth, "on that month's last day");
+            beforeFirst.DayOfYear.Should().Be(beforeFirst.DaysInYear, "which is that year's last day");
+        }
+
+        var last = Read(lastDay, calendar);
+        var afterLast = Read(lastDay.AddDays(1), calendar);
+
+        last.Day.Should().Be(last.DaysInMonth, "the table ends on a year's last day");
+        last.DayOfYear.Should().Be(last.DaysInYear);
+
+        afterLast.Year.Should().Be(last.Year + 1, "the day after starts the following year");
+        afterLast.Month.Should().Be(1);
+        afterLast.Day.Should().Be(1);
+        afterLast.DayOfYear.Should().Be(1);
+    }
+
+    private readonly record struct Read4(
+        int Year, int Month, int Day, string MonthCode,
+        int MonthsInYear, int DaysInMonth, int DaysInYear, int DayOfYear);
+
+    private static Read4 Read(DateTime date, string calendar)
+    {
+        var isoDate = date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+        var f = Fields(isoDate, calendar).Split('|');
+
+        return new Read4(
+            int.Parse(f[0], CultureInfo.InvariantCulture),
+            int.Parse(f[1], CultureInfo.InvariantCulture),
+            int.Parse(f[2], CultureInfo.InvariantCulture),
+            f[3],
+            int.Parse(f[4], CultureInfo.InvariantCulture),
+            int.Parse(f[5], CultureInfo.InvariantCulture),
+            int.Parse(f[6], CultureInfo.InvariantCulture),
+            int.Parse(f[7], CultureInfo.InvariantCulture));
+    }
+
+    /// <summary>
+    /// What the fields report has to be a lunisolar calendar, whatever the date: months of 29 or 30 days,
+    /// years of twelve or thirteen of them, and a well-formed month code.
+    /// </summary>
+    /// <remarks>
+    /// This is the general form of the defect. The ISO-like answer it replaces reported months of 28 or
+    /// 31 days and years of 365, which is what made it indistinguishable from a real one downstream.
+    /// </remarks>
+    [TestCase("chinese")]
+    [TestCase("dangi")]
+    public void EveryDatePastTheTableStillReportsALunisolarCalendar(string calendar)
+    {
+        var failures = new StringBuilder();
+        var sampled = 0;
+
+        for (var isoYear = -20_000; isoYear <= 20_000; isoYear += 401)
+        {
+            foreach (var isoMonth in new[] { 1, 4, 7, 10 })
+            {
+                var isoDate = (isoYear < 0 ? "-" : "+")
+                    + System.Math.Abs(isoYear).ToString("D6", CultureInfo.InvariantCulture)
+                    + "-" + isoMonth.ToString("D2", CultureInfo.InvariantCulture) + "-15";
+
+                sampled++;
+                var reported = Fields(isoDate, calendar).Split('|');
+                if (reported.Length != 9)
+                {
+                    failures.Append(isoDate).Append(": ").AppendLine(string.Join("|", reported));
+                    continue;
+                }
+
+                var day = int.Parse(reported[2], CultureInfo.InvariantCulture);
+                var monthCode = reported[3];
+                var monthsInYear = int.Parse(reported[4], CultureInfo.InvariantCulture);
+                var daysInMonth = int.Parse(reported[5], CultureInfo.InvariantCulture);
+                var daysInYear = int.Parse(reported[6], CultureInfo.InvariantCulture);
+                var dayOfYear = int.Parse(reported[7], CultureInfo.InvariantCulture);
+
+                if (monthsInYear is not (12 or 13)
+                    || daysInMonth is not (29 or 30)
+                    || daysInYear < 353 || daysInYear > 385
+                    || day < 1 || day > daysInMonth
+                    || dayOfYear < 1 || dayOfYear > daysInYear
+                    || !WellFormedLunisolarMonthCode.IsMatch(monthCode))
+                {
+                    failures.Append(isoDate).Append(": ").AppendLine(string.Join("|", reported));
+                }
+            }
+        }
+
+        sampled.Should().BeGreaterThan(350);
+        failures.ToString().Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// The general form of the defect, over all eleven non-ISO calendars: whatever the date, the fields
+    /// have to describe the calendar that was asked, not the ISO one wearing its name.
+    /// </summary>
+    /// <remarks>
+    /// A lunisolar year has twelve or thirteen months of 29 or 30 days; a Coptic or Ethiopic one has
+    /// thirteen, twelve of thirty days and a thirteenth of five or six; an Islamic one twelve of 29 or 30;
+    /// a Persian or Indian one twelve of 29 to 31. None of them has a 365-day year of 28-to-31-day months,
+    /// which is what an ISO answer under a calendar's name looks like. Only <c>chinese</c> and
+    /// <c>dangi</c> ever gave one — the other nine already had a reckoning of their own to fall back on —
+    /// which is what makes this the regression guard for all eleven rather than a test of two.
+    /// </remarks>
+    [TestCase("chinese", 12, 13, 29, 30, 353, 385)]
+    [TestCase("dangi", 12, 13, 29, 30, 353, 385)]
+    [TestCase("hebrew", 12, 13, 29, 30, 353, 385)]
+    [TestCase("persian", 12, 12, 29, 31, 365, 366)]
+    [TestCase("indian", 12, 12, 29, 31, 365, 366)]
+    [TestCase("coptic", 13, 13, 5, 30, 365, 366)]
+    [TestCase("ethiopic", 13, 13, 5, 30, 365, 366)]
+    [TestCase("ethioaa", 13, 13, 5, 30, 365, 366)]
+    [TestCase("islamic-umalqura", 12, 12, 29, 30, 354, 355)]
+    [TestCase("islamic-civil", 12, 12, 29, 30, 354, 355)]
+    [TestCase("islamic-tbla", 12, 12, 29, 30, 354, 355)]
+    public void NoCalendarReportsIsoFieldsUnderItsOwnName(
+        string calendar,
+        int minMonthsInYear,
+        int maxMonthsInYear,
+        int minDaysInMonth,
+        int maxDaysInMonth,
+        int minDaysInYear,
+        int maxDaysInYear)
+    {
+        var failures = new StringBuilder();
+        var sampled = 0;
+
+        for (var isoYear = -20_000; isoYear <= 20_000; isoYear += 991)
+        {
+            foreach (var isoMonth in new[] { 1, 7 })
+            {
+                var isoDate = (isoYear < 0 ? "-" : "+")
+                    + System.Math.Abs(isoYear).ToString("D6", CultureInfo.InvariantCulture)
+                    + "-" + isoMonth.ToString("D2", CultureInfo.InvariantCulture) + "-15";
+
+                sampled++;
+                var reported = Fields(isoDate, calendar).Split('|');
+                if (reported.Length != 9)
+                {
+                    failures.Append(isoDate).Append(": ").AppendLine(string.Join("|", reported));
+                    continue;
+                }
+
+                var monthsInYear = int.Parse(reported[4], CultureInfo.InvariantCulture);
+                var daysInMonth = int.Parse(reported[5], CultureInfo.InvariantCulture);
+                var daysInYear = int.Parse(reported[6], CultureInfo.InvariantCulture);
+
+                if (monthsInYear < minMonthsInYear || monthsInYear > maxMonthsInYear
+                    || daysInMonth < minDaysInMonth || daysInMonth > maxDaysInMonth
+                    || daysInYear < minDaysInYear || daysInYear > maxDaysInYear
+                    || !WellFormedMonthCode.IsMatch(reported[3]))
+                {
+                    failures.Append(isoDate).Append(": ").AppendLine(string.Join("|", reported));
+                }
+            }
+        }
+
+        sampled.Should().BeGreaterThan(70);
+        failures.ToString().Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// A date read out of a calendar has to go back into it: the fields the accessors report, handed to
+    /// <c>from</c>, are the date they were read off. That is what <c>with</c> and every
+    /// <c>PlainYearMonth</c> conversion depend on.
+    /// </summary>
+    [TestCase("chinese")]
+    [TestCase("dangi")]
+    public void FieldsReadPastTheTableGoBackIntoTheCalendar(string calendar)
+    {
+        var failures = new StringBuilder();
+
+        foreach (var isoDate in new[]
+                 {
+                     "-020000-05-05", "-000500-03-03", "0500-01-01", "1500-06-15",
+                     "1800-01-01", "1900-12-31", "2200-08-08", "2300-01-01", "9999-12-31",
+                 })
+        {
+            var roundTripped = Evaluate(
+                $"(function () {{ var d = Temporal.PlainDate.from('{isoDate}').withCalendar('{calendar}');" +
+                $" return Temporal.PlainDate.from({{ calendar: '{calendar}', year: d.year," +
+                " monthCode: d.monthCode, day: d.day }).equals(d); })()");
+
+            if (!string.Equals(roundTripped, "true", StringComparison.Ordinal))
+            {
+                failures.Append(calendar).Append(' ').Append(isoDate).Append(": ").AppendLine(roundTripped);
+            }
+        }
+
+        failures.ToString().Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Nothing inside a table moves. The two calendars are read across their whole tabulated span and
+    /// have to answer exactly what they answered before, which is what makes this a fallback rather than
+    /// a replacement.
+    /// </summary>
+    /// <remarks>
+    /// Except where the table contradicts itself, which <c>KoreanLunisolarCalendar</c> does:
+    /// <c>GetMonth</c> names month 13 for 1189-01-09 while <c>GetLeapMonth</c> reports that year as
+    /// having none, so <c>GetDaysInMonth</c> refuses the month <c>GetMonth</c> just named. Those dates
+    /// used to come back as ISO fields under the calendar's name — the same defect from a second cause —
+    /// and are now reckoned like the ones past the end of the table. They are skipped here because there
+    /// is no table answer to compare against.
+    /// </remarks>
+    [TestCase("chinese", "1901-02-19", "2101-01-28")]
+    [TestCase("dangi", "0918-02-19", "2051-02-10")]
+    public void ADateInsideTheTableIsStillAnsweredByTheTable(string calendar, string first, string last)
+    {
+        var table = calendar switch
+        {
+            "chinese" => (EastAsianLunisolarCalendar) new ChineseLunisolarCalendar(),
+            _ => new KoreanLunisolarCalendar(),
+        };
+
+        var failures = new StringBuilder();
+        var sampled = 0;
+
+        var from = DateTime.ParseExact(first, "yyyy-MM-dd", CultureInfo.InvariantCulture);
+        var to = DateTime.ParseExact(last, "yyyy-MM-dd", CultureInfo.InvariantCulture);
+
+        for (var date = from; date <= to; date = date.AddDays(97))
+        {
+            try
+            {
+                _ = table.GetDaysInMonth(table.GetYear(date), table.GetMonth(date));
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                continue;
+            }
+
+            sampled++;
+            var isoDate = date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+            var reported = Fields(isoDate, calendar).Split('|');
+
+            var expected = string.Join(
+                "|",
+                table.GetYear(date).ToString(CultureInfo.InvariantCulture),
+                table.GetMonth(date).ToString(CultureInfo.InvariantCulture),
+                table.GetDayOfMonth(date).ToString(CultureInfo.InvariantCulture));
+
+            var actual = string.Join("|", reported[0], reported[1], reported[2]);
+            if (!string.Equals(expected, actual, StringComparison.Ordinal))
+            {
+                failures.Append(isoDate).Append(": table said ").Append(expected)
+                    .Append(", engine said ").AppendLine(actual);
+            }
+        }
+
+        sampled.Should().BeGreaterThan(700);
+        failures.ToString().Should().BeEmpty();
+    }
+}

--- a/Jint/Native/Temporal/NonIsoCalendars.Lunisolar.cs
+++ b/Jint/Native/Temporal/NonIsoCalendars.Lunisolar.cs
@@ -1,0 +1,756 @@
+namespace Jint.Native.Temporal;
+
+/// <summary>
+/// Which lunisolar reckoning a date is being read in — the two differ only in the meridian their
+/// new moons and solar terms are timed against.
+/// </summary>
+internal enum LunisolarRegion
+{
+    /// <summary>The Chinese calendar (<c>chinese</c>), timed against Beijing.</summary>
+    China,
+
+    /// <summary>The Korean calendar (<c>dangi</c>), timed against Seoul.</summary>
+    Korea,
+}
+
+/// <summary>
+/// One lunisolar year: where it starts, how many months it has, and which of them is the leap month.
+/// </summary>
+internal sealed class LunisolarYear
+{
+    /// <summary>The related Gregorian year, which is the year <c>chinese</c> and <c>dangi</c> report.</summary>
+    internal int Year;
+
+    /// <summary>Days since 1970-01-01 of the first day of the first month.</summary>
+    internal long Start;
+
+    /// <summary>Twelve, or thirteen in a year carrying a leap month.</summary>
+    internal int MonthCount;
+
+    /// <summary>Zero-based index of the leap month, or −1 when the year has none.</summary>
+    internal int LeapIndex;
+
+    /// <summary>
+    /// <see cref="MonthCount"/> + 1 entries: the first day of each month, and then the first day of the
+    /// following year, so a month's length is always the difference between two adjacent entries.
+    /// </summary>
+    internal long[] MonthStarts = [];
+
+    internal int DaysInYear => (int) (MonthStarts[MonthCount] - Start);
+
+    internal int DaysInMonth(int ordinalMonth) => (int) (MonthStarts[ordinalMonth] - MonthStarts[ordinalMonth - 1]);
+}
+
+/// <summary>
+/// The astronomical reckoning behind the Chinese and Korean lunisolar calendars, used where
+/// <see cref="System.Globalization.ChineseLunisolarCalendar"/> and
+/// <see cref="System.Globalization.KoreanLunisolarCalendar"/> stop.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The two BCL classes are tables, and short ones: <c>ChineseLunisolarCalendar</c> spans ISO 1901-02-19 to
+/// 2101-01-28 and <c>KoreanLunisolarCalendar</c> 918-02-19 to 2051-02-10, while
+/// <c>Temporal.PlainDate</c> spans ±10<sup>8</sup> days. Outside the table the engine used to answer with
+/// the ISO year, <c>M{isoMonth}</c> and twelve months a year — Gregorian fields wearing a lunisolar label
+/// (<see href="https://github.com/sebastienros/jint/issues/3451"/>). It cannot refuse instead:
+/// <see href="https://tc39.es/proposal-temporal/#sec-temporal-nonisocalendarisotodate">NonISOCalendarISOToDate</see>
+/// is declared as returning <em>a Calendar Date Record</em>, with no throw completion, and
+/// <c>get PlainDate.prototype.monthCode</c> reads it without <c>?</c>. So it has to answer, and the answer
+/// has to be the calendar.
+/// </para>
+/// <para>
+/// What is implemented is the reckoning both calendars are actually defined by: months begin on the day of
+/// an astronomical new moon in the calendar's own time zone, the eleventh month is the one containing the
+/// winter solstice, and a year that needs a thirteenth month takes it at the first month carrying no major
+/// solar term. The solar-longitude, new-moon and ephemeris-correction series are Reingold and Dershowitz,
+/// <em>Calendrical Calculations</em> (4th ed.), §14.4 and §19.4 — the same body of algorithms ICU reckons
+/// these calendars with. It is a fallback, not a replacement: inside a BCL calendar's range that table
+/// still answers, and <see cref="NonIsoCalendars"/> only reaches this file outside it.
+/// </para>
+/// <para>
+/// <b>Every search here is bounded.</b> The series are polynomials in centuries from J2000, and a quarter
+/// of a million years out their higher-order terms grow until the new-moon sequence is no longer strictly
+/// increasing. A correction loop that assumed monotonicity would not terminate there, and a CLR loop
+/// inside one interpreter step crosses no statement boundary, so no execution constraint could interrupt
+/// it (<see href="https://github.com/sebastienros/jint/issues/3428"/>). Each loop below therefore has an
+/// iteration cap and a defined answer when it reaches it: further out the reckoning degrades, which
+/// implementation-defined permits, but it always answers and always returns.
+/// </para>
+/// </remarks>
+internal static class LunisolarAstronomy
+{
+    private const double MeanSynodicMonth = 29.530588861;
+    private const double MeanTropicalYear = 365.242189;
+
+    /// <summary>Days since 1970-01-01 of 2000-01-01 12:00 UT, the epoch the series are written against.</summary>
+    private const double J2000 = 10957.5;
+
+    /// <summary>The solar longitude of the winter solstice, which defines the eleventh month.</summary>
+    private const double WinterSolstice = 270.0;
+
+    /// <summary>
+    /// How far a bounded correction loop may walk. Every one of them normally settles in one or two
+    /// steps; the cap only matters where the series stop being monotone, and there it fixes an answer
+    /// rather than searching forever.
+    /// </summary>
+    private const int MaxCorrectionSteps = 8;
+
+    /// <summary>
+    /// How far the winter-solstice scan may walk from its estimate. The estimate is accurate to about a
+    /// day for any date the series still models, and one year of slack covers the rest.
+    /// </summary>
+    private const int MaxSolsticeScan = 400;
+
+    private static readonly long _koreaZoneChange1912 = TemporalHelpers.IsoDateToDays(1912, 1, 1);
+    private static readonly long _koreaZoneChange1954 = TemporalHelpers.IsoDateToDays(1954, 3, 21);
+    private static readonly long _koreaZoneChange1961 = TemporalHelpers.IsoDateToDays(1961, 8, 10);
+    private static readonly long _daysTo1900 = TemporalHelpers.IsoDateToDays(1900, 1, 1);
+
+    // Reading a date's fields asks for the same year once per accessor, and a year costs a dozen new
+    // moons and a pair of solstice searches to build. One entry per calendar is enough for that, and
+    // [ThreadStatic] is what makes it safe without a lock: the value is a pure function of the year, so
+    // two threads computing it separately compute the same thing, and neither can see the other's
+    // half-written object. Nothing engine-affine goes in here.
+    [ThreadStatic]
+    private static LunisolarYear? _memoChina;
+
+    [ThreadStatic]
+    private static LunisolarYear? _memoKorea;
+
+    /// <summary>
+    /// The lunisolar year containing <paramref name="days"/> (days since 1970-01-01).
+    /// </summary>
+    internal static LunisolarYear ForFixed(long days, LunisolarRegion region)
+    {
+        var memo = region == LunisolarRegion.China ? _memoChina : _memoKorea;
+        if (memo is not null && days >= memo.Start && days < memo.MonthStarts[memo.MonthCount])
+        {
+            return memo;
+        }
+
+        return Remember(Build(NewYearOnOrBefore(days, region), region), region);
+    }
+
+    /// <summary>
+    /// The lunisolar year whose first month falls in the Gregorian year <paramref name="year"/>, or null
+    /// when no lunisolar year starts in it — reachable only where the series have drifted far enough for
+    /// a Gregorian year to contain no new year at all.
+    /// </summary>
+    internal static LunisolarYear? ForYear(int year, LunisolarRegion region)
+    {
+        var memo = region == LunisolarRegion.China ? _memoChina : _memoKorea;
+        if (memo is not null && memo.Year == year)
+        {
+            return memo;
+        }
+
+        // A related Gregorian year outside Temporal's own ISO range cannot name a representable date
+        // whatever this answers, and the series are polynomials: evaluating them at an arbitrary caller-
+        // supplied year is how a field record ends up built from an overflowed double.
+        if (year < -271821 || year > 275760)
+        {
+            return null;
+        }
+
+        // A lunisolar new year falls in the first two months of its related Gregorian year, so the new
+        // year on or before that year's 1 July is normally the one wanted. The two bounded walks below
+        // correct for a drift large enough to have moved it out of the first half of the year.
+        var start = NewYearOnOrBefore(TemporalHelpers.IsoDateToDays(year, 7, 1), region);
+
+        for (var i = 0; i < MaxCorrectionSteps && GregorianYearOf(start) > year; i++)
+        {
+            start = NewYearOnOrBefore(start - 1, region);
+        }
+
+        for (var i = 0; i < MaxCorrectionSteps; i++)
+        {
+            var next = NewYearOnOrBefore(start + 400, region);
+            if (next <= start || GregorianYearOf(next) > year)
+            {
+                break;
+            }
+
+            start = next;
+        }
+
+        return GregorianYearOf(start) == year ? Remember(Build(start, region), region) : null;
+    }
+
+    private static LunisolarYear Remember(LunisolarYear year, LunisolarRegion region)
+    {
+        if (region == LunisolarRegion.China)
+        {
+            _memoChina = year;
+        }
+        else
+        {
+            _memoKorea = year;
+        }
+
+        return year;
+    }
+
+    private static LunisolarYear Build(long start, LunisolarRegion region)
+    {
+        // 400 days is longer than any lunisolar year (thirteen months is at most 385 days) and shorter
+        // than two of them, so the new year on or before it is always the following one.
+        var next = NewYearOnOrBefore(start + 400, region);
+
+        var starts = new long[14];
+        starts[0] = start;
+
+        var count = 13;
+        for (var k = 1; k <= 13; k++)
+        {
+            starts[k] = NewMoonOnOrAfter(starts[k - 1] + 1, region);
+            if (starts[k] >= next)
+            {
+                count = k;
+                break;
+            }
+        }
+
+        starts[count] = System.Math.Max(next, starts[count - 1] + 1);
+
+        var leapIndex = -1;
+        if (count == 13)
+        {
+            for (var k = 0; k < count; k++)
+            {
+                // NoMajorSolarTerm is the cheap half of the test and is true for at most a month or two
+                // in a year, so IsLeapMonth -- which has to reckon the whole sui the month belongs to --
+                // is asked only about those.
+                if (NoMajorSolarTerm(starts[k], region) && IsLeapMonth(starts[k], region))
+                {
+                    leapIndex = k;
+                    break;
+                }
+            }
+
+            // A thirteen-month year has a leap month by construction. Where the series have degraded far
+            // enough that no month reports itself leap, the last one takes the role, so that the display
+            // months stay inside M01..M12 and the month codes stay well-formed.
+            if (leapIndex < 0)
+            {
+                leapIndex = count - 1;
+            }
+        }
+
+        return new LunisolarYear
+        {
+            Year = GregorianYearOf(start),
+            Start = start,
+            MonthCount = count,
+            LeapIndex = leapIndex,
+            MonthStarts = starts,
+        };
+    }
+
+    #region Lunisolar structure
+
+    /// <summary>
+    /// The first day of the lunisolar year containing <paramref name="days"/>.
+    /// </summary>
+    private static long NewYearOnOrBefore(long days, LunisolarRegion region)
+    {
+        var newYear = NewYearInSui(days, region);
+        return days >= newYear ? newYear : NewYearInSui(days - 180, region);
+    }
+
+    /// <summary>
+    /// The first day of the lunisolar year in the <em>sui</em> — the solstice-to-solstice span —
+    /// containing <paramref name="days"/>. A sui of thirteen new moons carries the leap month, and the
+    /// new year is then one month later than it would otherwise be.
+    /// </summary>
+    private static long NewYearInSui(long days, LunisolarRegion region)
+    {
+        var s1 = WinterSolsticeOnOrBefore(days, region);
+        var s2 = WinterSolsticeOnOrBefore(s1 + 370, region);
+        var m12 = NewMoonOnOrAfter(s1 + 1, region);
+        var m13 = NewMoonOnOrAfter(m12 + 1, region);
+        var nextM11 = NewMoonBefore(s2 + 1, region);
+
+        var leapSui = (long) System.Math.Round((nextM11 - m12) / MeanSynodicMonth) == 12L;
+        if (leapSui && (NoMajorSolarTerm(m12, region) || NoMajorSolarTerm(m13, region)))
+        {
+            return NewMoonOnOrAfter(m13 + 1, region);
+        }
+
+        return m13;
+    }
+
+    /// <summary>
+    /// Whether the month beginning on <paramref name="monthStart"/> is the leap month of the
+    /// <em>sui</em> it falls in — the solstice-to-solstice span, which is the window the rule is stated
+    /// over rather than the calendar year.
+    /// </summary>
+    /// <remarks>
+    /// Reading it off the calendar year instead is wrong, and 2033 is where it shows: that year holds two
+    /// months with no major solar term, one in a sui of twelve months, which can carry no leap month at
+    /// all, and one in the following sui of thirteen, which is the leap eleventh month the calendar
+    /// actually has.
+    /// </remarks>
+    private static bool IsLeapMonth(long monthStart, LunisolarRegion region)
+    {
+        var s1 = WinterSolsticeOnOrBefore(monthStart, region);
+        var s2 = WinterSolsticeOnOrBefore(s1 + 370, region);
+        var m12 = NewMoonOnOrAfter(s1 + 1, region);
+        var nextM11 = NewMoonBefore(s2 + 1, region);
+
+        if ((long) System.Math.Round((nextM11 - m12) / MeanSynodicMonth) != 12L)
+        {
+            // A sui of twelve months has no month to spare.
+            return false;
+        }
+
+        // The leap month is the first month of the sui carrying no major solar term, so any earlier one
+        // that carries none takes the role instead.
+        var month = m12;
+        for (var i = 0; i < 14 && month < monthStart; i++)
+        {
+            if (NoMajorSolarTerm(month, region))
+            {
+                return false;
+            }
+
+            var following = NewMoonOnOrAfter(month + 1, region);
+            if (following <= month)
+            {
+                break;
+            }
+
+            month = following;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Whether the month beginning on <paramref name="monthStart"/> contains no major solar term, which
+    /// is the first half of what makes a month a leap month.
+    /// </summary>
+    private static bool NoMajorSolarTerm(long monthStart, LunisolarRegion region)
+    {
+        return CurrentMajorSolarTerm(monthStart, region)
+            == CurrentMajorSolarTerm(NewMoonOnOrAfter(monthStart + 1, region), region);
+    }
+
+    /// <summary>The index, 1 to 12, of the major solar term in force on <paramref name="days"/>.</summary>
+    private static int CurrentMajorSolarTerm(long days, LunisolarRegion region)
+    {
+        var longitude = SolarLongitude(UniversalFromStandard(days, region));
+        return Amod(2 + (int) System.Math.Floor(longitude / 30.0), 12);
+    }
+
+    private static long WinterSolsticeOnOrBefore(long days, LunisolarRegion region)
+    {
+        var approx = EstimatePriorSolarLongitude(WinterSolstice, UniversalFromStandard(days + 1, region));
+        var candidate = (long) System.Math.Floor(approx) - 1L;
+
+        for (var i = 0; i < MaxSolsticeScan; i++)
+        {
+            if (WinterSolstice < SolarLongitude(UniversalFromStandard(candidate + 1, region)))
+            {
+                return candidate;
+            }
+
+            candidate++;
+        }
+
+        return (long) System.Math.Floor(approx);
+    }
+
+    private static long NewMoonOnOrAfter(long days, LunisolarRegion region)
+    {
+        var moment = UniversalFromStandard(days, region);
+        var moon = NthNewMoon(NewMoonIndexBefore(moment) + 1);
+        return (long) System.Math.Floor(StandardFromUniversal(moon, region));
+    }
+
+    private static long NewMoonBefore(long days, LunisolarRegion region)
+    {
+        var moment = UniversalFromStandard(days, region);
+        var moon = NthNewMoon(NewMoonIndexBefore(moment));
+        return (long) System.Math.Floor(StandardFromUniversal(moon, region));
+    }
+
+    /// <summary>
+    /// The largest <c>n</c> with <c>NthNewMoon(n)</c> strictly before <paramref name="moment"/>. The mean
+    /// synodic month gives a first index; the three bounded walks below correct it.
+    /// </summary>
+    private static long NewMoonIndexBefore(double moment)
+    {
+        var n = (long) System.Math.Round((moment - _newMoonZero) / MeanSynodicMonth);
+
+        // The mean synodic month alone is not enough of an estimate: the difference between dynamical and
+        // universal time is a quadratic in the year, and a hundred thousand years out it is more than a
+        // year on its own, which is a dozen months of error in a linear guess. Stepping by the residual
+        // converges from any distance, in one step for every date the series are accurate over.
+        for (var i = 0; i < MaxCorrectionSteps; i++)
+        {
+            var step = (long) System.Math.Round((moment - NthNewMoon(n)) / MeanSynodicMonth);
+            if (step == 0L)
+            {
+                break;
+            }
+
+            n += step;
+        }
+
+        for (var i = 0; i < MaxCorrectionSteps && NthNewMoon(n) >= moment; i++)
+        {
+            n--;
+        }
+
+        for (var i = 0; i < MaxCorrectionSteps && NthNewMoon(n + 1) < moment; i++)
+        {
+            n++;
+        }
+
+        return n;
+    }
+
+    #endregion
+
+    #region Time zones
+
+    /// <summary>
+    /// The calendar's own zone offset, in days. Both calendars are reckoned in civil time at a meridian,
+    /// and both changed which one: China from Beijing local mean time to UTC+8 in 1929, Korea from
+    /// China's meridian to its own in 1912 and then twice more.
+    /// </summary>
+    private static double Zone(double moment, LunisolarRegion region)
+    {
+        var days = (long) System.Math.Floor(moment);
+
+        if (region == LunisolarRegion.China)
+        {
+            // 1397/180 hours is the mean solar time of 116°25′E, the meridian of the Beijing observatory.
+            return GregorianYearOf(days) < 1929 ? 1397.0 / 180.0 / 24.0 : 8.0 / 24.0;
+        }
+
+        // Korea reckoned the Chinese calendar, in Chinese time, until 1912; KoreanLunisolarCalendar's own
+        // table says so, and reading those centuries against Seoul's meridian instead disagrees with it
+        // more than twice as often. From 1912 the reckoning is Korea's own civil time, which moved twice.
+        if (days < _koreaZoneChange1912) return 1397.0 / 180.0 / 24.0;
+        if (days < _koreaZoneChange1954) return 9.0 / 24.0;
+        if (days < _koreaZoneChange1961) return 8.5 / 24.0;
+        return 9.0 / 24.0;
+    }
+
+    private static double UniversalFromStandard(double moment, LunisolarRegion region) => moment - Zone(moment, region);
+
+    private static double StandardFromUniversal(double moment, LunisolarRegion region) => moment + Zone(moment, region);
+
+    #endregion
+
+    #region Solar longitude
+
+    private static readonly int[] _solarCoefficients =
+    [
+        403406, 195207, 119433, 112392, 3891, 2819, 1721, 660, 350, 334,
+        314, 268, 242, 234, 158, 132, 129, 114, 99, 93,
+        86, 78, 72, 68, 64, 46, 38, 37, 32, 29,
+        28, 27, 27, 25, 24, 21, 21, 20, 18, 17,
+        14, 13, 13, 13, 12, 10, 10, 10, 10,
+    ];
+
+    private static readonly double[] _solarMultipliers =
+    [
+        270.54861, 340.19128, 63.91854, 331.26220, 317.843, 86.631, 240.052, 310.26, 247.23, 260.87,
+        297.82, 343.14, 166.79, 81.53, 3.50, 132.75, 182.95, 162.03, 29.8, 266.4,
+        249.2, 157.6, 257.8, 185.1, 69.9, 8.0, 197.1, 250.4, 65.3, 162.7,
+        341.5, 291.6, 98.5, 146.7, 110.0, 5.2, 342.6, 230.9, 256.1, 45.3,
+        242.9, 115.2, 151.8, 285.3, 53.3, 126.6, 205.7, 85.9, 146.1,
+    ];
+
+    private static readonly double[] _solarAddends =
+    [
+        0.9287892, 35999.1376958, 35999.4089666, 35998.7287385, 71998.20261, 71998.4403, 36000.35726,
+        71997.4812, 32964.4678, -19.4410, 445267.1117, 45036.8840, 3.1008, 22518.4434, -19.9739,
+        65928.9345, 9038.0293, 3034.7684, 33718.148, 3034.448, -2280.773, 29929.992, 31556.493,
+        149.588, 9037.750, 107997.405, -4444.176, 151.771, 67555.316, 31556.080, -4561.540,
+        107996.706, 1221.655, 62894.167, 31437.369, 14578.298, -31931.757, 34777.243, 1221.999,
+        62894.511, -4442.039, 107997.909, 119.066, 16859.071, -4.578, 26895.292, -39.127,
+        12297.536, 90073.778,
+    ];
+
+    /// <summary>The apparent longitude of the sun, in degrees, at a universal <paramref name="moment"/>.</summary>
+    private static double SolarLongitude(double moment)
+    {
+        var c = JulianCenturies(moment);
+
+        var sum = 0.0;
+        for (var i = 0; i < _solarCoefficients.Length; i++)
+        {
+            sum += _solarCoefficients[i] * SinDegrees(_solarMultipliers[i] + _solarAddends[i] * c);
+        }
+
+        var longitude = 282.7771834 + 36000.76953744 * c + 0.000005729577951308232 * sum;
+        return Mod(longitude + Aberration(c) + Nutation(c), 360.0);
+    }
+
+    private static double Nutation(double c)
+    {
+        var a = 124.90 - 1934.134 * c + 0.002063 * c * c;
+        var b = 201.11 + 72001.5377 * c + 0.00057 * c * c;
+        return -0.004778 * SinDegrees(a) - 0.0003667 * SinDegrees(b);
+    }
+
+    private static double Aberration(double c)
+    {
+        return 0.0000974 * CosDegrees(177.63 + 35999.01848 * c) - 0.005575;
+    }
+
+    /// <summary>
+    /// An estimate of the last moment at or before <paramref name="moment"/> at which the sun was at
+    /// <paramref name="longitude"/>, run back at the sun's mean rate and then corrected once.
+    /// </summary>
+    private static double EstimatePriorSolarLongitude(double longitude, double moment)
+    {
+        var rate = MeanTropicalYear / 360.0;
+        var tau = moment - rate * Mod(SolarLongitude(moment) - longitude, 360.0);
+        var delta = Mod(SolarLongitude(tau) - longitude + 180.0, 360.0) - 180.0;
+        return System.Math.Min(moment, tau - rate * delta);
+    }
+
+    #endregion
+
+    #region New moons
+
+    private static readonly double[] _newMoonSineCoefficients =
+    [
+        -0.40720, 0.17241, 0.01608, 0.01039, 0.00739, -0.00514, 0.00208, -0.00111, -0.00057, 0.00056,
+        -0.00042, 0.00042, 0.00038, -0.00024, -0.00007, 0.00004, 0.00004, 0.00003, 0.00003, -0.00003,
+        0.00003, -0.00002, -0.00002, 0.00002,
+    ];
+
+    private static readonly int[] _newMoonEccentricityFactors =
+    [
+        0, 1, 0, 0, 1, 1, 2, 0, 0, 1, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    ];
+
+    private static readonly int[] _newMoonSolarCoefficients =
+    [
+        0, 1, 0, 0, -1, 1, 2, 0, 0, 1, 0, 1, -1, 2, 0, 3, 1, 0, 1, -1, -1, 1, 0, 0,
+    ];
+
+    private static readonly int[] _newMoonLunarCoefficients =
+    [
+        1, 0, 2, 0, 1, 1, 0, 1, 1, 2, 3, 0, 0, 1, 0, 0, 1, 2, 2, 0, 1, 1, 3, 4,
+    ];
+
+    private static readonly int[] _newMoonMoonCoefficients =
+    [
+        0, 0, 0, 2, 0, 0, 0, -2, 2, 0, 0, 2, 2, 0, 4, 0, -2, 2, 0, -2, -2, 2, 0, 0,
+    ];
+
+    private static readonly double[] _newMoonAdditionalConstants =
+    [
+        251.88, 251.83, 349.42, 84.66, 141.74, 207.14, 154.84, 34.52, 207.19, 291.34, 161.72, 239.56, 331.55,
+    ];
+
+    private static readonly double[] _newMoonAdditionalCoefficients =
+    [
+        0.016321, 26.651886, 36.412478, 18.206239, 53.303771, 2.453732, 7.306860, 27.261239, 0.121824,
+        1.844379, 24.198154, 25.513099, 3.592518,
+    ];
+
+    private static readonly double[] _newMoonAdditionalFactors =
+    [
+        0.000165, 0.000164, 0.000126, 0.000110, 0.000062, 0.000060, 0.000056, 0.000047, 0.000042, 0.000040,
+        0.000037, 0.000035, 0.000023,
+    ];
+
+    /// <summary>
+    /// The universal moment of the <paramref name="n"/>th new moon after the one of January 2000,
+    /// counting the new moon of −11 CE as index 0.
+    /// </summary>
+    private static double NthNewMoon(long n)
+    {
+        var k = n - 24724L;
+        var c = k / 1236.85;
+        var c2 = c * c;
+        var c3 = c2 * c;
+        var c4 = c3 * c;
+
+        var approx = J2000
+            + 5.09766
+            + MeanSynodicMonth * 1236.85 * c
+            + 0.00015437 * c2
+            - 0.000000150 * c3
+            + 0.00000000073 * c4;
+
+        var eccentricity = 1.0 - 0.002516 * c - 0.0000074 * c2;
+        var solarAnomaly = 2.5534 + 29.10535670 * 1236.85 * c - 0.0000014 * c2 - 0.00000011 * c3;
+        var lunarAnomaly = 201.5643 + 385.81693528 * 1236.85 * c + 0.0107582 * c2 + 0.00001238 * c3 - 0.000000058 * c4;
+        var moonArgument = 160.7108 + 390.67050284 * 1236.85 * c - 0.0016118 * c2 - 0.00000227 * c3 + 0.000000011 * c4;
+        var omega = 124.7746 - 1.56375588 * 1236.85 * c + 0.0020672 * c2 + 0.00000215 * c3;
+
+        var eccentricitySquared = eccentricity * eccentricity;
+
+        var correction = -0.00017 * SinDegrees(omega);
+        for (var i = 0; i < _newMoonSineCoefficients.Length; i++)
+        {
+            var factor = _newMoonEccentricityFactors[i] switch
+            {
+                0 => 1.0,
+                1 => eccentricity,
+                _ => eccentricitySquared,
+            };
+
+            correction += _newMoonSineCoefficients[i]
+                * factor
+                * SinDegrees(
+                    _newMoonSolarCoefficients[i] * solarAnomaly
+                    + _newMoonLunarCoefficients[i] * lunarAnomaly
+                    + _newMoonMoonCoefficients[i] * moonArgument);
+        }
+
+        var extra = 0.000325 * SinDegrees(299.77 + 132.8475848 * c - 0.009173 * c2);
+
+        var additional = 0.0;
+        for (var i = 0; i < _newMoonAdditionalConstants.Length; i++)
+        {
+            additional += _newMoonAdditionalFactors[i]
+                * SinDegrees(_newMoonAdditionalConstants[i] + _newMoonAdditionalCoefficients[i] * k);
+        }
+
+        var moment = approx + correction + extra + additional;
+        return moment - EphemerisCorrection(moment);
+    }
+
+    #endregion
+
+    #region Ephemeris correction
+
+    // Hoisted rather than written as `params` arrays at the call sites: EphemerisCorrection runs on
+    // every solar-longitude and new-moon evaluation, and a params array there is an allocation per call.
+    private static readonly double[] _correction2006 = [62.92, 0.32217, 0.005589];
+    private static readonly double[] _correction1987 = [63.86, 0.3345, -0.060374, 0.0017275, 0.000651814, 0.00002373599];
+    private static readonly double[] _correction1900 = [-0.00002, 0.000297, 0.025184, -0.181133, 0.553040, -0.861938, 0.677066, -0.212591];
+    private static readonly double[] _correction1800 =
+    [
+        -0.000009, 0.003844, 0.083563, 0.865736, 4.867575, 15.845535, 31.332267, 38.291999,
+        28.316289, 11.636204, 2.043794,
+    ];
+    private static readonly double[] _correction1700 = [8.118780842, -0.005092142, 0.003336121, -0.0000266484];
+    private static readonly double[] _correction1600 = [120.0, -0.9808, -0.01532, 0.000140272128];
+    private static readonly double[] _correction0500 = [1574.2, -556.01, 71.23472, 0.319781, -0.8503463, -0.005050998, 0.0083572073];
+    private static readonly double[] _correctionAncient = [10583.6, -1014.41, 33.78311, -5.952053, -0.1798452, 0.022174192, 0.0090316521];
+
+    private static double JulianCenturies(double moment)
+    {
+        return (moment + EphemerisCorrection(moment) - J2000) / 36525.0;
+    }
+
+    /// <summary>
+    /// The difference between dynamical and universal time, in days, as a function of the year — the
+    /// piecewise fit of Reingold and Dershowitz, §14.2, itself following Morrison and Stephenson.
+    /// </summary>
+    private static double EphemerisCorrection(double moment)
+    {
+        var year = GregorianYearOf((long) System.Math.Floor(moment));
+        var c = (TemporalHelpers.IsoDateToDays(year, 7, 1) - _daysTo1900) / 36525.0;
+        var y2000 = year - 2000;
+
+        if (year >= 2051 && year <= 2150)
+        {
+            var t = (year - 1820) / 100.0;
+            return (-20.0 + 32.0 * t * t + 0.5628 * (2150 - year)) / 86400.0;
+        }
+
+        if (year >= 2006 && year <= 2050)
+        {
+            return Poly(y2000, _correction2006) / 86400.0;
+        }
+
+        if (year >= 1987 && year <= 2005)
+        {
+            return Poly(y2000, _correction1987) / 86400.0;
+        }
+
+        if (year >= 1900 && year <= 1986)
+        {
+            return Poly(c, _correction1900);
+        }
+
+        if (year >= 1800 && year <= 1899)
+        {
+            return Poly(c, _correction1800);
+        }
+
+        if (year >= 1700 && year <= 1799)
+        {
+            return Poly(year - 1700, _correction1700) / 86400.0;
+        }
+
+        if (year >= 1600 && year <= 1699)
+        {
+            return Poly(year - 1600, _correction1600) / 86400.0;
+        }
+
+        if (year >= 500 && year <= 1599)
+        {
+            return Poly((year - 1000) / 100.0, _correction0500) / 86400.0;
+        }
+
+        if (year > -500 && year < 500)
+        {
+            return Poly(year / 100.0, _correctionAncient) / 86400.0;
+        }
+
+        var far = (year - 1820) / 100.0;
+        return (-20.0 + 32.0 * far * far) / 86400.0;
+    }
+
+    #endregion
+
+    #region Arithmetic helpers
+
+    private static double Poly(double x, double[] coefficients)
+    {
+        var result = 0.0;
+        for (var i = coefficients.Length - 1; i >= 0; i--)
+        {
+            result = result * x + coefficients[i];
+        }
+
+        return result;
+    }
+
+    /// <summary>Non-negative modulo, which the trigonometric reductions all assume.</summary>
+    private static double Mod(double x, double y)
+    {
+        var r = x - y * System.Math.Floor(x / y);
+        return r < 0.0 ? r + y : r;
+    }
+
+    /// <summary>Modulo mapped into 1..<paramref name="y"/> rather than 0..<paramref name="y"/>−1.</summary>
+    private static int Amod(int x, int y)
+    {
+        var r = x % y;
+        if (r <= 0)
+        {
+            r += y;
+        }
+
+        return r;
+    }
+
+    private static double SinDegrees(double degrees) => System.Math.Sin(degrees * System.Math.PI / 180.0);
+
+    private static double CosDegrees(double degrees) => System.Math.Cos(degrees * System.Math.PI / 180.0);
+
+    /// <summary>The proleptic Gregorian year containing the given count of days since 1970-01-01.</summary>
+    private static int GregorianYearOf(long days) => NonIsoCalendars.IsoFromDays(days).Year;
+
+    #endregion
+
+    /// <summary>
+    /// The anchor <see cref="NewMoonIndexBefore"/> counts new moons from. Declared last on purpose:
+    /// static field initializers run in textual order, and computing it calls <see cref="NthNewMoon"/>,
+    /// which reads every series table above.
+    /// </summary>
+    private static readonly double _newMoonZero = NthNewMoon(0);
+}

--- a/Jint/Native/Temporal/NonIsoCalendars.cs
+++ b/Jint/Native/Temporal/NonIsoCalendars.cs
@@ -134,8 +134,8 @@ internal static class NonIsoCalendars
         {
             return calendar switch
             {
-                "chinese" => LunisolarToCalendarDate(ChineseCal, in isoDate),
-                "dangi" => LunisolarToCalendarDate(DangiCal, in isoDate),
+                "chinese" => LunisolarToCalendarDate(ChineseCal, LunisolarRegion.China, in isoDate),
+                "dangi" => LunisolarToCalendarDate(DangiCal, LunisolarRegion.Korea, in isoDate),
                 "hebrew" => HebrewToCalendarDate(in isoDate),
                 "persian" => PersianToCalendarDate(in isoDate),
                 "coptic" => FixedEpochToCalendarDate(CopticEpochDays, in isoDate),
@@ -150,7 +150,14 @@ internal static class NonIsoCalendars
         }
         catch (ArgumentOutOfRangeException)
         {
-            // Fall back to ISO-like fields when the ISO date is outside the .NET calendar's range
+            // Unreachable for the eleven calendars above, and it is the point of
+            // https://github.com/sebastienros/jint/issues/3451 that it is: answering with ISO fields under
+            // another calendar's name is indistinguishable downstream from answering correctly. Each of
+            // the eleven now has a reckoning of its own to fall back on past the end of whatever backs it
+            // -- the lunisolar pair since #3451, the others before it -- and each falls back to that where
+            // it applies rather than to this. What remains here is the last resort of a static analysis
+            // that cannot see that, and Jint.Tests/Runtime/NonIsoCalendarOutOfRangeFieldTests.cs is what
+            // says no calendar reaches it.
             var monthCode = $"M{isoDate.Month:D2}";
             var daysInMonth = IsoDate.IsoDateInMonth(isoDate.Year, isoDate.Month);
             var daysInYear = IsoDate.IsLeapYear(isoDate.Year) ? 366 : 365;
@@ -184,8 +191,8 @@ internal static class NonIsoCalendars
 
         var result = calendar switch
         {
-            "chinese" => LunisolarDateToIso(ChineseCal, year, monthCode, month, day, overflow),
-            "dangi" => LunisolarDateToIso(DangiCal, year, monthCode, month, day, overflow),
+            "chinese" => LunisolarDateToIso(ChineseCal, LunisolarRegion.China, year, monthCode, month, day, overflow),
+            "dangi" => LunisolarDateToIso(DangiCal, LunisolarRegion.Korea, year, monthCode, month, day, overflow),
             "hebrew" => HebrewDateToIso(year, monthCode, month, day, overflow),
             "persian" => PersianDateToIso(year, monthCode, month, day, overflow),
             "coptic" => FixedEpochDateToIso(CopticEpochDays, 13, year, monthCode, month, day, overflow),
@@ -1607,56 +1614,97 @@ internal static class NonIsoCalendars
 
     #region Lunisolar (Chinese/Dangi) Calendar
 
-    private static CalendarDate LunisolarToCalendarDate(EastAsianLunisolarCalendar cal, in IsoDate isoDate)
+    private static CalendarDate LunisolarToCalendarDate(EastAsianLunisolarCalendar cal, LunisolarRegion region, in IsoDate isoDate)
     {
-        var dt = new DateTime(isoDate.Year, isoDate.Month, isoDate.Day);
-
-        // If outside supported range, fall back to ISO-like fields
-        if (dt < cal.MinSupportedDateTime || dt > cal.MaxSupportedDateTime)
+        // ChineseLunisolarCalendar is a table of ISO 1901-02-19 to 2101-01-28 and KoreanLunisolarCalendar
+        // one of 918-02-19 to 2051-02-10, while Temporal.PlainDate spans a quarter of a million years each
+        // way. Outside the table the same calendar is reckoned astronomically rather than answered with
+        // ISO fields under its name (https://github.com/sebastienros/jint/issues/3451). System.DateTime
+        // cannot even hold an ISO year outside 1-9999, so that is checked before one is constructed.
+        if (isoDate.Year < 1 || isoDate.Year > 9999)
         {
-            throw new ArgumentOutOfRangeException(nameof(isoDate));
+            return LunisolarAlgorithmicFromIso(region, in isoDate);
         }
 
-        var year = cal.GetYear(dt);
-        var ordinalMonth = cal.GetMonth(dt);
-        var day = cal.GetDayOfMonth(dt);
-        var leapMonth = cal.GetLeapMonth(year);
+        var dt = new DateTime(isoDate.Year, isoDate.Month, isoDate.Day);
 
-        bool isLeapMonth;
-        string monthCode;
-
-        if (leapMonth > 0 && ordinalMonth >= leapMonth)
+        if (dt < cal.MinSupportedDateTime || dt > cal.MaxSupportedDateTime)
         {
-            if (ordinalMonth == leapMonth)
+            return LunisolarAlgorithmicFromIso(region, in isoDate);
+        }
+
+        try
+        {
+            var year = cal.GetYear(dt);
+            var ordinalMonth = cal.GetMonth(dt);
+            var day = cal.GetDayOfMonth(dt);
+            var leapMonth = cal.GetLeapMonth(year);
+
+            bool isLeapMonth;
+            string monthCode;
+
+            if (leapMonth > 0 && ordinalMonth >= leapMonth)
             {
-                var displayMonth = leapMonth - 1;
-                isLeapMonth = true;
-                monthCode = $"M{displayMonth:D2}L";
+                if (ordinalMonth == leapMonth)
+                {
+                    var displayMonth = leapMonth - 1;
+                    isLeapMonth = true;
+                    monthCode = $"M{displayMonth:D2}L";
+                }
+                else
+                {
+                    var displayMonth = ordinalMonth - 1;
+                    isLeapMonth = false;
+                    monthCode = $"M{displayMonth:D2}";
+                }
             }
             else
             {
-                var displayMonth = ordinalMonth - 1;
                 isLeapMonth = false;
-                monthCode = $"M{displayMonth:D2}";
+                monthCode = $"M{ordinalMonth:D2}";
             }
+
+            var monthsInYear = leapMonth > 0 ? 13 : 12;
+            var daysInMonth = cal.GetDaysInMonth(year, ordinalMonth);
+            var daysInYear = cal.GetDaysInYear(year);
+            var inLeapYear = leapMonth > 0;
+
+            return new CalendarDate(year, ordinalMonth, monthCode, day, isLeapMonth, monthsInYear, daysInMonth, daysInYear, inLeapYear);
         }
-        else
+        catch (ArgumentOutOfRangeException)
         {
-            isLeapMonth = false;
-            monthCode = $"M{ordinalMonth:D2}";
+            // The table advertises the date and then declines part of it. KoreanLunisolarCalendar reports
+            // month 13 for 1189-01-09 and no leap month for the year holding it, so GetDaysInMonth refuses
+            // the very month GetMonth just named -- and the date came back as ISO fields under the
+            // calendar's name, which is the defect this arm exists to stop.
+            return LunisolarAlgorithmicFromIso(region, in isoDate);
         }
-
-        var monthsInYear = leapMonth > 0 ? 13 : 12;
-        var daysInMonth = cal.GetDaysInMonth(year, ordinalMonth);
-        var daysInYear = cal.GetDaysInYear(year);
-        var inLeapYear = leapMonth > 0;
-
-        return new CalendarDate(year, ordinalMonth, monthCode, day, isLeapMonth, monthsInYear, daysInMonth, daysInYear, inLeapYear);
     }
 
-    private static IsoDate? LunisolarDateToIso(EastAsianLunisolarCalendar cal, int year, string? monthCode, int month, int day, string overflow)
+    private static IsoDate? LunisolarDateToIso(EastAsianLunisolarCalendar cal, LunisolarRegion region, int year, string? monthCode, int month, int day, string overflow)
     {
         int ordinalMonth;
+
+        // GetLeapMonth answers for exactly the years the BCL table covers and throws for the rest, so it
+        // is also the test for which reckoning a year belongs to. Outside the table the whole year --
+        // its month count, which month is the leap one, how long each is, and where day 1 falls -- comes
+        // from the astronomical reckoning instead, so that a date cannot be resolved half one way.
+        LunisolarYear? algorithmic = null;
+        var leapMonth = 0;
+        try
+        {
+            leapMonth = cal.GetLeapMonth(year);
+        }
+        catch
+        {
+            algorithmic = LunisolarAstronomy.ForYear(year, region);
+            if (algorithmic is null)
+            {
+                return null;
+            }
+
+            leapMonth = algorithmic.LeapIndex + 1;
+        }
 
         if (monthCode is not null)
         {
@@ -1667,16 +1715,6 @@ internal static class NonIsoCalendars
             if (displayMonth < 1 || displayMonth > 12)
             {
                 return null;
-            }
-
-            var leapMonth = 0;
-            try
-            {
-                leapMonth = cal.GetLeapMonth(year);
-            }
-            catch
-            {
-                // Year out of range
             }
 
             if (isLeap)
@@ -1725,15 +1763,7 @@ internal static class NonIsoCalendars
         }
 
         // Constrain ordinal month to valid range
-        var maxMonths = 12;
-        try
-        {
-            maxMonths = cal.GetLeapMonth(year) > 0 ? 13 : 12;
-        }
-        catch
-        {
-            // Year out of range
-        }
+        var maxMonths = algorithmic?.MonthCount ?? (leapMonth > 0 ? 13 : 12);
 
         if (string.Equals(overflow, "constrain", StringComparison.Ordinal))
         {
@@ -1746,13 +1776,20 @@ internal static class NonIsoCalendars
 
         // Constrain day
         int maxDay;
-        try
+        if (algorithmic is not null)
         {
-            maxDay = cal.GetDaysInMonth(year, ordinalMonth);
+            maxDay = algorithmic.DaysInMonth(ordinalMonth);
         }
-        catch
+        else
         {
-            maxDay = 30;
+            try
+            {
+                maxDay = cal.GetDaysInMonth(year, ordinalMonth);
+            }
+            catch
+            {
+                maxDay = 30;
+            }
         }
 
         if (string.Equals(overflow, "constrain", StringComparison.Ordinal))
@@ -1764,6 +1801,11 @@ internal static class NonIsoCalendars
             return null;
         }
 
+        if (algorithmic is not null)
+        {
+            return IsoFromDays(algorithmic.MonthStarts[ordinalMonth - 1] + day - 1);
+        }
+
         try
         {
             var dt = cal.ToDateTime(year, ordinalMonth, day, 0, 0, 0, 0);
@@ -1771,8 +1813,65 @@ internal static class NonIsoCalendars
         }
         catch
         {
+            // The year is one the table covers, but this particular date is past the table's own first
+            // or last day -- the Chinese table begins at 1901-02-19 and ends at 2101-01-28, neither of
+            // which is a year boundary. Answer it in the reckoning the years on either side use rather
+            // than with nothing.
+            return LunisolarAlgorithmicToIso(region, year, ordinalMonth, day);
+        }
+    }
+
+    /// <summary>
+    /// Reads an ISO date as a lunisolar date without the BCL table, for the dates outside it.
+    /// </summary>
+    private static CalendarDate LunisolarAlgorithmicFromIso(LunisolarRegion region, in IsoDate isoDate)
+    {
+        var days = TemporalHelpers.IsoDateToDays(isoDate.Year, isoDate.Month, isoDate.Day);
+        var year = LunisolarAstronomy.ForFixed(days, region);
+
+        var ordinalMonth = 1;
+        while (ordinalMonth < year.MonthCount && year.MonthStarts[ordinalMonth] <= days)
+        {
+            ordinalMonth++;
+        }
+
+        var day = (int) (days - year.MonthStarts[ordinalMonth - 1]) + 1;
+        var isLeapMonth = ordinalMonth - 1 == year.LeapIndex;
+
+        // A leap month carries the display number of the month it follows, and every month after it in
+        // the year is displaced by one -- which is exactly how the BCL arm above reads GetLeapMonth.
+        var displayMonth = year.LeapIndex >= 0 && ordinalMonth - 1 >= year.LeapIndex ? ordinalMonth - 1 : ordinalMonth;
+        var monthCode = isLeapMonth ? $"M{displayMonth:D2}L" : $"M{displayMonth:D2}";
+
+        return new CalendarDate(
+            year.Year,
+            ordinalMonth,
+            monthCode,
+            day,
+            isLeapMonth,
+            year.MonthCount,
+            year.DaysInMonth(ordinalMonth),
+            year.DaysInYear,
+            year.MonthCount == 13);
+    }
+
+    /// <summary>
+    /// Places an already-resolved ordinal month and day in a lunisolar year the BCL table does not cover.
+    /// </summary>
+    private static IsoDate? LunisolarAlgorithmicToIso(LunisolarRegion region, int year, int ordinalMonth, int day)
+    {
+        var resolved = LunisolarAstronomy.ForYear(year, region);
+        if (resolved is null || ordinalMonth < 1 || ordinalMonth > resolved.MonthCount)
+        {
             return null;
         }
+
+        if (day < 1 || day > resolved.DaysInMonth(ordinalMonth))
+        {
+            return null;
+        }
+
+        return IsoFromDays(resolved.MonthStarts[ordinalMonth - 1] + day - 1);
     }
 
     #endregion
@@ -2974,6 +3073,13 @@ internal static class NonIsoCalendars
     {
         return TemporalHelpers.IsoDateToDays(year, month, day) + 2440588L;
     }
+
+    /// <summary>
+    /// The proleptic ISO date for a count of days since 1970-01-01, which is the scale
+    /// <see cref="LunisolarAstronomy"/> reckons in. <see cref="JdnToIso"/> answers for every Julian Day
+    /// Number, so the nullable it returns never is one here.
+    /// </summary>
+    internal static IsoDate IsoFromDays(long days) => JdnToIso(days + 2440588L)!.Value;
 
     /// <summary>
     /// Converts an Islamic Umm al-Qura calendar date to an ISO date.

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -2317,15 +2317,20 @@ arithmetic for another. The provider is asked for every calendar it claims, and 
 conversions are already what every field accessor reads. Over the same 774,158-case sweep the two paths
 agree on 100.000% of cases within the BCL calendars' ranges. The 1.7% that differ are all `chinese` and
 `dangi` dates whose arithmetic leaves `ChineseLunisolarCalendar`'s 1901–2101 or `KoreanLunisolarCalendar`'s
-2051 ceiling, and out there the two now part in kind rather than in detail:
+2051 ceiling, and out there the two part in kind rather than in detail:
 [#3452](https://github.com/sebastienros/jint/pull/3452) made the engine's own arithmetic **refuse** a result
-it cannot represent, while the provider path goes on answering — because `IsoToCalendarFields` and
-`CalendarFieldsToIso` fall back to ISO-like fields past the end of a BCL calendar, and always did, which is
-what every field accessor on such a date has always read. So
+it cannot represent, while the provider path — which is written in the two conversions, and those still
+answer — goes on answering. So
 `Temporal.PlainDate.from('1950-01-01').withCalendar('chinese').subtract({ years: 100 })` is a `RangeError`
-on a default engine and `1849-11-13` under any provider that claims `chinese`. Both terminate, and neither
-is the Chinese calendar. To keep a calendar on the engine's own arithmetic, do not claim it: override
-`IsSupported` to return `false` for it, or drop it from `GetSupportedCalendars`.
+on a default engine and a date under any provider that claims `chinese`. To keep a calendar on the engine's
+own arithmetic, do not claim it: override `IsSupported` to return `false` for it, or drop it from
+`GetSupportedCalendars`.
+
+What that answering path answers *with* changed after this section was written:
+[4.50](#450-a-date-past-a-lunisolar-calendars-table-is-still-reckoned-in-that-calendar-3451) gave `chinese`
+and `dangi` a real reckoning past the end of their tables, where the conversions used to fall back to
+ISO-like fields. The subtraction above was `1849-11-13` — the ninth month, day 29, from a date in the
+eleventh month, day 13 — and is now `1849-12-26`, which is the eleventh month, day 13.
 
 A host provider is also free to clamp where the engine no longer does, and a conversion that answers with
 its own boundary date every time is what made the month walk stand still forever. The walk keeps a
@@ -2520,6 +2525,65 @@ of `Temporal` still reckoning in ISO with another calendar's name attached — `
 `subtract` and `total` all already reckoned in the calendar — so a value that changes here was disagreeing
 with all of them. An ISO `relativeTo` is unaffected, and so is a duration rounded without one: nothing
 outside the calendar path moves.
+
+### 4.50 A date past a lunisolar calendar's table is still reckoned in that calendar ([#3451](https://github.com/sebastienros/jint/issues/3451))
+
+`ChineseLunisolarCalendar` spans ISO 1901-02-19 to 2101-01-28 and `KoreanLunisolarCalendar` 918-02-19 to
+2051-02-10, while `Temporal.PlainDate` spans a quarter of a million years each way. Outside those two
+tables the field accessors answered with the ISO year, `M{isoMonth}`, the ISO days-in-month and twelve
+months a year — Gregorian fields wearing a lunisolar label, and nothing downstream could tell them from
+real ones.
+
+```js
+const d = Temporal.PlainDate.from('1800-01-01').withCalendar('chinese');
+d.year;         // 5.0: 1800    5.x: 1799
+d.monthCode;    // 5.0: "M01"   5.x: "M12"
+d.day;          // 5.0: 1       5.x: 7
+d.daysInMonth;  // 5.0: 31      5.x: 30
+d.daysInYear;   // 5.0: 365     5.x: 354
+```
+
+Refusing instead was not open to the engine.
+[`NonISOCalendarISOToDate`](https://tc39.es/proposal-temporal/#sec-temporal-nonisocalendarisotodate) is
+declared as returning *a Calendar Date Record* — not "either a normal completion … or a throw completion",
+the phrasing its neighbour [`NonISODateAdd`](https://tc39.es/proposal-temporal/#sec-temporal-nonisodateadd)
+carries and which is what lets the *arithmetic* refuse — and `get PlainDate.prototype.monthCode` reads it
+without `?`. So the accessors have to answer, and `withCalendar` has no range to validate against either.
+
+What answers now is the reckoning both calendars are defined by: months begin on the day of an
+astronomical new moon in the calendar's own time zone, the eleventh month is the one containing the winter
+solstice, and a year needing a thirteenth month takes it at the first month of its *sui* carrying no major
+solar term. It is a fallback, not a replacement — inside a table that table still answers, byte for byte —
+and it reproduces both tables exactly across every year over which they tabulate this calendar rather than
+an older one: `chinese` from 1929, `dangi` from 1912, to the end of each.
+
+**What could break:** anything reading `year`, `month`, `monthCode`, `day`, `dayOfYear`, `daysInMonth`,
+`daysInYear`, `monthsInYear` or `inLeapYear` off a `chinese` or `dangi` date outside those tables, and
+`from`, `with`, `equals`, `toPlainYearMonth`, `toPlainMonthDay` and `Intl` formatting, which all read the
+same conversion. Every one of those values changes, because every one of them was the ISO value. Nine
+other non-ISO calendars are untouched: each already had a reckoning of its own to fall back on past the end
+of its BCL calendar, which is why only these two ever gave an ISO answer.
+
+Two consequences worth naming:
+
+- **A date the Korean table names but will not measure** is now reckoned too. `KoreanLunisolarCalendar`
+  reports month 13 for 1189-01-09 and reports the year holding it as having no leap month, so
+  `GetDaysInMonth` refuses the month `GetMonth` just named; the date used to come back as ISO fields for
+  that reason rather than for being out of range.
+- **Arithmetic past a table's end still refuses**, unchanged from
+  [4.44](#444-calendar-arithmetic-is-answered-by-whoever-answers-for-the-calendar-3403) and
+  [#3452](https://github.com/sebastienros/jint/pull/3452): `add`, `subtract`, `until` and `since` are
+  written against the BCL calendar directly, and a result it cannot represent is still a `RangeError`.
+  That is the same split `hebrew` and `persian` have always had — fields reckoned, arithmetic refused.
+  What does change is the **provider** path: §4.44 said a provider claiming `chinese` walks the two
+  conversions and so answers `1849-11-13` where a default engine raises `RangeError`, because those
+  conversions fell back to ISO-like fields. They no longer do, so that walk is now the Chinese calendar
+  rather than an ISO one wearing its name; the two paths still part in kind, but the answering one is no
+  longer wrong.
+
+Far past either table the series the reckoning is built on lose accuracy — beyond roughly ±70,000 years a
+month can come back at 28 or 31 days — which is what implementation-defined permits and what every engine
+computing these calendars does. Every search is bounded, so it degrades rather than failing to return.
 
 ## 5. New in v5
 


### PR DESCRIPTION
Fixes #3451.

## What was wrong

`ChineseLunisolarCalendar` is a table of ISO 1901-02-19 to 2101-01-28 and `KoreanLunisolarCalendar` one of
918-02-19 to 2051-02-10, while `Temporal.PlainDate` spans a quarter of a million years each way. Outside
the table, `NonIsoCalendars.IsoToCalendarDate` answered from a `catch (ArgumentOutOfRangeException)` with
the ISO year, `M{isoMonth}`, the ISO days-in-month and twelve months a year:

```js
const d = Temporal.PlainDate.from('1800-01-01').withCalendar('chinese');
d.year;         // 1800     — 1800-01-01 is not in the Chinese year 1800
d.monthCode;    // "M01"    — nor is it day 1 of a month coded M01
d.day;          // 1
d.daysInMonth;  // 31       — no lunisolar month has 31 days
d.daysInYear;   // 365
```

Gregorian fields wearing a lunisolar label, with nothing downstream able to tell them from real ones — and
`toString`, `from`, `with`, `equals`, `toPlainYearMonth`, `toPlainMonthDay` and `Intl` formatting all read
that same conversion. **Only `chinese` and `dangi` ever reached it:** the other nine non-ISO calendars
already have a reckoning of their own to fall back on past the end of whatever backs them (`hebrew` and
`persian` algorithmic, `islamic-umalqura` tabular, and the remaining six are pure epoch arithmetic with no
BCL calendar at all). A test in this PR pins that.

## Refuse or answer: what the spec requires

Refusing is not open to the engine, and the specification is unambiguous about which of the two it is —
the distinction is in the return-type line of the abstract operation.

| operation | declared to return |
| --- | --- |
| [`NonISOCalendarISOToDate`](https://tc39.es/proposal-temporal/#sec-temporal-nonisocalendarisotodate) | **a Calendar Date Record** |
| [`NonISODateAdd`](https://tc39.es/proposal-temporal/#sec-temporal-nonisodateadd) | either a normal completion containing an ISO Date Record **or a throw completion** |

`NonISODateAdd`'s throw completion is exactly what let #3452 make out-of-range *arithmetic* a `RangeError`.
`NonISOCalendarISOToDate` has no such clause; `CalendarISOToDate` calls it without `?`, and
`get Temporal.PlainDate.prototype.monthCode` is `return CalendarISOToDate(…).[[MonthCode]]` — no `?` there
either. A `RangeError` from a field accessor would be a spec violation.

Nor could the refusal be moved to construction, which the issue asks about: `withCalendar` swaps the
calendar slot and validates nothing against it, because there is no range to validate against — the
specification does not admit the idea of a calendar that covers only part of Temporal's range. Which
calendars an implementation supports is implementation-defined; over what span it supports one is not.

So the accessors must answer, and the answer has to be the calendar.

## What changed

`Jint/Native/Temporal/NonIsoCalendars.Lunisolar.cs` implements the reckoning both calendars are actually
defined by: months begin on the day of an astronomical new moon in the calendar's own time zone, the
eleventh month is the one containing the winter solstice, and a year needing a thirteenth month takes it at
the first month of its *sui* — the solstice-to-solstice span — carrying no major solar term. The solar
longitude, new moon and ephemeris-correction series are Reingold and Dershowitz, *Calendrical Calculations*
(4th ed.) §14.4 and §19.4, the same body of algorithms ICU reckons these calendars with.

It is a fallback, not a replacement: inside a BCL table that table still answers, and a test sweeps both
tables end to end to say so. Two entry points now reach the reckoning:

- `LunisolarToCalendarDate` — outside the table's range, and for an ISO year outside `System.DateTime`'s
  own 1–9999.
- `LunisolarDateToIso` — for a year the table does not cover, taking the year's month count, leap month,
  month lengths and day-1 from the reckoning together, so a date cannot be resolved half one way.

```js
Temporal.PlainDate.from('1800-01-01').withCalendar('chinese');
// year 1799, monthCode "M12", day 7, monthsInYear 12, daysInMonth 30, daysInYear 354
```

**The sui is the window the leap-month rule is stated over, not the calendar year**, and 2033 is where
reading it off the year instead shows: that year holds two months with no major solar term, one in a sui of
twelve months — which can carry no leap month at all — and one in the following sui of thirteen, which is
the leap eleventh month the calendar actually has. Taking the first of the two put the leap month at
ordinal 8 instead of 12 and moved 384 days.

### Every search is bounded

The series are polynomials in centuries from J2000, and a quarter of a million years out their higher-order
terms grow until the new-moon sequence is no longer strictly increasing. A correction loop assuming
monotonicity would not terminate there — and a CLR loop inside one interpreter step crosses no statement
boundary, so no execution constraint could interrupt it (#3428). Every loop here has an iteration cap and a
defined answer at it. A sweep over ±100,000 years, which does not return at all without that, is a test.

## Evidence: it reproduces both tables

There is nothing to check an answer against past the end of a table, so what the tests do instead is run
the reckoning across the whole of both tables and require it to reproduce them. An algorithm that
reproduces two independently compiled tables day for day is the same algorithm outside them.

**`KoreanLunisolarCalendar` from 1912 to 2051 — 50,811 days, zero disagreements, on all three target
frameworks.** 1912 is when Korea began reckoning its own calendar rather than China's, so those are all the
days that table has to say about the calendar this implements, and 2051-02-10 is exactly where the
reckoning takes over.

The rest is bounded rather than exact, for three reasons and only the first is about the reckoning:

1. A new moon within minutes of local midnight lands on either side of it, moving one month boundary by a
   day and so 30 days at a time.
2. The centuries before China's Shixian reform of 1645 are a different calendar — mean solar terms rather
   than true ones — which no modern algorithm reproduces and none should.
3. **The tables do not agree with each other across target frameworks.** `ChineseLunisolarCalendar` reads
   2057-09-28 as 2057/9/1 on .NET 8 and as 2057/8/30 on .NET Framework 4.8 and .NET 10.
   `KoreanLunisolarCalendar` on .NET Framework begins five days earlier than its .NET Core counterpart
   (918-02-14 rather than 918-02-19) and reads 1500-06-15 as 1500/5/19 where .NET Core reads 1500/5/9.

| window | .NET 8 | .NET 10 | .NET Framework 4.8 |
| --- | ---: | ---: | ---: |
| `dangi` 1912 → 2051 (50,811 days) | **0** | **0** | **0** |
| `chinese` 1929 → 2101 (62,850 days) | 0 | 30 | 90 |
| `chinese` 1901 → 2101 (73,027 days) | 30 | 60 | 120 |
| `dangi` 1654 → 2051 (145,042 days) | 2,218 | 2,218 | 2,750 |

Every one of those is a whole month boundary moved by one day. The `chinese` 1901–1929 residual is one
month of 1906 on .NET 8.

The boundary itself is checked structurally rather than by date, since the tables differ: the day before a
table's first day is the last day of the preceding year, on that year's last month's last day, and the day
after its last day is day 1, month 1 of the following year.

## Failing-test evidence

`Jint.Tests/Runtime/NonIsoCalendarOutOfRangeFieldTests.cs` against **unfixed `main`**:

```
Failed!  - Failed: 9, Passed: 13, Total: 22

Failed TheReportedDatePastTheChineseRangeReportsChineseFields
  expected "1799|12|7|M12|12|30|354|331|false", got "1800|1|1|M01|12|31|365|1|false"

Failed EveryDatePastTheTableStillReportsALunisolarCalendar("chinese")   (and "dangi")
  -020000-01-15: -20000|1|15|M01|12|31|366|15|true      ← a 31-day month in a 366-day lunisolar year
  … and every other sampled date past the table

Failed NoCalendarReportsIsoFieldsUnderItsOwnName("chinese")   (and "dangi")
  the other nine calendars pass, on main and after — they never reached the ISO fallback

Failed TheReckoningJoinsTheTableWithoutASeam("chinese")   (and "dangi")
Failed ThePastDateTheKoreanTableAlsoCoversReadsTheSameInBoth
Failed APastDateReadsTheSameInChineseAndInDangi  (×3, since folded into the above)
```

`ADateInsideTheTableIsStillAnsweredByTheTable` passes on `main` and after: nothing inside a table moves.

## Two things that came out of writing it

**A date the Korean table names and then will not measure.** `KoreanLunisolarCalendar` reports month 13 for
1189-01-09 and reports the year holding it as having no leap month, so `GetDaysInMonth` refuses the month
`GetMonth` just named. That `ArgumentOutOfRangeException` reached the same ISO-like fallback — the defect
from a second cause, inside the table's advertised range rather than past it. It is reckoned now.

**§4.44's provider example was stale.** That section says a provider claiming `chinese` answers
`1849-11-13` for `PlainDate.from('1950-01-01').withCalendar('chinese').subtract({ years: 100 })` where a
default engine raises `RangeError`, because the generic provider walk is written in the two conversions and
those fell back to ISO-like fields. They no longer do, so it now answers `1849-12-26` — the eleventh month,
day 13, from a date in the eleventh month, day 13, which is what subtracting a hundred years should do.
`1849-11-13` was the ninth month, day 29. The section is amended, and the two paths still part in kind.

## What this does not change

`add`, `subtract`, `until` and `since` are written against the BCL calendar directly, so a result past the
end of a table is still the `RangeError` #3452 made it. That is the same split `hebrew` and `persian` have
always had — fields reckoned past the end of the BCL calendar, arithmetic refused there — and this leaves
it where it is rather than making the lunisolar pair the odd ones out. Routing that arithmetic through the
conversions for all four is worth doing and is a separate change; `NonIsoCalendarRangeTests` passes
unchanged here.

Far past either table the series lose accuracy — beyond roughly ±70,000 years a month can come back at 28
or 31 days — which is what implementation-defined permits and what every engine computing these calendars
does. It degrades; it always answers and always returns.

## Test results

- `Jint.Tests`: **10,909 passed / 0 failed** on `net8.0` and `net10.0`, **7,533 / 0** on `net472`.
- `Jint.Tests.PublicInterface`: 3,231 / 3,241 / 2,609 passed, 0 failed.
- `Jint.Tests.CommonScripts`: 28 passed, 0 failed.
- `Jint.Tests.Test262`: **102,495 passed / 0 failed / 189 skipped** — identical to `main`.

Migration guide: **§4.50**, plus an amendment to §4.44's provider example.
