### PR TITLE
Temporal: chinese and dangi read the same on every target framework

### DIFF
--- a/Jint.Tests/Runtime/LunisolarCalendarAgreementTests.cs
+++ b/Jint.Tests/Runtime/LunisolarCalendarAgreementTests.cs
@@ -1,0 +1,192 @@
+#nullable enable
+
+using System.Globalization;
+using System.Text;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// The <c>chinese</c> and <c>dangi</c> calendars answer the same on every target framework, and what they
+/// answer is the calendar those two names denote.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Nothing here compares the engine against a <c>System.Globalization</c> calendar, which is the practice
+/// that let <see href="https://github.com/sebastienros/jint/issues/3484"/> hide: every test that read
+/// <c>chinese</c> or <c>dangi</c> compared it to whichever of those tables the runtime it was executing on
+/// happened to carry, so three different answers all looked right.
+/// <c>ChineseLunisolarCalendar</c> reads 2057-09-28 as 2057/9/1 on .NET 8 and as 2057/8/30 on .NET
+/// Framework 4.8 and .NET 10; .NET Framework's <c>KoreanLunisolarCalendar</c> begins five days earlier
+/// than .NET Core's and disagrees with it about 8,251 of the 9,106 month starts before 1600.
+/// </para>
+/// <para>
+/// The expectations below come from outside the engine instead. The <c>chinese</c> ones are the Hong Kong
+/// Observatory's published Gregorian–Lunar Calendar Conversion Table
+/// (<see href="https://www.hko.gov.hk/en/gts/time/conversion.htm"/>), which covers 1901–2100 and is the
+/// reference the calendar is maintained against. The <c>dangi</c> ones before 1912 are the Chinese
+/// calendar of the same years, because Korea reckoned China's calendar until then, and are corroborated
+/// by ICU and by .NET Core's table, both of which agree with them. <see cref="EveryMonthBeginsAtANewMoon"/>
+/// needs no authority at all.
+/// </para>
+/// </remarks>
+public class LunisolarCalendarAgreementTests
+{
+    private static string Fields(string isoDate, string calendar)
+    {
+        var engine = new Engine();
+        return engine.Evaluate(
+            $@"(function () {{
+                 try {{
+                   var d = Temporal.PlainDate.from('{isoDate}').withCalendar('{calendar}');
+                   return d.year + '|' + d.monthCode + '|' + d.day;
+                 }} catch (e) {{ return e.constructor.name + ': ' + e.message; }}
+               }})()").AsString();
+    }
+
+    /// <summary>
+    /// The two dates the issue leads with, and the ones on either side of them that separate the three
+    /// runtimes. Each is the first day of a lunar month, so a table that is a day out reports it as day
+    /// 29 or 30 of the month before.
+    /// </summary>
+    /// <remarks>
+    /// Reading down the "before" column says which runtime each case used to fail on: 2057-09-28 was
+    /// 2057/M08/30 on .NET Framework and .NET 10, 2089-09-04 and 2097-08-07 were the month before on
+    /// .NET Framework, and the four <c>dangi</c> dates were five to nine days out on .NET Framework.
+    /// </remarks>
+    [TestCase("chinese", "1901-02-19", "1901|M01|1", TestName = "chinese, the first day the old table covered")]
+    [TestCase("chinese", "1917-03-23", "1917|M02L|1", TestName = "chinese, the leap second month of 1917")]
+    [TestCase("chinese", "1922-06-25", "1922|M05L|1", TestName = "chinese, the leap fifth month of 1922")]
+    [TestCase("chinese", "1987-07-26", "1987|M06L|1", TestName = "chinese, the leap sixth month of 1987")]
+    [TestCase("chinese", "2020-05-23", "2020|M04L|1", TestName = "chinese, the leap fourth month of 2020")]
+    [TestCase("chinese", "2024-02-10", "2024|M01|1", TestName = "chinese, new year 2024")]
+    [TestCase("chinese", "2033-12-22", "2033|M11L|1", TestName = "chinese, the leap eleventh month of 2033")]
+    [TestCase("chinese", "2057-09-28", "2057|M09|1", TestName = "chinese, the ninth month of 2057")]
+    [TestCase("chinese", "2089-09-04", "2089|M08|1", TestName = "chinese, the eighth month of 2089")]
+    [TestCase("chinese", "2097-08-07", "2097|M07|1", TestName = "chinese, the seventh month of 2097")]
+    [TestCase("chinese", "1800-01-01", "1799|M12|7", TestName = "chinese, a century before the old table")]
+    [TestCase("dangi", "1000-08-08", "1000|M07|1", TestName = "dangi, the seventh month of 1000")]
+    [TestCase("dangi", "1200-03-01", "1200|M02|8", TestName = "dangi, the second month of 1200")]
+    [TestCase("dangi", "1400-06-15", "1400|M05|14", TestName = "dangi, the fifth month of 1400")]
+    [TestCase("dangi", "1500-06-15", "1500|M05|9", TestName = "dangi, the fifth month of 1500")]
+    [TestCase("dangi", "1912-02-18", "1912|M01|1", TestName = "dangi, new year 1912")]
+    [TestCase("dangi", "2020-05-23", "2020|M04L|1", TestName = "dangi, the leap fourth month of 2020")]
+    [TestCase("dangi", "2050-01-01", "2049|M12|8", TestName = "dangi, near the end of the old Korean table")]
+    public void ADateReadsTheSameOnEveryTargetFramework(string calendar, string isoDate, string expected)
+    {
+        Fields(isoDate, calendar).Should().Be(expected, $"{calendar} {isoDate}");
+    }
+
+    /// <summary>
+    /// Korea reckoned China's calendar until 1912, so over the years both of the retired tables covered —
+    /// 1901 through 1911 — <c>dangi</c> and <c>chinese</c> have to be the same calendar day for day.
+    /// </summary>
+    [Test]
+    public void DangiIsTheChineseCalendarBefore1912()
+    {
+        var failures = new StringBuilder();
+
+        for (var date = new DateTime(1901, 2, 19); date < new DateTime(1912, 1, 1); date = date.AddDays(13))
+        {
+            var iso = date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+            var chinese = Fields(iso, "chinese");
+            var dangi = Fields(iso, "dangi");
+            if (!string.Equals(chinese, dangi, StringComparison.Ordinal))
+            {
+                failures.Append(iso).Append(": chinese ").Append(chinese).Append(", dangi ").AppendLine(dangi);
+            }
+        }
+
+        failures.ToString().Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// The one property of a lunisolar calendar that needs no table and no authority: a month begins on
+    /// the day of a new moon. Every month start the engine reports has to sit within two days of the mean
+    /// new moon, which is loose enough for the ±0.6 day the true conjunction wanders from the mean and for
+    /// any meridian, and tight enough that a table which is not a lunisolar calendar cannot pass.
+    /// </summary>
+    /// <remarks>
+    /// This is what convicts .NET Framework's <c>KoreanLunisolarCalendar</c> without appeal to any
+    /// reference: over 918–1600 it puts 8,225 of its 8,447 month starts more than two days from a new
+    /// moon, a median of 7.2 days out — around first quarter. ICU, .NET Core's two tables and the
+    /// reckoning all sit inside ±2 days for every one of theirs.
+    /// </remarks>
+    [TestCase("chinese")]
+    [TestCase("dangi")]
+    public void EveryMonthBeginsAtANewMoon(string calendar)
+    {
+        // The mean synodic month and the mean new moon of 2000-01-06 18:14 UT, as a Julian day number.
+        const double MeanSynodicMonth = 29.530588861;
+        const double MeanNewMoonJ2000 = 2451550.09766;
+
+        var engine = new Engine();
+        var failures = new StringBuilder();
+        var monthStarts = 0;
+
+        foreach (var year in new[] { 950, 1100, 1250, 1400, 1500, 1600, 1750, 1850, 1920, 1990, 2030, 2080 })
+        {
+            for (var date = new DateTime(year, 1, 1); date < new DateTime(year + 1, 1, 1); date = date.AddDays(1))
+            {
+                var iso = date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+                var day = engine.Evaluate(
+                    $"Temporal.PlainDate.from('{iso}').withCalendar('{calendar}').day").AsNumber();
+
+                if (day != 1)
+                {
+                    continue;
+                }
+
+                monthStarts++;
+
+                // Julian day number of this date at midnight UT.
+                var julianDay = 2440587.5 + (date - new DateTime(1970, 1, 1)).TotalDays;
+                var cycles = System.Math.Round((julianDay + 0.5 - MeanNewMoonJ2000) / MeanSynodicMonth);
+                var offset = MeanNewMoonJ2000 + (MeanSynodicMonth * cycles) - julianDay;
+
+                if (System.Math.Abs(offset) > 2.0)
+                {
+                    failures.Append(iso).Append(": day 1 of a month, ")
+                        .Append(offset.ToString("F2", CultureInfo.InvariantCulture))
+                        .AppendLine(" days from the nearest mean new moon");
+                }
+            }
+        }
+
+        monthStarts.Should().BeGreaterThan(140);
+        failures.ToString().Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// <c>Intl.DateTimeFormat</c> and <c>Temporal</c> read the same calendar, so they have to name the
+    /// same month and day — including outside the span the retired tables covered, where
+    /// <c>Intl</c> used to clamp to the table's own first or last date and report that instead.
+    /// </summary>
+    [TestCase("chinese", "1800-01-01")]
+    [TestCase("chinese", "2057-09-28")]
+    [TestCase("chinese", "2200-06-15")]
+    [TestCase("dangi", "1500-06-15")]
+    [TestCase("dangi", "2057-09-28")]
+    [TestCase("dangi", "0800-01-01")]
+    public void IntlNamesTheSameDayAsTemporal(string calendar, string isoDate)
+    {
+        var year = int.Parse(isoDate.Substring(0, 4), NumberStyles.None, CultureInfo.InvariantCulture);
+        var month = int.Parse(isoDate.Substring(5, 2), NumberStyles.None, CultureInfo.InvariantCulture);
+        var day = int.Parse(isoDate.Substring(8, 2), NumberStyles.None, CultureInfo.InvariantCulture);
+
+        var engine = new Engine();
+        var both = engine.Evaluate(
+            $@"(function () {{
+                 var d = Temporal.PlainDate.from('{isoDate}').withCalendar('{calendar}');
+                 var parts = new Intl.DateTimeFormat('en-u-ca-{calendar}', {{
+                     year: 'numeric', month: 'numeric', day: 'numeric', timeZone: 'UTC' }})
+                   .formatToParts(new Date(Date.UTC({year}, {month - 1}, {day})));
+                 var read = {{}};
+                 for (var i = 0; i < parts.length; i++) {{ read[parts[i].type] = parts[i].value; }}
+                 return d.year + '/' + Number(d.monthCode.substring(1, 3)) + '/' + d.day
+                      + '  ' + read.relatedYear + '/' + read.month + '/' + read.day;
+               }})()").AsString();
+
+        var halves = both.Split(new[] { "  " }, StringSplitOptions.None);
+        halves[1].Should().Be(halves[0], $"{calendar} {isoDate}: Intl and Temporal name the same day");
+    }
+}

