### PR TITLE
Interop: two engines in one process do not decide each other's conversions and operators (backport of #3521 and #3526)

### DIFF
--- a/Jint.Tests.PublicInterface/HostDelegateConversionTests.cs
+++ b/Jint.Tests.PublicInterface/HostDelegateConversionTests.cs
@@ -1,0 +1,128 @@
+#nullable enable
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// Pins that the CLR delegate a JavaScript function converts to is the one built for the target type the
+/// host asked for, in every engine that asks (sebastienros/jint#3434).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The conversion is memoized so <c>host.on(f)</c> and <c>host.off(f)</c> hand the host the same
+/// <see cref="Delegate"/> instance, which is the identity <c>-=</c> needs. The memo used to be keyed on the
+/// function alone, and one level down on that function's AST node — neither of which carries the delegate
+/// type the compiled binder was built for. The AST node is process-wide state and
+/// <see cref="Engine.PrepareScript"/> is documented as shareable across engines, so whichever engine
+/// evaluated a shared preparation first decided the target type for every engine after it, and the
+/// reflection invoke that followed rejected the delegate it was handed with
+/// <c>ArgumentException: Object of type 'Notify' cannot be converted to type 'Transform'</c>.
+/// </para>
+/// <para>
+/// This is the embedder-visible half of it: two engines, different host types, one cached
+/// <c>Prepared&lt;Script&gt;</c> — the shape the README recommends for production.
+/// </para>
+/// </remarks>
+public class HostDelegateConversionTests
+{
+    public delegate void Notify(int value);
+
+    public delegate string Transform(string value);
+
+    public sealed class NotifyHost
+    {
+        public string Call(Notify f)
+        {
+            f(1);
+            return "notify";
+        }
+    }
+
+    public sealed class TransformHost
+    {
+        public string Call(Transform f) => "transform:" + f("x");
+    }
+
+    public delegate string Feed(Payload value);
+
+    public sealed class Payload
+    {
+        public int Value => 42;
+    }
+
+    public sealed class PayloadHost
+    {
+        public string Call(Feed f) => f(new Payload());
+    }
+
+    private const string Source = "host.call(function (x) { return String(x); });";
+
+    [Fact]
+    public void TwoEnginesSharingOnePreparedScript()
+    {
+        var prepared = Engine.PrepareScript(Source);
+
+        var first = new Engine();
+        first.SetValue("host", new NotifyHost());
+        first.Evaluate(prepared).AsString().Should().Be("notify");
+
+        var second = new Engine();
+        second.SetValue("host", new TransformHost());
+        second.Evaluate(prepared).AsString().Should().Be("transform:x");
+    }
+
+    [Fact]
+    public void TwoEnginesSharingOnePreparedScriptInTheOtherOrder()
+    {
+        var prepared = Engine.PrepareScript(Source);
+
+        var first = new Engine();
+        first.SetValue("host", new TransformHost());
+        first.Evaluate(prepared).AsString().Should().Be("transform:x");
+
+        var second = new Engine();
+        second.SetValue("host", new NotifyHost());
+        second.Evaluate(prepared).AsString().Should().Be("notify");
+    }
+
+    /// <summary>
+    /// The other half of what the shared AST-node cache holds: the compiled binder marshals the host's
+    /// arguments into the realm of the engine that is running, not of whichever engine compiled it. One
+    /// delegate type is enough here — the two engines share the binder by design — so this is the case the
+    /// target-type key alone does not cover.
+    /// </summary>
+    [Fact]
+    public void ASharedBinderMarshalsIntoTheRunningEnginesRealm()
+    {
+        var prepared = Engine.PrepareScript("host.call(function (x) { return String(x instanceof Object) + ':' + x.Value; });");
+
+        var first = new Engine();
+        first.SetValue("host", new PayloadHost());
+        first.Evaluate(prepared).AsString().Should().Be("true:42");
+
+        var second = new Engine();
+        second.SetValue("host", new PayloadHost());
+        second.Evaluate(prepared).AsString().Should().Be("true:42",
+            "an object built by the first engine's realm is not an Object in the second engine's");
+    }
+
+    /// <summary>
+    /// The same preparation alternating between the two engines: each engine keeps answering for its own
+    /// host type however many times the other one has run in between.
+    /// </summary>
+    [Fact]
+    public void AlternatingEnginesOnOnePreparedScript()
+    {
+        var prepared = Engine.PrepareScript(Source);
+
+        var notify = new Engine();
+        notify.SetValue("host", new NotifyHost());
+        var transform = new Engine();
+        transform.SetValue("host", new TransformHost());
+
+        for (var i = 0; i < 5; i++)
+        {
+            notify.Evaluate(prepared).AsString().Should().Be("notify");
+            transform.Evaluate(prepared).AsString().Should().Be("transform:x");
+        }
+    }
+}

