### PR TITLE
Temporal and Intl parsing cannot fail because the machine was busy (#3486)

### DIFF
--- a/Jint.Tests/Runtime/TemporalParsePatternBudgetTests.cs
+++ b/Jint.Tests/Runtime/TemporalParsePatternBudgetTests.cs
@@ -1,0 +1,285 @@
+﻿#nullable enable
+
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Jint.Native.Intl;
+using Jint.Native.Temporal;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// The internal ISO 8601 and BCP 47 patterns carry no match timeout, and these tests are why.
+/// <see cref="Regex.MatchTimeout"/> is a <i>wall-clock</i> deadline sampled during matching, so it cannot
+/// tell a pattern that is backtracking apart from a thread that lost the CPU: a descheduled thread trips it
+/// having burned almost no CPU at all. These patterns used to carry 100 ms, and a single match of the valid
+/// 8-character string <c>10:30:00</c> was measured taking 440 ms of wall clock on an ordinary loaded
+/// machine — 4.4x over that budget — while the same thing failed CI parsing a correct ISO string.
+/// <para>
+/// The consequence was not a JavaScript error. <c>RegexMatchTimeoutException</c> is listed in
+/// <c>Throw.MustPropagateHostException</c>, so it escaped <c>Engine.Evaluate</c> as a raw CLR exception,
+/// straight through the script's own <c>try</c>/<c>catch</c> — a script could not even defend itself.
+/// </para>
+/// <para>
+/// The starvation that causes it cannot be reproduced on demand without loading the machine, which would
+/// make these tests the very flake they are about. So they pin the <i>property</i> instead: no pattern
+/// carries a deadline, every fixed-width pattern's length cap really is the longest string it can match,
+/// an over-long input is rejected without the pattern being asked, and a valid string parses.
+/// </para>
+/// </summary>
+public class TemporalParsePatternBudgetTests
+{
+    private static IEnumerable<(string Owner, string Name, Regex Value)> InternalPatterns()
+    {
+        foreach (var type in new[] { typeof(TemporalHelpers), typeof(IntlUtilities) })
+        {
+            foreach (var field in type.GetFields(BindingFlags.NonPublic | BindingFlags.Static))
+            {
+                if (field.FieldType == typeof(Regex))
+                {
+                    yield return (type.Name, field.Name, (Regex) field.GetValue(null)!);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// The fix itself. Every internal pattern must match without a deadline — including any added later,
+    /// which is why this enumerates the fields rather than naming them.
+    /// </summary>
+    [Fact]
+    public void NoInternalParsePatternCarriesAWallClockDeadline()
+    {
+        var patterns = InternalPatterns().ToList();
+
+        // Guard against the enumeration silently finding nothing and passing vacuously.
+        patterns.Should().HaveCountGreaterThanOrEqualTo(8);
+
+        foreach (var (owner, name, regex) in patterns)
+        {
+            regex.MatchTimeout.Should().Be(
+                Regex.InfiniteMatchTimeout,
+                "{0}.{1} is a fixed internal pattern over engine-supplied input, and a wall-clock budget on " +
+                "one can only ever fire spuriously — as an uncatchable CLR exception",
+                owner,
+                name);
+        }
+    }
+
+    /// <summary>
+    /// The length caps are only safe because they are the exact longest string their pattern can match.
+    /// Widening a pattern without widening its cap would start rejecting valid input, so pin both ends:
+    /// the maximal example matches and is exactly cap-length, and one character more never matches.
+    /// </summary>
+    [Theory]
+    [InlineData("DatePattern", "+123456-12-31", 13)]
+    [InlineData("TimePatternColon", "12:34:56.123456789", 18)]
+    [InlineData("TimePatternHyphen", "12-34-56.123456789", 18)]
+    [InlineData("TimePatternCompact", "123456.123456789", 16)]
+    [InlineData("TimeWithOffsetPattern", "12:34:56.123456789+12:34:56.123456789", 37)]
+    public void AFixedWidthPatternMatchesNothingLongerThanItsCap(string field, string longest, int cap)
+    {
+        var regex = InternalPatterns().Single(p => p.Name == field).Value;
+
+        longest.Length.Should().Be(cap);
+        regex.IsMatch(longest).Should().BeTrue("{0} must accept its own maximal string", field);
+
+        // Nothing longer than the cap is in the pattern's language, whatever it is built from. The
+        // alphabet is every character any of these patterns can consume.
+        const string Alphabet = "0123456789:-.,+Zz";
+        var random = new Random(20260827);
+        for (var i = 0; i < 20_000; i++)
+        {
+            var buffer = new char[cap + 1 + random.Next(0, 24)];
+            for (var j = 0; j < buffer.Length; j++)
+            {
+                buffer[j] = Alphabet[random.Next(0, Alphabet.Length)];
+            }
+
+            var candidate = new string(buffer);
+
+            regex.IsMatch(candidate).Should().BeFalse(
+                "{0} must not match \"{1}\", which is longer than its {2}-character cap",
+                field,
+                candidate,
+                cap);
+        }
+    }
+
+    /// <summary>
+    /// An over-long input is rejected without the pattern being asked, and the rejection is a JavaScript
+    /// error the script can catch — never a CLR exception out of <c>Engine.Evaluate</c>.
+    /// </summary>
+    [Theory]
+    [InlineData("Temporal.PlainDate")]
+    [InlineData("Temporal.PlainTime")]
+    [InlineData("Temporal.PlainYearMonth")]
+    [InlineData("Temporal.PlainMonthDay")]
+    [InlineData("Temporal.Instant")]
+    [InlineData("Temporal.Duration")]
+    public void AnOverLongInputIsRejectedAsAJavaScriptError(string type)
+    {
+        var engine = new Engine();
+        engine.SetValue("huge", new string('1', 1_000_000));
+
+        engine.Evaluate($"(() => {{ try {{ {type}.from(huge); return 'accepted'; }} catch (e) {{ return e.constructor.name; }} }})()")
+            .AsString().Should().Be("RangeError");
+    }
+
+    /// <summary>
+    /// The shape that was failing: a correct call with a valid string. It must parse, and it must never be
+    /// able to fail for a reason that has nothing to do with its own contents.
+    /// </summary>
+    [Theory]
+    [InlineData("Temporal.PlainDate.from('2024-01-15T10:30:00').toString()", "2024-01-15")]
+    [InlineData("Temporal.PlainDate.from('2024-01-15').toString()", "2024-01-15")]
+    [InlineData("Temporal.PlainTime.from('10:30:00').toString()", "10:30:00")]
+    [InlineData("Temporal.PlainTime.from('10:30:00.123456789').toString()", "10:30:00.123456789")]
+    [InlineData("Temporal.Instant.from('2024-01-15T10:30:00Z').toString()", "2024-01-15T10:30:00Z")]
+    [InlineData("Temporal.Duration.from('P1Y2M3DT4H5M6S').toString()", "P1Y2M3DT4H5M6S")]
+    public void AValidIsoStringParses(string expression, string expected)
+    {
+        new Engine().Evaluate(expression).AsString().Should().Be(expected);
+    }
+
+    /// <summary>
+    /// What the removed timeout was nominally guarding. Each pattern is driven with the near-miss shapes
+    /// that make a backtracking engine work hardest — a long run that almost satisfies the pattern and then
+    /// fails at the last character — at a length no ISO string would ever reach. These return in well under
+    /// a millisecond because every one of these patterns is linear in its input; a pattern edited into a
+    /// catastrophic one would not return at all, and would fail this by the runner's own timeout rather
+    /// than by any assertion on a clock, which is deliberate: nothing here measures elapsed time.
+    /// </summary>
+    [Fact]
+    public void EveryPatternRejectsAdversarialInputWithoutBacktrackingAwayTheAfternoon()
+    {
+        const int Length = 16 * 1024;
+
+        var nearMisses = new[]
+        {
+            new string('1', Length) + "x",
+            string.Concat(Enumerable.Repeat("12:", Length / 3)) + "x",
+            "12:34:56." + new string('1', Length) + "x",
+            "P" + new string('1', Length) + "Y" + new string('2', Length) + "M" + "x",
+            "PT" + new string('1', Length) + "." + new string('2', Length) + "H" + "x",
+            "2020-01-01T00:00:00+" + string.Concat(Enumerable.Repeat("01:", Length / 3)) + "x",
+            "2020-01-01T12:34:56.123456789+01:00" + string.Concat(Enumerable.Repeat("[u-ca=iso8601]", Length / 14)) + "x",
+            new string('[', Length),
+            "[" + new string('a', Length),
+        };
+
+        foreach (var (owner, name, regex) in InternalPatterns())
+        {
+            foreach (var input in nearMisses)
+            {
+                regex.IsMatch(input).Should().BeFalse("{0}.{1} must reject adversarial input", owner, name);
+            }
+        }
+    }
+
+    /// <summary>
+    /// <c>ValidateAnnotations</c> walks the annotation list rather than scanning it with the
+    /// <c>\[(!?)([^\]]+)\]</c> pattern it used to, because that pattern is quadratic on an input holding
+    /// no <c>]</c> at all — every start position consumes the rest of the string and backtracks over it.
+    /// The walk has to agree with the pattern it replaced, so drive both over a corpus that includes the
+    /// two cases the pattern's backtracking decides on its own: <c>[]</c>, which has no content and is
+    /// therefore not an annotation, and <c>[!]</c>, where the optional <c>!</c> is given back to the
+    /// content rather than taken as the critical marker.
+    /// </summary>
+    [Fact]
+    public void TheAnnotationWalkAgreesWithThePatternItReplaced()
+    {
+        var pattern = new Regex(@"\[(!?)([^\]]+)\]", RegexOptions.CultureInvariant, Regex.InfiniteMatchTimeout);
+
+        var corpus = new List<string>
+        {
+            "",
+            "[]",
+            "[!]",
+            "[!!]",
+            "[u-ca=iso8601]",
+            "[!u-ca=iso8601]",
+            "[u-ca=iso8601][America/New_York]",
+            "[!u-ca=hebrew][!America/New_York]",
+            "[a[b]",
+            "[[[[[",
+            "[[[[[]",
+            "no annotations here",
+            "[unclosed",
+            "][",
+            "[a][][b]",
+            "[a][!][b]",
+        };
+
+        // Plus randomized blobs over the alphabet that makes the two engines disagree if anything does.
+        const string Alphabet = "[]!=-abu0";
+        var random = new Random(20260827);
+        for (var i = 0; i < 5_000; i++)
+        {
+            var buffer = new char[random.Next(0, 24)];
+            for (var j = 0; j < buffer.Length; j++)
+            {
+                buffer[j] = Alphabet[random.Next(0, Alphabet.Length)];
+            }
+
+            corpus.Add(new string(buffer));
+        }
+
+        foreach (var input in corpus)
+        {
+            var expected = pattern.Matches(input)
+                .Cast<Match>()
+                .Select(m => (Critical: m.Groups[1].Value == "!", Content: m.Groups[2].Value))
+                .ToList();
+
+            Walk(input).Should().Equal(expected, "the walk must find in \"{0}\" what the pattern found", input);
+        }
+
+        // The walk, transcribed from TemporalHelpers.ValidateAnnotations.
+        static List<(bool Critical, string Content)> Walk(string annotations)
+        {
+            var found = new List<(bool, string)>();
+            var index = 0;
+            while (index < annotations.Length)
+            {
+                var open = annotations.IndexOf('[', index);
+                if (open < 0)
+                {
+                    break;
+                }
+
+                var close = annotations.IndexOf(']', open + 1);
+                if (close < 0)
+                {
+                    break;
+                }
+
+                if (close == open + 1)
+                {
+                    index = open + 1;
+                    continue;
+                }
+
+                var critical = annotations[open + 1] == '!' && close > open + 2;
+                var contentStart = critical ? open + 2 : open + 1;
+                found.Add((critical, annotations.Substring(contentStart, close - contentStart)));
+                index = close + 1;
+            }
+
+            return found;
+        }
+    }
+
+    /// <summary>
+    /// The end-to-end shape the retired annotation pattern was quadratic on. It must be rejected as a
+    /// JavaScript error rather than spending the afternoon backtracking or raising a CLR exception.
+    /// </summary>
+    [Fact]
+    public void AnAnnotationTailWithNoClosingBracketIsRejected()
+    {
+        var engine = new Engine();
+        engine.SetValue("tail", "2020-01-01T00:00:00Z" + new string('[', 200_000));
+
+        engine.Evaluate("(() => { try { Temporal.Instant.from(tail); return 'accepted'; } catch (e) { return e.constructor.name; } })()")
+            .AsString().Should().Be("RangeError");
+    }
+}

--- a/Jint/Native/Intl/IntlUtilities.cs
+++ b/Jint/Native/Intl/IntlUtilities.cs
@@ -68,10 +68,15 @@ internal static class IntlUtilities
     // Accepts: language[-script][-region][-variant]*[-extension]*[-privateuse]
     // Extensions use single-character singletons like -u- for Unicode extensions
     // Full spec: https://www.rfc-editor.org/rfc/bcp/bcp47.txt
+    // No match timeout, for the reason spelled out over the Temporal ISO patterns in TemporalHelpers:
+    // Regex.MatchTimeout is a wall-clock deadline, so on a loaded machine it fails a valid input having
+    // burned no CPU, and RegexMatchTimeoutException escapes Engine.Evaluate as a CLR exception rather
+    // than a catchable JavaScript error. This pattern is fixed and internal, and every repetition in it
+    // is forced by a distinct leading '-', so it is linear in the length of the tag it is given.
     private static readonly Regex LanguageTagPattern = new(
         "^[a-zA-Z]{2,8}(?:-[a-zA-Z0-9]{1,8})*$",
         RegexOptions.Compiled | RegexOptions.CultureInvariant,
-        TimeSpan.FromMilliseconds(100));
+        Regex.InfiniteMatchTimeout);
 
     /// <summary>
     /// Grandfathered tags that map to canonical forms.

--- a/Jint/Native/Temporal/TemporalHelpers.cs
+++ b/Jint/Native/Temporal/TemporalHelpers.cs
@@ -112,16 +112,32 @@ internal static class TemporalHelpers
         return new IsoDateTime(date, new IsoTime(hour, minute, second, millisecond, microsecond, nanosecond));
     }
 
-    // Regex patterns for ISO 8601 parsing
-    // Note: Adding timeout for safety against ReDoS attacks
+    // Regex patterns for ISO 8601 parsing.
+    //
+    // These patterns take no match timeout, and that is deliberate. Regex.MatchTimeout is a *wall-clock*
+    // deadline sampled while matching, so it cannot tell "this pattern is backtracking" apart from "this
+    // thread lost the CPU" — a descheduled thread trips it having burned almost no CPU at all. That is not
+    // hypothetical: with the 100 ms budget these patterns used to carry, a single match of the valid,
+    // 8-character string "10:30:00" was measured taking 440 ms of wall clock on an ordinary loaded
+    // developer machine, and the same thing turned up as a CI failure parsing a correct ISO string. Because
+    // RegexMatchTimeoutException is listed in Throw.MustPropagateHostException, that spurious failure did
+    // not surface as a JavaScript error a script could catch — it escaped Engine.Evaluate as a raw CLR
+    // exception, straight through the script's own try/catch.
+    //
+    // What a timeout was there to guard against is instead guarded by construction. These patterns are
+    // fixed and internal — only the *input* is script-supplied, never the pattern — and every one of them
+    // is linear in the length of that input, so their cost is bounded by bounding the input. The
+    // fixed-width patterns below therefore carry an exact maximum length and reject anything longer
+    // without matching at all (see MaxIsoDateLength and friends). The two whose grammar is genuinely
+    // unbounded — InstantPattern's annotation tail and DurationPattern's digit runs — can carry no such
+    // cap without rejecting valid input, and rest on that measured linearity instead.
 #pragma warning disable MA0023 // Use RegexOptions.ExplicitCapture - we need numbered capture groups
-    private static readonly TimeSpan RegexTimeout = TimeSpan.FromMilliseconds(100);
 
     // ISO 8601 date pattern: supports both extended (YYYY-MM-DD) and basic (YYYYMMDD) formats
     private static readonly Regex DatePattern = new(
         @"^([+-]?\d{4,6})(?:-(\d{2})-(\d{2})|(\d{2})(\d{2}))$",
         RegexOptions.Compiled | RegexOptions.CultureInvariant,
-        RegexTimeout);
+        Regex.InfiniteMatchTimeout);
 
     // Time pattern supporting multiple formats per spec TimeSpec grammar:
     // Hour | Hour TimeSeparator MinuteSecond | Hour TimeSeparator MinuteSecond TimeSeparator TimeSecond [.fraction]
@@ -131,30 +147,44 @@ internal static class TemporalHelpers
     private static readonly Regex TimePatternColon = new(
         @"^(\d{2})(?::(\d{2})(?::(\d{2})(?:[.,](\d{1,9}))?)?)?$",
         RegexOptions.Compiled | RegexOptions.CultureInvariant,
-        RegexTimeout);
+        Regex.InfiniteMatchTimeout);
 
     private static readonly Regex TimePatternHyphen = new(
         @"^(\d{2})(?:-(\d{2})(?:-(\d{2})(?:[.,](\d{1,9}))?)?)?$",
         RegexOptions.Compiled | RegexOptions.CultureInvariant,
-        RegexTimeout);
+        Regex.InfiniteMatchTimeout);
 
     private static readonly Regex TimePatternCompact = new(
         @"^(\d{2})(?:(\d{2})(?:(\d{2})(?:[.,](\d{1,9}))?)?)?$",
         RegexOptions.Compiled | RegexOptions.CultureInvariant,
-        RegexTimeout);
+        Regex.InfiniteMatchTimeout);
 
     // Duration pattern already supports comma via [.,]
     private static readonly Regex DurationPattern = new(
         @"^([+-])?P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?(?:T(?:(\d+)(?:[.,](\d{1,9}))?H)?(?:(\d+)(?:[.,](\d{1,9}))?M)?(?:(\d+)(?:[.,](\d{1,9}))?S)?)?$",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase,
-        RegexTimeout);
+        Regex.InfiniteMatchTimeout);
 
     // Instant pattern already supports comma via [.,]
     private static readonly Regex InstantPattern = new(
         @"^([+-]\d{6}|\d{4})-?(\d{2})-?(\d{2})[Tt ](\d{2})(?::?(\d{2})(?::?(\d{2})(?:[.,](\d{1,9}))?)?)?([Zz]|([+-])(\d{2})(?::?(\d{2})(?::?(\d{2})(?:[.,](\d{1,9}))?)?)?)((?:\[!?[^\]]+\])*)$",
         RegexOptions.Compiled | RegexOptions.CultureInvariant,
-        RegexTimeout);
+        Regex.InfiniteMatchTimeout);
 #pragma warning restore MA0023
