### PR TITLE
Interop: the extension methods an engine installs are the ones registered when its callbacks have finished

### DIFF
--- a/Jint.Tests.PublicInterface/SecurityConfigurationTests.cs
+++ b/Jint.Tests.PublicInterface/SecurityConfigurationTests.cs
@@ -416,16 +416,41 @@ public class SecurityConfigurationTests
         codes.Should().Contain(SecurityDiagnosticCodes.StackOverflowGuardDisabled);
     }
 
+    /// <summary>
+    /// The registry as it stands when the configuration callbacks have finished is what an engine installs -
+    /// for the prototypes and for the resolver alike - so a callback that empties it uninstalls both, and the
+    /// report taken from the engine says so. https://github.com/sebastienros/jint/issues/3568
+    /// </summary>
     [Test]
-    public void EffectiveEngineReportUsesInstalledExtensionMethodCache()
+    public void AConfigureCallbackThatEmptiesTheRegistryUninstallsTheExtensionMethods()
     {
         var options = CreateSafeOptions().AddExtensionMethods(typeof(SecurityConfigurationUnsafeExtensions));
         options.Configure(_ => options.Interop.ExtensionMethodTypes.Clear());
 
-        var report = new Engine(options).Diagnostics.ValidateSecurityConfiguration();
+        var engine = new Engine(options);
 
-        report.Diagnostics.Should().ContainSingle(
-            diagnostic => diagnostic.Code == SecurityDiagnosticCodes.ClrExtensionMethodsConfigured);
+        engine.Diagnostics.ValidateSecurityConfiguration().Diagnostics
+            .Should().NotContain(
+                diagnostic => diagnostic.Code == SecurityDiagnosticCodes.ClrExtensionMethodsConfigured);
+        Invoking(() => engine.Evaluate("'x'.ReadSecret()")).Should().Throw<JavaScriptException>();
+    }
+
+    /// <summary>
+    /// And the same registry read the other way: a container type registered from a callback is installed, so
+    /// the report taken from the engine reports it exactly as it does one registered on the options directly.
+    /// </summary>
+    [Test]
+    public void AConfigureCallbackThatFillsTheRegistryInstallsTheExtensionMethods()
+    {
+        var options = CreateSafeOptions();
+        options.Configure(_ => options.AddExtensionMethods(typeof(SecurityConfigurationUnsafeExtensions)));
+
+        var engine = new Engine(options);
+
+        engine.Diagnostics.ValidateSecurityConfiguration().Diagnostics
+            .Should().ContainSingle(
+                diagnostic => diagnostic.Code == SecurityDiagnosticCodes.ClrExtensionMethodsConfigured);
+        engine.Evaluate("'x'.ReadSecret()").AsString().Should().Be("x");
     }
 
     [Test]

