### PR TITLE
Temporal: a persian year the .NET table stops inside is measured by the calendar

### DIFF
--- a/Jint.Tests/Runtime/CalendarBandEdgeTests.cs
+++ b/Jint.Tests/Runtime/CalendarBandEdgeTests.cs
@@ -1,0 +1,212 @@
+#nullable enable
+
+using System.Text;
+using Jint.Native.Temporal;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// A backing <see cref="System.Globalization.Calendar"/> whose table stops part-way through one of its
+/// own years reports that part as the whole year. These pin that the engine does not believe it, and that
+/// a month addition therefore stays additive across the end of the table.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>PersianCalendar</c> is cut off by <c>DateTime</c> rather than by its own data: its
+/// <c>MaxSupportedDateTime</c> is ISO 9999-12-31, which falls inside Persian 9378, and every question
+/// about that year comes back truncated — ten months rather than twelve, 289 days rather than 365, and a
+/// tenth month thirteen days long rather than thirty. A step that stopped inside that month had its day
+/// clamped to the thirteenth and carried the loss forward, while a step that flew over the month kept it,
+/// so eight months in one go and eight one at a time landed a day apart
+/// (<see href="https://github.com/sebastienros/jint/issues/3523"/>).
+/// </para>
+/// <para>
+/// <b>How additivity is asserted.</b> Only from a day no month can be short of. Persian months hold 29 to
+/// 31 days and Hebrew months 29 or 30, so a start on day 29 or earlier is never clamped by any month it
+/// can land on, and bulk and stepped addition have to agree exactly. Above that they legitimately diverge
+/// in every calendar — ISO 2024-01-31 plus two months is March 31, and one month twice is March 29 — so
+/// those starts are skipped rather than asserted.
+/// </para>
+/// </remarks>
+public class CalendarBandEdgeTests
+{
+    /// <summary>The issue's own repro: eight months in one step, and eight single steps.</summary>
+    [Test]
+    public void EightMonthsInOneStepAndEightSingleStepsAgreeAtTheEndOfThePersianTable()
+    {
+        var engine = new Engine();
+
+        var bulk = engine.Evaluate(
+            "Temporal.PlainDate.from('9999-06-01').withCalendar('persian').add({ months: 8 }).toString()").AsString();
+
+        var stepped = engine.Evaluate(
+            """
+            (() => {
+                let d = Temporal.PlainDate.from('9999-06-01').withCalendar('persian');
+                for (let i = 0; i < 8; i++) { d = d.add({ months: 1 }); }
+                return d.toString();
+            })()
+            """).AsString();
+
+        stepped.Should().Be(bulk);
+    }
+
+    /// <summary>
+    /// Every day across the last thirty years the table covers and the first thirty past it, stepped by
+    /// one month at a time and in one go, forwards and backwards.
+    /// </summary>
+    /// <remarks>
+    /// The window is dense rather than sampled on purpose: the seam is one day wide, and a stride wide
+    /// enough to be cheap is a stride wide enough to step over it.
+    /// </remarks>
+    [TestCase("persian", 9969, 62)]
+    [TestCase("hebrew", 1553, 62)]
+    [TestCase("hebrew", 2209, 62)]
+    public void ABulkMonthAdditionMatchesSingleStepsAcrossABandEdge(string calendar, int firstIsoYear, int isoYears)
+    {
+        var failures = new StringBuilder();
+        var cases = 0;
+        var failed = 0;
+        var skipped = 0;
+
+        var first = TemporalHelpers.IsoDateToDays(firstIsoYear, 1, 1);
+        var last = TemporalHelpers.IsoDateToDays(firstIsoYear + isoYears, 1, 1);
+
+        for (var epochDay = first; epochDay < last; epochDay++)
+        {
+            var start = TemporalHelpers.DaysToIsoDate(epochDay);
+            if (NonIsoCalendars.IsoToCalendarDate(calendar, in start).Day > 29)
+            {
+                skipped++;
+                continue;
+            }
+
+            foreach (var sign in Signs)
+            {
+                var stepped = start;
+                for (var months = 1; months <= 13; months++)
+                {
+                    cases++;
+                    stepped = NonIsoCalendars.CalendarDateAdd(calendar, in stepped, 0, sign, "constrain");
+                    var bulk = NonIsoCalendars.CalendarDateAdd(calendar, in start, 0, sign * months, "constrain");
+
+                    if (bulk == stepped)
+                    {
+                        continue;
+                    }
+
+                    failed++;
+                    if (failures.Length < 2000)
+                    {
+                        failures.Append(Show(start)).Append(sign < 0 ? " - " : " + ").Append(months)
+                            .Append(" months: ").Append(Show(bulk)).Append(" in one go, ").Append(Show(stepped))
+                            .Append(" one at a time").AppendLine();
+                    }
+                }
+            }
+        }
+
+        cases.Should().BeGreaterThan(500_000, "the window has to be dense enough to contain the seam");
+        skipped.Should().BeGreaterThan(0, "days a short month can clamp are deliberately not asserted");
+        failures.ToString().Should().BeEmpty("{0} of {1} cases disagreed, the first of them being", failed, cases);
+    }
+
+    /// <summary>
+    /// A difference measured across the edge and added back reaches where it was measured to, in every
+    /// unit a date difference can be largest in.
+    /// </summary>
+    [TestCase("persian", "9999-01-15", "+010000-07-20")]
+    [TestCase("persian", "9999-06-01", "+010000-02-01")]
+    [TestCase("persian", "9998-11-30", "+010001-04-09")]
+    [TestCase("persian", "9999-12-31", "+010000-01-02")]
+    [TestCase("hebrew", "1582-06-14", "1584-02-02")]
+    [TestCase("hebrew", "2239-01-15", "2241-08-08")]
+    public void ADifferenceAcrossABandEdgeAddsBackToWhereItWasMeasuredTo(string calendar, string one, string two)
+    {
+        var engine = new Engine();
+
+        foreach (var largestUnit in LargestUnits)
+        {
+            var script =
+                $$"""
+                (() => {
+                    const a = Temporal.PlainDate.from('{{one}}').withCalendar('{{calendar}}');
+                    const b = Temporal.PlainDate.from('{{two}}').withCalendar('{{calendar}}');
+                    return a.add(a.until(b, { largestUnit: '{{largestUnit}}' })).toString();
+                })()
+                """;
+
+            engine.Evaluate(script).AsString().Should()
+                .Be($"{two}[u-ca={calendar}]", "a.until(b) in {0} added back to a", largestUnit);
+        }
+    }
+
+    /// <summary>
+    /// The year the Persian table stops inside holds the twelve months and 365 days the calendar gives
+    /// it, not the ten months and 289 days the table has room for.
+    /// </summary>
+    [Test]
+    public void ThePartialYearAtTheEndOfThePersianTableIsAnsweredByTheReckoning()
+    {
+        var engine = new Engine();
+
+        var fields = engine.Evaluate(
+            """
+            (() => {
+                const d = Temporal.PlainDate.from('9999-12-31').withCalendar('persian');
+                return [d.year, d.monthCode, d.day, d.monthsInYear, d.daysInMonth, d.daysInYear].join(' ');
+            })()
+            """).AsString();
+
+        fields.Should().Be("9378 M10 13 12 30 365");
+    }
+
+    /// <summary>
+    /// The year before it is one the table holds whole, and stays the table's: 9377 is a leap year of 366
+    /// days there and a common year of 365 by the arithmetic reckoning, so this says which one answered.
+    /// </summary>
+    [Test]
+    public void TheLastWholeYearThePersianTableHoldsIsStillReadFromTheTable()
+    {
+        var engine = new Engine();
+
+        var fields = engine.Evaluate(
+            """
+            (() => {
+                const d = Temporal.PlainDate.from('9998-06-01').withCalendar('persian');
+                return [d.year, d.monthCode, d.day, d.daysInYear, d.inLeapYear].join(' ');
+            })()
+            """).AsString();
+
+        fields.Should().Be("9377 M03 15 366 true");
+    }
+
+    /// <summary>
+    /// The eleventh and twelfth months of that year, and the second half of its tenth, are dates the
+    /// calendar holds even though the table has no room for them, so <c>reject</c> has nothing to reject.
+    /// </summary>
+    [TestCase(10, 20)]
+    [TestCase(11, 1)]
+    [TestCase(12, 29)]
+    public void ADayThePersianTableHasNoRoomForIsStillADayOfTheCalendar(int month, int day)
+    {
+        var engine = new Engine();
+
+        var round = engine.Evaluate(
+            $$"""
+            (() => {
+                const d = Temporal.PlainDate.from(
+                    { calendar: 'persian', year: 9378, month: {{month}}, day: {{day}} }, { overflow: 'reject' });
+                return [d.year, d.month, d.day].join(' ');
+            })()
+            """).AsString();
+
+        round.Should().Be($"9378 {month} {day}");
+    }
+
+    private static readonly int[] Signs = [1, -1];
+
+    private static readonly string[] LargestUnits = ["year", "month", "week", "day"];
+
+    private static string Show(in IsoDate date) => $"{date.Year:D4}-{date.Month:D2}-{date.Day:D2}";
+}

