### PR TITLE
Interop: an index on a wrapped host collection is one property, and a filter that hides the indexer hides it

### DIFF
--- a/Jint.Tests.PublicInterface/HostCollectionIndexAgreementTests.cs
+++ b/Jint.Tests.PublicInterface/HostCollectionIndexAgreementTests.cs
@@ -1,0 +1,300 @@
+#nullable enable
+
+using System.Collections;
+using Jint.Runtime;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// One question — <em>does this index exist?</em> — asked of a wrapped CLR collection through every lane an
+/// embedder's script can reach it: <c>in</c>, <c>hasOwnProperty</c>, the indexed read,
+/// <c>Object.getOwnPropertyDescriptor</c>, <c>propertyIsEnumerable</c> and <c>Object.getOwnPropertyNames</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// They have to give one answer. <see href="https://tc39.es/ecma262/#sec-ordinaryhasproperty">OrdinaryHasProperty</see>
+/// is defined in terms of <c>[[GetOwnProperty]]</c>, so <c>3 in list</c> being <see langword="false"/> while
+/// <c>list.hasOwnProperty(3)</c> is <see langword="true"/> on the same object is not a divergence between two
+/// lanes an implementation may choose — it is a contradiction. It was the state of every array-like wrapper
+/// until #3423: the view owned <c>Get</c>, <c>Set</c>, <c>HasProperty</c>, <c>Delete</c> and the key
+/// enumerations, and left <c>[[GetOwnProperty]]</c> to <see cref="Jint.Runtime.Interop.ObjectWrapper"/>, which
+/// resolves the reflected indexer and reports a descriptor for <em>any</em> parseable index.
+/// </para>
+/// <para>
+/// Every shape below is an ordinary embedder exposure and every one of them reaches a different wrapper, which
+/// is the point: the contradiction was in the shared base and so was in all of them.
+/// </para>
+/// </remarks>
+public class HostCollectionIndexAgreementTests
+{
+    /// <summary>Every wrapper an array-like CLR target reaches, named by the exposure that produces it.</summary>
+    public static TheoryData<string> Shapes =>
+        new()
+        {
+            "List<int>",
+            "int[]",
+            "IReadOnlyList<int>",
+            "IList<int>",
+            "ArrayList",
+        };
+
+    /// <summary>
+    /// Keys that name no position of a three-element view: past the end, far past it, negative, and the two
+    /// integer-shaped spellings that are not canonical array indices.
+    /// </summary>
+    public static TheoryData<string> AbsentIndices => new() { "3", "10", "-1", "'3.5'", "'08'", "'+3'" };
+
+    /// <summary>Both spellings of every position the view does have — <c>x[1]</c> and <c>x['1']</c> are one key.</summary>
+    public static TheoryData<string> PresentIndices => new() { "0", "1", "2", "'0'", "'2'" };
+
+    private const string AllAbsent = "false,false,false,false,false,false";
+    private const string AllPresent = "true,true,true,true,true,true";
+
+    [Theory]
+    [MemberData(nameof(Shapes))]
+    public void EveryLaneAgreesThatAnAbsentIndexIsAbsent(string shape)
+    {
+        foreach (var key in AbsentIndices)
+        {
+            var engine = CreateEngine(shape);
+
+            Lanes(engine, key).Should().Be(AllAbsent,
+                "{0}[{1}] is not a position of the view, so no lane may report it as one", shape, key);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(Shapes))]
+    public void EveryLaneAgreesThatAPresentIndexIsPresent(string shape)
+    {
+        foreach (var key in PresentIndices)
+        {
+            var engine = CreateEngine(shape);
+
+            Lanes(engine, key).Should().Be(AllPresent,
+                "{0}[{1}] is a position of the view, so every lane reports it", shape, key);
+        }
+    }
+
+    /// <summary>
+    /// The descriptor lane resolved the reflected indexer and cached what it built, so a position that had been
+    /// asked about once went on being reported after the collection shrank past it. Reading the range first is
+    /// what makes the cached descriptor unreachable.
+    /// </summary>
+    [Fact]
+    public void AnIndexStopsExistingWhenTheCollectionShrinksPastIt()
+    {
+        var engine = CreateEngine("List<int>");
+
+        engine.Evaluate("x.hasOwnProperty(2)").AsBoolean().Should().BeTrue();
+
+        engine.Execute("x.length = 1");
+
+        Lanes(engine, "2").Should().Be(AllAbsent, "the third element is gone, and the cached descriptor for it is not the answer");
+    }
+
+    /// <summary>
+    /// A position the view does not have cannot be defined into one either, or it would exist for
+    /// <c>[[GetOwnProperty]]</c> and not for anything else. The refusal is what script already saw — the
+    /// reflected indexer's descriptor was non-configurable — so this pins the answer, not a new one.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(Shapes))]
+    public void DefiningAnAbsentIndexIsRefused(string shape)
+    {
+        var engine = CreateEngine(shape);
+
+        engine.Evaluate("Reflect.defineProperty(x, 5, { value: 42 })").AsBoolean().Should().BeFalse();
+        Record.Exception(() => engine.Execute("Object.defineProperty(x, 5, { value: 42 })"))
+            .Should().BeOfType<JavaScriptException>();
+        Lanes(engine, "5").Should().Be(AllAbsent, "nothing was defined");
+    }
+
+    /// <summary>
+    /// The one target shape that answers a string key from its own keys rather than by index — Newtonsoft's
+    /// <c>JObject</c> is both an <c>IDictionary&lt;string, _&gt;</c> and an <c>IList&lt;_&gt;</c> — is stood in for
+    /// here by a type with the same two interfaces. Its index-shaped keys are dictionary keys and must keep
+    /// answering as such.
+    /// </summary>
+    [Fact]
+    public void ADictionaryShapedArrayLikeStillAnswersFromItsKeys()
+    {
+        var engine = new Engine(options => options.AllowClr());
+        engine.SetValue("x", new KeyedList { { "3", 42 } });
+
+        engine.Evaluate("'3' in x").AsBoolean().Should().BeTrue();
+        engine.Evaluate("x.hasOwnProperty('3')").AsBoolean().Should().BeTrue();
+        engine.Evaluate("x['3']").AsNumber().Should().Be(42);
+    }
+
+    /// <summary>
+    /// Named CLR members are not positions and were never part of the disagreement; asserted so that reading
+    /// the index range first cannot be mistaken for owning every key.
+    /// </summary>
+    [Fact]
+    public void ANamedMemberIsUnaffected()
+    {
+        var engine = CreateEngine("List<int>");
+
+        engine.Evaluate("x.hasOwnProperty('Count')").AsBoolean().Should().BeTrue();
+        engine.Evaluate("x.Count").AsNumber().Should().Be(3);
+        engine.Evaluate("x.hasOwnProperty('NoSuchMember')").AsBoolean().Should().BeFalse();
+    }
+
+    /// <summary>
+    /// The six answers, in the order <see cref="AllAbsent"/> and <see cref="AllPresent"/> spell them, joined so
+    /// that a failure names every lane that disagreed instead of stopping at the first.
+    /// </summary>
+    private static string Lanes(Engine engine, string key) => engine.Evaluate($$"""
+        [
+            ({{key}} in x),
+            x.hasOwnProperty({{key}}),
+            x[{{key}}] !== undefined,
+            Object.getOwnPropertyDescriptor(x, {{key}}) !== undefined,
+            x.propertyIsEnumerable({{key}}),
+            Object.getOwnPropertyNames(x).indexOf(String({{key}})) >= 0
+        ].join(',')
+        """).AsString();
+
+    private static Engine CreateEngine(string shape)
+    {
+        var engine = new Engine(options =>
+        {
+            options.AllowClr();
+            options.Interop.AllowWrite = true;
+            options.Interop.ArrayConversion = ArrayConversionMode.LiveView;
+        });
+
+        engine.SetValue("x", Target(shape));
+        return engine;
+    }
+
+    private static object Target(string shape) => shape switch
+    {
+        "List<int>" => new List<int> { 1, 2, 3 },
+        "int[]" => new[] { 1, 2, 3 },
+        "IReadOnlyList<int>" => new ReadOnlyItems(1, 2, 3),
+        "IList<int>" => new IndexedItems(1, 2, 3),
+        "ArrayList" => new ArrayList { 1, 2, 3 },
+        _ => throw new ArgumentOutOfRangeException(nameof(shape), shape, "unknown shape"),
+    };
+
+    /// <summary>A host collection reachable only through <see cref="IReadOnlyList{T}"/>.</summary>
+    private sealed class ReadOnlyItems : IReadOnlyList<int>
+    {
+        private readonly List<int> _items;
+
+        public ReadOnlyItems(params int[] items) => _items = [.. items];
+
+        public int this[int index] => _items[index];
+
+        public int Count => _items.Count;
+
+        public IEnumerator<int> GetEnumerator() => _items.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => _items.GetEnumerator();
+    }
+
+    /// <summary>
+    /// A host collection that implements <see cref="IList{T}"/> and the non-generic <see cref="ICollection"/>
+    /// but not the non-generic <see cref="IList"/>.
+    /// </summary>
+    private sealed class IndexedItems : IList<int>, ICollection
+    {
+        private readonly List<int> _items;
+
+        public IndexedItems(params int[] items) => _items = [.. items];
+
+        public int this[int index] { get => _items[index]; set => _items[index] = value; }
+
+        public int Count => _items.Count;
+
+        public bool IsReadOnly => false;
+
+        public void Add(int item) => _items.Add(item);
+
+        public void Clear() => _items.Clear();
+
+        public bool Contains(int item) => _items.Contains(item);
+
+        public void CopyTo(int[] array, int arrayIndex) => _items.CopyTo(array, arrayIndex);
+
+        public int IndexOf(int item) => _items.IndexOf(item);
+
+        public void Insert(int index, int item) => _items.Insert(index, item);
+
+        public bool Remove(int item) => _items.Remove(item);
+
+        public void RemoveAt(int index) => _items.RemoveAt(index);
+
+        public IEnumerator<int> GetEnumerator() => _items.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => _items.GetEnumerator();
+
+        bool ICollection.IsSynchronized => false;
+
+        object ICollection.SyncRoot => this;
+
+        void ICollection.CopyTo(Array array, int index) => ((ICollection) _items).CopyTo(array, index);
+    }
+
+    /// <summary>
+    /// Both an <c>IDictionary&lt;string, int&gt;</c> and an <c>IList&lt;int&gt;</c>, the way Newtonsoft's
+    /// <c>JObject</c> is: its index-shaped keys are dictionary keys.
+    /// </summary>
+    private sealed class KeyedList : IDictionary<string, int>, IList<int>
+    {
+        private readonly Dictionary<string, int> _byKey = new(StringComparer.Ordinal);
+
+        public int this[string key] { get => _byKey[key]; set => _byKey[key] = value; }
+
+        public int this[int index] { get => _byKey.Values.ElementAt(index); set => throw new NotSupportedException(); }
+
+        public ICollection<string> Keys => _byKey.Keys;
+
+        public ICollection<int> Values => _byKey.Values;
+
+        public int Count => _byKey.Count;
+
+        public bool IsReadOnly => false;
+
+        public void Add(string key, int value) => _byKey.Add(key, value);
+
+        public void Add(KeyValuePair<string, int> item) => _byKey.Add(item.Key, item.Value);
+
+        public void Add(int item) => throw new NotSupportedException();
+
+        public void Clear() => _byKey.Clear();
+
+        public bool Contains(KeyValuePair<string, int> item) => _byKey.Contains(item);
+
+        public bool Contains(int item) => _byKey.ContainsValue(item);
+
+        public bool ContainsKey(string key) => _byKey.ContainsKey(key);
+
+        public void CopyTo(KeyValuePair<string, int>[] array, int arrayIndex)
+            => ((ICollection<KeyValuePair<string, int>>) _byKey).CopyTo(array, arrayIndex);
+
+        public void CopyTo(int[] array, int arrayIndex) => _byKey.Values.CopyTo(array, arrayIndex);
+
+        public int IndexOf(int item) => throw new NotSupportedException();
+
+        public void Insert(int index, int item) => throw new NotSupportedException();
+
+        public bool Remove(string key) => _byKey.Remove(key);
+
+        public bool Remove(KeyValuePair<string, int> item) => _byKey.Remove(item.Key);
+
+        public bool Remove(int item) => throw new NotSupportedException();
+
+        public void RemoveAt(int index) => throw new NotSupportedException();
+
+        public bool TryGetValue(string key, out int value) => _byKey.TryGetValue(key, out value);
+
+        IEnumerator<KeyValuePair<string, int>> IEnumerable<KeyValuePair<string, int>>.GetEnumerator() => _byKey.GetEnumerator();
+
+        IEnumerator<int> IEnumerable<int>.GetEnumerator() => _byKey.Values.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => _byKey.GetEnumerator();
+    }
+}

--- a/Jint.Tests.PublicInterface/HostCollectionIndexBoundsTests.cs
+++ b/Jint.Tests.PublicInterface/HostCollectionIndexBoundsTests.cs
@@ -1,0 +1,208 @@
+#nullable enable
+
+using System.Collections;
+using System.Globalization;
+using Jint.Native;
+using Jint.Runtime;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// A host collection that has a count and an indexer of its own, and none of the three interfaces that would
+/// give it an array-like <em>view</em>. It is wrapped plainly, so every index-shaped key resolves the
+/// reflected indexer — which takes whatever index it parsed out of the key straight to the collection.
+/// </summary>
+/// <remarks>
+/// <para>
+/// #3384 gave an <c>ArrayLikeWrapper</c> ownership of every index-shaped key, so an out-of-range write is
+/// refused rather than handed over. The refusal lives in the array-like view, and this shape does not get one:
+/// a plain <see cref="Jint.Runtime.Interop.ObjectWrapper"/> still went to the indexer and let the collection's
+/// own <see cref="ArgumentOutOfRangeException"/> out of <c>Evaluate</c>, where neither a script
+/// <c>try</c>/<c>catch</c> nor a host <c>catch (JavaScriptException)</c> can see it (#3422).
+/// </para>
+/// <para>
+/// The guard cannot be the array-like one, because a plain wrapper's indexer lane also serves
+/// <c>Dictionary&lt;int, string&gt;</c>, where <c>d[99] = "x"</c> is a legitimate add. Both halves are pinned
+/// here.
+/// </para>
+/// </remarks>
+public class HostCollectionIndexBoundsTests
+{
+    /// <summary>Keys naming a position a three-element window cannot address, in both spellings.</summary>
+    public static TheoryData<string> UnaddressableIndices => new() { "3", "'3'", "10", "-1", "'-1'", "'08'", "'+3'" };
+
+    [Theory]
+    [MemberData(nameof(UnaddressableIndices))]
+    public void ReadingAnIndexTheCollectionCannotAddressAnswersUndefined(string key)
+    {
+        var engine = CreateEngine(out _);
+
+        engine.Evaluate($"x[{key}]").Should().Be(JsValue.Undefined,
+            "there is no element at {0}, and a hole reads undefined rather than raising the collection's own exception", key);
+    }
+
+    [Theory]
+    [MemberData(nameof(UnaddressableIndices))]
+    public void WritingAnIndexTheCollectionCannotAddressIsTheOrdinarySetRefusal(string key)
+    {
+        var engine = CreateEngine(out var window);
+
+        engine.Execute($"x[{key}] = 9");
+        engine.Evaluate($"Reflect.set(x, {key}, 9)").AsBoolean().Should().BeFalse();
+
+        var thrown = Record.Exception(() => engine.Execute($"'use strict'; x[{key}] = 9;"));
+        thrown.Should().BeOfType<JavaScriptException>("a refused [[Set]] in strict mode is a TypeError");
+        ((JavaScriptException) thrown!).Error.Get("name").AsString().Should().Be("TypeError");
+
+        window.Should().Equal(new[] { 1, 2, 3 }, "nothing reached the collection");
+    }
+
+    [Theory]
+    [MemberData(nameof(UnaddressableIndices))]
+    public void EveryExistenceLaneAgreesThatSuchAnIndexIsAbsent(string key)
+    {
+        var engine = CreateEngine(out _);
+
+        engine.Evaluate($"[({key} in x), x.hasOwnProperty({key}), x.propertyIsEnumerable({key}), Object.getOwnPropertyDescriptor(x, {key}) !== undefined].join(',')")
+            .AsString().Should().Be("false,false,false,false",
+                "{0} is not a position of the collection, so no lane may report it as one", key);
+    }
+
+    [Theory]
+    [MemberData(nameof(UnaddressableIndices))]
+    public void DeletingSuchAnIndexSucceedsWithoutTouchingTheCollection(string key)
+    {
+        var engine = CreateEngine(out var window);
+
+        engine.Evaluate($"delete x[{key}]").AsBoolean().Should().BeTrue("OrdinaryDelete returns true for a property that is not there");
+        window.Should().Equal(1, 2, 3);
+    }
+
+    /// <summary>
+    /// The contrast that says the guard is a bound and not a ban on integer keys: every position the
+    /// collection does have still reads and writes through its own indexer.
+    /// </summary>
+    [Theory]
+    [InlineData("0", 1d)]
+    [InlineData("'0'", 1d)]
+    [InlineData("2", 3d)]
+    [InlineData("'2'", 3d)]
+    public void APositionTheCollectionHasIsUnaffected(string key, double expected)
+    {
+        var engine = CreateEngine(out var window);
+
+        engine.Evaluate($"x[{key}]").AsNumber().Should().Be(expected);
+        engine.Evaluate($"{key} in x").AsBoolean().Should().BeTrue();
+        engine.Evaluate($"x.hasOwnProperty({key})").AsBoolean().Should().BeTrue();
+
+        engine.Execute($"x[{key}] = 9");
+        window[int.Parse(key.Trim('\''), CultureInfo.InvariantCulture)].Should().Be(9);
+    }
+
+    /// <summary>Named CLR members of the same target keep resolving; only index-shaped keys are the view's.</summary>
+    [Fact]
+    public void NamedMembersAreUnaffected()
+    {
+        var engine = CreateEngine(out _);
+
+        engine.Evaluate("x.Count").AsNumber().Should().Be(3);
+        engine.Evaluate("x.length").AsNumber().Should().Be(3);
+        engine.Evaluate("Array.prototype.join.call(x, '-')").AsString().Should().Be("1-2-3");
+    }
+
+    /// <summary>
+    /// The other half of the trade-off. A wrapper's indexer lane also serves a dictionary, where a key outside
+    /// what it currently holds is a legitimate add and refusing it would be the bug. `IsArrayLike` is what
+    /// separates the two, and it is `false` for a dictionary.
+    /// </summary>
+    [Fact]
+    public void AnIntegerKeyedDictionaryStillAdds()
+    {
+        var engine = new Engine(options =>
+        {
+            options.AllowClr();
+            options.Interop.AllowWrite = true;
+        });
+        var dictionary = new Dictionary<int, string> { [1] = "one" };
+        engine.SetValue("x", dictionary);
+
+        engine.Execute("x[99] = 'ninety-nine'");
+
+        dictionary.Should().ContainKey(99).WhoseValue.Should().Be("ninety-nine");
+        engine.Evaluate("x[99]").AsString().Should().Be("ninety-nine");
+        engine.Evaluate("x[1]").AsString().Should().Be("one");
+    }
+
+    /// <summary>
+    /// A string-keyed indexer on an array-like target is not the collection's positions, and the check reads
+    /// the resolved accessor's index parameter rather than guessing from the key, so it stays out of the way.
+    /// <c>headers["3"]</c> is the header named <c>3</c>, whatever the count happens to be.
+    /// </summary>
+    [Fact]
+    public void AStringKeyedIndexerOnAnArrayLikeTargetStillAnswers()
+    {
+        var engine = new Engine(options =>
+        {
+            options.AllowClr();
+            options.Interop.AllowWrite = true;
+        });
+        engine.SetValue("x", new NamedValues { ["3"] = "the third", ["etag"] = "abc" });
+
+        engine.Evaluate("x['3']").AsString().Should().Be("the third");
+        engine.Evaluate("x['etag']").AsString().Should().Be("abc");
+    }
+
+    private static Engine CreateEngine(out Window window)
+    {
+        window = new Window(1, 2, 3);
+        var engine = new Engine(options =>
+        {
+            options.AllowClr();
+            options.Interop.AllowWrite = true;
+        });
+        engine.SetValue("x", window);
+        return engine;
+    }
+
+    /// <summary>
+    /// Bounded and indexed, and neither an <see cref="IList{T}"/>, an <see cref="IReadOnlyList{T}"/> nor a
+    /// non-generic <see cref="IList"/> — so no array-like view is built for it and every part of that is
+    /// load-bearing. <see cref="IReadOnlyCollection{T}"/> is what gives it a <c>Count</c>, and the declared
+    /// indexer is what the reflected member lane resolves for an index-shaped key.
+    /// </summary>
+    public sealed class Window : IReadOnlyCollection<int>
+    {
+        private readonly List<int> _items;
+
+        public Window(params int[] items) => _items = [.. items];
+
+        public int this[int index] { get => _items[index]; set => _items[index] = value; }
+
+        public int Count => _items.Count;
+
+        public IEnumerator<int> GetEnumerator() => _items.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => _items.GetEnumerator();
+    }
+
+    /// <summary>
+    /// An array-like target whose indexer is keyed by <see cref="string"/>, the shape a
+    /// <c>NameValueCollection</c> has.
+    /// </summary>
+    public sealed class NamedValues : IReadOnlyCollection<string>
+    {
+        private readonly Dictionary<string, string> _values = new(StringComparer.Ordinal);
+
+        public string this[string name]
+        {
+            get => _values.TryGetValue(name, out var value) ? value : string.Empty;
+            set => _values[name] = value;
+        }
+
+        public int Count => _values.Count;
+
+        public IEnumerator<string> GetEnumerator() => _values.Values.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => _values.Values.GetEnumerator();
+    }
+}