--- a/Jint.Tests.PublicInterface/OperatorOverloadResolutionCacheTests.cs
+++ b/Jint.Tests.PublicInterface/OperatorOverloadResolutionCacheTests.cs
@@ -1,0 +1,184 @@
+#nullable enable
+
+using System.Diagnostics.CodeAnalysis;
+using Jint.Runtime.Interop;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// Which operator overload a <c>+</c> over host types selects is resolved once and remembered, and the
+/// resolution reads two things the embedder configures: <see cref="Options.InteropOptions.ValueCoercion"/>
+/// and the installed <see cref="ITypeConverter"/>. Two engines configured differently must therefore not
+/// answer one another's operator resolutions.
+/// </summary>
+/// <remarks>
+/// One host type per test — the resolution cache never evicts, so a type reused across tests would make
+/// them order-dependent on each other rather than self-contained.
+/// </remarks>
+public class OperatorOverloadResolutionCacheTests
+{
+    #region converter-decided resolution
+
+    /// <summary>
+    /// A host type whose only <c>+</c> is <c>(T, T)</c>. Evaluating <c>'s' + v</c> therefore asks whether a
+    /// string can become a <c>T</c> — a question no structural scoring rule can answer, so the installed
+    /// converter answers it and decides between an operator call and plain string concatenation.
+    /// </summary>
+    public sealed class MoneyA
+    {
+        public static string operator +(MoneyA left, MoneyA right) => "operator";
+    }
+
+    public sealed class MoneyB
+    {
+        public static string operator +(MoneyB left, MoneyB right) => "operator";
+    }
+
+    public sealed class MoneyC
+    {
+        public static string operator +(MoneyC left, MoneyC right) => "operator";
+    }
+
+    public sealed class MoneyD
+    {
+        public static string operator +(MoneyD left, MoneyD right) => "operator";
+    }
+
+    /// <summary>
+    /// Converts a string to whatever target type is asked for by handing back that type's default instance,
+    /// and defers everything else to the stock conversions. That is the shape of a host converter that
+    /// teaches the engine one of its own types — and it is what makes <c>'s' + v</c> resolve to the operator.
+    /// </summary>
+    private sealed class StringToHostTypeConverter : DefaultTypeConverter
+    {
+        public StringToHostTypeConverter(Engine engine) : base(engine)
+        {
+        }
+
+        public override bool TryConvert(object? value, Type type, IFormatProvider formatProvider, [NotNullWhen(true)] out object? converted)
+        {
+            if (value is string && (type == typeof(MoneyA) || type == typeof(MoneyB) || type == typeof(MoneyC) || type == typeof(MoneyD)))
+            {
+                converted = Activator.CreateInstance(type)!;
+                return true;
+            }
+
+            return base.TryConvert(value, type, formatProvider, out converted);
+        }
+    }
+
+    private static Engine StockEngine() => new(options => options.Interop.AllowOperatorOverloading = true);
+
+    private static Engine ConverterEngine() => new(options =>
+    {
+        options.Interop.AllowOperatorOverloading = true;
+        options.SetTypeConverter(engine => new StringToHostTypeConverter(engine));
+    });
+
+    private static string Add(Engine engine, object host)
+    {
+        engine.SetValue("v", host);
+        return engine.Evaluate("'s' + v").AsString();
+    }
+
+    [Fact]
+    public void StockEngineAloneConcatenates()
+    {
+        Add(StockEngine(), new MoneyA()).Should().NotBe("operator");
+    }
+
+    [Fact]
+    public void ConverterEngineAloneCallsTheOperator()
+    {
+        Add(ConverterEngine(), new MoneyB()).Should().Be("operator");
+    }
+
+    [Fact]
+    public void AConverterEngineDoesNotDecideForAStockEngine()
+    {
+        Add(ConverterEngine(), new MoneyC()).Should().Be("operator");
+        Add(StockEngine(), new MoneyC()).Should().NotBe("operator");
+    }
+
+    [Fact]
+    public void AStockEngineDoesNotDecideForAConverterEngine()
+    {
+        Add(StockEngine(), new MoneyD()).Should().NotBe("operator");
+        Add(ConverterEngine(), new MoneyD()).Should().Be("operator");
+    }
+
+    #endregion
+
+    #region coercion-decided resolution
+
+    /// <summary>
+    /// A host type whose only <c>+</c> takes a <see cref="string"/> on the right. Handing it an opaque host
+    /// object is a pair no structural rule recognizes, so whether the candidate survives at all is decided
+    /// by <see cref="Options.InteropOptions.ValueCoercion"/>'s string rule.
+    /// </summary>
+    public sealed class CoercedA
+    {
+        public static string operator +(CoercedA left, string right) => "operator";
+    }
+
+    public sealed class CoercedB
+    {
+        public static string operator +(CoercedB left, string right) => "operator";
+    }
+
+    public sealed class CoercedC
+    {
+        public static string operator +(CoercedC left, string right) => "operator";
+    }
+
+    public sealed class CoercedD
+    {
+        public static string operator +(CoercedD left, string right) => "operator";
+    }
+
+    /// <summary>Carries nothing the engine can convert, so only the coercion rule can bind it to a string.</summary>
+    public sealed class Opaque;
+
+    private static Engine CoercingEngine() => new(options => options.Interop.AllowOperatorOverloading = true);
+
+    private static Engine NonCoercingEngine() => new(options =>
+    {
+        options.Interop.AllowOperatorOverloading = true;
+        options.Interop.ValueCoercion = ValueCoercionType.None;
+    });
+
+    private static string AddOpaque(Engine engine, object host)
+    {
+        engine.SetValue("v", host);
+        engine.SetValue("o", new Opaque());
+        return engine.Evaluate("v + o").AsString();
+    }
+
+    [Fact]
+    public void CoercingEngineAloneCallsTheOperator()
+    {
+        AddOpaque(CoercingEngine(), new CoercedA()).Should().Be("operator");
+    }
+
+    [Fact]
+    public void NonCoercingEngineAloneConcatenates()
+    {
+        AddOpaque(NonCoercingEngine(), new CoercedB()).Should().NotBe("operator");
+    }
+
+    [Fact]
+    public void ACoercingEngineDoesNotDecideForANonCoercingOne()
+    {
+        AddOpaque(CoercingEngine(), new CoercedC()).Should().Be("operator");
+        AddOpaque(NonCoercingEngine(), new CoercedC()).Should().NotBe("operator");
+    }
+
+    [Fact]
+    public void ANonCoercingEngineDoesNotDecideForACoercingOne()
+    {
+        AddOpaque(NonCoercingEngine(), new CoercedD()).Should().NotBe("operator");
+        AddOpaque(CoercingEngine(), new CoercedD()).Should().Be("operator");
+    }
+
+    #endregion
+}

