### PR TITLE
Intl: a number's digits are computed once, for every style and every notation

### DIFF
--- a/Jint.Tests/Runtime/IntlNumberFormatPartsTests.cs
+++ b/Jint.Tests/Runtime/IntlNumberFormatPartsTests.cs
@@ -67,7 +67,16 @@ public class IntlNumberFormatPartsTests
         "{ notation: 'scientific' }",
         "{ notation: 'engineering' }",
         "{ notation: 'compact' }",
-        "{ notation: 'compact', compactDisplay: 'long' }"
+        "{ notation: 'compact', compactDisplay: 'long' }",
+        // https://tc39.es/ecma402/#sec-partitionnumberpattern scales the value by
+        // https://tc39.es/ecma402/#sec-computeexponent and then runs FormatNumericToString over the
+        // mantissa, so a digit option applies to a notation's number exactly as it applies to any other
+        "{ notation: 'scientific', maximumSignificantDigits: 2 }",
+        "{ notation: 'engineering', minimumSignificantDigits: 4 }",
+        "{ notation: 'compact', maximumSignificantDigits: 4 }",
+        "{ notation: 'compact', compactDisplay: 'long', minimumSignificantDigits: 3 }",
+        "{ notation: 'compact', maximumFractionDigits: 2 }",
+        "{ notation: 'scientific', signDisplay: 'exceptZero' }"
     ];
 
     private const string Values =
@@ -75,15 +84,23 @@ public class IntlNumberFormatPartsTests
         // values ToIntlMathematicalValue reads exactly, which no double holds: a BigInt, an integer
         // string past 2^53, and a decimal string with more significant digits than a double carries
         + "987654321987654321n, -987654321987654321n, '987654321987654321', '1.00000000000000012', "
-        // whole doubles past 2^63, where a cast to long saturates rather than answers
-        + "1e21, 1e25]";
+        // whole doubles past 2^63, where a cast to long saturates rather than answers, and one past
+        // 10^15, where a .NET custom format string stops writing the digits Number::toString kept
+        + "1e21, 1e25, 12345678901234567890, 1e300]";
 
     /// <summary>
     /// The defect: <c>format</c> transliterated and <c>formatToParts</c> did not, so
     /// <c>new Intl.NumberFormat('en', { numberingSystem: 'arab' })</c> wrote <c>"١,٢٣٤٫٥"</c> from one lane
     /// and <c>"1,234.5"</c> from the other. The grid asserts the join outright, so it also stands over the
     /// four disagreements that had nothing to do with digits — a unit pattern's prefix, a currency's sign,
-    /// scientific notation of zero, and a non-finite value's style.
+    /// scientific notation of zero, and a non-finite value's style — and over the four the digit lanes
+    /// added: fifteen significant digits under the decimal style, a saturated <c>long</c> under compact, a
+    /// significant-digit option under a notation, and a notation's sign display.
+    /// <para>
+    /// <c>format</c> is now the concatenation itself rather than a second assembly of the same characters,
+    /// so what the grid asserts is that this one assembly reaches every combination in it without throwing
+    /// or dropping a part. The exact strings the four defects produced are asserted separately, below.
+    /// </para>
     /// </summary>
     [Test]
     public void PartsConcatenateToFormat()
@@ -920,6 +937,158 @@ public class IntlNumberFormatPartsTests
         const string Usd =
             "new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumSignificantDigits: 2 })";
         Format(Usd, "1234n").Should().Be("$1,200").And.Be(Format(Usd, "1234"));
+    }
+
+    /// <summary>
+    /// A Number's digits are the seventeen <c>Number::toString</c> can write, in the string lane as much
+    /// as in the parts lane: https://tc39.es/ecma402/#sec-tointlmathematicalvalue reads a Number by
+    /// parsing that string, and never by rounding it again.
+    /// </summary>
+    /// <remarks>
+    /// The defect: <c>FormatDecimal</c> handed the value to <c>double.ToString("#,##0.###")</c>, and a
+    /// .NET custom numeric format string rounds at fifteen significant digits. So
+    /// <c>format(12345678901234567890)</c> wrote <c>"12,345,678,901,234,600,000"</c> against the parts'
+    /// <c>"12,345,678,901,234,567,000"</c> — and <c>style: "unit"</c> reported the first, because
+    /// <c>FormatUnit</c> formatted its number with <c>FormatDecimal</c>.
+    /// </remarks>
+    [Test]
+    public void TheStringLaneKeepsEverySignificantDigitTheValueHas()
+    {
+        // 12345678901234567890 as a decimal literal does not parse to the same double on every target
+        // framework this builds for, so the value is written as the double the issue is about — the one
+        // Number::toString spells with seventeen significant digits and .NET's "#,##0.###" with fifteen.
+        const string Value = "1.2345678901234567e19";
+        _engine.Evaluate($"({Value}).toString()").AsString().Should().Be("12345678901234567000");
+
+        const string Expected = "12,345,678,901,234,567,000";
+        const string Plain = "new Intl.NumberFormat('en-US')";
+        Format(Plain, Value).Should().Be(Expected);
+        Join(Plain, Value).Should().Be(Expected);
+
+        const string Meter = "new Intl.NumberFormat('en-US', { style: 'unit', unit: 'meter' })";
+        Format(Meter, Value).Should().Be(Expected + " m");
+        Join(Meter, Value).Should().Be(Expected + " m");
+
+        const string Usd = "new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' })";
+        Format(Usd, Value).Should().Be("$" + Expected + ".00");
+    }
+
+    /// <summary>
+    /// A compact mantissa is written from digits, so it is written for a value of any size:
+    /// https://tc39.es/ecma402/#sec-computeexponentformagnitude stops at the largest abbreviation the
+    /// locale has, and everything above it is the mantissa spelled out.
+    /// </summary>
+    /// <remarks>
+    /// The defect: both compact lanes split their scaled value with <c>(long) Math.Truncate(...)</c>, and
+    /// .NET pins an out-of-range conversion rather than throwing — so they agreed, on
+    /// <c>long.MaxValue</c>'s digits, and <c>format(1e300)</c> was <c>"9223372036854775807T"</c>.
+    /// </remarks>
+    [Test]
+    public void ACompactMantissaPastTheRangeOfALongIsStillItsOwnDigits()
+    {
+        const string Compact = "new Intl.NumberFormat('en-US', { notation: 'compact' })";
+
+        // there is no abbreviation past a trillion, so 1e300 is 10^288 of them
+        var sextillion = "1" + new string('0', 288) + "T";
+        Format(Compact, "1e300").Should().Be(sextillion);
+        Join(Compact, "1e300").Should().Be(sextillion);
+
+        Format(Compact, "1e21").Should().Be("1000000000T");
+        Join(Compact, "1e21").Should().Be("1000000000T");
+
+        // CLDR's compact patterns carry no group separator, so a wide mantissa is one integer part
+        Parts(Compact, "1e21").Should()
+            .Be("""[{"type":"integer","value":"1000000000"},{"type":"compact","value":"T"}]""");
+    }
+
+    /// <summary>
+    /// https://tc39.es/ecma402/#sec-partitionnumberpattern computes the exponent first and runs
+    /// https://tc39.es/ecma402/#sec-formatnumberstring over the scaled value, so a notation's mantissa
+    /// reads <c>[[MinimumSignificantDigits]]</c> and <c>[[MaximumSignificantDigits]]</c> the way a
+    /// standard-notation number does.
+    /// </summary>
+    /// <remarks>
+    /// The defect: the three notation lanes rounded a mantissa of their own at
+    /// <c>maximumFractionDigits</c> and read neither option, so both lanes agreed on an answer that
+    /// ignored it — <c>"1.235E4"</c> for 12345 at <c>maximumSignificantDigits: 2</c>, and <c>"12K"</c> at
+    /// <c>maximumSignificantDigits: 4</c>.
+    /// </remarks>
+    [Test]
+    public void ANotationsMantissaReadsTheSignificantDigitOptions()
+    {
+        const string Scientific =
+            "new Intl.NumberFormat('en-US', { notation: 'scientific', maximumSignificantDigits: 2 })";
+        Format(Scientific, "12345").Should().Be("1.2E4");
+        Join(Scientific, "12345").Should().Be("1.2E4");
+
+        const string Engineering =
+            "new Intl.NumberFormat('en-US', { notation: 'engineering', maximumSignificantDigits: 2 })";
+        Format(Engineering, "12345").Should().Be("12E3");
+        Join(Engineering, "12345").Should().Be("12E3");
+
+        const string Compact =
+            "new Intl.NumberFormat('en-US', { notation: 'compact', maximumSignificantDigits: 4 })";
+        Format(Compact, "12345").Should().Be("12.35K");
+        Join(Compact, "12345").Should().Be("12.35K");
+
+        // the minimum is a floor under a notation too
+        const string Padded =
+            "new Intl.NumberFormat('en-US', { notation: 'scientific', minimumSignificantDigits: 4 })";
+        Format(Padded, "1000").Should().Be("1.000E3");
+        Join(Padded, "1000").Should().Be("1.000E3");
+    }
+
+    /// <summary>
+    /// Compact notation with no digit option of its own is the one case
+    /// https://tc39.es/ecma402/#sec-setnumberformatdigitoptions configures itself: one to two significant
+    /// digits at more-precision against no fraction digits, which is what it resolves to.
+    /// </summary>
+    /// <remarks>
+    /// That rounding is the reason <c>1234</c> is <c>"1.2K"</c> and <c>12345</c> is <c>"12K"</c>, and it
+    /// used to be open-coded in the compact lanes as "two significant figures" instead of being read from
+    /// the formatter — which is why the significant-digit options had nowhere to arrive.
+    /// </remarks>
+    [Test]
+    public void CompactResolvesTheDigitOptionsTheAlgorithmGivesIt()
+    {
+        var resolved = _engine.Evaluate(
+            "JSON.stringify(new Intl.NumberFormat('en-US', { notation: 'compact' }).resolvedOptions())").AsString();
+
+        resolved.Should().Contain("\"minimumFractionDigits\":0");
+        resolved.Should().Contain("\"maximumFractionDigits\":0");
+        resolved.Should().Contain("\"minimumSignificantDigits\":1");
+        resolved.Should().Contain("\"maximumSignificantDigits\":2");
+        resolved.Should().Contain("\"roundingPriority\":\"morePrecision\"");
+
+        const string Compact = "new Intl.NumberFormat('en-US', { notation: 'compact' })";
+        Format(Compact, "1234").Should().Be("1.2K");
+        Format(Compact, "12345").Should().Be("12K");
+
+        // an explicit digit option is the formatter's own, so the default is not applied over it
+        var explicitly = _engine.Evaluate(
+            "JSON.stringify(new Intl.NumberFormat('en-US', { notation: 'compact', maximumFractionDigits: 2 })"
+            + ".resolvedOptions())").AsString();
+        explicitly.Should().Contain("\"roundingPriority\":\"auto\"");
+        explicitly.Should().NotContain("minimumSignificantDigits");
+    }
+
+    /// <summary>
+    /// https://tc39.es/ecma402/#sec-computeexponent re-reads the exponent when rounding the mantissa
+    /// carries it into the next magnitude, which is what its own note is about.
+    /// </summary>
+    /// <remarks>
+    /// The defect: the compact lanes picked an abbreviation from the unrounded value and never looked
+    /// again, so 999999 rounded to a thousand thousands and was written <c>"1000K"</c> rather than
+    /// <c>"1M"</c>.
+    /// </remarks>
+    [Test]
+    public void ACompactMantissaThatRoundsUpTakesTheNextAbbreviation()
+    {
+        const string Compact = "new Intl.NumberFormat('en-US', { notation: 'compact' })";
+        Format(Compact, "999999").Should().Be("1M");
+        Join(Compact, "999999").Should().Be("1M");
+        Format(Compact, "999999999").Should().Be("1B");
+        Format(Compact, "999").Should().Be("999");
     }
 
     private string Format(string formatter, string value)

--- a/Jint.Tests/SpecAnchors.txt
+++ b/Jint.Tests/SpecAnchors.txt
@@ -14,8 +14,8 @@
 # The 'verified' date is the only thing bounding anchor rot: a clause renamed upstream keeps
 # resolving here until somebody re-runs that.
 #
-verified: 2026-08-30
-anchors: 1242
+verified: 2026-08-31
+anchors: 1245
 absent: 2
 !proposal-decorators sec-autoaccessordefinitionevaluation  # tc39.es still renders the 2018 descriptor design, which has no such clause
 !proposal-decorators sec-createdecoratorcontextobject  # tc39.es still renders the 2018 descriptor design, which has no such clause
@@ -857,6 +857,8 @@ ecma402 sec-chaindatetimeformat
 ecma402 sec-coerceoptionstoobject
 ecma402 sec-collapsenumberrange
 ecma402 sec-collationsoflocale
