### PR TITLE
Strings: a short `+` chain no longer pays for a deferred representation it never takes

### DIFF
--- a/Jint.Tests/Runtime/StringConcatenationTests.cs
+++ b/Jint.Tests/Runtime/StringConcatenationTests.cs
@@ -61,7 +61,87 @@ public class StringConcatenationTests
 
         engine.Evaluate("'a' + 'b'").Should().BeOfType<JsString>();
         engine.Evaluate("'a' + 'b' + 'c'").Should().BeOfType<JsString>();
+        engine.Evaluate("'a' + 'b' + 'c' + 'd'").Should().BeOfType<JsString>();
+        engine.Evaluate("'a' + 'b' + 'c' + 'd' + 'e' + 'f'").Should().BeOfType<JsString>();
         engine.Evaluate($"'x'.repeat({JsString.MinDeferredConcatenationLength - 2}) + 'y'").Should().BeOfType<JsString>();
+    }
+
+    /// <summary>
+    /// A chain mixes operands that are already strings with operands that are not, and the two are
+    /// carried in different forms up to the point where the cutoff is read — so this is where a chain
+    /// would put an operand's characters in the wrong place, or read the wrong length and take the
+    /// wrong side of the cutoff. Every arity has its own join, so every arity is spelled out.
+    /// </summary>
+    [TestCase("y + '-' + m", "2007-11")]
+    [TestCase("'[' + y + ']' + m", "[2007]11")]
+    [TestCase("y + '-' + m + '-' + d", "2007-11-29")]
+    [TestCase("y + '-' + m + '-' + d + ' ' + y + ':' + m + ':' + d", "2007-11-29 2007:11:29")]
+    [TestCase("'' + y + m + d", "20071129")]
+    [TestCase("'' + y + m + d + '.'", "20071129.")]
+    [TestCase("y + '-' + m + '-' + d + '!'", "2007-11-29!")]
+    public void AChainMixingCoercedAndStringOperandsProducesTheSameCharacters(string expression, string expected)
+    {
+        var engine = new Engine();
+        engine.Execute("var y = 2007, m = 11, d = 29;");
+
+        var value = engine.Evaluate(expression);
+
+        value.Should().BeOfType<JsString>();
+        value.AsString().Should().Be(expected);
+    }
+
+    /// <summary>
+    /// The two-operand form of the same mix: one side is already a string and the other coerces, which
+    /// is what <c>n + "x"</c> is. Below the cutoff the result is flat and above it the deferred node is
+    /// still built — the operand that had to be coerced is not what decides that, the length is.
+    /// </summary>
+    [Test]
+    public void APairWithOneCoercedOperandTakesBothSidesOfTheCutoff()
+    {
+        // through variables, so nothing here is folded away before the lane under test sees it
+        var engine = new Engine();
+        var pad = JsString.MinDeferredConcatenationLength;
+        engine.Execute($"var n = 12345, letter = 'a', wide = 'x'.repeat({pad});");
+
+        engine.Evaluate("n + letter").AsString().Should().Be("12345a");
+        engine.Evaluate("letter + n").AsString().Should().Be("a12345");
+        engine.Evaluate("n + letter").Should().BeOfType<JsString>();
+
+        var deferred = engine.Evaluate("n + wide");
+        deferred.Should().BeOfType<JsString.RopeString>();
+        deferred.AsString().Should().Be("12345" + new string('x', pad));
+
+        var deferredPrepend = engine.Evaluate("wide + n");
+        deferredPrepend.Should().BeOfType<JsString.RopeString>();
+        deferredPrepend.AsString().Should().Be(new string('x', pad) + "12345");
+    }
+
+    /// <summary>
+    /// What the deferred representation must not cost the chains that never reach it. A chain of short
+    /// pieces — a formatted date, which is what SunSpider's date-format rows build — lands far below the
+    /// cutoff and is copied eagerly, so it has to allocate what it allocated before the representation
+    /// existed: its result, the characters its non-string operands coerce to, and the one array its
+    /// operands live in.
+    /// <para>
+    /// Coercing every operand to a <see cref="JsString"/> before the cutoff had been read cost a second
+    /// array per chain and a wrapper object per non-string operand, every byte of it dead by the time the
+    /// result was copied out. Bytes per evaluation of the eleven-operand chain below, taken as a delta of
+    /// a thread-local allocation counter so the figure does not depend on what else the machine is doing:
+    /// 576 to 272 on net10.0 and net8.0, 712 to 296 on net472.
+    /// </para>
+    /// </summary>
+    [Test]
+    public void AShortChainDoesNotPayForTheDeferredRepresentation()
+    {
+        if (!GCPolyfills.AllocatedBytesForCurrentThreadIsSupported)
+        {
+            // see AccumulatingWithPlusIsNoLongerQuadratic for why this reports rather than fails
+            return;
+        }
+
+        var perEvaluation = AllocatedBytesPerChainEvaluation("y + '-' + m + '-' + d + ' ' + y + ':' + m + ':' + d", 20_000);
+
+        perEvaluation.Should().BeLessThan(ShortChainAllocationCeiling);
     }
 
     /// <summary>
