### PR TITLE
Tests: maxStackSize is a request, so the depth that has to exceed it is measured rather than named

### DIFF
--- a/Jint.Tests.PublicInterface/HostModuleGraphSecurityTests.cs
+++ b/Jint.Tests.PublicInterface/HostModuleGraphSecurityTests.cs
@@ -711,68 +711,111 @@ public sealed class HostModuleGraphSecurityTests
     }
 
     /// <summary>
-    /// A stack the chain below cannot possibly fit in, so that what this suite measures is Jint's probe and
-    /// not the machine it runs on.
+    /// The stack the walk under test runs on: the smallest a thread request is honoured with.
     /// </summary>
     /// <remarks>
-    /// 256 KB is the floor a thread request is rounded up to on Windows, and at that size a plain import
-    /// chain reaches roughly two hundred modules before either recursive phase runs out — measured on
-    /// <c>net8.0</c>, x64, Release. <see cref="LongChainLength"/> is five times that, which is the point: the
-    /// per-module cost differs by runtime, architecture and operating system by tens of percent, and it was
-    /// exactly a margin thinner than that which let
-    /// <see href="https://github.com/sebastienros/jint/issues/3308">#3308</see> pass on four legs and end the
-    /// process on the fifth. Nothing decided by codegen can move a factor of five.
+    /// 256 KB is the floor Windows rounds a request up to, so asking for less buys nothing there. How much
+    /// stack it actually yields is a platform question and deliberately not assumed to be 256 KB, which is why
+    /// the chain that has to outgrow it is measured rather than named — see <see cref="ChainLengths"/>.
     /// </remarks>
-    private const int StackTooSmallForTheChain = 256 * 1024;
+    private const int StackUnderTest = 256 * 1024;
 
     /// <summary>
-    /// A module graph deeper than the calling thread can recurse over fails with a <c>RangeError</c> the host
-    /// catches, naming the module it gave up on, and leaves an engine that still runs script.
+    /// The chain lengths tried, in order, until one of them meets the probe.
     /// </summary>
     /// <remarks>
-    /// The property being pinned is that there <em>is</em> an outcome. Linking and evaluation descend once
-    /// per module (<see href="https://github.com/sebastienros/jint/issues/3401">#3401</see>), so before the
-    /// probe this same call ended the process: a native stack overflow, which .NET does not deliver to any
-    /// <c>catch</c>, no exception, no log. A host whose whole reason for implementing
-    /// <see cref="IModuleLoader"/> is to serve a graph it did not author could be killed by one.
-    /// <para>
-    /// Deliberately not asserted: <em>which</em> of the two phases gave up. Linking descends first and
-    /// evaluation's frames are the larger, so which one meets the reserve first is a question about frame
-    /// layout on the day. <see cref="GraphDepth_AnEvaluationTooDeepForTheStackLeavesTheGraphErrored"/> is
-    /// where the evaluation half is selected on purpose.
-    /// </para>
+    /// This was a single length once — <see cref="LongChainLength"/>, five times the depth measured to trip on
+    /// a 256 KB Windows thread. That reasoning was sound about frame sizes and wrong about stacks, because
+    /// <c>maxStackSize</c> is a request rather than a grant and the margin was therefore a margin over the
+    /// wrong quantity. The <em>frames</em> do agree across platforms to within a percent — the probe trips at
+    /// about 156 modules on a 256 KB Windows thread, and 4.x measured 157 for the same code — but a runner is
+    /// free to hand over more stack than was asked for, and one did: on <c>ubuntu-latest</c> the same
+    /// 1,000-module chain on the same 256 KB request linked and evaluated <em>successfully</em>, so the test
+    /// failed expecting an exception that legitimately never happened
+    /// (<see href="https://github.com/sebastienros/jint/issues/3550">#3550</see>). Growing the chain until the
+    /// walk meets the probe measures the machine instead of predicting it, which is the only portable form of
+    /// this test: whatever stack the platform really granted, doubling reaches the end of it. The cap is what
+    /// makes a genuine regression report itself rather than be pursued forever, and it is sized by
+    /// measurement rather than by argument — forcing the request up locally, the walk meets the probe at
+    /// 16,000 modules on an 8 MB stack and at 32,000 on a 16 MB one, which is the largest stack anything in
+    /// this repository's tests asks for. The last entry is twice that again.
     /// </remarks>