+ecma402 sec-computeexponent
+ecma402 sec-computeexponentformagnitude
 ecma402 sec-createdatetimeformat
 ecma402 sec-createstringlistfromiterable
 ecma402 sec-date-time-style-format
@@ -933,6 +935,7 @@ ecma402 sec-properties-of-the-intl-collator-prototype-object
 ecma402 sec-resolvelocale
 ecma402 sec-resolveoptions
 ecma402 sec-segments-objects
+ecma402 sec-setnumberformatdigitoptions
 ecma402 sec-the-intl-collator-constructor
 ecma402 sec-tointlmathematicalvalue
 ecma402 sec-torawfixed

--- a/Jint/Native/Intl/Data/CompactPatterns.cs
+++ b/Jint/Native/Intl/Data/CompactPatterns.cs
@@ -80,6 +80,75 @@ internal static partial class CompactPatterns
             return Threshold;
         }
 
+        /// <summary>
+        /// The exponent https://tc39.es/ecma402/#sec-computeexponentformagnitude scales a number of the
+        /// given <paramref name="magnitude"/> by, and the abbreviation written after the scaled number.
+        /// </summary>
+        /// <remarks>
+        /// Zero, with no abbreviation, whenever this locale writes the number out instead: below its own
+        /// threshold, and at a magnitude whose abbreviation the locale does not have — <c>de</c> has no
+        /// short form for a thousand, so <c>12345</c> is <c>"12.345"</c> and not <c>"12,3 K"</c>. The
+        /// magnitudes come from the divisors rather than from a fixed 3/6/9/12, because a locale can count
+        /// in a different unit: <c>ja</c> abbreviates at 万 (10^4) and 億 (10^8).
+        /// </remarks>
+        public int CompactExponent(int magnitude, bool isLong, out string suffix)
+        {
+            suffix = "";
+
+            if (magnitude < MagnitudeOf(GetThreshold(isLong)))
+            {
+                return 0;
+            }
+
+            int exponent;
+            string abbreviation;
+            if (magnitude >= 12)
+            {
+                exponent = 12;
+                abbreviation = isLong ? LongTrillion : ShortTrillion;
+            }
+            else if (magnitude >= MagnitudeOf(DivisorBillion))
+            {
+                exponent = MagnitudeOf(DivisorBillion);
+                abbreviation = isLong ? LongBillion : ShortBillion;
+            }
+            else if (magnitude >= MagnitudeOf(DivisorMillion))
+            {
+                exponent = MagnitudeOf(DivisorMillion);
+                abbreviation = isLong ? LongMillion : ShortMillion;
+            }
+            else if (magnitude >= 3)
+            {
+                exponent = 3;
+                abbreviation = isLong ? LongThousand : ShortThousand;
+            }
+            else
+            {
+                return 0;
+            }
+
+            if (string.IsNullOrEmpty(abbreviation))
+            {
+                return 0;
+            }
+
+            suffix = abbreviation;
+            return exponent;
+        }
+
+        /// <summary>The power of ten a divisor is, which every one of them is.</summary>
+        private static int MagnitudeOf(long powerOfTen)
+        {
+            var magnitude = 0;
+            while (powerOfTen >= 10)
+            {
+                powerOfTen /= 10;
+                magnitude++;
+            }
+
+            return magnitude;
+        }
+
         public static LocaleCompactData Default { get; } = new LocaleCompactData();
     }
 }

--- a/Jint/Native/Intl/JsNumberFormat.cs
+++ b/Jint/Native/Intl/JsNumberFormat.cs
@@ -217,19 +217,14 @@ internal sealed class JsNumberFormat : ObjectInstance
     /// </summary>
     /// <remarks>
     /// https://tc39.es/ecma402/#sec-formatnumber is the concatenation of exactly the parts
-    /// https://tc39.es/ecma402/#sec-formatnumbertoparts returns. A non-finite value reads its result from
-    /// that list rather than assembling a second one, which is what keeps the style's affixes — a currency
-    /// symbol, a unit, a percent sign — on both sides of the same walk.
+    /// https://tc39.es/ecma402/#sec-formatnumbertoparts returns, so this reads that list rather than
+    /// assembling a second one. Every lane that assembled a second one disagreed with the parts somewhere:
+    /// the decimal lane handed its value to <c>double.ToString</c>, which rounds a custom format string at
+    /// fifteen significant digits where https://tc39.es/ecma402/#sec-tointlmathematicalvalue reads
+    /// seventeen, so <c>format(12345678901234567890)</c> wrote <c>…234,600,000</c> against the parts'
+    /// <c>…567,000</c>.
     /// </remarks>
-    internal string Format(double value)
-    {
-        if (!double.IsFinite(value))
-        {
-            return ConcatenateParts(FormatToParts(value));
-        }
-
-        return Transliterate(FormatCore(value));
-    }
+    internal string Format(double value) => ConcatenateParts(FormatToParts(value));
 
     private static string ConcatenateParts(List<NumberFormatPart> parts)
     {
@@ -247,608 +242,8 @@ internal sealed class JsNumberFormat : ObjectInstance
         return builder.ToString();
     }
 
-    /// <summary>
-    /// Rewrites an assembled result in <c>[[NumberingSystem]]</c>: the digits wherever they stand, and the
-    /// one character this formatter writes as its decimal separator.
-    /// </summary>
-    /// <remarks>
-    /// Rewriting every full stop instead — which is what the shared
-    /// <see cref="Data.ResolvedNumberingSystem.Transliterate(string)"/> does — reaches the full stops a pattern owns
-    /// as well as the one the number owns, and a locale whose own separator is a comma has both:
-    /// <c>de-DE</c> compact writes <c>"1,2 Mio."</c>, where the comma is the number's and the full stop
-    /// belongs to the abbreviation. https://tc39.es/ecma402/#sec-partitionnumberpattern puts the two in
-    /// different parts — <c>decimal</c> and <c>compact</c> — and only the first is a number.
-    /// </remarks>
-    private string Transliterate(string result)
-    {
-        if (!_numberingSystem.RewritesDigits)
-        {
-            return result;
-        }
-
-        var separator = DecimalSeparator;
-        if (_numberingSystem.RewritesDecimalSeparator && separator.Length == 1)
-        {
-            return _numberingSystem.Transliterate(result, separator[0]);
-        }
-
-        return _numberingSystem.TransliterateDigitsOnly(result);
-    }
-
-    /// <summary>
-    /// The decimal separator this formatter's own lanes write, which is the currency one for a currency and
-    /// the number one for everything else.
-    /// </summary>
-    private string DecimalSeparator
-    {
-        get
-        {
-            if (string.Equals(Style, "currency", StringComparison.Ordinal))
-            {
-                return NumberFormatInfo.CurrencyDecimalSeparator;
-            }
-
-            return NumberFormatInfo.NumberDecimalSeparator;
-        }
-    }
-
-    private string FormatCore(double value)
-    {
-        // Handle notation first (scientific, engineering, compact)
-        if (!string.Equals(Notation, "standard", StringComparison.Ordinal))
-        {
-            return FormatWithNotation(value);
-        }
-
-        // https://tc39.es/ecma402/#sec-formatnumber is the concatenation of exactly the parts
-        // https://tc39.es/ecma402/#sec-formatnumbertoparts returns, and under the significant-digit
-        // options — and under a rounding priority, which needs both roundings to compare them — that is
-        // the lane https://tc39.es/ecma402/#sec-torawprecision lives in.
-        if (MinimumSignificantDigits.HasValue
-            || MaximumSignificantDigits.HasValue
-            || !string.Equals(RoundingPriority, "auto", StringComparison.Ordinal))
-        {
-            return ConcatenateParts(FormatToPartsCore(value));
-        }
-
-        return Style switch
-        {
-            "currency" => FormatCurrency(value),
-            "percent" => FormatPercent(value),
-            "unit" => FormatUnit(value),
-            _ => FormatDecimal(value)
-        };
-    }
-
-    private string FormatWithNotation(double value)
-    {
-        if (string.Equals(Notation, "scientific", StringComparison.Ordinal))
-        {
-            return FormatScientific(value);
-        }
-
-        if (string.Equals(Notation, "engineering", StringComparison.Ordinal))
-        {
-            return FormatEngineering(value);
-        }
-
-        if (string.Equals(Notation, "compact", StringComparison.Ordinal))
-        {
-            return FormatCompact(value);
-        }
-
-        return FormatDecimal(value);
-    }
-
     /// <summary>Distinguishes -0 from +0, which format differently but compare equal.</summary>
     private static bool IsNegativeZero(double value) => value == 0 && double.IsNegativeInfinity(1 / value);