--- a/Jint.Tests/Runtime/DelegateConversionTargetTypeTests.cs
+++ b/Jint.Tests/Runtime/DelegateConversionTargetTypeTests.cs
@@ -1,0 +1,119 @@
+#nullable enable
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// A JavaScript function converted to a CLR delegate is cached so that <c>host.on(f)</c> and
+/// <c>host.off(f)</c> hand the host the same <see cref="Delegate"/> instance. These cover the other half of
+/// that contract: the cached delegate is the one built for the target type being asked for, not for whichever
+/// target type asked first (https://github.com/sebastienros/jint/issues/3434).
+/// </summary>
+public class DelegateConversionTargetTypeTests
+{
+    public delegate void Notify(int value);
+
+    public delegate string Transform(string value);
+
+    public sealed class NotifyHost
+    {
+        public string Call(Notify f)
+        {
+            f(1);
+            return "notify";
+        }
+    }
+
+    public sealed class TransformHost
+    {
+        public string Call(Transform f) => "transform:" + f("x");
+    }
+
+    public sealed class BothHost
+    {
+        public Notify? LastNotify { get; private set; }
+
+        public Transform? LastTransform { get; private set; }
+
+        public string A(Notify f)
+        {
+            LastNotify = f;
+            f(1);
+            return "notify";
+        }
+
+        public string B(Transform f)
+        {
+            LastTransform = f;
+            return "transform:" + f("x");
+        }
+    }
+
+    /// <summary>Control: each host alone works, and always did.</summary>
+    [Fact]
+    public void ControlEachHostAlone()
+    {
+        var one = new Engine();
+        one.SetValue("host", new NotifyHost());
+        one.Evaluate("host.call(function (x) { return String(x); })").AsString().Should().Be("notify");
+
+        var two = new Engine();
+        two.SetValue("host", new TransformHost());
+        two.Evaluate("host.call(function (x) { return String(x); })").AsString().Should().Be("transform:x");
+    }
+
+    /// <summary>The bound-delegate cache: one function instance, two delegate types, one engine.</summary>
+    [Fact]
+    public void OneFunctionInstanceTwoDelegateTypes()
+    {
+        var engine = new Engine();
+        engine.SetValue("host", new BothHost());
+
+        var result = engine.Evaluate("""
+            var f = function (x) { return String(x); };
+            host.a(f) + '|' + host.b(f);
+            """).AsString();
+
+        result.Should().Be("notify|transform:x");
+    }
+
+    /// <summary>The binder cache: two instances of one AST node, two delegate types, one engine.</summary>
+    [Fact]
+    public void TwoInstancesOfOneAstNodeTwoDelegateTypes()
+    {
+        var engine = new Engine();
+        engine.SetValue("host", new BothHost());
+
+        var result = engine.Evaluate("""
+            function make() { return function (x) { return String(x); }; }
+            host.a(make()) + '|' + host.b(make());
+            """).AsString();
+
+        result.Should().Be("notify|transform:x");
+    }
+
+    /// <summary>
+    /// The reason the cache exists: one function instance converted twice to the same delegate type is the
+    /// same <see cref="Delegate"/> instance, which is the identity <c>-=</c> needs. Per target type now,
+    /// rather than for the first target type only.
+    /// </summary>
+    [Fact]
+    public void SameFunctionAndSameTargetTypeIsTheSameDelegateInstance()
+    {
+        var host = new BothHost();
+        var engine = new Engine();
+        engine.SetValue("host", host);
+
+        engine.Execute("var f = function (x) { return String(x); };");
+
+        engine.Execute("host.a(f);");
+        var firstNotify = host.LastNotify;
+        engine.Execute("host.b(f);");
+        var firstTransform = host.LastTransform;
+
+        engine.Execute("host.a(f);");
+        engine.Execute("host.b(f);");
+
+        host.LastNotify.Should().BeSameAs(firstNotify);
+        host.LastTransform.Should().BeSameAs(firstTransform);
+    }
+}

--- a/Jint.Tests/Runtime/GarbageCollectionTests.cs
+++ b/Jint.Tests/Runtime/GarbageCollectionTests.cs
@@ -201,6 +201,47 @@ public class GarbageCollectionTests
         }
     }
 
