### PR TITLE
Intl.NumberFormat: formatToParts and formatRangeToParts read the value format reads

### DIFF
--- a/Jint.Tests/Runtime/IntlNumberFormatPartsTests.cs
+++ b/Jint.Tests/Runtime/IntlNumberFormatPartsTests.cs
@@ -52,7 +52,10 @@ public class IntlNumberFormatPartsTests
     ];
 
     private const string Values =
-        "[0, 1, -1, 0.5, 1234.5, -1234.5, 1234567.891, 12345678901234, NaN, Infinity, -Infinity]";
+        "[0, 1, -1, 0.5, 1234.5, -1234.5, 1234567.891, 12345678901234, NaN, Infinity, -Infinity, "
+        // values ToIntlMathematicalValue reads exactly, which no double holds: a BigInt, an integer
+        // string past 2^53, and a decimal string with more significant digits than a double carries
+        + "987654321987654321n, -987654321987654321n, '987654321987654321', '1.00000000000000012']";
 
     /// <summary>
     /// The defect: <c>format</c> transliterated and <c>formatToParts</c> did not, so
@@ -124,7 +127,10 @@ public class IntlNumberFormatPartsTests
                 var optionSets = [{}, { minimumFractionDigits: 2 }, { style: 'percent' },
                                   { style: 'unit', unit: 'meter' }, { notation: 'compact' },
                                   { style: 'currency', currency: 'USD' }];