-
-    private string FormatScientific(double value)
-    {
-        if (!double.IsFinite(value))
-        {
-            return FormatDecimal(value);
-        }
-
-        // Get the exponent. https://tc39.es/ecma402/#sec-partitionnotationsubpattern writes "0" for an
-        // exponent of zero rather than omitting the exponent, so exactly zero is "0E0". Zero's mantissa is
-        // taken as positive and signed below, because .NET Framework and .NET disagree on whether a custom
-        // format string writes negative zero's sign.
-        var exponent = value == 0 ? 0 : (int) System.Math.Floor(System.Math.Log10(System.Math.Abs(value)));
-        var mantissa = value == 0 ? 0d : value / System.Math.Pow(10, exponent);
-
-        // Round the mantissa
-        mantissa = ApplyRounding(mantissa, MaximumFractionDigits);
-
-        // Format mantissa
-        var mantissaFormat = MaximumFractionDigits > 0
-            ? "0." + new string('0', MinimumFractionDigits) + new string('#', MaximumFractionDigits - MinimumFractionDigits)
-            : "0";
-        var mantissaStr = mantissa.ToString(mantissaFormat, NumberFormatInfo);
-        if (IsNegativeZero(value))
-        {
-            mantissaStr = NumberFormatInfo.NegativeSign + mantissaStr;
-        }
-
-        // Format exponent (no plus sign for positive exponents per spec). PartitionNotationSubPattern
-        // takes the exponent's minus sign from the resolved locale's data, so it comes from this
-        // object's own NumberFormatInfo - as the mantissa above does - and never from the host's
-        // ambient culture. https://tc39.es/ecma402/#sec-partitionnotationsubpattern
-        return $"{mantissaStr}E{exponent.ToString(NumberFormatInfo)}";
-    }
-
-    private string FormatEngineering(double value)
-    {
-        if (!double.IsFinite(value))
-        {
-            return FormatDecimal(value);
-        }
-
-        // Engineering notation uses exponents that are multiples of 3. See FormatScientific for why zero
-        // still carries one, and why its mantissa is signed separately.
-        var exponent = value == 0 ? 0 : (int) System.Math.Floor(System.Math.Log10(System.Math.Abs(value)));
-        var engineeringExponent = (int) (System.Math.Floor(exponent / 3.0) * 3);
-        var mantissa = value == 0 ? 0d : value / System.Math.Pow(10, engineeringExponent);
-
-        // Round the mantissa
-        mantissa = ApplyRounding(mantissa, MaximumFractionDigits);
-
-        // Format mantissa
-        var mantissaFormat = MaximumFractionDigits > 0
-            ? "0." + new string('0', MinimumFractionDigits) + new string('#', MaximumFractionDigits - MinimumFractionDigits)
-            : "0";
-        var mantissaStr = mantissa.ToString(mantissaFormat, NumberFormatInfo);
-        if (IsNegativeZero(value))
-        {
-            mantissaStr = NumberFormatInfo.NegativeSign + mantissaStr;
-        }
-
-        // Format exponent (no plus sign for positive exponents per spec). See FormatScientific for why
-        // the exponent's sign comes from this object's NumberFormatInfo rather than the ambient culture.
-        return $"{mantissaStr}E{engineeringExponent.ToString(NumberFormatInfo)}";
-    }
-
-    private string FormatCompact(double value)
-    {
-        // Handle special values first
-        if (double.IsNaN(value))
-        {
-            return NumberFormatInfo.NaNSymbol;
-        }
-
-        if (double.IsPositiveInfinity(value))
-        {
-            return NumberFormatInfo.PositiveInfinitySymbol;
-        }
-
-        if (double.IsNegativeInfinity(value))
-        {
-            return NumberFormatInfo.NegativeSign + NumberFormatInfo.PositiveInfinitySymbol;
-        }
-
-        var absValue = System.Math.Abs(value);
-        var isNegative = value < 0;
-        var isLong = string.Equals(CompactDisplay, "long", StringComparison.Ordinal);
-
-        // Get locale-specific compact patterns
-        var patterns = Data.CompactPatterns.GetPatterns(Locale);
-        var threshold = patterns.GetThreshold(isLong);
-
-        // For values below threshold, use regular decimal formatting
-        if (absValue < threshold)
-        {
-            return FormatCompactSmallValue(value, absValue, isNegative);
-        }
-
-        // Determine the appropriate compact unit
-        string suffix;
-        string longSuffix;
-        double divisor;
-
-        // For East Asian languages (ja, ko, zh), use different divisors
-        var divisorMillion = patterns.DivisorMillion;
-        var divisorBillion = patterns.DivisorBillion;
-
-        if (absValue >= 1_000_000_000_000)
-        {
-            suffix = patterns.ShortTrillion;
-            longSuffix = patterns.LongTrillion;
-            divisor = 1_000_000_000_000;
-        }
-        else if (absValue >= divisorBillion)
-        {
-            suffix = patterns.ShortBillion;
-            longSuffix = patterns.LongBillion;
-            divisor = divisorBillion;
-        }
-        else if (absValue >= divisorMillion)
-        {
-            suffix = patterns.ShortMillion;
-            longSuffix = patterns.LongMillion;
-            divisor = divisorMillion;
-        }
-        else if (absValue >= 1000)
-        {
-            var thousandSuffix = isLong ? patterns.LongThousand : patterns.ShortThousand;
-            if (string.IsNullOrEmpty(thousandSuffix))
-            {
-                // No thousand suffix for this locale/mode, use small value formatting
-                return FormatCompactSmallValue(value, absValue, isNegative);
-            }
-            suffix = patterns.ShortThousand;
-            longSuffix = patterns.LongThousand;
-            divisor = 1000;
-        }
-        else
-        {
-            // Below compact threshold but above small value handling
-            return FormatCompactSmallValue(value, absValue, isNegative);
-        }
-
-        // If suffix is empty, don't use compact notation
-        var actualSuffix = isLong ? longSuffix : suffix;
-        if (string.IsNullOrEmpty(actualSuffix))
-        {
-            return FormatCompactSmallValue(value, absValue, isNegative);
-        }
-
-        var compactValue = absValue / divisor;
-
-        // Use 2 significant figures for compact notation
-        var compactMagnitude = compactValue >= 1 ? (int) System.Math.Floor(System.Math.Log10(compactValue)) : 0;
-        var compactDecimalPlaces = 1 - compactMagnitude; // For 2 sig figs
-        if (compactDecimalPlaces < 0)
-        {
-            compactDecimalPlaces = 0;
-        }
-
-        compactValue = ApplyRounding(compactValue, compactDecimalPlaces);
-
-        // Format the number part using locale's decimal separator
-        string compactFormatted;
-        if (compactDecimalPlaces > 0 && compactValue != System.Math.Floor(compactValue))
-        {
-            compactFormatted = compactValue.ToString("F" + compactDecimalPlaces, NumberFormatInfo);
-            // Trim trailing zeros after decimal
-            var decSep = NumberFormatInfo.NumberDecimalSeparator;
-            if (compactFormatted.Contains(decSep, StringComparison.Ordinal))
-            {
-                compactFormatted = compactFormatted.TrimEnd('0');
-                if (compactFormatted.EndsWith(decSep, StringComparison.Ordinal))
-                {
-                    compactFormatted = compactFormatted.Substring(0, compactFormatted.Length - decSep.Length);
-                }
-            }
-        }
-        else
-        {
-            compactFormatted = ((long) compactValue).ToString(NumberFormatInfo);
-        }
-
-        // Build result with appropriate spacing
-        string result;
-        if (isLong)
-        {
-            // Long format: spacing depends on locale
-            if (patterns.LongSpace)
-            {
-                result = compactFormatted + " " + actualSuffix;
-            }
-            else
-            {
-                result = compactFormatted + actualSuffix;
-            }
-        }
-        else
-        {
-            // Short format: spacing depends on locale
-            if (patterns.ShortSpace)
-            {
-                result = compactFormatted + "\u00a0" + actualSuffix;
-            }
-            else
-            {
-                result = compactFormatted + actualSuffix;
-            }
-        }
-
-        return isNegative ? NumberFormatInfo.NegativeSign + result : result;
-    }
-
-    private string FormatCompactSmallValue(double value, double absValue, bool isNegative)
-    {
-        if (absValue == 0)
-        {
-            return "0";
-        }
-
-        // For values >= 1, format with locale's grouping/decimal separators
-        if (absValue >= 1)
-        {
-            var magnitude = (int) System.Math.Floor(System.Math.Log10(absValue));
-
-            // Determine decimal places based on magnitude
-            int decimalPlaces;
-            if (magnitude >= 4)
-            {
-                // 10000+ - no decimals, use grouping
-                decimalPlaces = 0;
-            }
-            else if (magnitude >= 2)
-            {
-                // 100-9999 - no decimals
-                decimalPlaces = 0;
-            }
-            else
-            {
-                // 1-99 - use 2 significant figures
-                decimalPlaces = 1 - magnitude;
-            }
-
-            var rounded = ApplyRounding(absValue, decimalPlaces);
-
-            string formatted;
-            if (decimalPlaces <= 0)
-            {
-                // Use grouping only for numbers with 5+ digits (10000+)
-                if (rounded >= 10000)
-                {
-                    formatted = rounded.ToString("#,##0", NumberFormatInfo);
-                }
-                else
-                {
-                    formatted = ((long) rounded).ToString(CultureInfo.InvariantCulture);
-                }
-            }
-            else
-            {
-                formatted = rounded.ToString("F" + decimalPlaces, NumberFormatInfo);
-                // Trim trailing zeros
-                var decSep = NumberFormatInfo.NumberDecimalSeparator;
-                if (formatted.Contains(decSep, StringComparison.Ordinal))
-                {
-                    formatted = formatted.TrimEnd('0');
-                    if (formatted.EndsWith(decSep, StringComparison.Ordinal))
-                    {
-                        formatted = formatted.Substring(0, formatted.Length - decSep.Length);
-                    }
-                }
-            }
-
-            return isNegative ? NumberFormatInfo.NegativeSign + formatted : formatted;
-        }
-
-        // For values < 1
-        var smallMagnitude = (int) System.Math.Floor(System.Math.Log10(absValue));
-        var smallDecimalPlaces = 1 - smallMagnitude; // 2 sig figs
-
-        var smallRounded = ApplyRounding(absValue, smallDecimalPlaces);
-        var smallFormatted = smallRounded.ToString("F" + smallDecimalPlaces, NumberFormatInfo);
-
-        // Trim trailing zeros but keep at least required precision
-        var sep = NumberFormatInfo.NumberDecimalSeparator;
-        if (smallFormatted.Contains(sep, StringComparison.Ordinal))
-        {
-            smallFormatted = smallFormatted.TrimEnd('0');
-            if (smallFormatted.EndsWith(sep, StringComparison.Ordinal))
-            {
-                smallFormatted = smallFormatted.Substring(0, smallFormatted.Length - sep.Length);
-            }
-        }
-
-        return isNegative ? NumberFormatInfo.NegativeSign + smallFormatted : smallFormatted;
-    }
-
-    private List<NumberFormatPart> FormatCompactToParts(double value)
-    {
-        var parts = new List<NumberFormatPart>();
-
-        // Handle special values
-        if (double.IsNaN(value))
-        {
-            parts.Add(new NumberFormatPart("nan", NumberFormatInfo.NaNSymbol));
-            return parts;
-        }
-
-        if (double.IsPositiveInfinity(value))
-        {
-            parts.Add(new NumberFormatPart("infinity", NumberFormatInfo.PositiveInfinitySymbol));
-            return parts;
-        }
-
-        if (double.IsNegativeInfinity(value))
-        {
-            parts.Add(new NumberFormatPart("minusSign", NumberFormatInfo.NegativeSign));
-            parts.Add(new NumberFormatPart("infinity", NumberFormatInfo.PositiveInfinitySymbol));
-            return parts;
-        }
-
-        var absValue = System.Math.Abs(value);
-        var isNegative = value < 0;
-        var isLong = string.Equals(CompactDisplay, "long", StringComparison.Ordinal);
-
-        // Handle sign
-        if (isNegative)
-        {
-            parts.Add(new NumberFormatPart("minusSign", NumberFormatInfo.NegativeSign));
-        }
-
-        // Get locale-specific compact patterns
-        var patterns = Data.CompactPatterns.GetPatterns(Locale);
-        var threshold = patterns.GetThreshold(isLong);
-
-        // For values below threshold, format as regular decimal parts
-        if (absValue < threshold || absValue == 0)
-        {
-            AddDecimalParts(parts, absValue);
-            return parts;
-        }
-
-        // Determine the appropriate compact unit
-        string? compactSuffix = null;
-        double divisor = 1;
-
-        var divisorMillion = patterns.DivisorMillion;
-        var divisorBillion = patterns.DivisorBillion;
-
-        if (absValue >= 1_000_000_000_000)
-        {
-            compactSuffix = isLong ? patterns.LongTrillion : patterns.ShortTrillion;
-            divisor = 1_000_000_000_000;
-        }
-        else if (absValue >= divisorBillion)
-        {
-            compactSuffix = isLong ? patterns.LongBillion : patterns.ShortBillion;
-            divisor = divisorBillion;
-        }
-        else if (absValue >= divisorMillion)
-        {
-            compactSuffix = isLong ? patterns.LongMillion : patterns.ShortMillion;
-            divisor = divisorMillion;
-        }
-        else if (absValue >= 1000)
-        {
-            var thousandSuffix = isLong ? patterns.LongThousand : patterns.ShortThousand;
-            if (!string.IsNullOrEmpty(thousandSuffix))
-            {
-                compactSuffix = thousandSuffix;
-                divisor = 1000;
-            }
-        }
-
-        // If no compact suffix, format as decimal parts
-        if (string.IsNullOrEmpty(compactSuffix))
-        {
-            AddDecimalParts(parts, absValue);
-            return parts;
-        }
-
-        var compactValue = absValue / divisor;
-
-        // Round to 2 significant figures
-        var compactMagnitude = compactValue >= 1 ? (int) System.Math.Floor(System.Math.Log10(compactValue)) : 0;
-        var compactDecimalPlaces = 1 - compactMagnitude;
-        if (compactDecimalPlaces < 0)
-        {
-            compactDecimalPlaces = 0;
-        }
-
-        compactValue = ApplyRounding(compactValue, compactDecimalPlaces);
-
-        // Add integer part
-        var integerPart = (long) System.Math.Truncate(compactValue);
-        parts.Add(new NumberFormatPart("integer", integerPart.ToString(CultureInfo.InvariantCulture)));
-
-        // Add decimal part if needed
-        var fractionValue = compactValue - integerPart;
-        if (compactDecimalPlaces > 0 && fractionValue > 0.00001)
-        {
-            parts.Add(new NumberFormatPart("decimal", NumberFormatInfo.NumberDecimalSeparator));
-
-            var multiplier = System.Math.Pow(10, compactDecimalPlaces);
-            var fractionInt = (long) System.Math.Round(fractionValue * multiplier);
-            var fractionStr = fractionInt.ToString(CultureInfo.InvariantCulture);
-
-            // Trim trailing zeros
-            fractionStr = fractionStr.TrimEnd('0');
-            if (fractionStr.Length > 0)
-            {
-                parts.Add(new NumberFormatPart("fraction", fractionStr));
-            }
-        }
-
-        // Add literal space and compact suffix (only if locale uses space)
-        if (isLong && patterns.LongSpace)
-        {
-            parts.Add(new NumberFormatPart("literal", " "));
-        }
-        else if (!isLong && patterns.ShortSpace)
-        {
-            parts.Add(new NumberFormatPart("literal", "\u00a0")); // Non-breaking space for short format
-        }
-        // For formats without space, we don't add a literal part
-
-        parts.Add(new NumberFormatPart("compact", compactSuffix!));
-
-        return parts;
-    }
-
-    private void AddDecimalParts(List<NumberFormatPart> parts, double value)
-    {
-        if (value == 0)
-        {
-            parts.Add(new NumberFormatPart("integer", "0"));
-            return;
-        }
-
-        var magnitude = value >= 1 ? (int) System.Math.Floor(System.Math.Log10(value)) : 0;
-        int decimalPlaces;
-
-        if (magnitude >= 4)
-        {
-            decimalPlaces = 0;
-        }
-        else if (magnitude >= 2)
-        {
-            decimalPlaces = 0;
-        }
-        else if (value >= 1)
-        {
-            decimalPlaces = 1 - magnitude;
-        }
-        else
-        {
-            var smallMagnitude = (int) System.Math.Floor(System.Math.Log10(value));
-            decimalPlaces = 1 - smallMagnitude;
-        }
-
-        var rounded = ApplyRounding(value, decimalPlaces);
-
-        // Add integer part
-        var integerPart = (long) System.Math.Truncate(rounded);
-        var intStr = integerPart.ToString(CultureInfo.InvariantCulture);
-
-        // Add grouping for large numbers
-        if (rounded >= 10000)
-        {
-            intStr = integerPart.ToString("#,##0", NumberFormatInfo);
-            // Parse groups and add as separate parts
-            var groups = intStr.Split(new[] { NumberFormatInfo.NumberGroupSeparator }, StringSplitOptions.None);
-            for (var i = 0; i < groups.Length; i++)
-            {
-                if (i > 0)
-                {
-                    parts.Add(new NumberFormatPart("group", NumberFormatInfo.NumberGroupSeparator));
-                }
-                parts.Add(new NumberFormatPart("integer", groups[i]));
-            }
-        }
-        else
-        {
-            parts.Add(new NumberFormatPart("integer", intStr));
-        }
-
-        // Add decimal part if needed
-        if (decimalPlaces > 0)
-        {
-            var fractionValue = rounded - integerPart;
-            if (fractionValue > 0.00001)
-            {
-                parts.Add(new NumberFormatPart("decimal", NumberFormatInfo.NumberDecimalSeparator));
-
-                var multiplier = System.Math.Pow(10, decimalPlaces);
-                var fractionInt = (long) System.Math.Round(fractionValue * multiplier);
-                var fractionStr = fractionInt.ToString(CultureInfo.InvariantCulture).PadLeft(decimalPlaces, '0');
-
-                // Trim trailing zeros
-                fractionStr = fractionStr.TrimEnd('0');
-                if (fractionStr.Length > 0)
-                {
-                    parts.Add(new NumberFormatPart("fraction", fractionStr));
-                }
-            }
-        }
-    }
 
     /// <summary>
     /// Applies rounding to a value based on the RoundingMode and RoundingIncrement settings.
