### PR TITLE
Temporal: a dateStyle writes only the fields a year-month or a month-day has

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -213,12 +213,6 @@
 
     // === INTL402 TEMPORAL EXCLUSIONS ===
 
-    // The month-name half of these two passes; what still fails is the last assertion of each, that a
-    // dateStyle writes neither PlainMonthDay's reference year nor PlainYearMonth's reference day. Removed
-    // by making toLocaleString drop the reference field from the pattern a dateStyle resolves to.
-    "intl402/Temporal/PlainMonthDay/prototype/toLocaleString/dateStyle.js",
-    "intl402/Temporal/PlainYearMonth/prototype/toLocaleString/dateStyle.js",
-
     // Remaining intl402/Temporal calendar failures
     "intl402/DateTimeFormat/prototype/formatToParts/compare-to-temporal-lunisolar.js",
     "intl402/Temporal/PlainDate/from/roundtrip-from-property-bag.js",

--- a/Jint.Tests/Runtime/IntlTests.cs
+++ b/Jint.Tests/Runtime/IntlTests.cs
@@ -1360,6 +1360,77 @@ public class IntlTests
     }
 
     /// <summary>
+    /// <see href="https://tc39.es/proposal-temporal/#sec-adjustdatetimestyleformat">AdjustDateTimeStyleFormat</see>
+    /// narrows the pattern a <c>dateStyle</c> resolved to down to the fields the value has, so neither the
+    /// reference year a <c>Temporal.PlainMonthDay</c> carries nor the reference day a
+    /// <c>Temporal.PlainYearMonth</c> carries is written.
+    /// </summary>
+    [TestCase("en-US", "full", "August 2026", "August 27")]
+    [TestCase("en-US", "long", "August 2026", "August 27")]
+    [TestCase("en-US", "medium", "Aug 2026", "Aug 27")]
+    [TestCase("en-US", "short", "8/26", "8/27")]
+    [TestCase("de-DE", "full", "August 2026", "27. August")]
+    [TestCase("de-DE", "short", "08.2026", "27.08")]
+    [TestCase("fr-FR", "full", "août 2026", "27 août")]
+    [TestCase("ja-JP", "full", "2026年8月", "8月27日")]
+    [TestCase("pt-PT", "full", "agosto de 2026", "27 de agosto")]
+    public void ADateStyleWritesOnlyTheFieldsAYearMonthOrAMonthDayHas(
+        string locale, string dateStyle, string yearMonth, string monthDay)
+    {
+        var script = $$"""
+            (function () {
+              const ym = new Temporal.PlainYearMonth(2026, 8, 'gregory', 27);
+              const md = new Temporal.PlainMonthDay(8, 27, 'gregory', 2222);
+              const options = { dateStyle: '{{dateStyle}}' };
+              const f = new Intl.DateTimeFormat('{{locale}}', options);
+              return [
+                ym.toLocaleString('{{locale}}', options),
+                f.format(ym),
+                f.formatToParts(ym).map(p => p.value).join(''),
+                md.toLocaleString('{{locale}}', options),
+                f.format(md),
+                f.formatToParts(md).map(p => p.value).join('')
+              ].join('|');
+            })()
+            """;
+
+        var expected = string.Join("|", yearMonth, yearMonth, yearMonth, monthDay, monthDay, monthDay);
+        _engine.Evaluate(script).AsString().Should().Be(expected);
+    }
+
+    /// <summary>
+    /// The narrowing takes the fields out of the pattern the style resolved to, so what is left is still the
+    /// locale's own: its field order, its own separators, and the field widths the style itself asked for -
+    /// a two-digit year under <c>"short"</c>, the month written out under <c>"long"</c>.
+    /// </summary>
+    [Test]
+    public void ANarrowedDateStyleKeepsTheLocalesOwnShape()
+    {
+        const string Script = """
+            (function () {
+              const ym = new Temporal.PlainYearMonth(2026, 8, 'gregory', 27);
+              const md = new Temporal.PlainMonthDay(8, 27, 'gregory', 2222);
+              const wrong = [];
+              for (const locale of ['en-US', 'en-GB', 'de-DE', 'fr-FR', 'ja-JP', 'pt-PT', 'ru-RU', 'hu-HU', 'sv-SE']) {
+                for (const dateStyle of ['full', 'long', 'medium', 'short']) {
+                  const y = ym.toLocaleString(locale, { dateStyle });
+                  const m = md.toLocaleString(locale, { dateStyle });
+                  if (y.includes('27')) wrong.push(locale + ' ' + dateStyle + ' year-month wrote the reference day: ' + y);
+                  if (m.includes('2222')) wrong.push(locale + ' ' + dateStyle + ' month-day wrote the reference year: ' + m);
+                  if (!y.includes('26')) wrong.push(locale + ' ' + dateStyle + ' year-month lost the year: ' + y);
+                  if (!m.includes('27')) wrong.push(locale + ' ' + dateStyle + ' month-day lost the day: ' + m);
+                  if (/^[\s\p{P}]|[\s,;\/-]$/u.test(y)) wrong.push(locale + ' ' + dateStyle + ' year-month kept a stray separator: ' + y);
+                  if (/^[\s\p{P}]|[\s,;\/-]$/u.test(m)) wrong.push(locale + ' ' + dateStyle + ' month-day kept a stray separator: ' + m);
+                }
+              }
+              return wrong.join(' | ');
+            })()
+            """;
+
+        _engine.Evaluate(Script).AsString().Should().BeEmpty();
+    }
+
+    /// <summary>
     /// <see href="https://tc39.es/ecma402/#sec-resolveoptions">ResolveOptions</see> step 3 reads the
     /// <c>localeMatcher</c> option through <c>GetOption</c>, which admits only <c>"lookup"</c> and
     /// <c>"best fit"</c> and raises a <c>RangeError</c> for anything else. <c>Intl.PluralRules</c> left the