--- a/Jint.Tests.PublicInterface/HostCollectionIndexWriteTests.cs
+++ b/Jint.Tests.PublicInterface/HostCollectionIndexWriteTests.cs
@@ -1,0 +1,464 @@
+#nullable enable
+
+using System.Collections;
+using System.Collections.ObjectModel;
+using Jint.Runtime;
+using Jint.Runtime.Interop;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// Pins what an index names on a wrapped CLR collection: the same position whichever way script spelled it,
+/// and never an index the collection is left to reject.
+///
+/// <para>
+/// <c>x[3]</c> and <c>x["3"]</c> are one property key — <c>ToPropertyKey</c> makes both the String
+/// <c>"3"</c> — so they must be one answer. Until #3384 they were two: a number key was answered by the
+/// array-like view, and a string key by the reflected indexer, which took whatever index it parsed out of
+/// the key straight to the collection and let its <see cref="ArgumentOutOfRangeException"/> past script.
+/// </para>
+///
+/// <para>
+/// The growable half is the other question the issue asks. A wrapped <see cref="List{T}"/> answers
+/// <c>x.length = 5</c> by growing, so <c>x[3] = 9</c> — the same request, spelled the way a script author
+/// spells it — grows too: the view is an extensible ordinary object and the position can exist, so
+/// <c>CreateDataProperty</c> succeeds. A fixed-size or read-only target keeps the refusal #3381 and #3385
+/// gave it.
+/// </para>
+/// </summary>
+public class HostCollectionIndexWriteTests
+{
+    private static readonly string[] _growableShapes =
+    [
+        nameof(List<int>),
+        "ListOfString",
+        nameof(Collection<int>),
+        nameof(HostList),
+        nameof(ArrayList),
+        nameof(HostUntypedList),
+    ];
+
+    public static TheoryData<string> GrowableShapes => new(_growableShapes);
+
+    /// <summary>
+    /// Both spellings of every index-shaped key, so that a row cannot pass because the test happened to
+    /// write the one the engine already answered.
+    /// </summary>
+    public static TheoryData<string, string> GrowableShapesAndIndexSpellings
+    {
+        get
+        {
+            var data = new TheoryData<string, string>();
+            foreach (var shape in _growableShapes)
+            {
+                data.Add(shape, "3");
+                data.Add(shape, "'3'");
+            }
+
+            return data;
+        }
+    }
+
+    private static (object Host, Func<IReadOnlyList<string>> Read) CreateGrowableShape(string kind)
+    {
+        switch (kind)
+        {
+            case nameof(List<int>):
+            {
+                var items = new List<int> { 1, 2, 3 };
+                return (items, () => Render(items));
+            }
+            case "ListOfString":
+            {
+                // a reference item type, whose grown slots are null rather than a zero
+                var items = new List<string?> { "1", "2", "3" };
+                return (items, () => Render(items));
+            }
+            case nameof(Collection<int>):
+            {
+                var items = new Collection<int> { 1, 2, 3 };
+                return (items, () => Render(items));
+            }
+            case nameof(HostList):
+            {
+                var items = new List<int> { 1, 2, 3 };
+                return (new HostList(items), () => Render(items));
+            }
+            case nameof(ArrayList):
+            {
+                var items = new ArrayList { 1, 2, 3 };
+                return (items, () => Render(items.Cast<object?>()));
+            }
+            case nameof(HostUntypedList):
+            {
+                var items = new List<int> { 1, 2, 3 };
+                return (new HostUntypedList(items), () => Render(items));
+            }
+            default:
+                throw new ArgumentOutOfRangeException(nameof(kind), kind, "unknown shape");
+        }
+    }
+
+    private static IReadOnlyList<string> Render<T>(IEnumerable<T> items)
+        => items.Select(i => i?.ToString() ?? "null").ToList();
+
+    private static Engine CreateEngine(object host, bool strict = false)
+    {
+        var engine = new Engine(options =>
+        {
+            options.Strict = strict;
+            options.Interop.AllowWrite = true;
+        });
+        engine.SetValue("x", host);
+        return engine;
+    }
+
+    /// <summary>
+    /// The reported defect: an index write at the end of a growable list raised the CLR's own
+    /// <see cref="ArgumentOutOfRangeException"/> out of <c>Evaluate</c>, where a <c>length</c> write of the
+    /// same size grew the list.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(GrowableShapesAndIndexSpellings))]
+    public void AnIndexWriteAtTheEndOfAGrowableCollectionAppends(string shape, string index)
+    {
+        var (host, read) = CreateGrowableShape(shape);
+        var engine = CreateEngine(host);
+
+        engine.Execute("x[" + index + "] = 9");
+
+        read().Should().Equal("1", "2", "3", "9");
+        engine.Evaluate("x.length").AsNumber().Should().Be(4);
+    }
+
+    /// <summary>
+    /// An index past the end makes room the way the <c>length</c> write does, so the two agree cell for
+    /// cell — which is the whole point of the change, and what a JavaScript array's <c>a[5] = 9</c> means.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(GrowableShapesAndIndexSpellings))]
+    public void AnIndexWritePastTheEndGrowsExactlyAsTheLengthWriteDoes(string shape, string index)
+    {
+        var key = index == "3" ? "5" : "'5'";
+
+        var (throughIndex, readIndex) = CreateGrowableShape(shape);
+        CreateEngine(throughIndex).Execute("x[" + key + "] = 9");
+
+        var (throughLength, readLength) = CreateGrowableShape(shape);
+        CreateEngine(throughLength).Execute("x.length = 6; x[" + key + "] = 9");
+
+        readIndex().Should().Equal(readLength(), "growing through an index and growing through length are one request");
+        readIndex().Should().HaveCount(6);
+        readIndex()[5].Should().Be("9");
+    }
+
+    /// <summary>
+    /// The ordinary ways a script copies into a host list. Both are specified as <c>Set(O, k, v, true)</c>
+    /// over string keys, so both used to reach the reflected indexer and raise a CLR exception.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(GrowableShapes))]
+    public void CopyingIntoAGrowableCollectionGrowsIt(string shape)
+    {
+        var (host, read) = CreateGrowableShape(shape);
+        CreateEngine(host).Execute("Object.assign(x, { 3: 9 })");
+        read().Should().Equal("1", "2", "3", "9");
+
+        var (spreadHost, spreadRead) = CreateGrowableShape(shape);
+        CreateEngine(spreadHost).Execute("var src = { 3: 9 }; for (var k in src) { x[k] = src[k]; }");
+        spreadRead().Should().Equal("1", "2", "3", "9");
+    }
+
+    /// <summary>
+    /// A key that is index-shaped but can never be a position of the view: negative, non-canonical, or past
+    /// what the target can address. Each one used to be parsed by the reflected indexer and handed to the
+    /// collection; the view owes script the ordinary <c>[[Set]]</c> refusal instead — silent outside strict
+    /// mode, a <c>TypeError</c> inside it — because <c>x[-1]</c> reads <c>undefined</c> and <c>-1 in x</c>
+    /// is <see langword="false"/>, so a position it could be read back from does not exist.
+    /// </summary>
+    [Theory]
+    [InlineData("x[-1] = 9")]
+    [InlineData("x['-1'] = 9")]
+    [InlineData("x['08'] = 9")]
+    [InlineData("x['+3'] = 9")]
+    [InlineData("x[2147483648] = 9")]
+    public void AnIndexTheViewCannotHoldIsRefusedRatherThanHandedToTheCollection(string operation)
+    {
+        var (host, read) = CreateGrowableShape(nameof(List<int>));
+
+        CreateEngine(host).Evaluate(Probe(operation, strict: false)).AsString().Should().Be("no-throw");
+        read().Should().Equal("1", "2", "3");
+
+        CreateEngine(host, strict: true).Evaluate(Probe(operation, strict: true)).AsString().Should().Be("TypeError");
+        read().Should().Equal("1", "2", "3");
+    }
+
+    /// <summary>
+    /// The read side of the same key. <c>x["3"]</c> raised <see cref="ArgumentOutOfRangeException"/> out of
+    /// <c>Evaluate</c> where <c>x[3]</c> read <c>undefined</c> — a plain read of an absent index, on every
+    /// array-like wrapper including the read-only ones.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(GrowableShapes))]
+    public void ReadingAnAbsentIndexIsUndefinedInEitherSpelling(string shape)
+    {
+        var (host, _) = CreateGrowableShape(shape);
+        var engine = CreateEngine(host);
+
+        foreach (var key in new[] { "3", "'3'", "-1", "'-1'", "'08'" })
+        {
+            engine.Evaluate("x[" + key + "] === undefined").AsBoolean()
+                .Should().BeTrue("reading x[{0}] of a three-element view is a hole", key);
+        }
+    }
+
+    /// <summary>
+    /// <c>delete</c> of a position that is not there is a no-op that succeeds, and of one that is there
+    /// resets the slot. Both spellings agree; before, the number spelling reached the collection with an
+    /// out-of-range index and the string spelling refused an in-range one.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(GrowableShapes))]
+    public void DeletingAnIndexAnswersFromTheViewInEitherSpelling(string shape)
+    {
+        var (absentHost, absentRead) = CreateGrowableShape(shape);
+        var absent = CreateEngine(absentHost);
+        absent.Evaluate("delete x[3]").AsBoolean().Should().BeTrue();
+        absent.Evaluate("delete x['3']").AsBoolean().Should().BeTrue();
+        absent.Evaluate("delete x[-1]").AsBoolean().Should().BeTrue();
+        absentRead().Should().Equal("1", "2", "3");
+
+        var (presentHost, presentRead) = CreateGrowableShape(shape);
+        CreateEngine(presentHost).Evaluate("delete x['0']").AsBoolean().Should().BeTrue();
+        presentRead().Should().HaveCount(3);
+        presentRead()[0].Should().NotBe("1", "an in-range delete resets the slot, whichever way the index is spelled");
+    }
+
+    /// <summary>
+    /// The refusals a growable collection keeps. Neither is about the index: one is the engine's write
+    /// switch and the other is the object's own extensibility, and both are checked before the position is.
+    /// </summary>
+    [Theory]
+    [InlineData("3")]
+    [InlineData("'3'")]
+    public void GrowthStillNeedsWritesEnabledAndAnExtensibleView(string index)
+    {
+        var items = new List<int> { 1, 2, 3 };
+        // spelled out rather than left to the default: this branch ships Interop.AllowWrite on, so a bare
+        // `new Engine()` would be testing the growth lane rather than the write switch that gates it
+        var noWrites = new Engine(options => options.Interop.AllowWrite = false).SetValue("x", items);
+        noWrites.Execute("x[" + index + "] = 9");
+        items.Should().Equal(1, 2, 3);
+
+        var frozen = CreateEngine(items);
+        frozen.Execute("Object.preventExtensions(x); x[" + index + "] = 9");
+        items.Should().Equal(1, 2, 3);
+    }
+
+    /// <summary>
+    /// The fixed-size half, unchanged by the growth lane and now answering the string spelling too: an
+    /// in-range element write works and anything outside the bounds is the <c>TypeError</c> #3381 gave it.
+    /// A <c>T[]</c> live view used to raise <see cref="IndexOutOfRangeException"/> for
+    /// <c>x['3'] = 9</c> and, worse, <see cref="ArgumentException"/> for the perfectly ordinary
+    /// <c>x['2'] = 9</c> — the reflected indexer for a <c>T[]</c> is the object-typed
+    /// <see cref="IList"/> one, so the write bypassed item-type coercion.
+    /// </summary>
+    [Fact]
+    public void AFixedSizeViewAnswersBothSpellingsOfAnIndex()
+    {
+        var array = new[] { 1, 2, 3 };
+
+        var writable = LiveViewEngine(array);
+        writable.Execute("x['2'] = 9");
+        array.Should().Equal(1, 2, 9);
+
+        LiveViewEngine(array).Evaluate(Probe("x['3'] = 9", strict: false)).AsString().Should().Be("TypeError");
+        LiveViewEngine(array).Evaluate(Probe("x[3] = 9", strict: false)).AsString().Should().Be("TypeError");
+        array.Should().Equal(1, 2, 9);
+    }
+
+    private static Engine LiveViewEngine(object host)
+    {
+        var engine = new Engine(options =>
+        {
+            options.Interop.AllowWrite = true;
+            options.Interop.ArrayConversion = ArrayConversionMode.LiveView;
+        });
+        engine.SetValue("x", host);
+        return engine;
+    }
+
+    /// <summary>
+    /// An array or list handed to script under a read-only contract must refuse element writes in either
+    /// spelling. It used to refuse only the string one, and by accident: the reflected indexer of
+    /// <see cref="IReadOnlyList{T}"/> is get-only, while the view took its writability from the target.
+    /// </summary>
+    [Theory]
+    [InlineData("x[0] = 9")]
+    [InlineData("x['0'] = 9")]
+    [InlineData("x[3] = 9")]
+    [InlineData("x['3'] = 9")]
+    [InlineData("x.length = 5")]
+    public void AnExposedReadOnlyContractRefusesElementWritesInEitherSpelling(string operation)
+    {
+        var array = new[] { 1, 2, 3 };
+
+        ExposedReadOnly(array, strict: false).Evaluate(Probe(operation, strict: false)).AsString()
+            .Should().Be("no-throw", "a failed [[Set]] is silent outside strict mode");
+        array.Should().Equal(1, 2, 3);
+
+        ExposedReadOnly(array, strict: true).Evaluate(Probe(operation, strict: true)).AsString()
+            .Should().Be("TypeError", "a failed [[Set]] is a TypeError in strict mode");
+        array.Should().Equal(1, 2, 3);
+    }
+
+    [Theory]
+    [InlineData("x.push(9)")]
+    [InlineData("Object.assign(x, { 3: 9 })")]
+    public void AnExposedReadOnlyContractRefusesAGrowingGenericWithATypeError(string operation)
+    {
+        var array = new[] { 1, 2, 3 };
+
+        ExposedReadOnly(array, strict: false).Evaluate(Probe(operation, strict: false)).AsString()
+            .Should().Be("TypeError", "{0} is Set(O, k, v, true)", operation);
+        array.Should().Equal(1, 2, 3);
+    }
+
+    private static Engine ExposedReadOnly(int[] array, bool strict)
+    {
+        var engine = new Engine(options =>
+        {
+            options.Strict = strict;
+            options.Interop.AllowWrite = true;
+        });
+        engine.SetValue("x", ObjectWrapper.Create(engine, array, typeof(IReadOnlyList<int>)));
+        return engine;
+    }
+
+    /// <summary>
+    /// The blanket statement the three issues in this family are all about: whatever the shape and however
+    /// the index is spelled, what leaves <c>Evaluate</c> is a JavaScript error or nothing at all.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(GrowableShapes))]
+    public void NoIndexOperationLetsAClrExceptionPastScript(string shape)
+    {
+        string[] operations =
+        [
+            "x[3] = 9", "x['3'] = 9", "x[5] = 9", "x['5'] = 9", "x[-1] = 9", "x['-1'] = 9", "x['08'] = 9",
+            "x[2147483648] = 9", "x[3]", "x['3']", "x[-1]", "x['-1']", "delete x[3]", "delete x['3']",
+            "delete x[-1]", "Object.assign(x, { 4: 9 })",
+        ];
+
+        foreach (var operation in operations)
+        {
+            foreach (var strict in new[] { false, true })
+            {
+                var (host, _) = CreateGrowableShape(shape);
+                var engine = CreateEngine(host, strict);
+
+                var thrown = Record.Exception(() => engine.Execute(operation));
+
+                thrown.Should().Match(e => e == null || e is JavaScriptException,
+                    "{0} on {1} must answer script, not the CLR", operation, shape);
+            }
+        }
+    }
+
+    private static string Probe(string operation, bool strict)
+    {
+        var prologue = strict ? "'use strict';\n" : "";
+        return prologue
+            + "(function () { try { " + operation + "; return 'no-throw'; } "
+            + "catch (e) { return e instanceof TypeError ? 'TypeError' : 'unexpected: ' + e; } })()";
+    }
+
+    /// <summary>
+    /// A growable host list reaching the engine through the generic interface only.
+    /// </summary>
+    private sealed class HostList : IList<int>
+    {
+        private readonly List<int> _items;
+
+        public HostList(List<int> items) => _items = items;
+
+        public int Count => _items.Count;
+
+        public bool IsReadOnly => false;
+
+        public int this[int index]
+        {
+            get => _items[index];
+            set => _items[index] = value;
+        }
+
+        public void Add(int item) => _items.Add(item);
+
+        public void Clear() => _items.Clear();
+
+        public bool Contains(int item) => _items.Contains(item);
+
+        public void CopyTo(int[] array, int arrayIndex) => _items.CopyTo(array, arrayIndex);
+
+        public IEnumerator<int> GetEnumerator() => _items.GetEnumerator();
+
+        public int IndexOf(int item) => _items.IndexOf(item);
+
+        public void Insert(int index, int item) => _items.Insert(index, item);
+
+        public bool Remove(int item) => _items.Remove(item);
+
+        public void RemoveAt(int index) => _items.RemoveAt(index);
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    /// <summary>
+    /// A growable host list reaching the engine through the non-generic interface only, which is the
+    /// untyped view every typed one degrades to under Native AOT.
+    /// </summary>
+    private sealed class HostUntypedList : IList
+    {
+        private readonly List<int> _items;
+
+        public HostUntypedList(List<int> items) => _items = items;
+
+        public int Count => _items.Count;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => false;
+
+        public bool IsSynchronized => false;
+
+        public object SyncRoot => this;
+
+        public object? this[int index]
+        {
+            get => _items[index];
+            set => _items[index] = Convert.ToInt32(value, System.Globalization.CultureInfo.InvariantCulture);
+        }
+
+        public int Add(object? value)
+        {
+            _items.Add(Convert.ToInt32(value, System.Globalization.CultureInfo.InvariantCulture));
+            return _items.Count - 1;
+        }
+
+        public void Clear() => _items.Clear();
+
+        public bool Contains(object? value) => _items.Contains(Convert.ToInt32(value, System.Globalization.CultureInfo.InvariantCulture));
+
+        public void CopyTo(Array array, int index) => ((ICollection) _items).CopyTo(array, index);
+
+        public IEnumerator GetEnumerator() => _items.GetEnumerator();
+
+        public int IndexOf(object? value) => _items.IndexOf(Convert.ToInt32(value, System.Globalization.CultureInfo.InvariantCulture));
+
+        public void Insert(int index, object? value) => _items.Insert(index, Convert.ToInt32(value, System.Globalization.CultureInfo.InvariantCulture));
+
+        public void Remove(object? value) => _items.Remove(Convert.ToInt32(value, System.Globalization.CultureInfo.InvariantCulture));
+
+        public void RemoveAt(int index) => _items.RemoveAt(index);
+    }
+}

--- a/Jint.Tests.PublicInterface/HostExposedCollectionTypeTests.cs
+++ b/Jint.Tests.PublicInterface/HostExposedCollectionTypeTests.cs
@@ -1,0 +1,338 @@
+#nullable enable
+
+using System.Collections;
+using Jint.Runtime;
+using Jint.Runtime.Interop;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// A host object exposed to script under a collection <em>contract</em> rather than under its own type.
+/// <c>ObjectWrapper.Create(engine, target, typeof(IList&lt;int&gt;))</c> is public API, is what a
+/// <see cref="Options.WrapObjectDelegate"/> writes, and is what the member lane hands over for a property
+/// whose <em>declared</em> type is a collection interface — so everything below runs on every target
+/// framework and every leg, under a plain JIT with no trimming and no Native AOT anywhere near it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The exposure decides which wrapper is built, and the wrapper is what decides what script may do: whether
+/// elements can be written, whether the collection can grow, and which lane <c>Array.prototype</c> takes.
+/// <c>ResolveArrayLikeWrapperFactoryType</c> looked for <c>IList&lt;&gt;</c> and <c>IReadOnlyList&lt;&gt;</c>
+/// among the exposed type's <c>GetInterfaces()</c> and nowhere else. An interface is not among its own —
+/// <c>typeof(IList&lt;int&gt;)</c> yields <c>ICollection&lt;int&gt;</c>, <c>IEnumerable&lt;int&gt;</c> and
+/// <c>IEnumerable</c> — so exposing a collection <em>as</em> one of the two contracts the method is written to
+/// recognize found nothing, and the engine fell back to a wrapper the exposure had not named: a plain
+/// <see cref="ObjectWrapper"/> when the target is not a non-generic <see cref="IList"/>, and a
+/// target-writable <c>ListWrapper</c> when it is (#3421).
+/// </para>
+/// </remarks>
+public class HostExposedCollectionTypeTests
+{
+    /// <summary>
+    /// Which wrapper each exposure produces. Asserted by name because the wrapper types are internal, and
+    /// asserted at all because it is the fact every behaviour below follows from: a matrix that only checked
+    /// answers would go on passing while the engine quietly served them from the wrong view.
+    /// </summary>
+    [Theory]
+    [InlineData("IndexedItems", "IList<int>", "GenericListWrapper`1")]
+    [InlineData("IndexedItems", null, "GenericListWrapper`1")]
+    [InlineData("ReadOnlyItems", "IReadOnlyList<int>", "ReadOnlyListWrapper`1")]
+    [InlineData("ReadOnlyItems", null, "ReadOnlyListWrapper`1")]
+    [InlineData("List<int>", "IList<int>", "GenericListWrapper`1")]
+    [InlineData("List<int>", "IReadOnlyList<int>", "ReadOnlyListWrapper`1")]
+    [InlineData("int[]", "IReadOnlyList<int>", "ReadOnlyListWrapper`1")]
+    [InlineData("int[]", "IList<int>", "GenericListWrapper`1")]
+    [InlineData("int[]", null, "ArrayWrapper`1")]
+    public void TheExposedContractDecidesTheWrapper(string target, string? exposedAs, string expected)
+    {
+        var engine = new Engine(options => options.AllowClr());
+
+        var wrapper = ObjectWrapper.Create(engine, Target(target), ExposedType(exposedAs));
+
+        wrapper.GetType().Name.Should().Be(expected,
+            "{0} exposed as {1} names that contract, and the wrapper is what honours it", target, exposedAs ?? "its own type");
+    }
+
+    /// <summary>
+    /// A contract with no index in it names no view: <see cref="ICollection{T}"/> and
+    /// <see cref="IEnumerable{T}"/> are count-and-enumerate, so a target reachable only through them keeps the
+    /// plain wrapper. The check considers the exposed type itself, not every generic interface it can see.
+    /// </summary>
+    [Theory]
+    [InlineData("ICollection<int>")]
+    [InlineData("IEnumerable<int>")]
+    public void AContractWithNoIndexProducesNoView(string exposedAs)
+    {
+        var engine = new Engine(options => options.AllowClr());
+
+        var wrapper = ObjectWrapper.Create(engine, new IndexedItems(1, 2, 3), ExposedType(exposedAs));
+
+        wrapper.GetType().Should().Be<ObjectWrapper>();
+    }
+
+    /// <summary>
+    /// A host may hand <see cref="ObjectWrapper.Create(Engine, object, Type?)"/> a type its target does not
+    /// implement. Every typed wrapper casts the target to the contract the exposure named, and until the
+    /// exposed type itself was consulted such a factory could only be found by scanning the target's own
+    /// interfaces — so the cast could not fail. It keeps the answer it has always had rather than becoming an
+    /// <see cref="InvalidCastException"/> out of a wrapper creation.
+    /// </summary>
+    [Fact]
+    public void AnExposedTypeTheTargetDoesNotImplementIsNotCastTo()
+    {
+        var engine = new Engine(options => options.AllowClr());
+
+        var wrapper = ObjectWrapper.Create(engine, new IndexedItems(1, 2, 3), typeof(IReadOnlyList<int>));
+
+        wrapper.GetType().Should().Be<ObjectWrapper>("IndexedItems is not an IReadOnlyList<int>");
+    }
+
+    /// <summary>
+    /// Every read an <c>Array.prototype</c> generic makes over the exposed collection, plus the element read
+    /// and the two iteration forms. These answered correctly before too — through the plain wrapper's
+    /// reflection lane — so they are the half that must not change.
+    /// </summary>
+    [Theory]
+    [InlineData("Array.prototype.join.call(host, '-')", "1-2-3")]
+    [InlineData("Array.prototype.indexOf.call(host, 3)", 2d)]
+    [InlineData("Array.prototype.filter.call(host, function (x) { return x > 1; }).join('-')", "2-3")]
+    [InlineData("Array.prototype.map.call(host, function (x) { return x * 2; }).join('-')", "2-4-6")]
+    [InlineData("Array.prototype.slice.call(host, 1).join('-')", "2-3")]
+    [InlineData("Array.from(host).join('-')", "1-2-3")]
+    [InlineData("[...host].join('-')", "1-2-3")]
+    [InlineData("host.length", 3d)]
+    [InlineData("host[1]", 2d)]
+    [InlineData("JSON.stringify(host)", "[1,2,3]")]
+    public void ReadsThroughAnExposedContractAreUnchanged(string script, object expected)
+    {
+        var engine = CreateEngine("IndexedItems", "IList<int>", out _);
+
+        engine.Evaluate(script).ToObject().Should().Be(expected);
+    }
+
+    /// <summary>
+    /// The element keys of the view now enumerate as an array's do. Through the plain wrapper the same object
+    /// reported its reflected CLR member names instead — <c>IndexOf</c>, <c>Insert</c>, <c>RemoveAt</c> — for
+    /// a target script sees as a list.
+    /// </summary>
+    [Fact]
+    public void AnExposedCollectionEnumeratesItsPositions()
+    {
+        var engine = CreateEngine("IndexedItems", "IList<int>", out _);
+
+        engine.Evaluate("JSON.stringify(Object.keys(host))").AsString().Should().Be("[\"0\",\"1\",\"2\"]");
+        engine.Evaluate("JSON.stringify(Object.getOwnPropertyNames(host))").AsString().Should().Be("[\"0\",\"1\",\"2\"]");
+    }
+
+    /// <summary>
+    /// <see cref="IList{T}"/> declares a settable indexer, <c>Add</c> and <c>RemoveAt</c>, so a collection
+    /// exposed under it is writable and growable — which is what the typed wrapper the contract names gives
+    /// it, and what the plain wrapper could not.
+    /// </summary>
+    [Fact]
+    public void AWritableExposedContractIsWritableAndGrowable()
+    {
+        var engine = CreateEngine("IndexedItems", "IList<int>", out var items);
+
+        engine.Execute("host[0] = 9");
+        items.Should().Equal(new[] { 9, 2, 3 }, "IList<int> has a settable indexer");
+
+        engine.Evaluate("Array.prototype.push.call(host, 4)").AsNumber().Should().Be(4);
+        items.Should().Equal(new[] { 9, 2, 3, 4 }, "IList<int> has Add");
+
+        engine.Evaluate("Array.prototype.pop.call(host)").AsNumber().Should().Be(4);
+        items.Should().Equal(new[] { 9, 2, 3 }, "IList<int> has RemoveAt");
+
+        engine.Execute("host.length = 5");
+        items.Should().Equal(new[] { 9, 2, 3, 0, 0 });
+    }
+
+    /// <summary>
+    /// The other half. <see cref="IReadOnlyList{T}"/> declares a get-only indexer and no mutator at all, so a
+    /// <see cref="List{T}"/> handed to script under it must refuse every mutation — and refuse it as a
+    /// JavaScript error, not as a CLR exception. #3384 gave the refusal to a <c>ListWrapper</c> that took its
+    /// writability from the target; the exposure now gets the wrapper that says so from its type argument.
+    /// </summary>
+    [Theory]
+    [InlineData("Array.prototype.push.call(host, 4)")]
+    [InlineData("Array.prototype.pop.call(host)")]
+    [InlineData("Array.prototype.reverse.call(host)")]
+    [InlineData("Array.prototype.splice.call(host, 0, 0)")]
+    [InlineData("host.length = 5")]
+    public void AReadOnlyExposedContractRefusesMutationWithAJavaScriptError(string script)
+    {
+        var engine = CreateEngine("List<int>", "IReadOnlyList<int>", out var items);
+
+        Record.Exception(() => engine.Execute(script)).Should().Match(e => e == null || e is JavaScriptException,
+            "{0} must answer script, not the CLR", script);
+        items.Should().Equal(new[] { 1, 2, 3 }, "the collection is untouched");
+    }
+
+    [Fact]
+    public void AReadOnlyExposedContractStillReads()
+    {
+        var engine = CreateEngine("List<int>", "IReadOnlyList<int>", out _);
+
+        engine.Evaluate("host.length").AsNumber().Should().Be(3);
+        engine.Evaluate("host[1]").AsNumber().Should().Be(2);
+        engine.Evaluate("Array.prototype.join.call(host, '-')").AsString().Should().Be("1-2-3");
+        engine.Evaluate("host[3]").IsUndefined().Should().BeTrue();
+
+        engine.Execute("host[0] = 9");
+        engine.Evaluate("host[0]").AsNumber().Should().Be(1, "an element write through a read-only contract is refused");
+    }
+
+    /// <summary>
+    /// Whatever the exposure names, nothing script can do to the collection leaves a CLR exception to the
+    /// embedder. The two rows are the two contracts that name a view — a growable one and a read-only one —
+    /// so the same sixteen operations are answered from opposite ends of what the exposure permits.
+    /// </summary>
+    [Theory]
+    [InlineData("IndexedItems", "IList<int>")]
+    [InlineData("List<int>", "IReadOnlyList<int>")]
+    public void NoOperationOnAnExposedCollectionLetsAClrExceptionPastScript(string target, string exposedAs)
+    {
+        foreach (var script in new[]
+                 {
+                     "host[3] = 9",
+                     "host['3'] = 9",
+                     "host[-1] = 9",
+                     "Array.prototype.pop.call(host)",
+                     "Array.prototype.shift.call(host)",
+                     "Array.prototype.unshift.call(host, 0)",
+                     "Array.prototype.fill.call(host, 9)",
+                     "Array.prototype.reverse.call(host)",
+                     "Array.prototype.sort.call(host, function (a, b) { return b - a; })",
+                     "Array.prototype.splice.call(host, 0, 1)",
+                     "Array.prototype.push.call(host, 4)",
+                     "Array.from(host).join('-')",
+                     "[...host].join('-')",
+                     "host.length = 5",
+                     "delete host[3]",
+                     "JSON.stringify(host)",
+                 })
+        {
+            var engine = CreateEngine(target, exposedAs, out _);
+
+            Record.Exception(() => engine.Execute(script)).Should().Match(e => e == null || e is JavaScriptException,
+                "{0} on a collection exposed as {1} must answer script, not the CLR", script, exposedAs);
+        }
+    }
+
+    /// <summary>
+    /// The same exposure through the hook an embedder actually configures rather than through a hand-made
+    /// wrapper: <see cref="Options.WrapObjectDelegate"/> receives the target and returns the wrapper, and
+    /// narrowing what script sees is the reason the hook exists.
+    /// </summary>
+    [Fact]
+    public void AWrapObjectHandlerCanExposeAHostCollectionAsAGenericInterface()
+    {
+        var engine = new Engine(options =>
+        {
+            options.AllowClr();
+            options.Interop.AllowWrite = true;
+            options.Interop.WrapObjectHandler = static (e, target, _) => target is List<int>
+                ? ObjectWrapper.Create(e, target, typeof(IReadOnlyList<int>))
+                : ObjectWrapper.Create(e, target);
+        });
+        engine.SetValue("host", new List<int> { 1, 2, 3 });
+
+        engine.Evaluate("Array.prototype.join.call(host, '-')").AsString().Should().Be("1-2-3");
+        Record.Exception(() => engine.Execute("Array.prototype.push.call(host, 4)"))
+            .Should().BeOfType<JavaScriptException>("the handler narrowed the exposure to a read-only contract");
+    }
+
+    private static Engine CreateEngine(string target, string? exposedAs, out IEnumerable<int> host)
+    {
+        var instance = (IEnumerable<int>) Target(target);
+        host = instance;
+        var engine = new Engine(options =>
+        {
+            options.AllowClr();
+            options.Interop.AllowWrite = true;
+        });
+        engine.SetValue("host", ObjectWrapper.Create(engine, instance, ExposedType(exposedAs)));
+        return engine;
+    }
+
+    private static object Target(string target) => target switch
+    {
+        "IndexedItems" => new IndexedItems(1, 2, 3),
+        "ReadOnlyItems" => new ReadOnlyItems(1, 2, 3),
+        "List<int>" => new List<int> { 1, 2, 3 },
+        "int[]" => new[] { 1, 2, 3 },
+        _ => throw new ArgumentOutOfRangeException(nameof(target), target, "unknown target"),
+    };
+
+    private static Type? ExposedType(string? exposedAs) => exposedAs switch
+    {
+        null => null,
+        "IList<int>" => typeof(IList<int>),
+        "IReadOnlyList<int>" => typeof(IReadOnlyList<int>),
+        "ICollection<int>" => typeof(ICollection<int>),
+        "IEnumerable<int>" => typeof(IEnumerable<int>),
+        _ => throw new ArgumentOutOfRangeException(nameof(exposedAs), exposedAs, "unknown exposure"),
+    };
+
+    /// <summary>
+    /// A host collection that implements <see cref="IList{T}"/> and the non-generic <see cref="ICollection"/>
+    /// but <em>not</em> the non-generic <see cref="IList"/>. Every part of that is load-bearing: the generic
+    /// interface is what gives the type an index, the non-generic <see cref="ICollection"/> is where
+    /// <c>ArrayOperations</c> reads the count, and the absence of the non-generic <see cref="IList"/> is what
+    /// left the exposure with no <c>ListWrapper</c> to fall back to and therefore no view at all.
+    /// </summary>
+    private sealed class IndexedItems : IList<int>, ICollection
+    {
+        private readonly List<int> _items;
+
+        public IndexedItems(params int[] items) => _items = [.. items];
+
+        public int this[int index] { get => _items[index]; set => _items[index] = value; }
+
+        public int Count => _items.Count;
+
+        public bool IsReadOnly => false;
+
+        public void Add(int item) => _items.Add(item);
+
+        public void Clear() => _items.Clear();
+
+        public bool Contains(int item) => _items.Contains(item);
+
+        public void CopyTo(int[] array, int arrayIndex) => _items.CopyTo(array, arrayIndex);
+
+        public int IndexOf(int item) => _items.IndexOf(item);
+
+        public void Insert(int index, int item) => _items.Insert(index, item);
+
+        public bool Remove(int item) => _items.Remove(item);
+
+        public void RemoveAt(int index) => _items.RemoveAt(index);
+
+        public IEnumerator<int> GetEnumerator() => _items.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => _items.GetEnumerator();
+
+        bool ICollection.IsSynchronized => false;
+
+        object ICollection.SyncRoot => this;
+
+        void ICollection.CopyTo(Array array, int index) => ((ICollection) _items).CopyTo(array, index);
+    }
+
+    /// <summary>The read-only sibling, reachable only through <see cref="IReadOnlyList{T}"/>.</summary>
+    private sealed class ReadOnlyItems : IReadOnlyList<int>
+    {
+        private readonly List<int> _items;
+
+        public ReadOnlyItems(params int[] items) => _items = [.. items];
+
+        public int this[int index] => _items[index];
+
+        public int Count => _items.Count;
+
+        public IEnumerator<int> GetEnumerator() => _items.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => _items.GetEnumerator();
+    }
+}

--- a/Jint.Tests.PublicInterface/HostIndexerFilterTests.cs
+++ b/Jint.Tests.PublicInterface/HostIndexerFilterTests.cs
@@ -1,13 +1,23 @@
+using System.Collections.Generic;
+using System.Reflection;
 using Jint.Native;
+using Jint.Runtime;
 using Jint.Runtime.Interop;
 
 namespace Jint.Tests.PublicInterface;
 
 /// <summary>
-/// A member filter that rejects an indexer must actually hide indexed access —
-/// the resolver's default-indexer fast path must consult the filter with the
-/// same polarity as the candidate scan below it.
+/// A member filter that rejects an indexer must actually hide indexed access — on a plain wrapped object
+/// and on a wrapped collection alike, and in every lane: reads, existence, writes, growth, deletion and the
+/// <c>Array.prototype</c> generics an array-like view attracts.
 /// </summary>
+/// <remarks>
+/// <see cref="TypeResolver.MemberFilter"/> is CLR-containment configuration: it is how a host says which
+/// members script may reach. Every engine below sets <c>AllowWrite = true</c> — which is this branch's
+/// default and is spelled out anyway, because that is the configuration the containment question is
+/// actually asked in: with writes off, a write is refused for a reason that has nothing to do with the
+/// filter and proves nothing about it (#3558).
+/// </remarks>
 public class HostIndexerFilterTests
 {
     private sealed class IndexedHost
@@ -17,18 +27,33 @@ public class HostIndexerFilterTests
         public string Name => "host";
     }
 
+    /// <summary>
+    /// The filter the reproduction uses: everything except a property that takes index parameters.
+    /// </summary>
+    private static bool ExcludesIndexers(MemberInfo member)
+        => member is not PropertyInfo property || property.GetIndexParameters().Length == 0;
+
     private static Engine BuildEngine(bool allowIndexer)
     {
         var resolver = allowIndexer
             ? new TypeResolver()
-            : new TypeResolver
-            {
-                MemberFilter = static member => member is not System.Reflection.PropertyInfo property || property.GetIndexParameters().Length == 0,
-            };
+            : new TypeResolver { MemberFilter = ExcludesIndexers };
 
-        var engine = new Engine(options => options.Interop.TypeResolver = resolver);
+        var engine = new Engine(options =>
+        {
+            options.Interop.TypeResolver = resolver;
+            options.Interop.AllowWrite = true;
+        });
         engine.SetValue("host", new IndexedHost());
         return engine;
+    }
+
+    private static (Engine Engine, List<long> List) BuildListEngine(bool allowIndexer)
+    {
+        var engine = BuildEngine(allowIndexer);
+        var list = new List<long> { 1, 2, 3 };
+        engine.SetValue("list", list);
+        return (engine, list);
     }
 
     [Fact]
@@ -59,24 +84,228 @@ public class HostIndexerFilterTests
     [Fact]
     public void AMemberFilterExcludingTheIndexerBlocksIndexedWrites()
     {
+        var (engine, list) = BuildListEngine(allowIndexer: false);
+
+        engine.Evaluate("list[0] = 42;");
+
+        list[0].Should().Be(1, "a filter-excluded indexer must not be written through");
+    }
+
+    [Fact]
+    public void AMemberFilterExcludingTheIndexerBlocksTheStringSpellingOfAnIndexedWrite()
+    {
+        var (engine, list) = BuildListEngine(allowIndexer: false);
+
+        engine.Evaluate("list['0'] = 42;");
+
+        list[0].Should().Be(1, "x[0] and x['0'] are one property key, so one filter decision answers both");
+    }
+
+    [Fact]
+    public void AMemberFilterExcludingTheIndexerBlocksGrowth()
+    {
+        var (engine, list) = BuildListEngine(allowIndexer: false);
+
+        engine.Evaluate("list[3] = 42;");
+
+        list.Should().HaveCount(3, "a write past the end reaches the collection through the same hidden indexer");
+    }
+
+    [Fact]
+    public void AMemberFilterExcludingTheIndexerRefusesAnIndexedWriteInStrictMode()
+    {
+        var (engine, list) = BuildListEngine(allowIndexer: false);
+
+        Invoking(() => engine.Evaluate("'use strict'; list[0] = 42;"))
+            .Should().Throw<JavaScriptException>("a refused [[Set]] is a TypeError in strict mode");
+
+        list[0].Should().Be(1);
+    }
+
+    [Fact]
+    public void AMemberFilterExcludingTheIndexerHidesCollectionElements()
+    {
+        var (engine, _) = BuildListEngine(allowIndexer: false);
+
+        engine.Evaluate("list[0]").Should().Be(JsValue.Undefined);
+        engine.Evaluate("list['0']").Should().Be(JsValue.Undefined);
+    }
+
+    [Fact]
+    public void AMemberFilterExcludingTheIndexerLeavesNoElementProperties()
+    {
+        var (engine, _) = BuildListEngine(allowIndexer: false);
+
+        // "in" is defined in terms of [[GetOwnProperty]], so these three may not disagree
+        engine.Evaluate("0 in list").AsBoolean().Should().BeFalse();
+        engine.Evaluate("list.hasOwnProperty(0)").AsBoolean().Should().BeFalse();
+        engine.Evaluate("Object.keys(list).length").AsNumber().Should().Be(0);
+    }
+
+    [Fact]
+    public void AMemberFilterExcludingTheIndexerLeavesNothingToDelete()
+    {
+        var (engine, list) = BuildListEngine(allowIndexer: false);
+
+        engine.Evaluate("delete list[0]").AsBoolean().Should().BeTrue("deleting an absent property succeeds");
+
+        list[0].Should().Be(1, "and it must not reach the collection to zero the slot");
+    }
+
+    [Fact]
+    public void AMemberFilterExcludingTheIndexerBlocksTheArrayPrototypeGenerics()
+    {
+        var (engine, list) = BuildListEngine(allowIndexer: false);
+
+        Invoking(() => engine.Evaluate("Array.prototype.push.call(list, 9);"))
+            .Should().Throw<JavaScriptException>("push writes through the element lane the filter closed");
+
+        list.Should().Equal(1, 2, 3);
+    }
+
+    [Fact]
+    public void AMemberFilterExcludingTheIndexerBlocksASortFromReachingTheCollection()
+    {
         var engine = BuildEngine(allowIndexer: false);
-        var list = new System.Collections.Generic.List<long> { 1, 2, 3 };
+        var list = new List<long> { 3, 1, 2 };
         engine.SetValue("list", list);
 
         try
         {
-            engine.Evaluate("list[0] = 42;");
+            engine.Evaluate("Array.prototype.sort.call(list);");
         }
-        catch (Jint.Runtime.JavaScriptException)
+        catch (JavaScriptException)
         {
-            // a script-level rejection is fine
-        }
-        catch (InvalidOperationException)
-        {
-            // the wrapper's pre-existing surface for writes that resolve to nothing;
-            // what this test pins is that the filtered-out indexer is never written through
+            // a script-level refusal is the shape a hidden element lane owes a mutating generic
         }
 
-        list[0].Should().Be(1, "a filter-excluded indexer must not be written through");
+        list.Should().Equal(new long[] { 3, 1, 2 }, "sort reorders through the element lane the filter closed");
+    }
+
+    [Fact]
+    public void AFixedSizeArrayIsCoveredByTheSameDecision()
+    {
+        // LiveView so that the array crosses as a wrapper: it is this branch's default, and is spelled out
+        // because the decision only has anything to answer for a wrapper. Under ArrayConversionMode.Copy the
+        // array becomes a JsArray before any member is accessed, and a copy is a conversion of the value
+        // rather than an access to a member, so no member filter speaks for it.
+        var resolver = new TypeResolver { MemberFilter = ExcludesIndexers };
+        var engine = new Engine(options =>
+        {
+            options.Interop.TypeResolver = resolver;
+            options.Interop.AllowWrite = true;
+            options.Interop.ArrayConversion = ArrayConversionMode.LiveView;
+        });
+
+        var array = new long[] { 1, 2, 3 };
+        engine.SetValue("array", array);
+
+        engine.Evaluate("array[0]").Should().Be(JsValue.Undefined);
+        engine.Evaluate("array[0] = 42;");
+
+        array[0].Should().Be(1, "a CLR array declares no indexer of its own, so the decision is the one its IList indexer gets");
+    }
+
+    [Fact]
+    public void AReadOnlyExposureIsCoveredByTheSameDecision()
+    {
+        var engine = BuildEngine(allowIndexer: false);
+        IReadOnlyList<long> view = new List<long> { 1, 2, 3 };
+        engine.SetValue("view", view);
+
+        engine.Evaluate("view[0]").Should().Be(JsValue.Undefined);
+    }
+
+    [Fact]
+    public void TheDefaultConfigurationServesCollectionElements()
+    {
+        var (engine, list) = BuildListEngine(allowIndexer: true);
+
+        engine.Evaluate("list[0]").AsNumber().Should().Be(1);
+        engine.Evaluate("0 in list").AsBoolean().Should().BeTrue();
+
+        engine.Evaluate("list[0] = 42;");
+        list[0].Should().Be(42, "nothing here may cost an unfiltered engine its element lane");
+
+        engine.Evaluate("list[3] = 7;");
+        list.Should().Equal(42, 2, 3, 7);
+
+        engine.Evaluate("Array.prototype.push.call(list, 9);");
+        list.Should().Equal(42, 2, 3, 7, 9);
+    }
+
+    /// <summary>
+    /// Containment and writability are separate facts, and this branch is where that can be seen: writes are
+    /// on by default here, so a filtered engine that also turns them off must still hide the elements rather
+    /// than merely refuse to change them. On <c>main</c>, where <c>AllowWrite</c> defaults to
+    /// <see langword="false"/>, this is the configuration every write assertion above would silently have
+    /// been making, which is why they all say <c>AllowWrite = true</c>.
+    /// </summary>
+    [Fact]
+    public void TheContainmentDecisionDoesNotDependOnTheWriteConfiguration()
+    {
+        var resolver = new TypeResolver { MemberFilter = ExcludesIndexers };
+        var engine = new Engine(options =>
+        {
+            options.Interop.TypeResolver = resolver;
+            options.Interop.AllowWrite = false;
+        });
+
+        var list = new List<long> { 1, 2, 3 };
+        engine.SetValue("list", list);
+
+        engine.Evaluate("list[0]").Should().Be(JsValue.Undefined, "a hidden member reads undefined whether or not writes are on");
+        engine.Evaluate("0 in list").AsBoolean().Should().BeFalse();
+        engine.Evaluate("list.hasOwnProperty(0)").AsBoolean().Should().BeFalse();
+        engine.Evaluate("delete list[0]").AsBoolean().Should().BeTrue("there is no property here to refuse a delete of");
+
+        engine.Evaluate("list[0] = 42;");
+        list[0].Should().Be(1);
+    }
+
+    /// <summary>
+    /// The same, on the configuration an embedder of this branch gets without asking: <c>AllowWrite</c>
+    /// defaults to <see langword="true"/> here, so the filter is the only thing standing between script and
+    /// the collection.
+    /// </summary>
+    [Fact]
+    public void TheContainmentDecisionHoldsOnThisBranchsDefaultWriteConfiguration()
+    {
+        var resolver = new TypeResolver { MemberFilter = ExcludesIndexers };
+        var allowWrite = false;
+        var engine = new Engine(options =>
+        {
+            options.Interop.TypeResolver = resolver;
+            allowWrite = options.Interop.AllowWrite;
+        });
+        allowWrite.Should().BeTrue("this branch ships writes on, which is what makes the filter load-bearing");
+
+        var list = new List<long> { 1, 2, 3 };
+        engine.SetValue("list", list);
+
+        engine.Evaluate("list[0]").Should().Be(JsValue.Undefined);
+        engine.Evaluate("list[0] = 42;");
+        engine.Evaluate("list[3] = 42;");
+
+        list.Should().Equal(1, 2, 3);
+    }
+
+    [Fact]
+    public void AFilterThatKeepsTheIndexerKeepsTheElementLane()
+    {
+        // a filter that rejects something else entirely must not cost the collection its elements
+        var resolver = new TypeResolver { MemberFilter = static member => !string.Equals(member.Name, "Capacity", StringComparison.Ordinal) };
+        var engine = new Engine(options =>
+        {
+            options.Interop.TypeResolver = resolver;
+            options.Interop.AllowWrite = true;
+        });
+
+        var list = new List<long> { 1, 2, 3 };
+        engine.SetValue("list", list);
+
+        engine.Evaluate("list[0]").AsNumber().Should().Be(1);
+        engine.Evaluate("list[0] = 42;");
+        list[0].Should().Be(42);
     }
 }