--- a/Jint.Tests/Runtime/HebrewMonthSteppingTests.cs
+++ b/Jint.Tests/Runtime/HebrewMonthSteppingTests.cs
@@ -74,10 +74,9 @@ public class HebrewMonthSteppingTests
     /// own table.
     /// </summary>
     /// <remarks>
-    /// The Persian starts stay clear of ISO 9999, where the two spellings disagree by a day and have
-    /// since before any of this: the calendar's last year, 9378, holds ten months rather than twelve, so
-    /// a step that stops inside its eleventh materializes a date the table cannot place and the
-    /// arithmetic reckoning answers for, one day off what the table would have said.
+    /// The Persian start at ISO 9999-06-01 is the one the two spellings disagreed on until the year the
+    /// table stops inside stopped being read as a ten-month year; <see cref="CalendarBandEdgeTests"/>
+    /// sweeps the window it sits in day by day.
     /// </remarks>
     [TestCase("hebrew", "2000-01-01")]
     [TestCase("hebrew", "1582-11-30")]
@@ -85,6 +84,7 @@ public class HebrewMonthSteppingTests
     [TestCase("hebrew", "+010000-06-06")]
     [TestCase("persian", "2000-01-01")]
     [TestCase("persian", "9000-06-01")]
+    [TestCase("persian", "9999-06-01")]
     [TestCase("persian", "+010500-06-06")]
     public void SteppingByOneMonthAtATimeReachesTheSamePlace(string calendar, string start)
     {
@@ -184,8 +184,8 @@ public class HebrewMonthSteppingTests
     /// <summary>
     /// One step across the end of a backing calendar's table, which is where the year range the walk used
     /// to discover by catching <c>ArgumentOutOfRangeException</c> is now compared against. The Hebrew
-    /// table runs to ISO 2239-09-29 and starts at 1583-01-01; the Persian one stops in the middle of its
-    /// last year, 9378, which holds ten months rather than twelve.
+    /// table runs to ISO 2239-09-29 and starts at 1583-01-01; the Persian one stops in the middle of
+    /// 9378, which is why the band leaves that year out and the reckoning answers for it.
     /// </summary>
     [TestCase("hebrew", "1583-01-01", -13, "1581-12-12")]
     [TestCase("hebrew", "1583-01-01", -1, "1582-12-02")]

--- a/Jint/Native/Temporal/NonIsoCalendars.cs
+++ b/Jint/Native/Temporal/NonIsoCalendars.cs
@@ -47,35 +47,74 @@ internal static class NonIsoCalendars
     private static YearBand? _umAlQuraYears;
 
     /// <summary>
-    /// The years a backing <see cref="Calendar"/> answers for, read from the range it states itself.
+    /// The whole years a backing <see cref="Calendar"/> answers for, read from the range it states itself.
     /// </summary>
     [StructLayout(LayoutKind.Auto)]
     private readonly record struct YearBand(int Min, int Max)
     {
         public bool Covers(int year) => year >= Min && year <= Max;
 
-        public static YearBand Of(Calendar cal)
-            => new(cal.GetYear(cal.MinSupportedDateTime), cal.GetYear(cal.MaxSupportedDateTime));
+        /// <summary>
+        /// The band <paramref name="cal"/> states, with a boundary year it stops inside left out of it.
+        /// </summary>
+        /// <remarks>
+        /// A table cut off mid-year reports the part it holds as the whole year, and does so
+        /// consistently: <c>PersianCalendar</c> ends at ISO 9999-12-31 because <c>DateTime</c> does, and
+        /// answers for the Persian year that falls in — 9378 — with ten months, 289 days and a tenth
+        /// month thirteen days long. Nothing the table says contradicts any of it, so the only way to
+        /// notice is to ask the calendar's own reckoning how many months that year holds and see whether
+        /// the table can state a length for the last of them. Hebrew and Um al-Qura both end where their
+        /// data ends, on a year boundary, and are unchanged by this
+        /// (https://github.com/sebastienros/jint/issues/3523).
+        /// </remarks>
+        public static YearBand Of(string calendar, Calendar cal)
+        {
+            var min = cal.GetYear(cal.MinSupportedDateTime);
+            var max = cal.GetYear(cal.MaxSupportedDateTime);
+
+            if (min < max && !HoldsWholeYear(calendar, cal, min))
+            {
+                min++;
+            }
+
+            if (min < max && !HoldsWholeYear(calendar, cal, max))
+            {
+                max--;
+            }
+
+            return new(min, max);
+        }
+
+        private static bool HoldsWholeYear(string calendar, Calendar cal, int year)
+            => TryGetDaysInMonth(cal, year, GetMonthsInYear(calendar, cal: null, year), out _);
     }
 
     /// <summary>
-    /// Whether <paramref name="cal"/>'s own table covers <paramref name="year"/> — the question every
-    /// year-taking <see cref="Calendar"/> member below used to be asked by calling it and catching the
-    /// <see cref="ArgumentOutOfRangeException"/> it raises outside its range.
+    /// Whether <paramref name="cal"/>'s own table covers <paramref name="year"/> from its first month to
+    /// its last — the question every year-taking <see cref="Calendar"/> member below used to be asked by
+    /// calling it and catching the <see cref="ArgumentOutOfRangeException"/> it raises outside its range.
     /// </summary>
     /// <remarks>
-    /// <c>[GetYear(MinSupportedDateTime), GetYear(MaxSupportedDateTime)]</c> is exactly the band in which
-    /// <c>GetMonthsInYear</c>, <c>IsLeapYear</c>, <c>GetDaysInYear</c>, <c>GetLeapMonth</c> and
-    /// <c>GetDaysInMonth</c> (for a month that year holds) succeed on all three backing calendars: they
-    /// throw at <c>Min − 1</c> and <c>Max + 1</c> and nowhere inside, measured year by year across each
-    /// band and twenty years past both ends on <c>net472</c>, <c>net8.0</c> and <c>net10.0</c>. So the
-    /// comparison answers what the catch answered, and the walks below cross tens of thousands of years
-    /// outside the band, where an exception apiece was most of what a month step cost
+    /// <c>[GetYear(MinSupportedDateTime), GetYear(MaxSupportedDateTime)]</c>, less a boundary year the
+    /// table stops inside, is exactly the band in which <c>GetMonthsInYear</c>, <c>IsLeapYear</c>,
+    /// <c>GetDaysInYear</c>, <c>GetLeapMonth</c> and <c>GetDaysInMonth</c> (for a month that year holds)
+    /// answer for the calendar rather than for the table: they throw at <c>Min − 1</c> and <c>Max + 1</c>
+    /// and nowhere inside, measured year by year across each band and twenty years past both ends on
+    /// <c>net472</c>, <c>net8.0</c> and <c>net10.0</c>. So the comparison answers what the catch
+    /// answered, and the walks below cross tens of thousands of years outside the band, where an
+    /// exception apiece was most of what a month step cost
     /// (https://github.com/sebastienros/jint/issues/3520).
     /// <para>
-    /// <c>ToDateTime</c> is <em>not</em> one of them and keeps its <c>try</c>: Hebrew 5343 is inside the
-    /// band and its first four months still begin before <c>MinSupportedDateTime</c>, so a year the band
-    /// covers can still hold a date the calendar declines to place.
+    /// It says which reckoning knows how long a year and its months are, <em>not</em> where a date sits:
+    /// the table placed every ISO date it covers and goes on placing them, so a Persian date in 9378 that
+    /// the table can still put somewhere keeps the table's answer and round-trips back to the same
+    /// fields. What changed is only that its month is no longer thirteen days long.
+    /// </para>
+    /// <para>
+    /// <c>ToDateTime</c> is not one of the members above and keeps its <c>try</c>: Hebrew 5343 holds
+    /// twelve months the table can measure and is inside the band, and its first four still begin before
+    /// <c>MinSupportedDateTime</c>, so a year the band covers can hold a date the calendar declines to
+    /// place.
     /// </para>
     /// </remarks>
     private static bool SupportsYear(Calendar cal, int year) => YearsOf(cal).Covers(year);
@@ -86,10 +125,10 @@ internal static class NonIsoCalendars
     /// </summary>
     /// <remarks>
     /// <see cref="SupportsYear"/> answers for the year, which is the dimension a walk crosses by the
-    /// thousand. The month is the one it cannot answer for: a Hebrew common year has no thirteenth
-    /// month, and one year inside a band holds fewer months than its calendar nominally does — Persian
-    /// 9378, the year <c>MaxSupportedDateTime</c> falls in, stops at month 10. So this call keeps the
-    /// catch, and every caller has a reckoning of its own for what it declines.
+    /// thousand. The month is the one it cannot answer for: a Hebrew common year has no thirteenth month.
+    /// So this call keeps the catch, and every caller has a reckoning of its own for what it declines —
+    /// including <see cref="YearBand.Of"/>, which decides what a whole year is by asking it for the last
+    /// month of one.
     /// </remarks>
     private static bool TryGetDaysInMonth(Calendar cal, int year, int month, out int days)
     {
@@ -110,24 +149,32 @@ internal static class NonIsoCalendars
     {
         if (ReferenceEquals(cal, _hebrewCalendar))
         {
-            _hebrewYears ??= YearBand.Of(cal);
-            return _hebrewYears.Value;
+            return _hebrewYears ??= YearBand.Of("hebrew", cal);
         }
 
         if (ReferenceEquals(cal, _persianCalendar))
         {
-            _persianYears ??= YearBand.Of(cal);
-            return _persianYears.Value;
+            return _persianYears ??= YearBand.Of("persian", cal);
         }
 
         if (ReferenceEquals(cal, _umAlQuraCalendar))
         {
-            _umAlQuraYears ??= YearBand.Of(cal);
-            return _umAlQuraYears.Value;
+            return _umAlQuraYears ??= YearBand.Of("islamic-umalqura", cal);
         }
 
-        return YearBand.Of(cal);
+        return YearBand.Of(NameOf(cal), cal);
     }
+
+    /// <summary>
+    /// Which calendar a backing <see cref="Calendar"/> is, for an instance that reached
+    /// <see cref="YearsOf"/> without being one of the three it remembers.
+    /// </summary>
+    private static string NameOf(Calendar cal) => cal switch
+    {
+        HebrewCalendar => "hebrew",
+        PersianCalendar => "persian",
+        _ => "islamic-umalqura",
+    };
 
     // Epoch day constants (days since Unix epoch 1970-01-01)
     // Coptic epoch: Coptic year 1, month 1, day 1 = proleptic Gregorian August 29, 284 CE
@@ -2504,11 +2551,20 @@ internal static class NonIsoCalendars
         var year = cal.GetYear(dt);
         var ordinalMonth = cal.GetMonth(dt);
         var day = cal.GetDayOfMonth(dt);
-        var isLeapYear = cal.IsLeapYear(year);
+
+        // Where this date sits is the table's to say, since the table is what placed it. How long its
+        // month and its year are is not, for the year the table stops inside: 9378 answers with ten
+        // months, 289 days and a tenth month thirteen days long, which is DateTime's end rather than the
+        // calendar's, and a month reported thirteen days long is a month a step clamps its day against
+        // (https://github.com/sebastienros/jint/issues/3523).
+        var wholeYear = SupportsYear(cal, year);
+        var isLeapYear = wholeYear ? cal.IsLeapYear(year) : IsPersianLeapYearAlgorithmic(year);
+        var daysInMonth = wholeYear
+            ? cal.GetDaysInMonth(year, ordinalMonth)
+            : PersianAlgorithmicDaysInMonth(year, ordinalMonth);
+        var daysInYear = wholeYear ? cal.GetDaysInYear(year) : (isLeapYear ? 366 : 365);
 
         var monthCode = $"M{ordinalMonth:D2}";
-        var daysInMonth = cal.GetDaysInMonth(year, ordinalMonth);
-        var daysInYear = cal.GetDaysInYear(year);
 
         return new CalendarDate(year, ordinalMonth, monthCode, day, false, 12, daysInMonth, daysInYear, isLeapYear);
     }
@@ -2557,8 +2613,10 @@ internal static class NonIsoCalendars
             return null;
         }
 
