### PR TITLE
String.prototype.split loses its segments when a host constraint runs script

### DIFF
--- a/Jint.Tests.PublicInterface/HostConstraintReentrancyTests.cs
+++ b/Jint.Tests.PublicInterface/HostConstraintReentrancyTests.cs
@@ -1,0 +1,61 @@
+#nullable enable
+
+using Jint.Constraints;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// A host-supplied <see cref="Constraint"/> is host code, and the engine calls it from inside built-ins that
+/// are still part-way through their own work. A constraint that runs script — on a second engine, or on the
+/// same one — therefore re-enters the engine at points no script could reach on its own, and anything the
+/// interrupted built-in was holding across that call has to survive it. These pin the cases that did not.
+/// </summary>
+public class HostConstraintReentrancyTests
+{
+    /// <summary>
+    /// Runs a script of its own the first few times it is asked, then stands down so the outer script can
+    /// finish. Counted rather than unconditional because the nested evaluation checks constraints too.
+    /// </summary>
+    private sealed class ReenteringConstraint : Constraint
+    {
+        private readonly Engine _other = new();
+        private int _fired;
+
+        public int Fired => _fired;
+
+        public override void Check()
+        {
+            if (_fired++ >= 4)
+            {
+                return;
+            }
+
+            _other.Evaluate("'x,y,z'.split(',').length");
+        }
+
+        public override void Reset()
+        {
+        }
+    }
+
+    [Test]
+    public void SplitKeepsItsSegmentsAcrossAConstraintThatSplitsOnAnotherEngine()
+    {
+        // The split fast path checks constraints every 10,000 segments, so the source has to be long enough
+        // to reach one; the second engine's split then runs on the same thread, inside the first one's loop.
+        var constraint = new ReenteringConstraint();
+        var engine = new Engine(options => options.AddConstraint(constraint));
+
+        engine.Evaluate("'a,'.repeat(30000).split(',').length").AsNumber().Should().Be(30001);
+        constraint.Fired.Should().BeGreaterThan(0, "the constraint has to have re-entered for this to prove anything");
+    }
+
+    [Test]
+    public void SplitIsUnaffectedWhenNoConstraintReenters()
+    {
+        var engine = new Engine();
+
+        engine.Evaluate("'a,'.repeat(30000).split(',').length").AsNumber().Should().Be(30001);
+        engine.Evaluate("'a,b,c'.split(',').join('|')").AsString().Should().Be("a|b|c");
+    }
+}

--- a/Jint/Native/String/StringExecutionContext.cs
+++ b/Jint/Native/String/StringExecutionContext.cs
@@ -10,12 +10,53 @@ internal sealed class StringExecutionContext
     private static readonly ThreadLocal<StringExecutionContext> _executionContext = new ThreadLocal<StringExecutionContext>(() => new StringExecutionContext());
 
     private List<JsString>? _splitSegmentList;
+    private bool _splitSegmentListInUse;
 
     private StringExecutionContext()
     {
     }
 
-    public List<JsString> SplitSegmentList => _splitSegmentList ??= new List<JsString>();
+    /// <summary>
+    /// The scratch buffer <c>String.prototype.split</c> collects its segments in, reused across calls so the
+    /// common case allocates nothing.
+    /// </summary>
+    /// <remarks>
+    /// The buffer is thread-affine, not engine-affine, and the split loop is not a leaf: it calls
+    /// <c>Engine.Constraints.Check()</c> every <see cref="Engine.ConstraintCheckInterval"/> segments, and a
+    /// host-supplied <see cref="Constraint"/> may run script — on this engine or on another one sharing the
+    /// thread. A second split reached that way used to <c>Clear()</c> the very list the outer one was still
+    /// filling, so the outer split silently returned the wrong number of segments. Renting says who owns the
+    /// buffer: the re-entrant caller gets one of its own, and only the owner returns the shared one.
+    /// </remarks>
+    public List<JsString> RentSplitSegmentList()
+    {
+        if (_splitSegmentListInUse)
+        {
+            // re-entered while the shared buffer is live; the nested call gets a private one
+            return new List<JsString>();
+        }
+
+        _splitSegmentListInUse = true;
+        var list = _splitSegmentList ??= new List<JsString>();
+        list.Clear();
+        return list;
+    }
+
+    /// <summary>
+    /// Releases a buffer taken from <see cref="RentSplitSegmentList"/>. A private buffer handed to a
+    /// re-entrant caller is not the shared one and is simply dropped. Clearing on the way out is what stops
+    /// the shared buffer holding the last split's <see cref="JsString"/>s — and, through
+    /// <see cref="JsString.CreateSliced(string, int, int)"/>, the script source they may be views over —
+    /// until the next split on this thread.
+    /// </summary>
+    public void ReturnSplitSegmentList(List<JsString> list)
+    {
+        if (ReferenceEquals(list, _splitSegmentList))
+        {
+            list.Clear();
+            _splitSegmentListInUse = false;
+        }
+    }
 
     public static StringExecutionContext Current => _executionContext.Value!;
 }

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -1304,49 +1304,57 @@ internal sealed partial class StringPrototype : StringInstance
             return emptyResult;
         }
 
