### PR TITLE
Intl.NumberFormat: a non-finite value keeps the style written around it

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -226,20 +226,6 @@
     //"intl402/NumberFormat/prototype/formatRange/en-US.js",
     //"intl402/NumberFormat/prototype/formatRange/pt-PT.js",
     //"intl402/NumberFormat/prototype/formatRangeToParts/en-US.js",
-    // Unit formatting formatToParts - locale-specific unit patterns
-    "intl402/NumberFormat/prototype/formatToParts/unit-de-DE.js",
-    "intl402/NumberFormat/prototype/formatToParts/unit-ja-JP.js",
-    "intl402/NumberFormat/prototype/formatToParts/unit-ko-KR.js",
-    "intl402/NumberFormat/prototype/formatToParts/unit-zh-TW.js",
-    // Unit formatting format - as of test262 #5079 these derive the expected unit/number separator
-    // from the implementation's own formatToParts() output (via the getUnitSeparators helper) instead
-    // of hard-coding it. That transitively depends on the same CLDR unit-part data the formatToParts
-    // unit tests above are excluded for: ICU4N ships only core locale data, so Jint's formatToParts
-    // reports a different long-unit separator than its (correct) format() output, and the constructed
-    // expectation no longer matches. (e.g. format() yields "時速 -987 キロメートル" but the helper builds
-    // "時速-987 キロメートル".)
-    "intl402/NumberFormat/prototype/format/unit-ja-JP.js",
-    "intl402/NumberFormat/prototype/format/unit-zh-TW.js",
 
     // PluralRules - compact notation affects plural category
     //"intl402/PluralRules/prototype/select/notation.js",

--- a/Jint.Tests/Runtime/IntlNumberFormatPartsTests.cs
+++ b/Jint.Tests/Runtime/IntlNumberFormatPartsTests.cs
@@ -10,12 +10,12 @@ namespace Jint.Tests.Runtime;
 /// are the same characters read two ways — including when <c>[[NumberingSystem]]</c> is not Latin.
 /// </summary>
 /// <remarks>
