### PR TITLE
Interop: a host type converter's answer stays with the engine whose converter gave it

### DIFF
--- a/Jint.Tests/Runtime/InteropAccessorCacheSharingTests.cs
+++ b/Jint.Tests/Runtime/InteropAccessorCacheSharingTests.cs
@@ -49,6 +49,23 @@ public class InteropAccessorCacheSharingTests
         public string this[string key] => key + "!";
     }
 
+    /// <summary>
+    /// Carries both halves of the decision a host <see cref="ITypeConverter"/> makes during resolution: a
+    /// declared property an indexer of the same name shadows, and a key only the indexer can answer.
+    /// </summary>
+    public sealed class Bag
+    {
+        private readonly Dictionary<string, string> _entries = new()
+        {
+            ["Name"] = "from-indexer",
+            ["Extra"] = "indexer-only",
+        };
+
+        public string Name => "from-property";
+
+        public string? this[string key] => _entries.TryGetValue(key, out var value) ? value : null;
+    }
+
     private sealed class CountingResolver
     {
         private int _memberFilterCalls;
@@ -296,6 +313,88 @@ public class InteropAccessorCacheSharingTests
         custom.Evaluate("host.key").Should().Be("key!");
     }
 
+    [Fact]
+    public void TwoCustomTypeConvertersDoNotDecideForEachOther()
+    {
+        // Both engines report a host-installed converter, so the profile puts them in the same partition -
+        // but their converters answer differently, and that answer is what decides whether the declared
+        // property is handed the indexer to probe ahead of itself (#3560).
+        var resolver = new TypeResolver();
+        var narrow = CreateEngine(resolver, new Bag(), options => options.SetTypeConverter(_ => new NarrowTypeConverter()));
+        var wide = CreateEngine(resolver, new Bag(), options => options.SetTypeConverter(engine => new WrappingTypeConverter(engine)));
+
+        narrow.Evaluate("host.Name").Should().Be("from-property", "the narrow converter finds no usable indexer");
+        narrow.Evaluate("typeof host.Extra").Should().Be("undefined");
+
+        wide.Evaluate("host.Name").Should().Be("from-indexer", "the wide converter converts the member name to the indexer's key");
+        wide.Evaluate("host.Extra").Should().Be("indexer-only");
+    }
+
+    [Fact]
+    public void TwoCustomTypeConvertersDoNotDecideForEachOtherInEitherOrder()
+    {
+        var resolver = new TypeResolver();
+        var wide = CreateEngine(resolver, new Bag(), options => options.SetTypeConverter(engine => new WrappingTypeConverter(engine)));
+        var narrow = CreateEngine(resolver, new Bag(), options => options.SetTypeConverter(_ => new NarrowTypeConverter()));
+
+        wide.Evaluate("host.Name").Should().Be("from-indexer");
+        narrow.Evaluate("host.Name").Should().Be("from-property");
+
+        // a fresh wrapper, so the answer is resolved again rather than served from the first one's own store
+        wide.SetValue("second", new Bag());
+        wide.Evaluate("second.Name").Should().Be("from-indexer");
+        wide.Evaluate("second.Extra").Should().Be("indexer-only");
+    }
+
+    [Fact]
+    public void CustomTypeConverterEnginesStillShareWhatTheirConverterCannotDecide()
+    {
+        // The withholding is per type, not per engine: a type whose members no converter is consulted about
+        // keeps being resolved once for every engine sharing the resolver.
+        var counting = new CountingResolver();
+        var first = CreateEngine(counting.Resolver, new Host(1), options => options.SetTypeConverter(_ => new NarrowTypeConverter()));
+        var second = CreateEngine(counting.Resolver, new Host(2), options => options.SetTypeConverter(engine => new WrappingTypeConverter(engine)));
+        counting.Reset();
+
+        first.Evaluate("host.Value").Should().Be(1);
+        counting.Reset().Should().BeGreaterThan(0, "the first engine has to resolve the member");
+
+        second.Evaluate("host.Value").Should().Be(2);
+        counting.Reset().Should().Be(0, "Host declares no indexer, so nothing here depends on the converter");
+    }
+
+    [Fact]
+    public void CustomTypeConverterEnginesDoNotGrowTheSharedCachePerEngine()
+    {
+        // Keying the partition on the converter itself would be one entry set per engine in a cache that
+        // never evicts, and would pin every host converter for the life of the process.
+        var resolver = new TypeResolver();
+
+        Engine Create()
+        {
+            var engine = CreateEngine(resolver, new Bag(), options => options.SetTypeConverter(e => new WrappingTypeConverter(e)));
+            engine.SetValue("plain", new Host(1));
+            return engine;
+        }
+
+        void Exercise(Engine engine)
+        {
+            engine.Evaluate("host.Name").Should().Be("from-indexer");
+            engine.Evaluate("plain.Value").Should().Be(1);
+        }
+
+        Exercise(Create());
+        var countAfterFirstEngine = resolver.ResolvedAccessorCount;
+        countAfterFirstEngine.Should().BeGreaterThan(0, "Host carries no indexer, so its members are still shared");
+
+        for (var i = 0; i < 20; i++)
+        {
+            Exercise(Create());
+        }
+
+        resolver.ResolvedAccessorCount.Should().Be(countAfterFirstEngine);
+    }
+
     #endregion
 
     #region 3. nothing engine-affine is shared