-        // Constrain day. The algorithmic computation answers for every year past the end of the table,
-        // and for the one month inside it the table declines.
+        // Constrain day. The algorithmic computation answers for every year past the last whole one the
+        // table holds, which includes the partial year at the end of it: there the table's month lengths
+        // are DateTime's end rather than the calendar's. The placement below still tries the table
+        // first, so a day it can still put somewhere keeps the table's answer.
         var maxDay = SupportsYear(cal, year) && TryGetDaysInMonth(cal, year, ordinalMonth, out var tableDay)
             ? tableDay
             : PersianAlgorithmicDaysInMonth(year, ordinalMonth);

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -3848,6 +3848,43 @@ gives when it is the only one in the process. An engine that has installed its o
 longer shares operator resolutions with any other engine, so it resolves each `(operator, left, right)` triple
 once for itself rather than once for the process; an engine on the stock converter is unaffected, and shares
 with every stock engine that coerces the way it does.
+
+### 4.87 A `persian` year the .NET table stops inside is measured by the calendar ([#3523](https://github.com/sebastienros/jint/issues/3523))
+
+`PersianCalendar` ends at ISO 9999-12-31 because `DateTime` does, not because the Persian calendar does, and
+that date falls inside Persian year 9378. Asked about that year, the table answered with the part it holds —
+ten months, 289 days, and a tenth month thirteen days long — and answered consistently, so nothing it said
+gave the truncation away. A month step that stopped inside that tenth month had its day clamped to the
+thirteenth and carried the loss forward; one that flew over the month kept the day. So the two spellings of
+the same addition parted:
+
+```js
+const p = Temporal.PlainDate.from('9999-06-01').withCalendar('persian');
+
+// 5.0: +010000-02-01   5.x: +010000-02-01
+p.add({ months: 8 });
+
+// 5.0: +010000-01-31   5.x: +010000-02-01
+let d = p; for (let i = 0; i < 8; i++) { d = d.add({ months: 1 }); }
+```
+
+The year range each backing calendar is trusted for now covers only the years its table holds *whole*, so
+9378's month count and month lengths come from the same arithmetic reckoning that already answered for every
+year past it. Where a date **sits** is unchanged: the table placed every ISO date it covers and still does.
+
+**What could break**, all of it inside Persian 9378 and nowhere else:
+
+- `daysInMonth` for a date in its tenth month is `30` rather than `13`, and `daysInYear` for any date in the
+  year is `365` rather than `289` — ISO 9999-03-18 to 9999-12-31, 289 days in all;
+- days 14 to 30 of that tenth month are dates now. They used to constrain to ISO 9999-12-31 and to be
+  rejected under `overflow: 'reject'`; they now place at ISO +010000-01-02 through +010000-01-18;
+- an addition that lands in one of them lands there rather than collapsing onto ISO 9999-12-31, and a
+  difference measured across the seam no longer comes back with the mixed-sign day count that collapse
+  produced.
+
+**No date moved, and no other calendar changed.** Measured before and after over 417,136 field reads, 14.5
+million additions, 22,568 field-to-ISO conversions and 580,544 differences across seven calendars: the only
+answers that differ are the ones listed above.
 ## 5. New in v5
 
 Everything in the table below is opt-in: nothing in it is installed unless the host asks for it, so


