### PR TITLE
Array: map and slice hand a @@species constructor the length ToLength produced (#3510)

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -29,10 +29,6 @@
     // overflows and the whole test host dies, taking every other test in the process with it.
     "staging/sm/extensions/recursion.js",
 
-    // { length: Infinity } array generics: the loop is bounded only by the 30-second
-    // TimeoutInterval, which it reaches on every run.
-    "staging/sm/Array/to-length.js",
-
     // Non-terminating under an interpreter: each of these only ends at the 30-second
     // TimeoutInterval, and the DST ones additionally drive the engine into multi-GB
     // allocation. Removed when the underlying loop terminates, not by "make it faster".

--- a/Jint.Tests/Runtime/ArrayLikeLengthClampTests.cs
+++ b/Jint.Tests/Runtime/ArrayLikeLengthClampTests.cs
@@ -203,4 +203,70 @@ public class ArrayLikeLengthClampTests
 
         Assert.Equal("RangeError", result);
     }
+
+    /// <summary>
+    /// <see href="https://tc39.es/ecma262/#sec-arrayspeciescreate">ArraySpeciesCreate</see> passes the length
+    /// it was given straight to the <c>@@species</c> constructor; the <c>RangeError</c> for a length above
+    /// 2^32-1 is a step of <see href="https://tc39.es/ecma262/#sec-arraycreate">ArrayCreate</see>, which runs
+    /// only when nothing answered for <c>@@species</c>. <c>map</c> and <c>slice</c> raised it themselves,
+    /// before the species constructor was called at all.
+    /// </summary>
+    [Theory]
+    [InlineData("Array.prototype.map.call(proxy, function () { })")]
+    [InlineData("Array.prototype.slice.call(proxy, 0)")]
+    public void ASpeciesConstructorIsCalledWithTheLengthToLengthProduced(string call)
+    {
+        var result = Run(
+            "var seen = 'not called';" +
+            "var proxy = new Proxy([], { get: function (target, property) {" +
+            "    if (property === 'length') return Infinity;" +
+            "    if (property !== 'constructor') return undefined;" +
+            "    function fake(length) { seen = length; throw 'invoked'; }" +
+            "    fake[Symbol.species] = fake;" +
+            "    return fake;" +
+            "} });" +
+            "try { " + call + "; } catch (e) { return e + '|' + seen; }" +
+            "return 'no-throw|' + seen;");
+
+        // 9007199254740991 is Number.MAX_SAFE_INTEGER, which is ToLength(Infinity). The constructor throws
+        // rather than return, which is what stops the 2^53-1 element walk that would otherwise follow it.
+        Assert.Equal("invoked|9007199254740991", result);
+    }
+
+    /// <summary>
+    /// The length check was also in the wrong place in <c>map</c>'s step order: step 3 rejects a callback
+    /// that is not callable, and step 4 is the create. A <c>RangeError</c> raised before step 3 answered the
+    /// wrong complaint.
+    /// </summary>
+    [Theory]
+    [InlineData("Infinity")]
+    [InlineData("5e9")]
+    public void MapRejectsANonCallableCallbackBeforeItCreatesAnything(string length)
+    {
+        var result = Run(
+            "try { Array.prototype.map.call({ length: " + length + " }, 'not a function'); return 'no-throw'; }" +
+            "catch (e) { return e instanceof TypeError ? 'TypeError' : e.constructor.name; }");
+
+        Assert.Equal("TypeError", result);
+    }
+
+    /// <summary>
+    /// The other half of the same rule: with no <c>@@species</c> to answer, ArraySpeciesCreate does reach
+    /// ArrayCreate and the <c>RangeError</c> is raised there, exactly as before.
+    /// </summary>
+    [Theory]
+    [InlineData("Array.prototype.map.call({ length: LEN }, function () { })", "Infinity")]
+    [InlineData("Array.prototype.map.call({ length: LEN }, function () { })", "5e9")]
+    [InlineData("Array.prototype.map.call({ length: LEN }, function () { })", "4294967296")]
+    [InlineData("Array.prototype.slice.call({ length: LEN })", "Infinity")]
+    [InlineData("Array.prototype.slice.call({ length: LEN })", "5e9")]
+    [InlineData("Array.prototype.slice.call({ length: LEN })", "4294967296")]
+    public void AnOrdinaryArrayLikeTooLongToCreateStillRaisesRangeError(string call, string length)
+    {
+        var result = Run(
+            "try { " + call.Replace("LEN", length) + "; return 'no-throw'; }" +
+            "catch (e) { return e instanceof RangeError ? 'RangeError' : String(e); }");
+
+        Assert.Equal("RangeError", result);
+    }
 }

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -631,18 +631,18 @@ public sealed partial class ArrayPrototype : ArrayInstance
         var o = ArrayOperations.For(_realm, thisObject, forWrite: false);
         var len = o.GetLongLength();
 