--- a/Jint.Tests.PublicInterface/HostNonIndexedCollectionTests.cs
+++ b/Jint.Tests.PublicInterface/HostNonIndexedCollectionTests.cs
@@ -1,0 +1,304 @@
+#nullable enable
+
+using System.Collections;
+using Jint.Runtime;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// Pins what the <c>Array.prototype</c> generics do to a wrapped CLR collection that has a count but no
+/// index — <see cref="Queue{T}"/>, <see cref="Stack{T}"/>, <see cref="LinkedList{T}"/>,
+/// <see cref="SortedSet{T}"/>, <see cref="HashSet{T}"/>, and an embedder's own
+/// <see cref="System.Collections.ICollection"/>.
+///
+/// <para>
+/// Every one of those is array-like — it has a <c>Count</c>, so the wrapper carries <c>Array.prototype</c>
+/// and a live <c>length</c> — and none of them has an element at index 0. <c>ICollection</c> is a
+/// count-and-copy contract; the index is not in it. So the generics honour <c>length</c> and read
+/// <see langword="undefined"/> at every index, which is what an array-like with no index properties means in
+/// JavaScript, and iteration keeps yielding the real elements because that goes through the wrapper's
+/// <c>Symbol.iterator</c> instead. That split is the specification's, not an interop compromise:
+/// <c>Array.prototype.join</c> is <i>LengthOfArrayLike</i> plus <i>Get(O, ToString(k))</i>, while spread,
+/// <c>for..of</c>, <c>Array.from</c> and array destructuring are all <i>GetIterator</i>.
+/// </para>
+///
+/// <para>
+/// Before #3302 the five that implement the <em>non-generic</em> <c>ICollection</c> reached an indexed lane
+/// that cast their target to <c>IList</c>, so every generic above threw a raw
+/// <see cref="InvalidCastException"/> out of <c>Engine.Evaluate</c> — not a
+/// <see cref="Jint.Runtime.JavaScriptException"/>, so neither a host <c>catch</c> nor a script
+/// <c>try</c>/<c>catch</c> could see it. <see cref="HashSet{T}"/> is carried along here because it is a
+/// collection through the generic interface only and so was never admitted to that lane: it is the shape the
+/// other five now match.
+/// </para>
+/// </summary>
+public class HostNonIndexedCollectionTests
+{
+    public static TheoryData<string> CountedButNotIndexed => new TheoryData<string>
+    {
+        nameof(Queue<int>),
+        nameof(Stack<int>),
+        nameof(LinkedList<int>),
+        nameof(SortedSet<int>),
+        nameof(HashSet<int>),
+        nameof(CountOnlyCollection),
+    };
+
+    private static object CreateCollection(string kind) => kind switch
+    {
+        nameof(Queue<int>) => new Queue<int>(new[] { 1, 2, 3 }),
+        // enumerates top-first, so push 3, 2, 1 to iterate 1, 2, 3
+        nameof(Stack<int>) => new Stack<int>(new[] { 3, 2, 1 }),
+        nameof(LinkedList<int>) => new LinkedList<int>(new[] { 1, 2, 3 }),
+        nameof(SortedSet<int>) => new SortedSet<int> { 1, 2, 3 },
+        nameof(CountOnlyCollection) => new CountOnlyCollection(),
+        _ => new HashSet<int> { 1, 2, 3 },
+    };
+
+    private static Engine CreateEngine(object host, Action<Options>? configure = null)
+    {
+        var engine = new Engine(options => configure?.Invoke(options));
+        engine.SetValue("host", host);
+        return engine;
+    }
+
+    [Theory]
+    [MemberData(nameof(CountedButNotIndexed))]
+    public void TheIndexReadingGenericsHonourLengthAndFindNoElements(string kind)
+    {
+        var engine = CreateEngine(CreateCollection(kind));
+
+        // the count is there, and so is the prototype the generics are read off
+        engine.Evaluate("host.length").Should().Be(3);
+        engine.Evaluate("Object.getPrototypeOf(host) === Array.prototype").Should().BeTrue();
+
+        // ...but there is nothing at any index, so the separators alone show length was honoured
+        engine.Evaluate("host[0]").Should().BeUndefined();
+        engine.Evaluate("'0' in host").Should().BeFalse();
+        engine.Evaluate("Array.prototype.join.call(host, '-')").Should().Be("--");
+        engine.Evaluate("Array.prototype.map.call(host, function (x) { return x; }).join('-')").Should().Be("--");
+        engine.Evaluate("Array.prototype.slice.call(host).length").Should().Be(3);
+
+        // and the generics that skip absent indices see nothing at all
+        engine.Evaluate("Array.prototype.filter.call(host, function () { return true; }).length").Should().Be(0);
+        engine.Evaluate("Array.prototype.indexOf.call(host, 2)").Should().Be(-1);
+        engine.Evaluate("Array.prototype.includes.call(host, 2)").Should().BeFalse();
+        engine.Evaluate("""
+            var visited = 0;
+            Array.prototype.forEach.call(host, function () { visited++; });
+            visited;
+            """).Should().Be(0);
+    }
+
+    [Theory]
+    [MemberData(nameof(CountedButNotIndexed))]
+    public void EveryIteratingFormYieldsTheRealElements(string kind)
+    {
+        var engine = CreateEngine(CreateCollection(kind));
+
+        engine.Evaluate("[...host].join('-')").Should().Be("1-2-3");
+        engine.Evaluate("Array.from(host).join('-')").Should().Be("1-2-3");
+        engine.Evaluate("(function () { var r = []; for (var x of host) { r.push(x); } return r.join('-'); })()")
+            .Should().Be("1-2-3");
+    }
+
+    [Theory]
+    [MemberData(nameof(CountedButNotIndexed))]
+    public void ArrayDestructuringAgreesWithSpread(string kind)
+    {
+        // Both are GetIterator over the same value (https://tc39.es/ecma262/#sec-runtime-semantics-bindinginitialization),
+        // so an index-reading fast path is only allowed to stand in for the iterator where the two agree.
+        // Over a collection with no index they do not, and destructuring used to produce holes for a
+        // HashSet<T> and an InvalidCastException for the rest.
+        var engine = CreateEngine(CreateCollection(kind));
+
+        engine.Evaluate("(function () { var [...r] = host; return r.join('-'); })()").Should().Be("1-2-3");
+        engine.Evaluate("(function () { var [first] = host; return first; })()").Should().Be(1);
+        engine.Evaluate("(function () { var [, second] = host; return second; })()").Should().Be(2);
+    }
+
+    [Theory]
+    [MemberData(nameof(CountedButNotIndexed))]
+    public void NoClrExceptionEscapesIntoScript(string kind)
+    {
+        // The unambiguous half of #3302: whatever the answer is, it must be a JavaScript one. Every mutating
+        // generic is in here too, because the faulting lane was reached for writes as well as reads.
+        string[] scripts =
+        [
+            "Array.prototype.join.call(host, '-')",
+            "Array.prototype.map.call(host, function (x) { return x; })",
+            "Array.prototype.filter.call(host, function () { return true; })",
+            "Array.prototype.forEach.call(host, function () { })",
+            "Array.prototype.indexOf.call(host, 2)",
+            "Array.prototype.lastIndexOf.call(host, 2)",
+            "Array.prototype.includes.call(host, 2)",
+            "Array.prototype.slice.call(host)",
+            "Array.prototype.every.call(host, function () { return true; })",
+            "Array.prototype.some.call(host, function () { return true; })",
+            "Array.prototype.reduce.call(host, function (a, b) { return a + b; }, 0)",
+            "Array.prototype.flat.call(host)",
+            "Array.prototype.toString.call(host)",
+            "[...host]",
+            "Array.from(host)",
+            "(function () { var [...r] = host; return r; })()",
+            "Math.max.apply(null, host)",
+            "JSON.stringify(host)",
+            "try { Array.prototype.sort.call(host); } catch (e) { }",
+            "try { Array.prototype.reverse.call(host); } catch (e) { }",
+            "try { Array.prototype.push.call(host, 4); } catch (e) { }",
+            "try { Array.prototype.pop.call(host); } catch (e) { }",
+            "try { Array.prototype.fill.call(host, 0); } catch (e) { }",
+            "try { Array.prototype.splice.call(host, 0, 1); } catch (e) { }",
+        ];
+
+        foreach (var script in scripts)
+        {
+            var engine = CreateEngine(CreateCollection(kind));
+            var run = () => engine.Evaluate(script);
+            run.Should().NotThrow($"'{script}' must not leak a CLR exception for a {kind}");
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(CountedButNotIndexed))]
+    public void AGrowingGenericFailsAsACatchableTypeError(string kind)
+    {
+        // What still throws, and why that is right: push writes "length", which forwards to a read-only
+        // Count. That is an ordinary JavaScript refusal, visible to script and to a host catch.
+        var engine = CreateEngine(CreateCollection(kind));
+
+        engine.Evaluate("""
+            try {
+                Array.prototype.push.call(host, 4);
+                'no throw';
+            } catch (e) {
+                e instanceof TypeError ? 'TypeError' : 'other: ' + e;
+            }
+            """).Should().Be("TypeError");
+
+        var throwsFromHost = () => engine.Evaluate("Array.prototype.push.call(host, 4)");
+        throwsFromHost.Should().Throw<JavaScriptException>();
+    }
+
+    [Theory]
+    [MemberData(nameof(CountedButNotIndexed))]
+    public void ASortingGenericIsANoOp(string kind)
+    {
+        // The other half of the write side, and equally specified: sort collects the present elements
+        // (none), sorts them, and writes nothing back. The collection is untouched.
+        var collection = CreateCollection(kind);
+        var engine = CreateEngine(collection);
+
+        engine.Evaluate("Array.prototype.sort.call(host) === host").Should().BeTrue();
+        engine.Evaluate("Array.prototype.reverse.call(host) === host").Should().BeTrue();
+        engine.Evaluate("[...host].join('-')").Should().Be("1-2-3");
+    }
+
+    [Fact]
+    public void AnIndexerIsWhatDecidesWhetherTheElementsAreFound()
+    {
+        // The boundary from the other side: the same non-generic ICollection, with an integer indexer added.
+        // Nothing about it is an IList, so it takes the very same route — and the generics find every element
+        // through the reflected indexer. Before the fix this shape threw too, even though host[0] worked.
+        var engine = CreateEngine(new IndexedCountOnlyCollection());
+
+        engine.Evaluate("host.length").Should().Be(3);
+        engine.Evaluate("host[0]").Should().Be(1);
+        engine.Evaluate("Array.prototype.join.call(host, '-')").Should().Be("1-2-3");
+        engine.Evaluate("Array.prototype.indexOf.call(host, 2)").Should().Be(1);
+        engine.Evaluate("Array.prototype.filter.call(host, function (x) { return x > 1; }).join('-')").Should().Be("2-3");
+        engine.Evaluate("(function () { var [...r] = host; return r.join('-'); })()").Should().Be("1-2-3");
+    }
+
+    [Fact]
+    public void AnIndexableCollectionIsUnchanged()
+    {
+        // The control: List<T> has an indexer and keeps the indexed lane untouched.
+        var engine = CreateEngine(new List<int> { 1, 2, 3 });
+
+        engine.Evaluate("host.length").Should().Be(3);
+        engine.Evaluate("host[0]").Should().Be(1);
+        engine.Evaluate("'0' in host").Should().BeTrue();
+        engine.Evaluate("Array.prototype.join.call(host, '-')").Should().Be("1-2-3");
+        engine.Evaluate("Array.prototype.indexOf.call(host, 2)").Should().Be(1);
+        engine.Evaluate("Array.prototype.map.call(host, function (x) { return x * 2; }).join('-')").Should().Be("2-4-6");
+        engine.Evaluate("(function () { var [...r] = host; return r.join('-'); })()").Should().Be("1-2-3");
+    }
+
+    [Theory]
+    [MemberData(nameof(CountedButNotIndexed))]
+    public void TheConversionModesDoNotChangeAnyOfIt(string kind)
+    {
+        // ArrayConversionMode is about CLR arrays and EnumerableConversionMode about sequences with no count,
+        // so neither reaches a counted, non-indexed collection: it stays a live wrapper under all of them.
+        foreach (var configure in new Action<Options>[]
+                 {
+                     o => o.Interop.ArrayConversion = ArrayConversionMode.LiveView,
+                     o => o.Interop.EnumerableConversion = EnumerableConversionMode.Snapshot,
+                 })
+        {
+            var engine = CreateEngine(CreateCollection(kind), configure);
+
+            engine.Evaluate("host.length").Should().Be(3);
+            engine.Evaluate("Array.prototype.join.call(host, '-')").Should().Be("--");
+            engine.Evaluate("[...host].join('-')").Should().Be("1-2-3");
+        }
+    }
+
+    [Fact]
+    public void LengthStaysLive()
+    {
+        var queue = new Queue<int>(new[] { 1, 2, 3 });
+        var engine = CreateEngine(queue);
+
+        engine.Evaluate("host.length").Should().Be(3);
+
+        queue.Dequeue();
+        engine.Evaluate("host.length").Should().Be(2);
+        engine.Evaluate("[...host].join('-')").Should().Be("2-3");
+
+        queue.Clear();
+        engine.Evaluate("host.length").Should().Be(0);
+        engine.Evaluate("Array.prototype.join.call(host, '-')").Should().Be("");
+    }
+
+    /// <summary>
+    /// An embedder's own collection: a count and an enumerator, reachable through the non-generic
+    /// <see cref="System.Collections.ICollection"/> and nothing else. No indexer of any kind.
+    /// </summary>
+    private sealed class CountOnlyCollection : ICollection
+    {
+        private readonly int[] _items = [1, 2, 3];
+
+        public int Count => _items.Length;
+
+        public bool IsSynchronized => false;
+
+        public object SyncRoot => this;
+
+        public void CopyTo(Array array, int index) => _items.CopyTo(array, index);
+
+        public IEnumerator GetEnumerator() => _items.GetEnumerator();
+    }
+
+    /// <summary>
+    /// The same shape with an integer indexer, which is not an <see cref="IList"/> either — the members are
+    /// simply there to be reflected over.
+    /// </summary>
+    private sealed class IndexedCountOnlyCollection : ICollection
+    {
+        private readonly int[] _items = [1, 2, 3];
+
+        public int Count => _items.Length;
+
+        public bool IsSynchronized => false;
+
+        public object SyncRoot => this;
+
+        public int this[int index] => _items[index];
+
+        public void CopyTo(Array array, int index) => _items.CopyTo(array, index);
+
+        public IEnumerator GetEnumerator() => _items.GetEnumerator();
+    }
+}

