### PR TITLE
Temporal: adding months in hebrew counts the Metonic cycle

### DIFF
--- a/Jint.Tests.PublicInterface/HostTemporalCalendarConstraintTests.cs
+++ b/Jint.Tests.PublicInterface/HostTemporalCalendarConstraintTests.cs
@@ -2,13 +2,14 @@
 
 using System;
 using System.Threading;
+using Jint.Native.Temporal;
 using Jint.Runtime;
 
 namespace Jint.Tests.PublicInterface;
 
 /// <summary>
-/// A bulk month addition in a calendar whose years hold different numbers of months is a CLR walk of one
-/// step per calendar year crossed, and these pin that a host's bound reaches inside it.
+/// A bulk month addition in a calendar whose months are reached by walking one year at a time is a CLR
+/// loop inside one interpreter step, and these pin that a host's bound reaches inside it.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -17,34 +18,43 @@ namespace Jint.Tests.PublicInterface;
 /// <c>LimitExecutionTime</c> of 100 ms returned an answer two seconds later, a <c>LimitStatements</c> of ten
 /// returned one after two, and a token cancelled from another thread was never observed. Every test here
 /// therefore asserts that the exception is <em>raised</em>, never how long anything took: the budgets are
-/// chosen so that the work is orders of magnitude larger than the bound, and a machine under load only makes
-/// them fire sooner.
+/// chosen so that the work is far larger than the bound, and a machine under load only makes them fire
+/// sooner.
 /// </para>
 /// <para>
-/// <b>Why <c>hebrew</c>.</b> The measurements above were taken on <c>chinese</c>, which no longer walks at
-/// all: which month lies <em>n</em> lunations away is now a closed-form question. <c>hebrew</c> is the walk
-/// that remains — twelve months one year and thirteen the next, one step per year either way — so it is
-/// where the bound has to be proved. The one <c>chinese</c> case left is the step so large that the closed
-/// form declines it and the walk answers after all, which is the only way back into that loop.
+/// <b>Where the walk lives now.</b> The measurements above were taken on <c>chinese</c>, and the ones after
+/// them on <c>hebrew</c>; neither walks any more. Which month lies <em>n</em> lunations away is a closed-form
+/// question for <c>chinese</c> and <c>dangi</c>, and so is which month lies <em>n</em> months away on the
+/// Metonic cycle for <c>hebrew</c> (<see href="https://github.com/sebastienros/jint/issues/3520"/>). What
+/// still walks is the lane a host reaches by installing an <see cref="ICalendarProvider"/> of its own: a
+/// calendar only the host can convert has no cycle the engine could count, so its months are stepped a year
+/// at a time through the provider's own two conversions, asking each year how many months it holds. That is
+/// where a bound has to be proved, and it is a host-facing lane rather than an engine-internal one. The one
+/// <c>chinese</c> case kept is the step so large that the closed form declines it and the walk answers after
+/// all, which is the only way back into that loop.
 /// </para>
 /// </remarks>
 public class HostTemporalCalendarConstraintTests
 {
     /// <summary>
-    /// Three hundred thousand months is some twenty-five thousand Hebrew years, four orders of magnitude
-    /// past the walk's constraint-check interval and comfortably inside <c>Temporal</c>'s range — so the
+    /// Three hundred thousand months is some twenty-five thousand Hebrew years — three orders of magnitude
+    /// past the walk's constraint-check interval and comfortably inside <c>Temporal</c>'s range, so the
     /// engine owes the script a real answer, and the only question is whether it can be interrupted on the
-    /// way to it.
+    /// way to it. Under the provider it takes some 70 ms and spends 94 statements on checks, so a budget of five
+    /// cannot hold it.
     /// </summary>
-    private const string BulkHebrewAddition =
+    private const string BulkMonthAddition =
         "Temporal.PlainDate.from('2000-01-01').withCalendar('hebrew').add({ months: 300000 }).toString()";
 
-    /// <summary>Longer, for the budget that has to expire before it can fire.</summary>
-    private const string LongerBulkHebrewAddition =
+    /// <summary>
+    /// Longer, for the budget that has to expire before it can fire: about 900 ms of walking against a
+    /// 25 ms bound.
+    /// </summary>
+    private const string LongerBulkMonthAddition =
         "Temporal.PlainDate.from('2000-01-01').withCalendar('hebrew').add({ months: 3000000 }).toString()";
 
     /// <summary>A month difference is measured by walking, so the walk is where its cost is too.</summary>
-    private const string BulkHebrewDifference =
+    private const string BulkMonthDifference =
         "Temporal.PlainDate.from('2000-01-01').withCalendar('hebrew')"
         + ".until(Temporal.PlainDate.from('3000-01-01').withCalendar('hebrew'), { largestUnit: 'month' })"
         + ".toString()";
@@ -55,20 +65,31 @@ public class HostTemporalCalendarConstraintTests
     private const string UnsteppableChineseAddition =
         "Temporal.PlainDate.from('2000-01-01').withCalendar('chinese').add({ months: 20000000 }).toString()";
 
+    /// <summary>
+    /// An engine whose calendars are answered by a host provider, which is what puts every one of them on
+    /// the generic walk.
+    /// </summary>
+    private static Engine WithProvider(Action<Options> configure)
+        => new(options =>
+        {
+            options.Temporal.CalendarProvider = new HostCalendarProvider();
+            configure(options);
+        });
+
     [Test]
     public void AnExecutionTimeoutStopsABulkMonthAddition()
     {
-        var engine = new Engine(options => options.LimitExecutionTime(TimeSpan.FromMilliseconds(100)));
+        var engine = WithProvider(options => options.LimitExecutionTime(TimeSpan.FromMilliseconds(25)));
 
-        Assert.Throws<TimeoutException>(() => engine.Evaluate(LongerBulkHebrewAddition));
+        Assert.Throws<TimeoutException>(() => engine.Evaluate(LongerBulkMonthAddition));
     }
 
     [Test]
     public void AStatementBudgetStopsABulkMonthAddition()
     {
-        var engine = new Engine(options => options.LimitStatements(5));
+        var engine = WithProvider(options => options.LimitStatements(5));
 
-        Assert.Throws<StatementsCountOverflowException>(() => engine.Evaluate(BulkHebrewAddition));
+        Assert.Throws<StatementsCountOverflowException>(() => engine.Evaluate(BulkMonthAddition));
     }
 
     [Test]
@@ -76,9 +97,9 @@ public class HostTemporalCalendarConstraintTests
     {
         using var cancellation = new CancellationTokenSource();
         cancellation.Cancel();
-        var engine = new Engine(options => options.ObserveCancellation(cancellation.Token));
+        var engine = WithProvider(options => options.ObserveCancellation(cancellation.Token));
 
-        Assert.Throws<ExecutionCanceledException>(() => engine.Evaluate(BulkHebrewAddition));
+        Assert.Throws<ExecutionCanceledException>(() => engine.Evaluate(BulkMonthAddition));
     }
 
     [Test]
@@ -86,9 +107,9 @@ public class HostTemporalCalendarConstraintTests
     {
         using var cancellation = new CancellationTokenSource();
         cancellation.Cancel();
-        var engine = new Engine(options => options.ObserveCancellation(cancellation.Token));
+        var engine = WithProvider(options => options.ObserveCancellation(cancellation.Token));
 
-        Assert.Throws<ExecutionCanceledException>(() => engine.Evaluate(BulkHebrewDifference));
+        Assert.Throws<ExecutionCanceledException>(() => engine.Evaluate(BulkMonthDifference));
     }
 
     /// <summary>
@@ -113,7 +134,7 @@ public class HostTemporalCalendarConstraintTests
     [Test]
     public void AnOrdinaryAdditionIsNotChargedForTheCheck()
     {
-        var engine = new Engine(options => options.LimitStatements(1));
+        var engine = WithProvider(options => options.LimitStatements(1));
 
         var result = engine.Evaluate(
             "Temporal.PlainDate.from('2000-01-01').withCalendar('hebrew').add({ months: 13 }).toString()");
@@ -123,7 +144,8 @@ public class HostTemporalCalendarConstraintTests
 
     /// <summary>
     /// An engine with no constraints answers the bulk addition, and answers it the same as it always did:
-    /// the check bounds the walk without changing where it lands.
+    /// the check bounds the walk without changing where it lands, and counting months rather than walking
+    /// does not change where it lands either.
     /// </summary>
     [Test]
     public void AnUnboundedEngineStillAnswersTheBulkAddition()
@@ -135,4 +157,26 @@ public class HostTemporalCalendarConstraintTests
 
         result.AsString().Should().Be("2808-07-09[u-ca=hebrew]");
     }
+
+    /// <summary>
+    /// And the calendars the engine reckons itself no longer spend a budget at all: the same three million
+    /// months that walks under a provider is arithmetic here, so it fits in a statement budget of two —
+    /// where that walk needs nine hundred and forty-eight.
+    /// </summary>
+    [Test]
+    public void AnEngineReckonedCalendarSpendsNoBudgetOnABulkMonthAddition()
+    {
+        var engine = new Engine(options => options.LimitStatements(2));
+
+        var result = engine.Evaluate(LongerBulkMonthAddition);
+
+        result.AsString().Should().Be("+244556-01-22[u-ca=hebrew]");
+    }
 }
