### PR TITLE
Temporal: a difference past a calendar's range raises RangeError instead of spinning (#3452)

### DIFF
--- a/Jint.Tests/DedicatedThread.cs
+++ b/Jint.Tests/DedicatedThread.cs
@@ -99,13 +99,8 @@ internal static class DedicatedThread
             },
             maxStackSize)
         {
-            // A thread that outlives its join must not keep the process alive...
+            // A thread that outlives its join must not keep the process alive.
             IsBackground = true,
-
-            // ...and must not compete with the rest of the run for a core while it does. Background
-            // only governs process exit; a spinning thread goes on burning CPU until then, which is
-            // exactly the condition the suite's known wall-clock flakes fail under.
-            Priority = ThreadPriority.Lowest,
         };
 
         thread.Start();
@@ -114,6 +109,12 @@ internal static class DedicatedThread
         {
             if (!thread.Join(timeout))
             {
+                // Only now is the body known to be a runaway, and only a runaway must be kept off the
+                // cores the rest of the run needs. Background governs process exit and nothing else; a
+                // spinning thread goes on burning CPU until then, which is exactly the condition the
+                // suite's known wall-clock flakes fail under.
+                Demote(thread);
+
                 throw new XunitException(timeoutMessage ?? $"the test body did not complete within {timeout}");
             }
         }
@@ -123,5 +124,32 @@ internal static class DedicatedThread
         }
 
         exception?.Throw();
+    }
+
+    /// <summary>
+    /// Drops a runaway body to the lowest priority, once its join has timed out and not before.
+    /// </summary>
+    /// <remarks>
+    /// The priority a runaway deserves is not the priority a body that is going to finish deserves, and
+    /// this used to be set at construction so that every body got the runaway's. A thread at
+    /// <see cref="ThreadPriority.Lowest"/> is the last thing a saturated runner schedules, behind every
+    /// normal-priority xUnit worker beside it — measured on a two-core affinity mask with two busy
+    /// threads, a 0.1 ms body took 2.5 s at <c>Lowest</c> against 0.14 s at <c>Normal</c>. On a
+    /// four-core CI runner the first body in a fixture, which pays that fixture's cold JIT on top,
+    /// missed a 15-second budget doing ten microseconds of work.
+    /// <para>
+    /// The thread may have finished between the join timing out and this call, which the setter reports
+    /// as a <see cref="ThreadStateException"/>. Nothing is owed for a thread that is no longer running.
+    /// </para>
+    /// </remarks>
+    private static void Demote(Thread thread)
+    {
+        try
+        {
+            thread.Priority = ThreadPriority.Lowest;
+        }
+        catch (ThreadStateException)
+        {
+        }
     }
 }