--- a/Jint.Tests/Runtime/InteropTests.ClrArrayLiveView.cs
+++ b/Jint.Tests/Runtime/InteropTests.ClrArrayLiveView.cs
@@ -395,4 +395,42 @@ public partial class InteropTests
         list.Should().HaveCount(4);
         list[3].Should().Be(4);
     }
+
+    [Theory]
+    [InlineData("list.push(4)")]
+    [InlineData("list.pop()")]
+    [InlineData("list.splice(0, 1)")]
+    [InlineData("list.length = 1")]
+    [InlineData("list.length = 10")]
+    [InlineData("list[3] = 4")]
+    public void FixedSizeUntypedListRefusesResizeWithTypeError(string operation)
+    {
+        // ArrayList.FixedSize implements IList and no generic collection interface, so it resolves to the
+        // untyped ListWrapper - which is also what a T[] falls back to when its typed ArrayWrapper<T>
+        // cannot be instantiated (Native AOT over a value type, #3299). Until ListWrapper honoured
+        // IList.IsFixedSize, every length-changing operation reached IList.Add/RemoveAt and leaked the
+        // collection's own NotSupportedException past script instead of the TypeError the typed wrapper
+        // raises for the same operation.
+        var engine = CreateLiveViewEngine();
+        engine.SetValue("list", System.Collections.ArrayList.FixedSize(new System.Collections.ArrayList { 1, 2, 3 }));
+
+        var result = engine.Evaluate(
+            $"(function() {{ try {{ {operation}; return 'no-throw'; }} catch (e) {{ return e instanceof TypeError ? 'TypeError' : 'unexpected: ' + e; }} }})()");
+
+        result.AsString().Should().Be("TypeError");
+        engine.Evaluate("list.length").AsNumber().Should().Be(3);
+    }
+
+    [Fact]
+    public void GrowableUntypedListStillResizes()
+    {
+        var list = new System.Collections.ArrayList { 1, 2, 3 };
+        var engine = CreateLiveViewEngine();
+        engine.SetValue("list", list);
+
+        engine.Execute("list.push(4);");
+
+        list.Count.Should().Be(4);
+        list[3].Should().Be(4);
+    }
 }

