### PR TITLE
Two of the four caches cited as precedent no longer make the point

### DIFF
--- a/Jint/Runtime/Interop/MethodDescriptor.cs
+++ b/Jint/Runtime/Interop/MethodDescriptor.cs
@@ -196,7 +196,7 @@ internal sealed class MethodDescriptor
     // Trade-off: a static cache keyed by MethodBase pins that MethodBase - and therefore its
     // declaring assembly - for the lifetime of the process. That matches the precedent already set
     // by this codebase's other process-wide reflection caches (TypeDescriptor._cache,
-    // TypeReference._memberAccessors, JintBinaryExpression._knownOperators,
+    // CompiledMemberAccessor's four delegate tables, ReflectionExtensions._operatorOverloadMethodCache,
     // DefaultTypeConverter._knownCastOperators).
     //
     // A concurrent duplicate build for the same key is benign (both produce equivalent invokers and


### PR DESCRIPTION
The comment above `MethodDescriptor`'s shared invoker tables justifies pinning a `MethodBase` for the life of the process by naming four caches that already do it. Two of the four no longer say what it needs.

**`TypeReference._memberAccessors` does not exist.** `TypeReference`'s only static is its `JsString` name; its static members go through `TypeResolver.GetStaticAccessor`, whose `StaticAccessorCacheKey` carries the `InteropResolutionProfile` and which passes the same `IsShareable` / `IsConverterNeutral` gates as the instance lane. A reader following the citation finds nothing at all.

**`JintBinaryExpression._knownOperators` is still there but is now the wrong example.** Since #3526 it is the process-wide half of a pair: an engine with its own `ClrTypeConverter` gets a table of its own, precisely so that a process-lived static does not pin that converter and whatever engine it captured. Citing it as precedent for "pin it for the process" points at the case that decided not to.

Replaced with two that hold today and are the same shape as the tables being justified — `CompiledMemberAccessor`'s four `MemberInfo`-keyed delegate tables, and `ReflectionExtensions._operatorOverloadMethodCache`, a `Type`-keyed method list which is the pure-metadata part `_knownOperators` sits on top of.

Comment-only; no code change. `dotnet build -c Release Jint/Jint.csproj` clean, 0 warnings.

Found while auditing process-wide caches for #3426. The same dead name was in `Jint/Runtime/Interpreter/AGENTS.md`; #3522/#3563 already rewrote that paragraph, and this comment is the last place it survived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014W5mbjGhyvgAS4pivXoc4S
