### PR TITLE
The delegate-conversion tests all miss the instance-keyed cache

### DIFF
--- a/Jint.Tests.PublicInterface/HostDelegateConversionTests.cs
+++ b/Jint.Tests.PublicInterface/HostDelegateConversionTests.cs
@@ -42,6 +42,40 @@ public class HostDelegateConversionTests
         public string Call(Transform f) => "transform:" + f("x");
     }
 
+    public sealed class BothHost
+    {
+        public string Call(Notify f)
+        {
+            f(1);
+            return "notify";
+        }
+
+        public string CallTransform(Transform f) => "transform:" + f("x");
+    }
+
+    /// <summary>
+    /// One engine, one function <em>instance</em>, two delegate types. The shared-preparation tests below give
+    /// each engine a function of its own, so they exercise only the AST-keyed lane; this is the
+    /// instance-keyed one, where the same function object is asked for two different targets and the memo has
+    /// to answer with two different delegates rather than with the first one twice.
+    /// </summary>
+    [Test]
+    public void OneEngineConvertingOneFunctionToTwoDelegateTypes()
+    {
+        var engine = new Engine();
+        engine.SetValue("host", new BothHost());
+
+        engine.Evaluate("var f = function (x) { return String(x); }; host.call(f);")
+            .AsString().Should().Be("notify");
+
+        // the same f, now wanted as a Transform: served the Notify, this was
+        // ArgumentException: Object of type 'Notify' cannot be converted to type 'Transform'
+        engine.Evaluate("host.callTransform(f);").AsString().Should().Be("transform:x");
+
+        // and back again, so neither conversion evicted the other
+        engine.Evaluate("host.call(f);").AsString().Should().Be("notify");
+    }
+
     private const string Source = "host.call(function (x) { return String(x); });";
 
     [Test]


### PR DESCRIPTION
#3521 keyed both delegate caches by the target type. `HostDelegateConversionTests` pins it through three shapes — two engines on one `Prepared<Script>`, the same in the other order, and the two alternating — and every one of them gives each engine a function of its own.

That means all three exercise the **AST-keyed** cache. None exercises the **instance-keyed** one: no test asks a single function *instance* for two different delegate types, which is the entire reason the outer `ConditionalWeakTable<object, TypeKeyedCache<Delegate>>` carries a `TypeKeyedCache` rather than a bare `Delegate`.

## The gap, measured

Keying only the instance lane on a constant — so it behaves as it did before #3521 while the AST lane stays keyed by target type:

```diff
-if (!boundDelegates.TryGetValue(type, out var bound))
+if (!boundDelegates.TryGetValue(typeof(object), out var bound))
...
-bound = boundDelegates.GetOrAdd(type, targetBinder(functionInstance)!);
+bound = boundDelegates.GetOrAdd(typeof(object), targetBinder(functionInstance)!);
```

```
Passed!  - Failed: 0, Passed: 3
```

All three existing tests stay green. A simplification that folded the instance lane back to a plain weak table would have landed unnoticed.

The test added here fails under exactly that mutation, with the defect's own message:

```
Failed OneEngineConvertingOneFunctionToTwoDelegateTypes
  System.ArgumentException : Object of type 'Notify' cannot be converted to type 'Transform'.
```

and passes on `main` as it stands. It also converts back to the first type afterwards, so it says the two entries coexist rather than evict each other.

Test-only; no production change. Found while auditing process-wide caches for #3426 — I had an equivalent local fix and test predating #3521, and this is the only part of it `main` did not already have.

## Verification

`Jint.Tests.PublicInterface` `HostDelegateConversionTests`: 4/0 on net472, net8.0 and net10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014W5mbjGhyvgAS4pivXoc4S