-        var segments = StringExecutionContext.Current.SplitSegmentList;
-        segments.Clear();
-
-        // Direct scan instead of string.Split: avoids the throwaway result array
-        // string.Split allocates on every call, and stops scanning once lim
-        // segments have been collected. Each segment goes through CreateSliced so the
-        // retention policy decides copy vs zero-copy view against the source length.
-        var start = 0;
-        while ((uint) segments.Count < lim)
+        // Rented rather than taken: the loops below run the engine's constraints, a host constraint may run
+        // script, and a split reached that way shares this thread's buffer. See RentSplitSegmentList.
+        var stringContext = StringExecutionContext.Current;
+        var segments = stringContext.RentSplitSegmentList();
+        try
         {
-            if (segments.Count > 0 && segments.Count % ConstraintCheckInterval == 0)
+            // Direct scan instead of string.Split: avoids the throwaway result array
+            // string.Split allocates on every call, and stops scanning once lim
+            // segments have been collected. Each segment goes through CreateSliced so the
+            // retention policy decides copy vs zero-copy view against the source length.
+            var start = 0;
+            while ((uint) segments.Count < lim)
             {
-                engine.Constraints.Check();
+                if (segments.Count > 0 && segments.Count % ConstraintCheckInterval == 0)
+                {
+                    engine.Constraints.Check();
+                }
+
+                var index = sep.Length == 1
+                    ? s.IndexOf(sep[0], start)
+                    : s.IndexOf(sep, start, StringComparison.Ordinal);
+
+                if (index < 0)
+                {
+                    segments.Add(JsString.CreateSliced(s, start, s.Length - start));
+                    break;
+                }
+
+                segments.Add(JsString.CreateSliced(s, start, index - start));
+                start = index + sep.Length;
             }
 
-            var index = sep.Length == 1
-                ? s.IndexOf(sep[0], start)
-                : s.IndexOf(sep, start, StringComparison.Ordinal);
-
-            if (index < 0)
+            var length = (uint) System.Math.Min(segments.Count, lim);
+            var a = realm.Intrinsics.Array.ArrayCreate(length);
+            for (int i = 0; i < length; i++)
             {
-                segments.Add(JsString.CreateSliced(s, start, s.Length - start));
-                break;
+                if (i > 0 && i % ConstraintCheckInterval == 0)
+                {
+                    engine.Constraints.Check();
+                }
+
+                a.SetIndexValue((uint) i, segments[i], updateLength: false);
             }
 
-            segments.Add(JsString.CreateSliced(s, start, index - start));
-            start = index + sep.Length;
+            a.SetLength(length);
+            return a;
         }
-
-        var length = (uint) System.Math.Min(segments.Count, lim);
-        var a = realm.Intrinsics.Array.ArrayCreate(length);
-        for (int i = 0; i < length; i++)
+        finally
         {
-            if (i > 0 && i % ConstraintCheckInterval == 0)
-            {
-                engine.Constraints.Check();
-            }
-
-            a.SetIndexValue((uint) i, segments[i], updateLength: false);
+            stringContext.ReturnSplitSegmentList(segments);
         }
-
-        a.SetLength(length);
-        return a;
     }
 
     /// <summary>

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -4403,6 +4403,51 @@ or name it in the allow-list. There is no option to restore the old behaviour: a
 hides a member from reads and from enumeration while letting a write through is the failure mode such a
 control most needs not to have.
 
