### PR TITLE
Intl.DateTimeFormat formats in the calendar it reports

### DIFF
--- a/Jint.Tests/Runtime/IntlCalendarDefaultTests.cs
+++ b/Jint.Tests/Runtime/IntlCalendarDefaultTests.cs
@@ -124,6 +124,138 @@ public class IntlCalendarDefaultTests
             .AsString().Should().Be("gregory");
     }
 
+    /// <summary>
+    /// https://tc39.es/ecma402/#sec-formatdatetimepattern step 13 reads the field values out of
+    /// <c>dateTimeFormat.[[Calendar]]</c> — the calendar <c>resolvedOptions()</c> reports — so the two cannot
+    /// come apart. They did wherever the locale's own <see cref="System.Globalization.CultureInfo"/> carried a
+    /// non-Gregorian <see cref="System.Globalization.Calendar"/>: .NET applied that one on top of whatever Jint
+    /// had already applied, and <c>ar-SA</c> asked for <c>gregory</c> answered <c>"gregory"</c> and wrote
+    /// <c>14/3/1448</c>.
+    /// </summary>
+    [TestCase("ar-SA", "{ calendar: 'gregory', timeZone: 'UTC' }", "1448")]
+    [TestCase("ar-SA-u-ca-gregory", "{ timeZone: 'UTC' }", "1448")]
+    [TestCase("th-TH", "{ calendar: 'gregory', timeZone: 'UTC' }", "2569")]
+    [TestCase("fa-IR", "{ calendar: 'gregory', timeZone: 'UTC' }", "1405")]
+    public void ARequestedGregorianCalendarIsTheOneItFormatsIn(string locale, string options, string otherCalendarYear)
+    {
+        var formatted = Format(locale, options);
+
+        formatted.Calendar.Should().Be("gregory");
+        formatted.Value.Should().Contain("2026").And.NotContain(otherCalendarYear);
+        formatted.Parts.Should().Be(formatted.Value);
+    }
+
+    /// <summary>The Gregorian month and day come out too, not only the year.</summary>
+    [TestCase("ar-SA", "{ calendar: 'gregory', timeZone: 'UTC' }")]
+    [TestCase("th-TH", "{ calendar: 'gregory', timeZone: 'UTC' }")]
+    [TestCase("fa-IR", "{ calendar: 'gregory', timeZone: 'UTC' }")]
+    public void ARequestedGregorianCalendarWritesTheGregorianMonthAndDay(string locale, string options)
+    {
+        Fields(locale, options).Should().Be("2026-8-27");
+    }
+
+    /// <summary>
+    /// The other direction of the same invariant: with nothing requested the locale's own calendar is still
+    /// resolved, and is still the one the date is written in — now through Jint's own conversion rather than
+    /// .NET's.
+    /// </summary>
+    [TestCase("ar-SA", "islamic-umalqura", "1448-3-14")]
+    [TestCase("th-TH", "buddhist", "2569-8-27")]
+    [TestCase("fa-IR", "persian", "1405-6-5")]
+    [TestCase("en-US", "gregory", "2026-8-27")]
+    public void TheLocalesOwnCalendarIsStillTheOneItFormatsIn(string locale, string expectedCalendar, string expectedFields)
+    {
+        var formatted = Format(locale, "{ timeZone: 'UTC' }");
+
+        formatted.Calendar.Should().Be(expectedCalendar);
+        formatted.Parts.Should().Be(formatted.Value);
+        Fields(locale, "{ timeZone: 'UTC' }").Should().Be(expectedFields);
+    }
+
+    /// <summary>
+    /// A calendar a locale's own <see cref="System.Globalization.CultureInfo"/> knows nothing about is
+    /// reached the same way, so asking <c>ar-SA</c> for the Buddhist calendar writes a Buddhist year rather
+    /// than a Hijri one.
+    /// </summary>
+    [Test]
+    public void AThirdCalendarIsNeitherOfTheOtherTwo()
+    {
+        var formatted = Format("ar-SA", "{ calendar: 'buddhist', timeZone: 'UTC' }");
+
+        formatted.Calendar.Should().Be("buddhist");
+        formatted.Value.Should().Contain("2569");
+        formatted.Parts.Should().Be(formatted.Value);
+    }
+
+    /// <summary>
+    /// The month a name is written for moves with the resolved calendar's month, in every style — including
+    /// <c>"narrow"</c>, whose name is not read out of a pattern but derived from the abbreviated slot, which
+    /// the shipped <see cref="DefaultCldrProvider"/> fills from the locale's own calendar.
+    /// </summary>
+    [TestCase("narrow")]
+    [TestCase("short")]
+    [TestCase("long")]
+    [TestCase("numeric")]
+    public void TheMonthNameMovesWithTheResolvedCalendarsMonth(string style)
+    {
+        // 2026-08-05 and 2026-08-27 are one Gregorian month and two Hijri ones, Safar and Rabi' I.
+        var options = $"{{ calendar: 'gregory', month: '{style}', timeZone: 'UTC' }}";
+
+        MonthOn("Date.UTC(2026, 7, 5)", options).Should().Be(MonthOn("Date.UTC(2026, 7, 27)", options));
+        MonthOn("Date.UTC(2026, 8, 27)", options).Should().NotBe(MonthOn("Date.UTC(2026, 7, 27)", options));
+    }
+
+    private string MonthOn(string date, string options)
+        => _engine.Evaluate($"new Intl.DateTimeFormat('ar-SA', {options}).format(new Date({date}))").AsString();
+
+    /// <summary>
+    /// The culture a formatter adjusts is its own clone: the process-wide cache hands out a read-only
+    /// instance every engine shares, so one formatter asking for <c>gregory</c> must not be the next one's
+    /// calendar.
+    /// </summary>
+    [Test]
+    public void OneFormattersCalendarIsNotTheNextOnes()
+    {
+        Format("ar-SA", "{ calendar: 'gregory', timeZone: 'UTC' }").Value.Should().Contain("2026");
+        Format("ar-SA", "{ timeZone: 'UTC' }").Value.Should().Contain("1448");
+
+        new Engine().Evaluate(
+            "new Intl.DateTimeFormat('ar-SA', { timeZone: 'UTC' }).format(new Date(Date.UTC(2026, 7, 27)))")
+            .AsString().Should().Contain("1448");
+    }
+
+    /// <summary>2026-08-27 is 14 Rabi' I 1448, 5 Shahrivar 1405 and 27 August 2569 BE.</summary>
+    private (string Calendar, string Value, string Parts) Format(string locale, string options)
+    {
+        var script = $$"""
+            (function () {
+                var d = new Date(Date.UTC(2026, 7, 27));
+                var f = new Intl.DateTimeFormat('{{locale}}', {{options}});
+                var parts = f.formatToParts(d).map(function (p) { return p.value; }).join('');
+                return [f.resolvedOptions().calendar, f.format(d), parts].join('~');
+            })()
+            """;
+
+        var pieces = _engine.Evaluate(script).AsString().Split('~');
+        return (pieces[0], pieces[1], pieces[2]);
+    }
+
+    /// <summary>The year, month and day <c>formatToParts</c> names, so a separator cannot stand in for one.</summary>
+    private string Fields(string locale, string options)
+    {
+        var script = $$"""
+            (function () {
+                var d = new Date(Date.UTC(2026, 7, 27));
+                var f = new Intl.DateTimeFormat('{{locale}}', {{options}});
+                var seen = {};
+                f.formatToParts(d).forEach(function (p) { seen[p.type] = p.value; });
+                return [seen.year, seen.month, seen.day].join('-');
+            })()
+            """;
+
+        return _engine.Evaluate(script).AsString();
+    }
+
     /// <summary>The shipped provider's own answers, read directly.</summary>
     [Test]
     public void TheShippedProviderReadsCldrsTable()