--- a/Jint.Tests/Runtime/NonIsoCalendarRangeTests.cs
+++ b/Jint.Tests/Runtime/NonIsoCalendarRangeTests.cs
@@ -1,0 +1,221 @@
+#nullable enable
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Jint reckons the eleven non-ISO calendars with <c>System.Globalization.Calendar</c> classes and with
+/// fixed-epoch arithmetic, and several of those classes cover far less than Temporal's own date range —
+/// <c>ChineseLunisolarCalendar</c> spans ISO 1901-02-19 to 2101-01-28. These pin what happens at the
+/// boundary: a bounded, catchable <c>RangeError</c>, and never a walk that does not end.
+/// </summary>
+/// <remarks>
+/// The failure these replace is the worst one an engine has. <c>CalendarDateUntil</c> walks a month at a
+/// time towards its target and stops when a step passes it; a conversion that answered with the
+/// calendar's boundary date made every further step land on that same date, so no step ever passed and
+/// the loop had no other exit. It is a CLR loop inside one interpreter step, so it crosses no statement
+/// boundary and no execution constraint can interrupt it: <c>LimitStatements</c> never counts,
+/// <c>LimitExecutionTime</c> never gets a check, and a <c>CancellationToken</c> is never observed. That
+/// is why every case here runs on a dedicated thread with a join timeout — a regression has to fail the
+/// run rather than wedge it. See <see href="https://github.com/sebastienros/jint/issues/3428"/>.
+/// </remarks>
+public class NonIsoCalendarRangeTests
+{
+    /// <summary>
+    /// Generous next to the milliseconds every case below actually takes, and unreachable for a walk
+    /// that does not terminate at all — which is the only distinction this has to make.
+    /// </summary>
+    private static readonly TimeSpan Budget = TimeSpan.FromSeconds(15);
+
+    private static readonly string[] TheElevenNonIsoCalendars =
+    [
+        "chinese", "dangi", "hebrew", "persian",
+        "coptic", "ethiopic", "ethioaa", "indian",
+        "islamic-umalqura", "islamic-civil", "islamic-tbla",
+    ];
+
+    /// <summary>
+    /// Runs <paramref name="body"/> on a dedicated thread, failing the test if it has not finished inside
+    /// <see cref="Budget"/>. Nothing in this fixture may evaluate on the runner's own thread: the defect
+    /// under test is a non-terminating one, so a regression evaluated inline wedges the whole run instead
+    /// of reporting it.
+    /// </summary>
+    private static void Guarded(string what, Action body) => DedicatedThread.Run(
+        body,
+        joinTimeout: Budget,
+        timeoutMessage: $"did not finish within {Budget}: {what}",
+        maxStackSize: DedicatedThread.DefaultStackSize);
+
+    /// <summary>
+    /// Evaluates <paramref name="expression"/>, answering with its string value or with the constructor
+    /// name of the JavaScript error it raised.
+    /// </summary>
+    private static string Evaluate(string expression)
+    {
+        var result = "";
+
+        Guarded(expression, () =>
+        {
+            var engine = new Engine();
+            result = engine.Evaluate(
+                $"(function () {{ try {{ return String({expression}); }} catch (e) {{ return e.constructor.name; }} }})()").AsString();
+        });
+
+        return result;
+    }
+
+    /// <summary>
+    /// The report from the issue, verbatim. Before the fix this never returned.
+    /// </summary>
+    [Fact]
+    public void TheReportedMonthDifferencePastTheChineseRangeRaisesRangeError()
+    {
+        Evaluate(
+            "Temporal.PlainDate.from('1910-01-01').withCalendar('chinese')" +
+            ".until(Temporal.PlainDate.from('1900-01-03').withCalendar('chinese'), { largestUnit: 'year' })")
+            .Should().Be("RangeError");
+    }
+
+    /// <summary>
+    /// A difference is a sequence of additions, so every direction of walk and every largest unit that
+    /// walks has to be bounded — not only the one the report happened to name. Each row names the
+    /// boundary it steps past: chinese below its 1901 floor and above its 2101 ceiling, dangi above its
+    /// 2051 ceiling, hebrew below 1583 and above 2239, persian below 622.
+    /// </summary>
+    [Theory]
+    [InlineData("chinese", "1910-01-01", "1900-01-03")]
+    [InlineData("chinese", "2050-01-01", "2300-01-03")]
+    [InlineData("dangi", "2050-01-01", "2300-01-03")]
+    [InlineData("hebrew", "1990-01-01", "1000-01-03")]
+    [InlineData("hebrew", "2050-01-01", "2300-01-03")]
+    [InlineData("persian", "0700-01-01", "0300-01-03")]
+    public void ADifferencePastACalendarRangeRaisesRangeErrorInsteadOfSpinning(string calendar, string one, string two)
+    {
+        foreach (var largestUnit in new[] { "year", "month" })
+        {
+            foreach (var op in new[] { "until", "since" })
+            {
+                Evaluate(
+                    $"Temporal.PlainDate.from('{one}').withCalendar('{calendar}')" +
+                    $".{op}(Temporal.PlainDate.from('{two}').withCalendar('{calendar}'), {{ largestUnit: '{largestUnit}' }})")
+                    .Should().Be("RangeError", $"{calendar}.{op} by {largestUnit}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// The same walk backs <c>until</c> and <c>since</c> on every type that carries a calendar, and
+    /// <c>Duration</c>'s <c>round</c>/<c>total</c> reach it through <c>relativeTo</c>. Each of these was
+    /// its own way to lose the thread, so each is named rather than left to the one the report used.
+    /// </summary>
+    [Fact]
+    public void EveryDifferenceSurfaceThatWalksMonthsIsBounded()
+    {
+        const string Chinese = "withCalendar('chinese')";
+
+        Evaluate($"Temporal.PlainDateTime.from('1910-01-01T00:00').{Chinese}.until(Temporal.PlainDateTime.from('1900-01-03T00:00').{Chinese}, {{ largestUnit: 'year' }})")
+            .Should().Be("RangeError");
+
+        Evaluate($"Temporal.ZonedDateTime.from('1910-01-01T00:00[UTC]').{Chinese}.since(Temporal.ZonedDateTime.from('1900-01-03T00:00[UTC]').{Chinese}, {{ largestUnit: 'year' }})")
+            .Should().Be("RangeError");
+
+        Evaluate($"Temporal.PlainDate.from('1910-01-01').{Chinese}.toPlainYearMonth().until(Temporal.PlainDate.from('1900-01-03').{Chinese}.toPlainYearMonth(), {{ largestUnit: 'year' }})")
+            .Should().Be("RangeError");
+
+        Evaluate($"new Temporal.Duration(0, 0, 0, 200000).total({{ unit: 'year', relativeTo: Temporal.PlainDate.from('1990-01-01').{Chinese} }})")
+            .Should().Be("RangeError");
+
+        // round reaches the walk through a ZonedDateTime relativeTo. It does not reach it through a
+        // PlainDate one, because that arm reckons in "iso8601" whatever calendar the relativeTo carries
+        // -- a separate defect with its own issue, and the reason round answered where total refused
+        // even before this change.
+        Evaluate($"new Temporal.Duration(200).round({{ largestUnit: 'year', relativeTo: Temporal.ZonedDateTime.from('1990-01-01T00:00[UTC]').{Chinese} }})")
+            .Should().Be("RangeError");
+    }
+
+    /// <summary>
+    /// The other half of the same defect, and the one that answered rather than hanging: the boundary
+    /// date handed back was the calendar's <em>maximum</em> whichever end had been overrun, so
+    /// subtracting a century from a 1950 Chinese date moved it a century and a half forward, to
+    /// 2101-01-28, and reported success.
+    /// </summary>
+    [Theory]
+    [InlineData("chinese", "1950-01-01", "subtract({ years: 100 })")]
+    [InlineData("chinese", "2050-01-01", "add({ years: 100 })")]
+    [InlineData("chinese", "2050-01-01", "add({ months: 1200 })")]
+    [InlineData("dangi", "2050-01-01", "add({ years: 100 })")]
+    [InlineData("hebrew", "2050-01-01", "add({ years: 500 })")]
+    [InlineData("persian", "0700-01-01", "subtract({ years: 200 })")]
+    public void ArithmeticPastACalendarRangeRaisesRangeErrorInsteadOfAnsweringWithTheBoundary(string calendar, string from, string call)
+    {
+        Evaluate($"Temporal.PlainDate.from('{from}').withCalendar('{calendar}').{call}")
+            .Should().Be("RangeError");
+    }
+
+    /// <summary>
+    /// A <c>RangeError</c> is only an improvement on a hang if a script can act on it, which means it has
+    /// to be a JavaScript error and not a CLR exception on its way out of <c>Engine.Evaluate</c>.
+    /// </summary>
+    [Fact]
+    public void TheRefusalIsAJavaScriptErrorAScriptCanCatch()
+    {
+        var caught = "";
+
+        Guarded(nameof(TheRefusalIsAJavaScriptErrorAScriptCanCatch), () => caught = new Engine().Evaluate(
+            @"(function () {
+                try {
+                    Temporal.PlainDate.from('1910-01-01').withCalendar('chinese')
+                        .until(Temporal.PlainDate.from('1900-01-03').withCalendar('chinese'), { largestUnit: 'year' });
+                    return 'no error';
+                } catch (e) {
+                    return (e instanceof RangeError) + '|' + (e.message.length > 0);
+                }
+            })()").AsString());
+
+        caught.Should().Be("true|true");
+    }
+
+    /// <summary>
+    /// The refusal is a boundary, not a new ceiling on ordinary arithmetic: every calendar still measures
+    /// and still adds inside the range it supports, and the two still agree with each other.
+    /// </summary>
+    [Fact]
+    public void ArithmeticInsideEveryCalendarRangeIsUnchanged()
+    {
+        foreach (var calendar in TheElevenNonIsoCalendars)
+        {
+            Evaluate($"Temporal.PlainDate.from('1990-03-05').withCalendar('{calendar}').until(Temporal.PlainDate.from('2020-07-11').withCalendar('{calendar}'), {{ largestUnit: 'year' }})")
+                .Should().NotBe("RangeError", calendar);
+
+            Evaluate($"Temporal.PlainDate.from('1990-03-05').withCalendar('{calendar}').add({{ years: 5, months: 3, days: 2 }})")
+                .Should().NotBe("RangeError", calendar);
+
+            // add and until are the same reckoning read in opposite directions, so a date plus the
+            // difference to another date is that other date.
+            Evaluate(
+                $@"(function () {{
+                     var a = Temporal.PlainDate.from('1990-03-05').withCalendar('{calendar}');
+                     var b = Temporal.PlainDate.from('2020-07-11').withCalendar('{calendar}');
+                     return a.add(a.until(b, {{ largestUnit: 'year' }})).equals(b);
+                   }})()")
+                .Should().Be("true", calendar);
+        }
+    }
+
+    /// <summary>
+    /// The six calendars with no <c>System.Globalization.Calendar</c> behind them reckon by epoch-day
+    /// arithmetic and have no boundary to hit, which is why they answer where the BCL-backed ones refuse.
+    /// Pinned so that giving one of them a BCL implementation cannot quietly narrow it.
+    /// </summary>
+    [Theory]
+    [InlineData("coptic")]
+    [InlineData("ethiopic")]
+    [InlineData("ethioaa")]
+    [InlineData("indian")]
+    [InlineData("islamic-civil")]
+    [InlineData("islamic-tbla")]
+    public void ACalendarReckonedByArithmeticStillMeasuresAcrossTheWholeTemporalRange(string calendar)
+    {
+        Evaluate($"Temporal.PlainDate.from('1950-01-01').withCalendar('{calendar}').until(Temporal.PlainDate.from('-100000-01-03').withCalendar('{calendar}'), {{ largestUnit: 'year' }})")
+            .Should().StartWith("-P", calendar);
+    }
+}

--- a/Jint/Native/Temporal/CalendarRangeException.cs
+++ b/Jint/Native/Temporal/CalendarRangeException.cs
@@ -1,0 +1,26 @@
+namespace Jint.Native.Temporal;
+
+/// <summary>
+/// Signals that non-ISO calendar arithmetic left the range the calendar's implementation can represent.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Jint reckons the eleven non-ISO calendars with <see cref="System.Globalization.Calendar"/> classes and
+/// with fixed-epoch arithmetic, and several of those classes cover far less than Temporal's own date
+/// range: <c>ChineseLunisolarCalendar</c> spans ISO 1901-02-19 to 2101-01-28, <c>HebrewCalendar</c>
+/// 1583-01-01 to 2239-09-29. A step past either end has no date to answer with.
+/// </para>
+/// <para>
+/// What used to be answered there was the calendar's <em>maximum</em> supported date, whichever end had
+/// been overrun, which made <c>subtract</c> move forward and made <c>until</c>'s one-month-at-a-time walk
+/// stand still forever. <see cref="TemporalHelpers"/> catches this at the two calendar entry points and
+/// raises the <c>RangeError</c> that <c>CalendarDateAdd</c> raises for a result it cannot represent.
+/// </para>
+/// </remarks>
+internal sealed class CalendarRangeException : Exception
+{
+    internal CalendarRangeException(string calendar)
+        : base($"Date is outside the range supported by the '{calendar}' calendar")
+    {
+    }
+}

--- a/Jint/Native/Temporal/NonIsoCalendars.cs
+++ b/Jint/Native/Temporal/NonIsoCalendars.cs
@@ -282,13 +282,20 @@ internal static class NonIsoCalendars
         }
         catch (ArgumentOutOfRangeException)
         {
-            if (string.Equals(overflow, "reject", StringComparison.Ordinal))
-            {
-                throw new InvalidOperationException("reject");
-            }
-
-            // Fallback: clamp to calendar's valid range
-            return ClampToCalendarRange(cal, newYear, newOrdinalMonth, newDay);
+            // The result lies outside the range the backing System.Globalization.Calendar represents.
+            // That is not the month-or-day overflow "constrain" is allowed to clamp -- there is no
+            // nearby valid date to clamp to, only the calendar's own boundary -- so both overflow modes
+            // report it. NonISODateAdd is implementation-defined and may throw
+            // (https://tc39.es/proposal-temporal/#sec-temporal-nonisodateadd), and CalendarDateAdd
+            // raises a RangeError for a result it cannot represent
+            // (https://tc39.es/proposal-temporal/#sec-temporal-calendardateadd).
+            //
+            // The clamp this replaced answered with the calendar's MaxSupportedDateTime for an
+            // underflow as well as an overflow, so subtracting a century from a chinese date moved it
+            // forward to 2101-01-28 -- and, since every further step landed on that same date,
+            // CalendarDateUntil's month walk below never passed its target and never returned
+            // (https://github.com/sebastienros/jint/issues/3428).
+            throw new CalendarRangeException(calendar);
         }
     }
 