--- a/Jint.Tests/Runtime/NonIsoCalendarOutOfRangeFieldTests.cs
+++ b/Jint.Tests/Runtime/NonIsoCalendarOutOfRangeFieldTests.cs
@@ -12,12 +12,16 @@ namespace Jint.Tests.Runtime;
 /// </summary>
 /// <remarks>
 /// <para>
-/// <c>ChineseLunisolarCalendar</c> spans ISO 1901-02-19 to 2101-01-28 and <c>KoreanLunisolarCalendar</c>
+/// <c>ChineseLunisolarCalendar</c> spanned ISO 1901-02-19 to 2101-01-28 and <c>KoreanLunisolarCalendar</c>
 /// 918-02-19 to 2051-02-10, while <c>Temporal.PlainDate</c> spans a quarter of a million years each way.
 /// Outside those two tables the engine used to answer with the ISO year, <c>M{isoMonth}</c>, the ISO
 /// days-in-month and twelve months a year — Gregorian fields wearing a lunisolar label, with nothing
 /// downstream able to tell them from real ones
-/// (<see href="https://github.com/sebastienros/jint/issues/3451"/>).
+/// (<see href="https://github.com/sebastienros/jint/issues/3451"/>). Both tables have since been retired
+/// altogether, because they were not the same table on every target framework
+/// (<see href="https://github.com/sebastienros/jint/issues/3484"/>); what the fixed dates those two
+/// calendars must read as are pinned in <c>LunisolarCalendarAgreementTests</c>, against an authority
+/// outside the engine rather than against whichever table the runtime carries.
 /// </para>
 /// <para>
 /// Refusing instead is not open to the engine.
@@ -72,10 +76,10 @@ public class NonIsoCalendarOutOfRangeFieldTests
     /// it says the same thing.
     /// </summary>
     /// <remarks>
-    /// One date rather than a sweep, because .NET Framework's copy of the Korean table is not .NET Core's
-    /// — it starts five days earlier and reads 1500-06-15 as 1500/5/19 where .NET Core reads 1500/5/9.
-    /// The systematic form of this comparison, measured per runtime, is in
-    /// <c>LunisolarAstronomyTests</c>.
+    /// This read the Korean BCL table when it was written, which is why it was one date rather than a
+    /// sweep: .NET Framework's copy of that table was not .NET Core's, and read 1500-06-15 as 1500/5/19
+    /// where .NET Core read 1500/5/9. Neither table is read any more, so what it now says is that the two
+    /// calendars agree with each other where history says they must.
     /// </remarks>
     [Test]
     public void ThePastDateTheKoreanTableAlsoCoversReadsTheSameInBoth()
@@ -84,21 +88,21 @@ public class NonIsoCalendarOutOfRangeFieldTests
     }
 
     /// <summary>
-    /// The day before a table's first day and the day after its last: the reckoning that takes over has
-    /// to leave the calendar where the table left it, or the boundary is a visible seam.
+    /// The days on which the retired tables began and ended are ordinary days of the calendar: the
+    /// reckoning has to make one continuous calendar across them, with no boundary left where a table
+    /// used to hand over.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Stated structurally rather than as dates, because the tables themselves differ between target
-    /// frameworks. Both end on a year's last day, so what has to hold there is that the two sides make
-    /// one continuous calendar: the day after the table's last is day 1 of the following year.
+    /// Stated structurally rather than as dates, because the tables it was written against differed
+    /// between target frameworks. Both ended on a year's last day, so what has to hold there is that the
+    /// day after is day 1 of the following year.
     /// </para>
     /// <para>
-    /// The start of the table is asserted for <c>chinese</c> only. .NET Framework's
-    /// <c>KoreanLunisolarCalendar</c> begins on 918-02-14 and calls it day 1 of the Korean year 918,
-    /// while .NET Core's begins on 918-02-19 and calls that day 1 — so on .NET Framework there is no year
-    /// boundary at the table's start for the reckoning to join to, and the seam there is that table's,
-    /// not this one's.
+    /// The first day is asserted for <c>chinese</c> only. .NET Framework's <c>KoreanLunisolarCalendar</c>
+    /// began on 918-02-14 and called it day 1 of the Korean year 918, while .NET Core's began on
+    /// 918-02-19 and called that day 1 — one of the disagreements that retired both tables — so the
+    /// <c>MinSupportedDateTime</c> this reads is not a year boundary on every runtime.
     /// </para>
     /// </remarks>
     [TestCase("chinese", true)]
@@ -318,28 +322,23 @@ public class NonIsoCalendarOutOfRangeFieldTests
     }
 
     /// <summary>
-    /// Nothing inside a table moves. The two calendars are read across their whole tabulated span and
-    /// have to answer exactly what they answered before, which is what makes this a fallback rather than
-    /// a replacement.
+    /// Across the whole span the two retired tables covered, every date is a date of the calendar it is
+    /// read in, and the fields it reports build it back.
     /// </summary>
     /// <remarks>
-    /// Except where the table contradicts itself, which <c>KoreanLunisolarCalendar</c> does:
-    /// <c>GetMonth</c> names month 13 for 1189-01-09 while <c>GetLeapMonth</c> reports that year as
-    /// having none, so <c>GetDaysInMonth</c> refuses the month <c>GetMonth</c> just named. Those dates
-    /// used to come back as ISO fields under the calendar's name — the same defect from a second cause —
-    /// and are now reckoned like the ones past the end of the table. They are skipped here because there
-    /// is no table answer to compare against.
+    /// This used to compare the engine against the runtime's own <c>ChineseLunisolarCalendar</c> or
+    /// <c>KoreanLunisolarCalendar</c>, to say that the reckoning was a fallback and never a replacement.
+    /// It is a replacement now: those two tables are not the same table on every target framework, so a
+    /// test that compares against whichever one the runtime carries passes on all three while the engine
+    /// gives three different answers (<see href="https://github.com/sebastienros/jint/issues/3484"/>).
+    /// What replaces the comparison is <c>LunisolarCalendarAgreementTests</c>, whose expectations come
+    /// from the Hong Kong Observatory's published table and from a new-moon test that needs no table at
+    /// all; what stays here is the same span, swept for the properties any lunisolar calendar has.
     /// </remarks>
     [TestCase("chinese", "1901-02-19", "2101-01-28")]
     [TestCase("dangi", "0918-02-19", "2051-02-10")]