+
+/// <summary>
+/// A host provider that corrects nothing. Installing any provider is what routes every calendar through
+/// the generic arithmetic, which walks the two conversions a provider supplies — the walk a host with a
+/// calendar of its own is actually exposed to.
+/// </summary>
+file sealed class HostCalendarProvider : DefaultCalendarProvider;

--- a/Jint.Tests/Runtime/HebrewMonthSteppingTests.cs
+++ b/Jint.Tests/Runtime/HebrewMonthSteppingTests.cs
@@ -1,0 +1,206 @@
+#nullable enable
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Adding months in <c>hebrew</c> counts them on the Metonic cycle rather than walking one calendar year
+/// at a time, and a calendar whose years all hold the same number of months divides instead of walking
+/// too. These pin that they do, and that they land where the walk landed.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>How the bound is asserted.</b> Never with a clock — a wall-clock assertion on a shared machine is
+/// the flake it would exist to catch. The walk consults the engine's constraints every 256 years stepped
+/// (<see href="https://github.com/sebastienros/jint/issues/3511"/>) and a constraint check charges
+/// <c>MaxStatements</c> one statement, so a statement budget <em>is</em> a budget of years walked. A
+/// hundred thousand Hebrew months is some eight thousand years and would spend thirty-one of them;
+/// counting months spends none, so it fits in a budget of two with the script's own statement to spare.
+/// </para>
+/// <para>
+/// <b>Why the answers are written down.</b> Both reckonings were compared over 483,875 cases — every
+/// 37th day from ISO 1500 to 2400 against twenty month steps, twenty-one dates from ISO −400 to +100000
+/// against twenty-six steps out to three million months, and 528 <c>until</c> and <c>since</c>
+/// differences, all in <c>hebrew</c> and <c>persian</c>, plus 126,455 field reads across five calendars —
+/// and they agree on every one. The values below come from that comparison, so a change to any of them is
+/// a regression rather than a matter of taste
+/// (<see href="https://github.com/sebastienros/jint/issues/3520"/>).
+/// </para>
+/// </remarks>
+public class HebrewMonthSteppingTests
+{
+    private static string Add(Engine engine, string calendar, string start, long months)
+        => engine.Evaluate(
+                $"Temporal.PlainDate.from('{start}').withCalendar('{calendar}').add({{ months: {months} }}).toString()")
+            .AsString();
+
+    /// <summary>
+    /// The work bound. Walking three million months spends nine hundred and forty-seven statements on
+    /// constraint checks alone, so a budget of two is what says the walk did not happen.
+    /// </summary>
+    [TestCase("hebrew", 100_000, "+010085-03-13")]
+    [TestCase("hebrew", 300_000, "+026255-08-10")]
+    [TestCase("hebrew", 3_000_000, "+244556-01-22")]
+    [TestCase("persian", 3_000_000, "+251999-10-18")]
+    public void ABulkMonthAdditionDoesNotWalkYearByYear(string calendar, int months, string expected)
+    {
+        var engine = new Engine(options => options.LimitStatements(2));
+
+        Add(engine, calendar, "2000-01-01", months).Should().Be($"{expected}[u-ca={calendar}]");
+    }
+
+    /// <summary>
+    /// A month difference is measured by walking one month at a time from an estimate, and every step of
+    /// that walk used to be an <c>add</c> that walked the years between: eighteen thousand years of
+    /// <c>hebrew</c> took 71 seconds. The estimate is still stepped off one month at a time — a few
+    /// hundred steps, since the average month length it starts from is not exact — but each of those
+    /// steps is now arithmetic, which is the whole of the difference.
+    /// </summary>
+    [Test]
+    public void AMonthDifferenceDoesNotWalkYearByYear()
+    {
+        var engine = new Engine(options => options.LimitStatements(5));
+
+        var difference = engine.Evaluate(
+            "Temporal.PlainDate.from('2000-01-01').withCalendar('hebrew')"
+            + ".until(Temporal.PlainDate.from('+020000-01-01').withCalendar('hebrew'), { largestUnit: 'month' })"
+            + ".toString()").AsString();
+
+        difference.Should().Be("P222628M28D");
+    }
+
+    /// <summary>
+    /// Stepping there in one go and stepping there a month at a time have to agree, over a span that
+    /// crosses Adar I in both directions and, for three of the starts, the end of the backing calendar's
+    /// own table.
+    /// </summary>
+    /// <remarks>
+    /// The Persian starts stay clear of ISO 9999, where the two spellings disagree by a day and have
+    /// since before any of this: the calendar's last year, 9378, holds ten months rather than twelve, so
+    /// a step that stops inside its eleventh materializes a date the table cannot place and the
+    /// arithmetic reckoning answers for, one day off what the table would have said.
+    /// </remarks>
+    [TestCase("hebrew", "2000-01-01")]
+    [TestCase("hebrew", "1582-11-30")]
+    [TestCase("hebrew", "2239-01-15")]
+    [TestCase("hebrew", "+010000-06-06")]
+    [TestCase("persian", "2000-01-01")]
+    [TestCase("persian", "9000-06-01")]
+    [TestCase("persian", "+010500-06-06")]
+    public void SteppingByOneMonthAtATimeReachesTheSamePlace(string calendar, string start)
+    {
+        var engine = new Engine();
+
+        for (var months = 1; months <= 40; months++)
+        {
+            var direct = Add(engine, calendar, start, months);
+
+            var oneAtATime = engine.Evaluate(
+                $$"""
+                (() => {
+                    let d = Temporal.PlainDate.from('{{start}}').withCalendar('{{calendar}}');
+                    for (let i = 0; i < {{months}}; i++) { d = d.add({ months: 1 }); }
+                    return d.toString();
+                })()
+                """).AsString();
+
+            oneAtATime.Should().Be(direct, "stepping {0} months one at a time from {1}", months, start);
+        }
+    }
+
+    /// <summary>
+    /// Out and back on the first day of a month, where no day has to be clamped, returns where it
+    /// started.
+    /// </summary>
+    [TestCase("hebrew", 1)]
+    [TestCase("hebrew", 13)]
+    [TestCase("hebrew", 1237)]
+    [TestCase("hebrew", 100_000)]
+    [TestCase("persian", 1237)]
+    [TestCase("persian", 100_000)]
+    public void SteppingOutAndBackReturnsWhereItStarted(string calendar, int months)
+    {
+        var engine = new Engine();
+
+        var roundTrip = engine.Evaluate(
+            $$"""
+            Temporal.PlainDate.from({ year: 2000, monthCode: 'M01', day: 1, calendar: '{{calendar}}' })
+                .add({ months: {{months}} })
+                .subtract({ months: {{months}} })
+                .toString()
+            """).AsString();
+
+        var start = engine.Evaluate(
+            $"Temporal.PlainDate.from({{ year: 2000, monthCode: 'M01', day: 1, calendar: '{calendar}' }}).toString()")
+            .AsString();
+
+        roundTrip.Should().Be(start);
+    }
+
+    /// <summary>
+    /// A month index is a month index however it is reached, so a span split in two has to reach where
+    /// the whole span reaches.
+    /// </summary>
+    [TestCase("hebrew", "+042426-02-07")]
+    [TestCase("persian", "+043666-09-25")]
+    public void AMonthSpanSplitInTwoReachesWhereTheWholeSpanReaches(string calendar, string expected)
+    {
+        var engine = new Engine();
+
+        var whole = Add(engine, calendar, "2000-02-05", 500_000);
+
+        var halves = engine.Evaluate(
+            $"Temporal.PlainDate.from('2000-02-05').withCalendar('{calendar}')"
+            + ".add({ months: 250000 }).add({ months: 250000 }).toString()").AsString();
+
+        halves.Should().Be(whole);
+        whole.Should().Be($"{expected}[u-ca={calendar}]");
+    }
+
+    /// <summary>
+    /// The two directions have to be each other's inverse: adding back what a difference measured has to
+    /// land on the date it was measured to, including across the end of the backing calendar's table.
+    /// </summary>
+    [TestCase("hebrew", "1600-02-29", "2300-11-05")]
+    [TestCase("hebrew", "1500-01-01", "+012000-01-01")]
+    [TestCase("hebrew", "2239-09-29", "2240-10-15")]
+    [TestCase("persian", "1600-02-29", "2300-11-05")]
+    [TestCase("persian", "9000-01-01", "+010500-06-06")]
+    public void AddingWhatUntilMeasuredReachesTheDateItMeasuredTo(string calendar, string one, string two)
+    {
+        var engine = new Engine();
+
+        var reached = engine.Evaluate(
+            $$"""
+            (() => {
+                const a = Temporal.PlainDate.from('{{one}}').withCalendar('{{calendar}}');
+                const b = Temporal.PlainDate.from('{{two}}').withCalendar('{{calendar}}');
+                return a.add(a.until(b, { largestUnit: 'month' })).equals(b);
+            })()
+            """).AsBoolean();
+
+        reached.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// One step across the end of a backing calendar's table, which is where the year range the walk used
+    /// to discover by catching <c>ArgumentOutOfRangeException</c> is now compared against. The Hebrew
+    /// table runs to ISO 2239-09-29 and starts at 1583-01-01; the Persian one stops in the middle of its
+    /// last year, 9378, which holds ten months rather than twelve.
+    /// </summary>
+    [TestCase("hebrew", "1583-01-01", -13, "1581-12-12")]
+    [TestCase("hebrew", "1583-01-01", -1, "1582-12-02")]
+    [TestCase("hebrew", "1583-01-01", 1, "1583-01-30")]
+    [TestCase("hebrew", "2239-09-29", 1, "2239-10-28")]
+    [TestCase("hebrew", "2239-09-29", 13, "2240-10-15")]
+    [TestCase("hebrew", "+100000-01-01", -1, "+099999-12-02")]
+    [TestCase("hebrew", "+100000-01-01", 13, "+100001-01-20")]
+    [TestCase("persian", "9999-12-31", -1, "9999-12-01")]
+    [TestCase("persian", "9999-12-31", 1, "+010000-01-31")]
+    [TestCase("persian", "9999-12-31", 13, "+010001-01-30")]
+    public void AStepAcrossTheEndOfTheTableLandsWhereItAlwaysDid(string calendar, string start, int months, string expected)
+    {
+        var engine = new Engine();
+
+        Add(engine, calendar, start, months).Should().Be($"{expected}[u-ca={calendar}]");
+    }
+}

--- a/Jint/Native/Temporal/NonIsoCalendars.cs
+++ b/Jint/Native/Temporal/NonIsoCalendars.cs
@@ -20,9 +20,10 @@ namespace Jint.Native.Temporal;
 /// value nor a catchable JavaScript error. Every helper below that produces such a max therefore
 /// states why it cannot answer below 1, and each maximum taken from System.Globalization instead
 /// (Calendar.GetDaysInMonth, GetMonthsInYear, GetLeapMonth, IsLeapYear — all of which either answer 1
-/// or more or throw for a year outside the calendar's range) sits inside a try whose catch answers
-/// with a literal, with one of those helpers, or with the algorithmic reckoning the calendar's own
-/// field accessors read past the end of its table — never below 1. What keeps all of it true is
+/// or more or throw for a year outside the calendar's range) is asked only for a year that calendar
+/// covers (see SupportsYear); a year past the end of its table is answered with a literal, with one of
+/// those helpers, or with the algorithmic reckoning the calendar's own field accessors read there —
+/// never below 1. What keeps all of it true is
 /// Jint.Tests/Runtime/NonIsoCalendarTests.cs: 85,800 field combinations per overflow mode across all
 /// eleven calendars, every one of which has to come back as a date or as null rather than throw.
 /// </remarks>
@@ -40,6 +41,93 @@ internal static class NonIsoCalendars
     private static HebrewCalendar HebrewCal => _hebrewCalendar ??= new HebrewCalendar();
     private static PersianCalendar PersianCal => _persianCalendar ??= new PersianCalendar();
     private static UmAlQuraCalendar UmAlQuraCal => _umAlQuraCalendar ??= new UmAlQuraCalendar();
+
+    private static YearBand? _hebrewYears;
+    private static YearBand? _persianYears;
+    private static YearBand? _umAlQuraYears;
+
+    /// <summary>
+    /// The years a backing <see cref="Calendar"/> answers for, read from the range it states itself.
+    /// </summary>
+    [StructLayout(LayoutKind.Auto)]
+    private readonly record struct YearBand(int Min, int Max)
+    {
+        public bool Covers(int year) => year >= Min && year <= Max;
+
+        public static YearBand Of(Calendar cal)
+            => new(cal.GetYear(cal.MinSupportedDateTime), cal.GetYear(cal.MaxSupportedDateTime));
+    }
+
+    /// <summary>
+    /// Whether <paramref name="cal"/>'s own table covers <paramref name="year"/> — the question every
+    /// year-taking <see cref="Calendar"/> member below used to be asked by calling it and catching the
+    /// <see cref="ArgumentOutOfRangeException"/> it raises outside its range.
+    /// </summary>
+    /// <remarks>
+    /// <c>[GetYear(MinSupportedDateTime), GetYear(MaxSupportedDateTime)]</c> is exactly the band in which
+    /// <c>GetMonthsInYear</c>, <c>IsLeapYear</c>, <c>GetDaysInYear</c>, <c>GetLeapMonth</c> and
+    /// <c>GetDaysInMonth</c> (for a month that year holds) succeed on all three backing calendars: they
+    /// throw at <c>Min − 1</c> and <c>Max + 1</c> and nowhere inside, measured year by year across each
+    /// band and twenty years past both ends on <c>net472</c>, <c>net8.0</c> and <c>net10.0</c>. So the
+    /// comparison answers what the catch answered, and the walks below cross tens of thousands of years
+    /// outside the band, where an exception apiece was most of what a month step cost
+    /// (https://github.com/sebastienros/jint/issues/3520).
+    /// <para>
+    /// <c>ToDateTime</c> is <em>not</em> one of them and keeps its <c>try</c>: Hebrew 5343 is inside the
+    /// band and its first four months still begin before <c>MinSupportedDateTime</c>, so a year the band
+    /// covers can still hold a date the calendar declines to place.
+    /// </para>
+    /// </remarks>
+    private static bool SupportsYear(Calendar cal, int year) => YearsOf(cal).Covers(year);
+
+    /// <summary>
+    /// The length of an ordinal month according to <paramref name="cal"/>'s own table, or false for a
+    /// month that table does not reach.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="SupportsYear"/> answers for the year, which is the dimension a walk crosses by the
+    /// thousand. The month is the one it cannot answer for: a Hebrew common year has no thirteenth
+    /// month, and one year inside a band holds fewer months than its calendar nominally does — Persian
+    /// 9378, the year <c>MaxSupportedDateTime</c> falls in, stops at month 10. So this call keeps the
+    /// catch, and every caller has a reckoning of its own for what it declines.
+    /// </remarks>
+    private static bool TryGetDaysInMonth(Calendar cal, int year, int month, out int days)
+    {
+        try
+        {
+            days = cal.GetDaysInMonth(year, month);
+            return true;
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            days = 0;
+            return false;
+        }
+    }
+
+    /// <summary>The band of <paramref name="cal"/>, read once and remembered.</summary>
+    private static YearBand YearsOf(Calendar cal)
+    {
+        if (ReferenceEquals(cal, _hebrewCalendar))
+        {
+            _hebrewYears ??= YearBand.Of(cal);
+            return _hebrewYears.Value;
+        }
+
+        if (ReferenceEquals(cal, _persianCalendar))
+        {
+            _persianYears ??= YearBand.Of(cal);
+            return _persianYears.Value;
+        }
+
+        if (ReferenceEquals(cal, _umAlQuraCalendar))
+        {
+            _umAlQuraYears ??= YearBand.Of(cal);
+            return _umAlQuraYears.Value;
+        }
+
+        return YearBand.Of(cal);
+    }
 
     // Epoch day constants (days since Unix epoch 1970-01-01)
     // Coptic epoch: Coptic year 1, month 1, day 1 = proleptic Gregorian August 29, 284 CE
@@ -304,6 +392,73 @@ internal static class NonIsoCalendars
 
         steppedYear = landed.Year;
         steppedOrdinalMonth = ordinal;
+        return true;
+    }
+
+    /// <summary>
+    /// Where <paramref name="months"/> ordinal months out from (<paramref name="year"/>,
+    /// <paramref name="ordinalMonth"/>) lands in a calendar that can say so without walking, and false
+    /// for one that cannot.
+    /// </summary>
+    /// <remarks>
+    /// The walk this replaces asks each year in turn how many months it holds, which is one
+    /// <see cref="Calendar"/> call per year crossed and, past the end of that calendar's table, was one
+    /// caught <see cref="ArgumentOutOfRangeException"/> apiece. Both calendars that reach it answer the
+    /// question in closed form. Every <c>persian</c> year holds twelve months, so the month a step lands
+    /// on is a division. A <c>hebrew</c> year holds twelve or thirteen by the Metonic cycle — 235 months
+    /// every 19 years, with the leap years of a cycle fixed at 3, 6, 8, 11, 14, 17 and 19 — so
+    /// <see cref="HebrewMonthsBeforeYear"/> counts the months before a year and inverting it names the
+    /// year a month index falls in. Both are exact rather than approximate, which is what makes the
+    /// result identical to the walk's and makes <c>add</c> additive
+    /// (https://github.com/sebastienros/jint/issues/3520).
+    /// <para>
+    /// The one case it declines is a landing year no <see cref="int"/> can hold, which needs a duration
+    /// whose years and months are both in the billions. The walk stays as the fallback for that, as it
+    /// does for <c>chinese</c> and <c>dangi</c>, whose month lengths are an astronomical reckoning rather
+    /// than a cycle and are stepped by <see cref="TryStepLunisolarMonths"/> instead.
+    /// </para>
+    /// </remarks>
+    private static bool TryStepOrdinalMonths(
+        string calendar,
+        int year,
+        int ordinalMonth,
+        int months,
+        out int steppedYear,
+        out int steppedOrdinalMonth)
+    {
+        long landedYear;
+        long landedOrdinal;
+
+        if (string.Equals(calendar, "hebrew", StringComparison.Ordinal))
+        {
+            var index = HebrewMonthsBeforeYear(year) + ordinalMonth - 1 + months;
+            landedYear = HebrewYearOfMonthIndex(index);
+            landedOrdinal = index - HebrewMonthsBeforeYear(landedYear) + 1;
+        }
+        else
+        {
+            var monthsInYear = UniformMonthsInYear(calendar);
+            if (monthsInYear == 0)
+            {
+                steppedYear = year;
+                steppedOrdinalMonth = ordinalMonth;
+                return false;
+            }
+
+            var index = (long) year * monthsInYear + ordinalMonth - 1 + months;
+            landedYear = FloorDiv(index, monthsInYear);
+            landedOrdinal = index - landedYear * monthsInYear + 1;
+        }
+
+        if (landedYear > int.MaxValue || landedYear < int.MinValue)
+        {
+            steppedYear = year;
+            steppedOrdinalMonth = ordinalMonth;
+            return false;
+        }
+
+        steppedYear = (int) landedYear;
+        steppedOrdinalMonth = (int) landedOrdinal;
         return true;
     }
 
