### PR TITLE
Collections: a rotating key set moves its window instead of compacting the array

### DIFF
--- a/Jint.Benchmark/PropertyDeleteChurnBenchmark.cs
+++ b/Jint.Benchmark/PropertyDeleteChurnBenchmark.cs
@@ -11,13 +11,19 @@ namespace Jint.Benchmark;
 /// creation. The tombstones are reclaimed by compaction inside the resize an add would have needed
 /// anyway, so what is measured here is how much that reclamation costs on the shapes that provoke it.
 /// <para>
-/// The four collection rows are the distinguishable cases. <c>AddOnly</c> is the control: no removals, so
-/// nothing about its path changed. <c>AddThenRemoveNewest</c> removes the entry that was just added, which
-/// walks the high-water mark back and never compacts. <c>RotateOldest</c> is the one shape that keeps
-/// compacting — it adds a name never seen before and drops the oldest live one, so every step leaves a
-/// hole below the mark. <c>ReAddMiddle</c> looks like it should compact too and does not: after the first
-/// step the re-added name <em>is</em> the newest entry, so it takes the same shortcut
-/// <c>AddThenRemoveNewest</c> does. That asymmetry is the point of having both.
+/// The five collection rows are the distinguishable cases. <c>AddOnly</c> is the control: it never deletes,
+/// so what it prices is what the delete side costs a workload that has none, which is what the engine does
+/// far more of. <c>AddThenRemoveNewest</c> removes the entry that was just added, which
+/// walks the window's top back and never compacts. <c>RotateOldest</c> adds a name never seen before and
+/// drops the oldest live one; that shape used to leave a hole below the high-water mark on every step and
+/// so compacted every <c>capacity - live</c> adds forever, and it is what the circular window of #3315
+/// makes free — its removal advances the window's base instead. <c>RotateBehindPinnedKey</c> is the same
+/// rotation with one key that is never deleted sitting underneath it, which is what the window cannot
+/// help: the base is stuck on the pinned key, every removal is from the middle, and the compaction is
+/// still there. It is the degradation control, and what it prices is that the shape got no worse.
+/// <c>ReAddMiddle</c> looks like it should compact too and does not: after the first step the re-added
+/// name <em>is</em> the newest entry, so it takes the same shortcut <c>AddThenRemoveNewest</c> does. That
+/// asymmetry is the point of having both.
 /// </para>
 /// <para>
 /// They measure the collection rather than a script on purpose: an engine-level delete costs a property
@@ -149,7 +155,10 @@ public class PropertyDeleteChurnBenchmark
         return dictionary.Count;
     }
 
-    /// <summary>Steady-state rotation: every step adds a name never seen before and drops the oldest live one.</summary>
+    /// <summary>
+    /// Steady-state rotation: every step adds a name never seen before and drops the oldest live one, which
+    /// is what a bounded cache built out of an object does, and the shape the circular window makes free.
+    /// </summary>
     [Benchmark]
     public int RotateOldest()
     {
@@ -158,6 +167,26 @@ public class PropertyDeleteChurnBenchmark
         {
             dictionary[_fresh[step]] = _fresh;
             dictionary.Remove(step < _keys.Length ? _keys[step] : _fresh[step - _keys.Length]);
+        }
+
+        return dictionary.Count;
+    }
+
+    /// <summary>
+    /// The same rotation with an entry pinned underneath it — a name set once and never deleted, which any
+    /// object used as a cache with a field on it has. The window's base cannot advance past a live key, so
+    /// every removal is from the middle and leaves a tombstone only a compaction reclaims: this is the
+    /// shape <see cref="RotateOldest"/> was before the window, and it is here to show it did not get worse.
+    /// </summary>
+    [Benchmark]
+    public int RotateBehindPinnedKey()
+    {
+        var dictionary = Filled();
+        var rotating = _keys.Length - 1;
+        for (var step = 0; step < Steps; step++)
+        {
+            dictionary[_fresh[step]] = _fresh;
+            dictionary.Remove(step < rotating ? _keys[step + 1] : _fresh[step - rotating]);
         }
 
         return dictionary.Count;

--- a/Jint.Tests/Runtime/OwnPropertyCreationOrderTests.cs
+++ b/Jint.Tests/Runtime/OwnPropertyCreationOrderTests.cs
@@ -410,9 +410,518 @@ public class OwnPropertyCreationOrderTests
         dictionary["k7"].Should().Be(700);
     }
 
