### PR TITLE
Intl.NumberFormat: the significant-digit options are read in every lane and every style

### DIFF
--- a/Jint.Tests/Runtime/IntlNumberFormatPartsTests.cs
+++ b/Jint.Tests/Runtime/IntlNumberFormatPartsTests.cs
@@ -54,6 +54,16 @@ public class IntlNumberFormatPartsTests
         "{ style: 'percent', useGrouping: false }",
         "{ style: 'percent', minimumIntegerDigits: 3 }",
         "{ style: 'currency', currency: 'USD', currencySign: 'accounting' }",
+        // the significant-digit options, which ToRawPrecision applies whatever the style writes around them
+        "{ maximumSignificantDigits: 2 }",
+        "{ minimumSignificantDigits: 3 }",
+        "{ minimumSignificantDigits: 2, maximumSignificantDigits: 4 }",
+        "{ style: 'currency', currency: 'USD', maximumSignificantDigits: 2 }",
+        "{ style: 'currency', currency: 'USD', minimumSignificantDigits: 3 }",
+        "{ style: 'percent', maximumSignificantDigits: 2 }",
+        "{ style: 'unit', unit: 'meter', maximumSignificantDigits: 2 }",
+        "{ roundingPriority: 'morePrecision', maximumSignificantDigits: 2, maximumFractionDigits: 3 }",
+        "{ roundingPriority: 'lessPrecision', maximumSignificantDigits: 2, maximumFractionDigits: 3 }",
         "{ notation: 'scientific' }",
         "{ notation: 'engineering' }",
         "{ notation: 'compact' }",
@@ -808,6 +818,108 @@ public class IntlNumberFormatPartsTests
 
         const string Engineering = "new Intl.NumberFormat('en-US', { notation: 'engineering' })";
         Format(Engineering, "12345n").Should().Be(Format(Engineering, "12345"));
+    }
+
+    /// <summary>
+    /// https://tc39.es/ecma402/#sec-formatnumberstring computes the digits once, and which of the two
+    /// roundings it uses is the formatter's — never the style's. The significant-digit options reached the
+    /// decimal parts lane and no other, so a currency, a percent and a unit ignored them there.
+    /// </summary>
+    [Test]
+    public void TheSignificantDigitOptionsReachEveryStyle()
+    {
+        const string Usd =
+            "new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumSignificantDigits: 2 })";
+        Format(Usd, "1234.567").Should().Be("$1,200");
+        Join(Usd, "1234.567").Should().Be("$1,200");
+
+        const string Percent = "new Intl.NumberFormat('en-US', { style: 'percent', maximumSignificantDigits: 2 })";
+        Format(Percent, "1234.567").Should().Be("120,000%");
+        Join(Percent, "1234.567").Should().Be("120,000%");
+
+        const string Meter =
+            "new Intl.NumberFormat('en-US', { style: 'unit', unit: 'meter', maximumSignificantDigits: 2 })";
+        Format(Meter, "1234.567").Should().Be("1,200 m");
+        Join(Meter, "1234.567").Should().Be("1,200 m");
+    }
+
+    /// <summary>
+    /// https://tc39.es/ecma402/#sec-torawprecision's last steps remove up to
+    /// <c>maxPrecision - minPrecision</c> trailing zeros, exactly as
+    /// https://tc39.es/ecma402/#sec-torawfixed does for fraction digits.
+    /// </summary>
+    /// <remarks>
+    /// The defect: only the string lane trimmed, so <c>maximumSignificantDigits: 2</c> wrote <c>"0.4"</c>
+    /// from one lane and <c>"0.40"</c> from the other.
+    /// </remarks>
+    [Test]
+    public void ToRawPrecisionTrimsItsTrailingZeros()
+    {
+        const string TwoDigits = "new Intl.NumberFormat('en', { maximumSignificantDigits: 2 })";
+        Format(TwoDigits, "0.4").Should().Be("0.4");
+        Join(TwoDigits, "0.4").Should().Be("0.4");
+
+        const string TwoToFour =
+            "new Intl.NumberFormat('en', { minimumSignificantDigits: 2, maximumSignificantDigits: 4 })";
+        Format(TwoToFour, "2.9").Should().Be("2.9");
+        Join(TwoToFour, "2.9").Should().Be("2.9");
+        Format(TwoToFour, "2.90001").Should().Be("2.9");
+
+        // the trim stops at the minimum, so the zeros the minimum requires stay
+        const string ThreeToFive =
+            "new Intl.NumberFormat('en', { minimumSignificantDigits: 3, maximumSignificantDigits: 5 })";
+        Format(ThreeToFive, "1.2").Should().Be("1.20");
+        Join(ThreeToFive, "1.2").Should().Be("1.20");
+    }
+
+    /// <summary>
+    /// A Number's Intl mathematical value is the one
+    /// https://tc39.es/ecma402/#sec-tointlmathematicalvalue reads: <c>Number::toString</c>'s digits, which
+    /// is the shortest decimal that reads back as that double — not the double's own binary expansion.
+    /// </summary>
+    /// <remarks>
+    /// <c>maximumSignificantDigits</c> defaults to 21, so a lane reading the expansion had 21 digits to
+    /// write and wrote them: <c>0.4</c> came out as <c>"0.400000000000000022204"</c>. The parts lane got
+    /// there differently and worse — it scaled a fraction by 10^21 and cast the product to
+    /// <c>long</c>, which .NET saturates, so it wrote <c>long.MaxValue</c>'s digits as a fraction.
+    /// </remarks>
+    [Test]
+    public void ANumbersDigitsAreTheOnesNumberToStringWrites()
+    {
+        const string ThreeDigits = "new Intl.NumberFormat('en', { minimumSignificantDigits: 3 })";
+        Format(ThreeDigits, "0.4").Should().Be("0.400");
+        Join(ThreeDigits, "0.4").Should().Be("0.400");
+        Format(ThreeDigits, "0.5").Should().Be("0.500");
+        Join(ThreeDigits, "0.5").Should().Be("0.500");
+        Format(ThreeDigits, "1.1").Should().Be("1.10");
+        Join(ThreeDigits, "1.1").Should().Be("1.10");
+
+        const string TwoDigits = "new Intl.NumberFormat('en', { minimumSignificantDigits: 2 })";
+        Format(TwoDigits, "123.5").Should().Be("123.5");
+        Join(TwoDigits, "123.5").Should().Be("123.5");
+    }
+
+    /// <summary>
+    /// An exactly-read value takes ToRawPrecision too, and the minimum is a floor there as well.
+    /// </summary>
+    [Test]
+    public void AnExactValueReadsTheSignificantDigitOptionsAsWell()
+    {
+        const string ThreeDigits = "new Intl.NumberFormat('en', { minimumSignificantDigits: 3 })";
+        Format(ThreeDigits, "1n").Should().Be("1.00").And.Be(Format(ThreeDigits, "1"));
+        Format(ThreeDigits, "-5n").Should().Be("-5.00").And.Be(Format(ThreeDigits, "-5"));
+
+        const string TwoDigits = "new Intl.NumberFormat('en-US', { maximumSignificantDigits: 2 })";
+        Format(TwoDigits, "1234n").Should().Be("1,200").And.Be(Format(TwoDigits, "1234"));
+
+        // a value no double holds keeps every digit the rounding leaves
+        Format("new Intl.NumberFormat('en-US', { minimumSignificantDigits: 3, maximumSignificantDigits: 5 })",
+                "'12344501000000000000000000000000000'")
+            .Should().Be("12,345,000,000,000,000,000,000,000,000,000,000");
+
+        const string Usd =
+            "new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumSignificantDigits: 2 })";
+        Format(Usd, "1234n").Should().Be("$1,200").And.Be(Format(Usd, "1234"));
     }
 
     private string Format(string formatter, string value)

--- a/Jint/Native/Intl/JsNumberFormat.cs
+++ b/Jint/Native/Intl/JsNumberFormat.cs
@@ -300,6 +300,17 @@ internal sealed class JsNumberFormat : ObjectInstance
             return FormatWithNotation(value);
         }
 