-                var pairs = [[1, 5], [3, 3], [-5, -1], [0, 1000000], [1234.5, 2345.6]];
+                var pairs = [[1, 5], [3, 3], [-5, -1], [0, 1000000], [1234.5, 2345.6],
+                             // two ends a double cannot tell apart, which formatRange keeps apart
+                             ['987654321987654321', '987654321987654322'],
+                             [987654321987654321n, 987654321987654322n]];
                 function join(parts) { return parts.map(function (p) { return p.value; }).join(''); }
                 for (var l = 0; l < locales.length; l++) {
                     for (var o = 0; o < optionSets.length; o++) {
@@ -263,6 +269,59 @@ public class IntlNumberFormatPartsTests
         Join(Wide, "2.9").Should().Be("$2.900");
         Format(Wide, "2.98765").Should().Be("$2.9877");
         Join(Wide, "2.98765").Should().Be("$2.9877");
+    }
+
+    /// <summary>
+    /// https://tc39.es/ecma402/#sec-intl.numberformat.prototype.formattoparts reads its argument with
+    /// https://tc39.es/ecma402/#sec-tointlmathematicalvalue, not with <c>ToNumber</c>. It took a
+    /// <c>double</c>, so a BigInt did not convert at all.
+    /// </summary>
+    [Test]
+    public void ABigIntIsAValueBothLanesCanRead()
+    {
+        const string Plain = "new Intl.NumberFormat('en')";
+        Format(Plain, "1n").Should().Be("1");
+        Join(Plain, "1n").Should().Be("1");
+        Parts(Plain, "1n").Should().Be("""[{"type":"integer","value":"1"}]""");
+
+        // a value no double holds, so the two lanes can only agree by reading the same one
+        Format(Plain, "987654321987654321n").Should().Be("987,654,321,987,654,321");
+        Join(Plain, "987654321987654321n").Should().Be("987,654,321,987,654,321");
+        Format(Plain, "'987654321987654321'").Should().Be("987,654,321,987,654,321");
+        Join(Plain, "'987654321987654321'").Should().Be("987,654,321,987,654,321");
+
+        Join("new Intl.NumberFormat('en', { style: 'currency', currency: 'USD' })", "987654321987654321n")
+            .Should().Be("$987,654,321,987,654,321.00");
+        Join("new Intl.NumberFormat('en', { numberingSystem: 'arab' })", "987654321987654321n")
+            .Should().Be("٩٨٧,٦٥٤,٣٢١,٩٨٧,٦٥٤,٣٢١");
+    }
+
+    /// <summary>
+    /// https://tc39.es/ecma402/#sec-formatnumericrange and
+    /// https://tc39.es/ecma402/#sec-formatnumericrangetoparts are the same
+    /// https://tc39.es/ecma402/#sec-partitionnumberrangepattern over the same two Intl mathematical
+    /// values, so the lanes cannot disagree about the digits — nor about whether the range is a range,
+    /// which that algorithm decides by comparing the two ends formatted.
+    /// </summary>
+    [Test]
+    public void ARangeOfExactValuesIsARangeInBothLanes()
+    {
+        const string Nf = "new Intl.NumberFormat('en')";
+        const string Expected = "987,654,321,987,654,321–987,654,321,987,654,322";
+
+        Range(Nf, "'987654321987654321'", "'987654321987654322'").Should().Be(Expected);
+        JoinRange(Nf, "'987654321987654321'", "'987654321987654322'").Should().Be(Expected);
+
+        Range(Nf, "987654321987654321n", "987654321987654322n").Should().Be(Expected);
+        JoinRange(Nf, "987654321987654321n", "987654321987654322n").Should().Be(Expected);
+
+        // the two ends round to the same double, so reading them as doubles collapsed the range
+        _engine.Evaluate(
+            $"{Nf}.formatRangeToParts('987654321987654321', '987654321987654322').map(function (p) {{ return p.type; }})[0]")
+            .AsString().Should().NotBe("approximatelySign");
+
+        // two ends that really are one value still collapse
+        JoinRange(Nf, "'987654321987654321'", "'987654321987654321'").Should().Be("~987,654,321,987,654,321");
     }
 
     /// <summary>
@@ -581,6 +640,14 @@ public class IntlNumberFormatPartsTests
 
     private string Parts(string formatter, string value)
         => _engine.Evaluate($"JSON.stringify({formatter}.formatToParts({value}))").AsString();
+
+    private string Range(string formatter, string start, string end)
+        => _engine.Evaluate($"{formatter}.formatRange({start}, {end})").AsString();
+
+    private string JoinRange(string formatter, string start, string end)
+        => _engine.Evaluate(
+            $"{formatter}.formatRangeToParts({start}, {end}).map(function (p) {{ return p.value; }}).join('')")
+            .AsString();
 
     private string PartValue(string formatter, string value, string type)
         => _engine.Evaluate(

--- a/Jint/Native/Intl/Data/NumberingSystemData.cs
+++ b/Jint/Native/Intl/Data/NumberingSystemData.cs
@@ -39,17 +39,6 @@ internal readonly record struct ResolvedNumberingSystem(string Name, string? Dig
     public bool RewritesDecimalSeparator => DecimalSeparator != '.';
 
     /// <summary>
-    /// True when this character is one a number of this system is written with.
-    /// </summary>
-    /// <remarks>
-    /// <see cref="char.IsDigit(char)"/> alone is not that question: it answers the Unicode Nd category, and
-    /// <c>hanidec</c>'s zero is U+3007 IDEOGRAPHIC NUMBER ZERO, which is not in it — while
-    /// <c>mathbold</c>'s ten are astral, so each of them reaches this as a surrogate half.
-    /// </remarks>
-    public bool IsDigitCharacter(char c)
-        => char.IsDigit(c) || (Digits is not null && Digits.Contains(c));
-
-    /// <summary>
     /// Rewrites the ASCII digits and the decimal point of an already-formatted string in this system.
     /// </summary>
     public string Transliterate(string input) => NumberingSystemData.TransliterateDigits(input, Digits, '.', DecimalSeparator);

--- a/Jint/Native/Intl/JsNumberFormat.cs
+++ b/Jint/Native/Intl/JsNumberFormat.cs
@@ -10,6 +10,57 @@ namespace Jint.Native.Intl;
 internal readonly record struct NumberFormatPart(string Type, string Value);
 
 /// <summary>
+/// A value https://tc39.es/ecma402/#sec-tointlmathematicalvalue read, which is a mathematical value and
+/// not a <see cref="double"/> — so a BigInt and a decimal string keep every digit they were written with.
+/// </summary>
+/// <remarks>
+/// Both lanes take one of these. https://tc39.es/ecma402/#sec-formatnumber and
+/// https://tc39.es/ecma402/#sec-formatnumbertoparts are the same
+/// https://tc39.es/ecma402/#sec-partitionnumberpattern over the same argument, so a value one of them reads
+/// exactly is a value the other reads exactly; <see cref="Number"/> is what both fall back to, together,
+/// for a formatter with no exact lane for it.
+/// </remarks>
+[System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Auto)]
+internal readonly record struct IntlMathematicalValue
+{
+    private IntlMathematicalValue(double number, BigInteger mantissa, int fractionDigits, bool isExact)
+    {
+        Number = number;
+        Mantissa = mantissa;
+        FractionDigits = fractionDigits;
+        IsExact = isExact;
+    }
+
+    /// <summary>A value that is only ever a double — everything ToNumber was enough for.</summary>
+    internal static IntlMathematicalValue Of(double number) => new(number, BigInteger.Zero, 0, isExact: false);
+
+    /// <summary>A value read exactly, as <paramref name="mantissa"/> × 10^-<paramref name="fractionDigits"/>.</summary>
+    internal static IntlMathematicalValue Exact(BigInteger mantissa, int fractionDigits)
+        => new(ToDouble(mantissa, fractionDigits), mantissa, fractionDigits, isExact: true);
+
+    internal bool IsExact { get; }
+
+    /// <summary>The double this value rounds to, which is what a lane with no exact route for it writes.</summary>
+    internal double Number { get; }
+
+    internal BigInteger Mantissa { get; }
+
+    internal int FractionDigits { get; }
+
+    private static double ToDouble(BigInteger mantissa, int fractionDigits)
+    {
+        if (fractionDigits <= 0)
+        {
+            return (double) mantissa;
+        }
+
+        // Math.Pow(10, n) keeps any compounded rounding to a single division step, instead of
+        // accumulating it across `fractionDigits` separate divides.
+        return (double) mantissa / System.Math.Pow(10, fractionDigits);
+    }
+}
+
+/// <summary>
 /// https://tc39.es/ecma402/#sec-numberformat-objects
 /// Represents an Intl.NumberFormat instance with locale-aware number formatting.
 /// </summary>
@@ -76,9 +127,6 @@ internal sealed class JsNumberFormat : ObjectInstance
 
     internal string Locale { get; }
     internal string NumberingSystem => _numberingSystem.Name;
-
-    /// <summary>The resolved system itself, for a caller that has to read an already-formatted string back.</summary>
-    internal Data.ResolvedNumberingSystem ResolvedNumberingSystem => _numberingSystem;
 
     internal string Style { get; }
     internal string? Currency { get; }
@@ -892,31 +940,99 @@ internal sealed class JsNumberFormat : ObjectInstance
     }
 
     /// <summary>
-    /// Formats an exact decimal value (mantissa × 10^-fractionDigits) preserving precision
-    /// beyond what an IEEE-754 double can represent. Currently routes through the decimal
-    /// style only — currency / percent / unit / compact / engineering / scientific notations
-    /// still go through the double-based pipeline. Significant-digits rounding falls back to
-    /// <see cref="Format(BigInteger)"/> after rounding away the fraction.
+    /// https://tc39.es/ecma402/#sec-formatnumber, for a value read as a mathematical value rather than a
+    /// double: the concatenation of exactly the parts <see cref="FormatToParts(in IntlMathematicalValue)"/>
+    /// returns.
     /// </summary>
-    internal string FormatExactDecimal(BigInteger mantissa, int fractionDigits)
+    internal string Format(in IntlMathematicalValue value)
     {
-        // If the formatter uses any of the styles that require scaling or compact notation,
-        // we don't yet have an exact-decimal pipeline — fall back to double.
-        if (Style is "currency" or "percent" or "unit"
-            || !string.Equals(Notation, "standard", StringComparison.Ordinal))
+        if (!CanPartitionExactly(in value))
         {
-            return Format(MantissaToDouble(mantissa, fractionDigits));
+            return Format(value.Number);
         }
 
-        // Significant-digits rounding effectively discards trailing fraction digits beyond
-        // the kept precision. The BigInteger ApplySignificantDigitRounding path only handles
-        // integer-only mantissas, so when sig-digits combine with a non-zero fractionDigits
-        // we fall back to the double pipeline rather than build a richer carrier here.
-        if (MinimumSignificantDigits.HasValue || MaximumSignificantDigits.HasValue)
+        return ConcatenateParts(FormatToParts(in value));
+    }
+
+    /// <summary>
+    /// https://tc39.es/ecma402/#sec-formatnumbertoparts, for a value read as a mathematical value rather
+    /// than a double.
+    /// </summary>
+    internal List<NumberFormatPart> FormatToParts(in IntlMathematicalValue value)
+    {
+        if (!CanPartitionExactly(in value))
         {
-            return Format(MantissaToDouble(mantissa, fractionDigits));
+            return FormatToParts(value.Number);
         }
 
+        return TransliterateParts(PartitionExact(value.Mantissa, value.FractionDigits));
+    }
+
+    /// <summary>
+    /// Whether this formatter has a lane that writes <paramref name="value"/> without rounding it to a
+    /// double first. One answer, read by both lanes, so neither can format a value the other approximated.
+    /// </summary>
+    /// <remarks>
+    /// The exact lane covers a plain decimal number in every configuration, and the three scaled styles
+    /// only for a whole one: scaling a fraction, a notation's mantissa, and significant-digit rounding of a
+    /// fraction each need arithmetic the exact carrier does not do yet, and take the double.
+    /// </remarks>
+    private bool CanPartitionExactly(in IntlMathematicalValue value)
+    {
+        if (!value.IsExact)
+        {
+            return false;
+        }
+
+        var significantDigits = MinimumSignificantDigits.HasValue || MaximumSignificantDigits.HasValue;
+        var scaledStyle = Style is "currency" or "percent" or "unit";
+
+        if (value.FractionDigits > 0)
+        {
+            return !scaledStyle
+                && !significantDigits
+                && string.Equals(Notation, "standard", StringComparison.Ordinal);
+        }
+
+        return !significantDigits || !scaledStyle;
+    }
+
+    /// <summary>
+    /// https://tc39.es/ecma402/#sec-partitionnumberpattern over an exact
+    /// mantissa × 10^-<paramref name="fractionDigits"/>.
+    /// </summary>
+    private List<NumberFormatPart> PartitionExact(BigInteger mantissa, int fractionDigits)
+    {
+        if (fractionDigits > 0)
+        {
+            return ExactDecimalParts(mantissa, fractionDigits);
+        }
+
+        // Significant-digit rounding of a whole value is exact, so it stays on this lane.
+        var significantDigits = (MinimumSignificantDigits.HasValue || MaximumSignificantDigits.HasValue)
+            && Style is not ("currency" or "percent" or "unit");
+        if (significantDigits)
+        {
+            mantissa = ApplySignificantDigitRounding(mantissa);
+        }
+
+        return Style switch
+        {
+            "currency" => ExactCurrencyParts(mantissa),
+            "percent" => ExactPercentParts(mantissa),
+            "unit" => ExactUnitParts(mantissa),
+            // the significant-digits lane over a double writes a literal "-" rather than the locale's own
+            // sign, and the two lanes have to agree about which one this is
+            _ => ExactNumberParts(mantissa, useLiteralMinus: significantDigits)
+        };
+    }
+
+    /// <summary>
+    /// The parts of an exact mantissa × 10^-<paramref name="fractionDigits"/> under the decimal style:
+    /// https://tc39.es/ecma402/#sec-torawfixed on a mathematical value instead of on a double.
+    /// </summary>
+    private List<NumberFormatPart> ExactDecimalParts(BigInteger mantissa, int fractionDigits)
+    {
         var maxFrac = MaximumFractionDigits;
         var minFrac = MinimumFractionDigits;
 
@@ -981,68 +1097,119 @@ internal sealed class JsNumberFormat : ObjectInstance
             integerStr = ApplyGrouping(integerStr, false);
         }
 
-        var result = fractionStr.Length == 0
-            ? integerStr
-            : integerStr + NumberFormatInfo.NumberDecimalSeparator + fractionStr;
-
+        var parts = new List<NumberFormatPart>();
         if (originallyNegative)
         {
-            result = NumberFormatInfo.NegativeSign + result;
+            parts.Add(new NumberFormatPart("minusSign", NumberFormatInfo.NegativeSign));
         }
 
-        return Transliterate(result);
+        AddGroupedIntegerParts(parts, integerStr);
+
+        if (fractionStr.Length > 0)
+        {
+            parts.Add(new NumberFormatPart("decimal", NumberFormatInfo.NumberDecimalSeparator));
+            parts.Add(new NumberFormatPart("fraction", fractionStr));
+        }
+
+        return parts;
+    }
+
+    /// <summary>The parts of an exact whole value under the decimal style.</summary>
+    private List<NumberFormatPart> ExactNumberParts(BigInteger value, bool useLiteralMinus)
+    {
+        var isNegative = value.Sign < 0;
+        var abs = isNegative ? -value : value;
+        var digits = abs.ToString("R", CultureInfo.InvariantCulture);
+
+        if (ShouldApplyGrouping(digits.Length))
+        {
+            digits = ApplyGrouping(digits, false);
+        }
+
+        // Apply minimum integer digits padding
+        if (MinimumIntegerDigits > 1 && digits.Length < MinimumIntegerDigits)
+        {
+            digits = digits.PadLeft(MinimumIntegerDigits, '0');
+        }
+
+        var parts = new List<NumberFormatPart>();
+        if (isNegative)
+        {
+            // ar prefixes U+061C ARABIC LETTER MARK to its NegativeSign, which System.Globalization also
+            // writes for a double; the significant-digits lane writes a plain hyphen instead, so this
+            // follows whichever of the two the double lane would have written.
+            parts.Add(new NumberFormatPart("minusSign", useLiteralMinus ? "-" : NumberFormatInfo.NegativeSign));
+        }
+
+        AddGroupedIntegerParts(parts, digits);
+
+        if (MinimumFractionDigits > 0)
+        {
+            parts.Add(new NumberFormatPart("decimal", NumberFormatInfo.NumberDecimalSeparator));
+            parts.Add(new NumberFormatPart("fraction", new string('0', MinimumFractionDigits)));
+        }
+
+        return parts;
     }
 
     /// <summary>
