### PR TITLE
Intl: a date pattern's punctuation is not a decimal separator

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -198,9 +198,6 @@
     "intl402/Collator/prototype/compare/non-normative-phonebook.js",
     "intl402/Collator/usage-de.js",
 
-    // DateTimeFormat - hanidec numbering system has different AM/PM behavior in ICU/CLDR
-    "intl402/DateTimeFormat/prototype/format/numbering-system.js",
-
     // DateTimeFormat - Chinese/Dangi calendar date range issues (.NET ChineseLunisolarCalendar limitations)
     "intl402/DateTimeFormat/prototype/formatRangeToParts/chinese-calendar-dates.js",
     "intl402/DateTimeFormat/prototype/formatRangeToParts/dangi-calendar-dates.js",

--- a/Jint.Tests/Runtime/IntlNumberingSystemTests.cs
+++ b/Jint.Tests/Runtime/IntlNumberingSystemTests.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 
 using Jint.Native.Intl;
 
@@ -183,6 +183,66 @@ public class IntlNumberingSystemTests
 
         engine.Evaluate("new Intl.NumberFormat('ar-EG').format(1234.5)").AsString().Should().MatchRegex("[0-9]");
         engine.Evaluate("new Intl.DurationFormat('ar-EG').format({ hours: 12 })").AsString().Should().MatchRegex("[0-9]");
+    }
+
+    /// <summary>
+    /// A numbering system rewrites the digits of a date's fields, and nothing else the pattern wrote.
+    /// </summary>
+    /// <remarks>
+    /// https://tc39.es/ecma402/#sec-formatdatetimepattern splits the pattern with PartitionPattern and
+    /// copies every <c>literal</c> through untouched; <c>[[NumberingSystem]]</c> reaches only a field's
+    /// value, through the FormatNumeric calls in the numeric and 2-digit branches. Those values are
+    /// integers, so a date carries no decimal separator to rewrite — and <c>de-DE</c>, whose pattern
+    /// separates the fields with a full stop, is where rewriting one anyway shows up.
+    /// </remarks>
+    [Test]
+    public void ADatePatternsPunctuationIsNotADecimalSeparator()
+    {
+        var engine = new Engine();
+        const string TwentySeventhOfAugust = "new Date(Date.UTC(2026, 7, 27))";
+        // 27.08.2026 in Arabic-Indic digits, around the full stops de-DE's own pattern writes. Spelled
+        // out because a bidirectional literal is unreadable in a diff and easy to reorder by accident.
+        const string Expected = "٢٧.٠٨.٢٠٢٦";
+
+        var components = "new Intl.DateTimeFormat('de-DE', { numberingSystem: 'arab', "
+            + "year: 'numeric', month: '2-digit', day: '2-digit', timeZone: 'UTC' })";
+
+        engine.Evaluate($"{components}.format({TwentySeventhOfAugust})")
+            .AsString().Should().Be(Expected, "the pattern's full stops are literals, not decimal separators");
+        engine.Evaluate($"{components}.formatToParts({TwentySeventhOfAugust}).map(p => p.value).join('')")
+            .AsString().Should().Be(Expected, "https://tc39.es/ecma402/#sec-formatdatetime is the concatenation of the parts");
+
+        var styled = "new Intl.DateTimeFormat('de-DE', { numberingSystem: 'arab', dateStyle: 'short', timeZone: 'UTC' })";
+        engine.Evaluate($"{styled}.format({TwentySeventhOfAugust})")
+            .AsString().Should().Be(Expected, "a dateStyle pattern's full stops are literals too");
+    }
+
+    /// <summary>
+    /// The one separator a date formatter writes itself — the one before a fractional second — is the
+    /// numbering system's, and both lanes write it.
+    /// </summary>
+    /// <remarks>
+    /// No CLDR pattern supplies this separator: <c>fractionalSecondDigits</c> is a component option, and
+    /// the component lane assembles its own pattern around it. That makes the character
+    /// implementation-, locale- and numbering-system-dependent in the sense
+    /// https://tc39.es/ecma402/#sec-formatdatetimepattern allows, and <c>arab</c> writes U+066B for it —
+    /// which is a different question from the pattern text above, and is pinned here so that answering
+    /// the first one does not silently change this one.
+    /// </remarks>
+    [Test]
+    public void TheSeparatorBeforeAFractionalSecondIsTheNumberingSystems()
+    {
+        var engine = new Engine();
+        const string Instant = "new Date(Date.UTC(2026, 7, 27, 1, 2, 3, 456))";
+        // 02:03 and 456 in Arabic-Indic digits, around U+066B ARABIC DECIMAL SEPARATOR
+        const string Expected = "٠٢:٠٣٫٤٥٦";
+
+        var formatter = "new Intl.DateTimeFormat('en-US', { numberingSystem: 'arab', "
+            + "minute: '2-digit', second: '2-digit', fractionalSecondDigits: 3, timeZone: 'UTC' })";
+
+        engine.Evaluate($"{formatter}.format({Instant})").AsString().Should().Be(Expected);
+        engine.Evaluate($"{formatter}.formatToParts({Instant}).map(p => p.value).join('')")
+            .AsString().Should().Be(Expected);
     }
 
     private static void ShouldWriteArabicIndicDigits(Engine engine, string expression, string expectedDigits)