+
+    // Exact maximum lengths of the fixed-width patterns above: the longest string each one can match,
+    // which is what makes rejecting anything longer indistinguishable from letting the pattern reject it.
+    // Each was confirmed both by reading the grammar and by searching the pattern's own language for its
+    // longest member, and each is pinned by a test so a widened pattern cannot silently outgrow its bound.
+
+    /// <summary>Longest string <c>DatePattern</c> can match: <c>+123456-12-31</c>.</summary>
+    private const int MaxIsoDateLength = 13;
+
+    /// <summary>Longest string the time patterns can match: <c>12:34:56.123456789</c>.</summary>
+    private const int MaxIsoTimeLength = 18;
+
+    /// <summary>Longest string <c>TimeWithOffsetPattern</c> can match: <c>12:34:56.123456789+12:34:56.123456789</c>.</summary>
+    private const int MaxIsoTimeWithOffsetLength = 37;
 
     /// <summary>
     /// Parses an offset string like "+01:00" or "-05:30" to nanoseconds.
@@ -674,6 +704,10 @@ internal static class TemporalHelpers
         if (ContainsInvalidMinusSign(input))
             return null;
 
+        // Longer than the pattern could ever match, so the pattern is not asked.
+        if (input.Length > MaxIsoDateLength)
+            return null;
+
         var match = DatePattern.Match(input);
         if (!match.Success)
             return null;
