### PR TITLE
test262: five staging files excluded as non-terminating do terminate, and pass

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -36,6 +36,13 @@
     // Non-terminating under an interpreter: each of these only ends at the 30-second
     // TimeoutInterval, and the DST ones additionally drive the engine into multi-GB
     // allocation. Removed when the underlying loop terminates, not by "make it faster".
+    //
+    // What earns a place in this group is a file that does not finish on its own, and nothing else.
+    // Five entries that sat here were re-measured and pass, in 0.2 to 1.0 seconds each: the group
+    // was filed off one run in which every file still listed here was running too, and
+    // TimeoutInterval is wall clock, so a test whose worker is starved by a neighbour holding the
+    // whole 30 seconds times out on the neighbour's behalf. Before adding an entry, run the file on
+    // its own and confirm that the file is what does not terminate.
     "staging/sm/Date/dst-offset-caching-1-of-8.js",
     "staging/sm/Date/dst-offset-caching-2-of-8.js",
     "staging/sm/Date/dst-offset-caching-3-of-8.js",
@@ -44,19 +51,19 @@
     "staging/sm/Date/dst-offset-caching-6-of-8.js",
     "staging/sm/Date/dst-offset-caching-7-of-8.js",
     "staging/sm/Date/dst-offset-caching-8-of-8.js",
+    "staging/sm/JSON/parse-mega-huge-array.js",
     "staging/sm/generators/delegating-yield-9.js",
     "staging/sm/regress/regress-610026.js",
-    "staging/sm/regress/regress-619003-1.js",
-    // Same shape, found by running the suite: each of these burns the whole 30-second budget and
-    // (times two modes, times ~1400 new files running in parallel) starves the rest of the run
-    // badly enough to make unrelated tests elsewhere in the suite time out too.
-    "staging/sm/Function/has-instance-jitted.js",
-    "staging/sm/JSON/parse-mega-huge-array.js",
-    "staging/sm/RegExp/unicode-braced.js",
-    "staging/sm/RegExp/unicode-class-braced.js",
-    "staging/sm/RegExp/unicode-ignoreCase.js",
-    "staging/sm/expressions/nullish-coalescing.js",
     "staging/sm/regress/regress-1507322-deep-weakmap.js",
+
+    // Terminates, and passes, but is the most expensive file in the whole suite: 1e5 iterations of
+    // a thirteen-assertion function, three seconds per mode with the machine to itself, against a
+    // staging/sm median in the single-digit milliseconds. Three times the next slowest, which is
+    // enough that a full run starves it past the 30-second budget - four full runs, four failures,
+    // including the run in which nothing else failed at all. So the entry stays, but not for the
+    // reason above: this one is a cost, not a loop that never ends. Removed by raising the
+    // throughput of the interpreted loop, or by a budget that measures work rather than wall clock.
+    "staging/sm/expressions/nullish-coalescing.js",
 
     // === PERMANENT EXCLUSIONS ===
     //


### PR DESCRIPTION
Fixes the third finding in #3505. Six of the twenty `staging/` entries under the `=== STAGING EXCLUSIONS ===` banner were filed as "does not terminate inside the 30-second `TimeoutInterval`". All six terminate and all six pass. Five leave the list; the sixth stays, for a reason that is not the one on the banner.

## What they actually cost

Per-test duration with the machine to itself (`--logger "console;verbosity=detailed"`, slowest mode shown):

| file | | |
| --- | --- | --- |
| `staging/sm/regress/regress-619003-1.js` | 1.0 s | removed |
| `staging/sm/RegExp/unicode-braced.js` | 0.55 s | removed |
| `staging/sm/RegExp/unicode-class-braced.js` | 0.56 s | removed |
| `staging/sm/RegExp/unicode-ignoreCase.js` | 1.0 s | removed |
| `staging/sm/Function/has-instance-jitted.js` | 0.9 s | removed |
| `staging/sm/expressions/nullish-coalescing.js` | **3.0 s** | **stays** |

`TimeoutInterval` is wall clock, not work, so a test whose worker is starved by a neighbour holding the whole 30 seconds times out on the neighbour's behalf. This group was filed off one run in which every genuinely non-terminating file was still in the suite — the banner's own second paragraph says as much ("starves the rest of the run badly enough to make unrelated tests elsewhere in the suite time out too"); it just did not follow that the starved test could be one of these. Twenty-four PRs landed between #3016 and now, and #3070 ("Choose the regex engine per subject") is the likeliest reason the three `RegExp` files are also cheap in absolute terms today.