-        if (len > ArrayOperations.MaxArrayLength)
-        {
-            Throw.RangeError(_realm, "Invalid array length");
-        }
-
         var callbackfn = arguments.At(0);
         var thisArg = arguments.At(1);
         var callable = GetCallable(callbackfn);
 
-        var a = ArrayOperations.For(_realm.Intrinsics.Array.ArraySpeciesCreate(TypeConverter.ToObject(_realm, thisObject), (uint) len), forWrite: true);
+        // Step 4 hands len to ArraySpeciesCreate unchanged. The RangeError for a length above
+        // 2^32-1 belongs to https://tc39.es/ecma262/#sec-arraycreate, which ArraySpeciesCreate
+        // reaches only when nothing answered for @@species; a species constructor is entitled to
+        // receive the length LengthOfArrayLike produced, and ToLength(Infinity) is 2^53-1. Raising
+        // it up here refused that call before it happened.
+        var a = ArrayOperations.For(_realm.Intrinsics.Array.ArraySpeciesCreate(TypeConverter.ToObject(_realm, thisObject), len), forWrite: true);
         var invoker = CallbackInvoker.Rent(_engine, callable, 3, o.Target);
-        for (uint k = 0; k < len; k++)
+        for (ulong k = 0; k < len; k++)
         {
             if (k > 0 && k % ConstraintCheckInterval == 0)
             {
@@ -1672,22 +1672,21 @@ public sealed partial class ArrayPrototype : ArrayInstance
             }
         }
 
-        if (k < final && final - k > ArrayOperations.MaxArrayLength)
-        {
-            Throw.RangeError(_realm, "Invalid array length");
-        }
-
-        var length = (uint) System.Math.Max(0, (long) final - (long) k);
+        // Step 9 hands count to ArraySpeciesCreate unchanged; see the note in Map for why the
+        // RangeError of https://tc39.es/ecma262/#sec-arraycreate cannot be raised ahead of it.
+        var length = final > k ? final - k : 0UL;
         var a = _realm.Intrinsics.Array.ArraySpeciesCreate(TypeConverter.ToObject(_realm, thisObject), length);