@@ -264,6 +344,8 @@ public class StringConcatenationTests
     [TestCase("s = s + chunk")]
     [TestCase("s = chunk + s")]
     [TestCase("s = s + chunk + chunk")]
+    [TestCase("s = s + chunk + chunk + chunk + chunk")]
+    [TestCase("s = chunk + chunk + chunk + chunk + s")]
     public void AccumulatingWithPlusIsNoLongerQuadratic(string body)
     {
         if (!GCPolyfills.AllocatedBytesForCurrentThreadIsSupported)
@@ -299,5 +381,33 @@ public class StringConcatenationTests
         GCPolyfills.TryGetAllocatedBytesForCurrentThread(out var after);
 
         return after - before;
+    }
+
+    /// <summary>
+    /// The bytes one evaluation of a below-cutoff chain may allocate, loop included. It sits between the
+    /// two measurements in <see cref="AShortChainDoesNotPayForTheDeferredRepresentation"/>: 35% above the
+    /// largest of the three after-figures and 30% below the smallest before-figure, so neither the fix it
+    /// pins nor the regression it would catch is close enough to the line to be fragile.
+    /// </summary>
+    private const long ShortChainAllocationCeiling = 400;
+
+    private static long AllocatedBytesPerChainEvaluation(string expression, int iterations)
+    {
+        var engine = new Engine();
+        var script = Engine.PrepareScript(
+            $"(function (n) {{ var y = 2007, m = 11, d = 29, r = ''; for (var i = 0; i < n; i++) {{ r = {expression}; }} return r.length; }})(n)");
+
+        // warm the handler tree and the call-site caches, so what is measured is the loop and not the
+        // one-off cost of reaching it
+        engine.SetValue("n", 64);
+        engine.Evaluate(script);
+
+        engine.SetValue("n", iterations);
+        GC.Collect();
+        GCPolyfills.TryGetAllocatedBytesForCurrentThread(out var before);
+        engine.Evaluate(script);
+        GCPolyfills.TryGetAllocatedBytesForCurrentThread(out var after);
+
+        return (after - before) / iterations;
     }
 }

--- a/Jint/Native/JsString.cs
+++ b/Jint/Native/JsString.cs
@@ -364,11 +364,24 @@ public class JsString : JsValue, IEquatable<JsString>, IEquatable<string>
     /// allocation, and every consumer of the result would pay the flattening indirection for nothing.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Only the asymptotic behaviour above this line matters, and the exact value does not change it: a
     /// loop that accumulates in <c>n</c>-character pieces copies for the first
     /// <c>MinDeferredConcatenationLength / n</c> iterations and defers from then on, so the whole
     /// quadratic term is bounded by <c>MinDeferredConcatenationLength²</c> characters however long the
     /// loop runs. It is a knob for the small-string case, not for the fix.
