### PR TITLE
A module graph too deep to link raises an error the host can catch, instead of ending the process (#3415)

### DIFF
--- a/Jint.Tests.PublicInterface/HostModuleGraphDepthTests.cs
+++ b/Jint.Tests.PublicInterface/HostModuleGraphDepthTests.cs
@@ -67,7 +67,31 @@ public sealed class HostModuleGraphDepthTests
     /// </summary>
     private static readonly TimeSpan WedgeCeiling = TimeSpan.FromMinutes(2);
 
-    private const int LongChainLength = 1_000;
+    /// <summary>The stack the walk under test runs on: the smallest a thread request is honoured with.</summary>
+    /// <remarks>
+    /// 256 KB is the floor Windows rounds a request up to, so asking for less buys nothing there and the
+    /// depth cannot be pinned from this end. How much stack this actually yields is a platform question and
+    /// deliberately not assumed to be 256 KB — see <see cref="ChainLengths"/>.
+    /// </remarks>
+    private const int StackUnderTest = 256 * 1024;
+
+    /// <summary>
+    /// The chain lengths tried, in order, until one meets the probe.
+    /// </summary>
+    /// <remarks>
+    /// The suite used to name a single length and an argued margin — five times the depth measured to trip
+    /// on a 256 KB Windows thread. That reasoning was sound about frame sizes and wrong about stacks: the
+    /// <em>frames</em> agree across platforms to within a percent (this branch trips at 157 modules on a
+    /// 256 KB Windows thread, where main measured 156), but the requested stack size does not. On the Linux
+    /// runner the same 1,000-module chain on the same 256 KB request linked and evaluated <em>successfully</em>,
+    /// so the test asserted an exception that legitimately never happened and the margin was a margin over
+    /// the wrong quantity. Growing the chain until the walk meets the probe measures the machine instead of
+    /// predicting it, which is the only form of this test that is portable: whatever stack the platform
+    /// really handed over, doubling reaches the end of it. The cap exists so a regression is reported rather
+    /// than pursued forever — on a genuinely 8 MB stack the last entry is still several times too deep to
+    /// fit.
+    /// </remarks>
+    private static readonly int[] ChainLengths = [2_000, 4_000, 8_000, 16_000, 32_000];
 
     /// <summary>A chain of <paramref name="count"/> modules, each importing the next.</summary>
     private static Dictionary<string, string> ImportChain(int count)
@@ -97,22 +121,8 @@ public sealed class HostModuleGraphDepthTests
     }
 
     /// <summary>
-    /// A stack the chain below cannot possibly fit in, so that what this suite measures is Jint's probe and
-    /// not the machine it runs on.
-    /// </summary>
-    /// <remarks>
-    /// 256 KB is the floor a thread request is rounded up to on Windows, and at that size a chain reaches
-    /// roughly two hundred modules before a recursive phase runs out. <see cref="LongChainLength"/> is five
-    /// times that, which is the point: the per-module cost differs by runtime, architecture and operating
-    /// system by tens of percent, and it was exactly a margin thinner than that which let
-    /// <see href="https://github.com/sebastienros/jint/issues/3308">#3308</see> pass on four legs and end
-    /// the process on the fifth. Nothing decided by codegen can move a factor of five.
-    /// </remarks>
-    private const int StackTooSmallForTheChain = 256 * 1024;
-
-    /// <summary>
-    /// The slice a chain is walked in, chosen so that a phase driven slice by slice stays comfortably inside
-    /// <see cref="StackTooSmallForTheChain"/> — about half of what that stack holds.
+    /// The slice a chain is walked in, chosen so that a phase driven slice by slice stays shallow whatever
+    /// stack the preparing thread turns out to have.
     /// </summary>
     private const int SliceLength = 100;
 
@@ -136,6 +146,75 @@ public sealed class HostModuleGraphDepthTests
         }
     }
 