+### 4.98 A split survives a constraint that runs script ([#3565](https://github.com/sebastienros/jint/pull/3565))
+
+`String.prototype.split` with a string separator collects its segments into a scratch `List<JsString>` held
+on `StringExecutionContext`, reused between calls so the common case allocates nothing. That buffer is
+**thread**-affine, not engine-affine, and the loop that fills it is not a leaf: it calls
+`Engine.Constraints.Check()` every 10,000 segments, and a host-supplied `Constraint` is host code that may
+run script — on this engine, or on another one sharing the thread. A split reached that way cleared the very
+list the outer split was still filling, and the outer call then returned only the segments it had managed to
+add since.
+
+```csharp
+sealed class LoggingConstraint : Constraint
+{
+    private readonly Engine _reporter = new();
+
+    public override void Check() => _reporter.Evaluate("'x,y,z'.split(',').length");
+
+    public override void Reset() { }
+}
+
+var engine = new Engine(options => options.AddConstraint(new LoggingConstraint()));
+```
+
+```js
+// 5.0                                             5.x
+'a,'.repeat(30000).split(',').length;  // 20004                  30001
+```
+
+The wrong answer is silent: a shorter array, no exception, and nothing in it wrong except that most of it is
+missing. It needs a split long enough to reach a constraint check — 10,000 segments — so a host that hit it
+hit it only on its largest inputs.
+
+The buffer is now rented and returned rather than taken. The owner gets the shared list, a re-entrant caller
+gets a private one, and the release runs in a `finally`, so a constraint that throws mid-split leaves the
+buffer usable rather than permanently marked in use. Returning also clears it, which is worth knowing for a
+second reason: the segments are `JsString.CreateSliced` views that may reference the script source they were
+cut from, and the shared buffer used to hold the last split's segments — and therefore that source — until
+the next split on the thread.
+
+**What could break:** nothing a correct host observes. The only behaviour change is that a re-entrant split
+now returns the whole result instead of part of it, and a nested split allocates a list of its own rather
+than borrowing one. A host with no constraints, or with only the in-box ones — none of which run script —
+was never on the affected path and pays exactly what it paid before: one shared list per thread, one
+`Clear()` per call.
+
 ## 5. New in v5
 
 Everything in the table below is opt-in: nothing in it is installed unless the host asks for it, so


### PR DESCRIPTION
`String.prototype.split` with a string separator collects its segments into a scratch `List<JsString>` on `StringExecutionContext`, reused between calls so the common case allocates nothing. That buffer is **thread**-affine, not engine-affine, and it was taken with a `Clear()` and held across a call into host code:

```csharp
var segments = StringExecutionContext.Current.SplitSegmentList;
segments.Clear();

var start = 0;
while ((uint) segments.Count < lim)
{
    if (segments.Count > 0 && segments.Count % ConstraintCheckInterval == 0)
    {
        engine.Constraints.Check();   // <- host code, and it may run script
    }
    ...
```

`Engine.Constraints.Check()` runs every registered `Constraint`, and a host-supplied one is arbitrary host code. A constraint that evaluates script — on this engine or on another one sharing the thread — reaches `split` again, which `Clear()`s the very list the outer call is still filling. The outer split then returns only the segments it managed to add afterwards.

## Reproduction

```csharp
sealed class LoggingConstraint : Constraint
{
    private readonly Engine _reporter = new();
    public override void Check() => _reporter.Evaluate("'x,y,z'.split(',').length");
    public override void Reset() { }
}

var engine = new Engine(options => options.AddConstraint(new LoggingConstraint()));
engine.Evaluate("'a,'.repeat(30000).split(',').length");
```

```
Expected 30001, but found 20004 (difference of -9997).
```

Reproduced against `main` at 55a45cec5 on **net472, net8.0 and net10.0** — the test in this PR fails on all three before the fix. The wrong answer is silent: a shorter array, no exception, every element in it correct. It takes a split long enough to reach a constraint check — 10,000 segments — so a host that hits it hits it only on its largest inputs.

## The fix

The buffer is rented and returned rather than taken. `RentSplitSegmentList` hands the shared list to the owner and a private one to a re-entrant caller; `ReturnSplitSegmentList` only releases the shared one. The release is in a `finally`, so a constraint that throws mid-split leaves the buffer usable rather than permanently marked in use — which a bare guard flag would not have.

Returning also clears, which pays for itself a second time: the segments are `JsString.CreateSliced` views that may reference the script source they were cut from, and the shared buffer used to hold the last split's segments — and so that source — until the next split on the thread.

A host with no constraints, or with only the in-box ones (none of which run script), stays on exactly the path it was on: one shared list per thread, one `Clear()` per call, no allocation.

## How it was found

Auditing process-wide state whose correctness depends on something its container does not capture — the shape behind #3331, #3368, #3424/#3526 and #3434/#3521 — for #3426. This one is thread-wide rather than process-wide, and what the container omits is not configuration but **who is currently using it**, which is why nothing in that campaign's re-keying work reached it.

## Verification

- `dotnet build -c Release` clean, `TreatWarningsAsErrors` on
- `Jint.Tests`: 11601/0 (net8.0, net10.0), 8221/0 (net472)
- `Jint.Tests.PublicInterface`: 3344/0 (net8.0), 3354/0 (net10.0), 2721/0 (net472)
- `JINT_HOST_CONTRACT_VERIFICATION=1`: `Jint.Tests` 11601/0, `Jint.Tests.PublicInterface` 3357/0
- `Jint.Tests.Test262`: **102,537 passed / 0 failed / 151 skipped of 102,688**

`docs/v5-migration.md` §4.98.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014W5mbjGhyvgAS4pivXoc4S