-    /// Approximate a (mantissa, fractionDigits) decimal as a double for legacy code paths
-    /// that still expect a double. Loses the high-precision tail by definition; only used
-    /// for currency / percent / unit / compact / engineering / scientific styles where the
-    /// exact-decimal path isn't available yet.
+    /// Splits an already-grouped integer string into the <c>integer</c> and <c>group</c> parts
+    /// https://tc39.es/ecma402/#sec-partitionnumberpattern reports for it.
     /// </summary>
-    private static double MantissaToDouble(BigInteger mantissa, int fractionDigits)
+    private void AddGroupedIntegerParts(List<NumberFormatPart> parts, string integerText)
     {
-        if (fractionDigits <= 0)
-            return (double) mantissa;
+        var separator = NumberFormatInfo.NumberGroupSeparator;
+        if (separator.Length == 0 || integerText.IndexOf(separator, StringComparison.Ordinal) < 0)
+        {
+            parts.Add(new NumberFormatPart("integer", integerText));
+            return;
+        }
 
-        // Math.Pow(10, n) keeps any compounded rounding to a single division step, instead of
-        // accumulating it across `fractionDigits` separate divides.
-        return (double) mantissa / System.Math.Pow(10, fractionDigits);
+        var start = 0;
+        while (true)
+        {
+            var next = integerText.IndexOf(separator, start, StringComparison.Ordinal);
+            if (next < 0)
+            {
+                parts.Add(new NumberFormatPart("integer", integerText.Substring(start)));
+                return;
+            }
+
+            parts.Add(new NumberFormatPart("integer", integerText.Substring(start, next - start)));
+            parts.Add(new NumberFormatPart("group", separator));
+            start = next + separator.Length;
+        }
+    }
+
+    private List<NumberFormatPart> ExactCurrencyParts(BigInteger value)
+    {
+        var parts = new List<NumberFormatPart> { new("currency", NumberFormatInfo.CurrencySymbol) };
+        parts.AddRange(ExactNumberParts(value, useLiteralMinus: false));
+        return parts;
+    }
+
+    private List<NumberFormatPart> ExactPercentParts(BigInteger value)
+    {
+        // Percent multiplies by 100
+        var parts = ExactNumberParts(value * 100, useLiteralMinus: false);
+        parts.Add(new NumberFormatPart("percentSign", NumberFormatInfo.PercentSymbol));
+        return parts;
+    }
+
+    private List<NumberFormatPart> ExactUnitParts(BigInteger value)
+    {
+        var parts = new List<NumberFormatPart>();
+        GetUnitAffixes((double) value, out var beforeNumber, out var afterNumber);
+        AddUnitAffixParts(parts, beforeNumber, leading: true);
+        parts.AddRange(ExactNumberParts(value, useLiteralMinus: false));
+        AddUnitAffixParts(parts, afterNumber, leading: false);
+        return parts;
     }
 
     /// <summary>
     /// Formats a BigInteger according to the formatter's locale and options.
     /// </summary>
-    internal string Format(BigInteger value)
-    {
-        // For non-currency/percent/unit styles with significant digits, round the BigInteger
-        // directly so we keep precision for inputs that exceed double's 15-17 digit window.
-        // (Currency/percent/unit involve scaling/rounding paths that still go through double.)
-        var sigDigitsActive = (MinimumSignificantDigits.HasValue || MaximumSignificantDigits.HasValue)
-            && Style is not ("currency" or "percent" or "unit");
-        if (sigDigitsActive)
-        {
-            value = ApplySignificantDigitRounding(value);
-            // After rounding to significant digits, fall through to FormatDecimalBigInt.
-        }
-        else if (MinimumSignificantDigits.HasValue || MaximumSignificantDigits.HasValue)
-        {
-            return Format((double) value);
-        }
-
-        var result = Style switch
-        {
-            "currency" => FormatCurrencyBigInt(value),
-            "percent" => FormatPercentBigInt(value),
-            "unit" => FormatUnitBigInt(value),
-            // Significant-digits formatting in Format(double) uses a literal "-" sign
-            // (no locale-specific RTL marker), so match that to keep both code paths
-            // producing identical output for the same input.
-            _ => FormatDecimalBigInt(value, useLiteralMinus: sigDigitsActive)
-        };
-
-        // Apply numbering system digit transliteration
-        return Transliterate(result);
-    }
+    internal string Format(BigInteger value) => Format(IntlMathematicalValue.Exact(value, 0));
 
     /// <summary>
     /// Rounds a BigInteger so it carries at most <see cref="MaximumSignificantDigits"/>