@@ -733,6 +767,10 @@ internal static class TemporalHelpers
         if (ContainsInvalidMinusSign(input))
             return null;
 
+        // Longer than any of the three time patterns could ever match, so none of them is asked.
+        if (input.Length > MaxIsoTimeLength)
+            return null;
+
         // Try each format in order (prefer colon format as it's most common)
         Match? match = TimePatternColon.Match(input);
         if (!match.Success)
@@ -771,11 +809,6 @@ internal static class TemporalHelpers
     }
 
 #pragma warning disable MA0023
-    private static readonly Regex AnnotationPattern = new(
-        @"\[(!?)([^\]]+)\]",
-        RegexOptions.Compiled | RegexOptions.CultureInvariant,
-        RegexTimeout);
-
     // Pattern for validating time with optional offset (used for PlainDate date-time validation)
     // Supports both extended (HH:MM:SS) and compact (HHMMSS) ISO 8601 time formats
     // Extended: HH[:MM[:SS[.fff]]]  Compact: HH[MM[SS[.fff]]]
@@ -784,7 +817,7 @@ internal static class TemporalHelpers
     private static readonly Regex TimeWithOffsetPattern = new(
         @"^(\d{2})(?:(?::(\d{2})(?::(\d{2})(?:[.,](\d{1,9}))?)?)|(?:(\d{2})(?:(\d{2})(?:[.,](\d{1,9}))?)?))??(?:([Zz])|([+-])(\d{2})(?::?(\d{2})(?::?(\d{2})(?:[.,](\d{1,9}))?)?)?)?$",
         RegexOptions.Compiled | RegexOptions.CultureInvariant,
-        RegexTimeout);
+        Regex.InfiniteMatchTimeout);
 #pragma warning restore MA0023
 
     /// <summary>
