### PR TITLE
Backport: the process-wide Intl culture cache and Temporal zone cache are read-only and bounded, and a rejected zone is not remembered

### DIFF
--- a/Jint.Tests/Runtime/IntlCultureCacheTests.cs
+++ b/Jint.Tests/Runtime/IntlCultureCacheTests.cs
@@ -1,0 +1,65 @@
+#nullable enable
+
+using Jint.Native.Intl;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// The process-wide <c>IntlUtilities</c> culture cache is keyed on a locale tag a script chose, and every
+/// engine in the process shares it. These tests pin that a script cannot grow it without bound.
+/// </summary>
+/// <remarks>
+/// Non-parallelizable because the assertions are about a static shared by the whole test run: a fixture
+/// running beside this one would add its own tags to the same dictionary.
+/// </remarks>
+[CollectionDefinition(nameof(IntlCultureCacheTests), DisableParallelization = true)]
+[Collection(nameof(IntlCultureCacheTests))]
+public class IntlCultureCacheTests
+{
+    /// <summary>
+    /// <c>toLocaleLowerCase</c> is core <c>String.prototype</c> -- no <c>Intl</c> opt-in, no WebApi, nothing --
+    /// and ECMA-402 requires a structurally valid but unknown tag to be accepted rather than rejected, so
+    /// every tag the loop invents used to become a permanent entry no engine's <c>LimitMemory</c> could see.
+    /// </summary>
+    [Fact]
+    public void ScriptSuppliedLocaleTagsDoNotGrowTheProcessWideCultureCache()
+    {
+        var engine = new Engine();
+        engine.Execute("for (var i = 0; i < 2000; i++) { 'x'.toLocaleLowerCase('en-abcd' + i); }");
+
+        IntlUtilities.CultureCacheCount.Should().BeLessThanOrEqualTo(IntlUtilities.CultureCacheBound);
+    }
+
+    /// <summary>
+    /// The same key space reached through <c>Intl</c> itself, where <c>BestAvailableLocale</c> additionally
+    /// asks for every truncated prefix of the requested tag.
+    /// </summary>
+    [Fact]
+    public void RequestedLocalesOfAnIntlFormatterDoNotGrowTheProcessWideCultureCache()
+    {
+        var engine = new Engine();
+        engine.Execute("for (var i = 0; i < 2000; i++) { new Intl.NumberFormat('en-abcd' + i + '-efgh' + i).format(1); }");
+
+        IntlUtilities.CultureCacheCount.Should().BeLessThanOrEqualTo(IntlUtilities.CultureCacheBound);
+    }
+
+    /// <summary>
+    /// The bound is not allowed to become a correctness problem: a tag resolved after the cache overflowed
+    /// answers exactly as it did before, because the value is a total function of the key.
+    /// </summary>
+    [Fact]
+    public void AnEvictedTagResolvesToTheSameCultureItDidBefore()
+    {
+        var before = IntlUtilities.GetCultureInfo("de-DE");
+        before.Should().NotBeNull();
+
+        var engine = new Engine();
+        engine.Execute("for (var i = 0; i < 2000; i++) { 'x'.toLocaleLowerCase('en-abcd' + i); }");
+
+        var after = IntlUtilities.GetCultureInfo("de-DE");
+        after.Should().NotBeNull();
+        after!.Name.Should().Be(before!.Name);
+        after.IsReadOnly.Should().BeTrue();
+        after.NumberFormat.NumberDecimalSeparator.Should().Be(before.NumberFormat.NumberDecimalSeparator);
+    }
+}

--- a/Jint.Tests/Runtime/IntlTests.cs
+++ b/Jint.Tests/Runtime/IntlTests.cs
@@ -1,4 +1,6 @@
-﻿using Jint.Runtime;
+﻿using System.Globalization;
+using Jint.Native.Intl;
+using Jint.Runtime;
 
 namespace Jint.Tests.Runtime;
 