+    /// <summary>What the walk under test did, once a chain long enough to reach the probe was found.</summary>
+    private sealed record Probed(int Length, Exception Failure, Exception? Again, double Afterwards);
+
+    /// <summary>
+    /// Grows the chain until importing it meets the probe, with every phase before the one under test
+    /// already driven, and hands back what that import raised.
+    /// </summary>
+    /// <remarks>
+    /// The preparation runs on an ordinary thread and only the walk under test runs on
+    /// <see cref="StackUnderTest"/>. Two reasons, and the second is why it is not merely tidier: a prepared
+    /// graph is not what this test is about, and where a platform's probe reserve is itself larger than the
+    /// small stack — a 64 KB page size makes the runtime's reserve 768 KB — preparing on that stack would
+    /// meet the probe during setup and report a failure about the wrong thing.
+    /// </remarks>
+    private static Probed DriveUntilProbed(string phase, Action<Jint.Runtime.Modules.Module> prepare)
+    {
+        foreach (var length in ChainLengths)
+        {
+            var modules = ImportChain(length);
+            Engine engine = null!;
+
+            DedicatedThread.Run(
+                () =>
+                {
+                    engine = ChainEngine(modules);
+                    InSlices(engine, modules, prepare);
+                },
+                joinTimeout: WedgeCeiling,
+                timeoutMessage: $"preparing a {length}-module chain for {phase} did not complete within {WedgeCeiling}");
+
+            Exception? failure = null;
+            Exception? again = null;
+            var afterwards = 0d;
+
+            DedicatedThread.Run(
+                () =>
+                {
+                    failure = Record.Exception(() => engine.Modules.Import("0.js"));
+                    if (failure is null)
+                    {
+                        return;
+                    }
+
+                    // Asked on the same thread as the first import, because "the same way again" is only
+                    // meaningful where the stack is the same too.
+                    again = Record.Exception(() => engine.Modules.Import("0.js"));
+
+                    // The other half of the promise the guard makes for script recursion: an engine that is
+                    // still usable. Nothing about a native stack overflow leaves one.
+                    afterwards = engine.Evaluate("1 + 1").AsNumber();
+                },
+                joinTimeout: WedgeCeiling,
+                timeoutMessage: $"importing a {length}-module chain did not complete within {WedgeCeiling}",
+                maxStackSize: StackUnderTest);
+
+            if (failure is not null)
+            {
+                return new Probed(length, failure, again, afterwards);
+            }
+        }
+
+        Assert.Fail(
+            $"a chain of {ChainLengths[^1]} modules {phase} inside a {StackUnderTest / 1024} KB thread request without " +
+            "ever meeting the stack probe, so nothing here exercised it. Either the request bought a far larger stack " +
+            "than any platform is known to give it, or the probe is no longer armed.");
+
+        throw new InvalidOperationException("unreachable");
+    }
+
     /// <summary>
     /// A module graph deeper than the calling thread can link fails with a <c>RangeError</c> the host
     /// catches, naming the module it gave up on, and leaves an engine that still runs script.
@@ -148,36 +227,18 @@ public sealed class HostModuleGraphDepthTests
     /// <see cref="IModuleLoader"/> is to serve a graph it did not author could be killed by one.
     /// <para>
     /// The linking half is selected rather than hoped for: loading the chain in slices first means the only
-    /// walk left with a thousand levels to descend is linking's.
+    /// walk left with the whole chain to descend is linking's.
     /// </para>
     /// </remarks>
     [Fact]
     public void ALinkTooDeepForTheStackThrowsRatherThanEndingTheProcess()
     {
-        var modules = ImportChain(LongChainLength);
-        Exception? failure = null;
-        var afterwards = 0d;
+        var probed = DriveUntilProbed("linking", static m => m.LoadRequestedModules());
 
-        DedicatedThread.Run(
-            () =>
-            {
-                var engine = ChainEngine(modules);
-                InSlices(engine, modules, static m => m.LoadRequestedModules());
-
-                failure = Record.Exception(() => engine.Modules.Import("0.js"));
-
-                // The other half of the promise the guard makes for script recursion: an engine that is
-                // still usable. Nothing about a native stack overflow leaves one.
-                afterwards = engine.Evaluate("1 + 1").AsNumber();
-            },
-            joinTimeout: WedgeCeiling,
-            timeoutMessage: $"importing a pre-loaded {LongChainLength}-module chain did not complete within {WedgeCeiling}",
-            maxStackSize: StackTooSmallForTheChain);
-
-        failure.Should().BeOfType<JavaScriptException>()
+        probed.Failure.Should().BeOfType<JavaScriptException>()
             .Which.Message.Should().StartWith("Maximum call stack size exceeded while linking module '");
 
-        afterwards.Should().Be(2);
+        probed.Afterwards.Should().Be(2);
     }
 
     /// <summary>
@@ -189,39 +250,25 @@ public sealed class HostModuleGraphDepthTests
     /// This is what makes the evaluation half of the probe hand back a throw <em>completion</em> where the
     /// linking half throws. <c>Evaluate</c> step 9.a is the only thing that marks the modules still on the
     /// Tarjan stack, and only an abrupt completion returned to it reaches that step; an exception thrown past