--- a/Jint.Tests/SpecAnchors.txt
+++ b/Jint.Tests/SpecAnchors.txt
@@ -14,8 +14,8 @@
 # The 'verified' date is the only thing bounding anchor rot: a clause renamed upstream keeps
 # resolving here until somebody re-runs that.
 #
-verified: 2026-08-31
-anchors: 1251
+verified: 2026-09-02
+anchors: 1252
 absent: 2
 !proposal-decorators sec-autoaccessordefinitionevaluation  # tc39.es still renders the 2018 descriptor design, which has no such clause
 !proposal-decorators sec-createdecoratorcontextobject  # tc39.es still renders the 2018 descriptor design, which has no such clause
@@ -1051,6 +1051,7 @@ proposal-source-phase-imports sec-%abstractmodulesource%
 proposal-source-phase-imports sec-ContinueDynamicImport
 proposal-source-phase-imports sec-module-source-objects
 proposal-source-phase-imports sec-source-text-module-record-initialize-environment
+proposal-temporal sec-adjustdatetimestyleformat
 proposal-temporal sec-applyunsignedroundingmode
 proposal-temporal sec-checkisodaysrange
 proposal-temporal sec-createdatetimeformat

--- a/Jint/Native/Intl/DateTimeFormatConstructor.cs
+++ b/Jint/Native/Intl/DateTimeFormatConstructor.cs
@@ -460,6 +460,16 @@ internal sealed partial class DateTimeFormatConstructor : Constructor
         // stays the only one anything converts to.
         var calendarPinned = TryPinGregorianCalendar(dateTimeFormatInfo, culture);
 
+        // https://tc39.es/proposal-temporal/#sec-adjustdatetimestyleformat - a dateStyle resolves to the
+        // locale's own date pattern, and the format a year-month or a month-day is written with is that
+        // pattern narrowed to the fields the type carries. Which type asked is what required says.
+        var dateStyleFields = required switch
+        {
+            DateTimeRequired.YearMonth => DateStyleFields.YearMonth,
+            DateTimeRequired.MonthDay => DateStyleFields.MonthDay,
+            _ => DateStyleFields.All,
+        };
+
         // https://tc39.es/ecma402/#sec-formatdatetimepattern — the month, weekday and day-period names a
         // pattern writes are locale data. Every one of them is produced by handing a .NET pattern to
         // this culture, so seeding the culture's own tables is the one place a host's names reach all of
