### PR TITLE
Temporal and Intl parsing cannot fail because the machine was busy

### DIFF
--- a/Jint.Tests/Runtime/TemporalParsePatternBudgetTests.cs
+++ b/Jint.Tests/Runtime/TemporalParsePatternBudgetTests.cs
@@ -1,0 +1,282 @@
+#nullable enable
+
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Jint.Native.Intl;
+using Jint.Native.Temporal;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// The internal ISO 8601 and BCP 47 patterns carry no match timeout, and these tests are why.
+/// <see cref="Regex.MatchTimeout"/> is a <i>wall-clock</i> deadline sampled during matching, so it cannot
+/// tell a pattern that is backtracking apart from a thread that lost the CPU: a descheduled thread trips it
+/// having burned almost no CPU at all. These patterns used to carry 100 ms, and a single match of the valid
+/// 8-character string <c>10:30:00</c> was measured taking 440 ms of wall clock on an ordinary loaded
+/// machine — 4.4x over that budget — while the same thing failed CI parsing a correct ISO string.
+/// <para>
+/// The consequence was not a JavaScript error. <c>RegexMatchTimeoutException</c> is listed in
+/// <c>Throw.MustPropagateHostException</c>, so it escaped <c>Engine.Evaluate</c> as a raw CLR exception,
+/// straight through the script's own <c>try</c>/<c>catch</c> — a script could not even defend itself.
+/// </para>
+/// <para>
+/// The starvation that causes it cannot be reproduced on demand without loading the machine, which would
+/// make these tests the very flake they are about. So they pin the <i>property</i> instead: no pattern
+/// carries a deadline, every fixed-width pattern's length cap really is the longest string it can match,
+/// an over-long input is rejected without the pattern being asked, and a valid string parses.
+/// </para>
+/// </summary>
+public class TemporalParsePatternBudgetTests
+{
+    private static IEnumerable<(string Owner, string Name, Regex Value)> InternalPatterns()
+    {
+        foreach (var type in new[] { typeof(TemporalHelpers), typeof(IntlUtilities) })
+        {
+            foreach (var field in type.GetFields(BindingFlags.NonPublic | BindingFlags.Static))
+            {
+                if (field.FieldType == typeof(Regex))
+                {
+                    yield return (type.Name, field.Name, (Regex) field.GetValue(null)!);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// The fix itself. Every internal pattern must match without a deadline — including any added later,
+    /// which is why this enumerates the fields rather than naming them.
+    /// </summary>
+    [Test]
+    public void NoInternalParsePatternCarriesAWallClockDeadline()
+    {
+        var patterns = InternalPatterns().ToList();
+
+        // Guard against the enumeration silently finding nothing and passing vacuously.
+        patterns.Should().HaveCountGreaterThanOrEqualTo(8);
+
+        foreach (var (owner, name, regex) in patterns)
+        {
+            regex.MatchTimeout.Should().Be(
+                Regex.InfiniteMatchTimeout,
+                "{0}.{1} is a fixed internal pattern over engine-supplied input, and a wall-clock budget on " +
+                "one can only ever fire spuriously — as an uncatchable CLR exception",
+                owner,
+                name);
+        }
+    }
+
+    /// <summary>
+    /// The length caps are only safe because they are the exact longest string their pattern can match.
+    /// Widening a pattern without widening its cap would start rejecting valid input, so pin both ends:
+    /// the maximal example matches and is exactly cap-length, and one character more never matches.
+    /// </summary>
+    [TestCase("DatePattern", "+123456-12-31", 13)]
+    [TestCase("TimePatternColon", "12:34:56.123456789", 18)]
+    [TestCase("TimePatternHyphen", "12-34-56.123456789", 18)]
+    [TestCase("TimePatternCompact", "123456.123456789", 16)]
+    [TestCase("TimeWithOffsetPattern", "12:34:56.123456789+12:34:56.123456789", 37)]
+    public void AFixedWidthPatternMatchesNothingLongerThanItsCap(string field, string longest, int cap)
+    {
+        var regex = InternalPatterns().Single(p => p.Name == field).Value;
+
+        longest.Length.Should().Be(cap);
+        regex.IsMatch(longest).Should().BeTrue("{0} must accept its own maximal string", field);
+
+        // Nothing longer than the cap is in the pattern's language, whatever it is built from. The
+        // alphabet is every character any of these patterns can consume.
+        const string Alphabet = "0123456789:-.,+Zz";
+        var random = new Random(20260827);
+        for (var i = 0; i < 20_000; i++)
+        {
+            var buffer = new char[cap + 1 + random.Next(0, 24)];
+            for (var j = 0; j < buffer.Length; j++)
+            {
+                buffer[j] = Alphabet[random.Next(0, Alphabet.Length)];
+            }
+
+            var candidate = new string(buffer);
+
+            regex.IsMatch(candidate).Should().BeFalse(
+                "{0} must not match \"{1}\", which is longer than its {2}-character cap",
+                field,
+                candidate,
+                cap);
+        }
+    }
+
+    /// <summary>
+    /// An over-long input is rejected without the pattern being asked, and the rejection is a JavaScript
+    /// error the script can catch — never a CLR exception out of <c>Engine.Evaluate</c>.
+    /// </summary>
+    [TestCase("Temporal.PlainDate")]
+    [TestCase("Temporal.PlainTime")]
+    [TestCase("Temporal.PlainYearMonth")]
+    [TestCase("Temporal.PlainMonthDay")]
+    [TestCase("Temporal.Instant")]
+    [TestCase("Temporal.Duration")]
+    public void AnOverLongInputIsRejectedAsAJavaScriptError(string type)
+    {
+        var engine = new Engine();
+        engine.SetValue("huge", new string('1', 1_000_000));
+
+        engine.Evaluate($"(() => {{ try {{ {type}.from(huge); return 'accepted'; }} catch (e) {{ return e.constructor.name; }} }})()")
+            .AsString().Should().Be("RangeError");
+    }
+
+    /// <summary>
+    /// The shape that was failing: a correct call with a valid string. It must parse, and it must never be
+    /// able to fail for a reason that has nothing to do with its own contents.
+    /// </summary>
+    [TestCase("Temporal.PlainDate.from('2024-01-15T10:30:00').toString()", "2024-01-15")]
+    [TestCase("Temporal.PlainDate.from('2024-01-15').toString()", "2024-01-15")]
+    [TestCase("Temporal.PlainTime.from('10:30:00').toString()", "10:30:00")]
+    [TestCase("Temporal.PlainTime.from('10:30:00.123456789').toString()", "10:30:00.123456789")]
+    [TestCase("Temporal.Instant.from('2024-01-15T10:30:00Z').toString()", "2024-01-15T10:30:00Z")]
+    [TestCase("Temporal.Duration.from('P1Y2M3DT4H5M6S').toString()", "P1Y2M3DT4H5M6S")]
+    public void AValidIsoStringParses(string expression, string expected)
+    {
+        new Engine().Evaluate(expression).AsString().Should().Be(expected);
+    }
+
+    /// <summary>
+    /// What the removed timeout was nominally guarding. Each pattern is driven with the near-miss shapes
+    /// that make a backtracking engine work hardest — a long run that almost satisfies the pattern and then
+    /// fails at the last character — at a length no ISO string would ever reach. These return in well under
+    /// a millisecond because every one of these patterns is linear in its input; a pattern edited into a
+    /// catastrophic one would not return at all, and would fail this by the runner's own timeout rather
+    /// than by any assertion on a clock, which is deliberate: nothing here measures elapsed time.
+    /// </summary>
+    [Test]
+    public void EveryPatternRejectsAdversarialInputWithoutBacktrackingAwayTheAfternoon()
+    {
+        const int Length = 16 * 1024;
+
+        var nearMisses = new[]
+        {
+            new string('1', Length) + "x",
+            string.Concat(Enumerable.Repeat("12:", Length / 3)) + "x",
+            "12:34:56." + new string('1', Length) + "x",
+            "P" + new string('1', Length) + "Y" + new string('2', Length) + "M" + "x",
+            "PT" + new string('1', Length) + "." + new string('2', Length) + "H" + "x",
+            "2020-01-01T00:00:00+" + string.Concat(Enumerable.Repeat("01:", Length / 3)) + "x",
+            "2020-01-01T12:34:56.123456789+01:00" + string.Concat(Enumerable.Repeat("[u-ca=iso8601]", Length / 14)) + "x",
+            new string('[', Length),
+            "[" + new string('a', Length),
+        };
+
+        foreach (var (owner, name, regex) in InternalPatterns())
+        {
+            foreach (var input in nearMisses)
+            {
+                regex.IsMatch(input).Should().BeFalse("{0}.{1} must reject adversarial input", owner, name);
+            }
+        }
+    }
+
+    /// <summary>
+    /// <c>ValidateAnnotations</c> walks the annotation list rather than scanning it with the
+    /// <c>\[(!?)([^\]]+)\]</c> pattern it used to, because that pattern is quadratic on an input holding
+    /// no <c>]</c> at all — every start position consumes the rest of the string and backtracks over it.
+    /// The walk has to agree with the pattern it replaced, so drive both over a corpus that includes the
+    /// two cases the pattern's backtracking decides on its own: <c>[]</c>, which has no content and is
+    /// therefore not an annotation, and <c>[!]</c>, where the optional <c>!</c> is given back to the
+    /// content rather than taken as the critical marker.
+    /// </summary>
+    [Test]
+    public void TheAnnotationWalkAgreesWithThePatternItReplaced()
+    {
+        var pattern = new Regex(@"\[(!?)([^\]]+)\]", RegexOptions.CultureInvariant, Regex.InfiniteMatchTimeout);
+
+        var corpus = new List<string>
+        {
+            "",
+            "[]",
+            "[!]",
+            "[!!]",
+            "[u-ca=iso8601]",
+            "[!u-ca=iso8601]",
+            "[u-ca=iso8601][America/New_York]",
+            "[!u-ca=hebrew][!America/New_York]",
+            "[a[b]",
+            "[[[[[",
+            "[[[[[]",
+            "no annotations here",
+            "[unclosed",
+            "][",
+            "[a][][b]",
+            "[a][!][b]",
+        };
+
+        // Plus randomized blobs over the alphabet that makes the two engines disagree if anything does.
+        const string Alphabet = "[]!=-abu0";
+        var random = new Random(20260827);
+        for (var i = 0; i < 5_000; i++)
+        {
+            var buffer = new char[random.Next(0, 24)];
+            for (var j = 0; j < buffer.Length; j++)
+            {
+                buffer[j] = Alphabet[random.Next(0, Alphabet.Length)];
+            }
+
+            corpus.Add(new string(buffer));
+        }
+
+        foreach (var input in corpus)
+        {
+            var expected = pattern.Matches(input)
+                .Cast<Match>()
+                .Select(m => (Critical: m.Groups[1].Value == "!", Content: m.Groups[2].Value))
+                .ToList();
+
+            Walk(input).Should().Equal(expected, "the walk must find in \"{0}\" what the pattern found", input);
+        }
+
+        // The walk, transcribed from TemporalHelpers.ValidateAnnotations.
+        static List<(bool Critical, string Content)> Walk(string annotations)
+        {
+            var found = new List<(bool, string)>();
+            var index = 0;
+            while (index < annotations.Length)
+            {
+                var open = annotations.IndexOf('[', index);
+                if (open < 0)
+                {
+                    break;
+                }
+
+                var close = annotations.IndexOf(']', open + 1);
+                if (close < 0)
+                {
+                    break;
+                }
+
+                if (close == open + 1)
+                {
+                    index = open + 1;
+                    continue;
+                }
+
+                var critical = annotations[open + 1] == '!' && close > open + 2;
+                var contentStart = critical ? open + 2 : open + 1;
+                found.Add((critical, annotations.Substring(contentStart, close - contentStart)));
+                index = close + 1;
+            }
+
+            return found;
+        }
+    }
+
+    /// <summary>
+    /// The end-to-end shape the retired annotation pattern was quadratic on. It must be rejected as a
+    /// JavaScript error rather than spending the afternoon backtracking or raising a CLR exception.
+    /// </summary>
+    [Test]
+    public void AnAnnotationTailWithNoClosingBracketIsRejected()
+    {
+        var engine = new Engine();
+        engine.SetValue("tail", "2020-01-01T00:00:00Z" + new string('[', 200_000));
+
+        engine.Evaluate("(() => { try { Temporal.Instant.from(tail); return 'accepted'; } catch (e) { return e.constructor.name; } })()")
+            .AsString().Should().Be("RangeError");
+    }
+}

--- a/Jint/Native/Intl/IntlUtilities.cs
+++ b/Jint/Native/Intl/IntlUtilities.cs
@@ -110,10 +110,15 @@ internal static class IntlUtilities
     // Accepts: language[-script][-region][-variant]*[-extension]*[-privateuse]
     // Extensions use single-character singletons like -u- for Unicode extensions
     // Full spec: https://www.rfc-editor.org/rfc/bcp/bcp47.txt
+    // No match timeout, for the reason spelled out over the Temporal ISO patterns in TemporalHelpers:
+    // Regex.MatchTimeout is a wall-clock deadline, so on a loaded machine it fails a valid input having
+    // burned no CPU, and RegexMatchTimeoutException escapes Engine.Evaluate as a CLR exception rather
+    // than a catchable JavaScript error. This pattern is fixed and internal, and every repetition in it
+    // is forced by a distinct leading '-', so it is linear in the length of the tag it is given.
     private static readonly Regex LanguageTagPattern = new(
         "^[a-zA-Z]{2,8}(?:-[a-zA-Z0-9]{1,8})*$",
         RegexOptions.Compiled | RegexOptions.CultureInvariant,
-        TimeSpan.FromMilliseconds(100));
+        Regex.InfiniteMatchTimeout);
 
     /// <summary>
     /// Grandfathered tags that map to canonical forms.

--- a/Jint/Native/Temporal/TemporalHelpers.cs
+++ b/Jint/Native/Temporal/TemporalHelpers.cs
@@ -113,16 +113,32 @@ internal static class TemporalHelpers
         return new IsoDateTime(date, new IsoTime(hour, minute, second, millisecond, microsecond, nanosecond));
     }
 
-    // Regex patterns for ISO 8601 parsing
-    // Note: Adding timeout for safety against ReDoS attacks
+    // Regex patterns for ISO 8601 parsing.
+    //
+    // These patterns take no match timeout, and that is deliberate. Regex.MatchTimeout is a *wall-clock*
+    // deadline sampled while matching, so it cannot tell "this pattern is backtracking" apart from "this
+    // thread lost the CPU" — a descheduled thread trips it having burned almost no CPU at all. That is not
+    // hypothetical: with the 100 ms budget these patterns used to carry, a single match of the valid,
+    // 8-character string "10:30:00" was measured taking 440 ms of wall clock on an ordinary loaded
+    // developer machine, and the same thing turned up as a CI failure parsing a correct ISO string. Because
+    // RegexMatchTimeoutException is listed in Throw.MustPropagateHostException, that spurious failure did
+    // not surface as a JavaScript error a script could catch — it escaped Engine.Evaluate as a raw CLR
+    // exception, straight through the script's own try/catch.
+    //
+    // What a timeout was there to guard against is instead guarded by construction. These patterns are
+    // fixed and internal — only the *input* is script-supplied, never the pattern — and every one of them
+    // is linear in the length of that input, so their cost is bounded by bounding the input. The
+    // fixed-width patterns below therefore carry an exact maximum length and reject anything longer
+    // without matching at all (see MaxIsoDateLength and friends). The two whose grammar is genuinely
+    // unbounded — InstantPattern's annotation tail and DurationPattern's digit runs — can carry no such
+    // cap without rejecting valid input, and rest on that measured linearity instead.
 #pragma warning disable MA0023 // Use RegexOptions.ExplicitCapture - we need numbered capture groups
-    private static readonly TimeSpan RegexTimeout = TimeSpan.FromMilliseconds(100);
 
     // ISO 8601 date pattern: supports both extended (YYYY-MM-DD) and basic (YYYYMMDD) formats
     private static readonly Regex DatePattern = new(
         @"^([+-]?\d{4,6})(?:-(\d{2})-(\d{2})|(\d{2})(\d{2}))$",
         RegexOptions.Compiled | RegexOptions.CultureInvariant,
-        RegexTimeout);
+        Regex.InfiniteMatchTimeout);
 
     // Time pattern supporting multiple formats per spec TimeSpec grammar:
     // Hour | Hour TimeSeparator MinuteSecond | Hour TimeSeparator MinuteSecond TimeSeparator TimeSecond [.fraction]
@@ -132,30 +148,44 @@ internal static class TemporalHelpers
     private static readonly Regex TimePatternColon = new(
         @"^(\d{2})(?::(\d{2})(?::(\d{2})(?:[.,](\d{1,9}))?)?)?$",
         RegexOptions.Compiled | RegexOptions.CultureInvariant,
-        RegexTimeout);
+        Regex.InfiniteMatchTimeout);
 
     private static readonly Regex TimePatternHyphen = new(
         @"^(\d{2})(?:-(\d{2})(?:-(\d{2})(?:[.,](\d{1,9}))?)?)?$",
         RegexOptions.Compiled | RegexOptions.CultureInvariant,
-        RegexTimeout);
+        Regex.InfiniteMatchTimeout);
 
     private static readonly Regex TimePatternCompact = new(
         @"^(\d{2})(?:(\d{2})(?:(\d{2})(?:[.,](\d{1,9}))?)?)?$",
         RegexOptions.Compiled | RegexOptions.CultureInvariant,
-        RegexTimeout);
+        Regex.InfiniteMatchTimeout);
 
     // Duration pattern already supports comma via [.,]
     private static readonly Regex DurationPattern = new(
         @"^([+-])?P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?(?:T(?:(\d+)(?:[.,](\d{1,9}))?H)?(?:(\d+)(?:[.,](\d{1,9}))?M)?(?:(\d+)(?:[.,](\d{1,9}))?S)?)?$",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase,
-        RegexTimeout);
+        Regex.InfiniteMatchTimeout);
 
     // Instant pattern already supports comma via [.,]
     private static readonly Regex InstantPattern = new(
         @"^([+-]\d{6}|\d{4})-?(\d{2})-?(\d{2})[Tt ](\d{2})(?::?(\d{2})(?::?(\d{2})(?:[.,](\d{1,9}))?)?)?([Zz]|([+-])(\d{2})(?::?(\d{2})(?::?(\d{2})(?:[.,](\d{1,9}))?)?)?)((?:\[!?[^\]]+\])*)$",
         RegexOptions.Compiled | RegexOptions.CultureInvariant,
-        RegexTimeout);
+        Regex.InfiniteMatchTimeout);
 #pragma warning restore MA0023