@@ -574,6 +729,12 @@ internal static class NonIsoCalendars
         {
             newYear = steppedYear;
             newOrdinalMonth = steppedMonth;
+        }
+        else if (months != 0
+            && TryStepOrdinalMonths(calendar, newYear, newOrdinalMonth, months, out var countedYear, out var countedMonth))
+        {
+            newYear = countedYear;
+            newOrdinalMonth = countedMonth;
         }
         else if (months != 0)
         {
@@ -1511,9 +1672,47 @@ internal static class NonIsoCalendars
         return r;
     }
 
+    /// <summary>
+    /// How many months the Hebrew years before <paramref name="year"/> hold, counted from year 1 — the
+    /// month index Tishrei of that year begins at.
+    /// </summary>
+    /// <remarks>
+    /// The Metonic cycle fixes it: 235 months every 19 years, with the leap years of a cycle at 3, 6, 8,
+    /// 11, 14, 17 and 19, which is the same cycle <see cref="IsHebrewLeapYearAlgorithmic"/> reads. It is
+    /// also the quantity the Reingold–Dershowitz year start below counts days from, so the two agree by
+    /// construction. Floor division, so it extends into proleptic years.
+    /// </remarks>
+    private static long HebrewMonthsBeforeYear(long year) => FloorDiv(235L * year - 234L, 19L);
+
+    /// <summary>
+    /// The Hebrew year the month at <paramref name="index"/> falls in, inverting
+    /// <see cref="HebrewMonthsBeforeYear"/>.
+    /// </summary>
+    /// <remarks>
+    /// Nineteen years per 235 months is the estimate, and the two corrections below settle it — never
+    /// more than a year out, and checked rather than assumed, so the answer is the year whose own month
+    /// count contains the index rather than one derived from a rounding.
+    /// </remarks>
+    private static long HebrewYearOfMonthIndex(long index)
+    {
+        var year = FloorDiv(index * 19L, 235L) + 1L;
+
+        while (HebrewMonthsBeforeYear(year) > index)
+        {
+            year--;
+        }
+
+        while (HebrewMonthsBeforeYear(year + 1L) <= index)
+        {
+            year++;
+        }
+
+        return year;
+    }
+
     private static long HebrewElapsedDays(int year)
     {
-        long monthsElapsed = FloorDiv(235L * year - 234L, 19L);
+        long monthsElapsed = HebrewMonthsBeforeYear(year);
         long partsElapsed = 12084L + 13753L * monthsElapsed;
         long days = 29L * monthsElapsed + FloorDiv(partsElapsed, 25920L);
         // Lo Adu Rosh dehiyya: postpone Tishrei 1 to avoid Sun/Wed/Fri.
@@ -1738,16 +1937,11 @@ internal static class NonIsoCalendars
 
         if (calendar is "hebrew")
         {
-            try
-            {
-                return HebrewCal.IsLeapYear(year) ? 6 : 0;
-            }
-            catch
-            {
-                // Out of .NET range: use algorithmic 19-year cycle
-                // Years 3, 6, 8, 11, 14, 17, 19 of each 19-year cycle are leap years
-                return IsHebrewLeapYearAlgorithmic(year) ? 6 : 0;
-            }
+            // Past the end of .NET's table, the algorithmic 19-year cycle answers: years 3, 6, 8, 11,
+            // 14, 17 and 19 of each cycle are leap years.
+            var hebrew = HebrewCal;
+            var isLeap = SupportsYear(hebrew, year) ? hebrew.IsLeapYear(year) : IsHebrewLeapYearAlgorithmic(year);
+            return isLeap ? 6 : 0;
         }
 
         if (calendar is "chinese" or "dangi")
@@ -1779,24 +1973,35 @@ internal static class NonIsoCalendars
     }
 
     /// <summary>