+    /// <summary>
+    /// A rotating key set — a fresh name in, the oldest one out, which is what an object used as a bounded
+    /// cache does — is the shape the tombstones cost the most: every step left a hole below the high-water
+    /// mark, so the table compacted every <c>capacity - live</c> adds forever and settled on four times its
+    /// live key count. The entries now live in a circular window whose base advances when the oldest entry
+    /// goes, so that shape reaches no compaction at all (#3315). What the window must not disturb is the
+    /// one thing the tombstones exist for: enumeration order, which now has to survive the window wrapping
+    /// the array.
+    /// </summary>
+    [Test]
+    public void ARotatingKeySetKeepsCreationOrderAcrossAWrap()
+    {
+        var dictionary = new StringDictionarySlim<int>();
+        var model = new List<string>();
+        var next = 0;
+
+        for (var i = 0; i < 16; i++)
+        {
+            dictionary["k" + i] = i;
+            model.Add("k" + i);
+        }
+
+        for (var step = 0; step < 5_000; step++)
+        {
+            Churn(dictionary, model, ref next, dropOldest: true);
+
+            if (step % 97 == 0)
+            {
+                NamesOf(dictionary).Should().Equal(model);
+            }
+        }
+
+        NamesOf(dictionary).Should().Equal(model);
+        dictionary.Count.Should().Be(16);
+    }
+
+    /// <summary>
+    /// The same rotation, priced in slots: the window travels around the array instead of leaving a trail
+    /// of tombstones behind it, so the table holds the live key count rounded up to a power of two — 32
+    /// for 16 live keys plus the one that is transiently added before the oldest goes. Compaction settled
+    /// the same table on 64.
+    /// </summary>
+    [Test]
+    public void ARotatingKeySetSettlesAtItsLiveCountRatherThanFourTimesIt()
+    {
+        var dictionary = new StringDictionarySlim<int>();
+        var model = new List<string>();
+        var next = 0;
+
+        for (var i = 0; i < 16; i++)
+        {
+            dictionary["k" + i] = i;
+            model.Add("k" + i);
+        }
+
+        for (var step = 0; step < 10_000; step++)
+        {
+            Churn(dictionary, model, ref next, dropOldest: true);
+        }
+
+        dictionary.Count.Should().Be(16);
+        EntryCapacityOf(dictionary).Should().Be(32);
+    }
+
+    /// <summary>
+    /// The window is only free while the churn touches its ends. Here the oldest entry stays put and the
+    /// keys above it churn, so the base cannot advance and the tombstones pile up exactly as they did
+    /// before: this is the degradation path, and what it must do is degrade to the old behaviour rather
+    /// than to something worse. The table still compacts, still stays bounded, and still enumerates in
+    /// creation order.
+    /// </summary>
+    [Test]
+    public void ChurnBehindAPinnedOldestKeyStillCompactsAndStaysBounded()
+    {
+        var dictionary = new StringDictionarySlim<int>();
+        var model = new List<string>();
+        var next = 0;
+
+        for (var i = 0; i < 16; i++)
+        {
+            dictionary["k" + i] = i;
+            model.Add("k" + i);
+        }
+
+        for (var step = 0; step < 5_000; step++)
+        {
+            // Never the oldest: every removal is from the middle, so every one leaves a tombstone.
+            Churn(dictionary, model, ref next, dropOldest: false);
+
+            if (step % 97 == 0)
+            {
+                NamesOf(dictionary).Should().Equal(model);
+            }
+        }
+
+        NamesOf(dictionary).Should().Equal(model);
+        model[0].Should().Be("k0");
+        dictionary.Count.Should().Be(16);
+        EntryCapacityOf(dictionary).Should().Be(64);
+    }
+
+    /// <summary>
+    /// The novel state: a window that wraps the end of the array while it is resized. Both halves of
+    /// <c>Resize</c> have to be reached with the window in that state — the growth that unwraps it into a
+    /// doubled array, and the in-place compaction that keeps the base where it is and squeezes the
+    /// survivors down towards it — and neither may reorder a key. Each round rotates far enough to carry
+    /// the base past the end of the array, then pins the oldest entry so the tombstones fill the wrapped
+    /// window.
+    /// </summary>
+    [Test]
+    public void AWrappedWindowIsGrownAndCompactedWithoutLosingTheOrder()
+    {
+        var dictionary = new StringDictionarySlim<int>();
+        var model = new List<string>();
+        var next = 0;
+
+        for (var i = 0; i < 16; i++)
+        {
+            dictionary["k" + i] = i;
+            model.Add("k" + i);
+        }
+
+        var grewWhileWrapped = 0;
+        var compactedInPlaceWhileWrapped = 0;
+
+        for (var round = 0; round < 3; round++)
+        {
+            // The base advances one slot per rotation, so this takes at most a capacity's worth of them.
+            for (var step = 0; step < 1_000 && !WindowIsWrapped(dictionary); step++)
+            {
+                Churn(dictionary, model, ref next, dropOldest: true);
+            }
+
+            WindowIsWrapped(dictionary).Should().BeTrue("rotating past the end of the array is what wraps the window");
+
+            for (var step = 0; step < 400; step++)
+            {
+                var wrapped = WindowIsWrapped(dictionary);
+                var capacity = EntryCapacityOf(dictionary);
+                var width = WindowWidthOf(dictionary);
+
+                Churn(dictionary, model, ref next, dropOldest: false);
+
+                if (WindowWidthOf(dictionary) != width + 1 && wrapped)
+                {
+                    // The window did not simply grow by the added entry, so Resize ran.
+                    if (EntryCapacityOf(dictionary) == capacity)
+                    {
+                        compactedInPlaceWhileWrapped++;
+                    }
+                    else
+                    {
+                        grewWhileWrapped++;
+                    }
+                }
+
+                NamesOf(dictionary).Should().Equal(model);
+            }
+        }
+
+        grewWhileWrapped.Should().BeGreaterThan(0);
+        compactedInPlaceWhileWrapped.Should().BeGreaterThan(0);
+    }
+
+    /// <summary>
+    /// The other way out of a wrapped window: a table that rotated for a while and then only grew. There is
+    /// nothing to compact, so the survivors are copied into the doubled array in two runs — the tail of the
+    /// old array first, then the head — and the window starts over at slot 0. Getting those two runs the
+    /// wrong way round would reverse the object's keys around the wrap point and nothing else would notice.
+    /// </summary>
+    [Test]
+    public void AWrappedWindowWithNothingToCompactIsUnwrappedByGrowing()
+    {
+        var dictionary = new StringDictionarySlim<int>();
+        var model = new List<string>();
+        var next = 0;
+
+        for (var i = 0; i < 16; i++)
+        {
+            dictionary["k" + i] = i;
+            model.Add("k" + i);
+        }
+
+        for (var step = 0; step < 1_000 && !WindowIsWrapped(dictionary); step++)
+        {
+            Churn(dictionary, model, ref next, dropOldest: true);
+        }
+
+        WindowIsWrapped(dictionary).Should().BeTrue();
+        WindowWidthOf(dictionary).Should().Be(dictionary.Count, "a rotation leaves no tombstones behind it");
+
+        var capacity = EntryCapacityOf(dictionary);
+        while (EntryCapacityOf(dictionary) == capacity)
+        {
+            var name = "g" + next++;
+            dictionary[name] = next;
+            model.Add(name);
+        }
+
+        EntryCapacityOf(dictionary).Should().Be(capacity * 2);
+        WindowIsWrapped(dictionary).Should().BeFalse("growing is where a wrapped window unwraps");
+        NamesOf(dictionary).Should().Equal(model);
+    }
+
+    /// <summary>
+    /// The pooled reset, which a function environment does on every reuse: it keeps the grown arrays and
+    /// has to put the window back at the base of them, wrapped or not, or the next refill would enumerate
+    /// from wherever the last one happened to stop.
+    /// </summary>
+    [Test]
+    public void ClearPreservingCapacityResetsAWrappedWindow()
+    {
+        var dictionary = new StringDictionarySlim<int>();
+        var model = new List<string>();
+        var next = 0;
+
+        for (var i = 0; i < 16; i++)
+        {
+            dictionary["k" + i] = i;
+            model.Add("k" + i);
+        }
+
+        for (var step = 0; step < 200 && !WindowIsWrapped(dictionary); step++)
+        {
+            Churn(dictionary, model, ref next, dropOldest: true);
+        }
+
+        WindowIsWrapped(dictionary).Should().BeTrue();
+        var capacity = EntryCapacityOf(dictionary);
+
+        dictionary.ClearPreservingCapacity();
+
+        dictionary.Count.Should().Be(0);
+        NamesOf(dictionary).Should().BeEmpty();
+        EntryCapacityOf(dictionary).Should().Be(capacity);
+
+        var refilled = new List<string>();
+        for (var i = 0; i < 20; i++)
+        {
+            dictionary["r" + i] = i;
+            refilled.Add("r" + i);
+        }
+
+        NamesOf(dictionary).Should().Equal(refilled);
+        EntryCapacityOf(dictionary).Should().Be(capacity);
+    }
+
+    /// <summary>
+    /// A randomized cross-check of both stores against the same model, at the collection level rather than
+    /// through the engine: 50,000 operations over a key space narrow enough that the window wraps, fills
+    /// and compacts many times, with every live key looked up again at each checkpoint so that a wrap
+    /// cannot quietly strand an entry its bucket chain still points at. Deterministic seeds, so a failure
+    /// is reproducible. The symbol store is the same generic class as the object's, so string keys in it
+    /// exercise the identical window arithmetic.
+    /// </summary>
+    [TestCase(1)]
+    [TestCase(2)]
+    [TestCase(3)]
+    public void RandomizedChurnKeepsBothStoresInCreationOrder(int seed)
+    {
+        var random = new Random(seed);
+        var strings = new StringDictionarySlim<int>();
+        var symbols = new DictionarySlim<string, int>();
+        var model = new List<string>();
+
+        for (var step = 0; step < 50_000; step++)
+        {
+            var name = "x" + random.Next(24);
+            if (random.Next(2) == 0)
+            {
+                if (!model.Contains(name))
+                {
+                    model.Add(name);
+                }
+
+                strings[name] = step;
+                symbols[name] = step;
+            }
+            else
+            {
+                model.Remove(name);
+                strings.Remove(name);
+                symbols.Remove(name);
+            }
+
+            if (step % 499 == 0)
+            {
+                AssertBothStoresMatch(strings, symbols, model);
+            }
+        }
+
+        AssertBothStoresMatch(strings, symbols, model);
+    }
+
+    /// <summary>
+    /// The window's own arithmetic, checked after every single operation rather than only through what an
+    /// enumeration can see. The add path is one comparison — <c>_lastIndex == _limit</c> — so everything
+    /// that keeps it from writing over a live key is in that bound: it is the capacity while the window
+    /// runs to the end of the array and the base while the window wraps below it, it is never below the
+    /// top, the base is a live entry whenever the table is not empty, and an emptied table is back at slot
+    /// 0 so the next refill starts there. The mix keeps all three removal positions and both resets in
+    /// play, because the states this walks through are the ones a prefix-shaped table never reached.
+    /// </summary>
+    [TestCase(11)]
+    [TestCase(12)]
+    public void TheWindowBoundStaysTheOneAnAddMayTest(int seed)
+    {
+        var random = new Random(seed);
+        var dictionary = new StringDictionarySlim<int>();
+        var model = new List<string>();
+        var next = 0;
+
+        for (var step = 0; step < 10_000; step++)
+        {
+            switch (random.Next(7))
+            {
+                case 0 when model.Count > 0:
+                    // The oldest: the base advances past the slot and any tombstones behind it.
+                    Drop(dictionary, model, model[0]);
+                    break;
+                case 1 when model.Count > 0:
+                    // The newest: the top walks back.
+                    Drop(dictionary, model, model[model.Count - 1]);
+                    break;
+                case 2 when model.Count > 0:
+                    // The middle: a tombstone only a resize reclaims.
+                    Drop(dictionary, model, model[random.Next(model.Count)]);
+                    break;
+                case 3 when model.Count > 8:
+                    // A drain, which has to retire the window along with the last live entry.
+                    while (model.Count > 0)
+                    {
+                        Drop(dictionary, model, model[0]);
+                    }
+
+                    break;
+                case 4 when model.Count > 8:
+                    // The pooled reset, from wherever the window happens to have travelled to.
+                    dictionary.ClearPreservingCapacity();
+                    model.Clear();
+                    break;
+                default:
+                    var name = "n" + next++;
+                    dictionary[name] = next;
+                    model.Add(name);
+                    break;
+            }
+
+            AssertWindowInvariants(dictionary);
+        }
+
+        NamesOf(dictionary).Should().Equal(model);
+    }
+
+    private static void Drop(StringDictionarySlim<int> dictionary, List<string> model, string name)
+    {
+        dictionary.Remove(name).Should().BeTrue();
+        model.Remove(name);
+    }
+
+    private static void AssertWindowInvariants<T>(StringDictionarySlim<T> dictionary)
+    {
+        var capacity = EntryCapacityOf(dictionary);
+        var first = PrivateInt(dictionary, "_firstIndex");
+        var last = PrivateInt(dictionary, "_lastIndex");
+        var limit = PrivateInt(dictionary, "_limit");
+
+        if (last > limit || limit != capacity && limit != first || (uint) first >= (uint) capacity)
+        {
+            Assert.Fail(
+                $"window [{first}, {last}) bounded at {limit} over {capacity} slots: the bound is the "
+                + "capacity while the window runs to the end of the array and the base while it wraps "
+                + "below it, and the top may never pass it");
+        }
+
+        if (dictionary.Count == 0)
+        {
+            if (first != last)
+            {
+                Assert.Fail($"an emptied table closes its window, but this one is [{first}, {last})");
+            }
+
+            return;
+        }
+
+        if (WindowWidthOf(dictionary) < dictionary.Count)
+        {
+            Assert.Fail($"the window is {WindowWidthOf(dictionary)} slots wide but holds {dictionary.Count} live entries");
+        }
+
+        if (NextOfSlot(dictionary, first) == -2)
+        {
+            Assert.Fail(
+                "the base came to rest on a tombstone, so the next removal of the oldest entry would no "
+                + "longer recognize itself and one delete from the middle would disarm the fast path");
+        }
+    }
+
+    /// <summary>The chain link of a slot, which is <c>-2</c> exactly when a removal left a tombstone.</summary>
+    private static int NextOfSlot<T>(StringDictionarySlim<T> dictionary, int index)
+    {
+        var entries = (Array) typeof(StringDictionarySlim<T>)
+            .GetField("_entries", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(dictionary)!;
+
+        var entry = entries.GetValue(index)!;
+        return (int) entry.GetType().GetField("next", BindingFlags.Instance | BindingFlags.Public)!.GetValue(entry)!;
+    }
+
+    private static void AssertBothStoresMatch(StringDictionarySlim<int> strings, DictionarySlim<string, int> symbols, List<string> model)
+    {
+        NamesOf(strings).Should().Equal(model);
+        symbols.Select(static pair => pair.Key).ToList().Should().Equal(model);
+        strings.Count.Should().Be(model.Count);
+        symbols.Count.Should().Be(model.Count);
+
+        foreach (var name in model)
+        {
+            strings.TryGetValue(name, out _).Should().BeTrue();
+            symbols.TryGetValue(name, out _).Should().BeTrue();
+        }
+    }
+
+    /// <summary>
+    /// The same rotation through the engine, which is where it actually happens: a bounded cache built out
+    /// of a plain object, listed with the built-in every embedder calls. The name pool is narrower than the
+    /// churn, so names come back — and a name that comes back is a new property, which belongs last.
+    /// </summary>
+    [TestCase(false)]
+    [TestCase(true)]
+    public void RotatingPropertiesKeepCreationOrderAcrossAWrap(bool symbolKeys)
+    {
+        var subject = symbolKeys
+            ? "var key = function (i) { return syms[i]; }; var list = function (o) { return Object.getOwnPropertySymbols(o).map(String).join(','); }; var name = function (i) { return String(syms[i]); };"
+            : "var key = function (i) { return 'x' + i; }; var list = function (o) { return Object.keys(o).join(','); }; var name = function (i) { return 'x' + i; };";
+
+        var engine = new Engine();
+        var result = engine.Evaluate($$"""
+            var syms = [];
+            for (var i = 0; i < 60; i++) syms.push(Symbol('y' + i));
+            {{subject}}
+
+            var o = {};
+            var model = [];
+            for (var i = 0; i < 20; i++) { o[key(i)] = i; model.push(i); }
+
+            for (var n = 0; n < 600; n++) {
+                var i = (20 + n) % 60;
+                var at = model.indexOf(i);
+                if (at >= 0) { model.splice(at, 1); delete o[key(i)]; }
+                o[key(i)] = n;
+                model.push(i);
+                delete o[key(model.shift())];
+            }
+
+            var want = model.map(name).join(',');
+            list(o) === want ? 'OK:' + model.length : 'MISMATCH\n got  ' + list(o) + '\n want ' + want;
+            """).AsString();
+
+        result.Should().Be("OK:20");
+    }
+
+    private static void Churn(StringDictionarySlim<int> dictionary, List<string> model, ref int next, bool dropOldest)
+    {
+        var name = "n" + next++;
+        dictionary[name] = next;
+        model.Add(name);
+
+        var victim = dropOldest ? model[0] : model[model.Count / 2];
+        dictionary.Remove(victim).Should().BeTrue();
+        model.Remove(victim);
+    }
+
+    private static List<string> NamesOf<T>(StringDictionarySlim<T> dictionary) =>
+        dictionary.Select(static pair => pair.Key.Name).ToList();
+
     private static int EntryCapacityOf<T>(StringDictionarySlim<T> dictionary)
     {
         var field = typeof(StringDictionarySlim<T>).GetField("_entries", BindingFlags.Instance | BindingFlags.NonPublic);
         return ((Array) field!.GetValue(dictionary)!).Length;
+    }
+
+    /// <summary>The window wraps when it runs off the end of the array and continues at slot 0.</summary>
+    private static bool WindowIsWrapped<T>(StringDictionarySlim<T> dictionary) =>
+        dictionary.Count > 0
+        && PrivateInt(dictionary, "_firstIndex") + WindowWidthOf(dictionary) > EntryCapacityOf(dictionary);
+
+    /// <summary>
+    /// The width of the window in slots — live entries plus the tombstones between them. It is not stored:
+    /// the distance from the base to the top is it, and the one distance that reads as zero is a full
+    /// window, since an empty one leaves no live entries to count.
+    /// </summary>
+    private static int WindowWidthOf<T>(StringDictionarySlim<T> dictionary)
+    {
+        if (dictionary.Count == 0)
+        {
+            return 0;
+        }
+
+        var capacity = EntryCapacityOf(dictionary);
+        var width = (PrivateInt(dictionary, "_lastIndex") - PrivateInt(dictionary, "_firstIndex")) & (capacity - 1);
+        return width == 0 ? capacity : width;
+    }
+
+    private static int PrivateInt<T>(StringDictionarySlim<T> dictionary, string name)
+    {
+        var field = typeof(StringDictionarySlim<T>).GetField(name, BindingFlags.Instance | BindingFlags.NonPublic);
+        if (field is null)
+        {
+            Assert.Fail($"StringDictionarySlim<T> has no {name}: the circular window these tests are about does not exist in this build.");
+        }
+
+        return (int) field!.GetValue(dictionary)!;
     }
 }

