### PR TITLE
Interop: a read-only host collection refuses script with a JavaScript error, not the CLR's own (backport of #3385)

### DIFF
--- a/Jint.Tests.PublicInterface/HostReadOnlyCollectionTests.cs
+++ b/Jint.Tests.PublicInterface/HostReadOnlyCollectionTests.cs
@@ -1,0 +1,306 @@
+#nullable enable
+
+using System.Collections;
+using System.Collections.Immutable;
+using System.Collections.ObjectModel;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// Pins what a wrapped CLR collection that declares itself read-only owes script when it is asked to
+/// change: a JavaScript error the script can catch, never the CLR's own
+/// <see cref="NotSupportedException"/> escaping <c>Evaluate</c>.
+///
+/// <para>
+/// Which JavaScript answer depends on the operation, not on the collection. <c>push</c>, <c>pop</c>,
+/// <c>splice</c>, <c>sort</c> and <c>reverse</c> are specified in terms of <c>Set(O, k, v, true)</c> and
+/// <c>DeletePropertyOrThrow</c>, so a refusal is a <c>TypeError</c> in either mode. A bare assignment —
+/// <c>host[0] = 9</c>, <c>host.length = 5</c>, <c>delete host[0]</c> — is an ordinary <c>[[Set]]</c> or
+/// <c>[[Delete]]</c> returning <see langword="false"/>, which is a <c>TypeError</c> in strict mode and
+/// silent in sloppy mode. Both halves are asserted below, because "make everything throw" would be wrong
+/// in the second one.
+/// </para>
+///
+/// <para>
+/// The contrast case is a collection that is fixed-size rather than read-only, which refuses the same
+/// length changes and still accepts element writes. <see cref="ArraySegment{T}"/> is the shape that makes
+/// the distinction load-bearing: it reports <see cref="ICollection{T}.IsReadOnly"/> as
+/// <see langword="true"/> meaning only that it cannot grow, exactly as <c>T[]</c> does.
+/// </para>
+/// </summary>
+public class HostReadOnlyCollectionTests
+{
+    private static Engine CreateEngine(object host, bool strict = false)
+    {
+        var engine = new Engine(options =>
+        {
+            options.Strict = strict;
+            options.Interop.AllowWrite = true;
+        });
+        engine.SetValue("host", host);
+        return engine;
+    }
+
+    /// <summary>
+    /// Every shape an embedder reaches for when it wants to hand script a collection it may read but not
+    /// change. They resolve to two different wrappers — <c>ReadOnlyCollection&lt;T&gt;</c> and a host
+    /// <see cref="IList{T}"/> to the generic list view, the rest to the read-only list view — and before
+    /// #3382 the two disagreed about which of them leaked which CLR exception.
+    /// </summary>
+    private static readonly string[] _readOnlyShapes =
+    [
+        nameof(ReadOnlyCollection<int>),
+        nameof(ImmutableList),
+        nameof(ImmutableArray),
+        nameof(HostReadOnlyList),
+        nameof(HostReadOnlySequence),
+        nameof(ArrayList),
+    ];
+
+    public static TheoryData<string> ReadOnlyShapes
+    {
+        get
+        {
+            var data = new TheoryData<string>();
+            foreach (var shape in _readOnlyShapes)
+            {
+                data.Add(shape);
+            }
+
+            return data;
+        }
+    }
+
+    private static (object Host, Func<IReadOnlyList<int>> Read) CreateReadOnlyShape(string kind)
+    {
+        switch (kind)
+        {
+            case nameof(ReadOnlyCollection<int>):
+            {
+                var items = new List<int> { 1, 2, 3 };
+                return (new ReadOnlyCollection<int>(items), () => items);
+            }
+            case nameof(ImmutableList):
+            {
+                var items = ImmutableList.Create(1, 2, 3);
+                return (items, () => items);
+            }
+            case nameof(ImmutableArray):
+            {
+                var items = ImmutableArray.Create(1, 2, 3);
+                return (items, () => items);
+            }
+            case nameof(HostReadOnlyList):
+            {
+                var items = new List<int> { 1, 2, 3 };
+                return (new HostReadOnlyList(items), () => items);
+            }
+            case nameof(HostReadOnlySequence):
+            {
+                var items = new List<int> { 1, 2, 3 };
+                return (new HostReadOnlySequence(items), () => items);
+            }
+            case nameof(ArrayList):
+            {
+                var items = ArrayList.ReadOnly(new ArrayList { 1, 2, 3 });
+                return (items, () => items.Cast<int>().ToList());
+            }
+            default:
+                throw new ArgumentOutOfRangeException(nameof(kind), kind, "unknown shape");
+        }
+    }
+
+    /// <summary>
+    /// The five <c>Array.prototype</c> generics that change a length. <c>sort</c> and <c>reverse</c> are
+    /// spelled through <c>Array.prototype</c> deliberately: several of these shapes carry a CLR
+    /// <c>Sort</c>/<c>Reverse</c> member of their own, and a wrapped member wins over the prototype, so
+    /// <c>host.sort(…)</c> would measure member resolution rather than the refusal.
+    /// </summary>
+    public static TheoryData<string, string> ThrowingOperations
+    {
+        get
+        {
+            var data = new TheoryData<string, string>();
+            foreach (var shape in _readOnlyShapes)
+            {
+                data.Add(shape, "host.push(4)");
+                data.Add(shape, "host.pop()");
+                data.Add(shape, "host.splice(0, 1)");
+                data.Add(shape, "Array.prototype.sort.call(host, function (a, b) { return b - a; })");
+                data.Add(shape, "Array.prototype.reverse.call(host)");
+            }
+
+            return data;
+        }
+    }
+
+    /// <summary>
+    /// The assignments, which the specification refuses differently: silently in sloppy mode.
+    /// </summary>
+    public static TheoryData<string, string> AssigningOperations
+    {
+        get
+        {
+            var data = new TheoryData<string, string>();
+            foreach (var shape in _readOnlyShapes)
+            {
+                data.Add(shape, "host[0] = 9");
+                data.Add(shape, "host[3] = 9");
+                data.Add(shape, "host.length = 5");
+                data.Add(shape, "host.length = 1");
+                data.Add(shape, "delete host[0]");
+            }
+
+            return data;
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(ThrowingOperations))]
+    public void AnArrayGenericThatMustGrowAReadOnlyCollectionThrowsACatchableTypeError(string shape, string operation)
+    {
+        var (host, read) = CreateReadOnlyShape(shape);
+
+        foreach (var strict in new[] { false, true })
+        {
+            var engine = CreateEngine(host, strict);
+
+            // the catch is script-side on purpose: a CLR NotSupportedException escaping Evaluate is
+            // invisible to it, which is the whole defect (#3382)
+            var outcome = engine.Evaluate(Probe(operation, strict)).AsString();
+
+            outcome.Should().Be("TypeError", "{0} on a read-only {1} is Set(O, k, v, true)", operation, shape);
+            read().Should().Equal(1, 2, 3);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(AssigningOperations))]
+    public void AnAssignmentToAReadOnlyCollectionIsRefusedSilentlyInSloppyModeAndThrowsInStrictMode(string shape, string operation)
+    {
+        var (host, read) = CreateReadOnlyShape(shape);
+
+        CreateEngine(host).Evaluate(Probe(operation, strict: false)).AsString()
+            .Should().Be("no-throw", "a failed [[Set]] is silent outside strict mode");
+        read().Should().Equal(1, 2, 3);
+
+        CreateEngine(host, strict: true).Evaluate(Probe(operation, strict: true)).AsString()
+            .Should().Be("TypeError", "a failed [[Set]] is a TypeError in strict mode");
+        read().Should().Equal(1, 2, 3);
+    }
+
+    /// <summary>
+    /// The refusal an embedder actually reads is the ordinary one a frozen JavaScript array gives — the
+    /// element write is what fails, and it names the property. Nothing here invents an interop-specific
+    /// message, which is the point: the refusal happens in <c>[[Set]]</c>, before the collection is
+    /// reached at all.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ReadOnlyShapes))]
+    public void TheRefusalIsTheOrdinaryReadOnlyPropertyTypeError(string shape)
+    {
+        var (host, _) = CreateReadOnlyShape(shape);
+        var engine = CreateEngine(host);
+
+        var message = engine.Evaluate("(function () { try { host.push(4); return ''; } catch (e) { return e.message; } })()").AsString();
+
+        message.Should().Contain("read only property '3'");
+    }
+
+    [Fact]
+    public void AGrowableListStillGrows()
+    {
+        // the control: nothing above may be bought by refusing writes that were always legitimate
+        var items = new List<int> { 1, 2, 3 };
+        var engine = CreateEngine(items);
+
+        engine.Execute("host.push(4); host[0] = 9; host.length = 6;");
+
+        items.Should().Equal(9, 2, 3, 4, 0, 0);
+    }
+
+    /// <summary>
+    /// <see cref="ArraySegment{T}"/> reports <see cref="ICollection{T}.IsReadOnly"/> as
+    /// <see langword="true"/> to mean it cannot grow, the same lie <c>T[]</c> tells through the same
+    /// interface, so it must be treated as fixed-size and keep its element writes.
+    /// </summary>
+    [Fact]
+    public void AnArraySegmentIsFixedSizeRatherThanReadOnly()
+    {
+        var array = new[] { 1, 2, 3 };
+        var engine = CreateEngine(new ArraySegment<int>(array));
+
+        engine.Evaluate(Probe("host.push(4)", strict: false)).AsString().Should().Be("TypeError");
+        engine.Evaluate(Probe("host[0] = 9", strict: false)).AsString().Should().Be("no-throw");
+
+        array.Should().Equal(9, 2, 3);
+    }
+
+    private static string Probe(string operation, bool strict)
+    {
+        var prologue = strict ? "'use strict';\n" : "";
+        return prologue
+            + "(function () { try { " + operation + "; return 'no-throw'; } "
+            + "catch (e) { return e instanceof TypeError ? 'TypeError' : 'unexpected: ' + e; } })()";
+    }
+
+    /// <summary>
+    /// A host list that declares itself read-only through <see cref="ICollection{T}.IsReadOnly"/> and
+    /// throws from every mutator, which is what the interface's contract asks of an implementer.
+    /// </summary>
+    private sealed class HostReadOnlyList : IList<int>
+    {
+        private readonly List<int> _items;
+
+        public HostReadOnlyList(List<int> items) => _items = items;
+
+        public int Count => _items.Count;
+
+        public bool IsReadOnly => true;
+
+        public int this[int index]
+        {
+            get => _items[index];
+            set => throw new NotSupportedException("Collection is read-only.");
+        }
+
+        public void Add(int item) => throw new NotSupportedException("Collection is read-only.");
+
+        public void Clear() => throw new NotSupportedException("Collection is read-only.");
+
+        public bool Contains(int item) => _items.Contains(item);
+
+        public void CopyTo(int[] array, int arrayIndex) => _items.CopyTo(array, arrayIndex);
+
+        public IEnumerator<int> GetEnumerator() => _items.GetEnumerator();
+
+        public int IndexOf(int item) => _items.IndexOf(item);
+
+        public void Insert(int index, int item) => throw new NotSupportedException("Collection is read-only.");
+
+        public bool Remove(int item) => throw new NotSupportedException("Collection is read-only.");
+
+        public void RemoveAt(int index) => throw new NotSupportedException("Collection is read-only.");
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    /// <summary>
+    /// The other half of the read-only surface: a type that offers no write at all, so the wrapper's
+    /// refusal cannot come from the target and has to come from the engine.
+    /// </summary>
+    private sealed class HostReadOnlySequence : IReadOnlyList<int>
+    {
+        private readonly List<int> _items;
+
+        public HostReadOnlySequence(List<int> items) => _items = items;
+
+        public int Count => _items.Count;
+
+        public int this[int index] => _items[index];
+
+        public IEnumerator<int> GetEnumerator() => _items.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -1032,10 +1032,12 @@ public partial class InteropTests : IDisposable
     [Fact]
     public void ReadOnlyCollectionWrapper_RejectsIndexWriteCleanly()
     {
-        // A runtime read-only IList<T> (e.g. List<T>.AsReadOnly()) is wrapped as a writable
-        // GenericListWrapper, but its backing indexer throws. The element write must be rejected
-        // through the normal [[Set]] path (TypeError in strict, silent no-op in non-strict), NOT
-        // surface a raw NotSupportedException from the underlying collection.
+        // A runtime read-only IList<T> (e.g. List<T>.AsReadOnly()) reaches GenericListWrapper, whose
+        // backing indexer throws. The element write must be rejected through the normal [[Set]] path
+        // (TypeError in strict, silent no-op in non-strict), NOT surface a raw NotSupportedException
+        // from the underlying collection. What refuses it is now the wrapper's own
+        // ICollection<T>.IsReadOnly rather than the get-only indexer the reflected write happened to
+        // find, which is why the length-changing generics stopped leaking too (#3382).
         var readOnly = new List<int> { 1, 2 }.AsReadOnly();
 
         var strict = new Engine(x => x.Strict());

--- a/Jint/Native/Array/ArrayOperations.cs
+++ b/Jint/Native/Array/ArrayOperations.cs
@@ -808,7 +808,19 @@ internal abstract class ArrayOperations : IEnumerable<JsValue>
 
         public override void Set(ulong index, JsValue value, bool updateLength = false, bool throwOnError = true)
         {
-            _target.SetAt((int) index, value);
+            // CanWrite, not Options.Interop.AllowWrite: a wrapper over a target that declared itself
+            // read-only refuses the write, and the refusal it owes an Array.prototype generic is the
+            // TypeError Set(O, k, v, true) raises on a false [[Set]] - which is what routing through the
+            // wrapper produces, where SetAt would reach the collection and let its NotSupportedException
+            // past script (#3382).
+            if (_target.CanWrite)
+            {
+                _target.SetAt((int) index, value);
+            }
+            else
+            {
+                _target.Set(JsNumber.Create(index), value, throwOnError);
+            }
         }
 
         public override void DeletePropertyOrThrow(ulong index)

--- a/Jint/Runtime/Interop/ObjectWrapper.Specialized.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.Specialized.cs
@@ -166,7 +166,7 @@ internal abstract class ArrayLikeWrapper : ObjectWrapper
 
     public sealed override bool Delete(JsValue property)
     {
-        if (!_engine.Options.Interop.AllowWrite)
+        if (!CanWrite)
         {
             return false;
         }
@@ -325,15 +325,16 @@ internal abstract class ArrayLikeWrapper : ObjectWrapper
 
         if (ReferenceEquals(receiver, this) && property.IsNumber())
         {
-            // An in-range element write to a read-only or non-extensible (frozen) wrapper must be refused:
+            // An element write to a read-only or non-extensible (frozen) wrapper must be refused:
             // base.SetSlow would otherwise materialize a throwaway descriptor and return true, silently
-            // "succeeding" (#2541). Everything else — writable in-range writes, growth, out-of-range,
-            // negative and non-integral indices — defers to base.Set, which writes through and already
-            // rejects runtime read-only collections (e.g. ReadOnlyCollection<T>) cleanly. Wrappers don't
-            // track per-element writability, so a non-extensible wrapper blocks existing-element writes too
-            // — a deliberate, contained interop divergence from the spec.
+            // "succeeding" (#2541), or reach the reflected indexer with an out-of-range growth write and
+            // let the collection's own NotSupportedException past script (#3382). Everything else —
+            // writable in-range writes, growth, negative and non-integral indices — defers to base.Set,
+            // which writes through and already rejects a get-only indexer (e.g. ReadOnlyCollection<T>)
+            // cleanly. Wrappers don't track per-element writability, so a non-extensible wrapper blocks
+            // existing-element writes too — a deliberate, contained interop divergence from the spec.
             var numValue = ((JsNumber) property)._value;
-            if (TypeConverter.IsIntegralNumber(numValue) && numValue >= 0 && numValue < Length
+            if (TypeConverter.IsIntegralNumber(numValue) && numValue >= 0
                 && (!CanWrite || !Extensible))
             {
                 return false;
@@ -364,7 +365,14 @@ internal abstract class ArrayLikeWrapper : ObjectWrapper
         return base.Set(property, value, receiver);
     }
 
-    protected virtual bool CanWrite => _engine.Options.Interop.AllowWrite;
+    /// <summary>
+    /// Whether an element of this view may be written at all: the engine must be configured for writes
+    /// and the target must not have declared itself read-only. Consulted by <see cref="Set"/>,
+    /// <see cref="Delete"/> and by <c>ArrayOperations</c>' array-like lane, so that a refusal is the
+    /// ordinary <c>[[Set]]</c>/<c>[[Delete]]</c> <see langword="false"/> — a <c>TypeError</c> in strict
+    /// mode, silent in sloppy — rather than a CLR exception from the collection.
+    /// </summary>
+    internal bool CanWrite => _engine.Options.Interop.AllowWrite && !IsReadOnly;
 
     /// <summary>
     /// Whether the underlying collection cannot change its length (CLR arrays). Enables the direct
@@ -372,9 +380,52 @@ internal abstract class ArrayLikeWrapper : ObjectWrapper
     /// </summary>
     protected virtual bool IsFixedSize => false;
 
+    /// <summary>
+    /// Whether the underlying collection refuses every mutation, elements included — what
+    /// <see cref="ICollection{T}.IsReadOnly"/> and <see cref="IList.IsReadOnly"/> declare. Strictly
+    /// stronger than <see cref="IsFixedSize"/>, which forbids only the length change.
+    /// </summary>
+    protected virtual bool IsReadOnly => false;
+
+    /// <summary>
+    /// The refusal every length-changing operation on a fixed-size target owes script: a
+    /// <c>TypeError</c> it can catch, never the CLR <see cref="NotSupportedException"/> the underlying
+    /// collection would raise.
+    /// </summary>
+    [DoesNotReturn]
+    protected void ThrowFixedSize() => Throw.TypeError(_engine.Realm, "Cannot resize a fixed-size CLR array");
+
+    /// <summary>
+    /// The backstop for a read-only target, and deliberately unreachable: <see cref="CanWrite"/> is false
+    /// for one, so every lane refuses before a mutator is called and script gets the ordinary
+    /// <c>[[Set]]</c>/<c>[[Delete]]</c> refusal a frozen JavaScript array gives. It exists so that a lane
+    /// added later cannot reach <c>Add</c>/<c>RemoveAt</c> and leak the collection's own
+    /// <see cref="NotSupportedException"/> past script the way three of them did until #3382.
+    /// </summary>
+    [DoesNotReturn]
+    protected void ThrowReadOnly() => Throw.TypeError(_engine.Realm, "Cannot modify a read-only CLR collection");
+
+    /// <summary>
+    /// Guard at the head of every length-changing operation of a wrapper that takes its two facts from
+    /// the target rather than from its type argument. Read-only is answered first because it is the
+    /// stronger claim: a collection can be both (<c>ArrayList.ReadOnly</c>), and only one message is right.
+    /// </summary>
+    protected void ThrowIfLengthCannotChange()
+    {
+        if (IsReadOnly)
+        {
+            ThrowReadOnly();
+        }
+
+        if (IsFixedSize)
+        {
+            ThrowFixedSize();
+        }
+    }
+
     public void SetAt(int index, JsValue value)
     {
-        if (_engine.Options.Interop.AllowWrite)
+        if (CanWrite)
         {
             EnsureCapacity(index + 1);
             DoSetAt(index, ConvertToItemType(value));
@@ -421,12 +472,22 @@ internal abstract class ArrayLikeWrapper : ObjectWrapper
 internal sealed class ListWrapper : ArrayLikeWrapper
 {
     private readonly IList? _list;
+    private readonly bool _readOnly;
 
     internal ListWrapper(Engine engine, IList target, Type type)
         : base(engine, target, typeof(object), type, elementAccessMayRunHostCode: target is not (Array or ArrayList))
     {
         _list = target;
+        _readOnly = target.IsReadOnly;
     }
+
+    /// <summary>
+    /// Read from the target, because the non-generic <see cref="IList"/> is the only place that says so:
+    /// <c>ArrayList.ReadOnly</c> and an embedder's own read-only <see cref="IList"/> raise
+    /// <see cref="NotSupportedException"/> from <c>Add</c>/<c>RemoveAt</c> and from the indexer setter,
+    /// which script cannot catch (#3382).
+    /// </summary>
+    protected override bool IsReadOnly => _readOnly;
 
     public override int Length => _list?.Count ?? 0;
 
@@ -448,22 +509,58 @@ internal sealed class ListWrapper : ArrayLikeWrapper
         }
     }
 
-    public override void AddDefault() => _list?.Add(null);
+    public override void AddDefault()
+    {
+        ThrowIfLengthCannotChange();
+        _list?.Add(null);
+    }
 
-    public override void Add(JsValue value) => _list?.Add(ConvertToItemType(value));
+    public override void Add(JsValue value)
+    {
+        ThrowIfLengthCannotChange();
+        _list?.Add(ConvertToItemType(value));
+    }
 
-    public override void RemoveAt(int index) => _list?.RemoveAt(index);
+    public override void RemoveAt(int index)
+    {
+        ThrowIfLengthCannotChange();
+        _list?.RemoveAt(index);
+    }
 }
 
 internal class GenericListWrapper<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicFields)] T> : ArrayLikeWrapper
 {
     private readonly IList<T> _list;
+    private readonly bool _fixedSize;
+    private readonly bool _readOnly;
 
     public GenericListWrapper(Engine engine, IList<T> target, Type? type)
         : base(engine, target, typeof(T), type, elementAccessMayRunHostCode: target is not (T[] or List<T>))
     {
         _list = target;
+        _fixedSize = IsFixedSizeArray(target);
+        _readOnly = !_fixedSize && target.IsReadOnly;
     }
+
+    /// <summary>
+    /// The two shapes whose <see cref="ICollection{T}.IsReadOnly"/> means <em>cannot grow</em> rather
+    /// than <em>cannot be written</em>, which is the one place the generic interface's single flag
+    /// disagrees with the non-generic <see cref="IList"/>'s two. Both accept element writes and refuse
+    /// every length change, so they are fixed-size here and not read-only. A <c>T[]</c> reaches this
+    /// wrapper when the exposed type is a declared <see cref="IList{T}"/> rather than the array type,
+    /// which <see cref="ObjectWrapper.Create(Engine, object, Type?)"/> and <c>clrHelper</c> both allow.
+    /// </summary>
+    private static bool IsFixedSizeArray(IList<T> target) => target is T[] or ArraySegment<T>;
+
+    protected override bool IsFixedSize => _fixedSize;
+
+    /// <summary>
+    /// Taken from the target's own <see cref="ICollection{T}.IsReadOnly"/>: a
+    /// <c>ReadOnlyCollection&lt;T&gt;</c>, an immutable collection and a host list that declares itself
+    /// read-only all raise <see cref="NotSupportedException"/> from <c>Add</c>/<c>RemoveAt</c> and from
+    /// the indexer setter, which script cannot catch (#3382).
+    /// </summary>
+    protected override bool IsReadOnly => _readOnly;
 
     public override int Length => _list.Count;
 
@@ -491,15 +588,34 @@ internal class GenericListWrapper<[DynamicallyAccessedMembers(DynamicallyAccesse
 
     protected override void DoSetAt(int index, object? value) => _list[index] = (T) value!;
 
-    public override void AddDefault() => _list.Add(default!);
+    public override void AddDefault()
+    {
+        ThrowIfLengthCannotChange();
+        _list.Add(default!);
+    }
 
     public override void Add(JsValue value)
     {
+        ThrowIfLengthCannotChange();
         var converted = ConvertToItemType(value);
         _list.Add((T) converted!);
     }
 
-    public override void RemoveAt(int index) => _list.RemoveAt(index);
+    public override void RemoveAt(int index)
+    {
+        ThrowIfLengthCannotChange();
+        _list.RemoveAt(index);
+    }
+
+    public override void EnsureCapacity(int capacity)
+    {
+        if (capacity > Length)
+        {
+            ThrowIfLengthCannotChange();
+        }
+
+        base.EnsureCapacity(capacity);
+    }
 }
 
 /// <summary>
@@ -571,9 +687,6 @@ internal sealed class ArrayWrapper<[DynamicallyAccessedMembers(DynamicallyAccess
             ThrowFixedSize();
         }
     }
-
-    [DoesNotReturn]
-    private void ThrowFixedSize() => Throw.TypeError(_engine.Realm, "Cannot resize a fixed-size CLR array");
 }
 
 internal sealed class ReadOnlyListWrapper<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicFields)] T> : ArrayLikeWrapper
@@ -610,15 +723,20 @@ internal sealed class ReadOnlyListWrapper<[DynamicallyAccessedMembers(Dynamicall
         return Undefined;
     }
 
-    protected override bool CanWrite => false;
+    /// <summary>
+    /// An <see cref="IReadOnlyList{T}"/> exposes no write of any kind, so this view is read-only in the
+    /// full sense. It replaces the <c>CanWrite</c> override this class used to carry, which said the same
+    /// thing about element writes alone and left <c>Array.prototype</c>'s length-changing generics
+    /// reaching the mutators below — where they raised the CLR's own
+    /// <see cref="NotSupportedException"/> past script (#3382).
+    /// </summary>
+    protected override bool IsReadOnly => true;
 
-    public override void AddDefault() => Throw.NotSupportedException();
+    public override void AddDefault() => ThrowReadOnly();
 
-    protected override void DoSetAt(int index, object? value) => Throw.NotSupportedException();
+    protected override void DoSetAt(int index, object? value) => ThrowReadOnly();
 
-    public override void Add(JsValue value) => Throw.NotSupportedException();
+    public override void Add(JsValue value) => ThrowReadOnly();
 
-    public override void RemoveAt(int index) => Throw.NotSupportedException();
-
-    public override void EnsureCapacity(int capacity) => Throw.NotSupportedException();
+    public override void RemoveAt(int index) => ThrowReadOnly();
 }


### PR DESCRIPTION
Backport of #3385 (`10b0955dc` on `main`), which fixes #3382.

## The observable change, stated plainly

**This changes the exception type an embedder sees.** Script that asks a read-only host collection to
change used to raise the CLR's `System.NotSupportedException` out of `Engine.Evaluate`; it now raises a
`TypeError` — in strict mode, or silently refuses in sloppy mode, depending on the operation. An embedder
whose code reads

```csharp
try { engine.Evaluate(script); }
catch (NotSupportedException) { /* the script tried to write my read-only list */ }
```

will no longer see that exception, and one that has a bare `catch (JavaScriptException)` will start seeing
a refusal it never saw before. A `catch (Exception)` is unaffected.

It qualifies as a correctness fix rather than a feature all the same, for two reasons that are worth
separating. It is **spec-required**: `push`, `pop`, `splice`, `sort` and `reverse` are specified in terms
of `Set(O, k, v, true)` and `DeletePropertyOrThrow`, which raise a `TypeError` on a false `[[Set]]`, and a
bare assignment is an ordinary `[[Set]]` returning `false`. And the exception it replaces was **not
catchable from script at all** — neither a script `try`/`catch` nor a host `catch (JavaScriptException)`
could see it — so the behaviour being changed is one no script could handle and one whose only host-side
handler was a `catch` on a CLR type the engine never promised to raise. The maintainer should judge that
trade; it is the only behavioural change in the PR.

## Before, on unmodified `4.x`

`Jint.Tests.PublicInterface/HostReadOnlyCollectionTests.cs` was added to this branch on its own, with no
engine change, and run on both target frameworks. Six read-only shapes × ten operations × both modes, plus
the growable control, the message, and the `ArraySegment<T>` reclassification:

| Target framework | Failed | Passed | Total |
| --- | --- | --- | --- |
| `net10.0` | **52** | 16 | 68 |
| `net472` | **52** | 16 | 68 |

Every one of the 52 is a `System.NotSupportedException` escaping `Engine.Evaluate` — there is not a single
other failure shape in the list. Two representative ones:

```
Failed …AnArrayGenericThatMustGrowAReadOnlyCollectionThrowsACatchableTypeError(shape: "ReadOnlyCollection", operation: "host.push(4)")
 System.NotSupportedException : Collection is read-only.
   at Jint.Runtime.Interop.ArrayLikeWrapper.SetAt(Int32 index, JsValue value)
   at Jint.Native.Array.ArrayPrototype.Push(JsValue thisObject, ReadOnlySpan`1 arguments)
   …
   at Jint.Engine.Evaluate(String code, String source)

Failed …TheRefusalIsTheOrdinaryReadOnlyPropertyTypeError(shape: "ImmutableList")
 System.NotSupportedException : Specified method is not supported.
   at Jint.Runtime.Throw.NotSupportedException(String message)
   at Jint.Runtime.Interop.ArrayLikeWrapper.SetAt(Int32 index, JsValue value)
```

The 16 that pass are the assignments `ReadOnlyCollection<T>`'s get-only indexer already refused by
accident, and the `IReadOnlyList<T>` length writes `CanWrite => false` already refused.

`main` measured 49/19 on the same file. The three extra failures here are `ArrayList.ReadOnly`'s length
writes and `delete`, which on `main` are refused by #3381's `ListWrapper.IsFixedSize` — a PR that is not on
this branch and is not needed for this one.

## After

| Target framework | Failed | Passed | Total |
| --- | --- | --- | --- |
| `net10.0` | 0 | **68** | 68 |
| `net472` | 0 | **68** | 68 |

The `TypeError` an embedder actually reads is the ordinary one — *Cannot assign to read only property '3'
of object '#&lt;Object&gt;'* — because the refusal now happens in `[[Set]]`, before the collection is
reached at all. Nothing invents an interop-specific message.

## What changed

One fact taken from the target, and three call sites:

* `ArrayLikeWrapper` gains `IsReadOnly`; `CanWrite` becomes `AllowWrite && !IsReadOnly` and stops being
  virtual. `ReadOnlyListWrapper<T>`'s `CanWrite => false` override becomes `IsReadOnly => true`, which is
  the same statement about element writes plus the one it was missing about the length.
* `ListWrapper` reads `IList.IsReadOnly`; `GenericListWrapper<T>` reads `ICollection<T>.IsReadOnly`.
* The three lanes that consulted `Options.Interop.AllowWrite` **directly** rather than through `CanWrite`
  now consult `CanWrite`: `ArrayLikeWrapper.Delete`, `ArrayLikeWrapper.SetAt`, and `ArrayOperations`'
  `ArrayLikeOperations.Set`. Those three are precisely what made the mutators reachable for a read-only
  target.
* Because of that the mutators are now **unreachable** for a read-only wrapper. Their bodies still refuse —
  `ThrowReadOnly()` instead of `Throw.NotSupportedException()` — as a documented backstop, so a lane added
  later cannot re-open the same hole.

### The one carve-out

`ICollection<T>.IsReadOnly` cannot be taken at face value. `System.Array` and `ArraySegment<T>` both report
`true` through it to mean *cannot grow*, and both accept element writes — the non-generic `IList` asks
`IsReadOnly` and `IsFixedSize` separately and the generic interface collapsed them into one flag.
`GenericListWrapper<T>` therefore treats a `T[]` or an `ArraySegment<T>` target as **fixed-size** and
everything else's declaration as the truth. That reclassifies `ArraySegment<T>`, which is the point rather
than a side effect: it leaked `NotSupportedException` from `push`/`pop`/`splice`/a `length` write and
`ArgumentOutOfRangeException` from a write past the end, and now answers exactly as an `int[]` live view
does while keeping `host[0] = 9`.

## Two adaptations this branch needed, and one thing left out

`4.x`'s interop has diverged from `main`, so two hunks are not literal copies:

1. **`ThrowFixedSize` moves up** from `ArrayWrapper<T>` (where it was `private`) to `ArrayLikeWrapper` (as
   `protected`), unchanged in message and behaviour, because the shared `ThrowIfLengthCannotChange` guard
   needs it. On `main` #3381 had already hoisted it.
2. **The integral-index refusal in `ArrayLikeWrapper.Set` drops its `numValue < Length` bound**, which is
   how the line already reads on `main` — it lost the bound in #3054 (*Disable projected CLR writes by
   default*), a v5 change that is not on this branch. Without that removal a read-only target's *growth*
   write — which is exactly what `push` is — still fell through to the reflected indexer, so
   `push`/`host[3] = 9` continued to leak `NotSupportedException` for the two shapes whose indexer setter
   throws rather than being get-only: a host `IList<T>` that declares `IsReadOnly`, and
   `ArrayList.ReadOnly`. Measured: with the rest of the port in place and this bound still present, 6 of
   the 68 cases still failed, all six with `System.NotSupportedException : Collection is read-only.`
   Removing it changes nothing else on this branch, because `ObjectWrapper.Set` already refuses when
   `Interop.AllowWrite` is off (`!accessor.Writable || !AllowWrite`) and when the wrapper is not extensible.

Deliberately **not** folded in: anything from the host-collection index cluster (#3356, #3416, #3464,
#3472, #3480, #3425). None of it is required here — the one line above predates #3416 and comes from #3054
instead — and it is being evaluated separately as a unit. #3381 is not needed either.

Also unchanged, exactly as on `main`: a growable `List<int>` still refuses `list[3] = 9` with a raw
`ArgumentOutOfRangeException` while `list.length = 5` grows it. Same defect class, different cause, out of
scope.

## Verification

* `dotnet build -c Release` — 0 errors. The one MSBuild warning (MSB3277, a package assembly-version
  conflict in `Jint.Tests.CommonScripts`' `net472` leg) is pre-existing and unrelated.
* `Jint.Tests` — 6,958 passed on `net10.0`, 6,873 on `net472`, 0 failed.
* `Jint.Tests.PublicInterface` — 1,570 passed on `net10.0`, 1,563 on `net472`, 0 failed. The public API
  baselines did not move: `CanWrite`, `IsReadOnly` and the two refusals are all members of `internal` types.
* `Jint.Tests.CommonScripts` — 28 passed on each of `net10.0` and `net472`, 0 failed.
* `Jint.Tests.SourceGenerators` — 52 passed, 0 failed.
* Both suites again with `JINT_HOST_CONTRACT_VERIFICATION=1` — 0 failed on both target frameworks.
* `Jint.Tests.Test262` — 102,499 passed, 0 failed, 185 skipped of 102,684, matching this branch's control
  exactly. The full run lost `intl402/supportedLocalesOf-unicode-extensions-ignored.js` in both modes to
  load on this shared machine (31 s each, against a 30 s engine default); the two pass in 2 s in isolation.
* No benchmark: the read path (`Get`/`GetJsValueAt`) is untouched, and the write path trades one virtual
  `CanWrite` call for one virtual `IsReadOnly` call. Wrapping a host `IList`/`IList<T>` now reads one extra
  interface property once, at construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014W5mbjGhyvgAS4pivXoc4S