+        // https://tc39.es/ecma402/#sec-formatnumber is the concatenation of exactly the parts
+        // https://tc39.es/ecma402/#sec-formatnumbertoparts returns, and under the significant-digit
+        // options — and under a rounding priority, which needs both roundings to compare them — that is
+        // the lane https://tc39.es/ecma402/#sec-torawprecision lives in.
+        if (MinimumSignificantDigits.HasValue
+            || MaximumSignificantDigits.HasValue
+            || !string.Equals(RoundingPriority, "auto", StringComparison.Ordinal))
+        {
+            return ConcatenateParts(FormatToPartsCore(value));
+        }
+
         return Style switch
         {
             "currency" => FormatCurrency(value),
@@ -985,8 +996,7 @@ internal sealed class JsNumberFormat : ObjectInstance
     /// scaled mantissa or an abbreviation, https://tc39.es/ecma402/#sec-partitionnotationsubpattern picks
     /// it from the value's own magnitude, and the exact carrier does not do that arithmetic — so a value
     /// this lane would otherwise keep whole takes the double instead, and gets the exponent the same
-    /// formatter writes for a Number. Scaling a fraction, and rounding one to significant digits, are the
-    /// other two cases it hands over.
+    /// formatter writes for a Number. Scaling a fraction is the other case it hands over.
     /// </remarks>
     private bool CanPartitionExactly(in IntlMathematicalValue value)
     {
@@ -1000,17 +1010,8 @@ internal sealed class JsNumberFormat : ObjectInstance
             return false;
         }
 
-        // Significant-digit rounding under a scaled style, and scaling a fraction at all, are the two
-        // pieces of arithmetic the exact carrier does not do yet.
-        var significantDigits = MinimumSignificantDigits.HasValue || MaximumSignificantDigits.HasValue;
-        var scaledStyle = Style is "currency" or "percent" or "unit";
-
-        if (value.FractionDigits > 0)
-        {
-            return !scaledStyle && !significantDigits;
-        }
-
-        return !significantDigits || !scaledStyle;
+        // Scaling a fraction is the one piece of arithmetic the exact carrier does not do yet.
+        return value.FractionDigits == 0 || Style is not ("currency" or "percent" or "unit");
     }
 
     /// <summary>
@@ -1035,15 +1036,12 @@ internal sealed class JsNumberFormat : ObjectInstance
             abs *= 100;
         }
 
-        // Significant-digit rounding of a whole value is exact, so it stays on this lane.
-        var significantDigits = (MinimumSignificantDigits.HasValue || MaximumSignificantDigits.HasValue)
-            && Style is not ("currency" or "percent" or "unit");
-        if (significantDigits)
-        {
-            abs = ApplySignificantDigitRounding(abs);
-        }
-
-        var body = ExactBody(abs, fractionDigits, out var displaysAsZero);
+        // https://tc39.es/ecma402/#sec-formatnumberstring, over digits rather than over a double: which
+        // of the two roundings applies is the formatter's, not the carrier's.
+        var body = MinimumSignificantDigits.HasValue || MaximumSignificantDigits.HasValue
+            ? ExactPrecisionBody(abs, fractionDigits)
+            : ExactBody(abs, fractionDigits);
+        var displaysAsZero = body.IsZero;
 
         var showNegativeSign = isNegative;
         var showPositiveSign = false;
@@ -1077,9 +1075,7 @@ internal sealed class JsNumberFormat : ObjectInstance
                 AppendUnitParts(parts, in body, showNegativeSign, showPositiveSign, (double) mantissa);
                 break;
             default:
-                // the significant-digits lane over a double writes a literal "-" rather than the locale's
-                // own sign, and the two lanes have to agree about which one this is
-                AppendSignPart(parts, showNegativeSign, showPositiveSign, significantDigits ? "-" : null);
+                AppendSignPart(parts, showNegativeSign, showPositiveSign);
                 AddNumberParts(parts, in body);
                 break;
         }
@@ -1093,7 +1089,7 @@ internal sealed class JsNumberFormat : ObjectInstance
     /// <see cref="MaximumFractionDigits"/> with halfExpand, then trimmed of up to
     /// <c>maximumFractionDigits - minimumFractionDigits</c> trailing zeros.
     /// </summary>