@@ -1080,39 +1247,6 @@ internal sealed class JsNumberFormat : ObjectInstance
         return isNegative ? -rounded : rounded;
     }
 
-    private string FormatDecimalBigInt(BigInteger value, bool useLiteralMinus = false)
-    {
-        // Format absolute value via invariant culture, then prepend either the locale-aware
-        // NegativeSign (which for ar adds the U+061C ALM marker that System.Globalization
-        // also adds for double formatting) or a literal '-' to mirror the significant-digits
-        // path in Format(double).
-        var isNegative = value.Sign < 0;
-        var abs = isNegative ? -value : value;
-        var digits = abs.ToString("R", CultureInfo.InvariantCulture);
-
-        if (ShouldApplyGrouping(digits.Length))
-        {
-            digits = ApplyGrouping(digits, false);
-        }
-
-        // Apply minimum integer digits padding
-        if (MinimumIntegerDigits > 1 && digits.Length < MinimumIntegerDigits)
-        {
-            digits = digits.PadLeft(MinimumIntegerDigits, '0');
-        }
-
-        var negativeSign = useLiteralMinus ? "-" : NumberFormatInfo.NegativeSign;
-        var formatted = isNegative ? negativeSign + digits : digits;
-
-        // Handle minimumFractionDigits for BigInt (add decimal zeros)
-        if (MinimumFractionDigits > 0)
-        {
-            formatted += NumberFormatInfo.NumberDecimalSeparator + new string('0', MinimumFractionDigits);
-        }
-
-        return formatted;
-    }
-
     private string ApplyGrouping(string number, bool isNegative)
     {
         var startIndex = isNegative ? 1 : 0;
@@ -1143,56 +1277,6 @@ internal sealed class JsNumberFormat : ObjectInstance
         }
 
         return result.ToString();
-    }
-
-    private string FormatCurrencyBigInt(BigInteger value)
-    {
-        // For currency, we need to handle the formatting manually for BigInt
-        var formatted = FormatDecimalBigInt(value);
-        var symbol = NumberFormatInfo.CurrencySymbol;
-        return symbol + formatted;
-    }
-
-    private string FormatPercentBigInt(BigInteger value)
-    {
-        // Percent multiplies by 100
-        var percentValue = value * 100;
-        return FormatDecimalBigInt(percentValue) + NumberFormatInfo.PercentSymbol;
-    }
-
-    private string FormatUnitBigInt(BigInteger value)
-    {
-        var formattedNumber = FormatDecimalBigInt(value);
-        var unitDisplay = UnitDisplay ?? "short";
-        var unitStr = Unit ?? "";
-
-        // Try to get unit patterns from CLDR provider
-        var unitPatterns = CldrProvider.GetUnitPatterns(Locale, unitStr, unitDisplay);
-        if (unitPatterns != null)
-        {
-            // Use the CLDR pattern - it already contains spacing information
-            // Select singular or plural pattern based on the absolute value
-            var isSingular = BigInteger.Abs(value) == BigInteger.One;
-            var pattern = isSingular ? (unitPatterns.One ?? unitPatterns.Other) : unitPatterns.Other;
-            return pattern.Replace("{0}", formattedNumber);
-        }
-
-        // Fallback to legacy behavior if no CLDR pattern found
-        var unitSuffix = GetUnitSuffix(unitStr, unitDisplay, (double) value);
-
-        // Determine if we need a space before the unit
-        // Narrow display never has space; percent/degree units don't have space
-        var needsSpace = !string.Equals(unitDisplay, "narrow", StringComparison.Ordinal) &&
-                        !string.Equals(unitStr, "percent", StringComparison.Ordinal) &&
-                        !string.Equals(unitStr, "celsius", StringComparison.Ordinal) &&
-                        !string.Equals(unitStr, "fahrenheit", StringComparison.Ordinal);
-
-        if (needsSpace)
-        {
-            return $"{formattedNumber} {unitSuffix}";
-        }
-
-        return $"{formattedNumber}{unitSuffix}";
     }
 
     private string FormatDecimal(double value)
@@ -2271,20 +2355,26 @@ internal sealed class JsNumberFormat : ObjectInstance
     /// of locales, numbering systems and styles and asserts the two agree, rather than assuming it.
     /// </para>
     /// </remarks>
-    internal List<NumberFormatPart> FormatToParts(double value)
-    {
-        var parts = FormatToPartsCore(value);
+    internal List<NumberFormatPart> FormatToParts(double value) => TransliterateParts(FormatToPartsCore(value));
 
-        if (_numberingSystem.RewritesDigits)
+    /// <summary>
+    /// Rewrites every part that carries the number itself in <c>[[NumberingSystem]]</c>, leaving the
+    /// pattern text alone.
+    /// </summary>
+    private List<NumberFormatPart> TransliterateParts(List<NumberFormatPart> parts)
+    {
+        if (!_numberingSystem.RewritesDigits)
         {
-            for (var i = 0; i < parts.Count; i++)
+            return parts;
+        }
+
+        for (var i = 0; i < parts.Count; i++)
+        {
+            var part = parts[i];
+            var transliterated = TransliterateNumericPart(part.Type, part.Value);
+            if (!ReferenceEquals(transliterated, part.Value))
             {
-                var part = parts[i];
-                var transliterated = TransliterateNumericPart(part.Type, part.Value);
-                if (!ReferenceEquals(transliterated, part.Value))
-                {
-                    parts[i] = new NumberFormatPart(part.Type, transliterated);
-                }
+                parts[i] = new NumberFormatPart(part.Type, transliterated);
             }
         }
 
@@ -3186,11 +3276,21 @@ internal sealed class JsNumberFormat : ObjectInstance
         bool showPositiveSign,
         double value)
     {
+        GetUnitAffixes(value, out var beforeNumber, out var afterNumber);
+
+        AddUnitAffixParts(parts, beforeNumber, leading: true);
+        AppendSignPart(parts, showNegativeSign, showPositiveSign);
+        AddNumberParts(parts, in body);
+        AddUnitAffixParts(parts, afterNumber, leading: false);
+    }
+
+    /// <summary>
+    /// The two sides of the CLDR unit pattern this formatter writes around a number of the given size.
+    /// </summary>
+    private void GetUnitAffixes(double value, out string beforeNumber, out string afterNumber)
+    {
         var unitDisplay = UnitDisplay ?? "short";
         var unitStr = Unit ?? "";
-
-        string beforeNumber;
-        string afterNumber;
 
         // Try to get unit patterns from CLDR provider
         var unitPatterns = CldrProvider.GetUnitPatterns(Locale, unitStr, unitDisplay);
@@ -3204,25 +3304,19 @@ internal sealed class JsNumberFormat : ObjectInstance
 
             beforeNumber = placeholderIndex >= 0 ? pattern.Substring(0, placeholderIndex) : "";
             afterNumber = placeholderIndex >= 0 ? pattern.Substring(placeholderIndex + 3) : "";
-        }
-        else
-        {
-            // Fallback to legacy behavior, which only ever writes a suffix
-            beforeNumber = "";
-
-            // Narrow display never has space; percent/degree units don't have space
-            var needsSpace = !string.Equals(unitDisplay, "narrow", StringComparison.Ordinal) &&
-                            !string.Equals(unitStr, "percent", StringComparison.Ordinal) &&
-                            !string.Equals(unitStr, "celsius", StringComparison.Ordinal) &&
-                            !string.Equals(unitStr, "fahrenheit", StringComparison.Ordinal);
-
-            afterNumber = (needsSpace ? " " : "") + GetUnitSuffix(unitStr, unitDisplay, value);
+            return;
         }
 
-        AddUnitAffixParts(parts, beforeNumber, leading: true);
-        AppendSignPart(parts, showNegativeSign, showPositiveSign);
-        AddNumberParts(parts, in body);
-        AddUnitAffixParts(parts, afterNumber, leading: false);
+        // Fallback to legacy behavior, which only ever writes a suffix
+        beforeNumber = "";
+
+        // Narrow display never has space; percent/degree units don't have space
+        var needsSpace = !string.Equals(unitDisplay, "narrow", StringComparison.Ordinal) &&
+                        !string.Equals(unitStr, "percent", StringComparison.Ordinal) &&
+                        !string.Equals(unitStr, "celsius", StringComparison.Ordinal) &&
+                        !string.Equals(unitStr, "fahrenheit", StringComparison.Ordinal);
+
+        afterNumber = (needsSpace ? " " : "") + GetUnitSuffix(unitStr, unitDisplay, value);
     }
 
     /// <summary>