@@ -523,7 +533,8 @@ internal sealed partial class DateTimeFormatConstructor : Constructor
             timeZoneName,
             hasExplicitFormatComponents,
             dateTimeFormatInfo,
-            culture);
+            culture,
+            dateStyleFields);
     }
 
     /// <summary>

--- a/Jint/Native/Intl/DateTimeFormatPrototype.cs
+++ b/Jint/Native/Intl/DateTimeFormatPrototype.cs
@@ -279,34 +279,20 @@ internal sealed partial class DateTimeFormatPrototype : Prototype
                 effectiveDateStyle = null;
             }
 
-            // For PlainYearMonth/PlainMonthDay, convert dateStyle to component-based formatting
-            // because these types need specific fields omitted (day for YearMonth, year for MonthDay)
-            if (effectiveDateStyle != null && required is DateTimeRequired.YearMonth or DateTimeRequired.MonthDay)
+            // https://tc39.es/proposal-temporal/#sec-adjustdatetimestyleformat - a year-month and a month-day
+            // are written with the pattern the dateStyle resolved to, narrowed to the fields they have. The
+            // narrowing is the formatter's, so that both lanes into it - this one and toLocaleString - write
+            // the locale's own field widths and separators rather than an approximation of them.
+            var dateStyleFields = required switch
             {
-                var isShort = string.Equals(effectiveDateStyle, "short", StringComparison.Ordinal);
-                var isMedium = string.Equals(effectiveDateStyle, "medium", StringComparison.Ordinal);
-                string? year = null, month = null, day = null;
+                DateTimeRequired.YearMonth => DateStyleFields.YearMonth,
+                DateTimeRequired.MonthDay => DateStyleFields.MonthDay,
+                _ => DateStyleFields.All,
+            };
 
-                if (required == DateTimeRequired.YearMonth)
-                {
-                    year = "numeric";
-                    month = isShort ? "numeric" : isMedium ? "short" : "long";
-                }
-                else // MonthDay
-                {
-                    month = isShort ? "numeric" : isMedium ? "short" : "long";
-                    day = "numeric";
-                }
-
-                return new JsDateTimeFormat(
-                    _engine, dtf._prototype!, dtf.Locale, dtf.Calendar, dtf.ResolvedNumberingSystem,
-                    dtf.TimeZone, dtf.HourCycle, null, null,
-                    null, null, year, month, day, null, null, null, null, null,
-                    null, false, dtf.DateTimeFormatInfo, dtf.CultureInfo);
-            }
-
-            // Return modified DTF if styles were stripped, otherwise return as-is
-            if (!string.Equals(effectiveDateStyle, dtf.DateStyle, StringComparison.Ordinal)
+            // Return modified DTF if styles were stripped or fields narrowed, otherwise return as-is
+            if (dateStyleFields != DateStyleFields.All
+                || !string.Equals(effectiveDateStyle, dtf.DateStyle, StringComparison.Ordinal)
                 || !string.Equals(effectiveTimeStyle, dtf.TimeStyle, StringComparison.Ordinal))
             {
                 return new JsDateTimeFormat(
@@ -315,7 +301,7 @@ internal sealed partial class DateTimeFormatPrototype : Prototype
                     dtf.Weekday, dtf.Era, dtf.Year, dtf.Month, dtf.Day, dtf.DayPeriod,
                     dtf.Hour, dtf.Minute, dtf.Second, dtf.FractionalSecondDigits,
                     dtf.TimeZoneName, dtf.HasExplicitFormatComponents,
-                    dtf.DateTimeFormatInfo, dtf.CultureInfo);
+                    dtf.DateTimeFormatInfo, dtf.CultureInfo, dateStyleFields);
             }
             return dtf;
         }