@@ -386,6 +393,19 @@ internal static class NonIsoCalendars
             var prevMonths = months;
             months += sign;
             var nextIso = CalendarDateAdd(calendar, in one, years, months, "constrain");
+
+            // The loop's only exit is "this step passed two", so a step that does not move the date
+            // never takes it: one more month of a walk that stands still is still standing still,
+            // however many are taken. Every conversion that used to saturate now raises
+            // CalendarRangeException rather than answering with a boundary date, which is what makes
+            // this a structural guarantee rather than a live path -- and it stays here so that a future
+            // calendar, or a host-supplied one, cannot reintroduce the hang of issue #3428 by adding a
+            // clamp somewhere below.
+            if (nextIso == currentIso)
+            {
+                throw new CalendarRangeException(calendar);
+            }
+
             var nextCal = IsoToCalendarDate(calendar, in nextIso);
             // Un-constrain the day in calendar-field space: if AddCalendar forced day down
             // to fit the target month, we still want to consider "next" as standing at the
@@ -1313,15 +1333,6 @@ internal static class NonIsoCalendars
         {
             return 30; // fallback
         }
-    }
-
-    /// <summary>
-    /// Clamps a date to the calendar's supported range.
-    /// </summary>
-    private static IsoDate ClampToCalendarRange(Calendar cal, int year, int month, int day)
-    {
-        var dt = cal.MaxSupportedDateTime;
-        return new IsoDate(dt.Year, dt.Month, dt.Day);
     }
 
     #endregion