--- a/Jint.Tests/Runtime/ExtensionMethods/ConfigureCallbackRegistrationTests.cs
+++ b/Jint.Tests/Runtime/ExtensionMethods/ConfigureCallbackRegistrationTests.cs
@@ -1,0 +1,109 @@
+﻿using Jint.Native;
+using Jint.Runtime;
+using Jint.Tests.Runtime.Domain;
+
+namespace Jint.Tests.Runtime.ExtensionMethods;
+
+/// <summary>
+/// A callback registered with <c>Options.Configure</c> runs from <c>Options.Apply</c>, which is also what
+/// attaches extension methods to the prototypes - so a callback that registers a container type has to reach
+/// both that attach and <c>TypeResolver</c>. https://github.com/sebastienros/jint/issues/3568
+/// </summary>
+public class ConfigureCallbackRegistrationTests
+{
+    [Test]
+    public void ExtensionMethodsRegisteredFromConfigureCallbackReachThePrototypes()
+    {
+        var engine = new Engine(options =>
+        {
+            options.Configure(_ => options.AddExtensionMethods(typeof(CustomStringExtensions)));
+        });
+
+        engine.Evaluate("'Hello World!'.Backwards()").AsString().Should().Be("!dlroW olleH");
+    }
+
+    [Test]
+    public void ExtensionMethodsRegisteredFromConfigureCallbackReachTheResolver()
+    {
+        var person = new Person { Name = "Mickey Mouse", Age = 35 };
+
+        var engine = new Engine(options =>
+        {
+            options.Configure(_ => options.AddExtensionMethods(typeof(PersonExtensions)));
+        });
+        engine.SetValue("person", person);
+
+        engine.Evaluate("person.MultiplyAge(2)").AsInteger().Should().Be(70);
+    }
+
+    [Test]
+    public void ExtensionMethodsRegisteredBeforeAndFromAConfigureCallbackAreBothHonoured()
+    {
+        var person = new Person { Name = "Mickey Mouse", Age = 35 };
+
+        var engine = new Engine(options =>
+        {
+            options.AddExtensionMethods(typeof(PersonExtensions));
+            options.Configure(_ => options.AddExtensionMethods(typeof(CustomStringExtensions)));
+        });
+        engine.SetValue("person", person);
+
+        engine.Evaluate("person.MultiplyAge(2)").AsInteger().Should().Be(70);
+        engine.Evaluate("'Hello World!'.Backwards()").AsString().Should().Be("!dlroW olleH");
+    }
+
+    [Test]
+    public void ExtensionMethodsRegisteredFromAConfigureCallbackAreReportedBySecurityConfiguration()
+    {
+        var engine = new Engine(options =>
+        {
+            options.Configure(_ => options.AddExtensionMethods(typeof(CustomStringExtensions)));
+        });
+
+        engine.Diagnostics.ValidateSecurityConfiguration().Diagnostics
+            .Select(d => d.Code)
+            .Should().Contain(SecurityDiagnosticCodes.ClrExtensionMethodsConfigured);
+    }
+
+    [Test]
+    public void AnUntrustedEngineSeesNoneOfWhatItsConfigureCallbackRegistered()
+    {
+        var engine = new Engine(options =>
+        {
+            options.Configure(e => e.Options.AddExtensionMethods(typeof(PersonExtensions)));
+            options.ForUntrustedCode(new UntrustedCodeLimits
+            {
+                TimeoutInterval = TimeSpan.FromSeconds(5),
+                MaxStatements = 100_000,
+                MemoryLimit = 16_000_000,
+                MaxRecursionDepth = 64,
+                MaxArraySize = 10_000,
+                RegexTimeout = TimeSpan.FromMilliseconds(100),
+                PromiseTimeout = TimeSpan.FromMilliseconds(100),
+                MaxOperationDuration = TimeSpan.FromSeconds(10),
+            });
+        });
+
+        // The profile clears the registry on its way through Apply, and the refresh sits after it - so what
+        // the callback registered reaches neither the prototypes nor the resolver.
+        engine.Diagnostics.ValidateSecurityConfiguration().Diagnostics
+            .Select(d => d.Code)
+            .Should().NotContain(SecurityDiagnosticCodes.ClrExtensionMethodsConfigured);
+    }
+
+    [Test]
+    public void RegisteringFromAConfigureCallbackIsRefusedOnceTheOptionsAreFrozen()
+    {
+        var options = new Options();
+        options.Configure(_ => options.AddExtensionMethods(typeof(CustomStringExtensions)));
+
+        var first = new Engine(options);
+        first.Evaluate("'Hello World!'.Backwards()").AsString().Should().Be("!dlroW olleH");
+
+        // The first engine froze the options it was handed, so the callback's own registration is what the
+        // second engine refuses - the freeze is the guard, and it names the registry that was written to.
+        var second = () => new Engine(options);
+        second.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Options.Interop.ExtensionMethodTypes*");
+    }
+}

--- a/Jint/AGENTS.md
+++ b/Jint/AGENTS.md
@@ -92,6 +92,15 @@ first (`Engine.TakePrivateWebApiOptions`) — an `Options` is shareable, and for
 keeps process-wide, so a per-tenant client set there used to reach every default-built engine. The copy stays
 frozen; the guard is suspended for it on the calling thread alone.
 