+
+    // Exact maximum lengths of the fixed-width patterns above: the longest string each one can match,
+    // which is what makes rejecting anything longer indistinguishable from letting the pattern reject it.
+    // Each was confirmed both by reading the grammar and by searching the pattern's own language for its
+    // longest member, and each is pinned by a test so a widened pattern cannot silently outgrow its bound.
+
+    /// <summary>Longest string <c>DatePattern</c> can match: <c>+123456-12-31</c>.</summary>
+    private const int MaxIsoDateLength = 13;
+
+    /// <summary>Longest string the time patterns can match: <c>12:34:56.123456789</c>.</summary>
+    private const int MaxIsoTimeLength = 18;
+
+    /// <summary>Longest string <c>TimeWithOffsetPattern</c> can match: <c>12:34:56.123456789+12:34:56.123456789</c>.</summary>
+    private const int MaxIsoTimeWithOffsetLength = 37;
 
     /// <summary>
     /// Parses an offset string like "+01:00" or "-05:30" to nanoseconds.
@@ -675,6 +705,10 @@ internal static class TemporalHelpers
         if (ContainsInvalidMinusSign(input))
             return null;
 
+        // Longer than the pattern could ever match, so the pattern is not asked.
+        if (input.Length > MaxIsoDateLength)
+            return null;
+
         var match = DatePattern.Match(input);
         if (!match.Success)
             return null;