@@ -325,6 +424,22 @@ public class InteropAccessorCacheSharingTests
     /// Behaves exactly like the stock converter but is not it, so the engine counts as having a
     /// host-installed <see cref="ITypeConverter"/>.
     /// </summary>
+    /// <summary>
+    /// Declines every conversion, including the string to string the stock converter accepts outright, so
+    /// resolution finds no indexer this member name can be handed to.
+    /// </summary>
+    private sealed class NarrowTypeConverter : ITypeConverter
+    {
+        public object? Convert(object? value, Type type, IFormatProvider formatProvider)
+            => throw new NotSupportedException();
+
+        public bool TryConvert(object? value, Type type, IFormatProvider formatProvider, [NotNullWhen(true)] out object? converted)
+        {
+            converted = null;
+            return false;
+        }
+    }
+
     private sealed class WrappingTypeConverter : ITypeConverter
     {
         private readonly ITypeConverter _inner;

--- a/Jint/Runtime/Interop/TypeResolver.cs
+++ b/Jint/Runtime/Interop/TypeResolver.cs
@@ -37,6 +37,12 @@ public sealed class TypeResolver
     private readonly ConcurrentDictionary<Type, bool> _indexedElementExposure = new();
 
     /// <summary>
+    /// Memo behind <see cref="ResolutionConsultsConverter"/>, populated only for engines carrying an
+    /// <see cref="ITypeConverter"/> of the host's own and therefore having a question to ask at all.
+    /// </summary>
+    private readonly ConcurrentDictionary<Type, bool> _converterKeyedIndexers = new();
+
+    /// <summary>
     /// How many accessors this resolver currently holds. The cache never evicts, so this is the retention
     /// the resolver commits to: it must stay bounded by the distinct members the engines using it resolve,
     /// and must not grow with the number of engines constructed.
@@ -87,6 +93,7 @@ public sealed class TypeResolver
     {
         _reflectionAccessors.Clear();
         _indexedElementExposure.Clear();
+        _converterKeyedIndexers.Clear();
     }
 
     /// <summary>
@@ -304,8 +311,16 @@ public sealed class TypeResolver
 
         var key = new AccessorCacheKey(type, member, requirement, profile);
 
+        // Every engine carrying an ITypeConverter of the host's own lands in one partition, because the
+        // profile can only record that the converter is not the stock one - naming the converter itself
+        // would pin a host object in a cache that lives for the process. So when resolving this type asks
+        // that converter a question, the engine neither answers from the shared cache nor adds to it: the
+        // answer belongs to the converter that gave it, not to the partition every such engine shares
+        // (#3560).
+        var converterDecides = !engine._typeConverterIsDefault && ResolutionConsultsConverter(type);
+
         var factories = _reflectionAccessors;
-        if (factories.TryGetValue(key, out var accessor))
+        if (!converterDecides && factories.TryGetValue(key, out var accessor))
         {
             if (throwOnError
                 && ReferenceEquals(accessor, ConstantValueAccessor.NullAccessor)
@@ -324,7 +339,7 @@ public sealed class TypeResolver
             return accessor;
         }
 
-        if (IsShareable(engine, accessor))
+        if (!converterDecides && IsShareable(engine, accessor))
         {
             // racy, we don't care: both racers resolved the same member the same way
             factories.TryAdd(key, accessor);
@@ -358,6 +373,66 @@ public sealed class TypeResolver
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// Whether resolving a member of <paramref name="type"/> asks the engine's <see cref="ITypeConverter"/>
+    /// anything, and therefore produces an answer that belongs to that converter alone.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="IndexerAccessor.TryFindIndexer"/> converts the member <em>name</em> to the index type of
+    /// every single-parameter indexer the type or one of its interfaces offers; an <see cref="int"/>-keyed
+    /// one is the only kind settled without the converter, from the name itself. That single answer decides
+    /// whether the declared member is handed an indexer to probe ahead of itself, so it reaches well past the
+    /// <see cref="IndexerAccessor"/> that <see cref="IsShareable"/> withholds. The scan is deliberately
+    /// blind to the member filter and to which accessors an indexer carries: answering "yes" too readily only
+    /// costs such an engine a re-resolution per wrapper, while answering "no" wrongly hands one host
+    /// converter's decision to another. Memoized per resolver and per type, and asked only by an engine whose
+    /// converter is not the stock one, so the default configuration pays nothing.
+    /// </remarks>
+    private bool ResolutionConsultsConverter(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.Interfaces)] Type type)
+    {
+        if (_converterKeyedIndexers.TryGetValue(type, out var consults))
+        {
+            return consults;
+        }
+
+        consults = HasConverterKeyedIndexer(type);
+        if (!consults)
+        {
+            foreach (var interfaceType in type.GetInterfaces())
+            {
+                if (HasConverterKeyedIndexer(interfaceType))
+                {
+                    consults = true;
+                    break;
+                }
+            }
+        }
+
+        // GetOrAdd's value overload rather than TryAdd, so a race still hands every caller the same answer
+        return _converterKeyedIndexers.GetOrAdd(type, consults);
+    }
+
+    /// <summary>
+    /// Whether <paramref name="type"/> offers a single-parameter indexer keyed by anything other than
+    /// <see cref="int"/> — the one index type <see cref="IndexerAccessor.TryFindIndexer"/> keys without
+    /// consulting the engine's <see cref="ITypeConverter"/>.
+    /// </summary>
+    private static bool HasConverterKeyedIndexer(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type type)
+    {
+        foreach (var candidate in type.GetProperties())
+        {
+            var indexParameters = candidate.GetIndexParameters();
+            if (indexParameters.Length == 1 && indexParameters[0].ParameterType != typeof(int))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private ReflectionAccessor ResolvePropertyDescriptorFactory(


### PR DESCRIPTION
`TypeResolver`'s accessor cache is shared between the engines using it, and is partitioned by an
`InteropResolutionProfile` that reduces a host-installed `ITypeConverter` to a single `bool` —
deliberately, because naming the converter itself would pin a host object in a cache that lives for the
process. That bool is what keeps a stock engine and a converter engine apart, and it is why #3522's own
tests pass on this branch. But it puts **every** engine carrying a converter of its own into one
partition.

Resolution asks that converter a question. `IndexerAccessor.TryFindIndexer` converts the member *name* to
the index type of each single-parameter indexer the type offers, and that one answer decides both whether
an `IndexerAccessor` is built and whether the declared member's `PropertyAccessor` is handed an
`indexerToTry` — which `ReflectionAccessor.GetValue` probes **before** the declared member. `IsShareable`
withheld only the first half:

```csharp
if (accessor is IndexerAccessor && !engine._typeConverterIsDefault)
{
    return false;
}
```

A `PropertyAccessor` is not an `IndexerAccessor`, so the second half passed straight through, in both
directions.

## The trace

Measured on `4.x` at 953ed25f5, `net472` and `net10.0`, over a host type carrying both a declared `Name`
property and a `this[string]` whose dictionary answers `Name` and `Extra`:

| order | narrow-converter engine reads `bag.Name` | wide-converter engine reads `bag.Name` |
| --- | --- | --- |
| narrow first | `from-property` | `from-property` ❌ — alone it reads `from-indexer` |
| wide first | `from-indexer` ❌ — alone it reads `from-property` | `from-indexer` |

Same host type, same member name, and the answer depends on which engine ran first. In the narrow-first
order the stored `PropertyAccessor` carries no `indexerToTry`; in the wide-first order it carries one, and
the narrow engine — whose converter refuses that very conversion — is handed an indexer probe it could
never have resolved for itself.

The mirror case is a key only the indexer can answer: the narrow engine stores "no such member" for
`bag.Extra`, and the wide engine — which has an indexer that answers it — is served that.

## The fix

An engine with a converter of its own now neither answers from the shared cache nor adds to it for a type
whose resolution consults that converter. That is a type offering a single-parameter indexer keyed by
anything other than `int`, which is the one index type `TryFindIndexer` settles from the member name alone
without asking. The predicate is memoized per resolver and per type, is asked only by an engine whose
converter is not the stock one — so the default configuration pays nothing — and is deliberately blind to
the member filter and to which accessors an indexer carries: answering "yes" too readily costs such an
engine a re-resolution per wrapper, which is exactly what the `IndexerAccessor` exclusion above already
cost it for the other half of the same decision. Answering "no" wrongly is the bug.

This is the branch-local shape #3560 describes, restricted to the partition `4.x` still has. `main`'s
shape — dropping `stockTypeConverter` from the profile and excluding per type with `IsConverterNeutral` —
is the v5 refactor, and removing the partition changes an existing default; it is deliberately not here.

Keying the partition on the converter instead was rejected twice over. It would pin the converter and its
engine for the life of the process, which is the reason #3559 gave for keeping an engine's operator
resolutions on the engine rather than in the process-wide table. And weakly keyed — a
`ConditionalWeakTable` generation counter — it would still grow a cache that never evicts by one entry set
per engine constructed, which is the retention `ResolvedAccessorCount` exists to bound and
`ExtensionMethodEnginesDoNotGrowTheSharedCachePerEngine` already pins.

## Tests

Four more facts in `Jint.Tests/Runtime/InteropAccessorCacheSharingTests`, which already owns this bargain:
the two orders of the trace above, the guard that two engines with *different* converters still share a
type no converter is consulted about (so the withholding stays per type rather than per engine), and the
guard that such engines add nothing to the shared cache per engine — the one the rejected shape would have
broken.

Failing first on unfixed `4.x`: **2 of 18 on `net10.0`, 2 of 18 on `net472`**.

`dotnet build -c Release` clean; `Jint.Tests` 6999/0 (net10.0) and 6914/0 (net472),
`Jint.Tests.PublicInterface` 1820/0 and 1812/0, `Jint.Tests.CommonScripts` 28/0 both,
`Jint.Tests.SourceGenerators` 52/0; test262 102,499 passed / 0 failed / 185 skipped of 102,684, matching
the branch control exactly.

No benchmark: the gate is a single `bool` field test that short-circuits for every engine on the stock
converter, so no default-configuration lane is reached at all. Engines carrying a host converter do lose
cross-engine sharing for indexer-bearing types; that lane was never benchmarked and the cost is bounded by
`ObjectWrapper`'s own per-wrapper descriptor store, but it is the one place worth gating if the interop
suite ever grows a custom-converter row.

Closes #3560

