### PR TITLE
Intl.NumberFormat: an exactly-read value wears the same pattern a Number wears, and a percent's digits are ToRawFixed's

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -180,8 +180,8 @@
     // Locale fallback chains - zh-CN should match zh-Hans-CN in supportedLocalesOf
     //"intl402/fallback-locales-are-supported.js",
     //"intl402/supportedLocalesOf-consistent-with-resolvedOptions.js",
-    // NumberFormat - Indian lakh/crore grouping and compact patterns
-    // NumberFormat - Indian lakh/crore compact notation (1L for 100K, 1C for 10M)
+    // NumberFormat - Indian lakh/crore compact notation (1L for 100K, 1C for 10M); the file's
+    // useGrouping: "always" and "min2" halves pass now, and only its compact block still fails
     "intl402/NumberFormat/prototype/format/useGrouping-extended-en-IN.js",
     // formatRange - locale-specific range patterns + sign-collapse + string precision (unblocks once P1.2/P1.3 land)
     //"intl402/NumberFormat/prototype/formatRange/en-US.js",

--- a/Jint.Tests/Runtime/IntlNumberFormatPartsTests.cs
+++ b/Jint.Tests/Runtime/IntlNumberFormatPartsTests.cs
@@ -27,7 +27,8 @@ public class IntlNumberFormatPartsTests
         "mathbold"
     ];
 
-    private static readonly string[] Locales = ["en", "en-US", "de-DE", "fr-FR", "pt-PT", "ar-EG", "ja-JP"];
+    // en-IN groups its digits 3, then 2 — 12,34,567 — which no lane may assume away
+    private static readonly string[] Locales = ["en", "en-US", "de-DE", "fr-FR", "pt-PT", "ar-EG", "ja-JP", "en-IN"];
 
     private static readonly string[] OptionSets =
     [
@@ -45,6 +46,14 @@ public class IntlNumberFormatPartsTests
         "{ style: 'currency', currency: 'EUR', minimumFractionDigits: 3, maximumFractionDigits: 4 }",
         "{ style: 'unit', unit: 'meter' }",
         "{ style: 'unit', unit: 'kilometer-per-hour', unitDisplay: 'long' }",
+        // a percent with a fraction-digit count, which ToRawFixed trims rather than pads, and with each
+        // of the options .NET's "P" specifier does not read at all
+        "{ style: 'percent', maximumFractionDigits: 1 }",
+        "{ style: 'percent', minimumFractionDigits: 3, maximumFractionDigits: 4 }",
+        "{ style: 'percent', signDisplay: 'always' }",
+        "{ style: 'percent', useGrouping: false }",
+        "{ style: 'percent', minimumIntegerDigits: 3 }",
+        "{ style: 'currency', currency: 'USD', currencySign: 'accounting' }",
         "{ notation: 'scientific' }",
         "{ notation: 'engineering' }",
         "{ notation: 'compact' }",
@@ -55,7 +64,9 @@ public class IntlNumberFormatPartsTests
         "[0, 1, -1, 0.5, 1234.5, -1234.5, 1234567.891, 12345678901234, NaN, Infinity, -Infinity, "
         // values ToIntlMathematicalValue reads exactly, which no double holds: a BigInt, an integer
         // string past 2^53, and a decimal string with more significant digits than a double carries
-        + "987654321987654321n, -987654321987654321n, '987654321987654321', '1.00000000000000012']";
+        + "987654321987654321n, -987654321987654321n, '987654321987654321', '1.00000000000000012', "
+        // whole doubles past 2^63, where a cast to long saturates rather than answers
+        + "1e21, 1e25]";
 
     /// <summary>
     /// The defect: <c>format</c> transliterated and <c>formatToParts</c> did not, so
@@ -629,6 +640,174 @@ public class IntlNumberFormatPartsTests
                 """
                 [{"type":"integer","value":"987"},{"type":"literal","value":" "},{"type":"unit","value":"Kilometer pro Stunde"}]
                 """);