-    private NumberBody ExactBody(BigInteger absMantissa, int fractionDigits, out bool displaysAsZero)
+    private NumberBody ExactBody(BigInteger absMantissa, int fractionDigits)
     {
         if (fractionDigits > MaximumFractionDigits)
         {
@@ -1101,8 +1097,6 @@ internal sealed class JsNumberFormat : ObjectInstance
             absMantissa = (absMantissa + divisor / 2) / divisor;
             fractionDigits = MaximumFractionDigits;
         }
-
-        displaysAsZero = absMantissa.IsZero;
 
         var digits = absMantissa.ToString("R", CultureInfo.InvariantCulture);
 
@@ -1148,53 +1142,11 @@ internal sealed class JsNumberFormat : ObjectInstance
     /// </summary>
     internal string Format(BigInteger value) => Format(IntlMathematicalValue.Exact(value, 0));
 
-    /// <summary>
-    /// Rounds a BigInteger so it carries at most <see cref="MaximumSignificantDigits"/>
-    /// significant digits, using the spec's "halfExpand" rounding (round half away from zero).
-    /// </summary>
-    private BigInteger ApplySignificantDigitRounding(BigInteger value)
-    {
-        if (!MaximumSignificantDigits.HasValue || value.IsZero)
-            return value;
-
-        var maxSig = MaximumSignificantDigits.Value;
-        var isNegative = value.Sign < 0;
-        var abs = isNegative ? -value : value;
-
-        // Number of decimal digits in |value|.
-        var digitCount = abs.ToString("R", CultureInfo.InvariantCulture).Length;
-        if (digitCount <= maxSig)
-            return value;
-
-        // Drop the last (digitCount - maxSig) digits with halfExpand rounding.
-        var dropDigits = digitCount - maxSig;
-        var divisor = BigInteger.Pow(10, dropDigits);
-        var halfDivisor = divisor / 2;
-        var rounded = (abs + halfDivisor) / divisor * divisor;
-
-        // Rounding can push the digit count up by one (e.g., 99500 with 3 sig digits → 100000).
-        // ECMA-402 keeps the same significant-digit count, so re-trim if that happened.
-        var roundedDigitCount = rounded.ToString("R", CultureInfo.InvariantCulture).Length;
-        if (roundedDigitCount > digitCount)
-        {
-            divisor *= 10;
-            rounded = rounded / divisor * divisor;
-        }
-
-        return isNegative ? -rounded : rounded;
-    }
-
     private string FormatDecimal(double value)
     {
         // Check if value is negative (including -0)
         var isNegative = value < 0 || double.IsNegativeInfinity(1 / value);
         var absValue = System.Math.Abs(value);
-
-        // Handle significant digits and roundingPriority
-        if (MinimumSignificantDigits.HasValue || MaximumSignificantDigits.HasValue)
-        {
-            return FormatWithSignificantDigits(value);
-        }
 
         // Apply rounding based on MaximumFractionDigits
         absValue = ApplyRounding(absValue, MaximumFractionDigits);
@@ -1295,287 +1247,6 @@ internal sealed class JsNumberFormat : ObjectInstance
         return formatted;
     }
 
-    private string FormatWithSignificantDigits(double value)
-    {
-        if (!double.IsFinite(value))
-        {
-            return value.ToString(NumberFormatInfo);
-        }
-
-        var minSigDigits = MinimumSignificantDigits ?? 1;
-        var maxSigDigits = MaximumSignificantDigits ?? 21;
-
-        // Format based on roundingPriority per ECMA-402 §15.5.14 RoundingDecisionForLeadingZeros
-        if (string.Equals(RoundingPriority, "lessPrecision", StringComparison.Ordinal) ||
-            string.Equals(RoundingPriority, "morePrecision", StringComparison.Ordinal))
-        {
-            var sigDigitsResult = FormatToSignificantDigits(value, minSigDigits, maxSigDigits);
-            var fracDigitsResult = FormatWithFractionDigits(value);
-
-            // Parse both results back to numeric values to compare precision loss
-            var sigValue = ParseFormattedNumber(sigDigitsResult);
-            var fracValue = ParseFormattedNumber(fracDigitsResult);
-
-            // Calculate precision loss (distance from original value)
-            var sigPrecisionLoss = System.Math.Abs(value - sigValue);
-            var fracPrecisionLoss = System.Math.Abs(value - fracValue);
-
-            // Count displayed digits in each result
-            var sigDigitsCount = CountSignificantDigits(sigDigitsResult);
-            var fracDigitsCount = CountSignificantDigits(fracDigitsResult);
-
-            // Determine if each result is constrained by explicit min/max
-            var sdHasExplicitMin = MinimumSignificantDigitsExplicit;
-            var sdHasExplicitMax = MaximumSignificantDigitsExplicit;
-
-            // Get the actual minimum constraint values for comparison
-            var sdMinConstraint = sdHasExplicitMin ? minSigDigits : 0;
-            // FD minimum is the number of fraction digits required (adds to total digits)
-            var fdMinConstraint = MinimumFractionDigits;
-
-            if (string.Equals(RoundingPriority, "morePrecision", StringComparison.Ordinal))
-            {
-                // morePrecision: prefer the result closer to original value
-                if (sigPrecisionLoss < fracPrecisionLoss - 1e-15)
-                {
-                    return sigDigitsResult;
-                }
-                if (fracPrecisionLoss < sigPrecisionLoss - 1e-15)
-                {
-                    return fracDigitsResult;
-                }
-
-                // When values are equal (tie):
-                // If only SD max is explicit (no explicit SD min), prefer FD (minimum-constrained)
-                if (sdHasExplicitMax && !sdHasExplicitMin)
-                {
-                    return fracDigitsResult;
-                }
-
-                // If SD has explicit max AND min, compare the constraint ranges to determine
-                // which allows more precision potential.
-                if (sdHasExplicitMax && sdHasExplicitMin)
-                {
-                    // Compare maximum constraints - larger max = allows more precision
-                    // SD max is in significant digits; FD max is fraction digits + 1 (for integer digit)
-                    var effectiveFdMax = MaximumFractionDigits + 1;
-                    if (maxSigDigits > effectiveFdMax)
-                    {
-                        return sigDigitsResult;
-                    }
-                    if (effectiveFdMax > maxSigDigits)
-                    {
-                        return fracDigitsResult;
-                    }
-                    // Maximums are equal - compare minimums
-                    // Higher minimum = requires more precision
-                    var effectiveFdMin = MinimumFractionDigits + 1;
-                    if (minSigDigits >= effectiveFdMin)
-                    {
-                        return sigDigitsResult;
-                    }
-                    return fracDigitsResult;
-                }
-
-                // Both have only minimums (no explicit max): prefer SD (the significant digits result)
-                // This follows the spec's preference for significant digits when constraints are equivalent
-                return sigDigitsResult;
-            }
-            else // lessPrecision
-            {
-                // lessPrecision: prefer the result farther from original value
-                if (sigPrecisionLoss > fracPrecisionLoss + 1e-15)
-                {
-                    return sigDigitsResult;
-                }
-                if (fracPrecisionLoss > sigPrecisionLoss + 1e-15)
-                {
-                    return fracDigitsResult;
-                }
-
-                // When values are equal (tie):
-                // If only SD max is explicit (no explicit SD min), prefer SD (no minimum constraint)
-                if (sdHasExplicitMax && !sdHasExplicitMin)
-                {
-                    return sigDigitsResult;
-                }
-
-                // If SD has explicit max AND min, compare constraint ranges
-                // For lessPrecision, prefer smaller max = less precision potential
-                if (sdHasExplicitMax && sdHasExplicitMin)
-                {
-                    var effectiveFdMax = MaximumFractionDigits + 1;
-                    if (maxSigDigits < effectiveFdMax)
-                    {
-                        return sigDigitsResult;
-                    }
-                    if (effectiveFdMax < maxSigDigits)
-                    {
-                        return fracDigitsResult;
-                    }
-                    // Maximums are equal - compare minimums
-                    // For lessPrecision, smaller minimum = less precision required
-                    var effectiveFdMin = MinimumFractionDigits + 1;
-                    if (minSigDigits <= effectiveFdMin)
-                    {
-                        return sigDigitsResult;
-                    }
-                    return fracDigitsResult;
-                }
-
-                // Default for lessPrecision: prefer FD (fraction digits result)
-                return fracDigitsResult;
-            }
-        }
-
-        // Default: use significant digits
-        return FormatToSignificantDigits(value, minSigDigits, maxSigDigits);
-    }
-
-    private string FormatWithFractionDigits(double value)
-    {
-        value = ApplyRounding(value, MaximumFractionDigits);
-        var integerDigits = (int) (value == 0 ? 1 : System.Math.Floor(System.Math.Log10(System.Math.Abs(value))) + 1);
-
-        string integerPart;
-        if (ShouldApplyGrouping(integerDigits))
-        {
-            integerPart = MinimumIntegerDigits <= 1 ? "#,##0" :
-                MinimumIntegerDigits == 2 ? "#,#00" :
-                MinimumIntegerDigits == 3 ? "#,000" :
-                new string('0', MinimumIntegerDigits - 3) + ",000";
-        }
-        else
-        {
-            integerPart = new string('0', MinimumIntegerDigits);
-        }
-
-        string format;
-        if (MaximumFractionDigits == 0)
-        {
-            format = integerPart;
-        }
-        else
-        {
-            var fractionPart = new string('0', MinimumFractionDigits);
-            if (MaximumFractionDigits > MinimumFractionDigits)
-            {
-                fractionPart += new string('#', MaximumFractionDigits - MinimumFractionDigits);
-            }
-            format = $"{integerPart}.{fractionPart}";
-        }
-
-        return value.ToString(format, NumberFormatInfo);
-    }
-
-    private string FormatToSignificantDigits(double value, int minSigDigits, int maxSigDigits)
-    {
-        // Check for negative zero (1.0 / -0 == -Infinity)
-        var isNegativeZero = value == 0 && 1.0 / value == double.NegativeInfinity;
-
-        if (value == 0)
-        {
-            // Use the locale's decimal separator so numbering-system transliteration leaves it
-            // alone. Without this, `.` would be replaced by the numbering-system's default
-            // separator (e.g. Arabic ٫) even when the locale wants a different one (de → `,`).
-            var zeroResult = minSigDigits > 1
-                ? "0" + NumberFormatInfo.NumberDecimalSeparator + new string('0', minSigDigits - 1)
-                : "0";
-            return isNegativeZero ? "-" + zeroResult : zeroResult;
-        }
-
-        var isNegative = value < 0;
-        var absValue = System.Math.Abs(value);
-
-        // Get the order of magnitude
-        var magnitude = (int) System.Math.Floor(System.Math.Log10(absValue));
-
-        // Round to max significant digits first
-        var decimalPlacesForRounding = maxSigDigits - magnitude - 1;
-        double rounded;
-        if (decimalPlacesForRounding >= 0)
-        {
-            rounded = ApplyRounding(value, decimalPlacesForRounding);
-        }
-        else
-        {
-            // Need to round to whole numbers or higher
-            var divisor = System.Math.Pow(10, -decimalPlacesForRounding);
-            rounded = ApplyRounding(value / divisor, 0) * divisor;
-        }
-
-        // After rounding, take absolute value for formatting
-        rounded = System.Math.Abs(rounded);
-
-        // For the actual formatting, format with max precision
-        // then trim unnecessary trailing zeros beyond minSigDigits
-        string result;
-        if (decimalPlacesForRounding <= 0)
-        {
-            result = rounded.ToString("F0", CultureInfo.InvariantCulture);
-        }
-        else
-        {
-            // Format with max precision, then we'll trim
-            var formatSpec = "F" + decimalPlacesForRounding;
-            result = rounded.ToString(formatSpec, CultureInfo.InvariantCulture);
-
-            // Trim trailing zeros beyond minSigDigits
-            if (result.Contains('.'))
-            {
-                var currentSigDigits = CountSignificantDigits(result);
-                while (currentSigDigits > minSigDigits && result[result.Length - 1] == '0' && result.Contains('.'))
-                {
-                    result = result.Substring(0, result.Length - 1);
-                    currentSigDigits = CountSignificantDigits(result);
-                }
-                // Remove trailing decimal point if no fraction left
-                if (result[result.Length - 1] == '.')
-                {
-                    result = result.Substring(0, result.Length - 1);
-                }
-            }
-        }
-
-        // Ensure minimum significant digits (add trailing zeros if needed)
-        var finalSigDigits = CountSignificantDigits(result);
-        if (finalSigDigits < minSigDigits)
-        {
-            var zerosToAdd = minSigDigits - finalSigDigits;
-            if (!result.Contains('.'))
-            {
-                result += "." + new string('0', zerosToAdd);
-            }
-            else
-            {
-                result += new string('0', zerosToAdd);
-            }
-        }
-
-        // Apply grouping and locale-specific separators
-        var decimalIdx = result.IndexOf('.');
-        var intPartForGrouping = decimalIdx >= 0 ? result.Substring(0, decimalIdx) : result;
-        var fracPart = decimalIdx >= 0 ? result.Substring(decimalIdx + 1) : null; // Exclude the '.'
-        var intDigitCount = intPartForGrouping.Length;
-
-        if (ShouldApplyGrouping(intDigitCount))
-        {
-            intPartForGrouping = ApplyGroupingToString(intPartForGrouping);
-        }
-
-        // Build result with locale-specific decimal separator
-        if (fracPart != null)
-        {
-            result = intPartForGrouping + NumberFormatInfo.NumberDecimalSeparator + fracPart;
-        }
-        else
-        {
-            result = intPartForGrouping;
-        }
-
-        return isNegative ? "-" + result : result;
-    }
-
     private string ApplyGroupingToString(string integerPart)
     {
         var boundaries = GroupBoundariesOf(integerPart.Length);
@@ -1596,163 +1267,8 @@ internal sealed class JsNumberFormat : ObjectInstance
         return sb.Append(integerPart, start, integerPart.Length - start).ToString();
     }
 
-    private static int CountSignificantDigits(string formatted)
-    {
-        var count = 0;
-        var foundNonZero = false;
-        var inFraction = false;
-
-        foreach (var c in formatted)
-        {
-            if (c == '.' || c == ',')
-            {
-                if (c == '.')
-                {
-                    inFraction = true;
-                }
-                continue;
-            }
-
-            if (c == '-')
-            {
-                continue;
-            }
-
-            if (char.IsDigit(c))
-            {
-                if (c != '0')
-                {
-                    foundNonZero = true;
-                }
-
-                if (foundNonZero)
-                {
-                    count++;
-                }
-                else if (inFraction && c == '0')
-                {
-                    // Leading zeros after decimal don't count
-                    continue;
-                }
-            }
-        }
-
-        return count == 0 ? 1 : count; // At least 1 for "0"
-    }
-
-    /// <summary>
-    /// Parses a formatted number string back to a double value.
-    /// Used for comparing precision loss between different formatting approaches.
-    /// Handles non-ASCII digit systems (Arabic, Thai, etc.) and locale-specific decimal separators.
-    /// </summary>
-    private double ParseFormattedNumber(string formatted)
-    {
-        // Use the locale's decimal separator to properly identify decimal vs grouping
-        var decimalSeparator = NumberFormatInfo.NumberDecimalSeparator;
-
-        // Build a clean numeric string by extracting digits and decimal point
-        var sb = new System.Text.StringBuilder(formatted.Length);
-        var hasDecimal = false;
-        var isNegative = false;
-
-        for (var i = 0; i < formatted.Length; i++)
-        {
-            var c = formatted[i];
-
-            // Handle negative sign (various forms)
-            if ((c == '-' || c == '\u2212') && sb.Length == 0) // ASCII minus or Unicode minus
-            {
-                isNegative = true;
-                continue;
-            }
-
-            // Check if this position matches the locale's decimal separator
-            if (!hasDecimal && decimalSeparator.Length > 0 && i + decimalSeparator.Length <= formatted.Length)
-            {
-                var match = true;
-                for (var j = 0; j < decimalSeparator.Length; j++)
-                {
-                    if (formatted[i + j] != decimalSeparator[j])
-                    {
-                        match = false;
-                        break;
-                    }
-                }
-                if (match)
-                {
-                    sb.Append('.');
-                    hasDecimal = true;
-                    i += decimalSeparator.Length - 1;
-                    continue;
-                }
-            }
-
-            // Handle other decimal separators (. or Arabic decimal ٫)
-            if ((c == '.' || c == '٫' || c == '\u066B') && !hasDecimal)
-            {
-                sb.Append('.');
-                hasDecimal = true;
-                continue;
-            }
-
-            // Skip grouping separators (likely . or , or space depending on locale)
-            if (c == ',' || c == ' ' || c == '\u00A0' || c == '\u202F') // Also handle narrow no-break space
-            {
-                continue;
-            }
-
-            // Handle ASCII digits 0-9
-            if (char.IsAsciiDigit(c))
-            {
-                sb.Append(c);
-                continue;
-            }
-
-            // Handle Arabic-Indic digits ٠-٩ (U+0660 to U+0669)
-            if (c >= '\u0660' && c <= '\u0669')
-            {
-                sb.Append((char) ('0' + (c - '\u0660')));
-                continue;
-            }
-
-            // Handle Extended Arabic-Indic digits ۰-۹ (U+06F0 to U+06F9)
-            if (c >= '\u06F0' && c <= '\u06F9')
-            {
-                sb.Append((char) ('0' + (c - '\u06F0')));
-                continue;
-            }
-
-            // Handle other numeric systems using char.GetNumericValue
-            var numericValue = char.GetNumericValue(c);
-            if (numericValue >= 0 && numericValue <= 9)
-            {
-                sb.Append((char) ('0' + (int) numericValue));
-            }
-            // Skip grouping separators, currency symbols, etc.
-        }
-
-        if (sb.Length == 0)
-        {
-            return 0;
-        }
-
-        if (double.TryParse(sb.ToString(), System.Globalization.NumberStyles.Float,
-            System.Globalization.CultureInfo.InvariantCulture, out var result))
-        {
-            return isNegative ? -result : result;
-        }
-
-        return 0;
-    }
-
     private string FormatCurrency(double value)
     {
-        // Handle significant digits if specified
-        if (MinimumSignificantDigits.HasValue || MaximumSignificantDigits.HasValue)
-        {
-            return FormatCurrencyWithSignificantDigits(value);
-        }
-
         // Check for negative zero (1.0 / -0 == -Infinity)
         var isNegativeZero = value == 0 && double.IsNegativeInfinity(1.0 / value);
         var isNegative = value < 0 || isNegativeZero;
@@ -1967,75 +1483,6 @@ internal sealed class JsNumberFormat : ObjectInstance
         };
     }
 