@@ -2491,7 +2502,11 @@ internal static class NonIsoCalendars
         }
 
         var result = IndianDateToIso(newYear, null, newMonth, newDay, overflow);
-        return result ?? isoDate; // fallback to input if conversion fails
+
+        // Answering with the input date when the conversion cannot be made -- which is what this did --
+        // is a no-progress answer: `add` reports that adding a year changed nothing, and the month walk
+        // in CalendarDateUntil takes the same step forever. See CalendarRangeException.
+        return result ?? throw new CalendarRangeException("indian");
     }
 
     /// <summary>
@@ -2970,7 +2985,10 @@ internal static class NonIsoCalendars
 
         // Convert back to ISO using the appropriate calendar
         var result = CalendarDateToIso(calendar, newYear, null, newMonth, newDay, overflow);
-        return result ?? isoDate;
+
+        // Same no-progress hazard as the Indian arm above: the input date is not an answer to
+        // "add a year to this", and a step that stands still is one CalendarDateUntil never gets past.
+        return result ?? throw new CalendarRangeException(calendar);
     }
 
     /// <summary>

--- a/Jint/Native/Temporal/PlainDate/PlainDatePrototype.cs
+++ b/Jint/Native/Temporal/PlainDate/PlainDatePrototype.cs
@@ -526,7 +526,7 @@ internal sealed partial class PlainDatePrototype : Prototype
         }
 
         // Step 6: Get date difference using calendar