-    public void ADateInsideTheTableIsStillAnsweredByTheTable(string calendar, string first, string last)
+    public void EveryDateTheRetiredTablesCoveredIsADateOfItsCalendar(string calendar, string first, string last)
     {
-        var table = calendar switch
-        {
-            "chinese" => (EastAsianLunisolarCalendar) new ChineseLunisolarCalendar(),
-            _ => new KoreanLunisolarCalendar(),
-        };
-
         var failures = new StringBuilder();
         var sampled = 0;
 
@@ -348,30 +347,40 @@ public class NonIsoCalendarOutOfRangeFieldTests
 
         for (var date = from; date <= to; date = date.AddDays(97))
         {
-            try
-            {
-                _ = table.GetDaysInMonth(table.GetYear(date), table.GetMonth(date));
-            }
-            catch (ArgumentOutOfRangeException)
-            {
-                continue;
-            }
-
             sampled++;
             var isoDate = date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
             var reported = Fields(isoDate, calendar).Split('|');
-
-            var expected = string.Join(
-                "|",
-                table.GetYear(date).ToString(CultureInfo.InvariantCulture),
-                table.GetMonth(date).ToString(CultureInfo.InvariantCulture),
-                table.GetDayOfMonth(date).ToString(CultureInfo.InvariantCulture));
-
-            var actual = string.Join("|", reported[0], reported[1], reported[2]);
-            if (!string.Equals(expected, actual, StringComparison.Ordinal))
+            if (reported.Length != 9)
             {
-                failures.Append(isoDate).Append(": table said ").Append(expected)
-                    .Append(", engine said ").AppendLine(actual);
+                failures.Append(isoDate).Append(": ").AppendLine(string.Join("|", reported));
+                continue;
+            }
+
+            var day = int.Parse(reported[2], CultureInfo.InvariantCulture);
+            var monthsInYear = int.Parse(reported[4], CultureInfo.InvariantCulture);
+            var daysInMonth = int.Parse(reported[5], CultureInfo.InvariantCulture);
+            var daysInYear = int.Parse(reported[6], CultureInfo.InvariantCulture);
+            var dayOfYear = int.Parse(reported[7], CultureInfo.InvariantCulture);
+
+            if (monthsInYear is not (12 or 13)
+                || daysInMonth is not (29 or 30)
+                || daysInYear < 353 || daysInYear > 385
+                || day < 1 || day > daysInMonth
+                || dayOfYear < 1 || dayOfYear > daysInYear
+                || !WellFormedLunisolarMonthCode.IsMatch(reported[3]))
+            {
+                failures.Append(isoDate).Append(": ").AppendLine(string.Join("|", reported));
+                continue;
+            }
+
+            var roundTripped = Evaluate(
+                $"(function () {{ var d = Temporal.PlainDate.from('{isoDate}').withCalendar('{calendar}');" +
+                $" return Temporal.PlainDate.from({{ calendar: '{calendar}', year: d.year," +
+                " monthCode: d.monthCode, day: d.day }).equals(d); })()");
+
+            if (!string.Equals(roundTripped, "true", StringComparison.Ordinal))
+            {
+                failures.Append(isoDate).Append(": does not build back: ").AppendLine(roundTripped);
             }
         }
 

--- a/Jint/Native/Intl/ChineseCalendarHelper.cs
+++ b/Jint/Native/Intl/ChineseCalendarHelper.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using Jint.Native.Temporal;
 
 namespace Jint.Native.Intl;
 
@@ -9,16 +10,6 @@ namespace Jint.Native.Intl;
 /// </summary>
 internal static class ChineseCalendarHelper
 {
-    // Lazy initialization to avoid startup overhead when Chinese calendar is not used
-    private static ChineseLunisolarCalendar? _chineseCalendar;
-    private static KoreanLunisolarCalendar? _koreanCalendar;
-
-    private static ChineseLunisolarCalendar ChineseCalendar =>
-        _chineseCalendar ??= new ChineseLunisolarCalendar();
-
-    private static KoreanLunisolarCalendar KoreanCalendar =>
-        _koreanCalendar ??= new KoreanLunisolarCalendar();
-
     /// <summary>
     /// The 10 Heavenly Stems (天干 Tiāngān) in Chinese characters.
     /// Used as part of the 60-year sexagenary cycle.
@@ -64,7 +55,7 @@ internal static class ChineseCalendarHelper
     /// <returns>Chinese calendar date information including related year, year name, month, and day.</returns>
     public static ChineseCalendarDate GetChineseDate(DateTime dateTime)
     {
-        return GetLunisolarDate(dateTime, ChineseCalendar, isDangi: false);
+        return GetLunisolarDate(dateTime, "chinese");
     }
 
     /// <summary>
@@ -75,54 +66,51 @@ internal static class ChineseCalendarHelper
     /// <returns>Dangi calendar date information including related year, year name, month, and day.</returns>
     public static ChineseCalendarDate GetDangiDate(DateTime dateTime)
     {
-        return GetLunisolarDate(dateTime, KoreanCalendar, isDangi: true);
+        return GetLunisolarDate(dateTime, "dangi");
     }
 
-    private static ChineseCalendarDate GetLunisolarDate(DateTime dateTime, EastAsianLunisolarCalendar calendar, bool isDangi)
+    /// <summary>
+    /// The lunisolar fields of a date, read through the same conversion <c>Temporal</c> reads, so the two
+    /// name the same day.
+    /// </summary>
+    /// <remarks>
+    /// This used to read <c>ChineseLunisolarCalendar</c> and <c>KoreanLunisolarCalendar</c> directly, and
+    /// to clamp a date outside their span to the table's own first or last date and report that instead —
+    /// so 1800-01-01 formatted as the Chinese new year of 1901. Those tables are also not the same table
+    /// on every target framework (https://github.com/sebastienros/jint/issues/3484).
+    /// </remarks>
+    private static ChineseCalendarDate GetLunisolarDate(DateTime dateTime, string calendar)
     {
-        // Clamp to supported range
-        var minDate = calendar.MinSupportedDateTime;
-        var maxDate = calendar.MaxSupportedDateTime;
+        var fields = NonIsoCalendars.IsoToCalendarDate(calendar, new IsoDate(dateTime.Year, dateTime.Month, dateTime.Day));
 
-        if (dateTime < minDate)
+        // The month code is M plus the display month, with an L for a leap month; a leap month carries the
+        // display number of the month it follows, which is what Intl renders as "4bis".
+        var displayMonth = int.Parse(
+            fields.MonthCode.AsSpan(1, 2),
+            NumberStyles.None,
+            CultureInfo.InvariantCulture);
+
+        return new ChineseCalendarDate(
+            fields.Year,
+            GetSexagenaryYearName(SexagenaryYearOf(fields.Year)),
+            displayMonth,
+            fields.Day,
+            fields.IsLeapMonth);
+    }
+
+    /// <summary>
+    /// The 1-to-60 position of a lunisolar year in the sexagenary cycle. 1984 is 甲子, position 1, which
+    /// is the anchor <c>EastAsianLunisolarCalendar.GetSexagenaryYear</c> counts from too.
+    /// </summary>
+    private static int SexagenaryYearOf(int relatedYear)
+    {
+        var position = (relatedYear - 3) % 60;
+        if (position <= 0)
         {
-            dateTime = minDate;
-        }
-        else if (dateTime > maxDate)
-        {
-            dateTime = maxDate;
-        }
-
-        var year = calendar.GetYear(dateTime);
-        var month = calendar.GetMonth(dateTime);
-        var day = calendar.GetDayOfMonth(dateTime);
-
-        // Check if this is a leap month
-        var leapMonth = calendar.GetLeapMonth(year);
-        var isLeapMonth = leapMonth > 0 && month == leapMonth;
-
-        // Adjust month number for display (leap month has same number as previous month)
-        var displayMonth = month;
-        if (leapMonth > 0 && month >= leapMonth)
-        {
-            // If we're in or past the leap month, adjust the month number
-            displayMonth = month - 1;
-            if (month == leapMonth)
-            {
-                isLeapMonth = true;
-            }
+            position += 60;
         }
 
-        // The year from both ChineseLunisolarCalendar and KoreanLunisolarCalendar
-        // is already the Gregorian-aligned "related year" (the Gregorian year that mostly
-        // contains this lunar year). No offset adjustment is needed for either calendar.
-        var relatedYear = year;
-
-        // Get the sexagenary cycle year name (干支)
-        var sexagenaryYear = calendar.GetSexagenaryYear(dateTime);
-        var yearName = GetSexagenaryYearName(sexagenaryYear);
-
-        return new ChineseCalendarDate(relatedYear, yearName, displayMonth, day, isLeapMonth);
+        return position;
     }
 
     /// <summary>

--- a/Jint/Native/Temporal/CalendarRangeException.cs
+++ b/Jint/Native/Temporal/CalendarRangeException.cs
@@ -5,12 +5,12 @@ namespace Jint.Native.Temporal;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Jint reckons the eleven non-ISO calendars with <see cref="System.Globalization.Calendar"/> classes and
-/// with fixed-epoch arithmetic, and several of those classes cover far less than Temporal's own date
-/// range: <c>ChineseLunisolarCalendar</c> spans ISO 1901-02-19 to 2101-01-28, <c>HebrewCalendar</c>
-/// 1583-01-01 to 2239-09-29. The end of one of those is <em>not</em> what this reports: each of the four
-/// has a reckoning of its own past it, the same one its field accessors read, and the arithmetic asks it
-/// rather than refusing. What is left is a step past Temporal's own range, which no reckoning can place.
+/// Jint reckons the eleven non-ISO calendars with <see cref="System.Globalization.Calendar"/> classes,
+/// with fixed-epoch arithmetic and with astronomy, and the calendar classes cover far less than Temporal's
+/// own date range: <c>HebrewCalendar</c> spans ISO 1583-01-01 to 2239-09-29, <c>PersianCalendar</c> from
+/// 622. The end of one of those is <em>not</em> what this reports: each calendar has a reckoning of its
+/// own past it, the same one its field accessors read, and the arithmetic asks it rather than refusing.
+/// What is left is a step past Temporal's own range, which no reckoning can place.
 /// </para>
 /// <para>
 /// What used to be answered there was the calendar's <em>maximum</em> supported date, whichever end had

--- a/Jint/Native/Temporal/NonIsoCalendars.Lunisolar.cs
+++ b/Jint/Native/Temporal/NonIsoCalendars.Lunisolar.cs
@@ -44,21 +44,28 @@ internal sealed class LunisolarYear
 }
 
 /// <summary>
-/// The astronomical reckoning behind the Chinese and Korean lunisolar calendars, used where
-/// <see cref="System.Globalization.ChineseLunisolarCalendar"/> and
-/// <see cref="System.Globalization.KoreanLunisolarCalendar"/> stop.
+/// The astronomical reckoning behind the Chinese and Korean lunisolar calendars, and the only thing that
+/// answers for either of them.
 /// </summary>
 /// <remarks>
 /// <para>
-/// The two BCL classes are tables, and short ones: <c>ChineseLunisolarCalendar</c> spans ISO 1901-02-19 to
-/// 2101-01-28 and <c>KoreanLunisolarCalendar</c> 918-02-19 to 2051-02-10, while
-/// <c>Temporal.PlainDate</c> spans ±10<sup>8</sup> days. Outside the table the engine used to answer with
-/// the ISO year, <c>M{isoMonth}</c> and twelve months a year — Gregorian fields wearing a lunisolar label
-/// (<see href="https://github.com/sebastienros/jint/issues/3451"/>). It cannot refuse instead:
+/// <see cref="System.Globalization.ChineseLunisolarCalendar"/> and
+/// <see cref="System.Globalization.KoreanLunisolarCalendar"/> are tables, and short ones: ISO 1901-02-19
+/// to 2101-01-28 and 918-02-19 to 2051-02-10, while <c>Temporal.PlainDate</c> spans ±10<sup>8</sup> days.
+/// Outside them the engine used to answer with the ISO year, <c>M{isoMonth}</c> and twelve months a year —
+/// Gregorian fields wearing a lunisolar label (<see href="https://github.com/sebastienros/jint/issues/3451"/>).
+/// It cannot refuse instead:
 /// <see href="https://tc39.es/proposal-temporal/#sec-temporal-nonisocalendarisotodate">NonISOCalendarISOToDate</see>
 /// is declared as returning <em>a Calendar Date Record</em>, with no throw completion, and
 /// <c>get PlainDate.prototype.monthCode</c> reads it without <c>?</c>. So it has to answer, and the answer
 /// has to be the calendar.
+/// </para>
+/// <para>
+/// Nor are those two tables the same table on every target framework, which is why nothing reads them any
+/// more: <c>ChineseLunisolarCalendar</c> read 2057-09-28 as 2057/9/1 on .NET 8 and as 2057/8/30 on .NET
+/// Framework 4.8 and .NET 10, and .NET Framework's <c>KoreanLunisolarCalendar</c> put 8,225 of its 8,447
+/// month starts before 1600 more than two days from a new moon
+/// (<see href="https://github.com/sebastienros/jint/issues/3484"/>).
 /// </para>
 /// <para>
 /// What is implemented is the reckoning both calendars are actually defined by: months begin on the day of
@@ -66,8 +73,9 @@ internal sealed class LunisolarYear
 /// winter solstice, and a year that needs a thirteenth month takes it at the first month carrying no major
 /// solar term. The solar-longitude, new-moon and ephemeris-correction series are Reingold and Dershowitz,
 /// <em>Calendrical Calculations</em> (4th ed.), §14.4 and §19.4 — the same body of algorithms ICU reckons
-/// these calendars with. It is a fallback, not a replacement: inside a BCL calendar's range that table
-/// still answers, and <see cref="NonIsoCalendars"/> only reaches this file outside it.
+/// these calendars with. Measured against the Hong Kong Observatory's published conversion table over
+/// 1901–2100, it names one of 2,473 month boundaries differently, where the three BCL tables name none,
+/// one and three, and ICU fifteen.
 /// </para>
 /// <para>
 /// <b>Every search here is bounded.</b> The series are polynomials in centuries from J2000, and a quarter
@@ -110,14 +118,15 @@ internal static class LunisolarAstronomy
 
     /// <summary>
     /// How many built years each calendar keeps. A power of two, so the slot is a mask rather than a
-    /// division, and wide enough that the centuries a script actually walks stay resident.
+    /// division, and wide enough to hold the ±75-year window <c>FindReferenceYear</c> sweeps for a
+    /// <c>PlainMonthDay</c> without a year evicting another: 151 consecutive years map to 151 slots.
     /// </summary>
     /// <remarks>
     /// A year costs a dozen new moons and a pair of solstice searches to build, and reading one date's
     /// fields asks for the same year once per accessor, so the first tier is what makes reading a date
     /// cost one build rather than six. The second is what makes a month-by-month difference walk
-    /// affordable now that one past the end of a table is answered rather than refused: measuring
-    /// 2050-01-01 to 2300-01-03 in months steps through 250 lunisolar years some three thousand times.
+    /// affordable: measuring 2050-01-01 to 2300-01-03 in months steps through 250 lunisolar years some
+    /// three thousand times.
     /// </remarks>
     private const int YearCacheSize = 256;
 

--- a/Jint/Native/Temporal/NonIsoCalendars.cs
+++ b/Jint/Native/Temporal/NonIsoCalendars.cs
@@ -27,15 +27,15 @@ namespace Jint.Native.Temporal;
 /// </remarks>
 internal static class NonIsoCalendars
 {
-    // Lazy calendar instances to avoid startup overhead
-    private static ChineseLunisolarCalendar? _chineseCalendar;
-    private static KoreanLunisolarCalendar? _koreanCalendar;
+    // Lazy calendar instances to avoid startup overhead. There is deliberately no
+    // ChineseLunisolarCalendar or KoreanLunisolarCalendar here: those two tables are not the same table
+    // on every target framework, so one script gave three answers
+    // (https://github.com/sebastienros/jint/issues/3484). Both calendars are reckoned by
+    // LunisolarAstronomy instead, which is the same code everywhere.
     private static HebrewCalendar? _hebrewCalendar;
     private static PersianCalendar? _persianCalendar;
     private static UmAlQuraCalendar? _umAlQuraCalendar;
 
-    private static ChineseLunisolarCalendar ChineseCal => _chineseCalendar ??= new ChineseLunisolarCalendar();
-    private static KoreanLunisolarCalendar DangiCal => _koreanCalendar ??= new KoreanLunisolarCalendar();
     private static HebrewCalendar HebrewCal => _hebrewCalendar ??= new HebrewCalendar();
     private static PersianCalendar PersianCal => _persianCalendar ??= new PersianCalendar();
     private static UmAlQuraCalendar UmAlQuraCal => _umAlQuraCalendar ??= new UmAlQuraCalendar();
@@ -135,8 +135,8 @@ internal static class NonIsoCalendars
         {
             return calendar switch
             {
-                "chinese" => LunisolarToCalendarDate(ChineseCal, LunisolarRegion.China, in isoDate),
-                "dangi" => LunisolarToCalendarDate(DangiCal, LunisolarRegion.Korea, in isoDate),
+                "chinese" => LunisolarAlgorithmicFromIso(LunisolarRegion.China, in isoDate),
+                "dangi" => LunisolarAlgorithmicFromIso(LunisolarRegion.Korea, in isoDate),
                 "hebrew" => HebrewToCalendarDate(in isoDate),
                 "persian" => PersianToCalendarDate(in isoDate),
                 "coptic" => FixedEpochToCalendarDate(CopticEpochDays, in isoDate),
@@ -229,8 +229,8 @@ internal static class NonIsoCalendars
     {
         return calendar switch
         {
-            "chinese" => LunisolarDateToIso(ChineseCal, LunisolarRegion.China, year, monthCode, month, day, overflow),
-            "dangi" => LunisolarDateToIso(DangiCal, LunisolarRegion.Korea, year, monthCode, month, day, overflow),
+            "chinese" => LunisolarDateToIso(LunisolarRegion.China, year, monthCode, month, day, overflow),
+            "dangi" => LunisolarDateToIso(LunisolarRegion.Korea, year, monthCode, month, day, overflow),
             "hebrew" => HebrewDateToIso(year, monthCode, month, day, overflow),
             "persian" => PersianDateToIso(year, monthCode, month, day, overflow),
             "coptic" => FixedEpochDateToIso(CopticEpochDays, 13, year, monthCode, month, day, overflow),
@@ -498,18 +498,25 @@ internal static class NonIsoCalendars
         }
 
         // Convert back to ISO
-        try
+        if (cal is not null)
         {
-            var dt = cal.ToDateTime(newYear, newOrdinalMonth, newDay, 0, 0, 0, 0);
-            return new IsoDate(dt.Year, dt.Month, dt.Day);
+            try
+            {
+                var dt = cal.ToDateTime(newYear, newOrdinalMonth, newDay, 0, 0, 0, 0);
+                return new IsoDate(dt.Year, dt.Month, dt.Day);
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                // Past the end of the table, which is not the end of the calendar. Fall through to the
+                // conversion, which reckons those years.
+            }
         }
-        catch (ArgumentOutOfRangeException)
+
         {
-            // The result lies outside the range the backing System.Globalization.Calendar represents --
-            // which is the end of a table, not the end of the calendar. The conversion this calls has a
-            // reckoning of its own for exactly those years, and it is the reckoning the field accessors
-            // already read the same date with, so placing the result there is what keeps one date from
-            // getting two verdicts (https://github.com/sebastienros/jint/issues/3483).
+            // The conversion this calls has a reckoning of its own past the end of every backing
+            // calendar, and it is the reckoning the field accessors already read the same date with, so
+            // placing the result there is what keeps one date from getting two verdicts
+            // (https://github.com/sebastienros/jint/issues/3483).
             //
             // BuiltinCalendarDateToIso rather than CalendarDateToIso: the latter's last-resort arm
             // answers an unplaceable date with its fields read as ISO, which is a different calendar's
@@ -1189,8 +1196,8 @@ internal static class NonIsoCalendars
         var isLeapMonthCode = monthCode.Length == 4 && monthCode[3] == 'L';
 
         var bestYear = int.MinValue;
-        var bestIsoTicks = long.MinValue;
-        var upperBound = new DateTime(isoReferenceYear, 12, 31).Ticks;
+        var bestIsoDays = long.MinValue;
+        var upperBound = TemporalHelpers.IsoDateToDays(isoReferenceYear, 12, 31);
         for (var y = approxYear - window; y <= approxYear + window; y++)
         {
             if (isLeapMonthCode)
@@ -1211,13 +1218,18 @@ internal static class NonIsoCalendars
                     continue; // day not valid in this year — skip in pass 1
                 }
 
-                var dt = cal.ToDateTime(y, ordinal, day, 0, 0, 0, 0);
+                var placed = PlaceOrdinalMonth(calendar, cal, y, ordinal, day);
+                if (placed is null)
+                {
+                    continue;
+                }
+
                 // Pick the LATEST valid ISO date that's ≤ end-of-refYear. When two calendar
                 // years both produce ISO dates in refYear (e.g. Hebrew M04 D26 in 5732 → 1972-01
                 // and 5733 → 1972-12), the spec says use the later one.
-                if (dt.Ticks <= upperBound && dt.Ticks > bestIsoTicks)
+                if (placed.Value <= upperBound && placed.Value > bestIsoDays)
                 {
-                    bestIsoTicks = dt.Ticks;
+                    bestIsoDays = placed.Value;
                     bestYear = y;
                 }
             }
@@ -1239,7 +1251,7 @@ internal static class NonIsoCalendars
         if (isLeapMonthCode)
         {
             var futureYear = int.MinValue;
-            var futureIsoTicks = long.MaxValue;
+            var futureIsoDays = long.MaxValue;
             for (var y = approxYear - window; y <= approxYear + window; y++)
             {
                 var leapOrdinal = GetLeapMonthOrdinal(calendar, cal, y);
@@ -1250,10 +1262,11 @@ internal static class NonIsoCalendars
                     var ordinal = MonthCodeToOrdinal(calendar, cal, y, monthCode, "reject");
                     var maxDay = GetDaysInMonthCal(calendar, cal, y, ordinal);
                     if (day > maxDay) continue;
-                    var dt = cal.ToDateTime(y, ordinal, day, 0, 0, 0, 0);
-                    if (dt.Ticks > upperBound && dt.Ticks < futureIsoTicks)
+                    var placed = PlaceOrdinalMonth(calendar, cal, y, ordinal, day);
+                    if (placed is null) continue;
+                    if (placed.Value > upperBound && placed.Value < futureIsoDays)
                     {
-                        futureIsoTicks = dt.Ticks;
+                        futureIsoDays = placed.Value;
                         futureYear = y;
                     }
                 }
@@ -1292,16 +1305,16 @@ internal static class NonIsoCalendars
                 var ordinal = MonthCodeToOrdinal(calendar, cal, y, monthCode, "reject");
                 var maxDay = GetDaysInMonthCal(calendar, cal, y, ordinal);
                 var clampedDay = System.Math.Min(day, maxDay);
-                var dt = cal.ToDateTime(y, ordinal, clampedDay, 0, 0, 0, 0);
-                if (dt.Ticks > upperBound)
+                var placed = PlaceOrdinalMonth(calendar, cal, y, ordinal, clampedDay);
+                if (placed is null || placed.Value > upperBound)
                 {
                     continue;
                 }
 
-                if (maxDay > fallbackMaxDay || (maxDay == fallbackMaxDay && dt.Ticks > fallbackKey))
+                if (maxDay > fallbackMaxDay || (maxDay == fallbackMaxDay && placed.Value > fallbackKey))
                 {
                     fallbackMaxDay = maxDay;
-                    fallbackKey = dt.Ticks;
+                    fallbackKey = placed.Value;
                     fallbackYear = y;
                 }
             }
@@ -1312,6 +1325,30 @@ internal static class NonIsoCalendars
         }
 
         return fallbackYear != int.MinValue ? fallbackYear : approxYear;
+    }
+
+    /// <summary>
+    /// Where a resolved (year, ordinal month, day) lands, as days since 1970-01-01, or null when this
+    /// calendar cannot place it. The backing <see cref="Calendar"/> answers where there is one, and the
+    /// engine's own conversion answers where there is not.
+    /// </summary>
+    private static long? PlaceOrdinalMonth(string calendar, Calendar? cal, int year, int ordinalMonth, int day)
+    {
+        if (cal is not null)
+        {
+            try
+            {
+                var dt = cal.ToDateTime(year, ordinalMonth, day, 0, 0, 0, 0);
+                return TemporalHelpers.IsoDateToDays(dt.Year, dt.Month, dt.Day);
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                return null;
+            }
+        }
+
+        var iso = BuiltinCalendarDateToIso(calendar, year, null, ordinalMonth, day, "reject");
+        return iso is null ? null : TemporalHelpers.IsoDateToDays(iso.Value.Year, iso.Value.Month, iso.Value.Day);
     }
 
     #region Private Helpers
@@ -1517,12 +1554,18 @@ internal static class NonIsoCalendars
         return JdnToIso(jdn);
     }
 
-    private static Calendar GetCalendar(string calendar)
+    /// <summary>
+    /// The <see cref="Calendar"/> backing a calendar, or null for one the engine reckons for itself.
+    /// </summary>
+    /// <remarks>
+    /// <c>chinese</c> and <c>dangi</c> answer null: their BCL tables are not the same table on every
+    /// target framework, so nothing reads them (https://github.com/sebastienros/jint/issues/3484).
+    /// </remarks>
+    private static Calendar? GetCalendar(string calendar)
     {
         return calendar switch
         {
-            "chinese" => ChineseCal,
-            "dangi" => DangiCal,
+            "chinese" or "dangi" => null,
             "hebrew" => HebrewCal,
             "persian" => PersianCal,
             "islamic-umalqura" => UmAlQuraCal,
@@ -1533,8 +1576,18 @@ internal static class NonIsoCalendars
     /// <summary>
     /// Converts an ISO year to an approximate calendar year.
     /// </summary>
-    private static int IsoYearToCalendarYear(string calendar, Calendar cal, int isoYear)
+    /// <remarks>
+    /// A lunisolar calendar year carries the number of the Gregorian year it mostly falls in, so the ISO
+    /// year is already the answer for <c>chinese</c> and <c>dangi</c>, which is what the null arm returns
+    /// and what their BCL calendars returned for them before they were retired.
+    /// </remarks>
+    private static int IsoYearToCalendarYear(string calendar, Calendar? cal, int isoYear)
     {
+        if (cal is null)
+        {
+            return isoYear;
+        }
+
         try
         {
             // Use July 1 of the ISO year as a reference point
@@ -1577,24 +1630,16 @@ internal static class NonIsoCalendars
             }
         }
 
-        // Chinese/Dangi: use EastAsianLunisolarCalendar.GetLeapMonth
-        if (cal is null)
+        if (calendar is "chinese" or "dangi")
         {
-            return 0;
-        }
-
-        try
-        {
-            return ((EastAsianLunisolarCalendar) cal).GetLeapMonth(year);
-        }
-        catch
-        {
-            // Past the end of the table. Answering "no leap month" here is the same mistake as
-            // answering with ISO fields under the calendar's name: the reckoning the field accessors
-            // already use knows which month of this year is the leap one, so ask it.
+            // Which month of a lunisolar year is the leap one is the reckoning to say, for every year.
+            // The BCL tables answered it differently on different target frameworks, and only for the
+            // centuries they cover (https://github.com/sebastienros/jint/issues/3484).
             var resolved = LunisolarAstronomy.ForYear(year, RegionOf(calendar));
             return resolved is null ? 0 : resolved.LeapIndex + 1;
         }
+
+        return 0;
     }
 
     /// <summary>
@@ -1634,6 +1679,12 @@ internal static class NonIsoCalendars
             return 13;
         }
 
+        if (calendar is "chinese" or "dangi")
+        {
+            var reckoned = LunisolarAstronomy.ForYear(year, RegionOf(calendar));
+            return reckoned?.MonthCount ?? 12;
+        }
+
         if (cal is null)
         {
             return 12;
@@ -1649,15 +1700,6 @@ internal static class NonIsoCalendars
             if (calendar is "hebrew")
             {
                 return IsHebrewLeapYearAlgorithmic(year) ? 13 : 12;
-            }
-
-            if (calendar is "chinese" or "dangi")
-            {
-                var resolved = LunisolarAstronomy.ForYear(year, RegionOf(calendar));
-                if (resolved is not null)
-                {
-                    return resolved.MonthCount;
-                }
             }
 
             return 12;
@@ -1733,97 +1775,24 @@ internal static class NonIsoCalendars
 
     #region Lunisolar (Chinese/Dangi) Calendar
 
-    private static CalendarDate LunisolarToCalendarDate(EastAsianLunisolarCalendar cal, LunisolarRegion region, in IsoDate isoDate)
+    /// <summary>
+    /// Resolves a lunisolar calendar date to ISO. Null when this calendar cannot place these fields.
+    /// </summary>
+    /// <remarks>
+    /// The whole year -- its month count, which month is the leap one, how long each month is, and where
+    /// day 1 of each falls -- comes from one <see cref="LunisolarYear"/>, so a date cannot be resolved
+    /// half one way and half another.
+    /// </remarks>
+    private static IsoDate? LunisolarDateToIso(LunisolarRegion region, int year, string? monthCode, int month, int day, string overflow)
     {
-        // ChineseLunisolarCalendar is a table of ISO 1901-02-19 to 2101-01-28 and KoreanLunisolarCalendar
-        // one of 918-02-19 to 2051-02-10, while Temporal.PlainDate spans a quarter of a million years each
-        // way. Outside the table the same calendar is reckoned astronomically rather than answered with
-        // ISO fields under its name (https://github.com/sebastienros/jint/issues/3451). System.DateTime
-        // cannot even hold an ISO year outside 1-9999, so that is checked before one is constructed.
-        if (isoDate.Year < 1 || isoDate.Year > 9999)
+        var resolved = LunisolarAstronomy.ForYear(year, region);
+        if (resolved is null)
         {
-            return LunisolarAlgorithmicFromIso(region, in isoDate);
+            return null;
         }
 
-        var dt = new DateTime(isoDate.Year, isoDate.Month, isoDate.Day);
-
-        if (dt < cal.MinSupportedDateTime || dt > cal.MaxSupportedDateTime)
-        {
-            return LunisolarAlgorithmicFromIso(region, in isoDate);
-        }
-
-        try
-        {
-            var year = cal.GetYear(dt);
-            var ordinalMonth = cal.GetMonth(dt);
-            var day = cal.GetDayOfMonth(dt);
-            var leapMonth = cal.GetLeapMonth(year);
-
-            bool isLeapMonth;
-            string monthCode;
-
-            if (leapMonth > 0 && ordinalMonth >= leapMonth)
-            {
-                if (ordinalMonth == leapMonth)
-                {
-                    var displayMonth = leapMonth - 1;
-                    isLeapMonth = true;
-                    monthCode = $"M{displayMonth:D2}L";
-                }
-                else
-                {
-                    var displayMonth = ordinalMonth - 1;
-                    isLeapMonth = false;
-                    monthCode = $"M{displayMonth:D2}";
-                }
-            }
-            else
-            {
-                isLeapMonth = false;
-                monthCode = $"M{ordinalMonth:D2}";
-            }
-
-            var monthsInYear = leapMonth > 0 ? 13 : 12;
-            var daysInMonth = cal.GetDaysInMonth(year, ordinalMonth);
-            var daysInYear = cal.GetDaysInYear(year);
-            var inLeapYear = leapMonth > 0;
-
-            return new CalendarDate(year, ordinalMonth, monthCode, day, isLeapMonth, monthsInYear, daysInMonth, daysInYear, inLeapYear);
-        }
-        catch (ArgumentOutOfRangeException)
-        {
-            // The table advertises the date and then declines part of it. KoreanLunisolarCalendar reports
-            // month 13 for 1189-01-09 and no leap month for the year holding it, so GetDaysInMonth refuses
-            // the very month GetMonth just named -- and the date came back as ISO fields under the
-            // calendar's name, which is the defect this arm exists to stop.
-            return LunisolarAlgorithmicFromIso(region, in isoDate);
-        }
-    }
-
-    private static IsoDate? LunisolarDateToIso(EastAsianLunisolarCalendar cal, LunisolarRegion region, int year, string? monthCode, int month, int day, string overflow)
-    {
+        var leapMonth = resolved.LeapIndex + 1;
         int ordinalMonth;
-
-        // GetLeapMonth answers for exactly the years the BCL table covers and throws for the rest, so it
-        // is also the test for which reckoning a year belongs to. Outside the table the whole year --
-        // its month count, which month is the leap one, how long each is, and where day 1 falls -- comes
-        // from the astronomical reckoning instead, so that a date cannot be resolved half one way.
-        LunisolarYear? algorithmic = null;
-        var leapMonth = 0;
-        try
-        {
-            leapMonth = cal.GetLeapMonth(year);
-        }
-        catch
-        {
-            algorithmic = LunisolarAstronomy.ForYear(year, region);
-            if (algorithmic is null)
-            {
-                return null;
-            }
-
-            leapMonth = algorithmic.LeapIndex + 1;
-        }
 
         if (monthCode is not null)
         {
@@ -1881,8 +1850,7 @@ internal static class NonIsoCalendars
             ordinalMonth = month;
         }
 
-        // Constrain ordinal month to valid range
-        var maxMonths = algorithmic?.MonthCount ?? (leapMonth > 0 ? 13 : 12);
+        var maxMonths = resolved.MonthCount;
 
         if (string.Equals(overflow, "constrain", StringComparison.Ordinal))
         {
@@ -1893,23 +1861,7 @@ internal static class NonIsoCalendars
             return null;
         }
 
-        // Constrain day
-        int maxDay;
-        if (algorithmic is not null)
-        {
-            maxDay = algorithmic.DaysInMonth(ordinalMonth);
-        }
-        else
-        {
-            try
-            {
-                maxDay = cal.GetDaysInMonth(year, ordinalMonth);
-            }
-            catch
-            {
-                maxDay = 30;
-            }
-        }
+        var maxDay = resolved.DaysInMonth(ordinalMonth);
 
         if (string.Equals(overflow, "constrain", StringComparison.Ordinal))
         {
@@ -1920,28 +1872,11 @@ internal static class NonIsoCalendars
             return null;
         }
 
-        if (algorithmic is not null)
-        {
-            return IsoFromDays(algorithmic.MonthStarts[ordinalMonth - 1] + day - 1);
-        }
-
-        try
-        {
-            var dt = cal.ToDateTime(year, ordinalMonth, day, 0, 0, 0, 0);
-            return new IsoDate(dt.Year, dt.Month, dt.Day);
-        }
-        catch
-        {
-            // The year is one the table covers, but this particular date is past the table's own first
-            // or last day -- the Chinese table begins at 1901-02-19 and ends at 2101-01-28, neither of
-            // which is a year boundary. Answer it in the reckoning the years on either side use rather
-            // than with nothing.
-            return LunisolarAlgorithmicToIso(region, year, ordinalMonth, day);
-        }
+        return IsoFromDays(resolved.MonthStarts[ordinalMonth - 1] + day - 1);
     }
 
     /// <summary>
-    /// Reads an ISO date as a lunisolar date without the BCL table, for the dates outside it.
+    /// Reads an ISO date as a lunisolar date, for every date in Temporal's range.
     /// </summary>
     private static CalendarDate LunisolarAlgorithmicFromIso(LunisolarRegion region, in IsoDate isoDate)
     {
@@ -1972,25 +1907,6 @@ internal static class NonIsoCalendars
             year.DaysInMonth(ordinalMonth),
             year.DaysInYear,
             year.MonthCount == 13);
-    }
-
-    /// <summary>
-    /// Places an already-resolved ordinal month and day in a lunisolar year the BCL table does not cover.
-    /// </summary>
-    private static IsoDate? LunisolarAlgorithmicToIso(LunisolarRegion region, int year, int ordinalMonth, int day)
-    {
-        var resolved = LunisolarAstronomy.ForYear(year, region);
-        if (resolved is null || ordinalMonth < 1 || ordinalMonth > resolved.MonthCount)
-        {
-            return null;
-        }
-
-        if (day < 1 || day > resolved.DaysInMonth(ordinalMonth))
-        {
-            return null;
-        }
-
-        return IsoFromDays(resolved.MonthStarts[ordinalMonth - 1] + day - 1);
     }
 
     #endregion

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -2532,9 +2532,11 @@ without `?`. So the accessors have to answer, and `withCalendar` has no range to
 What answers now is the reckoning both calendars are defined by: months begin on the day of an
 astronomical new moon in the calendar's own time zone, the eleventh month is the one containing the winter
 solstice, and a year needing a thirteenth month takes it at the first month of its *sui* carrying no major
-solar term. It is a fallback, not a replacement — inside a table that table still answers, byte for byte —
-and it reproduces both tables exactly across every year over which they tabulate this calendar rather than
-an older one: `chinese` from 1929, `dangi` from 1912, to the end of each.
+solar term. It landed as a fallback rather than a replacement — inside a table that table still answered,
+byte for byte — and it reproduces both tables exactly across every year over which they tabulate this
+calendar rather than an older one: `chinese` from 1929, `dangi` from 1912, to the end of each. It is the
+replacement now, for the reason
+[4.71](#471-chinese-and-dangi-read-the-same-on-every-target-framework-3484) gives.
 
 **What could break:** anything reading `year`, `month`, `monthCode`, `day`, `dayOfYear`, `daysInMonth`,
 `daysInYear`, `monthsInYear` or `inLeapYear` off a `chinese` or `dangi` date outside those tables, and
@@ -3224,6 +3226,59 @@ astronomical reckoning keeps a process-wide cache of built years. Adding or subt
 still linear in the years crossed for `chinese`, `dangi` and `hebrew`, so
 `add({ months: 3000000 })` is seconds of work that no execution constraint interrupts; the six calendars
 with no backing calendar have always been closed-form there and are unaffected.
+
+### 4.71 `chinese` and `dangi` read the same on every target framework ([#3484](https://github.com/sebastienros/jint/issues/3484))
+
+The `chinese` and `dangi` calendars were read from `System.Globalization.ChineseLunisolarCalendar` and
+`KoreanLunisolarCalendar`, and **those are not the same table on every runtime**. So one script gave three
+answers:
+
+```js
+Temporal.PlainDate.from('1500-06-15').withCalendar('dangi').day;
+// 5.0:  net472 19   net8.0 9    net10.0 9
+// 5.x:  9 everywhere
+
+Temporal.PlainDate.from('2057-09-28').withCalendar('chinese').monthCode;
+// 5.0:  net472 "M08"  net8.0 "M09"  net10.0 "M08"
+// 5.x:  "M09" everywhere
+```
+
+Both calendars are now reckoned by the astronomical implementation
+[4.50](#450-a-date-past-a-lunisolar-calendars-table-is-still-reckoned-in-that-calendar-3451) added for the
+dates past the end of those tables, for **every** date rather than only for those. It is the same code on
+every runtime, and it is at least as accurate as the tables it replaces: measured against the Hong Kong
+Observatory's published conversion table over 1901–2100 (2,473 months), it names one month boundary
+differently, where .NET 8's table names none, .NET 10's one and .NET Framework's three. ICU — which is
+what every other JavaScript engine reckons these two calendars with — names fifteen, including the leap
+month of 1917, 1922 and 1987.
+
+**What could break:** any `chinese` or `dangi` value inside ISO 1901–2101 and 918–2051 respectively.
+Concretely, and this is the whole list for `chinese` across 1901–2100:
+
+| what moves | before | after |
+| --- | --- | --- |
+| 1906-04-24 | `M04` day 1 | `M04` day 2 |
+| 2057-09-28 | `M08` day 30 on `net472`/`net10.0`, `M09` day 1 on `net8.0` | `M09` day 1 |
+| 2089-09-04 | `M07` day 30 on `net472` | `M08` day 1 |
+| 2097-08-07 | `M06` day 30 on `net472` | `M07` day 1 |
+
+`dangi` from 1912 does not move at all on any runtime — the reckoning reproduces the modern Korean
+calendar exactly, all 1,720 months of it from 1912 to 2051. Before 1912 it moves: on `net472` it moves a
+great deal, because that runtime's `KoreanLunisolarCalendar` puts 8,225 of its 8,447 month starts before
+1600 more than two days away from a new moon, a median of 7.2 days out. On .NET Core it moves for about
+one month start in twenty after 1300 and more often before it, where that table records a calendar
+computed by pre-modern methods that no modern reckoning reproduces — the same trade every other engine
+makes, none of which carries such a table either.
+
+`Intl.DateTimeFormat` with `-u-ca-chinese` or `-u-ca-dangi` moves with it, and gains one thing besides: a
+date outside the retired tables used to be **clamped** to the table's own first or last date and formatted
+as that, so 1800-01-01 printed as the Chinese new year of 1901. It now prints the date asked for, and
+agrees with `Temporal` field for field.
+
+**Performance.** Reading the six calendar fields off dates in one year, 100 times, is about twice as fast
+as it was — a per-thread cache of built years serves more than the single entry it replaces. Reading them
+off a hundred *different* years costs six to fourteen times more than the table lookup did, since each
+fresh year is a dozen new moons and two solstice searches to build.
 
 ## 5. New in v5
 


### PR DESCRIPTION
Fixes #3484. **Stacked on #3502** — its commit is the first of the two here, so merge that one first.

## What was wrong

`chinese` and `dangi` were read from `System.Globalization.ChineseLunisolarCalendar` and
`KoreanLunisolarCalendar`, and **those are not the same table on every runtime**. One script, three
answers:

```js
Temporal.PlainDate.from('1500-06-15').withCalendar('dangi').day;
// net472: 19      net8.0: 9       net10.0: 9

Temporal.PlainDate.from('2057-09-28').withCalendar('chinese').monthCode;
// net472: "M08"   net8.0: "M09"   net10.0: "M08"
```

Nothing tested it, because every test compared the engine against whichever of those tables the runtime it
was executing on happened to carry — so all three looked right.

## The investigation, because the obvious fix might have been wrong

The issue proposed replacing the tables with the astronomical reckoning #3482 added, and warned that the
reckoning disagrees with the `dangi` table by 2,218 days over 1654–2051 while matching it exactly over
1912–2051 — which could mean the table encodes real Korean history that a modern reckoning cannot
reproduce. So the tables were measured against sources outside .NET before anything was changed.

**1. Which runtime matches the authority?** ICU is what every other JavaScript engine reckons these
calendars with, and it is *not* a reliable reference for `chinese`: measured against the Hong Kong
Observatory's published Gregorian–Lunar Calendar Conversion Table over 1901–2100 (2,473 months), ICU 78
names nine month boundaries differently **and puts the leap month of 1917, 1922 and 1987 on the wrong
month** — it reads 1987-07-26 as month 7 where HKO reads it as the leap sixth month, 闰六月, which is what
the Chinese calendar of 1987 has.

| source, `chinese` 1901–2100 | wrong month boundaries | misplaced leap months |
| --- | ---: | ---: |
| `ChineseLunisolarCalendar` on .NET 8 | **0** | 0 |
| the reckoning in this PR | **1** (1906-04-24) | 0 |
| `ChineseLunisolarCalendar` on .NET 10 | 1 (2057-09-28) | 0 |
| `ChineseLunisolarCalendar` on .NET Framework 4.8 | 3 | 0 |
| ICU 78 (Node 24) | 9 | 3 |

The reckoning's single divergence is the pre-1929 meridian: China reckoned its calendar at Beijing local
mean time until 1929, which the reckoning models and ICU does not. Reckoning 1901–1928 at UTC+8 instead was
measured — it moves the 1906 boundary onto HKO's and moves **three** others off it (1914, 1916, 1920), so
the meridian change is kept.

**2. Where the tables disagree with each other, which is right?** For `dangi` this needs no authority at
all. A lunisolar month begins on the day of a new moon, so every month start has to sit within a day or so
of one. Over 918–1600, taking the mean new moon as the reference:

| source, `dangi` 918–1600 (8,447 month starts) | more than 2 days from a new moon | median offset |
| --- | ---: | ---: |
| ICU 78 | 0 | +0.17 d |
| the reckoning in this PR | 0 | +0.18 d |
| `KoreanLunisolarCalendar` on .NET 8 / .NET 10 | 2 | +0.05 d |
| **`KoreanLunisolarCalendar` on .NET Framework 4.8** | **8,225** | **+7.18 d** |

.NET Framework's copy is not a lunisolar calendar over those centuries: it puts day 1 of a month around
first quarter. It is not "different history" — 1500-06-15 reads as 1500/5/19 there, which places the month
start ten days before the conjunction. Its modern half is fine: over 1901–1911, where `dangi` must equal
`chinese` because Korea reckoned China's calendar, all three tables and ICU agree with HKO exactly.

**3. So what is defensible?** Reckoning everywhere. It is the only option that gives one answer; it is at
least as accurate as any of the three tables against the one authority that covers the disputed years; it
reproduces the modern Korean calendar exactly (1,720 months, 1912–2051, zero differences on all three
runtimes); and it repairs a runtime whose `dangi` was not a lunisolar calendar at all before ~1550.

The cost is real and is stated in the migration guide: before 1912, .NET Core's Korean table records a
calendar computed by pre-modern methods — its divergence from any modern computation jumps from ~8% to
~45% below 1281, which is where the Shoushi reform of 1281 sits, so it is plausibly a historical record —
and that is replaced by modern rules applied backwards. No other Temporal implementation preserves it
either; ICU carries no such table.

## What changed

- `NonIsoCalendars` no longer instantiates either lunisolar `Calendar`. `GetCalendar` answers null for
  `chinese`/`dangi`, and the year's month count, its leap month, a month's length and where a resolved
  (year, ordinal, day) lands all come from `LunisolarAstronomy`.
- `LunisolarToCalendarDate` and the dual-path `LunisolarDateToIso` are gone; one conversion each way.
- `PlaceOrdinalMonth` replaces the three `cal.ToDateTime` calls in `PlainMonthDay`'s reference-year search,
  which now compares epoch days rather than `DateTime.Ticks`. For the calendars that still have a backing
  `Calendar` it is the identical call, so nothing there moves.
- **`Intl.DateTimeFormat` reads the same conversion.** It used to read the tables directly *and* clamp a
  date outside them to the table's own first or last date and format that — `1800-01-01` in `chinese`
  printed as the Chinese new year of 1901. It now prints the date asked for and agrees with `Temporal`
  field for field. The sexagenary year name is computed rather than read off `GetSexagenaryYear`, from the
  same 1984 = 甲子 anchor.
- The reckoning's two-tier year cache comes from #3502, which needed it for the same reason: without
  the shared 256-entry tier, `PlainMonthDay`'s ±75-year reference-year sweep rebuilt every year on
  every call and eleven `intl402/Temporal/PlainMonthDay` test262 files timed out at 30 s. With it they
  pass in under a second.

## Failing-test evidence

`Jint.Tests/Runtime/LunisolarCalendarAgreementTests.cs` against **unfixed `main`**, and the point is that
it fails *differently on each runtime*:

```
net472    Failed! - Failed: 12, Passed: 15, Total: 27
  Failed chinese, the ninth month of 2057            expected 2057|M09|1, got 2057|M08|30
  Failed chinese, the eighth month of 2089           expected 2089|M08|1, got 2089|M07|30
  Failed chinese, the seventh month of 2097          expected 2097|M07|1, got 2097|M06|30
  Failed dangi, the seventh month of 1000            expected 1000|M07|1,  got 1000|M07|6
  Failed dangi, the second month of 1200             expected 1200|M02|8,  got 1200|M02|15
  Failed dangi, the fifth month of 1400              expected 1400|M05|14, got 1400|M05|23
  Failed dangi, the fifth month of 1500              expected 1500|M05|9,  got 1500|M05|19
  Failed EveryMonthBeginsAtANewMoon("dangi")
  Failed IntlNamesTheSameDayAsTemporal ×4

net8.0    Failed! - Failed:  4, Passed: 23, Total: 27
  Failed IntlNamesTheSameDayAsTemporal ×4

net10.0   Failed! - Failed:  5, Passed: 22, Total: 27
  Failed chinese, the ninth month of 2057
  Failed IntlNamesTheSameDayAsTemporal ×4
```

After: **27 passed on all three**.

Every expectation in that file comes from outside the engine — the HKO table for `chinese`, the Chinese
calendar of the same years for pre-1912 `dangi` (corroborated by ICU and by .NET Core's table), and
`EveryMonthBeginsAtANewMoon` from the mean synodic month, which needs no reference at all.

`NonIsoCalendarOutOfRangeFieldTests.ADateInsideTheTableIsStillAnsweredByTheTable` is replaced rather than
updated: comparing the engine to the runtime's own table is exactly the practice that let this hide. What
takes its place sweeps the same span for the properties any lunisolar calendar has, and for the field
round-trip.

## Performance

100 dates, six calendar fields read off each, milliseconds per pass, median of five, against **plain
`main`** — which is what an embedder actually moves from, and which had neither the reckoning for these
dates nor the year cache #3502 adds:

| workload | net472 | net8.0 | net10.0 |
| --- | --- | --- | --- |
| warm, 1750–1850 — reckoned on `main` too | 28.78 → **1.34** | 10.40 → **1.38** | 10.38 → **1.13** |
| warm, 1950–2050 — the BCL table on `main` | 1.77 → 1.27 | 0.99 → 1.23 | 1.16 → 1.19 |
| warm, one year read 100× | 1.64 → 1.26 | 0.60 → 1.07 | 0.69 → 1.22 |
| cold, 100 never-built years, one pass (JIT included) | 471 → 437 | 281 → 243 | 305 → 240 |

The one solid signal is the first row: dates the engine already reckoned are 7 to 21× faster, because the
cache serves what the single memo entry could not. The rest sits inside this machine's run-to-run spread —
repeating either tree moves those rows by up to 2.4× — so the honest reading is that a steady-state field
read costs about what the table lookup did, and measuring this branch against #3502 rather than against
`main` produces no signal at all above that spread.

## Testing

- `dotnet build -c Release` on the solution — clean, bar the one pre-existing `MSB3277` in
  `Jint.Tests.CommonScripts` on `net472`.
- `Jint.Tests` — **net472 7,734 / net8.0 11,114 / net10.0 11,114 passed, 0 failed**.
- `Jint.Tests.PublicInterface` — net472 2,679 / net8.0 3,302 / net10.0 3,312 passed, 0 failed.
- `Jint.Tests.CommonScripts` 28 on each of two TFMs, `Jint.Tests.SourceGenerators` 71 — 0 failed.
- `Jint.Tests.Test262` — **102,519 passed, 165 skipped**, plus four known under-load flakes: three
  `staging/sm` 30-second timeouts and one `Atomics/notify`. All four pass in isolation (179 passed, 0
  failed), and 102,519 + 4 = 102,523, which is the control measured on this base with nothing applied.

Migration guide: §4.71, and §4.50's "it is a fallback, not a replacement" now points at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014W5mbjGhyvgAS4pivXoc4S