+**Which side of `Options.Apply` a derived field is read on is a decision, not an accident.** `Apply` runs the
+host's `Configure` callbacks, so anything a callback may legitimately set has to be read after it —
+`_maxRecursionDepth`, `_operatorOverloadingAllowed`, `_valueCoercion` and `_interopResolutionProfile` all are.
+The extension-method lookup was not, so `options.Configure(_ => options.AddExtensionMethods(…))` reached
+neither the prototypes nor `TypeResolver`, while the attach beside it read the grown registry and ran anyway
+([#3568](https://github.com/sebastienros/jint/issues/3568)). After `Apply` also means after the
+untrusted-code profile's re-expansion, which clears registries from inside it: a refresh placed before that
+would hand a hardened engine what its own callback registered.
+
 ### Type co-location
 
 Keep small supporting types — enums, record structs, tiny helpers — **in the same file** as the type they serve, provided they share a namespace and the file stays readable (e.g. `ModuleImportPhase` lives in `ModuleRequest.cs`). Split them out when the type has several independent consumers, is `public` and needs its own XML-doc discoverability, or when the file would exceed ~500 lines or mix unrelated concepts.

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -1479,7 +1479,17 @@ public sealed partial class Engine : IDisposable
     internal readonly JsValueArrayPool _jsValueArrayPool;
     internal readonly ObjectTraverseStackPool _objectTraverseStackPool;
     internal TailCallRequest? _tailCallRequest;
-    internal readonly ExtensionMethodCache _extensionMethods;
+    /// <summary>
+    /// The registered extension methods, keyed by the type they extend. Consulted by
+    /// <see cref="Runtime.Interop.TypeResolver"/> and by the prototype attach in <see cref="Options.Apply"/>.
+    /// </summary>
+    /// <remarks>
+    /// Not <c>readonly</c>: it is built at the top of construction, because a configuration callback can
+    /// reach interop, and re-derived once from <see cref="Options.Apply"/> after every callback has run —
+    /// registering a container type from <c>Options.Configure</c> has to reach both consumers, and the attach
+    /// beside that refresh already reads the registration list live.
+    /// </remarks>
+    internal ExtensionMethodCache _extensionMethods;
 
     /// <summary>
     /// The converter every interop conversion actually goes through, which is what engine-internal call sites
@@ -1604,6 +1614,8 @@ public sealed partial class Engine : IDisposable
         Options = sourceOptions.CreateEngineOptions();
         _untrustedCodeLimits = Options.UntrustedCodeLimits;
 
+        // A first reading, so that interop reached from a configuration callback has a lookup to consult.
+        // Options.Apply takes it again once those callbacks have run - see RefreshExtensionMethods.
         _extensionMethods = ExtensionMethodCache.Build(Options.Interop.ExtensionMethodTypes);
 
         Reset();
@@ -1742,6 +1754,29 @@ public sealed partial class Engine : IDisposable
         // rule can be stated without an exception.
         Options.MakeReadOnly();
         sourceOptions.MakeReadOnly();
+    }
+
+    /// <summary>
+    /// Re-derives <see cref="_extensionMethods"/> from the registration list as it stands once every
+    /// configuration callback has run. Called by <see cref="Options.Apply"/>, immediately before the attach
+    /// that reads that list.
+    /// </summary>
+    /// <remarks>
+    /// A callback registered with <c>Options.Configure</c> is a documented place to finish configuring an
+    /// engine, and a container type registered from one used to reach neither the prototypes nor
+    /// <see cref="Runtime.Interop.TypeResolver"/> (sebastienros/jint#3568) — while the attach beside this call
+    /// read the grown list and ran anyway, so one half of the feature already behaved as if it were supported.
+    /// <para>
+    /// Unconditional, so that a callback which <em>clears</em> the registry — which is what an untrusted-code
+    /// profile does on its way through <c>Apply</c> — drops the lookup as well as the attach.
+    /// <see cref="Runtime.Interop.Reflection.ExtensionMethodCache.Build"/> answers an empty registry from a
+    /// count check and an unchanged one from its intern table, so the common engine pays nothing and an
+    /// extension-method host pays one lookup against the prototype sweep that follows.
+    /// </para>
+    /// </remarks>
+    internal void RefreshExtensionMethods()
+    {
+        _extensionMethods = ExtensionMethodCache.Build(Options.Interop.ExtensionMethodTypes);
     }
 
     private static void ValidateModuleOptions(Options.ModuleOptions modules)

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -675,6 +675,13 @@ public sealed partial class Options
         }
 #endif
 