-    /// it leaves them in <c>evaluating</c> forever. Measured against a build that throws instead: the first
-    /// import fails as it does here and the second one <b>succeeds</b>, handing the host a namespace for a
-    /// graph not one body of which ever ran. That is the failure this second assertion exists for — a
-    /// half-evaluated graph that reports itself as fine is worse than the crash the probe replaced.
+    /// it leaves them in <c>evaluating</c> forever. Measured on this branch against a build that throws
+    /// instead: the first import fails as it does here and the second one <b>succeeds</b>, handing the host
+    /// a namespace for a graph not one body of which ever ran. That is the failure this second assertion
+    /// exists for — a half-evaluated graph that reports itself as fine is worse than the crash the probe
+    /// replaced.
     /// <para>
     /// The evaluation half is selected rather than hoped for: linking the chain in slices first means the
-    /// only walk left with a thousand levels to descend is evaluation's.
+    /// only walk left with the whole chain to descend is evaluation's.
     /// </para>
     /// </remarks>
     [Fact]
     public void AnEvaluationTooDeepForTheStackLeavesTheGraphErrored()
     {
-        var modules = ImportChain(LongChainLength);
-        Exception? first = null;
-        Exception? second = null;
+        var probed = DriveUntilProbed("evaluation", static m => m.Link());
 
-        DedicatedThread.Run(
-            () =>
-            {
-                var engine = ChainEngine(modules);
-                InSlices(engine, modules, static m => m.Link());
-
-                first = Record.Exception(() => engine.Modules.Import("0.js"));
-                second = Record.Exception(() => engine.Modules.Import("0.js"));
-            },
-            joinTimeout: WedgeCeiling,
-            timeoutMessage: $"importing a pre-linked {LongChainLength}-module chain did not complete within {WedgeCeiling}",
-            maxStackSize: StackTooSmallForTheChain);
-
-        first.Should().BeOfType<JavaScriptException>()
+        probed.Failure.Should().BeOfType<JavaScriptException>()
             .Which.Message.Should().StartWith("Maximum call stack size exceeded while evaluating module '");
 
-        second.Should().BeOfType<JavaScriptException>()
-            .Which.Message.Should().Be(first!.Message);
+        probed.Again.Should().BeOfType<JavaScriptException>()
+            .Which.Message.Should().Be(probed.Failure.Message);
     }
 }

