### PR TITLE
ShadowRealm: a value the host registers, and the members its wrapper builds eagerly, belong to that realm

### DIFF
--- a/Jint.Tests.PublicInterface/ShadowRealmValueRealmTests.cs
+++ b/Jint.Tests.PublicInterface/ShadowRealmValueRealmTests.cs
@@ -1,0 +1,255 @@
+#nullable enable
+
+using Jint.Native;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// A value a host registers on a shadow realm's global object has to belong to <em>that</em> realm: script
+/// running inside the realm must see an ordinary object or function of the intrinsics it can reach.
+/// </summary>
+/// <remarks>
+/// The dual of <c>CrossRealmAttributionTests</c>, which pins the same rule for what a built-in produces. A
+/// wrapper built while the principal realm was running and then installed on a shadow realm's global carried
+/// the principal realm's <c>Object.prototype</c>, so <c>instanceof Object</c> inside the realm answered
+/// <see langword="false"/> for a value the host had just handed it — and a realm is exactly a distinct set of
+/// intrinsics.
+/// </remarks>
+public class ShadowRealmValueRealmTests
+{
+    public sealed class Company
+    {
+        public Company(string name) => Name = name;
+
+        public string Name { get; }
+
+        public string Shout() => Name.ToUpperInvariant();
+    }
+
+    [Fact]
+    public void ATypedHostObjectBelongsToTheRealmItIsRegisteredOn()
+    {
+        var engine = new Engine();
+        var shadowRealm = engine.Intrinsics.ShadowRealm.Construct();
+
+        shadowRealm.SetValue("company", new Company("acme"));
+
+        shadowRealm.Evaluate("company instanceof Object").Should().BeTrue();
+        shadowRealm.Evaluate("Object.getPrototypeOf(company) === Object.prototype").Should().BeTrue();
+    }
+
+    [Fact]
+    public void AnUntypedHostObjectBelongsToTheRealmItIsRegisteredOn()
+    {
+        var engine = new Engine();
+        var shadowRealm = engine.Intrinsics.ShadowRealm.Construct();
+
+        object company = new Company("acme");
+        shadowRealm.SetValue("company", company);
+
+        shadowRealm.Evaluate("company instanceof Object").Should().BeTrue();
+        shadowRealm.Evaluate("Object.getPrototypeOf(company) === Object.prototype").Should().BeTrue();
+    }
+
+    [Fact]
+    public void ADelegateBelongsToTheRealmItIsRegisteredOn()
+    {
+        var engine = new Engine();
+        var shadowRealm = engine.Intrinsics.ShadowRealm.Construct();
+
+        shadowRealm.SetValue("shout", new Func<string, string>(s => s.ToUpperInvariant()));
+
+        shadowRealm.Evaluate("shout instanceof Function").Should().BeTrue();
+        shadowRealm.Evaluate("Object.getPrototypeOf(shout) === Function.prototype").Should().BeTrue();
+        shadowRealm.Evaluate("shout('acme')").Should().Be("ACME");
+    }
+
+    [Fact]
+    public void ATypeReferenceBelongsToTheRealmItIsRegisteredOn()
+    {
+        var engine = new Engine();
+        var shadowRealm = engine.Intrinsics.ShadowRealm.Construct();
+
+        shadowRealm.SetValue("Company", typeof(Company));
+
+        // a type reference has a prototype object of its own, which is where the realm's chain is joined
+        shadowRealm.Evaluate("Object.getPrototypeOf(Object.getPrototypeOf(Company)) === Object.prototype").Should().BeTrue();
+        shadowRealm.Evaluate("new Company('acme') instanceof Object").Should().BeTrue();
+    }
+
+    [Fact]
+    public void AProjectedArrayBelongsToTheRealmItIsRegisteredOn()
+    {
+        var engine = new Engine();
+        var shadowRealm = engine.Intrinsics.ShadowRealm.Construct();
+
+        shadowRealm.SetValue("names", new[] { "acme", "initech" });
+
+        shadowRealm.Evaluate("names instanceof Array").Should().BeTrue();
+        shadowRealm.Evaluate("Object.getPrototypeOf(names) === Array.prototype").Should().BeTrue();
+    }
+
+    /// <summary>
+    /// The other half of the same rule: registering on a shadow realm must not make the engine's own
+    /// registrations answer to a realm the script cannot reach.
+    /// </summary>
+    [Fact]
+    public void TheEnginesOwnRegistrationsStillBelongToThePrincipalRealm()
+    {
+        var engine = new Engine();
+        var shadowRealm = engine.Intrinsics.ShadowRealm.Construct();
+
+        shadowRealm.SetValue("company", new Company("acme"));
+        engine.SetValue("company", new Company("initech"));
+
+        engine.Evaluate("company instanceof Object").Should().BeTrue();
+        engine.Evaluate("Object.getPrototypeOf(company) === Object.prototype").Should().BeTrue();
+        engine.Evaluate("company.Name").Should().Be("initech");
+        shadowRealm.Evaluate("company.Name").Should().Be("acme");
+    }
+
+    /// <summary>
+    /// The negative half, stated directly: the wrapper must not answer to the principal realm's
+    /// <c>Object</c>. The probe is the principal constructor itself, handed in through the one overload that
+    /// installs a value untouched, so the comparison happens inside the realm against the very intrinsic the
+    /// wrapper used to inherit from.
+    /// </summary>
+    [Fact]
+    public void AHostObjectIsNotAnInstanceOfThePrincipalRealmsObject()
+    {
+        var engine = new Engine();
+        var shadowRealm = engine.Intrinsics.ShadowRealm.Construct();
+
+        shadowRealm.SetValue("PrincipalObject", (JsValue) engine.Intrinsics.Object);
+        shadowRealm.SetValue("company", new Company("acme"));
+
+        shadowRealm.Evaluate("company instanceof PrincipalObject").Should().BeFalse();
+        shadowRealm.Evaluate("company instanceof Object").Should().BeTrue();
+    }
+
+    /// <summary>
+    /// The three members <see cref="Jint.Runtime.Interop.ObjectWrapper"/> builds eagerly in its constructor
+    /// — <c>Symbol.dispose</c>, <c>Symbol.asyncDispose</c> and <c>toJSON</c> — are functions like any other
+    /// and belong to the realm the object they hang off belongs to.
+    /// </summary>
+    /// <remarks>
+    /// They used to be built through the public <c>ClrFunction(Engine, string, …)</c> constructor, which pins
+    /// the engine's <em>original</em> intrinsics. That is right for a function a host wires up against an
+    /// engine (#2893, <c>HostClrFunctionRealmTests</c>) and wrong for one the engine builds for an object it
+    /// is creating, because the object's own prototype comes from the running realm. The two disagreed on the
+    /// same object: <c>handle.Dispose instanceof Function</c> was true while
+    /// <c>handle[Symbol.dispose] instanceof Function</c> was false (#3365).
+    /// </remarks>
+    [Fact]
+    public void TheDisposeMemberOfAHostObjectBelongsToTheRealmItIsRegisteredOn()
+    {
+        var engine = new Engine();
+        var shadowRealm = engine.Intrinsics.ShadowRealm.Construct();
+
+        shadowRealm.SetValue("handle", new Handle());
+
+        // the lazily resolved member, which reads engine.Realm when it is materialized and was always right
+        shadowRealm.Evaluate("handle.Dispose instanceof Function").Should().BeTrue();
+
+        shadowRealm.Evaluate("typeof handle[Symbol.dispose]").Should().Be("function");
+        shadowRealm.Evaluate("handle[Symbol.dispose] instanceof Function").Should().BeTrue();
+        shadowRealm.Evaluate("Object.getPrototypeOf(handle[Symbol.dispose]) === Function.prototype").Should().BeTrue();
+    }
+
+#if !NETFRAMEWORK
+    [Fact]
+    public void TheAsyncDisposeMemberOfAHostObjectBelongsToTheRealmItIsRegisteredOn()
+    {
+        var engine = new Engine();
+        var shadowRealm = engine.Intrinsics.ShadowRealm.Construct();
+
+        shadowRealm.SetValue("handle", new AsyncHandle());
+
+        shadowRealm.Evaluate("handle[Symbol.asyncDispose] instanceof Function").Should().BeTrue();
+        shadowRealm.Evaluate("Object.getPrototypeOf(handle[Symbol.asyncDispose]) === Function.prototype").Should().BeTrue();
+    }
+#endif
+
+    [Fact]
+    public void TheToJsonMemberOfAHostObjectBelongsToTheRealmItIsRegisteredOn()
+    {
+        var engine = new Engine();
+        var shadowRealm = engine.Intrinsics.ShadowRealm.Construct();
+
+        shadowRealm.SetValue("payload", new Payload());
+
+        shadowRealm.Evaluate("payload.toJSON instanceof Function").Should().BeTrue();
+        shadowRealm.Evaluate("Object.getPrototypeOf(payload.toJSON) === Function.prototype").Should().BeTrue();
+        shadowRealm.Evaluate("JSON.stringify(payload)").Should().Be("\"acme\"");
+    }
+
+    /// <summary>
+    /// The negative half, stated against the very intrinsic the members used to inherit from.
+    /// </summary>
+    [Fact]
+    public void AnEagerlyBuiltMemberIsNotAFunctionOfThePrincipalRealm()
+    {
+        var engine = new Engine();
+        var shadowRealm = engine.Intrinsics.ShadowRealm.Construct();
+
+        shadowRealm.SetValue("PrincipalFunction", (JsValue) engine.Intrinsics.Function);
+        shadowRealm.SetValue("handle", new Handle());
+
+        shadowRealm.Evaluate("handle[Symbol.dispose] instanceof PrincipalFunction").Should().BeFalse();
+        shadowRealm.Evaluate("handle[Symbol.dispose] instanceof Function").Should().BeTrue();
+    }
+
+    /// <summary>
+    /// The other half of the rule, and why the answer is "the realm the wrapper was created in" rather than a
+    /// realm stored on the wrapper: an object the host registers on the engine keeps the principal realm's
+    /// intrinsics, exactly as its own prototype does.
+    /// </summary>
+    [Fact]
+    public void TheEagerlyBuiltMembersOfAnEngineRegistrationStayInThePrincipalRealm()
+    {
+        var engine = new Engine();
+        engine.Intrinsics.ShadowRealm.Construct();
+
+        engine.SetValue("handle", new Handle());
+
+        engine.Evaluate("handle[Symbol.dispose] instanceof Function").Should().BeTrue();
+        engine.Evaluate("Object.getPrototypeOf(handle[Symbol.dispose]) === Function.prototype").Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Disposal kept working throughout, because a call never consults the prototype — which is why the
+    /// defect was invisible to everything except a feature detection or a reach for <c>call</c>/<c>bind</c>.
+    /// </summary>
+    [Fact]
+    public void ADisposableHostObjectIsStillDisposableInsideTheRealm()
+    {
+        var engine = new Engine();
+        var shadowRealm = engine.Intrinsics.ShadowRealm.Construct();
+
+        var handle = new Handle();
+        shadowRealm.SetValue("handle", handle);
+
+        shadowRealm.Evaluate("handle[Symbol.dispose].call(handle)");
+
+        handle.Disposed.Should().BeTrue();
+    }
+
+    public sealed class Handle : IDisposable
+    {
+        public bool Disposed { get; private set; }
+
+        public void Dispose() => Disposed = true;
+    }
+
+#if !NETFRAMEWORK
+    public sealed class AsyncHandle : IAsyncDisposable
+    {
+        public ValueTask DisposeAsync() => default;
+    }
+#endif
+
+    public sealed class Payload
+    {
+        public string toJSON() => "acme";
+    }
+}

--- a/Jint/Native/ShadowRealm/ShadowRealm.cs
+++ b/Jint/Native/ShadowRealm/ShadowRealm.cs
@@ -58,6 +58,7 @@ public sealed class ShadowRealm : ObjectInstance
     [RequiresUnreferencedCode("User supplied delegate")]
     public ShadowRealm SetValue(string name, Delegate value)
     {
+        using var realmScope = EnterRealm();
         _shadowRealm.GlobalObject.FastSetProperty(name, new PropertyDescriptor(new DelegateWrapper(_engine, value), PropertyFlag.NonEnumerable));
         return this;
     }
@@ -84,17 +85,46 @@ public sealed class ShadowRealm : ObjectInstance
 
     public ShadowRealm SetValue(string name, JsValue value)
     {
+        using var realmScope = EnterRealm();
         _shadowRealm.GlobalObject.Set(name, value);
         return this;
     }
 
     public ShadowRealm SetValue(string name, object obj)
     {
+        using var realmScope = EnterRealm();
+
         var value = obj is Type t
             ? TypeReference.CreateTypeReference(_engine, t)
             : JsValue.FromObject(_engine, obj);
 
         return SetValue(name, value);
+    }
+
+    /// <summary>
+    /// Makes this shadow realm the engine's running realm for the duration of the scope, so a value built
+    /// inside it belongs to this realm rather than to whichever realm the host called from.
+    /// </summary>
+    /// <remarks>
+    /// It is the execution context <see cref="ShadowRealmImportValue"/> already enters, used for the same
+    /// reason: <c>Engine.Realm</c> is the running context's realm, and every interop construction reads it
+    /// to pick a prototype — <see cref="JsValue.FromObject"/> through the <c>ObjectInstance</c> base
+    /// constructor, <see cref="TypeReference.CreateTypeReference(Engine, Type)"/> through
+    /// <c>TypeReferencePrototype</c>, and <c>DelegateWrapper</c> directly. Without it a wrapper installed on
+    /// this realm's global object carried the principal realm's <c>Object.prototype</c>, and
+    /// <c>instanceof Object</c> inside the realm answered false for it (sebastienros/jint#3325).
+    /// The overloads taking a primitive reach it through the <see cref="JsValue"/> one, which takes the
+    /// scope as well: installation happening in the realm being written is one rule rather than two.
+    /// </remarks>
+    private RealmScope EnterRealm()
+    {
+        _engine.EnterExecutionContext(in _executionContext);
+        return new RealmScope(_engine);
+    }
+
+    private readonly struct RealmScope(Engine engine) : IDisposable
+    {
+        public void Dispose() => engine.LeaveExecutionContext();
     }
 
 

--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -80,19 +80,34 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
             }
         }
 