-    [Test]
-    public void GraphDepth_AnImportTooDeepForTheStackThrowsRatherThanEndingTheProcess()
+    private static readonly int[] ChainLengths = [2_000, 4_000, 8_000, 16_000, 32_000, 64_000];
+
+    /// <summary>What the walk under test did, once a chain long enough to reach the probe was found.</summary>
+    private sealed record Probed(int Length, Exception Failure, Exception? Again, double Afterwards);
+
+    /// <summary>
+    /// Grows the chain until importing it on <see cref="StackUnderTest"/> meets the probe, and hands back what
+    /// that import raised, what a second import of the same root raised, and what the engine did afterwards.
+    /// </summary>
+    /// <remarks>
+    /// Only the import under test runs on the small stack; the engine, and whatever <paramref name="prepare"/>
+    /// has to drive before it, are built on an ordinary one. Two reasons, and the second is why that is not
+    /// merely tidier: a prepared graph is not what these tests are about, and where a platform's probe reserve
+    /// is itself larger than the small stack — a 64 KB page size puts the runtime's reserve at 768 KB —
+    /// preparing on that stack would meet the probe during setup and report a failure about the wrong thing.
+    /// </remarks>
+    private static Probed DriveUntilProbed(string chain, Action<Engine, Dictionary<string, string>>? prepare = null)
     {
-        var modules = ImportChain(LongChainLength);
-        Exception? failure = null;
-        var afterwards = 0d;
+        foreach (var length in ChainLengths)
+        {
+            var modules = ImportChain(length);
+            Engine engine = null!;
 
-        DedicatedThread.Run(
-            () =>
+            DedicatedThread.Run(
+                () =>
+                {
+                    engine = ChainEngine(modules);
+                    prepare?.Invoke(engine, modules);
+                },
+                joinTimeout: TestBudgets.WedgeCeiling,
+                timeoutMessage: $"setting up a {chain} {length}-module chain did not complete within {TestBudgets.WedgeCeiling}");
+
+            Exception? failure = null;
+            Exception? again = null;
+            var afterwards = 0d;
+
+            DedicatedThread.Run(
+                () =>
+                {
+                    failure = Caught.Exception(() => engine.Modules.Import("0.js"));
+                    if (failure is null)
+                    {
+                        return;
+                    }
+
+                    // Asked on the same thread as the first import, because "the same way again" is only
+                    // meaningful where the stack is the same too.
+                    again = Caught.Exception(() => engine.Modules.Import("0.js"));
+
+                    // The other half of the promise the guard makes for script recursion: an engine that is
+                    // still usable. Nothing about a native stack overflow leaves one.
+                    afterwards = engine.Evaluate("1 + 1").AsNumber();
+                },
+                // A wedge ceiling, not an assertion: a graph walk that stopped terminating would hang the run
+                // rather than fail it.
+                joinTimeout: TestBudgets.WedgeCeiling,
+                timeoutMessage: $"importing a {chain} {length}-module chain did not complete within {TestBudgets.WedgeCeiling}",
+                maxStackSize: StackUnderTest);
+
+            if (failure is not null)
             {
-                var engine = ChainEngine(modules);
-                failure = Caught.Exception(() => engine.Modules.Import("0.js"));
+                return new Probed(length, failure, again, afterwards);
+            }
+        }
 
-                // The other half of the promise the guard makes for script recursion: an engine that is
-                // still usable. Nothing about a native stack overflow leaves one.
-                afterwards = engine.Evaluate("1 + 1").AsNumber();
-            },
-            joinTimeout: TestBudgets.WedgeCeiling,
-            timeoutMessage: $"importing a {LongChainLength}-module chain did not complete within {TestBudgets.WedgeCeiling}",
-            maxStackSize: StackTooSmallForTheChain);
+        Assert.Fail(
+            $"a {chain} chain of {ChainLengths[^1]} modules imported inside a {StackUnderTest / 1024} KB thread "
+            + "request without ever meeting the stack probe, so nothing here exercised it. Either the request "
+            + "bought a far larger stack than any platform is known to give it, or the probe is no longer armed.");
 
-        failure.Should().BeOfType<JavaScriptException>()
-            .Which.Message.Should().StartWith("Maximum call stack size exceeded while ")
-            .And.Contain("module '");
-
-        afterwards.Should().Be(2);
+        throw new InvalidOperationException("unreachable");
     }
 
     /// <summary>