--- a/Jint.Tests.PublicInterface/HostModuleGraphDepthTests.cs
+++ b/Jint.Tests.PublicInterface/HostModuleGraphDepthTests.cs
@@ -1,0 +1,227 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using Jint;
+using Jint.Runtime;
+using Jint.Runtime.Modules;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// What an embedder gets when a module graph is deeper than the thread importing it can recurse over.
+/// Tests live here because the public-interface project has no <c>InternalsVisibleTo</c> grant, so every
+/// green assertion proves an embedder can reach the surface.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>InnerModuleLinking</c> and <c>InnerModuleEvaluation</c> descend once per module, the way the spec
+/// writes them, so how deep a graph an engine can link and evaluate is decided by the calling thread's
+/// stack rather than by anything the host configured. Exceeding it was a native stack overflow: no
+/// exception, nothing in a <c>catch</c>, no log, and the process gone. With
+/// <c>options.Constraints.StackOverflowGuard</c> on, both algorithms probe for headroom before descending
+/// and fail the way script recursion already does.
+/// </para>
+/// <para>
+/// Each test drives its own phase deliberately rather than importing a cold graph, because the load phase
+/// recurses per module too and would meet the reserve first. That third recursion is
+/// <see href="https://github.com/sebastienros/jint/issues/3401">#3401</see>'s remaining half and is not
+/// probed here: the load phase reports failure by rejecting its own promise, so a throw out of it would be
+/// a different contract rather than the same one in another place.
+/// </para>
+/// </remarks>
+public sealed class HostModuleGraphDepthTests
+{
+    /// <summary>Simple in-memory module loader returning fixed source per specifier.</summary>
+    private sealed class DictLoader : ModuleLoader
+    {
+        private readonly Dictionary<string, string> _modules;
+
+        public DictLoader(Dictionary<string, string> modules) => _modules = modules;
+
+        public override ResolvedSpecifier Resolve(string? referencingModuleLocation, ModuleRequest moduleRequest)
+        {
+            var key = moduleRequest.Specifier;
+            if (key.StartsWith("./", StringComparison.Ordinal))
+            {
+                key = key.Substring(2);
+            }
+
+            return new ResolvedSpecifier(moduleRequest, key, new Uri($"file:///base/{key}"), SpecifierType.RelativeOrAbsolute);
+        }
+
+        protected override string LoadModuleContents(Engine engine, ResolvedSpecifier resolved)
+        {
+            if (_modules.TryGetValue(resolved.Key!, out var source))
+            {
+                return source;
+            }
+
+            throw new ModuleResolutionException($"Module not found: {resolved.Key}", resolved.ModuleRequest.Specifier, null, null);
+        }
+    }
+
+    /// <summary>
+    /// A wedge ceiling, never an assertion: every test here asserts an outcome rather than a duration, and
+    /// this exists only so a graph walk that stopped terminating is reported instead of hanging the run.
+    /// </summary>
+    private static readonly TimeSpan WedgeCeiling = TimeSpan.FromMinutes(2);
+
+    private const int LongChainLength = 1_000;
+
+    /// <summary>A chain of <paramref name="count"/> modules, each importing the next.</summary>
+    private static Dictionary<string, string> ImportChain(int count)
+    {
+        var modules = new Dictionary<string, string>(count, StringComparer.Ordinal);
+        for (var i = 0; i < count - 1; i++)
+        {
+            modules[$"{i}.js"] = $"import './{i + 1}.js';";
+        }
+
+        modules[$"{count - 1}.js"] = "export default 1;";
+        return modules;
+    }
+
+    /// <summary>
+    /// An engine serving <paramref name="modules"/> with the guard on, which is what arms the probe: the
+    /// module pipeline follows <c>Constraints.StackOverflowGuard</c> rather than introducing a switch of
+    /// its own, and on this branch that flag is opt-in.
+    /// </summary>
+    private static Engine ChainEngine(Dictionary<string, string> modules)
+    {
+        return new Engine(o =>
+        {
+            o.EnableModules(new DictLoader(modules));
+            o.Constraints.StackOverflowGuard = true;
+        });
+    }
+
+    /// <summary>
+    /// A stack the chain below cannot possibly fit in, so that what this suite measures is Jint's probe and
+    /// not the machine it runs on.
+    /// </summary>
+    /// <remarks>
+    /// 256 KB is the floor a thread request is rounded up to on Windows, and at that size a chain reaches
+    /// roughly two hundred modules before a recursive phase runs out. <see cref="LongChainLength"/> is five
+    /// times that, which is the point: the per-module cost differs by runtime, architecture and operating
+    /// system by tens of percent, and it was exactly a margin thinner than that which let
+    /// <see href="https://github.com/sebastienros/jint/issues/3308">#3308</see> pass on four legs and end
+    /// the process on the fifth. Nothing decided by codegen can move a factor of five.
+    /// </remarks>
+    private const int StackTooSmallForTheChain = 256 * 1024;
+
+    /// <summary>
+    /// The slice a chain is walked in, chosen so that a phase driven slice by slice stays comfortably inside
+    /// <see cref="StackTooSmallForTheChain"/> — about half of what that stack holds.
+    /// </summary>
+    private const int SliceLength = 100;
+
+    /// <summary>
+    /// Drives <paramref name="phase"/> over <paramref name="modules"/> bottom-up in slices, so the whole
+    /// chain reaches that phase's end state without the phase ever having recursed more than one slice deep.
+    /// </summary>
+    /// <remarks>
+    /// Each slice is driven from a module of its own whose single import is the slice's first module. The
+    /// records underneath are the engine's, keyed by resolved specifier and so shared by every slice, which
+    /// is what makes each slice after the first stop at a dependency the previous slice already advanced.
+    /// </remarks>
+    private static void InSlices(Engine engine, Dictionary<string, string> modules, Action<Jint.Runtime.Modules.Module> phase)
+    {
+        for (var start = modules.Count - SliceLength; start >= 0; start -= SliceLength)
+        {
+            var location = $"slice{start}.js";
+            var request = new ModuleRequest(location, []);
+            var resolved = new ResolvedSpecifier(request, location, new Uri($"file:///base/{location}"), SpecifierType.RelativeOrAbsolute);
+            phase(ModuleFactory.BuildSourceTextModule(engine, resolved, $"import './{start}.js';"));
+        }
+    }
+
+    /// <summary>
+    /// A module graph deeper than the calling thread can link fails with a <c>RangeError</c> the host
+    /// catches, naming the module it gave up on, and leaves an engine that still runs script.
+    /// </summary>
+    /// <remarks>
+    /// The property being pinned is that there <em>is</em> an outcome. Linking descends once per module
+    /// (<see href="https://github.com/sebastienros/jint/issues/3401">#3401</see>), so before the probe this
+    /// same call ended the process: a native stack overflow, which .NET does not deliver to any
+    /// <c>catch</c>, no exception, no log. A host whose whole reason for implementing
+    /// <see cref="IModuleLoader"/> is to serve a graph it did not author could be killed by one.
+    /// <para>
+    /// The linking half is selected rather than hoped for: loading the chain in slices first means the only
+    /// walk left with a thousand levels to descend is linking's.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void ALinkTooDeepForTheStackThrowsRatherThanEndingTheProcess()
+    {
+        var modules = ImportChain(LongChainLength);
+        Exception? failure = null;
+        var afterwards = 0d;
+
+        DedicatedThread.Run(
+            () =>
+            {
+                var engine = ChainEngine(modules);
+                InSlices(engine, modules, static m => m.LoadRequestedModules());
+
+                failure = Record.Exception(() => engine.Modules.Import("0.js"));
+
+                // The other half of the promise the guard makes for script recursion: an engine that is
+                // still usable. Nothing about a native stack overflow leaves one.
+                afterwards = engine.Evaluate("1 + 1").AsNumber();
+            },
+            joinTimeout: WedgeCeiling,
+            timeoutMessage: $"importing a pre-loaded {LongChainLength}-module chain did not complete within {WedgeCeiling}",
+            maxStackSize: StackTooSmallForTheChain);
+
+        failure.Should().BeOfType<JavaScriptException>()
+            .Which.Message.Should().StartWith("Maximum call stack size exceeded while linking module '");
+
+        afterwards.Should().Be(2);
+    }
+
+    /// <summary>
+    /// An evaluation that runs out of stack leaves the graph <em>errored</em> — every module it had reached
+    /// marked evaluated with that error — rather than stranded mid-evaluation. Importing the same root again
+    /// therefore fails the same way instead of waiting for a promise nothing will ever settle.
+    /// </summary>
+    /// <remarks>
+    /// This is what makes the evaluation half of the probe hand back a throw <em>completion</em> where the
+    /// linking half throws. <c>Evaluate</c> step 9.a is the only thing that marks the modules still on the
+    /// Tarjan stack, and only an abrupt completion returned to it reaches that step; an exception thrown past
+    /// it leaves them in <c>evaluating</c> forever. Measured against a build that throws instead: the first
+    /// import fails as it does here and the second one <b>succeeds</b>, handing the host a namespace for a
+    /// graph not one body of which ever ran. That is the failure this second assertion exists for — a
+    /// half-evaluated graph that reports itself as fine is worse than the crash the probe replaced.
+    /// <para>
+    /// The evaluation half is selected rather than hoped for: linking the chain in slices first means the
+    /// only walk left with a thousand levels to descend is evaluation's.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void AnEvaluationTooDeepForTheStackLeavesTheGraphErrored()
+    {
+        var modules = ImportChain(LongChainLength);
+        Exception? first = null;
+        Exception? second = null;
+
+        DedicatedThread.Run(
+            () =>
+            {
+                var engine = ChainEngine(modules);
+                InSlices(engine, modules, static m => m.Link());
+
+                first = Record.Exception(() => engine.Modules.Import("0.js"));
+                second = Record.Exception(() => engine.Modules.Import("0.js"));
+            },
+            joinTimeout: WedgeCeiling,
+            timeoutMessage: $"importing a pre-linked {LongChainLength}-module chain did not complete within {WedgeCeiling}",
+            maxStackSize: StackTooSmallForTheChain);
+
+        first.Should().BeOfType<JavaScriptException>()
+            .Which.Message.Should().StartWith("Maximum call stack size exceeded while evaluating module '");
+
+        second.Should().BeOfType<JavaScriptException>()
+            .Which.Message.Should().Be(first!.Message);
+    }
+}

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -685,8 +685,9 @@ public class Options
         public int MaxExecutionStackCount { get; set; } = StackGuard.Disabled;
 
         /// <summary>