-    private string FormatCurrencyWithSignificantDigits(double value)
-    {
-        var isNegative = value < 0;
-        var isZero = value == 0;
-        var absValue = System.Math.Abs(value);
-
-        // Format using significant digits
-        var formatted = FormatToSignificantDigits(absValue, MinimumSignificantDigits ?? 1, MaximumSignificantDigits ?? 21);
-
-        var symbol = NumberFormatInfo.CurrencySymbol;
-        var useAccountingFormat = string.Equals(CurrencySign, "accounting", StringComparison.Ordinal);
-
-        // Build currency string based on locale pattern
-        var posPattern = NumberFormatInfo.CurrencyPositivePattern;
-        string formattedCurrency;
-
-        const string Nbsp = "\u00A0"; // Non-breaking space per CLDR
-        switch (posPattern)
-        {
-            case 0: // $n
-                formattedCurrency = symbol + formatted;
-                break;
-            case 1: // n$
-                formattedCurrency = formatted + symbol;
-                break;
-            case 2: // $ n
-                formattedCurrency = symbol + Nbsp + formatted;
-                break;
-            case 3: // n $
-            default:
-                formattedCurrency = formatted + Nbsp + symbol;
-                break;
-        }
-
-        // Determine sign display
-        var showNegativeSign = isNegative && !isZero;
-        var showPositiveSign = false;
-
-        switch (SignDisplay)
-        {
-            case "always":
-                showPositiveSign = !isNegative;
-                break;
-            case "exceptZero":
-                showPositiveSign = !isNegative && !isZero;
-                showNegativeSign = isNegative && !isZero;
-                break;
-            case "never":
-                showNegativeSign = false;
-                break;
-        }
-
-        if (showNegativeSign)
-        {
-            if (useAccountingFormat)
-            {
-                return FormatNegativeCurrency(formatted, symbol);
-            }
-            return NumberFormatInfo.NegativeSign + formattedCurrency;
-        }
-
-        if (showPositiveSign)
-        {
-            return NumberFormatInfo.PositiveSign + formattedCurrency;
-        }
-
-        return formattedCurrency;
-    }
-
     /// <summary>
     /// https://tc39.es/ecma402/#sec-formatnumber under the percent style, which is the concatenation of
     /// exactly the parts https://tc39.es/ecma402/#sec-formatnumbertoparts returns.