### PR DESCRIPTION
Fixes #3523. Present on `main` today at `2255b5c9` — #3525 landed after the issue was filed and touched the
one site the issue names, and reproduces it unchanged.

## What is wrong

`PersianCalendar` ends at ISO 9999-12-31 because `DateTime` does, not because the Persian calendar does, and
that date falls inside Persian year 9378. Asked about that year the table answers with the part it holds —
**ten months, 289 days, and a tenth month thirteen days long** — and answers *consistently*: `GetMonthsInYear`
says 10, `GetDaysInYear` says 289, `GetDaysInMonth(9378, 10)` says 13 and `GetDayOfYear(MaxSupportedDateTime)`
says 289. Nothing the table says contradicts anything else it says, which is why a truncated year is invisible
from inside it.

A month step that *stopped* inside that tenth month therefore had its day clamped to the thirteenth and
carried the loss forward, while a step that flew over the month kept it:

```js
const p = Temporal.PlainDate.from('9999-06-01').withCalendar('persian');   // 9378-M03-14

p.add({ months: 8 });                                              // +010000-02-01
let d = p; for (let i = 0; i < 8; i++) { d = d.add({ months: 1 }); }  // +010000-01-31
```

Steps +1 to +7 agree; the two spellings part at +8 and stay a day apart after it. Swept day by day over the
last thirty years the table covers and the first thirty past it, **2,496 of 560,976 additions disagreed**, and
the stepped route collapses hundreds of distinct starts onto the same answer:

```
9998-12-31 + 13 months: 10000-02-01 in one go, 10000-01-31 one at a time
9999-01-01 + 13 months: 10000-02-02 in one go, 10000-01-31 one at a time
9999-01-02 + 13 months: 10000-02-03 in one go, 10000-01-31 one at a time
…
```

`until` was collateral: a difference measured across the seam came back **mixed-sign**, which no Temporal
duration may be — `persian` from ISO +010000-02-16 back to +010000-01-07 answered `-1 month` and `+7 days`,
because the intermediate the month walk left off at had been clamped onto 9999-12-31.

## The fix

**The band a backing `Calendar` is trusted for now covers only the years its table holds whole.** #3525's
`SupportsYear` is still the one site that decides which reckoning answers for a year; `YearBand.Of` now trims
a boundary year off the band when the table cannot state a length for the last month that year holds — asked
of the calendar's *own* reckoning, which is the only thing the table's self-consistent account can be checked
against. So Persian 9378's month count and month lengths come from the same arithmetic reckoning that already
answered for every year past it, and its tenth month is thirty days long.

The issue's other option — asking the table how many months a year holds — was rejected: it would have made
9378 a ten-month year, so a month step would skip its eleventh and twelfth months entirely, some fifty-nine
days at a stride.

**Where a date sits is not what this decides.** The table placed every ISO date it covers and still does, so
the placement in `PersianDateToIso` still tries `ToDateTime` first and falls to the reckoning only for a date
the table has no room for. That is what keeps `fields → ISO → fields` the identity, which is the property
additivity actually needs, and it is why **no date moved**.