+    /// </para>
+    /// <para>
+    /// The arithmetic under the value: a <see cref="RopeString"/> is 56 bytes on 64-bit — header, the
+    /// inherited type and memo fields, two operand references and the length — and it does not remove
+    /// the flat allocation, it postpones it. A result that is read once therefore costs those 56 bytes
+    /// and one indirection <em>more</em> than copying it would have; the node earns them back only
+    /// across iterations, where the operand it holds would otherwise be copied again. So the line sits
+    /// far above the point where a node is merely affordable — and what the path <em>below</em> the line
+    /// allocates matters more than where the line is. A chain that stays below it has to cost what it
+    /// cost before this representation existed; when it did not, SunSpider's date-format rows paid for a
+    /// deferral they never took (#3527).
+    /// </para>
     /// </remarks>
     internal const int MinDeferredConcatenationLength = 512;
 

--- a/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
@@ -1,10 +1,12 @@
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Numerics;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Text;
 using Jint.Extensions;
 using Jint.Native;
 using Jint.Native.Object;
@@ -1552,20 +1554,23 @@ internal abstract class JintBinaryExpression : JintExpression
     {
         if (lprim.IsString() || rprim.IsString())
         {
-            // ToJsString rather than ToString: the operands keep their own representation, so a large
-            // left operand is not materialized just to be copied. JsString.Concat then decides whether
-            // the result is worth deferring - which is what keeps `s = s + x` in a loop linear.
-            var left = TypeConverter.ToJsString(lprim);
-            var right = TypeConverter.ToJsString(rprim);
-
-            // Checked before the result is built, deferred or not. The realm is resolved only inside
-            // the cold branch, so the warm path pays one widened add and one compare.
-            if ((long) left.Length + right.Length > JsString.MaxLength)
+            // Two operands that are already strings — a '+' between two string-valued expressions — need
+            // no coercion at all: each keeps its own representation, so a large one is never materialized
+            // just to be copied, and JsString.Concat decides whether the result is worth deferring, which
+            // is what keeps `s = s + x` in a loop linear.
+            if (lprim is JsString left && rprim is JsString right)
             {
-                Throw.RangeError(context.Engine.Realm, "Invalid string length");
+                // Checked before the result is built, deferred or not. The realm is resolved only inside
+                // the cold branch, so the warm path pays one widened add and one compare.
+                if ((long) left.Length + right.Length > JsString.MaxLength)
+                {
+                    Throw.RangeError(context.Engine.Realm, "Invalid string length");
+                }
+
+                return JsString.Concat(left, right);
             }
 
-            return JsString.Concat(left, right);
+            return ConcatWithCoercedOperand(context, lprim, rprim);
         }
 
         if (AreNonBigIntOperands(lprim, rprim))
@@ -1575,6 +1580,41 @@ internal abstract class JintBinaryExpression : JintExpression
 
         AssertValidBigIntArithmeticOperands(lprim, rprim);
         return JsBigInt.Create(TypeConverter.ToBigInt(lprim) + TypeConverter.ToBigInt(rprim));
+    }
+
+    /// <summary>
+    /// The concatenating pair where one side is not a string yet — <c>n + "x"</c>, the shape a formatted
+    /// value takes. That side coerces to text, and the <see cref="JsString"/> wrapper a uniform coercion
+    /// would put around that text is allocated only on the branch that actually defers: below the cutoff
+    /// the result is copied out of the characters themselves, so the wrapper would be allocated and
+    /// unwrapped in the same breath.
+    /// </summary>
+    /// <remarks>
+    /// The left operand is coerced before the right one — <c>ToString</c> of a symbol throws, and which
+    /// side throws first is observable — and each side's length is read from whichever form it took,
+    /// both of which answer it without materializing anything.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static JsString ConcatWithCoercedOperand(EvaluationContext context, JsValue lprim, JsValue rprim)
+    {
+        var left = lprim as JsString;
+        var leftText = left is null ? TypeConverter.ToStringNonString(lprim) : null;
+        var right = rprim as JsString;
+        var rightText = right is null ? TypeConverter.ToStringNonString(rprim) : null;
+
+        var leftLength = leftText?.Length ?? left!.Length;
+        var rightLength = rightText?.Length ?? right!.Length;
+        if ((long) leftLength + rightLength > JsString.MaxLength)
+        {
+            Throw.RangeError(context.Engine.Realm, "Invalid string length");
+        }
+
+        if (leftLength + rightLength < JsString.MinDeferredConcatenationLength)
+        {
+            return JsString.Create(string.Concat(leftText ?? left!.ToString(), rightText ?? right!.ToString()));
+        }
+
+        return JsString.Concat(left ?? JsString.Create(leftText!), right ?? JsString.Create(rightText!));
     }
 
     /// <summary>