+    }
+
+    /// <summary>
+    /// ToRawFixed's trim is the same two steps whatever the style wraps them in, so a percent asked for
+    /// one fraction digit writes none when that digit would be a zero.
+    /// </summary>
+    /// <remarks>
+    /// The defect: the percent string lane was .NET's <c>"P"</c> specifier over
+    /// <c>NumberFormatInfo.PercentDecimalDigits</c>, which the constructor sets to
+    /// <c>maximumFractionDigits</c> — so it wrote exactly that many digits always.
+    /// </remarks>
+    [Test]
+    public void APercentTrimsItsFractionDownToTheMinimum()
+    {
+        const string OneDigit = "new Intl.NumberFormat('en-US', { style: 'percent', maximumFractionDigits: 1 })";
+        Format(OneDigit, "0.4").Should().Be("40%");
+        Join(OneDigit, "0.4").Should().Be("40%");
+        Format(OneDigit, "0.455").Should().Be("45.5%");
+        Join(OneDigit, "0.455").Should().Be("45.5%");
+
+        const string Wide =
+            "new Intl.NumberFormat('en-US', { style: 'percent', minimumFractionDigits: 3, maximumFractionDigits: 4 })";
+        Format(Wide, "2.9").Should().Be("290.000%");
+        Join(Wide, "2.9").Should().Be("290.000%");
+        Format(Wide, "2.912345").Should().Be("291.2345%");
+        Join(Wide, "2.912345").Should().Be("291.2345%");
+    }
+
+    /// <summary>
+    /// The percent pattern is walked around a number the rest of the options built, so the options that
+    /// build it are read: the sign, the grouping and the integer-digit floor.
+    /// </summary>
+    /// <remarks>
+    /// <c>"P"</c> reads one datum and it is the fraction-digit count, so none of these reached the string
+    /// lane at all — <c>signDisplay: "always"</c> wrote no plus sign, <c>useGrouping: false</c> grouped
+    /// anyway, and <c>minimumIntegerDigits</c> padded nothing.
+    /// </remarks>
+    [Test]
+    public void APercentReadsTheOptionsThatBuildItsNumber()
+    {
+        const string Always = "new Intl.NumberFormat('en-US', { style: 'percent', signDisplay: 'always' })";
+        Format(Always, "0.4").Should().Be("+40%");
+        Join(Always, "0.4").Should().Be("+40%");
+
+        const string Never = "new Intl.NumberFormat('en-US', { style: 'percent', signDisplay: 'never' })";
+        Format(Never, "-0.4").Should().Be("40%");
+        Join(Never, "-0.4").Should().Be("40%");
+
+        const string NoGrouping = "new Intl.NumberFormat('en-US', { style: 'percent', useGrouping: false })";
+        Format(NoGrouping, "1234.567").Should().Be("123457%");
+        Join(NoGrouping, "1234.567").Should().Be("123457%");
+
+        const string ThreeIntegers = "new Intl.NumberFormat('en-US', { style: 'percent', minimumIntegerDigits: 3 })";
+        Format(ThreeIntegers, "0.04").Should().Be("004%");
+        Join(ThreeIntegers, "0.04").Should().Be("004%");
+    }
+
+    /// <summary>
+    /// The space a percent pattern puts before its sign is CLDR's U+00A0, which is the character
+    /// <c>intl402/BigInt/prototype/toLocaleString/de-DE.js</c> asserts. .NET writes a plain space for the
+    /// same locale, so the pattern says where the space goes and CLDR says which space it is.
+    /// </summary>
+    [Test]
+    public void APercentPatternsSpaceIsTheOneCldrWrites()
+    {
+        const string German = "new Intl.NumberFormat('de-DE', { style: 'percent' })";
+        Format(German, "2").Should().Be("200 %");
+        Join(German, "2").Should().Be("200 %");
+    }
+
+    /// <summary>
+    /// A locale whose groups are not three digits wide keeps them in both lanes: <c>en-IN</c> writes
+    /// <c>12,34,567</c>, which is what <c>NumberFormatInfo.NumberGroupSizes</c> carries as <c>[3, 2]</c>.
+    /// </summary>
+    [Test]
+    public void TheGroupsAreTheWidthsTheLocaleUses()
+    {
+        const string Indian = "new Intl.NumberFormat('en-IN')";
+        Format(Indian, "1234567.891").Should().Be("12,34,567.891");
+        Join(Indian, "1234567.891").Should().Be("12,34,567.891");
+
+        // .NET Framework and .NET disagree about whether en-IN spaces its currency symbol, so the digits
+        // are what is asserted here
+        Join("new Intl.NumberFormat('en-IN', { style: 'currency', currency: 'INR' })", "123456789")
+            .Should().EndWith("12,34,56,789.00");
+        Join("new Intl.NumberFormat('en-IN', { style: 'percent' })", "1234567.891").Should().Be("12,34,56,789%");
+    }
+
+    /// <summary>
+    /// A value a <c>long</c> cannot hold is written, not saturated:
+    /// https://tc39.es/ecma402/#sec-tointlmathematicalvalue reads a Number as <c>Number::toString</c>'s
+    /// digits, and every one of them survives to https://tc39.es/ecma402/#sec-torawfixed.
+    /// </summary>
+    /// <remarks>
+    /// The defect: the parts lane split its value with <c>(long) Math.Truncate(value)</c>, and .NET's
+    /// saturating conversion pins everything from 2^63 up to <c>long.MaxValue</c> — so every such value
+    /// formatted as <c>9,223,372,036,854,775,807.9223372036854775807</c>, whatever it was.
+    /// </remarks>
+    [Test]
+    public void AValuePastTheRangeOfALongIsStillItsOwnDigits()
+    {
+        const string Plain = "new Intl.NumberFormat('en-US')";
+        const string Sextillion = "1,000,000,000,000,000,000,000";
+        Format(Plain, "1e21").Should().Be(Sextillion);
+        Join(Plain, "1e21").Should().Be(Sextillion);
+
+        Join("new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' })", "1e21")
+            .Should().Be("$" + Sextillion + ".00");
+        Join("new Intl.NumberFormat('en-US', { style: 'unit', unit: 'meter' })", "1e21")
+            .Should().Be(Sextillion + " m");
+        Join("new Intl.NumberFormat('en-US', { style: 'percent' })", "1e19")
+            .Should().Be(Sextillion + "%");
+    }
+
+    /// <summary>
+    /// A value read exactly is dressed in the pattern a Number of the same size is dressed in:
+    /// https://tc39.es/ecma402/#sec-partitionnumberpattern chooses that pattern with
+    /// https://tc39.es/ecma402/#sec-getnumberformatpattern, which reads the style and the sign and never
+    /// the value's carrier.
+    /// </summary>
+    /// <remarks>
+    /// The defect: the exact lane wrote the currency symbol and then the number, with none of the locale's
+    /// pattern, its accounting form or the sign display — so <c>format(-123n)</c> was <c>"$-123.00"</c>
+    /// where <c>format(-123)</c> was <c>"-$123.00"</c>, and a suffix-currency locale put its symbol in
+    /// front.
+    /// </remarks>
+    [Test]
+    public void AnExactValueTakesTheSamePatternADoubleTakes()
+    {
+        const string Usd = "new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' })";
+        Format(Usd, "-123n").Should().Be("-$123.00").And.Be(Format(Usd, "-123"));
+
+        const string Euro = "new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' })";
+        Format(Euro, "123n").Should().Be("123,00 €").And.Be(Format(Euro, "123"));
+
+        const string Accounting =
+            "new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', currencySign: 'accounting' })";
+        Format(Accounting, "-123n").Should().Be("($123.00)").And.Be(Format(Accounting, "-123"));
+
+        const string Always = "new Intl.NumberFormat('en-US', { signDisplay: 'always' })";
+        Format(Always, "5n").Should().Be("+5").And.Be(Format(Always, "5"));
+
+        // a decimal string long enough to reach the exact lane takes the same pattern
+        Format(Usd, "'987654321987654321'").Should().Be("$987,654,321,987,654,321.00");
+        Format(Accounting, "'-987654321987654321'").Should().Be("($987,654,321,987,654,321.00)");
+    }
+
+    /// <summary>
+    /// A notation writes a scaled mantissa or an abbreviation that
+    /// https://tc39.es/ecma402/#sec-partitionnotationsubpattern picks from the value's own magnitude, and
+    /// an exactly-read value gets the one a Number of that magnitude gets.
+    /// </summary>
+    /// <remarks>
+    /// The defect: the exact lane never looked at <c>[[Notation]]</c>, so a BigInt and a long numeric
+    /// string wrote a plain grouped decimal under every notation.
+    /// </remarks>
+    [Test]
+    public void AnExactValueTakesTheNotationTheFormatterWasGiven()
+    {
+        const string Scientific = "new Intl.NumberFormat('en-US', { notation: 'scientific' })";
+        Format(Scientific, "12345n").Should().Be("1.235E4").And.Be(Format(Scientific, "12345"));
+        Format(Scientific, "'987654321987654321'").Should().Be("9.877E17");
+
+        const string Compact = "new Intl.NumberFormat('en-US', { notation: 'compact' })";
+        Format(Compact, "12345n").Should().Be("12K").And.Be(Format(Compact, "12345"));
+
+        const string Engineering = "new Intl.NumberFormat('en-US', { notation: 'engineering' })";
+        Format(Engineering, "12345n").Should().Be(Format(Engineering, "12345"));
     }
 
     private string Format(string formatter, string value)

--- a/Jint.Tests/SpecAnchors.txt
+++ b/Jint.Tests/SpecAnchors.txt
@@ -15,7 +15,7 @@
 # resolving here until somebody re-runs that.
 #
 verified: 2026-08-30
-anchors: 1240
+anchors: 1242
 absent: 2
 !proposal-decorators sec-autoaccessordefinitionevaluation  # tc39.es still renders the 2018 descriptor design, which has no such clause
 !proposal-decorators sec-createdecoratorcontextobject  # tc39.es still renders the 2018 descriptor design, which has no such clause
@@ -864,6 +864,7 @@ ecma402 sec-formatdatetime
 ecma402 sec-formatdatetimepattern
 ecma402 sec-formatdatetimetoparts
 ecma402 sec-formatnumber
+ecma402 sec-formatnumberstring
 ecma402 sec-formatnumbertoparts
 ecma402 sec-formatnumerichours
 ecma402 sec-formatnumericminutes
@@ -935,6 +936,7 @@ ecma402 sec-segments-objects
 ecma402 sec-the-intl-collator-constructor
 ecma402 sec-tointlmathematicalvalue
 ecma402 sec-torawfixed
+ecma402 sec-torawprecision
 ecma402 segmenter-objects
 ecma402 sup-String.prototype.localeCompare
 ecma402 sup-bigint.prototype.tolocalestring

--- a/Jint/Native/Intl/JsNumberFormat.cs
+++ b/Jint/Native/Intl/JsNumberFormat.cs
@@ -849,6 +849,14 @@ internal sealed class JsNumberFormat : ObjectInstance
             return value;
         }
 
+        // A double from 2^53 up carries no fraction at all, so rounding one is the identity — and
+        // scaling it by a power of ten to round it is not, since the product is past what a double
+        // holds exactly: 1e21 came back as 999999999999999900000.
+        if (decimalPlaces > 0 && System.Math.Abs(value) >= 9007199254740992d)
+        {
+            return value;
+        }
+
         var multiplier = System.Math.Pow(10, decimalPlaces);
         var scaled = value * multiplier;
 