-/// The grids below compare each numbering system against <c>latn</c> rather than asserting the join outright:
-/// what is being pinned is that <b>asking for a numbering system introduces no disagreement</b>, so a
-/// combination whose Latin lanes already differ is skipped instead of being silently blessed. Four such
-/// combinations exist today, all of them about locale data rather than digits — a <c>ja-JP</c> long unit
-/// name, an <c>ar-EG</c> negative currency's directionality mark, <c>notation: "scientific"</c> of exactly
-/// zero, and a non-finite value under <c>style: "currency"</c> or <c>"unit"</c>.
+/// <see cref="PartsConcatenateToFormat"/> asserts the join outright, in every numbering system and in
+/// <c>latn</c> alike. The other two grids compare each numbering system against <c>latn</c> instead, which
+/// pins the narrower claim that <b>asking for a numbering system introduces no disagreement</b> and skips a
+/// combination whose Latin lanes already differ rather than silently blessing it. One such combination
+/// exists today and it belongs to the range lane: <c>formatRange</c> of a currency writes the symbol once
+/// where its parts lane repeats it per endpoint.
 /// </remarks>
 public class IntlNumberFormatPartsTests
 {
@@ -53,7 +53,9 @@ public class IntlNumberFormatPartsTests
     /// <summary>
     /// The defect: <c>format</c> transliterated and <c>formatToParts</c> did not, so
     /// <c>new Intl.NumberFormat('en', { numberingSystem: 'arab' })</c> wrote <c>"١,٢٣٤٫٥"</c> from one lane
-    /// and <c>"1,234.5"</c> from the other.
+    /// and <c>"1,234.5"</c> from the other. The grid asserts the join outright, so it also stands over the
+    /// four disagreements that had nothing to do with digits — a unit pattern's prefix, a currency's sign,
+    /// scientific notation of zero, and a non-finite value's style.
     /// </summary>
     [Test]
     public void PartsConcatenateToFormat()
@@ -67,22 +69,25 @@ public class IntlNumberFormatPartsTests
                 var optionSets = [{{string.Join(", ", OptionSets)}}];
                 var values = {{Values}};
                 function join(parts) { return parts.map(function (p) { return p.value; }).join(''); }
+                function check(nf, system, locale, o, value) {
+                    var joined = join(nf.formatToParts(value));
+                    var formatted = nf.format(value);
+                    if (joined !== formatted) {
+                        bad.push(locale + '/' + system + '/' + o + '/' + value
+                            + ': format=' + formatted + ' parts=' + joined);
+                    }
+                }
                 for (var l = 0; l < locales.length; l++) {
                     for (var o = 0; o < optionSets.length; o++) {
                         var latin = new Intl.NumberFormat(locales[l], optionSets[o]);
+                        for (var v = 0; v < values.length; v++) {
+                            check(latin, 'latn', locales[l], o, values[v]);
+                        }
                         for (var s = 0; s < systems.length; s++) {
                             var options = Object.assign({ numberingSystem: systems[s] }, optionSets[o]);
                             var nf = new Intl.NumberFormat(locales[l], options);
                             for (var v = 0; v < values.length; v++) {
-                                if (join(latin.formatToParts(values[v])) !== latin.format(values[v])) {
-                                    continue;
-                                }
-                                var joined = join(nf.formatToParts(values[v]));
-                                var formatted = nf.format(values[v]);
-                                if (joined !== formatted) {
-                                    bad.push(locales[l] + '/' + systems[s] + '/' + o + '/' + values[v]
-                                        + ': format=' + formatted + ' parts=' + joined);
-                                }
+                                check(nf, systems[s], locales[l], o, values[v]);
                             }
                         }
                     }
@@ -282,6 +287,183 @@ public class IntlNumberFormatPartsTests
         _engine.Evaluate("new Intl.RelativeTimeFormat('en', { numeric: 'auto' }).format(-1, 'day')")
             .AsString().Should().Be("yesterday");
     }
+
+    /// <summary>
+    /// A non-finite value chooses only the number's own text.
+    /// https://tc39.es/ecma402/#sec-partitionnumberpattern's NaN and infinity branches set nothing but
+    /// <c>formattedString</c>, so the pattern https://tc39.es/ecma402/#sec-getnumberformatpattern selects is
+    /// still walked and the currency symbol, the unit and the percent sign are still written around it.
+    /// </summary>
+    [Test]
+    public void ANonFiniteValueKeepsTheStyleAroundIt()
+    {
+        const string Usd = "new Intl.NumberFormat('en', { style: 'currency', currency: 'USD' })";
+        Format(Usd, "NaN").Should().Be("$NaN");
+        Format(Usd, "Infinity").Should().Be("$∞");
+        Format(Usd, "-Infinity").Should().Be("-$∞");
+
+        const string Percent = "new Intl.NumberFormat('en', { style: 'percent' })";
+        Format(Percent, "NaN").Should().Be("NaN%");
+        Format(Percent, "-Infinity").Should().Be("-∞%");
+
+        const string Meter = "new Intl.NumberFormat('en', { style: 'unit', unit: 'meter' })";
+        Format(Meter, "NaN").Should().Be("NaN m");
+        Format(Meter, "Infinity").Should().Be("∞ m");
+
+        // de-DE writes the number, a non-breaking space and the symbol, and NaN takes the same pattern
+        // every non-negative value takes
+        Format("new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' })", "NaN")
+            .Should().Be("NaN €");
+    }
+
+    /// <summary>
+    /// The parts lane reports the pattern the string lane writes, one part per pattern part:
+    /// https://tc39.es/ecma402/#sec-partitionnotationsubpattern makes the number itself exactly one
+    /// <c>nan</c> or <c>infinity</c> part, and everything else around it belongs to the style.
+    /// </summary>
+    [Test]
+    public void ANonFiniteValuesPartsCarryTheStyleToo()
+    {
+        const string Usd = "new Intl.NumberFormat('en', { style: 'currency', currency: 'USD' })";
+        Parts(Usd, "NaN").Should().Be("""[{"type":"currency","value":"$"},{"type":"nan","value":"NaN"}]""");
+        Parts(Usd, "-Infinity").Should().Be(
+            """[{"type":"minusSign","value":"-"},{"type":"currency","value":"$"},{"type":"infinity","value":"∞"}]""");
+
+        Parts("new Intl.NumberFormat('en', { style: 'percent' })", "NaN")
+            .Should().Be("""[{"type":"nan","value":"NaN"},{"type":"percentSign","value":"%"}]""");
+
+        Parts("new Intl.NumberFormat('en', { style: 'unit', unit: 'meter' })", "NaN")
+            .Should().Be(
+                """[{"type":"nan","value":"NaN"},{"type":"literal","value":" "},{"type":"unit","value":"m"}]""");
+    }
+
+    /// <summary>
+    /// <c>currencySign: "accounting"</c> takes the negative pattern for -∞ as it does for any other negative
+    /// value, and the two lanes agree on which one that is.
+    /// </summary>
+    [Test]
+    public void AccountingWrapsANonFiniteValueTheWayItWrapsAFiniteOne()
+    {
+        const string Accounting =
+            "new Intl.NumberFormat('en', { style: 'currency', currency: 'USD', currencySign: 'accounting' })";
+        Format(Accounting, "-5").Should().Be("($5.00)");
+        Format(Accounting, "-Infinity").Should().Be("($∞)");
+        Join(Accounting, "-Infinity").Should().Be("($∞)");
+    }
+
+    /// <summary>
+    /// https://tc39.es/ecma402/#sec-partitionnotationsubpattern gives a non-finite value one part and no
+    /// notation sub-pattern, so no exponent is ever written for it — which is what test262's
+    /// <c>engineering-scientific-en-US.js</c> asserts.
+    /// </summary>
+    [Test]
+    public void NotationAddsNoExponentToANonFiniteValue()
+    {
+        const string Scientific = "new Intl.NumberFormat('en', { notation: 'scientific' })";
+        Format(Scientific, "NaN").Should().Be("NaN");
+        Format(Scientific, "Infinity").Should().Be("∞");
+        Format(Scientific, "-Infinity").Should().Be("-∞");
+        Join(Scientific, "-Infinity").Should().Be("-∞");
+    }
+
+    /// <summary>
+    /// Zero is a finite value like any other, and
+    /// https://tc39.es/ecma402/#sec-partitionnotationsubpattern writes <c>"0"</c> for an exponent of zero
+    /// rather than dropping the exponent. The parts lane already did; the string lane fell back to plain
+    /// decimal formatting.
+    /// </summary>
+    [Test]
+    public void ScientificNotationOfZeroStillHasAnExponent()
+    {
+        const string Scientific = "new Intl.NumberFormat('en', { notation: 'scientific' })";
+        Format(Scientific, "0").Should().Be("0E0");
+        Format("new Intl.NumberFormat('en', { notation: 'engineering' })", "0").Should().Be("0E0");
+        Format(Scientific, "-0").Should().Be("-0E0");
+        Join(Scientific, "-0").Should().Be("-0E0");
+        Format(Scientific, "5").Should().Be("5E0");
+    }
+
+    /// <summary>
+    /// ECMA-402 calls the sign "the ILND String representing the minus sign", so it is the locale's own
+    /// datum in both lanes: <c>ar</c> prefixes U+061C ARABIC LETTER MARK, which the string lane wrote for a
+    /// plain number and not for a currency.
+    /// </summary>
+    /// <remarks>
+    /// The sign itself is read back out of the formatter rather than written here, because it is locale data
+    /// and the two frameworks do not carry the same: .NET gives <c>ar</c> the directionality mark, .NET
+    /// Framework a plain hyphen.
+    /// </remarks>
+    [Test]
+    public void TheCurrencySignIsTheOneTheLocaleWrites()
+    {
+        var minusSign = PartValue("new Intl.NumberFormat('ar-EG')", "-5", "minusSign");
+        var plusSign = PartValue("new Intl.NumberFormat('ar-EG', { signDisplay: 'always' })", "5", "plusSign");
+
+        const string Egp = "new Intl.NumberFormat('ar-EG', { style: 'currency', currency: 'EGP' })";
+        Format(Egp, "-5").Should().StartWith(minusSign).And.Be(Join(Egp, "-5"));
+
+        const string Always =
+            "new Intl.NumberFormat('ar-EG', { style: 'currency', currency: 'EGP', signDisplay: 'always' })";
+        Format(Always, "5").Should().StartWith(plusSign).And.Be(Join(Always, "5"));
+
+        // ar has no accounting parentheses, so accounting falls through to the same negative pattern
+        const string Accounting =
+            "new Intl.NumberFormat('ar-EG', { style: 'currency', currency: 'EGP', currencySign: 'accounting' })";
+        Format(Accounting, "-5").Should().StartWith(minusSign).And.Be(Join(Accounting, "-5"));
+    }
+
+    /// <summary>
+    /// A CLDR unit pattern can put text on both sides of the number, and
+    /// https://tc39.es/ecma402/#sec-partitionnumberpattern's <c>unitPrefix</c> branch appends a <c>unit</c>
+    /// part for the leading one. test262's <c>formatToParts/unit-ja-JP.js</c> builds its expectation from
+    /// that part, and <c>format/unit-ja-JP.js</c> reads the separator back out of the same list.
+    /// </summary>
+    [Test]
+    public void AUnitPatternsPrefixIsAPartOfItsOwn()
+    {
+        const string Japanese =
+            "new Intl.NumberFormat('ja-JP', { style: 'unit', unit: 'kilometer-per-hour', unitDisplay: 'long' })";
+        Format(Japanese, "1").Should().Be("時速 1 キロメートル");
+        Parts(Japanese, "1").Should().Be(
+            """
+            [{"type":"unit","value":"時速"},{"type":"literal","value":" "},{"type":"integer","value":"1"},{"type":"literal","value":" "},{"type":"unit","value":"キロメートル"}]
+            """);
+
+        // the sign stands inside the pattern, after its prefix
+        Parts(Japanese, "-987").Should().Be(
+            """
+            [{"type":"unit","value":"時速"},{"type":"literal","value":" "},{"type":"minusSign","value":"-"},{"type":"integer","value":"987"},{"type":"literal","value":" "},{"type":"unit","value":"キロメートル"}]
+            """);
+
+        // ko-KR separates the prefix from the number but not the number from the suffix
+        Parts("new Intl.NumberFormat('ko-KR', { style: 'unit', unit: 'kilometer-per-hour', unitDisplay: 'long' })", "987")
+            .Should().Be(
+                """
+                [{"type":"unit","value":"시속"},{"type":"literal","value":" "},{"type":"integer","value":"987"},{"type":"unit","value":"킬로미터"}]
+                """);
+
+        // a pattern with no prefix keeps reporting none
+        Parts("new Intl.NumberFormat('de-DE', { style: 'unit', unit: 'kilometer-per-hour', unitDisplay: 'long' })", "987")
+            .Should().Be(
+                """
+                [{"type":"integer","value":"987"},{"type":"literal","value":" "},{"type":"unit","value":"Kilometer pro Stunde"}]
+                """);
+    }
+
+    private string Format(string formatter, string value)
+        => _engine.Evaluate($"{formatter}.format({value})").AsString();
+
+    private string Join(string formatter, string value)
+        => _engine.Evaluate(
+            $"{formatter}.formatToParts({value}).map(function (p) {{ return p.value; }}).join('')").AsString();
+
+    private string Parts(string formatter, string value)
+        => _engine.Evaluate($"JSON.stringify({formatter}.formatToParts({value}))").AsString();
+
+    private string PartValue(string formatter, string value, string type)
+        => _engine.Evaluate(
+            $"{formatter}.formatToParts({value}).filter(function (p) {{ return p.type === '{type}'; }})[0].value")
+            .AsString();
 
     private void AssertNoMismatch(string script)
     {

--- a/Jint/Native/Intl/JsNumberFormat.cs
+++ b/Jint/Native/Intl/JsNumberFormat.cs
@@ -163,9 +163,36 @@ internal sealed class JsNumberFormat : ObjectInstance
     /// <summary>
     /// Formats a number according to the formatter's locale and options.
     /// </summary>
+    /// <remarks>
+    /// https://tc39.es/ecma402/#sec-formatnumeric is the concatenation of exactly the parts
+    /// https://tc39.es/ecma402/#sec-formatnumerictoparts returns. A non-finite value reads its result from
+    /// that list rather than assembling a second one, which is what keeps the style's affixes — a currency
+    /// symbol, a unit, a percent sign — on both sides of the same walk.
+    /// </remarks>
     internal string Format(double value)
     {
+        if (!double.IsFinite(value))
+        {
+            return ConcatenateParts(FormatToParts(value));
+        }
+
         return Transliterate(FormatCore(value));
+    }
+
+    private static string ConcatenateParts(List<NumberFormatPart> parts)
+    {
+        if (parts.Count == 1)
+        {
+            return parts[0].Value;
+        }
+
+        var builder = new System.Text.StringBuilder();
+        foreach (var part in parts)
+        {
+            builder.Append(part.Value);
+        }
+
+        return builder.ToString();
     }
 
     /// <summary>
@@ -250,16 +277,22 @@ internal sealed class JsNumberFormat : ObjectInstance
         return FormatDecimal(value);
     }
 
+    /// <summary>Distinguishes -0 from +0, which format differently but compare equal.</summary>
+    private static bool IsNegativeZero(double value) => value == 0 && double.IsNegativeInfinity(1 / value);
+
     private string FormatScientific(double value)
     {
-        if (!double.IsFinite(value) || value == 0)
+        if (!double.IsFinite(value))
         {
             return FormatDecimal(value);
         }
 
-        // Get the exponent
-        var exponent = (int) System.Math.Floor(System.Math.Log10(System.Math.Abs(value)));
-        var mantissa = value / System.Math.Pow(10, exponent);
+        // Get the exponent. https://tc39.es/ecma402/#sec-partitionnotationsubpattern writes "0" for an
+        // exponent of zero rather than omitting the exponent, so exactly zero is "0E0". Zero's mantissa is
+        // taken as positive and signed below, because .NET Framework and .NET disagree on whether a custom
+        // format string writes negative zero's sign.
+        var exponent = value == 0 ? 0 : (int) System.Math.Floor(System.Math.Log10(System.Math.Abs(value)));
+        var mantissa = value == 0 ? 0d : value / System.Math.Pow(10, exponent);
 
         // Round the mantissa
         mantissa = ApplyRounding(mantissa, MaximumFractionDigits);
@@ -269,6 +302,10 @@ internal sealed class JsNumberFormat : ObjectInstance
             ? "0." + new string('0', MinimumFractionDigits) + new string('#', MaximumFractionDigits - MinimumFractionDigits)
             : "0";
         var mantissaStr = mantissa.ToString(mantissaFormat, NumberFormatInfo);
+        if (IsNegativeZero(value))
+        {
+            mantissaStr = NumberFormatInfo.NegativeSign + mantissaStr;
+        }
 
         // Format exponent (no plus sign for positive exponents per spec). PartitionNotationSubPattern
         // takes the exponent's minus sign from the resolved locale's data, so it comes from this
@@ -279,15 +316,16 @@ internal sealed class JsNumberFormat : ObjectInstance
 
     private string FormatEngineering(double value)
     {
-        if (!double.IsFinite(value) || value == 0)
+        if (!double.IsFinite(value))
         {
             return FormatDecimal(value);
         }
 
-        // Engineering notation uses exponents that are multiples of 3
-        var exponent = (int) System.Math.Floor(System.Math.Log10(System.Math.Abs(value)));
+        // Engineering notation uses exponents that are multiples of 3. See FormatScientific for why zero
+        // still carries one, and why its mantissa is signed separately.
+        var exponent = value == 0 ? 0 : (int) System.Math.Floor(System.Math.Log10(System.Math.Abs(value)));
         var engineeringExponent = (int) (System.Math.Floor(exponent / 3.0) * 3);
-        var mantissa = value / System.Math.Pow(10, engineeringExponent);
+        var mantissa = value == 0 ? 0d : value / System.Math.Pow(10, engineeringExponent);
 
         // Round the mantissa
         mantissa = ApplyRounding(mantissa, MaximumFractionDigits);
@@ -297,6 +335,10 @@ internal sealed class JsNumberFormat : ObjectInstance
             ? "0." + new string('0', MinimumFractionDigits) + new string('#', MaximumFractionDigits - MinimumFractionDigits)
             : "0";
         var mantissaStr = mantissa.ToString(mantissaFormat, NumberFormatInfo);
+        if (IsNegativeZero(value))
+        {
+            mantissaStr = NumberFormatInfo.NegativeSign + mantissaStr;
+        }
 
         // Format exponent (no plus sign for positive exponents per spec). See FormatScientific for why
         // the exponent's sign comes from this object's NumberFormatInfo rather than the ambient culture.
@@ -1823,13 +1865,15 @@ internal sealed class JsNumberFormat : ObjectInstance
             }
             else
             {
-                // Standard format uses minus sign before everything
-                result = $"-{formattedCurrency}";
+                // Standard format uses minus sign before everything. ECMA-402 calls it "the ILND String
+                // representing the minus sign", so it is the locale's own datum and not a literal "-":
+                // ar writes U+061C ARABIC LETTER MARK ahead of it, which is what the parts lane reports.
+                result = NumberFormatInfo.NegativeSign + formattedCurrency;
             }
         }
         else if (showPositiveSign)
         {
-            result = $"+{formattedCurrency}";
+            result = NumberFormatInfo.PositiveSign + formattedCurrency;
         }
         else
         {
@@ -1907,26 +1951,27 @@ internal sealed class JsNumberFormat : ObjectInstance
         // 8: -n $, 9: -$ n, 10: n $-, 11: $ n-, 12: $ -n, 13: n- $, 14: ($ n), 15: (n $)
         var negPattern = NumberFormatInfo.CurrencyNegativePattern;
         const string Nbsp = " "; // Non-breaking space
+        var minus = NumberFormatInfo.NegativeSign;
 
         return negPattern switch
         {
             0 => $"({symbol}{numberPart})",
-            1 => $"-{symbol}{numberPart}",
-            2 => $"{symbol}-{numberPart}",
-            3 => $"{symbol}{numberPart}-",
+            1 => $"{minus}{symbol}{numberPart}",
+            2 => $"{symbol}{minus}{numberPart}",
+            3 => $"{symbol}{numberPart}{minus}",
             4 => $"({numberPart}{symbol})",
-            5 => $"-{numberPart}{symbol}",
-            6 => $"{numberPart}-{symbol}",
-            7 => $"{numberPart}{symbol}-",
-            8 => $"-{numberPart}{Nbsp}{symbol}",
-            9 => $"-{symbol}{Nbsp}{numberPart}",
-            10 => $"{numberPart}{Nbsp}{symbol}-",
-            11 => $"{symbol}{Nbsp}{numberPart}-",
-            12 => $"{symbol}{Nbsp}-{numberPart}",
-            13 => $"{numberPart}-{Nbsp}{symbol}",
+            5 => $"{minus}{numberPart}{symbol}",
+            6 => $"{numberPart}{minus}{symbol}",
+            7 => $"{numberPart}{symbol}{minus}",
+            8 => $"{minus}{numberPart}{Nbsp}{symbol}",
+            9 => $"{minus}{symbol}{Nbsp}{numberPart}",
+            10 => $"{numberPart}{Nbsp}{symbol}{minus}",
+            11 => $"{symbol}{Nbsp}{numberPart}{minus}",
+            12 => $"{symbol}{Nbsp}{minus}{numberPart}",
+            13 => $"{numberPart}{minus}{Nbsp}{symbol}",
             14 => $"({symbol}{Nbsp}{numberPart})",
             15 => $"({numberPart}{Nbsp}{symbol})",
-            _ => $"-{symbol}{numberPart}"
+            _ => $"{minus}{symbol}{numberPart}"
         };
     }
 
@@ -1988,12 +2033,12 @@ internal sealed class JsNumberFormat : ObjectInstance
             {
                 return FormatNegativeCurrency(formatted, symbol);
             }
-            return $"-{formattedCurrency}";
+            return NumberFormatInfo.NegativeSign + formattedCurrency;
         }
 
         if (showPositiveSign)
         {
-            return $"+{formattedCurrency}";
+            return NumberFormatInfo.PositiveSign + formattedCurrency;
         }
 
         return formattedCurrency;