+        // A JsArray source caps len -- and so both k and final -- at 2^32-1, so the copy's uint
+        // arguments are in range on this lane whatever the generic one above had to allow for.
         if (thisObject is JsArray ai && a is JsArray a2)
         {
-            a2.CopyValues(ai, (uint) k, 0, length);
+            a2.CopyValues(ai, (uint) k, 0, (uint) length);
         }
         else
         {
             // slower path
             var operations = ArrayOperations.For(a, forWrite: true);
-            uint n = 0;
+            ulong n = 0;
             for (; k < final; k++, n++)
             {
                 if (n > 0 && n % ConstraintCheckInterval == 0)


### PR DESCRIPTION
Backport of #3510 to `4.x`.

## What was wrong

`Array.prototype.map` and `Array.prototype.slice` checked the source's length against the 2^32-1 array limit themselves and raised `RangeError` **before** calling [ArraySpeciesCreate](https://tc39.es/ecma262/#sec-arrayspeciescreate):

```csharp
if (len > ArrayOperations.MaxArrayLength)
{
    Throw.RangeError(_realm, "Invalid array length");
}
```

Neither algorithm has that step. `map` is `O` → `len` → *IsCallable* → `ArraySpeciesCreate(O, len)`; `slice` is `count` → `ArraySpeciesCreate(O, count)`. The `RangeError` belongs to [ArrayCreate](https://tc39.es/ecma262/#sec-arraycreate), which ArraySpeciesCreate reaches only when nothing answered for `@@species`. A receiver that *does* supply a species constructor is entitled to have it called with whatever `ToLength` produced — and `ToLength` clamps to 2^53-1, it does not truncate:

```js
var proxy = new Proxy([], {
    get(target, property) {
        if (property === "length") return Infinity;
        function fake(length) { throw length; }
        fake[Symbol.species] = fake;
        return fake;
    }
});

Array.prototype.map.call(proxy, () => {});
// before: RangeError: Invalid array length
// after:  9007199254740991, thrown by the species constructor (V8, SpiderMonkey)
```

Two smaller consequences fell out of the same misplaced check:

* it ran **before** `map`'s step 3, so `Array.prototype.map.call({length: Infinity}, "not a function")` answered `RangeError` where every other engine answers `TypeError`;
* having established `len <= 2^32-1`, `map` then truncated it with `(uint) len` and walked it with a `uint` counter. With the check gone the counter has to be the `ulong` the length already is — which is what `filter` next door has always used.

`filter`, `splice`, `concat`, `flat` and `flatMap` create their result with a length of 0 and were already correct; `map` and `slice` are the only two callers that passed a real length, and they share the one `ArraySpeciesCreate`, so the fix is at those two call sites.

## Differences from #3510

The `Jint/Native/Array/ArrayPrototype.cs` hunks are **byte-identical** to main's — `4.x` already carries #3248 (backported as #3328), so `ArraySpeciesCreate`, `SetLength` and `CreateDataPropertyOrThrow` already take `ulong` here and the widened counters need nothing extra.

Two porting differences:

* **`Jint.Tests` on `4.x` is xUnit v3, not NUnit** (main migrated in #3409; `4.x` never did). The five cases are transcribed attribute-for-attribute — `[TestCase]` → `[Theory]` + `[InlineData]`, `Assert.That(x, Is.EqualTo(y))` → `Assert.Equal(y, x)` — with the scripts, corpora and expected values untouched. The one shape change: main's `AnOrdinaryArrayLikeTooLongToCreateStillRaisesRangeError` loops over three lengths inside the body and passes the length as NUnit's failure message, which xUnit's `Assert.Equal` has no overload for; the same 2 × 3 corpus is spelled as six `[InlineData]` rows instead, so a failing row names its own length.
* main's `docs/v5-migration.md` hunk has no counterpart — `4.x` has no such file.

## Evidence

Ported test file on **unfixed** `4.x`, then with the fix (`Jint.Tests` targets `net472`, which consumes Jint's `net462` asset, and `net10.0`):

| | net472 (Jint net462) | net10.0 |
| --- | --- | --- |
| before | **Failed: 4**, Passed: 65, Total: 69 | **Failed: 4**, Passed: 65, Total: 69 |
| after | Failed: 0, **Passed: 69**, Total: 69 | Failed: 0, **Passed: 69**, Total: 69 |

The same four rows fail on both frameworks: `ASpeciesConstructorIsCalledWithTheLengthToLengthProduced` for `map` and for `slice` (`RangeError: Invalid array length|not called` instead of `invoked|9007199254740991`), and `MapRejectsANonCallableCallbackBeforeItCreatesAnything` for `Infinity` and `5e9` (`RangeError` instead of `TypeError`). The six rows pinning the *unchanged* half — no `@@species` to answer, so ArrayCreate's `RangeError` is still what comes out — pass before and after.

## test262

Paired runs on this branch and on its merge base (`e556d2744`, unfixed `4.x`), same machine, same pinned SHA `3655e746`:

| | passed | failed | skipped | total |
| --- | --- | --- | --- | --- |
| `4.x` (`e556d2744`) | 102,495 | 0 | 189 | 102,684 |
| this branch | **102,497** | 0 | **187** | 102,684 |

Exactly +2 passed / -2 skipped: the two modes of `staging/sm/Array/to-length.js`, which this removes from `Test262Harness.settings.json`. Nothing else moved, and neither run hit the contention flakes this box sometimes shows on `staging/sm/Array/toSpliced-dense.js` or `sort_large_countingsort`.

The exclusion's stated reason -- *"the loop is bounded only by the 30-second `TimeoutInterval`, which it reaches on every run"* -- was wrong. The file fails in tens of milliseconds, on its last assertion, and the reason was this conformance gap. Everything else in it (`indexOf`, `lastIndexOf`, `every`, `some`, `forEach`, `filter`, `reduce`, `reduceRight`, `find`, `findIndex`, `fill`, `copyWithin`, `includes`, `Array.from`) already passed.

## Full suite

`dotnet build -c Release` clean, and green on both target frameworks:

| project | net472 | net10.0 |
| --- | --- | --- |
| `Jint.Tests` | 6758 passed / 4 skipped | 6843 passed / 4 skipped |
| `Jint.Tests.PublicInterface` | 1493 passed / 9 skipped | 1500 passed / 9 skipped |
| `Jint.Tests.CommonScripts` | 28 passed | 28 passed |
| `Jint.Tests.SourceGenerators` | — | 52 passed |

## Performance

No measurement: the widened counter is in `map`'s generic lane, which invokes a user callback per element and already routes every index through `ArrayOperations.TryGetValue(ulong)`. The plain-`JsArray` fast path (`arrayInstance.Map`) is taken before any of this and is untouched, as is `slice`'s `CopyValues` lane, whose `uint` arguments are still in range because a `JsArray` source caps the length at 2^32-1 by construction.