@@ -973,9 +981,12 @@ internal sealed class JsNumberFormat : ObjectInstance
     /// double first. One answer, read by both lanes, so neither can format a value the other approximated.
     /// </summary>
     /// <remarks>
-    /// The exact lane covers a plain decimal number in every configuration, and the three scaled styles
-    /// only for a whole one: scaling a fraction, a notation's mantissa, and significant-digit rounding of a
-    /// fraction each need arithmetic the exact carrier does not do yet, and take the double.
+    /// The exact lane covers the standard notation in every style, and only there: a notation writes a
+    /// scaled mantissa or an abbreviation, https://tc39.es/ecma402/#sec-partitionnotationsubpattern picks
+    /// it from the value's own magnitude, and the exact carrier does not do that arithmetic — so a value
+    /// this lane would otherwise keep whole takes the double instead, and gets the exponent the same
+    /// formatter writes for a Number. Scaling a fraction, and rounding one to significant digits, are the
+    /// other two cases it hands over.
     /// </remarks>
     private bool CanPartitionExactly(in IntlMathematicalValue value)
     {
@@ -984,14 +995,19 @@ internal sealed class JsNumberFormat : ObjectInstance
             return false;
         }
 
+        if (!string.Equals(Notation, "standard", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        // Significant-digit rounding under a scaled style, and scaling a fraction at all, are the two
+        // pieces of arithmetic the exact carrier does not do yet.
         var significantDigits = MinimumSignificantDigits.HasValue || MaximumSignificantDigits.HasValue;
         var scaledStyle = Style is "currency" or "percent" or "unit";
 
         if (value.FractionDigits > 0)
         {
-            return !scaledStyle
-                && !significantDigits
-                && string.Equals(Notation, "standard", StringComparison.Ordinal);
+            return !scaledStyle && !significantDigits;
         }
 
         return !significantDigits || !scaledStyle;
@@ -1001,11 +1017,22 @@ internal sealed class JsNumberFormat : ObjectInstance
     /// https://tc39.es/ecma402/#sec-partitionnumberpattern over an exact
     /// mantissa × 10^-<paramref name="fractionDigits"/>.
     /// </summary>
+    /// <remarks>
+    /// The value's digits are the only thing this lane owns. Everything written around them — the currency
+    /// pattern https://tc39.es/ecma402/#sec-getnumberformatpattern selects, its accounting form, the unit's
+    /// two affixes, the percent sign and the sign itself — is the same pattern walk a
+    /// <see cref="double"/> takes, so a value read exactly cannot be dressed differently from the value a
+    /// Number of the same size is dressed in.
+    /// </remarks>
     private List<NumberFormatPart> PartitionExact(BigInteger mantissa, int fractionDigits)
     {
-        if (fractionDigits > 0)
+        var isNegative = mantissa.Sign < 0;
+        var abs = isNegative ? -mantissa : mantissa;
+
+        if (string.Equals(Style, "percent", StringComparison.Ordinal))
         {
-            return ExactDecimalParts(mantissa, fractionDigits);
+            // percent scales by 100, which the exact carrier does by moving the mantissa, not the point
+            abs *= 100;
         }
 
         // Significant-digit rounding of a whole value is exact, so it stays on this lane.
@@ -1013,46 +1040,70 @@ internal sealed class JsNumberFormat : ObjectInstance
             && Style is not ("currency" or "percent" or "unit");
         if (significantDigits)
         {
-            mantissa = ApplySignificantDigitRounding(mantissa);
+            abs = ApplySignificantDigitRounding(abs);
         }
 
-        return Style switch
+        var body = ExactBody(abs, fractionDigits, out var displaysAsZero);
+
+        var showNegativeSign = isNegative;
+        var showPositiveSign = false;
+        switch (SignDisplay)
         {
-            "currency" => ExactCurrencyParts(mantissa),
-            "percent" => ExactPercentParts(mantissa),
-            "unit" => ExactUnitParts(mantissa),
-            // the significant-digits lane over a double writes a literal "-" rather than the locale's own
-            // sign, and the two lanes have to agree about which one this is
-            _ => ExactNumberParts(mantissa, useLiteralMinus: significantDigits)
-        };
+            case "always":
+                showPositiveSign = !isNegative;
+                break;
+            case "exceptZero":
+                showPositiveSign = !isNegative && !displaysAsZero;
+                showNegativeSign = isNegative && !displaysAsZero;
+                break;
+            case "negative":
+                showNegativeSign = isNegative && !displaysAsZero;
+                break;
+            case "never":
+                showNegativeSign = false;
+                break;
+        }
+
+        var parts = new List<NumberFormatPart>();
+        switch (Style)
+        {
+            case "currency":
+                AppendCurrencyParts(parts, in body, showNegativeSign, showPositiveSign);
+                break;
+            case "percent":
+                AppendPercentParts(parts, in body, showNegativeSign, showPositiveSign);
+                break;
+            case "unit":
+                AppendUnitParts(parts, in body, showNegativeSign, showPositiveSign, (double) mantissa);
+                break;
+            default:
+                // the significant-digits lane over a double writes a literal "-" rather than the locale's
+                // own sign, and the two lanes have to agree about which one this is
+                AppendSignPart(parts, showNegativeSign, showPositiveSign, significantDigits ? "-" : null);
+                AddNumberParts(parts, in body);
+                break;
+        }
+
+        return parts;
     }
 
     /// <summary>
-    /// The parts of an exact mantissa × 10^-<paramref name="fractionDigits"/> under the decimal style:
-    /// https://tc39.es/ecma402/#sec-torawfixed on a mathematical value instead of on a double.
+    /// The digits https://tc39.es/ecma402/#sec-torawfixed writes for a non-negative exact
+    /// <paramref name="absMantissa"/> × 10^-<paramref name="fractionDigits"/>: rounded at
+    /// <see cref="MaximumFractionDigits"/> with halfExpand, then trimmed of up to
+    /// <c>maximumFractionDigits - minimumFractionDigits</c> trailing zeros.
     /// </summary>
-    private List<NumberFormatPart> ExactDecimalParts(BigInteger mantissa, int fractionDigits)
+    private NumberBody ExactBody(BigInteger absMantissa, int fractionDigits, out bool displaysAsZero)
     {
-        var maxFrac = MaximumFractionDigits;
-        var minFrac = MinimumFractionDigits;
-
-        // Track the original sign so a "-0.000..." input that rounds to zero still displays
-        // as negative (ECMA-402 preserves negative-zero in formatted output).
-        var originallyNegative = mantissa.Sign < 0;
-
-        // Trim or round fraction digits to MaximumFractionDigits using halfExpand.
-        if (fractionDigits > maxFrac)
+        if (fractionDigits > MaximumFractionDigits)
         {
-            var dropDigits = fractionDigits - maxFrac;
-            var divisor = BigInteger.Pow(10, dropDigits);
-            var halfDivisor = divisor / 2;
-            var absM = originallyNegative ? -mantissa : mantissa;
-            var rounded = (absM + halfDivisor) / divisor;
-            mantissa = originallyNegative ? -rounded : rounded;
-            fractionDigits = maxFrac;
+            var divisor = BigInteger.Pow(10, fractionDigits - MaximumFractionDigits);
+            absMantissa = (absMantissa + divisor / 2) / divisor;
+            fractionDigits = MaximumFractionDigits;
         }
 
-        var absMantissa = mantissa.Sign < 0 ? -mantissa : mantissa;
+        displaysAsZero = absMantissa.IsZero;
+
         var digits = absMantissa.ToString("R", CultureInfo.InvariantCulture);
 
         string integerStr;
@@ -1073,11 +1124,15 @@ internal sealed class JsNumberFormat : ObjectInstance
             fractionStr = digits.Substring(digits.Length - fractionDigits);
         }
 
-        // Trim trailing zeros down to MinimumFractionDigits.
+        var minFrac = MinimumFractionDigits;
         if (fractionStr.Length > minFrac)
         {
             var keep = fractionStr.Length;
-            while (keep > minFrac && fractionStr[keep - 1] == '0') keep--;
+            while (keep > minFrac && fractionStr[keep - 1] == '0')
+            {
+                keep--;
+            }
+
             fractionStr = fractionStr.Substring(0, keep);
         }
         else if (fractionStr.Length < minFrac)
@@ -1085,125 +1140,7 @@ internal sealed class JsNumberFormat : ObjectInstance
             fractionStr = fractionStr.PadRight(minFrac, '0');
         }
 