@@ -864,6 +259,17 @@ internal sealed class JsNumberFormat : ObjectInstance
         // scaling it by a power of ten to round it is not, since the product is past what a double
         // holds exactly: 1e21 came back as 999999999999999900000.
         if (decimalPlaces > 0 && System.Math.Abs(value) >= 9007199254740992d)
+        {
+            return value;
+        }
+
+        // The same identity, at the other end: rounding at a place below the value's last significant
+        // digit changes nothing, and scaling by 10^decimalPlaces to do it anyway does — 100000 multiplied
+        // by 10^20 and divided back is 100000.00000000001, which maximumFractionDigits: 20 then wrote out.
+        // Where the last digit sits is read from Number::toString, which is where this object's digits come
+        // from everywhere else. A rounding increment is excluded because it is not the identity there:
+        // it rounds to a multiple at that place whether or not the value has a digit in it.
+        if (decimalPlaces > 0 && RoundingIncrement == 1 && value != 0 && IsRoundedAlready(value, decimalPlaces))
         {
             return value;
         }
@@ -889,6 +295,16 @@ internal sealed class JsNumberFormat : ObjectInstance
         }
 
         return scaled / multiplier;
+    }
+
+    /// <summary>
+    /// Whether <paramref name="value"/>'s last significant digit already sits at or above the
+    /// <paramref name="decimalPlaces"/> place, so rounding it there leaves it alone.
+    /// </summary>
+    private static bool IsRoundedAlready(double value, int decimalPlaces)
+    {
+        DecimalDigitsOf(System.Math.Abs(value), out var significand, out var exponent);
+        return exponent - significand.Length + 1 >= -decimalPlaces;
     }
 
     private double ApplyRoundingMode(double scaled, bool isPositive)
@@ -1041,41 +457,22 @@ internal sealed class JsNumberFormat : ObjectInstance
         var body = MinimumSignificantDigits.HasValue || MaximumSignificantDigits.HasValue
             ? ExactPrecisionBody(abs, fractionDigits)
             : ExactBody(abs, fractionDigits);
-        var displaysAsZero = body.IsZero;
-
-        var showNegativeSign = isNegative;
-        var showPositiveSign = false;
-        switch (SignDisplay)
-        {
-            case "always":
-                showPositiveSign = !isNegative;
-                break;
-            case "exceptZero":
-                showPositiveSign = !isNegative && !displaysAsZero;
-                showNegativeSign = isNegative && !displaysAsZero;
-                break;
-            case "negative":
-                showNegativeSign = isNegative && !displaysAsZero;
-                break;
-            case "never":
-                showNegativeSign = false;
-                break;
-        }
+        var sign = SignFor(isNegative, body.IsZero);
 
         var parts = new List<NumberFormatPart>();
         switch (Style)
         {
             case "currency":
-                AppendCurrencyParts(parts, in body, showNegativeSign, showPositiveSign);
+                AppendCurrencyParts(parts, in body, sign.ShowNegative, sign.ShowPositive);
                 break;
             case "percent":
-                AppendPercentParts(parts, in body, showNegativeSign, showPositiveSign);
+                AppendPercentParts(parts, in body, sign.ShowNegative, sign.ShowPositive);
                 break;
             case "unit":
-                AppendUnitParts(parts, in body, showNegativeSign, showPositiveSign, (double) mantissa);
+                AppendUnitParts(parts, in body, sign.ShowNegative, sign.ShowPositive, (double) mantissa);
                 break;
             default:
-                AppendSignPart(parts, showNegativeSign, showPositiveSign);
+                AppendSignPart(parts, sign.ShowNegative, sign.ShowPositive);
                 AddNumberParts(parts, in body);
                 break;
         }
@@ -1142,288 +539,6 @@ internal sealed class JsNumberFormat : ObjectInstance
     /// </summary>
     internal string Format(BigInteger value) => Format(IntlMathematicalValue.Exact(value, 0));
 
-    private string FormatDecimal(double value)
-    {
-        // Check if value is negative (including -0)
-        var isNegative = value < 0 || double.IsNegativeInfinity(1 / value);
-        var absValue = System.Math.Abs(value);
-
-        // Apply rounding based on MaximumFractionDigits
-        absValue = ApplyRounding(absValue, MaximumFractionDigits);
-        var displaysAsZero = absValue == 0;
-        var isNaN = double.IsNaN(value);
-
-        // Determine if we should show a sign based on signDisplay
-        var showNegativeSign = isNegative;
-        var showPositiveSign = false;
-
-        switch (SignDisplay)
-        {
-            case "always":
-                // NaN still gets a plus sign for "always"
-                showPositiveSign = !isNegative;
-                break;
-            case "exceptZero":
-                // NaN never gets a sign for exceptZero (NaN is not a number, neither zero nor non-zero)
-                showPositiveSign = !isNegative && !displaysAsZero && !isNaN;
-                showNegativeSign = isNegative && !displaysAsZero;
-                break;
-            case "negative":
-                showPositiveSign = false;
-                showNegativeSign = isNegative && !displaysAsZero;
-                break;
-            case "never":
-                showNegativeSign = false;
-                showPositiveSign = false;
-                break;
-        }
-
-        value = absValue;
-
-        // Build custom format string that respects min integer digits, min/max fraction digits
-        // e.g., MinimumIntegerDigits=3, MinimumFractionDigits=1, MaximumFractionDigits=3 -> "000.0##"
-
-        // Build integer part with minimum integer digits
-        // Calculate integer digits for min2 grouping check
-        var integerDigits = (int) (value == 0 ? 1 : System.Math.Floor(System.Math.Log10(System.Math.Abs(value))) + 1);
-
-        string integerPart;
-        if (ShouldApplyGrouping(integerDigits))
-        {
-            // For grouping, we need at least 4 characters for the group separator pattern
-            // e.g., "#,##0" for 1 min digit, "#,#00" for 2, "#,000" for 3, "0,000" for 4+
-            if (MinimumIntegerDigits <= 1)
-            {
-                integerPart = "#,##0";
-            }
-            else if (MinimumIntegerDigits == 2)
-            {
-                integerPart = "#,#00";
-            }
-            else if (MinimumIntegerDigits == 3)
-            {
-                integerPart = "#,000";
-            }
-            else
-            {
-                // For 4+, we need additional leading zeros
-                var extraZeros = new string('0', MinimumIntegerDigits - 3);
-                integerPart = extraZeros + ",000";
-            }
-        }
-        else
-        {
-            integerPart = new string('0', MinimumIntegerDigits);
-        }
-
-        string format;
-        if (MaximumFractionDigits == 0)
-        {
-            format = integerPart;
-        }
-        else
-        {
-            var fractionPart = new string('0', MinimumFractionDigits);
-            if (MaximumFractionDigits > MinimumFractionDigits)
-            {
-                fractionPart += new string('#', MaximumFractionDigits - MinimumFractionDigits);
-            }
-            format = $"{integerPart}.{fractionPart}";
-        }
-
-        var formatted = value.ToString(format, NumberFormatInfo);
-
-        // Apply sign based on signDisplay
-        if (showNegativeSign)
-        {
-            return NumberFormatInfo.NegativeSign + formatted;
-        }
-
-        if (showPositiveSign)
-        {
-            return NumberFormatInfo.PositiveSign + formatted;
-        }
-
-        return formatted;
-    }
-
-    private string ApplyGroupingToString(string integerPart)
-    {
-        var boundaries = GroupBoundariesOf(integerPart.Length);
-        if (boundaries.Count == 0)
-        {
-            return integerPart;
-        }
-
-        var separator = NumberFormatInfo.NumberGroupSeparator;
-        var sb = new System.Text.StringBuilder(integerPart.Length + boundaries.Count * separator.Length);
-        var start = 0;
-        foreach (var boundary in boundaries)
-        {
-            sb.Append(integerPart, start, boundary - start).Append(separator);
-            start = boundary;
-        }
-
-        return sb.Append(integerPart, start, integerPart.Length - start).ToString();
-    }
-
-    private string FormatCurrency(double value)
-    {
-        // Check for negative zero (1.0 / -0 == -Infinity)
-        var isNegativeZero = value == 0 && double.IsNegativeInfinity(1.0 / value);
-        var isNegative = value < 0 || isNegativeZero;
-        var absValue = System.Math.Abs(value);
-
-        // Apply rounding - use MaximumFractionDigits directly (constructor sets appropriate defaults)
-        var fractionDigits = MaximumFractionDigits;
-        absValue = ApplyRounding(absValue, fractionDigits);
-
-        // Check if rounded value displays as zero
-        var displaysAsZero = absValue < System.Math.Pow(10, -fractionDigits) / 2;
-
-        // Determine if we should show a sign and what kind
-        var showNegativeSign = isNegative;
-        var showPositiveSign = false;
-        var useAccountingFormat = string.Equals(CurrencySign, "accounting", StringComparison.Ordinal);
-
-        // Handle signDisplay
-        switch (SignDisplay)
-        {
-            case "always":
-                showPositiveSign = !isNegative;
-                break;
-            case "exceptZero":
-                // For exceptZero, don't show sign if the displayed value is zero
-                showPositiveSign = !isNegative && !displaysAsZero;
-                showNegativeSign = isNegative && !displaysAsZero;
-                break;
-            case "negative":
-                // For negative, only show negative sign for truly negative, non-zero display
-                showPositiveSign = false;
-                showNegativeSign = isNegative && !displaysAsZero;
-                break;
-            case "never":
-                showNegativeSign = false;
-                showPositiveSign = false;
-                break;
-        }
-
-        // Format the absolute value
-        var symbol = NumberFormatInfo.CurrencySymbol;
-
-        // Build the number part
-        var integral = System.Math.Truncate(absValue);
-        var fractionValue = absValue - integral;
-
-        // Format integer with grouping
-        var intStr = IntegerDigitsOf(integral);
-        var digitCount = intStr.Length;
-        if (ShouldApplyGrouping(digitCount))
-        {
-            intStr = ApplyGroupingToString(intStr);
-        }
-
-        // Format fraction. https://tc39.es/ecma402/#sec-torawfixed rounds at maximumFractionDigits and
-        // then removes up to maximumFractionDigits - minimumFractionDigits trailing zeros, so a currency
-        // whose two digit counts differ writes the narrower one when the wider one would only be zeros.
-        var fractionStr = "";
-        if (fractionDigits > 0)
-        {
-            var digits = FractionDigitsOf(fractionValue, fractionDigits);
-            if (digits.Length > 0)
-            {
-                fractionStr = NumberFormatInfo.CurrencyDecimalSeparator + digits;
-            }
-        }
-
-        var numberPart = intStr + fractionStr;
-
-        // Build result based on locale's currency pattern
-        // CurrencyPositivePattern: 0=$n, 1=n$, 2=$ n, 3=n $
-        // Use non-breaking space (U+00A0) per CLDR conventions
-        var pattern = NumberFormatInfo.CurrencyPositivePattern;
-        const string Nbsp = " ";
-        string formattedCurrency;
-
-        switch (pattern)
-        {
-            case 0: // $n
-                formattedCurrency = symbol + numberPart;
-                break;
-            case 1: // n$
-                formattedCurrency = numberPart + symbol;
-                break;
-            case 2: // $ n
-                formattedCurrency = symbol + Nbsp + numberPart;
-                break;
-            case 3: // n $
-            default:
-                formattedCurrency = numberPart + Nbsp + symbol;
-                break;
-        }
-
-        // Apply sign based on signDisplay
-        string result;
-        if (showNegativeSign)
-        {
-            if (useAccountingFormat)
-            {
-                // Use CLDR-based accounting format (parentheses for most locales)
-                result = FormatAccountingNegativeCurrency(numberPart, symbol);
-            }
-            else
-            {
-                // Standard format uses minus sign before everything. ECMA-402 calls it "the ILND String
-                // representing the minus sign", so it is the locale's own datum and not a literal "-":
-                // ar writes U+061C ARABIC LETTER MARK ahead of it, which is what the parts lane reports.
-                result = NumberFormatInfo.NegativeSign + formattedCurrency;
-            }
-        }
-        else if (showPositiveSign)
-        {
-            result = NumberFormatInfo.PositiveSign + formattedCurrency;
-        }
-        else
-        {
-            result = formattedCurrency;
-        }
-
-        return result;
-    }
-
-    /// <summary>
-    /// Formats a negative currency value for accounting format using CLDR-based patterns.
-    /// </summary>
-    private string FormatAccountingNegativeCurrency(string numberPart, string symbol)
-    {
-        // CLDR accounting patterns vary by locale:
-        // - English, Japanese, Korean, Chinese locales use parentheses
-        // - German, French, and other European locales use minus sign (same as standard)
-        // Check if locale uses parentheses for accounting
-        if (UsesParenthesesForAccounting())
-        {
-            // Use parentheses matching the positive pattern position:
-            // Positive pattern 0 ($n) → Accounting uses "($n)"
-            // Positive pattern 1 (n$) → Accounting uses "(n$)"
-            // Positive pattern 2 ($ n) → Accounting uses "($ n)"
-            // Positive pattern 3 (n $) → Accounting uses "(n $)"
-            var posPattern = NumberFormatInfo.CurrencyPositivePattern;
-            const string Nbsp = "\u00A0"; // Non-breaking space
-
-            return posPattern switch
-            {
-                0 => $"({symbol}{numberPart})", // ($n)
-                1 => $"({numberPart}{symbol})", // (n$)
-                2 => $"({symbol}{Nbsp}{numberPart})", // ($ n)
-                3 => $"({numberPart}{Nbsp}{symbol})", // (n $)
-                _ => $"({symbol}{numberPart})"
-            };
-        }
-
-        // Fall back to standard negative currency format (minus sign)
-        return FormatNegativeCurrency(numberPart, symbol);
-    }
-
     /// <summary>
     /// Determines if the current locale uses parentheses for accounting format.
     /// Based on CLDR accounting currency patterns.