@@ -2046,74 +1493,7 @@ internal sealed class JsNumberFormat : ObjectInstance
     /// fraction digits always, never the trim https://tc39.es/ecma402/#sec-torawfixed ends with, and none
     /// of <c>signDisplay</c>, <c>useGrouping</c> or <c>minimumIntegerDigits</c> at all.
     /// </remarks>
-    private string FormatPercent(double value)
-    {
-        // Handle significant digits for percent formatting
-        if (MinimumSignificantDigits.HasValue || MaximumSignificantDigits.HasValue)
-        {
-            var percentValue = value * 100;
-            var formatted = FormatWithSignificantDigits(percentValue);
-            // Apply locale-specific percent pattern
-            return ApplyPercentPattern(formatted, percentValue >= 0);
-        }
-
-        return ConcatenateParts(FormatPercentToParts(value));
-    }
-
-    /// <summary>
-    /// Applies locale-specific percent formatting pattern.
-    /// Uses non-breaking space (U+00A0) for spacing as per CLDR.
-    /// </summary>
-    private string ApplyPercentPattern(string formattedNumber, bool isPositive)
-    {
-        var symbol = NumberFormatInfo.PercentSymbol;
-        const string Nbsp = "\u00A0"; // Non-breaking space
-        int pattern;
-
-        if (isPositive)
-        {
-            pattern = NumberFormatInfo.PercentPositivePattern;
-            // PercentPositivePattern values:
-            // 0: n %  (space between)
-            // 1: n%   (no space)
-            // 2: %n   (symbol before, no space)
-            // 3: % n  (symbol before, space)
-            return pattern switch
-            {
-                0 => formattedNumber + Nbsp + symbol,
-                1 => formattedNumber + symbol,
-                2 => symbol + formattedNumber,
-                3 => symbol + Nbsp + formattedNumber,
-                _ => formattedNumber + symbol
-            };
-        }
-        else
-        {
-            pattern = NumberFormatInfo.PercentNegativePattern;
-            // the sign is the locale's own, so it is also what has to be stripped back off
-            var minus = NumberFormatInfo.NegativeSign;
-            var absNumber = formattedNumber.StartsWith(minus, StringComparison.Ordinal)
-                ? formattedNumber.Substring(minus.Length)
-                : formattedNumber;
-            // PercentNegativePattern values vary by locale
-            return pattern switch
-            {
-                0 => minus + absNumber + Nbsp + symbol,
-                1 => minus + absNumber + symbol,
-                2 => minus + symbol + absNumber,
-                3 => symbol + minus + absNumber,
-                4 => symbol + absNumber + minus,
-                5 => absNumber + minus + symbol,
-                6 => absNumber + symbol + minus,
-                7 => minus + symbol + Nbsp + absNumber,
-                8 => absNumber + Nbsp + symbol + minus,
-                9 => symbol + Nbsp + absNumber + minus,
-                10 => symbol + Nbsp + minus + absNumber,
-                11 => absNumber + minus + Nbsp + symbol,
-                _ => minus + absNumber + symbol
-            };
-        }
-    }
+    private string FormatPercent(double value) => ConcatenateParts(FormatPercentToParts(value));
 
     private string FormatUnit(double value)
     {
@@ -2335,6 +1715,31 @@ internal sealed class JsNumberFormat : ObjectInstance
         internal static NumberBody Finite(string integerDigits, string fractionDigits) => new(integerDigits, fractionDigits, null);
 
         internal static NumberBody Of(NumberFormatPart nonFinite) => new("", "", nonFinite);
+
+        /// <summary>Whether every digit written is a zero, which is what <c>signDisplay</c> reads.</summary>
+        internal bool IsZero
+        {
+            get
+            {
+                foreach (var c in IntegerDigits)
+                {
+                    if (c != '0')
+                    {
+                        return false;
+                    }
+                }
+
+                foreach (var c in FractionDigits)
+                {
+                    if (c != '0')
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+        }
     }
 
     /// <summary>
@@ -2347,6 +1752,220 @@ internal sealed class JsNumberFormat : ObjectInstance
         return NumberBody.Finite(
             IntegerDigitsOf(integral),
             FractionDigitsOf(roundedAbsValue - integral, MaximumFractionDigits));
+    }
+
+    /// <summary>
+    /// https://tc39.es/ecma402/#sec-formatnumberstring over a finite value: the digits, before any pattern
+    /// is written around them.
+    /// </summary>
+    /// <remarks>
+    /// The specification computes these once, for every style — the style decides only what is written
+    /// around them. Jint had four copies over a <see cref="double"/> and three of them had no
+    /// significant-digit route at all, so <c>maximumSignificantDigits</c> was read under the decimal style
+    /// and silently ignored under a currency, a percent and a unit. The value keeps its sign here even
+    /// though only its digits come back, because <c>GetUnsignedRoundingMode</c> reads it: <c>ceil</c>
+    /// rounds a positive value's magnitude up and a negative one's down.
+    /// </remarks>
+    private NumberBody FormatNumericToString(double value)
+    {
+        if (string.Equals(RoundingPriority, "auto", StringComparison.Ordinal))
+        {
+            return MinimumSignificantDigits.HasValue || MaximumSignificantDigits.HasValue
+                ? RawPrecisionBody(value, out _)
+                : RawFixedBody(value);
+        }
+
+        // more-precision and less-precision compute both and keep one, chosen by which rounded further:
+        // ToRawFixed's magnitude is -maximumFractionDigits and ToRawPrecision's is e - p + 1.
+        var significant = RawPrecisionBody(value, out var significantMagnitude);
+        var fixedIsMorePrecise = -MaximumFractionDigits < significantMagnitude;
+        var takeFixed = string.Equals(RoundingPriority, "morePrecision", StringComparison.Ordinal)
+            ? fixedIsMorePrecise
+            : !fixedIsMorePrecise;
+
+        return takeFixed ? RawFixedBody(value) : significant;
+    }
+
+    /// <summary>
+    /// https://tc39.es/ecma402/#sec-torawfixed over a finite value.
+    /// </summary>
+    private NumberBody RawFixedBody(double value)
+        => FiniteBody(System.Math.Abs(ApplyRounding(value, MaximumFractionDigits)));
+
+    /// <summary>
+    /// https://tc39.es/ecma402/#sec-torawprecision over a finite value, reporting the
+    /// <c>[[RoundingMagnitude]]</c> the priority comparison reads.
+    /// </summary>
+    private NumberBody RawPrecisionBody(double value, out int roundingMagnitude)
+    {
+        var minSig = MinimumSignificantDigits ?? 1;
+        var maxSig = MaximumSignificantDigits ?? 21;
+        var absValue = System.Math.Abs(value);
+
+        if (absValue != 0)
+        {
+            var magnitude = (int) System.Math.Floor(System.Math.Log10(absValue));
+            var decimalPlaces = maxSig - magnitude - 1;
+
+            double rounded;
+            if (decimalPlaces >= 0)
+            {
+                rounded = ApplyRounding(value, decimalPlaces);
+            }
+            else
+            {
+                var divisor = System.Math.Pow(10, -decimalPlaces);
+                rounded = ApplyRounding(value / divisor, 0) * divisor;
+            }
+
+            absValue = System.Math.Abs(rounded);
+        }
+
+        if (absValue == 0)
+        {
+            roundingMagnitude = 1 - maxSig;
+            return RawPrecision("0", 0, minSig, maxSig);
+        }
+
+        DecimalDigitsOf(absValue, out var significand, out var exponent);
+        roundingMagnitude = exponent - maxSig + 1;
+        return RawPrecision(significand, exponent, minSig, maxSig);
+    }
+
+    /// <summary>
+    /// https://tc39.es/ecma402/#sec-torawprecision over an exact
+    /// <paramref name="absMantissa"/> × 10^-<paramref name="fractionDigits"/>.
+    /// </summary>
+    private NumberBody ExactPrecisionBody(BigInteger absMantissa, int fractionDigits)
+    {
+        var minSig = MinimumSignificantDigits ?? 1;
+        var maxSig = MaximumSignificantDigits ?? 21;
+
+        if (absMantissa.IsZero)
+        {
+            return RawPrecision("0", 0, minSig, maxSig);
+        }
+
+        var digits = absMantissa.ToString("R", CultureInfo.InvariantCulture);
+        var end = digits.Length;
+        while (end > 1 && digits[end - 1] == '0')
+        {
+            end--;
+        }
+
+        return RawPrecision(digits.Substring(0, end), digits.Length - 1 - fractionDigits, minSig, maxSig);
+    }
+
+    /// <summary>
+    /// https://tc39.es/ecma402/#sec-torawprecision's last steps: <paramref name="significand"/> × 10^
+    /// <paramref name="exponent"/> written out to <paramref name="maxSig"/> digits, split at the decimal
+    /// point, and stripped of up to <c>maxSig - minSig</c> trailing zeros.
+    /// </summary>
+    /// <remarks>
+    /// The trim is the step the parts lane never had, which is why <c>maximumSignificantDigits: 2</c> wrote
+    /// <c>"0.40"</c> where the string lane wrote <c>"0.4"</c>.
+    /// </remarks>
+    private static NumberBody RawPrecision(string significand, int exponent, int minSig, int maxSig)
+    {
+        var m = significand.Length > maxSig
+            ? RoundDigits(significand, maxSig, ref exponent)
+            : significand.PadRight(maxSig, '0');
+
+        string integerStr;
+        string fractionStr;
+        if (exponent >= maxSig - 1)
+        {
+            integerStr = m + new string('0', exponent - maxSig + 1);
+            fractionStr = string.Empty;
+        }
+        else if (exponent >= 0)
+        {
+            integerStr = m.Substring(0, exponent + 1);
+            fractionStr = m.Substring(exponent + 1);
+        }
+        else
+        {
+            integerStr = "0";
+            fractionStr = new string('0', -(exponent + 1)) + m;
+        }
+
+        var cut = maxSig - minSig;
+        var keep = fractionStr.Length;
+        while (cut > 0 && keep > 0 && fractionStr[keep - 1] == '0')
+        {
+            keep--;
+            cut--;
+        }
+
+        return NumberBody.Finite(integerStr, keep == fractionStr.Length ? fractionStr : fractionStr.Substring(0, keep));
+    }
+
+    /// <summary>Keeps the leading <paramref name="keep"/> digits, rounding half away from zero.</summary>
+    private static string RoundDigits(string digits, int keep, ref int exponent)
+    {
+        var kept = digits.Substring(0, keep).ToCharArray();
+        if (digits[keep] < '5')
+        {
+            return new string(kept);
+        }
+
+        for (var i = keep - 1; i >= 0; i--)
+        {
+            if (kept[i] != '9')
+            {
+                kept[i]++;
+                return new string(kept);
+            }
+
+            kept[i] = '0';
+        }
+
+        // every digit was a nine, so the carry adds one to the magnitude
+        exponent++;
+        return "1".PadRight(keep, '0');
+    }
+
+    /// <summary>
+    /// A non-negative finite <see cref="double"/> as significant digits and the exponent of the first of
+    /// them, which is how https://tc39.es/ecma402/#sec-tointlmathematicalvalue reads a Number: the digits
+    /// of <c>Number::toString</c>, the shortest decimal that reads back as this double.
+    /// </summary>
+    /// <remarks>
+    /// Reading the double's own binary expansion instead is what made <c>minimumSignificantDigits: 3</c>
+    /// write <c>"0.400000000000000022204"</c> for <c>0.4</c>: the Intl mathematical value of the Number
+    /// <c>0.4</c> is exactly four tenths, because the specification reads it through
+    /// <c>Number::toString</c> before it reads it as a mathematical value at all.
+    /// </remarks>
+    private static void DecimalDigitsOf(double absValue, out string significand, out int exponent)
+    {
+        var text = Number.NumberPrototype.ToNumberString(absValue);
+
+        var exponentIndex = text.IndexOf('e');
+        var written = 0;
+        if (exponentIndex >= 0)
+        {
+            written = int.Parse(text.AsSpan(exponentIndex + 1), NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture);
+            text = text.Substring(0, exponentIndex);
+        }
+
+        var point = text.IndexOf('.');
+        var digits = point < 0 ? text : text.Remove(point, 1);
+        var integerLength = point < 0 ? text.Length : point;
+
+        var first = 0;
+        while (first < digits.Length - 1 && digits[first] == '0')
+        {
+            first++;
+        }
+
+        var last = digits.Length;
+        while (last > first + 1 && digits[last - 1] == '0')
+        {
+            last--;
+        }
+
+        significand = digits.Substring(first, last - first);
+        exponent = integerLength - 1 - first + written;
     }
 
     /// <summary>
@@ -2458,19 +2077,13 @@ internal sealed class JsNumberFormat : ObjectInstance
 
     /// <remarks>
     /// ECMA-402 calls the sign "the ILND String representing the minus sign", so it is the locale's own
-    /// datum: <c>ar</c> prefixes U+061C ARABIC LETTER MARK to it. <paramref name="minusSignOverride"/> is
-    /// for the one lane that does not write it — the significant-digits lane over a
-    /// <see cref="double"/> writes a plain hyphen, and the two lanes have to agree about which one this is.
+    /// datum in every lane: <c>ar</c> prefixes U+061C ARABIC LETTER MARK to it.
     /// </remarks>
-    private void AppendSignPart(
-        List<NumberFormatPart> parts,
-        bool showNegativeSign,
-        bool showPositiveSign,
-        string? minusSignOverride = null)
+    private void AppendSignPart(List<NumberFormatPart> parts, bool showNegativeSign, bool showPositiveSign)
     {
         if (showNegativeSign)
         {
-            parts.Add(new NumberFormatPart("minusSign", minusSignOverride ?? NumberFormatInfo.NegativeSign));
+            parts.Add(new NumberFormatPart("minusSign", NumberFormatInfo.NegativeSign));
         }
         else if (showPositiveSign)
         {
@@ -2610,9 +2223,8 @@ internal sealed class JsNumberFormat : ObjectInstance
         var isNegative = value < 0 || double.IsNegativeInfinity(1 / value); // Handles -0
         var absValue = System.Math.Abs(value);
 
-        // Apply rounding first to determine if value displays as zero
-        absValue = ApplyRounding(absValue, MaximumFractionDigits);
-        var displaysAsZero = absValue == 0;
+        var body = FormatNumericToString(value);
+        var displaysAsZero = body.IsZero;
 
         // Determine if we should show a sign based on signDisplay
         var showNegativeSign = isNegative;
@@ -2638,122 +2250,10 @@ internal sealed class JsNumberFormat : ObjectInstance
                 break;
         }
 
-        if (showNegativeSign)
-        {
-            parts.Add(new NumberFormatPart("minusSign", NumberFormatInfo.NegativeSign));
-        }
-        else if (showPositiveSign)
-        {
-            parts.Add(new NumberFormatPart("plusSign", NumberFormatInfo.PositiveSign));
-        }
-
-        value = absValue;
-
-        // Handle significant digits if specified
-        if (MinimumSignificantDigits.HasValue || MaximumSignificantDigits.HasValue)
-        {
-            FormatWithSignificantDigitsToParts(parts, value);
-            return parts;
-        }
-
-        // Value is already rounded
-        AddNumberParts(parts, FiniteBody(value));
+        AppendSignPart(parts, showNegativeSign, showPositiveSign);
+        AddNumberParts(parts, in body);
 
         return parts;
-    }
-
-    /// <summary>
-    /// Formats a number with significant digits and adds parts to the list.
-    /// </summary>
-    private void FormatWithSignificantDigitsToParts(List<NumberFormatPart> parts, double value)
-    {
-        if (value == 0)
-        {
-            var minSigDigits = MinimumSignificantDigits ?? 1;
-            if (minSigDigits > 1)
-            {
-                parts.Add(new NumberFormatPart("integer", "0"));
-                parts.Add(new NumberFormatPart("decimal", NumberFormatInfo.NumberDecimalSeparator));
-                parts.Add(new NumberFormatPart("fraction", new string('0', minSigDigits - 1)));
-            }
-            else
-            {
-                parts.Add(new NumberFormatPart("integer", "0"));
-            }
-            return;
-        }
-
-        var minSig = MinimumSignificantDigits ?? 1;
-        var maxSig = MaximumSignificantDigits ?? 21;
-
-        // Get the order of magnitude
-        var magnitude = (int) System.Math.Floor(System.Math.Log10(value));
-        var decimalPlaces = maxSig - magnitude - 1;
-
-        // Round to the required number of significant digits
-        double rounded;
-        if (decimalPlaces >= 0)
-        {
-            rounded = ApplyRounding(value, decimalPlaces);
-        }
-        else
-        {
-            // Need to round to whole numbers or higher
-            var divisor = System.Math.Pow(10, -decimalPlaces);
-            rounded = ApplyRounding(value / divisor, 0) * divisor;
-        }
-
-        // Get integer and fraction parts from rounded value
-        var integerPart = (long) System.Math.Truncate(rounded);
-        var fractionValue = rounded - integerPart;
-
-        // Calculate actual significant digits we have
-        var intStr = integerPart.ToString(CultureInfo.InvariantCulture);
-        var currentSigDigits = intStr.TrimStart('0').Length;
-        if (currentSigDigits == 0) currentSigDigits = 1;
-
-        // Format integer part with grouping
-        FormatIntegerToParts(parts, intStr);
-
-        // Calculate fraction digits needed
-        var fractionDigitsNeeded = 0;
-        if (decimalPlaces > 0)
-        {
-            fractionDigitsNeeded = decimalPlaces;
-        }
-
-        // Ensure minimum significant digits
-        var zerosToAdd = minSig - currentSigDigits;
-        if (zerosToAdd > fractionDigitsNeeded)
-        {
-            fractionDigitsNeeded = zerosToAdd;
-        }
-
-        // Add fraction if needed
-        if (fractionDigitsNeeded > 0 || fractionValue > 0)
-        {
-            parts.Add(new NumberFormatPart("decimal", NumberFormatInfo.NumberDecimalSeparator));
-
-            // Format fraction
-            var fractionDigits = System.Math.Max(fractionDigitsNeeded, decimalPlaces > 0 ? decimalPlaces : 0);
-            if (fractionDigits > 0)
-            {
-                var multiplier = System.Math.Pow(10, fractionDigits);
-                var fractionInt = (long) System.Math.Round(fractionValue * multiplier);
-                var fractionStr = fractionInt.ToString(CultureInfo.InvariantCulture).PadLeft(fractionDigits, '0');
-                parts.Add(new NumberFormatPart("fraction", fractionStr));
-            }
-            else if (zerosToAdd > 0)
-            {
-                parts.Add(new NumberFormatPart("fraction", new string('0', zerosToAdd)));
-            }
-        }
-        else if (zerosToAdd > 0)
-        {
-            // Need to add trailing zeros to meet minSig requirement
-            parts.Add(new NumberFormatPart("decimal", NumberFormatInfo.NumberDecimalSeparator));
-            parts.Add(new NumberFormatPart("fraction", new string('0', zerosToAdd)));
-        }
     }
 
     private void FormatIntegerToParts(List<NumberFormatPart> parts, string intStr)
@@ -2859,11 +2359,10 @@ internal sealed class JsNumberFormat : ObjectInstance
         var isNegative = value < 0 || double.IsNegativeInfinity(1 / value); // Handles -0
         var absValue = System.Math.Abs(value);
 
-        // Apply rounding first to determine if value displays as zero. The digit count is the one
-        // https://tc39.es/ecma402/#sec-torawfixed rounds at, which the constructor has already defaulted
-        // to the currency's own — an explicit maximumFractionDigits of zero is a caller asking for none.
-        absValue = ApplyRounding(absValue, MaximumFractionDigits);
-        var displaysAsZero = absValue == 0;
+        // The digits are https://tc39.es/ecma402/#sec-formatnumberstring's, which is one operation for
+        // every style: the currency pattern is written around them and never instead of them.
+        var body = FormatNumericToString(value);
+        var displaysAsZero = body.IsZero;
 
         // Determine if we should show a negative sign based on signDisplay
         var showNegativeSign = isNegative;
@@ -2889,7 +2388,7 @@ internal sealed class JsNumberFormat : ObjectInstance
                 break;
         }
 