-        // Apply MinimumIntegerDigits padding.
-        if (MinimumIntegerDigits > 1 && integerStr.Length < MinimumIntegerDigits)
-        {
-            integerStr = integerStr.PadLeft(MinimumIntegerDigits, '0');
-        }
-
-        // Apply grouping if needed.
-        if (ShouldApplyGrouping(integerStr.Length))
-        {
-            integerStr = ApplyGrouping(integerStr, false);
-        }
-
-        var parts = new List<NumberFormatPart>();
-        if (originallyNegative)
-        {
-            parts.Add(new NumberFormatPart("minusSign", NumberFormatInfo.NegativeSign));
-        }
-
-        AddGroupedIntegerParts(parts, integerStr);
-
-        if (fractionStr.Length > 0)
-        {
-            parts.Add(new NumberFormatPart("decimal", NumberFormatInfo.NumberDecimalSeparator));
-            parts.Add(new NumberFormatPart("fraction", fractionStr));
-        }
-
-        return parts;
-    }
-
-    /// <summary>The parts of an exact whole value under the decimal style.</summary>
-    private List<NumberFormatPart> ExactNumberParts(BigInteger value, bool useLiteralMinus)
-    {
-        var isNegative = value.Sign < 0;
-        var abs = isNegative ? -value : value;
-        var digits = abs.ToString("R", CultureInfo.InvariantCulture);
-
-        if (ShouldApplyGrouping(digits.Length))
-        {
-            digits = ApplyGrouping(digits, false);
-        }
-
-        // Apply minimum integer digits padding
-        if (MinimumIntegerDigits > 1 && digits.Length < MinimumIntegerDigits)
-        {
-            digits = digits.PadLeft(MinimumIntegerDigits, '0');
-        }
-
-        var parts = new List<NumberFormatPart>();
-        if (isNegative)
-        {
-            // ar prefixes U+061C ARABIC LETTER MARK to its NegativeSign, which System.Globalization also
-            // writes for a double; the significant-digits lane writes a plain hyphen instead, so this
-            // follows whichever of the two the double lane would have written.
-            parts.Add(new NumberFormatPart("minusSign", useLiteralMinus ? "-" : NumberFormatInfo.NegativeSign));
-        }
-
-        AddGroupedIntegerParts(parts, digits);
-
-        if (MinimumFractionDigits > 0)
-        {
-            parts.Add(new NumberFormatPart("decimal", NumberFormatInfo.NumberDecimalSeparator));
-            parts.Add(new NumberFormatPart("fraction", new string('0', MinimumFractionDigits)));
-        }
-
-        return parts;
-    }
-
-    /// <summary>
-    /// Splits an already-grouped integer string into the <c>integer</c> and <c>group</c> parts
-    /// https://tc39.es/ecma402/#sec-partitionnumberpattern reports for it.
-    /// </summary>
-    private void AddGroupedIntegerParts(List<NumberFormatPart> parts, string integerText)
-    {
-        var separator = NumberFormatInfo.NumberGroupSeparator;
-        if (separator.Length == 0 || integerText.IndexOf(separator, StringComparison.Ordinal) < 0)
-        {
-            parts.Add(new NumberFormatPart("integer", integerText));
-            return;
-        }
-
-        var start = 0;
-        while (true)
-        {
-            var next = integerText.IndexOf(separator, start, StringComparison.Ordinal);
-            if (next < 0)
-            {
-                parts.Add(new NumberFormatPart("integer", integerText.Substring(start)));
-                return;
-            }
-
-            parts.Add(new NumberFormatPart("integer", integerText.Substring(start, next - start)));
-            parts.Add(new NumberFormatPart("group", separator));
-            start = next + separator.Length;
-        }
-    }
-
-    private List<NumberFormatPart> ExactCurrencyParts(BigInteger value)
-    {
-        var parts = new List<NumberFormatPart> { new("currency", NumberFormatInfo.CurrencySymbol) };
-        parts.AddRange(ExactNumberParts(value, useLiteralMinus: false));
-        return parts;
-    }
-
-    private List<NumberFormatPart> ExactPercentParts(BigInteger value)
-    {
-        // Percent multiplies by 100
-        var parts = ExactNumberParts(value * 100, useLiteralMinus: false);
-        parts.Add(new NumberFormatPart("percentSign", NumberFormatInfo.PercentSymbol));
-        return parts;
-    }
-
-    private List<NumberFormatPart> ExactUnitParts(BigInteger value)
-    {
-        var parts = new List<NumberFormatPart>();
-        GetUnitAffixes((double) value, out var beforeNumber, out var afterNumber);
-        AddUnitAffixParts(parts, beforeNumber, leading: true);
-        parts.AddRange(ExactNumberParts(value, useLiteralMinus: false));
-        AddUnitAffixParts(parts, afterNumber, leading: false);
-        return parts;
+        return NumberBody.Finite(integerStr, fractionStr);
     }
 
     /// <summary>
@@ -1245,38 +1182,6 @@ internal sealed class JsNumberFormat : ObjectInstance
         }
 
         return isNegative ? -rounded : rounded;
-    }
-
-    private string ApplyGrouping(string number, bool isNegative)
-    {
-        var startIndex = isNegative ? 1 : 0;
-        var integerPart = number.Substring(startIndex);
-
-        if (integerPart.Length <= 3)
-        {
-            return number;
-        }
-
-        var groupSeparator = NumberFormatInfo.NumberGroupSeparator;
-        var result = new System.Text.StringBuilder();
-
-        var count = 0;
-        for (var i = integerPart.Length - 1; i >= 0; i--)
-        {
-            if (count > 0 && count % 3 == 0)
-            {
-                result.Insert(0, groupSeparator);
-            }
-            result.Insert(0, integerPart[i]);
-            count++;
-        }
-
-        if (isNegative)
-        {
-            result.Insert(0, '-');
-        }
-
-        return result.ToString();
     }
 
     private string FormatDecimal(double value)
@@ -1673,26 +1578,22 @@ internal sealed class JsNumberFormat : ObjectInstance
 
     private string ApplyGroupingToString(string integerPart)
     {
-        if (integerPart.Length <= 3)
+        var boundaries = GroupBoundariesOf(integerPart.Length);
+        if (boundaries.Count == 0)
         {
             return integerPart;
         }
 
-        var groupSeparator = NumberFormatInfo.NumberGroupSeparator;
-        var sb = new System.Text.StringBuilder();
-        var count = 0;
-
-        for (var i = integerPart.Length - 1; i >= 0; i--)
+        var separator = NumberFormatInfo.NumberGroupSeparator;
+        var sb = new System.Text.StringBuilder(integerPart.Length + boundaries.Count * separator.Length);
+        var start = 0;
+        foreach (var boundary in boundaries)
         {
-            if (count > 0 && count % 3 == 0)
-            {
-                sb.Insert(0, groupSeparator);
-            }
-            sb.Insert(0, integerPart[i]);
-            count++;
+            sb.Append(integerPart, start, boundary - start).Append(separator);
+            start = boundary;
         }
 
-        return sb.ToString();
+        return sb.Append(integerPart, start, integerPart.Length - start).ToString();
     }
 
     private static int CountSignificantDigits(string formatted)