-        /// Whether every entry into an interpreted function probes the remaining native stack and throws a
-        /// catchable <c>RangeError: Maximum call stack size exceeded</c> when it is nearly gone. Defaults to
+        /// Whether the engine probes the remaining native stack — on every entry into an interpreted
+        /// function, and on every module of a graph being linked or evaluated — and throws a catchable
+        /// <c>RangeError: Maximum call stack size exceeded</c> when it is nearly gone. Defaults to
         /// <see langword="false"/>.
         /// </summary>
         /// <remarks>
@@ -721,6 +722,17 @@ public class Options
         /// call row worse than about 1%, so it ships opt-in. A host whose scripts are all its own can bound
         /// them with <see cref="MaxRecursionDepth"/> and pay nothing; a host sandboxing untrusted input
         /// generally cannot, and a couple of percent on deep recursion is the price of staying alive.
+        /// </para>
+        /// <para>
+        /// It also covers recursion nobody wrote: <c>InnerModuleLinking</c> and <c>InnerModuleEvaluation</c>
+        /// descend once per module, so how deep a graph an engine can link and evaluate is otherwise decided
+        /// by the calling thread's stack — and exceeding it ends the process (sebastienros/jint#3401). With
+        /// this on, a graph too deep to link raises a <c>RangeError</c> naming the module the walk gave up
+        /// on, and leaves the engine usable. That half of the guard is <em>not</em> displaced by
+        /// <see cref="MaxExecutionStackCount"/>: that limit's own probe sits at the call expression, which no
+        /// part of the module pipeline reaches, so there would be nothing in its place. It is a catchable
+        /// failure rather than a raised ceiling — the load phase recurses per module as well and is not
+        /// probed, so a host serving genuinely deep graphs should still import them on a thread sized for it.
         /// </para>
         /// <para>
         /// It is a backstop, not a policy. <see cref="MaxRecursionDepth"/> counts frames and is checked