--- a/Jint/Native/Array/ArrayOperations.cs
+++ b/Jint/Native/Array/ArrayOperations.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Reflection;
 using Jint.Native.Number;
 using Jint.Native.Object;
 using Jint.Native.String;
@@ -67,18 +68,26 @@ internal abstract class ArrayOperations : IEnumerable<JsValue>
             return new ArrayLikeObjectOperations(arrayLikeObject);
         }
 
-        if (instance is ArrayLikeWrapper arrayWrapper)
+        // HasIndexedElements rather than the type alone: a view whose indexer the host's member filter
+        // rejects has no elements to offer this lane, and falls through to ObjectOperations for the same
+        // reason a Queue<T> does — the generics honour the wrapper's length, read undefined at each index
+        // and take the wrapper's own [[Set]] refusal for each write (#3558).
+        if (instance is ArrayLikeWrapper { HasIndexedElements: true } arrayWrapper)
         {
             return new ArrayLikeOperations(arrayWrapper);
         }
 
-        if (instance is ObjectWrapper wrapper)
+        // A wrapped CLR collection reaches the indexed lane only when it has an index to read: ICollection is
+        // a count-and-copy contract, so Queue<T>, Stack<T>, LinkedList<T> and SortedSet<T> are array-like and
+        // have no element at index 0. They fall through to ObjectOperations, where the generics honour the
+        // wrapper's length and read undefined at each index — which is what an array-like with no index
+        // properties means, and what a HashSet<T> (a collection through the generic interface only, so never
+        // admitted here in the first place) has always done.
+        if (instance is ObjectWrapper { HasIndexedElements: true } wrapper
+            && wrapper._typeDescriptor.IsArrayLike
+            && wrapper.Target is ICollection)
         {
-            var descriptor = wrapper._typeDescriptor;
-            if (descriptor.IsArrayLike && wrapper.Target is ICollection)
-            {
-                return new IndexWrappedOperations(wrapper);
-            }
+            return new IndexWrappedOperations(wrapper);
         }
 
         return new ObjectOperations(instance);