@@ -1895,11 +1796,11 @@ internal sealed class JsNumberFormat : ObjectInstance
         var symbol = NumberFormatInfo.CurrencySymbol;
 
         // Build the number part
-        var integerPart = (long) System.Math.Truncate(absValue);
-        var fractionValue = absValue - integerPart;
+        var integral = System.Math.Truncate(absValue);
+        var fractionValue = absValue - integral;
 
         // Format integer with grouping
-        var intStr = integerPart.ToString(CultureInfo.InvariantCulture);
+        var intStr = IntegerDigitsOf(integral);
         var digitCount = intStr.Length;
         if (ShouldApplyGrouping(digitCount))
         {
@@ -2135,20 +2036,28 @@ internal sealed class JsNumberFormat : ObjectInstance
         return formattedCurrency;
     }
 
+    /// <summary>
+    /// https://tc39.es/ecma402/#sec-formatnumber under the percent style, which is the concatenation of
+    /// exactly the parts https://tc39.es/ecma402/#sec-formatnumbertoparts returns.
+    /// </summary>
+    /// <remarks>
+    /// The digits were .NET's <c>"P"</c> specifier, which consults one datum — <c>PercentDecimalDigits</c>,
+    /// which the constructor sets to <c>maximumFractionDigits</c> — and therefore wrote exactly that many
+    /// fraction digits always, never the trim https://tc39.es/ecma402/#sec-torawfixed ends with, and none
+    /// of <c>signDisplay</c>, <c>useGrouping</c> or <c>minimumIntegerDigits</c> at all.
+    /// </remarks>
     private string FormatPercent(double value)
     {
-        // Percent multiplies by 100
-        var percentValue = value * 100;
-
         // Handle significant digits for percent formatting
         if (MinimumSignificantDigits.HasValue || MaximumSignificantDigits.HasValue)
         {
+            var percentValue = value * 100;
             var formatted = FormatWithSignificantDigits(percentValue);
             // Apply locale-specific percent pattern
             return ApplyPercentPattern(formatted, percentValue >= 0);
         }
 
-        return value.ToString("P", NumberFormatInfo);
+        return ConcatenateParts(FormatPercentToParts(value));
     }
 
     /// <summary>
@@ -2409,15 +2318,68 @@ internal sealed class JsNumberFormat : ObjectInstance
 
     /// <summary>
     /// What a pattern walk writes where https://tc39.es/ecma402/#sec-partitionnumberpattern puts its
-    /// <c>number</c> part: a finite value split into its integer and fraction, or the single part
-    /// https://tc39.es/ecma402/#sec-partitionnotationsubpattern makes of NaN and infinity.
+    /// <c>number</c> part: the digits https://tc39.es/ecma402/#sec-formatnumberstring produced, or the
+    /// single part https://tc39.es/ecma402/#sec-partitionnotationsubpattern makes of NaN and infinity.
     /// </summary>
+    /// <remarks>
+    /// The digits are carried as the two strings ToRawFixed wrote and not as a <c>long</c> plus a
+    /// <c>double</c>, because the same pattern walk has to serve a value read exactly — a BigInt, a long
+    /// decimal string — as well as one read as a <see cref="double"/>, and an exact value's digits are
+    /// not a <c>long</c>. <see cref="FractionDigits"/> is empty when ToRawFixed's last two steps removed
+    /// every one of them, which is what decides whether a decimal separator is written at all: neither
+    /// lane writes a separator with nothing after it.
+    /// </remarks>
     [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Auto)]
-    private readonly record struct NumberBody(long IntegerPart, double FractionValue, NumberFormatPart? NonFinite)
+    private readonly record struct NumberBody(string IntegerDigits, string FractionDigits, NumberFormatPart? NonFinite)
     {
-        internal static NumberBody Finite(long integerPart, double fractionValue) => new(integerPart, fractionValue, null);
+        internal static NumberBody Finite(string integerDigits, string fractionDigits) => new(integerDigits, fractionDigits, null);
 
-        internal static NumberBody Of(NumberFormatPart nonFinite) => new(0, 0, nonFinite);
+        internal static NumberBody Of(NumberFormatPart nonFinite) => new("", "", nonFinite);
+    }
+
+    /// <summary>
+    /// The digits https://tc39.es/ecma402/#sec-torawfixed writes for a non-negative value already rounded
+    /// at <see cref="MaximumFractionDigits"/>.
+    /// </summary>
+    private NumberBody FiniteBody(double roundedAbsValue)
+    {
+        var integral = System.Math.Truncate(roundedAbsValue);
+        return NumberBody.Finite(
+            IntegerDigitsOf(integral),
+            FractionDigitsOf(roundedAbsValue - integral, MaximumFractionDigits));
+    }
+
+    /// <summary>
+    /// The integer digits of a non-negative whole <see cref="double"/>, however large.
+    /// </summary>
+    /// <remarks>
+    /// Past <see cref="long.MaxValue"/> a cast does not answer: .NET saturates, so every value from
+    /// 2^63 up wrote the same 9223372036854775807. The digits are
+    /// <c>Number::toString</c>'s instead — the shortest decimal that reads back as this double, which is
+    /// what https://tc39.es/ecma402/#sec-tointlmathematicalvalue reads a Number as — with its exponent
+    /// written out, since https://tc39.es/ecma402/#sec-torawfixed works on digits and not on a magnitude.
+    /// </remarks>
+    private static string IntegerDigitsOf(double integral)
+    {
+        if (integral < 9.2e18)
+        {
+            return ((long) integral).ToString(CultureInfo.InvariantCulture);
+        }
+
+        var text = Number.NumberPrototype.ToNumberString(integral);
+        var exponentIndex = text.IndexOf('e');
+        if (exponentIndex < 0)
+        {
+            return text;
+        }
+
+        var mantissa = text.Substring(0, exponentIndex);
+        var exponent = int.Parse(text.AsSpan(exponentIndex + 1), NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture);
+        var point = mantissa.IndexOf('.');
+        var integerLength = (point < 0 ? mantissa.Length : point) + exponent;
+        var digits = point < 0 ? mantissa : mantissa.Remove(point, 1);
+
+        return digits.PadRight(integerLength, '0');
     }
 
     private List<NumberFormatPart> FormatToPartsCore(double value)
@@ -2494,11 +2456,21 @@ internal sealed class JsNumberFormat : ObjectInstance
         return parts;
     }
 
-    private void AppendSignPart(List<NumberFormatPart> parts, bool showNegativeSign, bool showPositiveSign)
+    /// <remarks>
+    /// ECMA-402 calls the sign "the ILND String representing the minus sign", so it is the locale's own
+    /// datum: <c>ar</c> prefixes U+061C ARABIC LETTER MARK to it. <paramref name="minusSignOverride"/> is
+    /// for the one lane that does not write it — the significant-digits lane over a
+    /// <see cref="double"/> writes a plain hyphen, and the two lanes have to agree about which one this is.
+    /// </remarks>
+    private void AppendSignPart(
+        List<NumberFormatPart> parts,
+        bool showNegativeSign,
+        bool showPositiveSign,
+        string? minusSignOverride = null)
     {
         if (showNegativeSign)
         {
-            parts.Add(new NumberFormatPart("minusSign", NumberFormatInfo.NegativeSign));
+            parts.Add(new NumberFormatPart("minusSign", minusSignOverride ?? NumberFormatInfo.NegativeSign));
         }
         else if (showPositiveSign)
         {
@@ -2517,12 +2489,12 @@ internal sealed class JsNumberFormat : ObjectInstance
             return;
         }
 
-        FormatIntegerToParts(parts, body.IntegerPart);
+        FormatIntegerToParts(parts, body.IntegerDigits);
 
-        if (MinimumFractionDigits > 0 || (body.FractionValue > 0 && MaximumFractionDigits > 0))
+        if (body.FractionDigits.Length > 0)
         {
             parts.Add(new NumberFormatPart("decimal", NumberFormatInfo.NumberDecimalSeparator));
-            FormatFractionToParts(parts, body.FractionValue);
+            parts.Add(new NumberFormatPart("fraction", body.FractionDigits));
         }
     }
 
