### PR TITLE
Intl: a cached month or day-period name is keyed on the calendar it was asked about

### DIFF
--- a/Jint.Tests.PublicInterface/HostLocaleProviderTests.cs
+++ b/Jint.Tests.PublicInterface/HostLocaleProviderTests.cs
@@ -264,6 +264,76 @@ public class HostLocaleProviderTests
             .AsString().Should().Be("Monday");
     }
 
+    /// <summary>
+    /// <c>GetMonthNames</c> and <c>GetDayPeriods</c> take a calendar, so a provider that answers for one of
+    /// them itself and delegates the rest asks the base for more than one — and each calendar has to get its
+    /// own answer, whichever order they were asked in.
+    /// </summary>
+    /// <remarks>
+    /// Asked of the provider rather than through <c>Intl.DateTimeFormat</c>, because a formatter on a non-ISO
+    /// calendar writes a numeric month whatever names it holds: <c>AddMonthPart</c> has no month-name data for
+    /// one and falls back to the number. The provider is the extension point either way, and this is the shape
+    /// a host reaches it in.
+    /// </remarks>
+    [Test]
+    public void ADerivedProviderDelegatingTwoCalendarsToTheBaseGetsOneAnswerPerCalendar()
+    {
+        var provider = new SolarMonthsForBuddhist();
+
+        // the calendar the subclass answers for is its own data
+        provider.GetMonthNames("en-GB", "long", "buddhist").Should().StartWith("Makara");
+
+        // …and the ones it delegates are the base's: one answer per calendar, not the first one asked for
+        var gregory = provider.GetMonthNames("en-GB", "long", "gregory");
+        var japanese = provider.GetMonthNames("en-GB", "long", "japanese");
+
+        gregory.Should().StartWith("January");
+        japanese.Should().StartWith("January");
+        japanese.Should().NotBeSameAs(gregory);
+
+        // …and asking for one does not displace the other, in either direction
+        provider.GetMonthNames("en-GB", "long", "gregory").Should().BeSameAs(gregory);
+        provider.GetMonthNames("en-GB", "long", "buddhist").Should().StartWith("Makara");
+        provider.GetMonthNames("en-GB", "long", "japanese").Should().BeSameAs(japanese);
+
+        // the style the subclass does not answer for is the inherited data, for its own calendar too
+        provider.GetMonthNames("en-GB", "short", "buddhist").Should().StartWith("Jan");
+    }
+
+    /// <summary>
+    /// The same promise seen from the base itself: the two members that take a calendar cache their answer
+    /// process-wide, and one entry per calendar is what lets a delegating override be answered correctly.
+    /// </summary>
+    /// <remarks>
+    /// The shipped bodies read the culture's own names, so the two calendars come back equal — the assertions
+    /// are that they are two answers rather than one, which is a property of the key rather than of the data.
+    /// </remarks>
+    [Test]
+    public void TheDefaultProviderCachesOneNameArrayPerCalendarItWasAskedAbout()
+    {
+        var provider = DefaultCldrProvider.Instance;
+
+        var gregoryMonths = provider.GetMonthNames("en-US", "long", "gregory");
+        var buddhistMonths = provider.GetMonthNames("en-US", "long", "buddhist");
+
+        gregoryMonths.Should().NotBeNull();
+        buddhistMonths.Should().NotBeSameAs(gregoryMonths);
+        buddhistMonths.Should().Equal(gregoryMonths);
+        provider.GetMonthNames("en-US", "long", "buddhist").Should().BeSameAs(buddhistMonths);
+        provider.GetMonthNames("en-US", "long", "gregory").Should().BeSameAs(gregoryMonths);
+
+        var gregoryPeriods = provider.GetDayPeriods("en-US", "short", "gregory");
+        var buddhistPeriods = provider.GetDayPeriods("en-US", "short", "buddhist");
+
+        gregoryPeriods.Should().NotBeNull();
+        buddhistPeriods.Should().NotBeSameAs(gregoryPeriods);
+        buddhistPeriods.Should().Equal(gregoryPeriods);
+        provider.GetDayPeriods("en-US", "short", "buddhist").Should().BeSameAs(buddhistPeriods);
+
+        // …and the member that takes no calendar keeps its one answer per locale and style
+        provider.GetWeekdayNames("en-US", "long").Should().BeSameAs(provider.GetWeekdayNames("en-US", "long"));
+    }
+
     [Test]
     public void AddingACalendarTheEngineHasNeverSeenIsThreeOverrides()
     {
@@ -425,6 +495,15 @@ file sealed class RevolutionaryMonths : DefaultCldrProvider
     public override string[]? GetMonthNames(string locale, string style, string? calendar)
         => string.Equals(style, "long", StringComparison.Ordinal)
             ? ["Nivose", "Pluviose", "Ventose", "Germinal", "Floreal", "Prairial", "Messidor", "Thermidor", "Fructidor", "Vendemiaire", "Brumaire", "Frimaire"]
+            : base.GetMonthNames(locale, style, calendar);
+}
+
+/// <summary>One calendar's long month names; every other calendar, style and member is inherited.</summary>
+file sealed class SolarMonthsForBuddhist : DefaultCldrProvider
+{
+    public override string[]? GetMonthNames(string locale, string style, string? calendar)
+        => string.Equals(calendar, "buddhist", StringComparison.Ordinal) && string.Equals(style, "long", StringComparison.Ordinal)
+            ? ["Makara", "Kumbha", "Mina", "Mesha", "Vrishabha", "Mithuna", "Karka", "Simha", "Kanya", "Tula", "Vrischika", "Dhanus"]
             : base.GetMonthNames(locale, style, calendar);
 }
 