@@ -734,6 +768,10 @@ internal static class TemporalHelpers
         if (ContainsInvalidMinusSign(input))
             return null;
 
+        // Longer than any of the three time patterns could ever match, so none of them is asked.
+        if (input.Length > MaxIsoTimeLength)
+            return null;
+
         // Try each format in order (prefer colon format as it's most common)
         Match? match = TimePatternColon.Match(input);
         if (!match.Success)
@@ -772,11 +810,6 @@ internal static class TemporalHelpers
     }
 
 #pragma warning disable MA0023
-    private static readonly Regex AnnotationPattern = new(
-        @"\[(!?)([^\]]+)\]",
-        RegexOptions.Compiled | RegexOptions.CultureInvariant,
-        RegexTimeout);
-
     // Pattern for validating time with optional offset (used for PlainDate date-time validation)
     // Supports both extended (HH:MM:SS) and compact (HHMMSS) ISO 8601 time formats
     // Extended: HH[:MM[:SS[.fff]]]  Compact: HH[MM[SS[.fff]]]
@@ -785,7 +818,7 @@ internal static class TemporalHelpers
     private static readonly Regex TimeWithOffsetPattern = new(
         @"^(\d{2})(?:(?::(\d{2})(?::(\d{2})(?:[.,](\d{1,9}))?)?)|(?:(\d{2})(?:(\d{2})(?:[.,](\d{1,9}))?)?))??(?:([Zz])|([+-])(\d{2})(?::?(\d{2})(?::?(\d{2})(?:[.,](\d{1,9}))?)?)?)?$",
         RegexOptions.Compiled | RegexOptions.CultureInvariant,
-        RegexTimeout);
+        Regex.InfiniteMatchTimeout);
 #pragma warning restore MA0023
 
     /// <summary>