--- a/Jint/Native/Intl/DateTimeFormatConstructor.cs
+++ b/Jint/Native/Intl/DateTimeFormatConstructor.cs
@@ -429,6 +429,14 @@ internal sealed partial class DateTimeFormatConstructor : Constructor
         // in becomes "gregory" rather than a calendar nothing can write a date with.
         calendar ??= GetDefaultCalendarForLocale(resolvedLocale);
 
+        // https://tc39.es/ecma402/#sec-formatdatetimepattern step 13 takes the field values from
+        // dateTimeFormat.[[Calendar]] — the calendar resolvedOptions() reports — and JsDateTimeFormat is
+        // where that calendar is applied, by ResolveCalendarFieldsForFormatting, working from a proleptic
+        // Gregorian DateTime. A DateTimeFormatInfo whose own Calendar is not Gregorian would apply a second
+        // one underneath, so this formatter's copy is pinned to Gregorian first and the resolved calendar
+        // stays the only one anything converts to.
+        var calendarPinned = TryPinGregorianCalendar(dateTimeFormatInfo, culture);
+
         // https://tc39.es/ecma402/#sec-formatdatetimepattern — the month, weekday and day-period names a
         // pattern writes are locale data. Every one of them is produced by handing a .NET pattern to
         // this culture, so seeding the culture's own tables is the one place a host's names reach all of