+    /// How many months every year of <paramref name="calendar"/> holds, or 0 for one whose years differ.
+    /// </summary>
+    /// <remarks>
+    /// Eight of the eleven are the same length every year, which is what lets
+    /// <see cref="TryStepOrdinalMonths"/> divide rather than walk. The three that are not are
+    /// <c>chinese</c>, <c>dangi</c> and <c>hebrew</c>, whose years hold twelve months or thirteen.
+    /// </remarks>
+    private static int UniformMonthsInYear(string calendar) => calendar switch
+    {
+        "persian" or "indian" or "islamic-umalqura" or "islamic-civil" or "islamic-tbla" => 12,
+        "coptic" or "ethiopic" or "ethioaa" => 13,
+        _ => 0,
+    };
+
+    /// <summary>
     /// Gets the number of months in a calendar year.
     /// </summary>
     /// <remarks>
     /// Never below 12: every arm answers 12 or 13 outright, and Calendar.GetMonthsInYear answers 12 or
-    /// 13 for the lunisolar calendars that reach it — or throws for a year outside its range, which the
-    /// catch answers with 12 or 13 too. The value becomes the max of Math.Clamp(month, 1, ...); see the
-    /// type's remarks for what an answer below 1 would cost.
+    /// 13 for the lunisolar calendars that reach it — for a year outside its range the reckoning past
+    /// the end of its table answers 12 or 13 too. The value becomes the max of Math.Clamp(month, 1, ...);
+    /// see the type's remarks for what an answer below 1 would cost.
     /// </remarks>
     private static int GetMonthsInYear(string calendar, Calendar? cal, int year)
     {
-        if (calendar is "persian" or "indian" or "islamic-umalqura" or "islamic-civil" or "islamic-tbla")
+        var uniform = UniformMonthsInYear(calendar);
+        if (uniform != 0)
         {
-            return 12;
-        }
-
-        if (calendar is "coptic" or "ethiopic" or "ethioaa")
-        {
-            return 13;
+            return uniform;
         }
 
         if (calendar is "chinese" or "dangi")
@@ -1805,25 +2010,18 @@ internal static class NonIsoCalendars
             return reckoned?.MonthCount ?? 12;
         }
 