+    [Fact]
+    public void SharedPreparedScriptConvertingFunctionsToDelegatesDoesNotRetainEngines()
+    {
+        // The delegate a JavaScript function converts to is memoized in two process-wide tables, the lower of
+        // which is keyed on the function's AST node — shared, and outliving every engine that runs a prepared
+        // script. Both are keyed by the target delegate type as well since #3434, so the AST node now holds one
+        // compiled binder per delegate type rather than one in total; this is the pin that those binders stayed
+        // engine-neutral, taking their target as a parameter rather than closing over the engine that built them.
+
+        var prepared = Engine.PrepareScript("""
+            host.a(function (x) { { let y = x; return String(y); } });
+            host.b(function (x) { { let y = x; return String(y); } });
+            """);
+
+        const int count = 20;
+        var references = new List<WeakReference>(count);
+        for (var i = 0; i < count; i++)
+        {
+            references.Add(ConvertOnceAndForget(prepared));
+        }
+
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+        GC.WaitForPendingFinalizers();
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+
+        var aliveCount = references.Count(static r => r.IsAlive);
+        prepared.Program.ShouldCarryPublishedInterpreterState();
+
+        aliveCount.Should().Be(0, $"{aliveCount} of {count} engines were not collected — the shared delegate binder cache still pins engines.");
+
+        // NoInlining so the engine reference cannot be stack-rooted in this frame across the GC.Collect calls.
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        static WeakReference ConvertOnceAndForget(Prepared<Script> prepared)
+        {
+            var engine = new Engine();
+            engine.SetValue("host", new DelegateConversionTargetTypeTests.BothHost());
+            engine.Execute(prepared);
+            return new WeakReference(engine);
+        }
+    }
+
     private static void AssertNoEngineRetained(Prepared<Script> prepared)
     {
         const int count = 20;

--- a/Jint.Tests/Runtime/OperatorOverloadResolutionCacheTests.cs
+++ b/Jint.Tests/Runtime/OperatorOverloadResolutionCacheTests.cs
@@ -1,0 +1,74 @@
+#nullable enable
+
+using Jint.Runtime.Interop;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Which table an engine remembers its operator-overload resolutions in. The public-interface suite pins the
+/// answers two engines must not take from each other; this pins the mechanism that keeps them apart, since
+/// "both engines were right" is also what a cache that was never consulted looks like.
+/// </summary>
+public class OperatorOverloadResolutionCacheTests
+{
+    public sealed class Amount
+    {
+        public static string operator +(Amount left, Amount right) => "operator";
+    }
+
+    /// <summary>Behaves exactly like the stock converter but is not it, which is what makes it a host one.</summary>
+    private sealed class WrappingTypeConverter : DefaultTypeConverter
+    {
+        public WrappingTypeConverter(Engine engine) : base(engine)
+        {
+        }
+    }
+
+    private static Engine Evaluate(Action<Options>? configure = null)
+    {
+        var engine = new Engine(options =>
+        {
+            options.Interop.AllowOperatorOverloading = true;
+            configure?.Invoke(options);
+        });
+
+        engine.SetValue("a", new Amount());
+        engine.SetValue("b", new Amount());
+        engine.Evaluate("a + b").AsString().Should().Be("operator");
+        return engine;
+    }
+
+    [Fact]
+    public void AStockEngineRemembersInTheProcessWideTable()
+    {
+        var engine = Evaluate();
+
+        engine._engineOperatorOverloads.Should().BeNull(
+            "the stock converter resolves what every other stock engine would, so the answer is shareable");
+    }
+
+    [Fact]
+    public void AnEngineWithItsOwnConverterRemembersOnItself()
+    {
+        var engine = Evaluate(options => options.SetTypeConverter(e => new WrappingTypeConverter(e)));
+
+        engine._engineOperatorOverloads.Should().NotBeNull().And.HaveCount(1,
+            "this engine's converter answers overload scoring's last rule, so its resolution is its own");
+
+        // and it really is a cache: a second evaluation of the same pair adds nothing
+        engine.Evaluate("a + b").AsString().Should().Be("operator");
+        engine._engineOperatorOverloads.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void SwappingTheConverterDropsWhatTheOldOneDecided()
+    {
+        var engine = Evaluate(options => options.SetTypeConverter(e => new WrappingTypeConverter(e)));
+        engine._engineOperatorOverloads.Should().HaveCount(1);
+
+        engine.TypeConverter = new WrappingTypeConverter(engine);
+
+        engine._engineOperatorOverloads.Should().BeEmpty(
+            "every entry was scored against the converter that has just been replaced");
+    }
+}

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Jint.Collections;
@@ -346,6 +347,24 @@ public sealed partial class Engine : IDisposable
     // one Options instance be shared by engines that are already running.
     internal readonly bool _operatorOverloadingAllowed;
 
+    // Snapshot of Options.Interop.ValueCoercion, read the same way and for the same reason. It steers
+    // overload scoring's gray-zone rule, so it is part of the key JintBinaryExpression remembers an
+    // operator-overload resolution under: two engines that coerce differently can rank the same candidates
+    // differently, and must not answer from one another's entries.
+    internal readonly ValueCoercionType _valueCoercion;
+
+    /// <summary>
+    /// Operator-overload resolutions belonging to this engine alone, created on first use and only by an
+    /// engine whose <see cref="TypeConverter"/> is not the stock one.
+    /// </summary>
+    /// <remarks>
+    /// Such an engine's converter answers overload scoring's last rule, so its resolutions are not the ones a
+    /// stock engine would reach and cannot go in the process-wide table - nor could that table be keyed on the
+    /// converter, which is a host object handed this engine by its factory and would pin both for the life of
+    /// the process. The <see cref="TypeConverter"/> setter drops these when the converter changes.
+    /// </remarks>
+    internal ConcurrentDictionary<JintBinaryExpression.OperatorKey, MethodDescriptor?>? _engineOperatorOverloads;
+
     internal readonly ReferencePool _referencePool;
     internal readonly ArgumentsInstancePool _argumentsInstancePool;
     internal readonly JsValueArrayPool _jsValueArrayPool;
@@ -366,6 +385,11 @@ public sealed partial class Engine : IDisposable
         {
             _typeConverter = value;
             _typeConverterIsDefault = value.GetType() == typeof(DefaultTypeConverter);
+
+            // Every operator-overload resolution this engine remembered was scored against the converter
+            // being replaced, and the stock table it may now be entitled to was not. Nothing is resolved
+            // before the first assignment, so this is a no-op during construction.
+            _engineOperatorOverloads?.Clear();
         }
     }
 
@@ -511,6 +535,7 @@ public sealed partial class Engine : IDisposable
         // documented place to finish configuring an engine, and enabling operator overloading from
         // one has to reach the expressions that consult it.
         _operatorOverloadingAllowed = Options.Interop.AllowOperatorOverloading;
+        _valueCoercion = Options.Interop.ValueCoercion;
 
         // likewise after Apply, which is where a custom ITypeConverter gets installed
         _interopResolutionProfile = new InteropResolutionProfile(

--- a/Jint/Runtime/Interop/DefaultTypeConverter.cs
+++ b/Jint/Runtime/Interop/DefaultTypeConverter.cs
@@ -6,9 +6,11 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using Jint.Extensions;
 using Jint.Native;
 using Jint.Native.Function;
+using Jint.Native.Object;
 using Expression = System.Linq.Expressions.Expression;
 
 #pragma warning disable IL2026
@@ -46,6 +48,7 @@ public class DefaultTypeConverter : ITypeConverter
     private static readonly MethodInfo changeTypeIfConvertible = typeof(DefaultTypeConverter).GetMethod(
         nameof(ChangeTypeOnlyIfConvertible), BindingFlags.NonPublic | BindingFlags.Static)!;
     private static readonly MethodInfo jsValueFromObject = jsValueType.GetMethod(nameof(JsValue.FromObject))!;
+    private static readonly PropertyInfo objectInstanceEngine = typeof(ObjectInstance).GetProperty(nameof(ObjectInstance.Engine))!;
     private static readonly MethodInfo jsValueToObject = jsValueType.GetMethod(nameof(JsValue.ToObject))!;
 
 
@@ -92,8 +95,80 @@ public class DefaultTypeConverter : ITypeConverter
         return TryConvertInternal(value, type, formatProvider, propagateException: false, out converted, out _);
     }
 
-    private static readonly ConditionalWeakTable<IFunction, Func<object, Delegate>> _targetBinderDelegateCache = new();
-    private static readonly ConditionalWeakTable<object, Delegate> _boundTargetDelegateCache = new();
+    private static readonly ConditionalWeakTable<IFunction, TypeKeyedCache<Func<object, Delegate>>> _targetBinderDelegateCache = new();
+    private static readonly ConditionalWeakTable<object, TypeKeyedCache<Delegate>> _boundTargetDelegateCache = new();
+
+    private static readonly ConditionalWeakTable<IFunction, TypeKeyedCache<Func<object, Delegate>>>.CreateValueCallback _createBinderCache =
+        static _ => new TypeKeyedCache<Func<object, Delegate>>();
+
+    private static readonly ConditionalWeakTable<object, TypeKeyedCache<Delegate>>.CreateValueCallback _createBoundDelegateCache =
+        static _ => new TypeKeyedCache<Delegate>();
+
+    /// <summary>
+    /// An append-only map from a target delegate <see cref="Type"/> to the artefact that was built for it.
+    /// </summary>
+    /// <remarks>
+    /// The two delegate caches above are process-wide and keyed on something that does not carry the target
+    /// type: a function instance, and one level below it that function's AST node, which a shared
+    /// <c>Prepared&lt;Script&gt;</c> makes process-wide state outliving every engine that runs it. Entries are
+    /// added and never replaced, so the delegate identity an event unregistration needs holds per target type;
+    /// the list is one node long for the overwhelming majority of functions, which are converted to exactly
+    /// one delegate type. Nothing stored here is engine-affine - a <see cref="Type"/>, and a binder that takes
+    /// its target as a parameter and reads the engine off it - so the AST node stays shareable across engines.
+    /// </remarks>
+    private sealed class TypeKeyedCache<T> where T : class
+    {
+        private Node? _head;
+
+        internal bool TryGetValue(Type type, [NotNullWhen(true)] out T? value)
+        {
+            var node = Volatile.Read(ref _head);
+            while (node is not null)
+            {
+                if (ReferenceEquals(node._type, type))
+                {
+                    value = node._value;
+                    return true;
+                }
+
+                node = node._next;
+            }
+
+            value = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Publishes <paramref name="value"/> for <paramref name="type"/>, or returns what a concurrent
+        /// caller published for it first - the winner is the one instance every caller then sees.
+        /// </summary>
+        internal T GetOrAdd(Type type, T value)
+        {
+            while (true)
+            {
+                var head = Volatile.Read(ref _head);
+                for (var node = head; node is not null; node = node._next)
+                {
+                    if (ReferenceEquals(node._type, type))
+                    {
+                        return node._value;
+                    }
+                }
+
+                if (ReferenceEquals(Interlocked.CompareExchange(ref _head, new Node(type, value, head), head), head))
+                {
+                    return value;
+                }
+            }
+        }
+
+        private sealed class Node(Type type, T value, Node? next)
+        {
+            internal readonly Type _type = type;
+            internal readonly T _value = value;
+            internal readonly Node? _next = next;
+        }
+    }
 
     private bool TryConvertInternal(
         object? value,
@@ -206,20 +281,33 @@ public class DefaultTypeConverter : ITypeConverter
                 var functionInstance = func.Target;
 
                 // caching of .NET delegates per function instance is required to be able to support
-                // unregistering event handlers (see ShouldExecuteActionCallbackOnEventChanged)
-                var d = functionInstance is not null ?
-                    _boundTargetDelegateCache.GetValue(functionInstance!, target =>
+                // unregistering event handlers (see ShouldExecuteActionCallbackOnEventChanged). Both caches
+                // are keyed by the target delegate type as well, because that type is what the compiled
+                // binder bakes in and neither a function instance nor its AST node carries it - and the AST
+                // node is process-wide state, so a shared Prepared<Script> otherwise lets whichever engine
+                // converted first decide the delegate type for every engine after it (#3434).
+                Delegate d;
+                if (functionInstance is not null)
+                {
+                    var boundDelegates = _boundTargetDelegateCache.GetValue(functionInstance, _createBoundDelegateCache);
+                    if (!boundDelegates.TryGetValue(type, out var bound))
                     {
                         var astFunction = (functionInstance as Function)?._functionDefinition?.Function;
 
-                        // use a single builder per unique function AST
+                        // use a single builder per unique function AST and target delegate type
                         var targetBinder = astFunction is not null
-                            ? _targetBinderDelegateCache.GetValue(astFunction, _ => BuildTargetBinderDelegate(type, func))
+                            ? GetOrBuildTargetBinderDelegate(astFunction, type, func)
                             : BuildTargetBinderDelegate(type, func);
 
-                        return targetBinder(target)!;
-                    }) :
-                    BuildDelegate(type, func, Expression.Constant(functionInstance, functionInstance!.GetType())).Compile();
+                        bound = boundDelegates.GetOrAdd(type, targetBinder(functionInstance)!);
+                    }
+
+                    d = bound;
+                }
+                else
+                {
+                    d = BuildDelegate(type, func, Expression.Constant(functionInstance, functionInstance!.GetType())).Compile();
+                }
 
                 converted = d;
                 return true;
@@ -395,6 +483,17 @@ public class DefaultTypeConverter : ITypeConverter
 #endif
     }
 
+    private Func<object, Delegate> GetOrBuildTargetBinderDelegate(
+        IFunction astFunction,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type delegateType,
+        JsCallDelegate function)
+    {
+        var binders = _targetBinderDelegateCache.GetValue(astFunction, _createBinderCache);
+        return binders.TryGetValue(delegateType, out var binder)
+            ? binder
+            : binders.GetOrAdd(delegateType, BuildTargetBinderDelegate(delegateType, function));
+    }
+
     private Func<object, Delegate> BuildTargetBinderDelegate(
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type delegateType,
         JsCallDelegate function)
@@ -432,13 +531,23 @@ public class DefaultTypeConverter : ITypeConverter
 
         var initializers = new List<MethodCallExpression>(parameters.Length);
 
+        // The engine whose realm the arguments are marshalled into is read off the target function rather
+        // than baked in as a constant, because this expression tree is compiled once per (AST node, target
+        // delegate type) into a process-wide cache that a shared Prepared<Script> keeps alive past every
+        // engine that ran it. A constant would hand every later engine the first one's realm - a JsValue
+        // belonging to an engine that is not running - and pin that engine for the life of the AST (#3434).
+        // A target that is not an ObjectInstance cannot reach the shared cache, so it keeps the constant.
+        var targetEngine = typeof(ObjectInstance).IsAssignableFrom(targetExpression.Type)
+            ? (Expression) Expression.Property(Expression.Convert(targetExpression, typeof(ObjectInstance)), objectInstanceEngine)
+            : Expression.Constant(_engine, engineType);
+
         for (var i = 0; i < parameters.Length; i++)
         {
             var param = parameters[i];
             if (param.Type.IsValueType)
             {
                 var boxing = Expression.Convert(param, objectType);
-                initializers.Add(Expression.Call(null, jsValueFromObject, Expression.Constant(_engine, engineType), boxing));
+                initializers.Add(Expression.Call(null, jsValueFromObject, targetEngine, boxing));
             }
             else if (param.Type.IsArray &&
                      arguments[i].GetCustomAttribute<ParamArrayAttribute>() is not null &&
@@ -451,12 +560,12 @@ public class DefaultTypeConverter : ITypeConverter
                     var condition = Expression.IfThen(checkIndex, Expression.Return(returnLabel, Expression.ArrayAccess(param, Expression.Constant(j))));
                     var block = Expression.Block(condition, Expression.Label(returnLabel, Expression.Constant(JsValue.Undefined)));
 
-                    initializers.Add(Expression.Call(null, jsValueFromObject, Expression.Constant(_engine, engineType), block));
+                    initializers.Add(Expression.Call(null, jsValueFromObject, targetEngine, block));
                 }
             }
             else
             {
-                initializers.Add(Expression.Call(null, jsValueFromObject, Expression.Constant(_engine, engineType), param));
+                initializers.Add(Expression.Call(null, jsValueFromObject, targetEngine, param));
             }
         }
 

