### PR TITLE
Interop: a host operator reports what it threw, and an overload the argument cannot bind to is not a match

### DIFF
--- a/Jint.Tests.PublicInterface/HostOperatorExceptionTests.cs
+++ b/Jint.Tests.PublicInterface/HostOperatorExceptionTests.cs
@@ -1,0 +1,110 @@
+#nullable enable
+
+using Jint.Runtime;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// A host <c>operator</c> that throws is a host method that throws, and the embedder has to receive the
+/// same exception from both.
+/// </summary>
+/// <remarks>
+/// Every other interop call site normalizes what it catches with
+/// <c>e as TargetInvocationException ?? new TargetInvocationException(e)</c>; the operator-overloading path
+/// wrapped <c>e.InnerException</c> instead, and by the time it catches, the invoke has already been
+/// unwrapped — so <c>InnerException</c> is the host exception's own cause, or nothing at all. The pairs
+/// below are the measurement: the same failure raised from an ordinary method and from an operator, which
+/// must arrive identically.
+/// </remarks>
+public class HostOperatorExceptionTests
+{
+    public sealed class Meter
+    {
+        public Meter(double value) => Value = value;
+
+        public double Value { get; }
+
+        /// <summary>A plain failure, with a message and no cause of its own.</summary>
+        public static Meter operator +(Meter left, Meter right) => throw new InvalidOperationException("HOST BOOM");
+
+        /// <summary>A failure that carries a cause, which is the half that got reported instead of it.</summary>
+        public static Meter operator -(Meter left, Meter right)
+            => throw new NotSupportedException("metres do not subtract", new ArgumentException("nested cause"));
+
+        public Meter Add(Meter other) => throw new InvalidOperationException("HOST BOOM");
+
+        public Meter Subtract(Meter other)
+            => throw new NotSupportedException("metres do not subtract", new ArgumentException("nested cause"));
+    }
+
+    private static Exception? Evaluate(string source)
+    {
+        var engine = new Engine(options => options.Interop.AllowOperatorOverloading = true);
+        engine.SetValue("a", new Meter(1));
+        engine.SetValue("b", new Meter(2));
+
+        try
+        {
+            engine.Evaluate(source);
+            return null;
+        }
+        catch (Exception e)
+        {
+            return e;
+        }
+    }
+
+    [Fact]
+    public void AHostOperatorsFailureArrivesWithItsMessage()
+    {
+        var fromMethod = Evaluate("a.Add(b)");
+        var fromOperator = Evaluate("a + b");
+
+        fromMethod.Should().BeOfType<InvalidOperationException>().Which.Message.Should().Be("HOST BOOM");
+        fromOperator.Should().BeOfType<InvalidOperationException>().Which.Message.Should().Be("HOST BOOM");
+    }
+
+    [Fact]
+    public void AHostOperatorsFailureArrivesRatherThanItsCause()
+    {
+        var fromMethod = Evaluate("a.Subtract(b)");
+        var fromOperator = Evaluate("a - b");
+
+        fromMethod.Should().BeOfType<NotSupportedException>().Which.Message.Should().Be("metres do not subtract");
+        fromOperator.Should().BeOfType<NotSupportedException>().Which.Message.Should().Be("metres do not subtract");
+    }
+
+    [Fact]
+    public void TheSameHoldsWhenTheHostAsksForClrExceptionsToBeCaught()
+    {
+        // The handler names the host exception, which is how an embedder writes one. Wrapping
+        // e.InnerException handed it a JavaScriptErrorWrapperException instead - the engine's own carrier
+        // for an error value, which no host handler recognizes - so the handler declined and that wrapper
+        // left Evaluate as the exception the embedder saw, invisible to the script's own catch as well.
+        static Engine NewEngine()
+        {
+            var engine = new Engine(options =>
+            {
+                options.Interop.AllowOperatorOverloading = true;
+                options.CatchClrExceptions(e => e is InvalidOperationException);
+            });
+            engine.SetValue("a", new Meter(1));
+            engine.SetValue("b", new Meter(2));
+            return engine;
+        }
+
+        var fromMethod = Invoking(() => NewEngine().Evaluate("a.Add(b)")).Should().Throw<JavaScriptException>().Which;
+        var fromOperator = Invoking(() => NewEngine().Evaluate("a + b")).Should().Throw<JavaScriptException>().Which;
+
+        fromMethod.Message.Should().Be("HOST BOOM");
+        fromOperator.Message.Should().Be("HOST BOOM");
+
+        JintException.TryGetClrException(fromMethod, out var fromMethodClr).Should().BeTrue();
+        JintException.TryGetClrException(fromOperator, out var fromOperatorClr).Should().BeTrue();
+        fromMethodClr.Should().BeOfType<InvalidOperationException>();
+        fromOperatorClr.Should().BeOfType<InvalidOperationException>();
+
+        // and the script's own catch reaches it, which it did not while the wrapper was escaping
+        NewEngine().Evaluate("try { a + b } catch (e) { e.message }").AsString().Should().Be("HOST BOOM");
+    }
+}