-        var dateDifference = TemporalHelpers.CalendarDateUntil(temporalDate.Calendar, temporalDate.IsoDate, other.IsoDate, largestUnit);
+        var dateDifference = TemporalHelpers.CalendarDateUntil(temporalDate.Calendar, temporalDate.IsoDate, other.IsoDate, largestUnit, _realm);
 
         // Step 7-10: If rounding needed, use RoundRelativeDuration
         DurationRecord result;

--- a/Jint/Native/Temporal/PlainYearMonth/PlainYearMonthPrototype.cs
+++ b/Jint/Native/Temporal/PlainYearMonth/PlainYearMonthPrototype.cs
@@ -489,7 +489,7 @@ internal sealed partial class PlainYearMonthPrototype : Prototype
         TemporalHelpers.CheckISODaysRange(_realm, otherDate);
 
         // Step 11: Get date difference using calendar
-        var dateDifference = TemporalHelpers.CalendarDateUntil(ym1.Calendar, thisDate, otherDate, largestUnit);
+        var dateDifference = TemporalHelpers.CalendarDateUntil(ym1.Calendar, thisDate, otherDate, largestUnit, _realm);
 
         // Step 12: AdjustDateDurationRecord - zero out weeks and days (PlainYearMonth only has years/months)
         var yearsMonthsDifference = new DurationRecord(

--- a/Jint/Native/Temporal/TemporalHelpers.cs
+++ b/Jint/Native/Temporal/TemporalHelpers.cs
@@ -1,4 +1,5 @@
-﻿using System.Globalization;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -2689,6 +2690,11 @@ internal static class TemporalHelpers
 
                 return result;
             }
+            catch (CalendarRangeException ex)
+            {
+                ThrowCalendarRange(realm, ex);
+                return default;
+            }
             catch (InvalidOperationException ex) when (string.Equals(ex.Message, "reject", StringComparison.Ordinal))
             {
                 if (realm != null)
@@ -2702,6 +2708,22 @@ internal static class TemporalHelpers
         {
             throw new NotSupportedException($"Calendar '{calendar}' not yet supported");
         }
+    }
+
+    /// <summary>
+    /// Reports arithmetic that left the range a non-ISO calendar's implementation can represent as the
+    /// <c>RangeError</c> <see href="https://tc39.es/proposal-temporal/#sec-temporal-calendardateadd">CalendarDateAdd</see>
+    /// raises for a result it cannot produce.
+    /// </summary>
+    [DoesNotReturn]
+    private static void ThrowCalendarRange(Realm? realm, CalendarRangeException ex)
+    {
+        if (realm is not null)
+        {
+            Throw.RangeError(realm, ex.Message);
+        }
+
+        throw ex;
     }
 
     /// <summary>
@@ -5750,7 +5772,7 @@ internal static class TemporalHelpers
         var endDateTime = GetISODateTimeFor(timeZoneProvider, timeZone, ns2);
 
         // Step 4: Get initial difference - only use the date portion