+        // The three members below are the only ones this constructor builds eagerly, and each is a function
+        // of the realm this wrapper is being created in — the same realm ObjectInstance's constructor just
+        // took this object's own prototype from, and the one ArrayLikeWrapper takes Array.prototype from a
+        // few lines above. That is what an ObjectWrapper answers with: not a realm of its own, but whichever
+        // one is running when it is built, which ShadowRealm.SetValue brackets deliberately (#3367).
+        //
+        // The public ClrFunction(Engine, string, …) constructor is the wrong one here, and not by accident:
+        // it pins engine._originalIntrinsics so that a function a *host* wires up against an engine belongs
+        // to the principal realm whatever was constructed since (#2893, HostClrFunctionRealmTests). Used
+        // here it made these three principal-realm functions hanging off a shadow-realm object, so
+        // `handle.Dispose instanceof Function` was true while `handle[Symbol.dispose] instanceof Function`
+        // was false on the same object — every lazily resolved member reads engine.Realm at materialization
+        // and was already right (#3365).
+        var realm = engine.Realm;
+
         if (_typeDescriptor.IsDisposable)
         {
-            SetProperty(GlobalSymbolRegistry.Dispose, new PropertyDescriptor(new ClrFunction(engine, "dispose", static (thisObject, _) =>
+            SetProperty(GlobalSymbolRegistry.Dispose, new PropertyDescriptor(new ClrFunction(engine, realm, "dispose", static (thisObject, _) =>
             {
                 ((thisObject as ObjectWrapper)?.Target as IDisposable)?.Dispose();
                 return Undefined;
-            }), PropertyFlag.NonEnumerable));
+            }, 0), PropertyFlag.NonEnumerable));
         }
 
 #if SUPPORTS_ASYNC_DISPOSE
         if (_typeDescriptor.IsAsyncDisposable)
         {
-            SetProperty(GlobalSymbolRegistry.AsyncDispose, new PropertyDescriptor(new ClrFunction(engine, "asyncDispose", (thisObject, _) =>
+            SetProperty(GlobalSymbolRegistry.AsyncDispose, new PropertyDescriptor(new ClrFunction(engine, realm, "asyncDispose", (thisObject, _) =>
             {
                 var target = ((thisObject as ObjectWrapper)?.Target as IAsyncDisposable)?.DisposeAsync();
                 if (target is not null)
@@ -100,14 +115,14 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
                     return ConvertAwaitableToPromise(engine, target);
                 }
                 return Undefined;
-            }), PropertyFlag.NonEnumerable));
+            }, 0), PropertyFlag.NonEnumerable));
         }
 #endif
 
         if (_typeDescriptor.ToJsonMethod is not null)
         {
             // Wrap the toJSON method in a ClrFunction with the expected signature for JSON.stringify
-            var toJsonFunction = new ClrFunction(engine, "toJSON", (thisObject, arguments) =>
+            var toJsonFunction = new ClrFunction(engine, realm, "toJSON", (thisObject, arguments) =>
             {
                 var wrapper = thisObject as ObjectWrapper;
                 if (wrapper is null)
@@ -126,7 +141,7 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
                     Throw.MeaningfulException(engine, exception);
                     return Undefined;
                 }
-            });
+            }, 0);
 
             // toJSON should be writable, configurable, and non-enumerable to match JavaScript standard
             // (e.g., Date.prototype.toJSON has these same flags)