-        if (cal is null)
-        {
-            return 12;
-        }
-
-        try
+        if (cal is not null && SupportsYear(cal, year))
         {
             return cal.GetMonthsInYear(year);
         }
-        catch
-        {
-            // For Hebrew out-of-range, use algorithmic leap year detection
-            if (calendar is "hebrew")
-            {
-                return IsHebrewLeapYearAlgorithmic(year) ? 13 : 12;
-            }
 
-            return 12;
+        // For Hebrew out-of-range, use algorithmic leap year detection
+        if (calendar is "hebrew")
+        {
+            return IsHebrewLeapYearAlgorithmic(year) ? 13 : 12;
         }
+
+        return 12;
     }
 
     /// <summary>
@@ -1836,16 +2034,9 @@ internal static class NonIsoCalendars
     /// </remarks>
     private static int GetDaysInMonthCal(string calendar, Calendar? cal, int year, int month)
     {
-        if (cal is not null)
+        if (cal is not null && SupportsYear(cal, year) && TryGetDaysInMonth(cal, year, month, out var days))
         {
-            try
-            {
-                return cal.GetDaysInMonth(year, month);
-            }
-            catch
-            {
-                // Past the end of the table; fall through to the reckoning below.
-            }
+            return days;
         }
 
         return AlgorithmicDaysInMonth(calendar, year, month);
@@ -2111,15 +2302,7 @@ internal static class NonIsoCalendars
                 return null;
             }
 