--- a/Jint/Collections/DictionarySlim.cs
+++ b/Jint/Collections/DictionarySlim.cs
@@ -22,8 +22,15 @@ namespace Jint.Collections;
 /// <see href="https://tc39.es/ecma262/#sec-ordinaryownpropertykeys">OrdinaryOwnPropertyKeys</see> requires
 /// them "in ascending chronological order of property creation". A removed entry therefore leaves a
 /// tombstone rather than joining a free list an add would pop from — reusing a vacated slot would hand a
-/// key an enumeration position older than its creation. See <see cref="Resize"/> for how the tombstones
-/// are reclaimed.
+/// key an enumeration position older than its creation.
+/// </para>
+/// <para>
+/// The entries occupy a window <c>[_firstIndex, _lastIndex)</c> over the array rather than a prefix of it,
+/// and that window may wrap the end of the array, so a removal at <em>either</em> end retires its slot
+/// instead of leaving a hole: the top walks back when the newest key goes, and the base advances when the
+/// oldest one does. A rotating key set — a fresh name in, the oldest one out, which is what an object used
+/// as a bounded cache does — therefore never compacts at all. Only a removal from the middle leaves a
+/// tombstone behind, and <see cref="Resize"/> is where those are reclaimed.
 /// </para>
 /// </summary>
 [DebuggerDisplay("Count = {Count}")]
@@ -43,8 +50,16 @@ internal sealed class DictionarySlim<TKey, TValue> : IReadOnlyCollection<KeyValu
 
     // Number of live entries.
     private int _count;
-    // High-water mark: _entries[0.._lastIndex) are live entries and tombstones, in insertion order.
+    // Base of the window: the oldest occupied slot, and a live entry whenever _count is not 0.
+    private int _firstIndex;
+    // The slot the next add writes. The window [_firstIndex, _lastIndex) holds the live entries and the
+    // tombstones between them, in insertion order, and may wrap the end of the array.
     private int _lastIndex;
+    // The one bound the add path tests: the exclusive limit on _lastIndex. It is the capacity while the
+    // window runs to the end of the array, the base while the window wraps below it, and 0 for the shared
+    // dummy array, which nothing may write to. So it is what tells a full window from an empty one, since
+    // both leave _firstIndex equal to _lastIndex.
+    private int _limit;
     // 1-based index into _entries; 0 means empty
     private int[] _buckets;
     private Entry[] _entries;
@@ -64,6 +79,7 @@ internal sealed class DictionarySlim<TKey, TValue> : IReadOnlyCollection<KeyValu
     {
         _buckets = HashHelpers.SizeOneIntArray;
         _entries = InitialEntries;
+        // _limit is left at 0 so that the first add makes room: the dummy arrays are shared statics.
     }
 
     public DictionarySlim(int capacity)
@@ -73,6 +89,7 @@ internal sealed class DictionarySlim<TKey, TValue> : IReadOnlyCollection<KeyValu
         capacity = HashHelpers.PowerOf2(capacity);
         _buckets = new int[capacity];
         _entries = new Entry[capacity];
+        _limit = capacity;
     }
 
     public int Count => _count;
@@ -83,7 +100,9 @@ internal sealed class DictionarySlim<TKey, TValue> : IReadOnlyCollection<KeyValu
     public void Clear()
     {
         _count = 0;
+        _firstIndex = 0;
         _lastIndex = 0;
+        _limit = 0;
         _buckets = HashHelpers.SizeOneIntArray;
         _entries = InitialEntries;
     }
@@ -145,12 +164,23 @@ internal sealed class DictionarySlim<TKey, TValue> : IReadOnlyCollection<KeyValu
                 _count--;
 
                 // Removing the newest entry can hand its slot straight back without disturbing the order
-                // of anything older, which is what makes add-then-remove churn free of compaction.
-                if (entryIndex == _lastIndex - 1)
+                // of anything older, which is what makes add-then-remove churn free of
+                // compaction. Only the top moves, so the bound the add path tests does not change: the
+                // free space it reopens is the free space it was already allowed to write. It closes the
+                // window where it stands when that entry was also the last live one, which is an empty
+                // window like any other — the next add reopens it on the slot it just gave back.
+                //
+                // The test is written inverted, and everything that is not this case is behind one call,
+                // because that is what the JIT lays out as a comparison this path falls straight through
+                // into its single store and its return — the shape the high-water mark had, with no
+                // taken branch on it. Spelling it as an if/else, or asking about the base here as well,
+                // moves the store out of line and puts a taken branch on the commonest delete there is.
+                if (entryIndex != _lastIndex - 1)
                 {
-                    _lastIndex = entryIndex;
+                    return RetireSlot(entries, entryIndex);
                 }
 
