### PR TITLE
Array: map and slice hand a @@species constructor the length ToLength produced

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -29,10 +29,6 @@
     // overflows and the whole test host dies, taking every other test in the process with it.
     "staging/sm/extensions/recursion.js",
 
-    // { length: Infinity } array generics: the loop is bounded only by the 30-second
-    // TimeoutInterval, which it reaches on every run.
-    "staging/sm/Array/to-length.js",
-
     // Non-terminating under an interpreter: each of these only ends at the 30-second
     // TimeoutInterval, and the DST ones additionally drive the engine into multi-GB
     // allocation. Removed when the underlying loop terminates, not by "make it faster".

--- a/Jint.Tests/Runtime/ArrayLikeLengthClampTests.cs
+++ b/Jint.Tests/Runtime/ArrayLikeLengthClampTests.cs
@@ -195,4 +195,66 @@ public class ArrayLikeLengthClampTests
 
         Assert.That(result, Is.EqualTo("RangeError"));
     }
+
+    /// <summary>
+    /// <see href="https://tc39.es/ecma262/#sec-arrayspeciescreate">ArraySpeciesCreate</see> passes the length
+    /// it was given straight to the <c>@@species</c> constructor; the <c>RangeError</c> for a length above
+    /// 2^32-1 is a step of <see href="https://tc39.es/ecma262/#sec-arraycreate">ArrayCreate</see>, which runs
+    /// only when nothing answered for <c>@@species</c>. <c>map</c> and <c>slice</c> raised it themselves,
+    /// before the species constructor was called at all.
+    /// </summary>
+    [TestCase("Array.prototype.map.call(proxy, function () { })")]
+    [TestCase("Array.prototype.slice.call(proxy, 0)")]
+    public void ASpeciesConstructorIsCalledWithTheLengthToLengthProduced(string call)
+    {
+        var result = Run(
+            "var seen = 'not called';" +
+            "var proxy = new Proxy([], { get: function (target, property) {" +
+            "    if (property === 'length') return Infinity;" +
+            "    if (property !== 'constructor') return undefined;" +
+            "    function fake(length) { seen = length; throw 'invoked'; }" +
+            "    fake[Symbol.species] = fake;" +
+            "    return fake;" +
+            "} });" +
+            "try { " + call + "; } catch (e) { return e + '|' + seen; }" +
+            "return 'no-throw|' + seen;");
+
+        // 9007199254740991 is Number.MAX_SAFE_INTEGER, which is ToLength(Infinity). The constructor throws
+        // rather than return, which is what stops the 2^53-1 element walk that would otherwise follow it.
+        Assert.That(result, Is.EqualTo("invoked|9007199254740991"));
+    }
+
+    /// <summary>
+    /// The length check was also in the wrong place in <c>map</c>'s step order: step 3 rejects a callback
+    /// that is not callable, and step 4 is the create. A <c>RangeError</c> raised before step 3 answered the
+    /// wrong complaint.
+    /// </summary>
+    [TestCase("Infinity")]
+    [TestCase("5e9")]
+    public void MapRejectsANonCallableCallbackBeforeItCreatesAnything(string length)
+    {
+        var result = Run(
+            "try { Array.prototype.map.call({ length: " + length + " }, 'not a function'); return 'no-throw'; }" +
+            "catch (e) { return e instanceof TypeError ? 'TypeError' : e.constructor.name; }");
+
+        Assert.That(result, Is.EqualTo("TypeError"));
+    }
+
+    /// <summary>
+    /// The other half of the same rule: with no <c>@@species</c> to answer, ArraySpeciesCreate does reach
+    /// ArrayCreate and the <c>RangeError</c> is raised there, exactly as before.
+    /// </summary>
+    [TestCase("Array.prototype.map.call({ length: LEN }, function () { })")]
+    [TestCase("Array.prototype.slice.call({ length: LEN })")]
+    public void AnOrdinaryArrayLikeTooLongToCreateStillRaisesRangeError(string call)
+    {
+        foreach (var length in new[] { "Infinity", "5e9", "4294967296" })
+        {
+            var result = Run(
+                "try { " + call.Replace("LEN", length) + "; return 'no-throw'; }" +
+                "catch (e) { return e instanceof RangeError ? 'RangeError' : String(e); }");
+
+            Assert.That(result, Is.EqualTo("RangeError"), length);
+        }
+    }
 }

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -631,18 +631,18 @@ public sealed partial class ArrayPrototype : ArrayInstance
         var o = ArrayOperations.For(_realm, thisObject, forWrite: false);
         var len = o.GetLongLength();
 