@@ -1365,5 +1367,36 @@ public class IntlTests
             """;
 
         _engine.Evaluate(script).AsNumber().Should().Be(1);
+    }
+
+    /// <summary>
+    /// The <c>CultureInfo</c> instances <c>IntlUtilities</c> caches are process-wide: one per locale tag,
+    /// shared by every engine, never evicted. A <c>CultureInfo</c> is writable unless it is explicitly made
+    /// read-only -- <c>useUserOverride: false</c> only suppresses the Windows user regional overrides -- so
+    /// without this the two places that adjust a format for one formatter could instead have adjusted it for
+    /// every engine in the process, and nothing would have reported it.
+    /// </summary>
+    /// <remarks>
+    /// Both of those places clone before writing (<c>DateTimeFormatConstructor</c> clones the culture and its
+    /// <c>DateTimeFormatInfo</c>, <c>NumberFormatConstructor</c> clones the <c>NumberFormatInfo</c>) and a
+    /// clone of a read-only instance is writable, which is why the whole <c>Intl</c> suite is the other half
+    /// of this test: it exercises both of those paths on every construction.
+    /// </remarks>
+    [Theory]
+    [InlineData("en-US")]
+    [InlineData("de-DE")]
+    [InlineData("ar-SA")]
+    public void ACachedCultureIsReadOnly(string locale)
+    {
+        var culture = IntlUtilities.GetCultureInfo(locale);
+
+        culture.Should().NotBeNull();
+        culture!.IsReadOnly.Should().BeTrue();
+        IntlUtilities.GetCultureInfo(locale).Should().BeSameAs(culture);
+
+        // what the two format-adjusting call sites do, and what has to keep working
+        ((CultureInfo) culture.Clone()).IsReadOnly.Should().BeFalse();
+        ((DateTimeFormatInfo) culture.DateTimeFormat.Clone()).IsReadOnly.Should().BeFalse();
+        ((NumberFormatInfo) culture.NumberFormat.Clone()).IsReadOnly.Should().BeFalse();
     }
 }

--- a/Jint.Tests/Runtime/TemporalTimeZoneCacheTests.cs
+++ b/Jint.Tests/Runtime/TemporalTimeZoneCacheTests.cs
@@ -1,0 +1,227 @@
+#nullable enable
+
+using Jint.Native.Temporal;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// <c>DefaultTimeZoneProvider.Instance</c> is the provider every unconfigured engine gets, so its resolution
+/// cache is process-wide in practice. These tests pin that a script cannot grow it without bound.
+/// </summary>
+/// <remarks>
+/// Non-parallelizable because the assertions are about a static shared by the whole test run: a fixture
+/// running beside this one would add its own zones to the same dictionary.
+/// </remarks>
+[CollectionDefinition(nameof(TemporalTimeZoneCacheTests), DisableParallelization = true)]
+[Collection(nameof(TemporalTimeZoneCacheTests))]
+public class TemporalTimeZoneCacheTests
+{
+    /// <summary>
+    /// <c>IsValidTimeZone</c> ends in the same resolution the working paths use, so validation used to
+    /// populate the cache and every <i>rejected</i> identifier became a permanent entry.
+    /// </summary>
+    [Fact]
+    public void RejectedTimeZoneIdentifiersDoNotGrowTheProcessWideCache()
+    {
+        var engine = new Engine();
+        engine.Execute("""
+            for (var i = 0; i < 500; i++) {
+                try { Temporal.ZonedDateTime.from({ year: 2020, month: 1, day: 1, timeZone: 'A/' + i }); }
+                catch (e) { }
+            }
+            """);
+
+        DefaultTimeZoneProvider.Instance.TimeZoneCacheCount
+            .Should().BeLessThanOrEqualTo(DefaultTimeZoneProvider.TimeZoneCacheBound);
+    }
+
+    /// <summary>
+    /// The identifiers that <i>do</i> resolve are a large key space too, because an offset identifier
+    /// resolves to a zone the provider manufactures from the string.
+    /// </summary>
+    [Fact]
+    public void OffsetTimeZoneIdentifiersDoNotGrowTheProcessWideCache()
+    {
+        var engine = new Engine();
+        engine.Execute("""
+            function pad(n) { return (n < 10 ? '0' : '') + n; }
+            for (var h = 0; h < 24; h++) {
+                for (var m = 0; m < 60; m++) {
+                    Temporal.ZonedDateTime
+                        .from({ year: 2020, month: 1, day: 1, timeZone: '+' + pad(h) + ':' + pad(m) })
+                        .getTimeZoneTransition('next');
+                }
+            }
+            """);
+
+        DefaultTimeZoneProvider.Instance.TimeZoneCacheCount
+            .Should().BeLessThanOrEqualTo(DefaultTimeZoneProvider.TimeZoneCacheBound);
+    }
+
+    /// <summary>
+    /// The bound is not allowed to become a correctness problem: a zone resolved after the cache overflowed
+    /// answers exactly as it did before, because the value is a total function of the identifier.
+    /// </summary>
+    [Fact]
+    public void AnEvictedZoneAnswersExactlyAsItDidBefore()
+    {
+        var engine = new Engine();
+        const string Script = "Temporal.ZonedDateTime.from({ year: 2020, month: 6, day: 1, timeZone: 'Europe/Helsinki' }).offsetNanoseconds";
+
+        var before = engine.Evaluate(Script).AsNumber();
+
+        engine.Execute("""
+            function pad(n) { return (n < 10 ? '0' : '') + n; }
+            for (var h = 0; h < 24; h++) {
+                for (var m = 0; m < 60; m++) {
+                    Temporal.ZonedDateTime
+                        .from({ year: 2020, month: 1, day: 1, timeZone: '+' + pad(h) + ':' + pad(m) })
+                        .getTimeZoneTransition('next');
+                }
+            }
+            """);
+
+        engine.Evaluate(Script).AsNumber().Should().Be(before);
+    }
+
+    /// <summary>
+    /// The syntactic screen that answers an impossible identifier without a system lookup must never decline
+    /// an identifier the system can actually resolve, so every zone this machine has has to survive it.
+    /// </summary>
+    [Fact]
+    public void EverySystemTimeZoneIdentifierSurvivesTheSyntacticScreen()
+    {
+        var provider = DefaultTimeZoneProvider.Instance;
+        var screened = 0;
+
+        foreach (var zone in TimeZoneInfo.GetSystemTimeZones())
+        {
+            if (!zone.Id.Contains('/'))
+            {
+                // Windows identifiers ("Eastern Standard Time") are declined by the IANA naming rule that
+                // predates this change, and the screen is not what decides them.
+                continue;
+            }
+
+            provider.IsValidTimeZone(zone.Id).Should().BeTrue(because: $"'{zone.Id}' is a zone this machine has");
+            screened++;
+        }
+
+        foreach (var id in provider.GetAvailableTimeZones())
+        {
+            if (id.Contains('/'))
+            {
+                provider.IsValidTimeZone(id).Should().BeTrue(because: $"'{id}' is reported as available");
+                screened++;
+            }
+        }
+
+#if !NETFRAMEWORK
+        // On Windows the first loop does nothing, because the system's zones are Windows identifiers. Ask
+        // .NET for the IANA name of each instead: that is the key space the screen actually has to survive,
+        // and it is a real check on the platform where the first loop is empty.
+        foreach (var zone in TimeZoneInfo.GetSystemTimeZones())
+        {
+            if (TimeZoneInfo.TryConvertWindowsIdToIanaId(zone.Id, out var ianaId))
+            {
+                DefaultTimeZoneProvider.IsPlausibleIanaName(ianaId)
+                    .Should().BeTrue(because: $"'{ianaId}' is what .NET calls '{zone.Id}'");
+                screened++;
+            }
+        }
+#endif
+
+        // never vacuous: Linux fills the first loop, Windows the second and third
+        screened.Should().BeGreaterThan(0);
+    }
+
+    /// <summary>
+    /// A rejection is not merely bounded, it is not remembered at all -- which is what stops a script that
+    /// invents plausible-looking identifiers from paying the cache in entries.
+    /// </summary>
+    [Fact]
+    public void ARejectedIdentifierIsNotRemembered()
+    {
+        var provider = DefaultTimeZoneProvider.Instance;
+
+        // survives the syntactic screen, so it reaches the system lookup and is rejected there
+        var unknown = "Europe/Nowhere_" + Guid.NewGuid().ToString("N");
+        var before = provider.TimeZoneCacheCount;
+
+        provider.IsValidTimeZone(unknown).Should().BeFalse();
+
+        provider.TimeZoneCacheCount.Should().Be(before);
+    }
+
+    /// <summary>
+    /// Every shape the TZDB actually uses has to survive the screen, or it would decline an identifier the
+    /// system could resolve.
+    /// </summary>
+    [Theory]
+    [InlineData("America/New_York")]
+    [InlineData("America/Argentina/Buenos_Aires")]
+    [InlineData("America/Port-au-Prince")]
+    [InlineData("Antarctica/DumontDUrville")]
+    [InlineData("Asia/Ho_Chi_Minh")]
+    [InlineData("Etc/GMT+5")]
+    [InlineData("Etc/GMT-14")]
+    [InlineData("Pacific/Chatham")]
+    [InlineData("US/Eastern")]
+    [InlineData("posix/America/New_York")]
+    [InlineData("right/UTC")]
+    public void TheSyntacticScreenAcceptsEveryTzdbNameShape(string id)
+    {
+        DefaultTimeZoneProvider.IsPlausibleIanaName(id).Should().BeTrue();
+    }
+
+    /// <summary>
+    /// And nothing that cannot be one, which is the half that costs an invented identifier nothing.
+    /// </summary>
+    [Theory]
+    [InlineData("A/0")]
+    [InlineData("Europe/0London")]
+    [InlineData("Europe/")]
+    [InlineData("/Europe")]
+    [InlineData("Europe//London")]
+    [InlineData("Europe/Lond on")]
+    [InlineData("Europe/Lond*on")]
+    [InlineData("Europe/Londön")]
+    [InlineData("")]
+    public void TheSyntacticScreenDeclinesWhatCannotNameAZone(string id)
+    {
+        DefaultTimeZoneProvider.IsPlausibleIanaName(id).Should().BeFalse();
+    }
+
+    [Fact]
+    public void TheSyntacticScreenDeclinesAnAbsurdlyLongIdentifier()
+    {
+        DefaultTimeZoneProvider.IsPlausibleIanaName("Europe/" + new string('a', 1_000_000)).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// A rejected identifier stays rejected and a valid one stays valid, whether or not the answer was
+    /// remembered.
+    /// </summary>
+    [Theory]
+    [InlineData("A/0", false)]
+    [InlineData("Not A Zone", false)]
+    [InlineData("Europe/Nowhere", false)]
+    [InlineData("ACT", false)]
+    [InlineData("Europe/Helsinki", true)]
+    [InlineData("europe/helsinki", true)]
+    [InlineData("UTC", true)]
+    [InlineData("Etc/UTC", true)]
+    [InlineData("America/Argentina/Buenos_Aires", true)]
+    [InlineData("+01:00", true)]
+    [InlineData("-05:30", true)]
+    [InlineData("+0130", true)]
+    [InlineData("+01", true)]
+    [InlineData("+01:00:00", false)]
+    public void AnAnswerIsTheSameOnEveryAsking(string timeZoneId, bool expected)
+    {
+        var provider = DefaultTimeZoneProvider.Instance;
+
+        provider.IsValidTimeZone(timeZoneId).Should().Be(expected);
+        provider.IsValidTimeZone(timeZoneId).Should().Be(expected);
+    }
+}

--- a/Jint/Extensions/Polyfills.cs
+++ b/Jint/Extensions/Polyfills.cs
@@ -496,3 +496,37 @@ internal static class CharUnicodeInfoPolyfills
 #endif
     }
 }
+
+internal static class TimeZoneInfoPolyfills
+{
+    extension(TimeZoneInfo)
+    {
+#if !NET8_0_OR_GREATER
+        // TimeZoneInfo.TryFindSystemTimeZoneById arrived in .NET 8, so net462, netstandard2.0 and
+        // netstandard2.1 all need it. Downlevel there is no way to ask without a throw, so this is the
+        // catch the call site would otherwise write -- what it buys is that the call site reads as the
+        // question it is on every target framework, and that net8 and net10, which have the real method,
+        // answer it without an exception at all. Both exceptions the real method reports as "no" are
+        // caught, so the polyfill answers what .NET 8 answers rather than what one call site happened to
+        // catch.
+        public static bool TryFindSystemTimeZoneById(string id, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out TimeZoneInfo? timeZoneInfo)
+        {
+            try
+            {
+                timeZoneInfo = TimeZoneInfo.FindSystemTimeZoneById(id);
+                return true;
+            }
+            catch (TimeZoneNotFoundException)
+            {
+                timeZoneInfo = null;
+                return false;
+            }
+            catch (InvalidTimeZoneException)
+            {
+                timeZoneInfo = null;
+                return false;
+            }
+        }
+#endif
+    }
+}

--- a/Jint/Native/Intl/IntlUtilities.cs
+++ b/Jint/Native/Intl/IntlUtilities.cs
@@ -61,8 +61,9 @@ internal static class IntlUtilities
 
         return thisObject;
     }
-    // Cache for CultureInfo instances to avoid repeated allocations.
-    // CultureInfo with useUserOverride:false is immutable, safe to cache and share.
+    // Cache for CultureInfo instances to avoid repeated allocations. The entries are shared by every engine
+    // in the process, so CreateCultureInfo hands them out read-only rather than trusting every call site not
+    // to write to one.
     private static readonly ConcurrentDictionary<string, CultureInfo?> _cultureCache = new(StringComparer.OrdinalIgnoreCase);
     // BCP 47 language tag pattern (permissive to accept Unicode extensions)
     // Accepts: language[-script][-region][-variant]*[-extension]*[-privateuse]
@@ -1776,7 +1777,15 @@ internal static class IntlUtilities
             // data. GetCultureInfo returns a cached read-only culture that may have different
             // NumberFormatInfo patterns (e.g., CurrencyNegativePattern).
             // useUserOverride: false ensures consistent behavior regardless of Windows regional settings.
-            return new CultureInfo(cultureTag, false);
+            //
+            // Read-only because the instance is cached process-wide and handed to every engine: a write to
+            // its DateTimeFormat or NumberFormat would be one engine's setting becoming another engine's
+            // formatting, with nothing to report it. useUserOverride:false does not make a CultureInfo
+            // read-only - only CultureInfo.ReadOnly does - and wrapping does not undo the line above,
+            // because it marks the instance it is given rather than re-resolving the culture. Both places
+            // that adjust a format (DateTimeFormatConstructor, NumberFormatConstructor) clone first, and a
+            // clone of a read-only culture or format is writable.
+            return CultureInfo.ReadOnly(new CultureInfo(cultureTag, false));
         }
         catch (CultureNotFoundException)
         {

--- a/Jint/Native/Intl/IntlUtilities.cs
+++ b/Jint/Native/Intl/IntlUtilities.cs
@@ -64,7 +64,26 @@ internal static class IntlUtilities
     // Cache for CultureInfo instances to avoid repeated allocations. The entries are shared by every engine
     // in the process, so CreateCultureInfo hands them out read-only rather than trusting every call site not
     // to write to one.
+    //
+    // The key is a locale tag a script chose. ECMA-402 requires CanonicalizeLocaleList to accept any
+    // structurally valid tag rather than reject an unknown one, so 'x'.toLocaleLowerCase('en-abcd' + i) --
+    // core String.prototype, on an engine that opted into nothing -- invents a distinct key on every
+    // iteration, and BestAvailableLocale asks again for every truncated prefix. The cache is therefore
+    // bounded the same way RegExpParseCache is: once it holds Capacity distinct tags it is cleared and
+    // refilled. Real scripts use a handful of locales and fill it once.
     private static readonly ConcurrentDictionary<string, CultureInfo?> _cultureCache = new(StringComparer.OrdinalIgnoreCase);
+
+    // Cleared (not LRU-evicted) on overflow: cheap, thread-safe, allocates nothing on the hit path and is
+    // self-healing when the working set shifts. Dropping an entry can only cost one re-resolution and never
+    // a different answer -- the value is a total function of the tag, and the instance handed out is
+    // read-only, so an engine still holding one keeps a culture equal to whatever the next lookup produces.
+    private const int CultureCacheCapacity = 256;
+
+    /// <summary>Number of cached locale tags. Exists so the growth test can assert on the bound.</summary>
+    internal static int CultureCacheCount => _cultureCache.Count;
+
+    /// <summary>The bound <see cref="CultureCacheCount"/> can never exceed for long.</summary>
+    internal static int CultureCacheBound => CultureCacheCapacity;
     // BCP 47 language tag pattern (permissive to accept Unicode extensions)
     // Accepts: language[-script][-region][-variant]*[-extension]*[-privateuse]
     // Extensions use single-character singletons like -u- for Unicode extensions
@@ -1764,7 +1783,21 @@ internal static class IntlUtilities
             return null;
         }
 
-        return _cultureCache.GetOrAdd(locale, static key => CreateCultureInfo(key));
+        if (_cultureCache.TryGetValue(locale, out var cached))
+        {
+            return cached;
+        }
+
+        var culture = CreateCultureInfo(locale);
+
+        if (_cultureCache.Count >= CultureCacheCapacity)
+        {
+            _cultureCache.Clear();
+        }
+
+        // GetOrAdd rather than the indexer: another thread may already have published an instance for this
+        // tag, and a caller holding that one has to keep matching what the next lookup returns.
+        return _cultureCache.GetOrAdd(locale, culture);
     }
 
     private static CultureInfo? CreateCultureInfo(string locale)

--- a/Jint/Native/Temporal/DefaultTimeZoneProvider.cs
+++ b/Jint/Native/Temporal/DefaultTimeZoneProvider.cs
@@ -37,8 +37,31 @@ public sealed class DefaultTimeZoneProvider : ITimeZoneProvider
     // Unix epoch in .NET ticks
     private static readonly long UnixEpochTicks = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).Ticks;
 
-    // Cache for resolved time zones
-    private readonly ConcurrentDictionary<string, TimeZoneInfo?> _timeZoneCache = new(StringComparer.OrdinalIgnoreCase);
+    // Cache of resolved time zones. The field is instance-scoped, which is right, but the instance that
+    // matters is Instance, the singleton every unconfigured engine gets from Options.Temporal.TimeZoneProvider,
+    // so in practice it is process-wide and outlives the engine that filled it.
+    //
+    // Only a resolution that *succeeded* is stored. A rejected identifier is never remembered: the identifier
+    // is a string a script chose and there is no bound on how many distinct ones it can invent, so a negative
+    // cache is unbounded growth no engine's LimitMemory can see. CreateTimeZone answers an identifier that
+    // cannot name a zone from the string alone, which makes recomputing a rejection cheaper than the
+    // dictionary write that would remember it.
+    //
+    // The successes need a bound of their own, because an offset identifier resolves to a zone this provider
+    // manufactures rather than to one the system has: getTimeZoneTransition on a ZonedDateTime built with
+    // '+HH:MM' reaches here, and there are 1440 of those. Once the cache holds Capacity entries it is cleared
+    // and refilled -- the rule RegExpParseCache uses: cheap, thread-safe, nothing on the hit path and
+    // self-healing when the working set shifts. A dropped entry costs one re-resolution and never a different
+    // answer, since the value is a total function of the identifier and TimeZoneInfo is immutable.
+    private const int TimeZoneCacheCapacity = 256;
+
+    private readonly ConcurrentDictionary<string, TimeZoneInfo> _timeZoneCache = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Number of cached time zones. Exists so the growth test can assert on the bound.</summary>
+    internal int TimeZoneCacheCount => _timeZoneCache.Count;
+
+    /// <summary>The bound <see cref="TimeZoneCacheCount"/> can never exceed for long.</summary>
+    internal static int TimeZoneCacheBound => TimeZoneCacheCapacity;
 
     // Common IANA to Windows mappings (subset for common cases)
     private static readonly Dictionary<string, string> IanaToWindows = new(StringComparer.OrdinalIgnoreCase)
@@ -659,82 +682,109 @@ public sealed class DefaultTimeZoneProvider : ITimeZoneProvider
 
     private TimeZoneInfo? ResolveTimeZone(string timeZoneId)
     {
-        return _timeZoneCache.GetOrAdd(timeZoneId, id =>
+        if (_timeZoneCache.TryGetValue(timeZoneId, out var cached))
         {
-            // Handle UTC
-            if (id.Equals("UTC", StringComparison.OrdinalIgnoreCase) ||
-                id.Equals("Etc/UTC", StringComparison.OrdinalIgnoreCase))
-            {
-                return TimeZoneInfo.Utc;
-            }
+            return cached;
+        }
 
-            // Handle offset strings (e.g., +01:00, -05:30, +01:30:00)
-            var offset = ParseOffsetString(id);
-            if (offset.HasValue)
-            {
-                // .NET TimeZoneInfo only supports whole minute offsets, but we need to allow
-                // seconds precision for Temporal. We'll create a custom TimeZoneInfo with
-                // the offset rounded to minutes, but GetOffsetNanosecondsFor will return the exact offset.
-                //
-                // IMPORTANT: TimeZoneInfo.CreateCustomTimeZone only accepts offsets within ±14 hours,
-                // but ISO 8601/Temporal allows ±23:59. We clamp to ±14 hours for the TimeZoneInfo,
-                // but GetOffsetNanosecondsFor will still return the actual parsed offset.
-                var totalMinutes = (int) offset.Value.TotalMinutes;
-                const int MaxOffsetMinutes = 14 * 60; // ±14 hours
-                if (totalMinutes > MaxOffsetMinutes)
-                    totalMinutes = MaxOffsetMinutes;
-                else if (totalMinutes < -MaxOffsetMinutes)
-                    totalMinutes = -MaxOffsetMinutes;
+        var resolved = CreateTimeZone(timeZoneId);
+        if (resolved is null)
+        {
+            // Deliberately not remembered -- see the note on _timeZoneCache. IsValidTimeZone ends here, so a
+            // negative entry would be one per rejected identifier, and a script chooses those.
+            return null;
+        }
 
-                var roundedOffset = TimeSpan.FromMinutes(totalMinutes);
-                return TimeZoneInfo.CreateCustomTimeZone(id, roundedOffset, id, id);
-            }
+        if (_timeZoneCache.Count >= TimeZoneCacheCapacity)
+        {
+            _timeZoneCache.Clear();
+        }
 
-            // On Windows, .NET resolves non-IANA identifiers (Java abbreviations like ACT, BST, etc.)
-            // Reject identifiers that don't follow IANA naming conventions
-            if (!IsValidIanaIdentifier(id))
-            {
-                return null;
-            }
+        // GetOrAdd rather than the indexer: another thread may already have published an instance for this
+        // identifier, and a caller holding that one has to keep matching what the next lookup returns.
+        return _timeZoneCache.GetOrAdd(timeZoneId, resolved);
+    }
 
-            // Try direct lookup first
-            try
-            {
-                return TimeZoneInfo.FindSystemTimeZoneById(id);
-            }
-            catch (TimeZoneNotFoundException)
-            {
-                // Continue to mapping
-            }
+    private static TimeZoneInfo? CreateTimeZone(string id)
+    {
+        // Handle UTC
+        if (id.Equals("UTC", StringComparison.OrdinalIgnoreCase) ||
+            id.Equals("Etc/UTC", StringComparison.OrdinalIgnoreCase))
+        {
+            return TimeZoneInfo.Utc;
+        }
 
-            // Try IANA to Windows mapping (case-insensitive via dictionary comparer)
-            if (IsWindowsPlatform() &&
-                IanaToWindows.TryGetValue(id, out var windowsId))
-            {
-                try
-                {
-                    return TimeZoneInfo.FindSystemTimeZoneById(windowsId);
-                }
-                catch (TimeZoneNotFoundException)
-                {
-                    // Continue
-                }
-            }
+        // Handle offset strings (e.g., +01:00, -05:30, +01:30:00)
+        var offset = ParseOffsetString(id);
+        if (offset.HasValue)
+        {
+            // .NET TimeZoneInfo only supports whole minute offsets, but we need to allow
+            // seconds precision for Temporal. We'll create a custom TimeZoneInfo with
+            // the offset rounded to minutes, but GetOffsetNanosecondsFor will return the exact offset.
+            //
+            // IMPORTANT: TimeZoneInfo.CreateCustomTimeZone only accepts offsets within ±14 hours,
+            // but ISO 8601/Temporal allows ±23:59. We clamp to ±14 hours for the TimeZoneInfo,
+            // but GetOffsetNanosecondsFor will still return the actual parsed offset.
+            var totalMinutes = (int) offset.Value.TotalMinutes;
+            const int MaxOffsetMinutes = 14 * 60; // ±14 hours
+            if (totalMinutes > MaxOffsetMinutes)
+                totalMinutes = MaxOffsetMinutes;
+            else if (totalMinutes < -MaxOffsetMinutes)
+                totalMinutes = -MaxOffsetMinutes;
+
+            var roundedOffset = TimeSpan.FromMinutes(totalMinutes);
+            return TimeZoneInfo.CreateCustomTimeZone(id, roundedOffset, id, id);
+        }
+
+        // On Windows, .NET resolves non-IANA identifiers (Java abbreviations like ACT, BST, etc.)
+        // Reject identifiers that don't follow IANA naming conventions. This is the screen that answers an
+        // identifier a script invented -- 'A/0', 'A/1', ... -- from the string alone: no system lookup, no
+        // exception, nothing retained.
+        if (!IsValidIanaIdentifier(id))
+        {
+            return null;
+        }
+
+        // Try direct lookup first. TryFindSystemTimeZoneById rather than FindSystemTimeZoneById in a catch:
+        // on net8 and net10 an identifier the system does not have is answered without a throw at all, and
+        // below that the polyfill is the same catch written once.
+        if (TimeZoneInfo.TryFindSystemTimeZoneById(id, out var direct))
+        {
+            return direct;
+        }
+
+        // Try IANA to Windows mapping (case-insensitive via dictionary comparer)
+        if (IsWindowsPlatform() &&
+            IanaToWindows.TryGetValue(id, out var windowsId) &&
+            TimeZoneInfo.TryFindSystemTimeZoneById(windowsId, out var mapped))
+        {
+            return mapped;
+        }
 
 #if NET8_0_OR_GREATER
-            // Case-insensitive fallback: try all system timezones
-            foreach (var systemTz in TimeZoneInfo.GetSystemTimeZones())
-            {
-                if (string.Equals(systemTz.Id, id, StringComparison.OrdinalIgnoreCase))
-                {
-                    return systemTz;
-                }
-            }
+        // Case-insensitive fallback over the system's zones, answered from a dictionary built once rather
+        // than by re-scanning every zone the machine has on each unresolved identifier.
+        return SystemTimeZonesByIdIgnoreCase.Value.TryGetValue(id, out var systemTz) ? systemTz : null;
+#else
+        return null;
 #endif
-
-            return null;
-        });
     }
+
+#if NET8_0_OR_GREATER
+    // Built once from the same TimeZoneInfo.GetSystemTimeZones() the linear scan used to walk, in the same
+    // order, so first-wins here is the first match that scan returned.
+    private static readonly Lazy<Dictionary<string, TimeZoneInfo>> SystemTimeZonesByIdIgnoreCase = new(static () =>
+    {
+        var zones = TimeZoneInfo.GetSystemTimeZones();
+        var map = new Dictionary<string, TimeZoneInfo>(zones.Count, StringComparer.OrdinalIgnoreCase);
+        foreach (var zone in zones)
+        {
+            map.TryAdd(zone.Id, zone);
+        }
+
+        return map;
+    });
+#endif
 
     /// <summary>
     /// Parses an offset string like "+01:00" or "-05:30" to a TimeSpan.
@@ -898,15 +948,72 @@ public sealed class DefaultTimeZoneProvider : ITimeZoneProvider
     /// </summary>
     private static bool IsValidIanaIdentifier(string id)
     {
-        // IDs containing '/' are Area/Location format (always valid IANA)
+        // IDs containing '/' are Area/Location format, valid IANA as long as every component could be a TZDB
+        // name at all. That second half is what keeps an identifier a script invented from reaching a system
+        // lookup: it is answered from the string, and it only ever declines what the lookup would decline.
         if (id.Contains('/'))
         {
-            return true;
+            return IsPlausibleIanaName(id);
         }
 
         // IDs containing digits with letters (like EST5EDT, CST6CDT) are IANA compound TZ names
         // Known single-word IANA identifiers (Zone and Link names from TZDB)
         return s_validSingleWordIanaIds.Contains(id);
+    }
+
+    // No TZDB name comes close; the longest the database has is America/Argentina/ComodRivadavia at 32, and
+    // the posix/ and right/ prefixes .NET exposes on Unix add six. The bound exists so that hashing a
+    // megabyte of script-supplied text is not the cost of asking whether it names a time zone.
+    private const int MaxIanaIdentifierLength = 128;
+
+    /// <summary>
+    /// Whether <paramref name="id"/> has the shape of a TZDB Zone or Link name: '/'-separated components,
+    /// each beginning with an ASCII letter and continuing with letters, digits, '.', '_', '+' or '-'.
+    /// </summary>
+    /// <remarks>
+    /// Every name in the database fits -- <c>Etc/GMT+5</c>, <c>America/Port-au-Prince</c>,
+    /// <c>America/Argentina/Buenos_Aires</c>, and the <c>posix/</c> and <c>right/</c> prefixes .NET exposes
+    /// on Unix -- so declining anything else costs no identifier a system lookup could have resolved. That
+    /// is what <c>EverySystemTimeZoneIdentifierSurvivesTheSyntacticScreen</c> pins, against whatever zones
+    /// the machine running the tests happens to have.
+    /// </remarks>
+    internal static bool IsPlausibleIanaName(string id)
+    {
+        if (id.Length == 0 || id.Length > MaxIanaIdentifierLength)
+        {
+            return false;
+        }
+
+        var atComponentStart = true;
+        for (var i = 0; i < id.Length; i++)
+        {
+            var c = id[i];
+
+            if (atComponentStart)
+            {
+                if (!char.IsAsciiLetter(c))
+                {
+                    return false;
+                }
+
+                atComponentStart = false;
+                continue;
+            }
+
+            if (c == '/')
+            {
+                atComponentStart = true;
+                continue;
+            }
+
+            if (!char.IsAsciiLetterOrDigit(c) && c != '.' && c != '_' && c != '+' && c != '-')
+            {
+                return false;
+            }
+        }
+
+        // a trailing '/' leaves an empty component
+        return !atComponentStart;
     }
 
     private static readonly HashSet<string> s_validSingleWordIanaIds = new(StringComparer.OrdinalIgnoreCase)


### PR DESCRIPTION
Backports three merged `main` fixes to `4.x`, in the order they landed there. All three are about the same shape: a process-wide cache keyed on a string a script chose, shared by every engine, never evicted — and in one case handed out writable.

| Backported | `main` squash | 4.x commit |
| --- | --- | --- |
| [#3448](https://github.com/sebastienros/jint/pull/3448) Intl: the culture every engine shares is handed out read-only | `d6dbcfe8c` | `c5e2f4a4d` |
| [#3462](https://github.com/sebastienros/jint/pull/3462) Intl: the shared culture cache is bounded | `1676c9c15` | `a129ea72d` |
| [#3471](https://github.com/sebastienros/jint/pull/3471) Temporal: a rejected time zone identifier is not remembered | `0867d36e8` | `9161ec51a` |

Together they close [#3438](https://github.com/sebastienros/jint/issues/3438) and [#3439](https://github.com/sebastienros/jint/issues/3439) on the maintenance branch.

## What each one changes

**#3448** — `IntlUtilities` cached one `CultureInfo` per locale tag under a comment claiming `useUserOverride: false` made it immutable. It does not; that flag only suppresses the Windows user regional overrides. The instance was writable and handed straight out to eleven call sites, so one future `culture.NumberFormat.CurrencySymbol = …` would have been one engine's write becoming another engine's formatting, on state outliving every engine that touched it. `CultureInfo.ReadOnly` marks the instance it is given rather than re-resolving the culture, so the reason `new CultureInfo(...)` is used instead of `CultureInfo.GetCultureInfo(...)` stands untouched, and a clone of a read-only culture or format is writable — which is what keeps `DateTimeFormatConstructor` and `NumberFormatConstructor` working unchanged.

**#3462** — the same cache had no bound, and its key is a tag a script chose: ECMA-402 requires `CanonicalizeLocaleList` to accept a structurally valid but *unknown* tag rather than reject it, and `'x'.toLocaleLowerCase('en-abcd' + i)` is core `String.prototype` on an engine that opted into nothing. It is now bounded at 256 distinct tags, cleared and refilled on overflow — the rule `RegExpParseCache` already uses here. A hit costs exactly what it cost before: one `ConcurrentDictionary.TryGetValue`, no recency list, no allocation.

**#3471** — `DefaultTimeZoneProvider.Instance` is the provider every unconfigured engine gets, and `IsValidTimeZone` ended in the same `ResolveTimeZone` the working paths use, so every **rejected** identifier became a permanent entry. Rejections are no longer cached at all, which is defensible only because a miss is now cheap: the IANA naming screen checks that every `/`-separated component could be a TZDB name (so `A/0`, `Europe/`, `Europe//London` and a megabyte of text are answered from the string), the direct lookup uses `TimeZoneInfo.TryFindSystemTimeZoneById` instead of `FindSystemTimeZoneById` in a `catch`, and the case-insensitive fallback reads a dictionary built once instead of re-scanning every system zone. The *successes* are bounded at 256 too, because `getTimeZoneTransition` on a `ZonedDateTime` built from `+HH:MM` reaches the resolver with 1440 distinct valid spellings.

## Evidence: the tests run against unfixed 4.x

Ported onto `e556d274` with only the two count accessors added (no bound, no read-only, no screen), the same set fails on both legs — **9 failed / 24**, identical on `net10.0` and on `net472`, which is the leg that consumes the `net462` asset:

<table>
<tr><th></th><th>net472 (net462 asset)</th><th>net10.0</th></tr>
<tr><td colspan="3"><b>#3448</b></td></tr>
<tr><td><code>IntlTests.ACachedCultureIsReadOnly</code> ×3 (en-US, de-DE, ar-SA)</td><td colspan="2"><code>Expected culture!.IsReadOnly to be True, but found False.</code></td></tr>
<tr><td colspan="3"><b>#3462</b></td></tr>
<tr><td><code>ScriptSuppliedLocaleTagsDoNotGrowTheProcessWideCultureCache</code></td><td>found <b>4004</b> (bound 256)</td><td>found <b>4003</b> (bound 256)</td></tr>
<tr><td><code>RequestedLocalesOfAnIntlFormatterDoNotGrowTheProcessWideCultureCache</code></td><td>found <b>4004</b></td><td>found <b>4003</b></td></tr>
<tr><td><code>AnEvictedTagResolvesToTheSameCultureItDidBefore</code></td><td colspan="2">fails on the read-only half it inherits from #3448</td></tr>
<tr><td colspan="3"><b>#3471</b></td></tr>
<tr><td><code>RejectedTimeZoneIdentifiersDoNotGrowTheProcessWideCache</code></td><td>found <b>501</b></td><td>found <b>1942</b></td></tr>
<tr><td><code>OffsetTimeZoneIdentifiersDoNotGrowTheProcessWideCache</code></td><td>found <b>1948</b></td><td>found <b>1948</b></td></tr>
<tr><td><code>ARejectedIdentifierIsNotRemembered</code></td><td colspan="2">one rejection, <code>+1</code> entry</td></tr>
</table>

(The two rejected-identifier counts differ only because the class shares one process-wide cache with the offset test and the runner orders them differently per leg; both are far over 256.)

With the three fixes: **46 / 46 passed on `net10.0` and on `net472`.** The four `#3471` tests that cannot exist against unfixed code — they call `IsPlausibleIanaName`, which is the fix — are `EverySystemTimeZoneIdentifierSurvivesTheSyntacticScreen` (walks every zone this machine has, plus the IANA name .NET gives for each Windows id, with a counter so it can never pass vacuously), `TheSyntacticScreenAcceptsEveryTzdbNameShape`, `TheSyntacticScreenDeclinesWhatCannotNameAZone` and `TheSyntacticScreenDeclinesAnAbsurdlyLongIdentifier`.

## Full suite, `dotnet build -c Release` + `dotnet test -c Release`, 0 warnings from the compiler

```
Jint.Tests               6794 / 6794 (net472)     6879 / 6879 (net10.0)
Jint.Tests.PublicInterface  1493 / 1493 (net472)     1500 / 1500 (net10.0)
Jint.Tests.CommonScripts      28 / 28   (net472)       28 / 28   (net10.0)
Jint.Tests.SourceGenerators                             52 / 52   (net10.0)
Jint.Tests.Test262        102495 passed / 0 failed / 189 skipped
```

The test262 figure is the branch's control figure exactly.

## Divergences from `main`

Every source hunk applied verbatim (`git apply -3`, clean, all three), with two adaptations:

- **The tests are xUnit.** 4.x's `Jint.Tests` has not taken the NUnit move, so `[Test]` → `[Fact]`, `[TestCase]` → `[InlineData]`, and `[NonParallelizable]` → `[CollectionDefinition(..., DisableParallelization = true)]` + `[Collection(...)]`, which is how `GarbageCollectionTests` and `SharedObjectShapeTests` already say it here. Every assertion is unchanged.
- **`net462`, not `net472`.** One comment in the `TryFindSystemTimeZoneById` polyfill names the target frameworks that need it; on this branch the floor is `net462`, matching how `DefaultTimeZoneProvider.IsWindowsPlatform` already words it.

Two smaller notes. `ACachedCultureIsReadOnly` is appended at the end of `IntlTests` rather than inserted where `main` has it — the neighbouring test there does not exist on 4.x — and `IntlTests` gains `using System.Globalization;` and `using Jint.Native.Intl;`, which `main`'s copy already had. `Jint/Native/Intl/IntlUtilities.cs`, `Jint/Native/Temporal/DefaultTimeZoneProvider.cs` and `Jint/Extensions/Polyfills.cs` needed no other adaptation: 4.x's `DefaultTimeZoneProvider` is `sealed` where `main`'s is extensible, but nothing in this change touches that, and 4.x's `Polyfills.cs` already carries the C# extension-member blocks and the `char.IsAscii*` backfills the screen needs.

## No public API change

`IntlUtilities` is internal. `DefaultTimeZoneProvider` is public, but everything added to it — `TimeZoneCacheCount`, `TimeZoneCacheBound`, `IsPlausibleIanaName` — is `internal`, and no existing member changes its signature or its answer. What changes is what is retained and what a miss costs. The `Jint.Tests.PublicInterface` baselines are untouched and green on both legs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014W5mbjGhyvgAS4pivXoc4S