@@ -443,7 +451,7 @@ internal sealed partial class DateTimeFormatConstructor : Constructor
         // culture on the machine and compares all five arrays entry by entry.
         var cldrProvider = _engine.Options.Intl.CldrProvider;
         var namesChanged = !ReferenceEquals(cldrProvider, DefaultCldrProvider.Instance)
-            && ApplyProviderNames(cldrProvider, dateTimeFormatInfo, culture.DateTimeFormat, resolvedLocale, calendar);
+            && ApplyProviderNames(cldrProvider, dateTimeFormatInfo, resolvedLocale, calendar);
 
         // https://tc39.es/ecma402/#table-datetimeformat-components — "narrow" is a value of weekday and of
         // month in its own right, and there is no .NET pattern letter for it. The narrow name goes into the
@@ -453,13 +461,17 @@ internal sealed partial class DateTimeFormatConstructor : Constructor
         // the same formatter still needs: month and weekday have separate arrays, and a formatter carrying
         // dateStyle or timeStyle has neither option set.
         //
-        // Unlike the block above this asks the shared singleton too, and the guard is the option rather than
-        // the provider's identity: it is asked only when a narrow style is actually requested, so a default
-        // construction is untouched, and asking it there teaches something — .NET's narrow weekday names live
-        // in a slot no pattern letter reaches, and it has no narrow month names at all.
-        namesChanged |= ApplyNarrowNames(cldrProvider, dateTimeFormatInfo, resolvedLocale, calendar, month, weekday);
+        // Unlike the block above this reaches the shared singleton's data too, and the guard is the option
+        // rather than the provider's identity: it is read only when a narrow style is actually requested, so a
+        // default construction is untouched, and reading it there teaches something — .NET's narrow weekday
+        // names live in a slot no pattern letter reaches, and it has no narrow month names at all.
+        namesChanged |= ApplyNarrowNames(cldrProvider, dateTimeFormatInfo, culture, resolvedLocale, calendar, month, weekday);
 
-        if (namesChanged)
+        // The culture IntlUtilities hands out is read-only and shared process-wide, so a formatter that
+        // adjusted anything formats through a clone carrying its own DateTimeFormatInfo instead. Both lanes
+        // read it: the string lane hands the CultureInfo to DateTime.ToString, the parts lane reads month
+        // and weekday names out of the same instance.
+        if (namesChanged || calendarPinned)
         {
             culture = (CultureInfo) culture.Clone();
             culture.DateTimeFormat = dateTimeFormatInfo;
@@ -512,6 +524,60 @@ internal sealed partial class DateTimeFormatConstructor : Constructor
     }
 
     /// <summary>