-        AppendCurrencyParts(parts, FiniteBody(absValue), showNegativeSign, showPositiveSign);
+        AppendCurrencyParts(parts, in body, showNegativeSign, showPositiveSign);
 
         return parts;
     }
@@ -3110,9 +2609,8 @@ internal sealed class JsNumberFormat : ObjectInstance
         var isNegative = value < 0 || double.IsNegativeInfinity(1 / value); // Handles -0
 
         // Multiply by 100 for percent
-        var percentValue = System.Math.Abs(value) * 100;
-        percentValue = ApplyRounding(percentValue, MaximumFractionDigits);
-        var displaysAsZero = percentValue == 0;
+        var body = FormatNumericToString(value * 100);
+        var displaysAsZero = body.IsZero;
 
         // Determine if we should show a sign based on signDisplay
         var showNegativeSign = isNegative;
@@ -3137,7 +2635,7 @@ internal sealed class JsNumberFormat : ObjectInstance
                 break;
         }
 
-        AppendPercentParts(parts, FiniteBody(percentValue), showNegativeSign, showPositiveSign);
+        AppendPercentParts(parts, in body, showNegativeSign, showPositiveSign);
 
         return parts;
     }
@@ -3190,9 +2688,8 @@ internal sealed class JsNumberFormat : ObjectInstance
         var isNegative = value < 0 || double.IsNegativeInfinity(1 / value); // Handles -0
         var absValue = System.Math.Abs(value);
 