-        if (len > ArrayOperations.MaxArrayLength)
-        {
-            Throw.RangeError(_realm, "Invalid array length");
-        }
-
         var callbackfn = arguments.At(0);
         var thisArg = arguments.At(1);
         var callable = GetCallable(callbackfn);
 
-        var a = ArrayOperations.For(_realm.Intrinsics.Array.ArraySpeciesCreate(TypeConverter.ToObject(_realm, thisObject), (uint) len), forWrite: true);
+        // Step 4 hands len to ArraySpeciesCreate unchanged. The RangeError for a length above
+        // 2^32-1 belongs to https://tc39.es/ecma262/#sec-arraycreate, which ArraySpeciesCreate
+        // reaches only when nothing answered for @@species; a species constructor is entitled to
+        // receive the length LengthOfArrayLike produced, and ToLength(Infinity) is 2^53-1. Raising
+        // it up here refused that call before it happened.
+        var a = ArrayOperations.For(_realm.Intrinsics.Array.ArraySpeciesCreate(TypeConverter.ToObject(_realm, thisObject), len), forWrite: true);
         var invoker = CallbackInvoker.Rent(_engine, callable, 3, o.Target);
-        for (uint k = 0; k < len; k++)
+        for (ulong k = 0; k < len; k++)
         {
             if (k > 0 && k % ConstraintCheckInterval == 0)
             {
@@ -1672,22 +1672,21 @@ public sealed partial class ArrayPrototype : ArrayInstance
             }
         }
 
-        if (k < final && final - k > ArrayOperations.MaxArrayLength)
-        {
-            Throw.RangeError(_realm, "Invalid array length");
-        }
-
-        var length = (uint) System.Math.Max(0, (long) final - (long) k);
+        // Step 9 hands count to ArraySpeciesCreate unchanged; see the note in Map for why the
+        // RangeError of https://tc39.es/ecma262/#sec-arraycreate cannot be raised ahead of it.
+        var length = final > k ? final - k : 0UL;
         var a = _realm.Intrinsics.Array.ArraySpeciesCreate(TypeConverter.ToObject(_realm, thisObject), length);