@@ -1446,88 +561,6 @@ internal sealed class JsNumberFormat : ObjectInstance
             "zh" => true,
             _ => false
         };
-    }
-
-    /// <summary>
-    /// Formats a negative currency value according to the locale's CurrencyNegativePattern.
-    /// Uses non-breaking space (U+00A0) per CLDR conventions.
-    /// </summary>
-    private string FormatNegativeCurrency(string numberPart, string symbol)
-    {
-        // CurrencyNegativePattern values:
-        // 0: ($n), 1: -$n, 2: $-n, 3: $n-, 4: (n$), 5: -n$, 6: n-$, 7: n$-
-        // 8: -n $, 9: -$ n, 10: n $-, 11: $ n-, 12: $ -n, 13: n- $, 14: ($ n), 15: (n $)
-        var negPattern = NumberFormatInfo.CurrencyNegativePattern;
-        const string Nbsp = " "; // Non-breaking space
-        var minus = NumberFormatInfo.NegativeSign;
-
-        return negPattern switch
-        {
-            0 => $"({symbol}{numberPart})",
-            1 => $"{minus}{symbol}{numberPart}",
-            2 => $"{symbol}{minus}{numberPart}",
-            3 => $"{symbol}{numberPart}{minus}",
-            4 => $"({numberPart}{symbol})",
-            5 => $"{minus}{numberPart}{symbol}",
-            6 => $"{numberPart}{minus}{symbol}",
-            7 => $"{numberPart}{symbol}{minus}",
-            8 => $"{minus}{numberPart}{Nbsp}{symbol}",
-            9 => $"{minus}{symbol}{Nbsp}{numberPart}",
-            10 => $"{numberPart}{Nbsp}{symbol}{minus}",
-            11 => $"{symbol}{Nbsp}{numberPart}{minus}",
-            12 => $"{symbol}{Nbsp}{minus}{numberPart}",
-            13 => $"{numberPart}{minus}{Nbsp}{symbol}",
-            14 => $"({symbol}{Nbsp}{numberPart})",
-            15 => $"({numberPart}{Nbsp}{symbol})",
-            _ => $"{minus}{symbol}{numberPart}"
-        };
-    }
-
-    /// <summary>
-    /// https://tc39.es/ecma402/#sec-formatnumber under the percent style, which is the concatenation of
-    /// exactly the parts https://tc39.es/ecma402/#sec-formatnumbertoparts returns.
-    /// </summary>
-    /// <remarks>
-    /// The digits were .NET's <c>"P"</c> specifier, which consults one datum — <c>PercentDecimalDigits</c>,
-    /// which the constructor sets to <c>maximumFractionDigits</c> — and therefore wrote exactly that many
-    /// fraction digits always, never the trim https://tc39.es/ecma402/#sec-torawfixed ends with, and none
-    /// of <c>signDisplay</c>, <c>useGrouping</c> or <c>minimumIntegerDigits</c> at all.
-    /// </remarks>
-    private string FormatPercent(double value) => ConcatenateParts(FormatPercentToParts(value));
-
-    private string FormatUnit(double value)
-    {
-        var formattedNumber = FormatDecimal(value);
-        var unitDisplay = UnitDisplay ?? "short";
-        var unitStr = Unit ?? "";
-
-        // Try to get unit patterns from CLDR provider
-        var unitPatterns = CldrProvider.GetUnitPatterns(Locale, unitStr, unitDisplay);
-        if (unitPatterns != null)
-        {
-            // Use the CLDR pattern - it already contains spacing information
-            // Select singular or plural pattern based on the absolute value
-            var isSingular = System.Math.Abs(value) == 1;
-            var pattern = isSingular ? (unitPatterns.One ?? unitPatterns.Other) : unitPatterns.Other;
-            return pattern.Replace("{0}", formattedNumber);
-        }
-
-        // Fallback to legacy behavior if no CLDR pattern found
-        var unitSuffix = GetUnitSuffix(unitStr, unitDisplay, value);
-
-        // Determine if we need a space before the unit
-        // Narrow display never has space; percent/degree units don't have space
-        var needsSpace = !string.Equals(unitDisplay, "narrow", StringComparison.Ordinal) &&
-                        !string.Equals(unitStr, "percent", StringComparison.Ordinal) &&
-                        !string.Equals(unitStr, "celsius", StringComparison.Ordinal) &&
-                        !string.Equals(unitStr, "fahrenheit", StringComparison.Ordinal);
-
-        if (needsSpace)
-        {
-            return $"{formattedNumber} {unitSuffix}";
-        }
-
-        return $"{formattedNumber}{unitSuffix}";
     }
 
     private static string GetUnitSuffix(string unit, string display, double value)
@@ -1637,11 +670,11 @@ internal sealed class JsNumberFormat : ObjectInstance
     /// <remarks>
     /// <para>
     /// https://tc39.es/ecma402/#sec-formatnumber is defined as the concatenation of exactly the parts
-    /// https://tc39.es/ecma402/#sec-formatnumbertoparts returns, so both lanes write
-    /// <c>[[NumberingSystem]]</c>'s digits or neither does. <see cref="Format(double)"/> transliterates the
-    /// assembled string; this lane transliterates the parts a number's digits went into, which is the same
-    /// rewrite applied one part at a time. <c>IntlNumberFormatPartsTests.PartsConcatenateToFormat</c> walks a grid
-    /// of locales, numbering systems and styles and asserts the two agree, rather than assuming it.
+    /// https://tc39.es/ecma402/#sec-formatnumbertoparts returns, and <see cref="Format(double)"/> is now
+    /// that concatenation, so <c>[[NumberingSystem]]</c>'s digits — and every other character — reach both
+    /// lanes or neither. <c>IntlNumberFormatPartsTests.PartsConcatenateToFormat</c> still walks its grid of
+    /// locales, numbering systems and styles: what it asserts is no longer that two assemblies agree but
+    /// that this one assembly never throws or drops a part anywhere in the grid.
     /// </para>
     /// </remarks>
     internal List<NumberFormatPart> FormatToParts(double value) => TransliterateParts(FormatToPartsCore(value));
@@ -1678,9 +711,8 @@ internal sealed class JsNumberFormat : ObjectInstance
     /// </summary>
     /// <remarks>
     /// <c>decimal</c> is a separator rather than a digit, and is here because a numbering system can carry
-    /// one of its own — <c>arab</c> writes U+066B — which is the same rewrite
-    /// <see cref="Transliterate(string)"/> applies to the assembled string. <c>group</c> is a separator the
-    /// system has no opinion about, and keeps the locale's.
+    /// one of its own — <c>arab</c> writes U+066B. <c>group</c> is a separator the system has no opinion
+    /// about, and keeps the locale's.
     /// </remarks>
     private string TransliterateNumericPart(string type, string value)
     {
@@ -1746,12 +778,31 @@ internal sealed class JsNumberFormat : ObjectInstance
     /// The digits https://tc39.es/ecma402/#sec-torawfixed writes for a non-negative value already rounded
     /// at <see cref="MaximumFractionDigits"/>.
     /// </summary>
+    /// <remarks>
+    /// The value's digits are read once, from <c>Number::toString</c>, and then split and trimmed by the
+    /// same operation an exactly-read value takes — so a double and a decimal string of the same digits
+    /// cannot be split differently. Splitting a double instead, with <c>Truncate</c> and a fraction scaled
+    /// by 10^maximumFractionDigits, wrote fractions the value does not have: at
+    /// <c>maximumFractionDigits: 20</c> the fraction of 1.0000000000000001 came out
+    /// <c>"00000000000000022204"</c>, which is the binary expansion and not the number.
+    /// </remarks>
     private NumberBody FiniteBody(double roundedAbsValue)
     {
-        var integral = System.Math.Truncate(roundedAbsValue);
-        return NumberBody.Finite(
-            IntegerDigitsOf(integral),
-            FractionDigitsOf(roundedAbsValue - integral, MaximumFractionDigits));
+        if (roundedAbsValue == 0)
+        {
+            return ExactBody(BigInteger.Zero, 0);
+        }
+
+        DecimalDigitsOf(roundedAbsValue, out var significand, out var exponent);
+
+        // significand × 10^scale is the value, so a non-negative scale is a whole number written out and a
+        // negative one is that many fraction digits
+        var scale = exponent - significand.Length + 1;
+        var mantissa = BigInteger.Parse(significand, CultureInfo.InvariantCulture);
+
+        return scale >= 0
+            ? ExactBody(mantissa * BigInteger.Pow(10, scale), 0)
+            : ExactBody(mantissa, -scale);
     }
 
     /// <summary>
@@ -1968,39 +1019,6 @@ internal sealed class JsNumberFormat : ObjectInstance
         exponent = integerLength - 1 - first + written;
     }
 
-    /// <summary>
-    /// The integer digits of a non-negative whole <see cref="double"/>, however large.
-    /// </summary>
-    /// <remarks>
-    /// Past <see cref="long.MaxValue"/> a cast does not answer: .NET saturates, so every value from
-    /// 2^63 up wrote the same 9223372036854775807. The digits are
-    /// <c>Number::toString</c>'s instead — the shortest decimal that reads back as this double, which is
-    /// what https://tc39.es/ecma402/#sec-tointlmathematicalvalue reads a Number as — with its exponent
-    /// written out, since https://tc39.es/ecma402/#sec-torawfixed works on digits and not on a magnitude.
-    /// </remarks>
-    private static string IntegerDigitsOf(double integral)
-    {
-        if (integral < 9.2e18)
-        {
-            return ((long) integral).ToString(CultureInfo.InvariantCulture);
-        }
-
-        var text = Number.NumberPrototype.ToNumberString(integral);
-        var exponentIndex = text.IndexOf('e');
-        if (exponentIndex < 0)
-        {
-            return text;
-        }
-
-        var mantissa = text.Substring(0, exponentIndex);
-        var exponent = int.Parse(text.AsSpan(exponentIndex + 1), NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture);
-        var point = mantissa.IndexOf('.');
-        var integerLength = (point < 0 ? mantissa.Length : point) + exponent;
-        var digits = point < 0 ? mantissa : mantissa.Remove(point, 1);
-
-        return digits.PadRight(integerLength, '0');
-    }
-
     private List<NumberFormatPart> FormatToPartsCore(double value)
     {
         if (!double.IsFinite(value))
@@ -2075,6 +1093,27 @@ internal sealed class JsNumberFormat : ObjectInstance
         return parts;
     }
 
