### PR TITLE
Native AOT: an annotation is only preserved when a probe can fail without it

### DIFF
--- a/Jint.AotExample.UnrootedHost/Hosts.cs
+++ b/Jint.AotExample.UnrootedHost/Hosts.cs
@@ -1,0 +1,101 @@
+namespace UnrootedAotProbe;
+
+/// <summary>
+/// Host types for the probes that measure what a <c>[DynamicallyAccessedMembers]</c> annotation
+/// <em>preserves</em>, as opposed to what the engine does at run time.
+/// </summary>
+/// <remarks>
+/// <para>
+/// They live in their own assembly for one reason: <c>Jint.AotExample</c> roots itself and <c>Jint</c> with
+/// <c>TrimmerRootAssembly</c>, so every host type declared beside <c>Program.cs</c> survives whatever an
+/// annotation says and no probe over one can tell the annotation from the root. This assembly is
+/// deliberately <b>not</b> rooted, so the only thing standing between these members and the trimmer is the
+/// attribute on the entry point each is registered through.
+/// </para>
+/// <para>
+/// Nothing in C# may read a member below. A single call from <c>Program.cs</c> — or an <c>InternalsVisibleTo</c>
+/// test, or a debugger-friendly <c>ToString</c> override that touched a property — roots it, and the probe
+/// that member is the subject of silently stops measuring anything. That is the same failure the rooting of
+/// <c>Jint.AotExample</c> itself creates, one assembly further out.
+/// </para>
+/// </remarks>
+public sealed class PreservedByAnnotation
+{
+    /// <summary>A public field. Preserved by <c>PublicFields</c>.</summary>
+    public string Field = "preserved field";
+
+    /// <summary>A public property. Preserved by <c>PublicProperties</c>.</summary>
+    public string Name => "preserved";
+
+    /// <summary>A public method. Preserved by <c>PublicMethods</c>.</summary>
+    public string Greet(string who) => "hello " + who;
+}
+
+/// <summary>
+/// The same shape as <see cref="PreservedByAnnotation"/>, registered through an entry point that carries
+/// <c>[RequiresUnreferencedCode]</c> instead — so nothing preserves these members and the trimmer takes them.
+/// </summary>
+/// <remarks>
+/// A distinct type rather than the one above, because a <c>[DynamicallyAccessedMembers]</c> annotation is a
+/// whole-program fact about the type it names: registering one instance through <c>SetValue&lt;T&gt;</c>
+/// anywhere would preserve the members for every other lane as well, and the negative probe would pass by
+/// borrowing the positive one's preservation.
+/// </remarks>
+public sealed class TrimmedWithoutAnnotation
+{
+    /// <summary>The member the negative probe reads. Under Native AOT it is not there.</summary>
+    public string Name => "not preserved";
+}
+
+/// <summary>
+/// A host sequence whose array-likeness Jint can only discover through <c>Type.GetInterfaces()</c>, and which
+/// nothing in C# ever uses as an <see cref="IReadOnlyList{T}"/>.
+/// </summary>
+/// <remarks>
+/// This is the subject of the <c>Interfaces</c> entry that
+/// <see href="https://github.com/sebastienros/jint/issues/3396">#3396</see> added to the shared annotation.
+/// The indexer is an ordinary public property and survives on <c>PublicProperties</c> alone, so
+/// <c>seq[1]</c> is not the measurement; <c>seq.length</c> is, because that arrives only when
+/// <c>ObjectWrapper.ResolveArrayLikeWrapperFactoryType</c> finds <see cref="IReadOnlyList{T}"/> among the
+/// interfaces the trimmer left behind.
+/// </remarks>
+public sealed class PreservedInterfaceSequence : IReadOnlyList<string>
+{
+    private readonly string[] _items = ["x", "y"];
+
+    /// <inheritdoc />
+    public string this[int index] => _items[index];
+
+    /// <inheritdoc />
+    public int Count => _items.Length;
+
+    /// <inheritdoc />
+    public IEnumerator<string> GetEnumerator() => ((IEnumerable<string>) _items).GetEnumerator();
+
+    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => _items.GetEnumerator();
+}
+
+/// <summary>An interface nothing in this program implements, dispatches on, or names but the class below.</summary>
+public interface IHiddenBehindAnInterface
+{
+    /// <summary>The member the explicit-implementation probe reads.</summary>
+    string Hidden { get; }
+}
+
+/// <summary>
+/// A host type whose only script-visible member is an <b>explicit</b> interface implementation, over an
+/// interface used nowhere else in the closed program.
+/// </summary>
+/// <remarks>
+/// It is the shape that isolates the <c>Interfaces</c> entry of the shared annotation rather than riding on
+/// it. <c>IReadOnlyList&lt;string&gt;</c> does not isolate anything: Jint implements against it and rooted
+/// types beside <c>Program.cs</c> use it, so ILC keeps that interface implementation whether the annotation
+/// asks for it or not. Here the interface exists for this one class — and the measured answer is that the
+/// member is <b>not</b> reachable under Native AOT even so, because <c>Interfaces</c> asks for the
+/// implemented interfaces and not for their members, and <c>TypeResolver</c>'s walk needs
+/// <c>iface.GetProperties()</c> to answer.
+/// </remarks>
+public sealed class ExplicitInterfaceOnly : IHiddenBehindAnInterface
+{
+    string IHiddenBehindAnInterface.Hidden => "behind an interface";
+}