@@ -2537,8 +2509,13 @@ internal sealed class JsNumberFormat : ObjectInstance
             return;
         }
 
-        FormatIntegerToParts(parts, body.IntegerPart);
-        AddFractionPartsIfNeeded(parts, body.FractionValue);
+        FormatIntegerToParts(parts, body.IntegerDigits);
+
+        if (body.FractionDigits.Length > 0)
+        {
+            parts.Add(new NumberFormatPart("decimal", NumberFormatInfo.CurrencyDecimalSeparator));
+            parts.Add(new NumberFormatPart("fraction", body.FractionDigits));
+        }
     }
 
     private List<NumberFormatPart> FormatNotationToParts(double value)
@@ -2680,20 +2657,7 @@ internal sealed class JsNumberFormat : ObjectInstance
         }
 
         // Value is already rounded
-
-        // Split into integer and fraction parts
-        var integerPart = (long) System.Math.Truncate(value);
-        var fractionValue = value - integerPart;
-
-        // Format integer part with grouping
-        FormatIntegerToParts(parts, integerPart);
-
-        // Format fraction part if needed
-        if (MinimumFractionDigits > 0 || (fractionValue > 0 && MaximumFractionDigits > 0))
-        {
-            parts.Add(new NumberFormatPart("decimal", NumberFormatInfo.NumberDecimalSeparator));
-            FormatFractionToParts(parts, fractionValue);
-        }
+        AddNumberParts(parts, FiniteBody(value));
 
         return parts;
     }
@@ -2749,7 +2713,7 @@ internal sealed class JsNumberFormat : ObjectInstance
         if (currentSigDigits == 0) currentSigDigits = 1;
 
         // Format integer part with grouping
-        FormatIntegerToParts(parts, integerPart);
+        FormatIntegerToParts(parts, intStr);
 
         // Calculate fraction digits needed
         var fractionDigitsNeeded = 0;
@@ -2792,49 +2756,67 @@ internal sealed class JsNumberFormat : ObjectInstance
         }
     }
 
-    private void FormatIntegerToParts(List<NumberFormatPart> parts, long integerValue)
+    private void FormatIntegerToParts(List<NumberFormatPart> parts, string intStr)
     {
-        var intStr = integerValue.ToString(CultureInfo.InvariantCulture);
-
         // Pad with zeros if needed
         if (intStr.Length < MinimumIntegerDigits)
         {
             intStr = intStr.PadLeft(MinimumIntegerDigits, '0');
         }
 
-        var digitCount = intStr.Length;
-        var applyGrouping = ShouldApplyGrouping(digitCount);
-
-        if (!applyGrouping)
+        if (!ShouldApplyGrouping(intStr.Length))
         {
             parts.Add(new NumberFormatPart("integer", intStr));
             return;
         }
 
-        // Add grouped integer parts
-        var groupSeparator = NumberFormatInfo.NumberGroupSeparator;
-        var groupSize = 3;
-        var position = intStr.Length % groupSize;
-        if (position == 0) position = groupSize;
-
-        var currentGroup = intStr.Substring(0, position);
-        parts.Add(new NumberFormatPart("integer", currentGroup));
-
-        while (position < intStr.Length)
+        var separator = NumberFormatInfo.NumberGroupSeparator;
+        var start = 0;
+        foreach (var boundary in GroupBoundariesOf(intStr.Length))
         {
-            parts.Add(new NumberFormatPart("group", groupSeparator));
-            parts.Add(new NumberFormatPart("integer", intStr.Substring(position, groupSize)));
-            position += groupSize;
+            parts.Add(new NumberFormatPart("integer", intStr.Substring(start, boundary - start)));
+            parts.Add(new NumberFormatPart("group", separator));
+            start = boundary;
         }
+
+        parts.Add(new NumberFormatPart("integer", intStr.Substring(start)));
     }
 
-    private void FormatFractionToParts(List<NumberFormatPart> parts, double fractionValue)
+    /// <summary>
+    /// Where the locale puts a group separator in an integer of <paramref name="digitCount"/> digits, left
+    /// to right.
+    /// </summary>
+    /// <remarks>
+    /// A group is not always three digits: <c>en-IN</c> writes <c>12,34,567</c>, and
+    /// <see cref="NumberFormatInfo.NumberGroupSizes"/> carries that as <c>[3, 2]</c> — the sizes apply from
+    /// the right, and the last one repeats until a zero ends the grouping. Assuming three is the reason the
+    /// parts lane wrote <c>1,234,567</c> where the string lane wrote <c>12,34,567</c>.
+    /// </remarks>
+    private List<int> GroupBoundariesOf(int digitCount)
     {
-        var fractionStr = FractionDigitsOf(fractionValue, MaximumFractionDigits);
-        if (fractionStr.Length > 0)
+        var sizes = NumberFormatInfo.NumberGroupSizes;
+        var boundaries = new List<int>();
+        var position = digitCount;
+
+        for (var i = 0; position > 0; i++)
         {
-            parts.Add(new NumberFormatPart("fraction", fractionStr));
+            var size = sizes.Length == 0 ? 0 : sizes[System.Math.Min(i, sizes.Length - 1)];
+            if (size <= 0)
+            {
+                break;
+            }
+
+            position -= size;
+            if (position <= 0)
+            {
+                break;
+            }
+
+            boundaries.Add(position);
         }
+
+        boundaries.Reverse();
+        return boundaries;
     }
 
     /// <summary>
@@ -2907,11 +2889,7 @@ internal sealed class JsNumberFormat : ObjectInstance
                 break;
         }
 
-        // Split value
-        var integerPart = (long) System.Math.Truncate(absValue);
-        var fractionValue = absValue - integerPart;
-
-        AppendCurrencyParts(parts, NumberBody.Finite(integerPart, fractionValue), showNegativeSign, showPositiveSign);
+        AppendCurrencyParts(parts, FiniteBody(absValue), showNegativeSign, showPositiveSign);
 
         return parts;
     }
@@ -3126,20 +3104,6 @@ internal sealed class JsNumberFormat : ObjectInstance
         }
     }
 
-    private void AddFractionPartsIfNeeded(List<NumberFormatPart> parts, double fractionValue)
-    {
-        if (MaximumFractionDigits == 0)
-        {
-            return;
-        }
-
-        if (MinimumFractionDigits > 0 || fractionValue > 0)
-        {
-            parts.Add(new NumberFormatPart("decimal", NumberFormatInfo.CurrencyDecimalSeparator));
-            FormatFractionToParts(parts, fractionValue);
-        }
-    }
-
     private List<NumberFormatPart> FormatPercentToParts(double value)
     {
         var parts = new List<NumberFormatPart>();
@@ -3173,10 +3137,7 @@ internal sealed class JsNumberFormat : ObjectInstance
                 break;
         }
 
-        var integerPart = (long) System.Math.Truncate(percentValue);
-        var fractionValue = percentValue - integerPart;
-
-        AppendPercentParts(parts, NumberBody.Finite(integerPart, fractionValue), showNegativeSign, showPositiveSign);
+        AppendPercentParts(parts, FiniteBody(percentValue), showNegativeSign, showPositiveSign);
 
         return parts;
     }