--- a/Jint/Runtime/CallStack/StackGuard.cs
+++ b/Jint/Runtime/CallStack/StackGuard.cs
@@ -30,12 +30,21 @@ internal sealed class StackGuard
     // specific request, so it wins.
     private readonly bool _backstopEnabled;
 
+    // The same snapshot without that exclusion, for the recursions that are not on a call path at all.
+    // The exclusion above is about ordering between two probes a few native frames apart on one path;
+    // MaxExecutionStackCount's lane is TryEnterOnCurrentStack, which nothing but a call expression
+    // reaches, so on the module pipeline there is nothing for it to win against — and honouring the
+    // exclusion there would leave an engine that asked for a call-depth limit with no protection at all
+    // for a deep import.
+    private readonly bool _graphGuardEnabled;
+
     public StackGuard(Engine engine)
     {
         _engine = engine;
         _maxExecutionStackCount = engine.Options.Constraints.MaxExecutionStackCount;
         _enabled = _maxExecutionStackCount != Disabled;
         _backstopEnabled = !_enabled && engine.Options.Constraints.StackOverflowGuard;
+        _graphGuardEnabled = engine.Options.Constraints.StackOverflowGuard;
     }
 
     /// <summary>
@@ -86,6 +95,32 @@ internal sealed class StackGuard
         {
             ProbeStackHeadroom();
         }
