### PR TITLE
Intl: a collapsed number range is collapsed in both lanes

### DIFF
--- a/Jint.Tests/Runtime/IntlNumberFormatPartsTests.cs
+++ b/Jint.Tests/Runtime/IntlNumberFormatPartsTests.cs
@@ -10,12 +10,11 @@ namespace Jint.Tests.Runtime;
 /// are the same characters read two ways — including when <c>[[NumberingSystem]]</c> is not Latin.
 /// </summary>
 /// <remarks>
-/// <see cref="PartsConcatenateToFormat"/> asserts the join outright, in every numbering system and in
-/// <c>latn</c> alike. The other two grids compare each numbering system against <c>latn</c> instead, which
-/// pins the narrower claim that <b>asking for a numbering system introduces no disagreement</b> and skips a
-/// combination whose Latin lanes already differ rather than silently blessing it. One such combination
-/// exists today and it belongs to the range lane: <c>formatRange</c> of a currency writes the symbol once
-/// where its parts lane repeats it per endpoint.
+/// <see cref="PartsConcatenateToFormat"/> and <see cref="RangePartsConcatenateToFormatRange"/> assert the
+/// join outright, in every numbering system and in <c>latn</c> alike; the relative-time grid compares each
+/// numbering system against <c>latn</c> instead, which pins the narrower claim that <b>asking for a
+/// numbering system introduces no disagreement</b> and skips a combination whose Latin lanes already differ
+/// rather than silently blessing it.
 /// </remarks>
 public class IntlNumberFormatPartsTests
 {
@@ -98,11 +97,16 @@ public class IntlNumberFormatPartsTests
     }
 
     /// <summary>
-    /// The range lanes are the same operation twice, plus the literal between them.
-    /// https://tc39.es/ecma402/#sec-formatnumericrange is the concatenation of
-    /// https://tc39.es/ecma402/#sec-formatnumericrangetoparts, so a range that is not collapsed has to join
-    /// back to the string.
+    /// The range lanes are the same operation twice, plus the literal between them — collapsed or not.
     /// </summary>