+                _lastIndex = entryIndex;
                 return true;
             }
             lastIndex = entryIndex;
@@ -158,6 +188,66 @@ internal sealed class DictionarySlim<TKey, TValue> : IReadOnlyCollection<KeyValu
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Retires a just-vacated slot that was not the newest: the window's base advances when it was the
+    /// oldest — which is what makes a rotating key set free of compaction — and nothing moves when it was
+    /// neither.
+    /// <para>
+    /// It advances past any tombstones behind that slot as well, so that the base keeps pointing at a live
+    /// entry: otherwise it would come to rest on a tombstone and the next removal of the oldest would no
+    /// longer recognize itself, and one delete from the middle would disarm the fast path for good. A
+    /// removal from the middle leaves its tombstone where it is, because reclaiming it would move the keys
+    /// above it and their position <em>is</em> their creation order; those are what <see cref="Resize"/>
+    /// squeezes out.
+    /// </para>
+    /// </summary>
+    /// <returns>
+    /// Always <see langword="true" />, which is <see cref="Remove"/>'s own answer: returning it lets the
+    /// caller hand this half of the work over with a tail call instead of a call and a join, which is what
+    /// keeps the newest-entry path straight-line.
+    /// </returns>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private bool RetireSlot(Entry[] entries, int retired)
+    {
+        // Neither end: the tombstone stays where it is, and only Resize reclaims it. Splitting the walk
+        // off keeps this half small, so the commoner of the two answers costs a compare and a return.
+        return retired != _firstIndex || RetireBase(entries, retired);
+    }
+
+    /// <summary>
+    /// Advances the window's base past the slot the oldest entry has just vacated, and past any tombstones
+    /// behind it. Its <see langword="true" /> is <see cref="RetireSlot"/>'s.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private bool RetireBase(Entry[] entries, int retired)
+    {
+        var length = entries.Length;
+        if (_count == 0)
+        {
+            // The last live entry is gone, so the window goes back to the base of the array and the next
+            // add starts at slot 0 again; every slot it held was cleared as it was removed, which is what
+            // makes starting over safe. It is also what ends the walk below: with nothing live left there
+            // would be nothing for it to stop on.
+            _firstIndex = 0;
+            _lastIndex = 0;
+            _limit = length;
+            return true;
+        }
+
+        var first = (retired + 1) & (length - 1);
+        while (entries[first].next == Tombstone)
+        {
+            first = (first + 1) & (length - 1);
+        }
+
+        _firstIndex = first;
+
+        // The window wraps once its top is at or below the new base, and then the base is the slot an add
+        // may not reach; otherwise the free space runs to the end of the array.
+        _limit = _lastIndex <= first ? first : length;
+        return true;
     }
 
     // Not safe for concurrent _reads_ (at least, if either of them add)
@@ -192,13 +282,15 @@ internal sealed class DictionarySlim<TKey, TValue> : IReadOnlyCollection<KeyValu
     [MethodImpl(MethodImplOptions.NoInlining)]
     private ref TValue AddKey(TKey key, int bucketIndex)
     {
-        // Always appends: the new entry is the newest key, and enumeration is entry order.
+        // Always appends at the top of the window: the new entry is the newest key, and enumeration is
+        // window order. _limit is the one thing standing between _lastIndex and a slot it may not write,
+        // so the window costs this path a field read where the mark cost an array length read — and one
+        // comparison, where the mark needed two.
         Entry[] entries = _entries;
-        if (_lastIndex == entries.Length || entries.Length == 1)
+        if (_lastIndex == _limit)
         {
-            entries = Resize();
+            entries = MakeRoom();
             bucketIndex = key.GetHashCode() & (_buckets.Length - 1);
-            // entry indexes of surviving entries were not reordered by Resize
         }
 
         var entryIndex = _lastIndex++;
@@ -210,10 +302,43 @@ internal sealed class DictionarySlim<TKey, TValue> : IReadOnlyCollection<KeyValu
     }
 
     /// <summary>
-    /// Makes room at the top of the entry array, which is the only place an add may write.
+    /// Makes room at the top of the window, which is the only place an add may write, for a window that
+    /// has reached its bound.
     /// <para>
-    /// With no removals this is the plain doubling it has always been. Otherwise the tombstones left by
-    /// <see cref="Remove"/> are squeezed out — in place when the live entries fit in half the capacity,
+    /// There are three ways to have reached it, and only the last one costs anything. A window that has run
+    /// to the end of the array while its base has moved off slot 0 <em>wraps</em>, which is a pair of field
+    /// writes and no data movement at all: that is a rotating key set, and it is why one never compacts. A
+    /// window based at slot 0 is the shape the type has always had, and <see cref="Resize"/> is the code it
+    /// has always run. Anything else is a full window that does not start at slot 0, which
+    /// <see cref="ResizeWindow"/> grows or squeezes.
+    /// </para>
+    /// </summary>
+    private Entry[] MakeRoom()
+    {
+        var entries = _entries;
+        if (_firstIndex != 0)
+        {
+            if (_lastIndex == entries.Length)
+            {
+                // Free space at the bottom of the array, which the window rotated away from: it continues
+                // there, and the base is now the slot the top may not reach.
+                _lastIndex = 0;
+                _limit = _firstIndex;
+                return entries;
+            }
+
+            return ResizeWindow(entries);
+        }
+
+        return Resize();
+    }
+
+    /// <summary>
+    /// Makes room for a window based at slot 0, which is every table that has never had its oldest entry
+    /// removed — and so the only shape this had before the window existed.
+    /// <para>
+    /// With no removals this is the plain doubling it has always been. Otherwise the tombstones left by a
+    /// removal from the middle are squeezed out — in place when the live entries fit in half the capacity,
     /// and into a doubled array when they do not. Compaction preserves relative order, so it is invisible
     /// to enumeration; insisting on the half is what keeps adds amortized O(1), since every call here is
     /// followed by at least <c>capacity / 2</c> adds before the next one.
@@ -222,15 +347,15 @@ internal sealed class DictionarySlim<TKey, TValue> : IReadOnlyCollection<KeyValu
     /// The half is measured rather than chosen. It is consulted only by a table that has both left
     /// tombstones and filled its array, and because capacities are powers of two it does not tune the
     /// cost continuously — it decides which power of two such a table settles on, and the interval
-    /// between compactions is then the capacity minus the live count. A quarter settles a rotating key
-    /// set at twice its live count and costs a compaction every <c>n</c> adds; a half settles it at four
-    /// times and costs one every <c>3n</c>. Measured against slot reuse that is +34.8% and +8.9%. Going
-    /// on to a three-quarters erases the rest and doubles the ceiling again, which is the trade this
-    /// stops short of; #3285 carries the curve and the memory figures at every setting.
+    /// between compactions is then the capacity minus the live count. It was measured on a rotating key
+    /// set, which no longer reaches this method at all; what still does is a table whose oldest entry
+    /// stays put while the keys above it churn. #3285 carries that curve and the memory figures at every
+    /// setting, and #3315 is why the shape it was measured on is now free.
     /// </para>
     /// </summary>
     private Entry[] Resize()
     {
+        Debug.Assert(_firstIndex == 0);
         Debug.Assert(_lastIndex == _entries.Length || _entries.Length == 1);
 
         var entries = _entries;
@@ -279,6 +404,7 @@ internal sealed class DictionarySlim<TKey, TValue> : IReadOnlyCollection<KeyValu
 
         _lastIndex = count;
         _entries = newEntries;
+        _limit = newEntries.Length;
 
         var buckets = _buckets;
         while (count-- > 0)
@@ -289,6 +415,134 @@ internal sealed class DictionarySlim<TKey, TValue> : IReadOnlyCollection<KeyValu
         }
 
         return newEntries;