@@ -2045,23 +2090,27 @@ internal sealed class JsNumberFormat : ObjectInstance
         else
         {
             pattern = NumberFormatInfo.PercentNegativePattern;
-            var absNumber = formattedNumber.Length > 0 && formattedNumber[0] == '-' ? formattedNumber.Substring(1) : formattedNumber;
+            // the sign is the locale's own, so it is also what has to be stripped back off
+            var minus = NumberFormatInfo.NegativeSign;
+            var absNumber = formattedNumber.StartsWith(minus, StringComparison.Ordinal)
+                ? formattedNumber.Substring(minus.Length)
+                : formattedNumber;
             // PercentNegativePattern values vary by locale
             return pattern switch
             {
-                0 => "-" + absNumber + Nbsp + symbol,
-                1 => "-" + absNumber + symbol,
-                2 => "-" + symbol + absNumber,
-                3 => symbol + "-" + absNumber,
-                4 => symbol + absNumber + "-",
-                5 => absNumber + "-" + symbol,
-                6 => absNumber + symbol + "-",
-                7 => "-" + symbol + Nbsp + absNumber,
-                8 => absNumber + Nbsp + symbol + "-",
-                9 => symbol + Nbsp + absNumber + "-",
-                10 => symbol + Nbsp + "-" + absNumber,
-                11 => absNumber + "-" + Nbsp + symbol,
-                _ => "-" + absNumber + symbol
+                0 => minus + absNumber + Nbsp + symbol,
+                1 => minus + absNumber + symbol,
+                2 => minus + symbol + absNumber,
+                3 => symbol + minus + absNumber,
+                4 => symbol + absNumber + minus,
+                5 => absNumber + minus + symbol,
+                6 => absNumber + symbol + minus,
+                7 => minus + symbol + Nbsp + absNumber,
+                8 => absNumber + Nbsp + symbol + minus,
+                9 => symbol + Nbsp + absNumber + minus,
+                10 => symbol + Nbsp + minus + absNumber,
+                11 => absNumber + minus + Nbsp + symbol,
+                _ => minus + absNumber + symbol
             };
         }
     }
@@ -2261,45 +2310,24 @@ internal sealed class JsNumberFormat : ObjectInstance
         };
     }
 