-        var diff = DifferenceISODateTime(startDateTime, endDateTime, calendar, largestUnit);
+        var diff = DifferenceISODateTime(realm, startDateTime, endDateTime, calendar, largestUnit);
         var dateDifference = new DurationRecord(diff.Years, diff.Months, diff.Weeks, diff.Days, 0, 0, 0, 0, 0, 0);
 
         // Step 5: Create intermediate datetime by adding date portion to start
@@ -6030,7 +6052,7 @@ internal static class TemporalHelpers
         }
 
         // Step 3: DifferenceISODateTime to get the diff
-        var diff = DifferenceISODateTime(isoDateTime1, isoDateTime2, calendar, unit);
+        var diff = DifferenceISODateTime(realm, isoDateTime1, isoDateTime2, calendar, unit);
 
         // Step 4: If unit is nanosecond, return diff time duration directly
         if (string.Equals(unit, "nanosecond", StringComparison.Ordinal))
@@ -6196,7 +6218,7 @@ internal static class TemporalHelpers
             var weeksEnd = AddDaysToISODate(weeksStart, (int) duration.Days);
 
             // Step 4: Calculate weeks between weeksStart and weeksEnd
-            var untilResult = CalendarDateUntil(calendar, weeksStart, weeksEnd, "week");
+            var untilResult = CalendarDateUntil(calendar, weeksStart, weeksEnd, "week", realm);
 
             // Step 5: Round total weeks (original weeks + calculated weeks from days)
             var weeks = RoundNumberToIncrement(duration.Weeks + untilResult.Weeks, increment, "trunc");