+    /// <remarks>
+    /// https://tc39.es/ecma402/#sec-formatnumericrange is the concatenation of
+    /// https://tc39.es/ecma402/#sec-formatnumericrangetoparts, both of them
+    /// https://tc39.es/ecma402/#sec-partitionnumberrangepattern, whose last step is
+    /// https://tc39.es/ecma402/#sec-collapsenumberrange. The collapse being implementation-defined does not
+    /// let the two lanes disagree about it, so the Latin lanes are asserted outright here rather than used
+    /// as a licence to skip a pair.
+    /// </remarks>
     [Test]
     public void RangePartsConcatenateToFormatRange()
     {
@@ -126,7 +130,9 @@ public class IntlNumberFormatPartsTests
                             for (var p = 0; p < pairs.length; p++) {
                                 var a = pairs[p][0], b = pairs[p][1];
                                 if (join(latin.formatRangeToParts(a, b)) !== latin.formatRange(a, b)) {
-                                    continue;
+                                    bad.push(locales[l] + '/latn/' + o + '/' + pairs[p]
+                                        + ': formatRange=' + latin.formatRange(a, b)
+                                        + ' parts=' + join(latin.formatRangeToParts(a, b)));
                                 }
                                 var joined = join(nf.formatRangeToParts(a, b));
                                 var formatted = nf.formatRange(a, b);
@@ -141,6 +147,61 @@ public class IntlNumberFormatPartsTests
                 return JSON.stringify(bad);
             })()
             """);
+    }
+
+    /// <summary>
+    /// The collapse belongs to the partition, so an endpoint whose sign or symbol was elided is elided in
+    /// the parts as well.
+    /// </summary>
+    /// <remarks>
+    /// The defect: <c>CollapseNumberRange</c> was implemented by rewriting <c>formatRange</c>'s two
+    /// already-formatted endpoints, and the parts lane — which had no way to say an endpoint's own parts
+    /// were dropped — wrote both ends in full. The four rows below are the shapes test262's
+    /// <c>formatRange/en-US.js</c> and <c>formatRange/pt-PT.js</c> assert for the string lane; neither file
+    /// asserts the parts, which is why they were free to disagree.
+    /// </remarks>
+    [Test]
+    public void BothRangeLanesReportTheSameCollapse()
+    {
+        // A prefix-currency locale sharing a sign and a symbol: written once at the front, tight separator.
+        ShouldCollapseAlike("en-US", "{ style: 'currency', currency: 'USD' }", "-5, -1", "-$5.00–1.00");
+        ShouldCollapseAlike("en-US", "{ style: 'currency', currency: 'USD', signDisplay: 'always' }", "2.9, 3.1", "+$2.90–3.10");
+
+        // A shared symbol with no shared sign is ambiguous collapsed, so it is not collapsed.
+        ShouldCollapseAlike("en-US", "{ style: 'currency', currency: 'USD', maximumFractionDigits: 0 }", "3, 5", "$3 – $5");
+
+        // A suffix-currency locale sharing the trailing symbol: written once at the back, loose separator.
+        ShouldCollapseAlike("pt-PT", "{ style: 'currency', currency: 'EUR', maximumFractionDigits: 0 }", "3, 5", "3 - 5 €");
+        ShouldCollapseAlike("pt-PT", "{ style: 'currency', currency: 'EUR', signDisplay: 'always' }", "2.9, 3.1", "+2,90 - 3,10 €");
+        ShouldCollapseAlike("de-DE", "{ style: 'currency', currency: 'USD' }", "1, 5", "1,00 – 5,00 $");
+    }
+
+    /// <summary>
+    /// A collapsed range still reports which end every surviving part came from.
+    /// </summary>
+    [Test]
+    public void ACollapsedRangeStillNamesEachPartsSource()
+    {
+        var parts = _engine.Evaluate(
+            """
+            JSON.stringify(new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', signDisplay: 'always' })
+                .formatRangeToParts(2.9, 3.1))
+            """).AsString();
+
+        parts.Should().Be(
+            """
+            [{"type":"plusSign","value":"+","source":"startRange"},{"type":"currency","value":"$","source":"startRange"},{"type":"integer","value":"2","source":"startRange"},{"type":"decimal","value":".","source":"startRange"},{"type":"fraction","value":"90","source":"startRange"},{"type":"literal","value":"–","source":"shared"},{"type":"integer","value":"3","source":"endRange"},{"type":"decimal","value":".","source":"endRange"},{"type":"fraction","value":"10","source":"endRange"}]
+            """);
+    }
+
+    private void ShouldCollapseAlike(string locale, string options, string operands, string expected)
+    {
+        var formatter = $"new Intl.NumberFormat('{locale}', {options})";
+
+        _engine.Evaluate($"{formatter}.formatRange({operands})")
+            .AsString().Should().Be(expected, "formatRange writes the collapsed range");
+        _engine.Evaluate($"{formatter}.formatRangeToParts({operands}).map(function (p) {{ return p.value; }}).join('')")
+            .AsString().Should().Be(expected, "formatRangeToParts carries the same collapse");
     }
 
     /// <summary>

--- a/Jint/Native/Intl/Data/NumberingSystemData.cs
+++ b/Jint/Native/Intl/Data/NumberingSystemData.cs
@@ -39,6 +39,17 @@ internal readonly record struct ResolvedNumberingSystem(string Name, string? Dig
     public bool RewritesDecimalSeparator => DecimalSeparator != '.';
 
     /// <summary>
+    /// True when this character is one a number of this system is written with.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="char.IsDigit(char)"/> alone is not that question: it answers the Unicode Nd category, and
+    /// <c>hanidec</c>'s zero is U+3007 IDEOGRAPHIC NUMBER ZERO, which is not in it — while
+    /// <c>mathbold</c>'s ten are astral, so each of them reaches this as a surrogate half.
+    /// </remarks>
+    public bool IsDigitCharacter(char c)
+        => char.IsDigit(c) || (Digits is not null && Digits.Contains(c));
+
+    /// <summary>
     /// Rewrites the ASCII digits and the decimal point of an already-formatted string in this system.
     /// </summary>
     public string Transliterate(string input) => NumberingSystemData.TransliterateDigits(input, Digits, '.', DecimalSeparator);

--- a/Jint/Native/Intl/JsNumberFormat.cs
+++ b/Jint/Native/Intl/JsNumberFormat.cs
@@ -76,6 +76,10 @@ internal sealed class JsNumberFormat : ObjectInstance
 
     internal string Locale { get; }
     internal string NumberingSystem => _numberingSystem.Name;
+
+    /// <summary>The resolved system itself, for a caller that has to read an already-formatted string back.</summary>
+    internal Data.ResolvedNumberingSystem ResolvedNumberingSystem => _numberingSystem;
+
     internal string Style { get; }
     internal string? Currency { get; }
     internal string? CurrencyDisplay { get; }

--- a/Jint/Native/Intl/NumberFormatPrototype.cs
+++ b/Jint/Native/Intl/NumberFormatPrototype.cs
@@ -1,5 +1,6 @@
 ﻿using System.Globalization;
 using System.Numerics;
+using System.Runtime.InteropServices;
 using Jint.Native.BigInt;
 using Jint.Native.Object;
 using Jint.Runtime;
@@ -359,15 +360,192 @@ internal sealed partial class NumberFormatPrototype : Prototype
         return numberFormat.Format(number);
     }
 
+    /// <summary>One part of a formatted range: what https://tc39.es/ecma402/#sec-formatnumericrangetoparts reports.</summary>
+    [StructLayout(LayoutKind.Auto)]
+    private readonly record struct RangePart(string Type, string Value, string Source);
+
     /// <summary>
-    /// Joins two formatted range endpoints using ECMA-402 / ICU-style range patterns.
-    /// Supports:
-    /// — A locale-specific separator (e.g. en uses en-dash `–`, pt uses ASCII hyphen `-`).
-    /// — Suffix collapse for locales whose currency follows the number (pt-PT etc.) —
-    ///   shared trailing currency moves to the end of the range, separator gets spaces.
-    /// — Sign+currency prefix collapse (signDisplay=always with prefix-currency locales) —
-    ///   duplicate sign+currency dropped from end, tight separator.
+    /// https://tc39.es/ecma402/#sec-partitionnumberrangepattern, including its last step,
+    /// https://tc39.es/ecma402/#sec-collapsenumberrange.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The collapse being implementation-defined does not make it one lane's post-processing of the other's
+    /// output: it is step 8 of the partition both lanes read, so an endpoint whose sign or currency it
+    /// elides is elided in the parts as well. This is where <c>formatRangeToParts</c> gets it.
+    /// </para>
+    /// <para>
+    /// <c>formatRange</c> does not come through here, and the reason is precision rather than principle:
+    /// <see cref="JsNumberFormat.FormatToParts"/> takes a <see cref="double"/>, while
+    /// <see cref="FormatRangeOperand"/> keeps a BigInt and a long decimal string exact — test262's
+    /// <c>formatRange/en-US.js</c> asserts a range of two 18-digit integers that differ in their last digit.
+    /// So the same two shapes are stated twice, here and in <see cref="CollapseFormattedRange"/>, and
+    /// <c>IntlNumberFormatPartsTests.RangePartsConcatenateToFormatRange</c> is what holds them together.
+    /// </para>
+    /// </remarks>
+    private static List<RangePart> PartitionNumberRangePattern(JsNumberFormat numberFormat, double x, double y)
+    {
+        var startParts = numberFormat.FormatToParts(x);
+        var endParts = numberFormat.FormatToParts(y);
+
+        var result = new List<RangePart>(startParts.Count + endParts.Count + 1);
+
+        // Step 4: when the two ends format alike the range is one approximate value, all of it shared.
+        if (string.Equals(JoinParts(startParts), JoinParts(endParts), StringComparison.Ordinal))
+        {
+            result.Add(new RangePart("approximatelySign", "~", "shared"));
+            foreach (var part in startParts)
+            {
+                result.Add(new RangePart(part.Type, part.Value, "shared"));
+            }
+            return result;
+        }
+
+        var plan = PlanRangeCollapse(numberFormat, startParts, endParts);
+
+        for (var i = 0; i < startParts.Count - plan.DropFromStartTail; i++)
+        {
+            result.Add(new RangePart(startParts[i].Type, startParts[i].Value, "startRange"));
+        }
+
+        result.Add(new RangePart("literal", plan.Separator, "shared"));
+
+        for (var i = plan.DropFromEndHead; i < endParts.Count; i++)
+        {
+            result.Add(new RangePart(endParts[i].Type, endParts[i].Value, "endRange"));
+        }
+
+        return result;
+    }
+
+    /// <summary>What <see cref="PlanRangeCollapse"/> decided: how much of each end is redundant, and which separator to write.</summary>
+    [StructLayout(LayoutKind.Auto)]
+    private readonly record struct RangeCollapsePlan(int DropFromStartTail, int DropFromEndHead, string Separator);
+
+    /// <summary>
+    /// https://tc39.es/ecma402/#sec-collapsenumberrange, on the parts rather than on the string: the two
+    /// ICU range-pattern shapes <see cref="CollapseFormattedRange"/> implements, expressed as "these
+    /// endpoint parts are redundant".
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A prefix-currency locale whose two ends share a sign <em>and</em> a symbol writes them once at the
+    /// front and tightens the separator — test262's <c>formatRange/en-US.js</c> asserts
+    /// <c>"+$2.90–3.10"</c>. A suffix-currency locale whose two ends share a trailing symbol writes it once
+    /// at the back — its <c>formatRange/pt-PT.js</c> asserts <c>"3 - 5 €"</c> and
+    /// <c>"+2,90 - 3,10 €"</c>. A shared symbol with no shared sign is not collapsed at all, which is
+    /// the same file's <c>"$3 – $5"</c>.
+    /// </para>
+    /// <para>
+    /// The scan stops at the first part that carries the number itself, so two ends that happen to end in
+    /// the same digits do not have those digits mistaken for a shared affix.
+    /// </para>
+    /// </remarks>
+    private static RangeCollapsePlan PlanRangeCollapse(
+        JsNumberFormat numberFormat,
+        List<NumberFormatPart> startParts,
+        List<NumberFormatPart> endParts)
+    {
+        GetRangeSeparators(numberFormat.Locale, out var tight, out var loose);
+
+        if (!string.Equals(numberFormat.Style, "currency", StringComparison.Ordinal))
+        {
+            return new RangeCollapsePlan(0, 0, tight);
+        }
+
+        var limit = System.Math.Min(startParts.Count, endParts.Count);
+
+        var prefixLength = 0;
+        while (prefixLength < limit && IsSharedAffix(startParts[prefixLength], endParts[prefixLength]))
+        {
+            prefixLength++;
+        }
+
+        var suffixLength = 0;
+        while (prefixLength + suffixLength < limit
+               && IsSharedAffix(startParts[startParts.Count - 1 - suffixLength], endParts[endParts.Count - 1 - suffixLength]))
+        {
+            suffixLength++;
+        }
+
+        var prefixHasSign = ContainsSignPart(startParts, 0, prefixLength);
+        var prefixHasCurrency = ContainsCurrencyPart(startParts, 0, prefixLength);
+
+        if (prefixHasSign && prefixHasCurrency)
+        {
+            return new RangeCollapsePlan(0, prefixLength, tight);
+        }
+
+        if (ContainsCurrencyPart(startParts, startParts.Count - suffixLength, suffixLength))
+        {
+            return new RangeCollapsePlan(suffixLength, prefixHasSign ? prefixLength : 0, loose);
+        }
+
+        return new RangeCollapsePlan(0, 0, loose);
+    }
+
+    /// <summary>
+    /// True when two parts at matching positions are the same piece of pattern text — the sign, the symbol
+    /// or the spacing around them. A part that carries the number is never one, however equal it looks.
+    /// </summary>
+    private static bool IsSharedAffix(NumberFormatPart a, NumberFormatPart b)
+    {
+        if (!string.Equals(a.Type, b.Type, StringComparison.Ordinal)
+            || !string.Equals(a.Value, b.Value, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        return a.Type switch
+        {
+            "integer" or "fraction" or "group" or "decimal" or "exponentInteger" or "nan" or "infinity" => false,
+            _ => true
+        };
+    }
+
+    private static bool ContainsSignPart(List<NumberFormatPart> parts, int start, int count)
+    {
+        for (var i = start; i < start + count; i++)
+        {
+            if (string.Equals(parts[i].Type, "plusSign", StringComparison.Ordinal)
+                || string.Equals(parts[i].Type, "minusSign", StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool ContainsCurrencyPart(List<NumberFormatPart> parts, int start, int count)
+    {
+        for (var i = start; i < start + count; i++)
+        {
+            if (string.Equals(parts[i].Type, "currency", StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Joins two formatted range endpoints using ECMA-402 / ICU-style range patterns — the string lane's
+    /// half of https://tc39.es/ecma402/#sec-collapsenumberrange.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="PlanRangeCollapse"/> states the same two shapes on parts, and
+    /// <c>IntlNumberFormatPartsTests.RangePartsConcatenateToFormatRange</c> is what keeps the two honest.
+    /// Every string this lane writes is exercised by test262's <c>formatRange/en-US.js</c> and
+    /// <c>formatRange/pt-PT.js</c>.
+    /// <para>Supports:</para>
+    /// <para>— A locale-specific separator (e.g. en uses en-dash `–`, pt uses ASCII hyphen `-`).</para>
+    /// <para>— Suffix collapse for locales whose currency follows the number (pt-PT etc.) —
+    ///   shared trailing currency moves to the end of the range, separator gets spaces.</para>
+    /// <para>— Sign+currency prefix collapse (signDisplay=always with prefix-currency locales) —
+    ///   duplicate sign+currency dropped from end, tight separator.</para>
+    /// </remarks>
     private static string CollapseFormattedRange(JsNumberFormat numberFormat, string startFormatted, string endFormatted)
     {
         var isCurrencyStyle = string.Equals(numberFormat.Style, "currency", StringComparison.Ordinal);
@@ -378,20 +556,31 @@ internal sealed partial class NumberFormatPrototype : Prototype
         // the suffix typically contains the currency symbol (often preceded by NBSP).
         // Stop as soon as we hit a digit so we don't gobble part of the number itself
         // when both ends happen to share trailing digits (e.g. "+2,90 €" / "+3,10 €").
+        // "A digit" is [[NumberingSystem]]'s question, not char.IsDigit's: hanidec's zero is U+3007, which
+        // is not in the Nd category at all, so scanning past it turned "-$五.〇〇–一.〇〇" into "-$五–一.〇〇".
+        var numberingSystem = numberFormat.ResolvedNumberingSystem;
         var suffixLen = 0;
         var maxSuffix = System.Math.Min(startFormatted.Length, endFormatted.Length);
         while (suffixLen < maxSuffix)
         {
             var ch = startFormatted[startFormatted.Length - 1 - suffixLen];
             if (ch != endFormatted[endFormatted.Length - 1 - suffixLen]) break;
-            if (char.IsDigit(ch)) break;
+            if (numberingSystem.IsDigitCharacter(ch)) break;
             suffixLen++;
         }
 
-        // Find longest common prefix (but stop at the suffix boundary).
+        // Find longest common prefix (but stop at the suffix boundary), and stop at a digit for the same
+        // reason the suffix scan does: what is shared here is the sign and the symbol, never part of the
+        // number. Reading two ends' digits as shared text is how "-$𝟓.𝟎𝟎–𝟏.𝟎𝟎" lost the high half of a
+        // mathbold digit, both ends of which begin with the same surrogate.
         var prefixLen = 0;
         var maxPrefix = System.Math.Min(startFormatted.Length - suffixLen, endFormatted.Length - suffixLen);
-        while (prefixLen < maxPrefix && startFormatted[prefixLen] == endFormatted[prefixLen]) prefixLen++;
+        while (prefixLen < maxPrefix
+               && startFormatted[prefixLen] == endFormatted[prefixLen]
+               && !numberingSystem.IsDigitCharacter(startFormatted[prefixLen]))
+        {
+            prefixLen++;
+        }
 
         if (isCurrencyStyle)
         {
@@ -434,22 +623,6 @@ internal sealed partial class NumberFormatPrototype : Prototype
         // Decimal / percent / unit: use the locale's separator. en-US convention (and the test
         // expectation) is the tight form; pt-PT and similar use a spaced ASCII hyphen.
         return startFormatted + sepTight + endFormatted;
-    }
-
-    /// <summary>
-    /// The literal <c>formatRange</c> puts between two endpoints it did not collapse, which is what
-    /// <c>formatRangeToParts</c> writes as its shared <c>literal</c> part.
-    /// </summary>
-    /// <remarks>
-    /// The one shape this does not reproduce is a currency range whose two ends share a sign and a symbol
-    /// (<c>signDisplay: "always"</c>): <see cref="CollapseFormattedRange"/> drops the duplicate from the end
-    /// and tightens the separator, and the parts lane has no way to say that an endpoint's own parts were
-    /// elided. test262 asserts the two shapes below and not that one.
-    /// </remarks>
-    private static string RangeSeparator(JsNumberFormat numberFormat)
-    {
-        GetRangeSeparators(numberFormat.Locale, out var tight, out var loose);
-        return string.Equals(numberFormat.Style, "currency", StringComparison.Ordinal) ? loose : tight;
     }
 
     // TODO: read range patterns from CLDR (e.g. via Options.Intl.CldrProvider) instead of
@@ -509,70 +682,16 @@ internal sealed partial class NumberFormatPrototype : Prototype
             Throw.TypeError(_realm, "start and end are required");
         }
 
-        var startNum = ToRangeNumber(start);
-        var endNum = ToRangeNumber(end);
+        var parts = PartitionNumberRangePattern(numberFormat, ToRangeNumber(start), ToRangeNumber(end));
 
-        // Get parts for both numbers
-        var startParts = numberFormat.FormatToParts(startNum);
-        var endParts = numberFormat.FormatToParts(endNum);
-
-        // Reconstruct formatted strings from parts to avoid redundant Format() calls
-        var startFormatted = JoinParts(startParts);
-        var endFormatted = JoinParts(endParts);
-        var approximatelyEqual = string.Equals(startFormatted, endFormatted, StringComparison.Ordinal);
-
-        var result = new JsArray(Engine);
-        uint index = 0;
-
-        if (approximatelyEqual)
+        var result = new JsArray(Engine, (uint) parts.Count);
+        for (var i = 0; i < parts.Count; i++)
         {
-            // Add approximately sign first
-            var approxPart = ObjectInstance.OrdinaryObjectCreate(Engine, Engine.Realm.Intrinsics.Object.PrototypeObject);
-            approxPart.CreateDataPropertyOrThrow("type", "approximatelySign");
-            approxPart.CreateDataPropertyOrThrow("value", "~");
-            approxPart.CreateDataPropertyOrThrow("source", "shared");
-            result.SetIndexValue(index++, approxPart, updateLength: true);
-
-            // Add all parts with source "shared"
-            foreach (var part in startParts)
-            {
-                var partObj = ObjectInstance.OrdinaryObjectCreate(Engine, Engine.Realm.Intrinsics.Object.PrototypeObject);
-                partObj.CreateDataPropertyOrThrow("type", part.Type);
-                partObj.CreateDataPropertyOrThrow("value", part.Value);
-                partObj.CreateDataPropertyOrThrow("source", "shared");
-                result.SetIndexValue(index++, partObj, updateLength: true);
-            }
-        }
-        else
-        {
-            // Add start parts with source "startRange"
-            foreach (var part in startParts)
-            {
-                var partObj = ObjectInstance.OrdinaryObjectCreate(Engine, Engine.Realm.Intrinsics.Object.PrototypeObject);
-                partObj.CreateDataPropertyOrThrow("type", part.Type);
-                partObj.CreateDataPropertyOrThrow("value", part.Value);
-                partObj.CreateDataPropertyOrThrow("source", "startRange");
-                result.SetIndexValue(index++, partObj, updateLength: true);
-            }
-
-            // Add separator — the one CollapseFormattedRange would have written between the same two
-            // endpoints, so the parts join back to what formatRange() returns. A currency range keeps both
-            // ends in full and takes the spaced separator; every other style takes the locale's tight one.
-            var separator = ObjectInstance.OrdinaryObjectCreate(Engine, Engine.Realm.Intrinsics.Object.PrototypeObject);
-            separator.CreateDataPropertyOrThrow("type", "literal");
-            separator.CreateDataPropertyOrThrow("value", RangeSeparator(numberFormat));
-            separator.CreateDataPropertyOrThrow("source", "shared");
-            result.SetIndexValue(index++, separator, updateLength: true);
-
-            // Add end parts with source "endRange"
-            foreach (var part in endParts)
-            {
-                var partObj = ObjectInstance.OrdinaryObjectCreate(Engine, Engine.Realm.Intrinsics.Object.PrototypeObject);
-                partObj.CreateDataPropertyOrThrow("type", part.Type);
-                partObj.CreateDataPropertyOrThrow("value", part.Value);
-                partObj.CreateDataPropertyOrThrow("source", "endRange");
-                result.SetIndexValue(index++, partObj, updateLength: true);
-            }
+            var partObj = ObjectInstance.OrdinaryObjectCreate(Engine, Engine.Realm.Intrinsics.Object.PrototypeObject);
+            partObj.CreateDataPropertyOrThrow("type", parts[i].Type);
+            partObj.CreateDataPropertyOrThrow("value", parts[i].Value);
+            partObj.CreateDataPropertyOrThrow("source", parts[i].Source);
+            result.SetIndexValue((uint) i, partObj, updateLength: true);
         }
 
         return result;

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -2970,6 +2970,46 @@ Two consequences fall out of there being one pattern:
 pinning `formatToParts` output for a styled formatter. `timeStyle` is untouched, and a formatter built from
 component options (`year`/`month`/`day`/…) is untouched. There is no option that restores the old shape:
 the two lanes disagreeing was the defect.
+
+### 4.63 A collapsed number range is collapsed in both lanes ([#3466](https://github.com/sebastienros/jint/issues/3466))
+
+[FormatNumericRange](https://tc39.es/ecma402/#sec-formatnumericrange) is the concatenation of exactly the
+parts [FormatNumericRangeToParts](https://tc39.es/ecma402/#sec-formatnumericrangetoparts) returns — both of
+them [PartitionNumberRangePattern](https://tc39.es/ecma402/#sec-partitionnumberrangepattern), whose last step
+is [CollapseNumberRange](https://tc39.es/ecma402/#sec-collapsenumberrange). The collapse being
+implementation-defined does not let the two lanes disagree about it: it happens *inside* the partition both
+of them read.
+
+Jint implemented it outside, by rewriting `formatRange`'s two already-formatted endpoints. The parts lane had
+no way to say that an endpoint's own parts had been elided, so it wrote both ends in full:
+
+```js
+const nf = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' });
+// 4.16.x / earlier 5.0
+nf.formatRange(-5, -1);                                      // "-$5.00–1.00"
+nf.formatRangeToParts(-5, -1).map(p => p.value).join('');    // "-$5.00 – -$1.00"
+
+const de = new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'USD' });
+de.formatRange(1, 5);                                        // "1,00 – 5,00 $"
+de.formatRangeToParts(1, 5).map(p => p.value).join('');      // "1,00 $ – 5,00 $"
+
+// 5.x — one partition, read two ways
+nf.formatRangeToParts(-5, -1).map(p => p.value).join('');    // "-$5.00–1.00"
+de.formatRangeToParts(1, 5).map(p => p.value).join('');      // "1,00 – 5,00 $"
+```
+
+The collapse itself is unchanged, and so is every string `formatRange` returned: a prefix-currency locale
+whose two ends share a sign *and* a symbol writes them once at the front and tightens the separator, a
+suffix-currency locale whose two ends share a trailing symbol writes it once at the back, and a shared symbol
+with no shared sign is not collapsed at all. Those are the three shapes test262's `formatRange/en-US.js` and
+`formatRange/pt-PT.js` assert, and neither file asserts the parts — which is what let the two drift.
+
+**What could break:** a caller reading `formatRangeToParts` for a **currency** range whose two endpoints
+share affixes now gets the elided list rather than two full endpoints, and the shared `literal` separator is
+whichever one `formatRange` writes for that range rather than always the spaced form. Every non-currency
+range is unchanged, and so is every `formatRange` string. A part that survives still names its
+`source` — `"startRange"`, `"endRange"` or `"shared"` — so code that groups by `source` keeps working; code
+that assumed the end always repeats the start's currency does not.
 ## 5. New in v5
 
 Everything in the table below is opt-in: nothing in it is installed unless the host asks for it, so


### PR DESCRIPTION
> **Stacked on #3489.** This branch carries #3489's commit underneath its own, because the tightened grid
> below depends on that PR's `ar-EG` currency-sign fix. Merge #3489 first; this diff then shrinks to its own
> single commit. It is fifth in the Intl wave: #3489 → #3488 → #3487 → #3490 → this.

[FormatNumericRange](https://tc39.es/ecma402/#sec-formatnumericrange) is the concatenation of exactly the
parts [FormatNumericRangeToParts](https://tc39.es/ecma402/#sec-formatnumericrangetoparts) returns — both of
them [PartitionNumberRangePattern](https://tc39.es/ecma402/#sec-partitionnumberrangepattern), whose last step
is [CollapseNumberRange](https://tc39.es/ecma402/#sec-collapsenumberrange). The collapse being
implementation-defined does not let the two lanes disagree about it: it happens *inside* the partition both
of them read.

Jint implemented it outside, by rewriting `formatRange`'s two already-formatted endpoints, and the parts lane
had no way to say that an endpoint's own parts had been elided — so it wrote both ends in full, separator
included:

```js
const nf = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' });
nf.formatRange(-5, -1);                                    // "-$5.00–1.00"
nf.formatRangeToParts(-5, -1).map(p => p.value).join('');  // "-$5.00 – -$1.00"   ← before

const de = new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'USD' });
de.formatRange(1, 5);                                      // "1,00 – 5,00 $"
de.formatRangeToParts(1, 5).map(p => p.value).join('');    // "1,00 $ – 5,00 $"   ← before
```

## The failing tests

Against unmodified `NumberFormatPrototype.cs` (3 failed / 7 passed):

```
  Failed BothRangeLanesReportTheSameCollapse
   Expected … to be the same string because formatRangeToParts carries the same collapse, but they differ at index 6:
         ↓ (actual)
  "-$5.00 – -$1.00"
  "-$5.00–1.00"
         ↑ (expected).

  Failed ACollapsedRangeStillNamesEachPartsSource
   Expected string to be the same string, but they differ at index 297:
              ↓ (actual)
  "…,"value":" – ","source":"shared"},{"type":"plusSig…"
  "…,"value":"–","source":"shared"},{"type":"integer",…"
              ↑ (expected).

  Failed RangePartsConcatenateToFormatRange
   … "["en/latn/5/-5,-1: formatRange=-$5.00–1.00 parts=-$5.00 –…"
```

## What changed

`PlanRangeCollapse` states the collapse on parts, as "these endpoint parts are redundant", and
`PartitionNumberRangePattern` applies it — so `formatRangeToParts` reports the elision and names each
surviving part's `source`. The three shapes are unchanged, and are the ones test262 asserts for the string
lane: a prefix-currency locale whose ends share a sign **and** a symbol writes them once at the front and
tightens the separator (`formatRange/en-US.js`: `"+$2.90–3.10"`); a suffix-currency locale whose ends share a
trailing symbol writes it once at the back (`formatRange/pt-PT.js`: `"3 - 5 €"`, `"+2,90 - 3,10 €"`); a shared
symbol with no shared sign is not collapsed (`"$3 – $5"`). Neither file asserts the parts, which is what let
the two drift.

`formatRange` keeps its own collapse, and the reason is precision rather than principle:
`JsNumberFormat.FormatToParts` takes a `double`, while `FormatRangeOperand` keeps a BigInt and a long decimal
string exact — `formatRange/en-US.js` asserts a range of two 18-digit integers differing in their last digit.
**#3494** tracks closing that gap, after which the string lane can be the concatenation the specification says
it is. `RangePartsConcatenateToFormatRange` is what holds the two statements together until then; it now
asserts the Latin lanes **outright** instead of skipping a pair whose Latin lanes already disagreed, which is
the escape hatch #3489 makes removable.

### Two defects the tightened grid found in the string lane's collapse

Both fixed here, both invisible until the grid stopped skipping:

* its "stop at a digit" guard asked `char.IsDigit`, which is the Unicode `Nd` category and does **not**
  contain `hanidec`'s U+3007 IDEOGRAPHIC NUMBER ZERO — so `"-$五.〇〇–一.〇〇"` collapsed to `"-$五–一.〇〇"`;
* its prefix scan had no such guard at all, so two `mathbold` endpoints beginning with the same high surrogate
  were cut **between the halves of a digit**, leaving a lone low surrogate in the output.

`ResolvedNumberingSystem.IsDigitCharacter` is the question actually being asked — the system's own ten digits,
or Unicode's when it names none.

## Verification

* `dotnet build -c Release` clean; `dotnet test -c Release Jint.Tests/Jint.Tests.csproj` green on all three
  target frameworks (net472 7,615 · net8.0 and net10.0 10,991 each).
* test262: **102,507 passed / 0 failed / 177 skipped** for this stack (control on `main`: 102,495 / 0 / 189;
  the +12 and −12 are #3489's six un-excluded unit files in their strict and sloppy runs — this change removes
  no exclusions of its own and regresses none). A full run on a loaded box reported two failures on
  `intl402/supportedLocalesOf-unicode-extensions-ignored.js`, a 32 s `TimeoutException`; the same two pass in
  isolation in 2 s.
* `MigrationGuideTests` green. Migration guide: **§4.63**.

Fixes #3466
