### PR TITLE
Intl.NumberFormat: a currency's fraction digits are the two counts it was given

### DIFF
--- a/Jint.Tests/Runtime/IntlNumberFormatPartsTests.cs
+++ b/Jint.Tests/Runtime/IntlNumberFormatPartsTests.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 
 namespace Jint.Tests.Runtime;
 
@@ -38,6 +38,11 @@ public class IntlNumberFormatPartsTests
         "{ style: 'percent' }",
         "{ style: 'currency', currency: 'USD' }",
         "{ style: 'currency', currency: 'EUR', currencyDisplay: 'name' }",
+        // an explicit fraction-digit count on a currency, which is the pair of digit counts
+        // https://tc39.es/ecma402/#sec-torawfixed rounds at and trims to
+        "{ style: 'currency', currency: 'USD', maximumFractionDigits: 0 }",
+        "{ style: 'currency', currency: 'USD', minimumFractionDigits: 1 }",
+        "{ style: 'currency', currency: 'EUR', minimumFractionDigits: 3, maximumFractionDigits: 4 }",
         "{ style: 'unit', unit: 'meter' }",
         "{ style: 'unit', unit: 'kilometer-per-hour', unitDisplay: 'long' }",
         "{ notation: 'scientific' }",
@@ -202,6 +207,62 @@ public class IntlNumberFormatPartsTests
             .AsString().Should().Be(expected, "formatRange writes the collapsed range");
         _engine.Evaluate($"{formatter}.formatRangeToParts({operands}).map(function (p) {{ return p.value; }}).join('')")
             .AsString().Should().Be(expected, "formatRangeToParts carries the same collapse");
+    }
+
+    /// <summary>
+    /// https://tc39.es/ecma402/#sec-torawfixed rounds at <c>maximumFractionDigits</c> and then removes up
+    /// to <c>maximumFractionDigits - minimumFractionDigits</c> trailing zeros. Both lanes read the same two
+    /// numbers, so a currency told to write no fraction rounds rather than truncates.
+    /// </summary>
+    [Test]
+    public void ACurrencyRoundsAtTheFractionDigitsItWasGiven()
+    {
+        const string NoFraction =
+            "new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 })";
+        Format(NoFraction, "2.9").Should().Be("$3");
+        Join(NoFraction, "2.9").Should().Be("$3");
+        Parts(NoFraction, "2.9").Should().Be(
+            """[{"type":"currency","value":"$"},{"type":"integer","value":"3"}]""");
+
+        Format(NoFraction, "0.5").Should().Be("$1");
+        Join(NoFraction, "0.5").Should().Be("$1");
+        Format(NoFraction, "1234.567").Should().Be("$1,235");
+        Join(NoFraction, "1234.567").Should().Be("$1,235");
+
+        // a currency whose own default is already zero reaches the same rounding without being asked
+        const string Yen = "new Intl.NumberFormat('en-US', { style: 'currency', currency: 'JPY' })";
+        Format(Yen, "2.9").Should().Be("¥3");
+        Join(Yen, "2.9").Should().Be("¥3");
+    }
+
+    /// <summary>
+    /// ToRawFixed's last two steps are the trim: a currency whose two digit counts differ writes the
+    /// narrower one when the wider one would only be zeros.
+    /// </summary>
+    [Test]
+    public void ACurrencyTrimsItsFractionDownToTheMinimum()
+    {
+        const string OneDigit =
+            "new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', minimumFractionDigits: 1 })";
+        Format(OneDigit, "0.4").Should().Be("$0.4");
+        Join(OneDigit, "0.4").Should().Be("$0.4");
+        Format(OneDigit, "0.45").Should().Be("$0.45");
+        Join(OneDigit, "0.45").Should().Be("$0.45");
+
+        // minimumFractionDigits 0 lets the whole fraction go, decimal separator included
+        const string NoMinimum =
+            "new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', minimumFractionDigits: 0 })";
+        Format(NoMinimum, "2").Should().Be("$2");
+        Join(NoMinimum, "2").Should().Be("$2");
+        Format(NoMinimum, "2.5").Should().Be("$2.5");
+        Join(NoMinimum, "2.5").Should().Be("$2.5");
+
+        const string Wide =
+            "new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', minimumFractionDigits: 3, maximumFractionDigits: 4 })";
+        Format(Wide, "2.9").Should().Be("$2.900");
+        Join(Wide, "2.9").Should().Be("$2.900");
+        Format(Wide, "2.98765").Should().Be("$2.9877");
+        Join(Wide, "2.98765").Should().Be("$2.9877");
     }
 
     /// <summary>