--- a/Jint.AotExample.UnrootedHost/Jint.AotExample.UnrootedHost.csproj
+++ b/Jint.AotExample.UnrootedHost/Jint.AotExample.UnrootedHost.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    The unrooted half of Jint's Native AOT probe. Jint.AotExample references it and deliberately does NOT
+    list it in TrimmerRootAssembly, so the host types in here are preserved by nothing except the
+    [DynamicallyAccessedMembers] on the entry point each is registered through - which is what lets a probe
+    tell an annotation apart from a root. See Jint.AotExample/AGENTS.md.
+
+    It references nothing on purpose. A reference to Jint would give the trimmer a reason to keep members
+    these types are supposed to lose, and would let a future maintainer close the measurement by accident.
+  -->
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>UnrootedAotProbe</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!--
+      Directory.Build.props adds these for every project in the repository because Jint parses with
+      Acornima. This one references no packages at all, by design, so the global usings would be the only
+      thing forcing a reference on it.
+    -->
+    <Using Remove="Acornima" />
+    <Using Remove="Acornima.Ast" />
+  </ItemGroup>
+
+</Project>

--- a/Jint.AotExample/AGENTS.md
+++ b/Jint.AotExample/AGENTS.md
@@ -161,7 +161,11 @@ because both tokens are constants.
    script reaches — to be trimmed away.
 4. Add a `Probe` to `Jint.AotExample/Program.cs`, with a sibling using the other kind of type argument
    where the lane is generic. A `KnownAotGap` is for a shape that must *keep* throwing; it is checked
-   in both directions, so a gap that closes fails the leg.
+   in both directions, so a gap that closes fails the leg. A `KnownTrimmedAway` is for a shape that must
+   keep answering **wrongly** — see the next section — and is checked in both directions for the same
+   reason.
+5. If what you added is an *annotation* rather than a lane, its subject goes in
+   `Jint.AotExample.UnrootedHost`, not beside `Program.cs`. See below.
 
 The eight annotated members today are `OptionsExtensions.AllowClr` (two overloads),
 `OptionsExtensions.AddExtensionMethods`, `Engine.SetValue(string, object?)`,
@@ -192,6 +196,47 @@ in the *host's* code. The array half is fixed; the delegate half is not, and the
   the same signature as `SetValue<T>` after substitution and would make every delegate call site
   ambiguous. Widening the annotation is not the fix either; knowing that the annotation is what an
   embedder pays is the point.