@@ -3193,6 +3154,10 @@ internal sealed class JsNumberFormat : ObjectInstance
         // Determine if symbol comes before or after, and if there's spacing
         // Positive patterns: 0="n %", 1="n%", 2="%n", 3="% n"
         var symbolAfter = pattern == 0 || pattern == 1;
+        // CLDR's de percent pattern is "#,##0 %" with U+00A0, which is the character
+        // intl402/BigInt/prototype/toLocaleString/de-DE.js asserts; .NET writes a plain space for the
+        // same locale, so the pattern says where the space goes and CLDR says which space it is.
+        const string Nbsp = "\u00A0";
         var hasSpace = pattern == 0 || pattern == 3;
 
         if (!symbolAfter)
@@ -3201,7 +3166,7 @@ internal sealed class JsNumberFormat : ObjectInstance
             parts.Add(new NumberFormatPart("percentSign", NumberFormatInfo.PercentSymbol));
             if (hasSpace)
             {
-                parts.Add(new NumberFormatPart("literal", " "));
+                parts.Add(new NumberFormatPart("literal", Nbsp));
             }
         }
 
@@ -3213,7 +3178,7 @@ internal sealed class JsNumberFormat : ObjectInstance
             // Symbol after number
             if (hasSpace)
             {
-                parts.Add(new NumberFormatPart("literal", " "));
+                parts.Add(new NumberFormatPart("literal", Nbsp));
             }
             parts.Add(new NumberFormatPart("percentSign", NumberFormatInfo.PercentSymbol));
         }
@@ -3252,10 +3217,7 @@ internal sealed class JsNumberFormat : ObjectInstance
                 break;
         }
 
-        var integerPart = (long) System.Math.Truncate(absValue);
-        var fractionValue = absValue - integerPart;
-
-        AppendUnitParts(parts, NumberBody.Finite(integerPart, fractionValue), showNegativeSign, showPositiveSign, value);
+        AppendUnitParts(parts, FiniteBody(absValue), showNegativeSign, showPositiveSign, value);
 
         return parts;
     }

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -3226,7 +3226,6 @@ astronomical reckoning keeps a process-wide cache of built years. Adding or subt
 still linear in the years crossed for `chinese`, `dangi` and `hebrew`, so
 `add({ months: 3000000 })` is seconds of work that no execution constraint interrupts; the six calendars
 with no backing calendar have always been closed-form there and are unaffected.
-
 ### 4.71 `chinese` and `dangi` read the same on every target framework ([#3484](https://github.com/sebastienros/jint/issues/3484))
 
 The `chinese` and `dangi` calendars were read from `System.Globalization.ChineseLunisolarCalendar` and
@@ -3350,6 +3349,76 @@ that file leaves the test262 exclusion list with this.
 `RangeError`, with the length appended to its message. Only a receiver that actually supplies a species
 constructor changes shape, and there the old behaviour was refusing to call code the specification requires
 be called.