--- a/Jint.Tests.PublicInterface/HostOperatorFallbackTests.cs
+++ b/Jint.Tests.PublicInterface/HostOperatorFallbackTests.cs
@@ -1,0 +1,112 @@
+#nullable enable
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// An operator overload the specification would never have selected is not selected.
+/// </summary>
+/// <remarks>
+/// <c>'s' + v</c>, <c>v + 's'</c>, <c>1 + v</c> and <c>true + v</c> are ordinary JavaScript:
+/// <c>ApplyStringOrNumericBinaryOperator</c> takes <c>ToPrimitive</c> of both operands and, one of them
+/// being a string, concatenates. Turning <see cref="Options.InteropOptions.AllowOperatorOverloading"/> on
+/// does not change that for a host type whose only <c>op_Addition</c> is <c>(T, T)</c> — there is no
+/// overload for those pairs, so there is nothing to select. Overload scoring nevertheless handed back
+/// <c>(T, T)</c> and the argument conversion then threw, so the option turned four spec-defined expressions
+/// into failures.
+/// </remarks>
+public class HostOperatorFallbackTests
+{
+    /// <summary>The shape that has no answer for any of the four: one operator, both parameters its own type.</summary>
+    public readonly struct Vector2D
+    {
+        public Vector2D(double x, double y)
+        {
+            X = x;
+            Y = y;
+        }
+
+        public double X { get; }
+
+        public double Y { get; }
+
+        public static Vector2D operator +(Vector2D left, Vector2D right) => new Vector2D(left.X + right.X, left.Y + right.Y);
+
+        public override string ToString() => $"({X}, {Y})";
+    }
+
+    /// <summary>The same shape with the mixed overloads declared, which must keep winning.</summary>
+    public readonly struct Metres
+    {
+        public Metres(double value) => Value = value;
+
+        public double Value { get; }
+
+        public static Metres operator +(Metres left, Metres right) => new Metres(left.Value + right.Value);
+
+        public static Metres operator +(Metres left, double right) => new Metres(left.Value + right);
+
+        public static Metres operator +(double left, Metres right) => new Metres(left + right.Value);
+
+        public static Metres operator +(string left, Metres right) => new Metres(right.Value);
+
+        public override string ToString() => $"{Value}m";
+    }
+
+    private static Engine NewEngine()
+    {
+        var engine = new Engine(options => options.Interop.AllowOperatorOverloading = true);
+        engine.SetValue("v", new Vector2D(1, 2));
+        engine.SetValue("m", new Metres(3));
+        return engine;
+    }
+
+    [Theory]
+    [InlineData("'text ' + v", "text (1, 2)")]
+    [InlineData("v + ' text'", "(1, 2) text")]
+    [InlineData("1 + v", "1(1, 2)")]
+    [InlineData("true + v", "true(1, 2)")]
+    [InlineData("'### ' + v + ' ###'", "### (1, 2) ###")]
+    public void AnOperandPairNoOverloadAcceptsFollowsOrdinaryJavaScript(string source, string expected)
+    {
+        NewEngine().Evaluate(source).Should().Be(expected);
+    }
+
+    [Fact]
+    public void TheOverloadThatDoesAcceptThePairIsStillSelected()
+    {
+        var engine = NewEngine();
+
+        // (T, T), (T, double), (double, T) and (string, T) are all declared, so all four are operator calls
+        // and none of them concatenates.
+        engine.Evaluate("(m + m).Value").Should().Be(6);
+        engine.Evaluate("(m + 4).Value").Should().Be(7);
+        engine.Evaluate("(4 + m).Value").Should().Be(7);
+        engine.Evaluate("('anything' + m).Value").Should().Be(3);
+    }
+
+    [Fact]
+    public void ANumericPairIsUnaffectedByTheOptionBeingOn()
+    {
+        NewEngine().Evaluate("1 + 2").Should().Be(3);
+        NewEngine().Evaluate("'a' + 'b'").Should().Be("ab");
+    }
+
+    [Fact]
+    public void TheHostValueStillReadsAsTheStringItsToStringProduces()
+    {
+        var engine = NewEngine();
+
+        engine.Evaluate("String(v)").Should().Be("(1, 2)");
+        engine.Evaluate("`${v}`").Should().Be("(1, 2)");
+        engine.Evaluate("[v].join('')").Should().Be("(1, 2)");
+    }
+
+    [Fact]
+    public void AnOperatorWithNoTextualFallbackReportsThatNoOverloadApplies()
+    {
+        // '-' has no string form to fall back to, so the pair is a number pair: ToNumber of an object with
+        // no numeric valueOf is NaN. That is what the specification says, and it is what an engine with the
+        // option off already did.
+        NewEngine().Evaluate("v - 1").AsNumber().Should().Be(double.NaN);
+    }
+}