+        // A JsArray source caps len -- and so both k and final -- at 2^32-1, so the copy's uint
+        // arguments are in range on this lane whatever the generic one above had to allow for.
         if (thisObject is JsArray ai && a is JsArray a2)
         {
-            a2.CopyValues(ai, (uint) k, 0, length);
+            a2.CopyValues(ai, (uint) k, 0, (uint) length);
         }
         else
         {
             // slower path
             var operations = ArrayOperations.For(a, forWrite: true);
-            uint n = 0;
+            ulong n = 0;
             for (; k < final; k++, n++)
             {
                 if (n > 0 && n % ConstraintCheckInterval == 0)

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -3315,6 +3315,41 @@ that quietly dropped yields now emits them, so a host that had pinned the old co
 assertion sees it change to the count every other engine reports. `staging/sm/generators/delegating-yield-9.js`
 leaves the test262 exclusion list with this.
 
+### 4.73 A `@@species` constructor is handed the length `ToLength` produced ([#3505](https://github.com/sebastienros/jint/issues/3505))
+
+`Array.prototype.map` and `Array.prototype.slice` checked the source's length against the 2^32-1 array limit
+themselves and raised `RangeError` before calling
+[ArraySpeciesCreate](https://tc39.es/ecma262/#sec-arrayspeciescreate). Neither algorithm has that step: the
+`RangeError` belongs to [ArrayCreate](https://tc39.es/ecma262/#sec-arraycreate), which ArraySpeciesCreate
+reaches only when nothing answered for `@@species`. A host or a script that supplied one never saw its
+constructor called, even though the length it was entitled to receive — `ToLength` clamps to 2^53-1 and never
+truncates — is a perfectly ordinary argument for a constructor that is not `Array`.
+
+```js
+var proxy = new Proxy([], {
+    get(target, property) {
+        if (property === "length") return Infinity;
+        function fake(length) { throw length; }
+        fake[Symbol.species] = fake;
+        return fake;
+    }
+});
+
+// 4.16.x / earlier 5.0: RangeError: Invalid array length
+// 5.x:                  9007199254740991, thrown by the species constructor
+try { Array.prototype.map.call(proxy, () => {}); } catch (e) { e; }
+```
+
+`filter`, `splice`, `concat`, `flat` and `flatMap` create their result with a length of 0 and already behaved
+this way, so the two that did not are the whole change. The five other array generics
+`staging/sm/Array/to-length.js` exercises — `indexOf`, `every`, `fill` and the rest — were already correct;
+that file leaves the test262 exclusion list with this.
+
+**What could break:** a `RangeError` that used to arrive from `map` or `slice` now arrives from whatever the
+`@@species` constructor does, which for the default case — no species, so ArrayCreate — is still a
+`RangeError`, with the length appended to its message. Only a receiver that actually supplies a species
+constructor changes shape, and there the old behaviour was refusing to call code the specification requires
+be called.
 ## 5. New in v5
 
 Everything in the table below is opt-in: nothing in it is installed unless the host asks for it, so


### PR DESCRIPTION
Fixes the second finding in #3505: `staging/sm/Array/to-length.js` was excluded as "the loop is bounded only by the 30-second `TimeoutInterval`". It is not — it fails in tens of milliseconds, on its last assertion, and the reason is a conformance gap.

## What was wrong

`Array.prototype.map` and `Array.prototype.slice` checked the source's length against the 2^32-1 array limit themselves and raised `RangeError` **before** calling [ArraySpeciesCreate](https://tc39.es/ecma262/#sec-arrayspeciescreate):

```csharp
if (len > ArrayOperations.MaxArrayLength)
{
    Throw.RangeError(_realm, "Invalid array length");
}
```

Neither algorithm has that step. `map` is `O` → `len` → *IsCallable* → `ArraySpeciesCreate(O, len)`; `slice` is `count` → `ArraySpeciesCreate(O, count)`. The `RangeError` belongs to [ArrayCreate](https://tc39.es/ecma262/#sec-arraycreate), which ArraySpeciesCreate reaches only when nothing answered for `@@species`. A receiver that *does* supply a species constructor is entitled to have it called with whatever `ToLength` produced — and `ToLength` clamps to 2^53-1, it does not truncate:

```js
var proxy = new Proxy([], {
    get(target, property) {
        if (property === "length") return Infinity;
        function fake(length) { throw length; }
        fake[Symbol.species] = fake;
        return fake;
    }
});

Array.prototype.map.call(proxy, () => {});
// before: RangeError: Invalid array length
// after:  9007199254740991, thrown by the species constructor (V8, SpiderMonkey)
```

Two smaller consequences fell out of the same misplaced check:

* it ran **before** `map`'s step 3, so `Array.prototype.map.call({length: Infinity}, "not a function")` answered `RangeError` where every other engine answers `TypeError`;
* having established `len <= 2^32-1`, `map` then truncated it with `(uint) len` and walked it with a `uint` counter. With the check gone the counter has to be the `ulong` the length already is — which is what `filter` next door has always used.

`filter`, `splice`, `concat`, `flat` and `flatMap` create their result with a length of 0 and were already correct; `map` and `slice` are the only two callers that passed a real length, and they share the one `ArraySpeciesCreate`, so the fix is at those two call sites.

## Tests

Four new cases in `Jint.Tests/Runtime/ArrayLikeLengthClampTests.cs` (the existing home for `ToLength` clamping), all verified to fail against unfixed code, plus a fifth pinning the unchanged half: with no `@@species` to answer, ArraySpeciesCreate does reach ArrayCreate and `RangeError` is still what comes out, for `Infinity`, `5e9` and `4294967296` alike.

`staging/sm/Array/to-length.js` leaves `Test262Harness.settings.json`; everything else in that file — `indexOf`, `lastIndexOf`, `every`, `some`, `forEach`, `filter`, `reduce`, `reduceRight`, `find`, `findIndex`, `fill`, `copyWithin`, `includes`, `Array.from` — already passed.

## Performance

No measurement: the widened counter is in `map`'s generic lane, which invokes a user callback per element and already routes every index through `ArrayOperations.TryGetValue(ulong)`. The plain-`JsArray` fast path (`arrayInstance.Map`) is taken before any of this and is untouched, as is `slice`'s `CopyValues` lane, whose `uint` arguments are still in range because a `JsArray` source caps the length at 2^32-1 by construction.

## test262

Control on `main`: **102,523 passed / 0 failed / 165 skipped of 102,688**.
This branch: ****102,525 passed / 0 failed / 163 skipped of 102,688** — the two modes of the removed file, and nothing else. (The run reported two 32 s `TimeoutException`s on `intl402/supportedLocalesOf-unicode-extensions-ignored.js`; both modes pass in 4 s standalone and are the known contention flake on this machine, not a file this branch touches.)**

Re-measured after rebasing onto `8f0aac567`: **102,522 passed / 3 failed / 163 skipped of 102,688** — all three failures 30-34 s `TimeoutException`s on files this branch does not touch (`staging/sm/Array/toSpliced-dense.js`, `staging/sm/expressions/short-circuit-compound-assignment.js`, `intl402/supportedLocalesOf-unicode-extensions-ignored.js`); `toSpliced-dense.js` measures 2 s per mode both with and without this change, so it is the same contention, not a regression. Migration guide section is **4.71**.