-            bool yearIsLeap;
-            try
-            {
-                yearIsLeap = cal.IsLeapYear(year);
-            }
-            catch
-            {
-                yearIsLeap = IsHebrewLeapYearAlgorithmic(year);
-            }
+            var yearIsLeap = SupportsYear(cal, year) ? cal.IsLeapYear(year) : IsHebrewLeapYearAlgorithmic(year);
 
             if (isLeap)
             {
@@ -2176,17 +2359,8 @@ internal static class NonIsoCalendars
         }
 
         // Constrain ordinal month
-        int maxMonths;
-        bool yearInDotNetRange = true;
-        try
-        {
-            maxMonths = cal.IsLeapYear(year) ? 13 : 12;
-        }
-        catch
-        {
-            yearInDotNetRange = false;
-            maxMonths = IsHebrewLeapYearAlgorithmic(year) ? 13 : 12;
-        }
+        var yearInDotNetRange = SupportsYear(cal, year);
+        var maxMonths = (yearInDotNetRange ? cal.IsLeapYear(year) : IsHebrewLeapYearAlgorithmic(year)) ? 13 : 12;
 
         if (string.Equals(overflow, "constrain", StringComparison.Ordinal))
         {
@@ -2198,17 +2372,9 @@ internal static class NonIsoCalendars
         }
 
         // Constrain day
-        int maxDay;
-        try
-        {
-            maxDay = yearInDotNetRange
-                ? cal.GetDaysInMonth(year, ordinalMonth)
-                : HebrewDaysInMonthOrdinal(year, ordinalMonth);
-        }
-        catch
-        {
-            maxDay = HebrewDaysInMonthOrdinal(year, ordinalMonth);
-        }
+        var maxDay = yearInDotNetRange && TryGetDaysInMonth(cal, year, ordinalMonth, out var tableDay)
+            ? tableDay
+            : HebrewDaysInMonthOrdinal(year, ordinalMonth);
 
         if (string.Equals(overflow, "constrain", StringComparison.Ordinal))
         {
@@ -2391,17 +2557,11 @@ internal static class NonIsoCalendars
             return null;
         }
 
-        // Constrain day
-        int maxDay;
-        try
-        {
-            maxDay = cal.GetDaysInMonth(year, ordinalMonth);
-        }
-        catch
-        {
-            // Fallback: use the algorithmic computation, which works for all years.
-            maxDay = PersianAlgorithmicDaysInMonth(year, ordinalMonth);
-        }
+        // Constrain day. The algorithmic computation answers for every year past the end of the table,
+        // and for the one month inside it the table declines.
+        var maxDay = SupportsYear(cal, year) && TryGetDaysInMonth(cal, year, ordinalMonth, out var tableDay)
+            ? tableDay
+            : PersianAlgorithmicDaysInMonth(year, ordinalMonth);
 
         if (string.Equals(overflow, "constrain", StringComparison.Ordinal))
         {
@@ -3282,33 +3442,29 @@ internal static class NonIsoCalendars
             return null;
         }
 
-        // Try UmAlQura calendar first
+        // Try UmAlQura calendar first, for a year its own table covers
         var cal = UmAlQuraCal;
-        try
+        if (SupportsYear(cal, year) && TryGetDaysInMonth(cal, year, ordinalMonth, out var maxDay))
         {
-            // Check if year is in UmAlQura's supported range
-            var minYear = cal.GetYear(cal.MinSupportedDateTime);
-            var maxYear = cal.GetYear(cal.MaxSupportedDateTime);
-
-            if (year >= minYear && year <= maxYear)
+            if (string.Equals(overflow, "constrain", StringComparison.Ordinal))
             {
-                var maxDay = cal.GetDaysInMonth(year, ordinalMonth);
-                if (string.Equals(overflow, "constrain", StringComparison.Ordinal))
-                {
-                    day = System.Math.Clamp(day, 1, maxDay);
-                }
-                else if (day < 1 || day > maxDay)
-                {
-                    return null;
-                }
+                day = System.Math.Clamp(day, 1, maxDay);
+            }
+            else if (day < 1 || day > maxDay)
+            {
+                return null;
+            }
 
+            try
+            {
                 var dt = cal.ToDateTime(year, ordinalMonth, day, 0, 0, 0, 0);
                 return new IsoDate(dt.Year, dt.Month, dt.Day);
             }
-        }
-        catch
-        {
-            // Fall through to islamic-civil
+            catch
+            {
+                // A date inside the year band the calendar still declines to place; fall through to
+                // islamic-civil, which is what the catch this replaced did for it.
+            }
         }
 
         // Fall back to islamic-civil algorithm