The one other change is that `PersianToCalendarDate` no longer reports the table's `daysInMonth` and
`daysInYear` for a year it stops inside — a date whose fields the engine reports has to be a date whose
arithmetic the engine performs (#3483), and 289 days in a twelve-month year was neither.

Hebrew and Um al-Qura both end where their *data* ends, on a year boundary, and the trim is a no-op for them:
Hebrew 5343 begins before `MinSupportedDateTime` but still answers with twelve months the table can measure,
so it stays in the band.

## What changed, measured

Every observable answer was dumped before and after, on `net8.0`, and diffed:

| | cases | lines that differ |
| --- | --- | --- |
| field reads (7 calendars, daily across each band edge) | 417,136 | 578 — all `persian`, all in 9378 |
| `add` (years × months × overflow) | 14,517,516 | 1,260 — all `persian`, all landing in 9378-M10 |
| fields → ISO (`constrain` and `reject`, boundary years) | 22,568 | 72 — `persian` 9378-M10 days 14–31 |
| `until` (4 largest units, 8 spans) | 580,544 | 30 — 5 `persian` differences at the seam |

Everything that differs is inside Persian 9378 and nowhere else:

- **no date moved** — year, ordinal month, monthCode, day, leap-month and leap-year came back identical on
  every one of the 417,136 field reads, including all 289 in 9378;
- `daysInMonth` in its tenth month is 30 rather than 13 and `daysInYear` anywhere in it is 365 rather than 289
  (ISO 9999-03-18 to 9999-12-31);
- days 14 to 30 of that tenth month are dates now — they used to constrain onto ISO 9999-12-31 and to be
  rejected under `overflow: 'reject'`, and now place at ISO +010000-01-02 through +010000-01-18;
- the five `until` differences all lose the mixed sign described above.

No other calendar's answers changed: `hebrew`, `islamic-umalqura`, `islamic-civil`, `chinese`, `coptic` and
`indian` are byte-identical across all four dumps.

## Tests

`Jint.Tests/Runtime/CalendarBandEdgeTests.cs`, which fails on unmodified `main` in four of its fourteen cases
and passes here:

- the issue's own repro;
- **the seam sweep** — every ISO day across the last thirty in-band years and the first thirty out-of-band
  ones, stepped one month at a time and in one go, forwards and backwards, thirteen months each way.
  `persian`: 560,976 cases, 2,496 disagreeing on `main`, none here. The Hebrew band edges get the identical
  sweep — 578,214 cases at the bottom and 578,188 at the top — and report nothing before *or* after, which is
  what says the shape does not hide there. #3525's sweep stepped by 37 days and could step over a seam one day
  wide; this one is dense on purpose. Only starts on day 29 or earlier are asserted, since a start above that
  legitimately diverges in every calendar (ISO 2024-01-31 plus two months is March 31, and one month twice is
  March 29);
- `a.add(a.until(b))` reaching `b` across each edge, in all four largest units;
- the partial year's fields, and the whole year before it still being read from the table — 9377 is a leap
  year of 366 days there and a common year of 365 by the reckoning, so the assertion says which one answered.

`Jint.Tests` is green on `net472`, `net8.0` and `net10.0`; `Jint.Tests.PublicInterface`, `Jint.Tests.CommonScripts`
and `Jint.Tests.SourceGenerators` too. **test262: 102,537 passed / 0 failed / 151 skipped of 102,688**, the
control figure exactly.

No benchmark is offered and none would say anything: the change is a comparison against two cached `int`s on a
path that already made one.

## Migration guide

§4.87, at the end of chapter 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014W5mbjGhyvgAS4pivXoc4S