--- a/Jint/Native/Intl/JsNumberFormat.cs
+++ b/Jint/Native/Intl/JsNumberFormat.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using System.Numerics;
 using Jint.Native.Object;
 
@@ -1822,14 +1822,17 @@ internal sealed class JsNumberFormat : ObjectInstance
             intStr = ApplyGroupingToString(intStr);
         }
 
-        // Format fraction
+        // Format fraction. https://tc39.es/ecma402/#sec-torawfixed rounds at maximumFractionDigits and
+        // then removes up to maximumFractionDigits - minimumFractionDigits trailing zeros, so a currency
+        // whose two digit counts differ writes the narrower one when the wider one would only be zeros.
         var fractionStr = "";
         if (fractionDigits > 0)
         {
-            var multiplier = System.Math.Pow(10, fractionDigits);
-            var fractionInt = (long) System.Math.Round(fractionValue * multiplier);
-            fractionStr = NumberFormatInfo.CurrencyDecimalSeparator +
-                         fractionInt.ToString(CultureInfo.InvariantCulture).PadLeft(fractionDigits, '0');
+            var digits = FractionDigitsOf(fractionValue, fractionDigits);
+            if (digits.Length > 0)
+            {
+                fractionStr = NumberFormatInfo.CurrencyDecimalSeparator + digits;
+            }
         }
 
         var numberPart = intStr + fractionStr;
@@ -2508,26 +2511,10 @@ internal sealed class JsNumberFormat : ObjectInstance
         // Add fraction part if needed
         if (MinimumFractionDigits > 0 || (fractionValue > 0 && MaximumFractionDigits > 0))
         {
-            parts.Add(new NumberFormatPart("decimal", NumberFormatInfo.NumberDecimalSeparator));
-
-            var fractionDigits = MaximumFractionDigits > 0 ? MaximumFractionDigits : MinimumFractionDigits;
-            var multiplier = System.Math.Pow(10, fractionDigits);
-            var fractionInt = (long) System.Math.Round(fractionValue * multiplier);
-            var fractionStr = fractionInt.ToString(CultureInfo.InvariantCulture).PadLeft(fractionDigits, '0');
-
-            // Trim trailing zeros above minimum
-            if (fractionStr.Length > MinimumFractionDigits)
-            {
-                var trimEnd = fractionStr.Length;
-                while (trimEnd > MinimumFractionDigits && fractionStr[trimEnd - 1] == '0')
-                {
-                    trimEnd--;
-                }
-                fractionStr = fractionStr.Substring(0, trimEnd);
-            }
-
+            var fractionStr = FractionDigitsOf(fractionValue, MaximumFractionDigits);
             if (fractionStr.Length > 0)
             {
+                parts.Add(new NumberFormatPart("decimal", NumberFormatInfo.NumberDecimalSeparator));
                 parts.Add(new NumberFormatPart("fraction", fractionStr));
             }
         }