+    /// Points one formatter's <see cref="DateTimeFormatInfo"/> at the culture's Gregorian calendar, so that
+    /// .NET writes proleptic Gregorian fields and the resolved calendar is the only one applied.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// https://tc39.es/ecma402/#sec-formatdatetimepattern step 13 says the fields come from
+    /// <c>dateTimeFormat.[[Calendar]]</c>, which <c>JsDateTimeFormat.ResolveCalendarFieldsForFormatting</c>
+    /// applies to a proleptic Gregorian <see cref="DateTime"/>. Where a locale's own
+    /// <see cref="CultureInfo"/> carries a non-Gregorian <see cref="Calendar"/> — <c>ar-SA</c>,
+    /// <c>fa-IR</c>, <c>th-TH</c> and a dozen others — every <c>DateTime.ToString(pattern, culture)</c>
+    /// applied a second conversion underneath, so a formatter reporting <c>"gregory"</c> wrote a Hijri,
+    /// Persian or Buddhist date, and the parts lane, which reads <see cref="DateTime.Year"/> directly,
+    /// disagreed with it field by field.
+    /// </para>
+    /// <para>
+    /// <see cref="DateTimeFormatInfo.Calendar"/> accepts only a calendar the culture lists, and a culture
+    /// can offer more than one <see cref="GregorianCalendarTypes"/>, so the instance comes from
+    /// <see cref="CultureInfo.OptionalCalendars"/> rather than being constructed. A culture offering none is
+    /// left alone: the wrong date is better than no formatter at all.
+    /// </para>
+    /// <para>
+    /// The setter resets the patterns, month names and era names it owns to the new calendar's, which is why
+    /// this runs before <see cref="ApplyProviderNames"/> seeds a host's data over them.
+    /// </para>
+    /// </remarks>
+    private static bool TryPinGregorianCalendar(DateTimeFormatInfo target, CultureInfo culture)
+    {
+        if (target.Calendar is GregorianCalendar)
+        {
+            return false;
+        }
+
+        foreach (var candidate in culture.OptionalCalendars)
+        {
+            if (candidate is not GregorianCalendar)
+            {
+                continue;
+            }
+
+            try
+            {
+                target.Calendar = candidate;
+                return true;
+            }
+            catch (ArgumentException)
+            {
+                return false;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Seeds one formatter's <see cref="DateTimeFormatInfo"/> with the month, weekday and day-period names
     /// a host <see cref="ICldrProvider"/> answers with, and reports whether any of them differed from what
     /// .NET already held. Reached only for a provider the host installed: <see cref="DefaultCldrProvider"/>'s
@@ -527,18 +593,22 @@ internal sealed partial class DateTimeFormatConstructor : Constructor
     /// The narrow styles are not read here. <see cref="ApplyNarrowNames"/> reads them instead, from every
     /// provider and only for the formatter that asked for one.
     /// </para>
+    /// <para>
+    /// "What .NET already held" is read off <paramref name="target"/> rather than off the culture, because
+    /// <see cref="TryPinGregorianCalendar"/> may already have re-based it: the names a formatter starts from
+    /// are the ones its own calendar carries.
+    /// </para>
     /// </remarks>
     private static bool ApplyProviderNames(
         ICldrProvider provider,
         DateTimeFormatInfo target,
-        DateTimeFormatInfo original,
         string locale,
         string? calendar)
     {
         var changed = false;
 
         var longMonths = provider.GetMonthNames(locale, "long", calendar);
-        if (DiffersFrom(longMonths, original.MonthNames, 12))
+        if (DiffersFrom(longMonths, target.MonthNames, 12))
         {
             target.MonthNames = WithTrailingEmpty(longMonths!);
             target.MonthGenitiveNames = WithTrailingEmpty(longMonths!);
@@ -546,7 +616,7 @@ internal sealed partial class DateTimeFormatConstructor : Constructor
         }
 
         var shortMonths = provider.GetMonthNames(locale, "short", calendar);
-        if (DiffersFrom(shortMonths, original.AbbreviatedMonthNames, 12))
+        if (DiffersFrom(shortMonths, target.AbbreviatedMonthNames, 12))
         {
             target.AbbreviatedMonthNames = WithTrailingEmpty(shortMonths!);
             target.AbbreviatedMonthGenitiveNames = WithTrailingEmpty(shortMonths!);
@@ -554,14 +624,14 @@ internal sealed partial class DateTimeFormatConstructor : Constructor
         }
 
         var longWeekdays = provider.GetWeekdayNames(locale, "long");
-        if (DiffersFrom(longWeekdays, original.DayNames, 7))
+        if (DiffersFrom(longWeekdays, target.DayNames, 7))
         {
             target.DayNames = (string[]) longWeekdays!.Clone();
             changed = true;
         }
 
         var shortWeekdays = provider.GetWeekdayNames(locale, "short");
-        if (DiffersFrom(shortWeekdays, original.AbbreviatedDayNames, 7))
+        if (DiffersFrom(shortWeekdays, target.AbbreviatedDayNames, 7))
         {
             target.AbbreviatedDayNames = (string[]) shortWeekdays!.Clone();
             changed = true;
@@ -570,8 +640,8 @@ internal sealed partial class DateTimeFormatConstructor : Constructor
         // The pattern letter is "tt", whose CLDR counterpart is the abbreviated day period.
         var dayPeriods = provider.GetDayPeriods(locale, "short", calendar);
         if (dayPeriods is { Length: 2 }
-            && (!string.Equals(dayPeriods[0], original.AMDesignator, StringComparison.Ordinal)
-                || !string.Equals(dayPeriods[1], original.PMDesignator, StringComparison.Ordinal)))
+            && (!string.Equals(dayPeriods[0], target.AMDesignator, StringComparison.Ordinal)
+                || !string.Equals(dayPeriods[1], target.PMDesignator, StringComparison.Ordinal)))
         {
             target.AMDesignator = dayPeriods[0];
             target.PMDesignator = dayPeriods[1];
@@ -587,12 +657,23 @@ internal sealed partial class DateTimeFormatConstructor : Constructor
     /// when <c>month</c> or <c>weekday</c> is <c>"narrow"</c>, and reports whether it wrote anything.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// An answer of the wrong length, or none at all, leaves the abbreviated names in place — which is the
     /// behaviour every release before this one had for a narrow style.
+    /// </para>
+    /// <para>
+    /// The shipped provider derives a narrow month from the abbreviated one and reads that out of the shared
+    /// culture, which carries the calendar the locale defaults to rather than the one this formatter
+    /// resolved. Narrowing <paramref name="target"/>'s own names instead is the same answer wherever the two
+    /// agree, and the resolved calendar's answer where <see cref="TryPinGregorianCalendar"/> has re-based
+    /// them. A host provider is asked either way, because it takes the calendar as an argument and can
+    /// answer for it, and weekday names are calendar-independent.
+    /// </para>
     /// </remarks>
     private static bool ApplyNarrowNames(
         ICldrProvider provider,
         DateTimeFormatInfo target,
+        CultureInfo culture,
         string locale,
         string? calendar,
         string? month,
@@ -602,7 +683,9 @@ internal sealed partial class DateTimeFormatConstructor : Constructor
 
         if (string.Equals(month, "narrow", StringComparison.Ordinal))
         {
-            var narrowMonths = provider.GetMonthNames(locale, "narrow", calendar);
+            var narrowMonths = ReferenceEquals(provider, DefaultCldrProvider.Instance)
+                ? DefaultCldrProvider.NarrowMonthsOf(culture, target.AbbreviatedMonthNames)
+                : provider.GetMonthNames(locale, "narrow", calendar);
             if (narrowMonths is { Length: 12 })
             {
                 target.AbbreviatedMonthNames = WithTrailingEmpty(narrowMonths);

--- a/Jint/Native/Intl/DefaultCldrProvider.cs
+++ b/Jint/Native/Intl/DefaultCldrProvider.cs
@@ -425,8 +425,15 @@ public class DefaultCldrProvider : ICldrProvider
     /// narrow month slot to read at all.
     /// </summary>
     private static string[] NarrowMonths(CultureInfo culture)
+        => NarrowMonthsOf(culture, culture.DateTimeFormat.AbbreviatedMonthNames);
+
+    /// <summary>
+    /// The same derivation over abbreviated names the caller already holds, so a formatter whose own
+    /// <see cref="DateTimeFormatInfo"/> carries a different calendar's names narrows those rather than the
+    /// ones the locale defaults to.
+    /// </summary>
+    internal static string[] NarrowMonthsOf(CultureInfo culture, string[] abbreviated)
     {
-        var abbreviated = culture.DateTimeFormat.AbbreviatedMonthNames;
         var result = new string[12];
         for (var i = 0; i < 12; i++)
         {

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -2850,6 +2850,47 @@ a locale whose unit pattern has a prefix (`ja-JP`, `ko-KR`, `zh-TW` long units),
 notation of zero, and a currency's sign in a locale whose sign is not ASCII. A string that was already the
 concatenation of its own parts does not move: this is the two lanes being brought onto one walk, and it is
 that walk that decides.
+
+### 4.60 `Intl.DateTimeFormat` formats in the calendar it reports ([#3467](https://github.com/sebastienros/jint/issues/3467))
+
+[FormatDateTimePattern](https://tc39.es/ecma402/#sec-formatdatetimepattern) step 13 reads a pattern's field
+values out of `dateTimeFormat.[[Calendar]]` — the resolved calendar, and the one `resolvedOptions().calendar`
+reports — so the two cannot come apart. They did wherever a locale's own .NET `CultureInfo` carried a
+non-Gregorian `Calendar` of its own: Jint applied the resolved calendar and .NET then applied the culture's on
+top, so `ar-SA` asked for `gregory` answered `"gregory"` and wrote a Hijri date. The parts lane, which reads
+the `DateTime` fields directly, applied only one of the two — which is why it disagreed with `format()` field
+by field rather than agreeing on the wrong answer.
+
+A formatter's `DateTimeFormatInfo` is now pinned to the culture's own Gregorian calendar, leaving the resolved
+calendar the only one anything converts to.
+
+```js
+const d = new Date(Date.UTC(2026, 7, 27)); // 27 August 2026 = 14 Rabi' I 1448
+
+// 5.0
+new Intl.DateTimeFormat('ar-SA', { calendar: 'gregory' }).format(d);        // "14/3/1448" - the Hijri date
+new Intl.DateTimeFormat('ar-SA', { calendar: 'gregory' }).formatToParts(d); // ...spells "14/3/2026"
+new Intl.DateTimeFormat('th-TH', { calendar: 'gregory' }).format(d);        // "27/8/2569" - the Buddhist year
+new Intl.DateTimeFormat('fa-IR', { calendar: 'gregory' }).format(d);        // "1405/6/5"  - the Persian date
+
+// 5.x - each of the six writes the Gregorian date its resolvedOptions() names
+new Intl.DateTimeFormat('ar-SA', { calendar: 'gregory' }).format(d);        // "27/8/2026"
+new Intl.DateTimeFormat('th-TH', { calendar: 'gregory' }).format(d);        // "27/8/2026"
+new Intl.DateTimeFormat('fa-IR', { calendar: 'gregory' }).format(d);        // "2026/8/27"
+```
+
+`-u-ca-gregory` is the same case and moves with it. The locale defaults are unchanged in both what they
+resolve to and what they write — `ar-SA` still reports `islamic-umalqura` and still prints `14/3/1448`,
+`th-TH` still prints `2569` and `fa-IR` still prints `1405` — but the conversion behind them is now Jint's
+own, the one that already served `new Intl.DateTimeFormat('en-US', { calendar: 'islamic-umalqura' })`.
+
+**What could break:** a formatter whose locale is one of the fifteen .NET cultures with a non-Gregorian
+default calendar — `ar-SA`, `th`/`th-TH`, and the Persian-calendar group `fa`, `fa-AF`, `fa-IR`, `ps`,
+`ps-AF`, `ckb-IR`, `lrc`, `lrc-IR`, `mzn`, `mzn-IR`, `uz-Arab`, `uz-Arab-AF` — *and* which asks for a
+different calendar than the locale's own. Those formatters wrote a date in the wrong calendar and now write it
+in the requested one. Every other locale is untouched, its culture having carried a Gregorian calendar all
+along.
+
 ## 5. New in v5
 
 Everything in the table below is opt-in: nothing in it is installed unless the host asks for it, so


### PR DESCRIPTION
Fixes #3467.

`Intl.DateTimeFormat` reported the requested calendar from `resolvedOptions()` and then did not format in it, whenever the locale's .NET `CultureInfo` carried a non-Gregorian `Calendar` of its own.

[FormatDateTimePattern](https://tc39.es/ecma402/#sec-formatdatetimepattern) step 13 is unambiguous about where the field values come from:

> 1. Let _localTime_ be ToLocalTime(_epochNanoseconds_, _dateTimeFormat_.[[Calendar]], _dateTimeFormat_.[[TimeZone]]).

`[[Calendar]]` is the resolved calendar — what the `calendar` option or a `-u-ca-` subtag set, and what `resolvedOptions().calendar` returns — so reporting one calendar and formatting in another is a plain violation.

## What was happening

Jint's own calendar machinery was never the problem: `JsDateTimeFormat.ResolveCalendarFieldsForFormatting` converts a proleptic-Gregorian `DateTime` to the resolved calendar, and `en-US` with `{ calendar: 'islamic-umalqura' }` correctly wrote `3/14/1448`. The second conversion was the problem. `IntlUtilities.GetCultureInfo("ar-SA")` hands back a `CultureInfo` whose `DateTimeFormat.Calendar` is `UmAlQuraCalendar`, so every `dateTime.ToString(pattern, culture)` in the string lane converted again — while the parts lane, which reads `dateTime.Year`/`.Month`/`.Day` directly, did not. That is also why the two lanes disagreed with each other.

With `d = new Date(Date.UTC(2026, 7, 27))` (27 August 2026 = 14 Rabi' I 1448), on `main`:

| formatter | `resolvedOptions().calendar` | `format(d)` | `formatToParts(d)` joined |
| --- | --- | --- | --- |
| `ar-SA` `{calendar:'gregory'}` | `gregory` | `14/3/1448` | `14/3/2026` |
| `ar-SA-u-ca-gregory` | `gregory` | `14/3/1448` | `14/3/2026` |
| `th-TH` `{calendar:'gregory'}` | `gregory` | `27/8/2569` | `27/8/2026` |
| `fa-IR` `{calendar:'gregory'}` | `gregory` | `1405/6/5` | `2026/6/5` |

## The fix

The invariant established: **the `CultureInfo`/`DateTimeFormatInfo` a `JsDateTimeFormat` formats through never applies a calendar conversion of its own.** `DateTimeFormatConstructor` already clones the `DateTimeFormatInfo` per formatter, so the clone is now pinned to the culture's own Gregorian calendar and Jint's resolved-calendar machinery is left as the single place a calendar is applied.

Details that mattered:

- `DateTimeFormatInfo.Calendar`'s setter accepts only a calendar the culture lists, and a culture can offer more than one `GregorianCalendarTypes`, so the instance comes from `CultureInfo.OptionalCalendars` rather than being constructed. A culture offering none is left alone rather than throwing out of a constructor.
- The setter resets the patterns, month names and era names it owns, so it runs **before** the host CLDR data is seeded — and `ApplyProviderNames` now reads "what .NET already held" off the clone rather than off the culture, since the clone is what the formatter starts from.
- `IntlUtilities.GetCultureInfo` hands out a **shared, read-only** `CultureInfo` (#3448, #3462). Only the per-formatter clone is mutated, and the string lane now formats through that clone — previously the `CultureInfo` was only re-based when the CLDR names changed.
- Narrow months follow the same rule. The shipped `DefaultCldrProvider` derives them from the abbreviated slot, which it reads out of the *shared* culture, so `ar-SA` + `gregory` + `month:'narrow'` would have narrowed a Hijri name list indexed by a Gregorian month. It now narrows the formatter's own names, which is the identical answer wherever no calendar was pinned.

Era names are unaffected — they come from `ICldrProvider.GetEraNames(locale, style, calendar)` with the *resolved* calendar, not from the culture.

## After

| formatter | `resolvedOptions().calendar` | `format(d)` | `formatToParts(d)` joined |
| --- | --- | --- | --- |
| `ar-SA` `{calendar:'gregory'}` | `gregory` | `27/8/2026` | `27/8/2026` |
| `ar-SA-u-ca-gregory` | `gregory` | `27/8/2026` | `27/8/2026` |
| `th-TH` `{calendar:'gregory'}` | `gregory` | `27/8/2026` | `27/8/2026` |
| `fa-IR` `{calendar:'gregory'}` | `gregory` | `2026/8/27` | `2026/8/27` |
| `ar-SA` (default) | `islamic-umalqura` | `14/3/1448` | `14/3/1448` |
| `th-TH` (default) | `buddhist` | `27/8/2569` | `27/8/2569` |
| `fa-IR` (default) | `persian` | `1405/6/5` | `1405/6/5` |

The defaults are unchanged in both what they resolve to and what they write — that is #3474's behaviour, now reached through Jint's own conversion instead of .NET's.

## The tests, run against the unfixed engine first

`Jint.Tests/Runtime/IntlCalendarDefaultTests.cs`, beside the `ca` resolution tests from #3474:

```
  Failed ARequestedGregorianCalendarIsTheOneItFormatsIn("ar-SA","{ calendar: 'gregory', timeZone: 'UTC' }","1448") [313 ms]
  Error Message:
   Expected formatted.Value "14/3/1448" to contain "2026".

  Failed ARequestedGregorianCalendarIsTheOneItFormatsIn("th-TH","{ calendar: 'gregory', timeZone: 'UTC' }","2569") [2 ms]
  Error Message:
   Expected formatted.Value "27/8/2569" to contain "2026".

  Failed ARequestedGregorianCalendarWritesTheGregorianMonthAndDay("ar-SA","{ calendar: 'gregory', timeZone: 'UTC' }") [46 ms]
  Error Message:
   Expected string to be the same string, but they differ at index 5:
        ↓ (actual)
  "2026-3-14"
  "2026-8-27"
        ↑ (expected).

Failed!  - Failed:     7, Passed:    28, Skipped:     0, Total:    35, Duration: 2 s - Jint.Tests.dll (net472)
```

Every case asserts that `format()` matches `resolvedOptions().calendar` **and** that `formatToParts()` joined equals `format()`, so neither lane can drift on its own. The four locale defaults are pinned the same way, and one test walks two dates in one Gregorian month but two Hijri ones so the month a name is written for cannot come from the wrong calendar in any style.

## Verification

- `dotnet build -c Release` and `dotnet test -c Release Jint.Tests/Jint.Tests.csproj` green on `net472`, `net8.0` and `net10.0` (10,952 / 7,576 passing).
- `Jint.Tests.PublicInterface` green on all three.
- test262: **102,495 passed / 0 failed / 189 skipped**, matching `main`. `Test262Harness.settings.json` is untouched: the six `intl402/Temporal/*/prototype/toLocaleString/dateStyle.js` exclusions were re-run directly and still fail on `dateStyle: long writes month of Ramadan out in full`, which needs non-Gregorian month *names* rather than a calendar; the `basic-islamic-umalqura.js` group is Temporal calendar arithmetic and does not reach `DateTimeFormat`.

## Out of scope

`dateStyle`/`timeStyle` output in the parts lane is still rebuilt from a hard-coded en-US field order and still does not apply the resolved calendar — that is #3469, in its own pull request. Nothing here touches `FormatDateStyleToParts`.

Migration guide: §4.56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014W5mbjGhyvgAS4pivXoc4S