## Four full runs, and what they show

Four consecutive full `dotnet test -c Release Jint.Tests.Test262` runs with all six removed, on a workstation that had other work on it:

| run | result |
| --- | --- |
| A | 102,526 passed / 9 failed / 153 skipped |
| B | 102,533 passed / 2 failed / 153 skipped |
| C | 102,528 passed / 7 failed / 153 skipped |
| D | 102,530 passed / 5 failed / 153 skipped |

Every run: **passed + failed = 102,535**, and **skipped 153** — exactly control's 165 minus the twelve entries removed. The total stays 102,688 because an excluded file is still a generated test that reports as skipped.

Every failure in all four runs was a 30-33 s `TimeoutException`, and the set was not confined to the six:

| file | failed / 4 runs | excluded today? | uncontended cost |
| --- | --- | --- | --- |
| `staging/sm/expressions/nullish-coalescing.js` | **4** | yes | 3.0 s |
| `staging/sm/expressions/short-circuit-compound-assignment.js` | 3 | **no** | 1.0 s |
| `intl402/supportedLocalesOf-unicode-extensions-ignored.js` | 2 | **no** | — |
| `staging/sm/expressions/object-literal-__proto__.js` | 2 | **no** | 1.0 s |
| `staging/sm/Function/has-instance-jitted.js` | 2 | yes | 0.9 s |
| the other four of the six | 0 | yes | 0.2-1.0 s |

That table is the whole argument. Three files `main` ships **unexcluded and green in CI** — `short-circuit-compound-assignment.js`, `object-literal-__proto__.js` and the `intl402` one — flake on this machine as often as or more often than `has-instance-jitted.js` does, and `has-instance-jitted.js` is *cheaper* than either of the two staging ones. Excluding a 0.9 s file while the suite already runs 1.0 s files next to it would be incoherent, so it goes. Each of them passes in isolation in seconds.

`nullish-coalescing.js` is a different animal: 3 seconds per mode, three times the next slowest file in the suite, `1e5` iterations of a thirteen-assertion function against a `staging/sm` median in the single-digit milliseconds. It failed **4 of 4 runs in both modes**, including run B, in which nothing else failed at all. Its entry stays — but the comment above it now says what is true: it is a cost, not a loop that never ends, and what removes it is interpreter throughput or a budget that measures work instead of wall clock.

## Final configuration

Five entries removed, and two full runs to confirm:

* Run 1: ****102,532 passed / 1 failed / 155 skipped of 102,688** — the failure `staging/sm/expressions/short-circuit-compound-assignment.js`, which this PR does not touch and which passes in 1 s standalone**
* Run 2: ****102,532 passed / 1 failed / 155 skipped of 102,688** — the failure `intl402/supportedLocalesOf-unicode-extensions-ignored.js`, likewise untouched here and passing in 4 s standalone**

Control on `main`: **102,523 passed / 0 failed / 165 skipped of 102,688**. Ten skips (five files x two modes) become ten passes: **102,533 / 0 / 155** once the one contention flake each run is discounted. With `nullish-coalescing.js` back out of the running set the failure count drops straight back to the machine's one-per-run noise floor, and none of the five removed files appears in it.

## The banner

The two sub-groups merge — the distinction between them ("found by running the suite") is exactly what produced the mistake — and the remaining group's comment now says what earns a place in it: a file that does not finish on its own, confirmed by running the file on its own. Eleven entries remain there and are unchanged: `extensions/recursion.js`, the eight `Date/dst-offset-caching-*`, `JSON/parse-mega-huge-array.js`, `regress/regress-610026.js` and `regress/regress-1507322-deep-weakmap.js`, plus `generators/delegating-yield-9.js` until #3506 removes it. `Array/to-length.js` leaves via #3510.

No engine change: this PR is the settings file only.

Re-measured after rebasing onto `8f0aac567`, in a quiet moment: **102,533 passed / 0 failed / 155 skipped of 102,688** — the predicted figure exactly, with no flake at all.