-        // Apply rounding first to determine if value displays as zero
-        absValue = ApplyRounding(absValue, MaximumFractionDigits);
-        var displaysAsZero = absValue == 0;
+        var body = FormatNumericToString(value);
+        var displaysAsZero = body.IsZero;
 
         // Determine if we should show a sign based on signDisplay
         var showNegativeSign = isNegative;
@@ -3217,7 +2714,7 @@ internal sealed class JsNumberFormat : ObjectInstance
                 break;
         }
 
-        AppendUnitParts(parts, FiniteBody(absValue), showNegativeSign, showPositiveSign, value);
+        AppendUnitParts(parts, in body, showNegativeSign, showPositiveSign, value);
 
         return parts;
     }

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -3419,6 +3419,71 @@ did. The significant-digit options are a separate algorithm —
 [ToRawPrecision](https://tc39.es/ecma402/#sec-torawprecision) rather than ToRawFixed — and are
 [#3499](https://github.com/sebastienros/jint/issues/3499).
 
+### 4.78 The significant-digit options are read in every lane and every style ([#3499](https://github.com/sebastienros/jint/issues/3499))
+
+[FormatNumericToString](https://tc39.es/ecma402/#sec-formatnumberstring) computes a value's digits **once**,
+choosing between [ToRawPrecision](https://tc39.es/ecma402/#sec-torawprecision) and
+[ToRawFixed](https://tc39.es/ecma402/#sec-torawfixed) by what the formatter was given — never by what the
+style writes around the digits. Jint had four copies of that decision over a `double`, three of which had no
+significant-digit route at all, so `minimumSignificantDigits` and `maximumSignificantDigits` reached one lane
+and not the other, in four separate ways.
+
+**They were ignored entirely by a currency, a percent and a unit in the parts lane:**
+
+```js
+const usd = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumSignificantDigits: 2 });
+usd.format(1234.567);                                   // "$1,200"
+usd.formatToParts(1234.567).map(p => p.value).join(''); // 5.0: "$1,234.57"   5.x: "$1,200"
+
+new Intl.NumberFormat('en-US', { style: 'percent', maximumSignificantDigits: 2 }).formatToParts(1234.567);
+                                                        // 5.0: "123,457%"    5.x: "120,000%"
+new Intl.NumberFormat('en-US', { style: 'unit', unit: 'meter', maximumSignificantDigits: 2 }).formatToParts(1234.567);
+                                                        // 5.0: "1,234.567 m" 5.x: "1,200 m"
+```
+
+**ToRawPrecision's trim reached only the string lane.** Its last steps remove up to
+`maxPrecision - minPrecision` trailing zeros, the same shape ToRawFixed has for fraction digits:
+
+```js
+const two = new Intl.NumberFormat('en', { maximumSignificantDigits: 2 });
+two.format(0.4);                                    // "0.4"
+two.formatToParts(0.4).map(p => p.value).join('');  // 5.0: "0.40"    5.x: "0.4"
+```
+
+**A `long` was leaking into a fraction part.** The parts lane computed `fractionDigits = maxSig - magnitude
+- 1` — 21 when `maximumSignificantDigits` defaults to 21 — and then cast `fractionValue * 10^21` to `long`,
+which .NET saturates rather than throwing:
+
+```js
+new Intl.NumberFormat('en', { minimumSignificantDigits: 3 }).formatToParts(0.5).map(p => p.value).join('');
+// 5.0: "0.009223372036854775807"   — 9223372036854775807 is long.MaxValue
+// 5.x: "0.500"
+```
+
+**And the string lane wrote the double's own binary expansion:**
+
+```js
+new Intl.NumberFormat('en', { minimumSignificantDigits: 3 }).format(0.4);
+// 5.0: "0.400000000000000022204"   5.x: "0.400"
+```
+
+That last one is not a judgement call, though it looks like one.
+[ToIntlMathematicalValue](https://tc39.es/ecma402/#sec-tointlmathematicalvalue) reads a Number by taking
+`Number::toString(x, 10)` — the **shortest** decimal that reads back as that double — and only then reading
+that string as a mathematical value. The Intl mathematical value of the Number `0.4` is therefore exactly
+four tenths, not `0.400000000000000022204…`, and `"0.400"` is what the specification requires rather than
+what other engines happen to do.
+
+One `FormatNumericToString` now serves both lanes and all four styles, which also gives the parts lane the
+`roundingPriority` comparison it never had — the specification decides `morePrecision` and `lessPrecision` by
+comparing the two roundings' `[[RoundingMagnitude]]`, and the parts lane simply ignored the option. An
+exactly-read value (a BigInt, a long numeric string) takes the same operation over its own digits, so it
+reads the minimum as a floor too: `format(1n)` under `minimumSignificantDigits: 3` was `"1"` and is `"1.00"`.
+
+**What could break:** any output at all from a formatter that names `minimumSignificantDigits` or
+`maximumSignificantDigits` — both lanes move, in every style — and any `format` under
+`roundingPriority: "morePrecision"` or `"lessPrecision"`. A formatter that names none of them is untouched.
+
 ## 5. New in v5
 
 Everything in the table below is opt-in: nothing in it is installed unless the host asks for it, so


### PR DESCRIPTION
> Stacked on #3514, which puts the digits in one place. Review/merge that first; this PR's diff is the
> second commit.

[FormatNumericToString](https://tc39.es/ecma402/#sec-formatnumberstring) computes a value's digits **once**,
choosing between [ToRawPrecision](https://tc39.es/ecma402/#sec-torawprecision) and
[ToRawFixed](https://tc39.es/ecma402/#sec-torawfixed) by what the formatter was given — never by what the
style writes around the digits. Jint had four copies of that decision over a `double`, three of which had no
significant-digit route at all, so `minimumSignificantDigits` and `maximumSignificantDigits` reached one lane
and not the other, in four separate ways. All four are one fix, because all four are that one operation
existing four times.

## 1. A currency, a percent and a unit ignored them in the parts lane

`FormatCurrencyToParts`, `FormatPercentToParts` and `FormatUnitToParts` had no branch at all:

```js
const usd = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumSignificantDigits: 2 });
usd.format(1234.567);                                   // "$1,200"
usd.formatToParts(1234.567).map(p => p.value).join(''); // before: "$1,234.57"    after: "$1,200"

new Intl.NumberFormat('en-US', { style: 'percent', maximumSignificantDigits: 2 }).formatToParts(1234.567);
                                                        // before: "123,457%"     after: "120,000%"
new Intl.NumberFormat('en-US', { style: 'unit', unit: 'meter', maximumSignificantDigits: 2 }).formatToParts(1234.567);
                                                        // before: "1,234.567 m"  after: "1,200 m"
```

## 2. ToRawPrecision's trim reached only the string lane

Its last steps remove up to `maxPrecision - minPrecision` trailing zeros, the same shape ToRawFixed has:

```js
const two = new Intl.NumberFormat('en', { maximumSignificantDigits: 2 });
two.format(0.4);                                    // "0.4"
two.formatToParts(0.4).map(p => p.value).join('');  // before: "0.40"    after: "0.4"
```

## 3. `long.MaxValue` leaked into a fraction part

The parts lane computed `fractionDigits = maxSig - magnitude - 1` — 21 when `maximumSignificantDigits`
defaults to 21 — and then cast `fractionValue * 10^21` to `long`, which .NET saturates rather than throwing:

```js
new Intl.NumberFormat('en', { minimumSignificantDigits: 3 }).formatToParts(0.5).map(p => p.value).join('');
// before: "0.009223372036854775807"   — 9223372036854775807 is long.MaxValue
// after:  "0.500"
```

## 4. The string lane wrote the double's own binary expansion

```js
new Intl.NumberFormat('en', { minimumSignificantDigits: 3 }).format(0.4);
// before: "0.400000000000000022204"   after: "0.400"
```

The issue flagged this one as a judgement call. **It is not.**
[ToIntlMathematicalValue](https://tc39.es/ecma402/#sec-tointlmathematicalvalue) reads a Number by taking
`Number::toString(x, 10)` — the *shortest* decimal that reads back as that double — and only then reading
that string as a mathematical value. The Intl mathematical value of the Number `0.4` is therefore exactly
four tenths, and `"0.400"` is what ECMA-402 requires, not merely what ICU happens to do. So the answer to
"what does agree mean here" is settled by the spec, and no compatibility argument is needed.

## What it is now

One `FormatNumericToString` produces a `NumberBody` — the digit strings #3514 introduced — and every lane and
every style reads it. `FormatWithSignificantDigits`, `FormatToSignificantDigits`, `FormatWithFractionDigits`,
`FormatCurrencyWithSignificantDigits`, `FormatWithSignificantDigitsToParts`, `ApplySignificantDigitRounding`,
`ApplyPercentPattern`, `CountSignificantDigits` and `ParseFormattedNumber` are all gone with it — about 500
lines, replaced by ToRawPrecision transcribed once.

Two things fall out of that. The parts lane gains the `roundingPriority` comparison it never had, decided the
way the specification decides it (compare the two roundings' `[[RoundingMagnitude]]`) rather than by the
string lane's heuristic of parsing both results back to doubles and comparing distances with a `1e-15`
epsilon. And the exact lane — a BigInt, a long numeric string — takes the same operation over its own digits,
so it reads the minimum as a floor too: `format(1n)` under `minimumSignificantDigits: 3` was `"1"` and is
`"1.00"`, which is what `format(1)` writes.

The sign is threaded into the producer rather than stripped before it, because
`GetUnsignedRoundingMode` reads it: `roundingMode: "ceil"` rounds a positive value's magnitude up and a
negative one's down, which is what `format-rounding-mode-ceil.js` and its three siblings assert.

## Proof

All five fail against the parent commit:

```
Failed TheSignificantDigitOptionsReachEveryStyle
   Expected Join(Usd, "1234.567") ...  "$1,234.57"  /  "$1,200"
Failed ToRawPrecisionTrimsItsTrailingZeros
   Expected Join(TwoDigits, "0.4") ...  "0.40"  /  "0.4"
Failed ANumbersDigitsAreTheOnesNumberToStringWrites
   Expected Format(ThreeDigits, "0.4") ...  "0.400000000000000022204"  /  "0.400"
Failed AnExactValueReadsTheSignificantDigitOptionsAsWell
   Expected Format(ThreeDigits, "1n") ...  "1"  /  "1.00"
Failed PartsConcatenateToFormat
   ["en/latn/18/1: format=1 parts=1.0", "en/latn/18/-1: …"]  /  []
```

The join grid gains nine option sets: the three significant-digit shapes on their own, the same under a
currency, a percent and a unit, and both rounding priorities.

## Verification

- `dotnet build -c Release`, `dotnet test -c Release`: every unit-test project green on `net472`, `net8.0`
  and `net10.0`.
- test262: **102,537 passed / 0 failed / 151 skipped** of 102,688, which is the control on this base
  commit. (#3513 took it to 102,533/155, then #3506 and #3510 each removed a staging exclusion worth
  two more passes.) Nothing moves. Runs on this machine also report 30-second `TimeoutException`s on a
  handful of `staging/sm` and `intl402/supportedLocalesOf-*` files; every one of them passes in
  isolation in four seconds and they are the known load flakes here.
- No test262 exclusion is added, and every `intl402/NumberFormat`, `intl402/BigInt/prototype/toLocaleString`,
  `PluralRules` and `RelativeTimeFormat` case passes.
- Migration guide: §4.78.

Fixes #3499

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014W5mbjGhyvgAS4pivXoc4S
