### PR TITLE
Intl: a calendar counting Gregorian months writes their names

### DIFF
--- a/Jint.Tests.Test262/IcuCldrProvider.cs
+++ b/Jint.Tests.Test262/IcuCldrProvider.cs
@@ -284,8 +284,93 @@ public sealed class IcuCldrProvider : ICldrProvider
     public string? GetDefaultCalendar(string locale)
         => _fallback.GetDefaultCalendar(locale);
 
+    /// <summary>
+    /// The month names of the calendar asked about. The fallback provider reads
+    /// <c>CultureInfo.DateTimeFormat</c>, whose names are the twelve Gregorian months, and answers nothing
+    /// for a calendar counting months of its own; CLDR is where those names live, and ICU4N ships the data
+    /// even though it has no <c>DateFormatSymbols</c> to read it with.
+    /// </summary>
+    /// <remarks>
+    /// The fallback goes first, so nothing a .NET culture already answers for changes hands.
+    /// </remarks>
     public string[]? GetMonthNames(string locale, string style, string? calendar)
-        => _fallback.GetMonthNames(locale, style, calendar);
+        => _fallback.GetMonthNames(locale, style, calendar) ?? CldrMonthNames(locale, style, calendar);
+
+    /// <summary>
+    /// The CLDR calendars to look one identifier's months up under, most specific first: several calendars
+    /// share one table — the three tabular Islamic ones are all <c>islamic</c>, and <c>dangi</c> takes
+    /// <c>chinese</c>'s names in every locale that has them.
+    /// </summary>
+    private static string[]? CldrCalendarKeys(string? calendar) => calendar switch
+    {
+        null or "gregory" or "iso8601" => ["gregorian"],
+        "ethioaa" => ["ethiopic-amete-alem", "ethiopic"],
+        "islamic-civil" or "islamic-tbla" or "islamic-umalqura" or "islamic-rgsa" or "islamic" => [calendar, "islamic"],
+        "dangi" => ["dangi", "chinese"],
+        "buddhist" or "japanese" or "roc" or "persian" or "hebrew" or "coptic" or "ethiopic"
+            or "indian" or "chinese" => [calendar],
+        _ => null
+    };
+
+    /// <summary>
+    /// Reads <c>calendar/&lt;key&gt;/monthNames/format/&lt;width&gt;</c>, from the locale where it has one and
+    /// from <c>root</c> otherwise — which is where CLDR keeps the English names of the calendars an <c>en</c>
+    /// bundle carries no month table for, and what ICU itself resolves to for them.
+    /// </summary>
+    /// <remarks>
+    /// The array is indexed by month number, so a thirteen-month calendar answers thirteen names. The Hebrew
+    /// array holds fourteen, the last being the leap year's Adar II, which no caller here can pick out: a
+    /// leap Adar II is month 7 and reads "Adar".
+    /// </remarks>
+    private static string[]? CldrMonthNames(string locale, string style, string? calendar)
+    {
+        var keys = CldrCalendarKeys(calendar);
+        var width = style switch
+        {
+            "long" => "wide",
+            "short" => "abbreviated",
+            "narrow" => "narrow",
+            _ => null
+        };
+
+        if (keys is null || width is null)
+        {
+            return null;
+        }
+
+        // "format" is the name a pattern writes, against "stand-alone" for a month named on its own.
+        foreach (var source in new[] { locale, "root" })
+        {
+            var bundle = GetBundle(source);
+            if (bundle is null)
+            {
+                continue;
+            }
+
+            foreach (var key in keys)
+            {
+                var months = GetBundleAt(bundle, $"calendar/{key}/monthNames/format/{width}");
+                if (months is null)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    if (months.GetStringArray() is { Length: > 0 } values)
+                    {
+                        return values;
+                    }
+                }
+                catch
+                {
+                    // A resource that is not an array of strings is not month names.
+                }
+            }
+        }
+
+        return null;
+    }
 
     public string[]? GetWeekdayNames(string locale, string style)
         => _fallback.GetWeekdayNames(locale, style);

--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -213,13 +213,11 @@
 
     // === INTL402 TEMPORAL EXCLUSIONS ===
 
-    // dateStyle with non-ISO calendar formatting (Islamic month names etc.)
-    "intl402/Temporal/Instant/prototype/toLocaleString/dateStyle.js",
-    "intl402/Temporal/PlainDate/prototype/toLocaleString/dateStyle.js",
-    "intl402/Temporal/PlainDateTime/prototype/toLocaleString/dateStyle.js",
+    // The month-name half of these two passes; what still fails is the last assertion of each, that a
+    // dateStyle writes neither PlainMonthDay's reference year nor PlainYearMonth's reference day. Removed
+    // by making toLocaleString drop the reference field from the pattern a dateStyle resolves to.
     "intl402/Temporal/PlainMonthDay/prototype/toLocaleString/dateStyle.js",
     "intl402/Temporal/PlainYearMonth/prototype/toLocaleString/dateStyle.js",