--- a/Jint/Native/Intl/NumberFormatPrototype.cs
+++ b/Jint/Native/Intl/NumberFormatPrototype.cs
@@ -65,41 +65,65 @@ internal sealed partial class NumberFormatPrototype : Prototype
 
         // Return a bound format function
         return new ClrFunction(Engine, "", (_, args) =>
+            numberFormat.Format(ToIntlMathematicalValue(args.At(0))), 1, PropertyFlag.Configurable);
+    }
+
+    /// <summary>
+    /// https://tc39.es/ecma402/#sec-tointlmathematicalvalue, which is what all four of
+    /// <c>format</c>, <c>formatToParts</c>, <c>formatRange</c> and <c>formatRangeToParts</c> read their
+    /// arguments with.
+    /// </summary>
+    /// <remarks>
+    /// It is <em>not</em> <c>ToNumber</c>: a BigInt and a decimal string carry more digits than a
+    /// <see cref="double"/> holds, and the specification keeps them, so that a value one lane writes
+    /// exactly is a value the other lane writes exactly.
+    /// </remarks>
+    private static IntlMathematicalValue ToIntlMathematicalValue(JsValue value)
+    {
+        if (value is JsBigInt bigInt)
         {
-            var value = args.At(0);
+            return IntlMathematicalValue.Exact(bigInt._value, 0);
+        }
 
-            // Handle BigInt values separately to preserve precision
-            if (value is JsBigInt bigInt)
+        if (value is BigIntInstance bigIntInstance)
+        {
+            return IntlMathematicalValue.Exact(bigIntInstance.BigIntData._value, 0);
+        }
+
+        // When a string represents an integer that exceeds Number.MAX_SAFE_INTEGER precision, route
+        // through the BigInteger path so significant digits are preserved exactly.
+        if (value is JsString jsStr)
+        {
+            var s = jsStr.ToString();
+            if (TryParseLargeInteger(s, out var bigValue))
             {
-                return numberFormat.Format(bigInt._value);
+                return IntlMathematicalValue.Exact(bigValue, 0);
             }
-
-            if (value is BigIntInstance bigIntInstance)
+            // Fractional decimal strings whose precision exceeds what double can represent
+            // (16+ significant digits): carry the (mantissa, fractionDigits) pair instead, so no
+            // trailing digit is lost to TypeConverter.ToNumber.
+            if (TryParseHighPrecisionDecimal(s, out var mantissa, out var fractionDigits))
             {
-                return numberFormat.Format(bigIntInstance.BigIntData._value);
+                return IntlMathematicalValue.Exact(mantissa, fractionDigits);
             }
+        }
 
-            // Per ECMA-402 ToIntlMathematicalValue: when a string represents an integer that
-            // exceeds Number.MAX_SAFE_INTEGER precision, route through the BigInteger path so
-            // significant digits are preserved exactly.
-            if (value is JsString jsStr)
-            {
-                var s = jsStr.ToString();
-                if (TryParseLargeInteger(s, out var bigValue))
-                {
-                    return numberFormat.Format(bigValue);
-                }
-                // Fractional decimal strings whose precision exceeds what double can represent
-                // (16+ significant digits): format directly from the (mantissa, fractionDigits)
-                // pair to avoid losing trailing digits via TypeConverter.ToNumber.
-                if (TryParseHighPrecisionDecimal(s, out var mantissa, out var fractionDigits))
-                {
-                    return numberFormat.FormatExactDecimal(mantissa, fractionDigits);
-                }
-            }
+        return IntlMathematicalValue.Of(TypeConverter.ToNumber(value));
+    }
 
-            return numberFormat.Format(TypeConverter.ToNumber(value));
-        }, 1, PropertyFlag.Configurable);
+    /// <summary>
+    /// One end of a range, which https://tc39.es/ecma402/#sec-partitionnumberrangepattern refuses to
+    /// partition when it is not-a-number.
+    /// </summary>
+    private IntlMathematicalValue ToRangeValue(JsValue value)
+    {
+        var converted = ToIntlMathematicalValue(value);
+        if (!converted.IsExact && double.IsNaN(converted.Number))
+        {
+            Throw.RangeError(_realm, "Invalid number value");
+        }
+
+        return converted;
     }
 
     /// <summary>
@@ -271,18 +295,7 @@ internal sealed partial class NumberFormatPrototype : Prototype
     {
         var numberFormat = ValidateNumberFormat(thisObject);
 
-        double number;
-        if (value.IsUndefined())
-        {
-            number = double.NaN;
-        }
-        else
-        {
-            number = TypeConverter.ToNumber(value);
-        }
-
-        // Get parts from the number format
-        var parts = numberFormat.FormatToParts(number);
+        var parts = numberFormat.FormatToParts(ToIntlMathematicalValue(value));
 
         // Convert to JsArray of objects
         var result = new JsArray(Engine, (uint) parts.Count);
@@ -311,53 +324,15 @@ internal sealed partial class NumberFormatPrototype : Prototype
             Throw.TypeError(_realm, "start and end are required");
         }
 
-        var startFormatted = FormatRangeOperand(numberFormat, start);
-        var endFormatted = FormatRangeOperand(numberFormat, end);
+        var parts = PartitionNumberRangePattern(numberFormat, ToRangeValue(start), ToRangeValue(end));
 
-        // If the numbers are the same when formatted, return with approximately sign
-        if (string.Equals(startFormatted, endFormatted, StringComparison.Ordinal))
+        var result = new System.Text.StringBuilder();
+        foreach (var part in parts)
         {
-            // Add approximately sign prefix
-            return $"~{startFormatted}";
+            result.Append(part.Value);
         }
 