@@ -2753,38 +2740,45 @@ internal sealed class JsNumberFormat : ObjectInstance
 
     private void FormatFractionToParts(List<NumberFormatPart> parts, double fractionValue)
     {
-        // Convert fraction to string with required precision
-        var fractionDigits = MaximumFractionDigits;
-        if (fractionDigits == 0 && MinimumFractionDigits > 0)
-        {
-            fractionDigits = MinimumFractionDigits;
-        }
-
-        var multiplier = System.Math.Pow(10, fractionDigits);
-        var fractionInt = (long) System.Math.Round(fractionValue * multiplier);
-        var fractionStr = fractionInt.ToString(CultureInfo.InvariantCulture).PadLeft(fractionDigits, '0');
-
-        // Trim trailing zeros if above minimum
-        if (fractionStr.Length > MinimumFractionDigits)
-        {
-            var trimEnd = fractionStr.Length;
-            while (trimEnd > MinimumFractionDigits && fractionStr[trimEnd - 1] == '0')
-            {
-                trimEnd--;
-            }
-            fractionStr = fractionStr.Substring(0, trimEnd);
-        }
-
-        // Ensure minimum fraction digits
-        if (fractionStr.Length < MinimumFractionDigits)
-        {
-            fractionStr = fractionStr.PadRight(MinimumFractionDigits, '0');
-        }
-
+        var fractionStr = FractionDigitsOf(fractionValue, MaximumFractionDigits);
         if (fractionStr.Length > 0)
         {
             parts.Add(new NumberFormatPart("fraction", fractionStr));
         }
+    }
+
+    /// <summary>
+    /// The fraction digits https://tc39.es/ecma402/#sec-torawfixed writes for a value already rounded to
+    /// <paramref name="fractionDigits"/> places: that many digits, less the trailing zeros its last two
+    /// steps remove down to <see cref="MinimumFractionDigits"/>.
+    /// </summary>
+    /// <remarks>
+    /// The result is empty when every digit was removed, which is what the caller has to notice: the
+    /// decimal separator goes with them, and neither lane writes a separator with nothing after it.
+    /// </remarks>
+    private string FractionDigitsOf(double fractionValue, int fractionDigits)
+    {
+        if (fractionDigits < MinimumFractionDigits)
+        {
+            fractionDigits = MinimumFractionDigits;
+        }
+
+        if (fractionDigits == 0)
+        {
+            return string.Empty;
+        }
+
+        var multiplier = System.Math.Pow(10, fractionDigits);
+        var fractionInt = (long) System.Math.Round(fractionValue * multiplier);
+        var digits = fractionInt.ToString(CultureInfo.InvariantCulture).PadLeft(fractionDigits, '0');
+
+        var keep = digits.Length;
+        while (keep > MinimumFractionDigits && digits[keep - 1] == '0')
+        {
+            keep--;
+        }
+
+        return keep == digits.Length ? digits : digits.Substring(0, keep);
     }
 
     private List<NumberFormatPart> FormatCurrencyToParts(double value)
@@ -2793,9 +2787,10 @@ internal sealed class JsNumberFormat : ObjectInstance
         var isNegative = value < 0 || double.IsNegativeInfinity(1 / value); // Handles -0
         var absValue = System.Math.Abs(value);
 
-        // Apply rounding first to determine if value displays as zero
-        var fractionDigits = MaximumFractionDigits > 0 ? MaximumFractionDigits : 2;
-        absValue = ApplyRounding(absValue, fractionDigits);
+        // Apply rounding first to determine if value displays as zero. The digit count is the one
+        // https://tc39.es/ecma402/#sec-torawfixed rounds at, which the constructor has already defaulted
+        // to the currency's own — an explicit maximumFractionDigits of zero is a caller asking for none.
+        absValue = ApplyRounding(absValue, MaximumFractionDigits);
         var displaysAsZero = absValue == 0;
 
         // Determine if we should show a negative sign based on signDisplay

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -3073,6 +3073,48 @@ that *raised* it above ten seconds gets the looser one. Either way the fix is th
 on `Constraints.RegexTimeout`, or pin one on the preparation's parsing options, which still wins. A host
 relying on the preparation report to warn about an unset `RegexTimeout` should validate the engine's
 `Options` instead.