-    /// The slice a chain is linked in, chosen so that linking's own recursion stays comfortably inside
-    /// <see cref="StackTooSmallForTheChain"/> — about half of what that stack holds.
+    /// The slice a chain is linked in, chosen so that linking driven slice by slice stays shallow whatever
+    /// stack the preparing thread turns out to have.
     /// </summary>
     private const int LinkSliceLength = 100;
 
@@ -797,6 +840,38 @@ public sealed class HostModuleGraphSecurityTests
     }
 
     /// <summary>
+    /// A module graph deeper than the calling thread can recurse over fails with a <c>RangeError</c> the host
+    /// catches, naming the module it gave up on, and leaves an engine that still runs script.
+    /// </summary>
+    /// <remarks>
+    /// The property being pinned is that there <em>is</em> an outcome. Linking and evaluation descend once
+    /// per module (<see href="https://github.com/sebastienros/jint/issues/3401">#3401</see>), so before the
+    /// probe this same call ended the process: a native stack overflow, which .NET does not deliver to any
+    /// <c>catch</c>, no exception, no log. A host whose whole reason for implementing
+    /// <see cref="IModuleLoader"/> is to serve a graph it did not author could be killed by one.
+    /// <para>
+    /// Deliberately not asserted: <em>which</em> of the two phases gave up. Linking descends first and
+    /// evaluation's frames are the larger, so which one meets the reserve first is a question about frame
+    /// layout on the day. <see cref="GraphDepth_AnEvaluationTooDeepForTheStackLeavesTheGraphErrored"/> is
+    /// where the evaluation half is selected on purpose.
+    /// </para>
+    /// </remarks>
+    [Test]
+    public void GraphDepth_AnImportTooDeepForTheStackThrowsRatherThanEndingTheProcess()
+    {
+        var probed = DriveUntilProbed("cold");
+
+        probed.Failure.Should().BeOfType<JavaScriptException>()
+            .Which.Message.Should().StartWith("Maximum call stack size exceeded while ")
+            .And.Contain("module '");
+
+        probed.Afterwards.Should().Be(
+            2,
+            "an engine that gave up on a {0}-module chain still has to run script",
+            probed.Length);
+    }
+
+    /// <summary>
     /// An evaluation that runs out of stack leaves the graph <em>errored</em> — every module it had reached
     /// marked evaluated with that error — rather than stranded mid-evaluation. Importing the same root again
     /// therefore fails the same way instead of waiting for a promise nothing will ever settle.
@@ -811,34 +886,19 @@ public sealed class HostModuleGraphSecurityTests
     /// half-evaluated graph that reports itself as fine is worse than the crash the probe replaced.
     /// <para>
     /// The evaluation half is selected rather than hoped for: linking the chain in slices first means the
-    /// only walk left with a thousand levels to descend is evaluation's.
+    /// only walk left with the whole chain to descend is evaluation's.
     /// </para>
     /// </remarks>
     [Test]
     public void GraphDepth_AnEvaluationTooDeepForTheStackLeavesTheGraphErrored()
     {
-        var modules = ImportChain(LongChainLength);
-        Exception? first = null;
-        Exception? second = null;
+        var probed = DriveUntilProbed("pre-linked", LinkInSlices);
 
-        DedicatedThread.Run(
-            () =>
-            {
-                var engine = ChainEngine(modules);
-                LinkInSlices(engine, modules);
-
-                first = Caught.Exception(() => engine.Modules.Import("0.js"));
-                second = Caught.Exception(() => engine.Modules.Import("0.js"));
-            },
-            joinTimeout: TestBudgets.WedgeCeiling,
-            timeoutMessage: $"importing a pre-linked {LongChainLength}-module chain did not complete within {TestBudgets.WedgeCeiling}",
-            maxStackSize: StackTooSmallForTheChain);
-
-        first.Should().BeOfType<JavaScriptException>()
+        probed.Failure.Should().BeOfType<JavaScriptException>()
             .Which.Message.Should().StartWith("Maximum call stack size exceeded while evaluating module '");
 
-        second.Should().BeOfType<JavaScriptException>()
-            .Which.Message.Should().Be(first!.Message);
+        probed.Again.Should().BeOfType<JavaScriptException>()
+            .Which.Message.Should().Be(probed.Failure.Message);
     }
 
     // Resolution hops