+    /// <summary>Which of the two signs a pattern writes around a finite value.</summary>
+    [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Auto)]
+    private readonly record struct SignDecision(bool ShowNegative, bool ShowPositive);
+
+    /// <summary>
+    /// Which sign https://tc39.es/ecma402/#sec-getnumberformatpattern selects a pattern for, read from
+    /// <c>[[SignDisplay]]</c> and from whether the digits that were produced are all zeros.
+    /// </summary>
+    /// <remarks>
+    /// One decision for every style and every notation, because the algorithm makes it once: the pattern
+    /// is chosen before it is walked, and what is walked around is the only thing a style changes.
+    /// </remarks>
+    private SignDecision SignFor(bool isNegative, bool displaysAsZero) => SignDisplay switch
+    {
+        "always" => new SignDecision(isNegative, !isNegative),
+        "exceptZero" => new SignDecision(isNegative && !displaysAsZero, !isNegative && !displaysAsZero),
+        "negative" => new SignDecision(isNegative && !displaysAsZero, false),
+        "never" => new SignDecision(false, false),
+        _ => new SignDecision(isNegative, false)
+    };
+
     /// <remarks>
     /// ECMA-402 calls the sign "the ILND String representing the minus sign", so it is the locale's own
     /// datum in every lane: <c>ar</c> prefixes U+061C ARABIC LETTER MARK to it.
@@ -2131,88 +1170,213 @@ internal sealed class JsNumberFormat : ObjectInstance
         }
     }
 
+    /// <summary>
+    /// https://tc39.es/ecma402/#sec-partitionnumberpattern under a notation: the exponent
+    /// https://tc39.es/ecma402/#sec-computeexponent picks, and the digits
+    /// https://tc39.es/ecma402/#sec-formatnumberstring writes for the mantissa it scales the value down to.
+    /// </summary>
+    /// <remarks>
+    /// The mantissa is an ordinary number to that operation, so a digit option applies to it exactly as it
+    /// applies to a standard-notation number. None of the three notations read one: each rounded a mantissa
+    /// of its own at <c>maximumFractionDigits</c> and never looked at <c>[[MaximumSignificantDigits]]</c>,
+    /// so <c>{ notation: "scientific", maximumSignificantDigits: 2 }</c> wrote <c>"1.235E4"</c> for 12345
+    /// where every other engine writes <c>"1.2E4"</c>. Compact then split its own mantissa with a cast to
+    /// <c>long</c>, which .NET pins instead of throwing, so every value from 2^63 up wrote
+    /// <see cref="long.MaxValue"/>'s digits and <c>1e300</c> came out <c>"9223372036854775807T"</c>.
+    /// </remarks>
     private List<NumberFormatPart> FormatNotationToParts(double value)
     {
-        // Handle compact notation separately
-        if (string.Equals(Notation, "compact", StringComparison.Ordinal))
-        {
-            return FormatCompactToParts(value);
-        }
-
         var parts = new List<NumberFormatPart>();
 
         // negative zero takes the negative pattern too, per https://tc39.es/ecma402/#sec-getnumberformatpattern
         var isNegative = value < 0 || IsNegativeZero(value);
-        if (isNegative)
-        {
-            parts.Add(new NumberFormatPart("minusSign", NumberFormatInfo.NegativeSign));
-            value = System.Math.Abs(value);
-        }
-        else if (ShouldShowPlusSign(value))
-        {
-            parts.Add(new NumberFormatPart("plusSign", NumberFormatInfo.PositiveSign));
-        }
+        var absValue = System.Math.Abs(value);
 
-        if (value == 0)
-        {
-            parts.Add(new NumberFormatPart("integer", "0"));
-            parts.Add(new NumberFormatPart("exponentSeparator", "E"));
-            parts.Add(new NumberFormatPart("exponentInteger", "0"));
-            return parts;
-        }
+        var exponent = ComputeExponent(absValue, out var compactSuffix);
+        var body = FormatNumericToString(ScaleDown(absValue, exponent));
 
-        int exponent;
-        double mantissa;
+        var sign = SignFor(isNegative, body.IsZero);
+        AppendSignPart(parts, sign.ShowNegative, sign.ShowPositive);
 
-        if (string.Equals(Notation, "engineering", StringComparison.Ordinal))
+        if (exponent == 0)
         {
-            // Engineering notation uses exponents that are multiples of 3
-            var rawExponent = (int) System.Math.Floor(System.Math.Log10(value));
-            exponent = (int) (System.Math.Floor(rawExponent / 3.0) * 3);
-            mantissa = value / System.Math.Pow(10, exponent);
+            // nothing was scaled, so the number is written by the standard sub-pattern — the one that groups
+            AddNumberParts(parts, in body);
         }
         else
         {
-            // Scientific notation
-            exponent = (int) System.Math.Floor(System.Math.Log10(value));
-            mantissa = value / System.Math.Pow(10, exponent);
+            AddNotationNumberParts(parts, in body);
         }
 
-        // Round the mantissa
-        mantissa = ApplyRounding(mantissa, MaximumFractionDigits);
-
-        // Split mantissa into integer and fraction
-        var integerPart = (long) System.Math.Truncate(mantissa);
-        var fractionValue = mantissa - integerPart;
-
-        // Add integer part
-        parts.Add(new NumberFormatPart("integer", integerPart.ToString(CultureInfo.InvariantCulture)));
-
-        // Add fraction part if needed
-        if (MinimumFractionDigits > 0 || (fractionValue > 0 && MaximumFractionDigits > 0))
+        if (string.Equals(Notation, "compact", StringComparison.Ordinal))
         {
-            var fractionStr = FractionDigitsOf(fractionValue, MaximumFractionDigits);
-            if (fractionStr.Length > 0)
-            {
-                parts.Add(new NumberFormatPart("decimal", NumberFormatInfo.NumberDecimalSeparator));
-                parts.Add(new NumberFormatPart("fraction", fractionStr));
-            }
+            AppendCompactSuffix(parts, compactSuffix);
+            return parts;
         }
 
-        // Add exponent separator
         parts.Add(new NumberFormatPart("exponentSeparator", "E"));
 
-        // Add exponent sign if negative
         if (exponent < 0)
         {
             parts.Add(new NumberFormatPart("exponentMinusSign", NumberFormatInfo.NegativeSign));
-            exponent = System.Math.Abs(exponent);
         }
 
-        // Add exponent integer
-        parts.Add(new NumberFormatPart("exponentInteger", exponent.ToString(CultureInfo.InvariantCulture)));
+        parts.Add(new NumberFormatPart(
+            "exponentInteger",
+            System.Math.Abs(exponent).ToString(CultureInfo.InvariantCulture)));
 
         return parts;
+    }
+
+    /// <summary>
+    /// https://tc39.es/ecma402/#sec-computeexponent: the power of ten this notation scales
+    /// <paramref name="absValue"/> by, together with the abbreviation compact notation writes after it.
+    /// </summary>
+    /// <remarks>
+    /// The last steps are the reason this is not a table lookup: rounding the mantissa can carry it into
+    /// the next magnitude, and the exponent is then the one that magnitude asks for. 999999 scaled by a
+    /// thousand rounds to 1000, which is one million — <c>"1M"</c>, where Jint wrote <c>"1000K"</c>.
+    /// </remarks>
+    private int ComputeExponent(double absValue, out string compactSuffix)
+    {
+        compactSuffix = string.Empty;
+
+        if (absValue == 0 || string.Equals(Notation, "standard", StringComparison.Ordinal))
+        {
+            return 0;
+        }
+
+        // the magnitude of the Intl mathematical value, which https://tc39.es/ecma402/#sec-tointlmathematicalvalue
+        // reads through Number::toString rather than through a logarithm
+        DecimalDigitsOf(absValue, out _, out var magnitude);
+
+        var exponent = ComputeExponentForMagnitude(magnitude, out compactSuffix);
+        var body = FormatNumericToString(ScaleDown(absValue, exponent));
+        if (body.IsZero || MagnitudeOf(in body) == magnitude - exponent)
+        {
+            return exponent;
+        }
+
+        return ComputeExponentForMagnitude(magnitude + 1, out compactSuffix);
+    }
+
+    /// <summary>
+    /// https://tc39.es/ecma402/#sec-computeexponentformagnitude, whose compact branch is the locale's own
+    /// datum and comes from <see cref="Data.CompactPatterns"/>.
+    /// </summary>
+    private int ComputeExponentForMagnitude(int magnitude, out string compactSuffix)
+    {
+        compactSuffix = string.Empty;
+
+        switch (Notation)
+        {
+            case "scientific":
+                return magnitude;
+            case "engineering":
+                return (int) (System.Math.Floor(magnitude / 3.0) * 3);
+            case "compact":
+                var isLong = string.Equals(CompactDisplay, "long", StringComparison.Ordinal);
+                return Data.CompactPatterns.GetPatterns(Locale).CompactExponent(magnitude, isLong, out compactSuffix);
+            default:
+                return 0;
+        }
+    }
+
+    /// <summary>
+    /// <paramref name="value"/> × 10^-<paramref name="exponent"/>, in steps a <see cref="double"/> holds.
+    /// </summary>
+    /// <remarks>
+    /// Scientific notation scales a value by its own magnitude, and the widest of those is wider than any
+    /// power of ten a double carries: <c>Math.Pow(10, 324)</c> is already an infinity, so scaling 5e-324
+    /// up in one step loses the number it was asked about. Every exponent inside ±300 divides exactly as it
+    /// did before, which is every exponent the conformance suite reaches.
+    /// </remarks>
+    private static double ScaleDown(double value, int exponent)
+    {
+        const int Step = 300;
+
+        while (exponent > Step)
+        {
+            value /= 1e300;
+            exponent -= Step;
+        }
+
+        while (exponent < -Step)
+        {
+            value *= 1e300;
+            exponent += Step;
+        }
+
+        return value / System.Math.Pow(10, exponent);
+    }
+
+    /// <summary>The power of ten of the first digit these digits carry.</summary>
+    private static int MagnitudeOf(in NumberBody body)
+    {
+        var integerDigits = body.IntegerDigits;
+        if (integerDigits.Length > 0 && integerDigits[0] != '0')
+        {
+            return integerDigits.Length - 1;
+        }
+
+        var fractionDigits = body.FractionDigits;
+        for (var i = 0; i < fractionDigits.Length; i++)
+        {
+            if (fractionDigits[i] != '0')
+            {
+                return -(i + 1);
+            }
+        }
+
+        return 0;
+    }
+
+    /// <summary>
+    /// Writes a scaled mantissa, which a notation's sub-pattern does not group.
+    /// </summary>
+    /// <remarks>
+    /// CLDR's compact patterns carry no group separator, so the mantissa of 1e21 in compact notation is
+    /// <c>"1000000000"</c> and not <c>"1,000,000,000"</c> — and a mantissa is the only thing wide enough
+    /// for the difference to show, since scientific and engineering keep theirs under four digits.
+    /// </remarks>
+    private void AddNotationNumberParts(List<NumberFormatPart> parts, in NumberBody body)
+    {
+        var integerDigits = body.IntegerDigits;
+        if (integerDigits.Length < MinimumIntegerDigits)
+        {
+            integerDigits = integerDigits.PadLeft(MinimumIntegerDigits, '0');
+        }
+
+        parts.Add(new NumberFormatPart("integer", integerDigits));
+
+        if (body.FractionDigits.Length > 0)
+        {
+            parts.Add(new NumberFormatPart("decimal", NumberFormatInfo.NumberDecimalSeparator));
+            parts.Add(new NumberFormatPart("fraction", body.FractionDigits));
+        }
+    }
+
+    /// <summary>
+    /// Writes the <c>compactSymbol</c> or <c>compactName</c> https://tc39.es/ecma402/#sec-partitionnotationsubpattern
+    /// puts after the number, and the literal the locale separates it with.
+    /// </summary>
+    private void AppendCompactSuffix(List<NumberFormatPart> parts, string compactSuffix)
+    {
+        if (compactSuffix.Length == 0)
+        {
+            return;
+        }
+
+        var patterns = Data.CompactPatterns.GetPatterns(Locale);
+        var isLong = string.Equals(CompactDisplay, "long", StringComparison.Ordinal);
+
+        if (isLong ? patterns.LongSpace : patterns.ShortSpace)
+        {
+            // a short abbreviation is separated by a non-breaking space, per CLDR
+            parts.Add(new NumberFormatPart("literal", isLong ? " " : "\u00a0"));
+        }
+
+        parts.Add(new NumberFormatPart("compact", compactSuffix));
     }
 
     private List<NumberFormatPart> FormatDecimalToParts(double value)