@@ -1594,6 +1634,14 @@ internal abstract class JintBinaryExpression : JintExpression
     /// an immutable node, so a chain that accumulates (<c>s = s + a + b</c>) never copies its
     /// accumulator. This is the same decision the two-operand form makes; deciding it here as well is
     /// what keeps the flattened chain from being the one shape that stayed quadratic.
+    /// </para>
+    /// <para>
+    /// Which side of that line a chain lands on is read off the operand lengths, and until it has been
+    /// read each operand is held in whichever form its coercion already produced — see
+    /// <c>AdditionChainExpression.Coerce</c>. A chain that lands on the short side then allocates its
+    /// result and the one array its operands live in, and nothing per operand beyond the characters the
+    /// coercion had to produce anyway; the deferred representation is not something a chain pays for
+    /// before it uses it.
     /// </para>
     /// <para>
     /// Evaluation order matches ApplyStringOrNumericBinaryOperator exactly: evaluate operand 0,
@@ -1837,31 +1885,31 @@ internal abstract class JintBinaryExpression : JintExpression
             }
 
             _kind = ChainKind.String;
-            var s0 = TypeConverter.ToJsString(p0);
-            var s1 = TypeConverter.ToJsString(p1);
+            var s0 = Coerce(p0);
+            var s1 = Coerce(p1);
 
             if (count == 3)
             {
-                var s2 = NextOperandAsJsString(context, operands[2]);
+                var s2 = NextOperandCoerced(context, operands[2]);
                 return ConcatThree(context, s0, s1, s2);
             }
 
             if (count == 4)
             {
-                var s2 = NextOperandAsJsString(context, operands[2]);
-                var s3 = NextOperandAsJsString(context, operands[3]);
+                var s2 = NextOperandCoerced(context, operands[2]);
+                var s3 = NextOperandCoerced(context, operands[3]);
                 return ConcatFour(context, s0, s1, s2, s3);
             }
 
-            var parts = new JsString[count];
+            var parts = new object[count];
             parts[0] = s0;
             parts[1] = s1;
-            long total = s0.Length + (long) s1.Length;
+            long total = LengthOf(s0) + (long) LengthOf(s1);
             for (var i = 2; i < count; i++)
             {
-                var next = NextOperandAsJsString(context, operands[i]);
+                var next = NextOperandCoerced(context, operands[i]);
                 parts[i] = next;
-                total += next.Length;
+                total += LengthOf(next);
             }
 
             CheckConcatenationLength(context, total);
@@ -1872,14 +1920,42 @@ internal abstract class JintBinaryExpression : JintExpression
         /// Evaluates one trailing operand and coerces it, in that order — past the opening pair each
         /// operand is coerced before the next one is evaluated.
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static object NextOperandCoerced(EvaluationContext context, JintExpression operand)
+            => Coerce(TypeConverter.ToPrimitive(operand.GetValue(context)));
+
+        /// <summary>
+        /// One operand's ToString, held in whichever of two forms costs nothing to produce: the
+        /// <see cref="JsString"/> it already was — whose representation has to survive, because
+        /// flattening it here is exactly the copy the deferred lane exists to avoid — or the plain text
+        /// a non-string primitive coerces to, which is what the eager concatenation below the cutoff
+        /// wants and needs no <see cref="JsString"/> wrapper around it.
+        /// </summary>
         /// <remarks>
-        /// <see cref="TypeConverter.ToJsString"/> rather than <see cref="TypeConverter.ToString(JsValue)"/>:
-        /// the two produce the same characters, but this one leaves a string operand in whatever
-        /// representation it already has, so a large one is not materialized just to be copied.
+        /// <see cref="TypeConverter.ToJsString"/> produces the same characters, but wraps that text in a
+        /// <see cref="JsString"/> the eager path unwraps again immediately — one dead object per
+        /// non-string operand, on every evaluation of a chain like <c>y + '-' + m + '-' + d</c>. Both
+        /// forms answer <see cref="LengthOf"/> without materializing anything, which is all the cutoff
+        /// is decided on, so nothing is given up by deciding after the coercion rather than before it.
         /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static JsString NextOperandAsJsString(EvaluationContext context, JintExpression operand)