-        return CollapseFormattedRange(numberFormat, startFormatted, endFormatted);
-    }
-
-    /// <summary>
-    /// Formats a single end of a range, preserving precision for high-precision string inputs.
-    /// </summary>
-    private string FormatRangeOperand(JsNumberFormat numberFormat, JsValue value)
-    {
-        if (value is JsBigInt bigInt)
-        {
-            return numberFormat.Format(bigInt._value);
-        }
-
-        if (value is BigIntInstance bigIntInstance)
-        {
-            return numberFormat.Format(bigIntInstance.BigIntData._value);
-        }
-
-        if (value is JsString jsStr)
-        {
-            var s = jsStr.ToString();
-            if (TryParseLargeInteger(s, out var bigValue))
-            {
-                return numberFormat.Format(bigValue);
-            }
-            if (TryParseHighPrecisionDecimal(s, out var mantissa, out var fractionDigits))
-            {
-                return numberFormat.FormatExactDecimal(mantissa, fractionDigits);
-            }
-        }
-
-        var number = TypeConverter.ToNumber(value);
-        if (double.IsNaN(number))
-        {
-            Throw.RangeError(_realm, "Invalid number value");
-        }
-        return numberFormat.Format(number);
+        return result.ToString();
     }
 
     /// <summary>One part of a formatted range: what https://tc39.es/ecma402/#sec-formatnumericrangetoparts reports.</summary>
@@ -375,18 +350,20 @@ internal sealed partial class NumberFormatPrototype : Prototype
     /// elides is elided in the parts as well. This is where <c>formatRangeToParts</c> gets it.
     /// </para>
     /// <para>
-    /// <c>formatRange</c> does not come through here, and the reason is precision rather than principle:
-    /// <see cref="JsNumberFormat.FormatToParts"/> takes a <see cref="double"/>, while
-    /// <see cref="FormatRangeOperand"/> keeps a BigInt and a long decimal string exact — test262's
-    /// <c>formatRange/en-US.js</c> asserts a range of two 18-digit integers that differ in their last digit.
-    /// So the same two shapes are stated twice, here and in <see cref="CollapseFormattedRange"/>, and
-    /// <c>IntlNumberFormatPartsTests.RangePartsConcatenateToFormatRange</c> is what holds them together.
+    /// <c>formatRange</c> is the concatenation of what this returns, which is what
+    /// https://tc39.es/ecma402/#sec-formatnumericrange says it is. It used to collapse a second time, on
+    /// its own two already-formatted strings, because this partition took a <see cref="double"/> and could
+    /// not carry the 18-digit range test262's <c>formatRange/en-US.js</c> asserts; it takes an
+    /// <see cref="IntlMathematicalValue"/> now, so there is one collapse and one place it is decided.
     /// </para>
     /// </remarks>
-    private static List<RangePart> PartitionNumberRangePattern(JsNumberFormat numberFormat, double x, double y)
+    private static List<RangePart> PartitionNumberRangePattern(
+        JsNumberFormat numberFormat,
+        in IntlMathematicalValue x,
+        in IntlMathematicalValue y)
     {
-        var startParts = numberFormat.FormatToParts(x);
-        var endParts = numberFormat.FormatToParts(y);
+        var startParts = numberFormat.FormatToParts(in x);
+        var endParts = numberFormat.FormatToParts(in y);
 
         var result = new List<RangePart>(startParts.Count + endParts.Count + 1);
 
@@ -423,9 +400,8 @@ internal sealed partial class NumberFormatPrototype : Prototype
     private readonly record struct RangeCollapsePlan(int DropFromStartTail, int DropFromEndHead, string Separator);
 
     /// <summary>
-    /// https://tc39.es/ecma402/#sec-collapsenumberrange, on the parts rather than on the string: the two
-    /// ICU range-pattern shapes <see cref="CollapseFormattedRange"/> implements, expressed as "these
-    /// endpoint parts are redundant".
+    /// https://tc39.es/ecma402/#sec-collapsenumberrange, expressed as "these endpoint parts are
+    /// redundant". Both lanes read it, because both lanes read the partition it is the last step of.
     /// </summary>
     /// <remarks>
     /// <para>
@@ -530,101 +506,6 @@ internal sealed partial class NumberFormatPrototype : Prototype
         return false;
     }
 
-    /// <summary>
-    /// Joins two formatted range endpoints using ECMA-402 / ICU-style range patterns — the string lane's
-    /// half of https://tc39.es/ecma402/#sec-collapsenumberrange.
-    /// </summary>
-    /// <remarks>
-    /// <see cref="PlanRangeCollapse"/> states the same two shapes on parts, and
-    /// <c>IntlNumberFormatPartsTests.RangePartsConcatenateToFormatRange</c> is what keeps the two honest.
-    /// Every string this lane writes is exercised by test262's <c>formatRange/en-US.js</c> and
-    /// <c>formatRange/pt-PT.js</c>.
-    /// <para>Supports:</para>
-    /// <para>— A locale-specific separator (e.g. en uses en-dash `–`, pt uses ASCII hyphen `-`).</para>
-    /// <para>— Suffix collapse for locales whose currency follows the number (pt-PT etc.) —
-    ///   shared trailing currency moves to the end of the range, separator gets spaces.</para>
-    /// <para>— Sign+currency prefix collapse (signDisplay=always with prefix-currency locales) —
-    ///   duplicate sign+currency dropped from end, tight separator.</para>
-    /// </remarks>
-    private static string CollapseFormattedRange(JsNumberFormat numberFormat, string startFormatted, string endFormatted)
-    {
-        var isCurrencyStyle = string.Equals(numberFormat.Style, "currency", StringComparison.Ordinal);
-        string sepTight, sepLoose;
-        GetRangeSeparators(numberFormat.Locale, out sepTight, out sepLoose);
-
-        // Find longest common suffix. When the locale puts currency after the number,
-        // the suffix typically contains the currency symbol (often preceded by NBSP).
-        // Stop as soon as we hit a digit so we don't gobble part of the number itself
-        // when both ends happen to share trailing digits (e.g. "+2,90 €" / "+3,10 €").
-        // "A digit" is [[NumberingSystem]]'s question, not char.IsDigit's: hanidec's zero is U+3007, which
-        // is not in the Nd category at all, so scanning past it turned "-$五.〇〇–一.〇〇" into "-$五–一.〇〇".
-        var numberingSystem = numberFormat.ResolvedNumberingSystem;
-        var suffixLen = 0;
-        var maxSuffix = System.Math.Min(startFormatted.Length, endFormatted.Length);
-        while (suffixLen < maxSuffix)
-        {
-            var ch = startFormatted[startFormatted.Length - 1 - suffixLen];
-            if (ch != endFormatted[endFormatted.Length - 1 - suffixLen]) break;
-            if (numberingSystem.IsDigitCharacter(ch)) break;
-            suffixLen++;
-        }
-
-        // Find longest common prefix (but stop at the suffix boundary), and stop at a digit for the same
-        // reason the suffix scan does: what is shared here is the sign and the symbol, never part of the
-        // number. Reading two ends' digits as shared text is how "-$𝟓.𝟎𝟎–𝟏.𝟎𝟎" lost the high half of a
-        // mathbold digit, both ends of which begin with the same surrogate.
-        var prefixLen = 0;
-        var maxPrefix = System.Math.Min(startFormatted.Length - suffixLen, endFormatted.Length - suffixLen);
-        while (prefixLen < maxPrefix
-               && startFormatted[prefixLen] == endFormatted[prefixLen]
-               && !numberingSystem.IsDigitCharacter(startFormatted[prefixLen]))
-        {
-            prefixLen++;
-        }
-
-        if (isCurrencyStyle)
-        {
-            var prefix = startFormatted.Substring(0, prefixLen);
-            var suffix = startFormatted.Substring(startFormatted.Length - suffixLen);
-            var prefixHasSign = ContainsSign(prefix);
-            var prefixHasCurrency = ContainsCurrencyChar(prefix);
-            var suffixHasCurrency = ContainsCurrencyChar(suffix);
-
-            // Prefix-currency locales (en-US) with shared sign+currency up front: tight separator,
-            // collapse the duplicate sign+currency from the end.
-            if (prefixHasSign && prefixHasCurrency)
-            {
-                var startTail = startFormatted.Substring(prefixLen, startFormatted.Length - prefixLen - suffixLen);
-                var endTail = endFormatted.Substring(prefixLen, endFormatted.Length - prefixLen - suffixLen);
-                return prefix + startTail + sepTight + endTail + suffix;
-            }
-
-            // Suffix-currency locales (pt-PT) with shared trailing currency: collapse to one
-            // currency at the end, with the loose separator. If the prefix also contains a
-            // shared sign, drop it from the end too.
-            if (suffixHasCurrency)
-            {
-                var startCore = startFormatted.Substring(prefixLen, startFormatted.Length - prefixLen - suffixLen);
-                var endCore = endFormatted.Substring(prefixLen, endFormatted.Length - prefixLen - suffixLen);
-                if (prefixHasSign)
-                {
-                    return prefix + startCore + sepLoose + endCore + suffix;
-                }
-                // No shared sign — keep the prefix-less cores and append the shared suffix.
-                var startNoSuffix = startFormatted.Substring(0, startFormatted.Length - suffixLen);
-                var endNoSuffix = endFormatted.Substring(0, endFormatted.Length - suffixLen);
-                return startNoSuffix + sepLoose + endNoSuffix + suffix;
-            }
-
-            // Currency without any meaningful sharing — keep both ends in full and use loose sep.
-            return startFormatted + sepLoose + endFormatted;
-        }
-
-        // Decimal / percent / unit: use the locale's separator. en-US convention (and the test
-        // expectation) is the tight form; pt-PT and similar use a spaced ASCII hyphen.
-        return startFormatted + sepTight + endFormatted;
-    }
-
     // TODO: read range patterns from CLDR (e.g. via Options.Intl.CldrProvider) instead of
     // hard-coding language detection here. Other locales (fr, ja, …) have their own pattern
     // shapes and will silently fall through to the en-style default until that data path