--- a/Jint.Tests.PublicInterface/HostOverloadScoringTests.cs
+++ b/Jint.Tests.PublicInterface/HostOverloadScoringTests.cs
@@ -1,0 +1,142 @@
+#nullable enable
+
+using Jint.Runtime;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// The three argument shapes overload scoring cannot recognize but the type converter still converts, and
+/// the one it must now refuse.
+/// </summary>
+/// <remarks>
+/// Scoring answers "how far is this argument from this parameter" with a dozen structural rules and used to
+/// end in a blanket "will rarely succeed", which <c>FindBestMatch</c> treats as a match — so a parameter type
+/// the value could not become was selected anyway and the call died converting it. The last rule now asks the
+/// installed converter instead, which is the only thing that can tell the three shapes below from the fourth.
+/// Each is a single-candidate method, so nothing but that last rule decides it.
+/// </remarks>
+public class HostOverloadScoringTests
+{
+    public enum LengthUnit
+    {
+        Pixel = 42,
+    }
+
+    /// <summary>Declares the conversion <em>from</em> <see cref="double"/> on itself, where no rule looking at the argument's own type can see it.</summary>
+    public readonly struct Fahrenheit
+    {
+        private Fahrenheit(double degrees) => Degrees = degrees;
+
+        public double Degrees { get; }
+
+        public static implicit operator Fahrenheit(double degrees) => new Fahrenheit(degrees);
+    }
+
+    public readonly struct Vector2D
+    {
+        public Vector2D(double x, double y)
+        {
+            X = x;
+            Y = y;
+        }
+
+        public double X { get; }
+
+        public double Y { get; }
+    }
+
+    public sealed class Host
+    {
+        public int CountMatches(Predicate<string> predicate)
+        {
+            var count = 0;
+            foreach (var candidate in new[] { "alpha", "beta", "gamma" })
+            {
+                if (predicate(candidate))
+                {
+                    count++;
+                }
+            }
+
+            return count;
+        }
+
+        public string DescribeTemperature(Fahrenheit temperature) => $"{temperature.Degrees}F";
+
+        public string DescribeUnit(LengthUnit unit) => $"unit {(int) unit}";
+
+        public string DescribeVector(Vector2D vector) => $"({vector.X}, {vector.Y})";
+    }
+
+    public sealed class Boxed
+    {
+        public Boxed(Vector2D vector) => Vector = vector;
+
+        public Vector2D Vector { get; }
+    }
+
+    private static Engine NewEngine()
+    {
+        var engine = new Engine();
+        engine.SetValue("host", new Host());
+        engine.SetValue("Boxed", typeof(Boxed));
+        return engine;
+    }
+
+    [Fact]
+    public void AJavaScriptFunctionStillBindsToADelegateParameter()
+    {
+        // JsCallDelegate is not assignable to Predicate<string>, is not IConvertible, and declares no cast
+        // operator; only the converter, which builds the delegate, knows this works.
+        NewEngine().Evaluate("host.CountMatches(s => s.length === 4)").Should().Be(1);
+    }
+
+    [Fact]
+    public void AConversionOperatorDeclaredOnTheParameterTypeIsStillFound()
+    {
+        // double declares nothing; Fahrenheit declares the implicit operator. The scoring rule that looks
+        // for one only reads the argument's own type, so this pair reaches the last rule.
+        NewEngine().Evaluate("host.DescribeTemperature(98.6)").Should().Be("98.6F");
+    }
+
+    [Fact]
+    public void AnEnumParameterStillTakesANumberOutsideItsDefinedMembers()
+    {
+        // Enum.IsDefined(LengthUnit, 0) is false, so the enum rule declines and the pair reaches the last
+        // rule; the converter parses it the way the CLR lets an enum hold any underlying value.
+        NewEngine().Evaluate("host.DescribeUnit(0)").Should().Be("unit 0");
+    }
+
+    [Fact]
+    public void AParameterTypeTheValueCannotBecomeIsNotSelected()
+    {
+        // Nothing converts a string to Vector2D. A method call reported that as a resolution failure
+        // already, because MethodInfoFunction.TryCall asks the converter per candidate and moves on when it
+        // declines - the scoring rule now asks that same question, so a candidate that cannot bind is no
+        // longer proposed in the first place rather than proposed and then declined.
+        var engine = NewEngine();
+
+        Invoking(() => engine.Evaluate("host.DescribeVector('text')"))
+            .Should().Throw<JavaScriptException>()
+            .WithMessage("No public methods with the specified arguments were found.");
+
+        engine.Evaluate("try { host.DescribeVector('text') } catch (e) { e instanceof TypeError }")
+            .AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void AConstructorParameterTheValueCannotBecomeIsRefusedRatherThanAttempted()
+    {
+        // Constructor resolution has no such retry: TypeReference calls the first match and stops. So a
+        // hopeless candidate was constructed with, and the conversion's InvalidCastException escaped
+        // Evaluate as a CLR exception no script catch could see. It is now the resolution failure it is.
+        var engine = NewEngine();
+
+        Invoking(() => engine.Evaluate("new Boxed('text')"))
+            .Should().Throw<JavaScriptException>()
+            .WithMessage("Could not resolve a constructor for type * for given arguments");
+
+        engine.Evaluate("try { new Boxed('text') } catch (e) { e instanceof TypeError }")
+            .AsBoolean().Should().BeTrue();
+    }
+}

--- a/Jint.Tests/Runtime/OperatorOverloadingTests.cs
+++ b/Jint.Tests/Runtime/OperatorOverloadingTests.cs
@@ -358,6 +358,15 @@ public class OperatorOverloadingTests
             ");
     }
 
