### PR TITLE
Generators: a loop that comes back to a yield* delegates again

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -52,7 +52,6 @@
     "staging/sm/Date/dst-offset-caching-7-of-8.js",
     "staging/sm/Date/dst-offset-caching-8-of-8.js",
     "staging/sm/JSON/parse-mega-huge-array.js",
-    "staging/sm/generators/delegating-yield-9.js",
     "staging/sm/regress/regress-610026.js",
     "staging/sm/regress/regress-1507322-deep-weakmap.js",
 

--- a/Jint.Tests/Runtime/GeneratorTests.cs
+++ b/Jint.Tests/Runtime/GeneratorTests.cs
@@ -871,6 +871,75 @@ public class GeneratorTests
         _engine.Evaluate(Script).AsString().Should().Be("[0,0]");
     }
 
+    [Test, CancelAfter(10000)]
+    public void ADelegatingYieldInsideAYieldStartsOverOnEveryLoopIteration()
+    {
+        // https://tc39.es/ecma262/#sec-generator-function-definitions-runtime-semantics-evaluation:
+        // every evaluation of `yield * AssignmentExpression` evaluates its operand and drives the
+        // resulting iterator to completion, so a loop that comes back round to the same yield* node
+        // starts a fresh delegation. Jint replays a generator body from the top on each resume and
+        // memoized what each yield node had already returned; the memo was never invalidated, so the
+        // second iteration answered the outer yield from the first iteration's value without ever
+        // evaluating the operand -- which abandoned the delegation and, because the operand carries
+        // the loop's own decrement here, left n unchanged and the loop running forever.
+        // staging/sm/generators/delegating-yield-9.js is this shape; SpiderMonkey and V8 both
+        // report eight results for countdown(3).
+        const string Script = """
+            function* countdown(n) {
+                while (n > 0) {
+                    yield (yield* countdown(--n));
+                }
+                return 34;
+            }
+
+            var results = [];
+            var it = countdown(3);
+            var result;
+            do {
+                result = it.next();
+                results.push(result.value + ':' + result.done);
+            } while (!result.done && results.length < 100);
+            return results.join(' ');
+        """;
+
+        // A regression here spins forever, and [CancelAfter] cannot abort a synchronous test method
+        // on its own; the engine has to observe the test's token for the timeout to bite.
+        var engine = new Engine(options => options.ObserveCancellation(TestContext.CurrentContext.CancellationToken));
+
+        engine.Evaluate(Script).Should().Be("34:false 34:false 34:false 34:false 34:false 34:false 34:false 34:true");
+    }
+
+    [Test, CancelAfter(10000)]
+    public void ADelegatingYieldInsideAYieldKeepsItsPlaceWhenTheDecrementIsElsewhere()
+    {
+        // The same defect without the runaway loop: with the decrement in its own statement the loop
+        // still terminates, but the outer yield answered from the memo instead of yielding, so two of
+        // the eight results went missing. Kept separate because a fix that only stopped the hang
+        // would leave this one silently wrong.
+        const string Script = """
+            function* countdown(n) {
+                while (n > 0) {
+                    n = n - 1;
+                    yield (yield* countdown(n));
+                }
+                return 34;
+            }
+
+            var results = [];
+            var it = countdown(3);
+            var result;
+            do {
+                result = it.next();
+                results.push(result.value + ':' + result.done);
+            } while (!result.done && results.length < 100);
+            return results.join(' ');
+        """;
+
+        var engine = new Engine(options => options.ObserveCancellation(TestContext.CurrentContext.CancellationToken));
+
+        engine.Evaluate(Script).Should().Be("34:false 34:false 34:false 34:false 34:false 34:false 34:false 34:true");
+    }
+
     [Test]
     public void GeneratorFunctionConstructorsInheritFromTheFunctionConstructor()
     {

--- a/Jint/Runtime/Interpreter/Expressions/JintYieldExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintYieldExpression.cs
@@ -172,7 +172,19 @@ internal sealed class JintYieldExpression : JintExpression
             // Fall through to normal yield logic
         }
 