+### 4.68 A currency's fraction digits are the two counts it was given, in both lanes ([#3493](https://github.com/sebastienros/jint/issues/3493))
+
+[ToRawFixed](https://tc39.es/ecma402/#sec-torawfixed) rounds at `maximumFractionDigits` and then removes up
+to `maximumFractionDigits - minimumFractionDigits` trailing zeros. A currency read neither number: the parts
+lane rounded at two digits whatever was asked for and then truncated the integer, and the string lane padded
+the fraction out to `maximumFractionDigits` and never trimmed it.
+
+```js
+const nf = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 });
+// 5.0 — the two lanes are a whole unit apart above .5
+nf.format(2.9);                  // "$3"
+nf.formatToParts(2.9);           // [currency "$"][integer "2"]  → "$2"
+
+// 5.x
+nf.formatToParts(2.9);           // [currency "$"][integer "3"]  → "$3"
+```
+
+A currency whose own default is zero digits reaches the same rounding without asking for anything, so this
+moves `JPY`, `KRW` and the other zero-digit currencies too: `formatToParts(2.9)` under `JPY` was `¥2` and is
+`¥3`.
+
+The trim is the other half, and it moves the string lane:
+
+```js
+const one = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', minimumFractionDigits: 1 });
+// 5.0
+one.format(0.4);                 // "$0.40"   — padded to the maximum, which is still 2
+one.formatToParts(0.4);          // "$0.4"    — its parts lane already trimmed
+// 5.x
+one.format(0.4);                 // "$0.4"
+
+const none = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', minimumFractionDigits: 0 });
+none.format(2);                  // 5.0: "$2.00"   5.x: "$2"
+```
+
+**What could break:** any currency output whose formatter names `minimumFractionDigits` or
+`maximumFractionDigits`, and any `formatToParts` walk over a currency with zero fraction digits — asked for
+or defaulted. A formatter that names neither is untouched, its two counts both being the currency's own.
+`style: "percent"` pads the same way and is not fixed here; that half is
+[#3498](https://github.com/sebastienros/jint/issues/3498), and the significant-digit options are
+[#3499](https://github.com/sebastienros/jint/issues/3499).
+
 ## 5. New in v5
 
 Everything in the table below is opt-in: nothing in it is installed unless the host asks for it, so


### PR DESCRIPTION
[ToRawFixed](https://tc39.es/ecma402/#sec-torawfixed) rounds at `maximumFractionDigits` and then, in its
last two steps, removes up to `maximumFractionDigits - minimumFractionDigits` trailing zeros. A currency read
neither number. The parts lane rounded at **two** digits whatever was asked for and then truncated the
integer, so it was a whole unit short of `format()` for anything above `.5`; the string lane padded the
fraction out to `maximumFractionDigits` and never trimmed it, so it was a digit long whenever the two counts
differed. [FormatNumeric](https://tc39.es/ecma402/#sec-formatnumber) is the concatenation of exactly the
parts [FormatNumericToParts](https://tc39.es/ecma402/#sec-formatnumbertoparts) returns, so neither is
allowed.

```js
const nf = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 });
nf.format(2.9);                                     // "$3"
nf.formatToParts(2.9).map(p => p.value).join('');   // "$2"   ← before

const one = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', minimumFractionDigits: 1 });
one.format(0.4);                                    // "$0.40"  ← before; its parts lane already said "$0.4"
```

A currency whose own default is zero digits reaches the rounding half without asking for anything, so `JPY`,
`KRW` and the rest of the zero-digit currencies were off by one in `formatToParts` for every value above
`.5`: `¥2` where `format` wrote `¥3`.

## The failing tests

Against unmodified `JsNumberFormat.cs` (3 failed / 14 passed):

```
  Failed ACurrencyRoundsAtTheFractionDigitsItWasGiven
   Expected Join(NoFraction, "2.9") to be the same string, but they differ at index 1:
    ↓ (actual)
  "$2"
  "$3"
    ↑ (expected).

  Failed ACurrencyTrimsItsFractionDownToTheMinimum
   Expected Format(OneDigit, "0.4") to be the same string, but they differ at index 4:
       ↓ (actual)
  "$0.40"
  "$0.4"
       ↑ (expected).

  Failed PartsConcatenateToFormat
   Expected string to be the same string because every part list joins back to the string the same
   formatter writes, but they differ at index 1:
    ↓ (actual)
  "["en/latn/7/0.5: format=$1 parts=$0","en/latn/7/1234.5:…"
  "[]"
    ↑ (expected).
```

`PartsConcatenateToFormat`'s grid gains three currency option sets — `maximumFractionDigits: 0`,
`minimumFractionDigits: 1`, and a `minimumFractionDigits: 3, maximumFractionDigits: 4` pair — which is
`OptionSets` reaching the combination the issue found was missing. That is 7 locales × 9 numbering systems ×
11 values per set, asserted as join-equality outright.

## What changed

* `FormatCurrencyToParts` rounds at `MaximumFractionDigits`. The `MaximumFractionDigits > 0 ? … : 2` it used
  read an explicit **zero** as "unset", which is the only reading under which a caller asking for no fraction
  gets two; the constructor has already defaulted the property to the currency's own digit count, which is
  what the string lane relied on all along.
* `FormatCurrency` applies ToRawFixed's trim, and drops the decimal separator with the digits when they all
  go — `{ minimumFractionDigits: 0 }` on USD writes `"$2"`, not `"$2.00"`.
* That trim existed in three copies, none of them shared. They collapse into one `FractionDigitsOf`, which is
  also where the other two `> 0 ? … : default` spellings of the digit count went: both were dead — the
  constructor keeps `minimumFractionDigits ≤ maximumFractionDigits`, so `max > 0 ? max : min` is `max`.

## What this does not fix, and why not

The issue asks whether `FormatCurrencyWithSignificantDigits` carries the same pattern. It does not — it reads
`MinimumSignificantDigits ?? 1` and `MaximumSignificantDigits ?? 21`, which are the spec's own defaults. The
real sibling there is that `FormatCurrencyToParts` has no significant-digits branch **at all** while
`FormatCurrency` does, and closing that alone would not make the two lanes agree: the disagreement would move
down into the shared significant-digit lanes, which have three further defects of their own — a missing
[ToRawPrecision](https://tc39.es/ecma402/#sec-torawprecision) trim, a `long.MaxValue` sentinel that reaches a
`fraction` part, and a string lane that writes a `double`'s exact 21-digit decimal expansion where every other
engine writes the shortest one. That is a different abstract operation and a design call worth arguing on its
own, so it is **#3499**, with the same-shaped padding defect for `style: "percent"` as **#3498**. Neither is
made worse here; both are stated with reproductions and with the option sets that fail.

## Verification

* Rebased onto `main` after #3495, #3490, #3487, #3277 and #3501 landed. The only conflicts were the two
  places both sides appended text — the test class and the end of the migration guide's chapter 4 — and the
  section moved to the end of that chapter afterwards, so its rank is right.
* `dotnet build -c Release` clean (`TreatWarningsAsErrors`); `dotnet test -c Release Jint.Tests` green on all
  three target frameworks — net472 7,660 · net8.0 and net10.0 11,040 each.
* test262: **102,523 passed / 0 failed / 165 skipped**, which is the control on `main` exactly — this change
  removes no exclusions and regresses none. Runs on this box are flaking on ~30 s `TimeoutException`s under
  load; a run of unmodified `main` in a clean worktree flaked the same way, on
  `intl402/supportedLocalesOf-unicode-extensions-ignored.js` (102,521 / 2 / 165), and every flaked file
  passes in seconds in isolation.
* `MigrationGuideTests` green. Migration guide: **§4.68**.

Fixes #3493
