### PR TITLE
Temporal: a date a calendar reports fields for is a date it reckons arithmetic in

### DIFF
--- a/Jint.Tests/Runtime/NonIsoCalendarArithmeticRangeTests.cs
+++ b/Jint.Tests/Runtime/NonIsoCalendarArithmeticRangeTests.cs
@@ -1,0 +1,154 @@
+#nullable enable
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Every non-ISO calendar answers its field accessors for every date in Temporal's range. These pin that
+/// its arithmetic answers for the same dates — that a calendar never reports two verdicts about whether
+/// the engine can reckon one date.
+/// </summary>
+public class NonIsoCalendarArithmeticRangeTests
+{
+    private static readonly TimeSpan Budget = TimeSpan.FromSeconds(15);
+
+    private static string Evaluate(string expression)
+    {
+        var result = "";
+
+        DedicatedThread.Run(
+            () =>
+            {
+                var engine = new Engine();
+                result = engine.Evaluate(
+                    $"(function () {{ try {{ return String({expression}); }} catch (e) {{ return e.constructor.name + ': ' + e.message; }} }})()").AsString();
+            },
+            joinTimeout: Budget,
+            timeoutMessage: $"did not finish within {Budget}: {expression}",
+            maxStackSize: DedicatedThread.DefaultStackSize);
+
+        return result;
+    }
+
+    /// <summary>
+    /// The four calendars a <c>System.Globalization.Calendar</c> backs over less than Temporal's range,
+    /// sampled below the floor and above the ceiling of each.
+    /// </summary>
+    private static IEnumerable<TestCaseData> PastTheirBackingRangeCases()
+    {
+        yield return new TestCaseData("hebrew", "1500-06-15").SetName("hebrew below its 1583 floor");
+        yield return new TestCaseData("hebrew", "2300-06-15").SetName("hebrew above its 2239 ceiling");
+        yield return new TestCaseData("persian", "0500-06-15").SetName("persian below its 622 floor");
+        yield return new TestCaseData("chinese", "1800-01-01").SetName("chinese below its 1901 floor");
+        yield return new TestCaseData("chinese", "2200-01-01").SetName("chinese above its 2101 ceiling");
+        yield return new TestCaseData("dangi", "0800-01-01").SetName("dangi below its 918 floor");
+        yield return new TestCaseData("dangi", "2200-01-01").SetName("dangi above its 2051 ceiling");
+    }
+
+    /// <summary>
+    /// The report from the issue, verbatim: the accessors reckon 1500-06-15 in the Hebrew calendar and
+    /// the arithmetic refuses the same date.
+    /// </summary>
+    [Test]
+    public void TheReportedHebrewDateAddsAMonthWhereItsYearIsAlreadyAnswered()
+    {
+        Evaluate("Temporal.PlainDate.from('1500-06-15').withCalendar('hebrew').year")
+            .Should().Be("5260");
+
+        Evaluate("Temporal.PlainDate.from('1500-06-15').withCalendar('hebrew').add({ months: 1 }).toString()")
+            .Should().NotStartWith("RangeError");
+    }
+
+    /// <summary>
+    /// Adding a month and taking it back is the identity, whichever side of a backing calendar's range
+    /// the date sits on. An answer that is merely produced is not enough; it has to be the calendar's.
+    /// </summary>
+    [TestCaseSource(nameof(PastTheirBackingRangeCases))]
+    public void AMonthAddedPastTheBackingRangeIsAMonthTakenBack(string calendar, string iso)
+    {
+        Evaluate(
+            $@"(function () {{
+                 var d = Temporal.PlainDate.from('{iso}').withCalendar('{calendar}');
+                 return d.add({{ months: 1 }}).subtract({{ months: 1 }}).equals(d);
+               }})()")
+            .Should().Be("true", $"{calendar} at {iso}");
+    }
+
+    /// <summary>
+    /// A year added past the range keeps the monthCode, which is what makes it calendar arithmetic and
+    /// not ISO arithmetic wearing the calendar's name.
+    /// </summary>
+    [TestCaseSource(nameof(PastTheirBackingRangeCases))]
+    public void AYearAddedPastTheBackingRangeKeepsTheMonthCode(string calendar, string iso)
+    {
+        Evaluate(
+            $@"(function () {{
+                 var d = Temporal.PlainDate.from('{iso}').withCalendar('{calendar}');
+                 var n = d.add({{ years: 1 }});
+                 return (n.year - d.year) + '|' + (n.monthCode === d.monthCode);
+               }})()")
+            .Should().Be("1|true", $"{calendar} at {iso}");
+    }
+
+    /// <summary>
+    /// <c>until</c> and <c>add</c> are the same reckoning read in opposite directions. Past the backing
+    /// range they have to stay each other's inverse, and the walk has to terminate while doing it.
+    /// </summary>
+    [TestCaseSource(nameof(PastTheirBackingRangeCases))]
+    public void TheMonthDifferencePastTheBackingRangeIsTheMonthsThatWereAdded(string calendar, string iso)
+    {
+        Evaluate(
+            $@"(function () {{
+                 var d = Temporal.PlainDate.from('{iso}').withCalendar('{calendar}');
+                 return d.until(d.add({{ months: 5 }}), {{ largestUnit: 'month' }}).toString();
+               }})()")
+            .Should().Be("P5M", $"{calendar} at {iso}");
+    }
+
+    /// <summary>
+    /// The whole of the point: whichever calendar and whichever date, a date whose year the engine reports
+    /// is a date whose arithmetic the engine performs. Nothing about a date says which of the two it will
+    /// get, so the engine may not answer one and refuse the other.
+    /// </summary>
+    [TestCase("chinese")]
+    [TestCase("dangi")]
+    [TestCase("hebrew")]
+    [TestCase("persian")]
+    [TestCase("coptic")]
+    [TestCase("ethiopic")]
+    [TestCase("ethioaa")]
+    [TestCase("indian")]
+    [TestCase("islamic-umalqura")]
+    [TestCase("islamic-civil")]
+    [TestCase("islamic-tbla")]
+    public void EveryCalendarThatReportsAYearAlsoAddsToIt(string calendar)
+    {
+        foreach (var iso in new[] { "-005000-06-15", "0500-06-15", "1500-06-15", "1990-03-05", "2300-06-15", "9000-06-15" })
+        {
+            Evaluate($"Temporal.PlainDate.from('{iso}').withCalendar('{calendar}').year")
+                .Should().NotStartWith("RangeError", $"{calendar} year at {iso}");
+
+            Evaluate($"Temporal.PlainDate.from('{iso}').withCalendar('{calendar}').add({{ months: 1 }}).toString()")
+                .Should().NotStartWith("RangeError", $"{calendar} add at {iso}");
+
+            Evaluate($"Temporal.PlainDate.from('{iso}').withCalendar('{calendar}').add({{ years: 3, months: 2 }}).toString()")
+                .Should().NotStartWith("RangeError", $"{calendar} add years at {iso}");
+        }
+    }
+
+    /// <summary>
+    /// A month added past the end of a table lands on the date the conversions name for the fields it
+    /// reports — which is the property that was broken: the arithmetic was reading a different reckoning
+    /// from the accessors, or refusing to read one at all.
+    /// </summary>
+    [TestCaseSource(nameof(PastTheirBackingRangeCases))]
+    public void TheDateAMonthAddedLandsOnIsTheDateItsOwnFieldsBuild(string calendar, string iso)
+    {
+        Evaluate(
+            $@"(function () {{
+                 var n = Temporal.PlainDate.from('{iso}').withCalendar('{calendar}').add({{ months: 1 }});
+                 var built = Temporal.PlainDate.from({{ calendar: '{calendar}', year: n.year, monthCode: n.monthCode, day: n.day }});
+                 return n.equals(built);
+               }})()")
+            .Should().Be("true", $"{calendar} at {iso}");
+    }
+}