@@ -794,6 +827,10 @@ internal static class TemporalHelpers
     public static bool IsValidTimeWithOffset(string timeString)
     {
         if (string.IsNullOrEmpty(timeString))
+            return false;
+
+        // Longer than the pattern could ever match, so the pattern is not asked.
+        if (timeString.Length > MaxIsoTimeWithOffsetLength)
             return false;
 
         var match = TimeWithOffsetPattern.Match(timeString);
@@ -983,15 +1020,47 @@ internal static class TemporalHelpers
 
     private static bool ValidateAnnotations(string annotations)
     {
-        var matches = AnnotationPattern.Matches(annotations);
         var calendarCount = 0;
         var hasCalendarCritical = false;
         var timeZoneCount = 0;
 
-        foreach (Match m in matches)
+        // Walks the annotation list rather than scanning it with a regex. The pattern this replaces —
+        // \[(!?)([^\]]+)\] — is quadratic on an input holding no ']' at all: every one of the n start
+        // positions consumes the rest of the string and then backtracks over it looking for a ']' that is
+        // not there. Reaching it needed a string that InstantPattern would have rejected first, so it was
+        // unreachable by an argument about the caller rather than by construction, and it was the one
+        // pattern here whose 100 ms budget could be spent on real work instead of on being descheduled.
+        // This loop is linear on every input, which is what lets the budget go.
+        var index = 0;
+        while (index < annotations.Length)
         {
-            var critical = string.Equals(m.Groups[1].Value, "!", StringComparison.Ordinal);
-            var content = m.Groups[2].Value;
+            var open = annotations.IndexOf('[', index);
+            if (open < 0)
+            {
+                break;
+            }
+
+            var close = annotations.IndexOf(']', open + 1);
+            if (close < 0)
+            {
+                // No ']' remains anywhere, so no further annotation can match from any later position.
+                break;
+            }
+
+            if (close == open + 1)
+            {
+                // "[]" — the pattern required at least one content character, so this is not an
+                // annotation; resume from just after the '[', exactly as an unanchored scan would.
+                index = open + 1;
+                continue;
+            }
+
+            // "!" is the critical marker only when content remains after it. In "[!]" the pattern's
+            // optional "!?" gave the '!' back to the content rather than match an empty annotation.
+            var critical = annotations[open + 1] == '!' && close > open + 2;
+            var contentStart = critical ? open + 2 : open + 1;
+            var content = annotations.Substring(contentStart, close - contentStart);
+            index = close + 1;
 
             var eqIndex = content.IndexOf('=');
             if (eqIndex >= 0)


### PR DESCRIPTION
Backport of #3486 (`main`: `ba18893a1`) to `4.x`. Fixes #3485 on this branch too.

## What an embedder on 4.x sees today

`Temporal.PlainDate.from('2024-01-15T10:30:00')` — a correct call with a valid string — can throw
`System.Text.RegularExpressions.RegexMatchTimeoutException`. It is not a `JintException` and not a
`JavaScriptException`: because `RegexMatchTimeoutException` is listed in `Throw.MustPropagateHostException`,
it goes **straight through the script's own `try`/`catch`** and reaches the host as a raw CLR exception
whose message blames "very large inputs or excessive backtracking" for a 19-character valid string.

`Regex.MatchTimeout` is a **wall-clock** deadline sampled while matching. It cannot tell "this pattern is
backtracking" apart from "this thread lost the CPU". Eight patterns in `TemporalHelpers.cs` and one in
`IntlUtilities.cs` carried 100 ms of it on this branch, byte-identical to what `main` carried.

## Evidence on this branch, before the fix

The new test file was compiled against **unfixed `4.x`** first, on both legs. `Jint.Tests` targets
`net472` (which resolves Jint's **`net462`** asset) and `net10.0`.

| leg | before the fix | after the fix |
| --- | --- | --- |
| `net472` → Jint `net462` | **Failed: 2, Passed: 19** | Passed: **21**, Failed: 0 |
| `net10.0` | **Failed: 2, Passed: 19** | Passed: **21**, Failed: 0 |

Both legs failed identically:

```
NoInternalParsePatternCarriesAWallClockDeadline
  Expected -1ms because TemporalHelpers.DatePattern is a fixed internal pattern over engine-supplied
  input, and a wall-clock budget on one can only ever fire spuriously — as an uncatchable CLR
  exception, but found 100ms.

EveryPatternRejectsAdversarialInputWithoutBacktrackingAwayTheAfternoon
  Expected regex.IsMatch(input) to be False because TemporalHelpers.AnnotationPattern must reject
  adversarial input, but found True.
```

## The quadratic pattern, measured on this branch

`AnnotationPattern` — `\[(!?)([^\]]+)\]` — is quadratic on input holding no `]`: each of the n start
positions consumes the rest of the string and backtracks over it. A throwaway probe drove the shipped
pattern (`RegexOptions.Compiled`) with `'['×n`, once with the 100 ms budget it ships with and once with
`Regex.InfiniteMatchTimeout` to read the genuine CPU cost:

| input | `net472` (Jint `net462`) with 100 ms budget | `net472` genuine CPU | `net10.0` genuine CPU |
| --- | --- | --- | --- |
| 4 KB | **`RegexMatchTimeoutException`** | 304.7 ms | 1.8 ms |
| 8 KB | **`RegexMatchTimeoutException`** | 951.0 ms | 1.1 ms |
| 16 KB | **`RegexMatchTimeoutException`** | 2209.5 ms | 4.1 ms |
| 32 KB | **`RegexMatchTimeoutException`** | 7080.9 ms | 15.6 ms |

That is real backtracking, not scheduling: 2x the input costs ~3x the time on both runtimes (`net10.0`'s
rewritten engine has a far smaller constant but the same shape — 4.1 → 15.6 ms across the last doubling).
The linear walk that replaces it costs **0.126 ms on `net472` and 0.107 ms on `net10.0`** over 200,000 `[`.

It was unreachable with such input only because its sole caller hands it `InstantPattern`'s group 14,
which that grammar already guarantees is well-formed — an argument about the caller, not a property of the
code. The probe was deleted; it is not part of this PR.

## The fix

Identical to #3486, applied unmodified:

- **Eight patterns** in `TemporalHelpers.cs` and **one** in `IntlUtilities.cs` now take
  `Regex.InfiniteMatchTimeout`. The failure mode is removed rather than relabelled.
- The **fixed-width** patterns reject anything longer than the longest string they could match, before
  matching — bounds 13, 18 and 37, pinned so a widened pattern cannot outgrow its cap silently.
- `AnnotationPattern` is **replaced by a linear walk**, pinned by a test that drives the walk and the
  retired pattern over ~5,000 inputs including the two cases the pattern's backtracking decided on its
  own: `[]`, which has no content and is not an annotation, and `[!]`, where the optional `!` is given
  back to the content.

`Options.Constraints.RegexTimeout` never reached these patterns and still does not — it bounds
script-supplied regular expressions, unchanged.

## Divergence from #3486

- **`Jint.Tests` on `4.x` is xUnit v3, not NUnit.** `TemporalParsePatternBudgetTests` is transcribed
  attribute-for-attribute: `[Test]` → `[Fact]`, `[TestCase(...)]` → `[Theory]` + `[InlineData(...)]`.
  Nothing else in the file changed — same assertions, same corpora, same seeds.
- **`docs/v5-migration.md` does not exist on `4.x`**, so that hunk is dropped. There is nothing to
  migrate: a host that caught `RegexMatchTimeoutException` around `Engine.Evaluate` to absorb this can
  simply drop that handler.
- The engine hunks applied **clean** — `4.x`'s pattern block is byte-identical to the pre-fix `main` one,
  so the two source files are the same after this as they are on `main`.

## Verification

- `dotnet build -c Release` — clean, `TreatWarningsAsErrors` on.
- `dotnet test -c Release`, both TFMs where the project has one:
  `Jint.Tests` **6,854** (net10.0) / **6,769** (net472), `Jint.Tests.PublicInterface` **1,500** / **1,493**,
  `Jint.Tests.CommonScripts` **28** / **28**, `Jint.Tests.SourceGenerators` **52** — all green, 0 failed.
- **test262: 102,491 passed / 189 skipped**, with 4 failures under full-solution parallel load —
  `staging/sm/Array/toSpliced-dense.js` and `staging/sm/TypedArray/sort_large_countingsort.js`, each
  ×2 for the strict/sloppy pair, each at **30–33 s**, i.e. the engine's 30-second default timeout. All
  four **pass in isolation in 4 s total**, and none of them touches Temporal or Intl. Load flakes on a
  busy shared box, unrelated to this change.