+    }
+
+    /// <summary>
+    /// Makes room for a full window that does not start at slot 0, which is a table whose base has moved
+    /// and whose middle has since filled with tombstones — a rotating key set with a key pinned under it.
+    /// The threshold is <see cref="Resize"/>'s, measured there.
+    /// <para>
+    /// Growing is the chance to unwrap, so the survivors land at the bottom of the doubled array in window
+    /// order and the window starts over at slot 0; when there is nothing to squeeze out that is two
+    /// <see cref="Array.Copy(Array, int, Array, int, int)"/> runs, the tail of the old array and then its
+    /// head, and taking them the other way round would reverse the keys around the wrap point. Compacting
+    /// in place instead leaves the base where it is and moves the survivors down towards it, so the write
+    /// cursor can never overtake the read cursor — which is what makes a wrapped window safe to squeeze
+    /// without a second array, and why it cannot be rebased to slot 0 in place.
+    /// </para>
+    /// </summary>
+    private Entry[] ResizeWindow(Entry[] entries)
+    {
+        var count = _count;
+        var length = entries.Length;
+        var mask = length - 1;
+        var first = _firstIndex;
+
+        Debug.Assert(first != 0);
+        Debug.Assert(_lastIndex == first);
+        // A bound below the capacity is only ever set on a window that holds a live entry, so the window
+        // reaching it is always a full one and never a closed one, which the squeeze below relies on.
+        Debug.Assert(count != 0);
+
+        if (count == length || count + 1 > length - (length >> 1))
+        {
+            var newSize = length * 2;
+            if ((uint) newSize > int.MaxValue) // uint cast handles overflow
+                throw new InvalidOperationException("Capacity Overflow");
+
+            var newEntries = new Entry[newSize];
+            _buckets = new int[newSize];
+
+            if (count == length)
+            {
+                var toEnd = length - first;
+                Array.Copy(entries, first, newEntries, 0, toEnd);
+                Array.Copy(entries, 0, newEntries, toEnd, first);
+            }
+            else
+            {
+                var target = 0;
+                var source = first;
+                for (var n = 0; n < length; n++)
+                {
+                    if (entries[source].next != Tombstone)
+                    {
+                        newEntries[target++] = entries[source];
+                    }
+
+                    source = (source + 1) & mask;
+                }
+
+                Debug.Assert(target == count);
+            }
+
+            _entries = newEntries;
+            _firstIndex = 0;
+            _lastIndex = count;
+            _limit = newSize;
+            RebuildChains(newEntries, _buckets, 0, count);
+            return newEntries;
+        }
+
+        Array.Clear(_buckets, 0, _buckets.Length);
+
+        var write = first;
+        var read = first;
+        for (var n = 0; n < length; n++)
+        {
+            if (entries[read].next != Tombstone)
+            {
+                if (write != read)
+                {
+                    entries[write] = entries[read];
+                }
+
+                write = (write + 1) & mask;
+            }
+
+            read = (read + 1) & mask;
+        }
+
+        Debug.Assert(write == ((first + count) & mask));
+
+        // Release the keys and values the squeezed-away slots still reference, wrapping at the end of the
+        // array the way the window itself does.
+        var vacated = length - count;
+        var toArrayEnd = length - write;
+        if (vacated <= toArrayEnd)
+        {
+            Array.Clear(entries, write, vacated);
+        }
+        else
+        {
+            Array.Clear(entries, write, toArrayEnd);
+            Array.Clear(entries, 0, vacated - toArrayEnd);
+        }
+
+        _lastIndex = write;
+        _limit = write <= first ? first : length;
+        RebuildChains(entries, _buckets, first, count);
+        return entries;
+    }
+
+    /// <summary>
+    /// Rehangs <paramref name="count"/> entries from <paramref name="first"/> onto empty buckets, walking
+    /// the window in order and wrapping at the end of the array. A bucket and a chain link are physical
+    /// slot indexes that encode no position in the window, which is why the moving base costs lookup
+    /// nothing and why only a resize has to do this at all.
+    /// </summary>
+    private static void RebuildChains(Entry[] entries, int[] buckets, int first, int count)
+    {
+        var mask = entries.Length - 1;
+        var bucketMask = buckets.Length - 1;
+        var index = first;
+        for (var n = 0; n < count; n++)
+        {
+            var bucketIndex = entries[index].key.GetHashCode() & bucketMask;
+            entries[index].next = buckets[bucketIndex] - 1;
+            buckets[bucketIndex] = index + 1;
+            index = (index + 1) & mask;
+        }
     }
 
     /// <summary>
@@ -317,7 +571,7 @@ internal sealed class DictionarySlim<TKey, TValue> : IReadOnlyCollection<KeyValu
         internal Enumerator(DictionarySlim<TKey, TValue> dictionary)
         {
             _dictionary = dictionary;
-            _index = 0;
+            _index = dictionary._firstIndex;
             _count = _dictionary._count;
             _current = default;
         }
@@ -332,14 +586,21 @@ internal sealed class DictionarySlim<TKey, TValue> : IReadOnlyCollection<KeyValu
 
             _count--;
 
-            // Skips the tombstones removals left behind; the live entries between them are still in
-            // insertion order, which is what this type exists to preserve.
-            while (_dictionary._entries[_index].next == Tombstone)
-                _index++;
+            // Walks the window from its base, wrapping at the end of the array, and skips the tombstones a
+            // removal from the middle left behind; the live entries between them are still in insertion
+            // order, which is what this type exists to preserve. The live count is what ends the walk, so
+            // it never has to test the window's top — and starting at the base is what spares it the run of
+            // tombstones a table that keeps dropping its oldest key used to leave below one.
+            var entries = _dictionary._entries;
+            var mask = entries.Length - 1;
+            var index = _index;
+            while (entries[index].next == Tombstone)
+            {
+                index = (index + 1) & mask;
+            }
 
-            _current = new KeyValuePair<TKey, TValue>(
-                _dictionary._entries[_index].key,
-                _dictionary._entries[_index++].value);
+            _current = new KeyValuePair<TKey, TValue>(entries[index].key, entries[index].value);
+            _index = (index + 1) & mask;
             return true;
         }
 
@@ -349,7 +610,7 @@ internal sealed class DictionarySlim<TKey, TValue> : IReadOnlyCollection<KeyValu
 
         void IEnumerator.Reset()
         {
-            _index = 0;
+            _index = _dictionary._firstIndex;
             _count = _dictionary._count;
             _current = default;
         }

--- a/Jint/Collections/StringDictionarySlim.cs
+++ b/Jint/Collections/StringDictionarySlim.cs
@@ -25,8 +25,15 @@ namespace Jint.Collections;
 /// <see href="https://tc39.es/ecma262/#sec-ordinaryownpropertykeys">OrdinaryOwnPropertyKeys</see> requires
 /// them "in ascending chronological order of property creation". A removed entry therefore leaves a
 /// tombstone rather than joining a free list an add would pop from — reusing a vacated slot would hand a
-/// key an enumeration position older than its creation. See <see cref="Resize"/> for how the tombstones
-/// are reclaimed.
+/// key an enumeration position older than its creation.
+/// </para>
+/// <para>
+/// The entries occupy a window <c>[_firstIndex, _lastIndex)</c> over the array rather than a prefix of it,
+/// and that window may wrap the end of the array, so a removal at <em>either</em> end retires its slot
+/// instead of leaving a hole: the top walks back when the newest key goes, and the base advances when the
+/// oldest one does. A rotating key set — a fresh name in, the oldest one out, which is what an object used
+/// as a bounded cache does — therefore never compacts at all. Only a removal from the middle leaves a
+/// tombstone behind, and <see cref="Resize"/> is where those are reclaimed.
 /// </para>
 /// </summary>
 [DebuggerTypeProxy(typeof(DictionarySlimDebugView<>))]
@@ -47,8 +54,16 @@ internal sealed class StringDictionarySlim<TValue> : DictionaryBase<TValue>, IRe
 
     // Number of live entries.
     private int _count;
-    // High-water mark: _entries[0.._lastIndex) are live entries and tombstones, in insertion order.
+    // Base of the window: the oldest occupied slot, and a live entry whenever _count is not 0.
+    private int _firstIndex;
+    // The slot the next add writes. The window [_firstIndex, _lastIndex) holds the live entries and the
+    // tombstones between them, in insertion order, and may wrap the end of the array.
     private int _lastIndex;
+    // The one bound the add path tests: the exclusive limit on _lastIndex. It is the capacity while the
+    // window runs to the end of the array, the base while the window wraps below it, and 0 for the shared
+    // dummy array, which nothing may write to. So it is what tells a full window from an empty one, since
+    // both leave _firstIndex equal to _lastIndex.
+    private int _limit;
     // 1-based index into _entries; 0 means empty
     private int[] _buckets;
     private Entry[] _entries;
@@ -67,6 +82,7 @@ internal sealed class StringDictionarySlim<TValue> : DictionaryBase<TValue>, IRe
     {
         _buckets = HashHelpers.SizeOneIntArray;
         _entries = InitialEntries;
+        // _limit is left at 0 so that the first add makes room: the dummy arrays are shared statics.
     }
 
     public StringDictionarySlim(int capacity)
@@ -76,6 +92,7 @@ internal sealed class StringDictionarySlim<TValue> : DictionaryBase<TValue>, IRe
         capacity = HashHelpers.PowerOf2(capacity);
         _buckets = new int[capacity];
         _entries = new Entry[capacity];
+        _limit = capacity;
     }
 
     public override int Count
@@ -90,7 +107,9 @@ internal sealed class StringDictionarySlim<TValue> : DictionaryBase<TValue>, IRe
     public void Clear()
     {
         _count = 0;
+        _firstIndex = 0;
         _lastIndex = 0;
+        _limit = 0;
         _buckets = HashHelpers.SizeOneIntArray;
         _entries = InitialEntries;
     }