--- a/Jint.Tests/Runtime/NonIsoCalendarRangeTests.cs
+++ b/Jint.Tests/Runtime/NonIsoCalendarRangeTests.cs
@@ -5,8 +5,9 @@ namespace Jint.Tests.Runtime;
 /// <summary>
 /// Jint reckons the eleven non-ISO calendars with <c>System.Globalization.Calendar</c> classes and with
 /// fixed-epoch arithmetic, and several of those classes cover far less than Temporal's own date range —
-/// <c>ChineseLunisolarCalendar</c> spans ISO 1901-02-19 to 2101-01-28. These pin what happens at the
-/// boundary: a bounded, catchable <c>RangeError</c>, and never a walk that does not end.
+/// <c>ChineseLunisolarCalendar</c> spans ISO 1901-02-19 to 2101-01-28. These pin what happens at the end
+/// of one: a bounded walk that terminates, and an answer reckoned in the calendar rather than the
+/// calendar's own boundary date handed back as though it were one.
 /// </summary>
 /// <remarks>
 /// The failure these replace is the worst one an engine has. <c>CalendarDateUntil</c> walks a month at a
@@ -17,6 +18,14 @@ namespace Jint.Tests.Runtime;
 /// <c>LimitExecutionTime</c> never gets a check, and a <c>CancellationToken</c> is never observed. That
 /// is why every case here runs on a dedicated thread with a join timeout — a regression has to fail the
 /// run rather than wedge it. See <see href="https://github.com/sebastienros/jint/issues/3428"/>.
+/// <para>
+/// What ends the walk is no longer a refusal. <see href="https://github.com/sebastienros/jint/issues/3483"/>
+/// pointed out that the field accessors reckon the same dates the arithmetic was refusing, so a step past
+/// the end of a table is now placed by the same reckoning the accessors read it with. Termination
+/// survives because that reckoning is strictly monotone in (year, ordinal month) and declines outright
+/// past Temporal's own range; the no-progress guard stays as the structural guarantee for one that
+/// saturates instead.
+/// </para>
 /// </remarks>
 public class NonIsoCalendarRangeTests
 {
@@ -67,17 +76,19 @@ public class NonIsoCalendarRangeTests
     /// The report from the issue, verbatim. Before the fix this never returned.
     /// </summary>
     [Test]
-    public void TheReportedMonthDifferencePastTheChineseRangeRaisesRangeError()
+    public void TheReportedMonthDifferencePastTheChineseRangeTerminates()
     {
         Evaluate(
             "Temporal.PlainDate.from('1910-01-01').withCalendar('chinese')" +
             ".until(Temporal.PlainDate.from('1900-01-03').withCalendar('chinese'), { largestUnit: 'year' })")
-            .Should().Be("RangeError");
+            .Should().Be("-P9Y12M17D");
     }
 
     /// <summary>
     /// A difference is a sequence of additions, so every direction of walk and every largest unit that
-    /// walks has to be bounded — not only the one the report happened to name.
+    /// walks has to terminate — not only the one the report happened to name — and the difference has to
+    /// be the one that takes the one date to the other, which is what says the walk stopped in the right
+    /// place rather than merely stopping.
     /// </summary>
     [TestCase("chinese", "1910-01-01", "1900-01-03", TestName = "chinese below its 1901 floor")]
     [TestCase("chinese", "2050-01-01", "2300-01-03", TestName = "chinese above its 2101 ceiling")]
@@ -85,16 +96,24 @@ public class NonIsoCalendarRangeTests
     [TestCase("hebrew", "1990-01-01", "1000-01-03", TestName = "hebrew below its 1583 floor")]
     [TestCase("hebrew", "2050-01-01", "2300-01-03", TestName = "hebrew above its 2239 ceiling")]
     [TestCase("persian", "0700-01-01", "0300-01-03", TestName = "persian below its 622 floor")]
-    public void ADifferencePastACalendarRangeRaisesRangeErrorInsteadOfSpinning(string calendar, string one, string two)
+    public void ADifferencePastACalendarRangeTerminatesAndTakesTheOneDateToTheOther(string calendar, string one, string two)
     {
         foreach (var largestUnit in new[] { "year", "month" })
         {
             foreach (var op in new[] { "until", "since" })
             {
+                // Both differences are reckoned from the receiver, so each is undone on the receiver:
+                // "a.until(b)" added to a is b, and "a.since(b)" subtracted from a is b.
+                var replay = string.Equals(op, "until", StringComparison.Ordinal) ? "a.add(d).equals(b)" : "a.subtract(d).equals(b)";
+
                 Evaluate(
-                    $"Temporal.PlainDate.from('{one}').withCalendar('{calendar}')" +
-                    $".{op}(Temporal.PlainDate.from('{two}').withCalendar('{calendar}'), {{ largestUnit: '{largestUnit}' }})")
-                    .Should().Be("RangeError", $"{calendar}.{op} by {largestUnit}");
+                    $@"(function () {{
+                         var a = Temporal.PlainDate.from('{one}').withCalendar('{calendar}');
+                         var b = Temporal.PlainDate.from('{two}').withCalendar('{calendar}');
+                         var d = a.{op}(b, {{ largestUnit: '{largestUnit}' }});
+                         return {replay};
+                       }})()")
+                    .Should().Be("true", $"{calendar}.{op} by {largestUnit}");
             }
         }
     }
@@ -110,57 +129,57 @@ public class NonIsoCalendarRangeTests
         const string Chinese = "withCalendar('chinese')";
 
         Evaluate($"Temporal.PlainDateTime.from('1910-01-01T00:00').{Chinese}.until(Temporal.PlainDateTime.from('1900-01-03T00:00').{Chinese}, {{ largestUnit: 'year' }})")
-            .Should().Be("RangeError");
+            .Should().StartWith("-P");
 
         Evaluate($"Temporal.ZonedDateTime.from('1910-01-01T00:00[UTC]').{Chinese}.since(Temporal.ZonedDateTime.from('1900-01-03T00:00[UTC]').{Chinese}, {{ largestUnit: 'year' }})")
-            .Should().Be("RangeError");
+            .Should().StartWith("P");
 
         Evaluate($"Temporal.PlainDate.from('1910-01-01').{Chinese}.toPlainYearMonth().until(Temporal.PlainDate.from('1900-01-03').{Chinese}.toPlainYearMonth(), {{ largestUnit: 'year' }})")
-            .Should().Be("RangeError");
+            .Should().StartWith("-P");
 
         Evaluate($"new Temporal.Duration(0, 0, 0, 200000).total({{ unit: 'year', relativeTo: Temporal.PlainDate.from('1990-01-01').{Chinese} }})")
-            .Should().Be("RangeError");
+            .Should().NotBe("RangeError");
 
         // round reaches the walk through a ZonedDateTime relativeTo. It does not reach it through a
         // PlainDate one, because that arm reckons in "iso8601" whatever calendar the relativeTo carries
-        // -- a separate defect with its own issue, and the reason round answered where total refused
-        // even before this change.
+        // -- a separate defect with its own issue.
         Evaluate($"new Temporal.Duration(200).round({{ largestUnit: 'year', relativeTo: Temporal.ZonedDateTime.from('1990-01-01T00:00[UTC]').{Chinese} }})")
-            .Should().Be("RangeError");
+            .Should().StartWith("P");
     }
 
     /// <summary>
     /// The other half of the same defect, and the one that answered rather than hanging: the boundary
     /// date handed back was the calendar's <em>maximum</em> whichever end had been overrun, so
     /// subtracting a century from a 1950 Chinese date moved it a century and a half forward, to
-    /// 2101-01-28, and reported success.
+    /// 2101-01-28, and reported success. It is now the date a century back, placed by the same
+    /// conversion that reads that date's fields.
     /// </summary>