@@ -2221,36 +1385,11 @@ internal sealed class JsNumberFormat : ObjectInstance
 
         // Handle sign
         var isNegative = value < 0 || double.IsNegativeInfinity(1 / value); // Handles -0
-        var absValue = System.Math.Abs(value);
 
         var body = FormatNumericToString(value);
-        var displaysAsZero = body.IsZero;
+        var sign = SignFor(isNegative, body.IsZero);
 
-        // Determine if we should show a sign based on signDisplay
-        var showNegativeSign = isNegative;
-        var showPositiveSign = false;
-
-        switch (SignDisplay)
-        {
-            case "always":
-                showPositiveSign = !isNegative;
-                break;
-            case "exceptZero":
-                showPositiveSign = !isNegative && !displaysAsZero;
-                showNegativeSign = isNegative && !displaysAsZero;
-                break;
-            case "negative":
-                showPositiveSign = false;
-                // For "negative" signDisplay, only show negative sign for truly negative, non-zero display
-                showNegativeSign = isNegative && !displaysAsZero;
-                break;
-            case "never":
-                showNegativeSign = false;
-                showPositiveSign = false;
-                break;
-        }
-
-        AppendSignPart(parts, showNegativeSign, showPositiveSign);
+        AppendSignPart(parts, sign.ShowNegative, sign.ShowPositive);
         AddNumberParts(parts, in body);
 
         return parts;
@@ -2319,76 +1458,17 @@ internal sealed class JsNumberFormat : ObjectInstance
         return boundaries;
     }
 
-    /// <summary>
-    /// The fraction digits https://tc39.es/ecma402/#sec-torawfixed writes for a value already rounded to
-    /// <paramref name="fractionDigits"/> places: that many digits, less the trailing zeros its last two
-    /// steps remove down to <see cref="MinimumFractionDigits"/>.
-    /// </summary>
-    /// <remarks>
-    /// The result is empty when every digit was removed, which is what the caller has to notice: the
-    /// decimal separator goes with them, and neither lane writes a separator with nothing after it.
-    /// </remarks>
-    private string FractionDigitsOf(double fractionValue, int fractionDigits)
-    {
-        if (fractionDigits < MinimumFractionDigits)
-        {
-            fractionDigits = MinimumFractionDigits;
-        }
-
-        if (fractionDigits == 0)
-        {
-            return string.Empty;
-        }
-
-        var multiplier = System.Math.Pow(10, fractionDigits);
-        var fractionInt = (long) System.Math.Round(fractionValue * multiplier);
-        var digits = fractionInt.ToString(CultureInfo.InvariantCulture).PadLeft(fractionDigits, '0');
-
-        var keep = digits.Length;
-        while (keep > MinimumFractionDigits && digits[keep - 1] == '0')
-        {
-            keep--;
-        }
-
-        return keep == digits.Length ? digits : digits.Substring(0, keep);
-    }
-
     private List<NumberFormatPart> FormatCurrencyToParts(double value)
     {
         var parts = new List<NumberFormatPart>();
         var isNegative = value < 0 || double.IsNegativeInfinity(1 / value); // Handles -0
-        var absValue = System.Math.Abs(value);
 
         // The digits are https://tc39.es/ecma402/#sec-formatnumberstring's, which is one operation for
         // every style: the currency pattern is written around them and never instead of them.
         var body = FormatNumericToString(value);
-        var displaysAsZero = body.IsZero;
+        var sign = SignFor(isNegative, body.IsZero);
 
-        // Determine if we should show a negative sign based on signDisplay
-        var showNegativeSign = isNegative;
-        var showPositiveSign = false;
-
-        switch (SignDisplay)
-        {
-            case "always":
-                showPositiveSign = !isNegative;
-                break;
-            case "exceptZero":
-                showPositiveSign = !isNegative && !displaysAsZero;
-                showNegativeSign = isNegative && !displaysAsZero;
-                break;
-            case "negative":
-                showPositiveSign = false;
-                // For "negative" signDisplay, only show negative sign for truly negative, non-zero display
-                showNegativeSign = isNegative && !displaysAsZero;
-                break;
-            case "never":
-                showNegativeSign = false;
-                showPositiveSign = false;
-                break;
-        }
-
-        AppendCurrencyParts(parts, in body, showNegativeSign, showPositiveSign);
+        AppendCurrencyParts(parts, in body, sign.ShowNegative, sign.ShowPositive);
 
         return parts;
     }
@@ -2610,32 +1690,9 @@ internal sealed class JsNumberFormat : ObjectInstance
 
         // Multiply by 100 for percent
         var body = FormatNumericToString(value * 100);
-        var displaysAsZero = body.IsZero;
+        var sign = SignFor(isNegative, body.IsZero);
 
-        // Determine if we should show a sign based on signDisplay
-        var showNegativeSign = isNegative;
-        var showPositiveSign = false;
-
-        switch (SignDisplay)
-        {
-            case "always":
-                showPositiveSign = !isNegative;
-                break;
-            case "exceptZero":
-                showPositiveSign = !isNegative && !displaysAsZero;
-                showNegativeSign = isNegative && !displaysAsZero;
-                break;
-            case "negative":
-                showPositiveSign = false;
-                showNegativeSign = isNegative && !displaysAsZero;
-                break;
-            case "never":
-                showNegativeSign = false;
-                showPositiveSign = false;
-                break;
-        }
-
-        AppendPercentParts(parts, in body, showNegativeSign, showPositiveSign);
+        AppendPercentParts(parts, in body, sign.ShowNegative, sign.ShowPositive);
 
         return parts;
     }
@@ -2686,35 +1743,11 @@ internal sealed class JsNumberFormat : ObjectInstance
     {
         var parts = new List<NumberFormatPart>();
         var isNegative = value < 0 || double.IsNegativeInfinity(1 / value); // Handles -0
-        var absValue = System.Math.Abs(value);
 
         var body = FormatNumericToString(value);
-        var displaysAsZero = body.IsZero;
+        var sign = SignFor(isNegative, body.IsZero);
 
-        // Determine if we should show a sign based on signDisplay
-        var showNegativeSign = isNegative;
-        var showPositiveSign = false;
-
-        switch (SignDisplay)
-        {
-            case "always":
-                showPositiveSign = !isNegative;
-                break;
-            case "exceptZero":
-                showPositiveSign = !isNegative && !displaysAsZero;
-                showNegativeSign = isNegative && !displaysAsZero;
-                break;
-            case "negative":
-                showPositiveSign = false;
-                showNegativeSign = isNegative && !displaysAsZero;
-                break;
-            case "never":
-                showNegativeSign = false;
-                showPositiveSign = false;
-                break;
-        }
-
-        AppendUnitParts(parts, in body, showNegativeSign, showPositiveSign, value);
+        AppendUnitParts(parts, in body, sign.ShowNegative, sign.ShowPositive, value);
 
         return parts;
     }
@@ -2812,15 +1845,4 @@ internal sealed class JsNumberFormat : ObjectInstance
         }
     }
 
-    private bool ShouldShowPlusSign(double value)
-    {
-        if (value <= 0) return false;
-
-        return SignDisplay switch
-        {
-            "always" => true,
-            "exceptZero" => value != 0,
-            _ => false
-        };
-    }
 }

--- a/Jint/Native/Intl/NumberFormatConstructor.cs
+++ b/Jint/Native/Intl/NumberFormatConstructor.cs
@@ -180,9 +180,12 @@ internal sealed partial class NumberFormatConstructor : Constructor
         }
 
         // Per spec: fractionDigits range is 0-100
-        var minimumFractionDigits = GetNumberOption(optionsObj, "minimumFractionDigits", 0, 100, minFracDefault);
+        var minFracDigitsValue = optionsObj.Get("minimumFractionDigits");
+        var maxFracDigitsValue = optionsObj.Get("maximumFractionDigits");
+        var hasFractionDigits = !minFracDigitsValue.IsUndefined() || !maxFracDigitsValue.IsUndefined();
+        var minimumFractionDigits = GetNumberOptionFromValue(minFracDigitsValue, "minimumFractionDigits", 0, 100, minFracDefault);
         // Per spec: maximumFractionDigits minimum is 0, fallback is max(mnfd, mxfdDefault)
-        var maximumFractionDigits = GetNumberOption(optionsObj, "maximumFractionDigits", 0, 100, System.Math.Max(minimumFractionDigits, maxFracDefault));
+        var maximumFractionDigits = GetNumberOptionFromValue(maxFracDigitsValue, "maximumFractionDigits", 0, 100, System.Math.Max(minimumFractionDigits, maxFracDefault));
 
         // Per spec: if mnfd > mxfd, adjust mnfd down to mxfd
         if (minimumFractionDigits > maximumFractionDigits)
@@ -216,6 +219,24 @@ internal sealed partial class NumberFormatConstructor : Constructor
         var compactDisplay = GetStringOption(optionsObj, "compactDisplay", CompactDisplayValues, "short");
         var useGrouping = GetUseGroupingOption(optionsObj, notation);
         var signDisplay = GetStringOption(optionsObj, "signDisplay", SignDisplayValues, "auto");
+
+        // https://tc39.es/ecma402/#sec-setnumberformatdigitoptions: compact notation asked for no digit
+        // option at all is the one case that leaves both roundings unconfigured, and the algorithm gives
+        // it a rounding of its own — one to two significant digits, at more-precision against no fraction
+        // digits. That is the rule that writes "1.2K" for 1234 and "12K" for 12345, and the compact lane
+        // now reads it here instead of open-coding a rounding of its own.
+        if (isCompact
+            && !minimumSignificantDigits.HasValue
+            && !maximumSignificantDigits.HasValue
+            && !hasFractionDigits
+            && string.Equals(roundingPriority, "auto", StringComparison.Ordinal))
+        {
+            minimumFractionDigits = 0;
+            maximumFractionDigits = 0;
+            minimumSignificantDigits = 1;
+            maximumSignificantDigits = 2;
+            roundingPriority = "morePrecision";
+        }
 
         // Validate roundingIncrement constraints
         if (roundingIncrement > 1)

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -3885,6 +3885,92 @@ year past it. Where a date **sits** is unchanged: the table placed every ISO dat
 **No date moved, and no other calendar changed.** Measured before and after over 417,136 field reads, 14.5
 million additions, 22,568 field-to-ISO conversions and 580,544 differences across seven calendars: the only
 answers that differ are the ones listed above.