+    /// <summary>
+    /// What a pattern walk writes where https://tc39.es/ecma402/#sec-partitionnumberpattern puts its
+    /// <c>number</c> part: a finite value split into its integer and fraction, or the single part
+    /// https://tc39.es/ecma402/#sec-partitionnotationsubpattern makes of NaN and infinity.
+    /// </summary>
+    [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Auto)]
+    private readonly record struct NumberBody(long IntegerPart, double FractionValue, NumberFormatPart? NonFinite)
+    {
+        internal static NumberBody Finite(long integerPart, double fractionValue) => new(integerPart, fractionValue, null);
+
+        internal static NumberBody Of(NumberFormatPart nonFinite) => new(0, 0, nonFinite);
+    }
+
     private List<NumberFormatPart> FormatToPartsCore(double value)
     {
-        var parts = new List<NumberFormatPart>();
-
-        // Handle special values
-        if (double.IsNaN(value))
+        if (!double.IsFinite(value))
         {
-            // For signDisplay "always", NaN gets a plus sign
-            if (string.Equals(SignDisplay, "always", StringComparison.Ordinal))
-            {
-                parts.Add(new NumberFormatPart("plusSign", NumberFormatInfo.PositiveSign));
-            }
-            parts.Add(new NumberFormatPart("nan", NumberFormatInfo.NaNSymbol));
-            return parts;
-        }
-
-        if (double.IsPositiveInfinity(value))
-        {
-            // For signDisplay "always" or "exceptZero", show plus sign (infinity is never zero)
-            if (string.Equals(SignDisplay, "always", StringComparison.Ordinal) ||
-                string.Equals(SignDisplay, "exceptZero", StringComparison.Ordinal))
-            {
-                parts.Add(new NumberFormatPart("plusSign", NumberFormatInfo.PositiveSign));
-            }
-            parts.Add(new NumberFormatPart("infinity", NumberFormatInfo.PositiveInfinitySymbol));
-            return parts;
-        }
-
-        if (double.IsNegativeInfinity(value))
-        {
-            // For signDisplay "negative", always show the minus sign (infinity is never zero)
-            // For "never", don't show the sign
-            // For "auto" (default), show the minus sign
-            if (!string.Equals(SignDisplay, "never", StringComparison.Ordinal))
-            {
-                parts.Add(new NumberFormatPart("minusSign", NumberFormatInfo.NegativeSign));
-            }
-            parts.Add(new NumberFormatPart("infinity", NumberFormatInfo.PositiveInfinitySymbol));
-            return parts;
+            return FormatNonFiniteToParts(value);
         }
 
         // Handle notation first
@@ -2318,6 +2346,104 @@ internal sealed class JsNumberFormat : ObjectInstance
         };
     }
 