-    [TestCase("chinese", "1950-01-01", "subtract({ years: 100 })")]
-    [TestCase("chinese", "2050-01-01", "add({ years: 100 })")]
-    [TestCase("chinese", "2050-01-01", "add({ months: 1200 })")]
-    [TestCase("dangi", "2050-01-01", "add({ years: 100 })")]
-    [TestCase("hebrew", "2050-01-01", "add({ years: 500 })")]
-    [TestCase("persian", "0700-01-01", "subtract({ years: 200 })")]
-    public void ArithmeticPastACalendarRangeRaisesRangeErrorInsteadOfAnsweringWithTheBoundary(string calendar, string from, string call)
+    [TestCase("chinese", "1950-01-01", "subtract({ years: 100 })", "1849-12-26")]
+    [TestCase("chinese", "2050-01-01", "add({ years: 100 })", "2150-01-06")]
+    [TestCase("chinese", "2050-01-01", "add({ months: 1200 })", "2147-01-09")]
+    [TestCase("dangi", "2050-01-01", "add({ years: 100 })", "2150-01-06")]
+    [TestCase("hebrew", "2050-01-01", "add({ years: 500 })", "2549-12-29")]
+    [TestCase("persian", "0700-01-01", "subtract({ years: 200 })", "0500-01-01")]
+    public void ArithmeticPastACalendarRangeAnswersInTheCalendarInsteadOfWithItsBoundary(string calendar, string from, string call, string expected)
     {
         Evaluate($"Temporal.PlainDate.from('{from}').withCalendar('{calendar}').{call}")
-            .Should().Be("RangeError");
+            .Should().Be($"{expected}[u-ca={calendar}]");
     }
 
     /// <summary>
-    /// A <c>RangeError</c> is only an improvement on a hang if a script can act on it, which means it has
-    /// to be a JavaScript error and not a CLR exception on its way out of <c>Engine.Evaluate</c>.
+    /// Temporal's own range still ends somewhere, and past it the refusal is all that is left. It is only
+    /// an improvement on a hang if a script can act on it, which means it has to be a JavaScript error
+    /// and not a CLR exception on its way out of <c>Engine.Evaluate</c>.
     /// </summary>
     [Test]