+### 4.88 `Intl.NumberFormat` computes its digits in one place, notations included ([#3517](https://github.com/sebastienros/jint/issues/3517))
+
+[FormatNumericToString](https://tc39.es/ecma402/#sec-formatnumberstring) is where a number's digits are
+decided, once, for every style and every notation — the style and the notation only choose what is written
+around them. [§4.59](#459-intlnumberformat-walks-one-pattern-for-both-lanes-non-finite-values-included-3465)
+brought the two lanes onto one pattern walk; this brings them onto one digit computation, and `format` is
+now literally the concatenation of the parts `formatToParts` returns, as
+[FormatNumber](https://tc39.es/ecma402/#sec-formatnumber) defines it. Three lanes were still computing
+their own, and each got a different answer wrong.
+
+**The decimal string lane rounded at fifteen significant digits.** It built a .NET custom numeric format
+string (`"#,##0.###"`) and handed the value to `double.ToString`, which rounds there;
+[ToIntlMathematicalValue](https://tc39.es/ecma402/#sec-tointlmathematicalvalue) reads a Number by parsing
+`Number::toString`, which keeps up to seventeen. `style: "unit"` reported the same, because it formatted its
+number with that lane:
+
+```js
+const nf = new Intl.NumberFormat('en-US');
+// 5.0: "12,345,678,901,234,600,000"      5.x: "12,345,678,901,234,567,000"
+nf.format(12345678901234567890);
+// its own formatToParts already said "12,345,678,901,234,567,000", as does every other engine
+```
+
+**The compact lane saturated a `long`.** It split its scaled value with `(long) Math.Truncate(…)`, and .NET
+pins an out-of-range conversion rather than throwing, so both lanes agreed on `long.MaxValue`'s digits.
+There is no CLDR abbreviation past a trillion, so the answer is the mantissa written out:
+
+```js
+const c = new Intl.NumberFormat('en-US', { notation: 'compact' });
+c.format(1e300);  // 5.0: "9223372036854775807T"   5.x: "1" followed by 288 zeros, then "T"
+```
+
+**No notation read the significant-digit options.**
+[PartitionNumberPattern](https://tc39.es/ecma402/#sec-partitionnumberpattern) calls
+[ComputeExponent](https://tc39.es/ecma402/#sec-computeexponent) first and *then* FormatNumericToString on
+the scaled value, so those options apply to a notation's mantissa exactly as they apply to any other number.
+The three notation lanes rounded a mantissa of their own at `maximumFractionDigits` and read neither:
+
+```js
+new Intl.NumberFormat('en-US', { notation: 'scientific', maximumSignificantDigits: 2 }).format(12345);
+// 5.0: "1.235E4"   5.x: "1.2E4"
+new Intl.NumberFormat('en-US', { notation: 'compact', maximumSignificantDigits: 4 }).format(12345);
+// 5.0: "12K"       5.x: "12.35K"
+```
+
+Compact's own rounding comes from the same place now.
+[SetNumberFormatDigitOptions](https://tc39.es/ecma402/#sec-setnumberformatdigitoptions) gives compact
+notation asked for no digit option a rounding of its own — one to two significant digits at
+more-precision against no fraction digits, which is what writes `"1.2K"` for 1234 and `"12K"` for 12345 —
+and that is a resolved option, not an internal convention:
+
+```js
+new Intl.NumberFormat('en-US', { notation: 'compact' }).resolvedOptions();
+// gains minimumSignificantDigits: 1, maximumSignificantDigits: 2, and roundingPriority: "morePrecision"
+```
+
+Four narrower disagreements go with them, all of them a notation lane now reading what the standard lane
+already read.
+
+`ComputeExponent` re-reads the exponent when rounding the mantissa carries it into the next magnitude,
+which is what its own note is about. Neither lane did: `format(999999)` under `notation: "compact"` was
+`"1000K"` and is `"1M"`, and under `"scientific"` `format(99999)` was `"10E4"` and is `"1E5"`.
+
+`signDisplay` reached no notation at all, so a plus sign was never written and `"never"` never suppressed a
+minus. `{ notation: 'scientific', signDisplay: 'always' }.format(1)` was `"1E0"` and is `"+1E0"`;
+`{ notation: 'scientific', signDisplay: 'never' }.format(-1)` was `"-1E0"` and is `"1E0"`;
+`{ notation: 'compact' }.format(-0)` was `"0"` and is `"-0"`, which is what the standard notation already
+wrote. `minimumIntegerDigits` reached none of them either, and now pads the mantissa.
+
+Rounding at a place below the value's last significant digit is the identity, and scaling by
+10^`maximumFractionDigits` to do it anyway was not. That reached the parts lane of every style:
+`{ maximumFractionDigits: 20 }.formatToParts(100000)` joined to `"100,000.00000000001455191523"`, and
+`{ minimumSignificantDigits: 3 }.format(0.00159)` was `"0.0015900000000000003"`. Both are the digits the
+value has now, because the split is made from `Number::toString`'s digits rather than from a `Truncate` and
+a fraction scaled by a power of ten.
+
+And a value small enough that the scaling overflowed produced a rounding of `NaN`, which was then written
+out: `{ maximumSignificantDigits: 2 }.format(1e-320)` was the three characters `"Nb0"` and is the number.
+
+**What could break:** any output holding more than fifteen significant digits, anything under a notation
+that also set a digit option or a `signDisplay`, a compact `resolvedOptions()` snapshot, and a
+`maximumFractionDigits` wide enough to reach past a double's digits. Measured across a grid of twelve
+locales, thirty-three option sets and thirty-nine values: the percent and currency styles do not move at
+all under the standard notation, and no string that was already the concatenation of its own parts changes
+except where one of the above applies.
+
 ## 5. New in v5
 
 Everything in the table below is opt-in: nothing in it is installed unless the host asks for it, so


### PR DESCRIPTION
Fixes #3517.

All three claims reproduce on `main` (`32989e89e`), and all three are the same shape: a lane that computes its own digits instead of reading [FormatNumericToString](https://tc39.es/ecma402/#sec-formatnumberstring)'s. So there is one fix, not three — `format` becomes the concatenation of the parts `formatToParts` returns, which is what [FormatNumber](https://tc39.es/ecma402/#sec-formatnumber) defines it to be, and the notation lane becomes [PartitionNumberPattern](https://tc39.es/ecma402/#sec-partitionnumberpattern)'s own shape.

## The three claims, on today's `main`

Verified by running the issue's repros against unmodified `main`:

```
1a format: 12,345,678,901,234,600,000        1b parts: 12,345,678,901,234,567,000
1d unit  : 12,345,678,901,234,600,000 m      1e parts: 12,345,678,901,234,567,000 m
2a compact 1e300: 9223372036854775807T       2c compact 1e21: 1000000000T
3a scientific maximumSignificantDigits:2 -> 1.235E4   (V8: 1.2E4)
3c compact    maximumSignificantDigits:4 -> 12K       (V8: 12.35K)
```

**1 — confirmed.** `FormatDecimal` built `"#,##0.###"` and handed the value to `double.ToString`; a .NET custom numeric format string rounds at fifteen significant digits. [ToIntlMathematicalValue](https://tc39.es/ecma402/#sec-tointlmathematicalvalue) reads a Number as *Let str be Number::toString(x, 10)* and then parses `str` as a StringNumericLiteral — the shortest decimal that reads back as the double, up to seventeen digits. `style: "unit"` reported the same because `FormatUnit` formatted its number with `FormatDecimal`.

**2 — confirmed.** Both compact lanes used `(long) Math.Truncate(...)`. The correct answer for `1e300` is the mantissa written out — there is no CLDR abbreviation past a trillion, so it is `"1"` followed by 288 zeros and a `T`, which is 1e300 × 10^-12.

**3 — confirmed.** [PartitionNumberPattern](https://tc39.es/ecma402/#sec-partitionnumberpattern) steps: *Set exponent to ComputeExponent(numberFormat, x). Set x to x × 10^-exponent. Let formatNumberResult be FormatNumericToString(numberFormat, x).* The digit options therefore apply to the mantissa exactly as they apply to a standard-notation number. None of `FormatScientific` / `FormatEngineering` / `FormatCompact` or their parts counterparts read `[[MinimumSignificantDigits]]` or `[[MaximumSignificantDigits]]`.

Every clause above was read from a freshly fetched <https://tc39.es/ecma402/>. `sec-computeexponent`, `sec-computeexponentformagnitude` and `sec-setnumberformatdigitoptions` are new citations and are in `Jint.Tests/SpecAnchors.txt`, added by the sanctioned `JINT_SPEC_ANCHORS=update` run (three anchors, `verified` date bumped, nothing else moved).

## The fix, in one place

`Format(double)` is `ConcatenateParts(FormatToParts(value))` and every string-assembling lane is gone — `FormatDecimal`, `FormatCurrency`, `FormatUnit`, `FormatScientific`, `FormatEngineering`, `FormatCompact`, `FormatCompactSmallValue`, `FormatAccountingNegativeCurrency`, `FormatNegativeCurrency`, `ApplyGroupingToString`, `AddDecimalParts`, `FormatCompactToParts` and the string transliterator. That is roughly 1,000 lines deleted against 330 added.

What replaces the three notation lanes is one method with the algorithm's shape:

```csharp
var exponent = ComputeExponent(absValue, out var compactSuffix);
var body = FormatNumericToString(ScaleDown(absValue, exponent));
```

`ComputeExponent` is [16.5.13](https://tc39.es/ecma402/#sec-computeexponent) including its last steps — the ones that re-read the exponent when rounding carries the mantissa into the next magnitude. `ComputeExponentForMagnitude`'s compact branch is the locale datum, and `CompactPatterns.LocaleCompactData.CompactExponent` answers it from the divisors already in the table, so `ja` still abbreviates at 万 and 億 rather than at 10^3 and 10^6.

Two supporting changes, both required by the collapse:

- **Compact's own rounding is read rather than open-coded.** [SetNumberFormatDigitOptions](https://tc39.es/ecma402/#sec-setnumberformatdigitoptions) gives compact-with-no-digit-option `[[MinimumSignificantDigits]] = 1`, `[[MaximumSignificantDigits]] = 2`, zero fraction digits and `more-precision`. That is the rule that writes `"1.2K"` for 1234 and `"12K"` for 12345; without it the shared `FormatNumericToString` would write `"1K"`. It is a resolved option, so `resolvedOptions()` now reports it.
- **Rounding at a place below the value's last significant digit is the identity.** `ApplyRounding` scaled by `10^decimalPlaces` and back, which is not: `100000` at `maximumFractionDigits: 20` came back as `100000.00000000001`. That reached the *parts* lane of every style on `main` already, and `format` inherited it the moment the lanes merged — `intl402/NumberFormat/prototype/format/value-decimal-string.js` caught it, which is exactly what that test is for. `FiniteBody` now splits `Number::toString`'s digits through the same `ExactBody` a BigInt takes, instead of `Truncate` plus a fraction scaled by a power of ten, so `IntegerDigitsOf` and `FractionDigitsOf` are gone too.

## Join-equality evidence

`PartsConcatenateToFormat`'s grid gains `12345678901234567890` and `1e300` to its values and six option sets pairing each notation with a digit option and a `signDisplay`. Against unmodified `main` that grid reports 40 mismatches over a reduced sweep, in three families:

```
en/{}/12345678901234567000                       format=12,345,678,901,234,600,000  parts=12,345,678,901,234,567,000
en/{style:unit,unit:meter}/12345678901234567000  format=...600,000 m                parts=...567,000 m
en/{notation:scientific,signDisplay:exceptZero}/1234.5  format=1.235E3              parts=+1.235E3
```

The third is a fourth defect the extended grid found: no notation lane read `signDisplay` at all, so the string lane wrote no plus sign and `"never"` never suppressed a minus.

The grid can no longer fail for a *disagreement* — `format` is the concatenation now — so the exact strings are asserted outright in five new tests, each of which fails on unmodified `main`:

| Test | On `main` |
| --- | --- |
| `TheStringLaneKeepsEverySignificantDigitTheValueHas` | `...901,234,600,000` |
| `ACompactMantissaPastTheRangeOfALongIsStillItsOwnDigits` | `9223372036854775807T` |
| `ANotationsMantissaReadsTheSignificantDigitOptions` | `1.235E4` |
| `CompactResolvesTheDigitOptionsTheAlgorithmGivesIt` | no `minimumSignificantDigits`, `roundingPriority: "auto"` |
| `ACompactMantissaThatRoundsUpTakesTheNextAbbreviation` | `1000K` for 999999 |

Run against `main` with the fix reverted and only the tests applied: `Failed: 6, Passed: 31` — the five above plus `PartsConcatenateToFormat`. With the fix: `Failed: 0, Passed: 37`.

`1.2345678901234567e19` is written in exponential form in the first of those because the decimal literal `12345678901234567890` **does not parse to the same double on every target framework**: `net10.0` gives the correctly-rounded one, `net8.0` and `net472` are one ulp away and spell it `12345678901234570000`. That is a parser difference unrelated to this issue and worth its own report; the grid's join-equality entry for that value holds on all three regardless.

## What moves

`docs/v5-migration.md` §4.88 has the whole list. Measured over 12 locales × 33 option sets × 39 values before and after: the percent and currency styles do not move at all under the standard notation, and the changes are the four defects plus `ComputeExponent`'s re-read (999999 compact is `"1M"` not `"1000K"`; 99999 scientific is `"1E5"` not `"10E4"`), `minimumIntegerDigits` reaching a notation, compact `format(-0)` gaining its sign as the standard notation already had it, and the two rounding-identity fixes (`{ maximumFractionDigits: 20 }.formatToParts(100000)` no longer joins to `100,000.00000000001455191523`, and `{ minimumSignificantDigits: 3 }.format(0.00159)` is `0.00159` rather than `0.0015900000000000003`).

## Verification

- `dotnet build -c Release` clean, `TreatWarningsAsErrors` on.
- `dotnet test -c Release Jint.Tests` — **0 failed** on net472 / net8.0 / net10.0 (11,228 · 11,228 · 7,848 passed).
- `Jint.Tests.PublicInterface`, `Jint.Tests.CommonScripts`, `Jint.Tests.SourceGenerators` — all green.
- test262 — **102,537 passed / 0 failed / 151 skipped** of 102,688, which is the control figure exactly.
- No exclusion could be removed. `intl402/NumberFormat/prototype/format/useGrouping-extended-en-IN.js` still fails on its compact block, which wants `"1L"` (lakh) for 100000; Jint's compact table has no Indian units, so its comment stays accurate.