@@ -599,13 +608,26 @@ internal abstract class ArrayOperations : IEnumerable<JsValue>
     {
         private readonly ObjectWrapper _target;
         private readonly ICollection _collection;
-        private readonly IList _list;
+        private readonly IList? _list;
 
+        // The caller guarantees ObjectWrapper.HasIndexedElements, so one of _list and the type descriptor's
+        // integer indexer answers an element read. Every member below was already written for a null _list,
+        // which is what says the hard cast this replaced was never the intent.
+        //
+        // A null _list is the Native AOT case: a runtime with no code for the typed factory's value-type
+        // instantiation degrades to a plain ObjectWrapper when the target is not a non-generic IList, and
+        // Jint.AotExample's IList<int> probe is what pins the lane, on a published native binary.
+        //
+        // It was briefly also a JIT case, and that was itself a defect rather than a route: exposing a host
+        // collection as IList<T> found no typed factory, because ResolveArrayLikeWrapperFactoryType scanned
+        // the exposed type's GetInterfaces() and an interface is not among its own (#3394 documented the
+        // route, #3421 closed it). Under a JIT every exposure that reports an integer index now gets the
+        // typed wrapper its own contract names, so nothing reaches this lane.
         public IndexWrappedOperations(ObjectWrapper wrapper)
         {
             _target = wrapper;
             _collection = (ICollection) wrapper.Target;
-            _list = (IList) wrapper.Target;
+            _list = wrapper.Target as IList;
         }
 
         public override ObjectInstance Target => _target;
@@ -616,21 +638,26 @@ internal abstract class ArrayOperations : IEnumerable<JsValue>
 
         public override void SetLength(ulong length)
         {
-            if (_list == null)
+            var list = _list;
+            if (list is null)
             {
-                throw new NotSupportedException();
+                // readable through the descriptor's indexer but with no IList to resize: route the write
+                // through the wrapper, whose read-only "length" refuses it as a JavaScript TypeError rather
+                // than as a CLR exception
+                _target.Set(CommonProperties.Length, length, true);
+                return;
             }
 
-            while (_list.Count > (int) length)
+            while (list.Count > (int) length)
             {
                 // shrink list to fit
-                _list.RemoveAt(_list.Count - 1);
+                list.RemoveAt(list.Count - 1);
             }
 
-            while (_list.Count < (int) length)
+            while (list.Count < (int) length)
             {
                 // expand list to fit
-                _list.Add(null);
+                list.Add(null);
             }
         }
 
@@ -654,13 +681,29 @@ internal abstract class ArrayOperations : IEnumerable<JsValue>
 
         private JsValue ReadValue(int index)
         {
-            if (_list is not null)
+            var list = _list;
+            if (list is not null)
             {
-                return (uint) index < _list.Count ? JsValue.FromObject(_target.Engine, _list[index]) : JsValue.Undefined;
+                return (uint) index < list.Count ? JsValue.FromObject(_target.Engine, list[index]) : JsValue.Undefined;
             }
 
-            // via reflection is slow, but better than nothing
-            return JsValue.FromObject(_target.Engine, _target._typeDescriptor.IntegerIndexerProperty!.GetValue(Target, [index]));
+            var indexer = _target._typeDescriptor.IntegerIndexerProperty;
+            if (indexer is null)
+            {
+                return JsValue.Undefined;
+            }
+
+            // via reflection is slow, but better than nothing. The receiver is the CLR object, not the
+            // wrapper around it — passing the wrapper was a TargetException waiting for the first caller.
+            try
+            {
+                return JsValue.FromObject(_target.Engine, indexer.GetValue(_target.Target, [index]));
+            }
+            catch (TargetInvocationException exception)
+            {
+                Throw.MeaningfulException(_target.Engine, exception);
+                return JsValue.Undefined;
+            }
         }
 
         public override bool HasProperty(ulong index) => index < (ulong) _collection.Count;
@@ -670,7 +713,24 @@ internal abstract class ArrayOperations : IEnumerable<JsValue>
 
         public override void Set(ulong index, JsValue value, bool updateLength = false, bool throwOnError = true)
         {
-            if (updateLength && _list != null && index >= (ulong) _list.Count)
+            var list = _list;
+            if (list is null && index >= (ulong) _collection.Count)
+            {
+                // There is no IList to grow, and the write below resolves the reflected indexer, which takes
+                // the index straight to the collection — List<T>'s own ArgumentOutOfRangeException out of
+                // Evaluate, where neither a script try/catch nor a host catch (JavaScriptException) can see
+                // it. A position this view cannot hold is refused the way its read-only "length" already is
+                // (#3394). The message is the one ObjectInstance.Set(p, v, throwOnError) gives, because that
+                // refusal is what is being stood in for.
+                if (throwOnError)
+                {
+                    Throw.TypeError(_target.Engine.Realm, $"Cannot assign to read only property '{index}' of object '#<Object>'");
+                }
+
+                return;
+            }
+
+            if (updateLength && list is not null && index >= (ulong) list.Count)
             {
                 SetLength(index + 1);
             }

--- a/Jint/Runtime/Interop/ObjectWrapper.Specialized.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.Specialized.cs
@@ -5,6 +5,8 @@ using System.Runtime.CompilerServices;
 using Jint.Extensions;
 using Jint.Native;
 using Jint.Native.Array;
+using Jint.Native.Object;
+using Jint.Runtime.Descriptors;
 
 namespace Jint.Runtime.Interop;
 
@@ -82,6 +84,14 @@ internal abstract class ArrayLikeWrapper : ObjectWrapper
     /// </summary>
     private readonly bool _elementAccessMayRunHostCode;
 
+    /// <summary>
+    /// Whether this view has element properties at all: the host's <see cref="TypeResolver.MemberFilter"/>
+    /// must admit the indexer the lanes below stand for. Read once per wrapper rather than per element, so a
+    /// filtered engine pays one memoized decision per exposed type and an unfiltered one pays a field read
+    /// (#3558).
+    /// </summary>
+    private readonly bool _elementsExposed;
+
     protected ArrayLikeWrapper(
         Engine engine,
         object obj,
@@ -91,6 +101,7 @@ internal abstract class ArrayLikeWrapper : ObjectWrapper
     {
         ItemType = itemType;
         _elementAccessMayRunHostCode = elementAccessMayRunHostCode;
+        _elementsExposed = IndexedElementsExposed;
         if (engine.Options.Interop.AttachArrayPrototype)
         {
             Prototype = engine.Intrinsics.Array.PrototypeObject;
@@ -102,22 +113,99 @@ internal abstract class ArrayLikeWrapper : ObjectWrapper
 
     public abstract int Length { get; }
 
+    // Every subclass is a view over something with an indexer, including the IReadOnlyList<T> one the type
+    // descriptor does not recognize as integer-indexed — so the only thing left to ask is whether the host's
+    // member filter lets script reach it. Answering false here is what routes every Array.prototype generic
+    // to ObjectOperations, exactly as a countable-but-not-indexable Queue<T> is routed (#3558).
+    internal sealed override bool HasIndexedElements => _elementsExposed;
+
+    /// <summary>
+    /// Whether <paramref name="property"/> spells a position this view does not have — index-shaped, and
+    /// either outside <c>[0, Length)</c> or never addressable at all (negative, non-canonical, past what the
+    /// target can hold).
+    /// </summary>
+    /// <remarks>
+    /// This is the single question every lane that answers <em>whether an index exists</em> has to answer the
+    /// same way. <see cref="Get"/>, <see cref="HasProperty"/> and <c>GetOwnPropertyKeys</c> already did;
+    /// <c>[[GetOwnProperty]]</c> did not, because it was left to <see cref="ObjectWrapper"/>, which resolves the
+    /// reflected indexer and reports a descriptor for <em>any</em> parseable index. So <c>3 in list</c> was
+    /// <see langword="false"/> while <c>list.hasOwnProperty(3)</c> was <see langword="true"/> on the same object,
+    /// which is not a divergence an implementation may choose:
+    /// <see href="https://tc39.es/ecma262/#sec-ordinaryhasproperty">OrdinaryHasProperty</see> is defined in terms
+    /// of <c>[[GetOwnProperty]]</c> (#3423).
+    /// <para>
+    /// A dictionary-shaped target (Newtonsoft's <c>JObject</c> is both <c>IDictionary&lt;string,_&gt;</c> and
+    /// <c>IList&lt;_&gt;</c>) answers a string key from its own keys, exactly as <see cref="HasProperty"/>
+    /// defers for it.
+    /// </para>
+    /// <para>
+    /// When the host's member filter rejects the indexer, <em>every</em> index-shaped key names an absent
+    /// position: the view has no elements to have positions of. That is also the answer the reflected lane
+    /// underneath already gave — it resolves no accessor for the hidden member, so <c>hasOwnProperty</c> and
+    /// <c>Object.keys</c> said so while <c>in</c> and the element lanes did not (#3558).
+    /// </para>
+    /// </remarks>
+    private bool NamesAbsentPosition(JsValue property)
+    {
+        if (_typeDescriptor.IsDictionary)
+        {
+            return false;
+        }
+
+        var key = ClassifyElementKey(property, out var index);
+        if (!_elementsExposed)
+        {
+            return key != ElementKey.None;
+        }
+
+        return key == ElementKey.OutOfBand
+               || (key == ElementKey.Position && (uint) index >= (uint) Length);
+    }
+
+    /// <summary>
+    /// The descriptor lane, answered from the view's index range before the reflected indexer is consulted.
+    /// Reached by <c>Object.getOwnPropertyDescriptor</c>, <c>Reflect.getOwnPropertyDescriptor</c>,
+    /// <c>hasOwnProperty</c>, <c>propertyIsEnumerable</c> and — through the default
+    /// <see cref="ObjectInstance.ProbeOwnProperty"/> — everything that asks whether a key exists.
+    /// </summary>
+    public sealed override PropertyDescriptor GetOwnProperty(JsValue property)
+        => NamesAbsentPosition(property) ? PropertyDescriptor.Undefined : base.GetOwnProperty(property);
+
+    /// <summary>
+    /// The existence probe, kept in step with <see cref="GetOwnProperty"/> by construction rather than by
+    /// deriving it: an absent position is answered without resolving an accessor or building a descriptor.
+    /// </summary>
+    protected internal sealed override OwnPropertyProbe ProbeOwnProperty(JsValue property)
+        => NamesAbsentPosition(property) ? OwnPropertyProbe.Missing : base.ProbeOwnProperty(property);
+
+    /// <summary>
+    /// A position this view does not have cannot be defined into existence either. Without this,
+    /// <c>Object.defineProperty(view, 5, …)</c> would store a descriptor in the wrapper's own property bag for
+    /// a key <see cref="GetOwnProperty"/> then denies — a property that both exists and does not. The refusal
+    /// is what script already saw (the reflected indexer's descriptor is non-configurable, so the redefinition
+    /// was rejected); it is now a property of the view rather than an accident of reflection.
+    /// </summary>
+    public sealed override bool DefineOwnProperty(JsValue property, PropertyDescriptor desc)
+        => !NamesAbsentPosition(property) && base.DefineOwnProperty(property, desc);
+
     public sealed override JsValue Get(JsValue property, JsValue receiver)
     {
-        if (property.IsInteger())
+        var key = ClassifyElementKey(property, out var index);
+        if (key == ElementKey.Position && _elementsExposed && (uint) index < (uint) Length)
         {
-            var index = property.AsInteger();
-            if ((uint) index < (uint) Length)
+            var result = GetJsValueAt(index);
+            if (_elementAccessMayRunHostCode)
             {
-                var result = GetJsValueAt(index);
-                if (_elementAccessMayRunHostCode)
-                {
-                    _engine.CheckAmortizedConstraintsAtHostBoundary();
-                }
-                return result;
+                _engine.CheckAmortizedConstraintsAtHostBoundary();
             }
+            return result;
+        }
 
-            // out-of-range and negative indices read like JS array holes
+        if (key != ElementKey.None)
+        {
+            // out-of-range, negative and non-canonical indices read like JS array holes — and so does every
+            // index of a view whose indexer the host's member filter hides, which is the answer the
+            // reflected lane gives for a filtered-out member (#3558)
             return Undefined;
         }
 
@@ -133,32 +221,18 @@ internal abstract class ArrayLikeWrapper : ObjectWrapper
             return base.HasProperty(property);
         }
 
-        if (property.IsNumber())
+        // membership of an array-like view is exactly the index range [0, Length); falling through would
+        // consult the reflected indexer, which reports presence for any parseable index (so e.g.
+        // "-1 in view" would be true)
+        var key = ClassifyElementKey(property, out var index);
+        if (key == ElementKey.Position)
         {
-            var value = ((JsNumber) property)._value;
-            if (TypeConverter.IsIntegralNumber(value))
-            {
-                // numeric membership of an array-like view is exactly the index range [0, Length);
-                // falling through would consult the reflected indexer, which reports presence for
-                // any parseable index (so e.g. "-1 in view" would be true). Compare as double so a
-                // negative or out-of-int-range index can never alias into range.
-                return value >= 0 && value < Length;
-            }
+            return _elementsExposed && (uint) index < (uint) Length;
         }
-        else if (property is JsString jsString)
+
+        if (key == ElementKey.OutOfBand)
         {
-            var str = jsString.ToString();
-            var index = ArrayInstance.ParseArrayIndex(str);
-            if (index != uint.MaxValue)
-            {
-                return index < (uint) Length;
-            }
-            // an integer-shaped but non-canonical key ("-1", "08") is not a member of the view
-            // either, and must not fall through to the reflected indexer's presence-only answer
-            if (long.TryParse(str, NumberStyles.Integer, CultureInfo.InvariantCulture, out _))
-            {
-                return false;
-            }
+            return false;
         }
 
         return base.HasProperty(property);
@@ -166,38 +240,52 @@ internal abstract class ArrayLikeWrapper : ObjectWrapper
 
     public sealed override bool Delete(JsValue property)
     {
+        if (!_elementsExposed && NamesAbsentPosition(property))
+        {
+            // The host's member filter hides this view's indexer, so there is no element property here to
+            // delete and OrdinaryDelete returns true for a property that is not there. Asked before the
+            // writability lanes below so the two refusals compose rather than mask each other: containment
+            // decides whether there is a property at all, writability only what may be done to one (#3558).
+            return true;
+        }
+
         if (!CanWrite)
         {
             return false;
         }
 
-        if (property.IsNumber())
+        var key = ClassifyElementKey(property, out var index);
+        if (key != ElementKey.None)
         {
-            var value = ((JsNumber) property)._value;
-            if (TypeConverter.IsIntegralNumber(value))
+            if (key == ElementKey.OutOfBand || (uint) index >= (uint) Length)
             {
-                if (IsFixedSize)
-                {
-                    // elements of a fixed-size CLR array view cannot be removed (and resetting them to a
-                    // default value on delete would let Array.prototype.pop/shift/splice silently zero
-                    // slots before their length write throws). Mirror integer-indexed exotic object
-                    // semantics instead: false for an in-range index, true for anything out of range.
-                    return value < 0 || value >= Length;
-                }
-
-                var defaultValue = default(object);
-                if (typeof(JsValue).IsAssignableFrom(ItemType))
-                {
-                    defaultValue = JsValue.Undefined;
-                }
-                else if (ItemType.IsValueType)
-                {
-                    defaultValue = Activator.CreateInstance(ItemType);
-                }
-
-                DoSetAt((int) value, defaultValue);
+                // there is no such position, so there is nothing to delete: OrdinaryDelete returns true
+                // for a property that is not there. Reaching the collection with the index instead is
+                // what raised the CLR's own ArgumentOutOfRangeException out of Evaluate (#3384).
                 return true;
             }
+
+            if (IsFixedSize)
+            {
+                // elements of a fixed-size CLR array view cannot be removed (and resetting them to a
+                // default value on delete would let Array.prototype.pop/shift/splice silently zero
+                // slots before their length write throws). Mirror integer-indexed exotic object
+                // semantics instead: false for an in-range index, true for anything out of range.
+                return false;
+            }
+
+            var defaultValue = default(object);
+            if (typeof(JsValue).IsAssignableFrom(ItemType))
+            {
+                defaultValue = JsValue.Undefined;
+            }
+            else if (ItemType.IsValueType)
+            {
+                defaultValue = Activator.CreateInstance(ItemType);
+            }
+
+            DoSetAt(index, defaultValue);
+            return true;
         }
 
         return base.Delete(property);
@@ -287,7 +375,12 @@ internal abstract class ArrayLikeWrapper : ObjectWrapper
 
         if (ReferenceEquals(receiver, this) && CommonProperties.Length.Equals(property))
         {
-            if (!CanWrite)
+            // A length write adds and removes elements — it is the element lane spelled by count rather than
+            // by position — so a view whose indexer the host's member filter hides has nothing to grow or
+            // truncate, and `list.length = 0` must not clear a collection whose elements script cannot see.
+            // The "length" forwarder itself keeps answering: it is produced from Count, a member the filter
+            // decides about separately (#3558).
+            if (!_elementsExposed || !CanWrite)
             {
                 return false;
             }
@@ -323,42 +416,54 @@ internal abstract class ArrayLikeWrapper : ObjectWrapper
             Throw.TypeError(_engine.Realm, "Invalid array length");
         }
 
-        if (ReferenceEquals(receiver, this) && property.IsNumber())
+        if (ReferenceEquals(receiver, this))
         {
-            // An element write to a read-only or non-extensible (frozen) wrapper must be refused:
-            // base.SetSlow would otherwise materialize a throwaway descriptor and return true, silently
-            // "succeeding" (#2541), or reach the reflected indexer with an out-of-range growth write and
-            // let the collection's own NotSupportedException past script (#3382). Everything else —
-            // writable in-range writes, growth, negative and non-integral indices — defers to base.Set,
-            // which writes through and already rejects a get-only indexer (e.g. ReadOnlyCollection<T>)
-            // cleanly. Wrappers don't track per-element writability, so a non-extensible wrapper blocks
-            // existing-element writes too — a deliberate, contained interop divergence from the spec.
-            var numValue = ((JsNumber) property)._value;
-            if (TypeConverter.IsIntegralNumber(numValue) && numValue >= 0
-                && (!CanWrite || !Extensible))
+            // Every index write is answered here rather than through the reflection indexer base.Set would
+            // resolve. That indexer takes the index straight to the collection, so it leaked the CLR's own
+            // ArgumentOutOfRangeException for anything outside [0, Count) and, for a T[], found the
+            // non-generic IList.Item (object-typed) overload, whose writes bypass item-type coercion (#3384).
+            var key = ClassifyElementKey(property, out var index);
+            if (key != ElementKey.None)
             {
-                return false;
-            }
-
-            // Fixed-size targets (CLR arrays) handle integral index writes here: in-range writes go
-            // straight to the backing store and anything else is a TypeError. The base.Set slow path
-            // below resolves the element writer through the reflection indexer, which for T[] finds
-            // the non-generic IList.Item (object-typed) indexer — element values would bypass item
-            // type coercion and out-of-range writes would leak CLR exceptions.
-            if (IsFixedSize && TypeConverter.IsIntegralNumber(numValue))
-            {
-                if (!CanWrite || !Extensible)
+                // An element write to a read-only or non-extensible (frozen) wrapper is refused as an
+                // ordinary [[Set]] false — silent in sloppy mode, a TypeError in strict — rather than by
+                // materializing a throwaway descriptor and returning true (#2541). Wrappers don't track
+                // per-element writability, so a non-extensible wrapper blocks existing-element writes too
+                // — a deliberate, contained interop divergence from the spec.
+                //
+                // Containment is asked first and gets the same ordinary refusal: a view whose indexer the
+                // host's member filter rejects has no element property here, so the fixed-size TypeError
+                // below must not fire for it — that message answers "you may not write *there*", which is
+                // a question about a lane script was never granted (#3558).
+                if (!_elementsExposed || !CanWrite || !Extensible)
                 {
                     return false;
                 }
 
-                if (numValue >= 0 && numValue < Length)
+                if (key == ElementKey.Position && (uint) index < (uint) Length)
                 {
-                    SetAt((int) numValue, value);
+                    SetAt(index, value);
                     return true;
                 }
 
-                Throw.TypeError(_engine.Realm, "Cannot write outside the bounds of a fixed-size CLR array");
+                if (IsFixedSize)
+                {
+                    Throw.TypeError(_engine.Realm, "Cannot write outside the bounds of a fixed-size CLR array");
+                }
+
+                if (key == ElementKey.OutOfBand)
+                {
+                    // a negative, non-canonical or unaddressable index is a position this view can never
+                    // have — Get answers undefined for it and HasProperty answers false — so the write is
+                    // the ordinary [[Set]] refusal rather than something the collection has to reject
+                    return false;
+                }
+
+                // At or past the end of a growable target. The view is an extensible ordinary object and
+                // the position can exist, so CreateDataProperty succeeds: make room and write, which is
+                // exactly what a "length" write of index + 1 does through the lane above.
+                SetAt(index, value);
+                return true;
             }
         }
 
@@ -390,7 +495,8 @@ internal abstract class ArrayLikeWrapper : ObjectWrapper
     /// <summary>
     /// The refusal every length-changing operation on a fixed-size target owes script: a
     /// <c>TypeError</c> it can catch, never the CLR <see cref="NotSupportedException"/> the underlying
-    /// collection would raise.
+    /// collection would raise. Shared by <see cref="ArrayWrapper{T}"/> and by <see cref="ListWrapper"/>,
+    /// which is what a <c>T[]</c> falls back to when the typed wrapper cannot be built (#3299).
     /// </summary>
     [DoesNotReturn]
     protected void ThrowFixedSize() => Throw.TypeError(_engine.Realm, "Cannot resize a fixed-size CLR array");
@@ -423,9 +529,15 @@ internal abstract class ArrayLikeWrapper : ObjectWrapper
         }
     }
 
+    /// <summary>
+    /// Writes one element, if this view may be written at all. The <see cref="_elementsExposed"/> half is the
+    /// backstop <see cref="ThrowReadOnly"/> is for its own fact: every lane already refuses before reaching
+    /// here, and a lane added later that does not must still not write through an indexer the host's member
+    /// filter hid.
+    /// </summary>
     public void SetAt(int index, JsValue value)
     {
-        if (CanWrite)
+        if (_elementsExposed && CanWrite)
         {
             EnsureCapacity(index + 1);
             DoSetAt(index, ConvertToItemType(value));
@@ -469,23 +581,60 @@ internal abstract class ArrayLikeWrapper : ObjectWrapper
     }
 }
 
+/// <summary>
+/// The untyped view over anything that is an <see cref="IList"/>. It is the least specific of the
+/// array-like wrappers and also the one a <c>T[]</c> or an <c>IList&lt;T&gt;</c> degrades to when its typed
+/// factory cannot be instantiated — Native AOT has no code for
+/// <c>ArrayWrapperFactory&lt;int&gt;</c> and friends (#3299) — so it takes the two facts the typed wrapper
+/// carried in its type argument from the target instead: the element type, and whether the length can
+/// change.
+/// </summary>
 internal sealed class ListWrapper : ArrayLikeWrapper
 {
     private readonly IList? _list;
+    private readonly bool _fixedSize;
     private readonly bool _readOnly;
 
     internal ListWrapper(Engine engine, IList target, Type type)
-        : base(engine, target, typeof(object), type, elementAccessMayRunHostCode: target is not (Array or ArrayList))
+        : base(engine, target, ElementTypeOf(target), type, elementAccessMayRunHostCode: target is not (Array or ArrayList))
     {
         _list = target;
-        _readOnly = target.IsReadOnly;
+        _fixedSize = target.IsFixedSize;
+
+        // Two ways this view is read-only: the target says so, or the exposed contract offers no writable
+        // indexer. The second half is what a T[] or a List<T> reaching the engine as IReadOnlyList<T>
+        // needs. ReadOnlyListWrapper<T> says read-only from its type argument, but an interface is not
+        // among its own GetInterfaces(), so ResolveArrayLikeWrapperFactoryType finds no typed factory for
+        // that exposure and it degrades to here. Until #3384 the element lane read the target's writability
+        // and wrote straight through a contract that had promised script it could only read; the refusal
+        // came from the reflected indexer instead, and therefore only for a string-spelled index.
+        _readOnly = target.IsReadOnly || !_typeDescriptor.IsIntegerIndexed;
     }
 
     /// <summary>
-    /// Read from the target, because the non-generic <see cref="IList"/> is the only place that says so:
-    /// <c>ArrayList.ReadOnly</c> and an embedder's own read-only <see cref="IList"/> raise
-    /// <see cref="NotSupportedException"/> from <c>Add</c>/<c>RemoveAt</c> and from the indexer setter,
-    /// which script cannot catch (#3382).
+    /// A <see cref="ListWrapper"/> over an array must coerce element writes to the array's element type,
+    /// exactly as <see cref="ArrayWrapper{T}"/> does from its type argument: <c>object</c> would hand
+    /// <c>IList.this[int]</c> the boxed <c>double</c> a JS number converts to and raise
+    /// <see cref="InvalidCastException"/> out of the assignment. Everything else keeps <c>object</c>,
+    /// which is all a non-generic <see cref="IList"/> promises.
+    /// </summary>
+    private static Type ElementTypeOf(IList target)
+        => target is Array array ? array.GetType().GetElementType() ?? typeof(object) : typeof(object);
+
+    /// <summary>
+    /// Read from the target rather than declared, because this wrapper serves both the growable case and
+    /// the fixed-size one: <c>System.Array</c> reaches it through <see cref="IList"/> whenever
+    /// <see cref="ArrayWrapper{T}"/> could not be built, and <c>ArrayList.FixedSize</c> reaches it always.
+    /// Without this every length-changing operation reached <c>IList.Add</c> and leaked that collection's
+    /// <see cref="NotSupportedException"/> past script instead of raising a catchable <c>TypeError</c>.
+    /// </summary>
+    protected override bool IsFixedSize => _fixedSize;
+
+    /// <summary>
+    /// Read from the target for the same reason as <see cref="IsFixedSize"/>, and separately from it
+    /// because the non-generic <see cref="IList"/> asks the two questions separately:
+    /// <c>ArrayList.FixedSize</c> is fixed-size and writable, <c>ArrayList.ReadOnly</c> is both, and an
+    /// embedder's own read-only <see cref="IList"/> may be neither fixed-size nor writable.
     /// </summary>
     protected override bool IsReadOnly => _readOnly;
 
@@ -525,6 +674,21 @@ internal sealed class ListWrapper : ArrayLikeWrapper
     {
         ThrowIfLengthCannotChange();
         _list?.RemoveAt(index);
+    }
+
+    public override void EnsureCapacity(int capacity)
+    {
+        if (_fixedSize || _readOnly)
+        {
+            if (capacity > Length)
+            {
+                ThrowIfLengthCannotChange();
+            }
+
+            return;
+        }
+
+        base.EnsureCapacity(capacity);
     }
 }
 

--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -1,8 +1,9 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Jint.Native;
 using Jint.Native.Array;
 using Jint.Native.Iterator;
@@ -208,26 +209,26 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
             }
             else
             {
-                // check for generic interfaces
-                foreach (var i in t.GetInterfaces())
+                // The exposed type itself, ahead of its interfaces. An interface is not among its own
+                // GetInterfaces() - typeof(IList<int>) yields ICollection<int>, IEnumerable<int> and
+                // IEnumerable, and never IList<int> - so exposing a collection *as* one of the two
+                // contracts this scan is written to recognize found nothing at all, and the caller fell
+                // back to a wrapper the exposure had not named: a plain ObjectWrapper for a target that is
+                // not an IList, and a target-writable ListWrapper for one that is. Both are exposures a
+                // WrapObjectDelegate writes and the member lane produces for a declared IList<T> /
+                // IReadOnlyList<T> property (#3421).
+                factoryType = TypedFactoryTypeFor(t);
+
+                if (factoryType is null)
                 {
-                    if (!i.IsGenericType)
+                    // check for generic interfaces
+                    foreach (var i in t.GetInterfaces())
                     {
-                        continue;
-                    }
-
-                    var arrayItemType = i.GenericTypeArguments[0];
-
-                    if (i.GetGenericTypeDefinition() == typeof(IList<>))
-                    {
-                        factoryType = typeof(GenericListWrapperFactory<>).MakeGenericType(arrayItemType);
-                        break;
-                    }
-
-                    if (i.GetGenericTypeDefinition() == typeof(IReadOnlyList<>))
-                    {
-                        factoryType = typeof(ReadOnlyListWrapperFactory<>).MakeGenericType(arrayItemType);
-                        break;
+                        factoryType = TypedFactoryTypeFor(i);
+                        if (factoryType is not null)
+                        {
+                            break;
+                        }
                     }
                 }
             }
@@ -252,7 +253,13 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
             }
         });
 