+    /// <summary>
+    /// Formats NaN or an infinity, which chooses only the number's own text.
+    /// </summary>
+    /// <remarks>
+    /// https://tc39.es/ecma402/#sec-partitionnumberpattern's non-finite branches set nothing but
+    /// <c>formattedString</c>: the pattern https://tc39.es/ecma402/#sec-getnumberformatpattern selects is
+    /// still selected and still walked, so the currency symbol, the unit and the percent sign are written
+    /// around it exactly as they are around a finite value. That algorithm reads NaN as
+    /// <c>positive-zero</c> and each infinity as the non-zero category of its own sign, which is what
+    /// decides the sign below. https://tc39.es/ecma402/#sec-partitionnotationsubpattern then makes the
+    /// number one part and never a notation sub-pattern, so no exponent is written for it either.
+    /// </remarks>
+    private List<NumberFormatPart> FormatNonFiniteToParts(double value)
+    {
+        var parts = new List<NumberFormatPart>();
+
+        var isNaN = double.IsNaN(value);
+        var body = NumberBody.Of(isNaN
+            ? new NumberFormatPart("nan", NumberFormatInfo.NaNSymbol)
+            : new NumberFormatPart("infinity", NumberFormatInfo.PositiveInfinitySymbol));
+
+        var isNegative = double.IsNegativeInfinity(value);
+        var showNegativeSign = isNegative && !string.Equals(SignDisplay, "never", StringComparison.Ordinal);
+        var showPositiveSign = !isNegative && SignDisplay switch
+        {
+            "always" => true,
+            // NaN is the zero category, so "exceptZero" leaves it unsigned while +∞ takes a plus
+            "exceptZero" => !isNaN,
+            _ => false
+        };
+
+        switch (Style)
+        {
+            case "currency":
+                AppendCurrencyParts(parts, in body, showNegativeSign, showPositiveSign);
+                break;
+            case "percent":
+                AppendPercentParts(parts, in body, showNegativeSign, showPositiveSign);
+                break;
+            case "unit":
+                AppendUnitParts(parts, in body, showNegativeSign, showPositiveSign, value);
+                break;
+            default:
+                AppendSignPart(parts, showNegativeSign, showPositiveSign);
+                AddNumberParts(parts, in body);
+                break;
+        }
+
+        return parts;
+    }
+
+    private void AppendSignPart(List<NumberFormatPart> parts, bool showNegativeSign, bool showPositiveSign)
+    {
+        if (showNegativeSign)
+        {
+            parts.Add(new NumberFormatPart("minusSign", NumberFormatInfo.NegativeSign));
+        }
+        else if (showPositiveSign)
+        {
+            parts.Add(new NumberFormatPart("plusSign", NumberFormatInfo.PositiveSign));
+        }
+    }
+
+    /// <summary>
+    /// Writes the number a pattern wraps, using the locale's number decimal separator.
+    /// </summary>
+    private void AddNumberParts(List<NumberFormatPart> parts, in NumberBody body)
+    {
+        if (body.NonFinite is { } nonFinite)
+        {
+            parts.Add(nonFinite);
+            return;
+        }
+
+        FormatIntegerToParts(parts, body.IntegerPart);
+
+        if (MinimumFractionDigits > 0 || (body.FractionValue > 0 && MaximumFractionDigits > 0))
+        {
+            parts.Add(new NumberFormatPart("decimal", NumberFormatInfo.NumberDecimalSeparator));
+            FormatFractionToParts(parts, body.FractionValue);
+        }
+    }
+
+    /// <summary>
+    /// Writes the number a currency pattern wraps, using the locale's currency decimal separator.
+    /// </summary>
+    private void AddCurrencyNumberParts(List<NumberFormatPart> parts, in NumberBody body)
+    {
+        if (body.NonFinite is { } nonFinite)
+        {
+            parts.Add(nonFinite);
+            return;
+        }
+
+        FormatIntegerToParts(parts, body.IntegerPart);
+        AddFractionPartsIfNeeded(parts, body.FractionValue);
+    }
+
     private List<NumberFormatPart> FormatNotationToParts(double value)
     {
         // Handle compact notation separately
@@ -2328,7 +2454,8 @@ internal sealed class JsNumberFormat : ObjectInstance
 
         var parts = new List<NumberFormatPart>();
 
-        var isNegative = value < 0;
+        // negative zero takes the negative pattern too, per https://tc39.es/ecma402/#sec-getnumberformatpattern
+        var isNegative = value < 0 || IsNegativeZero(value);
         if (isNegative)
         {
             parts.Add(new NumberFormatPart("minusSign", NumberFormatInfo.NegativeSign));
@@ -2662,9 +2789,6 @@ internal sealed class JsNumberFormat : ObjectInstance
         var isNegative = value < 0 || double.IsNegativeInfinity(1 / value); // Handles -0
         var absValue = System.Math.Abs(value);
 
-        // Get currency symbol
-        var currencySymbol = NumberFormatInfo.CurrencySymbol;
-
         // Apply rounding first to determine if value displays as zero
         var fractionDigits = MaximumFractionDigits > 0 ? MaximumFractionDigits : 2;
         absValue = ApplyRounding(absValue, fractionDigits);
@@ -2673,7 +2797,6 @@ internal sealed class JsNumberFormat : ObjectInstance
         // Determine if we should show a negative sign based on signDisplay
         var showNegativeSign = isNegative;
         var showPositiveSign = false;
-        var useAccountingFormat = string.Equals(CurrencySign, "accounting", StringComparison.Ordinal);
 
         switch (SignDisplay)
         {
@@ -2699,41 +2822,35 @@ internal sealed class JsNumberFormat : ObjectInstance
         var integerPart = (long) System.Math.Truncate(absValue);
         var fractionValue = absValue - integerPart;
 
-        // Determine pattern based on locale (use positive pattern as base)
-        var pattern = NumberFormatInfo.CurrencyPositivePattern;
-
-        // Build parts based on sign display and format
-        if (showNegativeSign)
-        {
-            if (useAccountingFormat)
-            {
-                // Use CLDR-based accounting format (parentheses for most locales)
-                BuildAccountingCurrencyNegativeParts(parts, currencySymbol, integerPart, fractionValue);
-            }
-            else
-            {
-                // Standard format uses minus sign
-                parts.Add(new NumberFormatPart("minusSign", NumberFormatInfo.NegativeSign));
-                BuildCurrencyPositiveParts(parts, pattern, currencySymbol, integerPart, fractionValue);
-            }
-        }
-        else if (showPositiveSign)
-        {
-            parts.Add(new NumberFormatPart("plusSign", NumberFormatInfo.PositiveSign));
-            BuildCurrencyPositiveParts(parts, pattern, currencySymbol, integerPart, fractionValue);
-        }
-        else
-        {
-            BuildCurrencyPositiveParts(parts, pattern, currencySymbol, integerPart, fractionValue);
-        }
+        AppendCurrencyParts(parts, NumberBody.Finite(integerPart, fractionValue), showNegativeSign, showPositiveSign);
 
         return parts;
     }
 
     /// <summary>
+    /// Walks the currency pattern https://tc39.es/ecma402/#sec-getnumberformatpattern selects, around
+    /// whatever number stands in it.
+    /// </summary>
+    private void AppendCurrencyParts(List<NumberFormatPart> parts, in NumberBody body, bool showNegativeSign, bool showPositiveSign)
+    {
+        var currencySymbol = NumberFormatInfo.CurrencySymbol;
+        var pattern = NumberFormatInfo.CurrencyPositivePattern;
+
+        if (showNegativeSign && string.Equals(CurrencySign, "accounting", StringComparison.Ordinal))
+        {
+            // Use CLDR-based accounting format (parentheses for most locales)
+            BuildAccountingCurrencyNegativeParts(parts, currencySymbol, in body);
+            return;
+        }
+
+        AppendSignPart(parts, showNegativeSign, showPositiveSign);
+        BuildCurrencyPositiveParts(parts, pattern, currencySymbol, in body);
+    }
+
+    /// <summary>
     /// Builds currency parts for accounting format (negative values with parentheses).
     /// </summary>
-    private void BuildAccountingCurrencyNegativeParts(List<NumberFormatPart> parts, string symbol, long integerPart, double fractionValue)
+    private void BuildAccountingCurrencyNegativeParts(List<NumberFormatPart> parts, string symbol, in NumberBody body)
     {
         // Check if locale uses parentheses for accounting
         if (UsesParenthesesForAccounting())
@@ -2747,14 +2864,12 @@ internal sealed class JsNumberFormat : ObjectInstance
                 case 0: // $n → ($n)
                     parts.Add(new NumberFormatPart("literal", "("));
                     parts.Add(new NumberFormatPart("currency", symbol));
-                    FormatIntegerToParts(parts, integerPart);
-                    AddFractionPartsIfNeeded(parts, fractionValue);
+                    AddCurrencyNumberParts(parts, in body);
                     parts.Add(new NumberFormatPart("literal", ")"));
                     break;
                 case 1: // n$ → (n$)
                     parts.Add(new NumberFormatPart("literal", "("));
-                    FormatIntegerToParts(parts, integerPart);
-                    AddFractionPartsIfNeeded(parts, fractionValue);
+                    AddCurrencyNumberParts(parts, in body);
                     parts.Add(new NumberFormatPart("currency", symbol));
                     parts.Add(new NumberFormatPart("literal", ")"));
                     break;
@@ -2762,15 +2877,13 @@ internal sealed class JsNumberFormat : ObjectInstance
                     parts.Add(new NumberFormatPart("literal", "("));
                     parts.Add(new NumberFormatPart("currency", symbol));
                     parts.Add(new NumberFormatPart("literal", Nbsp));
-                    FormatIntegerToParts(parts, integerPart);
-                    AddFractionPartsIfNeeded(parts, fractionValue);
+                    AddCurrencyNumberParts(parts, in body);
                     parts.Add(new NumberFormatPart("literal", ")"));
                     break;
                 case 3: // n $ → (n $)
                 default:
                     parts.Add(new NumberFormatPart("literal", "("));
-                    FormatIntegerToParts(parts, integerPart);
-                    AddFractionPartsIfNeeded(parts, fractionValue);
+                    AddCurrencyNumberParts(parts, in body);
                     parts.Add(new NumberFormatPart("literal", Nbsp));
                     parts.Add(new NumberFormatPart("currency", symbol));
                     parts.Add(new NumberFormatPart("literal", ")"));
@@ -2780,14 +2893,14 @@ internal sealed class JsNumberFormat : ObjectInstance
         else
         {
             // Fall back to standard negative currency pattern (minus sign)
-            BuildCurrencyNegativeParts(parts, symbol, integerPart, fractionValue);
+            BuildCurrencyNegativeParts(parts, symbol, in body);
         }
     }
 
     /// <summary>
     /// Builds currency parts for negative values using the locale's CurrencyNegativePattern.
     /// </summary>
-    private void BuildCurrencyNegativeParts(List<NumberFormatPart> parts, string symbol, long integerPart, double fractionValue)
+    private void BuildCurrencyNegativeParts(List<NumberFormatPart> parts, string symbol, in NumberBody body)
     {
         var negPattern = NumberFormatInfo.CurrencyNegativePattern;
         const string Nbsp = "\u00A0"; // Non-breaking space per CLDR
@@ -2797,57 +2910,48 @@ internal sealed class JsNumberFormat : ObjectInstance
             case 0: // ($n)
                 parts.Add(new NumberFormatPart("literal", "("));
                 parts.Add(new NumberFormatPart("currency", symbol));
-                FormatIntegerToParts(parts, integerPart);
-                AddFractionPartsIfNeeded(parts, fractionValue);
+                AddCurrencyNumberParts(parts, in body);
                 parts.Add(new NumberFormatPart("literal", ")"));
                 break;
             case 1: // -$n
                 parts.Add(new NumberFormatPart("minusSign", NumberFormatInfo.NegativeSign));
                 parts.Add(new NumberFormatPart("currency", symbol));
-                FormatIntegerToParts(parts, integerPart);
-                AddFractionPartsIfNeeded(parts, fractionValue);
+                AddCurrencyNumberParts(parts, in body);
                 break;
             case 2: // $-n
                 parts.Add(new NumberFormatPart("currency", symbol));
                 parts.Add(new NumberFormatPart("minusSign", NumberFormatInfo.NegativeSign));
-                FormatIntegerToParts(parts, integerPart);
-                AddFractionPartsIfNeeded(parts, fractionValue);
+                AddCurrencyNumberParts(parts, in body);
                 break;
             case 3: // $n-
                 parts.Add(new NumberFormatPart("currency", symbol));
-                FormatIntegerToParts(parts, integerPart);
-                AddFractionPartsIfNeeded(parts, fractionValue);
+                AddCurrencyNumberParts(parts, in body);
                 parts.Add(new NumberFormatPart("minusSign", NumberFormatInfo.NegativeSign));
                 break;
             case 4: // (n$)
                 parts.Add(new NumberFormatPart("literal", "("));
-                FormatIntegerToParts(parts, integerPart);
-                AddFractionPartsIfNeeded(parts, fractionValue);
+                AddCurrencyNumberParts(parts, in body);
                 parts.Add(new NumberFormatPart("currency", symbol));
                 parts.Add(new NumberFormatPart("literal", ")"));
                 break;
             case 5: // -n$
                 parts.Add(new NumberFormatPart("minusSign", NumberFormatInfo.NegativeSign));
-                FormatIntegerToParts(parts, integerPart);
-                AddFractionPartsIfNeeded(parts, fractionValue);
+                AddCurrencyNumberParts(parts, in body);
                 parts.Add(new NumberFormatPart("currency", symbol));
                 break;
             case 6: // n-$
-                FormatIntegerToParts(parts, integerPart);
-                AddFractionPartsIfNeeded(parts, fractionValue);
+                AddCurrencyNumberParts(parts, in body);
                 parts.Add(new NumberFormatPart("minusSign", NumberFormatInfo.NegativeSign));
                 parts.Add(new NumberFormatPart("currency", symbol));
                 break;
             case 7: // n$-
-                FormatIntegerToParts(parts, integerPart);
-                AddFractionPartsIfNeeded(parts, fractionValue);
+                AddCurrencyNumberParts(parts, in body);
                 parts.Add(new NumberFormatPart("currency", symbol));
                 parts.Add(new NumberFormatPart("minusSign", NumberFormatInfo.NegativeSign));
                 break;
             case 8: // -n $
                 parts.Add(new NumberFormatPart("minusSign", NumberFormatInfo.NegativeSign));
-                FormatIntegerToParts(parts, integerPart);
-                AddFractionPartsIfNeeded(parts, fractionValue);
+                AddCurrencyNumberParts(parts, in body);
                 parts.Add(new NumberFormatPart("literal", Nbsp));
                 parts.Add(new NumberFormatPart("currency", symbol));
                 break;
@@ -2855,12 +2959,10 @@ internal sealed class JsNumberFormat : ObjectInstance
                 parts.Add(new NumberFormatPart("minusSign", NumberFormatInfo.NegativeSign));
                 parts.Add(new NumberFormatPart("currency", symbol));
                 parts.Add(new NumberFormatPart("literal", Nbsp));
-                FormatIntegerToParts(parts, integerPart);
-                AddFractionPartsIfNeeded(parts, fractionValue);
+                AddCurrencyNumberParts(parts, in body);
                 break;
             case 10: // n $-
-                FormatIntegerToParts(parts, integerPart);
-                AddFractionPartsIfNeeded(parts, fractionValue);
+                AddCurrencyNumberParts(parts, in body);
                 parts.Add(new NumberFormatPart("literal", Nbsp));
                 parts.Add(new NumberFormatPart("currency", symbol));
                 parts.Add(new NumberFormatPart("minusSign", NumberFormatInfo.NegativeSign));
@@ -2868,20 +2970,17 @@ internal sealed class JsNumberFormat : ObjectInstance
             case 11: // $ n-
                 parts.Add(new NumberFormatPart("currency", symbol));
                 parts.Add(new NumberFormatPart("literal", Nbsp));
-                FormatIntegerToParts(parts, integerPart);
-                AddFractionPartsIfNeeded(parts, fractionValue);
+                AddCurrencyNumberParts(parts, in body);
                 parts.Add(new NumberFormatPart("minusSign", NumberFormatInfo.NegativeSign));
                 break;
             case 12: // $ -n
                 parts.Add(new NumberFormatPart("currency", symbol));
                 parts.Add(new NumberFormatPart("literal", Nbsp));
                 parts.Add(new NumberFormatPart("minusSign", NumberFormatInfo.NegativeSign));
-                FormatIntegerToParts(parts, integerPart);
-                AddFractionPartsIfNeeded(parts, fractionValue);
+                AddCurrencyNumberParts(parts, in body);
                 break;
             case 13: // n- $
-                FormatIntegerToParts(parts, integerPart);
-                AddFractionPartsIfNeeded(parts, fractionValue);
+                AddCurrencyNumberParts(parts, in body);
                 parts.Add(new NumberFormatPart("minusSign", NumberFormatInfo.NegativeSign));
                 parts.Add(new NumberFormatPart("literal", Nbsp));
                 parts.Add(new NumberFormatPart("currency", symbol));
@@ -2890,14 +2989,12 @@ internal sealed class JsNumberFormat : ObjectInstance
                 parts.Add(new NumberFormatPart("literal", "("));
                 parts.Add(new NumberFormatPart("currency", symbol));
                 parts.Add(new NumberFormatPart("literal", Nbsp));
-                FormatIntegerToParts(parts, integerPart);
-                AddFractionPartsIfNeeded(parts, fractionValue);
+                AddCurrencyNumberParts(parts, in body);
                 parts.Add(new NumberFormatPart("literal", ")"));
                 break;
             case 15: // (n $)
                 parts.Add(new NumberFormatPart("literal", "("));
-                FormatIntegerToParts(parts, integerPart);
-                AddFractionPartsIfNeeded(parts, fractionValue);
+                AddCurrencyNumberParts(parts, in body);
                 parts.Add(new NumberFormatPart("literal", Nbsp));
                 parts.Add(new NumberFormatPart("currency", symbol));
                 parts.Add(new NumberFormatPart("literal", ")"));
@@ -2905,43 +3002,37 @@ internal sealed class JsNumberFormat : ObjectInstance
             default:
                 parts.Add(new NumberFormatPart("minusSign", NumberFormatInfo.NegativeSign));
                 parts.Add(new NumberFormatPart("currency", symbol));
-                FormatIntegerToParts(parts, integerPart);
-                AddFractionPartsIfNeeded(parts, fractionValue);
+                AddCurrencyNumberParts(parts, in body);
                 break;
         }
     }
 
-    private void BuildCurrencyPositiveParts(List<NumberFormatPart> parts, int pattern, string symbol, long integerPart, double fractionValue)
+    private void BuildCurrencyPositiveParts(List<NumberFormatPart> parts, int pattern, string symbol, in NumberBody body)
     {
         const string Nbsp = "\u00A0"; // Non-breaking space per CLDR
         switch (pattern)
         {
             case 0: // $n
                 parts.Add(new NumberFormatPart("currency", symbol));
-                FormatIntegerToParts(parts, integerPart);
-                AddFractionPartsIfNeeded(parts, fractionValue);
+                AddCurrencyNumberParts(parts, in body);
                 break;
             case 1: // n$
-                FormatIntegerToParts(parts, integerPart);
-                AddFractionPartsIfNeeded(parts, fractionValue);
+                AddCurrencyNumberParts(parts, in body);
                 parts.Add(new NumberFormatPart("currency", symbol));
                 break;
             case 2: // $ n
                 parts.Add(new NumberFormatPart("currency", symbol));
                 parts.Add(new NumberFormatPart("literal", Nbsp));
-                FormatIntegerToParts(parts, integerPart);
-                AddFractionPartsIfNeeded(parts, fractionValue);
+                AddCurrencyNumberParts(parts, in body);
                 break;
             case 3: // n $
-                FormatIntegerToParts(parts, integerPart);
-                AddFractionPartsIfNeeded(parts, fractionValue);
+                AddCurrencyNumberParts(parts, in body);
                 parts.Add(new NumberFormatPart("literal", Nbsp));
                 parts.Add(new NumberFormatPart("currency", symbol));
                 break;
             default:
                 parts.Add(new NumberFormatPart("currency", symbol));
-                FormatIntegerToParts(parts, integerPart);
-                AddFractionPartsIfNeeded(parts, fractionValue);
+                AddCurrencyNumberParts(parts, in body);
                 break;
         }
     }
@@ -2993,6 +3084,20 @@ internal sealed class JsNumberFormat : ObjectInstance
                 break;
         }
 