--- a/Jint/Native/Intl/JsDateTimeFormat.cs
+++ b/Jint/Native/Intl/JsDateTimeFormat.cs
@@ -6,6 +6,29 @@ using Jint.Native.Temporal;
 namespace Jint.Native.Intl;
 
 /// <summary>
+/// The date fields a <c>dateStyle</c>'s pattern may write, which is the <c>allowedOptions</c> of
+/// https://tc39.es/proposal-temporal/#sec-adjustdatetimestyleformat.
+/// </summary>
+/// <remarks>
+/// A <c>dateStyle</c> resolves to the locale's own date pattern, which carries every field a full date
+/// has. A <c>Temporal.PlainYearMonth</c> and a <c>Temporal.PlainMonthDay</c> do not have all of them, and
+/// the fields they lack are held as reference values that are no part of the value: writing them puts a
+/// year of 1972 beside a month and a day. The format such a value is written with is that pattern narrowed
+/// to the fields the type carries.
+/// </remarks>
+internal enum DateStyleFields
+{
+    /// <summary>Every field the locale's own pattern carries.</summary>
+    All,
+
+    /// <summary>Era, year and month - what a <c>Temporal.PlainYearMonth</c> has.</summary>
+    YearMonth,
+
+    /// <summary>Month and day - what a <c>Temporal.PlainMonthDay</c> has.</summary>
+    MonthDay,
+}
+
+/// <summary>
 /// https://tc39.es/ecma402/#datetimeformat-objects
 /// Represents an Intl.DateTimeFormat instance with locale-aware date/time formatting.
 /// </summary>
@@ -34,7 +57,8 @@ internal sealed class JsDateTimeFormat : ObjectInstance
         string? timeZoneName,
         bool hasExplicitFormatComponents,
         DateTimeFormatInfo dateTimeFormatInfo,
-        CultureInfo cultureInfo) : base(engine)
+        CultureInfo cultureInfo,
+        DateStyleFields dateStyleFields = DateStyleFields.All) : base(engine)
     {
         _prototype = prototype;
         Locale = locale;
@@ -58,12 +82,16 @@ internal sealed class JsDateTimeFormat : ObjectInstance
         HasExplicitFormatComponents = hasExplicitFormatComponents;
         DateTimeFormatInfo = dateTimeFormatInfo;
         CultureInfo = cultureInfo;
+        _dateStyleFields = dateStyleFields;
     }
 
     private readonly Data.ResolvedNumberingSystem _numberingSystem;
 
     /// <summary>The dateStyle pattern, split once: a formatter's style and locale never change.</summary>
     private List<PatternRun>? _dateStyleRuns;
+
+    /// <summary>Which of that pattern's date fields the value this formatter writes actually has.</summary>
+    private readonly DateStyleFields _dateStyleFields;
 
     internal string Locale { get; }
     internal string? Calendar { get; }
@@ -1008,10 +1036,21 @@ internal sealed class JsDateTimeFormat : ObjectInstance
     };
 
     /// <summary>
+    /// The pattern this formatter's <c>dateStyle</c> writes: the locale's own styled pattern, narrowed to
+    /// the fields the value being formatted has.
+    /// </summary>
+    private List<PatternRun> GetDateStyleRuns()
+    {
+        var runs = GetLocaleDateStyleRuns();
+        NarrowToDateStyleFields(runs);
+        return runs;
+    }
+
+    /// <summary>
     /// https://tc39.es/ecma402/#sec-date-time-style-format - the pattern a <c>dateStyle</c> formats with comes
     /// from the locale's own data, which on .NET is that culture's long or short date pattern.
     /// </summary>