-        // Normal yield: evaluate argument and yield the value
+        // Normal yield: evaluate argument and yield the value.
+        //
+        // Reaching here is a *fresh* evaluation of this yield node, so whatever the node's previous
+        // evaluation produced stops being an answer to it. The memo above exists only to replay one
+        // evaluation - a statement that is re-executed from the top after a later suspension must
+        // not re-run the yields it already got past - and a loop that comes back round to the same
+        // node starts a new evaluation the memo has nothing to say about. Leaving the stale entry in
+        // place made `yield (yield* g())` inside a loop answer its second iteration with the first
+        // iteration's value without ever evaluating the operand, so the delegation was abandoned
+        // mid-flight (and, when the operand carried the loop's own decrement, the loop never ended).
+        generator?._yieldNodeValues?.Remove(_expression);
+        asyncGenerator?._yieldNodeValues?.Remove(_expression);
+
         JsValue value;
         if (_argument is not null)
         {

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -3280,6 +3280,41 @@ as it was — a per-thread cache of built years serves more than the single entr
 off a hundred *different* years costs six to fourteen times more than the table lookup did, since each
 fresh year is a dozen new moons and two solstice searches to build.
 
+### 4.72 A `yield*` a loop comes back to delegates again ([#3505](https://github.com/sebastienros/jint/issues/3505))
+
+Jint resumes a generator by replaying its body from the top and skipping the work the earlier passes already
+did, and part of that bookkeeping was a memo of what each `yield` node had last returned. Nothing ever
+invalidated an entry, so the *second* time a loop reached the same `yield` node it was answered from the
+first iteration's value — without evaluating its operand at all. A `yield` whose operand is a `yield*`
+therefore abandoned the new delegation before it started:
+
+```js
+function* countdown(n) {
+    while (n > 0) {
+        yield (yield* countdown(--n));
+    }
+    return 34;
+}
+
+// 4.16.x / earlier 5.0: never returns from the sixth next()
+// 5.x:                  [34, 34, 34, 34, 34, 34, 34], as SpiderMonkey and V8 report
+[...countdown(3)];
+```
+
+The hang is the same defect wearing its worst face: the un-evaluated operand here carries `--n`, so the loop
+counter never moved. Where the decrement sits in its own statement the loop still ends, and the answer is
+merely wrong — `countdown(3)` produced six `next()` results instead of eight, with no error and nothing to
+notice.
+Per
+[14.4.14](https://tc39.es/ecma262/#sec-generator-function-definitions-runtime-semantics-evaluation),
+each evaluation of `yield * AssignmentExpression` evaluates its operand, calls `GetIterator` on the result
+and drives that iterator, so a node a loop returns to starts a delegation of its own every time.
+
+**What could break:** nothing that was reading a correct value. A generator that hung now terminates, and one
+that quietly dropped yields now emits them, so a host that had pinned the old count in a snapshot or an
+assertion sees it change to the count every other engine reports. `staging/sm/generators/delegating-yield-9.js`
+leaves the test262 exclusion list with this.
+
 ## 5. New in v5
 
 Everything in the table below is opt-in: nothing in it is installed unless the host asks for it, so


### PR DESCRIPTION
Fixes one of the three findings in #3505: `staging/sm/generators/delegating-yield-9.js` was excluded as "does not terminate", and it really does not — but the cause is a defect in generator resumption, not a workload.

## What was wrong

Jint resumes a generator by replaying its body from the top and skipping the work earlier passes already did. Part of that bookkeeping is `GeneratorInstance._yieldNodeValues`, a memo of what each `yield` node last returned, so a statement re-executed after a later suspension does not re-run the yields it already got past.

Nothing ever invalidated an entry. The *second* time a loop reached the same `yield` node, the memo answered it with the first iteration's value — **without evaluating its operand at all**. For a `yield` whose operand is a `yield*` that is fatal in two different ways:

```js
function* countdown(n) {
    while (n > 0) {
        yield (yield* countdown(--n));   // the operand carries the decrement
    }
    return 34;
}
collect(countdown(3));   // never returns from the sixth next()
```

The un-evaluated operand carries `--n`, so `n` never moved and the `while` ran forever — one `next()` that never comes back, which is what the exclusion recorded. Move the decrement into its own statement and the loop terminates, but the answer is silently wrong: six `next()` results instead of eight, because the new delegation was abandoned before it started.

## The fix

Reaching the "normal yield" path is a *fresh* evaluation of that node, so the value its previous evaluation produced stops being an answer to it. One `Remove` on the way in, for both the sync and async generator memo.

The memo's real job is unaffected: it is consulted only on a replay (`_isResuming`), and the fresh-evaluation path is reached only when the memo missed, or when the previous resume already consumed its entry and execution has moved on — which is exactly the loop case.

Per [14.4.14](https://tc39.es/ecma262/#sec-generator-function-definitions-runtime-semantics-evaluation), every evaluation of `yield * AssignmentExpression` evaluates its operand, calls `GetIterator` on the result and drives that iterator, so a node a loop returns to starts a delegation of its own each time. `countdown(3)` now answers `34,34,34,34,34,34,34` + a final `{value: 34, done: true}` — eight results, matching SpiderMonkey and V8.

## Tests

Two new cases in `Jint.Tests/Runtime/GeneratorTests.cs`, both verified to fail against unfixed code (the first hangs until its `CancelAfter` token fires, the second returns six results). The second exists because a fix that only stopped the hang would leave the silent wrong answer in place.

`staging/sm/generators/delegating-yield-9.js` leaves `Test262Harness.settings.json`.

## test262

Control on `main`: **102,523 passed / 0 failed / 165 skipped of 102,688**.
This branch: **102,525 passed / 0 failed / 163 skipped of 102,688** — the two modes of the removed file, and nothing else. (One run reported a 30 s `TimeoutException` on `staging/sm/expressions/short-circuit-compound-assignment.js`; it passes in 1 s standalone and is the known contention flake on this machine, not a file this branch touches.)

## Known remaining gap

The same shape on an **async** generator (`async function* a(n) { while (n > 0) { yield (yield* a(--n)); } }`) hangs on `main` today; with this change it terminates but reports four results where V8 reports eight. That is a second, independent defect in the async delegation machinery — a nested async generator loses the `yield` that follows its own completed `yield*` — and is filed as #3509 rather than widened into this PR.

Re-measured after rebasing onto `8f0aac567`: **102,524 passed / 1 failed / 163 skipped of 102,688** — the failure again `staging/sm/expressions/short-circuit-compound-assignment.js`, at 41 s, which this branch does not touch and which passes in 1 s standalone. Migration guide section is **4.70**.