+        var integerPart = (long) System.Math.Truncate(percentValue);
+        var fractionValue = percentValue - integerPart;
+
+        AppendPercentParts(parts, NumberBody.Finite(integerPart, fractionValue), showNegativeSign, showPositiveSign);
+
+        return parts;
+    }
+
+    /// <summary>
+    /// Walks the percent pattern around whatever number stands in it, so the percent sign is written for a
+    /// non-finite value as it is for a finite one.
+    /// </summary>
+    private void AppendPercentParts(List<NumberFormatPart> parts, in NumberBody body, bool showNegativeSign, bool showPositiveSign)
+    {
         // Get the percent pattern to determine symbol position and spacing
         var pattern = NumberFormatInfo.PercentPositivePattern;
 
@@ -3011,25 +3116,8 @@ internal sealed class JsNumberFormat : ObjectInstance
             }
         }
 
-        if (showNegativeSign)
-        {
-            parts.Add(new NumberFormatPart("minusSign", NumberFormatInfo.NegativeSign));
-        }
-        else if (showPositiveSign)
-        {
-            parts.Add(new NumberFormatPart("plusSign", NumberFormatInfo.PositiveSign));
-        }
-
-        var integerPart = (long) System.Math.Truncate(percentValue);
-        var fractionValue = percentValue - integerPart;
-
-        FormatIntegerToParts(parts, integerPart);
-
-        if (MinimumFractionDigits > 0 || (fractionValue > 0 && MaximumFractionDigits > 0))
-        {
-            parts.Add(new NumberFormatPart("decimal", NumberFormatInfo.NumberDecimalSeparator));
-            FormatFractionToParts(parts, fractionValue);
-        }
+        AppendSignPart(parts, showNegativeSign, showPositiveSign);
+        AddNumberParts(parts, in body);
 
         if (symbolAfter)
         {
@@ -3040,8 +3128,6 @@ internal sealed class JsNumberFormat : ObjectInstance
             }
             parts.Add(new NumberFormatPart("percentSign", NumberFormatInfo.PercentSymbol));
         }
-
-        return parts;
     }
 
     private List<NumberFormatPart> FormatUnitToParts(double value)
@@ -3077,81 +3163,101 @@ internal sealed class JsNumberFormat : ObjectInstance
                 break;
         }
 
-        if (showNegativeSign)
-        {
-            parts.Add(new NumberFormatPart("minusSign", NumberFormatInfo.NegativeSign));
-        }
-        else if (showPositiveSign)
-        {
-            parts.Add(new NumberFormatPart("plusSign", NumberFormatInfo.PositiveSign));
-        }
-
         var integerPart = (long) System.Math.Truncate(absValue);
         var fractionValue = absValue - integerPart;
 
-        FormatIntegerToParts(parts, integerPart);
+        AppendUnitParts(parts, NumberBody.Finite(integerPart, fractionValue), showNegativeSign, showPositiveSign, value);
 
-        if (MinimumFractionDigits > 0 || (fractionValue > 0 && MaximumFractionDigits > 0))
-        {
-            parts.Add(new NumberFormatPart("decimal", NumberFormatInfo.NumberDecimalSeparator));
-            FormatFractionToParts(parts, fractionValue);
-        }
+        return parts;
+    }
 