--- a/Jint.Tests.PublicInterface/HostStackGuardThreadHopTests.cs
+++ b/Jint.Tests.PublicInterface/HostStackGuardThreadHopTests.cs
@@ -15,22 +15,91 @@ namespace Jint.Tests.PublicInterface;
 /// <para>
 /// Every test here runs on a deliberately small stack and asserts that the hop <em>happened</em> — that some
 /// engine work ran on a thread other than the one that entered. Without that assertion a machine with a
-/// roomier stack would pass them all without ever crossing the boundary they are about.
+/// roomier stack would pass them all without ever crossing the boundary they are about; with it, and with a
+/// depth named rather than measured, such a machine would instead fail them all on a hop that never had to
+/// occur. <see cref="DeepEnoughToHop"/> is therefore measured on the machine running the suite.
 /// </para>
 /// </summary>
 public class HostStackGuardThreadHopTests
 {
-    /// <summary>Smaller than the platform default, so the recursion below reliably crosses the hop.</summary>
+    /// <summary>
+    /// The stack the recursions below run on, asked for as smaller than the platform default. How much it
+    /// really buys is a platform question, which is why <see cref="DeepEnoughToHop"/> is measured on it
+    /// rather than named.
+    /// </summary>
     private const int SmallStack = 1024 * 1024;
-
-    /// <summary>Deeper than a 1 MB stack holds, so the lane hops rather than throwing.</summary>
-    private const int DeepEnoughToHop = 2000;
 
     /// <summary>High enough never to fire; this suite is about the hop, not about the limit.</summary>
     private const int UnreachedStackCount = 1_000_000;
 
     private const string RecurseThenProbe =
         "function recurse(n) { return n === 0 ? probe(n) : recurse(n - 1) + 0; }";
+
+    /// <summary>The recursion depths tried, in order, until one of them crosses the hop.</summary>
+    /// <remarks>
+    /// This was a single depth once, 2,000, argued as more than a 1 MB stack holds. The argument was about
+    /// the wrong quantity: <c>maxStackSize</c> is a request rather than a grant, so what
+    /// <see cref="SmallStack"/> buys is a platform's business and a runner that hands over more makes the
+    /// recursion fit — every assertion below then fails on a hop that legitimately never happened, which is
+    /// the shape <see href="https://github.com/sebastienros/jint/issues/3550">#3550</see> caught in the
+    /// module-graph suite. Growing the recursion until it crosses measures the machine rather than predicting
+    /// it, and the cap is what makes a lane that stopped hopping report itself instead of being pursued
+    /// forever. The cap is sized by measurement: forcing the request up locally, the recursion crosses at
+    /// 4,000 frames on an 8 MB stack and at 8,000 on a 16 MB one, the largest stack anything in this
+    /// repository's tests asks for.
+    /// </remarks>
+    private static readonly int[] CandidateDepths = [2_000, 4_000, 8_000, 16_000, 32_000];
+
+    private static int? _deepEnoughToHop;
+
+    /// <summary>
+    /// How deep this machine has to recurse before the lane hops, measured once and then reused: the runner
+    /// runs a fixture's tests sequentially, so nothing here races.
+    /// </summary>
+    private static int DeepEnoughToHop => _deepEnoughToHop ??= MeasureHopDepth();
+
+    /// <summary>
+    /// Recurses deeper and deeper on <see cref="SmallStack"/> until the probe at the bottom runs on a thread
+    /// other than the one that entered, and hands back the depth that did it.
+    /// </summary>
+    private static int MeasureHopDepth()
+    {
+        foreach (var depth in CandidateDepths)
+        {
+            var hopped = false;
+
+            DedicatedThread.Run(
+                () =>
+                {
+                    var engine = new Engine(options => options.Constraints.MaxExecutionStackCount = UnreachedStackCount);
+                    var entryThread = Environment.CurrentManagedThreadId;
+
+                    engine.SetValue("probe", new Func<int, int>(depthAtBottom =>
+                    {
+                        hopped = Environment.CurrentManagedThreadId != entryThread;
+                        return depthAtBottom;
+                    }));
+
+                    engine.Execute(RecurseThenProbe);
+                    engine.Evaluate($"recurse({depth})");
+                },
+                joinTimeout: TestBudgets.WedgeCeiling,
+                timeoutMessage: $"measuring the hop at {depth} frames did not complete within {TestBudgets.WedgeCeiling}",
+                maxStackSize: SmallStack);
+
+            if (hopped)
+            {
+                return depth;
+            }
+        }
+
+        Assert.Fail(
+            $"a recursion {CandidateDepths[^1]} frames deep ran inside a {SmallStack / 1024} KB thread request "
+            + "without ever crossing the guard's thread hop, so nothing here exercises it. Either the request "
+            + "bought a far larger stack than any platform is known to give it, or the lane no longer hops.");
+
+        throw new InvalidOperationException("unreachable");
+    }
 
     [Test]
     public void AHostCallbackReachedAcrossTheHopCanReEnterTheEngine()


### PR DESCRIPTION
`GraphDepth_AnImportTooDeepForTheStackThrowsRatherThanEndingTheProcess` and its evaluation sibling ran a 1,000-module import chain on a thread created with `maxStackSize: 256 * 1024` and asserted that the stack-headroom probe fired before the walk completed. Both constants assume the platform hands over roughly the stack that was asked for, and it is free not to: a runner that grants more makes the chain fit, the import succeed, and the test fail on an exception that legitimately never happens.

That is not hypothetical. The 4.x backport of the same tests (#3548) shipped with the identical constants and failed its first CI round on `ubuntu-latest` in exactly that shape, where a 256 KB request carried the whole 1,000-module walk. `main` passes today's runners; that is luck, not portability, and a runner-image kernel or glibc change turns it into a flake that reads like an engine regression.

The margin the old constant argued for — five times the ~156 modules a 256 KB Windows thread reaches — was a margin over the wrong quantity. It covers frame-size drift, which is real but small (4.x measures 157 against main's 156); it cannot cover the grant exceeding the request, and no pair of constants chosen on one machine can be right about that on another.

## What changed

Test shape only — **no engine code is touched**.

1. **The chain length is measured, not chosen.** `DriveUntilProbed` grows the chain 2,000 → 4,000 → … → 64,000 until the walk meets the probe, and the assertions run against whichever length did. Whatever stack the platform really granted, doubling reaches the end of it. The cap is what makes a genuine regression report itself — with a message that says which of the two possibilities it is — rather than run forever.
2. **Setup runs off the small thread.** The engine, and the slice-by-slice linking the evaluation test needs to select evaluation's walk, are now built on an ordinary stack. Where a platform's probe reserve is itself larger than the small stack — a 64 KB page size puts the runtime's reserve at 768 KB — preparing on that stack would meet the probe during setup and fail about the wrong thing.
3. **`HostStackGuardThreadHopTests` had the same assumption**, in the other direction: it recursed a fixed 2,000 frames on a 1 MB request and asserts that the thread hop *happened*, so a roomier grant fails all four of its tests on a hop that never had to occur. The depth is measured once per fixture and reused.

The caps are sized by measurement rather than by argument. Forcing the thread request up locally, the module walk meets the probe at 16,000 modules on 8 MB and at 32,000 on 16 MB; the hop is crossed at 4,000 frames on 8 MB and at 8,000 on 16 MB. 16 MB is the largest stack anything in this repository's tests asks for.

Nothing the suite pins about `MaxModuleGraphDepth`, `MaxModuleCount`, iterative loading or the resolution-hop budget is disturbed; `GraphDepth_LongSynchronousChainLoadsIteratively` and `GraphDepth_LongSynchronousChainImportsOnAStackSizedForTheRecursivePhases` keep naming 1,000, because a length is the right thing to name when the assertion is that the walk *completes*.

## Verification

- `dotnet build -c Release` and `dotnet test -c Release` green on `net472`, `net8.0` and `net10.0`.
- The failure itself needs a runner generous enough to make the old constants pass the chain, which is not reproducible on this Windows machine — the issue carries the CI evidence from #3548 instead.
- The calibration loop was proven to reach the probe by forcing the requested stack up locally: at 8 MB it settles on 16,000 modules and a 4,000-frame hop, at 16 MB on 32,000 modules and an 8,000-frame hop, green in every case. The last rung was added on the strength of those numbers.
- test262 is untouched and was not re-run: there is no engine change here.

Closes #3550