+    /// <remarks>
+    /// Green from #1011 in 2021 until sebastienros/jint#3407, without either assertion ever being reached.
+    /// <c>'### ' + v1</c> resolved to <c>op_Addition(Vector2D, Vector2D)</c>, whose first parameter cannot
+    /// take a string, and converting the argument threw; the failure left the engine as a
+    /// <see cref="System.Reflection.TargetInvocationException"/> whose <c>InnerException</c> was
+    /// <see langword="null" /> (sebastienros/jint#3408), and xUnit unwraps such an exception to its inner -
+    /// that is, to <see langword="null" /> - and records no failure at all. The operator path no longer
+    /// produces a contentless exception, so what this asserts is now actually asserted.
+    /// </remarks>
     [Fact]
     public void ShouldAllowStringConcatenateForOverloaded()
     {

--- a/Jint/Runtime/Interop/InteropHelper.cs
+++ b/Jint/Runtime/Interop/InteropHelper.cs
@@ -247,8 +247,28 @@ internal sealed class InteropHelper
             return 10;
         }
 
-        // will rarely succeed
-        return 100;
+        // Nothing above recognizes the pair, and that is not the same as the conversion being impossible.
+        // The installed converter still reaches a JS function -> delegate, a JS object -> POCO or target
+        // dictionary, a string -> enum, a JS array -> T[]/List<T>, and a cast operator declared on the
+        // *target* type - none of which any rule above can see, which is what "rarely succeeds" was for.
+        // Only the converter can tell the two apart, and it has to, because FindBestMatch discards a
+        // negative score and accepts every other: a hopeless candidate scored 100 is the best match
+        // whenever it is the only one. Ask the very converter MethodDescriptor.Call would use, so the
+        // score cannot claim a conversion the call then fails to perform.
+        //
+        // A parameter type still carrying open type parameters (T, Func<T, bool>) is the one case that
+        // cannot be asked: the type the argument will actually be converted to does not exist yet -
+        // MethodInfoFunction.ResolveMethod closes the method first - and handing an open type to the
+        // converter is an ArgumentException, not an answer. Those keep the undecided score.
+        if (paramType.ContainsGenericParameters
+            || engine.TypeConverter.TryConvert(objectValue, paramType, CultureInfo.InvariantCulture, out _))
+        {
+            // will rarely succeed
+            return 100;
+        }
+
+        // this is bad
+        return -1;
     }
 
     /// <summary>