--- a/Jint/Native/Intl/JsDateTimeFormat.cs
+++ b/Jint/Native/Intl/JsDateTimeFormat.cs
@@ -166,10 +166,15 @@ internal sealed class JsDateTimeFormat : ObjectInstance
             result = FormatWithComponents(dateTime, originalYear);
         }
 
-        // Apply numbering system transliteration if not using Latin digits
+        // Write [[NumberingSystem]]'s digits, and only its digits. https://tc39.es/ecma402/#sec-formatdatetimepattern
+        // splits the pattern with PartitionPattern and copies every "literal" through untouched; the
+        // numbering system reaches a field's value only, through the FormatNumeric calls in the "numeric"
+        // and "2-digit" branches. Those values are integers, so no field carries a decimal separator to
+        // rewrite - and rewriting every full stop instead reached the ones de-DE's own date pattern owns,
+        // turning 27.08.2026 into ٢٧٫٠٨٫٢٠٢٦.
         if (_numberingSystem.RewritesDigits)
         {
-            result = _numberingSystem.Transliterate(result);
+            result = _numberingSystem.TransliterateDigitsOnly(result);
         }
 
         return result;
@@ -1331,7 +1336,14 @@ internal sealed class JsDateTimeFormat : ObjectInstance
                     }
                     else if (firstChar == 'f')
                     {
-                        result.Append('.');
+                        // The separator before a fractional second is this formatter's own, not a
+                        // pattern's: no CLDR pattern supplies one, because fractionalSecondDigits is a
+                        // component option and this method assembles the pattern around it. The parts
+                        // lane writes the numbering system's decimal separator for it, so this lane
+                        // writes the same character - quoted, so .NET copies it out verbatim.
+                        result.Append('\'');
+                        result.Append(_numberingSystem.DecimalSeparator);
+                        result.Append('\'');
                     }
                 }
                 else if (firstChar == 'z')
@@ -1444,13 +1456,15 @@ internal sealed class JsDateTimeFormat : ObjectInstance
             FormatComponentsToParts(dateTime, result, originalYear);
         }
 