@@ -103,19 +122,55 @@ internal sealed class StringDictionarySlim<TValue> : DictionaryBase<TValue>, IRe
     /// </summary>
     public void ClearPreservingCapacity()
     {
-        if (_lastIndex == 0)
+        var entries = _entries;
+        if (entries.Length == 1)
         {
-            // Never grew past the shared dummy arrays — nothing to keep, nothing to clear. Tested on the
-            // high-water mark rather than on Count so that a table emptied by removals resets it: Count
-            // is already 0 there, and returning early would make the next refill append above the
-            // tombstones instead of starting at slot 0.
+            // Never grew past the shared dummy arrays — nothing to keep, nothing to clear, and nothing to
+            // reset: the window is still closed on slot 0, and the bound is still the 0 that refuses the
+            // shared array to the first add.
             return;
         }
 
-        Array.Clear(_buckets, 0, _buckets.Length);
-        Array.Clear(_entries, 0, _lastIndex);
-        _count = 0;
+        if (_count != 0)
+        {
+            var width = (_lastIndex - _firstIndex) & (entries.Length - 1);
+            if (width == 0)
+            {
+                // A full window leaves its two ends on the same slot; an empty one is handled above.
+                width = entries.Length;
+            }
+
+            Array.Clear(_buckets, 0, _buckets.Length);
+            ClearWindow(entries, _firstIndex, width);
+            _count = 0;
+        }
+
+        // A table emptied by removals has already cleared every slot it touched and unhooked every bucket,
+        // but its window closed wherever the last removal left it. Putting it back at the base of the
+        // array is what makes the next refill start from the bottom of the one it kept.
+        _firstIndex = 0;
         _lastIndex = 0;
+        _limit = entries.Length;
+    }
+
+    /// <summary>
+    /// Clears <paramref name="length"/> slots from <paramref name="start"/>, wrapping at the end of the
+    /// array the way the window itself does. Clearing rather than abandoning them is what releases the key
+    /// strings and values a retired slot still references — and what lets an add assume the slot it takes
+    /// holds a default value, which <see cref="SetOrUpdateValue"/> hands to its updater.
+    /// </summary>
+    private static void ClearWindow(Entry[] entries, int start, int length)
+    {
+        var toEnd = entries.Length - start;
+        if (length <= toEnd)
+        {
+            Array.Clear(entries, start, length);
+        }
+        else
+        {
+            Array.Clear(entries, start, toEnd);
+            Array.Clear(entries, 0, length - toEnd);
+        }
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -152,12 +207,23 @@ internal sealed class StringDictionarySlim<TValue> : DictionaryBase<TValue>, IRe
                 _count--;
 
                 // Removing the newest entry can hand its slot straight back without disturbing the order
-                // of anything older, which is what makes `o.k = v; delete o.k;` churn free of compaction.
-                if (entryIndex == _lastIndex - 1)
+                // of anything older, which is what makes `o.k = v; delete o.k;` churn free of
+                // compaction. Only the top moves, so the bound the add path tests does not change: the
+                // free space it reopens is the free space it was already allowed to write. It closes the
+                // window where it stands when that entry was also the last live one, which is an empty
+                // window like any other — the next add reopens it on the slot it just gave back.
+                //
+                // The test is written inverted, and everything that is not this case is behind one call,
+                // because that is what the JIT lays out as a comparison this path falls straight through
+                // into its single store and its return — the shape the high-water mark had, with no
+                // taken branch on it. Spelling it as an if/else, or asking about the base here as well,
+                // moves the store out of line and puts a taken branch on the commonest delete there is.
+                if (entryIndex != _lastIndex - 1)
                 {
-                    _lastIndex = entryIndex;
+                    return RetireSlot(entries, entryIndex);
                 }
 
+                _lastIndex = entryIndex;
                 return true;
             }
             lastIndex = entryIndex;
@@ -165,6 +231,66 @@ internal sealed class StringDictionarySlim<TValue> : DictionaryBase<TValue>, IRe
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Retires a just-vacated slot that was not the newest: the window's base advances when it was the
+    /// oldest — which is what makes a rotating key set free of compaction — and nothing moves when it was
+    /// neither.
+    /// <para>
+    /// It advances past any tombstones behind that slot as well, so that the base keeps pointing at a live
+    /// entry: otherwise it would come to rest on a tombstone and the next removal of the oldest would no
+    /// longer recognize itself, and one delete from the middle would disarm the fast path for good. A
+    /// removal from the middle leaves its tombstone where it is, because reclaiming it would move the keys
+    /// above it and their position <em>is</em> their creation order; those are what <see cref="Resize"/>
+    /// squeezes out.
+    /// </para>
+    /// </summary>
+    /// <returns>
+    /// Always <see langword="true" />, which is <see cref="Remove"/>'s own answer: returning it lets the
+    /// caller hand this half of the work over with a tail call instead of a call and a join, which is what
+    /// keeps the newest-entry path straight-line.
+    /// </returns>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private bool RetireSlot(Entry[] entries, int retired)
+    {
+        // Neither end: the tombstone stays where it is, and only Resize reclaims it. Splitting the walk
+        // off keeps this half small, so the commoner of the two answers costs a compare and a return.
+        return retired != _firstIndex || RetireBase(entries, retired);
+    }
+
+    /// <summary>
+    /// Advances the window's base past the slot the oldest entry has just vacated, and past any tombstones
+    /// behind it. Its <see langword="true" /> is <see cref="RetireSlot"/>'s.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private bool RetireBase(Entry[] entries, int retired)
+    {
+        var length = entries.Length;
+        if (_count == 0)
+        {
+            // The last live entry is gone, so the window goes back to the base of the array and the next
+            // add starts at slot 0 again; every slot it held was cleared as it was removed, which is what
+            // makes starting over safe. It is also what ends the walk below: with nothing live left there
+            // would be nothing for it to stop on.
+            _firstIndex = 0;
+            _lastIndex = 0;
+            _limit = length;
+            return true;
+        }
+
+        var first = (retired + 1) & (length - 1);
+        while (entries[first].next == Tombstone)
+        {
+            first = (first + 1) & (length - 1);
+        }
+
+        _firstIndex = first;
+
+        // The window wraps once its top is at or below the new base, and then the base is the slot an add
+        // may not reach; otherwise the free space runs to the end of the array.
+        _limit = _lastIndex <= first ? first : length;
+        return true;
     }
 
     public override ref TValue GetValueRefOrNullRef(Key key)
@@ -241,13 +367,15 @@ internal sealed class StringDictionarySlim<TValue> : DictionaryBase<TValue>, IRe
     [MethodImpl(MethodImplOptions.NoInlining)]
     private ref TValue AddKey(Key key, int bucketIndex)
     {
-        // Always appends: the new entry is the newest key, and enumeration is entry order.
+        // Always appends at the top of the window: the new entry is the newest key, and enumeration is
+        // window order. _limit is the one thing standing between _lastIndex and a slot it may not write,
+        // so the window costs this path a field read where the mark cost an array length read — and one
+        // comparison, where the mark needed two.
         Entry[] entries = _entries;
-        if (_lastIndex == entries.Length || entries.Length == 1)
+        if (_lastIndex == _limit)
         {
-            entries = Resize();
+            entries = MakeRoom();
             bucketIndex = key.HashCode & (_buckets.Length - 1);
-            // entry indexes of surviving entries were not reordered by Resize
         }
 
         var entryIndex = _lastIndex++;
@@ -259,10 +387,43 @@ internal sealed class StringDictionarySlim<TValue> : DictionaryBase<TValue>, IRe
     }
 
     /// <summary>
-    /// Makes room at the top of the entry array, which is the only place an add may write.
+    /// Makes room at the top of the window, which is the only place an add may write, for a window that
+    /// has reached its bound.
     /// <para>
-    /// With no removals this is the plain doubling it has always been. Otherwise the tombstones left by
-    /// <see cref="Remove"/> are squeezed out — in place when the live entries fit in half the capacity,
+    /// There are three ways to have reached it, and only the last one costs anything. A window that has run
+    /// to the end of the array while its base has moved off slot 0 <em>wraps</em>, which is a pair of field
+    /// writes and no data movement at all: that is a rotating key set, and it is why one never compacts. A
+    /// window based at slot 0 is the shape the type has always had, and <see cref="Resize"/> is the code it
+    /// has always run. Anything else is a full window that does not start at slot 0, which
+    /// <see cref="ResizeWindow"/> grows or squeezes.
+    /// </para>
+    /// </summary>
+    private Entry[] MakeRoom()
+    {
+        var entries = _entries;
+        if (_firstIndex != 0)
+        {
+            if (_lastIndex == entries.Length)
+            {
+                // Free space at the bottom of the array, which the window rotated away from: it continues
+                // there, and the base is now the slot the top may not reach.
+                _lastIndex = 0;
+                _limit = _firstIndex;
+                return entries;
+            }
+
+            return ResizeWindow(entries);
+        }
+
+        return Resize();
+    }
+
+    /// <summary>
+    /// Makes room for a window based at slot 0, which is every table that has never had its oldest entry
+    /// removed — and so the only shape this had before the window existed.
+    /// <para>
+    /// With no removals this is the plain doubling it has always been. Otherwise the tombstones left by a
+    /// removal from the middle are squeezed out — in place when the live entries fit in half the capacity,
     /// and into a doubled array when they do not. Compaction preserves relative order, so it is invisible
     /// to enumeration; insisting on the half is what keeps adds amortized O(1), since every call here is
     /// followed by at least <c>capacity / 2</c> adds before the next one.
@@ -271,15 +432,15 @@ internal sealed class StringDictionarySlim<TValue> : DictionaryBase<TValue>, IRe
     /// The half is measured rather than chosen. It is consulted only by a table that has both left
     /// tombstones and filled its array, and because capacities are powers of two it does not tune the
     /// cost continuously — it decides which power of two such a table settles on, and the interval
-    /// between compactions is then the capacity minus the live count. A quarter settles a rotating key
-    /// set at twice its live count and costs a compaction every <c>n</c> adds; a half settles it at four
-    /// times and costs one every <c>3n</c>. Measured against slot reuse that is +34.8% and +8.9%. Going
-    /// on to a three-quarters erases the rest and doubles the ceiling again, which is the trade this
-    /// stops short of; #3285 carries the curve and the memory figures at every setting.
+    /// between compactions is then the capacity minus the live count. It was measured on a rotating key
+    /// set, which no longer reaches this method at all; what still does is a table whose oldest entry
+    /// stays put while the keys above it churn. #3285 carries that curve and the memory figures at every
+    /// setting, and #3315 is why the shape it was measured on is now free.
     /// </para>
     /// </summary>
     private Entry[] Resize()
     {
+        Debug.Assert(_firstIndex == 0);
         Debug.Assert(_lastIndex == _entries.Length || _entries.Length == 1);
 
         var entries = _entries;
@@ -328,6 +489,7 @@ internal sealed class StringDictionarySlim<TValue> : DictionaryBase<TValue>, IRe
 
         _lastIndex = count;
         _entries = newEntries;
+        _limit = newEntries.Length;
 
         var buckets = _buckets;
         while (count-- > 0)
@@ -338,6 +500,123 @@ internal sealed class StringDictionarySlim<TValue> : DictionaryBase<TValue>, IRe
         }
 
         return newEntries;