-    public void TheRefusalIsAJavaScriptErrorAScriptCanCatch()
+    public void TheRefusalPastTemporalsOwnRangeIsAJavaScriptErrorAScriptCanCatch()
     {
         var caught = "";
 
-        Guarded(nameof(TheRefusalIsAJavaScriptErrorAScriptCanCatch), () => caught = new Engine().Evaluate(
+        Guarded(nameof(TheRefusalPastTemporalsOwnRangeIsAJavaScriptErrorAScriptCanCatch), () => caught = new Engine().Evaluate(
             @"(function () {
                 try {
-                    Temporal.PlainDate.from('1910-01-01').withCalendar('chinese')
-                        .until(Temporal.PlainDate.from('1900-01-03').withCalendar('chinese'), { largestUnit: 'year' });
+                    Temporal.PlainDate.from('2000-01-01').withCalendar('chinese').add({ years: 300000 });
                     return 'no error';
                 } catch (e) {
                     return (e instanceof RangeError) + '|' + (e.message.length > 0);
@@ -171,8 +190,8 @@ public class NonIsoCalendarRangeTests
     }
 
     /// <summary>
-    /// The refusal is a boundary, not a new ceiling on ordinary arithmetic: every calendar still measures
-    /// and still adds inside the range it supports, and the two still agree with each other.
+    /// The end of a table is not a new ceiling on ordinary arithmetic: every calendar still measures and
+    /// still adds inside the range it supports, and the two still agree with each other.
     /// </summary>
     [Test]
     public void ArithmeticInsideEveryCalendarRangeIsUnchanged()
@@ -198,17 +217,21 @@ public class NonIsoCalendarRangeTests
     }
 
     /// <summary>
-    /// The six calendars with no <c>System.Globalization.Calendar</c> behind them reckon by epoch-day
-    /// arithmetic and have no boundary to hit, which is why they answer where the BCL-backed ones refuse.
-    /// Pinned so that giving one of them a BCL implementation cannot quietly narrow it.
+    /// Every one of the eleven measures across the whole of Temporal's range. Six never had a
+    /// <c>System.Globalization.Calendar</c> to run out of; the other five reckon past the end of theirs.
     /// </summary>
+    [TestCase("chinese")]
+    [TestCase("dangi")]
+    [TestCase("hebrew")]
+    [TestCase("persian")]
     [TestCase("coptic")]
     [TestCase("ethiopic")]
     [TestCase("ethioaa")]
     [TestCase("indian")]
+    [TestCase("islamic-umalqura")]
     [TestCase("islamic-civil")]
     [TestCase("islamic-tbla")]
-    public void ACalendarReckonedByArithmeticStillMeasuresAcrossTheWholeTemporalRange(string calendar)
+    public void EveryNonIsoCalendarMeasuresAcrossTheWholeTemporalRange(string calendar)
     {
         Evaluate($"Temporal.PlainDate.from('1950-01-01').withCalendar('{calendar}').until(Temporal.PlainDate.from('-100000-01-03').withCalendar('{calendar}'), {{ largestUnit: 'year' }})")
             .Should().StartWith("-P", calendar);

--- a/Jint/Native/Temporal/CalendarRangeException.cs
+++ b/Jint/Native/Temporal/CalendarRangeException.cs
@@ -8,7 +8,9 @@ namespace Jint.Native.Temporal;
 /// Jint reckons the eleven non-ISO calendars with <see cref="System.Globalization.Calendar"/> classes and
 /// with fixed-epoch arithmetic, and several of those classes cover far less than Temporal's own date
 /// range: <c>ChineseLunisolarCalendar</c> spans ISO 1901-02-19 to 2101-01-28, <c>HebrewCalendar</c>
-/// 1583-01-01 to 2239-09-29. A step past either end has no date to answer with.
+/// 1583-01-01 to 2239-09-29. The end of one of those is <em>not</em> what this reports: each of the four
+/// has a reckoning of its own past it, the same one its field accessors read, and the arithmetic asks it
+/// rather than refusing. What is left is a step past Temporal's own range, which no reckoning can place.
 /// </para>
 /// <para>
 /// What used to be answered there was the calendar's <em>maximum</em> supported date, whichever end had

--- a/Jint/Native/Temporal/NonIsoCalendars.Lunisolar.cs
+++ b/Jint/Native/Temporal/NonIsoCalendars.Lunisolar.cs
@@ -1,3 +1,5 @@
+﻿using System.Threading;
+
 namespace Jint.Native.Temporal;
 
 /// <summary>
@@ -106,26 +108,69 @@ internal static class LunisolarAstronomy
     private static readonly long _koreaZoneChange1961 = TemporalHelpers.IsoDateToDays(1961, 8, 10);
     private static readonly long _daysTo1900 = TemporalHelpers.IsoDateToDays(1900, 1, 1);
 
-    // Reading a date's fields asks for the same year once per accessor, and a year costs a dozen new
-    // moons and a pair of solstice searches to build. One entry per calendar is enough for that, and
-    // [ThreadStatic] is what makes it safe without a lock: the value is a pure function of the year, so
-    // two threads computing it separately compute the same thing, and neither can see the other's
-    // half-written object. Nothing engine-affine goes in here.
+    /// <summary>
+    /// How many built years each calendar keeps. A power of two, so the slot is a mask rather than a
+    /// division, and wide enough that the centuries a script actually walks stay resident.
+    /// </summary>
+    /// <remarks>
+    /// A year costs a dozen new moons and a pair of solstice searches to build, and reading one date's
+    /// fields asks for the same year once per accessor, so the first tier is what makes reading a date
+    /// cost one build rather than six. The second is what makes a month-by-month difference walk
+    /// affordable now that one past the end of a table is answered rather than refused: measuring
+    /// 2050-01-01 to 2300-01-03 in months steps through 250 lunisolar years some three thousand times.
+    /// </remarks>
+    private const int YearCacheSize = 256;
+
+    // _lastChina / _lastKorea are the first tier and answer the common shape on their own: reading a run
+    // of dates asks for the same year over and over. They are [ThreadStatic] because they need no
+    // synchronisation at all that way.
     [ThreadStatic]
-    private static LunisolarYear? _memoChina;
+    private static LunisolarYear? _lastChina;
 
     [ThreadStatic]
-    private static LunisolarYear? _memoKorea;
+    private static LunisolarYear? _lastKorea;
+
+    // The second tier is shared, because a LunisolarYear is a pure function of its year and region --
+    // two threads building one separately build the same thing, and nothing engine-affine goes in here.
+    // Volatile.Write publishes it: every field of the year is written before the reference is, and the
+    // Volatile.Read below is the matching acquire, so no thread can observe a half-built one. A slot lost
+    // to a race costs a rebuild and nothing else.
+    private static readonly LunisolarYear?[] _cacheChina = new LunisolarYear?[YearCacheSize];
+
+    private static readonly LunisolarYear?[] _cacheKorea = new LunisolarYear?[YearCacheSize];
+
+    private static LunisolarYear?[] CacheFor(LunisolarRegion region)
+        => region == LunisolarRegion.China ? _cacheChina : _cacheKorea;
+
+    /// <summary>The cached year, or null when it has not been built.</summary>
+    private static LunisolarYear? Cached(int year, LunisolarRegion region)
+    {
+        var entry = Volatile.Read(ref CacheFor(region)[year & (YearCacheSize - 1)]);
+        return entry is not null && entry.Year == year ? entry : null;
+    }
 
     /// <summary>
     /// The lunisolar year containing <paramref name="days"/> (days since 1970-01-01).
     /// </summary>
     internal static LunisolarYear ForFixed(long days, LunisolarRegion region)
     {
-        var memo = region == LunisolarRegion.China ? _memoChina : _memoKorea;
-        if (memo is not null && days >= memo.Start && days < memo.MonthStarts[memo.MonthCount])
+        var last = region == LunisolarRegion.China ? _lastChina : _lastKorea;
+        if (last is not null && days >= last.Start && days < last.MonthStarts[last.MonthCount])
         {
-            return memo;
+            return last;
+        }
+
+        // A lunisolar year carries the number of the Gregorian year it mostly falls in, and begins in that
+        // year's first two months, so the year holding a date is that Gregorian year or the one before.
+        // The range check is what makes a hit a hit; the slot lookup only narrows the two candidates.
+        var gregorian = GregorianYearOf(days);
+        for (var candidate = gregorian; candidate >= gregorian - 1; candidate--)
+        {
+            var memo = Cached(candidate, region);
+            if (memo is not null && days >= memo.Start && days < memo.MonthStarts[memo.MonthCount])
+            {
+                return Remember(memo, region);
+            }
         }
 
         return Remember(Build(NewYearOnOrBefore(days, region), region), region);
@@ -138,10 +183,16 @@ internal static class LunisolarAstronomy
     /// </summary>
     internal static LunisolarYear? ForYear(int year, LunisolarRegion region)
     {
-        var memo = region == LunisolarRegion.China ? _memoChina : _memoKorea;
-        if (memo is not null && memo.Year == year)
+        var last = region == LunisolarRegion.China ? _lastChina : _lastKorea;
+        if (last is not null && last.Year == year)
         {
-            return memo;
+            return last;
+        }
+
+        var memo = Cached(year, region);
+        if (memo is not null)
+        {
+            return Remember(memo, region);
         }
 
         // A related Gregorian year outside Temporal's own ISO range cannot name a representable date
@@ -178,13 +229,15 @@ internal static class LunisolarAstronomy
 
     private static LunisolarYear Remember(LunisolarYear year, LunisolarRegion region)
     {
+        Volatile.Write(ref CacheFor(region)[year.Year & (YearCacheSize - 1)], year);
+
         if (region == LunisolarRegion.China)
         {
-            _memoChina = year;
+            _lastChina = year;
         }
         else
         {
-            _memoKorea = year;
+            _lastKorea = year;
         }
 
         return year;

--- a/Jint/Native/Temporal/NonIsoCalendars.cs
+++ b/Jint/Native/Temporal/NonIsoCalendars.cs
@@ -20,7 +20,8 @@ namespace Jint.Native.Temporal;
 /// states why it cannot answer below 1, and each maximum taken from System.Globalization instead
 /// (Calendar.GetDaysInMonth, GetMonthsInYear, GetLeapMonth, IsLeapYear — all of which either answer 1
 /// or more or throw for a year outside the calendar's range) sits inside a try whose catch answers
-/// with a literal or with one of those helpers. What keeps all of it true is
+/// with a literal, with one of those helpers, or with the algorithmic reckoning the calendar's own
+/// field accessors read past the end of its table — never below 1. What keeps all of it true is
 /// Jint.Tests/Runtime/NonIsoCalendarTests.cs: 85,800 field combinations per overflow mode across all
 /// eleven calendars, every one of which has to come back as a date or as null rather than throw.
 /// </remarks>
@@ -189,21 +190,7 @@ internal static class NonIsoCalendars
             return iso is null ? null : new IsoDate(iso.Value.Year, iso.Value.Month, iso.Value.Day);
         }
 
-        var result = calendar switch
-        {
-            "chinese" => LunisolarDateToIso(ChineseCal, LunisolarRegion.China, year, monthCode, month, day, overflow),
-            "dangi" => LunisolarDateToIso(DangiCal, LunisolarRegion.Korea, year, monthCode, month, day, overflow),
-            "hebrew" => HebrewDateToIso(year, monthCode, month, day, overflow),
-            "persian" => PersianDateToIso(year, monthCode, month, day, overflow),
-            "coptic" => FixedEpochDateToIso(CopticEpochDays, 13, year, monthCode, month, day, overflow),
-            "ethiopic" => FixedEpochDateToIso(EthiopicEpochDays, 13, year, monthCode, month, day, overflow),
-            "ethioaa" => FixedEpochDateToIso(EthioAAEpochDays, 13, year, monthCode, month, day, overflow),
-            "indian" => IndianDateToIso(year, monthCode, month, day, overflow),
-            "islamic-umalqura" => IslamicUmalquraDateToIso(year, monthCode, month, day, overflow),
-            "islamic-civil" => IslamicCivilTabularDateToIso(year, monthCode, month, day, overflow, 1948439L),
-            "islamic-tbla" => IslamicCivilTabularDateToIso(year, monthCode, month, day, overflow, 1948438L),
-            _ => throw new NotSupportedException($"Calendar '{calendar}' not supported by NonIsoCalendars")
-        };
+        var result = BuiltinCalendarDateToIso(calendar, year, monthCode, month, day, overflow);
 
         // If calendar conversion failed (e.g., year out of .NET calendar range),
         // fall back to treating fields as ISO (best effort)
@@ -226,6 +213,35 @@ internal static class NonIsoCalendars
         }
 
         return result;
+    }
+
+    /// <summary>
+    /// The engine's own reckoning of a calendar date, with no host provider consulted and no last-resort
+    /// ISO fallback: null means this calendar cannot place these fields, and says so.
+    /// </summary>
+    /// <remarks>
+    /// Each arm answers across the whole of Temporal's range, falling back past the end of whatever
+    /// <see cref="Calendar"/> backs it to a reckoning of its own — which is why
+    /// <see cref="CalendarDateAdd"/> can place a result the backing calendar declines by asking this
+    /// rather than by refusing.
+    /// </remarks>
+    private static IsoDate? BuiltinCalendarDateToIso(string calendar, int year, string? monthCode, int month, int day, string overflow)
+    {
+        return calendar switch
+        {
+            "chinese" => LunisolarDateToIso(ChineseCal, LunisolarRegion.China, year, monthCode, month, day, overflow),
+            "dangi" => LunisolarDateToIso(DangiCal, LunisolarRegion.Korea, year, monthCode, month, day, overflow),
+            "hebrew" => HebrewDateToIso(year, monthCode, month, day, overflow),
+            "persian" => PersianDateToIso(year, monthCode, month, day, overflow),
+            "coptic" => FixedEpochDateToIso(CopticEpochDays, 13, year, monthCode, month, day, overflow),
+            "ethiopic" => FixedEpochDateToIso(EthiopicEpochDays, 13, year, monthCode, month, day, overflow),
+            "ethioaa" => FixedEpochDateToIso(EthioAAEpochDays, 13, year, monthCode, month, day, overflow),
+            "indian" => IndianDateToIso(year, monthCode, month, day, overflow),
+            "islamic-umalqura" => IslamicUmalquraDateToIso(year, monthCode, month, day, overflow),
+            "islamic-civil" => IslamicCivilTabularDateToIso(year, monthCode, month, day, overflow, 1948439L),
+            "islamic-tbla" => IslamicCivilTabularDateToIso(year, monthCode, month, day, overflow, 1948438L),
+            _ => throw new NotSupportedException($"Calendar '{calendar}' not supported by NonIsoCalendars")
+        };
     }
 
     /// <summary>
@@ -376,6 +392,14 @@ internal static class NonIsoCalendars
     /// from being corrected in its field accessors and not in its arithmetic. The per-calendar
     /// implementations below answer for every calendar the provider leaves to the engine, so an engine
     /// that configures nothing reaches exactly the same one it always did.
+    /// <para>
+    /// The BCL arm asks its backing <see cref="Calendar"/> five things — a year's month count, its leap
+    /// month's ordinal, a monthCode's ordinal in that year, a month's length, and where a resolved
+    /// (year, ordinal, day) lands in ISO — and every one of them falls back to the same reckoning
+    /// <see cref="IsoToCalendarDate"/> and <see cref="BuiltinCalendarDateToIso"/> read past the end of
+    /// that calendar's table, so a date whose fields the engine reports is a date whose arithmetic the
+    /// engine performs (https://github.com/sebastienros/jint/issues/3483).
+    /// </para>
     /// </remarks>
     internal static IsoDate CalendarDateAdd(string calendar, in IsoDate isoDate, int years, int months, string overflow, Engine? engine = null)
     {
@@ -461,7 +485,7 @@ internal static class NonIsoCalendars
         }
 
         // Constrain day
-        var maxDay = GetDaysInMonthCal(cal, newYear, newOrdinalMonth);
+        var maxDay = GetDaysInMonthCal(calendar, cal, newYear, newOrdinalMonth);
         var newDay = calDate.Day;
         if (newDay > maxDay)
         {
@@ -481,19 +505,37 @@ internal static class NonIsoCalendars
         }
         catch (ArgumentOutOfRangeException)
         {
-            // The result lies outside the range the backing System.Globalization.Calendar represents.
-            // That is not the month-or-day overflow "constrain" is allowed to clamp -- there is no
-            // nearby valid date to clamp to, only the calendar's own boundary -- so both overflow modes
-            // report it. NonISODateAdd is implementation-defined and may throw
+            // The result lies outside the range the backing System.Globalization.Calendar represents --
+            // which is the end of a table, not the end of the calendar. The conversion this calls has a
+            // reckoning of its own for exactly those years, and it is the reckoning the field accessors
+            // already read the same date with, so placing the result there is what keeps one date from
+            // getting two verdicts (https://github.com/sebastienros/jint/issues/3483).
+            //
+            // BuiltinCalendarDateToIso rather than CalendarDateToIso: the latter's last-resort arm
+            // answers an unplaceable date with its fields read as ISO, which is a different calendar's
+            // answer wearing this one's name -- and, worse for the walk below, an answer whose progress
+            // says nothing about this calendar's.
+            var placed = BuiltinCalendarDateToIso(calendar, newYear, null, newOrdinalMonth, newDay, "constrain");
+            if (placed is not null)
+            {
+                return placed.Value;
+            }
+
+            // Nothing left that can place it: the reckoning declines for a year outside Temporal's own
+            // range, and there is no nearby valid date to clamp to, so both overflow modes report it.
+            // NonISODateAdd is implementation-defined and may throw
             // (https://tc39.es/proposal-temporal/#sec-temporal-nonisodateadd), and CalendarDateAdd
             // raises a RangeError for a result it cannot represent
             // (https://tc39.es/proposal-temporal/#sec-temporal-calendardateadd).
             //
-            // The clamp this replaced answered with the calendar's MaxSupportedDateTime for an
+            // The clamp both of these replaced answered with the calendar's MaxSupportedDateTime for an
             // underflow as well as an overflow, so subtracting a century from a chinese date moved it
             // forward to 2101-01-28 -- and, since every further step landed on that same date,
             // CalendarDateUntil's month walk below never passed its target and never returned
-            // (https://github.com/sebastienros/jint/issues/3428).
+            // (https://github.com/sebastienros/jint/issues/3428). What makes this arm safe where that
+            // clamp was not is that the reckoning it defers to is strictly monotone in (year, ordinal
+            // month), so a step still moves; CalendarDateUntil's no-progress guard stays as the
+            // structural backstop for a reckoning that saturates rather than progressing.
             throw new CalendarRangeException(calendar);
         }
     }
@@ -606,12 +648,25 @@ internal static class NonIsoCalendars
         {
             if (years != 0)
             {
-                // Whole-year skip estimate. How many months a year holds is the calendar's own answer, and
-                // for one only a provider knows nothing else here can give it, so the count the conversion
-                // already reported for the starting date's year is the guess — a guess, because the year
-                // beside it may hold one more or one fewer in a lunisolar calendar.
-                months = years * System.Math.Max(calOne.MonthsInYear, 1);
+                // Whole-year skip estimate, from the average month length the conversion already reported
+                // for the starting date's year. Multiplying the year span by that year's month count
+                // instead -- which is what this was -- drifts wherever a calendar's years do not all hold
+                // the same number of months: a lunisolar year holds twelve or thirteen, averaging 12.37, so
+                // starting from a thirteen-month year and walking a millennium overestimates by some 625
+                // months, every one of which the back-off loop below then steps off one at a time. The
+                // estimate only decides how long that walk is; the two loops decide the answer.
+                var monthsInYear = System.Math.Max(calOne.MonthsInYear, 1);
+                var averageMonthDays = System.Math.Max(calOne.DaysInYear, 1) / (double) monthsInYear;
+                months = (int) System.Math.Round((epochTwo - epochOne) / averageMonthDays);
+
+                // A provider free enough with its fields to report an average that puts the estimate on the
+                // wrong side of zero gets the old one, which at least has the sign of the walk.
+                if (System.Math.Sign(months) != sign)
+                {
+                    months = years * monthsInYear;
+                }
             }
+
             years = 0;
         }
 
@@ -690,7 +745,7 @@ internal static class NonIsoCalendars
             {
                 var ord = MonthCodeToOrdinal(calendar, cal, y, monthCode, "reject");
                 if (ord <= 0) continue;
-                var dim = GetDaysInMonthCal(cal, y, ord);
+                var dim = GetDaysInMonthCal(calendar, cal, y, ord);
                 if (dim > maxSeen) maxSeen = dim;
             }
             catch
@@ -717,7 +772,7 @@ internal static class NonIsoCalendars
             {
                 var ord = MonthCodeToOrdinal(calendar, cal, y, monthCode, "reject");
                 if (ord <= 0) continue;
-                var dim = GetDaysInMonthCal(cal, y, ord);
+                var dim = GetDaysInMonthCal(calendar, cal, y, ord);
                 if (dim > maxSeen) maxSeen = dim;
             }
             catch
@@ -1150,7 +1205,7 @@ internal static class NonIsoCalendars
             try
             {
                 var ordinal = MonthCodeToOrdinal(calendar, cal, y, monthCode, "reject");
-                var maxDay = GetDaysInMonthCal(cal, y, ordinal);
+                var maxDay = GetDaysInMonthCal(calendar, cal, y, ordinal);
                 if (day > maxDay)
                 {
                     continue; // day not valid in this year — skip in pass 1
@@ -1193,7 +1248,7 @@ internal static class NonIsoCalendars
                 try
                 {
                     var ordinal = MonthCodeToOrdinal(calendar, cal, y, monthCode, "reject");
-                    var maxDay = GetDaysInMonthCal(cal, y, ordinal);
+                    var maxDay = GetDaysInMonthCal(calendar, cal, y, ordinal);
                     if (day > maxDay) continue;
                     var dt = cal.ToDateTime(y, ordinal, day, 0, 0, 0, 0);
                     if (dt.Ticks > upperBound && dt.Ticks < futureIsoTicks)
@@ -1235,7 +1290,7 @@ internal static class NonIsoCalendars
             try
             {
                 var ordinal = MonthCodeToOrdinal(calendar, cal, y, monthCode, "reject");
-                var maxDay = GetDaysInMonthCal(cal, y, ordinal);
+                var maxDay = GetDaysInMonthCal(calendar, cal, y, ordinal);
                 var clampedDay = System.Math.Min(day, maxDay);
                 var dt = cal.ToDateTime(y, ordinal, clampedDay, 0, 0, 0, 0);
                 if (dt.Ticks > upperBound)
@@ -1534,9 +1589,19 @@ internal static class NonIsoCalendars
         }
         catch
         {
-            return 0;
+            // Past the end of the table. Answering "no leap month" here is the same mistake as
+            // answering with ISO fields under the calendar's name: the reckoning the field accessors
+            // already use knows which month of this year is the leap one, so ask it.
+            var resolved = LunisolarAstronomy.ForYear(year, RegionOf(calendar));
+            return resolved is null ? 0 : resolved.LeapIndex + 1;
         }
     }
+
+    /// <summary>
+    /// The meridian a lunisolar calendar is reckoned at, for the two the engine implements.
+    /// </summary>
+    private static LunisolarRegion RegionOf(string calendar)
+        => string.Equals(calendar, "dangi", StringComparison.Ordinal) ? LunisolarRegion.Korea : LunisolarRegion.China;
 
     /// <summary>
     /// Gets the display month number of the leap month at the given ordinal.
@@ -1586,6 +1651,15 @@ internal static class NonIsoCalendars
                 return IsHebrewLeapYearAlgorithmic(year) ? 13 : 12;
             }
 
+            if (calendar is "chinese" or "dangi")
+            {
+                var resolved = LunisolarAstronomy.ForYear(year, RegionOf(calendar));
+                if (resolved is not null)
+                {
+                    return resolved.MonthCount;
+                }
+            }
+
             return 12;
         }
     }
@@ -1593,21 +1667,66 @@ internal static class NonIsoCalendars
     /// <summary>
     /// Gets the number of days in a calendar month.
     /// </summary>
-    private static int GetDaysInMonthCal(Calendar? cal, int year, int month)
+    /// <remarks>
+    /// A year past the end of the backing <see cref="Calendar"/> is answered by the same reckoning the
+    /// field accessors read that year with, rather than with a flat 30 — a month length is what decides
+    /// where <see cref="CalendarDateAdd"/> clamps the day, so a guessed one places the wrong date.
+    /// </remarks>
+    private static int GetDaysInMonthCal(string calendar, Calendar? cal, int year, int month)
     {
-        if (cal is null)
+        if (cal is not null)
         {
-            return 30; // fallback for calendars without .NET Calendar
+            try
+            {
+                return cal.GetDaysInMonth(year, month);
+            }
+            catch
+            {
+                // Past the end of the table; fall through to the reckoning below.
+            }
         }
 
-        try
+        return AlgorithmicDaysInMonth(calendar, year, month);
+    }
+
+    /// <summary>
+    /// The length of an ordinal month in a year no <see cref="Calendar"/> covers, from the same
+    /// algorithmic reckoning <see cref="IsoToCalendarDate"/> and <see cref="CalendarDateToIso"/> use
+    /// there. 30 is the last resort, for a calendar with no reckoning of its own and for an ordinal that
+    /// does not occur in the year at all.
+    /// </summary>
+    private static int AlgorithmicDaysInMonth(string calendar, int year, int ordinalMonth)
+    {
+        switch (calendar)
         {
-            return cal.GetDaysInMonth(year, month);
+            case "chinese":
+            case "dangi":
+                var resolved = LunisolarAstronomy.ForYear(year, RegionOf(calendar));
+                if (resolved is not null && ordinalMonth >= 1 && ordinalMonth <= resolved.MonthCount)
+                {
+                    return resolved.DaysInMonth(ordinalMonth);
+                }
+
+                break;
+
+            case "hebrew":
+                if (ordinalMonth >= 1 && ordinalMonth <= 13)
+                {
+                    return HebrewDaysInMonthOrdinal(year, ordinalMonth);
+                }
+
+                break;
+
+            case "persian":
+                if (ordinalMonth >= 1 && ordinalMonth <= 12)
+                {
+                    return PersianAlgorithmicDaysInMonth(year, ordinalMonth);
+                }
+
+                break;
         }
-        catch
-        {
-            return 30; // fallback
-        }
+
+        return 30;
     }
 
     #endregion

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -2549,16 +2549,16 @@ Two consequences worth naming:
   reports month 13 for 1189-01-09 and reports the year holding it as having no leap month, so
   `GetDaysInMonth` refuses the month `GetMonth` just named; the date used to come back as ISO fields for
   that reason rather than for being out of range.
-- **Arithmetic past a table's end still refuses**, unchanged from
+- **Arithmetic past a table's end refused when this landed**, unchanged from
   [4.44](#444-calendar-arithmetic-is-answered-by-whoever-answers-for-the-calendar-3403) and
-  [#3452](https://github.com/sebastienros/jint/pull/3452): `add`, `subtract`, `until` and `since` are
-  written against the BCL calendar directly, and a result it cannot represent is still a `RangeError`.
-  That is the same split `hebrew` and `persian` have always had — fields reckoned, arithmetic refused.
-  What does change is the **provider** path: §4.44 said a provider claiming `chinese` walks the two
-  conversions and so answers `1849-11-13` where a default engine raises `RangeError`, because those
-  conversions fell back to ISO-like fields. They no longer do, so that walk is now the Chinese calendar
-  rather than an ISO one wearing its name; the two paths still part in kind, but the answering one is no
-  longer wrong.
+  [#3452](https://github.com/sebastienros/jint/pull/3452): `add`, `subtract`, `until` and `since` were
+  written against the BCL calendar directly, and a result it could not represent was a `RangeError` —
+  the same split `hebrew` and `persian` had always had, fields reckoned and arithmetic refused. That
+  split is what [4.70](#470-a-date-a-calendar-reports-fields-for-is-a-date-it-reckons-arithmetic-in-3483)
+  closes; the note stays because it is the reason the **provider** path changed here too. §4.44 said a
+  provider claiming `chinese` walks the two conversions and so answers `1849-11-13` where a default
+  engine raised `RangeError`, because those conversions fell back to ISO-like fields. They no longer do,
+  so that walk is the Chinese calendar rather than an ISO one wearing its name.
 
 Far past either table the series the reckoning is built on lose accuracy — beyond roughly ±70,000 years a
 month can come back at 28 or 31 days — which is what implementation-defined permits and what every engine
@@ -3166,6 +3166,64 @@ over a fraction) still takes the double, and now takes it in **both** lanes rath
 more digits, and of a decimal string carrying more than 16 significant digits. Each of those used to throw
 or to write a rounded number, and now writes what its own `format` writes. Nothing that passed a Number
 moves.
+
+### 4.70 A date a calendar reports fields for is a date it reckons arithmetic in ([#3483](https://github.com/sebastienros/jint/issues/3483))
+
+Four calendars are backed by a `System.Globalization.Calendar` that covers less than Temporal's range:
+`hebrew` (ISO 1583-01-01 to 2239-09-29), `persian` (from 622), `chinese` (1901–2101) and `dangi`
+(918–2051). Their field accessors have long answered past those bounds from a reckoning of the calendar's
+own — algorithmic for `hebrew` and `persian`, astronomical for the other two since
+[4.50](#450-a-date-past-a-lunisolar-calendars-table-is-still-reckoned-in-that-calendar-3451). Their
+arithmetic did not: it read the backing calendar directly and turned its refusal into a `RangeError`.
+
+```js
+const d = Temporal.PlainDate.from('1500-06-15').withCalendar('hebrew');
+d.year;               // 5260, in both
+d.monthCode;          // "M10", in both
+d.add({ days: 1 });   // answers in both -- days are added as ISO days
+d.add({ months: 1 }); // 5.0: RangeError   5.x: 1500-07-14[u-ca=hebrew]
+
+Temporal.PlainDate.from('1950-01-01').withCalendar('chinese').subtract({ years: 100 });
+// 5.0: RangeError   5.x: 1849-12-26[u-ca=chinese]
+```
+
+The five things the walk asks the backing calendar — how many months a year holds, which of them is the
+leap one, where a monthCode sits in a given year, how long a month is, and where a resolved
+(year, month, day) lands in ISO — now come from the same conversions the accessors read, for exactly the
+years the backing calendar declines. All eleven non-ISO calendars therefore measure and add across the
+whole of Temporal's range.
+
+**What could break:** code that treated the `RangeError` as the boundary of what the engine could reckon
+— a `catch` that fell back to `iso8601`, or a range check written against
+`ChineseLunisolarCalendar.MaxSupportedDateTime`. Those dates now produce a date. Nothing inside a backing
+calendar's range moves: the tables still answer there, and `add`/`until` still agree with each other and
+with `PlainDate.from({ calendar, year, monthCode, day })` everywhere.
+
+**What still refuses.** Temporal's own range does end, and past it `RangeError` is still the answer:
+
+```js
+Temporal.PlainDate.from('2000-01-01').withCalendar('chinese').add({ years: 300000 }); // RangeError
+```
+
+That refusal is what [`NonISODateAdd`](https://tc39.es/proposal-temporal/#sec-temporal-nonisodateadd)
+permits — it is declared as returning "either a normal completion containing an ISO Date Record or a throw
+completion", which is what let [#3452](https://github.com/sebastienros/jint/pull/3452) make out-of-range
+arithmetic a `RangeError` in the first place. The end of a *table* was never that boundary, though, and
+the difference walk that [#3428](https://github.com/sebastienros/jint/issues/3428) hung in stays bounded:
+the reckoning that now places these results is strictly monotone in (year, ordinal month), so every step
+of the walk moves, and `CalendarDateUntil`'s no-progress guard stays as the structural guarantee against
+one that saturates.
+
+**What it costs.** A difference these calendars used to refuse is now walked, and walking is not free.
+`until` with `largestUnit: 'month'` across 250 years of `chinese` takes about 190 ms; across 990 years,
+about 1.9 s. Two things keep that from being far worse: the whole-year estimate the walk starts from is
+now the average month length the calendar reports rather than the starting year's month count, which does
+not drift over a millennium — starting from a thirteen-month lunisolar year and walking one used to
+overshoot by some 625 months, every one of which the walk then stepped off one at a time — and the
+astronomical reckoning keeps a process-wide cache of built years. Adding or subtracting months in bulk is
+still linear in the years crossed for `chinese`, `dangi` and `hebrew`, so
+`add({ months: 3000000 })` is seconds of work that no execution constraint interrupts; the six calendars
+with no backing calendar have always been closed-form there and are unaffected.
 
 ## 5. New in v5
 


### PR DESCRIPTION
Fixes #3483.

## What was wrong

Four of the eleven non-ISO calendars are backed by a `System.Globalization.Calendar` that covers less
than Temporal's range — `hebrew` ISO 1583-01-01 to 2239-09-29, `persian` from 622, `chinese` 1901–2101,
`dangi` 918–2051. Their **field accessors** have long answered past those bounds from a reckoning of the
calendar's own: `HebrewAlgorithmicFromIso` / `HebrewAlgorithmicToIso` and the Persian pair, and the
astronomical reckoning #3482 added for the lunisolar pair. Their **arithmetic** did not.
`NonIsoCalendars.CalendarDateAdd` reached for the BCL calendar directly — `GetLeapMonthOrdinal`,
`MonthCodeToOrdinal`, `GetMonthsInYear`, `GetDaysInMonthCal`, and finally `cal.ToDateTime` — and turned
that last call's `ArgumentOutOfRangeException` into the `CalendarRangeException` #3452 introduced.

So the same date, in the same calendar, in the same engine, got two verdicts about whether the engine
could reckon it:

```js
const d = Temporal.PlainDate.from('1500-06-15').withCalendar('hebrew');
d.year;               // 5260   — reckoned, and right
d.monthCode;          // "M10"  — reckoned, and right
d.add({ days: 1 });   // answers — days are added as ISO days, never through the calendar
d.add({ months: 1 }); // RangeError: Date is outside the range supported by the 'hebrew' calendar
```

Nothing about a date says which of the two it will get. `withCalendar` validates nothing, `from` builds
these dates happily, `toString` prints them, `with` edits them, and `until` measures them by day — and
then `add({ months: 1 })` refuses. Six of the eleven calendars, the ones with no BCL calendar behind
them, already measured across the whole of Temporal's range; the other five stopped at the edge of a
table that is an implementation detail of Jint's, not a property of the calendar.

## Refusing is permitted, which is why this is not a conformance fix

[`NonISODateAdd`](https://tc39.es/proposal-temporal/#sec-temporal-nonisodateadd) is declared as returning
"either a normal completion containing an ISO Date Record **or a throw completion**", so a `RangeError`
there is spec-legal — that clause is exactly what let #3452 replace a hang with one. This is a coherence
fix, not a conformance one, and the argument for it is that the refusal was right against the alternative
it replaced and is not right against the one available now.

When #3452 landed, the alternative was `ClampToCalendarRange`, which answered with the calendar's
*maximum* date whichever end had been overrun — so `subtract` moved forward and `until`'s month walk
stood still forever. Refusing beat that. But the conversions know the answer, and #3482 finished the last
two calendars that did not. The arithmetic was simply not asking them.

## What changed

Every one of the five touchpoints now falls back to the same reckoning the field accessors read, for
exactly the years the backing calendar declines:

| what the walk asks the BCL calendar | past the end of its table |
| --- | --- |
| `GetLeapMonthOrdinal` | `LunisolarAstronomy.ForYear(...).LeapIndex + 1` for chinese/dangi; the Hebrew 19-year cycle already answered |
| `GetMonthsInYear` | `LunisolarYear.MonthCount`; the Hebrew arm already answered |
| `MonthCodeToOrdinal` | reads the leap ordinal above, so it follows |
| `GetDaysInMonthCal` | new `AlgorithmicDaysInMonth` — the reckoning's month length, `HebrewDaysInMonthOrdinal`, `PersianAlgorithmicDaysInMonth`. It used to answer a flat 30 |
| `cal.ToDateTime` | new `BuiltinCalendarDateToIso`, the same `switch` `CalendarDateToIso` runs, whose arms already reckon past their tables |

`BuiltinCalendarDateToIso` rather than `CalendarDateToIso`: the latter has a last-resort arm that answers
an unplaceable date with its fields read as ISO, which is another calendar's answer wearing this one's
name — and, worse for the walk below, an answer whose progress says nothing about this calendar's.

```js
Temporal.PlainDate.from('1500-06-15').withCalendar('hebrew').add({ months: 1 });
// 5.0: RangeError    5.x: 1500-07-14[u-ca=hebrew]   (M10 → M11)

Temporal.PlainDate.from('1950-01-01').withCalendar('chinese').subtract({ years: 100 });
// 5.0: RangeError    5.x: 1849-12-26[u-ca=chinese]

Temporal.PlainDate.from('1910-01-01').withCalendar('chinese')
    .until(Temporal.PlainDate.from('1900-01-03').withCalendar('chinese'), { largestUnit: 'year' });
// before #3452: never returned    5.0: RangeError    5.x: -P9Y12M17D
```

All eleven non-ISO calendars now measure and add across the whole of Temporal's range.

## The walk still terminates, and here is why

#3452's guarantee is the one thing that may not regress: `CalendarDateUntil` walks a month at a time and
its only exit is "this step passed the target", so an answer that does not progress is a hang no
execution constraint can interrupt (#3428). Three things keep it bounded, in that order:

1. **The reckoning is strictly monotone in (year, ordinal month).** `LunisolarAlgorithmicToIso` answers
   `MonthStarts[ordinal - 1] + day - 1`, `HebrewAlgorithmicToIso` and `PersianAlgorithmicToIso` sum month
   lengths from a year start, and `LunisolarAstronomy.Build` fills `MonthStarts` from a strictly
   increasing new-moon sequence. Every step therefore moves.
2. **It declines outright past Temporal's own range.** `LunisolarAstronomy.ForYear` returns null outside
   ISO −271821…275760, `BuiltinCalendarDateToIso` returns null, and `CalendarRangeException` is raised —
   still a `RangeError`, still catchable. That is the case
   `TheRefusalPastTemporalsOwnRangeIsAJavaScriptErrorAScriptCanCatch` now covers.
3. **The no-progress guard stays.** A step that does not move the date is still a `RangeError`, which is
   the structural guarantee against a reckoning that saturates rather than progressing — including a host
   `ICalendarProvider`, which is still free to.

Every case in `NonIsoCalendarRangeTests` and `NonIsoCalendarArithmeticRangeTests` runs on a dedicated
thread with a 15-second join, so a regression fails the run rather than wedging it, and both sweep to
±100,000 years.

## Terminating was not enough: what a walk that is now taken costs

CI found this and it is the more interesting half. A difference these four calendars used to refuse is now
*walked*, and the first version of this branch took longer than 15 seconds on the GitHub runners to
measure 250 years of `chinese` by month. Two changes, and the second is the one that mattered:

- **The whole-year estimate the walk starts from was the starting year's month count.** A lunisolar year
  holds twelve months or thirteen, averaging 12.37, so starting from a thirteen-month year and estimating
  a millennium overshoots by some 625 months — every one of which the back-off loop then stepped off one
  at a time. It is now the average month length the same conversion reports, `DaysInYear / MonthsInYear`,
  which does not drift; the two correction loops still decide the answer, so the estimate only decides how
  long the walk is.
- **`LunisolarAstronomy` keeps a two-tier cache of built years** — a `[ThreadStatic]` most-recent entry,
  which is what makes reading one date's six fields cost one build rather than six, and a shared 256-entry
  direct-mapped table published with `Volatile.Write`/`Volatile.Read`. A `LunisolarYear` is a pure function
  of its year and region, so sharing it is safe and a slot lost to a race costs a rebuild and nothing else.

| `until(..., { largestUnit: 'month' })` | first push | now |
| --- | ---: | ---: |
| `chinese` 2050 → 2300 (250 y) | >15 s on CI | 186 ms |
| `dangi` 2050 → 2300 | >15 s on CI | 62 ms |
| `hebrew` 2050 → 2300 | 22 ms | 3 ms |
| `chinese` 1990 → 1000 (990 y) | 36.3 s | 1.9 s |

What is left is that `add`/`subtract` of months in bulk is still linear in the years crossed for the three
calendars whose years hold a varying number of months, so `add({ months: 3000000 })` is seconds of
uninterruptible work. The six closed-form calendars answer the same query in ~100 ms and always could;
follow-up filed as #3511.

## Failing-test evidence

`Jint.Tests/Runtime/NonIsoCalendarArithmeticRangeTests.cs` against **unfixed `main`**:

```
Failed!  - Failed: 33, Passed: 7, Total: 40

Failed TheReportedHebrewDateAddsAMonthWhereItsYearIsAlreadyAnswered
  d.year is 5260, and d.add({ months: 1 }) is
  "RangeError: Date is outside the range supported by the 'hebrew' calendar"

Failed AMonthAddedPastTheBackingRangeIsAMonthTakenBack                  (all 7 dates)
Failed AYearAddedPastTheBackingRangeKeepsTheMonthCode                   (all 7 dates)
Failed TheMonthDifferencePastTheBackingRangeIsTheMonthsThatWereAdded    (all 7 dates)
Failed TheDateAMonthAddedLandsOnIsTheDateItsOwnFieldsBuild              (all 7 dates)
    hebrew below its 1583 floor / above its 2239 ceiling, persian below its 622 floor,
    chinese below 1901 / above 2101, dangi below 918 / above 2051

Failed EveryCalendarThatReportsAYearAlsoAddsToIt("chinese")  ("dangi", "hebrew", "persian")
  — the other seven calendars pass on main and after: they never had a table to run out of
```

On `main`, for the dates whose fields it answers:

```
hebrew  1500-06-15  .year       5260    .add({ months: 1 })  RangeError
chinese 1800-01-01  .monthCode  "M12"   .add({ months: 1 })  RangeError
persian 0500-06-15  .year       -121    .add({ years: 1 })   RangeError
dangi   0800-01-01                      .add({ months: 1 })  RangeError
```

## The pinned refusals this deliberately updates

`NonIsoCalendarRangeTests` pinned the #3452 behaviour, so 15 of its cases now assert the answer instead of
the refusal — which the issue names as the deliberate change. What that file is *for* has not moved: the
dedicated thread, the join timeout, the sweep over every difference surface that walks months, and the
`largestUnit`-by-`op` matrix all stay, and each case now also asserts that `a.add(a.until(b))` is `b` and
`a.subtract(a.since(b))` is `b` — a walk that stops in the right place, not merely one that stops.

`ArithmeticInsideEveryCalendarRangeIsUnchanged` passes on `main` and after: nothing inside a table moves.

## Testing

- `dotnet build -c Release` on the solution — clean, bar the one pre-existing `MSB3277` in
  `Jint.Tests.CommonScripts` on `net472`.
- `Jint.Tests` — **net472 7,707 / net8.0 11,086 / net10.0 11,087 passed**; the one `net8.0` failure was
  `Wpt.RunsTheFetchRedirectSuite`, unrelated to calendars, and passes in isolation.
- `Jint.Tests.PublicInterface` — net472 2,679 / net8.0 3,302 / net10.0 3,312 passed, 0 failed.
- `Jint.Tests.CommonScripts` 28 on each of two TFMs, `Jint.Tests.SourceGenerators` 71 — 0 failed.
- `Jint.Tests.Test262` — **102,521 passed, 165 skipped**, plus the two `staging/sm/Array/toSpliced-dense`
  30-second timeouts that are the known under-load flake and pass in isolation (182 passed, 0 failed).
  102,521 + 2 = 102,523, which is the control on this base measured with nothing applied.

Migration guide: §4.70, and §4.50's "arithmetic past a table's end still refuses" bullet now points at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014W5mbjGhyvgAS4pivXoc4S