+        // Both halves of the extension-method feature read the registration list here, after every
+        // configuration callback above has run and after the untrusted profile's re-expansion has had its
+        // say: the lookup TypeResolver consults is re-derived, and then the prototypes are attached. The
+        // engine's first reading was taken before the callbacks, and a container type registered from one
+        // used to reach neither (sebastienros/jint#3568).
+        engine.RefreshExtensionMethods();
+
         if (Interop.ExtensionMethodTypes.Count > 0)
         {
             AttachExtensionMethodsToPrototypes(engine);
@@ -933,6 +940,10 @@ public sealed partial class Options
         /// <summary>
         /// Types holding extension methods that should be considered when resolving methods.
         /// </summary>
+        /// <remarks>
+        /// Read once per engine, when the options are applied and so after any callback registered with
+        /// <c>Options.Configure</c> has run.
+        /// </remarks>
         public OptionsList<Type> ExtensionMethodTypes { get; private set; } = new("Options.Interop.ExtensionMethodTypes");
 
         /// <summary>

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -4485,6 +4485,41 @@ with `ToObject()` on every evaluation — and the reflection scan the table exis
 triple, now once per *process* rather than once per engine carrying a converter of its own. An engine that
 never turns the option on is not affected at all.
 
+### 4.100 `AddExtensionMethods` from a `Configure` callback reaches the engine ([#3568](https://github.com/sebastienros/jint/issues/3568))
+
+A callback registered with `options.Configure(...)` runs from `Options.Apply`, which is also what attaches
+extension methods to the prototypes. The lookup those two consumers read — the prototype attach and
+`TypeResolver` — was built before `Apply`, so a container type registered from inside a callback grew
+`Options.Interop.ExtensionMethodTypes` and nothing else. The attach ran (it reads the registration list, and
+the list had grown) and attached nothing.
+
+```csharp
+var engine = new Engine(options =>
+{
+    options.Configure(_ => options.AddExtensionMethods(typeof(MyExtensions)));
+});
+```
+
+```js
+// 5.0                                  5.x
+'Hello'.Backwards();  // TypeError: not a function      'olleH'
+```
+
+The lookup is now re-derived once, from `Apply`, after every configuration callback has run and after an
+untrusted-code profile has had its say. The registry as it stands at that moment is what the engine installs,
+for the prototypes and for the resolver alike. Registering outside a callback was never affected and is
+unchanged.
+
+The same registry read the other way changes with it: a callback that *empties* it — which is what
+`ForUntrustedCode` does on its way through `Apply` — now uninstalls the lookup as well as skipping the
+prototype attach. Before, such an engine attached nothing to its prototypes and went on resolving
+`obj.SomeExtension()` through `TypeResolver`.
+
+**What could break:** an engine whose `Configure` callback registers extension methods now has them, and one
+whose callback clears the registry no longer has them. `engine.Diagnostics.ValidateSecurityConfiguration()`
+reports `JINTSEC057` accordingly in both directions — it still reads what the engine installed rather than
+what the options list says, the two simply no longer disagree. A host that did not want a registration to
+take effect should stop making it; it was never a no-op to rely on.
 ## 5. New in v5
 
 Everything in the table below is opt-in: nothing in it is installed unless the host asks for it, so


### PR DESCRIPTION
`Options.Configure` is documented as a place to finish configuring an engine, and `Engine.cs` says so in as
many words — `_maxRecursionDepth`, `_operatorOverloadingAllowed`, `_valueCoercion` and
`_interopResolutionProfile` are all deliberately read *after* `Options.Apply` so a callback can still move
them. The extension-method lookup was read before it, and nothing said so.

```csharp
var engine = new Engine(options =>
{
    options.AllowClr(typeof(MyExtensions).Assembly);
    options.Configure(_ => options.AddExtensionMethods(typeof(MyExtensions)));   // silently ignored
});
```

`Options.Apply` runs the host's `Configure` callbacks *and* attaches the extension methods, gating that attach
on `Interop.ExtensionMethodTypes.Count > 0` — the live registry, which the callback had grown. So the attach
ran and attached nothing, because it reads `engine._extensionMethods`, built before any callback. The two
`TypeResolver` consultations (`ResolvePropertyDescriptorFactory`, `TryFindMemberAccessor`) missed them as
well. One half of the feature already behaved as if registering from a callback were supported; the other
half was a stale snapshot.

## The fix

The lookup is re-derived once, from `Apply`, immediately before the attach — after every configuration
callback has run and after the untrusted-code profile's re-expansion has had its say. The registry as it
stands at that moment is what the engine installs, for the prototypes and for the resolver alike.
`_interopResolutionProfile` is taken after `Apply` already and reads the field, so it captures the refreshed
instance and partitions `TypeResolver`'s shared accessor cache correctly. `TypeResolver` already documented
this ordering, in the comment that skips the cache while the profile is uncaptured: *"the extension method
lookup, for one, is only final once they have all run."*

Cost: `ExtensionMethodCache.Build` answers an empty registry from a `Count` check, so an engine that
registered nothing pays a branch. One that did pays a `Type[]` and an intern-table lookup, against the
seven-prototype reflection sweep that follows on the next line.

The refresh is unconditional rather than growth-only, which settles the mirror of the same defect: a callback
that *empties* the registry now uninstalls the lookup as well as skipping the attach. That is what
`ForUntrustedCode` does on its way through `Apply`, and it makes the containment principled instead of
accidental — previously such an engine attached nothing to its prototypes while `TypeResolver` went on
serving the methods. `SecurityConfigurationTests.EffectiveEngineReportUsesInstalledExtensionMethodCache`
pinned exactly that half-state; it is replaced by a pair pinning both directions. The engine report still
reads what the engine installed rather than what the options list says — the two simply no longer disagree.

## Scope, measured

Only the engine whose own callback did the registering was affected, and the issue's "the next engine built
from those options gets a correct lookup" no longer applies: `Options.MakeReadOnly()` at the end of
construction means the *second* engine's replayed callback is refused by the freeze, naming
`Options.Interop.ExtensionMethodTypes`. That is pinned too.

## Tests

`Jint.Tests/Runtime/ExtensionMethods/ConfigureCallbackRegistrationTests.cs` (6 cases) plus the reworked pair
in `Jint.Tests.PublicInterface/SecurityConfigurationTests.cs`. Failing-first against unfixed code: 5 of 6
failed on each of net472, net8.0 and net10.0 (the sixth is the untrusted-containment guard, which passed
before and after by design); all 6 pass after.

Full `dotnet build -c Release` and `dotnet test -c Release` green: Jint.Tests 11,631 / 11,631 / 8,251 (net10.0
/ net8.0 / net472), Jint.Tests.PublicInterface 3,356 / 3,346 / 2,723, CommonScripts 28 / 28, SourceGenerators
71. test262 102,537 passed, 0 failed, 151 skipped of 102,688.

`docs/v5-migration.md` §4.99 covers both directions. `Jint/AGENTS.md` gains the rule the bug generalises to:
which side of `Options.Apply` a derived field is read on is a decision, not an accident.

Closes #3568

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014W5mbjGhyvgAS4pivXoc4S