@@ -3478,23 +3634,9 @@ internal static class NonIsoCalendars
         if (calendar is "islamic-umalqura")
         {
             var cal = UmAlQuraCal;
-            try
-            {
-                var minYear = cal.GetYear(cal.MinSupportedDateTime);
-                var maxYear = cal.GetYear(cal.MaxSupportedDateTime);
-                if (newYear >= minYear && newYear <= maxYear)
-                {
-                    maxDay = cal.GetDaysInMonth(newYear, newMonth);
-                }
-                else
-                {
-                    maxDay = IslamicCivilDaysInMonth(newYear, newMonth);
-                }
-            }
-            catch
-            {
-                maxDay = IslamicCivilDaysInMonth(newYear, newMonth);
-            }
+            maxDay = SupportsYear(cal, newYear) && TryGetDaysInMonth(cal, newYear, newMonth, out var tableDay)
+                ? tableDay
+                : IslamicCivilDaysInMonth(newYear, newMonth);
         }
         else
         {

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -3617,14 +3617,60 @@ the cases a closed form must not answer — a year the reckoning cannot place, a
 in it, or a step so large no representable date could survive it — and it is interruptible either way, per
 [4.80](#480-a-bulk-month-addition-in-a-lunisolar-calendar-can-be-interrupted-3511).
 
-`hebrew` is unchanged and still walks: its years hold twelve or thirteen months too, but a step there is
-cheap arithmetic rather than an astronomical reckoning, so the walk costs about 1 µs a month.
+`hebrew` walked for one release more, and now counts its own cycle instead — see
+[4.82](#482-adding-months-in-hebrew-counts-the-metonic-cycle-3520).
 
 **What could break:** a `chinese` or `dangi` value produced by a month step of more than about 200,000
 months (some sixteen thousand years), or by any step from a date more than about that far out. Everything
 closer is unchanged, and that is measured rather than asserted: the two reckonings were compared over
 356,326 cases — every 37th day from ISO 1500 to 2400 plus a dozen dates further out, twenty month steps from
 −37 to +1200, and 444 `until` month differences, in both calendars — and they agree on every one.
+
+### 4.82 Adding months in `hebrew` counts the Metonic cycle ([#3520](https://github.com/sebastienros/jint/issues/3520))
+
+`hebrew` was the walk [4.81](#481-adding-months-in-chinese-or-dangi-counts-lunations-3511) left behind, and
+so was every other calendar the engine reads a BCL `Calendar` for. Adding months asked each year in turn how
+many months it held, one step per year crossed — and past the end of that calendar's own table, which for
+`hebrew` is only ISO 1583 to 2239, the question was answered by *catching* the
+`ArgumentOutOfRangeException` the call raises there. So most steps of a long walk cost an exception:
+
+```js
+// 5.0: 552 ms      5.x: 0.2 ms
+Temporal.PlainDate.from('2000-01-01').withCalendar('hebrew').add({ months: 1000000 });
+
+// 5.0: 1.5 s       5.x: 0.1 ms
+Temporal.PlainDate.from('2000-01-01').withCalendar('hebrew').add({ months: 3000000 });
+```
+
+A month difference is measured by walking one month at a time, and every step of *that* walk was an
+addition that walked the years between, so it was quadratic in the span:
+
+```js
+// 5.0: 71 s        5.x: 12 ms
+Temporal.PlainDate.from('2000-01-01').withCalendar('hebrew')
+  .until(Temporal.PlainDate.from('+020000-01-01').withCalendar('hebrew'), { largestUnit: 'month' });
+```
+
+Both are arithmetic now. A Hebrew year holds twelve months or thirteen by the Metonic cycle — 235 months
+every 19 years, with the leap years of a cycle fixed — so the months before a year are a division and the
+year a month index falls in is that division inverted; a calendar whose years all hold the same number of
+months, `persian` among them, divides by that number instead. The year range each backing calendar answers
+for is now read once from its own `MinSupportedDateTime` and `MaxSupportedDateTime` and compared against,
+rather than discovered by catching, which is what removes the exception from every out-of-range *field* read
+too.
+
+**No date moved.** The two reckonings were compared over 483,875 cases — every 37th day from ISO 1500 to
+2400 against twenty month steps, twenty-one dates from ISO −400 to +100000 against twenty-six steps out to
+three million months, 528 `until` and `since` differences, and 126,455 field reads across five calendars —
+and they agree on every one.
+
+**What could break:** an engine that configures a limit and evaluates one of these additions.
+[4.80](#480-a-bulk-month-addition-in-a-lunisolar-calendar-can-be-interrupted-3511) charges `LimitStatements`
+one statement per 256 years stepped, and for `hebrew` and `persian` there are no year steps left to charge,
+so a budget that used to expire on a bulk month addition now returns the date instead — the same reversal
+[4.81](#481-adding-months-in-chinese-or-dangi-counts-lunations-3511) made for `chinese` and `dangi`. A
+calendar a host `ICalendarProvider` answers for still walks, since only the provider knows how many months
+its years hold, and that walk is bounded exactly as before.
 
 ## 5. New in v5
 

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -3618,7 +3618,7 @@ in it, or a step so large no representable date could survive it — and it is i
 [4.80](#480-a-bulk-month-addition-in-a-lunisolar-calendar-can-be-interrupted-3511).
 
 `hebrew` walked for one release more, and now counts its own cycle instead — see
-[4.82](#482-adding-months-in-hebrew-counts-the-metonic-cycle-3520).
+[4.83](#483-adding-months-in-hebrew-counts-the-metonic-cycle-3520).
 
 **What could break:** a `chinese` or `dangi` value produced by a month step of more than about 200,000
 months (some sixteen thousand years), or by any step from a date more than about that far out. Everything
@@ -3626,7 +3626,7 @@ closer is unchanged, and that is measured rather than asserted: the two reckonin
 356,326 cases — every 37th day from ISO 1500 to 2400 plus a dozen dates further out, twenty month steps from
 −37 to +1200, and 444 `until` month differences, in both calendars — and they agree on every one.
 
-### 4.82 Adding months in `hebrew` counts the Metonic cycle ([#3520](https://github.com/sebastienros/jint/issues/3520))
+### 4.83 Adding months in `hebrew` counts the Metonic cycle ([#3520](https://github.com/sebastienros/jint/issues/3520))
 
 `hebrew` was the walk [4.81](#481-adding-months-in-chinese-or-dangi-counts-lunations-3511) left behind, and
 so was every other calendar the engine reads a BCL `Calendar` for. Adding months asked each year in turn how


### PR DESCRIPTION
Fixes #3520 — the half of #3511 that #3515 and #3519 left. Numbers below are from `main` at `f6fa93b`,
one `Evaluate` of one expression statement, on the machine this was developed on.

## What is wrong

`hebrew` was the walk #3519 left behind, and so was every other calendar the engine reads a BCL
`Calendar` for. `add({ months: n })` reached the right month by asking each calendar year in turn how many
months it held, one step per year crossed — and past the end of that calendar's own table, which for
`hebrew` is only ISO 1583 to 2239, that question was answered by **catching** the
`ArgumentOutOfRangeException` the call raises there. So a walk of ten thousand years threw ten thousand
exceptions, which is where its microsecond a month went.

A month difference is measured by walking one month at a time from an estimate, and every step of *that*
walk was an addition that walked the years between. Quadratic in the span:

| on `main` | |
| --- | --- |
| `hebrew` `add({ months: 100000 })` | 57.7 ms |
| `hebrew` `add({ months: 1000000 })` | 552 ms |
| `hebrew` `add({ months: 3000000 })` | 1.47 s |
| `hebrew` `until(…, { largestUnit: 'month' })` over 1,000 years | 177 ms |
| `hebrew` `until(…, { largestUnit: 'month' })` over 18,000 years | **71.0 s** |

That last row is the issue's 122 s, measured here on a faster box; the same call on `chinese` after #3519
is 5.6 ms.

## The fix

**The year range is read rather than discovered.** `[GetYear(MinSupportedDateTime),
GetYear(MaxSupportedDateTime)]` is read once per backing calendar and compared against, in place of the
`try`/`catch` probes in `GetMonthsInYear`, `GetLeapMonthOrdinal`, `GetDaysInMonthCal`, `HebrewDateToIso`
and `PersianDateToIso`. The two places that already computed that band inline for `islamic-umalqura` now
read the cached one.

**Months are counted rather than walked.** A Hebrew year holds twelve months or thirteen by the Metonic
cycle — 235 months every 19 years, with the leap years of a cycle fixed — so `HebrewMonthsBeforeYear` is a
division and the year a month index falls in is that division inverted; both are exact, in `long`, for
every year. A calendar whose years all hold the same number of months (`persian` here) divides by that
number instead. `NonIsoCalendars.TryStepOrdinalMonths` is the whole of it, and it sits beside
`TryStepLunisolarMonths` in the same `else if` chain. The year walk stays as the fallback for the one case
it declines — a landing year no `int` can hold — and, per #3515, it is interruptible either way.

`CalendarDateUntil`'s month lane is not touched. It did not need to be: its cost was its steps' cost, and
each step is now arithmetic.

The middle column is the range compare alone, with the walk still walking, so the two halves can be told
apart:

| | before | range compare | and counting |
| --- | --- | --- | --- |
| `hebrew` `add({ months: 100000 })` | 57.7 ms | 0.4 ms | 0.3 ms |
| `hebrew` `add({ months: 1000000 })` | 552 ms | 2.1 ms | 0.2 ms |
| `hebrew` `add({ months: 3000000 })` | 1.47 s | 2.6 ms | 0.1 ms |
| `persian` `add({ months: 3000000 })` | 0.8 ms | | 0.1 ms |
| `hebrew` `until` over 1,000 years by month | 177 ms | 4.8 ms | 0.7 ms |
| `hebrew` `until` over 18,000 years by month | **71.0 s** | 147 ms | **12.5 ms** |
| `persian` `until` over 18,000 years by month | 14.0 ms | | 6.1 ms |

**The exception was worth far more than the issue estimated.** It records the range compare as "roughly
10×"; measured on its own it is **260×** on the million-month addition and **480×** on the eighteen-thousand-year
difference, because a Hebrew walk of any length spends almost all of its steps outside a table that covers
657 years. Counting the months is the remaining 10× to 25× — and it is the half that takes the *statement
budget* to zero, which is the part a host can observe.

Stopwatch numbers over work three to five orders of magnitude larger than any measurement envelope; **no
`Jint.Benchmark` run is offered and none would say more**.

## One recorded claim held, and one needed a correction

The issue records that `[GetYear(Min), GetYear(Max)]` is *exactly* the throwing boundary on all three
backing calendars. Measured again here, year by year across each band and twenty years past both ends, on
`net472`, `net8.0` and `net10.0`: it holds for every member that takes only a **year** —
`GetMonthsInYear`, `IsLeapYear`, `GetDaysInYear`, `GetLeapMonth` — with zero mismatches, and `ToDateTime`
keeps its `try` for the reason the issue gives (Hebrew 5343 is inside the band and its first four months
begin before `MinSupportedDateTime`).

It does **not** hold for `GetDaysInMonth`, which also validates the month, and one year inside a band holds
fewer months than its calendar nominally does: **Persian 9378** — the year `MaxSupportedDateTime` falls in
— stops at month 10, so `GetDaysInMonth(9378, 11)` throws for a year the band covers. The first draft of
this change let that escape `engine.Evaluate` as a CLR `ArgumentOutOfRangeException`, and the equivalence
sweep below caught it on its first run. Every `GetDaysInMonth` call therefore keeps its catch, in one place
(`TryGetDaysInMonth`), gated on the band: **the band answers for the year, the catch answers for the
month.**

## Evidence

**483,875 compared cases, zero differences.** Both reckonings were run over every 37th day from ISO 1500 to
2400 (8,895 dates) against twenty month steps from −37 to +1200; twenty-one dates from ISO −400 to +100000
against twenty-six steps out to three million months; 528 `until` and `since` differences by `month` and by
`year` in both directions; and 126,455 field reads from ISO 1560 to 2320 plus every table boundary, across
`hebrew`, `persian`, `islamic-umalqura`, `islamic-civil` and `islamic-tbla`. Every line of the two outputs
is byte-identical. The sweep also took 71.6 s on `main` and 12.6 s here.

**Tests** — `Jint.Tests/Runtime/HebrewMonthSteppingTests.cs`, beside the lunisolar file it follows. The work
bound is asserted with a *statement budget*, never a clock: #3515 charges `MaxStatements` one statement per
256 years stepped, so `LimitStatements(2)` is a budget of 512 years walked. Against `main` the five
decisive cases fail and the thirty value-pinning ones pass — which is the same statement as "no answer
changed", made a second way:

```
# main
Failed ABulkMonthAdditionDoesNotWalkYearByYear("hebrew",100000,"+010085-03-13")
Failed ABulkMonthAdditionDoesNotWalkYearByYear("hebrew",300000,"+026255-08-10")
Failed ABulkMonthAdditionDoesNotWalkYearByYear("hebrew",3000000,"+244556-01-22")
Failed ABulkMonthAdditionDoesNotWalkYearByYear("persian",3000000,"+251999-10-18")
Failed AMonthDifferenceDoesNotWalkYearByYear
Failed!  - Failed: 5, Passed: 30, Total: 35   (net472, net8.0, net10.0 alike)

# this branch
Passed!  - Failed: 0, Passed: 35, Total: 35   (net472, net8.0, net10.0 alike)
```

Also asserted there: additivity (`add({months: 250000})` twice reaches `add({months: 500000})`, in both
calendars), that stepping one month at a time reaches where one step reaches from seven starts, four of
which cross or sit past the end of a table, that out-and-back returns where it started, that
`a.add(a.until(b))` is `b`, and ten single steps across a table boundary pinned to the dates `main` gives
them.

**test262** — `102,537 / 0 / 151` of 102,688, which is exactly what `main` scores in the same checkout
(the control figure of `102,541 / 0 / 147` predates `f6fa93b`; four tests moved from passed to skipped
before this branch existed). **The whole solution** is green on `net472`, `net8.0` and `net10.0`.

## One thing this moves rather than adds

#3515's `HostTemporalCalendarConstraintTests` pointed a timeout, a statement budget and a cancelled token at
a `chinese` addition; #3519 retargeted them onto `hebrew`, which was then the walk that remained. There is
no `hebrew` walk to point them at any more, so they move to the lane that will always have one: a calendar
a host `ICalendarProvider` answers for, whose months only the provider can count and are therefore stepped
a year at a time through its two conversions. That lane is reachable from `Jint.Tests.PublicInterface`
without `InternalsVisibleTo` — installing any derived `DefaultCalendarProvider` is what routes every
calendar through it — so it is a stronger host-facing test than the one it replaces, and it already passes
on `main`, which is the point: this change does not weaken that bound, it removes the work the bound was
holding back. The `chinese` case past the closed form's ceiling stays, and one test is new: the engine's own
`hebrew` now answers three million months inside `LimitStatements(2)`, where that walk needs 948.

## Not in this pull request

- **`until`'s remaining 12 ms.** The estimate it starts from is an average month length, which is out by a
  few hundred months over eighteen thousand years, and those months are still stepped one at a time. Each
  step is now arithmetic, so the cost is the ISO→Hebrew conversion at the far end rather than the walk.
- **A Persian boundary case that is not additive** (#3523), found while writing these tests and present on
  `main` identically: from ISO `9999-06-01`, `add({ months: 8 })` gives `+010000-02-01` while eight single
  steps give `+010000-01-31`. Persian year 9378 holds ten months in the table and twelve in Jint's
  reckoning, so a step that stops inside its eleventh materializes a date the table cannot place. This
  change reproduces `main` exactly, including there, and `SupportsYear` gives that fix a single site.

## Migration guide

§4.83, and §4.81's closing paragraph, which said `hebrew` still walks.