-            => TypeConverter.ToJsString(TypeConverter.ToPrimitive(operand.GetValue(context)));
+        private static object Coerce(JsValue primitive)
+            => primitive is JsString value ? (object) value : TypeConverter.ToStringNonString(primitive);
+
+        /// <inheritdoc cref="Coerce"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int LengthOf(object operand)
+            => operand is string text ? text.Length : Unsafe.As<JsString>(operand).Length;
+
+        /// <inheritdoc cref="Coerce"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static string TextOf(object operand)
+            => operand as string ?? Unsafe.As<JsString>(operand).ToString();
+
+        /// <inheritdoc cref="Coerce"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static JsString JsStringOf(object operand)
+            => operand as JsString ?? JsString.Create(Unsafe.As<string>(operand));
 
         /// <summary>
         /// The chain's whole result, in the two shapes it can take: a short one is concatenated in the
@@ -1889,31 +1965,31 @@ internal abstract class JintBinaryExpression : JintExpression
         /// form does not. Both callers — the direct path and the resumed one — share these, so the
         /// decision cannot drift between them.
         /// </summary>
-        private static JsString ConcatThree(EvaluationContext context, JsString s0, JsString s1, JsString s2)
+        private static JsString ConcatThree(EvaluationContext context, object s0, object s1, object s2)
         {
-            var total = (long) s0.Length + s1.Length + s2.Length;
+            var total = (long) LengthOf(s0) + LengthOf(s1) + LengthOf(s2);
             CheckConcatenationLength(context, total);
 
             if (total >= JsString.MinDeferredConcatenationLength)
             {
-                return JsString.Concat(JsString.Concat(s0, s1), s2);
+                return JsString.Concat(JsString.Concat(JsStringOf(s0), JsStringOf(s1)), JsStringOf(s2));
             }
 
-            return JsString.Create(string.Concat(s0.ToString(), s1.ToString(), s2.ToString()));
+            return JsString.Create(string.Concat(TextOf(s0), TextOf(s1), TextOf(s2)));
         }
 
         /// <inheritdoc cref="ConcatThree"/>
-        private static JsString ConcatFour(EvaluationContext context, JsString s0, JsString s1, JsString s2, JsString s3)
+        private static JsString ConcatFour(EvaluationContext context, object s0, object s1, object s2, object s3)
         {
-            var total = (long) s0.Length + s1.Length + s2.Length + s3.Length;
+            var total = (long) LengthOf(s0) + LengthOf(s1) + LengthOf(s2) + LengthOf(s3);
             CheckConcatenationLength(context, total);
 
             if (total >= JsString.MinDeferredConcatenationLength)
             {
-                return JsString.Concat(JsString.Concat(JsString.Concat(s0, s1), s2), s3);
+                return JsString.Concat(JsString.Concat(JsString.Concat(JsStringOf(s0), JsStringOf(s1)), JsStringOf(s2)), JsStringOf(s3));
             }
 
-            return JsString.Create(string.Concat(s0.ToString(), s1.ToString(), s2.ToString(), s3.ToString()));
+            return JsString.Create(string.Concat(TextOf(s0), TextOf(s1), TextOf(s2), TextOf(s3)));
         }
 
         /// <inheritdoc cref="ConcatThree"/>
@@ -1921,26 +1997,44 @@ internal abstract class JintBinaryExpression : JintExpression
         /// The five-or-more form, whose caller has already summed and checked the total — the 3- and
         /// 4-operand ones exist to keep the <see cref="string"/>[]-free <c>string.Concat</c> overloads.
         /// </remarks>