--- a/Jint/Native/Intl/DefaultCldrProvider.cs
+++ b/Jint/Native/Intl/DefaultCldrProvider.cs
@@ -47,7 +47,9 @@ public class DefaultCldrProvider : ICldrProvider
     /// </summary>
     public static readonly DefaultCldrProvider Instance = new();
 
-    // Caches for immutable locale-dependent data
+    // Caches for immutable locale-dependent data, keyed on every argument the answer is allowed to depend
+    // on — which for months and day periods includes the calendar, even though the bodies below read the
+    // culture's own names and so answer the same for all of them. See NameCacheKey.
     private static readonly ConcurrentDictionary<string, string[]?> _monthNameCache = new(StringComparer.Ordinal);
     private static readonly ConcurrentDictionary<string, string[]?> _weekdayNameCache = new(StringComparer.Ordinal);
     private static readonly ConcurrentDictionary<string, string[]?> _dayPeriodCache = new(StringComparer.Ordinal);
@@ -398,10 +400,38 @@ public class DefaultCldrProvider : ICldrProvider
 
     // === Date/Time Formatting ===
 
+    /// <summary>
+    /// The key a cached name array is stored under: every argument its member takes, so an entry can never
+    /// answer a question the caller did not ask.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The calendar is in it because the two members taking one are <c>public virtual</c> on a class hosts
+    /// derive from, and a derived provider answering per calendar for some calendars and delegating the rest
+    /// asks the base for more than one. Whether the base's answer happens to depend on the argument is a
+    /// property of today's body rather than of the contract, and these caches outlive every engine in the
+    /// process.
+    /// </para>
+    /// <para>
+    /// The key space stays closed: a calendar reaching a provider from <c>Intl.DateTimeFormat</c> has been
+    /// through <c>AvailableCalendars.ResolveForDateTimeFormat</c>, so it is one of the sixteen built-in
+    /// identifiers, one an <see cref="Temporal.ICalendarProvider"/> claims, or <c>"gregory"</c> — never a
+    /// string a script invented.
+    /// </para>
+    /// </remarks>
+    private static string NameCacheKey(string locale, string style, string? calendar)
+        => string.Concat(locale, "_", style, "_", calendar);
+
     /// <inheritdoc />