@@ -645,29 +526,6 @@ internal sealed partial class NumberFormatPrototype : Prototype
         loose = " – ";
     }
 
-    private static bool ContainsSign(string s)
-    {
-        foreach (var c in s)
-        {
-            if (c == '+' || c == '-' || c == '−') return true;
-        }
-        return false;
-    }
-
-    private static bool ContainsCurrencyChar(string s)
-    {
-        foreach (var c in s)
-        {
-            // UnicodeCategory.CurrencySymbol covers $, €, £, ¥, ₹, ﷼, ¤, etc. — every
-            // single-character currency mark we care about for prefix/suffix collapse.
-            if (char.GetUnicodeCategory(c) == System.Globalization.UnicodeCategory.CurrencySymbol)
-            {
-                return true;
-            }
-        }
-        return false;
-    }
-
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.numberformat.prototype.formatrangetoparts
     /// </summary>
@@ -682,7 +540,9 @@ internal sealed partial class NumberFormatPrototype : Prototype
             Throw.TypeError(_realm, "start and end are required");
         }
 
-        var parts = PartitionNumberRangePattern(numberFormat, ToRangeNumber(start), ToRangeNumber(end));
+        // The same mathematical values formatRange reads, so the two lanes cannot disagree about the
+        // digits — nor about whether the range collapsed, which is decided by comparing them formatted.
+        var parts = PartitionNumberRangePattern(numberFormat, ToRangeValue(start), ToRangeValue(end));
 
         var result = new JsArray(Engine, (uint) parts.Count);
         for (var i = 0; i < parts.Count; i++)
@@ -695,28 +555,6 @@ internal sealed partial class NumberFormatPrototype : Prototype
         }
 
         return result;