-        if (factory is not null)
+        // IsInstanceOfType is what keeps the factory's cast honest. Every factory casts the target to the
+        // contract the exposed type named - (T[]), (IList<T>), (IReadOnlyList<T>) - and until the exposed
+        // type itself was considered (#3421) a factory could only be found by scanning the target's own
+        // interface set, so the cast could not fail. A host is free to hand Create a type its target does
+        // not implement, and that exposure keeps the answer it has always had rather than becoming an
+        // InvalidCastException out of a wrapper creation.
+        if (factory is not null && type.IsInstanceOfType(target))
         {
             result = factory.Create(engine, target, type);
         }
@@ -279,6 +286,39 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
         }
 
         return result is not null;
+    }
+
+    /// <summary>
+    /// The closed factory type for one contract, or <see langword="null"/> when it names neither of the two
+    /// the typed wrappers are written for. Shared by the exposed type and its interfaces, which is what
+    /// makes the two answer identically.
+    /// </summary>
+    private static Type? TypedFactoryTypeFor(Type contract)
+    {
+#pragma warning disable IL2055
+#pragma warning disable IL3050
+
+        if (!contract.IsGenericType)
+        {
+            return null;
+        }
+
+        var definition = contract.GetGenericTypeDefinition();
+
+        if (definition == typeof(IList<>))
+        {
+            return typeof(GenericListWrapperFactory<>).MakeGenericType(contract.GenericTypeArguments[0]);
+        }
+
+        if (definition == typeof(IReadOnlyList<>))
+        {
+            return typeof(ReadOnlyListWrapperFactory<>).MakeGenericType(contract.GenericTypeArguments[0]);
+        }
+
+        return null;
+
+#pragma warning restore IL3050
+#pragma warning restore IL2055
     }
 
     private static readonly ConcurrentDictionary<Type, EnumerableSnapshotFactory> _enumerableSnapshotResolution = new();
@@ -322,9 +362,225 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
 
     internal override bool IsArrayLike => _typeDescriptor.IsArrayLike;
 
-    internal override bool HasOriginalIterator => IsArrayLike;
+    /// <summary>
+    /// Whether reading indices <c>0..length-1</c> off this wrapper produces the target's elements.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="TypeDescriptor.IsArrayLike"/> answers the weaker question of whether the target has a
+    /// <c>Count</c>, and <see cref="ICollection"/>, <see cref="ICollection{T}"/> and
+    /// <see cref="IReadOnlyCollection{T}"/> are all count-and-enumerate contracts with no index in them:
+    /// <see cref="Queue{T}"/>, <see cref="Stack{T}"/>, <see cref="LinkedList{T}"/> and
+    /// <see cref="HashSet{T}"/> are every one of them array-like with no element at index 0. An indexed lane
+    /// must gate on this rather than on array-likeness (#3302).
+    /// </remarks>
+    internal virtual bool HasIndexedElements => (_typeDescriptor.IsIntegerIndexed || Target is IList) && IndexedElementsExposed;
+
+    /// <summary>
+    /// Whether the host's <see cref="TypeResolver.MemberFilter"/> admits the indexer an indexed lane would
+    /// reach <see cref="Target"/>'s elements through. A filter that hides a member hides it from every lane,
+    /// and an element lane that answers from a view rather than from a resolved accessor is the one place
+    /// that has to ask on its own behalf (#3558).
+    /// </summary>
+    private protected bool IndexedElementsExposed
+        => _engine.Options.Interop.TypeResolver.ExposesIndexedElements(_engine, ClrType, _typeDescriptor.IntegerIndexerProperty);
+
+    // A wrapper's Symbol.iterator is never the array iterator — it enumerates the CLR target — so the
+    // index-reading fast path this enables (array destructuring) is indistinguishable from running that
+    // iterator only where index reads reproduce what enumeration yields. For a countable but non-indexable
+    // collection they do not: [...queue] yields the elements while every index reads undefined.
+    internal override bool HasOriginalIterator => IsArrayLike && HasIndexedElements;
 
     internal override bool IsIntegerIndexedArray => _typeDescriptor.IsIntegerIndexed;
+
+    /// <summary>
+    /// What a property key names on a wrapped indexed collection. Every element lane is keyed on the
+    /// <em>index</em> rather than on how script spelled it: <c>x[3]</c> and <c>x["3"]</c> are one property
+    /// key, because <see href="https://tc39.es/ecma262/#sec-topropertykey">ToPropertyKey</see> turns both
+    /// into the String <c>"3"</c>. Answering the two spellings from different lanes is answering one
+    /// question twice, and the lane that used to serve the string spelling was the reflected indexer, which
+    /// reaches the collection with whatever index it parses out of the key (#3384).
+    /// </summary>
+    /// <remarks>
+    /// It lives on the base class rather than on <see cref="ArrayLikeWrapper"/> because a plain wrapper over
+    /// a bounded collection asks the same question of the same keys — it simply has no array-like view to
+    /// answer it (#3422). A second definition of "index-shaped key" is the thing that would drift.
+    /// </remarks>
+    private protected enum ElementKey
+    {
+        /// <summary>Not a position: a member name, a symbol, a fractional number, or any string key of a dictionary-shaped target.</summary>
+        None,
+
+        /// <summary>A position the target could address. May be at or past the collection's current count.</summary>
+        Position,
+
+        /// <summary>Index-shaped but never a position: negative, non-canonical (<c>"08"</c>, <c>"+3"</c>), or past what the target can address.</summary>
+        OutOfBand,
+    }
+
+    /// <summary>
+    /// The highest position an element lane will address, one below <see cref="int.MaxValue"/> so that
+    /// growing to <c>index + 1</c> cannot overflow.
+    /// </summary>
+    private protected const int MaxPosition = int.MaxValue - 1;
+
+    private protected ElementKey ClassifyElementKey(JsValue property, out int index)
+    {
+        index = 0;
+
+        if (property is JsNumber number)
+        {
+            var value = number._value;
+            if (!TypeConverter.IsIntegralNumber(value))
+            {
+                return ElementKey.None;
+            }
+
+            if (value < 0 || value > MaxPosition)
+            {
+                return ElementKey.OutOfBand;
+            }
+
+            index = (int) value;
+            return ElementKey.Position;
+        }
+
+        // a symbol names no position, and a dictionary-shaped target (e.g. Newtonsoft's JObject: both
+        // IDictionary<string,_> and IList<_>) answers a string key from its own keys rather than by index
+        if (property is not JsString jsString || _typeDescriptor.IsDictionary)
+        {
+            return ElementKey.None;
+        }
+
+        var member = jsString.ToString();
+        var parsed = ArrayInstance.ParseArrayIndex(member);
+        if (parsed != uint.MaxValue)
+        {
+            if (parsed > MaxPosition)
+            {
+                return ElementKey.OutOfBand;
+            }
+
+            index = (int) parsed;
+            return ElementKey.Position;
+        }
+
+        // One character rules out every ordinary member name that reaches a wrapper — "length", "Count",
+        // "push" — which would otherwise pay a whole long.TryParse only to be rejected by it.
+        if (member.Length == 0 || !IsIntegerShapedStart(member[0]))
+        {
+            return ElementKey.None;
+        }
+
+        // an integer-shaped but non-canonical key ("-1", "08") is not a position either, and must not fall
+        // through to the reflected indexer, which parses one out of it and reaches the collection with an
+        // index the collection rejects
+        return long.TryParse(member, NumberStyles.Integer, CultureInfo.InvariantCulture, out _)
+            ? ElementKey.OutOfBand
+            : ElementKey.None;
+    }
+
+    /// <summary>
+    /// Whether <paramref name="c"/> can begin something <see cref="NumberStyles.Integer"/> parses: a digit,
+    /// a sign, or the leading white space it tolerates.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsIntegerShapedStart(char c)
+        => (uint) (c - '0') <= 9 || c == '-' || c == '+' || char.IsWhiteSpace(c);
+
+    /// <summary>
+    /// Whether <paramref name="property"/> spells a position <see cref="Target"/> cannot address, resolving
+    /// the member lane itself. For callers that have already resolved it, see the overload below.
+    /// </summary>
+    private bool IsUnaddressablePosition(JsValue property)
+    {
+        if (!_typeDescriptor.IsArrayLike)
+        {
+            return false;
+        }
+
+        var key = ClassifyElementKey(property, out var index);
+        return key != ElementKey.None
+               && IsUnaddressablePosition(key, index, ResolveMemberAccessor(property.ToString(), MemberResolutionRequirement.None));
+    }
+
+    /// <summary>
+    /// Whether <paramref name="property"/> spells a position <see cref="Target"/> cannot address, on a
+    /// wrapper whose element lane is <paramref name="accessor"/>.
+    /// </summary>
+    /// <remarks>
+    /// Two facts have to hold at once and neither is enough alone. The target must be <em>bounded</em>:
+    /// <see cref="TypeDescriptor.IsArrayLike"/> means it has a <c>Count</c> and is not a dictionary, and a
+    /// dictionary is exactly where a key outside what it holds is a legitimate add — <c>d[99] = "x"</c> on a
+    /// <c>Dictionary&lt;int, string&gt;</c> must keep working. And the member being resolved must be an
+    /// indexer keyed by an integer, so that a string-keyed indexer on an array-like target — a
+    /// <c>NameValueCollection</c> asked for <c>x["3"]</c> — goes on answering for its own key.
+    /// </remarks>
+    private bool IsUnaddressablePosition(JsValue property, ReflectionAccessor accessor)
+    {
+        if (!_typeDescriptor.IsArrayLike)
+        {
+            return false;
+        }
+
+        var key = ClassifyElementKey(property, out var index);
+        return key != ElementKey.None && IsUnaddressablePosition(key, index, accessor);
+    }
+
+    private bool IsUnaddressablePosition(ElementKey key, int index, ReflectionAccessor accessor)
+    {
+        if (accessor is not IndexerAccessor indexer
+            || !IsIntegerIndexParameter(indexer.FirstIndexParameter.ParameterType))
+        {
+            return false;
+        }
+
+        // a negative, non-canonical or unaddressable index is a position no collection can hold, so it
+        // needs no count read to be refused
+        return key == ElementKey.OutOfBand
+               || (TryGetTargetCount(out var count) && (uint) index >= (uint) count);
+    }
+
+    /// <summary>
+    /// Whether an indexer parameter of this type addresses a position. Anything else — a
+    /// <see cref="string"/>, an enum, a host key type — names something that is not one, and is none of the
+    /// bound check's business.
+    /// </summary>
+    internal static bool IsIntegerIndexParameter(Type parameterType)
+        => parameterType == typeof(int)
+           || parameterType == typeof(long)
+           || parameterType == typeof(short)
+           || parameterType == typeof(sbyte)
+           || parameterType == typeof(uint)
+           || parameterType == typeof(ulong)
+           || parameterType == typeof(ushort)
+           || parameterType == typeof(byte);
+
+    /// <summary>
+    /// The number of positions <see cref="Target"/> currently has. Only ever asked of an array-like target,
+    /// which is what says there is a count to read at all; <see langword="false"/> means it could not be
+    /// read, and the caller then refuses nothing.
+    /// </summary>
+    private bool TryGetTargetCount(out int count)
+    {
+        if (Target is ICollection collection)
+        {
+            count = collection.Count;
+            _engine.CheckAmortizedConstraintsAtHostBoundary();
+            return true;
+        }
+
+        // ICollection<T> and IReadOnlyCollection<T> carry a Count with no non-generic ICollection behind it.
+        // LengthProperty is the same member the wrapper's own "length" forwarder reads.
+        if (_typeDescriptor.LengthProperty?.GetValue(Target) is int length)
+        {
+            _engine.CheckAmortizedConstraintsAtHostBoundary();
+            count = length;
+            return true;
+        }
+
+        count = 0;
+        return false;
+    }
 
     public override bool Set(JsValue property, JsValue value, JsValue receiver)
     {
@@ -349,6 +605,16 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
             {
                 // can try utilize fast path
                 var accessor = ResolveMemberAccessor(member, MemberResolutionRequirement.Writable);
+
+                if (IsUnaddressablePosition(property, accessor))
+                {
+                    // The indexer below takes the index straight to the collection, which is where the
+                    // CLR's own ArgumentOutOfRangeException came from - invisible to a script try/catch and
+                    // to a host catch (JavaScriptException) alike. There is no position to write to, so the
+                    // answer owed is the ordinary [[Set]] refusal: silent outside strict mode, a TypeError
+                    // inside it (#3422).
+                    return false;
+                }
 
                 if (ReferenceEquals(accessor, ConstantValueAccessor.NullAccessor))
                 {
@@ -424,6 +690,14 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
             var written = _typeDescriptor.TrySetDictionaryValue(Target, clrKey!, clrValue);
             _engine.CheckAmortizedConstraintsAtHostBoundary();
             return written;
+        }
+
+        // A number key and its string spelling are one property key, and the lane below resolves the same
+        // reflected indexer by member name - so the bound the string lane above just applied has to be
+        // applied here too, before SetSlow reaches it (#3422).
+        if (!property.IsSymbol() && IsUnaddressablePosition(property))
+        {
+            return false;
         }
 
         return SetSlow(property, value);
@@ -687,7 +961,10 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
         if (protoResult.IsUndefined()
             && property is JsString
             && !_typeDescriptor.IsDictionary
-            && _engine.Options.Interop.ThrowOnUnresolvedMember)
+            && _engine.Options.Interop.ThrowOnUnresolvedMember
+            // an index outside a bounded collection is a hole, not a member the host forgot to declare:
+            // GetOwnProperty refused it rather than failing to resolve it (#3422)
+            && !IsUnaddressablePosition(property))
         {
             throw new MissingMemberException($"Cannot access property '{property}' on type '{ClrType.FullName}");
         }
@@ -759,8 +1036,10 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
             // Object.keys / for-in / spread over a wrapped array or list must yield "0".."n-1"
             // (members like Length or Count stay accessible, they just don't enumerate). Dictionary-shaped
             // targets (e.g. Newtonsoft's JObject, which is both IDictionary<string,_> and IList<_>)
-            // are handled by the dictionary branches above.
-            var length = arrayLike.Length;
+            // are handled by the dictionary branches above. A view whose indexer the host's member filter
+            // rejects has no element properties to report, which is the answer Object.keys already gave -
+            // every key it yielded was dropped again by the enumerability probe (#3558).
+            var length = arrayLike.HasIndexedElements ? arrayLike.Length : 0;
             for (var i = 0; i < length; i++)
             {
                 yield return JsString.Create(i);
@@ -999,6 +1278,14 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
                     accessor = runtimeAccessor;
                 }
             }