+    /// <remarks>
+    /// The answer is cached per locale, style and calendar. This body reads
+    /// <see cref="DateTimeFormatInfo.MonthNames"/>, which answers for whatever calendar the culture carries,
+    /// so it returns equal names for every calendar it is asked about; an override that answers per calendar
+    /// is what the key is for, and gets one entry per calendar rather than the first one it was asked for.
+    /// </remarks>
     public virtual string[]? GetMonthNames(string locale, string style, string? calendar)
     {
-        var cacheKey = string.Concat(locale, "_", style);
+        var cacheKey = NameCacheKey(locale, style, calendar);
         return _monthNameCache.GetOrAdd(cacheKey, _ =>
         {
             var culture = IntlUtilities.GetCultureInfo(locale);
@@ -488,9 +518,13 @@ public class DefaultCldrProvider : ICldrProvider
         => name.Length == 0 ? name : culture.TextInfo.ToUpper(StringInfo.GetNextTextElement(name, 0));
 
     /// <inheritdoc />
+    /// <remarks>
+    /// The answer is cached per locale and style, which is every argument there is: a weekday name is the
+    /// same in every calendar, which is why this is the one of the three name members taking no calendar.
+    /// </remarks>
     public virtual string[]? GetWeekdayNames(string locale, string style)
     {
-        var cacheKey = string.Concat(locale, "_", style);
+        var cacheKey = NameCacheKey(locale, style, calendar: null);
         return _weekdayNameCache.GetOrAdd(cacheKey, _ =>
         {
             var culture = IntlUtilities.GetCultureInfo(locale);
@@ -510,9 +544,14 @@ public class DefaultCldrProvider : ICldrProvider
     }
 
     /// <inheritdoc />
+    /// <remarks>
+    /// The answer is cached per locale, style and calendar, for the reason given over
+    /// <see cref="GetMonthNames"/>: this body reads the culture's own designators and answers the same for
+    /// every calendar, and an override that does not gets one entry per calendar.
+    /// </remarks>
     public virtual string[]? GetDayPeriods(string locale, string style, string? calendar)
     {
-        var cacheKey = string.Concat(locale, "_", style);
+        var cacheKey = NameCacheKey(locale, style, calendar);
         return _dayPeriodCache.GetOrAdd(cacheKey, _ =>
         {
             var culture = IntlUtilities.GetCultureInfo(locale);


### PR DESCRIPTION
Closes #3569.

`DefaultCldrProvider.GetMonthNames` and `GetDayPeriods` are `public virtual`, take a `calendar`, and built their cache key out of `(locale, style)` alone. Both caches are `private static`, so an entry outlives every engine in the process.

## What the premise turned out to be

The issue predicts that a derived provider delegating two calendars to `base` "gets whichever it asked for first, for the life of the process". That is true of the **entry** and not of the **answer**, and the difference matters enough to state:

- the cache is `private static` and only ever holds what **this class's own body** produced, so a derived override's answer never enters it;
- that body reads `CultureInfo.DateTimeFormat` and never looks at `calendar`, so both calendars are answered with an array of the same twelve strings.

I tried three shapes to observe a wrong answer from outside — a provider answering one calendar and delegating the rest, one delegating everything, one normalising an alias before delegating — and none of them can, for the same reason. Nothing dispatches back through a virtual member from inside the body either. So there is no wrong *value*, only a wrong *key*, and the one thing an embedder can observe is that two calendars come back as one array instance rather than two.

That is exactly what the issue recorded ("a key omission with no reachable in-box symptom"), so it is a latent defect rather than a live one, and the argument for fixing it is that the key should match the signature rather than match today's body.

## The fix

One `NameCacheKey(locale, style, calendar)` helper, used by all three name caches. The weekday cache passes `null` because a weekday name has no calendar — saying that once beats two shapes of key in one file, and it is why `GetWeekdayNames` is the one of the three that takes no calendar argument.

**Nothing observable changes today.** A `GetOrAdd` under the wider key hands back a second equal array rather than the first one. What changes is that an override answering per calendar and delegating the rest gets one base entry per calendar, and that a body which stops being calendar-independent is correct without anyone remembering the cache.

## The key space stays closed

The growth question this raises is the one #3462 had to answer for the culture cache, and it comes out the other way. A `calendar` reaching a provider from `Intl.DateTimeFormat` has been through `AvailableCalendars.ResolveForDateTimeFormat` — either the calendar option, the `-u-ca-` extension, or `GetDefaultCalendarForLocale`, and all three resolve or discard. So the value is one of the sixteen built-in identifiers, one an `ICalendarProvider` claims (a set fixed at configuration), or `"gregory"`; never a string a script invented. The key space is multiplied by a closed factor of at most seventeen, not opened.

It is also multiplied on two caches an unconfigured engine never touches: `GetMonthNames` and `GetDayPeriods` are reached only from `ApplyProviderNames`/`ApplyNarrowNames`, both of which skip `DefaultCldrProvider.Instance` by identity for these members. Only a host provider delegating to `base` fills them at all.

## Tests

Two, both in `Jint.Tests.PublicInterface/HostLocaleProviderTests.cs`, because `DefaultCldrProvider` is a public extension point and the assertions use nothing but its public API.

- `TheDefaultProviderCachesOneNameArrayPerCalendarItWasAskedAbout` — the base itself: two calendars are two answers, each still cached, and the member that takes no calendar keeps its one answer per locale and style.
- `ADerivedProviderDelegatingTwoCalendarsToTheBaseGetsOneAnswerPerCalendar` — the issue's own shape: a subclass answering `buddhist` itself and delegating the rest, asked in both directions.

Both assert on array identity, which is the only thing an embedder can see here — the contents are equal by construction, so the assertion is that there are two answers rather than one.

The second is asked of the provider rather than through `Intl.DateTimeFormat`, because a formatter on a non-ISO calendar writes a numeric month whatever names it holds. That is a separate defect, filed below.

Against the unfixed engine, both fail on all three frameworks:

```
Failed ADerivedProviderDelegatingTwoCalendarsToTheBaseGetsOneAnswerPerCalendar
   Did not expect japanese to refer to {"January", …}.
Failed TheDefaultProviderCachesOneNameArrayPerCalendarItWasAskedAbout
   Did not expect buddhistMonths to refer to {"January", …}.

Failed! - Failed: 2, Passed: 16, Total: 18 (net472 / net8.0 / net10.0)
```

## No migration row

No public signature changes, and no answer changes — the arrays a host receives hold the same strings they did, and every in-box consumer compares them element by element (`DiffersFrom`) or by length, never by reference. Nothing for `docs/v5-migration.md`.

## Found alongside

Two defects turned up while establishing that this one has no in-box symptom, both filed separately rather than folded in: 

- **#3573** — `Intl.DateTimeFormat` and `Intl.NumberFormat` drop a `-u-` extension carrying more than one key: `en-US-u-ca-buddhist-nu-arab` resolves to bare `en-US` with `gregory`/`latn`, because each constructor's own extension scanner consumes the *next* key into the current key's value. `Intl.Locale` and `Intl.getCanonicalLocales` read the same tag correctly.
- **#3574** — `Intl.DateTimeFormat` writes a bare number for `month: 'long'` on every calendar but `gregory`, including `buddhist`/`japanese`/`roc` whose month names *are* the Gregorian ones. It is also why the `calendar` argument this PR is about has no reachable effect through `Intl` today: `ApplyProviderNames` seeds a host's per-calendar names into the formatter, and the non-Gregorian lane then ignores them.


## Verification

Release, on `main` at `ef706d721`.

| suite | net472 | net8.0 | net10.0 |
| --- | --- | --- | --- |
| `Jint.Tests` | 8245 / 0 / 4 | 11625 / 0 / 5 | 11625 / 0 / 5 |
| `Jint.Tests.PublicInterface` | 2724 / 0 / 21 | 3347 / 0 / 21 | 3357 / 0 / 21 |
| `Jint.Tests.CommonScripts` | 28 / 0 / 0 | — | 28 / 0 / 0 |
| `Jint.Tests.SourceGenerators` | — | — | 71 / 0 / 0 |

test262: **102537 passed / 0 failed / 151 skipped of 102688** — unchanged.

`dotnet build -c Release` is clean (`TreatWarningsAsErrors`); the one `MSB3277` is the pre-existing test-infrastructure reference conflict in `Jint.Tests.CommonScripts`.

One earlier test262 run reported two failures, both `intl402/supportedLocalesOf-unicode-extensions-ignored.js` timing out at 31 s against the runner's 30-second budget while three other build/test sessions had the machine. In isolation the pair runs in 2 s, and the clean rerun above is green.