-    }
-
-    private double ToRangeNumber(JsValue value)
-    {
-        // Handle BigInt values - convert to double
-        if (value is JsBigInt bigInt)
-        {
-            return (double) bigInt._value;
-        }
-
-        if (value is BigIntInstance bigIntInstance)
-        {
-            return (double) bigIntInstance.BigIntData._value;
-        }
-
-        var number = TypeConverter.ToNumber(value);
-        if (double.IsNaN(number))
-        {
-            Throw.RangeError(_realm, "Invalid number value");
-        }
-
-        return number;
     }
 
     private static string JoinParts(List<NumberFormatPart> parts)

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -3115,6 +3115,58 @@ or defaulted. A formatter that names neither is untouched, its two counts both b
 [#3498](https://github.com/sebastienros/jint/issues/3498), and the significant-digit options are
 [#3499](https://github.com/sebastienros/jint/issues/3499).
 
+### 4.69 `formatToParts` and `formatRangeToParts` read the value `format` reads ([#3494](https://github.com/sebastienros/jint/issues/3494))
+
+[Intl.NumberFormat.prototype.formatToParts](https://tc39.es/ecma402/#sec-intl.numberformat.prototype.formattoparts)
+and [formatRangeToParts](https://tc39.es/ecma402/#sec-intl.numberformat.prototype.formatrangetoparts) read
+their arguments with [ToIntlMathematicalValue](https://tc39.es/ecma402/#sec-tointlmathematicalvalue), which
+keeps a BigInt and a decimal string exactly — that is the whole reason it is not `ToNumber`. Jint's parts
+lanes used `ToNumber`, so a BigInt did not convert at all and a long decimal string arrived as the nearest
+`double`.
+
+```js
+const nf = new Intl.NumberFormat('en');
+
+// 5.0
+nf.formatToParts(1n);                  // TypeError: Cannot convert a BigInt value to a number
+nf.formatToParts('987654321987654321').map(p => p.value).join('');
+// "987,654,321,987,654,272"           — format() wrote …321
+
+nf.formatRangeToParts('987654321987654321', '987654321987654322').map(p => p.value).join('');
+// "~987,654,321,987,654,272"          — an approximatelySign for a range with two distinct ends,
+//                                        where formatRange wrote "987,654,321,987,654,321–…322"
+
+// 5.x — both lanes read the same value, so both write the same digits
+nf.formatToParts(1n);                  // [{ type: "integer", value: "1" }]
+nf.formatToParts('987654321987654321').map(p => p.value).join('');  // "987,654,321,987,654,321"
+nf.formatRangeToParts('987654321987654321', '987654321987654322').map(p => p.value).join('');
+// "987,654,321,987,654,321–987,654,321,987,654,322"
+```
+
+Whether a range collapses is decided inside
+[PartitionNumberRangePattern](https://tc39.es/ecma402/#sec-partitionnumberrangepattern) by comparing the two
+ends *formatted*, so reading them as doubles also decided that question differently in the two lanes. It is
+now one decision over one pair of values.
+
+`formatRange` is now literally the concatenation of what `formatRangeToParts` returns, which is what
+[FormatNumericRange](https://tc39.es/ecma402/#sec-formatnumericrange) says it is. §4.63 stated the collapse
+on the parts and left the string lane collapsing a second time on its own two formatted strings, for one
+reason: the partition took a `double` and could not carry the range above. It takes the mathematical value
+now, so the second implementation is gone and there is one place the collapse is decided. Nothing it writes
+moves — the two were held in step by
+`IntlNumberFormatPartsTests.RangePartsConcatenateToFormatRange`, which is now an identity.
+
+`format`, `formatRange` and `BigInt.prototype.toLocaleString` write exactly what they wrote before, down to
+the byte: the exact string lane is now the concatenation of the exact parts lane rather than a second
+implementation of it, and the configurations it covers are unchanged — a formatter it had no exact lane for
+(a fraction under `style: "currency"`, `"percent"` or `"unit"`, a notation's mantissa, significant digits
+over a fraction) still takes the double, and now takes it in **both** lanes rather than one.
+
+**What could break:** `formatToParts` and `formatRangeToParts` of a BigInt, of an integer string of 17 or
+more digits, and of a decimal string carrying more than 16 significant digits. Each of those used to throw
+or to write a rounded number, and now writes what its own `format` writes. Nothing that passed a Number
+moves.
+
 ## 5. New in v5
 
 Everything in the table below is opt-in: nothing in it is installed unless the host asks for it, so


### PR DESCRIPTION
> **Stacked on #3500.** This branch carries #3500's commit underneath its own, because both edit
> `JsNumberFormat.cs` and the same test grid. Merge #3500 first; this diff then shrinks to its own single
> commit.

[Intl.NumberFormat.prototype.formatToParts](https://tc39.es/ecma402/#sec-intl.numberformat.prototype.formattoparts)
and [formatRangeToParts](https://tc39.es/ecma402/#sec-intl.numberformat.prototype.formatrangetoparts) read
their arguments with [ToIntlMathematicalValue](https://tc39.es/ecma402/#sec-tointlmathematicalvalue) — I
checked both clauses against the living standard, and that is what they say; keeping more digits than a
`double` holds is the entire reason that operation exists rather than `ToNumber`. Jint's parts lanes used
`ToNumber`, so a BigInt did not convert **at all** and a long decimal string arrived as the nearest double:

```js
const nf = new Intl.NumberFormat('en');

nf.formatToParts(1n);              // TypeError: Cannot convert a BigInt value to a number   ← before
nf.formatToParts('987654321987654321').map(p => p.value).join('');
// "987,654,321,987,654,272"       ← before; format() of the same string wrote …654,321

nf.formatRangeToParts('987654321987654321', '987654321987654322').map(p => p.value).join('');
// "~987,654,321,987,654,272"      ← before: an approximatelySign for a range with two distinct ends
```

That last one is the issue's own case and it is two failures, not one.
[PartitionNumberRangePattern](https://tc39.es/ecma402/#sec-partitionnumberrangepattern) decides whether a
range collapsed by comparing its two ends **formatted**, so a lane that reads the ends as doubles also
answers that question differently — and [FormatNumericRange](https://tc39.es/ecma402/#sec-formatnumericrange)
and [FormatNumericRangeToParts](https://tc39.es/ecma402/#sec-formatnumericrangetoparts) are both that one
partition over the same two values.

## The failing tests

Against unmodified `JsNumberFormat.cs` / `NumberFormatPrototype.cs` (3 failed / 16 passed):

```
  Failed ABigIntIsAValueBothLanesCanRead
   Jint.Runtime.JavaScriptException : Cannot convert a BigInt value to a number

  Failed ARangeOfExactValuesIsARangeInBothLanes
   Expected JoinRange(Nf, "'987654321987654321'", "'987654321987654322'") to be the same string,
   but they differ at index 0:
   ↓ (actual)
  "~987,654,321,987,654,272"
  "987,654,321,987,654,321–987,654,321,987,654,322"
   ↑ (expected).

  Failed PartsConcatenateToFormat
   Jint.Runtime.JavaScriptException : Cannot convert a BigInt value to a number
```

`PartsConcatenateToFormat`'s `Values` and `RangePartsConcatenateToFormatRange`'s `pairs` gain the values a
double cannot hold — a BigInt, an integer string past 2^53, a decimal string with 17 significant digits —
so the join-equality claim now stands over them in all 7 locales and 9 numbering systems, per option set.

## What changed

**One `ToIntlMathematicalValue`.** `format` and `formatRange` each carried their own copy of the same
BigInt / long-string / decimal-string ladder; `formatToParts` and `formatRangeToParts` each carried a
different, lossy one. There is now a single conversion in `NumberFormatPrototype`, returning an
`IntlMathematicalValue` — an exact mantissa × 10^-n, or the double everything else becomes — and all four
entry points read it. `ToRangeNumber` is gone; `ToRangeValue` is the one line that adds
`PartitionNumberRangePattern`'s not-a-number `RangeError`.

**One decision about whether the formatter can write it exactly.** `CanPartitionExactly` is asked by both
lanes, so neither can format a value the other approximated. Its answer is exactly the coverage the exact
string lane already had: a plain decimal number in any configuration, and the three scaled styles only for a
whole one — a fraction under `currency`/`percent`/`unit`, a notation's mantissa, and significant-digit
rounding over a fraction each need arithmetic the exact carrier does not do, and take the double *in both
lanes together*.

**The exact string lane is now the concatenation of the exact parts lane** rather than a second
implementation of it — the shape `Format(double)` already used for non-finite values. `FormatExactDecimal`,
`FormatDecimalBigInt`, `FormatCurrencyBigInt`, `FormatPercentBigInt` and `FormatUnitBigInt` are replaced by
their partitions; `Format(BigInteger)`, which `BigInt.prototype.toLocaleString` calls, is `Format` of an
exact value with no fraction digits.

**And so is `formatRange`.** #3495 stated the collapse on the parts and left the string lane collapsing a
second time on its own two already-formatted strings, for one reason, which it recorded on
`PartitionNumberRangePattern` and pointed at this issue: the partition took a `double` and could not carry
the 18-digit range `formatRange/en-US.js` asserts. It takes the mathematical value now, so that reason is
gone — `formatRange` is `ConcatenateParts(PartitionNumberRangePattern(…))`, which is what
[FormatNumericRange](https://tc39.es/ecma402/#sec-formatnumericrange) says it is, and
`CollapseFormattedRange` with its two character predicates is deleted (−120 lines). The two collapses were
held in step by `RangePartsConcatenateToFormatRange`, which is now an identity rather than a claim.

Because the string lanes are derived from the parts lanes, **every string they wrote before, they write byte
for byte** — each partition is a transcription of the same digit computation, and the grids are what prove
it. I checked the ones a reader would want checked by hand as well: `format(123n)` under USD is still
`"$123.00"`, `format(-123n)` still `"$-123.00"`, `de-DE` EUR still `"€123,00"`, `notation: 'scientific'` of
`12345n` still `"12,345"`, `(123n).toLocaleString('en-US')` still `"123"`.

Two of those are wrong, and visibly so: the exact lane's currency arm writes the sign *after* the symbol and
ignores the locale's currency pattern, its accounting and `signDisplay` options, and its notation. That is a
separate defect from this one — this issue is the two lanes reading **one value**, and they now share a
single implementation, so it is one place to fix rather than two. Filed as **#3504**.

## Verification

* Rebased onto `main` after #3495, #3490, #3487, #3277 and #3501 landed; #3495's `PartitionNumberRangePattern`
  is the one real conflict and is resolved by widening it from two `double`s to two mathematical values.
* `dotnet build -c Release` clean (`TreatWarningsAsErrors`); `dotnet test -c Release Jint.Tests` green on
  all three target frameworks — net472 7,662 · net8.0 and net10.0 11,042 each.
* test262: **102,523 passed / 0 failed / 165 skipped**, the control on `main` exactly. No exclusion is
  removed — no test262 file calls `formatToParts` with a BigInt or with a string past a double's window, and
  `formatRangeToParts/en-US.js`'s 18-digit case exists only in the `formatRange` file, which is why this
  went unnoticed. Runs on this box are flaking on ~30 s `TimeoutException`s under load; a run of unmodified
  `main` in a clean worktree flaked the same way (102,521 / 2 / 165), and every flaked file passes in seconds
  in isolation.
* `MigrationGuideTests` green. Migration guide: **§4.69**.

Fixes #3494