### PR DESCRIPTION
Backport of [#3367](https://github.com/sebastienros/jint/pull/3367) and [#3427](https://github.com/sebastienros/jint/pull/3427), the two ShadowRealm realm-affinity fixes, adapted to 4.x.

They land as one PR because the second only bites once the first exists. An `ObjectWrapper` takes its realm from whichever one is *running* when it is built, so until `SetValue` enters the shadow realm there is no shadow realm for the eagerly built members to belong to — porting #3427 alone would have been a no-op on 4.x.

## A value the host registers belongs to that realm (#3325)

`ShadowRealm.SetValue` converted its argument against whichever realm the host called from — the principal one — and then installed the result on the *shadow* realm's global object. The prototype came from the wrong realm, so script inside the realm did not recognize the object the host had just handed it:

```csharp
var shadowRealm = engine.Intrinsics.ShadowRealm.Construct();
shadowRealm.SetValue("company", new Company("acme"));

shadowRealm.Evaluate("company instanceof Object");   // false
```

That is the opposite of what a realm is for.

**Realm-scoped construction is entering that realm's execution context, and nothing else.** `Engine.Realm` is `ExecutionContext.Realm`, and every interop construction reads it to pick a prototype: `JsValue.FromObject` through `ObjectInstance`'s base constructor, `TypeReference.CreateTypeReference` through `TypeReferencePrototype`, `DelegateWrapper` outright. `ShadowRealmImportValue` in this very class already does exactly that, so `SetValue` now brackets its registration the same way, through a `RealmScope` that names it.

## The wrapper's eagerly built members agree with it (#3365)

`ObjectWrapper`'s constructor builds three members eagerly — `Symbol.dispose`, `Symbol.asyncDispose` and `toJSON` — through the public `ClrFunction(Engine, string, …)` constructor, which pins `engine._originalIntrinsics`. That pin is deliberate and is what #2893 fixed: a function a **host** wires up against an engine must belong to the realm the surrounding script can reach whatever realm happened to be current when it was built. It is the wrong constructor for a function the *engine* builds for an object it is creating, and the consequence was two answers on one object:

```js
handle.Dispose instanceof Function            // true   — resolved lazily, reads engine.Realm
handle[Symbol.dispose] instanceof Function    // false  — a Function of a realm this script cannot reach
```

`using` and `JSON.stringify` kept working throughout, because a call never consults the prototype. What did not work is anything asking *what the member is*: a feature detection, `Object.getPrototypeOf`, or a reach for `call`/`apply`/`bind`.

The issue asked which realm an `ObjectWrapper` answers with, and noted it has no `_realm` field. It needs none: the question is answered two constructors up, where `ObjectInstance`'s constructor takes `_prototype` from `engine.Realm.Intrinsics` and `ArrayLikeWrapper` takes `Array.prototype` from `engine.Intrinsics` — both the *running* realm. The three members simply have to agree with it, so each now uses the internal `ClrFunction(Engine, Realm, …)` constructor whose own doc comment names this exact case, with `engine.Realm`.

`ClrFunction(Engine, …)`, `HostFunction` and `Constructor(Engine, string)` keep pinning `engine._originalIntrinsics` and are untouched; `HostClrFunctionRealmTests` still passes. The distinction the two constructors draw is the whole rule: *the host's function belongs to the host's realm; the engine's function belongs to the object's.*

## How this differs from main, and what is deliberately not here

**Three overloads take the realm scope on 4.x rather than main's six — the same rule, not a narrower one.** main's `SetValue` had been widened to mirror `Engine.SetValue` (#3321) before #3367 landed on it, so it has `Type`, generic and array overloads that 4.x does not. On 4.x a `Type` and an array both arrive through `SetValue(string, object)`, and the four primitive overloads reach the `JsValue` one — which takes the scope as well, so installation happening in the realm being written stays one rule rather than two. Every path that converts or installs is covered, and the tests are written against the *behaviour*, not the overload list, so they pin the same seven facts.

Consequently main's `GlobalValueRegistration` hunk has no counterpart here — that class does not exist on 4.x, where the overloads convert inline.

**The `ImportValue` half of #3367 is deliberately omitted: its premise is absent on 4.x.** That half added `using var ownership = _engine.EnterHostCall();` so a second thread reaching `Evaluate` during a module load is refused. 4.x has no `EnterHostCall` and no engine-ownership reservation at all — `grep -rn "EnterHostCall" Jint/` returns nothing — so there is nothing to claim, no behaviour to fix, and no `HostEngineConcurrencyTests` to join. Porting the reservation would mean backporting the whole ownership mechanism, which is well past a one-sentence backport.

`docs/v5-migration.md` and `Jint/Runtime/Interop/AGENTS.md` do not exist on 4.x, and `UndocumentedPublicApi.txt` does not either, so those hunks are dropped. No public API signature moves — the constructor being called instead is `internal` and already existed on 4.x.

## Evidence

`Jint.Tests.PublicInterface/ShadowRealmValueRealmTests.cs`, translated to xUnit v3 (`[Test]` → `[Fact]`): one fact per converting overload, one per eagerly built member, both negative halves stated against the principal intrinsic handed into the realm through the `JsValue` overload, the two guards that an engine registration keeps the principal realm, and the control that disposal itself still works. The `Symbol.asyncDispose` pair is `#if !NETFRAMEWORK`, matching Jint's own `SUPPORTS_ASYNC_DISPOSE`.

**Failing first**, on unmodified `4.x` with only the tests added:

| TFM | before | after |
| --- | --- | --- |
| `net10.0` | **Failed: 10**, Passed: 3, Total: 13 | Failed: 0, **Passed: 13** |
| `net472` | **Failed: 9**, Passed: 3, Total: 12 | Failed: 0, **Passed: 12** |

Per fix, on unfixed 4.x:

* **#3367 (`SetValue`)** — 6 failing on both TFMs: the typed and untyped host object, the delegate, the type reference, the projected array, and the negative half. `Expected value to be "true (Boolean)", but found "false (Boolean)"`.
* **#3427 (eager members)** — 4 failing on `net10.0`, 3 on `net472` (`Symbol.asyncDispose` is `net10.0`-only): `Symbol.dispose`, `Symbol.asyncDispose`, `toJSON`, and the negative half `AnEagerlyBuiltMemberIsNotAFunctionOfThePrincipalRealm`, which fails the other way — `Expected value to be "false (Boolean)", but found "true (Boolean)"`.

The 3 that pass on unfixed 4.x are exactly the two guards (`TheEnginesOwnRegistrationsStillBelongToThePrincipalRealm`, `TheEagerlyBuiltMembersOfAnEngineRegistrationStayInThePrincipalRealm`) and the control (`ADisposableHostObjectIsStillDisposableInsideTheRealm`) — which is the point: they state what must *not* change, and it did not.

## Verification

* `dotnet build -c Release` — 0 errors, 0 code warnings.
* `Jint.Tests` — 6,958 passed on `net10.0`, 6,873 on `net472`, 0 failed.
* `Jint.Tests.PublicInterface` — 1,515 passed on `net10.0`, 1,507 on `net472`, 0 failed.
* `Jint.Tests.CommonScripts` — 28 passed on each, 0 failed.
* `Jint.Tests.SourceGenerators` — 52 passed, 0 failed.
* `Jint.Tests.Test262` — **102,499 passed, 0 failed, 185 skipped of 102,684**, matching the 4.x control exactly.

No benchmark: the change is which of two already-resolved prototype references three constructor-time allocations read, plus one execution-context push and pop per host `SetValue` call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014W5mbjGhyvgAS4pivXoc4S