-        // Add space and unit using CLDR pattern
+    /// <summary>
+    /// Walks the CLDR unit pattern around whatever number stands in it, both of its sides included.
+    /// </summary>
+    /// <remarks>
+    /// A pattern can put text on either side — <c>ja-JP</c>'s long kilometre-per-hour is
+    /// <c>"時速 {0} キロメートル"</c> — and https://tc39.es/ecma402/#sec-partitionnumberpattern appends a
+    /// <c>unit</c> part for each, the leading one before the sign. Reporting only the trailing side left
+    /// <c>formatToParts</c> describing a string <c>format</c> never wrote.
+    /// </remarks>
+    private void AppendUnitParts(
+        List<NumberFormatPart> parts,
+        in NumberBody body,
+        bool showNegativeSign,
+        bool showPositiveSign,
+        double value)
+    {
         var unitDisplay = UnitDisplay ?? "short";
         var unitStr = Unit ?? "";
+
+        string beforeNumber;
+        string afterNumber;
 
         // Try to get unit patterns from CLDR provider
         var unitPatterns = CldrProvider.GetUnitPatterns(Locale, unitStr, unitDisplay);
         if (unitPatterns != null)
         {
-            // Extract unit portion from pattern by removing {0} placeholder
+            // Extract the two sides of the pattern by removing the {0} placeholder
             // Select singular or plural pattern based on the absolute value
             var isSingular = System.Math.Abs(value) == 1;
             var pattern = isSingular ? (unitPatterns.One ?? unitPatterns.Other) : unitPatterns.Other;
             var placeholderIndex = pattern.IndexOf("{0}", StringComparison.Ordinal);
 
-            if (placeholderIndex >= 0)
-            {
-                // Pattern has format like "{0} km/h" or "時速 {0} キロメートル"
-                var beforeNumber = pattern.Substring(0, placeholderIndex);
-                var afterNumber = pattern.Substring(placeholderIndex + 3);
-
-                // The afterNumber part contains the unit (possibly with space)
-                if (!string.IsNullOrEmpty(afterNumber))
-                {
-                    // Check if it starts with a space
-                    if (afterNumber[0] == ' ')
-                    {
-                        parts.Add(new NumberFormatPart("literal", " "));
-                        parts.Add(new NumberFormatPart("unit", afterNumber.Substring(1)));
-                    }
-                    else
-                    {
-                        parts.Add(new NumberFormatPart("unit", afterNumber));
-                    }
-                }
-            }
+            beforeNumber = placeholderIndex >= 0 ? pattern.Substring(0, placeholderIndex) : "";
+            afterNumber = placeholderIndex >= 0 ? pattern.Substring(placeholderIndex + 3) : "";
         }
         else
         {
-            // Fallback to legacy behavior
-            var unitSuffix = GetUnitSuffix(unitStr, unitDisplay, absValue);
+            // Fallback to legacy behavior, which only ever writes a suffix
+            beforeNumber = "";
 
-            // Determine if we need a space before the unit
+            // Narrow display never has space; percent/degree units don't have space
             var needsSpace = !string.Equals(unitDisplay, "narrow", StringComparison.Ordinal) &&
                             !string.Equals(unitStr, "percent", StringComparison.Ordinal) &&
                             !string.Equals(unitStr, "celsius", StringComparison.Ordinal) &&
                             !string.Equals(unitStr, "fahrenheit", StringComparison.Ordinal);
 
-            if (needsSpace)
-            {
-                parts.Add(new NumberFormatPart("literal", " "));
-            }
-            parts.Add(new NumberFormatPart("unit", unitSuffix));
+            afterNumber = (needsSpace ? " " : "") + GetUnitSuffix(unitStr, unitDisplay, value);
         }
 
-        return parts;
+        AddUnitAffixParts(parts, beforeNumber, leading: true);
+        AppendSignPart(parts, showNegativeSign, showPositiveSign);
+        AddNumberParts(parts, in body);
+        AddUnitAffixParts(parts, afterNumber, leading: false);
+    }
+
+    /// <summary>
+    /// Splits one side of a unit pattern into the parts it is made of: the unit name, and the literal
+    /// separating it from the number.
+    /// </summary>
+    private static void AddUnitAffixParts(List<NumberFormatPart> parts, string affix, bool leading)
+    {
+        if (affix.Length == 0)
+        {
+            return;
+        }
+
+        // the separator sits between the two, so it trails a prefix and leads a suffix
+        var separatorIndex = leading ? affix.Length - 1 : 0;
+        var hasSeparator = affix[separatorIndex] == ' ';
+        var unit = hasSeparator
+            ? (leading ? affix.Substring(0, separatorIndex) : affix.Substring(1))
+            : affix;
+
+        if (leading && unit.Length > 0)
+        {
+            parts.Add(new NumberFormatPart("unit", unit));
+        }
+
+        if (hasSeparator)
+        {
+            parts.Add(new NumberFormatPart("literal", " "));
+        }
+
+        if (!leading && unit.Length > 0)
+        {
+            parts.Add(new NumberFormatPart("unit", unit));
+        }
     }
 
     private bool ShouldShowPlusSign(double value)

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -2593,7 +2593,6 @@ these patterns and still does not — it bounds script-supplied regular expressi
 (see [§4.42](#442-a-regex-built-at-run-time-is-bounded-by-the-configured-regextimeout)). A host that
 caught `RegexMatchTimeoutException` around `Engine.Evaluate` to absorb this can drop that handler; a host
 that treated it as a signal the script was hostile was reading a scheduling artefact.
-
 ### 4.55 An index a wrapped collection does not have does not exist, in every lane ([#3423](https://github.com/sebastienros/jint/issues/3423))
 
 On every array-like CLR wrapper, `[[HasProperty]]` and `[[GetOwnProperty]]` gave different answers for an
@@ -2793,6 +2792,63 @@ var worker = new Engine(options);
 
 Before this change that half happened by accident for `LimitExecutionTime` and never for `PromiseTimeout`.
 If you do not supply a `TimeProvider` at all, nothing here is observable.
+### 4.59 `Intl.NumberFormat` walks one pattern for both lanes, non-finite values included ([#3465](https://github.com/sebastienros/jint/issues/3465))
+
+[PartitionNumberPattern](https://tc39.es/ecma402/#sec-partitionnumberpattern)'s NaN and infinity branches
+choose the number's own text and nothing else, so the pattern
+[GetNumberFormatPattern](https://tc39.es/ecma402/#sec-getnumberformatpattern) selects is still selected and
+still walked. Neither lane did that: the parts lane returned the number alone, and the string lane handed a
+non-finite value to .NET's saturating `double`-to-`long` conversion.
+
+```js
+const usd = new Intl.NumberFormat('en', { style: 'currency', currency: 'USD' });
+// 5.0
+usd.format(NaN);       // "$0.00"
+usd.format(Infinity);  // "$9,223,372,036,854,775,807.9223372036854775807"  (and a different number on net472)
+usd.formatToParts(NaN);                                            // [nan]
+new Intl.NumberFormat('en', { style: 'percent' }).format(NaN);     // "NaN"
+new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(NaN);  // "0,00 €"
+
+// 5.x
+usd.format(NaN);       // "$NaN"
+usd.format(Infinity);  // "$∞"
+usd.formatToParts(NaN);                                            // [currency "$"][nan "NaN"]
+new Intl.NumberFormat('en', { style: 'percent' }).format(NaN);     // "NaN%"
+new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(NaN);  // "NaN €"
+```
+
+Three narrower disagreements between the same two lanes go with it.
+
+A CLDR unit pattern can put text on both sides of the number, and the parts lane reported only the trailing
+side — so `formatToParts` described a string `format` never wrote. The leading side is a `unit` part of its
+own, and the sign stands after it:
+
+```js
+const nf = new Intl.NumberFormat('ja-JP', { style: 'unit', unit: 'kilometer-per-hour', unitDisplay: 'long' });
+nf.format(1);         // "時速 1 キロメートル", unchanged
+nf.formatToParts(1);
+// 5.0: [integer "1"][literal " "][unit "キロメートル"]
+// 5.x: [unit "時速"][literal " "][integer "1"][literal " "][unit "キロメートル"]
+```
+
+`notation: "scientific"` and `"engineering"` of exactly zero fell back to plain decimal formatting, where
+[PartitionNotationSubPattern](https://tc39.es/ecma402/#sec-partitionnotationsubpattern) writes `"0"` for an
+exponent of zero like any other: `new Intl.NumberFormat('en', { notation: 'scientific' }).format(0)` was
+`"0"` and is `"0E0"`, which is what its own parts lane already said. A non-finite value takes no notation
+sub-pattern at all, so `format(Infinity)` stays `"∞"` under either notation.
+
+And the currency string lane interpolated a literal `"-"` and `"+"` where the parts lane read
+`NumberFormatInfo.NegativeSign` / `PositiveSign`. ECMA-402 calls it "the ILND String representing the minus
+sign", so it is the locale's own datum:
+`new Intl.NumberFormat('ar-EG', { style: 'currency', currency: 'EGP' }).format(-5)` gains the U+061C ARABIC
+LETTER MARK its parts lane always reported. Negative zero under a notation gains its sign for the same
+reason — `format(-0)` is `"-0E0"`, not `"0E0"`.
+
+**What could break:** any output that read a non-finite value through a `style`, a `formatToParts` walk over
+a locale whose unit pattern has a prefix (`ja-JP`, `ko-KR`, `zh-TW` long units), scientific or engineering
+notation of zero, and a currency's sign in a locale whose sign is not ASCII. A string that was already the
+concatenation of its own parts does not move: this is the two lanes being brought onto one walk, and it is
+that walk that decides.
 
 ## 5. New in v5
 

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -2792,6 +2792,7 @@ var worker = new Engine(options);
 
 Before this change that half happened by accident for `LimitExecutionTime` and never for `PromiseTimeout`.
 If you do not supply a `TimeProvider` at all, nothing here is observable.
+
 ### 4.59 `Intl.NumberFormat` walks one pattern for both lanes, non-finite values included ([#3465](https://github.com/sebastienros/jint/issues/3465))
 
 [PartitionNumberPattern](https://tc39.es/ecma402/#sec-partitionnumberpattern)'s NaN and infinity branches
@@ -2849,7 +2850,6 @@ a locale whose unit pattern has a prefix (`ja-JP`, `ko-KR`, `zh-TW` long units),
 notation of zero, and a currency's sign in a locale whose sign is not ASCII. A string that was already the
 concatenation of its own parts does not move: this is the two lanes being brought onto one walk, and it is
 that walk that decides.
-
 ## 5. New in v5
 
 Everything in the table below is opt-in: nothing in it is installed unless the host asks for it, so
@@ -3472,3 +3472,12 @@ number is stale by the time it lands — and because two of them edit different 
 git merges them cleanly and the duplicate only shows up in the rendered document. Whoever merges
 second renumbers, and repoints any `[§x.y](#xy-...)` link to the section. A collision that reaches
 `main` is a docs fix, not a rewrite of the section.
+
+**A rebase preserves a section's position, not its rank.** Renumbering the heading is only half of
+it: git replays the section where it sat, so once a lower-numbered section lands on `main` underneath
+a branch, that branch's entry ends up *above* it — distinct numbers, no conflict to resolve, and a
+document whose numbers run backwards. This happened during the v5 campaign to a branch that rebased
+with no conflict at all, which is exactly the case nothing draws attention to. So after **every**
+rebase, not only after one that conflicted, move the section block to the end of its chapter and run
+`dotnet test -c Release --filter "FullyQualifiedName~MigrationGuideTests"`; that is what
+`SectionNumbersAscendInDocumentOrder` is there to catch.


### PR DESCRIPTION
`Intl.NumberFormat.prototype.format` and `.formatToParts` are two readings of one walk:
[FormatNumeric](https://tc39.es/ecma402/#sec-formatnumeric) is defined as the concatenation of exactly the
parts [FormatNumericToParts](https://tc39.es/ecma402/#sec-formatnumerictoparts) returns, both of them
[PartitionNumberPattern](https://tc39.es/ecma402/#sec-partitionnumberpattern). #3470 fixed the digits half.
Four disagreements remained, none of them about digits.

Fixes #3465.

## 1. A non-finite value lost the style written around it

PartitionNumberPattern's NaN and infinity branches set `formattedString` and nothing else — the pattern
[GetNumberFormatPattern](https://tc39.es/ecma402/#sec-getnumberformatpattern) selects is still selected and
still walked, and that algorithm reads NaN as `positive-zero` and each infinity as the non-zero category of
its own sign. The parts lane short-circuited before the style switch, and the string lane handed the value
straight to .NET's saturating `double`→`long` conversion:

```js
const usd = new Intl.NumberFormat('en', { style: 'currency', currency: 'USD' });
usd.format(NaN);        // was "$0.00"                                            now "$NaN"
usd.format(Infinity);   // was "$9,223,372,036,854,775,807.9223372036854775807"   now "$∞"
usd.formatToParts(NaN); // was [nan]                                 now [currency "$"][nan "NaN"]

new Intl.NumberFormat('en', { style: 'percent' }).format(NaN);                       // "NaN" → "NaN%"
new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(NaN);  // "0,00 €" → "NaN €"
new Intl.NumberFormat('en', { style: 'unit', unit: 'meter' }).formatToParts(NaN);
// [nan] → [nan "NaN"][literal " "][unit "m"], which is what format() already wrote
```

The saturating conversion is also framework-dependent — `net472` produced `"$-9,223,372,036,854,775,808.…"`
where `net8.0` produced the positive one.

Rather than a second copy of the affix logic in the non-finite branch, the per-style pattern walks were
lifted into `AppendCurrencyParts` / `AppendPercentParts` / `AppendUnitParts`, each taking a `NumberBody`
that carries either a finite value's integer and fraction or the single `nan`/`infinity` part
[PartitionNotationSubPattern](https://tc39.es/ecma402/#sec-partitionnotationsubpattern) makes of a
non-finite one. `format` reads a non-finite result off that list rather than assembling a second one, so
the two lanes cannot drift again. PartitionNotationSubPattern gives a non-finite value one part and no
notation sub-pattern, so `notation: "scientific"` still adds no exponent to `∞`, which is what
`engineering-scientific-en-US.js` asserts and it still passes.

## 2. A unit pattern's prefix was dropped by the parts lane

`FormatUnitToParts` split the CLDR pattern into `beforeNumber` / `afterNumber` and never emitted the first,
so `formatToParts` described a string `format` never wrote. PartitionNumberPattern's `unitPrefix` branch
appends a `unit` part, and the sign stands after it:

```js
const nf = new Intl.NumberFormat('ja-JP', { style: 'unit', unit: 'kilometer-per-hour', unitDisplay: 'long' });
nf.format(1);         // "時速 1 キロメートル", unchanged
nf.formatToParts(1);
// was [integer "1"][literal " "][unit "キロメートル"]
// now [unit "時速"][literal " "][integer "1"][literal " "][unit "キロメートル"]
```

## 3. Scientific and engineering notation of exactly zero

Both opened with `if (!double.IsFinite(value) || value == 0) return FormatDecimal(value);`. The `value == 0`
half is wrong — PartitionNotationSubPattern's `scientificExponent` branch says *"If exponent = 0, let
exponentResult be `"0"`"* — so `format(0)` was `"0"` where its own parts lane already said `"0E0"`.
Negative zero takes the negative pattern in both lanes with it, so `format(-0)` is `"-0E0"`. The
`!double.IsFinite` half stays.

## 4. The currency string lane's sign

`FormatCurrency`, `FormatNegativeCurrency` and `FormatCurrencyWithSignificantDigits` interpolated a literal
`"-"` / `"+"` where the parts lane read `NumberFormatInfo.NegativeSign` / `PositiveSign`. ECMA-402 calls it
"the ILND String representing the minus sign", so it is the locale's own datum:
`new Intl.NumberFormat('ar-EG', { style: 'currency', currency: 'EGP' }).format(-5)` was `"-5٫00 EGP"` against
its parts lane's `[minusSign "؜-"]` — U+061C ARABIC LETTER MARK. `ApplyPercentPattern`, one method over, had
the same defect on both the sign it wrote and the one it stripped back off, and is fixed with it.

## Tests

`Jint.Tests/Runtime/IntlNumberFormatPartsTests.cs` — the grid #3470 added — now asserts the join **outright**
rather than skipping a combination whose Latin lanes already disagree; its `<remarks>` named these four as
the reason it could not. Seven locales × thirteen option sets × eleven values × eight numbering systems and
`latn`, with zero mismatches. Six focused tests were written first and run against unmodified code:

```
  Failed ANonFiniteValueKeepsTheStyleAroundIt [2 ms]
  Error Message:
   Expected Format(Usd, "NaN") to be the same string, but they differ at index 1:
    ↓ (actual)
  "$0.00"
  "$NaN"

  Failed AUnitPatternsPrefixIsAPartOfItsOwn [7 ms]
  Error Message:
   Expected Parts(Japanese, "1") to be the same string, but they differ at index 10:
             ↓ (actual)
  "[{"type":"integer","value":"1"},{"type":"literal","value":"…"
  "[{"type":"unit","value":"時速"},{"type":"literal","value":"…"

  Failed ScientificNotationOfZeroStillHasAnExponent [2 ms]
  Error Message:
   Expected Format(Scientific, "0") to be the same string, but they differ at index 1:
    ↓ (actual)
  "0"
  "0E0"

  Failed TheCurrencySignIsTheOneTheLocaleWrites [2 ms]
  Error Message:
   Expected Format(Egp, "-5") to be the same string, but they differ at index 0:
   ↓ (actual)
  "-5٫00 EGP"
  "؜-5٫00 EGP"

Failed!  - Failed:     6, Passed:     9, Skipped:     0, Total:    15
```

### test262

Six exclusions removed, all six now passing — the whole "Unit formatting" block, including the two whose
comment blamed missing ICU4N locale data when the cause was the unreported prefix part:

| Removed exclusion | Status |
| --- | --- |
| `intl402/NumberFormat/prototype/formatToParts/unit-de-DE.js` | passes (was already passing — a stale entry) |
| `intl402/NumberFormat/prototype/formatToParts/unit-ja-JP.js` | passes |
| `intl402/NumberFormat/prototype/formatToParts/unit-ko-KR.js` | passes |
| `intl402/NumberFormat/prototype/formatToParts/unit-zh-TW.js` | passes |
| `intl402/NumberFormat/prototype/format/unit-ja-JP.js` | passes |
| `intl402/NumberFormat/prototype/format/unit-zh-TW.js` | passes |

Suite: **102,507 passed / 0 failed / 177 skipped**, against 102,495 / 0 / 189 on `main` — +12, which is the
six files in both their strict and sloppy runs. (Three `staging/sm` `TimeoutException`s appeared in one full
run on a loaded machine and pass in isolation.)

`Jint.Tests` 10,942, `Jint.Tests.PublicInterface` 3,243, `Jint.Tests.CommonScripts` 28 and
`Jint.Tests.SourceGenerators` 71 all green on `net472`, `net8.0` and `net10.0`.

Migration guide: §4.59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014W5mbjGhyvgAS4pivXoc4S