+
+#### The unrooted half, and what an annotation is worth
+
+**A rooted subject cannot measure an annotation.** `Jint.AotExample` roots `Jint` and itself, so every host
+type declared beside `Program.cs` — `Company`, `ReadOnlyStrings`, `GenericHost`, `Box<T>` — survives
+whatever `SetValue<T>`'s `[DynamicallyAccessedMembers]` says, and a probe over one cannot tell the
+annotation from the root. `Jint.AotExample.UnrootedHost` is the second project that closes that
+([#3479](https://github.com/sebastienros/jint/issues/3479)): referenced, deliberately **not** in
+`TrimmerRootAssembly`, and the home of every host type whose only protection is the attribute on the entry
+point it is registered through. **Nothing in C# may read a member of a type in there** — one call from
+`Program.cs`, one `ToString` override that touches a property, and the probe silently stops measuring.
+
+**The standard of proof is that removing the annotation makes a probe fail.** Deleting
+`[DynamicallyAccessedMembers]` from `Engine.SetValue<T>(string, T?)` and
+`GlobalValueRegistration.RegisterTyped<T>` — nothing else — turns four probes red on a published native
+binary: the two unrooted ones, *and* `Dictionary<string, object>` / `Dictionary<string, int>`, which were
+already annotation-sensitive because their subject is a framework type this project does not root either.
+Those two discriminated by accident; nothing said they were the annotation's evidence, and rooting one
+more assembly would have retired them without a word. **A probe that passes either way must be deleted
+rather than kept — it reads as evidence and is not.**
+
+**`DynamicallyAccessedMemberTypes.Interfaces` is not what any probe here pins, and it is still worth
+carrying.** Two measurements, and neither is the one the entry looks like it should have:
+
+* Removing it from `InteropHelper.DefaultDynamicallyAccessedMemberTypes` leaves the unrooted
+  `IReadOnlyList<string>` probe **entirely green** — ILC keeps the interface implementations of a type whose
+  MethodTable it emits whenever the interface is used anywhere in the closed program, and Jint itself uses
+  that one. What that probe actually pins is `Count`, riding on `PublicProperties`. So no probe can be
+  written that discriminates the entry at run time, which is why none claims to.
+* What removing it *does* change is the **analysis**: the published inventory goes 67 → **75** (`IL2067`
+  8 → 11, `IL2070` 4 → 9), every one of them in Jint's files and in the embedder's build. That is the
+  opposite of `PublicNestedTypes`, which bought nothing and cost the embedder diagnostics; this one buys
+  nothing at run time and *saves* eight. **Do not delete it** on the strength of the first bullet.
+
+**And it does not reach a member behind an *explicit* implementation at all.** `Interfaces` asks for the
+implemented interfaces, not for their members, so `TypeResolver`'s `iface.GetProperties()` walk finds
+nothing and the member reads `undefined` with the annotation present and correct — pinned as a
+`KnownTrimmedAway`. Adding `typeof(TheInterface).GetProperties()` anywhere in the program makes it
+resolve, which is what identifies the missing thing as member metadata. **Do not close it by widening the
+constant**; the embedder closes it by rooting their own assembly, which is what `docs/v5-migration.md`
+§6.4 already tells them.
 
 #### Reading the example
 

--- a/Jint.AotExample/Jint.AotExample.csproj
+++ b/Jint.AotExample/Jint.AotExample.csproj
@@ -46,6 +46,16 @@
     <ProjectReference Include="..\Jint\Jint.csproj" />
 
     <!--
+      The unrooted half. Deliberately absent from the TrimmerRootAssembly list below, and that absence is
+      the whole measurement: every host type declared beside Program.cs is rooted wholesale, so a probe
+      over one cannot tell "the annotation preserved this member" from "the root did". The types in this
+      assembly have nothing but the attribute on the entry point they are registered through, so removing
+      that attribute makes a probe fail - which is what turns section 6.6 of docs/v5-migration.md from a
+      claim into a measurement.
+    -->
+    <ProjectReference Include="..\Jint.AotExample.UnrootedHost\Jint.AotExample.UnrootedHost.csproj" />
+
+    <!--
       Rooting Jint keeps the probe about *Jint's* AOT behaviour rather than about how much of Jint a
       given program happens to reach; a real embedder would not do this, so treat the run as an upper
       bound on what works, never a lower one.
@@ -54,6 +64,10 @@
       nothing calls it from C# - and `company.shout()` then fails as "not a function": a wrong answer
       with no AOT diagnostic anywhere. An embedder whose host types are reached only through Jint's
       reflection owes itself the same root.
+
+      Jint.AotExample.UnrootedHost is not here, on purpose. Adding it would make every probe in the
+      "annotation" group below pass unconditionally, which is worse than not having them: a probe that
+      cannot fail still reads as evidence.
     -->
     <TrimmerRootAssembly Include="Jint" />
     <TrimmerRootAssembly Include="Jint.AotExample" />

--- a/Jint.AotExample/Program.cs
+++ b/Jint.AotExample/Program.cs
@@ -3,13 +3,20 @@
 // AOT failure actually shows up: <IsAotCompatible> is a property, not evidence, and Jint's own csproj
 // still suppresses the eight IL warning codes that would substantiate it.
 //
-// Two kinds of entry live below.
+// Three kinds of entry live below.
 //
 //   Probe(...)        must succeed on every runtime. A failure fails the run.
 //   KnownAotGap(...)  must succeed under a JIT and must throw NotSupportedException under Native AOT.
 //                     Both directions are checked, so a gap that closes fails the native run and
 //                     forces this file to be updated - the same discipline the vendored
 //                     web-platform-tests exclusion table uses.
+//   KnownTrimmedAway(...)
+//                     must read its value under a JIT and must read `undefined` under Native AOT,
+//                     because the member was trimmed and nothing reported it. Checked in both
+//                     directions for the same reason, and it is the only entry here whose native
+//                     expectation is a WRONG ANSWER rather than a failure - which is precisely the
+//                     failure mode docs/v5-migration.md section 6.4 says to plan for, because no
+//                     diagnostic anywhere reports it.
 //
 // Every known gap is one shape: a generic instantiation over a VALUE TYPE built at run time, either
 // Type.MakeGenericType + Activator.CreateInstance or MethodInfo.MakeGenericMethod. Reference-type
@@ -44,10 +51,12 @@
 using Jint;
 using Jint.Native;
 using Jint.Runtime.Interop;
+using UnrootedAotProbe;
 
 var failures = 0;
 var probes = 0;
 var gaps = 0;
+var trimmed = 0;
 // A Native AOT image has no managed assembly file to point at, so Assembly.Location is the empty
 // string there and a path under every other host. Neither of the two obvious alternatives works:
 // PublishAot=true writes both RuntimeFeature.IsDynamicCodeSupported and .IsDynamicCodeCompiled as
@@ -430,6 +439,100 @@ Probe("extension methods", static () =>
     Expect("JINT", engine.Evaluate("company.shout()"));
 });
 
+// The annotation group. Everything above measures what the ENGINE does natively; these four measure what
+// an ATTRIBUTE preserves, which until now nothing did - Jint.AotExample roots itself and Jint, so every
+// host type declared at the bottom of this file survives whatever SetValue<T>'s
+// [DynamicallyAccessedMembers] says and a probe over one cannot tell the annotation from the root
+// (sebastienros/jint#3479). Their subjects live in Jint.AotExample.UnrootedHost, which the csproj
+// deliberately does not root, so the attribute is the only thing between these members and the trimmer.
+//
+// THE MEASUREMENT IS THAT REMOVING THE ANNOTATION MAKES A PROBE FAIL, and it was run on a published
+// native binary rather than reasoned about. Deleting [DynamicallyAccessedMembers] from
+// Engine.SetValue<T>(string, T?) and GlobalValueRegistration.RegisterTyped<T> - nothing else - turns four
+// probes red:
+//
+//   unrooted host type through SetValue<T>          expected <preserved> but got <>
+//   unrooted IReadOnlyList<string> through SetValue<T>  expected <2> but got <0>
+//   Dictionary<string, object> crossing             expected <1> but got <>
+//   Dictionary<string, int> crossing                expected <1> but got <>
+//
+// The last two are the correction #3479 needs: two probes that were ALREADY annotation-sensitive, because
+// their subject is a framework type this project does not root either. They discriminate by accident
+// rather than by design - nothing said they were the annotation's evidence, and rooting one more assembly
+// would have silently retired them - which is why the group below exists as well.
+//
+// A probe here that passes either way is not testing the annotation and must be deleted rather than kept:
+// it reads as evidence and is not.
+Probe("unrooted host type through SetValue<T>: the annotation preserves its members", static () =>
+{
+    var engine = new Engine(static cfg => cfg.AllowClr());
+
+    // T is inferred as PreservedByAnnotation, so the type parameter's [DynamicallyAccessedMembers] names
+    // exactly this type and the trimmer keeps its public property, field and method. This is the claim
+    // docs/v5-migration.md section 6.3 makes when it points an embedder away from SetValue(string, object?).
+    engine.SetValue("h", new PreservedByAnnotation());
+
+    Expect("preserved", engine.Evaluate("h.name"));
+    Expect("preserved field", engine.Evaluate("h.field"));
+    Expect("hello Mary", engine.Evaluate("h.greet('Mary')"));
+});
+
+// The other direction, and the one that had no executable form at all: the SILENT WRONG ANSWER that
+// section 6.4 warns about. Nothing preserves the member, nothing reports its absence, and script reads
+// `undefined` for a property that is plainly declared on the object it was handed.
+KnownTrimmedAway("unrooted host type through SetValue(string, object?): the member is gone", "not preserved", static () =>
+{
+    var engine = new Engine(static cfg => cfg.AllowClr());
+
+    // The cast is what picks the overload. `object` at the call site is the whole hazard the annotation
+    // cannot cover, which is why this overload carries [RequiresUnreferencedCode] instead - IL2026 here,
+    // suppressed for the file by the csproj.
+    engine.SetValue("h", (object) new TrimmedWithoutAnnotation());
+
+    return engine.Evaluate("h.name");
+});
+
+// Array-likeness, which is a second lane and not a second spelling of the probe above: seq[1] resolves the
+// type's own indexer, seq.length and the Array.prototype generics arrive only when
+// ObjectWrapper.ResolveArrayLikeWrapperFactoryType finds IReadOnlyList<> among the type's interfaces AND
+// can read Count. Removing the annotation answers <0> rather than throwing, which is why the length is
+// asserted and not merely the element.
+//
+// It is deliberately NOT called a probe of the Interfaces entry #3396 added to the shared set, because it
+// measured as not being one: removing DynamicallyAccessedMemberTypes.Interfaces from
+// InteropHelper.DefaultDynamicallyAccessedMemberTypes on its own leaves every assertion here passing. ILC
+// keeps the interface implementations of a type whose MethodTable it emits when the interface is used
+// anywhere in the closed program, and IReadOnlyList<string> is used by Jint and by the rooted types beside
+// this file. What fails here is Count going with PublicProperties. That entry earns its keep in the
+// ANALYSIS rather than in the binary - removing it takes the published inventory from 67 to 75 - so do not
+// read "no probe discriminates it" as "delete it".
+Probe("unrooted IReadOnlyList<string> through SetValue<T>: the annotation preserves what makes it array-like", static () =>
+{
+    var engine = new Engine(static cfg => cfg.AllowClr());
+    engine.SetValue("seq", new PreservedInterfaceSequence());
+
+    Expect(2, engine.Evaluate("seq.length"));
+    Expect("y", engine.Evaluate("seq[1]"));
+    Expect("x-y", engine.Evaluate("Array.prototype.join.call(seq, '-')"));
+});
+
+// The edge of the annotation, and the answer to the other half of #3479's question. TypeResolver walks
+// type.GetInterfaces() and then iface.GetProperties() to find a member a class implements only through an
+// interface. DynamicallyAccessedMemberTypes.Interfaces asks for the implemented interfaces; it does NOT ask
+// for their members, so the interface arrives with no property metadata and the walk finds nothing. The
+// annotation is present and correct, and the member still reads `undefined`.
+//
+// Measured, and the observer effect is worth recording because it is what identifies the missing thing:
+// adding `typeof(IHiddenBehindAnInterface).GetProperties()` anywhere in this file makes the read succeed,
+// because that constant token IS a request to preserve those members. An embedder hitting this closes it
+// the way section 6.4 says - by rooting their own assembly - not by widening Jint's annotation.
+KnownTrimmedAway("unrooted explicit interface implementation through SetValue<T>: Interfaces does not reach the member", "behind an interface", static () =>
+{
+    var engine = new Engine(static cfg => cfg.AllowClr());
+    engine.SetValue("h", new ExplicitInterfaceOnly());
+    return engine.Evaluate("h.hidden");
+});
+
 Probe("JSON round trip", static () =>
 {
     var engine = new Engine();
@@ -457,7 +560,7 @@ Probe("promise and async function", static () =>
 Console.WriteLine();
 if (failures == 0)
 {
-    Console.WriteLine($"ALL PROBES PASSED ({probes} probes, {gaps} known AOT gaps)");
+    Console.WriteLine($"ALL PROBES PASSED ({probes} probes, {gaps} known AOT gaps, {trimmed} known trimming gap{(trimmed == 1 ? "" : "s")})");
     return 0;
 }
 
@@ -519,6 +622,55 @@ void KnownAotGap(string name, Action action)
 
     failures++;
     Console.WriteLine($"FAIL  {name}: this known AOT gap now WORKS - promote it from KnownAotGap to Probe");
+}
+
+// The trimming counterpart of KnownAotGap. A member of an UNROOTED host type reached through an entry
+// point that carries no [DynamicallyAccessedMembers] is preserved by nothing, so under Native AOT it is
+// simply not there and the read answers `undefined`. That is the whole point of the entry: a trimmed member
+// raises nothing anywhere, so the only way to hold the claim is to assert the wrong answer and check the
+// other direction too - a member that starts surviving fails the native run and forces the annotation
+// inventory to be re-derived, exactly as a closing KnownAotGap does.
+void KnownTrimmedAway(string name, string underJit, Func<JsValue> read)
+{
+    trimmed++;
+
+    JsValue value;
+    try
+    {
+        value = read();
+    }
+    catch (Exception ex)
+    {
+        failures++;
+        Console.WriteLine($"FAIL  {name}: {ex.GetType().FullName}: {ex.Message}");
+        return;
+    }
+
+    if (dynamicCode)
+    {
+        try
+        {
+            Expect(underJit, value);
+        }
+        catch (Exception ex)
+        {
+            failures++;
+            Console.WriteLine($"FAIL  {name}: {ex.Message}");
+            return;
+        }
+
+        Console.WriteLine($"PASS  {name} (known trimming gap, the member is present under a JIT)");
+        return;
+    }
+
+    if (value.IsUndefined())
+    {
+        Console.WriteLine($"TRIM  {name}: reads undefined, and nothing anywhere said so.");
+        return;
+    }
+
+    failures++;
+    Console.WriteLine($"FAIL  {name}: the member SURVIVED trimming and read <{value.ToObject()}> - something now preserves it, so re-derive what and either promote this to a Probe or find a member that is genuinely unreachable");
 }
 
 static void Expect(object expected, JsValue actual)

--- a/Jint.slnx
+++ b/Jint.slnx
@@ -19,6 +19,7 @@
     <File Path=".github/workflows/release.yml" />
   </Folder>
   <Project Path="Jint.AotExample/Jint.AotExample.csproj" />
+  <Project Path="Jint.AotExample.UnrootedHost/Jint.AotExample.UnrootedHost.csproj" />
   <Project Path="Jint.Benchmark/Jint.Benchmark.csproj" />
   <Project Path="Jint.Repl/Jint.Repl.csproj" />
   <Project Path="Jint.SourceGenerators/Jint.SourceGenerators.csproj" />

--- a/Jint/Runtime/Interop/InteropHelper.cs
+++ b/Jint/Runtime/Interop/InteropHelper.cs
@@ -26,6 +26,19 @@ internal sealed class InteropHelper
     /// mode with no diagnostic anywhere.
     /// </para>
     /// <para>
+    /// Two things about that entry are measured rather than assumed, and both are needed before anyone
+    /// touches it (<see href="https://github.com/sebastienros/jint/issues/3479">#3479</see>). Removing it
+    /// changes <b>no</b> answer a published native binary gives, because ILC keeps the interface
+    /// implementations of a type whose MethodTable it emits whenever the interface is used anywhere in the
+    /// closed program — so no probe can be written that discriminates it at run time. What removing it does
+    /// change is the analysis: the published inventory goes 67 to 75, all in the embedder's build. And it
+    /// does not stretch to a member behind an <em>explicit</em> implementation, because it asks for the
+    /// interfaces and not for their members, so <c>iface.GetProperties()</c> has nothing to read — an
+    /// unrooted host type's explicit member reads <c>undefined</c> with this constant exactly as it stands,
+    /// which <c>Jint.AotExample</c> pins as a <c>KnownTrimmedAway</c>. Neither fact is a reason to widen it;
+    /// the second is the embedder's to close by rooting their own assembly.
+    /// </para>
+    /// <para>
     /// <see cref="DynamicallyAccessedMemberTypes.PublicNestedTypes"/> is deliberately <b>not</b> here, and
     /// that is a measured decision rather than an oversight. Member resolution really does call
     /// <see cref="Type.GetNestedType(string, System.Reflection.BindingFlags)"/> — a nested type is a member a

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -3161,6 +3161,10 @@ interface implementation nothing else uses, and Jint would then report a member 
 `undefined` — the failure mode [§6.4](#64-what-you-owe-your-own-project) warns about, with no
 diagnostic anywhere. Nothing in your code changes; the annotation is what keeps the interface.
 
+**It keeps the interface, not the interface's members**, and that distinction is measured rather than
+assumed — see [§6.7](#67-the-annotation-contract-is-measured-3479), which also says which half of this
+paragraph a published binary actually confirms.
+
 `TypeReference.ReferenceType` carries the same set now, so a type handed to
 `CreateTypeReference` is still annotated when the reference constructs it — through `Activator` and
 through the resolved constructor set alike. It was a plain `Type` before, and the promise the caller
@@ -3177,6 +3181,40 @@ six candidates with the annotation present and absent. So the requirement is sta
 the lookup happens, and the two `IL2072` it raises against `TypeReference.cs` are two of the
 diagnostics §6.4 counts. This is the `Delegate` trap in §6.4 again, and the choice was not to add a
 second one.
+
+### 6.7 The annotation contract is measured ([#3479](https://github.com/sebastienros/jint/issues/3479))
+
+Everything above [§6.3](#63-apis-that-now-warn) says about `SetValue<T>` preserving what Jint reflects
+over used to be a claim no run checked. `Jint.AotExample` roots both assemblies it publishes, so every
+host type its probes registered was preserved by the root and no probe could tell the annotation from it.
+There is now a second project, `Jint.AotExample.UnrootedHost`, that the AOT leg publishes and deliberately
+does **not** root, and four probes over it. Nothing in your code changes; what changes is that the two
+sentences below are now the output of a native binary rather than prose.
+
+**What the annotation does buy you.** Registering an unrooted host type through `SetValue<T>` — the
+overload C# picks whenever the static type at the call site is the host type — preserves its public
+property, field and method, and preserves enough of an `IReadOnlyList<T>` implementation for `.length` and
+the `Array.prototype` generics to work. Delete the `[DynamicallyAccessedMembers]` from `SetValue<T>` and
+those probes fail with `undefined` and `0`, along with `Dictionary<string, object>` and
+`Dictionary<string, int>`, which are framework types the example does not root either.
+
+**What it does not, and there are two.** Registering the same object through `SetValue(string, object?)`
+preserves nothing: the member reads `undefined`, script sees a property that is not there, and no
+diagnostic anywhere reports it. That is the silent wrong answer §6.4 is about, and it is now pinned as an
+executable entry rather than described. And a member reachable **only through an explicit interface
+implementation** reads `undefined` too, with the annotation present: `Interfaces` asks for the implemented
+interfaces, not for their members, so the walk that would find it has no metadata to read. Both close the
+same way, and it is the way §6.4 already gives:
+
+```xml
+<ItemGroup>
+  <TrimmerRootAssembly Include="YourAssembly" />
+</ItemGroup>
+```
+
+If you cannot root the whole assembly, an explicit interface member is reachable again as soon as anything
+in your program names it with a constant token — `typeof(IYourInterface).GetProperties()` is enough,
+because that *is* a request to preserve them.
 
 ## Keeping this document current
 


### PR DESCRIPTION
Closes #3479.

`Jint.AotExample` roots both assemblies it publishes, so every host type a probe registers is preserved by the root. No probe could tell that apart from what an annotation preserves — which means `docs/v5-migration.md` §6.3 and §6.6, the sections that tell an embedder `SetValue<T>` is the AOT-friendly way to expose a type *because* it preserves what Jint reflects over, rested on nothing executable.

### What is added

`Jint.AotExample.UnrootedHost`: a second project the AOT leg publishes, referenced by `Jint.AotExample` and deliberately **absent** from `TrimmerRootAssembly`. Its host types have nothing between them and the trimmer but the attribute on the entry point each is registered through. Nothing in C# may read one of their members — a single call from `Program.cs` roots it and the probe silently stops measuring.

Four entries read them, and `KnownTrimmedAway` is a third kind of entry beside `Probe` and `KnownAotGap`. It asserts the **wrong answer**: a trimmed member raises nothing anywhere, so pinning the `undefined` is the only way to hold the claim, and it is checked in both directions like a `KnownAotGap` — under a JIT the member must be there.

```
PASS  unrooted host type through SetValue<T>: the annotation preserves its members
TRIM  unrooted host type through SetValue(string, object?): the member is gone: reads undefined, and nothing anywhere said so.
PASS  unrooted IReadOnlyList<string> through SetValue<T>: the annotation preserves what makes it array-like
TRIM  unrooted explicit interface implementation through SetValue<T>: Interfaces does not reach the member: reads undefined, and nothing anywhere said so.

ALL PROBES PASSED (30 probes, 5 known AOT gaps, 2 known trimming gaps)
```

### The measurement: removing the annotation makes a probe fail

Run on a published native binary, not reasoned about. Deleting `[DynamicallyAccessedMembers]` from `Engine.SetValue<T>(string, T?)` and `GlobalValueRegistration.RegisterTyped<T>` — nothing else — and re-publishing:

```
FAIL  Dictionary<string, object> crossing: System.InvalidOperationException: expected <1> but got <>
FAIL  Dictionary<string, int> crossing: System.InvalidOperationException: expected <1> but got <>
FAIL  unrooted host type through SetValue<T>: the annotation preserves its members: System.InvalidOperationException: expected <preserved> but got <>
FAIL  unrooted IReadOnlyList<string> through SetValue<T>: the annotation preserves what makes it array-like: System.InvalidOperationException: expected <2> but got <0>
4 PROBE(S) FAILED
```

**That corrects the issue.** The two `Dictionary` rows were *already* annotation-sensitive, because a framework type is not rooted here either — so it is not true that no probe in the file could check what an annotation preserves. But they discriminate by accident rather than by design: nothing said they were the annotation's evidence, and rooting one more assembly would have retired them without a word.

### Three measurements of `DynamicallyAccessedMemberTypes.Interfaces`

The issue asked, as a side question, whether the `Interfaces` entry #3396 added is observable. The answer is more interesting than yes or no.

* **It changes no answer the binary gives.** Removing it from `InteropHelper.DefaultDynamicallyAccessedMemberTypes` on its own leaves the unrooted `IReadOnlyList<string>` probe entirely green: ILC keeps the interface implementations of a type whose MethodTable it emits when the interface is used anywhere in the closed program, and Jint uses that one. What that probe pins is `Count`, riding on `PublicProperties`, so it is named for what it measures rather than for what it was meant to.
* **It still earns its keep, in the analysis.** Removing it takes the published inventory from **67 to 75** (`IL2067` 8 → 11, `IL2070` 4 → 9), every one of them landing in the embedder's build. That is the exact inverse of `PublicNestedTypes`, which preserved nothing *and* cost diagnostics. So: no probe can discriminate the entry, and it must not be deleted on that basis — now written down beside the constant, in `Program.cs` and in `Jint.AotExample/AGENTS.md`, rather than rediscovered.
* **It does not reach a member behind an *explicit* implementation at all.** `Interfaces` asks for the implemented interfaces, not for their members, so `TypeResolver`'s `iface.GetProperties()` walk has nothing to read and the member reads `undefined` with the annotation present and correct. Pinned as the second `KnownTrimmedAway`. The observer effect identifies the missing thing: adding `typeof(TheInterface).GetProperties()` anywhere in the program makes it resolve, because that constant token *is* a request to preserve those members. Not closed by widening the constant — the embedder closes it by rooting their own assembly, which §6.4 already says.

§6.6 now says the annotation keeps the interface and not the interface's members, and points at the new §6.7.

### Verification

* `dotnet build -c Release` and `dotnet test -c Release`: green (Jint.Tests 10,910 · PublicInterface 3,243 · CommonScripts 28 · SourceGenerators 71, on the highest TFM of each).
* Native AOT published and run on Windows x64, in both directions: **30 probes, 5 known AOT gaps, 2 known trimming gaps**, and the same run under `dotnet run` where the two trimming gaps read their values instead. ILC analysis diagnostics unchanged at **67** — the new project adds none.
* `MigrationGuideTests`, `AgentInstructionFileTests`: green.
* Test262: **102,494 passed / 1 failed / 189 skipped**. The one failure is `intl402/supportedLocalesOf-unicode-extensions-ignored.js` at **30 s** against the harness's 30 s engine timeout — the documented load flake, on a box that had four other agent sessions running test262 at the same time. An earlier run of `Jint.Tests.Test262` alone on this branch finished green. Nothing here touches engine code: the branch is a new project, probes, documentation, and one XML-doc paragraph.

No public API change, so the five TFM baselines are untouched.

Migration guide: **§6.7**. `Jint.AotExample/AGENTS.md` gains the rule for the unrooted half and all three `Interfaces` measurements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014W5mbjGhyvgAS4pivXoc4S