-    "intl402/Temporal/ZonedDateTime/prototype/toLocaleString/dateStyle.js",
 
     // Remaining intl402/Temporal calendar failures
     "intl402/DateTimeFormat/prototype/formatToParts/compare-to-temporal-lunisolar.js",

--- a/Jint.Tests/Runtime/IntlCalendarMonthNameTests.cs
+++ b/Jint.Tests/Runtime/IntlCalendarMonthNameTests.cs
@@ -1,0 +1,287 @@
+#nullable enable
+
+using Jint.Native.Intl;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// https://tc39.es/ecma402/#table-datetimeformat-components makes <c>"long"</c>, <c>"short"</c> and
+/// <c>"narrow"</c> textual month formats, so a formatter answering one of them with a number is answering a
+/// different format. Which name it writes depends on what the resolved calendar counts months in, and there
+/// are two answers rather than one.
+/// </summary>
+public class IntlCalendarMonthNameTests
+{
+    private readonly Engine _engine = new();
+
+    /// <summary>2024-01-15 is 5 Shevat 5784, 4 Rajab 1445, 25 Dey 1402, 6 Toba 1740 and 25 Pausa 1945.</summary>
+    private const string January15 = "Date.UTC(2024, 0, 15)";
+
+    /// <summary>2024-09-08 is the third of the thirteenth month in both the Coptic and the Ethiopic year.</summary>
+    private const string September8 = "Date.UTC(2024, 8, 8)";
+
+    private string Month(string calendar, string style, string locale = "en-US", string date = January15)
+        => MonthOn(_engine, calendar, style, locale, date);
+
+    private static string MonthOn(Engine engine, string calendar, string style, string locale, string date)
+        => engine.Evaluate(
+                $"new Intl.DateTimeFormat('{locale}-u-ca-{calendar}', {{ month: '{style}', timeZone: 'UTC' }}).format({date})")
+            .AsString();
+
+    /// <summary>
+    /// The defect this pins: every calendar but <c>gregory</c> wrote a bare number for all three textual
+    /// styles. <c>buddhist</c>, <c>japanese</c> and <c>roc</c> differ from <c>gregory</c> in era and year
+    /// only — ICU writes "January" for all four — so the locale's own month name is the one to write.
+    /// </summary>
+    [TestCase("buddhist", "long", "January")]
+    [TestCase("buddhist", "short", "Jan")]
+    [TestCase("buddhist", "narrow", "J")]
+    [TestCase("japanese", "long", "January")]
+    [TestCase("japanese", "short", "Jan")]
+    [TestCase("japanese", "narrow", "J")]
+    [TestCase("roc", "long", "January")]
+    [TestCase("roc", "short", "Jan")]
+    [TestCase("roc", "narrow", "J")]
+    public void ACalendarCountingGregorianMonthsWritesTheGregorianName(string calendar, string style, string expected)
+    {
+        Month(calendar, style).Should().Be(expected);
+    }
+
+    /// <summary>
+    /// The same rule without a literal: whatever a locale writes for a Gregorian month, these three write for
+    /// the same month, in every style and in a locale whose own names are not English.
+    /// </summary>
+    [TestCase("buddhist")]
+    [TestCase("japanese")]
+    [TestCase("roc")]
+    public void SuchACalendarAgreesWithGregoryOnEveryMonthStyle(string calendar)
+    {
+        foreach (var style in new[] { "long", "short", "narrow", "numeric", "2-digit" })
+        {
+            foreach (var locale in new[] { "en-US", "de-DE", "th-TH", "ja-JP" })
+            {
+                Month(calendar, style, locale).Should().Be(
+                    Month("gregory", style, locale),
+                    "{0} counts the Gregorian months, for {1} in {2}", calendar, style, locale);
+            }
+        }
+    }
+
+    /// <summary>
+    /// A calendar counting months of its own is the other case, and the number is what the engine has: Jint
+    /// ships no month-name data for one, and a number is never a wrong name. ICU itself writes the number for
+    /// <c>"narrow"</c> on every one of these.
+    /// </summary>
+    [TestCase("islamic-civil", "7")]
+    [TestCase("islamic-tbla", "7")]
+    [TestCase("islamic-umalqura", "7")]
+    [TestCase("hebrew", "5")]
+    [TestCase("persian", "10")]
+    [TestCase("coptic", "5")]
+    [TestCase("ethiopic", "5")]
+    [TestCase("ethioaa", "5")]
+    [TestCase("indian", "10")]
+    [TestCase("chinese", "12")]
+    [TestCase("dangi", "12")]
+    public void ACalendarWithMonthsOfItsOwnKeepsTheNumberWithNoDataForIt(string calendar, string expected)
+    {
+        foreach (var style in new[] { "long", "short", "narrow" })
+        {
+            Month(calendar, style).Should().Be(expected, "{0} has no {1} month names to write", calendar, style);
+        }
+    }
+
+    /// <summary>
+    /// <see cref="ICldrProvider.GetMonthNames"/> takes the calendar for exactly this, and had no reachable
+    /// effect through <c>Intl</c> at all: a host supplying Hebrew month names had nowhere for them to be
+    /// written.
+    /// </summary>
+    [TestCase("long", "Shevat")]
+    [TestCase("short", "Sh")]
+    [TestCase("narrow", "S")]
+    public void AHostsMonthNamesForTheCalendarAreWritten(string style, string expected)
+    {
+        var engine = new Engine(options => options.Intl.CldrProvider = new HebrewMonths());
+
+        MonthOn(engine, "hebrew", style, "en-US", January15).Should().Be(expected);
+    }
+
+    /// <summary>
+    /// A thirteenth month is a month, and the calendars that have one carry a name for it. The
+    /// <see cref="System.Globalization.DateTimeFormatInfo"/> arrays a formatter seeds carry twelve names and a
+    /// trailing empty, which is why the calendar's own names are read from the provider rather than out of them.
+    /// </summary>
+    [Test]
+    public void AThirteenthMonthHasAName()
+    {
+        var engine = new Engine(options => options.Intl.CldrProvider = new CopticMonths());
+
+        MonthOn(engine, "coptic", "long", "en-US", September8).Should().Be("Nasie");
+        MonthOn(engine, "coptic", "long", "en-US", January15).Should().Be("Toba");
+    }
+
+    /// <summary>The calendar the formatter resolved is the one the provider is asked about.</summary>
+    [Test]
+    public void TheProviderIsAskedWithTheResolvedCalendar()
+    {
+        var provider = new RecordsWhatItWasAsked();
+        var engine = new Engine(options => options.Intl.CldrProvider = provider);
+
+        MonthOn(engine, "persian", "long", "en-US", January15);
+
+        provider.Calendars.Should().Contain("persian");
+    }
+
+    /// <summary>
+    /// <c>dateStyle</c> writes its month through the locale's own pattern rather than through the
+    /// <c>month</c> option, and the two lanes have to agree: an <c>MMMM</c> run had no name left to write either.
+    /// </summary>
+    [TestCase("full")]
+    [TestCase("long")]
+    [TestCase("medium")]
+    public void ADateStylePatternWritesTheCalendarsMonthName(string dateStyle)
+    {
+        var value = _engine.Evaluate(
+                $"new Intl.DateTimeFormat('en-US-u-ca-buddhist', {{ dateStyle: '{dateStyle}', timeZone: 'UTC' }}).format({January15})")
+            .AsString();
+
+        value.Should().Contain("Jan").And.Contain("2567");
+    }
+
+    /// <summary>
+    /// A <c>dateStyle</c> resolves to a pattern whose <c>MMMM</c> run is written by the other lane, and a
+    /// host's name for the calendar has to reach that one too.
+    /// </summary>
+    [TestCase("full")]
+    [TestCase("long")]
+    public void APatternsTextualMonthTakesAHostsNameForTheCalendar(string dateStyle)
+    {
+        var engine = new Engine(options => options.Intl.CldrProvider = new HebrewMonths());
+
+        engine.Evaluate(
+                $"new Intl.DateTimeFormat('en-US-u-ca-hebrew', {{ dateStyle: '{dateStyle}', timeZone: 'UTC' }}).format({January15})")
+            .AsString().Should().Contain("Shevat");
+    }
+
+    /// <summary><c>format</c> is the concatenation of the parts <c>formatToParts</c> walks, name included.</summary>
+    [Test]
+    public void FormatAndFormatToPartsWriteTheSameName()
+    {
+        var engine = new Engine(options => options.Intl.CldrProvider = new HebrewMonths());
+
+        var script = $$"""
+            (function () {
+                var f = new Intl.DateTimeFormat('en-US-u-ca-hebrew', { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' });
+                var parts = f.formatToParts({{January15}}).map(function (p) { return p.value; }).join('');
+                return [f.format({{January15}}), parts].join('~');
+            })()
+            """;
+
+        var pieces = engine.Evaluate(script).AsString().Split('~');
+        pieces[0].Should().Contain("Shevat");
+        pieces[1].Should().Be(pieces[0]);
+    }
+
+    /// <summary>The numeric styles are untouched: they were never the defect.</summary>
+    [TestCase("buddhist", "numeric", "1")]
+    [TestCase("buddhist", "2-digit", "01")]
+    [TestCase("hebrew", "numeric", "5")]
+    [TestCase("hebrew", "2-digit", "05")]
+    [TestCase("coptic", "numeric", "5")]
+    [TestCase("coptic", "2-digit", "05")]
+    public void ANumericMonthStaysANumber(string calendar, string style, string expected)
+    {
+        Month(calendar, style).Should().Be(expected);
+    }
+
+    /// <summary>
+    /// The shipped provider reads month names out of <see cref="System.Globalization.CultureInfo"/>, and those
+    /// are the Gregorian ones. Answering with them for <c>hebrew</c> would be a wrong name rather than no name,
+    /// and a host subclass delegating to <c>base</c> would inherit the lie.
+    /// </summary>
+    [TestCase("gregory")]
+    [TestCase("iso8601")]
+    [TestCase("buddhist")]
+    [TestCase("japanese")]
+    [TestCase("roc")]
+    [TestCase((string?) null)]
+    public void TheShippedProviderAnswersForTheCalendarsItsNamesAreFor(string? calendar)
+    {
+        DefaultCldrProvider.Instance.GetMonthNames("en-US", "long", calendar).Should().HaveCount(12);
+    }
+
+    [TestCase("hebrew")]
+    [TestCase("persian")]
+    [TestCase("islamic-civil")]
+    [TestCase("coptic")]
+    [TestCase("chinese")]
+    [TestCase("mayan")]
+    public void TheShippedProviderHasNoNamesForACalendarCountingItsOwnMonths(string calendar)
+    {
+        DefaultCldrProvider.Instance.GetMonthNames("en-US", "long", calendar).Should().BeNull();
+    }
+}
+
+/// <summary>A host with the thirteen Hebrew month names Jint ships none of, and no other datum.</summary>
+file sealed class HebrewMonths : DefaultCldrProvider
+{
+    private static readonly string[] Wide =
+    [
+        "Tishri", "Heshvan", "Kislev", "Tevet", "Shevat", "Adar I", "Adar II",
+        "Nisan", "Iyar", "Sivan", "Tammuz", "Av", "Elul"
+    ];
+
+    public override string[]? GetMonthNames(string locale, string style, string? calendar)
+    {
+        if (!string.Equals(calendar, "hebrew", StringComparison.Ordinal))
+        {
+            return base.GetMonthNames(locale, style, calendar);
+        }
+
+        return style switch
+        {
+            "long" => Wide,
+            "short" => Abbreviate(2),
+            "narrow" => Abbreviate(1),
+            _ => null
+        };
+    }
+
+    private static string[] Abbreviate(int length)
+    {
+        var result = new string[Wide.Length];
+        for (var i = 0; i < Wide.Length; i++)
+        {
+            result[i] = Wide[i].Substring(0, Math.Min(length, Wide[i].Length));
+        }
+
+        return result;
+    }
+}
+
+/// <summary>A host answering for the thirteen months of the Coptic year.</summary>
+file sealed class CopticMonths : DefaultCldrProvider
+{
+    private static readonly string[] Wide =
+    [
+        "Tout", "Baba", "Hator", "Kiahk", "Toba", "Amshir", "Baramhat",
+        "Baramouda", "Bashans", "Paona", "Epep", "Mesra", "Nasie"
+    ];
+
+    public override string[]? GetMonthNames(string locale, string style, string? calendar)
+        => string.Equals(calendar, "coptic", StringComparison.Ordinal) && string.Equals(style, "long", StringComparison.Ordinal)
+            ? Wide
+            : base.GetMonthNames(locale, style, calendar);
+}
+
+/// <summary>A host that adds nothing and remembers what it was asked.</summary>
+file sealed class RecordsWhatItWasAsked : DefaultCldrProvider
+{
+    public List<string> Calendars { get; } = [];
+
+    public override string[]? GetMonthNames(string locale, string style, string? calendar)
+    {
+        Calendars.Add(calendar ?? "<null>");
+        return base.GetMonthNames(locale, style, calendar);
+    }
+}