+### 4.77 A value read exactly wears the pattern a Number of that size wears, and a percent's digits are ToRawFixed's ([#3498](https://github.com/sebastienros/jint/issues/3498), [#3504](https://github.com/sebastienros/jint/issues/3504))
+
+[PartitionNumberPattern](https://tc39.es/ecma402/#sec-partitionnumberpattern) computes the digits once, with
+[FormatNumericToString](https://tc39.es/ecma402/#sec-formatnumberstring), and then walks the pattern
+[GetNumberFormatPattern](https://tc39.es/ecma402/#sec-getnumberformatpattern) selects around them. Jint
+computed both together, once per lane, and two lanes got it wrong in different ways.
+
+**The exact lane wrote the wrong pattern.** A BigInt, an integer string of 17 or more digits and a long
+decimal string take a lane that keeps every digit — and that lane wrote the currency symbol followed by the
+number, with none of the locale's own pattern, its accounting form, `signDisplay` or `notation`:
+
+```js
+const usd = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' });
+usd.format(-123);     // "-$123.00"
+usd.format(-123n);    // 5.0: "$-123.00"    5.x: "-$123.00"
+
+new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(123n);
+                      // 5.0: "€123,00"     5.x: "123,00 €"
+new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', currencySign: 'accounting' }).format(-123n);
+                      // 5.0: "$-123.00"    5.x: "($123.00)"
+new Intl.NumberFormat('en-US', { signDisplay: 'always' }).format(5n);
+                      // 5.0: "5"           5.x: "+5"
+new Intl.NumberFormat('en-US', { notation: 'scientific' }).format(12345n);
+                      // 5.0: "12,345"      5.x: "1.235E4"
+```
+
+The exact lane now produces only the digits, and hands them to the same pattern walk a `double` goes
+through. A notation is the one thing it cannot write exactly — the abbreviation and the exponent are chosen
+from the value's magnitude — so a formatter that names one takes the `double` lane in both of its own lanes,
+which is how `12345n` reaches `"1.235E4"`.
+
+**A percent's digits were .NET's, not ToRawFixed's.** The percent string lane was `value.ToString("P")`,
+which reads exactly one datum — `NumberFormatInfo.PercentDecimalDigits`, set from `maximumFractionDigits` —
+and therefore wrote that many fraction digits always, never the trim
+[ToRawFixed](https://tc39.es/ecma402/#sec-torawfixed) ends with, and none of `signDisplay`, `useGrouping` or
+`minimumIntegerDigits` at all:
+
+```js
+new Intl.NumberFormat('en-US', { style: 'percent', maximumFractionDigits: 1 }).format(0.4);
+                                                   // 5.0: "40.0%"    5.x: "40%"
+new Intl.NumberFormat('en-US', { style: 'percent', minimumFractionDigits: 3, maximumFractionDigits: 4 }).format(2.9);
+                                                   // 5.0: "290.0000%" 5.x: "290.000%"
+new Intl.NumberFormat('en-US', { style: 'percent', signDisplay: 'always' }).format(0.4);
+                                                   // 5.0: "40%"      5.x: "+40%"
+new Intl.NumberFormat('en-US', { style: 'percent', useGrouping: false }).format(1234.567);
+                                                   // 5.0: "123,457%" 5.x: "123457%"
+new Intl.NumberFormat('en-US', { style: 'percent', minimumIntegerDigits: 3 }).format(0.04);
+                                                   // 5.0: "4%"       5.x: "004%"
+```
+
+Two defects fall out of putting the digits in one place. A value from 2^63 up used to saturate, because the
+parts lanes split it with a cast to `long` and .NET pins an out-of-range conversion rather than throwing;
+and a group was assumed to be three digits wide, which `en-IN` does not do:
+
+```js
+new Intl.NumberFormat('en-US').formatToParts(1e21).map(p => p.value).join('');
+       // 5.0: "9,223,372,036,854,775,807.9223372036854775807"   5.x: "1,000,000,000,000,000,000,000"
+new Intl.NumberFormat('en-IN').formatToParts(1234567.891).map(p => p.value).join('');
+       // 5.0: "1,234,567.891"   5.x: "12,34,567.891", which is what its own format always wrote
+```
+
+**What could break:** any `style: "percent"` output whose formatter names a fraction-digit count,
+`signDisplay`, `useGrouping` or `minimumIntegerDigits` — a percent formatter that names none of them is
+untouched; any `format` or `formatToParts` of a BigInt or of a numeric string long enough to be read
+exactly, under a currency, a sign display or a notation; any `formatToParts` of a value at or past 2^63; and
+`en-IN` (and the other Indic locales) in the parts lane, which now groups the way its string lane already
+did. The significant-digit options are a separate algorithm —
+[ToRawPrecision](https://tc39.es/ecma402/#sec-torawprecision) rather than ToRawFixed — and are
+[#3499](https://github.com/sebastienros/jint/issues/3499).
+
 ## 5. New in v5
 
 Everything in the table below is opt-in: nothing in it is installed unless the host asks for it, so


### PR DESCRIPTION
[PartitionNumberPattern](https://tc39.es/ecma402/#sec-partitionnumberpattern) computes the digits once, with
[FormatNumericToString](https://tc39.es/ecma402/#sec-formatnumberstring), and then walks the pattern
[GetNumberFormatPattern](https://tc39.es/ecma402/#sec-getnumberformatpattern) selects around them. Jint
computed both together, once per lane, and two of those lanes got it wrong in different ways. Fixing either
one alone means writing the shared half twice more, so they are here together.

## The exact lane wrote the wrong pattern (#3504)

A BigInt, an integer string of 17 or more digits and a long decimal string take a lane that keeps every
digit. That lane wrote the currency symbol followed by the number, and nothing else — none of the locale's
own pattern, its accounting form, `signDisplay`, or `notation`:

```js
const usd = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' });
usd.format(-123);     // "-$123.00"
usd.format(-123n);    // before: "$-123.00"     after: "-$123.00"

new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(123n);
                      // before: "€123,00"      after: "123,00 €"
new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', currencySign: 'accounting' }).format(-123n);
                      // before: "$-123.00"     after: "($123.00)"
new Intl.NumberFormat('en-US', { signDisplay: 'always' }).format(5n);
                      // before: "5"            after: "+5"
new Intl.NumberFormat('en-US', { notation: 'scientific' }).format(12345n);
                      // before: "12,345"       after: "1.235E4"
```

`PartitionExact` now produces only the digits and hands them to the same pattern walk a `double` goes
through — `AppendCurrencyParts`, `AppendPercentParts`, `AppendUnitParts`, `AppendSignPart`. The three
transcribed style routines (`ExactCurrencyParts`, `ExactPercentParts`, `ExactUnitParts`) and the two
grouping routines beside them are gone.

A notation is the one thing the exact carrier cannot write: the abbreviation and the exponent are chosen
from the value's own magnitude by
[PartitionNotationSubPattern](https://tc39.es/ecma402/#sec-partitionnotationsubpattern). `CanPartitionExactly`
therefore returns `false` for any notation but `"standard"`, so such a formatter takes the `double` lane in
**both** its lanes and `12345n` reaches `"1.235E4"`.

## A percent's digits were .NET's, not ToRawFixed's (#3498)

The percent string lane was `value.ToString("P", NumberFormatInfo)`. `"P"` reads exactly one datum —
`PercentDecimalDigits`, which the constructor sets to `maximumFractionDigits` — so it wrote that many
fraction digits always, never the trim [ToRawFixed](https://tc39.es/ecma402/#sec-torawfixed) ends with, and
none of `signDisplay`, `useGrouping` or `minimumIntegerDigits` at all:

```js
new Intl.NumberFormat('en-US', { style: 'percent', maximumFractionDigits: 1 }).format(0.4);
                                                    // before: "40.0%"     after: "40%"
new Intl.NumberFormat('en-US', { style: 'percent', minimumFractionDigits: 3, maximumFractionDigits: 4 }).format(2.9);
                                                    // before: "290.0000%" after: "290.000%"
new Intl.NumberFormat('en-US', { style: 'percent', signDisplay: 'always' }).format(0.4);
                                                    // before: "40%"       after: "+40%"
new Intl.NumberFormat('en-US', { style: 'percent', useGrouping: false }).format(1234.567);
                                                    // before: "123,457%"  after: "123457%"
new Intl.NumberFormat('en-US', { style: 'percent', minimumIntegerDigits: 3 }).format(0.04);
                                                    // before: "4%"        after: "004%"
```

Its parts lane was right in every one of those cells, so the string lane is now the concatenation of it,
which is what [FormatNumeric](https://tc39.es/ecma402/#sec-formatnumber) says it is.

## What the two share, and two more defects that fall out of it

`NumberBody` — the thing a pattern walk writes its `number` part from — carried `(long IntegerPart, double
FractionValue)`. It now carries the two digit **strings** ToRawFixed wrote, which is what lets one pattern
walk serve a value read exactly as well as one read as a `double`. Two defects follow from putting the
digits in one place:

`AppendPercentParts` also writes CLDR's U+00A0 where the pattern has a space, which is the character
`intl402/BigInt/prototype/toLocaleString/de-DE.js` asserts — .NET writes a plain space for `de-DE`, so the
pattern says where the space goes and CLDR says which space it is.

```js
// a cast to long saturates rather than answers, so everything from 2^63 up wrote the same number
new Intl.NumberFormat('en-US').formatToParts(1e21).map(p => p.value).join('');
       // before: "9,223,372,036,854,775,807.9223372036854775807"
       // after:  "1,000,000,000,000,000,000,000"

// a group is not always three digits wide
new Intl.NumberFormat('en-IN').formatToParts(1234567.891).map(p => p.value).join('');
       // before: "1,234,567.891"    after: "12,34,567.891" — what its own format always wrote
```

`ApplyRounding` gets a guard for the same reason: a `double` from 2^53 up carries no fraction, so rounding
one is the identity, while scaling it by a power of ten to round it is not — `1e21` came back as
`999999999999999900000`.

## Proof

Every case is pinned in `Jint.Tests/Runtime/IntlNumberFormatPartsTests.cs`, and all seven fail against
unmodified `main`:

```
Failed APercentTrimsItsFractionDownToTheMinimum
   Expected Format(OneDigit, "0.4") to be the same string, but they differ at index 2:
   "40.0%"  /  "40%"
Failed APercentReadsTheOptionsThatBuildItsNumber
   Expected Format(Always, "0.4") ...  "40%"  /  "+40%"
Failed AnExactValueTakesTheSamePatternADoubleTakes
   Expected Format(Usd, "-123n") ...  "$-123.00"  /  "-$123.00"
Failed AnExactValueTakesTheNotationTheFormatterWasGiven
   Expected Format(Scientific, "12345n") ...  "12,345"  /  "1.235E4"
Failed AValuePastTheRangeOfALongIsStillItsOwnDigits
   Expected Join(Plain, "1e21") ...
   "9,223,372,036,854,775,807.9223372036854775807"  /  "1,000,000,000,000,000,000,000"
Failed TheGroupsAreTheWidthsTheLocaleUses
   Expected Join(Indian, "1234567.891") ...  "1,234,567.891"  /  "12,34,567.891"
Failed PartsConcatenateToFormat
   ["en/latn/0/1e+21: format=1,000,000,000,000,000,000,000…"]  /  []
```

The join grid — `parts.map(p => p.value).join('') === format(x)` over locales × numbering systems × option
sets × values — gains the five percent shapes, `currencySign: "accounting"`, `en-IN`, and two whole doubles
past 2^63.

`useGrouping-extended-en-IN.js` stays excluded, but its `useGrouping: "always"` and `"min2"` halves now pass
and only its lakh/crore compact block still fails, so its comment says that instead.

## Verification

- `dotnet build -c Release`, `dotnet test -c Release`: green.
- test262: **102,537 passed / 0 failed / 151 skipped** of 102,688, which is the control on this base
  commit. (#3513 took it to 102,533/155, then #3506 and #3510 each removed a staging exclusion worth
  two more passes.) Nothing moves. Runs on this machine also report 30-second `TimeoutException`s on a
  handful of `staging/sm` and `intl402/supportedLocalesOf-*` files; every one of them passes in
  isolation in four seconds and they are the known load flakes here.
- Migration guide: §4.77.
- `Jint.Tests/SpecAnchors.txt` gains `ecma402 sec-formatnumberstring`, verified live by the register
  refresh that #3512 added.

Fixes #3498
Fixes #3504

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014W5mbjGhyvgAS4pivXoc4S