-        private static JsString ConcatMany(JsString[] parts, long total)
+        private static JsString ConcatMany(object[] parts, long total)
         {
             if (total >= JsString.MinDeferredConcatenationLength)
             {
-                var accumulator = JsString.Concat(parts[0], parts[1]);
+                var accumulator = JsString.Concat(JsStringOf(parts[0]), JsStringOf(parts[1]));
                 for (var i = 2; i < parts.Length; i++)
                 {
-                    accumulator = JsString.Concat(accumulator, parts[i]);
+                    accumulator = JsString.Concat(accumulator, JsStringOf(parts[i]));
                 }
 
                 return accumulator;
             }
 
-            var strings = new string[parts.Length];
-            for (var i = 0; i < parts.Length; i++)
+            return JsString.Create(ConcatEagerly(parts));
+        }
+
+        /// <summary>
+        /// Joins a chain whose whole result is below the cutoff, in the one allocation that result is.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="string"/>[] that <see cref="string.Concat(string[])"/> takes would be a second
+        /// array on every such chain, on top of the array the operands already live in — and on a chain
+        /// this short those two arrays cost more than the copy the cutoff has already declined to defer.
+        /// The stack buffer is sized by the cutoff, so it is never grown and, the assembly being built
+        /// with <c>SkipLocalsInit</c>, never zeroed either; the method stays out of its caller's frame
+        /// because that frame is live while the operands — and any user code they reach — are evaluated.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static string ConcatEagerly(object[] parts)
+        {
+            var builder = new ValueStringBuilder(stackalloc char[JsString.MinDeferredConcatenationLength]);
+            foreach (var part in parts)
             {
-                strings[i] = parts[i].ToString();
+                builder.Append(TextOf(part));
             }
 
-            return JsString.Create(string.Concat(strings));
+            Debug.Assert(builder.Length < JsString.MinDeferredConcatenationLength, "the cutoff is what keeps the stack buffer from growing");
+            return builder.ToString();
         }
 
         /// <summary>
@@ -1967,30 +2061,21 @@ internal abstract class JintBinaryExpression : JintExpression
         {
             if (count == 3)
             {
-                return ConcatThree(
-                    context,
-                    TypeConverter.ToJsString(buffer[0]),
-                    TypeConverter.ToJsString(buffer[1]),
-                    TypeConverter.ToJsString(buffer[2]));
+                return ConcatThree(context, Coerce(buffer[0]), Coerce(buffer[1]), Coerce(buffer[2]));
             }
 
             if (count == 4)
             {
-                return ConcatFour(
-                    context,
-                    TypeConverter.ToJsString(buffer[0]),
-                    TypeConverter.ToJsString(buffer[1]),
-                    TypeConverter.ToJsString(buffer[2]),
-                    TypeConverter.ToJsString(buffer[3]));
+                return ConcatFour(context, Coerce(buffer[0]), Coerce(buffer[1]), Coerce(buffer[2]), Coerce(buffer[3]));
             }
 
-            var parts = new JsString[count];
+            var parts = new object[count];
             long total = 0;
             for (var i = 0; i < count; i++)
             {
-                var next = TypeConverter.ToJsString(buffer[i]);
+                var next = Coerce(buffer[i]);
                 parts[i] = next;
-                total += next.Length;
+                total += LengthOf(next);
             }
 
             CheckConcatenationLength(context, total);

--- a/Jint/Runtime/TypeConverter.cs
+++ b/Jint/Runtime/TypeConverter.cs
@@ -1004,7 +1004,13 @@ public static class TypeConverter
         return JsString.Create(ToStringNonString(o));
     }
 