--- a/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
@@ -785,7 +785,12 @@ internal abstract class JintBinaryExpression : JintExpression
                 }
                 catch (Exception e)
                 {
-                    Throw.MeaningfulException(context.Engine, new TargetInvocationException(e.InnerException));
+                    // The same normalization every other interop call site uses. Wrapping e.InnerException
+                    // instead reported the wrong exception twice over: MethodDescriptor.Call has already
+                    // unwrapped the invoke, so `e` is the host's own exception and its InnerException is
+                    // that exception's cause - null for the common case, which left MeaningfulException
+                    // with a contentless TargetInvocationException to report.
+                    Throw.MeaningfulException(context.Engine, e as TargetInvocationException ?? new TargetInvocationException(e));
                     result = null;
                     return false;
                 }


### PR DESCRIPTION
Backport of #3414 and #3417. They are one pull request here because on `4.x` the first is what makes the
second's failure visible, and the first alone turns an existing test red.

## The two fixes

**#3414** — `JintBinaryExpression.TryOperatorOverloading` was the only site in the assembly building
`new TargetInvocationException(e.InnerException)`. The four comparable sites — `DelegateWrapper`,
`CompilableMemberAccessor`, `GeneratedMemberAccessor`, `MethodInfoFunction` — all spell it
`e as TargetInvocationException ?? new TargetInvocationException(e)`. By the time that catch runs,
`MethodDescriptor.Call` has already unwrapped the invoke, so `e` **is** the host exception and its
`InnerException` is that exception's own cause — nothing at all in the common case.

**#3417** — `InteropHelper.CalculateMethodParameterScore` had no verdict for a plain type mismatch:
anything its dozen structural rules did not recognize fell through to `return 100; // will rarely succeed`.
`FindBestMatch` discards only a **negative** score, so 100 is a match, and a candidate the argument can
never bind to is the *best* match whenever it is the only one. The last rule now asks the installed
`ITypeConverter` — the very one `MethodDescriptor.Call` will use — so the score cannot claim a conversion
the call then fails to perform.

## Measured on `4.x`, before and after

Each row is the same failure raised from an ordinary host method and from an operator, which must arrive
identically. Identical on **net10.0** and **net472**.

`operator +` throws `InvalidOperationException("HOST BOOM")`, `operator -` throws
`NotSupportedException("metres do not subtract", new ArgumentException("nested cause"))`:

| what the script does | before | after |
| --- | --- | --- |
| `a.Add(b)` | `InvalidOperationException: HOST BOOM` | unchanged |
| `a + b` | `TargetInvocationException: Exception has been thrown by the target of an invocation.` | `InvalidOperationException: HOST BOOM` |
| `a.Subtract(b)` | `NotSupportedException: metres do not subtract` | unchanged |
| `a - b` | `ArgumentException: nested cause` | `NotSupportedException: metres do not subtract` |

With `CatchClrExceptions(e => e is InvalidOperationException)` — a handler that names the host exception,
which is how an embedder writes one — the wrapping handed that handler a `JavaScriptErrorWrapperException`,
the engine's own carrier for an error value, which no host handler recognizes. So the handler declined and
the wrapper left `Evaluate` as the exception the embedder saw, invisible to the script's own `catch` too:

| | before | after |
| --- | --- | --- |
| host catches, from `a.Add(b)` | `JavaScriptException`, `TryGetClrException` → `InvalidOperationException` | unchanged |
| host catches, from `a + b` | `JavaScriptErrorWrapperException`, `TryGetClrException` → nothing | `JavaScriptException`, `TryGetClrException` → `InvalidOperationException` |
| `try { a + b } catch (e) { e.message }` | never reached — the wrapper escapes `Evaluate` | `"HOST BOOM"` |

For a host type whose only `op_Addition` is `(T, T)`, with `AllowOperatorOverloading = true`:

| | before | after |
| --- | --- | --- |
| `'text ' + v` | throws | `"text (1, 2)"` |
| `v + ' text'` | throws | `"(1, 2) text"` |
| `1 + v` | throws | `"1(1, 2)"` |
| `true + v` | throws | `"true(1, 2)"` |
| `new Boxed('text')` | `InvalidCastException` out of `Evaluate`, which no script `catch` could see | `JavaScriptException` — the resolution failure it always was |

An overload that *does* accept the pair still wins: `(T, double)`, `(double, T)` and `(string, T)` are
operator calls exactly as before.

## Why they cannot be split here

`Jint.Tests/Runtime/OperatorOverloadingTests.ShouldAllowStringConcatenateForOverloaded` asserts
`'### ' + v1 + ' ###'`. It has been green since #1011 in 2021 **without either assertion ever being
reached**: the failure left the engine as a `TargetInvocationException` whose `InnerException` was `null`,
and xUnit unwraps such an exception to its inner — that is, to `null` — and records no failure at all.

That is measurable here rather than asserted. Running the new tests against `4.x`, both target frameworks
giving the same numbers:

| stage | net10.0 | net472 |
| --- | --- | --- |
| unfixed `4.x` | **4 failed**, 13 passed | **4 failed**, 13 passed |
| #3414 alone | **6 failed**, 11 passed | **6 failed**, 11 passed |
| both | **0 failed, 17 passed** | **0 failed, 17 passed** |

The count goes *up* after the first fix, and that is the point: the three `HostOperatorExceptionTests`
turn green while five operand-pair cases that had been passing start failing for the first time. They
were never passing — they were throwing a contentless exception xUnit discarded. #3417 is what makes them
pass, and it un-hides the existing test above at the same time, which is why the halves land together.

## Divergence from `main`

- `Engine._typeConverter` is `private` on `4.x` (it is `internal` on `main`), so the probe reads the
  public `engine.TypeConverter` property. On `4.x` that getter returns the field unchanged, so it is the
  same converter `MethodDescriptor.Call` uses.
- `docs/v5-migration.md` and `Jint/Runtime/Interop/AGENTS.md` do not exist on this branch; those hunks are
  dropped.
- `Jint.Tests` is xUnit here, so `[Test]` → `[Fact]` and `[TestCase]` → `[Theory]` + `[InlineData]`, and
  `ShouldAllowStringConcatenateForOverloaded` was never `[Ignore]`d on this branch (it was falsely green
  instead) — it gains only a remark recording that.
- The `CatchClrExceptions` test uses a selective handler rather than the blanket one. Under a blanket
  handler on `4.x` the engine rebuilds the error over its own `JavaScriptException` wrapper, so
  `TryGetClrException` hands back that wrapper rather than the host exception. `main` avoids this in
  `Throw.CreateClrError`, which is neither of these two PRs and is not backported here. The selective
  handler is the configuration where this change is observable on `4.x`, and it is the more realistic one.

## Verification

`dotnet build -c Release` clean, 0 warnings.

| suite | net10.0 | net472 |
| --- | --- | --- |
| `Jint.Tests` | 6920 passed, 0 failed, 4 skipped | 6835 passed, 0 failed, 4 skipped |
| `Jint.Tests.PublicInterface` | 1519 passed, 0 failed, 9 skipped | 1512 passed, 0 failed, 9 skipped |
| `Jint.Tests.CommonScripts` | 28 passed, 0 failed | 28 passed, 0 failed |
| `Jint.Tests.SourceGenerators` | 52 passed, 0 failed | — |

`Jint.Tests.Test262`: **102,499 passed, 0 failed**, 185 skipped (102,684 total). The branch control is
102,497 / 0 / 187 over the same total — two cases that had been skipping as load flakes ran and passed.
Unchanged, which is the number that matters for a change to operator dispatch.