--- a/Jint/Native/Intl/AvailableCalendars.cs
+++ b/Jint/Native/Intl/AvailableCalendars.cs
@@ -51,6 +51,47 @@ internal static class AvailableCalendars
     private static readonly StringSearchValues BuiltinLookup = new(Builtin, StringComparison.Ordinal);
 
     /// <summary>
+    /// The calendars that count the very months <c>gregory</c> counts, so that a month number of one names
+    /// the same month and the locale's own month names are the ones to write for it.
+    /// </summary>
+    /// <remarks>
+    /// <c>buddhist</c>, <c>japanese</c> and <c>roc</c> differ from <c>gregory</c> in era and year only — ICU
+    /// writes "January" for all four and a number for none of them. Every other calendar, this engine's or a
+    /// host's, counts months of its own, and a name for one has to come from data that knows that calendar:
+    /// <see cref="ICldrProvider.GetMonthNames"/>, which takes the calendar for exactly this.
+    /// </remarks>
+    private static readonly string[] GregorianMonthed = ["gregory", "iso8601", "buddhist", "japanese", "roc"];
+
+    /// <summary>
+    /// Whether <paramref name="calendar"/> counts the Gregorian months. A formatter that resolved one writes
+    /// its months exactly as <c>gregory</c> does, names included; every other calendar needs its own names, or
+    /// keeps the month number.
+    /// </summary>
+    /// <remarks>
+    /// A null calendar is the unresolved case and answers as <c>gregory</c>, so a caller with nothing resolved
+    /// reads the locale's own names rather than none. The comparison is case-insensitive because
+    /// <see cref="ICldrProvider.GetMonthNames"/> is public and its argument has been through no
+    /// canonicalization this class can see.
+    /// </remarks>
+    internal static bool UsesGregorianMonths(string? calendar)
+    {
+        if (calendar is null)
+        {
+            return true;
+        }
+
+        foreach (var candidate in GregorianMonthed)
+        {
+            if (string.Equals(calendar, candidate, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// A legacy spelling of <c>gregory</c> that predates the Unicode <c>type</c> grammar and cannot appear in
     /// a <c>-u-ca-</c> extension, being nine characters where the grammar allows eight. It is here because
     /// <c>Temporal</c> has always accepted it as a <c>calendar</c> field value.

--- a/Jint/Native/Intl/DefaultCldrProvider.cs
+++ b/Jint/Native/Intl/DefaultCldrProvider.cs
@@ -424,13 +424,25 @@ public class DefaultCldrProvider : ICldrProvider
 
     /// <inheritdoc />
     /// <remarks>
-    /// The answer is cached per locale, style and calendar. This body reads
-    /// <see cref="DateTimeFormatInfo.MonthNames"/>, which answers for whatever calendar the culture carries,
-    /// so it returns equal names for every calendar it is asked about; an override that answers per calendar
-    /// is what the key is for, and gets one entry per calendar rather than the first one it was asked for.
+    /// <para>
+    /// The answer is cached per locale, style and calendar. The names come from
+    /// <see cref="DateTimeFormatInfo.MonthNames"/>, and those are the twelve Gregorian months, so this
+    /// provider answers for the calendars that count them — <c>gregory</c>, <c>iso8601</c>, <c>buddhist</c>,
+    /// <c>japanese</c> and <c>roc</c>, which differ in era and year only — and answers null for a calendar
+    /// counting months of its own. Writing "May" for Shevat would be a wrong name rather than no name, and a
+    /// derived provider delegating the calendars it does not handle would inherit it.
+    /// </para>
+    /// <para>
+    /// A null calendar is the caller with nothing resolved, and reads the culture's names as before.
+    /// </para>
     /// </remarks>
     public virtual string[]? GetMonthNames(string locale, string style, string? calendar)
     {
+        if (!AvailableCalendars.UsesGregorianMonths(calendar))
+        {
+            return null;
+        }
+
         var cacheKey = NameCacheKey(locale, style, calendar);
         return _monthNameCache.GetOrAdd(cacheKey, _ =>
         {

--- a/Jint/Native/Intl/JsDateTimeFormat.cs
+++ b/Jint/Native/Intl/JsDateTimeFormat.cs
@@ -96,6 +96,62 @@ internal sealed class JsDateTimeFormat : ObjectInstance
     private ICldrProvider CldrProvider => _engine.Options.Intl.CldrProvider;
 
     /// <summary>
+    /// The resolved calendar's own month names, one array per textual style, asked for once each and only by
+    /// a formatter that writes one. An empty array is "asked, and there are none".
+    /// </summary>
+    private string[][]? _calendarMonthNames;
+
+    /// <summary>
+    /// The name this formatter writes for month <paramref name="month"/> of the calendar it resolved, or null
+    /// when there is none and the month number stands.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// https://tc39.es/ecma402/#table-datetimeformat-components makes <c>"long"</c>, <c>"short"</c> and
+    /// <c>"narrow"</c> textual, and a formatter is not free to answer one of them with a number. For a
+    /// calendar counting the Gregorian months the name is the locale's own and no lookup happens here — the
+    /// Gregorian lane writes it, host-seeded names and all. For a calendar counting months of its own the name
+    /// has to come from data that knows that calendar, which is what
+    /// <see cref="ICldrProvider.GetMonthNames"/> takes its <c>calendar</c> argument for.
+    /// </para>
+    /// <para>
+    /// The array is indexed by the calendar's month number, so it is as long as that calendar's year: thirteen
+    /// for Coptic, Ethiopic and a Hebrew or Chinese leap year. That is why the answer is read from the provider
+    /// rather than out of <see cref="DateTimeFormatInfo"/>, whose month arrays hold twelve names and a trailing
+    /// empty one. A month the array is too short for keeps its number, and so does an empty name.
+    /// </para>
+    /// <para>
+    /// With no answer the number stands, which is what every release before this one wrote for all three
+    /// styles, and what ICU itself writes for <c>"narrow"</c> on every one of these calendars.
+    /// </para>
+    /// </remarks>
+    private string? CalendarMonthName(int month, string? style)
+    {
+        var index = style switch
+        {
+            "long" => 0,
+            "short" => 1,
+            "narrow" => 2,
+            _ => -1
+        };
+
+        if (index < 0 || month < 1 || AvailableCalendars.UsesGregorianMonths(Calendar))
+        {
+            return null;
+        }
+
+        var cache = _calendarMonthNames ??= new string[3][];
+        var names = cache[index];
+        if (names is null)
+        {
+            names = CldrProvider.GetMonthNames(Locale, style!, Calendar) ?? [];
+            cache[index] = names;
+        }
+
+        return month <= names.Length && names[month - 1].Length > 0 ? names[month - 1] : null;
+    }
+
+    /// <summary>
     /// Formats a date according to the formatter's locale and options.
     /// </summary>
     /// <param name="dateTime">The .NET DateTime to format</param>
@@ -611,20 +667,21 @@ internal sealed class JsDateTimeFormat : ObjectInstance
             return;
         }
 
-        // Simple offset calendars: cheap arithmetic without going through NonIsoCalendars.
+        // Simple offset calendars: cheap arithmetic without going through NonIsoCalendars. Only the year is
+        // overridden, because only the year differs — https://tc39.es/ecma402/#table-datetimeformat-components
+        // makes "long", "short" and "narrow" textual month formats, and a month override is what forced them
+        // to a number. Leaving month and day to the Gregorian lane is what makes these calendars write the
+        // very name gregory writes, in every style and through both the component and the pattern lane, which
+        // is also what ICU does: buddhist, japanese and roc are the Gregorian months under another era.
         var sourceYear = originalYear ?? dateTime.Year;
         if (string.Equals(Calendar, "buddhist", StringComparison.OrdinalIgnoreCase))
         {
             year = sourceYear + 543;
-            month = dateTime.Month;
-            day = dateTime.Day;
             return;
         }
         if (string.Equals(Calendar, "roc", StringComparison.OrdinalIgnoreCase))
         {
             year = sourceYear - 1911;
-            month = dateTime.Month;
-            day = dateTime.Day;
             return;
         }
         if (string.Equals(Calendar, "japanese", StringComparison.OrdinalIgnoreCase))
@@ -649,8 +706,6 @@ internal sealed class JsDateTimeFormat : ObjectInstance
             if (eraYear.HasValue)
             {
                 year = eraYear;
-                month = dt.Month;
-                day = dt.Day;
             }
             return;
         }
@@ -688,22 +743,21 @@ internal sealed class JsDateTimeFormat : ObjectInstance
             {
                 "numeric" => chineseMonth.ToString(CultureInfo),
                 "2-digit" => chineseMonth.ToString("D2", CultureInfo),
-                // For textual months in lunisolar calendars, we still use numeric
-                // as Chinese month names are not typically used in Intl formatting
-                "long" or "short" or "narrow" => chineseMonth.ToString(CultureInfo),
+                // A lunisolar month has a name — ICU writes "Twelfth Month" — and Jint ships none, so the
+                // number stands unless a host answers for the calendar.
+                "long" or "short" or "narrow" => CalendarMonthName(chineseMonth, Month) ?? chineseMonth.ToString(CultureInfo),
                 _ => chineseMonth.ToString("D2", CultureInfo)
             };
         }
         else if (overrideMonth.HasValue)
         {
-            // Calendar-aware override (e.g. coptic month for the underlying ISO date).
-            // Textual month styles fall back to numeric since we don't have month-name data
-            // for arbitrary non-ISO calendars.
+            // Calendar-aware override (e.g. coptic month for the underlying ISO date). A textual style writes
+            // the calendar's own name for that month where there is one, and the number where there is not.
             monthValue = Month switch
             {
                 "numeric" => overrideMonth.Value.ToString(CultureInfo),
                 "2-digit" => overrideMonth.Value.ToString("D2", CultureInfo),
-                _ => overrideMonth.Value.ToString(CultureInfo)
+                _ => CalendarMonthName(overrideMonth.Value, Month) ?? overrideMonth.Value.ToString(CultureInfo)
             };
         }
         else
@@ -1153,7 +1207,14 @@ internal sealed class JsDateTimeFormat : ObjectInstance
             }
             else if (run.Field == 'M' && calendarMonth.HasValue)
             {
-                value = FormatOverride(calendarMonth.Value, run.Length);
+                // A three- or four-letter run is the pattern's textual month, and the calendar's own name is
+                // what belongs in it — the same name the month option's "short" and "long" write, so the two
+                // lanes agree. https://tc39.es/ecma402/#sec-formatdatetime is the concatenation of the parts
+                // https://tc39.es/ecma402/#sec-formatdatetimetoparts walks, and both go through here.
+                value = run.Length >= 3
+                    ? CalendarMonthName(calendarMonth.Value, run.Length >= 4 ? "long" : "short")
+                    : null;
+                value ??= FormatOverride(calendarMonth.Value, run.Length);
             }
             else if (run.Field == 'd' && run.Length <= 2 && calendarDay.HasValue)
             {
@@ -1209,8 +1270,8 @@ internal sealed class JsDateTimeFormat : ObjectInstance
     }
 
     /// <summary>
-    /// Writes an overridden field value. Only a two-letter run pads, because a calendar year is written as it
-    /// is counted - Reiwa 8 is "8", not "0008" - and a textual month run has no name left to write.
+    /// Writes an overridden field value as a number. Only a two-letter run pads, because a calendar year is
+    /// written as it is counted - Reiwa 8 is "8", not "0008".
     /// </summary>
     private string FormatOverride(int value, int length)
         => length == 2 ? value.ToString("D2", CultureInfo) : value.ToString(CultureInfo);

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -1,4 +1,4 @@
-﻿# Migrating from Jint 4.16 to Jint 5
+# Migrating from Jint 4.16 to Jint 5
 
 Jint 5 is under development on `main`. This document is the running record of every change a
 4.16.x embedder has to react to; it is written for someone upgrading, so it says what broke and
@@ -4568,6 +4568,53 @@ reports the ordinary catchable resolution failure instead of a CLR `OverflowExce
 back to ordinary JavaScript semantics — which is what a lone `byte` operator has always done with an
 out-of-range value. There is no switch that restores the old selection; a host that wants a large number to
 reach a member declares that member's parameter as `long`, `double` or `object`.
+
+### 4.102 A calendar counting Gregorian months writes their names ([#3574](https://github.com/sebastienros/jint/issues/3574))
+
+`Intl.DateTimeFormat` wrote a bare number for `month: 'long'`, `'short'` and `'narrow'` alike on every
+calendar but `gregory`, and for the textual month of every `dateStyle` pattern. `buddhist`, `japanese` and
+`roc` differ from `gregory` in era and year only, so their months now carry the locale's own names — which is
+what ICU, and therefore V8 and SpiderMonkey, write for all four:
+
+```js
+var f = new Intl.DateTimeFormat('en-US-u-ca-buddhist', { month: 'long', timeZone: 'UTC' });
+f.format(Date.UTC(2024, 0, 15));      // 5.0: "1"                  5.x: "January"
+
+new Intl.DateTimeFormat('en-US-u-ca-buddhist', { dateStyle: 'long', timeZone: 'UTC' })
+    .format(Date.UTC(2024, 0, 15));   // 5.0: "1 15, 2567"         5.x: "January 15, 2567"
+```
+
+A calendar counting months of its own — `hebrew`, `persian`, `coptic`, `ethiopic`, `ethioaa`, `indian`,
+`chinese`, `dangi` and the three tabular Islamic ones — keeps the number, because Jint ships no month-name
+data for one and a number is never a wrong name. It is also what ICU writes for `narrow` on every one of
+them. Supplying those names is `ICldrProvider.GetMonthNames`, whose `calendar` argument now reaches the
+formatter:
+
+```csharp
+sealed class HebrewMonths : DefaultCldrProvider
+{
+    public override string[]? GetMonthNames(string locale, string style, string? calendar)
+        => calendar == "hebrew" ? MyHebrewNames(style) : base.GetMonthNames(locale, style, calendar);
+}
+
+var engine = new Engine(options => options.Intl.CldrProvider = new HebrewMonths());
+engine.Evaluate("new Intl.DateTimeFormat('en-US-u-ca-hebrew', { month: 'long', timeZone: 'UTC' })" +
+                ".format(Date.UTC(2024, 0, 15))");   // 5.0: "5"   5.x: "Shevat"
+```
+
+The array is indexed by the calendar's month number, so a thirteen-month calendar answers with thirteen
+names — one more than `DateTimeFormatInfo` holds, which is why this lane reads the provider directly rather
+than the names `Intl.DateTimeFormat` seeds into its own `DateTimeFormatInfo`.
+
+`DefaultCldrProvider.GetMonthNames` changed with it: its names come from `CultureInfo.DateTimeFormat` and
+those are the twelve Gregorian months, so it now answers `null` for a calendar counting its own instead of
+handing back Gregorian names under that calendar's name. A derived provider that delegates the calendars it
+does not handle gets "no data" where it used to get a wrong answer.
+
+**What could break:** a script comparing formatted output against a hard-coded numeric month for `buddhist`,
+`japanese` or `roc`. There is no option to restore the number; format with `month: 'numeric'`, which was
+always the numeric format and is unchanged.
+
 ## 5. New in v5
 
 Everything in the table below is opt-in: nothing in it is installed unless the host asks for it, so


### PR DESCRIPTION
Closes #3574.

`new Intl.DateTimeFormat('en-US-u-ca-buddhist', { month: 'long', timeZone: 'UTC' }).format(Date.UTC(2024, 0, 15))` returned `"1"`. [`table-datetimeformat-components`](https://tc39.es/ecma402/#table-datetimeformat-components) makes `"long"`, `"short"` and `"narrow"` *textual* month formats, and a formatter is not free to answer one of them with a number.

Measured against Node 24 / ICU 78.3 for `{ month: 'long' }` on `Date.UTC(2024, 0, 15)`, `en-US`:

| calendar | ICU | before | after |
| --- | --- | --- | --- |
| `gregory` | January | January | January |
| `buddhist` | January | **1** | January |
| `japanese` | January | **1** | January |
| `roc` | January | **1** | January |
| `islamic-*` | Rajab | 7 | 7 |
| `hebrew` | Shevat | 5 | 5 |
| `persian` | Dey | 10 | 10 |
| `coptic` | Toba | 5 | 5 |
| `ethiopic` / `ethioaa` | Ter | 5 | 5 |
| `indian` | Pausa | 10 | 10 |
| `chinese` / `dangi` | Twelfth Month | 12 | 12 |

The issue reports the `month` option; the same defect was in the `dateStyle` lane, whose `FormatOverride` said so in as many words — *"a textual month run has no name left to write"*. `dateStyle: 'long'` for `buddhist` wrote `"1 15, 2567"`.

## Two calendar classes, two rules

**Calendars counting the Gregorian months** — `gregory`, `iso8601`, `buddhist`, `japanese`, `roc`. `buddhist`, `japanese` and `roc` differ from `gregory` in era and year only, so their month number *is* the Gregorian month number: `ResolveCalendarFieldsForFormatting` was computing `month = dateTime.Month; day = dateTime.Day;` — values equal to what the Gregorian lane writes anyway — and the mere presence of the override is what forced the number. It now overrides the **year alone**. Those three then write the very name `gregory` writes, through the same code: the locale's own name, a host's if `ApplyProviderNames` seeded one, and the narrow form `ApplyNarrowNames` put in the abbreviated slot — in both the component lane and the pattern lane, with no new lookup anywhere. ICU writes "January" for all four.

**Calendars counting months of their own** — everything else, this engine's or a host's. A name for one has to come from data that knows that calendar, which is what [`ICldrProvider.GetMonthNames`](https://github.com/sebastienros/jint/blob/main/Jint/Native/Intl/ICldrProvider.cs) takes its `calendar` argument for; it had **no reachable effect through `Intl` at all**. Both lanes now read it, once per formatter per style, indexed by the calendar's month number:

```csharp
sealed class HebrewMonths : DefaultCldrProvider
{
    public override string[]? GetMonthNames(string locale, string style, string? calendar)
        => calendar == "hebrew" ? MyHebrewNames(style) : base.GetMonthNames(locale, style, calendar);
}
// "5"  ->  "Shevat", for month: 'long' and for dateStyle: 'long' alike
```

The array is indexed by month number, so a thirteen-month calendar answers thirteen names — one more than `DateTimeFormatInfo`'s month arrays hold, which is why the answer is read from the provider rather than out of the formatter's own arrays. That is also this PR's first reachable use of #3579's calendar-aware cache key.

**Where no name source exists, the number stands.** Jint ships no month-name data for these calendars; a number is never a *wrong* name, it is what every release so far wrote, and it is what ICU itself writes for `narrow` on every one of them (`islamic-civil` narrow is `"7"`, `hebrew` narrow is `"5"`). Wiring .NET's own `HebrewCalendar` / `PersianCalendar` / `UmAlQuraCalendar` was considered and declined: `en-US` has none of them in `OptionalCalendars` so the issue's own case would not be served; .NET has no Coptic, Ethiopic or Indian calendar at all; and its Hebrew month naming shifts between leap and common years against a numbering Jint computes elsewhere — a second calendar underneath the one `TryPinGregorianCalendar` exists to keep out.

`DefaultCldrProvider.GetMonthNames` stops answering for a calendar its names are not for. It reads `CultureInfo.DateTimeFormat`, whose names are the twelve Gregorian months, so it answers for the five calendars that count them and `null` otherwise. A derived provider that handles some calendars and delegates the rest now gets "no data" where it used to get "May" under the name Shevat.

## test262

`Jint.Tests.Test262`'s `IcuCldrProvider` delegated month names to .NET too, so the harness had no names for these calendars either. It now reads `calendar/<key>/monthNames/format/<width>` out of the CLDR data ICU4N ships, falling back to `root` for the calendars an `en` bundle carries no month table for — which is what ICU itself resolves to for them.

That removes four exclusions, the `toLocaleString/dateStyle` tests for `Instant`, `PlainDate`, `PlainDateTime` and `ZonedDateTime`, which assert `"Ramadan"` for `en-u-ca-islamic-tbla`. All four were verified failing on `main` with the same settings file, so the removal is earned by this change rather than stale.

`PlainMonthDay` and `PlainYearMonth` stay excluded with a corrected comment: their month-name assertions pass now, and what still fails is a separate defect — a `dateStyle` writing `PlainMonthDay`'s reference year and `PlainYearMonth`'s reference day. Filed separately.

**102,545 / 0 / 143 of 102,688**, from 102,537 / 0 / 151. Total unchanged; eight cases moved from skipped to passing.

## Verification

- Failing first, identically on `net472`, `net8.0` and `net10.0`: **26 failed, 24 passed of 50**. After: **52 / 52** on all three (two cases added for the pattern lane).
- `dotnet build -c Release` and `dotnet test -c Release` green across the solution, `Jint.Tests.PublicInterface` included (3363 / 3353 / 2730 on net10.0 / net8.0 / net472).
- The only red in a full run was two 30-second timeouts that landed on a different test each time (`staging/sm/Array/toSpliced-dense.js` once, `intl402/supportedLocalesOf-unicode-extensions-ignored.js` the next) and passed in isolation in 3 s — machine load, not this change.

Migration guide: [§4.102](docs/v5-migration.md).