+    }
+
+    /// <summary>
+    /// Makes room for a full window that does not start at slot 0, which is a table whose base has moved
+    /// and whose middle has since filled with tombstones — a rotating key set with a key pinned under it.
+    /// The threshold is <see cref="Resize"/>'s, measured there.
+    /// <para>
+    /// Growing is the chance to unwrap, so the survivors land at the bottom of the doubled array in window
+    /// order and the window starts over at slot 0; when there is nothing to squeeze out that is two
+    /// <see cref="Array.Copy(Array, int, Array, int, int)"/> runs, the tail of the old array and then its
+    /// head, and taking them the other way round would reverse the keys around the wrap point. Compacting
+    /// in place instead leaves the base where it is and moves the survivors down towards it, so the write
+    /// cursor can never overtake the read cursor — which is what makes a wrapped window safe to squeeze
+    /// without a second array, and why it cannot be rebased to slot 0 in place.
+    /// </para>
+    /// </summary>
+    private Entry[] ResizeWindow(Entry[] entries)
+    {
+        var count = _count;
+        var length = entries.Length;
+        var mask = length - 1;
+        var first = _firstIndex;
+
+        Debug.Assert(first != 0);
+        Debug.Assert(_lastIndex == first);
+        // A bound below the capacity is only ever set on a window that holds a live entry, so the window
+        // reaching it is always a full one and never a closed one, which the squeeze below relies on.
+        Debug.Assert(count != 0);
+
+        if (count == length || count + 1 > length - (length >> 1))
+        {
+            var newSize = length * 2;
+            if ((uint) newSize > int.MaxValue) // uint cast handles overflow
+                throw new InvalidOperationException("Capacity Overflow");
+
+            var newEntries = new Entry[newSize];
+            _buckets = new int[newSize];
+
+            if (count == length)
+            {
+                var toEnd = length - first;
+                Array.Copy(entries, first, newEntries, 0, toEnd);
+                Array.Copy(entries, 0, newEntries, toEnd, first);
+            }
+            else
+            {
+                var target = 0;
+                var source = first;
+                for (var n = 0; n < length; n++)
+                {
+                    if (entries[source].next != Tombstone)
+                    {
+                        newEntries[target++] = entries[source];
+                    }
+
+                    source = (source + 1) & mask;
+                }
+
+                Debug.Assert(target == count);
+            }
+
+            _entries = newEntries;
+            _firstIndex = 0;
+            _lastIndex = count;
+            _limit = newSize;
+            RebuildChains(newEntries, _buckets, 0, count);
+            return newEntries;
+        }
+
+        Array.Clear(_buckets, 0, _buckets.Length);
+
+        var write = first;
+        var read = first;
+        for (var n = 0; n < length; n++)
+        {
+            if (entries[read].next != Tombstone)
+            {
+                if (write != read)
+                {
+                    entries[write] = entries[read];
+                }
+
+                write = (write + 1) & mask;
+            }
+
+            read = (read + 1) & mask;
+        }
+
+        Debug.Assert(write == ((first + count) & mask));
+
+        // Release the key strings and values the squeezed-away slots still reference.
+        ClearWindow(entries, write, length - count);
+
+        _lastIndex = write;
+        _limit = write <= first ? first : length;
+        RebuildChains(entries, _buckets, first, count);
+        return entries;
+    }
+
+    /// <summary>
+    /// Rehangs <paramref name="count"/> entries from <paramref name="first"/> onto empty buckets, walking
+    /// the window in order and wrapping at the end of the array. A bucket and a chain link are physical
+    /// slot indexes that encode no position in the window, which is why the moving base costs lookup
+    /// nothing and why only a resize has to do this at all.
+    /// </summary>
+    private static void RebuildChains(Entry[] entries, int[] buckets, int first, int count)
+    {
+        var mask = entries.Length - 1;
+        var bucketMask = buckets.Length - 1;
+        var index = first;
+        for (var n = 0; n < count; n++)
+        {
+            var bucketIndex = entries[index].key.HashCode & bucketMask;
+            entries[index].next = buckets[bucketIndex] - 1;
+            buckets[bucketIndex] = index + 1;
+            index = (index + 1) & mask;
+        }
     }
 
     /// <summary>
@@ -366,7 +645,7 @@ internal sealed class StringDictionarySlim<TValue> : DictionaryBase<TValue>, IRe
         internal Enumerator(StringDictionarySlim<TValue> dictionary)
         {
             _dictionary = dictionary;
-            _index = 0;
+            _index = dictionary._firstIndex;
             _count = _dictionary._count;
             _current = default;
         }
@@ -381,14 +660,21 @@ internal sealed class StringDictionarySlim<TValue> : DictionaryBase<TValue>, IRe
 
             _count--;
 
-            // Skips the tombstones removals left behind; the live entries between them are still in
-            // insertion order, which is what this type exists to preserve.
-            while (_dictionary._entries[_index].next == Tombstone)
-                _index++;
+            // Walks the window from its base, wrapping at the end of the array, and skips the tombstones a
+            // removal from the middle left behind; the live entries between them are still in insertion
+            // order, which is what this type exists to preserve. The live count is what ends the walk, so
+            // it never has to test the window's top — and starting at the base is what spares it the run of
+            // tombstones a table that keeps dropping its oldest key used to leave below one.
+            var entries = _dictionary._entries;
+            var mask = entries.Length - 1;
+            var index = _index;
+            while (entries[index].next == Tombstone)
+            {
+                index = (index + 1) & mask;
+            }
 
-            _current = new KeyValuePair<Key, TValue>(
-                _dictionary._entries[_index].key,
-                _dictionary._entries[_index++].value);
+            _current = new KeyValuePair<Key, TValue>(entries[index].key, entries[index].value);
+            _index = (index + 1) & mask;
             return true;
         }
 
@@ -398,7 +684,7 @@ internal sealed class StringDictionarySlim<TValue> : DictionaryBase<TValue>, IRe
 
         void IEnumerator.Reset()
         {
-            _index = 0;
+            _index = _dictionary._firstIndex;
             _count = _dictionary._count;
             _current = default;
         }


### PR DESCRIPTION
Fixes #3315.

#3285 made a removed entry a tombstone rather than a free slot the next add pops, because a JS
property store enumerates in entry order and reusing a vacated slot puts a key back in a position
older than its creation. It handed a slot straight back when the entry removed was the **newest** —
the high-water mark walks back — so `o.k = v; delete o.k` churn never reached a compaction.

There was no equivalent for the **oldest**, which is the shape of an object used as a bounded cache:

```js
o[fresh] = value;
delete o[oldest];
```

Every step left a hole below the mark, the array filled, and the table compacted every
`capacity − live` adds forever even though the live window never grew. On today's `main`, over
10,000 rotations: 16 live keys settle on capacity 64 and reclaim 209 times (10,000 / 48); 64 live
keys settle on 256 and reclaim 53 times (10,000 / 192).

## Why this is a rewrite, not a fixup

The first version of this change made the **window's width** a third field and used it as the add
path's "no room" test. The paired gate priced that on a workload with no deletes in it at all:

| row | median % | verdict |
| --- | ---: | --- |
| AddOnly[16] | **+9.86** | SLOWER |
| AddOnly[64] | +1.15 | SLOWER |
| AddThenRemoveNewest[16/64] | +5.11 / +7.22 | SLOWER |
| ReAddMiddle[16/64] | +4.48 / +5.08 | SLOWER |
| RotateOldest[16/64] | −5.53 / −7.33 | FASTER |

The rotation win was real, and every other row paid for it. **The binding constraint is that the add
path must not change**, so this version does not store the width at all.

A second gate then cleared `AddOnly` at both widths and kept the rotation win, but flagged
`AddThenRemoveNewest[64]` (+1.15…+1.64%, two independent pairs) — on a path whose *instructions* had
not changed. They had not; their **layout** had, and that is what the `Remove` section below is about.
The data-side explanation was ruled out by measurement, not by argument: the object does grow by 8
bytes, but the entry array's cache-line alignment is uniformly distributed over consecutive
invocations on both sides — the hot entry straddles a line in 35 of 96 rounds here against 32–36 of 96
on `main` — because a gen0 collection resets the bump pointer long before an 8-byte footprint
difference can bias it. Storing three ints instead of four would not have helped either: 16 bytes of
references plus 12 of ints pads to the same 32, so the object is 48 bytes either way.

## What is stored instead

`_limit`: the exclusive bound on `_lastIndex`. It is

- the **capacity** while the window runs to the end of the array,
- the **base** while the window wraps below it,
- and **0** for the shared one-element dummy array, which nothing may write to.

That single field is what tells a full window from an empty one — both leave `_firstIndex` equal to
`_lastIndex` — and it is what the add path already had to test against something.

### The add path, at the instruction level