@@ -795,6 +828,10 @@ internal static class TemporalHelpers
     public static bool IsValidTimeWithOffset(string timeString)
     {
         if (string.IsNullOrEmpty(timeString))
+            return false;
+
+        // Longer than the pattern could ever match, so the pattern is not asked.
+        if (timeString.Length > MaxIsoTimeWithOffsetLength)
             return false;
 
         var match = TimeWithOffsetPattern.Match(timeString);
@@ -984,15 +1021,47 @@ internal static class TemporalHelpers
 
     private static bool ValidateAnnotations(string annotations)
     {
-        var matches = AnnotationPattern.Matches(annotations);
         var calendarCount = 0;
         var hasCalendarCritical = false;
         var timeZoneCount = 0;
 
-        foreach (Match m in matches)
+        // Walks the annotation list rather than scanning it with a regex. The pattern this replaces —
+        // \[(!?)([^\]]+)\] — is quadratic on an input holding no ']' at all: every one of the n start
+        // positions consumes the rest of the string and then backtracks over it looking for a ']' that is
+        // not there. Reaching it needed a string that InstantPattern would have rejected first, so it was
+        // unreachable by an argument about the caller rather than by construction, and it was the one
+        // pattern here whose 100 ms budget could be spent on real work instead of on being descheduled.
+        // This loop is linear on every input, which is what lets the budget go.
+        var index = 0;
+        while (index < annotations.Length)
         {
-            var critical = string.Equals(m.Groups[1].Value, "!", StringComparison.Ordinal);
-            var content = m.Groups[2].Value;
+            var open = annotations.IndexOf('[', index);
+            if (open < 0)
+            {
+                break;
+            }
+
+            var close = annotations.IndexOf(']', open + 1);
+            if (close < 0)
+            {
+                // No ']' remains anywhere, so no further annotation can match from any later position.
+                break;
+            }
+
+            if (close == open + 1)
+            {
+                // "[]" — the pattern required at least one content character, so this is not an
+                // annotation; resume from just after the '[', exactly as an unanchored scan would.
+                index = open + 1;
+                continue;
+            }
+
+            // "!" is the critical marker only when content remains after it. In "[!]" the pattern's
+            // optional "!?" gave the '!' back to the content rather than match an empty annotation.
+            var critical = annotations[open + 1] == '!' && close > open + 2;
+            var contentStart = critical ? open + 2 : open + 1;
+            var content = annotations.Substring(contentStart, close - contentStart);
+            index = close + 1;
 
             var eqIndex = content.IndexOf('=');
             if (eqIndex >= 0)

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -2585,6 +2585,37 @@ Far past either table the series the reckoning is built on lose accuracy — bey
 month can come back at 28 or 31 days — which is what implementation-defined permits and what every engine
 computing these calendars does. Every search is bounded, so it degrades rather than failing to return.
 
+### 4.54 Parsing a `Temporal` or `Intl` string cannot fail because the machine was busy ([#3485](https://github.com/sebastienros/jint/issues/3485))
+
+The internal patterns that parse ISO 8601 strings for `Temporal` and validate BCP 47 tags for `Intl` each
+carried a 100 ms `Regex.MatchTimeout`. That is a **wall-clock** deadline sampled while matching, so it
+cannot tell a pattern that is backtracking apart from a thread that lost the CPU — and a descheduled
+thread trips it having burned almost no CPU at all. A single match of the valid, 8-character string
+`10:30:00` was measured taking 440 ms of wall clock on an ordinary loaded machine, 4.4x over that budget.
+
+The failure that produced was not a JavaScript error. `RegexMatchTimeoutException` is one of the
+exceptions Jint propagates to the host rather than converting, so it escaped `Engine.Evaluate` as a CLR
+exception, straight through the script's own `try`/`catch`:
+
+```csharp
+// 4.16.x, on a loaded machine: throws RegexMatchTimeoutException out of Evaluate, uncatchable by
+//                              the script, with a message blaming "very large inputs or excessive
+//                              backtracking" for a 19-character valid string
+// 5.x:     returns "2024-01-15"
+engine.Evaluate("try { Temporal.PlainDate.from('2024-01-15T10:30:00').toString() } catch (e) { 'caught' }");
+```
+
+The patterns are fixed and internal — only the input is script-supplied, never the pattern — and their
+cost is now bounded by construction instead: the fixed-width ones reject anything longer than the longest
+string they could match without matching at all, and the annotation list is walked rather than scanned
+with a pattern that was quadratic on input holding no `]`.
+
+**What could break:** nothing an embedder configured. `Options.Constraints.RegexTimeout` never reached
+these patterns and still does not — it bounds script-supplied regular expressions, which is unchanged
+(see [§4.42](#442-a-regex-built-at-run-time-is-bounded-by-the-configured-regextimeout)). A host that
+caught `RegexMatchTimeoutException` around `Engine.Evaluate` to absorb this can drop that handler; a host
+that treated it as a signal the script was hostile was reading a scheduling artefact.
+
 ## 5. New in v5
 
 Everything in the table below is opt-in: nothing in it is installed unless the host asks for it, so


### PR DESCRIPTION
Fixes #3485.

`main` is red because of this, but the red CI leg is the smaller half.

## What an embedder sees today

`Temporal.PlainDate.from('2024-01-15T10:30:00')` — a correct call with a valid string — can throw
`System.Text.RegularExpressions.RegexMatchTimeoutException`. Built against a Jint whose only change is a
shortened budget, standing in for the starvation:

```
--- 1. can SCRIPT catch it? ---
   *** escaped Engine.Evaluate DESPITE the script's try/catch ***
   type    : System.Text.RegularExpressions.RegexMatchTimeoutException
   JintException?       False
   JavaScriptException? False

--- 2. what the HOST sees out of Engine.Evaluate ---
   message : The Regex engine has timed out while trying to match a pattern to an input string. This can
             occur for many reasons, including very large inputs or excessive backtracking caused by
             nested quantifiers, back-references and other factors.
   at System.Text.RegularExpressions.RegexRunner.<CheckTimeout>g__ThrowRegexTimeout|25_0()
```

It is not a `JintException` and not a `JavaScriptException`. Because `RegexMatchTimeoutException` is listed
in `Throw.MustPropagateHostException`, it goes **straight through the script's own `try`/`catch`** — a
script cannot defend itself — and reaches the host as a raw CLR exception whose message blames "very large
inputs or excessive backtracking" for a 19-character valid string.

## Why it fires

`Regex.MatchTimeout` is a **wall-clock** deadline sampled while matching. It cannot tell "this pattern is
backtracking" apart from "this thread lost the CPU". Eight patterns in `TemporalHelpers.cs` and one in
`IntlUtilities.cs` carried 100 ms of it.

Driving `TimeWithOffsetPattern` with `"10:30:00"` — valid, 8 characters — 200,000 times on an ordinary
loaded machine, **no induced load**:

| | |
| --- | --- |
| median | 0.0101 ms |
| p99.9 | 0.061 ms |
| **max** | **440.4 ms** |
| max / median | 43,607x |

The maximum is **4.4x over the budget**, on a valid input, from scheduling alone. The timeout is confirmed
sampled even on inputs this short: with a 1-tick budget, `10:30:00`, `103000`, `10:30:00+01:00` and
`10:30:00.123456789+01:00:00` all throw.

## It is not catastrophic backtracking

Best-of-200, scheduling noise stripped, adversarial near-miss inputs, infinite match timeout:

| input length | TimeWithOffset | Instant | Duration |
| --- | --- | --- | --- |
| 1024 | 0.040 ms | 0.037 ms | 0.088 ms |
| 4096 | 0.096 ms | 0.098 ms | 0.304 ms |
| 16384 | 0.368 ms | 0.380 ms | 1.228 ms |

16x the input costs 9–14x the time. Even 16 KB of adversarial input costs under 2 ms of CPU. There is
nothing here a 100 ms budget catches — raising it to 2 s would only make the false positive rarer.

**One pattern was not linear, and this is the part that changed the fix.** `AnnotationPattern`
(`\[(!?)([^\]]+)\]`) is quadratic on input holding no `]`: each of the n start positions consumes the rest
of the string and backtracks over it. On net472 it exceeds 100 ms of *genuine* CPU at 16 KB — the new test
caught it against unfixed code with a real `RegexMatchTimeoutException`. It was unreachable with such input
only because its sole caller hands it `InstantPattern`'s group 14, which that grammar already guarantees is
well-formed — an argument about the caller, not a property of the code.

## The fix

Bounding the input length alone would not have fixed this: the failing input is short and valid, and the
exception fires because the thread was descheduled. And length cannot be capped uniformly — annotation
lists and duration digit runs are legitimately unbounded, so a small cap would reject valid input.

So the live budget goes, and the cost is bounded by construction instead:

- **Eight patterns** in `TemporalHelpers.cs` and **one** in `IntlUtilities.cs` now take
  `Regex.InfiniteMatchTimeout`. The failure mode is removed rather than relabelled.
- The **fixed-width** patterns reject anything longer than the longest string they could match, before
  matching. The bounds are exact — 13, 18, 16 and 37 — confirmed by reading the grammar and by searching
  each pattern's own language for its longest member, and pinned so a widened pattern cannot outgrow its
  cap silently.
- `AnnotationPattern` is **replaced by a linear walk**, so the one superlinear pattern is gone rather than
  left unbounded. A test drives the walk and the retired pattern over ~5,000 inputs including the two cases
  the pattern's backtracking decided on its own: `[]`, which has no content and is not an annotation, and
  `[!]`, where the optional `!` is given back to the content.

`Options.Constraints.RegexTimeout` never reached these patterns and still does not — it bounds
script-supplied regular expressions, unchanged (#3431 / §4.42).

## Tests

The starvation cannot be reproduced without loading the machine, which would make the test the very flake
it is about — so `TemporalParsePatternBudgetTests` pins the property instead, with **no timing assertion
anywhere**: no pattern carries a deadline, every cap is exactly the longest its pattern can match and
nothing longer matches (20,000 randomized probes per pattern), an over-long input is rejected as a
`RangeError` rather than a CLR exception, a valid string parses, and every pattern returns on 16 KB
adversarial input.

Verified failing against unfixed code first: `NoInternalParsePatternCarriesAWallClockDeadline` reports
`Expected -1ms ... but found 100ms`, and on net472
`EveryPatternRejectsAdversarialInputWithoutBacktrackingAwayTheAfternoon` dies with a real
`RegexMatchTimeoutException` on `AnnotationPattern`.

## Verification

- `dotnet build -c Release` — clean, `TreatWarningsAsErrors` on.
- `dotnet test -c Release` — green: `Jint.Tests` 10,926 (net8.0/net10.0) and 7,550 (net472),
  `Jint.Tests.PublicInterface` 3,232 / 3,242 / 2,610, `Jint.Tests.CommonScripts` 28, `Jint.Tests.SourceGenerators` 71.
- **test262: 102,495 passed / 0 failed / 189 skipped** — exactly the control.

One caveat worth recording: under full-solution parallel load this busy box also failed
`intl402/supportedLocalesOf-unicode-extensions-ignored.js` twice (35 s each). That is **pre-existing** — a
pristine `main` worktree at 5b2f8f121 fails the identical two cases under the same load, and both pass in
isolation. Not caused by this change, and arguably the same family of defect at a different site.

## Migration guide

§4.52. Nothing an embedder configured changes; a host that caught `RegexMatchTimeoutException` around
`Engine.Evaluate` to absorb this can drop that handler.
