### PR TITLE
Docs: the headless browser and DevTools protocol designs, in the long form the tracking issue points at

### DIFF
--- a/docs/design/devtools-protocol.md
+++ b/docs/design/devtools-protocol.md
@@ -1,0 +1,161 @@
+# DevTools protocol for Jint — design
+
+**Status: finalized design; implementation under way.** The authoritative statement of this design is the body
+of [sebastienros/jint#3575](https://github.com/sebastienros/jint/issues/3575); where this
+document and that issue disagree, the issue wins and this file is brought back into line. What this file adds is
+the longer form: the engine mechanisms each decision rests on, named so that a reader can find them.
+
+Everything normative here was read from the [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/)
+(the pinned `js_protocol.json` / `browser_protocol.json` under `tools/devtools-protocol/`), from V8's inspector
+design (`v8_inspector::V8InspectorClient::runMessageLoopOnPause`), and from what the clients actually send,
+recorded by `tools/cdp-histogram/` into `tools/devtools-protocol/handshakes/`.
+
+> **On citations.** This file cites files and members, not line numbers; a wrong line number still reads like a
+> fact. `grep` finds a member.
+
+---
+
+## 1. Why a protocol, and why this one
+
+Jint has had a debugger since 3.x (`Jint/Runtime/Debugger/`): breakpoints with conditions, step in/over/out,
+return-point stepping, a call stack with per-frame `this` and a scope chain whose `DebugScopeType` was written to
+mirror the protocol's `Debugger.Scope` types, expression evaluation in the paused context, and a `BeforeEvaluate`
+event per script. What it never had was a way for a tool to reach it. Two community attempts exist and both are
+dead: `Jither/Jint.DevToolsProtocol` (CDP `Debugger`/`Runtime`, built against a private branch, never worked,
+last push 2024-02) and `Jither/Jint.DebugAdapter` (Debug Adapter Protocol, "not ready for production use — at
+all", last push 2024-01). Their author's notes list the engine gaps that stopped them: no pause on exception, no
+way to enumerate breakpoint locations, a fresh `DebugInformation` per execution point. Those gaps are closed by
+the engine work in §5, inside Jint, where they belong.
+
+The protocol is CDP because every client that matters speaks it — Puppeteer, Playwright on Chromium,
+PuppeteerSharp, Playwright for .NET, chrome-remote-interface, chromedp, and the Chrome DevTools frontend itself.
+WebDriver BiDi is the W3C draft and Firefox's default; it is a later façade over the same session core (Lightpanda
+ships both from one core), not a first target. A Debug Adapter Protocol adapter for VS Code is likewise a thin
+layer over the same core, deferred. Nothing here invents a protocol.
+
+There are two layers because the two audiences differ:
+
+- **`Jint.DevTools`** is engine-level. It serves *every* embedder — a workflow engine, a CMS, a game — that wants
+  to attach Chrome DevTools to the scripts it runs: `Runtime`, `Debugger`, `Profiler`, `Console`, `Log`,
+  `Schema`, `Browser`, and `Target` for engine targets. A Jint engine appears to the frontend as a Node-flavoured
+  target (`js_app.html?v8only=true`), so the frontend never asks it for a page.
+- **`Jint.Browser`** adds the page-level domains (`Page`, `DOM`, `Network`, `Fetch`, `Input`, `Emulation`,
+  `Storage`, `Accessibility`, page `Target`s) on top of the same session core. It is the subject of
+  [`headless-browser.md`](headless-browser.md).
+
+## 2. The thread rule
+
+Every `JsValue` and every `Engine` is thread-affine: `Engine.EnterHostCall` and
+`Engine.VerifyValueConstructedOnOwningThread` fail fast when another thread touches them, and *Jint never starts a
+thread to run script* is load-bearing across the web-API family (see `docs/design/web-workers.md` §1). The
+protocol package is a *host*, so it may own threads, but the rule it lives by is:
+
+> A `JsValue` never leaves the engine thread. Transport threads move strings. Every domain method runs on the
+> engine thread. Every event is serialized on the engine thread before it is handed to the writer.
+
+The mechanism is one mailbox per target, `EngineDispatcher`, drained in exactly two places:
+
+1. **Running.** `Post(item)` enqueues and wakes the engine's loop through the public, thread-safe
+   `engine.Tasks.Post(Action)` (engine PR E1, a one-line public door over the internal
+   `Engine.AddToEventLoop(Action, generation)`). The drain therefore runs as an ordinary event-loop job on
+   whichever thread pumps the engine, wakes `Tasks.WaitForScheduledWork`, and interleaves with microtasks. A
+   command never calls `WaitForScheduledWork` or `UnwrapIfPromise` from inside a job (the pump's re-entrancy guard
+   forbids it); `Runtime.evaluate` with `awaitPromise` attaches reactions to the promise and answers when they
+   fire, which is V8's shape too.
+2. **Paused.** The debugger's pause is synchronous: `DebugHandler.Pause` invokes the `Break`/`Step` delegates
+   inline and the delegate's *return value* is the next `StepMode`. There is no resume token. So the protocol
+   traffic that a paused page generates — `Runtime.getProperties` for the Scope pane, `evaluateOnCallFrame` for
+   the console, `Debugger.resume` — is serviced by a message loop running **inside the paused handler on the
+   engine thread**, exactly `runMessageLoopOnPause`: send `Debugger.paused`, then wait on the mailbox signal,
+   drain pause-safe items, until a resume or step command sets the mode and ends the loop; send
+   `Debugger.resumed`; return the mode. Commands that would re-enter a public engine entry while paused
+   (`Runtime.runScript`, `Profiler.start`) are answered `-32000 "Not allowed while paused"`.
+
+Hosts integrate through `EngineTargetOptions.ThreadMode`:
+
+- `HostOwned` (default): the host's thread runs script and pumps; commands are serviced when it calls
+  `engine.Tasks.ProcessTasks()` or `target.Pump()`. A command waiting longer than `CommandTimeout` fails with
+  `-32000 "Engine is not being pumped"`, which is the diagnostic a host that forgot to pump needs.
+- `LibraryOwned`: the target starts one thread running drain → `ProcessTasks` → `WaitForScheduledWork`, the host
+  submits work with `target.Post(Action<Engine>)`, and the engine's single-drainer rule fail-fasts any host thread
+  that touches the engine directly.
+- `WaitForDebuggerOnStart` (`--inspect-brk`): the first posted work is held until a session sends
+  `Runtime.runIfWaitingForDebugger`.
+
+Client disconnect mid-pause detaches the session, which enqueues a control item; the pause loop resumes with
+`StepMode.None`, that session's breakpoints are removed, its exception mode and skip-all flag reset, its object
+groups released — V8's implicit `Debugger.disable`.
+
+## 3. Targets and sessions
+
+`/json/version` answers `webSocketDebuggerUrl: ws://host:port/devtools/browser/<id>`; `/json/list` lists targets
+with `type: "node"`, a direct `ws://…/devtools/page/<targetId>` endpoint (no `sessionId` on that socket), and
+`devtoolsFrontendUrl` in Node's form. Puppeteer requires flattened sessions: `Target.setAutoAttach(flatten: true)`
+emits `attachedToTarget` for existing targets (with `waitingForDebugger`), `Target.attachToTarget(flatten: true)`
+mints a `sessionId` that then rides every message; `flatten: false` is refused (no client sends it). One
+`Debugger`-enabled session per target at a time; `Runtime` is shared. This is a documented divergence from V8's
+per-session breakpoints.
+
+The transport is `TcpListener` + an HTTP/1.1 upgrade + `WebSocket.CreateFromStream` — no `HttpListener`, no
+ASP.NET dependency — behind `IDevToolsConnection`, with an `InProcessConnection` (string in, string out) for tests
+and embedding.
+
+## 4. The protocol layer is generated and checked in
+
+`tools/devtools-protocol/` vendors `js_protocol.json` and `browser_protocol.json` at a pinned commit
+(`pin.json`; a bump is a code change, as it is for test262 and WPT) and a `manifest.json` naming the domains
+whose types are generated and the methods and events that are implemented. A .NET generator emits
+`Jint.DevTools/Protocol/Generated/`: DTO records, per-domain abstract dispatch bases with one virtual per
+command, event factories, the `System.Text.Json` source-generation context, and the manifest tables
+`Schema.getDomains` answers from. Anything not in the manifest answers `-32601 "'X.y' wasn't found"`, Chrome's
+text — never a silent success.
+
+Checked-in output rather than a Roslyn generator, for four reasons: the JSON serializer context must be generated
+*over* the DTOs and generators cannot chain; `Jint.SourceGenerators` is netstandard2.0 and must carry no JSON
+dependency; generated code in the tree is reviewable, greppable and debuggable, which matters for a surface people
+read to learn what is implemented; and `tools/whatwg-encoding/` set the precedent. A currency test re-runs the
+emitter in memory and fails on drift. CDP enums are emitted as string constants (`JsonStringEnumMemberName` is
+.NET 9+; net8.0 must compile) so the whole layer is AOT-safe.
+
+`SpecCitationTests` only scans `tc39.es` URLs; CDP citations use the form
+`https://chromedevtools.github.io/devtools-protocol/tot/<Domain>/#method-<name>` and are verified offline against
+the vendored JSON by `ProtocolCitationTests`.
+
+## 5. Domains and the engine seams they ride
+
+| Domain | What it maps onto | Engine change |
+| --- | --- | --- |
+| `Runtime` | `engine.Evaluate` (running) or `DebugHandler.Evaluate` (paused); `getProperties` over `GetOwnPropertyKeys` + descriptors, accessors reported and never invoked; `awaitPromise` by reactions; `consoleAPICalled`; `exceptionThrown`/`exceptionRevoked` from `Tasks.PromiseRejectionTracker`; `getHeapUsage` from `Diagnostics.GetMemoryReport` | **E5** structured `ConsoleRecord` sink overload + public `ValueInspector` (previews that never run script, promoted from `ConsoleFormatter`) |
+| `Debugger` | `ScriptRegistry` on `DebugHandler.BeforeEvaluate` keyed by `Program` identity (a cached `Prepared<Script>` is announced once); breakpoints as `DevToolsBreakPoint : BreakPoint` (the class is unsealed for this); `pause` as a flag checked in `Skip`; scopes from `DebugScopeType` 1:1 | **E1** `TryGetSourceText(Program)` for `getScriptSource`; **E2** `GetStepLocations(Program)` for `getPossibleBreakpoints` and column snapping; **E3** pause on exceptions with caught/uncaught; **E4** evaluate on any call frame |
+| `Profiler` | `Profiler.Profile` synthesized from the evented `ScriptProfile` (`Jint/Profiling/`) behind an `IProfileSource` seam; precise/best-effort coverage from `CoverageReport` (`Jint/Runtime/Coverage/`) | none; the sampling profiler with Firefox Profiler output (#3572) plugs into the same seam later |
+| `Console`, `Log` | the structured record | E5 |
+| `Target`, `Browser`, `Schema` | the session core and the manifest | none |
+
+The five engine PRs are additive and public, so that a third party — AngleSharp.Js, a DAP adapter, a host's own
+tooling — can build the same thing without `InternalsVisibleTo`. `Jint.DevTools` itself consumes only public
+Jint API; that is deliberate, and it is what proves the seams are reachable.
+
+## 6. Costs, stated up front
+
+- `Options.Debugger.Enabled`, `Options.Profiling.Enabled` and `Options.Coverage.Enabled` are construction-time;
+  `UseDevTools` sets them, and a target added on an engine without them degrades per domain with an explicit
+  `-32000`.
+- Debug mode disarms the interpreter's tight-loop lane (`Jint/Constraints/AGENTS.md`), and the `Skip`
+  subscription adds a delegate call per execution point; the subscription is attached only while a session has
+  `Debugger` enabled, and benchmarks never run with it.
+- Source text is retained for `getScriptSource` through the same switch as `Function.prototype.toString`
+  (`RetainFunctionSourceText`), one weak-table entry per `Program`, not a second copy.
+- Remote-object handles are strong until `releaseObject`, `releaseObjectGroup` or session detach.
+
+## 7. Deliberately absent
+
+Async call stacks, source maps, blackboxing, `HeapProfiler`, per-session breakpoints, and any always-on mode.
+Each is a follow-up issue if a client turns out to need it.
+
+## 8. Verification
+
+In-process protocol tests over `InProcessConnection` (no sockets); recorded handshake fixtures of PuppeteerSharp
+and the DevTools frontend replayed as tests (no `-32601` for a manifest method, no unhandled exception for any
+other); a PuppeteerSharp end-to-end suite over a real WebSocket; a documented manual checklist for attaching the
+Chrome DevTools frontend; an AOT probe in `Jint.AotExample`; the host-contract verification leg with
+`JINT_HOST_CONTRACT_VERIFICATION=1`, which makes the thread rule exact.

--- a/docs/design/headless-browser.md
+++ b/docs/design/headless-browser.md
@@ -1,0 +1,203 @@
+# A headless browser on Jint — design
+
+**Status: finalized design; implementation under way.** The authoritative statement of this design is the body
+of [sebastienros/jint#3575](https://github.com/sebastienros/jint/issues/3575); where this
+document and that issue disagree, the issue wins and this file is brought back into line. What this file adds is
+the longer form: the mechanisms each decision rests on, named so that a reader can find them. The protocol half
+is [`devtools-protocol.md`](devtools-protocol.md).
+
+Everything normative here was read from the [DOM](https://dom.spec.whatwg.org/), [HTML](https://html.spec.whatwg.org/multipage/),
+[Fetch](https://fetch.spec.whatwg.org/), [XMLHttpRequest](https://xhr.spec.whatwg.org/) and
+[WebIDL](https://webidl.spec.whatwg.org/) living standards, and from the
+[Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/).
+
+> **On citations.** This file cites files and members, not line numbers.
+
+---
+
+## 1. The premise, and the one principle
+
+Jint already carries the web platform's non-DOM half — thirty opt-in subtrees under `Jint/WebApi/` that cover
+WinterTC's Minimum Common API except `WebAssembly` (declined by design), plus `fetch`, `WebSocket`,
+`EventSource`, `Storage`, `caches`, `Worker` and the Streams family. The only missing layer between that and a
+browser is the document: HTML parsing, the DOM, the CSSOM, and the runtime that ties navigation, script
+scheduling, timers, network and storage to a `Window`.
+
+**AngleSharp** already has the parser, the DOM and (with `AngleSharp.Css`) the CSSOM, and **AngleSharp.Js**
+already binds Jint to that DOM, executes `<script>`s, loads modules and import maps, and runs Web Workers. The
+project founder's guidance for this campaign is the principle every decision below is checked against:
+
+> Jint should add value to AngleSharp without competing too much.
+
+So: AngleSharp is the parser, the DOM and the CSSOM; nothing here re-implements any of them. What Jint owns is
+what nobody else has — a binding layer built on Jint's own shape and layout machinery instead of a reflection
+trampoline, a page runtime that wires Jint's timers, fetch, storage and workers into a `Window` under Jint's
+execution constraints, and the automation protocol. The generated bindings and the tree-aware event dispatcher
+are designed so that AngleSharp.Js can adopt them, and the offer is made as soon as they work; every AngleSharp
+or AngleSharp.Js defect the conformance lane finds is filed upstream, and where we can, fixed there. In every
+document and README sentence, `Jint.Browser` is "AngleSharp + Jint", never a rival DOM stack.
+
+## 2. What it is, and what it is not
+
+The shape is Lightpanda's, not Chromium's: **a browser that does not render.** DOM, JavaScript, network, storage,
+workers, and the Chrome DevTools Protocol so that Puppeteer, Playwright, PuppeteerSharp, Playwright for .NET,
+chrome-remote-interface and the Chrome DevTools frontend can drive it — in-process, with no native binaries and no
+browser download, on any platform .NET runs on, with Jint's statement, time and memory constraints bounding what
+a page may do. Kitesurf's framing of the trade is the honest one and it is exactly an interpreter's profile: a
+fraction of Chromium's CPU and memory per page, at some multiple of its wall-clock time.
+
+| v1 delivers | Out of v1 (absent, so feature detection is honest) |
+| --- | --- |
+| Full HTML5 parse with inline, external, `defer`, `async` and module scripts, import maps, `document.write`; generated DOM and CSSOM bindings; tree event dispatch; forms, history, cookies, storage, workers, `fetch`/`XMLHttpRequest`/`WebSocket`/`EventSource`; `MutationObserver`; stub `IntersectionObserver`/`ResizeObserver`; deterministic coordinate input; accessibility tree and markdown snapshots; CDP for Puppeteer/Playwright `connect`; a WPT lane; constraints per page | Layout-dependent APIs (`offsetWidth` is synthetic, `cssom-view`), rendering, screenshots, PDF, WebGL, canvas 2D, media, IndexedDB, WebAssembly, CSP enforcement, TLS-fingerprint stealth, iframe scripting (v1.1), `WindowProxy`, SharedWorker/ServiceWorker, drag and drop, real isolated worlds (v1.1) |
+
+`Page.captureScreenshot` answers a CDP error with a sentence, the way Lightpanda does.
+
+## 3. The runtime model
+
+- **The global stays `GlobalObject`.** `Host.CreateGlobalObject(Realm)` is virtual and `GlobalEnvironment`
+  tolerates a host-defined global, but substituting one forfeits the global-identifier inline cache
+  (`JintIdentifierExpression` keys on the realm's `GlobalObject`) and would mean re-installing every intrinsic
+  `GlobalObject.Properties` emits. Instead the global's `[[Prototype]]` becomes
+  `Window.prototype → EventTarget.prototype → Object.prototype` (`GlobalEnvironment.HasBindingOnGlobalPrototype`
+  already resolves prototype members as globals), and the per-document singletons — `document`, `location`,
+  `history`, `navigator`, `screen`, `window`, `frames`, `top`, `parent`, `customElements` — are own lazy
+  properties installed through the public `Engine.AddLazyGlobal`, which keeps them on the identifier cache.
+  `window instanceof EventTarget` holds through the chain; `EventTarget.prototype.addEventListener.call(window, …)`
+  works because `EventTargetPrototype.Brand` accepts the realm's global and maps it to the engine's
+  `GlobalEventTarget` (engine PR B1).
+- **One `Engine` per top-level navigation.** A navigation is a new realm in a browser; here it is a new engine
+  built from the same `BrowserOptions`, so "per document" and "per engine" coincide and no `WindowProxy` is needed
+  in v1. The previous engine receives `beforeunload`, `pagehide` and `unload`, its cancellation token is
+  cancelled, its pending fetches abandoned, and it is disposed on the page loop.
+- **One `PageLoop` thread per page**, owning the engine and the DOM: it drains a mailbox of host and protocol
+  work, calls `Tasks.ProcessTasks()`, runs the animation-frame lane, and sleeps by
+  `Tasks.TimeUntilNextScheduledWork` — the `WptHarness.PumpWorker` shape. Every public `Page` API and every CDP
+  command posts to the mailbox and awaits a completion; nothing else touches the engine or the DOM. Workers come
+  from a `ThreadPerWorkerProvider` (the package is a host, so it may start threads; the engine still never does).
+- **Iframes parse but do not run script in v1**: frames are real in the frame tree and their documents are
+  fetched and parsed, but `contentWindow` is `null`. v1.1 adds one realm per frame on the same engine through an
+  `Engine.WebApi.InstallInRealm(Realm)` seam (today `WebApiRegistration.InstallGlobals` targets the main realm
+  only); a second engine could never satisfy `parent.document`.
+
+## 4. The binding layer
+
+A curated generator, `tools/dom-bindings/`, reads `AngleSharp.dll` and `AngleSharp.Css.dll` at the pinned
+version through `System.Reflection.MetadataLoadContext` and treats AngleSharp's `[DomName]`, `[DomAccessor]`,
+`[DomConstructor]`, `[DomNoInterfaceObject]` and `[DomPutForwards]` attributes as the WebIDL they effectively
+are. It emits checked-in `Jint.Browser/Dom/Generated/*.g.cs`: one `JsObjectShape` per interface (methods,
+accessors, constants, a per-realm `constructor` slot, `@@toStringTag`), interface objects, the prototype chain
+down to Jint's `EventTarget.prototype`, a `DomTypeMap` from AngleSharp runtime type to shape, and collections
+over `ArrayLikeObject` / `NamedPropertyObject`. A curated `overrides.json` skips or replaces what the attributes
+cannot express: event-handler content attributes, `Task`-returning members, navigation-shaped members,
+`innerHTML`/`outerHTML` setters (routed through the parser driver so inserted scripts run), `[PutForwards]`.
+`JINT_DOM_BINDINGS=update` regenerates; a staleness test fails on drift — the `JINT_SPEC_ANCHORS` /
+`JINT_WPT_CENSUS` discipline. Checked-in rather than a live source generator for the same reasons as the
+protocol layer: reviewable diffs, an analyzer-free build, and swapping later is mechanical.
+
+Why generated on Jint shapes rather than AngleSharp.Js's reflection bindings: a shape-mode prototype per
+interface is what the inline caches and the prototype-method cache want, member bodies are static lambdas that
+call the AngleSharp interface member directly (interface dispatch, zero reflection), the output is AOT-safe, and
+it is the answer to the one actionable question Starling's "we will not embed Jint" poses — host-object cost.
+This is the piece offered upstream: AngleSharp.Js can adopt the generated bindings without adopting anything
+else here.
+
+Wrapper identity: `DomNodeObject : JsEventTarget` holds an `INode`, the prototype picked from `DomTypeMap`, the
+brand check in a generated member is the interface cast (`Illegal invocation` otherwise). One wrapper per node
+through a per-page `ConditionalWeakTable<INode, DomNodeObject>`: a node in the tree keeps its wrapper and its
+expandos alive (React and Vue rely on that), a node dropped by both the tree and script collects with its
+wrapper — the browsers' wrapper-preservation rule for free. Short-lived views (`DOMTokenList`, `NamedNodeMap`,
+`Range`, `CSSStyleDeclaration`) wrap with a strong reference.
+
+## 5. Events: one bus, Jint's
+
+**AngleSharp's event bus is neither observed nor driven by script.** Every script-visible event is a Jint `Event`
+dispatched through the tree-aware dispatcher engine PR B1 adds to `JsEventTarget` (DOM §2.9 dispatch, get the
+parent, the event path, retargeting, activation behaviour, over virtuals a DOM wrapper overrides), at the
+algorithm points the package owns: navigation (`readystatechange`, `DOMContentLoaded`, `load`, `pageshow`,
+`beforeunload`, `unload`), input (the `InputDispatcher`), forms (`submit`, `formdata`, `reset`, `invalid`),
+history (`popstate`, `hashchange`), observers, scripts (`load`/`error` on `<script>`). AngleSharp's own
+`Dispatch` calls run into AngleSharp's listener lists, which hold nothing script-registered, so they are
+invisible, and whatever AngleSharp-internal listeners exist keep working untouched. `DomNodeObject.GetParent`
+implements "get the parent": parent node or assigned slot; `ShadowRoot → host`; `Document → window` except for
+`load`; `Window → null`.
+
+## 6. Navigation and the parser baton
+
+A document fetch goes through Jint's own fetch pipeline (`FetchTransport`, engine-free by design) with the
+context's cookie jar, `Referer`/`Origin`, the `UrlFilter` re-checked per redirect hop and `MaxResponseBytes`
+bounding the document (engine PR B3 adds the base URL, referrer, cookie jar and observer seams). Then the
+`ParserDriver` runs AngleSharp's parser on a parser thread and hands a **baton** back and forth with the page
+loop: `IScriptingService.EvaluateScriptAsync` and the resource loader park the parser and give the DOM to the
+loop, which runs the script (or the fetch and any due tasks) and hands it back; completions use
+`RunContinuationsAsynchronously` so the parser never resumes inline on the loop thread. Invariant: exactly one
+side holds the baton, and only the holder touches the DOM. That is also what gives browser-correct timing — timers
+fire while the parser waits on a parser-blocking `<script src>`. If AngleSharp's synchronous parse turns out to
+call the scripting hook inline, the fallback is a fully synchronous parse on the loop with blocking script
+fetches: correct, with no timers mid-load. Classic, `defer`, `async` and module scripts, import maps and
+dynamic `import()` go over Jint's `IModuleLoader` against the page's fetch; `DOMContentLoaded` fires after the
+deferred scripts and `load` after subresources; `document.write` during parsing writes into the live text source
+while the parser is parked; `innerHTML` insertion routes through the same driver with a depth guard.
+
+## 7. Constraints per page
+
+The constraints gotcha in the root `AGENTS.md` applies twice over: a page is a host-driven sequence of entries,
+and its event loop is pumped. So a page's budget is built only from what survives the per-entry reset:
+`BrowserOptions.MaxTaskDuration` brackets each loop turn — one `ProcessTasks` drain, one baton hand-off, one
+animation-frame batch — with `OperationDeadlineConstraint.Begin/End`, so a runaway job chain throws into the
+diagnostics sink and the page survives; a per-page `MemoryLimitConstraint` bounds each job chain;
+`Page.Close` and `Target.closeTarget` cancel the page token registered with `ObserveCancellation`;
+`LimitExecutionTime` still governs each `Runtime.evaluate` / `Page.Evaluate` entry; `MaxDomNodes` is checked in
+the wrapper factory and the parser driver; `Timers.MaxActiveTimers` and the fetch limits apply; one `UrlFilter`
+covers document, subresource, XHR, WebSocket, EventSource and worker loads. `BrowserOptions.ForUntrustedContent`
+applies `Options.ForUntrustedCode` to page engines and `CopySecurityPosture` to their workers, with
+`BlockPrivateNetwork` on by default.
+
+## 8. Input without layout
+
+Every element gets a deterministic synthetic box (document order, no overlap) — the "flat renderer" — so that
+`elementFromPoint`, `getBoundingClientRect`, `DOM.getBoxModel`, `DOM.getNodeForLocation` and
+`Input.dispatchMouseEvent(x, y)` resolve without a layout engine. `dispatchMouseEvent` becomes the
+pointer/mouse event sequence with focus and click activation (`<a>` navigates, submit buttons submit,
+checkbox/radio toggle with legacy pre-activation rollback, `<label>` forwards, `<summary>` toggles, `<option>`
+selects); `dispatchKeyEvent` becomes `keydown`/`keypress`/`keyup` with editing on `<input>` and `<textarea>`
+(characters, Backspace/Delete, Home/End/arrows, selection, Enter implicit submission, Tab traversal,
+`beforeinput`/`input`/`change`); `insertText` and a `contenteditable`-lite complete it. WPT's `testdriver.js` is
+mapped onto the same dispatcher.
+
+## 9. The scoreboard
+
+WPT is the conformance suite the way test262 is the language's, with the discipline `Jint.Tests/Wpt/AGENTS.md`
+already enforces: the exclusion table is the artefact (an entry matches at least one failing test and no passing
+one), `NeedsTriage` empty is the signal, the census is a ceiling that only lowers. `Jint.Tests.Browser` adds the
+browser lane: the in-process `WptServer` serves `.html`, the real upstream `testharness.js`, `.headers` sidecars
+and `.sub.html` substitution; a `testharnessreport.js` overlay posts results through a page binding; the existing
+`.any.js` files run again inside a real `Window` realm through synthesized `.any.html` wrappers; the initial
+suites are `dom/nodes`, `dom/events`, `dom/collections`, `dom/lists`, `dom/traversal`, `html/dom`,
+`html/semantics/scripting-1/the-script-element`, `html/webappapis`, `html/browsers/history`,
+`html/browsers/the-window-object` (limited), `xhr`, `url` and `fetch/api` in page mode, `FileAPI`. A nightly
+real `wpt run` over CDP produces a public scoreboard later; it is not a PR gate. Next to it, an obstacle course
+of offline fixtures (React, Vue, Preact and Svelte TodoMVC, SSR hydration, jQuery 3 with `async: false`, htmx,
+Alpine, a `pushState` router, custom elements, modules with an import map, forms with redirects, a cookie login,
+`localStorage` persistence, `IntersectionObserver` and `MutationObserver` widgets, dialogs) each asserting a DOM
+end state and an empty error sink, and PuppeteerSharp / Playwright for .NET smoke suites over the in-process
+WebSocket.
+
+## 10. Packages and the engine seams
+
+| Where | What |
+| --- | --- |
+| `Jint/` (engine, public, additive) | B1 tree event dispatch; B2 `XMLHttpRequest` (`WebApiFeatures.XmlHttpRequest`, sync supported as a blocking wait on the engine-free transport); B3 fetch for documents (`BaseUrl`, referrer policy, `Origin`, `CookieJar`, `FetchObserver` with interception); B4 `PerformanceObserver`, `FileReader`, blob URLs |
+| `Jint.Browser/` (net8.0+, `InternalsVisibleTo` from Jint for now, promoted to public seams as they prove their shape) | the runtime of §3–§8 and the page-level CDP domains, plus the custom `Jint` domain (`getMarkdown`, `getText`, `getAccessibilitySnapshot`) |
+| `Jint.Browser.Tool/` | the `jint-browser` dotnet tool (`serve --port 9222`, `fetch <url> --dump html|text|markdown|ax`) and the MCP server |
+| `Jint.Tests.Browser/` | the WPT browser lane, the obstacle course, the client smoke suites |
+
+`Jint.Browser` ships `IsAotCompatible=false` in v1 and says so: AngleSharp is not trim-annotated. An AOT
+inventory is a v1.1 item once its warnings are counted.
+
+## 11. Verification
+
+Every PR keeps the repository's gates. Engine PRs run the affected WPT `.any.js` suites and, when they touch a hot
+path, the full SunSpider/Dromaeo tables. The browser lane's exclusion table and census, the obstacle course on all
+four CI legs, and the two .NET client smoke suites gate `Jint.Browser`. The benchmark that closes the campaign
+runs the same PuppeteerSharp script against `Jint.Browser`, headless Chromium and, where installed, Lightpanda,
+and records wall time, CPU and peak memory per page load in the honest framing of §2.


### PR DESCRIPTION
The longer form of #3575: two design documents naming the engine mechanisms each campaign decision rests on.

- `docs/design/devtools-protocol.md` — why CDP and why two layers (`Jint.DevTools` engine-level for every embedder, `Jint.Browser` page-level), the thread rule and the pause-time message loop (`runMessageLoopOnPause` inside the synchronous `Break`/`Step` handler), targets and flattened sessions, the generated-and-checked-in protocol layer, the domain-to-seam table naming the five additive engine PRs, costs, what is deliberately absent, verification.
- `docs/design/headless-browser.md` — the founder's principle (Jint adds value to AngleSharp without competing) and what follows from it, what v1 delivers and what is out, the runtime model (the global stays `GlobalObject`, one engine per navigation, one page-loop thread, iframes parse but do not script in v1), the generated binding layer on Jint shapes, one event bus, navigation and the parser baton, constraints per page, input without layout, the WPT browser lane and the obstacle course, packages and seams, verification.

Both follow the form of `docs/design/web-workers.md`: the issue wins where they disagree, and they cite files and members rather than line numbers. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