+        }
+
+        if (IsUnaddressablePosition(property, accessor))
+        {
+            // Reading the indexer at this position is the collection's own ArgumentOutOfRangeException, and
+            // reporting a descriptor for it is what made `3 in x` and hasOwnProperty answer true for a
+            // position that cannot be read at all. There is no element here, so there is no property (#3422).
+            return PropertyDescriptor.Undefined;
         }
 
         // A member resolving purely to registered extension methods must not shadow a same-named

--- a/Jint/Runtime/Interop/TypeResolver.cs
+++ b/Jint/Runtime/Interop/TypeResolver.cs
@@ -31,6 +31,12 @@ public sealed class TypeResolver
     private readonly ConcurrentDictionary<AccessorCacheKey, ReflectionAccessor> _reflectionAccessors = new();
 
     /// <summary>
+    /// Memo behind <see cref="ExposesIndexedElements"/>, populated only for resolvers carrying a
+    /// <see cref="MemberFilter"/> of the host's own and therefore having a decision to make at all.
+    /// </summary>
+    private readonly ConcurrentDictionary<Type, bool> _indexedElementExposure = new();
+
+    /// <summary>
     /// How many accessors this resolver currently holds. The cache never evicts, so this is the retention
     /// the resolver commits to: it must stay bounded by the distinct members the engines using it resolve,
     /// and must not grow with the number of engines constructed.
@@ -38,6 +44,7 @@ public sealed class TypeResolver
     internal int ResolvedAccessorCount => _reflectionAccessors.Count;
 
     private Predicate<MemberInfo> _memberFilter = static _ => true;
+    private bool _memberFilterIsDefault = true;
     private Func<MemberInfo, IEnumerable<string>> _memberNameCreator = NameCreator;
     private StringComparer _memberNameComparer = DefaultMemberNameComparer.Instance;
 
@@ -60,6 +67,7 @@ public sealed class TypeResolver
             if (!ReferenceEquals(_memberFilter, value))
             {
                 _memberFilter = value;
+                _memberFilterIsDefault = false;
                 InvalidateResolvedAccessors();
             }
         }
@@ -75,7 +83,83 @@ public sealed class TypeResolver
     /// have had to reason about anyway. Mutate the settings before handing the resolver to an engine when
     /// that matters.
     /// </remarks>
-    private void InvalidateResolvedAccessors() => _reflectionAccessors.Clear();
+    private void InvalidateResolvedAccessors()
+    {
+        _reflectionAccessors.Clear();
+        _indexedElementExposure.Clear();
+    }
+
+    /// <summary>
+    /// Whether <see cref="MemberFilter"/> admits the integer indexer an array-like view of
+    /// <paramref name="type"/> reaches its elements through, and therefore whether that view has element
+    /// properties at all.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A wrapped collection's element lanes do not resolve a member per access — that is the whole point of
+    /// <c>ArrayLikeWrapper</c>, which owns every index-shaped key so an out-of-range write cannot become the
+    /// collection's own <see cref="ArgumentOutOfRangeException"/> — so the filter has to be consulted about
+    /// the member those lanes stand for, once, rather than per element. The member is the one
+    /// <see cref="IndexerAccessor.TryFindIndexer"/> would have selected: the first integer-keyed indexer the
+    /// exposed type itself declares, falling back to <paramref name="descriptorIndexer"/> for a
+    /// <c>T[]</c>, which declares none of its own and reaches its elements through <c>IList.Item</c>. A type
+    /// offering no integer indexer at all leaves nothing to ask, and its view keeps its elements.
+    /// </para>
+    /// <para>
+    /// The answer is memoized per resolver and per type, and is engine-independent: the only part of
+    /// <see cref="Filter"/> an engine steers is <see cref="Options.InteropOptions.AllowGetType"/>, which
+    /// gates the name <c>GetType</c>, and the one shape that could carry it — an indexer renamed by
+    /// <c>[IndexerName("GetType")]</c> — is excluded from the memo rather than assumed away.
+    /// </para>
+    /// </remarks>
+    internal bool ExposesIndexedElements(
+        Engine engine,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type type,
+        PropertyInfo? descriptorIndexer)
+    {
+        if (_memberFilterIsDefault)
+        {
+            // the default filter admits everything, so there is no decision to look up and none to cache
+            return true;
+        }
+
+        if (_indexedElementExposure.TryGetValue(type, out var exposed))
+        {
+            return exposed;
+        }
+
+        var indexer = DeclaredIntegerIndexer(type) ?? descriptorIndexer;
+        exposed = indexer is null || Filter(engine, type, indexer);
+
+        if (indexer is null || !string.Equals(indexer.Name, nameof(GetType), StringComparison.Ordinal))
+        {
+            // GetOrAdd's value overload rather than TryAdd, so a race still hands every caller the same
+            // answer the dictionary holds
+            return _indexedElementExposure.GetOrAdd(type, exposed);
+        }
+
+        return exposed;
+    }
+
+    /// <summary>
+    /// The first integer-keyed single-parameter indexer <paramref name="type"/> declares itself, scanned the
+    /// way <see cref="IndexerAccessor.TryFindIndexer"/> scans — an explicitly implemented one is reported by
+    /// its interface alone and is deliberately not found here, exactly as it is not found there.
+    /// </summary>
+    private static PropertyInfo? DeclaredIntegerIndexer(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type type)
+    {
+        foreach (var candidate in type.GetProperties())
+        {
+            var indexParameters = candidate.GetIndexParameters();
+            if (indexParameters.Length == 1 && ObjectWrapper.IsIntegerIndexParameter(indexParameters[0].ParameterType))
+            {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
 
     internal bool Filter(Engine engine, Type targetType, MemberInfo m)
     {


### PR DESCRIPTION
Backport to `4.x` of the eight `main` pull requests that decide one question — **what an index-shaped key means on a wrapped CLR collection** — together with the fix for the containment hole the seventh of them opened. They are one unit: each moves the answer, and any subset leaves the lanes disagreeing with each other.

| PR | What it settled |
| --- | --- |
| [#3356](https://github.com/sebastienros/jint/pull/3356) | a host collection with a count is not a host collection with an index |
| [#3381](https://github.com/sebastienros/jint/pull/3381) | a degraded array view still refuses a resize |
| [#3425](https://github.com/sebastienros/jint/pull/3425) | the `IndexWrappedOperations` lane is not AOT-only, and a generic that must grow refuses instead of leaking |
| [#3416](https://github.com/sebastienros/jint/pull/3416) | an index on a host collection is one property, however script spelled it |
| [#3464](https://github.com/sebastienros/jint/pull/3464) | `hasOwnProperty` and `in` give one answer about an index on a wrapped collection |
| [#3472](https://github.com/sebastienros/jint/pull/3472) | an index outside a wrapped collection is refused, not handed to the collection |
| [#3480](https://github.com/sebastienros/jint/pull/3480) | a collection exposed as `IList<T>` or `IReadOnlyList<T>` gets the wrapper that contract names |
| [#3561](https://github.com/sebastienros/jint/pull/3561) | a member filter that hides an indexer hides a wrapped collection's elements (fixes #3558) |

[#3385](https://github.com/sebastienros/jint/pull/3385) is the ninth member of the cluster and is **already on this branch** as #3556, so its hunks are not here. Its suite, `HostReadOnlyCollectionTests`, is 68 of 68 green both before and after this change, which is what says so.

## What an embedder sees change

An index-shaped key is now the view's own property, whichever way script spelled it and whether or not the position exists.

- A read outside the range is `undefined`, not the collection's own `ArgumentOutOfRangeException` out of `Evaluate` — where neither a script `try`/`catch` nor a host `catch (JavaScriptException)` could see it.
- A write at the end grows a growable target, exactly as a `length` write of the same size already did.
- `in`, `hasOwnProperty`, `propertyIsEnumerable` and `getOwnPropertyDescriptor` give one answer. [`OrdinaryHasProperty`](https://tc39.es/ecma262/#sec-ordinaryhasproperty) is defined in terms of `[[GetOwnProperty]]`, so they may not disagree — and they did.
- `delete` of an absent position succeeds without reaching the collection.
- A countable-but-not-indexable target — `Queue<T>`, `Stack<T>`, `LinkedList<T>`, `SortedSet<T>` — is array-like with no element at index 0, rather than an `InvalidCastException` from a lane that cast it to `IList`. Iteration keeps yielding the real elements, because that is `Symbol.iterator`'s business.
- A collection handed over as `IList<T>` or `IReadOnlyList<T>` gets the wrapper that exposure names, so a read-only contract is read-only.

## Why #3561 is in the same change

`Options.Interop.TypeResolver.MemberFilter` is CLR-containment configuration — it is how a host says which members script may reach — and a member it rejects must read as `undefined` and must not be written. `ArrayLikeWrapper` answers every index-shaped key itself, which is the whole point of #3416 and #3384, but the view was never told what the filter had decided. The same filter, asked the same question, gave two answers depending on whether Jint happened to build a view.

**On this branch that matters more than it does on `main`.** `Options.Interop.AllowWrite` ships **on** here — #3054, which makes it default to `false`, is a v5 default change and is deliberately not backported — so a filter that hides the indexer is the only thing standing between script and the collection. Measured on this branch with the cluster applied and #3561 held back, three refusals had become writes (`list[0] = 42`, `list['0'] = 42`, growth `list[3] = 42`), and reads, `in`, `delete`, `push` and `sort` bypassed the filter entirely.

The whole element contract is closed rather than only the write half: under a filter that hides the indexer an array-like view has no element properties at all, and containment is asked **before** the read-only and fixed-size refusals of #3382/#3385 so the two compose rather than mask each other. Three lanes are deliberately left out and say so in the code: `length` (produced from `Count`, a member the filter decides about separately), iteration (`GetEnumerator`'s business), and `ArrayConversionMode.Copy` (a conversion of a value, not an access to a member).

## Evidence

Every number below is from **this branch, both target frameworks** (`net10.0` and `net472`), and the two legs produced **identical** counts.

### Failing-first, with the suites in place against stock `4.x` (`c5853e7a8`)

| Suite | Failed / total on stock `4.x` | After |
| --- | --- | --- |
| `HostNonIndexedCollectionTests` (#3356) | 33 / 45 | 0 |
| `HostExposedCollectionTypeTests` (#3425, #3480) | 21 / 33 | 0 |
| `HostCollectionIndexWriteTests` (#3416) | 56 / 63 | 0 |
| `HostCollectionIndexAgreementTests` (#3464) | 11 / 18 | 0 |
| `HostCollectionIndexBoundsTests` (#3472) | 28 / 35 | 0 |
| `HostIndexerFilterTests` (#3561) | 13 / 18 | 0 |
| `InteropTests.ClrArrayLiveView` new cases (#3381) | 6 / 7 | 0 |
| `HostReadOnlyCollectionTests` (#3385, already on `4.x`) | 0 / 68 | 0 / 68 |

### The #3561 half, isolated

With the cluster applied and the #3561 source held back, the five cluster suites are **194 of 194 green** and `HostIndexerFilterTests` is **13 of 18 failing** — the containment contract is the only thing left, which is exactly the state that made this backport a no-go until #3561 landed.

Narrowing to the test that existed here before this PR, `HostIndexerFilterTests.AMemberFilterExcludingTheIndexerBlocksIndexedWrites`:

| Source state | Result |
| --- | --- |
| stock `4.x` | 4 / 4 pass |
| cluster without #3561 | **1 failure** — the filtered-out indexer is written through |
| cluster with #3561 | 4 / 4 pass |

### Both write configurations

The configuration the containment contract is measured in differs from `main`'s, so the suite pins both:

- `TheContainmentDecisionHoldsOnThisBranchsDefaultWriteConfiguration` — `AllowWrite` left at this branch's default (`true`): elements leak without the fix.
- `TheContainmentDecisionDoesNotDependOnTheWriteConfiguration` — `AllowWrite = false`: the *reads* still leak without the fix, because a read never consulted the write switch. This is the configuration `main`'s suite was implicitly running in.

Both fail without #3561 and pass with it.

### Full runs

| Leg | Result |
| --- | --- |
| `dotnet build -c Release` (all five TFMs, `TreatWarningsAsErrors`) | 0 errors, 0 new warnings |
| `Jint.Tests` | 6995 / 6995 (`net10.0`), 6910 / 6910 (`net472`) |
| `Jint.Tests.PublicInterface` | 1820 / 1820 (`net10.0`), 1812 / 1812 (`net472`) |
| `Jint.Tests.CommonScripts` | 28 / 28 on both |
| `Jint.Tests.SourceGenerators` | 52 / 52 |
| `JINT_HOST_CONTRACT_VERIFICATION=1` (`Jint.Tests` + `Jint.Tests.PublicInterface`) | green on both TFMs |
| `Jint.Tests.Test262` | 102,499 passed / **0 failed** / 185 skipped of 102,684 — the branch control exactly |

## Deliberate divergences from `main`

- **#3054 stays out.** It is a v5 default change (`Interop.AllowWrite` defaulting to `false`), and its three `ObjectWrapper.Specialized.cs` conflict points are resolved in this branch's favour: `4.x` keeps its `Delete` and `ArrayOperations.Set` guards. Consequence for the suites: where `main` can leave the write switch to the default, `HostCollectionIndexWriteTests.GrowthStillNeedsWritesEnabledAndAnExtensibleView` and `HostIndexerFilterTests` spell it out, because a bare `new Engine()` here means the opposite of what it means there.
- **`Jint.AotExample` is not touched.** The probes #3381/#3425/#3480 add extend an AOT harness this branch does not have — its `Program.cs` is a 22-line stub — so porting them would mean backporting the whole #3305/#3307 AOT programme. The behaviour those probes cover is pinned instead by the `InteropTests.ClrArrayLiveView` cases (`ArrayList.FixedSize` is the same untyped `ListWrapper` a `T[]` degrades to under Native AOT).
- **`docs/v5-migration.md` §4.97 and `Jint/Runtime/Interop/AGENTS.md` do not exist on this branch.** Their reasoning is carried into the XML docs and comments beside the code instead.
- **The suites are xUnit v3 here**, not the NUnit `main` moved to in #3409.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014W5mbjGhyvgAS4pivXoc4S
