### PR TITLE
BigInt: a leading plus is part of the literal, on the decimal spelling alone (#3540)

### DIFF
--- a/Jint.Tests/Runtime/StringToBigIntTests.cs
+++ b/Jint.Tests/Runtime/StringToBigIntTests.cs
@@ -1,0 +1,158 @@
+#nullable enable
+
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// <c>StringToBigInt</c> reads a <c>StringIntegerLiteral</c>, and a leading sign is part of that grammar
+/// on the decimal spelling and on no other.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see href="https://tc39.es/ecma262/#sec-stringtobigint">StringToBigInt</see> parses its argument as
+/// <c>StringIntegerLiteral</c>, whose <c>StrIntegerLiteral</c> is either a <c>SignedInteger</c> —
+/// <c>DecimalDigits</c>, <c>+ DecimalDigits</c> or <c>- DecimalDigits</c> — or a
+/// <c>NonDecimalIntegerLiteral</c>, which takes no sign at all. Jint accepted only the minus, so
+/// <c>BigInt('+12')</c> was a <c>SyntaxError</c> where every other engine answers <c>12n</c>
+/// (<see href="https://github.com/sebastienros/jint/issues/3540">#3540</see>).
+/// </para>
+/// <para>
+/// The two halves are tested together on purpose: the sign has to start being accepted on the decimal
+/// spelling and has to keep being rejected on the hexadecimal, octal and binary ones, and a fix that
+/// only did the first half would look right from the issue alone.
+/// </para>
+/// </remarks>
+public class StringToBigIntTests
+{
+    /// <summary>
+    /// <c>SignedInteger ::: + DecimalDigits</c>, which is the production the issue is about.
+    /// </summary>
+    [TestCase("BigInt('+12')", "12")]
+    [TestCase("BigInt('-12')", "-12")]
+    [TestCase("BigInt('12')", "12")]
+    [TestCase("BigInt('+0')", "0")]
+    [TestCase("BigInt('-0')", "0")]
+    [TestCase("BigInt('+007')", "7")]
+    [TestCase("BigInt('+9007199254740993')", "9007199254740993")]
+    public void ASignedDecimalStringIsTheBigIntItNames(string expression, string expected)
+    {
+        new Engine().Evaluate(expression).ToString().Should().Be(expected);
+    }
+
+    /// <summary>
+    /// The value is exact past what a Number could hold, because nothing on this path is a double.
+    /// </summary>
+    [Test]
+    public void ASignedDecimalStringWiderThanANumberIsExact()
+    {
+        var digits = new string('9', 40);
+
+        new Engine().Evaluate($"BigInt('+{digits}') === BigInt('{digits}')").AsBoolean().Should().BeTrue();
+        new Engine().Evaluate($"BigInt('+{digits}').toString()").ToString().Should().Be(digits);
+        new Engine().Evaluate($"BigInt('-{digits}').toString()").ToString().Should().Be("-" + digits);
+    }
+
+    /// <summary>
+    /// <c>StringIntegerLiteral</c> is <c>StrWhiteSpace</c>-padded on both sides, and the sign sits inside
+    /// the padding rather than outside it.
+    /// </summary>
+    [TestCase("' +12 '")]
+    [TestCase("String.fromCharCode(0x09) + '+12' + String.fromCharCode(0x0A)")]
+    [TestCase("String.fromCharCode(0xFEFF) + '+12'")]
+    [TestCase("String.fromCharCode(0x00A0) + '+12' + String.fromCharCode(0x2028)")]
+    public void WhiteSpaceMayPadASignedDecimalString(string argument)
+    {
+        new Engine().Evaluate($"BigInt({argument}) === 12n").AsBoolean().Should().BeTrue();
+    }
+
+    /// <summary>
+    /// <c>NonDecimalIntegerLiteral</c> has no sign in its grammar, so a signed one is not a literal.
+    /// </summary>
+    [TestCase("'+0x10'")]
+    [TestCase("'-0x10'")]
+    [TestCase("'+0X10'")]
+    [TestCase("'+0b11'")]
+    [TestCase("'-0b11'")]
+    [TestCase("'+0o17'")]
+    [TestCase("'-0o17'")]
+    public void ASignedNonDecimalStringIsNotALiteral(string argument)
+    {
+        ShouldBeASyntaxError(argument);
+    }
+
+    /// <summary>
+    /// A sign that stands alone, doubles, or is separated from its digits is not a
+    /// <c>SignedInteger</c> either — nor is a decimal spelling carrying a fraction or an exponent, which
+    /// <c>StrIntegerLiteral</c> does not have.
+    /// </summary>
+    [TestCase("'+'")]
+    [TestCase("'-'")]
+    [TestCase("'++12'")]
+    [TestCase("'+-12'")]
+    [TestCase("'--12'")]
+    [TestCase("'+ 12'")]
+    [TestCase("'12+'")]
+    [TestCase("'12-'")]
+    [TestCase("'+12.5'")]
+    [TestCase("'+12.'")]
+    [TestCase("'+1e3'")]
+    [TestCase("'+Infinity'")]
+    [TestCase("'+ '")]
+    public void ASignWithoutDecimalDigitsIsASyntaxError(string argument)
+    {
+        ShouldBeASyntaxError(argument);
+    }
+
+    /// <summary>
+    /// Loose equality against a string runs the same conversion, in both operand orders
+    /// (<see href="https://tc39.es/ecma262/#sec-islooselyequal">IsLooselyEqual</see> steps 6 and 7).
+    /// </summary>
+    [TestCase("12n == '+12'", true)]
+    [TestCase("'+12' == 12n", true)]
+    [TestCase("-12n == '-12'", true)]
+    [TestCase("12n == '+13'", false)]
+    [TestCase("12n == '+0x0c'", false)]
+    [TestCase("0n == '+0'", true)]
+    public void LooseEqualityReadsTheSignToo(string expression, bool expected)
+    {
+        new Engine().Evaluate(expression).AsBoolean().Should().Be(expected);
+    }
+
+    /// <summary>
+    /// So does the relational comparison, which answers <c>false</c> for a string that is not a literal
+    /// and has to stop doing that for one that is.
+    /// </summary>
+    [TestCase("12n < '+13'", true)]
+    [TestCase("12n < '+11'", false)]
+    [TestCase("'+11' < 12n", true)]
+    [TestCase("'+13' < 12n", false)]
+    [TestCase("12n < '+0x1f'", false)]
+    public void RelationalComparisonReadsTheSignToo(string expression, bool expected)
+    {
+        new Engine().Evaluate(expression).AsBoolean().Should().Be(expected);
+    }
+
+    /// <summary>
+    /// The sibling lane already read the sign, and the two now agree wherever both accept the text.
+    /// </summary>
+    [TestCase("+12")]
+    [TestCase("-12")]
+    [TestCase("+0")]
+    [TestCase("+123456789")]
+    public void TheNumberLaneAndTheBigIntLaneReadTheSameSign(string text)
+    {
+        new Engine().Evaluate($"BigInt('{text}') === BigInt(Number('{text}'))").AsBoolean().Should().BeTrue();
+    }
+
+    private static void ShouldBeASyntaxError(string argument)
+    {
+        var engine = new Engine();
+
+        var exception = Invoking(() => engine.Evaluate($"BigInt({argument})"))
+            .Should().ThrowExactly<JavaScriptException>().Which;
+
+        exception.Error.InstanceofOperator(engine.Intrinsics.SyntaxError).Should().BeTrue(
+            $"BigInt({argument}) is not a StringIntegerLiteral");
+    }
+}

--- a/Jint.Tests/Runtime/WhiteSpaceDefinitionTests.cs
+++ b/Jint.Tests/Runtime/WhiteSpaceDefinitionTests.cs
@@ -181,10 +181,10 @@ public class WhiteSpaceDefinitionTests
     // here too until sebastienros/jint#3541 took the trailing NUL that long.TryParse read as a C string
     // terminator off this lane.
     [TestCase("Number('12' + c) === 12", "002E", TestName = "Number with a trailing pad")]
-    // "012" is a StringIntegerLiteral with a leading zero. BigInt also rejects a leading "+" that the
-    // grammar allows (sebastienros/jint#3540), which is likewise a defect of its own and not about white
-    // space, so it is absent from this list rather than present in it.
-    [TestCase("(function () { try { return BigInt(c + '12') === BigInt(12); } catch (e) { return false; } })()", "0030", TestName = "BigInt with a leading pad")]
+    // "+12" and "012" carry the StringIntegerLiteral's own leading sign and leading zero, which is the
+    // same pair the decimal lanes above admit: StrIntegerLiteral's SignedInteger takes either sign
+    // (sebastienros/jint#3540).
+    [TestCase("(function () { try { return BigInt(c + '12') === BigInt(12); } catch (e) { return false; } })()", "002B,0030", TestName = "BigInt with a leading pad")]
     [TestCase("(function () { try { return BigInt('12' + c) === BigInt(12); } catch (e) { return false; } })()", "", TestName = "BigInt with a trailing pad")]
     [TestCase("/\\s/.test(c)", "", TestName = "the backslash-s character class")]
     public void EveryLaneAcceptsExactlyTheSpecWhiteSpaceSet(string predicate, string grammarExtras)

--- a/Jint/Runtime/TypeConverter.cs
+++ b/Jint/Runtime/TypeConverter.cs
@@ -679,9 +679,12 @@ public static class TypeConverter
             var c = str[i];
             if (!char.IsDigit(c))
             {
-                if (i == 0 && (c == '-' || Character.IsDecimalDigit(c)))
+                // StrIntegerLiteral ::: SignedInteger | NonDecimalIntegerLiteral, and SignedInteger takes
+                // either sign: "+12" is as much a literal as "-12". The sign belongs to the decimal
+                // spelling alone, and a signed non-decimal one needs no rule of its own: the 0x, 0o and
+                // 0b lanes below all match at index 0, which the sign occupies.
+                if (i == 0 && c is '-' or '+')
                 {
-                    // ok
                     continue;
                 }
 

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -4271,6 +4271,39 @@ rather than an element. There is no option to restore the old behaviour: it was 
 ECMAScript one. A host that wants it can trim on the CLR side — `value.TrimEnd('\0')` — before the value
 reaches the engine.
 
+### 4.96 `BigInt` reads the leading `+` that `StringIntegerLiteral` signs ([#3540](https://github.com/sebastienros/jint/issues/3540))
+
+[StringToBigInt](https://tc39.es/ecma262/#sec-stringtobigint) parses its argument as a
+`StringIntegerLiteral`, and that grammar's `StrIntegerLiteral` is either a `SignedInteger` —
+`DecimalDigits`, `+ DecimalDigits` or `- DecimalDigits` — or a `NonDecimalIntegerLiteral`, which carries
+no sign at all. Jint walked the string once before parsing it and admitted a non-digit at the front only
+when it was `-`, so the plus was a `SyntaxError` on the one spelling the grammar signs, while
+`Number('+12')` had always been `12`.
+
+```js
+// 5.0: SyntaxError               5.x: 12n
+BigInt('+12');
+
+// 5.0: SyntaxError               5.x: 12n
+BigInt(' +12 ');
+
+// 5.0: false                     5.x: true
+12n == '+12';
+
+// 5.0: false                     5.x: true
+12n < '+13';
+```
+
+The sign belongs to the decimal spelling and to nothing else, so `BigInt('+0x10')`, `BigInt('-0b11')` and
+`BigInt('+0o17')` are still `SyntaxError`s, as are `'+'`, `'++12'`, `'+ 12'`, `'+12.5'` and `'+1e3'`.
+Nothing about which strings are rejected has otherwise moved.
+
+**What could break:** a host or script reading the `SyntaxError` as "this text is not an integer" — a
+`try`/`catch` around `BigInt(...)` used as a validator now accepts a plus-signed decimal string, and a
+`==` or `<` against a `BigInt` that answered `false` for one now compares it. There is no option to
+restore the old behaviour: the sign is part of the production `BigInt` says it parses, and every other
+engine reads it.
+
 ## 5. New in v5
 
 Everything in the table below is opt-in: nothing in it is installed unless the host asks for it, so


### PR DESCRIPTION
Closes #3540.

## What was wrong

[StringToBigInt](https://tc39.es/ecma262/#sec-stringtobigint) parses its argument as a `StringIntegerLiteral`:

```
StrIntegerLiteral ::: SignedInteger | NonDecimalIntegerLiteral
SignedInteger ::: DecimalDigits | + DecimalDigits | - DecimalDigits
```

`TypeConverter.TryStringToBigInt` walks the string once before parsing it and admitted a non-digit at
index 0 only when it was `-`. A leading `+` fell through to `return false`, which `StringToBigInt` turns
into a `SyntaxError` — on the one spelling the grammar signs, and while `Number('+12')` had always been
`12`. V8, SpiderMonkey and JavaScriptCore all answer `12n`.

```js
BigInt('+12');    // was SyntaxError, now 12n
BigInt(' +12 ');  // was SyntaxError, now 12n
12n == '+12';     // was false, now true
12n < '+13';      // was false, now true
```

The same conversion backs loose equality and relational comparison against a string
([IsLooselyEqual](https://tc39.es/ecma262/#sec-islooselyequal) steps 6 and 7, and the abstract relational
comparison), in both operand orders, so all four lanes move together.

## The fix

One condition in `TryStringToBigInt`: the pre-scan admits `+` beside `-` at index 0.

The sign stays the decimal spelling's alone, and that needs no rule of its own — the `0x`, `0o` and `0b`
lanes below the pre-scan all match their prefix at index 0, which a sign occupies, so `BigInt('+0x10')`,
`BigInt('-0b11')` and `BigInt('+0o17')` remain `SyntaxError`s. So do `'+'`, `'++12'`, `'+ 12'`, `'+12.5'`
and `'+1e3'`. Nothing about which strings are rejected has otherwise moved. The pre-scan also keeps
double duty as the guard that stops `BigInteger.TryParse`'s `NumberStyles.Integer` from admitting the
framework's white-space set, which is not `StrWhiteSpace`.

The `Character.IsDecimalDigit(c)` half of the old condition was dead: the branch is only reached when
`char.IsDigit(c)` is already false, and `char.IsDigit` is a superset of it.

## Tests

`Jint.Tests/Runtime/StringToBigIntTests.cs` (new) pins both halves — the sign has to start being accepted
on the decimal spelling *and* keep being rejected on the non-decimal ones — plus the white-space padding
around it, the exactness past 2^53, and the loose-equality and relational lanes in both operand orders.

`WhiteSpaceDefinitionTests`' whole-plane sweep recorded this defect as the reason U+002B was *absent*
from the "BigInt with a leading pad" grammar-extras list while `parseInt`, `parseFloat` and `Number` all
carry it. It is now present, so the sweep re-verifies the whole Basic Multilingual Plane against a lane
that agrees with its three siblings.

Failing-first on the unfixed tree, per target framework:

| Target framework | Before | After |
| --- | --- | --- |
| `net472`* | 6 failed / 40 passed | 82 passed |
| `net8.0` | 18 failed / 64 passed | 82 passed |
| `net10.0` | 18 failed / 64 passed | 82 passed |

\* the `net472` before-figure is a subset: on .NET Framework, NUnit's `ExceptionHelper` reflects over a
failing test's exception properties, and `JavaScriptException.Location` is `ref readonly`, so
`RuntimePropertyInfo.GetValue` throws `NotSupportedException : ByRef return value not supported in
reflection invocation` and the test host process dies mid-run. That is pre-existing and unrelated to this
change — it only shows up while a test is red — so the before-run there was narrowed to the cases whose
failure mode is an assertion rather than an escaping `JavaScriptException`. Filed as #3549.

test262 is unchanged at 102,537 passed / 0 failed / 151 skipped of 102,688, and no exclusion could be
removed: the suite has no coverage of a `+`-signed `StringIntegerLiteral` at all.
`constructor-from-decimal-string.js` tests the unsigned and `-`-signed spellings only, and
`constructor-from-string-syntax-errors.js` does not list one. Adding that coverage upstream is worth doing and is
not part of this change.

The migration guide entry is §4.96.