`AddKey` reads one field and makes one comparison where the mark read an array length and made two.
The JIT's own output for `StringDictionarySlim<__Canon>:AddKey` (`DOTNET_JitDisasm`, FullOpts):

```asm
; main
mov  rbp, gword ptr [rbx+0x10]   ; _entries
mov  ecx, dword ptr [rbp+0x08]   ; entries.Length
cmp  dword ptr [rbx+0x1C], ecx   ; _lastIndex == entries.Length ?
je   SHORT resize
cmp  ecx, 1                      ; entries.Length == 1 ?
jne  SHORT body

; this branch
mov  rbp, gword ptr [rbx+0x10]   ; _entries
mov  ecx, dword ptr [rbx+0x20]   ; _lastIndex
cmp  ecx, dword ptr [rbx+0x24]   ; == _limit ?
jne  SHORT body
```

**Two instructions fewer, one branch fewer.** Everything after that — `_lastIndex++`, the two entry
writes, the bucket update, `_count++` — is identical instruction for instruction, and the whole
method is five bytes shorter (151 against 156).

Running out of room calls `MakeRoom`, 47 bytes, whose first branch **tail-jumps** to the code
`Resize` has always been whenever the window is based at slot 0. So a table that has never deleted
anything reaches exactly today's resize — same growth test, same `Array.Copy`, same descending bucket
rebuild — through one extra compare and a tail jump. That is the entire per-resize cost on `AddOnly`,
against two instructions saved on every add.

The wrap itself, which is what makes a rotating key set free, is the other branch of `MakeRoom`:

```asm
xor  edx, edx
mov  dword ptr [rcx+0x20], edx   ; _lastIndex = 0
mov  dword ptr [rcx+0x24], ebx   ; _limit = _firstIndex
```

No data movement, no allocation, no bucket rebuild. The same 10,000 rotations reach **0** resizes,
at capacity 32 for 16 live keys and 128 for 64 — half what the compaction threshold settled on.

### What `Remove` costs

Its newest-entry branch is the one both delete-churn shapes run, so it is written to compile to main's
exact six instructions with **no taken branch on it**: the test is inverted and everything that is not
that case sits behind one tail call.

```asm
; main                                    ; this branch
dec dword ptr [rsi+0x18]                  dec dword ptr [rsi+0x18]
mov eax, dword ptr [rsi+0x1C]             mov eax, dword ptr [rsi+0x20]
dec eax                                   dec eax
cmp r14d, eax                             cmp r14d, eax
jne SHORT ...        ; not taken          jne SHORT ...        ; not taken
mov dword ptr [rsi+0x1C], r14d            mov dword ptr [rsi+0x20], r14d
mov eax, 1                                mov eax, 1
```

That shape is not what the obvious spelling produces. Four formulations were written and disassembled:
an `if/else`, an `else if` chain, and both of those with the base test at the call site all make RyuJIT
move the single store **out of line** and put a *taken* branch on the commonest delete there is. Only
"invert the test, hand the rest over with a tail call" lays it out straight-line — and that is what the
first gate caught (see below).

What this moves is the cost of a removal from the *middle*: it now reaches a small tail-called
`RetireSlot` (six instructions: compare the base, return) instead of one inline compare. The tombstone
walk is split off into `RetireBase` so that half stays small. `RotateBehindPinnedKey` is the row that
pays it, and it is branch-only.

Resetting an emptied table lives in the base branch, where the walk over tombstones needs the count
anyway; a table emptied through the *newest* branch simply closes its window where it stands, which is
an empty window like any other, and `ClearPreservingCapacity` puts it back at the base of the array it
kept.

## The invariants, and where this degrades

- **`_entries[_firstIndex]` is live whenever `_count` is not 0.** This is why the base advance skips
  the tombstones behind the slot it retires: without it the base would come to rest on a tombstone,
  the next removal of the oldest would no longer recognize itself, and one delete from the middle
  would disarm the fast path for good.
- **A bound below the capacity is only ever set on a window that holds a live entry**, so a window
  that has reached its bound is always a full one and never a closed one — which is what lets the
  in-place squeeze assume there is something to squeeze.

**When the oldest live entry is not removed, the base cannot advance and this degrades to exactly
today's behaviour** — every removal is from the middle, the tombstones pile up, the table compacts on
the same schedule, and it runs the same `Resize`. That is an object with one field set once and a
rotating key set above it; the benchmark carries it as `RotateBehindPinnedKey`.

### Growth, compaction, `Clear`, and the buckets

- **The hash buckets do not care about the moving base.** A bucket holds a physical slot index and a
  chain link is a physical slot index; neither encodes a position in the window.
- **Compacting in place keeps the base where it is** and moves the survivors down towards it, so the
  write cursor can never overtake the read cursor. Rebasing to 0 in place would not be safe: the
  survivors above the wrap point would overwrite unread slots below it.
- **Growing is the chance to unwrap.** The survivors land at the bottom of the doubled array in
  window order — two `Array.Copy` runs when there is nothing to compact, tail of the old array then
  head — and the window starts over at slot 0.
- **`ClearPreservingCapacity`** clears the window's slots, wrapping if it has to, and always puts the
  window back at slot 0; its early-out is now the dummy array itself.

### Both stores, not only the string one

`DictionarySlim` (the symbol store) gets the identical treatment. It is a deliberate near-duplicate
of `StringDictionarySlim` — same tombstone design, same doc comment, changed together by #3285 — and
letting one keep a high-water mark while the other has a window is a maintenance trap worth more than
the change costs.

No public API change: both types are `internal`, and nothing observable outside the assembly depends
on which slot a key occupies. The one thing that is observable — enumeration order — is what the
tests are about. **No migration-guide entry**, for the same reason #3285 has none: nothing an
embedder can see changes.

## Tests

`Jint.Tests/Runtime/OwnPropertyCreationOrderTests.cs` is the file #3273/#3285 left behind; the
wrap-around cases are appended to it, and they fail on unmodified `main` (four of them by asserting
the settled capacity or by naming a field that does not exist there).

The new one this rewrite adds is `TheWindowBoundStaysTheOneAnAddMayTest`, which checks the window
arithmetic **after every single operation** of a 10,000-step mix of oldest / newest / middle
removals, drains and pooled resets — the bound is the capacity or the base and never below the top,
the base is never a tombstone, the width never below the live count, an emptied table closes its
window. Since the add path is now one comparison against that bound, it is where a mistake would be.

**The tests catch a broken window.** Three mutations of the merged code:

| mutation | fails |
| --- | --- |
| base advance stops on the first slot instead of walking past tombstones | `TheWindowBoundStaysTheOneAnAddMayTest` (both arms) — and nothing else, which is why it exists |
| the bound never follows the base (`_limit = length` always) | 6 tests: both wrapped-resize cases, all three randomized arms, one invariant arm |
| the two unwrap `Array.Copy` runs the other way round | `AWrappedWindowWithNothingToCompactIsUnwrappedByGrowing` |

## Suites

Everything `-c Release`, freshly built, on this branch.

| suite | net472 | net8.0 | net10.0 |
| --- | --- | --- | --- |
| `Jint.Tests` | 0 / 8234 / 4 | 0 / 11614 / 5 | 0 / 11614 / 5 |
| `Jint.Tests.PublicInterface` | 0 / 2717 / 21 | 0 / 3340 / 21 | 0 / 3350 / 21 |
| `Jint.Tests.CommonScripts` | 0 / 28 / 0 | — | 0 / 28 / 0 |
| `Jint.Tests.SourceGenerators` | — | — | 0 / 71 / 0 |
| test262 | — | — | 0 / 102537 / 151 of 102688 |

(failed / passed / skipped; `dotnet build -c Release` on the solution is clean, `TreatWarningsAsErrors`
and all. The order tests were also run under `-c Debug`, where the `Debug.Assert`s in `Resize` and
`ResizeWindow` are live.)

The test262 figure is unchanged from the first revision of this branch, which measured the same
102,537 / 0 / 151 on `main` at its branch point.

## Benchmark, and what to expect from the gate

`PropertyDeleteChurnBenchmark` keeps the `RotateBehindPinnedKey` row from the first version — the
rotation with a pinned key underneath it that the window cannot help — so the shape that still
compacts is priced rather than assumed.

**No numbers here; the gate table follows in a comment.** Predicted direction per row:

| row | prediction | why |
| --- | --- | --- |
| `AddOnly[16]`, `AddOnly[64]` | flat, or slightly faster | two instructions fewer per add, one compare and a tail jump more per resize |
| `AddThenRemoveNewest[16/64]` | flat | the newest-entry path is now instruction-for-instruction main's, with no taken branch |
| `ReAddMiddle[16/64]` | flat | after the first step the re-added name is the newest, so it takes the same identical path |
| `RotateOldest[16/64]` | **faster** | zero resizes instead of one every `capacity − live` adds; the first version got −5.5 / −7.3% while also paying for a heavier add path |
| `RotateBehindPinnedKey` | branch-only row; a little slower than the previous revision | every removal is from the middle, and those now go through a tail-called `RetireSlot` |
| `ScriptKeysAfterRotation[16]` | faster | the churned table holds half the capacity and no tombstones, so the enumerator steps over nothing |
| `ScriptKeysAfterRotation[64]`, `ScriptRotateOldest[16/64]`, `ScriptDeleteReAdd[16/64]` | flat to slightly faster | the collection delta diluted by the engine's own cost |

Allocated bytes should fall on the rotation rows (the entry array settles at half the capacity) and
rise by 8 bytes per dictionary object, which now carries four `int` fields instead of two.