@@ -6619,6 +6641,7 @@ internal static class TemporalHelpers
     /// https://tc39.es/proposal-temporal/#sec-temporal-differenceisodatetime
     /// </summary>
     private static DurationRecord DifferenceISODateTime(
+        Realm? realm,
         IsoDateTime isoDateTime1,
         IsoDateTime isoDateTime2,
         string calendar,
@@ -6648,7 +6671,7 @@ internal static class TemporalHelpers
         var dateLargestUnit = LargerOfTwoTemporalUnits("day", largestUnit);
 
         // Step 9: Compute date difference using calendar
-        var dateDifference = CalendarDateUntil(calendar, isoDateTime1.Date, adjustedDate, dateLargestUnit);
+        var dateDifference = CalendarDateUntil(calendar, isoDateTime1.Date, adjustedDate, dateLargestUnit, realm);
 
         // Step 10-11: If largestUnit is smaller than day, add days to time
         if (!string.Equals(dateLargestUnit, largestUnit, StringComparison.Ordinal))
@@ -6762,7 +6785,7 @@ internal static class TemporalHelpers
     /// ISODateSurpasses algorithm (calendar.html:632-661) but uses direct arithmetic
     /// for O(1) performance on years/days instead of O(n) iteration.
     /// </summary>
-    internal static DurationRecord CalendarDateUntil(string calendar, IsoDate one, IsoDate two, string largestUnit)
+    internal static DurationRecord CalendarDateUntil(string calendar, IsoDate one, IsoDate two, string largestUnit, Realm? realm)
     {
         // Step 1: Get sign
         var sign = CompareIsoDates(one, two);
@@ -6778,7 +6801,18 @@ internal static class TemporalHelpers
         {
             if (NonIsoCalendars.IsNonIsoCalendar(calendar))
             {
-                return NonIsoCalendars.CalendarDateUntil(calendar, in one, in two, largestUnit);
+                try
+                {
+                    return NonIsoCalendars.CalendarDateUntil(calendar, in one, in two, largestUnit);
+                }
+                catch (CalendarRangeException ex)
+                {
+                    // The walk that measures the difference is a sequence of NonISODateAdd steps, so a
+                    // difference reaching past what the calendar can represent surfaces as the same
+                    // RangeError the addition itself raises -- rather than as the non-terminating walk
+                    // of issue #3428.
+                    ThrowCalendarRange(realm, ex);
+                }
             }
 
             throw new NotSupportedException($"Calendar '{calendar}' not yet supported");
@@ -6919,7 +6953,7 @@ internal static class TemporalHelpers
         }
 
         // Step 3: Get unrounded difference
-        var diff = DifferenceISODateTime(isoDateTime1, isoDateTime2, calendar, largestUnit);
+        var diff = DifferenceISODateTime(realm, isoDateTime1, isoDateTime2, calendar, largestUnit);
 
         // Step 4: If no rounding needed, return
         if (string.Equals(smallestUnit, "nanosecond", StringComparison.Ordinal) && roundingIncrement == 1)


### PR DESCRIPTION
Backport of #3452 to `4.x`. Fixes #3428 there too — the defect predates every released 4.x, and the hang
reproduces on this branch with the same shape and the same failure count as on `main`.

## What was wrong

`NonIsoCalendars.CalendarDateUntil` measures a difference by walking one month at a time from the source
towards the target, and its only exit is "this step passed the target". `NonIsoCalendars.CalendarDateAdd`
takes those steps, and when the conversion back to ISO left the range of the backing
`System.Globalization.Calendar` it did not report that — it answered with `ClampToCalendarRange`, which
ignored its year, month and day arguments entirely and returned `cal.MaxSupportedDateTime`:

```csharp
private static IsoDate ClampToCalendarRange(Calendar cal, int year, int month, int day)
{
    var dt = cal.MaxSupportedDateTime;
    return new IsoDate(dt.Year, dt.Month, dt.Day);
}
```

The calendar's *maximum*, whichever end had been overrun. So every further step of a backwards walk landed
on that same date, no step ever passed the target, and the loop had no other exit.

```js
Temporal.PlainDate.from('1910-01-01').withCalendar('chinese')
    .until(Temporal.PlainDate.from('1900-01-03').withCalendar('chinese'), { largestUnit: 'year' });
// never returned
```

`ChineseLunisolarCalendar` spans ISO 1901-02-19 to 2101-01-28, so the target is outside it.

**What an embedder saw** is the thread, and nothing else. It is a CLR loop inside one interpreter step, so
it crosses no statement boundary: `LimitStatements` never counted, `LimitExecutionTime` never got a check,
and a `CancellationToken` was never observed. A host that bounded untrusted script the documented way still
lost the thread, and the only way back was to end the process. Reachable from any script that can name a
`chinese`, `dangi`, `hebrew` or `persian` date, through `until`, `since` and `total` on `PlainDate`,
`PlainDateTime`, `PlainYearMonth`, `ZonedDateTime` and `Duration`.

The same clamp was also answering, rather than hanging, on the addition side — with the wrong date, and with
no signal that it was wrong. Measured on unfixed `4.x`:

```js
Temporal.PlainDate.from('1950-01-01').withCalendar('chinese').subtract({ years: 100 });
// 2101-01-28[u-ca=chinese]   -- subtracting a century moved it a century and a half forward
Temporal.PlainDate.from('2050-01-01').withCalendar('dangi').add({ years: 100 });
// 2051-02-10[u-ca=dangi]
Temporal.PlainDate.from('2050-01-01').withCalendar('hebrew').add({ years: 500 });
// 2239-09-29[u-ca=hebrew]
Temporal.PlainDate.from('0700-01-01').withCalendar('persian').subtract({ years: 200 });
// 9999-12-31[u-ca=persian]
```

## What changed

Identical in substance to #3452. Out-of-range calendar arithmetic reports itself instead of clamping.
`NonISODateAdd` is implementation-defined and is declared as returning "either a normal completion
containing an ISO Date Record or a throw completion"
([spec](https://tc39.es/proposal-temporal/#sec-temporal-nonisodateadd)), and `CalendarDateAdd` raises a
`RangeError` for a result it cannot represent
([spec](https://tc39.es/proposal-temporal/#sec-temporal-calendardateadd)). Both `overflow` modes report it:
leaving the calendar's range is not the month-or-day overflow `constrain` is allowed to clamp, because there
is no nearby valid date to clamp to — only the calendar's own boundary.

- `NonIsoCalendars.CalendarDateAdd` — `ClampToCalendarRange` is gone; the `ArgumentOutOfRangeException`
  from `cal.ToDateTime` becomes a `CalendarRangeException`.
- `NonIsoCalendars.IndianCalendarDateAdd` and `IslamicTabularCalendarDateAdd` — both answered
  `result ?? isoDate`, handing back their **input** date when the conversion failed. That is the same
  no-progress answer by a different route: `add` reports that adding a year changed nothing, and the walk
  takes the same step forever. Both now report instead.
- `NonIsoCalendars.CalendarDateUntil` — the walk keeps a no-progress guard of its own. With the three fixes
  above it is unreachable today; it stays as the structural guarantee that this loop terminates, so a clamp
  reintroduced anywhere below it cannot become a hang again.
- `TemporalHelpers.CalendarDateAdd` / `CalendarDateUntil` map it to `Throw.RangeError`. `realm` is threaded
  through `DifferenceISODateTime` and is now required on `CalendarDateUntil`, so no call site can lose it
  and turn a script-visible `RangeError` into a CLR exception escaping `Engine.Evaluate`.

All internal; **no public API change**.

## Divergence from the `main` PR

Three adaptations, all mechanical, and none of them changes what the fix does:

- **`ThrowCalendarArithmeticUnavailable` does not exist on `4.x`.** It arrived on `main` in separate work,
  and #3452 merely added a sibling beside it. That hunk is dropped: `4.x` keeps its
  `throw new NotSupportedException($"Calendar '{calendar}' not yet supported")` for a calendar with no
  arithmetic, and only `ThrowCalendarRange` is added. `using System.Diagnostics.CodeAnalysis;` had to come
  with it for the `[DoesNotReturn]`, which `main` already had a use for in that file.
- **`CalendarDateUntil` had no `realm` parameter at all on `4.x`.** On `main` it was already there as
  `Realm? realm = null` and #3452 only made it required; here it is added, required, and threaded through
  the three call sites that lacked it — `PlainDatePrototype.DifferenceTemporalPlainDate` and
  `PlainYearMonthPrototype.DifferenceYearMonth` (both pass `_realm`), and the `week` arm of
  `RoundRelativeDuration` in `TemporalHelpers` (which already held a `realm`). Every one had a realm at
  hand, so nothing had to be widened to carry one.
- **`Jint.Tests` is xUnit v3 on `4.x`.** `[Test]` → `[Fact]`, `[TestCase(…, TestName: …)]` → `[Theory]` +
  `[InlineData]` (the case names move into the doc comment, since `InlineData` has nowhere to put them),
  and `DedicatedThread`'s join timeout keeps throwing `XunitException` rather than NUnit's
  `AssertionException`.

`NonIsoCalendars.cs` is still one file on this branch — the `NonIsoCalendars.Lunisolar.cs` split is later
`main` work, after #3452 — so all four engine hunks in it applied unchanged, and the two `NonIsoCalendars`
entry points #3452 wraps are still the only two callers in the assembly here.

`Jint.Tests/DedicatedThread.cs` also carries #3452's second half: a body starts at normal priority and is
demoted to `ThreadPriority.Lowest` only once its join has timed out, at which point it is known to be a
runaway that must be kept off the cores the rest of the run needs. Starting every body at `Lowest` cost a
0.1 ms evaluation 2.5 s under two competitors on `main`'s measurement, which is what made the `net472` CI
leg red there. `4.x` has the same helper and the same starting priority, so it inherits the same fix.

## Failing-test evidence, per target framework

`Jint.Tests/Runtime/NonIsoCalendarRangeTests.cs` runs every case on a dedicated thread with a 15-second
join, so a regression fails the run rather than wedging it. Against the **unfixed `4.x` engine** (this
branch with `Jint/` reverted, test file and `DedicatedThread` change in place):

| | `net472` (the `net462` asset) | `net10.0` |
| --- | --- | --- |
| before | **Failed: 15**, Passed: 7, Total: 22 — 2 m 15 s | **Failed: 15**, Passed: 7, Total: 22 — 2 m 15 s |
| after | **Passed: 22**, Failed: 0 — 569 ms | **Passed: 22**, Failed: 0 — 332 ms |

Both frameworks fail the identical fifteen. Nine of them are the hang and account for two of those two and
a quarter minutes — each burning its whole 15-second budget in an uninterruptible CLR loop, which is exactly
what an embedder's thread was doing:

```
Failed …NonIsoCalendarRangeTests.TheReportedMonthDifferencePastTheChineseRangeRaisesRangeError [15 s]
  Error Message:
   did not finish within 00:00:15: Temporal.PlainDate.from('1910-01-01').withCalendar('chinese')
     .until(Temporal.PlainDate.from('1900-01-03').withCalendar('chinese'), { largestUnit: 'year' })
```

The other six are the boundary date answered as if it were the result, in a millisecond:

```
Failed …ArithmeticPastACalendarRangeRaisesRangeErrorInsteadOfAnsweringWithTheBoundary(
    calendar: "chinese", from: "1950-01-01", call: "subtract({ years: 100 })") [1 ms]
  Expected string to be the same string, but they differ at index 0:
  "2101-01-28[u-ca=chinese]"   (actual)
  "RangeError"                 (expected)
```

## Test suites

One `dotnet test -c Release` run on `1cfe8c34a`:

| suite | net472 | net10.0 |
| --- | --- | --- |
| `Jint.Tests` | 6857 passed, 0 failed, 4 skipped | 6942 passed, 0 failed, 4 skipped |
| `Jint.Tests.PublicInterface` | 1495 passed, 0 failed, 9 skipped | 1502 passed, 0 failed, 9 skipped |
| `Jint.Tests.CommonScripts` | 28 passed, 0 failed | 28 passed, 0 failed |
| `Jint.Tests.SourceGenerators` | — | 52 passed, 0 failed |

`Jint.Tests.Test262`: **102,499 passed, 0 failed**, 185 skipped (102,684 total) — the branch control,
unchanged. The full run reported two failures, both variants of
`intl402/supportedLocalesOf-unicode-extensions-ignored.js` timing out at 34 s against the engine's own
30-second default while three other test assemblies and a sibling suite shared the box. Re-run alone on the
same tree it passes in 2 s, and nothing in this change reaches `Intl.supportedLocalesOf`.

`dotnet build -c Release`: 0 errors, no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014W5mbjGhyvgAS4pivXoc4S