+    }
+
+    /// <summary>
+    /// Whether the current thread still has the runtime's reserve below it, for a caller about to add one
+    /// more level to a recursion that is linear in the size of a *host-supplied* graph rather than in
+    /// anything script wrote — <c>InnerModuleLinking</c> and <c>InnerModuleEvaluation</c>, which descend
+    /// once per module of an import graph.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Reports rather than throws, because the two module algorithms disagree about what failing looks
+    /// like: <c>InnerModuleLinking</c> throws and lets <c>Link</c>'s cleanup return the graph to unlinked,
+    /// while <c>InnerModuleEvaluation</c> has to hand back a <em>throw completion</em> so
+    /// <c>Evaluate</c> can mark every module still on the Tarjan stack evaluated-with-that-error instead of
+    /// stranding them in <c>evaluating</c>. An engine that survives the failure is the whole point; one
+    /// left holding a graph it can neither re-link nor re-evaluate would only be a slower way of losing it.
+    /// </para>
+    /// <para>
+    /// It is gated on <see cref="Options.ConstraintOptions.StackOverflowGuard"/> alone — see
+    /// <c>_graphGuardEnabled</c> — and costs one predictable branch plus, when armed, one comparison
+    /// against the thread's stack limit, per module of the graph. A graph is linked once.
+    /// </para>
+    /// </remarks>
+    public bool HasGraphRecursionHeadroom()
+    {
+        return !_graphGuardEnabled || RuntimeHelpers.TryEnsureSufficientExecutionStack();
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/Jint/Runtime/Modules/CyclicModule.cs
+++ b/Jint/Runtime/Modules/CyclicModule.cs
@@ -308,6 +308,17 @@ public abstract class CyclicModule : Module
     /// </summary>
     protected internal override int InnerModuleLinking(Stack<CyclicModule> stack, int index)
     {
+        // The spec writes this recursively and so does Jint, which makes the deepest graph an engine can
+        // link a property of the calling thread's stack rather than of anything the host configured — and
+        // exceeding it is a native stack overflow, which no host can catch. Probing here turns that into
+        // the same catchable RangeError deep script recursion gets (see StackGuard). The throw is safe to
+        // do from anywhere in this walk: Link's catch returns every module still on the Tarjan stack to
+        // unlinked, so the engine is usable afterwards.
+        if (!_engine._stackGuard.HasGraphRecursionHeadroom())
+        {
+            Throw.RangeError(_realm, $"Maximum call stack size exceeded while linking module '{Location ?? "(null)"}'");
+        }
+
         if (Status is
             ModuleStatus.Linking or
             ModuleStatus.Linked or
@@ -401,6 +412,17 @@ public abstract class CyclicModule : Module
     /// </summary>
     protected internal override Completion InnerModuleEvaluation(Stack<CyclicModule> stack, int index, ref int asyncEvalOrder)
     {
+        // The linking half's probe, in the shape this half needs. A throw completion rather than a throw:
+        // returning one lets Evaluate step 9.a mark every module still on the Tarjan stack evaluated with
+        // this error, which is the state the spec leaves an aborted evaluation in. Throwing instead leaves
+        // them in `evaluating` forever, and — measured, not reasoned — the *next* import of that root then
+        // succeeds, handing the host a namespace for a graph not one body of which ever ran.
+        if (!_engine._stackGuard.HasGraphRecursionHeadroom())
+        {
+            var tooDeep = _realm.Intrinsics.RangeError.Construct($"Maximum call stack size exceeded while evaluating module '{Location ?? "(null)"}'");
+            return new Completion(CompletionType.Throw, tooDeep, null!);
+        }
+
         if (Status is ModuleStatus.EvaluatingAsync or ModuleStatus.Evaluated)
         {
             if (_evalError is null)

--- a/README.md
+++ b/README.md
@@ -772,6 +772,15 @@ see. A third and older setting, `options.Constraints.MaxExecutionStackCount`, co
 a fresh thread instead of throwing; it is checked at call expressions only, so it does not cover the other
 routes above, and it takes precedence over the guard when both are set.
 
+The guard also covers recursion nobody wrote: linking and evaluating a module graph descend once per module,
+so a graph deep enough — a long chain of `import './next.js'` — used to end the process the same way. With
+the guard on it raises `RangeError: Maximum call stack size exceeded while linking module '…'`, naming the
+module the walk gave up on, and the engine goes on working. That half is not displaced by
+`MaxExecutionStackCount`, whose own check no part of the module pipeline reaches. It is a catchable failure
+rather than a raised ceiling: the load phase recurses per module too and is not probed, so how deep a graph
+you can import is still decided by the stack of the thread you import on, and a host serving genuinely deep
+graphs should import them on a thread provisioned for it.
+
 ## Using Modules
 
 You can use modules to `import` and `export` variables from multiple script files:


### PR DESCRIPTION
Backport of #3415 to `4.x`.

`CyclicModule.InnerModuleLinking` and `InnerModuleEvaluation` descend once per module, the way the spec
writes them, so the depth of a graph an engine can link and evaluate is decided by the calling thread's
stack rather than by anything the host configured. Exceeding it is a native stack overflow: no exception,
nothing in a `catch`, no log, and the process gone. Nothing stood in the way — execution constraints are not
evaluated during linking, and `Constraints.StackOverflowGuard` probes inside `ScriptFunction`'s four entry
points, which these algorithms never reach. That is what #3308 turned out to be.

Both algorithms now probe for headroom before descending, and each fails in the shape its own caller needs.

```
JavaScriptException: Maximum call stack size exceeded while linking module '/base/968.js'
```

## The two halves fail differently, and that is the whole design

**Linking throws.** `Link`'s existing `catch` already walks the Tarjan stack returning every module on it to
`unlinked`, which is exactly the cleanup a failure here needs, so the probe raises a `RangeError` through it
and the engine is usable afterwards.

**Evaluation returns a throw completion.** `Evaluate` step 9.a is the only thing that marks the modules
still on the Tarjan stack evaluated-*with*-the-error, and only an abrupt completion returned to it reaches
that step. Measured **on this branch**, against the identical build with only that half changed to throw:

| build | first `Import("0.js")` | second `Import("0.js")` |
| --- | --- | --- |
| throw completion (this PR) | `JavaScriptException` | same `JavaScriptException` |
| plain throw | `JavaScriptException` | **succeeds** — a namespace for a graph not one body of which ran |

A half-evaluated graph that reports itself as fine is worse than the crash the probe replaced, so
`AnEvaluationTooDeepForTheStackLeavesTheGraphErrored` pins the second import too.

The probe is gated on `Constraints.StackOverflowGuard` **alone** and deliberately does *not* stand down for
`MaxExecutionStackCount` the way the script backstop does. That exclusion exists because the two probes sit
a few native frames apart on one call path and the more specific request should win. The module pipeline is
not on that path — `MaxExecutionStackCount`'s lane is `TryEnterOnCurrentStack` at the call expression, which
nothing here reaches — so honouring the precedence would leave an engine that asked for a call-depth limit
with no probe at all for a deep import.

`Constraints.StackOverflowGuard` is opt-in on `4.x`, so this is opt-in too: an engine that did not ask for
the guard pays one predictable branch per module and behaves exactly as before. No new option, no new
public member.

## Evidence

Two tests in `Jint.Tests.PublicInterface`. Each prepares every phase before the one it is about, then runs
that walk on a small thread and asserts what came back.

**The chain length is measured, not chosen.** The first attempt at this named a single length with an
argued margin — 1,000, five times the 156 modules #3415 measured as the trip depth on a 256 KB thread — and
it failed the Linux legs with `found <null>`: the chain linked and evaluated *successfully* there, so the
test asserted an exception that legitimately never happened. The margin was over the wrong quantity. The
frames agree across platforms almost exactly (binary search on this branch: **157** modules on a 256 KB
Windows thread, against main's 156). What does not carry is the stack itself — `maxStackSize` is a request,
and on that runner it bought enough for a 1,000-deep walk. So the tests now grow the chain (2,000 … 32,000)
until the walk meets the probe and assert on whichever length did. Whatever stack the platform really handed
over, doubling reaches the end of it. Verified by forcing the stack up locally: **8 MB → green in 1.3 s,
16 MB → green in 6.5 s** (16 MB is the largest stack this suite ever asks for), against 0.3 s where the
first length already trips.

Preparation runs on an ordinary thread while it is at it. Only the walk under test needs the small one, and
where a platform's probe reserve is itself larger than that stack — a 64 KB page size makes the runtime's
reserve 768 KB — preparing there would meet the probe during setup and report a failure about the wrong
thing.

**Before** — the same two tests against this branch with only the engine change reverted. Both **end the
test process**; there is no failing test to report, because there is no process left to report it:

| test | `net10.0` | `net472` (the `net462` asset) |
| --- | --- | --- |
| `ALinkTooDeepForTheStackThrowsRatherThanEndingTheProcess` | exit 127, `Stack overflow.` → **433 × `CyclicModule.InnerModuleLinking`** | exit 127, `Process is terminated due to StackOverflowException.` |
| `AnEvaluationTooDeepForTheStackLeavesTheGraphErrored` | exit 127, `Stack overflow.` → **328 × `CyclicModule.InnerModuleEvaluation`** | exit 127, `Process is terminated due to StackOverflowException.` |

The stack walk in the fatal banner names the phase each test selects, which is how each one is known to be
driving the half it claims.

**After** — `Total: 2, Errors: 0, Failed: 0` on both, exit 0.

Full run, `dotnet build -c Release` clean (`TreatWarningsAsErrors`):

| suite | `net10.0` | `net472` |
| --- | --- | --- |
| `Jint.Tests` | 6,854 passed / 0 failed | 6,769 passed / 0 failed |
| `Jint.Tests.PublicInterface` | 1,502 passed / 0 failed | 1,495 passed / 0 failed |
| `Jint.Tests.CommonScripts` | 28 / 0 | 28 / 0 |
| `Jint.Tests.SourceGenerators` | 52 / 0 | — |

**Test262: 102,495 passed, 0 failed** — the control that matters here, since module code is heavily covered
and the evaluation half hands back a completion where an exception used to be impossible.

## What differs from #3415, and why

Left behind, all of it context for v5-only surface this branch does not have: the `docs/v5-migration.md`
entry (no such file here), the `Jint/Runtime/Modules/AGENTS.md` note (no co-located instruction files here),
and the edits to `HostModuleGraphSecurityTests` — that suite, `Options.Modules.MaxModuleCount` and
`Options.Modules.MaxModuleGraphDepth` are all v5. #3415 introduced no limit knob of its own, and neither
does this.

One behavioural difference worth naming. On `main` the load phase is iterative — `InnerModuleLoading` drives
a work queue — so a plain deep `Import` reaches linking. **On `4.x` the load phase still recurses per
module**, and on a stack too small it meets the reserve first: measured here, a cold 1,000-module import
dies with 151 × `InnerModuleLoading` frames before linking is ever entered. Making it iterative is a
separate machine (`Enqueue`/`TryBeginProcessing`/`Budget`/`ModuleGraphLimitException`) that arrived with v5's
module-graph limits, and it is not a backport. So the two tests here pre-drive the chain in slices to select
the phase they are about, and the load recursion stays unprobed on purpose: it reports failure by rejecting
its own promise, so a throw out of it would be a different contract rather than the same one in another
place.

Which means, as on `main`: this is a catchable *failure*, not a raised ceiling. How deep a graph an engine
can import is still decided by the thread's stack, and a host serving genuinely deep graphs should import
them on a thread provisioned for it. `README.md` and the `StackOverflowGuard` doc both say so.