-        // Apply numbering system transliteration if not using Latin digits
+        // The digits of every part, and nothing else - the same rewrite Format applies to the assembled
+        // string, one part at a time. A "literal" is pattern text, and the one separator this formatter
+        // writes itself, before a fractional second, is already the numbering system's.
         if (_numberingSystem.RewritesDigits)
         {
             for (var i = 0; i < result.Count; i++)
             {
                 var part = result[i];
-                var transliterated = _numberingSystem.Transliterate(part.Value);
+                var transliterated = _numberingSystem.TransliterateDigitsOnly(part.Value);
                 if (!ReferenceEquals(transliterated, part.Value))
                 {
                     result[i] = new DateTimePart(part.Type, transliterated);

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -2891,6 +2891,45 @@ different calendar than the locale's own. Those formatters wrote a date in the w
 in the requested one. Every other locale is untouched, its culture having carried a Gregorian calendar all
 along.
 
+### 4.61 `Intl.DateTimeFormat` writes the numbering system's digits, and leaves the pattern's punctuation alone ([#3468](https://github.com/sebastienros/jint/issues/3468))
+
+[FormatDateTimePattern](https://tc39.es/ecma402/#sec-formatdatetimepattern) splits the pattern with
+`PartitionPattern` and copies every `literal` through untouched; `[[NumberingSystem]]` reaches a *field's*
+value only, through the `FormatNumeric` calls in the `"numeric"` and `"2-digit"` branches. Those values are
+integers, so no date field carries a decimal separator to rewrite. Both lanes rewrote the whole assembled
+string instead — `format` the result, `formatToParts` every part including the literals — so a locale whose
+date pattern separates its fields with a full stop came out with the numbering system's decimal separator in
+place of its own punctuation:
+
+```js
+const f = new Intl.DateTimeFormat('de-DE', { numberingSystem: 'arab', dateStyle: 'short', timeZone: 'UTC' });
+
+// 4.16.x / earlier 5.0
+f.format(new Date(Date.UTC(2026, 7, 27)));  // "٢٧٫٠٨٫٢٠٢٦"  - U+066B ARABIC DECIMAL SEPARATOR for de-DE's full stops
+
+// 5.x
+f.format(new Date(Date.UTC(2026, 7, 27)));  // "٢٧.٠٨.٢٠٢٦"
+```
+
+This is [4.46](#446-intl-writes-the-numbering-systems-digits-in-the-parts-lane-and-only-in-the-number) one
+constructor over: the same "a literal is pattern text and only a number is a number" split, applied to
+`Intl.DateTimeFormat`'s two lanes rather than `Intl.NumberFormat`'s.
+
+The one separator this formatter writes *itself* is unchanged. `fractionalSecondDigits` is a component
+option, so no CLDR pattern supplies the character between the second and its fraction — the component lane
+assembles the pattern around it, and both lanes write the numbering system's decimal separator there, as the
+parts lane always did:
+
+```js
+new Intl.DateTimeFormat('en-US', { numberingSystem: 'arab', minute: '2-digit', second: '2-digit',
+                                   fractionalSecondDigits: 3, timeZone: 'UTC' })
+  .format(new Date(Date.UTC(2026, 7, 27, 1, 2, 3, 456)));  // "٠٢:٠٣٫٤٥٦" - unchanged
+```
+
+**What could break:** nothing on a default engine. Every formatter that resolves `latn` writes exactly what
+it wrote before, and `latn` is what an unconfigured engine resolves for every locale. Output moves only for a
+formatter that asked for another numbering system, or for an embedder whose `ICldrProvider` gives a locale a
+non-Latin default — and it moves towards the locale's own punctuation.
 ## 5. New in v5
 
 Everything in the table below is opt-in: nothing in it is installed unless the host asks for it, so


### PR DESCRIPTION
[FormatDateTimePattern](https://tc39.es/ecma402/#sec-formatdatetimepattern) splits the pattern with
`PartitionPattern` and copies every `literal` through untouched. `[[NumberingSystem]]` reaches a *field's*
value only — step 15.f, through the `FormatNumeric` calls in the `"numeric"` and `"2-digit"` branches — and
those values are integers, so no date field carries a decimal separator to rewrite.

Both lanes rewrote the whole assembled string instead: `format` the result, `formatToParts` every part
including the literals. `ResolvedNumberingSystem.Transliterate` turns `'.'` into the numbering system's
decimal separator, so a locale whose date pattern separates its fields with a full stop came out corrupted:

```js
new Intl.DateTimeFormat('de-DE', { numberingSystem: 'arab', dateStyle: 'short', timeZone: 'UTC' })
  .format(new Date(Date.UTC(2026, 7, 27)));
// before: "٢٧٫٠٨٫٢٠٢٦"  — U+066B ARABIC DECIMAL SEPARATOR where de-DE's full stops belong
// after:  "٢٧.٠٨.٢٠٢٦"
```

This is #3456 one constructor over, and it takes the fix #3470 gave `Intl.NumberFormat`: rewrite the digits,
and nothing else the pattern wrote. Both `JsDateTimeFormat` lanes now use `TransliterateDigitsOnly`.

## The failing test

`Jint.Tests/Runtime/IntlNumberingSystemTests.ADatePatternsPunctuationIsNotADecimalSeparator`, against
unmodified `Jint/Native/Intl/JsDateTimeFormat.cs`:

```
  Failed ADatePatternsPunctuationIsNotADecimalSeparator [307 ms]
  Error Message:
   Expected string to be the same string because the pattern's full stops are literals, not decimal separators, but they differ at index 2:
     ↓ (actual)
  "٢٧٫٠٨٫٢٠٢٦"
  "٢٧.٠٨.٢٠٢٦"
     ↑ (expected).
```

## The one separator that does not move

`fractionalSecondDigits` is a component option, so no CLDR pattern supplies the character between the second
and its fraction — Jint's component lane assembles the pattern around it. The parts lane always wrote the
numbering system's decimal separator there deliberately; the string lane got the same character by accident,
from the blanket rewrite. It now writes it explicitly, so the two lanes still agree and the output is
unchanged:

```js
new Intl.DateTimeFormat('en-US', { numberingSystem: 'arab', minute: '2-digit', second: '2-digit',
                                   fractionalSecondDigits: 3, timeZone: 'UTC' })
  .format(new Date(Date.UTC(2026, 7, 27, 1, 2, 3, 456)));  // "٠٢:٠٣٫٤٥٦", before and after
```

That is not a guess: `intl402/DateTimeFormat/prototype/format/numbering-system.js` pins exactly this, with
U+066B for `arab` and a plain full stop for `deva` and `hanidec`. `TheSeparatorBeforeAFractionalSecondIsTheNumberingSystems`
pins it on our side too, so answering the pattern-text question cannot silently answer this one.

## test262

**102,495 passed / 2 failed / 187 skipped** (control: 102,495 / 0 / 189).

The two failures are the known `TemporalHelpers` 100 ms regex match timeout (#3485) —
`RegexMatchTimeoutException` on `temporal-objects-ignore-timezone.js` and
`temporal-objects-format-weekday-long.js` — and are not from this branch; a second run produced a different
set of load flakes on the same box, including a 31 s `TimeoutException` on
`intl402/supportedLocalesOf-unicode-extensions-ignored.js`.

Skipped drops by two because
`intl402/DateTimeFormat/prototype/format/numbering-system.js` leaves the exclusion list. Its comment
("hanidec numbering system has different AM/PM behavior in ICU/CLDR") is stale: **all sixteen of its
assertions pass on unmodified `main` too** — I checked by reverting only `JsDateTimeFormat.cs` and re-running
them. It is removed here rather than elsewhere because it is the test262 file that covers precisely what this
branch changes, and it now guards the change. Filtered run afterwards:
`DateTimeFormat_prototype_format` — 288 passed, 0 failed, 10 skipped.

`dotnet test -c Release Jint.Tests/Jint.Tests.csproj` is green on all three target frameworks
(net472 7,531; net8.0 and net10.0 10,907 each).

Migration guide: **§4.57**.

Fixes #3468