--- a/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
@@ -15,8 +15,21 @@ namespace Jint.Runtime.Interpreter.Expressions;
 
 internal abstract class JintBinaryExpression : JintExpression
 {
-    private readonly record struct OperatorKey(string? OperatorName, Type Left, Type Right);
-    private static readonly ConcurrentDictionary<OperatorKey, MethodDescriptor> _knownOperators = new();
+    /// <summary>
+    /// Identifies one operator-overload resolution. <see cref="Coercion"/> is part of it because
+    /// <c>InteropHelper.CalculateMethodParameterScore</c>'s gray-zone rule reads it, so two engines
+    /// configured differently can rank the same candidates differently - and, with a single candidate, can
+    /// disagree about whether it survives scoring at all.
+    /// </summary>
+    [StructLayout(LayoutKind.Auto)]
+    internal readonly record struct OperatorKey(string? OperatorName, Type Left, Type Right, ValueCoercionType Coercion);
+
+    /// <summary>
+    /// Resolutions every engine agrees on, and therefore the ones that may be remembered for the process.
+    /// Only an engine running the stock <see cref="DefaultTypeConverter"/> reads or writes this; see
+    /// <see cref="TryOperatorOverloading"/> for why, and for where the others keep theirs.
+    /// </summary>
+    private static readonly ConcurrentDictionary<OperatorKey, MethodDescriptor?> _knownOperators = new();
 
     private protected readonly JintExpression _left;
     private protected readonly JintExpression _right;
@@ -749,6 +762,27 @@ internal abstract class JintBinaryExpression : JintExpression
 
     private readonly record struct MethodResolverState(JsCallArguments Arguments);
 
+    /// <summary>
+    /// The operator this pair of CLR operand types selects, resolved once and remembered.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The resolution runs <see cref="InteropHelper.FindBestMatch"/>, which reads two things the embedder
+    /// configures: <c>Options.Interop.ValueCoercion</c>, which the gray-zone scoring rule consults, and the
+    /// installed <see cref="ITypeConverter"/>, whose answer is the last rule outright - a conversion it
+    /// confirms keeps the candidate, one it refuses scores -1 and discards it. So the answer is not a
+    /// property of the operator name and the two types alone, and a process-wide cache keyed on those let
+    /// whichever engine evaluated first decide for every engine after it (#3424).
+    /// </para>
+    /// <para>
+    /// The coercion setting is a value, so it goes in the key and engines that share it share their entries.
+    /// The converter is an object a host builds - <c>Options.SetTypeConverter</c> hands its factory the
+    /// <see cref="Engine"/> - so keying a process-lived static on it would pin every such converter, and any
+    /// engine it captured, for the life of the process. It gates the choice of cache instead: an engine
+    /// running the stock converter resolves what every other stock engine would and shares the static one,
+    /// and an engine with a converter of its own keeps its resolutions on itself, where they die with it.
+    /// </para>
+    /// </remarks>
     internal static bool TryOperatorOverloading(
         EvaluationContext context,
         JsValue leftValue,
@@ -765,17 +799,19 @@ internal abstract class JintBinaryExpression : JintExpression
             var rightType = right.GetType();
             var arguments = new[] { leftValue, rightValue };
 
-            var key = new OperatorKey(clrName, leftType, rightType);
-            var method = _knownOperators.GetOrAdd(key, _ =>
+            var engine = context.Engine;
+            var key = new OperatorKey(clrName, leftType, rightType, engine._valueCoercion);
+            var cache = engine._typeConverterIsDefault
+                ? _knownOperators
+                : engine._engineOperatorOverloads ??= new ConcurrentDictionary<OperatorKey, MethodDescriptor?>();
+
+            if (!cache.TryGetValue(key, out var method))
             {
-                var leftMethods = leftType.GetOperatorOverloadMethods();
-                var rightMethods = rightType.GetOperatorOverloadMethods();
+                method = ResolveOperatorOverload(engine, clrName, leftType, rightType, arguments);
 
-                var methods = leftMethods.Concat(rightMethods).Where(x => string.Equals(x.Name, clrName, StringComparison.Ordinal) && x.GetParameters().Length == 2);
-                var methodDescriptors = MethodDescriptor.Build(methods.ToArray());
-
-                return InteropHelper.FindBestMatch(context.Engine, methodDescriptors, static (_, state) => state.Arguments, new MethodResolverState(arguments)).FirstOrDefault().Method;
-            });
+                // racy, we don't care: both racers resolved the same operator the same way
+                cache.TryAdd(key, method);
+            }
 
             if (method != null)
             {
@@ -804,6 +840,22 @@ internal abstract class JintBinaryExpression : JintExpression
 
         result = null;
         return false;
+    }
+
+    private static MethodDescriptor? ResolveOperatorOverload(
+        Engine engine,
+        string? clrName,
+        Type leftType,
+        Type rightType,
+        JsCallArguments arguments)
+    {
+        var leftMethods = leftType.GetOperatorOverloadMethods();
+        var rightMethods = rightType.GetOperatorOverloadMethods();
+
+        var methods = leftMethods.Concat(rightMethods).Where(x => string.Equals(x.Name, clrName, StringComparison.Ordinal) && x.GetParameters().Length == 2);
+        var methodDescriptors = MethodDescriptor.Build(methods.ToArray());
+
+        return InteropHelper.FindBestMatch(engine, methodDescriptors, static (_, state) => state.Arguments, new MethodResolverState(arguments)).FirstOrDefault().Method;
     }
 
     internal static JintExpression Build(NonLogicalBinaryExpression expression)

--- a/Jint/Runtime/Interpreter/Expressions/JintUnaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintUnaryExpression.cs
@@ -13,6 +13,18 @@ namespace Jint.Runtime.Interpreter.Expressions;
 
 internal sealed class JintUnaryExpression : JintExpression
 {
+    /// <summary>
+    /// A unary operator's resolution is the operand type's first <see cref="MethodInfo"/> of that name taking
+    /// one parameter, which is why this key carries nothing about the engine and this table may be shared by
+    /// the process: no score is computed, so neither <c>Options.Interop.ValueCoercion</c> nor the installed
+    /// <see cref="Jint.Runtime.Interop.ITypeConverter"/> is consulted.
+    /// </summary>
+    /// <remarks>
+    /// That is what makes it different from <see cref="JintBinaryExpression"/>'s table, whose key carries the
+    /// coercion setting and whose choice of table carries the converter (#3424). Anything that gives this one
+    /// a scoring step - a second candidate to choose between, <see cref="Jint.Runtime.Interop.InteropHelper.FindBestMatch"/>
+    /// - inherits those rules with it.
+    /// </remarks>
     private readonly record struct OperatorKey(string OperatorName, Type Operand);
     private static readonly ConcurrentDictionary<OperatorKey, MethodDescriptor?> _knownOperators = new();
 


### PR DESCRIPTION
Backport of #3521 (fixes #3434) and #3526 (fixes #3424) to `4.x`. Correctness only — the performance half
of the `main` work is deliberately out of scope, and #3522 is not here at all because its premise does not
exist on this branch (below).

## What was wrong on 4.x

Three process-wide interop caches were keyed on less than the answer they hold depends on, so in a process
running more than one engine, whichever engine reached one first decided for every engine after it.

### 1. The delegate a JavaScript function converts to (#3434)

`DefaultTypeConverter` memoizes the CLR delegate a function converts to — it has to, since `host.on(f)` and
`host.off(f)` only pair up if both conversions hand the host the same `Delegate` instance. The memo was
keyed on the function instance, and one level below it on that function's **AST node**:

```csharp
private static readonly ConditionalWeakTable<IFunction, Func<object, Delegate>> _targetBinderDelegateCache = new();
private static readonly ConditionalWeakTable<object, Delegate> _boundTargetDelegateCache = new();
```

Neither carries the target delegate `Type`, which is the one thing `BuildTargetBinderDelegate(type, func)`
bakes into the compiled binder. So the second target type a given function was converted for was served the
first one's delegate, and the reflection invoke behind the call rejected it. The AST node is process-wide
state and `Engine.PrepareScript` is documented as shareable, so two engines with different host types over
one cached `Prepared<Script>` — the shape the README recommends for production — disagreed by evaluation
order:

```
System.ArgumentException : Object of type '...+Notify' cannot be converted to type '...+Transform'.
```

### 2. …and the realm that binder marshals into

That same AST-node entry outlives every engine that ran the preparation, and on 4.x the binder baked the
**converting** engine in as `Expression.Constant(_engine, engineType)`. A second engine running the same
preparation therefore had its host callback's arguments marshalled through the *first* engine's realm, and
kept that engine, its realm and its intrinsics alive for the life of the AST. One delegate type is enough
to see it — the two engines share the binder by design, so the target-type key above does not cover it:

```
host.call(function (x) { return String(x instanceof Object) + ':' + x.Value; });
// engine A: true:42     engine B: false:42
```

`main` has been clear of this since #3395 made the binder read the engine off its target; that half is
carried over here, and it is what makes the shared entry legitimate at all rather than merely type-keyed.

### 3. Which CLR operator a `+` over host types selects (#3424)

`JintBinaryExpression._knownOperators` remembers which operator a `(name, left type, right type)` triple
selects, in a process-wide dictionary. The selection runs `InteropHelper.FindBestMatch`, which reads two
things the embedder configures and neither was in that key: `Options.Interop.ValueCoercion`, which
`CalculateMethodParameterScore`'s gray-zone rule consults, and the installed `ITypeConverter`, whose answer
is the last rule outright — a conversion it confirms keeps the candidate, one it refuses scores −1, which
discards it.

## The fixes

**Delegate caches** — both are keyed by target type now, through `TypeKeyedCache<T>`: an append-only
singly-linked list of `(Type, T)` nodes, read with `Volatile.Read` and published with one
`Interlocked.CompareExchange`, since a shared `Prepared<Script>` genuinely can be reached from several
engines at once. Entries are added and never replaced, so one `Delegate` per *(function instance, delegate
type)* is exactly the identity an event unregistration needs, where one per function instance was only
accidentally it. A composite key was not available: `ConditionalWeakTable` keys on reference identity, so a
`(function, Type)` key object would never match a later one and would root the function it names.

**The binder** reads the engine off its target (`((ObjectInstance) target).Engine`) instead of closing over
the converting one. A target that is not an `ObjectInstance` cannot reach the shared cache and keeps the
constant, so nothing outside the engine's own paths changes.

**Operator table** — the two inputs are handled differently because of what they are. `ValueCoercion` is a
value, so it goes in the key: one enum field in the struct's hash, nothing retained, and every engine that
coerces alike goes on sharing entries. It is snapshotted onto the engine at construction beside
`_operatorOverloadingAllowed`, the same way and for the same reason. The converter is an object the host
built — `Options.SetTypeConverter` hands its factory the `Engine` — so keying a process-lived static on it
would pin that converter and any engine it captured for the life of the process, which is the retention
`GarbageCollectionTests` exists to refuse. It selects the table instead: a stock-converter engine uses the
static one; an engine with a converter of its own uses `Engine._engineOperatorOverloads`, created on first
use, dropped when the converter is replaced, and collected with the engine.
`JintUnaryExpression._knownOperators` stays process-wide and unkeyed on purpose — it takes the first
one-parameter method of that name and computes no score, so it asks neither input; a comment now says so.

## Evidence

Ported from #3521/#3526 (xUnit v3 here, and `ITypeConverter`/`_typeConverterIsDefault` where `main` has
`ClrTypeConverter`/`_typeConverterTargetFilter`), plus one authored case for §2. Every count below is
identical on **net472** and **net10.0**.

Against unmodified `4.x` (`a943ec0c9`):

| Suite | Before | After |
| --- | --- | --- |
| `Jint.Tests` — `DelegateConversionTargetTypeTests` + `GarbageCollectionTests.SharedPreparedScript…` | **4 failed**, 1 passed | 5 passed |
| `Jint.Tests.PublicInterface` — `HostDelegateConversionTests` + `OperatorOverloadResolutionCacheTests` | **8 failed**, 4 passed | 12 passed |

The passing-before cases are the controls, and they are the point: `ControlEachHostAlone`, and the four
one-engine-at-a-time operator cases, pass before and after, so no answer an engine reaches on its own
changes. The failures cover both orders and both directions in each family —
`TwoEnginesSharingOnePreparedScriptInTheOtherOrder` so the fix cannot be a rule about which type wins,
`AlternatingEnginesOnOnePreparedScript` so it cannot be one slot the last engine through overwrites, and
`A{Converter,Stock}EngineDoesNotDecideForA{Stock,Converter}Engine` /
`A{Coercing,NonCoercing}EngineDoesNotDecideForA{NonCoercing,Coercing}One` for the operator table's two
inputs.

`Jint.Tests/Runtime/OperatorOverloadResolutionCacheTests.cs` pins the mechanism rather than the answers —
which table an engine used, and that replacing the converter drops what the old one decided — since "both
engines were right" is also what a cache that was never consulted looks like.

Full suites, `-c Release`:

- `Jint.Tests` 6988/6903 passed (net10.0/net472), 0 failed
- `Jint.Tests.PublicInterface` 1612/1604 passed, 0 failed
- `Jint.Tests.CommonScripts` 28/28 passed, `Jint.Tests.SourceGenerators` 52 passed
- test262 **102,499 passed / 0 failed / 185 skipped** of 102,684 — the branch's control figure exactly
- Solution build clean; the one MSBuild warning (`MSB3277`, `System.Memory` in `Jint.Tests.CommonScripts`
  on net472) is present on unmodified `4.x` too

## What is not here

**#3522 (`TypeResolver` converter neutrality) has no premise on this branch.** All seven of its tests pass
unmodified against untouched `4.x`, both TFMs, because 4.x still partitions the accessor cache by converter:
`AccessorCacheKey` carries `InteropResolutionProfile`, which carries `stockTypeConverter`. `main` dropped
that field in favour of the finer-grained `IsConverterNeutral`, and #3522 fixes a gap in that predicate —
v5-only work, and porting it would mean porting the partition removal, which changes an existing default.

One narrower relative of it does survive on 4.x and is **not** fixed here: the partition is binary, so two
engines with *two different* host converters share one partition, and `IsShareable` only withholds an
`IndexerAccessor` — not a `PropertyAccessor` whose `indexerToTry` that converter decided. Measured: an
engine whose converter declines every conversion reads `bag.Name` as `"from-property"`, and a second engine
with a different, permissive converter then reads `"from-property"` where it reads `"from-indexer"` when
alone. Filed separately rather than grown into this PR.