-    private List<PatternRun> GetDateStyleRuns()
+    private List<PatternRun> GetLocaleDateStyleRuns()
     {
         var formatInfo = CultureInfo.DateTimeFormat;
 
@@ -1163,6 +1202,134 @@ internal sealed class JsDateTimeFormat : ObjectInstance
     /// <summary>The marks a date pattern uses to set the weekday off from the rest of the date.</summary>
     private static bool IsListSeparator(char c)
         => c is ',' or ';' or '\u060C' or '\u3001' or '\u00B7';
+
+    /// <summary>
+    /// https://tc39.es/proposal-temporal/#sec-adjustdatetimestyleformat - drops from a styled pattern every
+    /// field the value being formatted does not have, along with the punctuation that was only there to set
+    /// that field off from what remains.
+    /// </summary>
+    /// <remarks>
+    /// ICU reaches the same answer by re-deriving a pattern for the narrowed skeleton, which is data this
+    /// engine has no equivalent of. Taking the fields out of the pattern the style already resolved to keeps
+    /// the locale's own field widths and order, which is what the operation inherits from its base format
+    /// either way: English "dddd, MMMM d, yyyy" becomes "MMMM yyyy" for a year-month and "MMMM d" for a
+    /// month-day, its "M/d/yy" becomes "M/yy" and "M/d", and Japanese "yyyy年M月d日" becomes "yyyy年M月".
+    /// </remarks>
+    private void NarrowToDateStyleFields(List<PatternRun> runs)
+    {
+        if (_dateStyleFields == DateStyleFields.All)
+        {
+            return;
+        }
+
+        // Neither type has a weekday, and the weekday is the one field whose punctuation is already known.
+        var startedWithField = runs.Count > 0 && !runs[0].IsLiteral;
+        RemoveWeekdayRun(runs);
+
+        var i = 0;
+        while (i < runs.Count)
+        {
+            if (runs[i].IsLiteral || IsAllowedDateStyleField(runs[i]))
+            {
+                i++;
+                continue;
+            }
+
+            RemoveFieldRun(runs, i);
+        }
+
+        TrimEdgeLiterals(runs, startedWithField);
+    }
+
+    /// <summary>Whether a pattern field is one the value being formatted has.</summary>
+    private bool IsAllowedDateStyleField(in PatternRun run) => run.Field switch
+    {
+        // A run of three or more 'd' is the weekday, which neither type has.
+        'd' => run.Length <= 2 && _dateStyleFields == DateStyleFields.MonthDay,
+        'M' => true,
+        'y' or 'g' => _dateStyleFields == DateStyleFields.YearMonth,
+        _ => false,
+    };
+
+    /// <summary>
+    /// Removes one field run together with the literal that was only there because of it, which is the one
+    /// on the side the field was joined to the rest of the pattern from.
+    /// </summary>
+    private static void RemoveFieldRun(List<PatternRun> runs, int index)
+    {
+        runs.RemoveAt(index);
+
+        // Text on the right went with the field it was written against, whether it separated that field from
+        // what follows or marked the field itself - Japanese keeps the month's 月 and loses the day's 日.
+        if (index < runs.Count && runs[index].IsLiteral)
+        {
+            runs.RemoveAt(index);
+            return;
+        }
+
+        if (index > 0 && runs[index - 1].IsLiteral)
+        {
+            // Nothing follows, so the text before the field either separated it from what remains, and goes,
+            // or is a mark the field before it is written with, and stays.
+            var literal = runs[index - 1].Literal!;
+            if (IsFieldSeparator(literal))
+            {
+                runs.RemoveAt(index - 1);
+            }
+            else
+            {
+                ReplaceLiteralRun(runs, index - 1, literal.TrimEnd());
+            }
+        }
+    }
+
+    /// <summary>
+    /// Whether a literal only stood between two fields, rather than being text one of them is written with.
+    /// </summary>
+    private static bool IsFieldSeparator(string literal)
+    {
+        foreach (var c in literal)
+        {
+            if (char.IsLetter(c))
+            {
+                // A word set off by a space - Portuguese "d 'de' MMMM" - separates; a mark written straight
+                // against a field is part of how that field reads.
+                return char.IsWhiteSpace(literal[0]);
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>Drops the separators a narrowed pattern is left starting or ending with.</summary>
+    /// <remarks>
+    /// A pattern that began with a field and now begins with text is beginning with what set that field off,
+    /// whatever it is made of - Thai writes its weekday and the day as one phrase - so the whole of it goes.
+    /// Nothing similar holds at the other end, where the text after the last field is that field's own mark.
+    /// </remarks>
+    private static void TrimEdgeLiterals(List<PatternRun> runs, bool startedWithField)
+    {
+        if (runs.Count > 0 && runs[0].IsLiteral && (startedWithField || IsFieldSeparator(runs[0].Literal!)))
+        {
+            runs.RemoveAt(0);
+        }
+
+        var last = runs.Count - 1;
+        if (last < 0 || !runs[last].IsLiteral)
+        {
+            return;
+        }
+
+        var literal = runs[last].Literal!;
+        if (IsFieldSeparator(literal))
+        {
+            runs.RemoveAt(last);
+        }
+        else
+        {
+            ReplaceLiteralRun(runs, last, literal.TrimEnd());
+        }
+    }
 
     /// <summary>
     /// Renders one pattern into parts. A calendar .NET is not counting this date in contributes numeric
@@ -1841,7 +2008,7 @@ internal sealed class JsDateTimeFormat : ObjectInstance
                 : ChineseCalendarHelper.GetDangiDate(dateTime);
 
             var isFull = string.Equals(DateStyle, "full", StringComparison.Ordinal);
-            if (isFull)
+            if (isFull && _dateStyleFields == DateStyleFields.All)
             {
                 result.Add(new DateTimePart("weekday", dateTime.ToString("dddd", CultureInfo)));
                 result.Add(new DateTimePart("literal", ", "));
@@ -1868,13 +2035,23 @@ internal sealed class JsDateTimeFormat : ObjectInstance
 
         // Month
         result.Add(new DateTimePart("month", date.Month.ToString(CultureInfo)));
+
+        // Day - a year-month has none, and writing one fills it from the reference value.
+        if (_dateStyleFields != DateStyleFields.YearMonth)
+        {
+            result.Add(new DateTimePart("literal", "/"));
+            result.Add(new DateTimePart("day", date.Day.ToString(CultureInfo)));
+        }
+
+        // Year - a month-day has none, for the same reason.
+        if (_dateStyleFields == DateStyleFields.MonthDay)
+        {
+            return;
+        }
+
         result.Add(new DateTimePart("literal", "/"));
 
-        // Day
-        result.Add(new DateTimePart("day", date.Day.ToString(CultureInfo)));
-        result.Add(new DateTimePart("literal", "/"));
-
-        // Year - use relatedYear and yearName for lunisolar calendars
+        // Use relatedYear and yearName for lunisolar calendars
         if (shortFormat)
         {
             result.Add(new DateTimePart("relatedYear", (date.RelatedYear % 100).ToString("D2", CultureInfo)));

--- a/Jint/Native/Temporal/PlainMonthDay/PlainMonthDayPrototype.cs
+++ b/Jint/Native/Temporal/PlainMonthDay/PlainMonthDayPrototype.cs
@@ -298,10 +298,10 @@ internal sealed partial class PlainMonthDayPrototype : Prototype
     private JsValue ToLocaleString(JsValue thisObject, JsValue locales, JsValue options)
     {
         var md = ValidatePlainMonthDay(thisObject);
-        // Per spec: CreateDateTimeFormat with required=~date~, defaults=~date~
-        // But for PlainMonthDay, we use month-day specific defaults (no year)
+        // CreateDateTimeFormat with required=~month-day~, defaults=~month-day~: the month and the day are the
+        // fields this type has, and the reference year it carries beside them is no part of the value.
         var dtf = _realm.Intrinsics.DateTimeFormat.CreateDateTimeFormat(
-            locales, options, required: Intl.DateTimeRequired.Date, defaults: Intl.DateTimeDefaults.MonthDay);
+            locales, options, required: Intl.DateTimeRequired.MonthDay, defaults: Intl.DateTimeDefaults.MonthDay);
 
         // Calendar mismatch check: PlainMonthDay calendar must match DTF calendar exactly
         var cal = md.Calendar;

--- a/Jint/Native/Temporal/PlainYearMonth/PlainYearMonthPrototype.cs
+++ b/Jint/Native/Temporal/PlainYearMonth/PlainYearMonthPrototype.cs
@@ -643,10 +643,10 @@ internal sealed partial class PlainYearMonthPrototype : Prototype
     private JsValue ToLocaleString(JsValue thisObject, JsValue locales, JsValue options)
     {
         var ym = ValidatePlainYearMonth(thisObject);
-        // Per spec: CreateDateTimeFormat with required=~date~, defaults=~date~
-        // But for PlainYearMonth, we use year-month specific defaults (no day)
+        // CreateDateTimeFormat with required=~year-month~, defaults=~year-month~: the year and the month are
+        // the fields this type has, and the reference day it carries beside them is no part of the value.
         var dtf = _realm.Intrinsics.DateTimeFormat.CreateDateTimeFormat(
-            locales, options, required: Intl.DateTimeRequired.Date, defaults: Intl.DateTimeDefaults.YearMonth);
+            locales, options, required: Intl.DateTimeRequired.YearMonth, defaults: Intl.DateTimeDefaults.YearMonth);
 
         // Calendar mismatch check: PlainYearMonth calendar must match DTF calendar exactly
         var cal = ym.Calendar;

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -4743,6 +4743,34 @@ which still cannot reopen what the profile closed.
 **What could break:** an engine that declared the profile from a callback did not exist — the construction
 threw. The message names the fix: call `options.ForUntrustedCode(limits)` before `new Engine(options)`.
 
+### 4.107 A `dateStyle` writes only the fields a year-month or a month-day has ([#3590](https://github.com/sebastienros/jint/issues/3590))
+
+`Temporal.PlainMonthDay` carries a reference year and `Temporal.PlainYearMonth` a reference day, neither of
+which is part of the value. A `dateStyle` resolves to the locale's own full date pattern, and both types
+filled that pattern's remaining field from their reference value, so a month-day printed a year of 1972 and a
+year-month printed a day. The pattern is now narrowed to the fields the type has, which is what
+[AdjustDateTimeStyleFormat](https://tc39.es/proposal-temporal/#sec-adjustdatetimestyleformat) says and what
+ICU, and therefore V8, write:
+
+```js
+new Temporal.PlainMonthDay(5, 31, 'gregory', 2222)
+    .toLocaleString('en', { dateStyle: 'full' });    // 5.0: "Friday, May 31, 2222"   5.x: "May 31"
+
+new Temporal.PlainYearMonth(2024, 5, 'gregory', 31)
+    .toLocaleString('en', { dateStyle: 'short' });   // 5.0: "5/31/24"                   5.x: "5/24"
+```
+
+`Intl.DateTimeFormat.prototype.format` and `formatToParts` narrow through the same code, so the two lanes now
+agree for these two types; the lane they took before dropped the same fields but rebuilt the rest from
+hard-coded component options, writing `"August, 2026"` where the locale's pattern has no comma and a
+four-digit year where `dateStyle: 'short'` asks for two. `Temporal.Instant`, `PlainDate`, `PlainDateTime`,
+`PlainTime` and `ZonedDateTime` are unaffected: they have every field their pattern writes.
+
+**What could break:** a script comparing a styled `PlainYearMonth` or `PlainMonthDay` against a hard-coded
+string. There is no option to restore the old output. To write a year beside a month-day, or a day beside a
+year-month, name the fields instead of the style — `{ year: 'numeric', month: 'long', day: 'numeric' }` — and
+supply the value that should stand in the field the type does not have.
+
 ## 5. New in v5
 
 Everything in the table below is opt-in: nothing in it is installed unless the host asks for it, so


### PR DESCRIPTION
`Temporal.PlainMonthDay` carries a reference year and `Temporal.PlainYearMonth` a reference day, neither of which is part of the value. A `dateStyle` resolves to the locale's own full date pattern, and `toLocaleString` filled that pattern's remaining field from the reference value:

```js
new Temporal.PlainMonthDay(5, 31, 'gregory', 2222).toLocaleString('en', { dateStyle: 'full' });
// before: "Friday, May 31, 2222"   after: "May 31"

new Temporal.PlainYearMonth(2024, 5, 'gregory', 31).toLocaleString('en', { dateStyle: 'short' });
// before: "5/31/24"                after: "5/24"
```

[AdjustDateTimeStyleFormat](https://tc39.es/proposal-temporal/#sec-adjustdatetimestyleformat) says the format such a value is written with is the styled pattern narrowed to the fields the type has — «era, year, month» for a year-month, «month, day» for a month-day. Node 24 agrees on every case below; `Instant`, `PlainDate`, `PlainDateTime`, `PlainTime` and `ZonedDateTime` are untouched, because they have every field their pattern writes.

### Where the narrowing happens

In `JsDateTimeFormat`, where the styled pattern is already split into field runs — so what is left is still the locale's own field widths, order and separators, which is what the operation inherits from its base format either way. ICU reaches the same answer by re-deriving a pattern for the narrowed skeleton, which is data this engine has no equivalent of.

| locale | pattern | year-month | month-day |
| --- | --- | --- | --- |
| `en-US` full | `dddd, MMMM d, yyyy` | `August 2026` | `August 27` |
| `en-US` short | `M/d/yy` | `8/26` | `8/27` |
| `de-DE` full | `dddd, d. MMMM yyyy` | `August 2026` | `27. August` |
| `ja-JP` full | `yyyy年M月d日dddd` | `2026年8月` | `8月27日` |
| `pt-PT` full | `dddd, d 'de' MMMM 'de' yyyy` | `agosto de 2026` | `27 de agosto` |

Removing a field takes with it the punctuation that was only there to set it off, and the three cases that decides are all real: text on the right of a removed field went with that field (Japanese keeps the month's 月 and loses the day's 日); text on the left goes only when it separated rather than marked, so a word set off by a space is dropped (`'de'`) and a mark written straight against the previous field is kept; and a pattern that began with a field and now begins with text is beginning with residue, which is what Thai's `ที่` — its weekday and day are one phrase — needed.

### The two lanes now agree

`Intl.DateTimeFormat.prototype.format` and `formatToParts` already dropped the right fields for these two types, but rebuilt the rest from hard-coded component options: `"August, 2026"` where the locale's pattern has no comma, and a four-digit year where `dateStyle: 'short'` asks for two. That approximation is gone — both lanes narrow through the formatter, so `ym.toLocaleString(locale, o)`, `f.format(ym)` and `f.formatToParts(ym).join('')` are one answer. `toLocaleString` also passes the `required` the spec gives it, `~year-month~` / `~month-day~` rather than `~date~`.

### Verification

**test262: 102,549 / 0 failed / 139 skipped of 102,688**, up four passes from 102,545 / 0 / 143 — entirely the two exclusions this removes:

```
intl402/Temporal/PlainMonthDay/prototype/toLocaleString/dateStyle.js
intl402/Temporal/PlainYearMonth/prototype/toLocaleString/dateStyle.js
```

Both were verified failing first with these settings on unmodified `main` (2b3b67e6), 4 cases, each on its last assertion only — `dateStyle: full should not format reference year at all` and `… reference day …`; their month-name assertions, `March` and `Ramadan`, already passed.

Two tests in `Jint.Tests/Runtime/IntlTests.cs`: nine exact-output cases across five locales and all four styles, and a sweep over nine locales asserting no reference field, no lost field and no stray separator. Ten cases, all ten failing on unmodified `main` on each of net472, net8.0 and net10.0, all ten passing here. Full `dotnet build -c Release` and `dotnet test -c Release` are green, `Jint.Tests.PublicInterface` included.

`docs/v5-migration.md` §4.107 records the output change. `Jint.Tests/SpecAnchors.txt` gains `sec-adjustdatetimestyleformat`, from a regeneration that re-verified all 1,252 anchors.

**No 4.x backport.** 4.x's `dateStyle` lane predates the pattern-run split this rests on, so nothing here applies to it; and its copies of these two tests would still fail their earlier month-name assertions, which pass on `main` only because of #3574 — also not on 4.x. A port would be a rewrite that removes no exclusion.

Closes #3590

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014W5mbjGhyvgAS4pivXoc4S