-    private static string ToStringNonString(JsValue o)
+    /// <summary>
+    /// The text half of <see cref="ToJsString"/>, for a value that is not already a <see cref="JsString"/>.
+    /// A caller that only needs characters — a concatenation that is about to copy them — calls this so it
+    /// does not allocate the <see cref="JsString"/> wrapper <see cref="ToJsString"/> would put around them
+    /// and immediately unwrap.
+    /// </summary>
+    internal static string ToStringNonString(JsValue o)
     {
         var type = o._type & ~InternalTypes.InternalFlags;
         switch (type)


### PR DESCRIPTION
`date-format-xparb` pays **+3.91%** since #3386 (#3527), and the [profile in that issue](https://github.com/sebastienros/jint/issues/3527#issuecomment-5492427290) put the cost under `AdditionChainExpression`: `RhpNewVariableSizeObject` under the chain ×2.0, `RhpNewPtrArrayFast` ×3.3, allocation events +23%, while `String.Concat` — the cost the deferred copy was meant to displace — did not move at all. The workload allocates *more* under the new lane, not less.

## The cutoff was never the problem

The issue proposed adding a length cutoff to the chain lane. There already is one, and it was already doing its job: `JsString.MinDeferredConcatenationLength` is 512 characters, and **both** the pairwise `+` (inside `JsString.Concat`) and the flattened chain (`ConcatThree` / `ConcatFour` / `ConcatMany`) test the summed operand lengths against it. xparb's chains are `"2007-01-01"` and `"Monday, January 01, 2007 1:11:11 AM"` — ten and thirty-five characters. They were on the **eager** side of the cutoff the entire time, and no threshold value can change that. Moving the line would only have pushed *more* chains onto the deferred path, which is the expensive one here.

What they paid for was the shape of the path below the line, which #3386 changed without meaning to:

| | before #3386 | after #3386 |
| --- | --- | --- |
| operand coercion | `TypeConverter.ToString` → a `string` | `TypeConverter.ToJsString` → a `string` **plus a `JsString` wrapper**, for every operand that is not already a string |
| `ConcatMany` storage | one `string[]` | a `JsString[]` **and** a `string[]` built from it for `string.Concat` |

xparb's `"l, F d, Y g:i:s A"` compiles to one fifteen-operand chain. Per evaluation that is a second 144-byte array plus a wrapper per numeric operand — `getFullYear()`, the hour expression — every byte of it dead before the result was copied out. That is the doubled variable-size allocations and the tripled pointer-array allocations the profile measured, and none of it existed before #3386.

## What changed

An operand is now held in **whichever form its coercion already produced**: the `JsString` it was — whose representation has to survive, because flattening it is precisely the copy the deferred lane exists to avoid — or the plain text a non-string primitive coerced to. Both answer their length without materializing anything, and the length is all the cutoff is decided on, so holding the cheaper form until the decision is made gives nothing up.

Below the cutoff the result is then joined through a `ValueStringBuilder` over a cutoff-sized stack buffer — free, since the assembly carries `[module: SkipLocalsInit]`, and it cannot grow because the cutoff bounds it — so there is no second array and no wrapper. Above the cutoff the fold through `JsString.Concat` is untouched.

The cutoff itself stays at 512, and its remarks now carry the arithmetic that was missing: a `RopeString` is 56 bytes on 64-bit and does not *remove* the flat allocation, it postpones it, so a result read once costs 56 bytes and an indirection **more** than copying it would have. The node earns them back only across iterations. Which is why the line sits far above the point where a node is merely affordable — and why what the path *below* the line allocates matters more than where the line is.

## Every lane that can reach the deferred representation

`JsString.Concat` is the only producer of `RopeString`, and it has exactly two callers.

| lane | verdict |
| --- | --- |
| `ApplyAdditionToPrimitives` — the pairwise `+`, and the pairwise fold a numeric chain falls back to | **covered.** Same 512 cutoff as before. Two operands that are already strings now take a branch that coerces nothing at all; the mixed pair (`n + "x"`) coerces to text and builds the wrapper only on the branch that goes on to defer. |
| `AdditionChainExpression` — the flattened `a + b + c […]`, both the direct path and the resumed one, which share the same three joins | **covered**, as described above. |
| `+=` — `JintAssignmentExpression` | **exempt.** Builds `JsString.ConcatenatedString`, the `StringBuilder`-backed mutable accumulator. Never calls `JsString.Concat`, never produces a `RopeString`. #3386 did not touch it and neither does this. |
| `String.prototype.concat` | **exempt**, for the same reason: `EnsureCapacity` / `Append` on `ConcatenatedString`. |
| `JsString.CreateSliced` → `SlicedString` | out of scope. A different deferred representation (a zero-copy view) with its own cutoff and retention budget, not introduced by #3386 and not implicated by the profile. |

## Semantics

Unchanged, deliberately and checkably. Every path produces the same characters through the same `JsString.Create`, so the same shared instances are returned for the empty and single-character results, and the same representation decision is taken on the same numbers — `typeof`, `.length`, indexing, equality and hashing all see exactly what they saw. Coercion order is preserved (left operand before right; `ToString` of a symbol still throws from the same side), and the length guard still runs on the summed lengths before anything is built. **No public API, no observable behaviour change, so no `docs/v5-migration.md` entry.**

## Failing first

`AShortChainDoesNotPayForTheDeferredRepresentation` measures bytes per evaluation of an eleven-operand short chain as a delta of `GC.GetAllocatedBytesForCurrentThread`, which says what a profile says without depending on what else the machine is doing. Measured against this branch and against `main` with only the three runtime files reverted:

| framework | `main` | this branch | |
| --- | ---: | ---: | ---: |
| net10.0 | 576 B | 272 B | −52.8% |
| net8.0 | 576 B | 272 B | −52.8% |
| net472 | 712 B | 296 B | −58.4% |

The ceiling is 400 B — 35% above the largest after-figure, 30% below the smallest before-figure — so it fails on every framework against unfixed code, and neither side is close enough to the line to be fragile.

The asymptotic guarantee #3386 exists for is pinned as before by `AccumulatingWithPlusIsNoLongerQuadratic` (allocation ratio at 4,000 vs 8,000 iterations under 3.0, plus a 16 MB absolute ceiling — the old shape allocated 640 MB), now extended with the two five-operand chain shapes that reach `ConcatMany`: `s = s + chunk + chunk + chunk + chunk` and `s = chunk + chunk + chunk + chunk + s`. Both stay linear.

Also added: the mixed coerced/string chain at every arity that has its own join (3, 4, 5, 6, 11) asserted character-for-character, and the two-operand mixed pair asserted on both sides of the cutoff — flat below it, `RopeString` above it in both leanings.

## Verification

- `dotnet build -c Release` — clean, 0 warnings, all five target frameworks.
- `Jint.Tests` — 11,625 passed on net10.0 and net8.0, 8,245 on net472, 0 failed.
- `Jint.Tests.PublicInterface` — 3,355 / 3,345 / 2,722 passed on net10.0 / net8.0 / net472, 0 failed.
- `Jint.Tests.CommonScripts` — 28/28 on net10.0 and net472. These are the SunSpider scripts themselves, `date-format-xparb` included, run for correctness.
- `Jint.Tests.SourceGenerators` — 71/71.
- **`Jint.Tests.Test262` — 102,537 passed, 0 failed, 151 skipped of 102,688.** Exactly the control.

## Benchmarks — not run

Nothing here was measured with BenchmarkDotNet; this machine runs agents concurrently. The paired gates belong to whoever runs them, and these are the predictions the change should be judged against:

1. **`date-format-xparb`, `string-tagcloud`, `crypto-md5` (SunSpider) — should recover.** These are the three rows #3527 records as having paid, and all three are built from short concatenations; xparb is the one with a measured mechanism and should move most.
2. **`ObjectRegExp` (Dromaeo) — must keep #3386's −8.9% to −11.5%.** Nothing on the deferring path changed: the cutoff, the fold and `RopeString` are all as they were, and a chain that crosses 512 characters takes the branch it took yesterday. A regression here would mean the operand-form change moved the cutoff decision, which is the one thing it is built not to do.
3. **`StringConcatLargeBenchmark`'s `Assign*` lanes — flat.** They accumulate past the cutoff within their first iterations and are deferred from then on.
4. **`ChainSmallThree` / `ChainSmallSix` — should improve slightly**, being exactly the eager-chain shape this touches.
5. **The `+=` rows (`AppendSmallChunks`, `AppendLargeChunks`, `BuildLargeThenScan`) — must be flat.** Not one line on their path changed.

## The other half of #3527

`bitops-3bit-bits-in-byte` — the +1.81% row — **does not reproduce**, and needs no code. The re-profile in [the analysis comment](https://github.com/sebastienros/jint/issues/3527#issuecomment-5492427290) found the candidate capture had *fewer* total samples than base (150,057 vs 152,123) with no function moved beyond ±0.3%; the row contains no string work in its loop, and the original figure was measured with a virus scanner active. The issue's own framing allows "not reproducible" as an outcome for that half, which is why this closes the issue rather than leaving it open on that row.

Fixes #3527.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014W5mbjGhyvgAS4pivXoc4S
