### PR TITLE
String to number: a trailing NUL pads neither a number string nor an array index (backport of #3544)

### DIFF
--- a/Jint.Tests/Runtime/NullCharacterPaddingTests.cs
+++ b/Jint.Tests/Runtime/NullCharacterPaddingTests.cs
@@ -1,0 +1,212 @@
+﻿#nullable enable
+using Jint.Native;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// U+0000 pads nothing. It is category <c>Cc</c> and in neither <c>WhiteSpace</c> nor <c>LineTerminator</c>,
+/// so it may not sit beside a <c>StringNumericLiteral</c> nor inside an array index — but the framework's
+/// number parsers end a number at one and accept whatever follows, the way a C string terminates.
+/// </summary>
+/// <remarks>
+/// The tolerance is the parser's and not a <see cref="System.Globalization.NumberStyles"/> flag's, so it
+/// survives every style combination and reaches every lane that hands raw script text to
+/// <c>long.TryParse</c>, <c>double.TryParse</c>, <c>double.Parse</c> or <c>uint.TryParse</c>
+/// (sebastienros/jint#3541).
+/// </remarks>
+public class NullCharacterPaddingTests
+{
+    private static JsValue Evaluate(string script) => new Engine().Evaluate(script);
+
+    private const string Nul = "var nul = String.fromCharCode(0);\n";
+
+    /// <summary>
+    /// Both of <c>ToNumber</c>'s parsers read a trailing NUL, so every spelling is affected: the whole-number
+    /// fast path takes a sign, an exponent and an empty fraction, and the general lane below it takes the
+    /// fractions the fast path turns down.
+    /// </summary>
+    [Theory]
+    [InlineData("'12' + nul")]
+    [InlineData("'12' + nul + nul")]
+    [InlineData("'1' + nul")]
+    [InlineData("'0' + nul")]
+    [InlineData("'-0' + nul")]
+    [InlineData("'-12' + nul")]
+    [InlineData("'+12' + nul")]
+    [InlineData("'1e3' + nul")]
+    [InlineData("'12.' + nul")]
+    [InlineData("'12.0' + nul")]
+    [InlineData("' 12' + nul")]
+    [InlineData("'12' + nul + ' '")]
+    [InlineData("'12 ' + nul")]
+    [InlineData("'1.5' + nul")]
+    [InlineData("'-1.5' + nul")]
+    [InlineData("'.5' + nul")]
+    [InlineData("'1.5e3' + nul")]
+    [InlineData("'0.0' + nul")]
+    public void ANumberStringPaddedWithATrailingNulIsNotANumber(string expression)
+    {
+        double.IsNaN(Evaluate(Nul + "Number(" + expression + ")").AsNumber()).Should().BeTrue();
+    }
+
+    /// <summary>
+    /// The lanes that were already right, so that the fix is the rest joining them rather than a new rule.
+    /// </summary>
+    [Theory]
+    [InlineData("nul + '12'")]
+    [InlineData("nul")]
+    [InlineData("'12' + nul + '34'")]
+    [InlineData("'0x10' + nul")]
+    [InlineData("'Infinity' + nul")]
+    public void TheLanesThatAlreadyRejectedANulGoOnRejectingIt(string expression)
+    {
+        double.IsNaN(Evaluate(Nul + "Number(" + expression + ")").AsNumber()).Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Every implicit <c>ToNumber</c> reads the same string, so the coercions that go through it answer
+    /// <c>NaN</c> too rather than only the explicit call.
+    /// </summary>
+    [Fact]
+    public void EveryImplicitToNumberReadsTheSameString()
+    {
+        Evaluate(Nul + "isNaN(+('12' + nul))").AsBoolean().Should().BeTrue();
+        Evaluate(Nul + "('12' + nul) == 12").AsBoolean().Should().BeFalse();
+        double.IsNaN(Evaluate(Nul + "('12' + nul) * 1").AsNumber()).Should().BeTrue();
+        double.IsNaN(Evaluate(Nul + "Math.abs('12' + nul)").AsNumber()).Should().BeTrue();
+        double.IsNaN(Evaluate(Nul + "Math.abs('1.5' + nul)").AsNumber()).Should().BeTrue();
+
+        // ToIntegerOrInfinity turns the NaN into 0, so the character read is the first one and not the second.
+        Evaluate(Nul + "'abc'.charAt('1' + nul)").AsString().Should().Be("a");
+    }
+
+    /// <summary>
+    /// What <c>ToNumber</c> may still read, unchanged — including <c>"12."</c>, a
+    /// <c>StrUnsignedDecimalLiteral</c> with an empty fraction, whose value is stated here rather than assumed.
+    /// </summary>
+    [Fact]
+    public void TheNumberStringsThatWereAlreadyRightKeepTheirValues()
+    {
+        Evaluate("Number('12')").AsNumber().Should().Be(12);
+        Evaluate("Number('12.')").AsNumber().Should().Be(12);
+        Evaluate("Number('12.0')").AsNumber().Should().Be(12);
+        Evaluate("Number('-12')").AsNumber().Should().Be(-12);
+        Evaluate("Number('+12')").AsNumber().Should().Be(12);
+        Evaluate("Number('1e3')").AsNumber().Should().Be(1000);
+        Evaluate("Number('1.5')").AsNumber().Should().Be(1.5);
+        Evaluate("Number('.5')").AsNumber().Should().Be(0.5);
+        Evaluate("Number('1.5e3')").AsNumber().Should().Be(1500);
+        Evaluate("Number('  ')").AsNumber().Should().Be(0);
+        Evaluate("Number('')").AsNumber().Should().Be(0);
+        Evaluate("Number('0x10')").AsNumber().Should().Be(16);
+        Evaluate("Number('Infinity')").AsNumber().Should().Be(double.PositiveInfinity);
+        Evaluate("Number('-Infinity')").AsNumber().Should().Be(double.NegativeInfinity);
+
+        // Trailing white space is still white space, and the trim above the parsers is what removes it.
+        Evaluate("Number('12 ')").AsNumber().Should().Be(12);
+        Evaluate("Number('1.5 ')").AsNumber().Should().Be(1.5);
+
+        // -0 keeps its sign, which is the one thing the fast path is there to get right by hand.
+        Evaluate("1 / Number('-0')").AsNumber().Should().Be(double.NegativeInfinity);
+        Evaluate("1 / Number('-0.0')").AsNumber().Should().Be(double.NegativeInfinity);
+        Evaluate("1 / Number('0')").AsNumber().Should().Be(double.PositiveInfinity);
+    }
+
+    /// <summary>
+    /// <c>parseInt</c> and <c>parseFloat</c> read the longest prefix and discard the rest, so a trailing NUL
+    /// was never observable on those lanes and stays unobservable.
+    /// </summary>
+    [Fact]
+    public void ThePrefixReadingLanesAreUnaffected()
+    {
+        Evaluate(Nul + "parseInt('12' + nul)").AsNumber().Should().Be(12);
+        Evaluate(Nul + "parseInt('12' + nul + '34')").AsNumber().Should().Be(12);
+        Evaluate(Nul + "parseFloat('12' + nul)").AsNumber().Should().Be(12);
+        Evaluate(Nul + "parseFloat('1.5' + nul)").AsNumber().Should().Be(1.5);
+        Evaluate(Nul + "1 / parseInt('-0' + nul)").AsNumber().Should().Be(double.NegativeInfinity);
+        Evaluate(Nul + "isNaN(parseInt(nul + '12'))").AsBoolean().Should().BeTrue();
+    }
+
+    /// <summary>
+    /// <c>BigInt</c> scans the characters itself before it parses, so it rejected the NUL already.
+    /// </summary>
+    [Fact]
+    public void BigIntGoesOnRefusingANul()
+    {
+        Evaluate(Nul + "(function () { try { BigInt('12' + nul); return 'no throw'; } catch (e) { return e.name; } })()")
+            .AsString().Should().Be("SyntaxError");
+    }
+
+    /// <summary>
+    /// An array index is the canonical decimal spelling of its value, so nothing may pad it — and the same
+    /// framework tolerance made <c>uint.TryParse</c> read one that carried a trailing NUL or trailing white
+    /// space as the index it merely resembled.
+    /// </summary>
+    [Theory]
+    [InlineData("'1' + nul")]
+    [InlineData("'1' + nul + nul")]
+    [InlineData("'1 '")]
+    [InlineData("'1\\t'")]
+    [InlineData("'1 ' + nul")]
+    [InlineData("' 1'")]
+    [InlineData("'+1'")]
+    [InlineData("'01'")]
+    public void AKeyThatMerelyResemblesAnArrayIndexIsNotOne(string expression)
+    {
+        Evaluate(Nul + "[1, 2, 3][" + expression + "] === undefined").AsBoolean().Should().BeTrue();
+    }
+
+    /// <summary>
+    /// And writing under such a key adds an ordinary property rather than an element, so neither
+    /// <c>length</c> nor the element itself moves.
+    /// </summary>
+    [Fact]
+    public void WritingUnderSuchAKeyDoesNotReachTheElements()
+    {
+        Evaluate(Nul + "(function () { var a = []; a['3' + nul] = 'z'; return a.length; })()")
+            .AsNumber().Should().Be(0);
+        Evaluate(Nul + "(function () { var a = []; a['3' + nul] = 'z'; return a[3] === undefined; })()")
+            .AsBoolean().Should().BeTrue();
+        Evaluate(Nul + "(function () { var a = []; a['3' + nul] = 'z'; return Object.keys(a).length === 1 && Object.keys(a)[0].length === 2; })()")
+            .AsBoolean().Should().BeTrue();
+        Evaluate("(function () { var a = []; a['3 '] = 'z'; return a.length; })()")
+            .AsNumber().Should().Be(0);
+    }
+
+    /// <summary>
+    /// The indices that are canonical go on being indices, which is the half of the guard that has to keep
+    /// working.
+    /// </summary>
+    [Fact]
+    public void TheCanonicalIndicesAreStillIndices()
+    {
+        Evaluate("[1, 2, 3]['0'] === 1 && [1, 2, 3]['2'] === 3").AsBoolean().Should().BeTrue();
+        Evaluate("(function () { var a = []; a['0'] = 'x'; a['10'] = 'y'; return a.length; })()")
+            .AsNumber().Should().Be(11);
+        Evaluate("(function () { var a = [1, 2, 3]; return a[1]; })()").AsNumber().Should().Be(2);
+    }
+
+    /// <summary>
+    /// A wrapped host list answers membership through the same parse, so a padded key stops reporting as a
+    /// position of the view - joining <c>"+1"</c>, <c>"01"</c> and <c>" 1"</c>, which it already turned down.
+    /// </summary>
+    /// <remarks>
+    /// Reading such a key still goes through the reflected indexer on this branch, which resolves every
+    /// integer-shaped spelling to the same element; that lane is a separate matter and is untouched here.
+    /// </remarks>
+    [Fact]
+    public void AWrappedHostListAnswersMembershipThroughTheSameParse()
+    {
+        var engine = new Engine();
+        engine.SetValue("list", new List<string> { "a", "b", "c" });
+
+        engine.Evaluate("list[1]").AsString().Should().Be("b");
+        engine.Evaluate("list['1']").AsString().Should().Be("b");
+
+        engine.Evaluate("'1' in list").AsBoolean().Should().BeTrue();
+        engine.Evaluate("String.fromCharCode(49, 0) in list").AsBoolean().Should().BeFalse();
+        engine.Evaluate("'1 ' in list").AsBoolean().Should().BeFalse();
+        engine.Evaluate("'+1' in list").AsBoolean().Should().BeFalse();
+        engine.Evaluate("'01' in list").AsBoolean().Should().BeFalse();
+    }
+}

--- a/Jint/Native/Array/ArrayInstance.cs
+++ b/Jint/Native/Array/ArrayInstance.cs
@@ -868,7 +868,14 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static uint ParseArrayIndex(string p)
     {
-        if (p.Length == 0 || p.Length > 1 && !IsInRange(p[0], '1', '9') || !uint.TryParse(p, out var d))
+        // An array index is the canonical decimal spelling of its value, so it both begins and ends in a
+        // digit - and the first-digit test is also what rules out the leading zero of a non-canonical "01".
+        // uint.TryParse alone tolerates padding an index may not carry: white space on either side, a leading
+        // sign, and a trailing U+0000 run it reads as a C string terminator whatever the styles say
+        // (sebastienros/jint#3541). Every one of those puts a non-digit at one end or the other.
+        if (p.Length == 0
+            || p.Length > 1 && (!IsInRange(p[0], '1', '9') || !IsInRange(p[p.Length - 1], '0', '9'))
+            || !uint.TryParse(p, out var d))
         {
             return uint.MaxValue;
         }

--- a/Jint/Runtime/TypeConverter.cs
+++ b/Jint/Runtime/TypeConverter.cs
@@ -243,6 +243,19 @@ public static class TypeConverter
             // that Jint's TrimEx considers whitespace per the ECMAScript spec.
             return 0;
         }
+
+        // A trailing U+0000 run pads nothing, and neither parser below rejects it: the framework's number
+        // parsers end a number at a U+0000 and accept however many follow it, the way a C string terminates,
+        // and no NumberStyles flag turns that off. U+0000 is category Cc and in neither WhiteSpace nor
+        // LineTerminator, so it pads a StringNumericLiteral under no reading of the grammar, and V8,
+        // SpiderMonkey and JavaScriptCore all answer NaN (sebastienros/jint#3541). The tolerance only fires
+        // when the run reaches the end of the string, and the trim above has already taken any white space
+        // off that end, so testing the last character catches every spelling it could read.
+        if (input[input.Length - 1] == '\0')
+        {
+            return double.NaN;
+        }
+
         firstChar = input[0];
 
         const NumberStyles NumberStyles = NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign |


### PR DESCRIPTION
Backport of #3544 to `4.x`. Closes #3541 on this branch.

`Number("12" + String.fromCharCode(0))` was `12` — and on this branch `Number("1.5" + String.fromCharCode(0))` was `1.5` too, which `main` never had.

The framework's number parsers end a number at a U+0000 and accept however many follow it, the way a C string terminates. No `NumberStyles` flag turns that off, and U+0000 is category `Cc`, in neither [WhiteSpace](https://tc39.es/ecma262/#sec-white-space) nor [LineTerminator](https://tc39.es/ecma262/#sec-line-terminators), so it pads a `StringNumericLiteral` under no reading of the grammar. V8, SpiderMonkey and JavaScriptCore all answer `NaN`.

```js
var nul = String.fromCharCode(0);

//                          before      after
Number('12' + nul);      // 12          NaN
Number('12' + nul + nul);// 12          NaN
Number('-12' + nul);     // -12         NaN
Number('1e3' + nul);     // 1000        NaN
Number('1.5' + nul);     // 1.5         NaN   <- main's fractional lane was already right; this one was not
Number('-1.5' + nul);    // -1.5        NaN
Number('.5' + nul);      // 0.5         NaN
Number(nul + '12');      // NaN         NaN   -- a leading NUL never survived the trim

[1, 2, 3]['1' + nul];    // 2           undefined
[1, 2, 3]['1 '];         // 2           undefined
(function () { var a = []; a['3' + nul] = 'z'; return a.length; })();
                         // 4           0
```

## Why the shape differs from main's

Main guards the whole-number **fast path**: it requires the last character to be a decimal digit before `long.TryParse` sees the string. That is enough there because main's general lane is `NumberParser.TryParseDouble`, which scans the characters itself and already rejected the NUL — hence "the fractional lane was always right" in #3544.

`4.x` predates `NumberParser`. Its general lane is `double.TryParse` (and `double.Parse` inside a `try` on .NET Framework), and **both** of those carry the same trailing-NUL tolerance as `long.TryParse`. Ported verbatim, main's fast-path guard would have moved `Number("12\0")` to `NaN` and left `Number("1.5\0")` at `1.5` — the fractional lane would go on leaking, in a spelling main never had to fix.

So the guard sits **above both parsers instead of on one of them**, as a single test right after the `TrimEx` step in `TypeConverter.ToNumber(string)`:

```csharp
if (input[input.Length - 1] == '\0')
{
    return double.NaN;
}
```

One comparison covers the integer and the fractional lane at once. It is sufficient because the framework's tolerance only fires when the NUL run reaches the **end** of the string (`"12\0" + "34"` was already `NaN`), and the trim above has already taken any white space off that end, so `"12\0 "` is tested as `"12\0"`. It is also the minimal guard: rejecting any trailing non-digit would take `Number("Infinity")` and `Number("0x1f")` with it.

`ArrayInstance.ParseArrayIndex` is character-identical on this branch, so **main's index guard applies verbatim** — first character `'1'`–`'9'` when the length is more than one *and* last character `'0'`–`'9'`, before `uint.TryParse`. An array index is the canonical decimal spelling of its value, so it begins and ends in a digit; the existing first-character test covered one end and this adds the other.

## Not ported

- `Jint.Tests/Runtime/WhiteSpaceDefinitionTests.cs` — that suite is `main`-only.
- `docs/v5-migration.md` §4.95 and the `Jint/Extensions/AGENTS.md` note — neither file exists on `4.x`.
- The wrapped-host-list half of main's test. `ObjectWrapper.ClassifyElementKey` is `main`-only; on `4.x` a CLR list's element **reads** go through the reflected indexer, which resolves `"+1"`, `"01"` and `" 1"` to element 1 already — a separate, pre-existing divergence that this change neither causes nor fixes. What `ParseArrayIndex` does reach here is `ObjectWrapper`'s membership answer, so the ported test pins that instead: `"1\0" in list` and `"1 " in list` were `true` and are now `false`, joining `"+1"`, `"01"` and `" 1"`, which that lane already turned down.

## Tests

`Jint.Tests/Runtime/NullCharacterPaddingTests.cs`, transcribed to xUnit v3 (`[TestCase]` → `[Theory]`/`[InlineData]`) and extended with the fractional-lane cases this branch needs (`'1.5' + nul`, `'-1.5' + nul`, `'.5' + nul`, `'1.5e3' + nul`, `'0.0' + nul`, `'12 ' + nul`). It also pins, deliberately, the lanes that were already right — the leading NUL, `parseInt`/`parseFloat`'s prefix rule, `BigInt`'s `SyntaxError`, `-0`'s sign, and the value every unpadded spelling keeps.

| | net472 | net10.0 |
| --- | --- | --- |
| before | **Failed: 26, Passed: 12** of 38 | **Failed: 26, Passed: 12** of 38 |
| after | Failed: 0, Passed: 38 | Failed: 0, Passed: 38 |

The 26 are the same tests on both frameworks: all 18 number-string cases (the 5 fractional ones included, so the .NET Framework `double.Parse` lane leaks identically), 5 of the 8 index-key cases, and the three multi-assertion facts.

Full Release build and test suite green on net472 and net10.0: `Jint.Tests` 6958/6873, `Jint.Tests.PublicInterface` 1500/1493, `Jint.Tests.CommonScripts` 28/28, `Jint.Tests.SourceGenerators` 52, all with zero failures.

test262 is unchanged at **102,499 / 0 / 185 of 102,684**, measured on this branch both with and without the change; it does not cover this. (One baseline run reported two `staging/sm` failures that a clean re-run did not reproduce — the known load flakes.)
