### PR TITLE
DevTools: a client can reach an engine, and every command it sends crosses to the thread that owns it

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,6 +32,7 @@
     <PackageVersion Include="NUnit3TestAdapter" Version="6.3.0" />
     <PackageVersion Include="Okojo" Version="0.1.2-preview.1" />
     <PackageVersion Include="PublicApiGenerator" Version="11.5.4" />
+    <PackageVersion Include="PuppeteerSharp" Version="25.8.0" />
     <PackageVersion Include="SharpZipLib" Version="1.4.2" />
     <PackageVersion Include="SourceMaps" Version="0.3.0" />
     <PackageVersion Include="Spectre.Console.Cli" Version="0.55.0" />

--- a/Jint.DevTools/AGENTS.md
+++ b/Jint.DevTools/AGENTS.md
@@ -41,12 +41,69 @@ Everything downstream of that follows:
   the repository-root [`AGENTS.md`](../AGENTS.md#gotchas); this package must never be the thing that breaks
   them.
 
-The **dispatcher** that brings a transport thread's message to the engine thread arrives with the WebSocket
-transport (campaign P2): a mailbox the engine drains, in the two thread modes a host can be in —
-`HostOwned`, where the host already pumps the engine and the dispatcher only enqueues, and `LibraryOwned`,
-where the package owns a loop. Until it lands, a session runs on whichever thread pumped it, and
-`InProcessConnection` is the only transport. **State the rule in code you write now**; do not write
-something a dispatcher will have to undo.
+### The mailbox, which is how a command reaches the engine
+
+`Session/EngineDispatcher.cs` is **the only path from a transport thread to the engine**, and every domain
+that holds engine state is registered on a session that goes through it (`DevToolsSession.UseGateway`). The
+mechanism, in order:
+
+1. A transport thread parses the envelope, resolves the session, and — because that session has a gateway —
+   hands the request to `EngineDispatcher.DispatchAsync`, which enqueues it and waits.
+2. The enqueue calls `engine.Tasks.Post(Drain)`, the one engine entry a thread that does not own the engine
+   may call. It wakes whichever thread is pumping.
+3. `Drain` runs **on the engine thread, inside an ordinary event-loop job**, answers the command, and
+   completes the waiting task with the finished JSON.
+4. The transport thread writes that string. **No `JsValue` ever crosses.**
+
+Four consequences that are not negotiable:
+
+- **A command runs inside a job, so it may not drain.** `WaitForScheduledWork` and any promise unwrap that
+  pumps are forbidden — the pump's re-entrancy guard refuses them. `Runtime.evaluate` with `awaitPromise`
+  attaches reactions and completes from the job that runs them, which is V8's shape too.
+- **The drain must never throw.** It is a job on the host's own pump; an exception there erupts out of
+  `ProcessTasks` into the host. Every item catches everything and answers with it.
+- **A command that times out is answered, not cancelled.** `CommandTimeout` bounds the *client's* wait; the
+  item stays queued and still runs when the engine is next pumped. The two timeout messages are told apart
+  deliberately — an item nothing dequeued says `Engine is not being pumped`, one that started and did not
+  finish says `Command timed out` — because a host debugging the wrong one wastes an afternoon.
+- **Host work and protocol commands share the queue**, so a host's `target.Post` runs in order with the
+  commands around it. The single exception is `WaitForDebuggerOnStart`: host work is held and protocol
+  commands are not, because otherwise the command that ends the wait could never be answered.
+
+The two thread modes are `EngineTargetOptions.ThreadMode`. `HostOwned` (the default) is the host's own loop;
+`EngineTarget.Pump` is a convenience over `engine.Tasks.ProcessTasks()`, not a second mechanism.
+`LibraryOwned` starts one thread running drain → `ProcessTasks` → `WaitForScheduledWork`, and the host
+submits work with `Post`/`PostAsync`. A host-owned target that has to wait for a debugger waits by
+*pumping* (`WaitForDebugger`), because the command that releases it is answered on that very thread.
+
+### Targets and sessions
+
+A `DevToolsSession` is a node. The **root** owns the connection and parses every envelope; a **child** is
+what one attachment minted, carries the `sessionId` that reaches it, and writes through its root. A message
+naming a `sessionId` nothing answers to is `-32001 "Session with given id not found."` — Chrome's wording,
+pinned by test, and a different thing from `-32000`.
+
+Two paths open a conversation, and `Transport/WebSocketServerTransport.cs` decides between them *before* the
+upgrade, so a client that guessed is told rather than left holding a socket:
+
+- `/devtools/browser/<browserId>` is a `BrowserSession`: `Schema`, `Browser`, `Target`. **None of it touches
+  an engine**, so it has no gateway and answers on the transport thread.
+- `/devtools/page/<targetId>` is a `TargetSession` on the root node itself — no `sessionId` on any message —
+  carrying `Runtime` and no `Target` domain at all, because one engine has no target tree.
+
+Three decisions worth not relitigating:
+
+- **Flattened sessions only.** `Target.attachToTarget` and `Target.setAutoAttach` refuse `flatten: false`
+  with `-32000 "Only flatten protocol is supported"`. The wrapped model routes every message through
+  `Target.sendMessageToTarget`, and **no client in `tools/devtools-protocol/handshakes/` sends it** — so
+  that command stays unimplemented (`-32601`) rather than buying a second routing path for nobody.
+- **`setAutoAttach` on an attached session is a success that attaches nothing.** Clients walk down the
+  target tree by sending it on every session they are handed; an engine target has no children, and a
+  refusal there reads to a client as a broken target.
+- **A browser context is not something an engine target has.** `getBrowserContexts` answers an empty list;
+  `createBrowserContext` and `disposeBrowserContext` answer `-32000` with the reason. Minting an identifier
+  that partitions nothing would tell a client its next target was isolated when it is not. The page package
+  is where contexts start meaning something.
 
 ### The pause loop
 
@@ -133,7 +190,10 @@ method is overridden on a registered domain, and nothing else is. So the workflo
 exactly three steps — add the manifest entry, regenerate, override the virtual — and skipping any of them
 fails.
 
-Registration lives in one place, `Domains/BuiltInDomains.RegisterOn`, which is what those tests read.
+Registration lives in one place, `Domains/BuiltInDomains`, which is what those tests read. There are two
+lists there rather than one because there are two kinds of session — a browser conversation answers about
+the server, an attachment answers about one engine — and `ProtocolManifestTests` reads both. A domain
+registered on only one of them and checked against only the other is a manifest entry nothing verifies.
 
 ### The envelope and the error codes
 
@@ -181,14 +241,22 @@ this is public.
 
 ### Visibility, and what is public
 
-**Everything in this package is `internal` today, and the public API baseline is empty on purpose.** The
-first member promoted out of that is a diff somebody reads — see
+**The public surface is the host's door and nothing else**: `DevToolsServer`, `DevToolsServerOptions`,
+`EngineTarget`, `EngineTargetOptions`, `ThreadMode`, and the `UseDevTools` extension with its
+`DevToolsEngineOptions`. Everything else — every protocol type, every dispatch base, every session class —
+is `internal`, and the baseline in `Jint.Tests.DevTools/Verify/` is the diff somebody reads when that
+changes; see
 [`Jint.Tests.PublicInterface/AGENTS.md`](../Jint.Tests.PublicInterface/AGENTS.md#the-public-api-baselines)
-for how a baseline is accepted. When something is promoted it carries
-`[Experimental(DevToolsDiagnosticIds.ProtocolExtensionPoint)]`, i.e. `JINTDT001`, which says its shape
-follows a living upstream document rather than this repository's compatibility contract. That is a separate
-identifier from Jint's `JINT0001` because the two say different things, and a host suppressing one has
-decided nothing about the other.
+for how one is accepted.
+
+**None of that surface carries `[Experimental]`, and that is a decision.** `JINTDT001` says *the shape of
+this member follows a living upstream document rather than this repository's compatibility contract*, which
+is true of a generated data transfer object and false of a server, a target and an options bag: those are
+Jint's own shapes and keep Jint's own contract, with a `docs/v5-migration.md` row when they change. The
+first member that really does publish a protocol shape is the one that carries the attribute — putting it
+on the entry point instead would make every host write a `#pragma` to use the package at all, and would
+leave the identifier meaning nothing in particular. It is a separate identifier from Jint's `JINT0001`
+because those two also say different things, and a host suppressing one has decided nothing about the other.
 
 **There is deliberately no `InternalsVisibleTo` grant from `Jint` to this package.** It consumes the
 published engine API and nothing else, which is the whole point: a protocol server that could only be
@@ -212,8 +280,19 @@ Not oversights, and not to be added without a decision:
   questions are `engine.Diagnostics` and the constraints, not this protocol.
 - **Per-session breakpoint state.** Breakpoints live on the engine's `DebugHandler`, so two sessions
   attached to one engine share them. Making them per-session means a filter on every pause.
-- **Sockets, in the skeleton.** The WebSocket transport and `/json/*` discovery arrive with the session
-  core; `InProcessConnection` is the whole transport until then.
+- **Remote-object handles.** `Runtime.evaluate` describes what it cannot send by value — type, subtype,
+  class name, one-line description — and mints no `objectId`. A handle is a promise to keep a value alive
+  until the client releases it, and half a table is worse than none: a client handed an identifier nothing
+  keeps alive is worse off than one told the value by description. `getProperties`, `callFunctionOn`,
+  `releaseObject`, `addBinding` and the `Runtime.awaitPromise` *command* all wait for that table; the
+  `awaitPromise` **parameter** of `Runtime.evaluate` is answered today, because it needs no handle.
+- **Previews.** For the same reason, and because a bounded preview is the same walk the table's describer
+  will do.
+- **The full protocol description at `/json/protocol`.** It answers what this server implements, derived
+  from the manifest. The pinned document is two megabytes of mostly commands answered here with `-32601`,
+  and a client reading it would be told it can call them.
+- **HTTP beyond the handful of `/json` documents.** `Transport/HttpRequestHead.cs` is not an HTTP server and
+  must not become one: no bodies, no chunked encoding, no keep-alive.
 
 ### Test strategy
 
@@ -229,6 +308,21 @@ everything it tests is `internal`.
 - **An extension point nothing ships yet is exercised by a domain the suite declares itself.**
   `DomainLifecycleTests` derives from a generated base exactly as a real domain would; an untested
   extension point is a design nobody has tried.
-- **What is not here yet**: the PuppeteerSharp end-to-end suite over a real WebSocket, and the manual
-  checklist for attaching `devtools://devtools/bundled/js_app.html?ws=`. Both arrive with the session core,
-  and both are how a claim about *client compatibility* is made — no in-process test can make one.
+- **The socket tests are not a duplicate of the in-process ones.** The envelope and the state machine are
+  the same code either way; the upgrade handshake, the frame handling, the single writer and the close
+  ordering are exercised by nothing without a socket, and that is where a protocol server goes wrong.
+  `Transport/DevToolsClient.cs` is the one helper, and **every wait in it is bounded** — a protocol test
+  that can hang is a CI leg that can hang, and the thing most likely to be wrong here is the thing that
+  makes a reply never arrive.
+- **`Clients/PuppeteerSharpTests.cs` is the only test that can claim client compatibility.** Everything
+  else asserts what this server answers; that one asserts that a library nobody here wrote is satisfied by
+  it. It launches no browser — `ConnectAsync` speaks to an endpoint that already exists — and it is pinned
+  to the version the recorded handshake came from.
+- **`Protocol/HandshakeReplayTests.cs` replays the recordings** in
+  `tools/devtools-protocol/handshakes/`: every method a real client was seen sending is sent here, a
+  manifest method must be answered, and every other must be *exactly* `-32601`. Its `Absent` table names
+  each unimplemented method and why, so the tolerance stays a decision — a re-recording or a client release
+  then arrives as a diff somebody reads rather than as a silently widened test.
+- **What is not here yet**: the manual checklist for attaching
+  `devtools://devtools/bundled/js_app.html?v8only=true&ws=`, which is how the front end's own behaviour is
+  claimed and which no automated test replaces.

--- a/Jint.DevTools/DevToolsEngineOptions.cs
+++ b/Jint.DevTools/DevToolsEngineOptions.cs
@@ -1,0 +1,81 @@
+namespace Jint.DevTools;
+
+/// <summary>
+/// What <see cref="DevToolsOptionsExtensions.UseDevTools"/> turns on beyond the parts every session needs.
+/// </summary>
+public sealed class DevToolsEngineOptions
+{
+    /// <summary>Creates a set of options, each at its default.</summary>
+    public DevToolsEngineOptions()
+    {
+    }
+
+    /// <summary>
+    /// Gets or sets whether the engine counts what it executes, so a client can ask for coverage. Defaults
+    /// to <see langword="false"/>.
+    /// </summary>
+    /// <remarks>
+    /// Off unless asked because it is the one switch here with a running cost the whole engine pays: it
+    /// arms the interpreter's per-statement lane for every script, attached or not. The rest of what
+    /// <see cref="DevToolsOptionsExtensions.UseDevTools"/> sets costs a session that never attaches nothing.
+    /// </remarks>
+    public bool Coverage { get; set; }
+}
+
+/// <summary>
+/// Configures an <see cref="Options"/> so that an engine built from it can be attached to.
+/// </summary>
+public static class DevToolsOptionsExtensions
+{
+    /// <summary>
+    /// Turns on everything a DevTools session needs from the engine, and nothing a client cannot use.
+    /// </summary>
+    /// <param name="options">The options to configure.</param>
+    /// <param name="configure">What else to turn on, or <see langword="null"/> for the defaults.</param>
+    /// <returns><paramref name="options"/>, so the call chains.</returns>
+    /// <remarks>
+    /// <para>
+    /// Sets <see cref="Options.DebuggerOptions.Enabled"/> so a client can pause,
+    /// <see cref="Options.RetainFunctionSourceText"/> so it can read the source it is paused in, and
+    /// <see cref="Options.ProfilingOptions.Enabled"/> so it can record a profile. Coverage is off unless
+    /// <see cref="DevToolsEngineOptions.Coverage"/> asks for it.
+    /// </para>
+    /// <para>
+    /// <b>All three are construction-time.</b> There is no way to turn them on later, so an engine built
+    /// without this can be listed and evaluated in but not paused in, and the domains that need what is
+    /// missing say so with an explicit refusal rather than answering something untrue.
+    /// </para>
+    /// <para>
+    /// <b>They are not free.</b> Debug mode disarms the interpreter's tight-loop lane, and retained source
+    /// text keeps one string per parsed program alive. That is the price of an attachable engine; an engine
+    /// the host never intends to attach to should not be built with it.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ArgumentNullException"><paramref name="options"/> is <see langword="null"/>.</exception>
+    /// <example>
+    /// <code>
+    /// var engine = new Engine(options => options.UseDevTools());
+    /// </code>
+    /// </example>
+    public static Options UseDevTools(this Options options, Action<DevToolsEngineOptions>? configure = null)
+    {
+        if (options is null)
+        {
+            Throw.ArgumentNull(nameof(options));
+        }
+
+        var devTools = new DevToolsEngineOptions();
+        configure?.Invoke(devTools);
+
+        options.Debugger.Enabled = true;
+        options.RetainFunctionSourceText = true;
+        options.Profiling.Enabled = true;
+
+        if (devTools.Coverage)
+        {
+            options.Coverage.Enabled = true;
+        }
+
+        return options;
+    }
+}

--- a/Jint.DevTools/DevToolsServer.cs
+++ b/Jint.DevTools/DevToolsServer.cs
@@ -1,0 +1,357 @@
+using System.Globalization;
+using Jint.DevTools.Domains;
+using Jint.DevTools.Protocol.Browser;
+using Jint.DevTools.Session;
+using Jint.DevTools.Transport;
+
+namespace Jint.DevTools;
+
+/// <summary>
+/// A Chrome DevTools Protocol endpoint over the engines a host gives it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The host end of the package: it listens, answers the discovery documents a client reads before it
+/// connects, and turns each accepted WebSocket into a conversation. What a client can then do is decided by
+/// the domains, and where each command runs is decided by the target it addresses.
+/// </para>
+/// <para>
+/// <b>The endpoint is unauthenticated, and that is the protocol's design rather than an omission.</b>
+/// Anything that can reach it can evaluate arbitrary script in the host process, which is why
+/// <see cref="DevToolsServerOptions.Host"/> defaults to loopback. Do not bind it to a routable address, and
+/// do not run one in production without a reason.
+/// </para>
+/// <para>
+/// A server may be built and used without ever being started: <see cref="Start"/> is what opens a socket,
+/// and everything else works the same for a host embedding the protocol without a port.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// var engine = new Engine(options => options.UseDevTools());
+///
+/// await using var server = new DevToolsServer(new DevToolsServerOptions { Port = 9222 });
+/// server.AddTarget(new EngineTarget(engine));
+/// server.Start();
+///
+/// // …the host's own loop, which is what runs the engine and answers the protocol:
+/// while (running)
+/// {
+///     engine.Tasks.ProcessTasks();
+///     engine.Tasks.WaitForScheduledWork(TimeSpan.FromMilliseconds(50));
+/// }
+/// </code>
+/// </example>
+public sealed class DevToolsServer : IAsyncDisposable
+{
+    private readonly List<EngineTarget> _targets = [];
+    private readonly List<EngineTarget> _owned = [];
+    private readonly List<BrowserSession> _browserSessions = [];
+    private readonly object _lock = new();
+
+    private WebSocketServerTransport? _transport;
+    private int _disposed;
+
+    /// <summary>Creates a server over <paramref name="options"/>.</summary>
+    /// <param name="options">How to listen and what to call itself, or the defaults.</param>
+    public DevToolsServer(DevToolsServerOptions? options = null)
+    {
+        Options = options ?? new DevToolsServerOptions();
+        Version = BrowserDomain.Version(Options.Product);
+        BrowserId = Identifiers.New();
+    }
+
+    /// <summary>Gets the identifier the browser endpoint's path carries.</summary>
+    public string BrowserId { get; }
+
+    /// <summary>Gets the port the server is listening on, or <c>0</c> when it has not been started.</summary>
+    /// <remarks>
+    /// The answer to <see cref="DevToolsServerOptions.Port"/> being <c>0</c>: read this after
+    /// <see cref="Start"/> for the ephemeral port the operating system chose.
+    /// </remarks>
+    public int BoundPort => _transport?.BoundPort ?? 0;
+
+    /// <summary>Gets the address a client connects to for the browser endpoint.</summary>
+    /// <exception cref="InvalidOperationException">The server has not been started.</exception>
+    public string BrowserWebSocketUrl
+    {
+        get
+        {
+            if (_transport is null)
+            {
+                Throw.InvalidOperation("The server has no address until it is started.");
+            }
+
+            return string.Create(CultureInfo.InvariantCulture, $"ws://{Authority}/devtools/browser/{BrowserId}");
+        }
+    }
+
+    /// <summary>Gets the targets a client can list and attach to, oldest first.</summary>
+    public IReadOnlyList<EngineTarget> Targets
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _targets.ToArray();
+            }
+        }
+    }
+
+    /// <summary>Gets how this server is configured.</summary>
+    internal DevToolsServerOptions Options { get; }
+
+    /// <summary>Gets what <c>Browser.getVersion</c> and <c>/json/version</c> answer.</summary>
+    internal GetVersionResponse Version { get; }
+
+    /// <summary>Gets the host and port a discovery document names, which is only valid once started.</summary>
+    internal string Authority => string.Create(CultureInfo.InvariantCulture, $"{Options.Host}:{BoundPort}");
+
+    /// <summary>Starts listening.</summary>
+    /// <exception cref="InvalidOperationException">The server is already started.</exception>
+    /// <exception cref="ObjectDisposedException">The server has been disposed.</exception>
+    public void Start()
+    {
+        ThrowIfDisposed();
+
+        if (_transport is not null)
+        {
+            Throw.InvalidOperation("The server is already started.");
+        }
+
+        var transport = new WebSocketServerTransport(this);
+        transport.Start();
+        _transport = transport;
+    }
+
+    /// <summary>Starts listening, for a host whose start-up path is asynchronous.</summary>
+    /// <param name="cancellationToken">Cancelled before the listener is opened, nothing is opened.</param>
+    /// <remarks>
+    /// Binding a listener is synchronous, so this is <see cref="Start"/> with a task around it rather than a
+    /// separate implementation; it exists so a host need not break its own <c>async</c> chain.
+    /// </remarks>
+    public Task StartAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        Start();
+        return Task.CompletedTask;
+    }
+
+    /// <summary>Adds a target, telling every connected client that it appeared.</summary>
+    /// <param name="target">The engine to publish.</param>
+    /// <remarks>
+    /// A client that asked for discovery is told through <c>Target.targetCreated</c>, and one that asked for
+    /// auto-attach is attached and told through <c>Target.attachedToTarget</c>, before this returns. Both
+    /// events reach the connection's writer queue rather than a socket, so this does not block on the
+    /// network.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException"><paramref name="target"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ObjectDisposedException">The server has been disposed.</exception>
+    public void AddTarget(EngineTarget target)
+    {
+        if (target is null)
+        {
+            Throw.ArgumentNull(nameof(target));
+        }
+
+        ThrowIfDisposed();
+
+        BrowserSession[] sessions;
+        lock (_lock)
+        {
+            if (_targets.Contains(target))
+            {
+                return;
+            }
+
+            _targets.Add(target);
+            sessions = _browserSessions.ToArray();
+        }
+
+        // The bound is the server's rather than the target's: a target may well have been built before the
+        // server it ends up on.
+        target.Dispatcher.CommandTimeout = Options.CommandTimeout;
+
+        foreach (var session in sessions)
+        {
+            Complete(session.TargetAddedAsync(target, CancellationToken.None));
+        }
+    }
+
+    /// <summary>Removes a target, telling every connected client that it went away.</summary>
+    /// <param name="target">The engine to stop publishing.</param>
+    /// <returns><see langword="true"/> when the target was published and now is not.</returns>
+    /// <remarks>
+    /// Every session attached to it is detached first, so a client is told the attachment ended before it is
+    /// told the target did. The <see cref="EngineTarget"/> itself is not disposed: it is the host's.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException"><paramref name="target"/> is <see langword="null"/>.</exception>
+    public bool RemoveTarget(EngineTarget target)
+    {
+        if (target is null)
+        {
+            Throw.ArgumentNull(nameof(target));
+        }
+
+        BrowserSession[] sessions;
+        lock (_lock)
+        {
+            if (!_targets.Remove(target))
+            {
+                return false;
+            }
+
+            sessions = _browserSessions.ToArray();
+        }
+
+        foreach (var session in sessions)
+        {
+            Complete(session.TargetRemovedAsync(target, CancellationToken.None));
+        }
+
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        if (_transport is { } transport)
+        {
+            await transport.DisposeAsync().ConfigureAwait(false);
+        }
+
+        EngineTarget[] owned;
+        lock (_lock)
+        {
+            owned = _owned.ToArray();
+            _owned.Clear();
+            _targets.Clear();
+            _browserSessions.Clear();
+        }
+
+        // Only the targets this server made: an engine the host handed over is still the host's, and
+        // stopping its thread would be this package deciding the lifetime of something it does not own.
+        foreach (var target in owned)
+        {
+            await target.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>Finds a published target by the identifier a client addresses it with.</summary>
+    internal EngineTarget? FindTarget(string targetId)
+    {
+        lock (_lock)
+        {
+            foreach (var target in _targets)
+            {
+                if (string.Equals(target.TargetId, targetId, StringComparison.Ordinal))
+                {
+                    return target;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Builds a target from <see cref="DevToolsServerOptions.EngineFactory"/> and publishes it.
+    /// </summary>
+    /// <remarks>
+    /// The target is <see cref="ThreadMode.LibraryOwned"/> and its lifetime is the server's, because there
+    /// is no host thread that ever agreed to pump it: a client asked for it, so the package runs it.
+    /// </remarks>
+    internal EngineTarget CreateTarget()
+    {
+        if (Options.EngineFactory is not { } factory)
+        {
+            return Throw.ServerError<EngineTarget>(
+                "No engine factory is configured",
+                "set DevToolsServerOptions.EngineFactory for a client to be able to create targets");
+        }
+
+        var target = new EngineTarget(factory(), new EngineTargetOptions { ThreadMode = ThreadMode.LibraryOwned });
+
+        lock (_lock)
+        {
+            _owned.Add(target);
+        }
+
+        AddTarget(target);
+        return target;
+    }
+
+    /// <summary>Removes a target at a client's request, disposing it when the server made it.</summary>
+    internal async ValueTask CloseTargetAsync(EngineTarget target)
+    {
+        RemoveTarget(target);
+
+        bool owned;
+        lock (_lock)
+        {
+            owned = _owned.Remove(target);
+        }
+
+        if (owned)
+        {
+            await target.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>Opens a conversation with the browser endpoint over <paramref name="connection"/>.</summary>
+    internal BrowserSession OpenBrowserSession(IDevToolsConnection connection, Action? closeRequested = null)
+    {
+        var session = new BrowserSession(this, connection, closeRequested);
+
+        lock (_lock)
+        {
+            _browserSessions.Add(session);
+        }
+
+        // Nothing is announced here, deliberately. A client is told about a target when it asks to be --
+        // through setDiscoverTargets or setAutoAttach -- and both replay what already exists, so announcing
+        // on connect would double every event for the client that then asks.
+        return session;
+    }
+
+    /// <summary>Opens a conversation with one target over <paramref name="connection"/>, with no sessions in it.</summary>
+    internal static TargetSession OpenTargetSession(IDevToolsConnection connection, EngineTarget target)
+    {
+        return TargetSession.Direct(new DevToolsSession(connection), target);
+    }
+
+    /// <summary>Forgets a conversation whose connection has gone, detaching everything it held.</summary>
+    internal void CloseBrowserSession(BrowserSession session)
+    {
+        lock (_lock)
+        {
+            _browserSessions.Remove(session);
+        }
+
+        session.DetachAll();
+    }
+
+    /// <summary>
+    /// Waits for an event that both shipped transports finish synchronously, so publishing a target is not
+    /// an asynchronous operation a host has to await.
+    /// </summary>
+    private static void Complete(ValueTask task)
+    {
+        if (task.IsCompletedSuccessfully)
+        {
+            return;
+        }
+
+        task.AsTask().GetAwaiter().GetResult();
+    }
+
+    private void ThrowIfDisposed()
+    {
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+    }
+}

--- a/Jint.DevTools/DevToolsServerOptions.cs
+++ b/Jint.DevTools/DevToolsServerOptions.cs
@@ -1,0 +1,96 @@
+namespace Jint.DevTools;
+
+/// <summary>
+/// How a <see cref="DevToolsServer"/> listens, what it calls itself, and what it refuses.
+/// </summary>
+/// <remarks>
+/// Read once, when the server is constructed. Changing an instance afterwards changes nothing about a
+/// server already built from it.
+/// </remarks>
+public sealed class DevToolsServerOptions
+{
+    /// <summary>The command timeout a target uses until a server tells it otherwise.</summary>
+    internal static readonly TimeSpan DefaultCommandTimeout = TimeSpan.FromSeconds(30);
+
+    /// <summary>Creates a set of options, each at its default.</summary>
+    public DevToolsServerOptions()
+    {
+    }
+
+    /// <summary>Gets or sets the address to listen on. Defaults to <c>127.0.0.1</c>.</summary>
+    /// <remarks>
+    /// <b>The default is loopback, and that is a security decision rather than a convenience.</b> A DevTools
+    /// endpoint is unauthenticated by design and evaluates arbitrary script in the host process; a host that
+    /// binds it to a routable address has published a remote code execution endpoint.
+    /// </remarks>
+    public string Host { get; set; } = "127.0.0.1";
+
+    /// <summary>Gets or sets the port to listen on, or <c>0</c> for an ephemeral one. Defaults to <c>0</c>.</summary>
+    /// <remarks>
+    /// Chrome's own default is 9222, which is what a client with no configuration looks for; the default
+    /// here is an ephemeral port, so that starting a server never collides with one already running. Read
+    /// <see cref="DevToolsServer.BoundPort"/> afterwards for what was chosen.
+    /// </remarks>
+    public int Port { get; set; }
+
+    /// <summary>Gets or sets what the server calls itself. Defaults to <c>Jint/</c> and the engine version.</summary>
+    /// <remarks>
+    /// It is what <c>Browser.getVersion</c> and <c>/json/version</c> answer, and therefore what a client
+    /// believes it is driving. Naming Jint rather than a Chrome build is deliberate: a client that branches
+    /// on the product should take its "unknown browser" path.
+    /// </remarks>
+    public string? Product { get; set; }
+
+    /// <summary>
+    /// Gets or sets how long a client waits for one command before it is told the engine is not being
+    /// pumped. Defaults to 30 seconds.
+    /// </summary>
+    /// <remarks>
+    /// It bounds the client's wait, not the command: a command that times out still runs when the engine is
+    /// next pumped. See <see cref="ThreadMode.HostOwned"/>.
+    /// </remarks>
+    public TimeSpan CommandTimeout { get; set; } = DefaultCommandTimeout;
+
+    /// <summary>
+    /// Gets or sets how long a client's command may wait while the engine is paused in the debugger.
+    /// Defaults to 30 seconds.
+    /// </summary>
+    /// <remarks>
+    /// Nothing pauses yet: the debugger domain and the pause-time message loop arrive separately. It is
+    /// declared now because the pause loop's bound is a host decision and a host writing its configuration
+    /// today should not have to revisit it.
+    /// </remarks>
+    public TimeSpan PauseTimeout { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>Gets or sets the largest message the server will accept. Defaults to 16 MiB.</summary>
+    /// <remarks>
+    /// A frame over the limit closes the connection with the WebSocket <c>1009</c> status rather than being
+    /// buffered, because the alternative is letting one client decide how much of the host's memory the
+    /// protocol may hold.
+    /// </remarks>
+    public int MaxMessageBytes { get; set; } = 16 * 1024 * 1024;
+
+    /// <summary>
+    /// Gets or sets whether <c>Browser.close</c> closes the client's connection rather than the host.
+    /// Defaults to <see langword="true"/>.
+    /// </summary>
+    /// <remarks>
+    /// Every client sends <c>Browser.close</c> on the way out, and a browser would exit. Jint is embedded in
+    /// somebody's process, so the default reads it as "this client is done": the connection closes and the
+    /// host keeps running. Set it to <see langword="false"/> for a host whose whole purpose is the endpoint
+    /// — a debugging tool — and stop the server yourself when the command arrives.
+    /// </remarks>
+    public bool CloseIsDisconnect { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets what builds an engine for <c>Target.createTarget</c> and <c>/json/new</c>, or
+    /// <see langword="null"/> to refuse both.
+    /// </summary>
+    /// <remarks>
+    /// <b>The factory runs on a transport thread</b>, so it must build an engine and nothing else; the
+    /// engine is not touched again until the target that owns it runs it. Without a factory both entry
+    /// points answer that no engine factory is configured, which is a truthful refusal rather than a
+    /// pretence that a client's <c>newPage</c> worked.
+    /// </remarks>
+    public Func<Engine>? EngineFactory { get; set; }
+}

--- a/Jint.DevTools/Domains/BrowserDomain.cs
+++ b/Jint.DevTools/Domains/BrowserDomain.cs
@@ -10,14 +10,16 @@ namespace Jint.DevTools.Domains;
 /// </summary>
 /// <remarks>
 /// <para>
-/// <c>getVersion</c> is the first command every client sends, and what it answers is what the client then
+/// <c>getVersion</c> is the first command most clients send, and what it answers is what the client then
 /// believes it is driving. So the product string says Jint and its version rather than impersonating a
 /// Chrome build: a client that branches on the product name should take its "unknown browser" path, and one
 /// that only reports it should report the truth.
 /// </para>
 /// <para>
-/// <c>close</c> is the host's decision, not this package's. Without a callback it succeeds and does nothing,
-/// which is what keeps a client that closes on the way out from failing.
+/// <c>close</c> is the host's decision, not this package's. Every client sends it on the way out and a
+/// browser would exit; Jint is embedded in somebody's process, so what the server does with it is
+/// <see cref="DevToolsServerOptions.CloseIsDisconnect"/>. Without a callback at all it succeeds and does
+/// nothing, which is what keeps a client that closes on the way out from failing.
 /// </para>
 /// <para>
 /// See <see href="https://chromedevtools.github.io/devtools-protocol/tot/Browser/#method-getVersion"/> and
@@ -26,34 +28,44 @@ namespace Jint.DevTools.Domains;
 /// </remarks>
 internal sealed class BrowserDomain : BrowserDomainBase
 {
-    private static readonly string _version = ReadJintVersion();
-
-    private static readonly GetVersionResponse _versionResponse = new()
-    {
-        ProtocolVersion = ProtocolManifest.ProtocolVersion,
-        Product = "Jint/" + _version,
-        Revision = "",
-        UserAgent = "Jint/" + _version,
-
-        // V8 reports its own engine version here. Jint's is the honest answer, and it parses as a version
-        // for the clients that read it as one.
-        JsVersion = _version,
-    };
-
+    private readonly GetVersionResponse _version;
     private readonly Action? _closeRequested;
 
     /// <summary>
-    /// Creates the domain, optionally with what to run when a client asks the browser to close.
+    /// Creates the domain over what the server calls itself, and what to run when a client asks it to close.
     /// </summary>
-    internal BrowserDomain(Action? closeRequested = null)
+    internal BrowserDomain(GetVersionResponse version, Action? closeRequested = null)
     {
+        _version = version;
         _closeRequested = closeRequested;
+    }
+
+    /// <summary>Jint's own version, with the source-link commit suffix removed because a client renders it.</summary>
+    internal static string JintVersion { get; } = ReadJintVersion();
+
+    /// <summary>Builds the answer to <c>getVersion</c>, taking the product string a host chose.</summary>
+    /// <param name="product">What the server calls itself, or <see langword="null"/> for Jint and its version.</param>
+    internal static GetVersionResponse Version(string? product)
+    {
+        var name = string.IsNullOrEmpty(product) ? "Jint/" + JintVersion : product;
+
+        return new GetVersionResponse
+        {
+            ProtocolVersion = ProtocolManifest.ProtocolVersion,
+            Product = name,
+            Revision = "",
+            UserAgent = name,
+
+            // V8 reports its own engine version here. Jint's is the honest answer, and it parses as a
+            // version for the clients that read it as one.
+            JsVersion = JintVersion,
+        };
     }
 
     /// <inheritdoc/>
     protected override ValueTask<GetVersionResponse> GetVersionAsync(EmptyParameters parameters, CommandContext context)
     {
-        return new ValueTask<GetVersionResponse>(_versionResponse);
+        return new ValueTask<GetVersionResponse>(_version);
     }
 
     /// <inheritdoc/>
@@ -63,10 +75,6 @@ internal sealed class BrowserDomain : BrowserDomainBase
         return new ValueTask<EmptyResult>(EmptyResult.Instance);
     }
 
-    /// <summary>
-    /// Jint's informational version with the source-link commit suffix removed, because a client renders
-    /// this string.
-    /// </summary>
     private static string ReadJintVersion()
     {
         var assembly = typeof(Engine).Assembly;

--- a/Jint.DevTools/Domains/BuiltInDomains.cs
+++ b/Jint.DevTools/Domains/BuiltInDomains.cs
@@ -1,3 +1,4 @@
+using Jint.DevTools.Protocol.Browser;
 using Jint.DevTools.Session;
 
 namespace Jint.DevTools.Domains;
@@ -6,17 +7,31 @@ namespace Jint.DevTools.Domains;
 /// The domains this package answers, named in one place.
 /// </summary>
 /// <remarks>
-/// This list and <c>manifest.json</c>'s <c>implementedMethods</c> are two statements of the same fact, and
+/// <para>
+/// This file and <c>manifest.json</c>'s <c>implementedMethods</c> are two statements of the same fact, and
 /// <c>Jint.Tests.DevTools/Protocol/ProtocolManifestTests.cs</c> holds them to each other: every listed
 /// method is overridden here, and nothing else is. Adding a domain without a manifest entry, or the other
 /// way round, fails rather than ships.
+/// </para>
+/// <para>
+/// There are two lists rather than one because there are two kinds of session. A browser session answers
+/// about the server — which engines exist, what the product is — and touches no engine, so its commands run
+/// on the transport thread. A target session answers about one engine and every command of it crosses to
+/// that engine's thread first.
+/// </para>
 /// </remarks>
 internal static class BuiltInDomains
 {
-    /// <summary>Registers every domain this package answers on <paramref name="session"/>.</summary>
-    /// <param name="session">The session to register on.</param>
+    /// <summary>Registers what a connection to the browser endpoint answers.</summary>
+    /// <param name="session">The root session of that connection.</param>
+    /// <param name="version">What <c>Browser.getVersion</c> answers.</param>
     /// <param name="closeRequested">What to run when a client sends <c>Browser.close</c>, if anything.</param>
-    internal static DevToolsSession RegisterOn(DevToolsSession session, Action? closeRequested = null)
+    /// <param name="targets">The <c>Target</c> domain the conversation keeps its discovery state on.</param>
+    internal static DevToolsSession RegisterBrowserDomains(
+        DevToolsSession session,
+        GetVersionResponse version,
+        Action? closeRequested,
+        TargetDomain targets)
     {
         if (session is null)
         {
@@ -25,6 +40,33 @@ internal static class BuiltInDomains
 
         return session
             .Register(new SchemaDomain())
-            .Register(new BrowserDomain(closeRequested));
+            .Register(new BrowserDomain(version, closeRequested))
+            .Register(targets);
+    }
+
+    /// <summary>Registers what one attachment to one engine answers.</summary>
+    /// <param name="session">The session node the attachment answers on.</param>
+    /// <param name="target">The engine it speaks to.</param>
+    /// <param name="browser">
+    /// The conversation the attachment belongs to, or <see langword="null"/> for a direct
+    /// <c>/devtools/page/</c> connection, which has no browser session and therefore no target tree.
+    /// </param>
+    internal static DevToolsSession RegisterTargetDomains(DevToolsSession session, EngineTarget target, BrowserSession? browser)
+    {
+        if (session is null)
+        {
+            Throw.ArgumentNull(nameof(session));
+        }
+
+        session.Register(new RuntimeDomain(target));
+
+        if (browser is not null)
+        {
+            // Clients walk down the target tree by sending setAutoAttach on every session they are given.
+            // An engine target has no children, so the nested copy answers it as the success it is.
+            session.Register(new TargetDomain(browser, nested: true));
+        }
+
+        return session;
     }
 }

--- a/Jint.DevTools/Domains/DevToolsDomain.cs
+++ b/Jint.DevTools/Domains/DevToolsDomain.cs
@@ -79,11 +79,21 @@ internal abstract class DevToolsDomain
     /// <summary>Runs when the client disables a domain it had enabled.</summary>
     protected virtual ValueTask OnDisabledAsync(CommandContext context) => default;
 
+    /// <summary>Gets the session this domain is registered with, once one has registered it.</summary>
+    /// <remarks>
+    /// A domain raising an event outside a command — a target appearing while nobody asked anything — needs
+    /// the session without a <see cref="CommandContext"/> to reach it through.
+    /// </remarks>
+    private protected DevToolsSession? Session => _session;
+
     /// <summary>Sends one event on the session this domain is registered with.</summary>
-    protected ValueTask EmitAsync(in ProtocolEvent @event, CommandContext context)
+    /// <remarks>
+    /// The event carries that session's own <c>sessionId</c>, so a domain never has to know which
+    /// attachment it is part of, and an event raised outside a command is addressed exactly as one raised
+    /// inside it.
+    /// </remarks>
+    protected ValueTask EmitAsync(in ProtocolEvent @event, CancellationToken cancellationToken = default)
     {
-        return _session is { } session
-            ? session.SendEventAsync(in @event, context.SessionId, context.CancellationToken)
-            : default;
+        return _session is { } session ? session.SendEventAsync(in @event, cancellationToken) : default;
     }
 }

--- a/Jint.DevTools/Domains/RemoteValues.cs
+++ b/Jint.DevTools/Domains/RemoteValues.cs
@@ -1,0 +1,445 @@
+using System.Buffers;
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using Jint.Diagnostics;
+using Jint.DevTools.Protocol.Runtime;
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+
+namespace Jint.DevTools.Domains;
+
+/// <summary>
+/// Turns one <see cref="JsValue"/> into the protocol's <c>Runtime.RemoteObject</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Runs on the engine thread, like everything else that touches a value, and answers a record of strings and
+/// JSON that may then cross to a transport thread.
+/// </para>
+/// <para>
+/// <b>Nothing here mints an <c>objectId</c>.</b> A handle is a promise to keep the value alive until the
+/// client releases it, and the table that keeps that promise arrives with the rest of the <c>Runtime</c>
+/// domain. Until then a value that cannot be sent by value is described — type, subtype, class name and a
+/// one-line description — which is what a client shows anyway, and no client is handed a handle it could
+/// later find dangling.
+/// </para>
+/// <para>
+/// The description comes from <see cref="ValueInspector"/>, which is the engine's own getter-free, trap-free
+/// describer: describing a value here executes none of that value's code. Sending a value <i>by value</i> is
+/// the deliberate exception — that is <c>JSON.stringify</c>'s contract and a client asking for it has asked
+/// for the getters to run.
+/// </para>
+/// </remarks>
+internal static class RemoteValues
+{
+    /// <summary>How deep a by-value serialization descends before it refuses.</summary>
+    private const int MaxByValueDepth = 20;
+
+    /// <summary>How many values one by-value serialization may write.</summary>
+    private const int MaxByValueNodes = 10_000;
+
+    private static readonly RemoteObject UndefinedObject = new() { Type = RemoteObjectTypeValues.Undefined };
+
+#pragma warning disable JINT0002 // ValueInspector is the engine's preview describer; this is what it is for
+    /// <summary>
+    /// The header alone: no entries, because a preview is the object table's business and this package has
+    /// none yet, and a walk nobody reads is work the engine thread should not do.
+    /// </summary>
+    private static readonly ValueInspectorOptions DescribeOnly = new() { MaxDepth = 0, MaxEntries = 0, MaxStringLength = 256 };
+#pragma warning restore JINT0002
+
+    /// <summary>Describes <paramref name="value"/> as the protocol's remote object.</summary>
+    /// <param name="value">The value to describe.</param>
+    /// <param name="byValue">Whether the client asked for the value itself rather than a description of it.</param>
+    internal static RemoteObject Describe(JsValue value, bool byValue)
+    {
+        if (value.IsUndefined())
+        {
+            return UndefinedObject;
+        }
+
+        if (value.IsNull())
+        {
+            return new RemoteObject
+            {
+                Type = RemoteObjectTypeValues.Object,
+                Subtype = RemoteObjectSubtypeValues.Null,
+                Value = Json("null"),
+            };
+        }
+
+        if (value.IsBoolean())
+        {
+            return new RemoteObject
+            {
+                Type = RemoteObjectTypeValues.Boolean,
+                Value = Json(value.AsBoolean() ? "true" : "false"),
+            };
+        }
+
+        if (value.IsString())
+        {
+            return new RemoteObject
+            {
+                Type = RemoteObjectTypeValues.String,
+                Value = Json(JsonString(value.AsString())),
+            };
+        }
+
+        if (value.IsNumber())
+        {
+            return Number(value);
+        }
+
+        if (value.IsBigInt())
+        {
+            var text = TypeConverter.ToString(value) + "n";
+            return new RemoteObject
+            {
+                Type = RemoteObjectTypeValues.Bigint,
+                UnserializableValue = text,
+                Description = text,
+            };
+        }
+
+        if (value.IsSymbol())
+        {
+            return new RemoteObject
+            {
+                Type = RemoteObjectTypeValues.Symbol,
+                Description = value.ToString(),
+            };
+        }
+
+        return byValue ? ByValue(value) : Described(value);
+    }
+
+    /// <summary>
+    /// Describes what a thrown <see cref="JavaScriptException"/> becomes, in the shape the front end reads.
+    /// </summary>
+    internal static ExceptionDetails Exception(JavaScriptException exception, int exceptionId, int executionContextId)
+    {
+        var location = exception.Location;
+
+        return new ExceptionDetails
+        {
+            ExceptionId = exceptionId,
+
+            // V8's word for "this came out of an evaluation rather than out of a compile". The front end
+            // prints it in front of the exception's own description.
+            Text = "Uncaught",
+
+            // The protocol counts lines from zero and Acornima counts them from one; its columns are
+            // already zero-based. A location the engine never filled in reads as the start of the script.
+            LineNumber = Math.Max(0, location.Start.Line - 1),
+            ColumnNumber = Math.Max(0, location.Start.Column),
+            Url = string.IsNullOrEmpty(location.SourceFile) ? null : location.SourceFile,
+            ExecutionContextId = executionContextId,
+            Exception = ThrownValue(exception),
+        };
+    }
+
+    /// <summary>
+    /// Describes a promise rejection, which carries no location because nothing threw where the client is
+    /// standing.
+    /// </summary>
+    internal static ExceptionDetails Rejection(JsValue reason, int exceptionId, int executionContextId)
+    {
+        return new ExceptionDetails
+        {
+            ExceptionId = exceptionId,
+
+            // V8's wording for a rejection reported through a command rather than through a throw, and what
+            // the front end prints in front of the reason.
+            Text = "Uncaught (in promise)",
+            LineNumber = 0,
+            ColumnNumber = 0,
+            ExecutionContextId = executionContextId,
+            Exception = Describe(reason, byValue: false),
+        };
+    }
+
+    private static RemoteObject ThrownValue(JavaScriptException exception)
+    {
+        var described = Describe(exception.Error, byValue: false);
+
+        // The description a client renders for an error is the message plus the stack, which is what the
+        // engine already renders for its own exception text; the inspector's one-liner is the class name.
+        return described with { Description = exception.GetJavaScriptErrorString() };
+    }
+
+    private static RemoteObject Number(JsValue value)
+    {
+        var number = value.AsNumber();
+
+        if (double.IsNaN(number))
+        {
+            return Unserializable("NaN");
+        }
+
+        if (double.IsPositiveInfinity(number))
+        {
+            return Unserializable("Infinity");
+        }
+
+        if (double.IsNegativeInfinity(number))
+        {
+            return Unserializable("-Infinity");
+        }
+
+        if (number == 0 && double.IsNegative(number))
+        {
+            // JSON has no negative zero, and a client that read 0 back would have been told something false.
+            return Unserializable("-0");
+        }
+
+        return new RemoteObject
+        {
+            Type = RemoteObjectTypeValues.Number,
+            Value = Json(number.ToString("R", CultureInfo.InvariantCulture)),
+
+            // The engine's own number-to-string, so what a client shows is what the script would print.
+            Description = TypeConverter.ToString(value),
+        };
+
+        static RemoteObject Unserializable(string text) => new()
+        {
+            Type = RemoteObjectTypeValues.Number,
+            UnserializableValue = text,
+            Description = text,
+        };
+    }
+
+#pragma warning disable JINT0002 // ValueInspector is the engine's preview describer; this is what it is for
+    private static RemoteObject Described(JsValue value)
+    {
+        var description = ValueInspector.Describe(value, DescribeOnly);
+        var (type, subtype) = Kind(description.Kind);
+
+        return new RemoteObject
+        {
+            Type = type,
+            Subtype = subtype,
+            ClassName = description.ClassName,
+            Description = description.Description,
+        };
+    }
+
+    private static (string Type, string? Subtype) Kind(ValueKind kind) => kind switch
+    {
+        ValueKind.Function => (RemoteObjectTypeValues.Function, null),
+        ValueKind.Array => (RemoteObjectTypeValues.Object, RemoteObjectSubtypeValues.Array),
+        ValueKind.TypedArray => (RemoteObjectTypeValues.Object, RemoteObjectSubtypeValues.Typedarray),
+        ValueKind.ArrayBuffer => (RemoteObjectTypeValues.Object, RemoteObjectSubtypeValues.Arraybuffer),
+        ValueKind.DataView => (RemoteObjectTypeValues.Object, RemoteObjectSubtypeValues.Dataview),
+        ValueKind.Map => (RemoteObjectTypeValues.Object, RemoteObjectSubtypeValues.Map),
+        ValueKind.Set => (RemoteObjectTypeValues.Object, RemoteObjectSubtypeValues.Set),
+        ValueKind.WeakMap => (RemoteObjectTypeValues.Object, RemoteObjectSubtypeValues.Weakmap),
+        ValueKind.WeakSet => (RemoteObjectTypeValues.Object, RemoteObjectSubtypeValues.Weakset),
+        ValueKind.Promise => (RemoteObjectTypeValues.Object, RemoteObjectSubtypeValues.Promise),
+        ValueKind.Error => (RemoteObjectTypeValues.Object, RemoteObjectSubtypeValues.Error),
+        ValueKind.Date => (RemoteObjectTypeValues.Object, RemoteObjectSubtypeValues.Date),
+        ValueKind.RegExp => (RemoteObjectTypeValues.Object, RemoteObjectSubtypeValues.Regexp),
+        ValueKind.Proxy => (RemoteObjectTypeValues.Object, RemoteObjectSubtypeValues.Proxy),
+        ValueKind.Generator => (RemoteObjectTypeValues.Object, RemoteObjectSubtypeValues.Generator),
+        ValueKind.Iterator => (RemoteObjectTypeValues.Object, RemoteObjectSubtypeValues.Iterator),
+
+        // A WeakRef, an arguments object, a CLR value projected into script and everything ordinary: the
+        // protocol has no subtype for any of them, and inventing one would be a lie a client acts on.
+        _ => (RemoteObjectTypeValues.Object, null),
+    };
+#pragma warning restore JINT0002
+
+    private static RemoteObject ByValue(JsValue value)
+    {
+        // A function has no JSON form -- JSON.stringify answers undefined for one -- so the client gets the
+        // description it would have got anyway rather than a null it cannot tell from a real one.
+        if (value.IsCallable())
+        {
+            return Described(value);
+        }
+
+        var buffer = new ArrayBufferWriter<byte>(256);
+        string? refusal;
+
+        using (var writer = new Utf8JsonWriter(buffer))
+        {
+            var state = new ByValueWriter(writer);
+            var written = state.Write(value, depth: 0);
+            refusal = written ? null : state.Refusal;
+        }
+
+        if (refusal is not null)
+        {
+            return Throw.ServerError<RemoteObject>("Object couldn't be returned by value", refusal);
+        }
+
+        return new RemoteObject
+        {
+            Type = RemoteObjectTypeValues.Object,
+            Subtype = value.IsArray() ? RemoteObjectSubtypeValues.Array : null,
+            Value = Json(Encoding.UTF8.GetString(buffer.WrittenSpan)),
+        };
+    }
+
+    private static string JsonString(string text)
+    {
+        var buffer = new ArrayBufferWriter<byte>(text.Length + 16);
+        using (var writer = new Utf8JsonWriter(buffer))
+        {
+            writer.WriteStringValue(text);
+        }
+
+        return Encoding.UTF8.GetString(buffer.WrittenSpan);
+    }
+
+    private static JsonElement Json(string text)
+    {
+        using var document = JsonDocument.Parse(text);
+        return document.RootElement.Clone();
+    }
+
+    /// <summary>
+    /// One by-value serialization: <c>JSON.stringify</c>'s shape, bounded in depth and in how much it writes,
+    /// and refusing a cycle rather than following it.
+    /// </summary>
+    private struct ByValueWriter(Utf8JsonWriter writer)
+    {
+        private readonly Utf8JsonWriter _writer = writer;
+        private List<ObjectInstance>? _path;
+        private int _nodes;
+
+        /// <summary>Gets why the walk stopped, once <see cref="Write"/> has answered false.</summary>
+        internal string? Refusal { get; private set; }
+
+        internal bool Write(JsValue value, int depth)
+        {
+            if (++_nodes > MaxByValueNodes)
+            {
+                Refusal = "the value has more members than one by-value result may carry";
+                return false;
+            }
+
+            if (value.IsNull() || value.IsUndefined())
+            {
+                // JSON.stringify writes undefined members as absent; a top-level undefined is answered as
+                // null, which is what a client's own deserializer expects to find in the value member.
+                _writer.WriteNullValue();
+                return true;
+            }
+
+            if (value.IsBoolean())
+            {
+                _writer.WriteBooleanValue(value.AsBoolean());
+                return true;
+            }
+
+            if (value.IsNumber())
+            {
+                var number = value.AsNumber();
+                if (double.IsNaN(number) || double.IsInfinity(number))
+                {
+                    _writer.WriteNullValue();
+                    return true;
+                }
+
+                _writer.WriteNumberValue(number);
+                return true;
+            }
+
+            if (value.IsString())
+            {
+                _writer.WriteStringValue(value.AsString());
+                return true;
+            }
+
+            if (value.IsBigInt() || value.IsSymbol())
+            {
+                Refusal = value.IsBigInt()
+                    ? "a BigInt has no JSON representation"
+                    : "a symbol has no JSON representation";
+                return false;
+            }
+
+            return WriteObject(value.AsObject(), depth);
+        }
+
+        private bool WriteObject(ObjectInstance instance, int depth)
+        {
+            if (depth >= MaxByValueDepth)
+            {
+                Refusal = "the value is nested deeper than one by-value result may carry";
+                return false;
+            }
+
+            var path = _path ??= [];
+            for (var i = 0; i < path.Count; i++)
+            {
+                if (ReferenceEquals(path[i], instance))
+                {
+                    Refusal = "the value refers to itself";
+                    return false;
+                }
+            }
+
+            path.Add(instance);
+            try
+            {
+                return instance.IsArray() ? WriteArray(instance, depth) : WriteMembers(instance, depth);
+            }
+            finally
+            {
+                path.RemoveAt(path.Count - 1);
+            }
+        }
+
+        private bool WriteArray(ObjectInstance instance, int depth)
+        {
+            var length = instance.Get("length");
+            var count = length.IsNumber() ? (long) length.AsNumber() : 0;
+
+            _writer.WriteStartArray();
+            for (long index = 0; index < count; index++)
+            {
+                if (!Write(instance.Get(index.ToString(CultureInfo.InvariantCulture)), depth + 1))
+                {
+                    return false;
+                }
+            }
+
+            _writer.WriteEndArray();
+            return true;
+        }
+
+        private bool WriteMembers(ObjectInstance instance, int depth)
+        {
+            _writer.WriteStartObject();
+            foreach (var property in instance.GetOwnProperties())
+            {
+                if (!property.Value.Enumerable || !property.Key.IsString())
+                {
+                    continue;
+                }
+
+                var member = instance.Get(property.Key);
+                if (member.IsUndefined() || member.IsCallable())
+                {
+                    // JSON.stringify omits both rather than writing them, and a client reading this back
+                    // through its own deserializer expects the same.
+                    continue;
+                }
+
+                _writer.WritePropertyName(property.Key.AsString());
+                if (!Write(member, depth + 1))
+                {
+                    return false;
+                }
+            }
+
+            _writer.WriteEndObject();
+            return true;
+        }
+    }
+}

--- a/Jint.DevTools/Domains/RuntimeDomain.cs
+++ b/Jint.DevTools/Domains/RuntimeDomain.cs
@@ -1,0 +1,232 @@
+using System.Globalization;
+using System.Text.Json;
+using Jint.DevTools.Protocol;
+using Jint.DevTools.Protocol.Runtime;
+using Jint.DevTools.Session;
+using Jint.Native;
+using Jint.Runtime;
+using Jint.Runtime.Interop;
+
+namespace Jint.DevTools.Domains;
+
+/// <summary>
+/// Answers the <c>Runtime</c> commands one session needs before anything else works: the execution context,
+/// the release of a target waiting for a debugger, and evaluation.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Deliberately the smaller half of the domain. Remote-object handles, <c>getProperties</c>,
+/// <c>callFunctionOn</c>, previews and the console events are the rest of it and arrive together, because
+/// each of them needs the object table and half a table is worse than none: a client handed an
+/// <c>objectId</c> nothing keeps alive is worse off than a client told the value by description.
+/// </para>
+/// <para>
+/// Every member runs on the engine thread, brought there by <see cref="EngineDispatcher"/>. The one thing it
+/// must never do is drain the event loop — that is what the <c>awaitPromise</c> path attaches reactions for
+/// rather than waiting.
+/// </para>
+/// <para>
+/// See <see href="https://chromedevtools.github.io/devtools-protocol/tot/Runtime/"/>.
+/// </para>
+/// </remarks>
+internal sealed class RuntimeDomain : RuntimeDomainBase
+{
+    /// <summary>
+    /// The one execution context an engine target has. Chrome numbers page contexts from 1 and so does this;
+    /// there is no second realm to number, because a <c>ShadowRealm</c> is not something a client can address.
+    /// </summary>
+    private const int MainExecutionContextId = 1;
+
+    private readonly EngineTarget _target;
+    private int _exceptionId;
+
+    internal RuntimeDomain(EngineTarget target)
+    {
+        _target = target;
+    }
+
+    /// <inheritdoc/>
+    protected override async ValueTask<EmptyResult> EnableAsync(EmptyParameters parameters, CommandContext context)
+    {
+        await MarkEnabledAsync(context).ConfigureAwait(false);
+        return EmptyResult.Instance;
+    }
+
+    /// <inheritdoc/>
+    protected override async ValueTask<EmptyResult> DisableAsync(EmptyParameters parameters, CommandContext context)
+    {
+        await MarkDisabledAsync(context).ConfigureAwait(false);
+        return EmptyResult.Instance;
+    }
+
+    /// <summary>
+    /// Announces the one execution context, which is what a client waits for before it evaluates anything.
+    /// </summary>
+    /// <remarks>
+    /// Replayed on every <c>enable</c> rather than raised once when the context appeared: the context
+    /// outlives every session, so a client attaching later would otherwise never hear of it. That is V8's
+    /// behaviour too.
+    /// </remarks>
+    protected override ValueTask OnEnabledAsync(CommandContext context)
+    {
+        var created = new ExecutionContextCreatedEvent
+        {
+            Context = new ExecutionContextDescription
+            {
+                Id = MainExecutionContextId,
+
+                // An engine target has no document, so it has no origin and no name to give. Chrome sends
+                // the empty string for both on a Node target and clients read them as opaque.
+                Origin = "",
+                Name = "",
+                UniqueId = _target.TargetId + "." + MainExecutionContextId.ToString(CultureInfo.InvariantCulture),
+                AuxData = AuxData,
+            },
+        };
+
+        return EmitAsync(RuntimeEvents.ExecutionContextCreated(created), context.CancellationToken);
+    }
+
+    /// <inheritdoc/>
+    protected override ValueTask<EmptyResult> RunIfWaitingForDebuggerAsync(EmptyParameters parameters, CommandContext context)
+    {
+        _target.Dispatcher.ReleaseDebuggerWait();
+        return new ValueTask<EmptyResult>(EmptyResult.Instance);
+    }
+
+    /// <summary>
+    /// Answers nothing, and truthfully: this package keeps no console buffer to discard.
+    /// </summary>
+    /// <remarks>
+    /// Answered rather than refused because clients send it while tidying up and a <c>-32601</c> there is
+    /// noise in a client's log about a state it does not have.
+    /// </remarks>
+    protected override ValueTask<EmptyResult> DiscardConsoleEntriesAsync(EmptyParameters parameters, CommandContext context)
+    {
+        return new ValueTask<EmptyResult>(EmptyResult.Instance);
+    }
+
+    /// <summary>
+    /// Answers a stable identifier for the engine, which is what a client groups targets sharing a heap by.
+    /// </summary>
+    /// <remarks>
+    /// One engine is one isolate here: engines share nothing, and a <c>JsValue</c> crossing between two of
+    /// them is unsupported, so the target's own identifier is exactly as unique as the isolate is.
+    /// </remarks>
+    protected override ValueTask<GetIsolateIdResponse> GetIsolateIdAsync(EmptyParameters parameters, CommandContext context)
+    {
+        return new ValueTask<GetIsolateIdResponse>(new GetIsolateIdResponse { Id = _target.TargetId });
+    }
+
+    /// <inheritdoc/>
+    protected override ValueTask<EvaluateResponse> EvaluateAsync(EvaluateRequest parameters, CommandContext context)
+    {
+        if (parameters.ContextId is { } contextId && contextId != MainExecutionContextId)
+        {
+            // Chrome's wording, which several clients match on to decide a context went away rather than
+            // that the call was wrong.
+            Throw.ServerError("Cannot find context with specified id");
+        }
+
+        var byValue = parameters.ReturnByValue == true;
+
+        JsValue value;
+        try
+        {
+            value = _target.Engine.Evaluate(parameters.Expression);
+        }
+        catch (JavaScriptException exception)
+        {
+            // A compile failure arrives here too: the engine raises a SyntaxError for one, with the
+            // location filled in, so there is one path rather than two and neither is a protocol error --
+            // the command was well formed and it is the client's expression that was not.
+            return new ValueTask<EvaluateResponse>(Failure(RemoteValues.Exception(exception, NextExceptionId(), MainExecutionContextId), exception.Error, byValue));
+        }
+
+        if (parameters.AwaitPromise == true && value.IsPromise())
+        {
+            return Settled(value, byValue);
+        }
+
+        return new ValueTask<EvaluateResponse>(new EvaluateResponse { Result = RemoteValues.Describe(value, byValue) });
+    }
+
+    /// <summary>
+    /// Answers when the promise settles, by attaching reactions to it.
+    /// </summary>
+    /// <remarks>
+    /// <b>Never by draining.</b> This runs inside an event-loop job and the pump's re-entrancy guard forbids
+    /// a nested drain, so the command completes from the job that runs the reaction — on this same thread,
+    /// with the value still in the engine's hands. What crosses back afterwards is a finished record.
+    /// </remarks>
+    private ValueTask<EvaluateResponse> Settled(JsValue promise, bool byValue)
+    {
+        var engine = _target.Engine;
+        var then = promise.Get("then");
+        if (!then.IsCallable())
+        {
+            return new ValueTask<EvaluateResponse>(new EvaluateResponse { Result = RemoteValues.Describe(promise, byValue) });
+        }
+
+        var completion = new TaskCompletionSource<EvaluateResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // Both reactions catch everything, and that is not defensive noise: they run as event-loop jobs, so
+        // anything they let escape erupts out of the host's own pump. Describing the settled value can fail
+        // -- a by-value result the protocol has no form for is a refusal -- and the client is what should
+        // hear about it.
+        var onFulfilled = new ClrFunction(engine, "", (_, arguments) =>
+        {
+            try
+            {
+                var result = arguments.Length > 0 ? arguments[0] : JsValue.Undefined;
+                completion.TrySetResult(new EvaluateResponse { Result = RemoteValues.Describe(result, byValue) });
+            }
+            catch (Exception exception)
+            {
+                completion.TrySetException(exception);
+            }
+
+            return JsValue.Undefined;
+        });
+
+        var onRejected = new ClrFunction(engine, "", (_, arguments) =>
+        {
+            try
+            {
+                var reason = arguments.Length > 0 ? arguments[0] : JsValue.Undefined;
+                completion.TrySetResult(Failure(RemoteValues.Rejection(reason, NextExceptionId(), MainExecutionContextId), reason, byValue));
+            }
+            catch (Exception exception)
+            {
+                completion.TrySetException(exception);
+            }
+
+            return JsValue.Undefined;
+        });
+
+        engine.Call(then, promise, [onFulfilled, onRejected]);
+        return new ValueTask<EvaluateResponse>(completion.Task);
+    }
+
+    private static EvaluateResponse Failure(ExceptionDetails details, JsValue thrown, bool byValue)
+    {
+        // The protocol wants both: the details a client renders in its console, and the thrown value itself
+        // as the command's result, which is what a client inspects.
+        return new EvaluateResponse
+        {
+            Result = RemoteValues.Describe(thrown, byValue && !thrown.IsObject()),
+            ExceptionDetails = details,
+        };
+    }
+
+    private int NextExceptionId() => ++_exceptionId;
+
+    private static JsonElement AuxData
+    {
+        get
+        {
+            using var document = JsonDocument.Parse("""{"isDefault":true,"type":"default"}""");
+            return document.RootElement.Clone();
+        }
+    }
+}

--- a/Jint.DevTools/Domains/TargetDomain.cs
+++ b/Jint.DevTools/Domains/TargetDomain.cs
@@ -1,0 +1,338 @@
+using Jint.DevTools.Protocol;
+using Jint.DevTools.Protocol.Target;
+using Jint.DevTools.Session;
+
+namespace Jint.DevTools.Domains;
+
+/// <summary>
+/// Answers the <c>Target</c> commands: what engines exist, and which of them a client is attached to.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Flattened sessions only.</b> <c>attachToTarget</c> and <c>setAutoAttach</c> both refuse
+/// <c>flatten: false</c> with <c>-32000</c>, because the alternative is the wrapped model —
+/// <c>Target.sendMessageToTarget</c> carrying a whole protocol message as a string — and no client recorded
+/// in <c>tools/devtools-protocol/handshakes/</c> asks for it. Answering both models would mean a second
+/// routing path kept alive forever for nobody.
+/// </para>
+/// <para>
+/// <b>A browser context is not something an engine target has.</b> <c>getBrowserContexts</c> answers an
+/// empty list, and <c>createBrowserContext</c> refuses with a reason rather than minting an identifier that
+/// partitions nothing: a client that was handed one would believe its next target was isolated. The page
+/// package, where a context really does own cookies and storage, is where they start meaning something.
+/// </para>
+/// <para>
+/// See <see href="https://chromedevtools.github.io/devtools-protocol/tot/Target/"/>.
+/// </para>
+/// </remarks>
+internal sealed class TargetDomain : TargetDomainBase
+{
+    private readonly BrowserSession _browser;
+    private readonly bool _nested;
+
+    private bool _discover;
+    private FilterEntry[]? _discoverFilter;
+    private bool _autoAttach;
+    private bool _autoAttachWaitsForDebugger;
+    private FilterEntry[]? _autoAttachFilter;
+
+    /// <summary>Creates the domain for one session.</summary>
+    /// <param name="browser">The conversation whose attachments this domain mints.</param>
+    /// <param name="nested">
+    /// Whether this is the copy on an attached session rather than on the browser session, which decides
+    /// only what <c>setAutoAttach</c> does: an engine target has no children to attach to.
+    /// </param>
+    internal TargetDomain(BrowserSession browser, bool nested)
+    {
+        _browser = browser;
+        _nested = nested;
+    }
+
+    /// <inheritdoc/>
+    protected override ValueTask<GetTargetsResponse> GetTargetsAsync(GetTargetsRequest parameters, CommandContext context)
+    {
+        var infos = new List<TargetInfo>();
+        foreach (var target in _browser.Server.Targets)
+        {
+            if (Matches(parameters.Filter, target.Type))
+            {
+                infos.Add(Describe(target));
+            }
+        }
+
+        return new ValueTask<GetTargetsResponse>(new GetTargetsResponse { TargetInfos = [.. infos] });
+    }
+
+    /// <inheritdoc/>
+    protected override ValueTask<GetTargetInfoResponse> GetTargetInfoAsync(GetTargetInfoRequest parameters, CommandContext context)
+    {
+        var target = Find(parameters.TargetId);
+        return new ValueTask<GetTargetInfoResponse>(new GetTargetInfoResponse { TargetInfo = Describe(target) });
+    }
+
+    /// <inheritdoc/>
+    protected override async ValueTask<EmptyResult> SetDiscoverTargetsAsync(SetDiscoverTargetsRequest parameters, CommandContext context)
+    {
+        var wasDiscovering = _discover;
+        _discover = parameters.Discover;
+        _discoverFilter = parameters.Filter;
+
+        if (_discover && !wasDiscovering)
+        {
+            // Chrome replays targetCreated for everything that already exists, which is what makes discovery
+            // usable by a client that connected after the targets did.
+            foreach (var target in _browser.Server.Targets)
+            {
+                if (Matches(_discoverFilter, target.Type))
+                {
+                    await EmitAsync(TargetEvents.TargetCreated(new TargetCreatedEvent { TargetInfo = Describe(target) }), context.CancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+
+        return EmptyResult.Instance;
+    }
+
+    /// <inheritdoc/>
+    protected override async ValueTask<EmptyResult> SetAutoAttachAsync(SetAutoAttachRequest parameters, CommandContext context)
+    {
+        if (parameters.Flatten != true)
+        {
+            RefuseUnflattened();
+        }
+
+        if (_nested)
+        {
+            // An engine target has no children, so there is nothing to attach to and nothing to remember.
+            // Answered as the success it is: a client walks down the tree by sending this on every session
+            // it is given, and a refusal there reads to it as a broken target.
+            return EmptyResult.Instance;
+        }
+
+        _autoAttach = parameters.AutoAttach;
+        _autoAttachWaitsForDebugger = parameters.WaitForDebuggerOnStart;
+        _autoAttachFilter = parameters.Filter;
+
+        if (!_autoAttach)
+        {
+            return EmptyResult.Instance;
+        }
+
+        foreach (var target in _browser.Server.Targets)
+        {
+            if (Matches(_autoAttachFilter, target.Type))
+            {
+                await AttachAsync(target, context.CancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        return EmptyResult.Instance;
+    }
+
+    /// <inheritdoc/>
+    protected override async ValueTask<AttachToTargetResponse> AttachToTargetAsync(AttachToTargetRequest parameters, CommandContext context)
+    {
+        if (parameters.Flatten != true)
+        {
+            RefuseUnflattened();
+        }
+
+        var target = Find(parameters.TargetId);
+        var sessionId = await AttachAsync(target, context.CancellationToken).ConfigureAwait(false);
+        return new AttachToTargetResponse { SessionId = sessionId };
+    }
+
+    /// <inheritdoc/>
+    protected override async ValueTask<EmptyResult> DetachFromTargetAsync(DetachFromTargetRequest parameters, CommandContext context)
+    {
+        var sessionId = parameters.SessionId;
+        if (sessionId is null && parameters.TargetId is { } targetId)
+        {
+            sessionId = _browser.SessionIdOf(Find(targetId));
+        }
+
+        if (sessionId is null)
+        {
+            Throw.InvalidParams("Invalid parameters", "either sessionId or targetId is required");
+        }
+
+        var detached = _browser.Detach(sessionId);
+        if (detached is null)
+        {
+            return Throw.SessionNotFound<EmptyResult>();
+        }
+
+        await EmitAsync(
+            TargetEvents.DetachedFromTarget(new DetachedFromTargetEvent { SessionId = sessionId, TargetId = detached.TargetId }),
+            context.CancellationToken).ConfigureAwait(false);
+
+        return EmptyResult.Instance;
+    }
+
+    /// <inheritdoc/>
+    protected override ValueTask<CreateTargetResponse> CreateTargetAsync(CreateTargetRequest parameters, CommandContext context)
+    {
+        var target = _browser.Server.CreateTarget();
+        return new ValueTask<CreateTargetResponse>(new CreateTargetResponse { TargetId = target.TargetId });
+    }
+
+    /// <inheritdoc/>
+    protected override async ValueTask<CloseTargetResponse> CloseTargetAsync(CloseTargetRequest parameters, CommandContext context)
+    {
+        var target = Find(parameters.TargetId);
+        await _browser.Server.CloseTargetAsync(target).ConfigureAwait(false);
+        return new CloseTargetResponse { Success = true };
+    }
+
+    /// <summary>
+    /// Answers success and does nothing, which is what activating a target means when there is no window.
+    /// </summary>
+    /// <remarks>
+    /// Refusing would be worse than useless: clients activate a target before driving it and read a failure
+    /// as the target being gone.
+    /// </remarks>
+    protected override ValueTask<EmptyResult> ActivateTargetAsync(ActivateTargetRequest parameters, CommandContext context)
+    {
+        Find(parameters.TargetId);
+        return new ValueTask<EmptyResult>(EmptyResult.Instance);
+    }
+
+    /// <inheritdoc/>
+    protected override ValueTask<GetBrowserContextsResponse> GetBrowserContextsAsync(EmptyParameters parameters, CommandContext context)
+    {
+        return new ValueTask<GetBrowserContextsResponse>(new GetBrowserContextsResponse { BrowserContextIds = [] });
+    }
+
+    /// <inheritdoc/>
+    protected override ValueTask<CreateBrowserContextResponse> CreateBrowserContextAsync(CreateBrowserContextRequest parameters, CommandContext context)
+    {
+        return Throw.ServerError<ValueTask<CreateBrowserContextResponse>>(
+            "Browser contexts are not supported",
+            "an engine target has no cookies, storage or cache to partition, so a context identifier would isolate nothing");
+    }
+
+    /// <inheritdoc/>
+    protected override ValueTask<EmptyResult> DisposeBrowserContextAsync(DisposeBrowserContextRequest parameters, CommandContext context)
+    {
+        return Throw.ServerError<ValueTask<EmptyResult>>(
+            "Browser contexts are not supported",
+            "an engine target has no cookies, storage or cache to partition, so there is no context to dispose");
+    }
+
+    /// <summary>Tells the client about a target that has just appeared, if it asked to be told.</summary>
+    internal async ValueTask TargetAddedAsync(EngineTarget target, CancellationToken cancellationToken)
+    {
+        if (_discover && Matches(_discoverFilter, target.Type))
+        {
+            await EmitAsync(TargetEvents.TargetCreated(new TargetCreatedEvent { TargetInfo = Describe(target) }), cancellationToken).ConfigureAwait(false);
+        }
+
+        if (_autoAttach && Matches(_autoAttachFilter, target.Type))
+        {
+            await AttachAsync(target, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>Tells the client about a target that has gone, detaching first if it was attached.</summary>
+    internal async ValueTask TargetRemovedAsync(EngineTarget target, CancellationToken cancellationToken)
+    {
+        if (_browser.SessionIdOf(target) is { } sessionId)
+        {
+            _browser.Detach(sessionId);
+            await EmitAsync(
+                TargetEvents.DetachedFromTarget(new DetachedFromTargetEvent { SessionId = sessionId, TargetId = target.TargetId }),
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        if (_discover && Matches(_discoverFilter, target.Type))
+        {
+            await EmitAsync(TargetEvents.TargetDestroyed(new TargetDestroyedEvent { TargetId = target.TargetId }), cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private async ValueTask<string> AttachAsync(EngineTarget target, CancellationToken cancellationToken)
+    {
+        var sessionId = _browser.Attach(target, out var created);
+        if (!created)
+        {
+            // Already attached, and announcing it again would have the client believe in two sessions.
+            return sessionId;
+        }
+
+        await EmitAsync(
+            TargetEvents.AttachedToTarget(new AttachedToTargetEvent
+            {
+                SessionId = sessionId,
+                TargetInfo = Describe(target, attached: true),
+
+                // What tells a client it must send Runtime.runIfWaitingForDebugger before anything the host
+                // posted will run. A target that is not holding anything says false, and the client's first
+                // evaluate goes straight through.
+                WaitingForDebugger = _autoAttachWaitsForDebugger && target.IsWaitingForDebugger,
+            }),
+            cancellationToken).ConfigureAwait(false);
+
+        return sessionId;
+    }
+
+    private EngineTarget Find(string? targetId)
+    {
+        if (targetId is not null && _browser.Server.FindTarget(targetId) is { } target)
+        {
+            return target;
+        }
+
+        // Chrome's wording, which clients match on to tell a target that went away from a call that was
+        // wrong.
+        return Throw.ServerError<EngineTarget>("No target with given id found");
+    }
+
+    private TargetInfo Describe(EngineTarget target, bool attached = false)
+    {
+        return new TargetInfo
+        {
+            TargetId = target.TargetId,
+            Type = target.Type,
+            Title = target.Title,
+            Url = target.Url,
+            Attached = attached || _browser.SessionIdOf(target) is not null,
+            CanAccessOpener = false,
+        };
+    }
+
+    [System.Diagnostics.CodeAnalysis.DoesNotReturn]
+    private static void RefuseUnflattened()
+    {
+        Throw.ServerError(
+            "Only flatten protocol is supported",
+            "the wrapped session model routes every message through Target.sendMessageToTarget, which this server does not answer");
+    }
+
+    /// <summary>
+    /// Decides whether a target's type passes one of the protocol's filters.
+    /// </summary>
+    /// <remarks>
+    /// The protocol's own rule: the first entry that matches the type — or that names no type, which matches
+    /// everything — decides, and <c>exclude</c> inverts it. A filter that matches nothing excludes, and no
+    /// filter at all includes, which is what a client sending none means.
+    /// </remarks>
+    private static bool Matches(FilterEntry[]? filter, string type)
+    {
+        if (filter is null || filter.Length == 0)
+        {
+            return true;
+        }
+
+        foreach (var entry in filter)
+        {
+            if (entry.Type is { } wanted && !string.Equals(wanted, type, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            return entry.Exclude != true;
+        }
+
+        return false;
+    }
+}

--- a/Jint.DevTools/EngineTarget.cs
+++ b/Jint.DevTools/EngineTarget.cs
@@ -1,0 +1,315 @@
+using Jint.DevTools.Session;
+
+namespace Jint.DevTools;
+
+/// <summary>
+/// One engine, as a client sees it: a target it can list, attach to and evaluate in.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A target owns the mailbox that brings a protocol command from a transport thread to the thread that runs
+/// the engine, which is the whole of the thread rule: a <see cref="Native.JsValue"/> never leaves the engine
+/// thread, and a transport thread only ever moves strings. Which thread that is comes from
+/// <see cref="EngineTargetOptions.ThreadMode"/>.
+/// </para>
+/// <para>
+/// The target reports itself to clients as Node's <c>node</c> type, so the DevTools front end opens its
+/// JavaScript-only layout and never asks the target for a page. Page targets belong to the browser package.
+/// </para>
+/// <para>
+/// <b>The target does not own the engine's lifetime.</b> Disposing it stops the thread it started, if it
+/// started one, and stops answering commands; the <see cref="Engine"/> is the host's, before and after.
+/// </para>
+/// </remarks>
+public sealed class EngineTarget : IAsyncDisposable
+{
+    /// <summary>
+    /// How long the library-owned loop parks before looking again. It is woken by every arrival, so this
+    /// bounds nothing but how quickly a cancellation with no work behind it is noticed.
+    /// </summary>
+    private static readonly TimeSpan IdleInterval = TimeSpan.FromMilliseconds(100);
+
+    /// <summary>The longest a single wait may ask for, which is what the blocking primitives accept.</summary>
+    private static readonly TimeSpan MaxWait = TimeSpan.FromMilliseconds(int.MaxValue);
+
+    private readonly EngineDispatcher _dispatcher;
+    private readonly CancellationTokenSource? _stopping;
+    private readonly Thread? _thread;
+    private readonly ManualResetEventSlim? _debuggerWaitEnded;
+
+    private int _disposed;
+
+    /// <summary>Creates a target over <paramref name="engine"/>.</summary>
+    /// <param name="engine">The engine a client attaches to.</param>
+    /// <param name="options">How the target presents itself and which thread runs it, or the defaults.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="engine"/> is <see langword="null"/>.</exception>
+    public EngineTarget(Engine engine, EngineTargetOptions? options = null)
+    {
+        if (engine is null)
+        {
+            Throw.ArgumentNull(nameof(engine));
+        }
+
+        options ??= new EngineTargetOptions();
+
+        Engine = engine;
+        Title = options.Title;
+        Url = options.Url;
+        ThreadMode = options.ThreadMode;
+        TargetId = Identifiers.New();
+
+        _dispatcher = new EngineDispatcher(engine, DevToolsServerOptions.DefaultCommandTimeout, options.WaitForDebuggerOnStart);
+
+        if (options.WaitForDebuggerOnStart)
+        {
+            var released = new ManualResetEventSlim(initialState: false);
+            _debuggerWaitEnded = released;
+            _dispatcher.DebuggerWaitEnded += released.Set;
+        }
+
+        if (ThreadMode != ThreadMode.LibraryOwned)
+        {
+            return;
+        }
+
+        _stopping = new CancellationTokenSource();
+        _thread = new Thread(RunLoop)
+        {
+            IsBackground = true,
+            Name = "Jint DevTools target " + TargetId,
+        };
+
+        _thread.Start();
+    }
+
+    /// <summary>Gets the engine this target attaches a client to.</summary>
+    public Engine Engine { get; }
+
+    /// <summary>Gets the opaque identifier a client addresses this target by.</summary>
+    public string TargetId { get; }
+
+    /// <summary>Gets the target's protocol type, which is always <c>node</c> for an engine target.</summary>
+    public string Type { get; } = "node";
+
+    /// <summary>Gets the name a client lists the target under.</summary>
+    public string Title { get; }
+
+    /// <summary>Gets the location a client shows for the target.</summary>
+    public string Url { get; }
+
+    /// <summary>Gets which thread runs the engine and answers commands addressed to this target.</summary>
+    public ThreadMode ThreadMode { get; }
+
+    /// <summary>Gets whether work posted to the target is still held for a client that has not released it.</summary>
+    public bool IsWaitingForDebugger => _dispatcher.IsWaitingForDebugger;
+
+    /// <summary>Gets the mailbox every protocol command addressed to this target crosses.</summary>
+    internal EngineDispatcher Dispatcher => _dispatcher;
+
+    /// <summary>
+    /// Gives the engine one turn: answers the protocol commands waiting for it, then runs the event loop.
+    /// </summary>
+    /// <remarks>
+    /// What a <see cref="ThreadMode.HostOwned"/> host calls from its own loop.
+    /// <see cref="Engine.TaskOperations.ProcessTasks"/> alone is enough — the mailbox wakes the loop through
+    /// <see cref="Engine.TaskOperations.Post(System.Action)"/> and is drained as an ordinary job — so this is
+    /// the convenience, not the mechanism.
+    /// </remarks>
+    /// <exception cref="ObjectDisposedException">The target has been disposed.</exception>
+    /// <exception cref="InvalidOperationException">The target is <see cref="ThreadMode.LibraryOwned"/>.</exception>
+    public void Pump()
+    {
+        ThrowIfDisposed();
+
+        if (ThreadMode == ThreadMode.LibraryOwned)
+        {
+            Throw.InvalidOperation("A LibraryOwned target pumps itself; calling Pump on it from another thread is what the engine's single-drainer guard refuses.");
+        }
+
+        _dispatcher.Drain();
+        Engine.Tasks.ProcessTasks();
+    }
+
+    /// <summary>Queues host work to run on the engine's own thread, from any thread.</summary>
+    /// <param name="work">What to run, given the engine.</param>
+    /// <remarks>
+    /// The supported way for a <see cref="ThreadMode.LibraryOwned"/> host to reach its engine, and safe from
+    /// a <see cref="ThreadMode.HostOwned"/> one too: the work runs in queue order with the protocol commands
+    /// around it. While <see cref="IsWaitingForDebugger"/> holds, it is held; protocol commands are not, or
+    /// the command that ends the wait could never be answered.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException"><paramref name="work"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ObjectDisposedException">The target has been disposed.</exception>
+    public void Post(Action<Engine> work)
+    {
+        if (work is null)
+        {
+            Throw.ArgumentNull(nameof(work));
+        }
+
+        ThrowIfDisposed();
+        _dispatcher.Post(work);
+    }
+
+    /// <summary>Queues host work and answers when it has run.</summary>
+    /// <param name="work">What to run, given the engine.</param>
+    /// <returns>A task that completes when <paramref name="work"/> has run, or faults with what it threw.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="work"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ObjectDisposedException">The target has been disposed.</exception>
+    public Task PostAsync(Action<Engine> work)
+    {
+        if (work is null)
+        {
+            Throw.ArgumentNull(nameof(work));
+        }
+
+        return PostAsync<object?>(engine =>
+        {
+            work(engine);
+            return null;
+        });
+    }
+
+    /// <summary>Queues host work and answers with what it returned.</summary>
+    /// <typeparam name="T">What the work answers with, which must be a CLR value rather than a <c>JsValue</c>.</typeparam>
+    /// <param name="work">What to run, given the engine.</param>
+    /// <returns>A task carrying the work's result, or faulted with what it threw.</returns>
+    /// <remarks>
+    /// <b>Never answer with a <see cref="Native.JsValue"/>.</b> It belongs to the engine's thread, and the
+    /// awaiting thread is not it; convert to a CLR value inside the work.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException"><paramref name="work"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ObjectDisposedException">The target has been disposed.</exception>
+    public Task<T> PostAsync<T>(Func<Engine, T> work)
+    {
+        if (work is null)
+        {
+            Throw.ArgumentNull(nameof(work));
+        }
+
+        ThrowIfDisposed();
+
+        var completion = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
+        _dispatcher.Post(engine =>
+        {
+            try
+            {
+                completion.TrySetResult(work(engine));
+            }
+            catch (Exception exception)
+            {
+                completion.TrySetException(exception);
+            }
+        });
+
+        return completion.Task;
+    }
+
+    /// <summary>
+    /// Pumps until a client releases a target started with
+    /// <see cref="EngineTargetOptions.WaitForDebuggerOnStart"/>.
+    /// </summary>
+    /// <param name="timeout">How long to wait before giving up.</param>
+    /// <returns><see langword="true"/> if a client released the target within <paramref name="timeout"/>.</returns>
+    /// <remarks>
+    /// What a <see cref="ThreadMode.HostOwned"/> host calls in place of its first
+    /// <see cref="Pump"/>: the command that ends the wait — <c>Runtime.runIfWaitingForDebugger</c> — is
+    /// itself answered on this thread, so a host that merely blocked would wait forever. A
+    /// <see cref="ThreadMode.LibraryOwned"/> target needs none of this and answers immediately.
+    /// </remarks>
+    /// <exception cref="ObjectDisposedException">The target has been disposed.</exception>
+    public bool WaitForDebugger(TimeSpan timeout)
+    {
+        ThrowIfDisposed();
+
+        if (!IsWaitingForDebugger)
+        {
+            return true;
+        }
+
+        // Clamped rather than validated: a host spelling "effectively no bound" passes something enormous,
+        // and both the wait below and the arithmetic after it reject anything past int.MaxValue milliseconds.
+        var bound = timeout < TimeSpan.Zero || timeout > MaxWait ? MaxWait : timeout;
+
+        if (ThreadMode == ThreadMode.LibraryOwned)
+        {
+            return _debuggerWaitEnded?.Wait(bound) ?? true;
+        }
+
+        var deadline = Environment.TickCount64 + (long) bound.TotalMilliseconds;
+        while (IsWaitingForDebugger)
+        {
+            Pump();
+
+            if (!IsWaitingForDebugger)
+            {
+                break;
+            }
+
+            var remaining = deadline - Environment.TickCount64;
+            if (remaining <= 0)
+            {
+                return false;
+            }
+
+            Engine.Tasks.WaitForScheduledWork(TimeSpan.FromMilliseconds(Math.Min(remaining, IdleInterval.TotalMilliseconds)));
+        }
+
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        if (_stopping is not null)
+        {
+            await _stopping.CancelAsync().ConfigureAwait(false);
+        }
+
+        if (_thread is not null && _thread.IsAlive)
+        {
+            _thread.Join(TimeSpan.FromSeconds(5));
+        }
+
+        _stopping?.Dispose();
+        _debuggerWaitEnded?.Dispose();
+    }
+
+    private void RunLoop()
+    {
+        var token = _stopping!.Token;
+
+        while (!token.IsCancellationRequested)
+        {
+            try
+            {
+                _dispatcher.Drain();
+                Engine.Tasks.ProcessTasks();
+                Engine.Tasks.WaitForScheduledWork(IdleInterval, token);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+#pragma warning disable CA1031 // the loop is the last thing between one bad command and a dead target
+            catch (Exception)
+#pragma warning restore CA1031
+            {
+                // A host callback or a script that threw out of the pump must not end the thread: every
+                // protocol command already answers its own failure, so what reaches here is host work, and
+                // the next turn is still owed to every other client.
+            }
+        }
+    }
+
+    private void ThrowIfDisposed()
+    {
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+    }
+
+}

--- a/Jint.DevTools/EngineTargetOptions.cs
+++ b/Jint.DevTools/EngineTargetOptions.cs
@@ -1,0 +1,42 @@
+namespace Jint.DevTools;
+
+/// <summary>
+/// How one <see cref="EngineTarget"/> presents itself to a client, and which thread runs it.
+/// </summary>
+/// <remarks>
+/// Read once, when the target is constructed. Changing an instance afterwards changes nothing about a
+/// target already built from it.
+/// </remarks>
+public sealed class EngineTargetOptions
+{
+    /// <summary>Creates a set of options, each at its default.</summary>
+    public EngineTargetOptions()
+    {
+    }
+
+    /// <summary>Gets or sets the name a client lists the target under. Defaults to <c>Jint engine</c>.</summary>
+    public string Title { get; set; } = "Jint engine";
+
+    /// <summary>Gets or sets the location a client shows for the target. Defaults to the empty string.</summary>
+    /// <remarks>
+    /// An engine target has no document, so there is nothing honest to put here; a host that runs one named
+    /// script per engine is the one that has something worth showing.
+    /// </remarks>
+    public string Url { get; set; } = "";
+
+    /// <summary>Gets or sets which thread runs the engine. Defaults to <see cref="ThreadMode.HostOwned"/>.</summary>
+    public ThreadMode ThreadMode { get; set; } = ThreadMode.HostOwned;
+
+    /// <summary>
+    /// Gets or sets whether the first work posted to the target is held until a client says to run it.
+    /// Defaults to <see langword="false"/>.
+    /// </summary>
+    /// <remarks>
+    /// Node's <c>--inspect-brk</c>: the target reports <c>waitingForDebugger</c> when a session attaches,
+    /// and nothing the host posted runs until some session sends <c>Runtime.runIfWaitingForDebugger</c>. A
+    /// <see cref="ThreadMode.HostOwned"/> host waits for that with
+    /// <see cref="EngineTarget.WaitForDebugger"/>; a <see cref="ThreadMode.LibraryOwned"/> one needs to do
+    /// nothing, because its own thread is already pumping.
+    /// </remarks>
+    public bool WaitForDebuggerOnStart { get; set; }
+}

--- a/Jint.DevTools/Protocol/Generated/ProtocolManifest.g.cs
+++ b/Jint.DevTools/Protocol/Generated/ProtocolManifest.g.cs
@@ -44,19 +44,44 @@ namespace Jint.DevTools.Protocol
         [
             "Browser.close",
             "Browser.getVersion",
+            "Runtime.disable",
+            "Runtime.discardConsoleEntries",
+            "Runtime.enable",
+            "Runtime.evaluate",
+            "Runtime.getIsolateId",
+            "Runtime.runIfWaitingForDebugger",
             "Schema.getDomains",
+            "Target.activateTarget",
+            "Target.attachToTarget",
+            "Target.closeTarget",
+            "Target.createBrowserContext",
+            "Target.createTarget",
+            "Target.detachFromTarget",
+            "Target.disposeBrowserContext",
+            "Target.getBrowserContexts",
+            "Target.getTargetInfo",
+            "Target.getTargets",
+            "Target.setAutoAttach",
+            "Target.setDiscoverTargets",
         ];
 
         /// <summary>The events this assembly emits.</summary>
         internal static global::System.Collections.Generic.IReadOnlyList<string> ImplementedEvents { get; } =
         [
+            "Runtime.executionContextCreated",
+            "Target.attachedToTarget",
+            "Target.detachedFromTarget",
+            "Target.targetCreated",
+            "Target.targetDestroyed",
         ];
 
         /// <summary>What <c>Schema.getDomains</c> answers.</summary>
         internal static global::System.Collections.Generic.IReadOnlyList<global::Jint.DevTools.Protocol.Schema.Domain> ReportedDomains { get; } =
         [
             new global::Jint.DevTools.Protocol.Schema.Domain { Name = "Browser", Version = "1.3" },
+            new global::Jint.DevTools.Protocol.Schema.Domain { Name = "Runtime", Version = "1.3" },
             new global::Jint.DevTools.Protocol.Schema.Domain { Name = "Schema", Version = "1.3" },
+            new global::Jint.DevTools.Protocol.Schema.Domain { Name = "Target", Version = "1.3" },
         ];
     }
 }

--- a/Jint.DevTools/Protocol/Generated/Runtime.g.cs
+++ b/Jint.DevTools/Protocol/Generated/Runtime.g.cs
@@ -1685,8 +1685,53 @@ namespace Jint.DevTools.Domains
             => global::Jint.DevTools.Throw.MethodNotFound<global::System.Threading.Tasks.ValueTask<global::Jint.DevTools.Protocol.Runtime.GetExceptionDetailsResponse>>("Runtime.getExceptionDetails");
 
         /// <inheritdoc/>
-        internal sealed override global::System.Threading.Tasks.ValueTask<string> DispatchAsync(string method, global::System.Text.Json.JsonElement? parameters, global::Jint.DevTools.Session.CommandContext context)
-            => global::Jint.DevTools.Throw.MethodNotFound<global::System.Threading.Tasks.ValueTask<string>>("Runtime." + method);
+        internal sealed override async global::System.Threading.Tasks.ValueTask<string> DispatchAsync(string method, global::System.Text.Json.JsonElement? parameters, global::Jint.DevTools.Session.CommandContext context)
+        {
+            switch (method)
+            {
+                case "disable":
+                {
+                    var result = await DisableAsync(global::Jint.DevTools.Protocol.ProtocolPayload.Read(parameters, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.EmptyParameters), context).ConfigureAwait(false);
+                    return global::System.Text.Json.JsonSerializer.Serialize(result, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.EmptyResult);
+                }
+
+                case "discardConsoleEntries":
+                {
+                    var result = await DiscardConsoleEntriesAsync(global::Jint.DevTools.Protocol.ProtocolPayload.Read(parameters, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.EmptyParameters), context).ConfigureAwait(false);
+                    return global::System.Text.Json.JsonSerializer.Serialize(result, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.EmptyResult);
+                }
+
+                case "enable":
+                {
+                    var result = await EnableAsync(global::Jint.DevTools.Protocol.ProtocolPayload.Read(parameters, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.EmptyParameters), context).ConfigureAwait(false);
+                    return global::System.Text.Json.JsonSerializer.Serialize(result, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.EmptyResult);
+                }
+
+                case "evaluate":
+                {
+                    var result = await EvaluateAsync(global::Jint.DevTools.Protocol.ProtocolPayload.Read(parameters, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.RuntimeEvaluateRequest), context).ConfigureAwait(false);
+                    return global::System.Text.Json.JsonSerializer.Serialize(result, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.RuntimeEvaluateResponse);
+                }
+
+                case "getIsolateId":
+                {
+                    var result = await GetIsolateIdAsync(global::Jint.DevTools.Protocol.ProtocolPayload.Read(parameters, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.EmptyParameters), context).ConfigureAwait(false);
+                    return global::System.Text.Json.JsonSerializer.Serialize(result, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.RuntimeGetIsolateIdResponse);
+                }
+
+                case "runIfWaitingForDebugger":
+                {
+                    var result = await RunIfWaitingForDebuggerAsync(global::Jint.DevTools.Protocol.ProtocolPayload.Read(parameters, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.EmptyParameters), context).ConfigureAwait(false);
+                    return global::System.Text.Json.JsonSerializer.Serialize(result, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.EmptyResult);
+                }
+
+                // A command manifest.json does not list is method-not-found BEFORE its parameters
+                // are looked at, which is the order Chrome answers in: a command a backend does not
+                // implement is not in its dispatch table at all, so its payload is never read.
+                default:
+                    return global::Jint.DevTools.Throw.MethodNotFound<string>("Runtime." + method);
+            }
+        }
     }
 
     /// <summary>Builds the <c>Runtime</c> domain's events.</summary>

--- a/Jint.DevTools/Protocol/Generated/Target.g.cs
+++ b/Jint.DevTools/Protocol/Generated/Target.g.cs
@@ -740,8 +740,89 @@ namespace Jint.DevTools.Domains
             => global::Jint.DevTools.Throw.MethodNotFound<global::System.Threading.Tasks.ValueTask<global::Jint.DevTools.Protocol.Target.OpenDevToolsResponse>>("Target.openDevTools");
 
         /// <inheritdoc/>
-        internal sealed override global::System.Threading.Tasks.ValueTask<string> DispatchAsync(string method, global::System.Text.Json.JsonElement? parameters, global::Jint.DevTools.Session.CommandContext context)
-            => global::Jint.DevTools.Throw.MethodNotFound<global::System.Threading.Tasks.ValueTask<string>>("Target." + method);
+        internal sealed override async global::System.Threading.Tasks.ValueTask<string> DispatchAsync(string method, global::System.Text.Json.JsonElement? parameters, global::Jint.DevTools.Session.CommandContext context)
+        {
+            switch (method)
+            {
+                case "activateTarget":
+                {
+                    var result = await ActivateTargetAsync(global::Jint.DevTools.Protocol.ProtocolPayload.Read(parameters, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.TargetActivateTargetRequest), context).ConfigureAwait(false);
+                    return global::System.Text.Json.JsonSerializer.Serialize(result, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.EmptyResult);
+                }
+
+                case "attachToTarget":
+                {
+                    var result = await AttachToTargetAsync(global::Jint.DevTools.Protocol.ProtocolPayload.Read(parameters, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.TargetAttachToTargetRequest), context).ConfigureAwait(false);
+                    return global::System.Text.Json.JsonSerializer.Serialize(result, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.TargetAttachToTargetResponse);
+                }
+
+                case "closeTarget":
+                {
+                    var result = await CloseTargetAsync(global::Jint.DevTools.Protocol.ProtocolPayload.Read(parameters, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.TargetCloseTargetRequest), context).ConfigureAwait(false);
+                    return global::System.Text.Json.JsonSerializer.Serialize(result, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.TargetCloseTargetResponse);
+                }
+
+                case "createBrowserContext":
+                {
+                    var result = await CreateBrowserContextAsync(global::Jint.DevTools.Protocol.ProtocolPayload.Read(parameters, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.TargetCreateBrowserContextRequest), context).ConfigureAwait(false);
+                    return global::System.Text.Json.JsonSerializer.Serialize(result, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.TargetCreateBrowserContextResponse);
+                }
+
+                case "getBrowserContexts":
+                {
+                    var result = await GetBrowserContextsAsync(global::Jint.DevTools.Protocol.ProtocolPayload.Read(parameters, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.EmptyParameters), context).ConfigureAwait(false);
+                    return global::System.Text.Json.JsonSerializer.Serialize(result, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.TargetGetBrowserContextsResponse);
+                }
+
+                case "createTarget":
+                {
+                    var result = await CreateTargetAsync(global::Jint.DevTools.Protocol.ProtocolPayload.Read(parameters, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.TargetCreateTargetRequest), context).ConfigureAwait(false);
+                    return global::System.Text.Json.JsonSerializer.Serialize(result, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.TargetCreateTargetResponse);
+                }
+
+                case "detachFromTarget":
+                {
+                    var result = await DetachFromTargetAsync(global::Jint.DevTools.Protocol.ProtocolPayload.Read(parameters, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.TargetDetachFromTargetRequest), context).ConfigureAwait(false);
+                    return global::System.Text.Json.JsonSerializer.Serialize(result, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.EmptyResult);
+                }
+
+                case "disposeBrowserContext":
+                {
+                    var result = await DisposeBrowserContextAsync(global::Jint.DevTools.Protocol.ProtocolPayload.Read(parameters, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.TargetDisposeBrowserContextRequest), context).ConfigureAwait(false);
+                    return global::System.Text.Json.JsonSerializer.Serialize(result, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.EmptyResult);
+                }
+
+                case "getTargetInfo":
+                {
+                    var result = await GetTargetInfoAsync(global::Jint.DevTools.Protocol.ProtocolPayload.Read(parameters, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.TargetGetTargetInfoRequest), context).ConfigureAwait(false);
+                    return global::System.Text.Json.JsonSerializer.Serialize(result, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.TargetGetTargetInfoResponse);
+                }
+
+                case "getTargets":
+                {
+                    var result = await GetTargetsAsync(global::Jint.DevTools.Protocol.ProtocolPayload.Read(parameters, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.TargetGetTargetsRequest), context).ConfigureAwait(false);
+                    return global::System.Text.Json.JsonSerializer.Serialize(result, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.TargetGetTargetsResponse);
+                }
+
+                case "setAutoAttach":
+                {
+                    var result = await SetAutoAttachAsync(global::Jint.DevTools.Protocol.ProtocolPayload.Read(parameters, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.TargetSetAutoAttachRequest), context).ConfigureAwait(false);
+                    return global::System.Text.Json.JsonSerializer.Serialize(result, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.EmptyResult);
+                }
+
+                case "setDiscoverTargets":
+                {
+                    var result = await SetDiscoverTargetsAsync(global::Jint.DevTools.Protocol.ProtocolPayload.Read(parameters, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.TargetSetDiscoverTargetsRequest), context).ConfigureAwait(false);
+                    return global::System.Text.Json.JsonSerializer.Serialize(result, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.EmptyResult);
+                }
+
+                // A command manifest.json does not list is method-not-found BEFORE its parameters
+                // are looked at, which is the order Chrome answers in: a command a backend does not
+                // implement is not in its dispatch table at all, so its payload is never read.
+                default:
+                    return global::Jint.DevTools.Throw.MethodNotFound<string>("Target." + method);
+            }
+        }
     }
 
     /// <summary>Builds the <c>Target</c> domain's events.</summary>

--- a/Jint.DevTools/Protocol/ProtocolError.cs
+++ b/Jint.DevTools/Protocol/ProtocolError.cs
@@ -29,6 +29,14 @@ internal static class ProtocolErrorCodes
 
     /// <summary>The command was understood and refused, which is where "not supported" lives.</summary>
     internal const int ServerError = -32000;
+
+    /// <summary>The message named a <c>sessionId</c> no attachment answers to.</summary>
+    /// <remarks>
+    /// Chromium's <c>SESSION_NOT_FOUND</c>, one below the generic server error and carrying its own
+    /// wording — <c>Session with given id not found.</c> — which clients match on to tell a stale session
+    /// apart from a command that failed.
+    /// </remarks>
+    internal const int SessionNotFound = -32001;
 }
 
 /// <summary>

--- a/Jint.DevTools/Session/BrowserSession.cs
+++ b/Jint.DevTools/Session/BrowserSession.cs
@@ -1,0 +1,132 @@
+using Jint.DevTools.Domains;
+using Jint.DevTools.Transport;
+
+namespace Jint.DevTools.Session;
+
+/// <summary>
+/// One client's conversation with the server: the browser-level domains, and every attachment it has made.
+/// </summary>
+/// <remarks>
+/// <para>
+/// What a connection to <c>/devtools/browser/&lt;browserId&gt;</c> becomes. Nothing registered here touches
+/// an engine — <c>Schema</c>, <c>Browser</c> and <c>Target</c> are all bookkeeping — so its commands are
+/// answered on the transport thread with no mailbox in between. Only the attachments it mints have a gateway.
+/// </para>
+/// <para>
+/// A target appearing or disappearing on the server reaches every browser session, which is what makes
+/// <c>setDiscoverTargets</c> and <c>setAutoAttach</c> mean anything after the fact rather than only at the
+/// moment they were sent.
+/// </para>
+/// </remarks>
+internal sealed class BrowserSession
+{
+    private readonly Dictionary<string, TargetSession> _attached = new(StringComparer.Ordinal);
+    private readonly TargetDomain _targets;
+
+    internal BrowserSession(DevToolsServer server, IDevToolsConnection connection, Action? closeRequested)
+    {
+        Server = server;
+        Session = new DevToolsSession(connection);
+        _targets = new TargetDomain(this, nested: false);
+
+        BuiltInDomains.RegisterBrowserDomains(Session, server.Version, closeRequested, _targets);
+    }
+
+    /// <summary>Gets the server whose targets this session sees.</summary>
+    internal DevToolsServer Server { get; }
+
+    /// <summary>Gets the root session node this conversation answers on.</summary>
+    internal DevToolsSession Session { get; }
+
+    /// <summary>Attaches to <paramref name="target"/>, minting the session a client then addresses it by.</summary>
+    /// <param name="target">The engine to attach to.</param>
+    /// <param name="created">
+    /// Whether this call is what made the attachment. The check and the mint are one locked step, so two
+    /// threads racing to attach the same target -- a client's <c>attachToTarget</c> and a host's
+    /// <c>AddTarget</c> reaching auto-attach -- produce one attachment and one announcement rather than two.
+    /// </param>
+    /// <returns>The session identifier, new or existing.</returns>
+    internal string Attach(EngineTarget target, out bool created)
+    {
+        lock (_attached)
+        {
+            foreach (var existing in _attached)
+            {
+                if (ReferenceEquals(existing.Value.Target, target))
+                {
+                    created = false;
+                    return existing.Key;
+                }
+            }
+
+            var sessionId = Identifiers.New();
+            _attached.Add(sessionId, TargetSession.Attach(this, target, sessionId));
+            created = true;
+            return sessionId;
+        }
+    }
+
+    /// <summary>Detaches one session, answering the target it was attached to.</summary>
+    internal EngineTarget? Detach(string sessionId)
+    {
+        TargetSession? attached;
+        lock (_attached)
+        {
+            if (!_attached.Remove(sessionId, out attached))
+            {
+                return null;
+            }
+        }
+
+        attached.Detach();
+        return attached.Target;
+    }
+
+    /// <summary>Answers whether this session is attached to <paramref name="target"/>, and under which identifier.</summary>
+    internal string? SessionIdOf(EngineTarget target)
+    {
+        lock (_attached)
+        {
+            foreach (var existing in _attached)
+            {
+                if (ReferenceEquals(existing.Value.Target, target))
+                {
+                    return existing.Key;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Detaches every attachment this session made, which is what a connection going away means.
+    /// </summary>
+    /// <remarks>
+    /// Nothing is announced: the client this would have been announced to is the one that has gone.
+    /// </remarks>
+    internal void DetachAll()
+    {
+        TargetSession[] sessions;
+
+        lock (_attached)
+        {
+            sessions = new TargetSession[_attached.Count];
+            _attached.Values.CopyTo(sessions, 0);
+            _attached.Clear();
+        }
+
+        foreach (var session in sessions)
+        {
+            session.Detach();
+        }
+    }
+
+    /// <summary>Tells this session that a target appeared on the server.</summary>
+    internal ValueTask TargetAddedAsync(EngineTarget target, CancellationToken cancellationToken)
+        => _targets.TargetAddedAsync(target, cancellationToken);
+
+    /// <summary>Tells this session that a target went away.</summary>
+    internal ValueTask TargetRemovedAsync(EngineTarget target, CancellationToken cancellationToken)
+        => _targets.TargetRemovedAsync(target, cancellationToken);
+}

--- a/Jint.DevTools/Session/DevToolsSession.cs
+++ b/Jint.DevTools/Session/DevToolsSession.cs
@@ -6,26 +6,39 @@ using Jint.DevTools.Transport;
 namespace Jint.DevTools.Session;
 
 /// <summary>
-/// One client's conversation: a connection, the domains it may address, and the envelope discipline between
-/// them.
+/// One addressable set of domains on one connection: the connection's own, or one attachment's, told apart
+/// by the <c>sessionId</c> a client puts on the message.
 /// </summary>
 /// <remarks>
 /// <para>
-/// A session reads one message, answers it, and writes one response — always exactly one, whatever went
-/// wrong. A client waiting on an <c>id</c> that never comes back is a hang rather than an error, so every
-/// path out of <see cref="HandleMessageAsync"/> writes something.
+/// A session is a node. The <b>root</b> owns the connection, parses every envelope and writes every reply;
+/// a <b>child</b> is what one <c>Target.attachToTarget</c> minted, carries the <c>sessionId</c> that reaches
+/// it, and writes through its root. A message with no <c>sessionId</c> is answered by the root, one naming a
+/// child by that child, and one naming nothing by <c>-32001</c>.
 /// </para>
 /// <para>
-/// Nothing here touches an engine, and by design: the session is what a transport thread hands text to, and
-/// bringing that text to the engine thread is the dispatcher's job, which arrives with the WebSocket
-/// transport. Until then a session runs wherever it was pumped from.
+/// A session answers every message with exactly one reply, whatever went wrong. A client waiting on an
+/// <c>id</c> that never comes back is a hang rather than an error, so every path out of
+/// <see cref="HandleMessageAsync"/> writes something.
+/// </para>
+/// <para>
+/// <b>Where a command runs is the gateway's decision, not the session's.</b> A session whose domains hold
+/// engine state is given an <see cref="ICommandGateway"/> — <see cref="EngineDispatcher"/> — and every
+/// command addressed to it crosses to the engine thread through that gateway before a domain sees it. A
+/// session with no gateway (the browser session: <c>Schema</c>, <c>Browser</c>, <c>Target</c>) answers on
+/// the transport thread, because none of it touches an engine.
 /// </para>
 /// </remarks>
 internal sealed class DevToolsSession
 {
-    private readonly IDevToolsConnection _connection;
+    private readonly IDevToolsConnection? _connection;
+    private readonly DevToolsSession _root;
     private readonly CommandRouter _router = new();
+    private readonly object _childLock;
+    private Dictionary<string, DevToolsSession>? _children;
+    private ICommandGateway? _gateway;
 
+    /// <summary>Creates the root session of <paramref name="connection"/>.</summary>
     internal DevToolsSession(IDevToolsConnection connection)
     {
         if (connection is null)
@@ -34,8 +47,23 @@ internal sealed class DevToolsSession
         }
 
         _connection = connection;
+        _root = this;
+        _childLock = new object();
         _connection.MessageReceived = HandleMessageAsync;
     }
+
+    private DevToolsSession(DevToolsSession root, string sessionId)
+    {
+        _root = root;
+        _childLock = root._childLock;
+        SessionId = sessionId;
+    }
+
+    /// <summary>
+    /// Gets the identifier a client addresses this session by, or <see langword="null"/> for a root session
+    /// — which is both the browser endpoint and a direct <c>/devtools/page/</c> connection.
+    /// </summary>
+    internal string? SessionId { get; }
 
     /// <summary>Gets the domains registered on this session.</summary>
     internal IReadOnlyCollection<DevToolsDomain> Domains => _router.Domains;
@@ -46,6 +74,52 @@ internal sealed class DevToolsSession
         _router.Add(domain);
         domain.Attach(this);
         return this;
+    }
+
+    /// <summary>
+    /// Sets what brings a command addressed to this session to the thread that may answer it.
+    /// </summary>
+    internal void UseGateway(ICommandGateway gateway)
+    {
+        _gateway = gateway;
+    }
+
+    /// <summary>Mints a child session under <paramref name="sessionId"/>, which must be unused.</summary>
+    internal DevToolsSession CreateChild(string sessionId)
+    {
+        var child = new DevToolsSession(_root, sessionId);
+
+        lock (_childLock)
+        {
+            var children = _root._children ??= new Dictionary<string, DevToolsSession>(StringComparer.Ordinal);
+            if (!children.TryAdd(sessionId, child))
+            {
+                Throw.InvalidOperation($"The session '{sessionId}' is already attached to this connection.");
+            }
+        }
+
+        return child;
+    }
+
+    /// <summary>Removes a child session, answering whether there was one.</summary>
+    internal bool RemoveChild(string sessionId)
+    {
+        lock (_childLock)
+        {
+            return _root._children?.Remove(sessionId) == true;
+        }
+    }
+
+    /// <summary>
+    /// Answers one command against this session's own domains, on whichever thread calls it.
+    /// </summary>
+    /// <remarks>
+    /// A gateway calls this once it has reached the thread the domains may be touched from; a session with
+    /// no gateway is called straight from <see cref="HandleMessageAsync"/>.
+    /// </remarks>
+    internal ValueTask<string> DispatchAsync(in ProtocolRequest request, CommandContext context)
+    {
+        return _router.DispatchAsync(in request, context);
     }
 
     /// <summary>
@@ -75,10 +149,14 @@ internal sealed class DevToolsSession
             var request = ProtocolMessage.Read(document.RootElement, id.Value);
             sessionId = request.SessionId;
 
-            var context = new CommandContext(this, request.SessionId, cancellationToken);
-            var result = await _router.DispatchAsync(in request, context).ConfigureAwait(false);
+            var session = Resolve(sessionId);
+            var context = new CommandContext(session, sessionId, cancellationToken);
 
-            await _connection.SendAsync(ProtocolMessage.WriteResponse(id.Value, result, sessionId), cancellationToken).ConfigureAwait(false);
+            var result = session._gateway is { } gateway
+                ? await gateway.DispatchAsync(session, request, context).ConfigureAwait(false)
+                : await session.DispatchAsync(in request, context).ConfigureAwait(false);
+
+            await SendAsync(ProtocolMessage.WriteResponse(id.Value, result, sessionId), cancellationToken).ConfigureAwait(false);
         }
         catch (ProtocolException exception)
         {
@@ -97,13 +175,41 @@ internal sealed class DevToolsSession
     }
 
     /// <summary>Sends one event, which no client is waiting on and which carries no identifier.</summary>
-    internal ValueTask SendEventAsync(in ProtocolEvent @event, string? sessionId, CancellationToken cancellationToken = default)
+    /// <remarks>
+    /// The <c>sessionId</c> is this session's own rather than a caller's: an event belongs to the session
+    /// that raised it, and a domain never has to remember which attachment it is part of.
+    /// </remarks>
+    internal ValueTask SendEventAsync(in ProtocolEvent @event, CancellationToken cancellationToken = default)
     {
-        return _connection.SendAsync(ProtocolMessage.WriteEvent(in @event, sessionId), cancellationToken);
+        return SendAsync(ProtocolMessage.WriteEvent(in @event, SessionId), cancellationToken);
+    }
+
+    /// <summary>Writes one finished message to the connection this session belongs to.</summary>
+    internal ValueTask SendAsync(string message, CancellationToken cancellationToken = default)
+    {
+        return _root._connection!.SendAsync(message, cancellationToken);
+    }
+
+    private DevToolsSession Resolve(string? sessionId)
+    {
+        if (sessionId is null)
+        {
+            return this;
+        }
+
+        lock (_childLock)
+        {
+            if (_root._children?.TryGetValue(sessionId, out var child) == true)
+            {
+                return child;
+            }
+        }
+
+        return Throw.SessionNotFound<DevToolsSession>();
     }
 
     private ValueTask FailAsync(long? id, int code, string message, string? details, string? sessionId, CancellationToken cancellationToken)
     {
-        return _connection.SendAsync(ProtocolMessage.WriteError(id, code, message, details, sessionId), cancellationToken);
+        return SendAsync(ProtocolMessage.WriteError(id, code, message, details, sessionId), cancellationToken);
     }
 }

--- a/Jint.DevTools/Session/EngineDispatcher.cs
+++ b/Jint.DevTools/Session/EngineDispatcher.cs
@@ -1,0 +1,239 @@
+using System.Collections.Concurrent;
+using Jint.DevTools.Protocol;
+
+namespace Jint.DevTools.Session;
+
+/// <summary>
+/// One target's mailbox, and <b>the only path from a transport thread to the engine</b>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The mechanism the thread rule rests on. A transport thread has a protocol request and no right to touch
+/// the engine, so it enqueues the work here and waits for the finished JSON;
+/// <see cref="Engine.TaskOperations.Post(System.Action)"/> — the one engine entry a thread that does not own
+/// the engine may call — wakes whichever thread is pumping, which runs <see cref="Drain"/> as an ordinary
+/// event-loop job and answers there. The reply that crosses back is a <see langword="string"/>, which is the
+/// invariant: no <c>JsValue</c> ever leaves the engine thread.
+/// </para>
+/// <para>
+/// <b>The drain runs inside an event-loop job.</b> That is what makes a command interleave with microtasks
+/// the way V8's does, and it is also what a command may not undo: nothing here may call
+/// <see cref="Engine.TaskOperations.WaitForScheduledWork(System.TimeSpan, System.Threading.CancellationToken)"/>
+/// or unwrap a promise by draining, because the pump's re-entrancy guard forbids it. A command that has to
+/// wait for a promise attaches reactions and completes later, from the job that runs them.
+/// </para>
+/// <para>
+/// <b>Host work and protocol commands share the queue</b>, so the order a host posted them in is the order
+/// they run in — with one deliberate exception: while the target is waiting for a debugger, host work is
+/// held and protocol commands are not, or the command that ends the wait could never be answered.
+/// </para>
+/// <para>
+/// <b>A command that times out is answered, not cancelled.</b> The item stays queued and still runs when the
+/// engine is next pumped; what the timeout decides is only that the client stops waiting. An engine nobody
+/// pumps would otherwise hang every client that ever spoke to it.
+/// </para>
+/// </remarks>
+internal sealed class EngineDispatcher : ICommandGateway
+{
+    private readonly Engine _engine;
+    private readonly Action _drain;
+    private readonly ConcurrentQueue<CommandItem> _commands = new();
+    private readonly ConcurrentQueue<Action<Engine>> _hostWork = new();
+
+    private int _waitingForDebugger;
+
+    internal EngineDispatcher(Engine engine, TimeSpan commandTimeout, bool waitForDebuggerOnStart)
+    {
+        _engine = engine;
+        _drain = Drain;
+        CommandTimeout = commandTimeout;
+        _waitingForDebugger = waitForDebuggerOnStart ? 1 : 0;
+    }
+
+    /// <summary>
+    /// Gets or sets how long a client waits for one command before it is told the engine is not pumped.
+    /// </summary>
+    /// <remarks>
+    /// Settable because a target may exist before the server it is added to, and the bound is the server's
+    /// configuration rather than the target's.
+    /// </remarks>
+    internal TimeSpan CommandTimeout { get; set; }
+
+    /// <summary>Gets whether host work is still held for a client that has not said to run it.</summary>
+    internal bool IsWaitingForDebugger => Volatile.Read(ref _waitingForDebugger) != 0;
+
+    /// <summary>
+    /// Raised on the engine thread the first time the wait for a debugger ends, so a host-owned target can
+    /// stop pumping for it.
+    /// </summary>
+    internal event Action? DebuggerWaitEnded;
+
+    /// <inheritdoc/>
+    public async ValueTask<string> DispatchAsync(DevToolsSession session, ProtocolRequest request, CommandContext context)
+    {
+        // The parameters are cloned out of the caller's JsonDocument, and that is not a micro-optimisation
+        // in reverse: a command that times out is answered while it is still queued, the caller then
+        // disposes its document -- returning its buffers to the pool -- and the engine thread would later
+        // read memory somebody else owns. A clone is backed by a document of its own.
+        var item = new CommandItem(session, request with { Parameters = request.Parameters?.Clone() }, context);
+        _commands.Enqueue(item);
+        ScheduleDrain();
+
+        try
+        {
+            return await item.Completion.Task.WaitAsync(CommandTimeout, context.CancellationToken).ConfigureAwait(false);
+        }
+        catch (TimeoutException)
+        {
+            // Told apart because the two are fixed differently, and a host reading the wrong one debugs the
+            // wrong thing: an item nothing ever dequeued means no thread is pumping, while one that started
+            // and did not finish means the command itself is slow or the script it ran has not returned.
+            return item.HasStarted
+                ? Throw.ServerError<string>(
+                    "Command timed out",
+                    "the engine began answering the command and had not finished within the command timeout")
+                : Throw.ServerError<string>(
+                    "Engine is not being pumped",
+                    "no thread ran the engine's event loop within the command timeout; call engine.Tasks.ProcessTasks() or EngineTarget.Pump(), or give the target ThreadMode.LibraryOwned");
+        }
+    }
+
+    /// <summary>Queues host work to run on the engine thread, from any thread.</summary>
+    internal void Post(Action<Engine> work)
+    {
+        _hostWork.Enqueue(work);
+        ScheduleDrain();
+    }
+
+    /// <summary>
+    /// Ends the wait for a debugger, releasing whatever host work was held. Idempotent, and a no-op on a
+    /// target that was never waiting.
+    /// </summary>
+    internal void ReleaseDebuggerWait()
+    {
+        if (Interlocked.Exchange(ref _waitingForDebugger, 0) == 0)
+        {
+            return;
+        }
+
+        DebuggerWaitEnded?.Invoke();
+        ScheduleDrain();
+    }
+
+    /// <summary>
+    /// Runs everything queued, on the engine thread.
+    /// </summary>
+    /// <remarks>
+    /// Called as the event-loop job <see cref="Engine.TaskOperations.Post(System.Action)"/> queued, and
+    /// directly by <see cref="EngineTarget.Pump"/> and the library-owned loop. It drains everything rather
+    /// than one item, so the extra passes an unconditional post produces cost a dequeue that finds nothing.
+    /// </remarks>
+    internal void Drain()
+    {
+        while (_commands.TryDequeue(out var item))
+        {
+            item.Run();
+        }
+
+        if (IsWaitingForDebugger)
+        {
+            return;
+        }
+
+        while (_hostWork.TryDequeue(out var work))
+        {
+            work(_engine);
+        }
+    }
+
+    /// <summary>
+    /// Wakes whichever thread pumps the engine, by queueing the drain as an ordinary event-loop job.
+    /// </summary>
+    /// <remarks>
+    /// One post per arrival, deliberately, rather than one per batch behind a "already scheduled" flag. Such
+    /// a flag is set before the post and cleared by the drain, so a job the engine <i>drops</i> — which
+    /// <see cref="Engine.AdvancedOperations.RestoreGlobalSnapshot"/> does to every job of the cycle it ends —
+    /// would leave it set for ever and every later arrival would decline to post, silently killing the
+    /// mailbox for a host that pumps through <see cref="Engine.TaskOperations.ProcessTasks"/> alone. Protocol
+    /// traffic is human-scale; a concurrent enqueue per message is not worth that.
+    /// </remarks>
+    private void ScheduleDrain()
+    {
+        _engine.Tasks.Post(_drain);
+    }
+
+    /// <summary>
+    /// One queued command: what to answer, and the promise the transport thread is waiting on.
+    /// </summary>
+    /// <remarks>
+    /// The completion source runs its continuations asynchronously, deliberately: completing it inline would
+    /// resume the transport thread's <c>await</c> <i>on the engine thread</i>, which is the one thing the
+    /// whole design exists to prevent.
+    /// </remarks>
+    private sealed class CommandItem
+    {
+        private readonly DevToolsSession _session;
+        private readonly ProtocolRequest _request;
+        private readonly CommandContext _context;
+        private int _started;
+
+        internal CommandItem(DevToolsSession session, ProtocolRequest request, CommandContext context)
+        {
+            _session = session;
+            _request = request;
+            _context = context;
+        }
+
+        internal TaskCompletionSource<string> Completion { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        /// <summary>Whether the engine thread has begun answering this command.</summary>
+        internal bool HasStarted => Volatile.Read(ref _started) != 0;
+
+        internal void Run()
+        {
+            Volatile.Write(ref _started, 1);
+
+            try
+            {
+                var pending = _session.DispatchAsync(in _request, _context);
+                if (pending.IsCompletedSuccessfully)
+                {
+                    Completion.TrySetResult(pending.Result);
+                    return;
+                }
+
+                // A command that answers later — Runtime.evaluate awaiting a promise — completes from the
+                // job that runs its reactions, which is this same thread. What crosses back is still only a
+                // string, so finishing the continuation inline is safe and saves a hop.
+                pending.AsTask().ContinueWith(
+                    static (task, state) => Complete(task, (TaskCompletionSource<string>) state!),
+                    Completion,
+                    CancellationToken.None,
+                    TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default);
+            }
+            catch (Exception exception)
+            {
+                // Everything the drain runs has to come back as a completion rather than as a throw: this
+                // runs inside an event-loop job, and an exception here erupts out of the host's pump.
+                Completion.TrySetException(exception);
+            }
+        }
+
+        private static void Complete(Task<string> task, TaskCompletionSource<string> completion)
+        {
+            if (task.IsFaulted)
+            {
+                completion.TrySetException(task.Exception!.InnerExceptions);
+            }
+            else if (task.IsCanceled)
+            {
+                completion.TrySetCanceled();
+            }
+            else
+            {
+                completion.TrySetResult(task.Result);
+            }
+        }
+    }
+}

--- a/Jint.DevTools/Session/ICommandGateway.cs
+++ b/Jint.DevTools/Session/ICommandGateway.cs
@@ -1,0 +1,25 @@
+using Jint.DevTools.Protocol;
+
+namespace Jint.DevTools.Session;
+
+/// <summary>
+/// What brings a command from the thread that read it to the thread that may answer it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The one seam the thread rule needs. A transport thread has a request and a session; it may not touch the
+/// engine those domains hold, so it hands both to a gateway and waits for the finished JSON. The only
+/// implementation is <see cref="EngineDispatcher"/>, which posts the work onto the engine's own event loop;
+/// a session with no engine behind it has no gateway and answers in place.
+/// </para>
+/// <para>
+/// The request's <see cref="ProtocolRequest.Parameters"/> is a <c>JsonElement</c> into the document the
+/// caller is still holding open, so a gateway may read it from another thread but may not keep it past the
+/// call.
+/// </para>
+/// </remarks>
+internal interface ICommandGateway
+{
+    /// <summary>Answers one command, wherever it has to run to be answered.</summary>
+    ValueTask<string> DispatchAsync(DevToolsSession session, ProtocolRequest request, CommandContext context);
+}

--- a/Jint.DevTools/Session/Identifiers.cs
+++ b/Jint.DevTools/Session/Identifiers.cs
@@ -1,0 +1,24 @@
+using System.Globalization;
+
+namespace Jint.DevTools.Session;
+
+/// <summary>
+/// The opaque identifiers the protocol hands clients: a browser, a target, a session.
+/// </summary>
+/// <remarks>
+/// Thirty-two uppercase hexadecimal characters, which is the shape Chrome's are and which more than one
+/// client parses as exactly that before putting it in a URL. Nothing about a target is derivable from its
+/// identifier, deliberately: a client that guessed one would be addressing an engine it was never told about.
+/// </remarks>
+internal static class Identifiers
+{
+    private static int _counter;
+
+    /// <summary>Mints one identifier, unique for the life of the process.</summary>
+    internal static string New()
+    {
+        var ordinal = Interlocked.Increment(ref _counter);
+        var guid = Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture).ToUpperInvariant();
+        return string.Create(CultureInfo.InvariantCulture, $"{guid.AsSpan(0, 24)}{ordinal:X8}");
+    }
+}

--- a/Jint.DevTools/Session/TargetSession.cs
+++ b/Jint.DevTools/Session/TargetSession.cs
@@ -1,0 +1,69 @@
+using Jint.DevTools.Domains;
+
+namespace Jint.DevTools.Session;
+
+/// <summary>
+/// One client's conversation with one engine: the domains that hold that engine's state, and the mailbox
+/// that brings a command to the thread allowed to touch it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Made two ways, and the difference is only which session node it hangs off. A client that attached through
+/// <c>Target.attachToTarget</c> gets a child node whose <c>sessionId</c> rides every message; a client that
+/// connected straight to <c>/devtools/page/&lt;targetId&gt;</c> gets the root node itself, and its messages
+/// carry no <c>sessionId</c> at all. Everything below that is the same.
+/// </para>
+/// <para>
+/// Detaching releases what this session owned and nothing the target owns: the engine and its thread belong
+/// to whoever made the target.
+/// </para>
+/// </remarks>
+internal sealed class TargetSession
+{
+    private readonly BrowserSession? _browser;
+
+    private TargetSession(DevToolsSession session, EngineTarget target, BrowserSession? browser)
+    {
+        Session = session;
+        Target = target;
+        _browser = browser;
+
+        // Everything registered below holds engine state, so every command addressed here crosses to the
+        // engine thread first. That is the whole of the thread rule, in one line.
+        session.UseGateway(target.Dispatcher);
+        BuiltInDomains.RegisterTargetDomains(session, target, browser);
+    }
+
+    /// <summary>Gets the session node this attachment answers on.</summary>
+    internal DevToolsSession Session { get; }
+
+    /// <summary>Gets the engine this session speaks to.</summary>
+    internal EngineTarget Target { get; }
+
+    /// <summary>
+    /// Gets the identifier a client addresses this session by, or <see langword="null"/> for a direct
+    /// connection.
+    /// </summary>
+    internal string? SessionId => Session.SessionId;
+
+    /// <summary>Attaches to <paramref name="target"/> under a new child of <paramref name="browser"/>.</summary>
+    internal static TargetSession Attach(BrowserSession browser, EngineTarget target, string sessionId)
+    {
+        return new TargetSession(browser.Session.CreateChild(sessionId), target, browser);
+    }
+
+    /// <summary>Builds the session a direct <c>/devtools/page/</c> connection speaks over.</summary>
+    internal static TargetSession Direct(DevToolsSession root, EngineTarget target)
+    {
+        return new TargetSession(root, target, browser: null);
+    }
+
+    /// <summary>Releases what this session owns, once.</summary>
+    internal void Detach()
+    {
+        if (SessionId is { } sessionId)
+        {
+            _browser?.Session.RemoveChild(sessionId);
+        }
+    }
+}

--- a/Jint.DevTools/ThreadMode.cs
+++ b/Jint.DevTools/ThreadMode.cs
@@ -1,0 +1,41 @@
+namespace Jint.DevTools;
+
+/// <summary>
+/// Which thread runs the engine behind an <see cref="EngineTarget"/>, and therefore which thread answers
+/// the protocol commands addressed to it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A <see cref="Native.JsValue"/> never leaves the engine thread and a transport thread only ever moves
+/// strings, so every command has to cross to whichever thread that is. This says which one it is.
+/// </para>
+/// <para>
+/// It is a property of the target rather than of the server: one server may carry a host-pumped engine and
+/// a library-pumped one at the same time.
+/// </para>
+/// </remarks>
+public enum ThreadMode
+{
+    /// <summary>
+    /// The host's own thread runs script and pumps; commands are answered when it next pumps.
+    /// </summary>
+    /// <remarks>
+    /// The default, and the shape of every embedder that already drives its engine — a workflow step, a
+    /// request handler, a game loop. Commands are serviced inside
+    /// <see cref="Engine.TaskOperations.ProcessTasks"/> or <see cref="EngineTarget.Pump"/>; one that waits
+    /// longer than <see cref="DevToolsServerOptions.CommandTimeout"/> fails with <c>-32000</c> and
+    /// <c>Engine is not being pumped</c>, which is the diagnostic a host that forgot to pump needs.
+    /// </remarks>
+    HostOwned,
+
+    /// <summary>
+    /// The target owns one thread, which pumps the engine and answers commands on it.
+    /// </summary>
+    /// <remarks>
+    /// For a host that wants an engine attachable without writing a loop. The host submits its own work
+    /// with <see cref="EngineTarget.Post(System.Action{Engine})"/> or
+    /// <see cref="EngineTarget.PostAsync{T}(System.Func{Engine, T})"/>; touching the engine from any other
+    /// thread trips the engine's own single-drainer guard rather than corrupting anything.
+    /// </remarks>
+    LibraryOwned,
+}

--- a/Jint.DevTools/Throw.cs
+++ b/Jint.DevTools/Throw.cs
@@ -66,6 +66,20 @@ internal static class Throw
         throw new ProtocolException(ProtocolErrorCodes.ServerError, message, details);
     }
 
+    /// <inheritdoc cref="ServerError(string, string?)"/>
+    [DoesNotReturn]
+    internal static T ServerError<T>(string message, string? details = null)
+    {
+        throw new ProtocolException(ProtocolErrorCodes.ServerError, message, details);
+    }
+
+    /// <summary>Raises the protocol's session-not-found error, <c>-32001</c>, in Chrome's own wording.</summary>
+    [DoesNotReturn]
+    internal static T SessionNotFound<T>()
+    {
+        throw new ProtocolException(ProtocolErrorCodes.SessionNotFound, "Session with given id not found.");
+    }
+
     /// <summary>Raises <see cref="ArgumentNullException"/> for a host-supplied argument.</summary>
     [DoesNotReturn]
     internal static void ArgumentNull(string parameterName)

--- a/Jint.DevTools/Transport/HttpDiscovery.cs
+++ b/Jint.DevTools/Transport/HttpDiscovery.cs
@@ -1,0 +1,258 @@
+using System.Buffers;
+using System.Globalization;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.Json;
+using Jint.DevTools.Protocol;
+
+namespace Jint.DevTools.Transport;
+
+/// <summary>
+/// One answer to a discovery request: the status a client branches on, and the document it reads.
+/// </summary>
+[StructLayout(LayoutKind.Auto)]
+internal readonly record struct HttpDiscoveryResponse(int Status, string Reason, string ContentType, string Body)
+{
+    /// <summary>The answer to a path no endpoint claims.</summary>
+    internal static HttpDiscoveryResponse NotFound { get; } = new(404, "Not Found", "text/plain; charset=UTF-8", "No such endpoint");
+
+    internal static HttpDiscoveryResponse Json(string body) => new(200, "OK", "application/json; charset=UTF-8", body);
+
+    internal static HttpDiscoveryResponse Text(string body) => new(200, "OK", "text/plain; charset=UTF-8", body);
+}
+
+/// <summary>
+/// The <c>/json</c> documents a client reads before it opens a socket.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Chrome serves these from the same port as the WebSocket endpoint, and clients depend on it: one that
+/// connects by URL rather than by socket address — Puppeteer's <c>browserURL</c>, Playwright's
+/// <c>connectOverCDP</c> — reads <c>webSocketDebuggerUrl</c> out of <c>/json/version</c> and connects to
+/// whatever it finds there. Which fields each client reads was recorded rather than guessed; see
+/// <c>tools/devtools-protocol/handshakes/</c>.
+/// </para>
+/// <para>
+/// <c>/json/protocol</c> answers what this server implements rather than the whole pinned description. The
+/// full one is two megabytes describing mostly commands answered here with <c>-32601</c>, and a client
+/// reading it would be told it can call them; this one tells it the truth and costs the package no embedded
+/// resource.
+/// </para>
+/// </remarks>
+internal static class HttpDiscovery
+{
+    /// <summary>Answers <paramref name="request"/>.</summary>
+    internal static ValueTask<HttpDiscoveryResponse> AnswerAsync(DevToolsServer server, HttpRequestHead request)
+    {
+        var path = request.Path;
+        var query = path.IndexOf('?', StringComparison.Ordinal);
+        if (query >= 0)
+        {
+            path = path.Substring(0, query);
+        }
+
+        path = path.TrimEnd('/');
+        if (path.Length == 0)
+        {
+            path = "/json";
+        }
+
+        return path switch
+        {
+            "/json/version" => Answered(HttpDiscoveryResponse.Json(Version(server))),
+            "/json" or "/json/list" => Answered(HttpDiscoveryResponse.Json(List(server))),
+            "/json/protocol" => Answered(HttpDiscoveryResponse.Json(Protocol())),
+            "/json/new" => Answered(New(server)),
+            _ => CommandAsync(server, path),
+        };
+
+        static ValueTask<HttpDiscoveryResponse> Answered(HttpDiscoveryResponse response) => new(response);
+    }
+
+    private static string Version(DevToolsServer server)
+    {
+        var version = server.Version;
+
+        var buffer = new ArrayBufferWriter<byte>(256);
+        using (var writer = new Utf8JsonWriter(buffer))
+        {
+            writer.WriteStartObject();
+            writer.WriteString("Browser", version.Product);
+            writer.WriteString("Protocol-Version", version.ProtocolVersion);
+            writer.WriteString("User-Agent", version.UserAgent);
+            writer.WriteString("V8-Version", version.JsVersion);
+
+            // Chrome answers a Blink revision here and clients only ever report it. Zero says "no engine of
+            // that kind" rather than borrowing a number from a browser this is not.
+            writer.WriteString("WebKit-Version", "0");
+            writer.WriteString("webSocketDebuggerUrl", server.BrowserWebSocketUrl);
+            writer.WriteEndObject();
+        }
+
+        return Utf8(buffer);
+    }
+
+    private static string List(DevToolsServer server)
+    {
+        var authority = server.Authority;
+
+        var buffer = new ArrayBufferWriter<byte>(512);
+        using (var writer = new Utf8JsonWriter(buffer))
+        {
+            writer.WriteStartArray();
+            foreach (var target in server.Targets)
+            {
+                WriteTarget(writer, authority, target);
+            }
+
+            writer.WriteEndArray();
+        }
+
+        return Utf8(buffer);
+    }
+
+    private static HttpDiscoveryResponse New(DevToolsServer server)
+    {
+        if (server.Options.EngineFactory is null)
+        {
+            // Chrome answers 500 with a body; 501 says the thing a host can act on — this server was not
+            // configured to make engines, rather than it tried and failed.
+            return new HttpDiscoveryResponse(
+                501,
+                "Not Implemented",
+                "text/plain; charset=UTF-8",
+                "No engine factory is configured; set DevToolsServerOptions.EngineFactory for a client to be able to create targets");
+        }
+
+        var target = server.CreateTarget();
+        var authority = server.Authority;
+
+        var buffer = new ArrayBufferWriter<byte>(256);
+        using (var writer = new Utf8JsonWriter(buffer))
+        {
+            WriteTarget(writer, authority, target);
+        }
+
+        return HttpDiscoveryResponse.Json(Utf8(buffer));
+    }
+
+    private static string Protocol()
+    {
+        var buffer = new ArrayBufferWriter<byte>(1024);
+        using (var writer = new Utf8JsonWriter(buffer))
+        {
+            var version = ProtocolManifest.ProtocolVersion;
+            var dot = version.IndexOf('.', StringComparison.Ordinal);
+
+            writer.WriteStartObject();
+            writer.WriteStartObject("version");
+            writer.WriteString("major", dot < 0 ? version : version.Substring(0, dot));
+            writer.WriteString("minor", dot < 0 ? "0" : version.Substring(dot + 1));
+            writer.WriteEndObject();
+
+            writer.WriteStartArray("domains");
+            foreach (var domain in ProtocolManifest.ReportedDomains)
+            {
+                writer.WriteStartObject();
+                writer.WriteString("domain", domain.Name);
+                WriteMembers(writer, "commands", ProtocolManifest.ImplementedMethods, domain.Name);
+                WriteMembers(writer, "events", ProtocolManifest.ImplementedEvents, domain.Name);
+                writer.WriteEndObject();
+            }
+
+            writer.WriteEndArray();
+            writer.WriteEndObject();
+        }
+
+        return Utf8(buffer);
+
+        static void WriteMembers(Utf8JsonWriter writer, string list, IReadOnlyList<string> qualified, string domain)
+        {
+            var prefix = domain + ".";
+
+            writer.WriteStartArray(list);
+            foreach (var name in qualified)
+            {
+                if (name.StartsWith(prefix, StringComparison.Ordinal))
+                {
+                    writer.WriteStartObject();
+                    writer.WriteString("name", name.AsSpan(prefix.Length));
+                    writer.WriteEndObject();
+                }
+            }
+
+            writer.WriteEndArray();
+        }
+    }
+
+    /// <summary>
+    /// The two endpoints that name a target in the path. Asynchronous because closing one may stop a thread,
+    /// and blocking a transport thread on that is how a listener stops accepting.
+    /// </summary>
+    private static async ValueTask<HttpDiscoveryResponse> CommandAsync(DevToolsServer server, string path)
+    {
+        if (Suffix(path, "/json/activate/") is { } activate)
+        {
+            // Nothing to raise or focus, so the honest answer is that the target is there. A client sends
+            // this before driving a target and reads a failure as the target being gone.
+            return server.FindTarget(activate) is null
+                ? HttpDiscoveryResponse.NotFound
+                : HttpDiscoveryResponse.Text("Target activated");
+        }
+
+        if (Suffix(path, "/json/close/") is { } close)
+        {
+            var target = server.FindTarget(close);
+            if (target is null)
+            {
+                return HttpDiscoveryResponse.NotFound;
+            }
+
+            await server.CloseTargetAsync(target).ConfigureAwait(false);
+            return HttpDiscoveryResponse.Text("Target is closing");
+        }
+
+        return HttpDiscoveryResponse.NotFound;
+    }
+
+    private static void WriteTarget(Utf8JsonWriter writer, string authority, EngineTarget target)
+    {
+        writer.WriteStartObject();
+        writer.WriteString("description", "");
+        writer.WriteString("devtoolsFrontendUrl", FrontendUrl(authority, target.TargetId));
+        writer.WriteString("id", target.TargetId);
+        writer.WriteString("title", target.Title);
+        writer.WriteString("type", target.Type);
+        writer.WriteString("url", target.Url);
+        writer.WriteString("webSocketDebuggerUrl", PageUrl(authority, target.TargetId));
+        writer.WriteEndObject();
+    }
+
+    private static string? Suffix(string path, string prefix)
+    {
+        return path.StartsWith(prefix, StringComparison.Ordinal) && path.Length > prefix.Length
+            ? path.Substring(prefix.Length)
+            : null;
+    }
+
+    /// <summary>
+    /// The address of the DevTools front end for one target, in Node's flavour.
+    /// </summary>
+    /// <remarks>
+    /// <c>v8only=true</c> is what makes the front end open its JavaScript-only layout — Sources, Console,
+    /// Memory — rather than asking the target for a page it does not have.
+    /// </remarks>
+    private static string FrontendUrl(string authority, string targetId)
+    {
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"devtools://devtools/bundled/js_app.html?experiments=true&v8only=true&ws={authority}/devtools/page/{targetId}");
+    }
+
+    private static string PageUrl(string authority, string targetId)
+    {
+        return string.Create(CultureInfo.InvariantCulture, $"ws://{authority}/devtools/page/{targetId}");
+    }
+
+    private static string Utf8(ArrayBufferWriter<byte> buffer) => Encoding.UTF8.GetString(buffer.WrittenSpan);
+}

--- a/Jint.DevTools/Transport/HttpRequestHead.cs
+++ b/Jint.DevTools/Transport/HttpRequestHead.cs
@@ -1,0 +1,104 @@
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Jint.DevTools.Transport;
+
+/// <summary>
+/// One HTTP/1.1 request head: the method, the path, and the few headers the upgrade needs.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Deliberately not an HTTP server. What arrives on this port is either a WebSocket upgrade or one of the
+/// half-dozen <c>/json</c> documents a client reads before it connects, and the whole of that is a request
+/// line plus headers. Nothing here reads a body, follows a chunked encoding or keeps a connection alive.
+/// </para>
+/// <para>
+/// The alternative was <c>HttpListener</c>, which on Windows registers a URL prefix with <c>http.sys</c> and
+/// wants an elevation-time reservation for anything but the default; a library a host embeds cannot ask for
+/// that. A <c>TcpListener</c> plus this needs nothing from the operating system that a socket does not.
+/// </para>
+/// </remarks>
+[StructLayout(LayoutKind.Auto)]
+internal readonly record struct HttpRequestHead(string Method, string Path, string? UpgradeKey)
+{
+    /// <summary>Whether this request asks to become a WebSocket.</summary>
+    internal bool IsWebSocketUpgrade => UpgradeKey is not null;
+
+    /// <summary>
+    /// Reads a request head from <paramref name="stream"/>, or answers <see langword="null"/> when the
+    /// client went away or sent something that is not one.
+    /// </summary>
+    /// <remarks>
+    /// Read one byte at a time, which is not an oversight: a buffered read would consume the first WebSocket
+    /// frames along with the headers, and <c>WebSocket.CreateFromStream</c> has
+    /// nowhere to put bytes that were read before it existed. A request head is a few hundred bytes and this
+    /// happens once per connection.
+    /// </remarks>
+    internal static async ValueTask<HttpRequestHead?> ReadAsync(Stream stream, int maxBytes, CancellationToken cancellationToken)
+    {
+        var buffer = new byte[Math.Min(maxBytes, 16 * 1024)];
+        var count = 0;
+        var single = new byte[1];
+
+        while (count < buffer.Length)
+        {
+            var read = await stream.ReadAsync(single.AsMemory(0, 1), cancellationToken).ConfigureAwait(false);
+            if (read == 0)
+            {
+                return null;
+            }
+
+            buffer[count++] = single[0];
+
+            if (count >= 4 &&
+                buffer[count - 4] == (byte) '\r' && buffer[count - 3] == (byte) '\n' &&
+                buffer[count - 2] == (byte) '\r' && buffer[count - 1] == (byte) '\n')
+            {
+                return Parse(Encoding.ASCII.GetString(buffer, 0, count - 4));
+            }
+        }
+
+        return null;
+    }
+
+    private static HttpRequestHead? Parse(string head)
+    {
+        var lines = head.Split("\r\n", StringSplitOptions.None);
+        if (lines.Length == 0)
+        {
+            return null;
+        }
+
+        var parts = lines[0].Split(' ');
+        if (parts.Length < 2)
+        {
+            return null;
+        }
+
+        var upgrades = false;
+        string? key = null;
+
+        for (var i = 1; i < lines.Length; i++)
+        {
+            var separator = lines[i].IndexOf(':', StringComparison.Ordinal);
+            if (separator <= 0)
+            {
+                continue;
+            }
+
+            var name = lines[i].AsSpan(0, separator).Trim();
+            var value = lines[i].AsSpan(separator + 1).Trim();
+
+            if (name.Equals("Upgrade", StringComparison.OrdinalIgnoreCase) && value.Contains("websocket", StringComparison.OrdinalIgnoreCase))
+            {
+                upgrades = true;
+            }
+            else if (name.Equals("Sec-WebSocket-Key", StringComparison.OrdinalIgnoreCase))
+            {
+                key = value.ToString();
+            }
+        }
+
+        return new HttpRequestHead(parts[0], parts[1], upgrades ? key : null);
+    }
+}

--- a/Jint.DevTools/Transport/WebSocketConnection.cs
+++ b/Jint.DevTools/Transport/WebSocketConnection.cs
@@ -1,0 +1,285 @@
+using System.Buffers;
+using System.Net.WebSockets;
+using System.Text;
+using System.Threading.Channels;
+
+namespace Jint.DevTools.Transport;
+
+/// <summary>
+/// One client's WebSocket: a reader task that hands text to the session, and a single writer task that puts
+/// text back on the wire.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>One writer, always.</b> Responses come from whichever thread answered a command and events come from
+/// the engine thread; two of them calling <see cref="WebSocket.SendAsync(ReadOnlyMemory{byte},
+/// WebSocketMessageType, bool, CancellationToken)"/> at once would interleave inside a frame and hand the
+/// client a broken message. Everything therefore goes through a channel that exactly one task drains.
+/// </para>
+/// <para>
+/// <b>Sending never blocks the caller.</b> The channel is unbounded and the write is a queue insertion, which
+/// is what lets the engine thread emit an event without waiting on a socket. The cost of that decision is
+/// that a client which stops reading grows the queue; the connection's own message bound does not cover it,
+/// and a bound on the queue would mean either dropping events or blocking the engine, both of which are
+/// worse than the memory.
+/// </para>
+/// <para>
+/// <b>Text frames only.</b> The protocol is JSON; a binary frame is closed with <c>1003</c> and a message
+/// over <see cref="DevToolsServerOptions.MaxMessageBytes"/> with <c>1009</c>, rather than being buffered
+/// until the host runs out of memory.
+/// </para>
+/// </remarks>
+internal sealed class WebSocketConnection : IDevToolsConnection, IAsyncDisposable
+{
+    /// <summary>How long a closing connection waits for what is still queued to reach the wire.</summary>
+    private static readonly TimeSpan FlushBound = TimeSpan.FromSeconds(5);
+
+    private readonly WebSocket _socket;
+    private readonly int _maxMessageBytes;
+
+    /// <summary>
+    /// What the single writer task drains. A <see langword="null"/> item is the close request: it travels
+    /// the queue like any other message, so everything already queued -- the reply to the very command that
+    /// asked for the close -- reaches the client before the socket goes.
+    /// </summary>
+    private readonly Channel<string?> _outgoing = Channel.CreateUnbounded<string?>(new UnboundedChannelOptions
+    {
+        SingleReader = true,
+        SingleWriter = false,
+    });
+
+    private int _closed;
+    private int _closeRequested;
+
+    internal WebSocketConnection(WebSocket socket, int maxMessageBytes)
+    {
+        _socket = socket;
+        _maxMessageBytes = maxMessageBytes;
+    }
+
+    /// <inheritdoc/>
+    public Func<string, CancellationToken, ValueTask>? MessageReceived { get; set; }
+
+    /// <inheritdoc/>
+    public Action? Closed { get; set; }
+
+    /// <inheritdoc/>
+    public ValueTask SendAsync(string message, CancellationToken cancellationToken = default)
+    {
+        _outgoing.Writer.TryWrite(message);
+        return default;
+    }
+
+    /// <summary>
+    /// Asks for the connection to close once the command that asked for it has been answered.
+    /// </summary>
+    /// <remarks>
+    /// What <c>Browser.close</c> becomes when the host reads it as a disconnect, and the ordering is the
+    /// whole of it: a command asks for this from <i>inside</i> its own dispatch, so its reply has not been
+    /// written yet. Closing here would drop that reply and the client would see a hang instead of the clean
+    /// goodbye it asked for. So this only raises a flag; the reader queues the close behind the reply once
+    /// the command has finished, and the writer honours it once everything queued is on the wire.
+    /// </remarks>
+    internal void RequestClose()
+    {
+        Volatile.Write(ref _closeRequested, 1);
+    }
+
+    /// <summary>
+    /// Runs the connection until the client goes away or <paramref name="cancellationToken"/> is cancelled.
+    /// </summary>
+    internal async Task RunAsync(CancellationToken cancellationToken)
+    {
+        using var stopping = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var writer = Task.Run(() => WriteAsync(stopping.Token), CancellationToken.None);
+
+        try
+        {
+            await ReadAsync(stopping.Token).ConfigureAwait(false);
+        }
+        finally
+        {
+            // Completing rather than cancelling, and waiting before cancelling: the writer drains what is
+            // still queued -- including the reply to whatever ended the connection -- and only then is the
+            // token pulled out from under it.
+            _outgoing.Writer.TryComplete();
+
+            try
+            {
+                await writer.WaitAsync(FlushBound, CancellationToken.None).ConfigureAwait(false);
+            }
+#pragma warning disable CA1031 // the writer's failure is the connection ending, which is what we are doing
+            catch (Exception)
+#pragma warning restore CA1031
+            {
+            }
+
+            await stopping.CancelAsync().ConfigureAwait(false);
+
+            try
+            {
+                await writer.ConfigureAwait(false);
+            }
+#pragma warning disable CA1031 // the writer's failure is the connection ending, which is what we are doing
+            catch (Exception)
+#pragma warning restore CA1031
+            {
+            }
+
+            RaiseClosed();
+        }
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask DisposeAsync()
+    {
+        _outgoing.Writer.TryComplete();
+
+        try
+        {
+            if (_socket.State == WebSocketState.Open)
+            {
+                await _socket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, statusDescription: null, CancellationToken.None).ConfigureAwait(false);
+            }
+        }
+#pragma warning disable CA1031 // a socket that cannot be closed politely is closed rudely, and that is fine
+        catch (Exception)
+#pragma warning restore CA1031
+        {
+        }
+
+        _socket.Dispose();
+        RaiseClosed();
+    }
+
+    private async Task ReadAsync(CancellationToken cancellationToken)
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(8 * 1024);
+        var message = new ArrayBufferWriter<byte>(8 * 1024);
+
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested && _socket.State == WebSocketState.Open)
+            {
+                WebSocketReceiveResult received;
+                try
+                {
+                    received = await _socket.ReceiveAsync(new ArraySegment<byte>(buffer), cancellationToken).ConfigureAwait(false);
+                }
+                catch (WebSocketException)
+                {
+                    // A client that vanished rather than closed. There is nothing to say to it.
+                    return;
+                }
+
+                if (received.MessageType == WebSocketMessageType.Close)
+                {
+                    await CloseAsync(WebSocketCloseStatus.NormalClosure, statusDescription: null).ConfigureAwait(false);
+                    return;
+                }
+
+                if (received.MessageType == WebSocketMessageType.Binary)
+                {
+                    await CloseAsync(WebSocketCloseStatus.InvalidMessageType, "the DevTools protocol is text").ConfigureAwait(false);
+                    return;
+                }
+
+                if (message.WrittenCount + received.Count > _maxMessageBytes)
+                {
+                    await CloseAsync(WebSocketCloseStatus.MessageTooBig, "message exceeds MaxMessageBytes").ConfigureAwait(false);
+                    return;
+                }
+
+                message.Write(buffer.AsSpan(0, received.Count));
+
+                if (!received.EndOfMessage)
+                {
+                    continue;
+                }
+
+                var text = Encoding.UTF8.GetString(message.WrittenSpan);
+                message.Clear();
+
+                if (MessageReceived is { } handler)
+                {
+                    await handler(text, cancellationToken).ConfigureAwait(false);
+                }
+
+                if (Volatile.Read(ref _closeRequested) != 0)
+                {
+                    // The command's reply is already queued, so the close goes in behind it.
+                    _outgoing.Writer.TryWrite(null);
+                    return;
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // The server is stopping, or the connection is being disposed.
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    private async Task WriteAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (await _outgoing.Reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                while (_outgoing.Reader.TryRead(out var message))
+                {
+                    if (_socket.State != WebSocketState.Open)
+                    {
+                        return;
+                    }
+
+                    if (message is null)
+                    {
+                        await CloseAsync(WebSocketCloseStatus.NormalClosure, statusDescription: null).ConfigureAwait(false);
+                        return;
+                    }
+
+                    var bytes = Encoding.UTF8.GetBytes(message);
+                    await _socket.SendAsync(bytes.AsMemory(), WebSocketMessageType.Text, endOfMessage: true, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (WebSocketException)
+        {
+            // The client went away mid-write. The reader notices too, and the connection ends there.
+        }
+    }
+
+    private async Task CloseAsync(WebSocketCloseStatus status, string? statusDescription)
+    {
+        try
+        {
+            if (_socket.State is WebSocketState.Open or WebSocketState.CloseReceived)
+            {
+                await _socket.CloseAsync(status, statusDescription, CancellationToken.None).ConfigureAwait(false);
+            }
+        }
+        catch (WebSocketException)
+        {
+        }
+        catch (OperationCanceledException)
+        {
+        }
+    }
+
+    private void RaiseClosed()
+    {
+        if (Interlocked.Exchange(ref _closed, 1) != 0)
+        {
+            return;
+        }
+
+        Closed?.Invoke();
+    }
+}

--- a/Jint.DevTools/Transport/WebSocketServerTransport.cs
+++ b/Jint.DevTools/Transport/WebSocketServerTransport.cs
@@ -1,0 +1,372 @@
+using System.Globalization;
+using System.Net;
+using System.Net.Sockets;
+using System.Net.WebSockets;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Jint.DevTools.Transport;
+
+/// <summary>
+/// The listener: a TCP socket, an HTTP/1.1 upgrade, and one WebSocket per client.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>A <see cref="TcpListener"/> rather than an <c>HttpListener</c>.</b> On Windows the latter registers a
+/// URL prefix with <c>http.sys</c>, which needs an administrative reservation for anything but the default
+/// prefix — something a library embedded in somebody else's process cannot ask for. Everything this endpoint
+/// serves is a request line, a few headers and either a document or an upgrade, so a socket plus
+/// <see cref="WebSocket.CreateFromStream(Stream, bool, string, TimeSpan)"/> needs nothing from the operating
+/// system that a socket does not. There is deliberately no ASP.NET dependency either: a host that already
+/// has one may keep it, and one that does not is not made to take it.
+/// </para>
+/// <para>
+/// Two paths open a conversation. <c>/devtools/browser/&lt;browserId&gt;</c> is the browser endpoint, where a
+/// client discovers targets and attaches to them; <c>/devtools/page/&lt;targetId&gt;</c> is one engine
+/// directly, and messages on it carry no <c>sessionId</c> at all. Anything else is 404 <i>before</i> the
+/// upgrade, so a client that guessed a path is told so rather than left holding an open socket.
+/// </para>
+/// </remarks>
+internal sealed class WebSocketServerTransport : IAsyncDisposable
+{
+    /// <summary>The GUID RFC 6455 §1.3 says to append to the client's key before hashing it.</summary>
+    private const string WebSocketGuid = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+
+    /// <summary>How much request head is read before a client is assumed to be sending something else.</summary>
+    private const int MaxRequestHeadBytes = 16 * 1024;
+
+    private readonly DevToolsServer _server;
+    private readonly CancellationTokenSource _stopping = new();
+    private readonly List<Task> _connections = [];
+
+    private TcpListener? _listener;
+    private Task? _accepting;
+    private int _disposed;
+
+    internal WebSocketServerTransport(DevToolsServer server)
+    {
+        _server = server;
+    }
+
+    /// <summary>Gets the port the listener bound to.</summary>
+    internal int BoundPort { get; private set; }
+
+    /// <summary>Binds the listener and starts accepting, which is what makes the port readable.</summary>
+    internal void Start()
+    {
+        var address = ResolveAddress(_server.Options.Host);
+        var listener = new TcpListener(address, _server.Options.Port);
+        listener.Start();
+
+        BoundPort = ((IPEndPoint) listener.LocalEndpoint).Port;
+        _listener = listener;
+        _accepting = Task.Run(() => AcceptAsync(_stopping.Token), CancellationToken.None);
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        await _stopping.CancelAsync().ConfigureAwait(false);
+        _listener?.Stop();
+
+        Task[] pending;
+        lock (_connections)
+        {
+            pending = _connections.ToArray();
+        }
+
+        if (_accepting is { } accepting)
+        {
+            await Quietly(accepting).ConfigureAwait(false);
+        }
+
+        foreach (var connection in pending)
+        {
+            await Quietly(connection).ConfigureAwait(false);
+        }
+
+        _stopping.Dispose();
+    }
+
+    private static IPAddress ResolveAddress(string host)
+    {
+        if (IPAddress.TryParse(host, out var parsed))
+        {
+            return parsed;
+        }
+
+        if (string.Equals(host, "localhost", StringComparison.OrdinalIgnoreCase))
+        {
+            return IPAddress.Loopback;
+        }
+
+        // A name rather than an address. Resolving it here rather than at bind time gives the host a
+        // failure naming what it configured.
+        var addresses = Dns.GetHostAddresses(host);
+        return addresses.Length > 0
+            ? addresses[0]
+            : throw new InvalidOperationException($"'{host}' does not resolve to an address to listen on.");
+    }
+
+    private async Task AcceptAsync(CancellationToken cancellationToken)
+    {
+        var listener = _listener!;
+
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            TcpClient client;
+            try
+            {
+                client = await listener.AcceptTcpClientAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+            catch (SocketException)
+            {
+                return;
+            }
+            catch (ObjectDisposedException)
+            {
+                return;
+            }
+
+            var connection = Task.Run(() => ServeAsync(client, cancellationToken), CancellationToken.None);
+
+            lock (_connections)
+            {
+                _connections.RemoveAll(static task => task.IsCompleted);
+                _connections.Add(connection);
+            }
+        }
+    }
+
+    private async Task ServeAsync(TcpClient client, CancellationToken cancellationToken)
+    {
+        using (client)
+        {
+            client.NoDelay = true;
+
+            var stream = client.GetStream();
+
+            HttpRequestHead? head;
+            try
+            {
+                head = await HttpRequestHead.ReadAsync(stream, MaxRequestHeadBytes, cancellationToken).ConfigureAwait(false);
+            }
+            catch (IOException)
+            {
+                return;
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+
+            if (head is not { } request)
+            {
+                return;
+            }
+
+            try
+            {
+                if (request.IsWebSocketUpgrade)
+                {
+                    await UpgradeAsync(stream, request, cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    await ServeDocumentAsync(stream, request, cancellationToken).ConfigureAwait(false);
+                }
+            }
+            catch (IOException)
+            {
+                // The client hung up in the middle. Every session it opened is torn down by the connection's
+                // own closed callback; there is nothing else owed to it.
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }
+    }
+
+    private async Task ServeDocumentAsync(NetworkStream stream, HttpRequestHead request, CancellationToken cancellationToken)
+    {
+        HttpDiscoveryResponse response;
+        try
+        {
+            response = await HttpDiscovery.AnswerAsync(_server, request).ConfigureAwait(false);
+        }
+#pragma warning disable CA1031 // a discovery document must never take the listener down with it
+        catch (Exception exception)
+#pragma warning restore CA1031
+        {
+            response = new HttpDiscoveryResponse(500, "Internal Server Error", "text/plain; charset=UTF-8", exception.Message);
+        }
+
+        var body = Encoding.UTF8.GetBytes(response.Body);
+        var head = string.Create(
+            CultureInfo.InvariantCulture,
+            $"HTTP/1.1 {response.Status} {response.Reason}\r\nContent-Type: {response.ContentType}\r\nContent-Length: {body.Length}\r\nConnection: close\r\n\r\n");
+
+        await stream.WriteAsync(Encoding.ASCII.GetBytes(head), cancellationToken).ConfigureAwait(false);
+        await stream.WriteAsync(body, cancellationToken).ConfigureAwait(false);
+        await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+
+        // Half-close, and this is not politeness. The caller disposes the TcpClient the moment this returns;
+        // a close with anything still unread -- a keep-alive client's pipelined request, a byte that arrived
+        // while the document was being built -- is answered by an RST, and an RST discards whatever is still
+        // in the send buffer. The client then sees a connection reset rather than the body, which is a
+        // failure that only shows up when the machine is loaded enough for the timing to matter. A FIN says
+        // "that is the whole response" and leaves the delivered bytes delivered.
+        Shutdown(stream);
+    }
+
+    /// <summary>
+    /// Ends the sending half of a connection, ignoring a socket that has already gone.
+    /// </summary>
+    private static void Shutdown(NetworkStream stream)
+    {
+        try
+        {
+            stream.Socket.Shutdown(SocketShutdown.Send);
+        }
+        catch (SocketException)
+        {
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+    }
+
+    private async Task UpgradeAsync(NetworkStream stream, HttpRequestHead request, CancellationToken cancellationToken)
+    {
+        var (kind, routed) = Route(request.Path);
+        if (kind == RouteKind.None)
+        {
+            // Answered as an ordinary 404 rather than upgraded and then closed: a client that guessed a
+            // path reads the status, and one that was upgraded first would only see the socket go.
+            await ServeDocumentAsync(stream, request with { Path = "/none" }, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        // SHA-1, and not a choice: RFC 6455 section 4.2.2 defines the handshake as SHA-1 of the client's key
+        // and a fixed GUID. It authenticates nothing and protects nothing -- it exists so that a cache or a
+        // proxy cannot be tricked into completing an upgrade -- so the weakness the analyzer names is not one
+        // here, and substituting a stronger hash would simply fail every client.
+#pragma warning disable CA5350
+        var accept = Convert.ToBase64String(SHA1.HashData(Encoding.ASCII.GetBytes(request.UpgradeKey + WebSocketGuid)));
+#pragma warning restore CA5350
+        var head = "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: " + accept + "\r\n\r\n";
+
+        await stream.WriteAsync(Encoding.ASCII.GetBytes(head), cancellationToken).ConfigureAwait(false);
+        await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+
+        var socket = WebSocket.CreateFromStream(stream, isServer: true, subProtocol: null, TimeSpan.FromSeconds(30));
+        var connection = new WebSocketConnection(socket, _server.Options.MaxMessageBytes);
+
+        await using (connection.ConfigureAwait(false))
+        {
+            var closed = routed is { } target ? OpenTarget(connection, target) : OpenBrowser(connection);
+
+            try
+            {
+                await connection.RunAsync(cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                closed?.Invoke();
+            }
+        }
+    }
+
+    private Action? OpenBrowser(WebSocketConnection connection)
+    {
+        var session = _server.OpenBrowserSession(connection, closeRequested: () =>
+        {
+            if (_server.Options.CloseIsDisconnect)
+            {
+                // Every client sends Browser.close on the way out and a browser would exit. Jint is in
+                // somebody else's process, so the client is what ends: its socket closes behind the reply to
+                // this very command, and the host runs on.
+                connection.RequestClose();
+            }
+        });
+
+        return () => _server.CloseBrowserSession(session);
+    }
+
+    private static Action? OpenTarget(WebSocketConnection connection, EngineTarget target)
+    {
+        // A direct connection owns nothing but itself: there is no attachment to release and no browser
+        // conversation to forget, so the connection ending is the whole of the teardown.
+        DevToolsServer.OpenTargetSession(connection, target);
+        return null;
+    }
+
+    /// <summary>
+    /// Decides which conversation a path opens.
+    /// </summary>
+    /// <returns>
+    /// <see cref="RouteKind.Browser"/> with no target for the browser endpoint,
+    /// <see cref="RouteKind.Target"/> with the engine for a direct one, and <see cref="RouteKind.None"/>
+    /// for anything else — including a stale identifier, so a client holding one is told the browser or the
+    /// target is gone rather than silently attached to a different one.
+    /// </returns>
+    private (RouteKind Kind, EngineTarget? Target) Route(string path)
+    {
+        var query = path.IndexOf('?', StringComparison.Ordinal);
+        if (query >= 0)
+        {
+            path = path.Substring(0, query);
+        }
+
+        if (path.StartsWith("/devtools/browser/", StringComparison.Ordinal))
+        {
+            var id = path.Substring("/devtools/browser/".Length);
+            return string.Equals(id, _server.BrowserId, StringComparison.Ordinal)
+                ? (RouteKind.Browser, null)
+                : (RouteKind.None, null);
+        }
+
+        if (path.StartsWith("/devtools/page/", StringComparison.Ordinal))
+        {
+            var id = path.Substring("/devtools/page/".Length);
+            return _server.FindTarget(id) is { } target ? (RouteKind.Target, target) : (RouteKind.None, null);
+        }
+
+        return (RouteKind.None, null);
+    }
+
+    /// <summary>What a WebSocket path names.</summary>
+    private enum RouteKind
+    {
+        /// <summary>Nothing this server serves.</summary>
+        None,
+
+        /// <summary>The browser endpoint, where a client discovers targets and attaches to them.</summary>
+        Browser,
+
+        /// <summary>One engine directly, whose messages carry no session identifier.</summary>
+        Target,
+    }
+
+    private static async Task Quietly(Task task)
+    {
+        try
+        {
+            await task.ConfigureAwait(false);
+        }
+#pragma warning disable CA1031 // shutting down is not the moment to raise what a finished task held
+        catch (Exception)
+#pragma warning restore CA1031
+        {
+        }
+    }
+}

--- a/Jint.Tests.DevTools/Clients/PuppeteerSharpTests.cs
+++ b/Jint.Tests.DevTools/Clients/PuppeteerSharpTests.cs
@@ -1,0 +1,200 @@
+using System.Text.Json;
+using Jint.DevTools;
+using PuppeteerSharp;
+
+namespace Jint.Tests.DevTools.Clients;
+
+/// <summary>
+/// A real client library, over a real socket: PuppeteerSharp connects, lists the target, opens a session and
+/// evaluates in it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the only test in the suite that can make a claim about <i>client compatibility</i>. Everything
+/// else asserts what this server answers; this asserts that a library nobody here wrote, written against
+/// Chrome, is satisfied by it. The version is the one the handshake in
+/// <c>tools/devtools-protocol/handshakes/puppeteersharp-dotnet.json</c> was recorded with, so what it sends
+/// here is what that file says it sends.
+/// </para>
+/// <para>
+/// <b>No browser is downloaded and none is launched.</b> <c>ConnectAsync</c> speaks to an endpoint that
+/// already exists, which is exactly what this server is; Puppeteer's browser-fetching machinery is never
+/// touched.
+/// </para>
+/// <para>
+/// A target is found by the location the host gave it and then confirmed by asking the engine for its own
+/// identifier through <c>Runtime.getIsolateId</c>, rather than by reading an identifier off the client's
+/// handle: what a client library exposes about a target type it has never heard of is the client's business,
+/// and a test written against it would be testing the client.
+/// </para>
+/// <para>
+/// What Puppeteer cannot do here is anything page-shaped — <c>NewPageAsync</c>, <c>GotoAsync</c>, <c>$</c> —
+/// because an engine target is a Node-flavoured target with no document. That is not a gap in the transport
+/// and is not closed by more of this package; it is what <c>Jint.Browser</c> is for.
+/// </para>
+/// </remarks>
+[NonParallelizable]
+public class PuppeteerSharpTests
+{
+    /// <summary>
+    /// Generous on purpose: it is there to stop a hang, not to assert a speed. Each of these finishes in
+    /// well under a second unloaded, and a two-core CI runner sharing the machine with four other test
+    /// processes has been seen to make this suite two orders of magnitude slower.
+    /// </summary>
+    private static readonly TimeSpan Bound = TimeSpan.FromSeconds(120);
+
+    [Test]
+    public async Task PuppeteerConnectsListsTheTargetOpensASessionAndEvaluates()
+    {
+        await using var server = new DevToolsServer();
+        await server.StartAsync();
+
+        await using var target = new EngineTarget(
+            new Engine(options => options.UseDevTools()),
+            new EngineTargetOptions { Title = "jint", Url = "jint://engine", ThreadMode = ThreadMode.LibraryOwned });
+
+        server.AddTarget(target);
+
+        await using var browser = await ConnectAsync(new ConnectOptions { BrowserWSEndpoint = server.BrowserWebSocketUrl });
+
+        browser.IsConnected.Should().BeTrue();
+        browser.Targets().Should().NotBeEmpty("the client asks for the target list while connecting, and an engine is on it");
+
+        var session = await SessionForAsync(browser, "jint://engine", target.TargetId);
+
+        var evaluated = await session.SendAsync(
+            "Runtime.evaluate",
+            new { expression = "6 * 7", returnByValue = true }).WaitAsync(Bound);
+
+        Value(evaluated).GetInt32().Should().Be(42);
+
+        await session.DetachAsync().WaitAsync(Bound);
+
+        browser.Disconnect();
+        browser.IsConnected.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// The other entry a client takes: read <c>/json/version</c> for the endpoint, then connect to it. It is
+    /// what <c>connect({ browserURL })</c> and <c>connectOverCDP(url)</c> both do, and it is the reason the
+    /// discovery documents are served from the same port.
+    /// </summary>
+    [Test]
+    public async Task PuppeteerConnectsThroughTheDiscoveryDocument()
+    {
+        await using var server = new DevToolsServer();
+        await server.StartAsync();
+
+        await using var target = new EngineTarget(
+            new Engine(options => options.UseDevTools()),
+            new EngineTargetOptions { Url = "jint://engine", ThreadMode = ThreadMode.LibraryOwned });
+
+        server.AddTarget(target);
+
+        await using var browser = await ConnectAsync(new ConnectOptions { BrowserURL = $"http://127.0.0.1:{server.BoundPort}" });
+
+        browser.IsConnected.Should().BeTrue();
+
+        var session = await SessionForAsync(browser, "jint://engine", target.TargetId);
+        var evaluated = await session.SendAsync("Runtime.evaluate", new { expression = "1 + 1", returnByValue = true }).WaitAsync(Bound);
+        Value(evaluated).GetInt32().Should().Be(2);
+
+        await session.DetachAsync().WaitAsync(Bound);
+    }
+
+    /// <summary>
+    /// Two engines behind one endpoint, which is the shape a host with a pool of them is in. Each session
+    /// reaches its own engine and no other.
+    /// </summary>
+    [Test]
+    public async Task PuppeteerSeesEveryTargetAndEvaluatesInEachSeparately()
+    {
+        await using var server = new DevToolsServer();
+        await server.StartAsync();
+
+        await using var first = new EngineTarget(
+            new Engine(options => options.UseDevTools()),
+            new EngineTargetOptions { Title = "first", Url = "jint://first", ThreadMode = ThreadMode.LibraryOwned });
+        await using var second = new EngineTarget(
+            new Engine(options => options.UseDevTools()),
+            new EngineTargetOptions { Title = "second", Url = "jint://second", ThreadMode = ThreadMode.LibraryOwned });
+
+        server.AddTarget(first);
+        server.AddTarget(second);
+
+        await first.PostAsync(engine => engine.SetValue("name", "first")).WaitAsync(Bound);
+        await second.PostAsync(engine => engine.SetValue("name", "second")).WaitAsync(Bound);
+
+        await using var browser = await ConnectAsync(new ConnectOptions { BrowserWSEndpoint = server.BrowserWebSocketUrl });
+
+        foreach (var (target, expected) in new[] { (first, "first"), (second, "second") })
+        {
+            var session = await SessionForAsync(browser, "jint://" + expected, target.TargetId);
+
+            var evaluated = await session.SendAsync(
+                "Runtime.evaluate",
+                new { expression = "name", returnByValue = true }).WaitAsync(Bound);
+
+            Value(evaluated).GetString().Should().Be(expected);
+
+            await session.DetachAsync().WaitAsync(Bound);
+        }
+    }
+
+    /// <summary>The <c>result.value</c> of a <c>Runtime.evaluate</c> reply the client handed back.</summary>
+    private static JsonElement Value(JsonElement? reply) => reply!.Value.GetProperty("result").GetProperty("value");
+
+    private static Task<IBrowser> ConnectAsync(ConnectOptions options)
+    {
+        options.ProtocolTimeout = (int) Bound.TotalMilliseconds;
+        return Puppeteer.ConnectAsync(options).WaitAsync(Bound);
+    }
+
+    /// <summary>
+    /// Opens a session on the client's handle for one engine, found by the location the host gave it, and
+    /// checks that it really is that engine before handing it back.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Bounded rather than immediate, because a client's target list is built from events it processes on
+    /// its own schedule: <c>ConnectAsync</c> has returned by the time the discovery events are in its
+    /// buffer, and reading the list in that window is a race the client owns and this test does not.
+    /// </para>
+    /// <para>
+    /// The target is found by <c>Url</c> — which is what <see cref="EngineTargetOptions.Url"/> put there,
+    /// so finding it is itself a check — and then confirmed by asking the engine for its own identifier.
+    /// Probing by opening a session on each candidate would not do: detaching from the wrong one takes it
+    /// out of the client's list of available targets, and the next search would not find it.
+    /// </para>
+    /// </remarks>
+    private static async Task<ICDPSession> SessionForAsync(IBrowser browser, string url, string targetId)
+    {
+        var deadline = DateTime.UtcNow + Bound;
+        var seen = 0;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            var targets = browser.Targets();
+            seen = targets.Length;
+
+            foreach (var candidate in targets)
+            {
+                if (candidate.Url != url)
+                {
+                    continue;
+                }
+
+                var session = await candidate.CreateCDPSessionAsync().WaitAsync(Bound);
+
+                var isolate = await session.SendAsync("Runtime.getIsolateId").WaitAsync(Bound);
+                isolate!.Value.GetProperty("id").GetString().Should().Be(targetId, "the session reaches the engine the client listed under '{0}'", url);
+
+                return session;
+            }
+
+            await Task.Delay(25);
+        }
+
+        throw new InvalidOperationException($"the client listed {seen} target(s) within {Bound} and none of them was at '{url}'");
+    }
+}

--- a/Jint.Tests.DevTools/Domains/DomainLifecycleTests.cs
+++ b/Jint.Tests.DevTools/Domains/DomainLifecycleTests.cs
@@ -13,9 +13,9 @@ namespace Jint.Tests.DevTools.Domains;
 /// </summary>
 /// <remarks>
 /// <para>
-/// No shipped domain uses either yet — the two implemented commands answer straight away — so the shape is
-/// exercised here through a domain of this suite's own, derived from a generated base exactly as a real one
-/// would be. That is deliberate: an untested extension point is a design nobody has tried.
+/// Exercised through a domain of this suite's own, derived from a generated base exactly as a real one is.
+/// That is deliberate: an untested extension point is a design nobody has tried, and the domains this
+/// package ships do not between them use every part of it.
 /// </para>
 /// <para>
 /// The commands are invoked directly rather than over the wire, and that is not a shortcut: dispatch is
@@ -29,7 +29,7 @@ public class DomainLifecycleTests
     public async Task EnablingTwiceRunsTheHookOnce()
     {
         var (session, domain, _) = Create();
-        var context = new CommandContext(session, sessionId: null, CancellationToken.None);
+        var context = new CommandContext(session, session.SessionId, CancellationToken.None);
 
         await domain.HandleEnableAsync(context);
         await domain.HandleEnableAsync(context);
@@ -42,7 +42,7 @@ public class DomainLifecycleTests
     public async Task DisablingRunsTheHookOnlyWhenItWasEnabled()
     {
         var (session, domain, _) = Create();
-        var context = new CommandContext(session, sessionId: null, CancellationToken.None);
+        var context = new CommandContext(session, session.SessionId, CancellationToken.None);
 
         await domain.HandleDisableAsync(context);
         domain.Disables.Should().Be(0);
@@ -54,12 +54,19 @@ public class DomainLifecycleTests
         domain.IsEnabled.Should().BeFalse();
     }
 
+    /// <summary>
+    /// An event carries the identifier of the session that raised it, which is what lets a domain on an
+    /// attached session emit without knowing which attachment it is part of.
+    /// </summary>
     [Test]
-    public async Task AnEventCarriesNoIdentifierAndReachesTheConnection()
+    public async Task AnEventCarriesTheRaisingSessionsIdentifierAndNoRequestIdentifier()
     {
-        var (session, domain, connection) = Create();
+        var (root, _, connection) = Create();
+        var child = root.CreateChild("S1");
+        var domain = new CountingLogDomain();
+        child.Register(domain);
 
-        await domain.RaiseAsync(new CommandContext(session, "S1", CancellationToken.None));
+        await domain.RaiseAsync();
 
         using var document = JsonDocument.Parse(connection.Sent[^1]);
         var message = document.RootElement;
@@ -78,16 +85,16 @@ public class DomainLifecycleTests
     [Test]
     public async Task AnUnsetOptionalMemberIsNotWritten()
     {
-        var (session, domain, connection) = Create();
+        var (_, domain, connection) = Create();
 
-        await domain.RaiseAsync(new CommandContext(session, sessionId: null, CancellationToken.None));
+        await domain.RaiseAsync();
 
         using var document = JsonDocument.Parse(connection.Sent[^1]);
         var entry = document.RootElement.GetProperty("params").GetProperty("entry");
 
         entry.TryGetProperty("url", out _).Should().BeFalse();
         entry.TryGetProperty("stackTrace", out _).Should().BeFalse();
-        document.RootElement.TryGetProperty("sessionId", out _).Should().BeFalse();
+        document.RootElement.TryGetProperty("sessionId", out _).Should().BeFalse("the root session has no identifier to put on its events");
     }
 
     private static (DevToolsSession Session, CountingLogDomain Domain, InProcessConnection Connection) Create()
@@ -113,7 +120,7 @@ public class DomainLifecycleTests
 
         internal ValueTask<EmptyResult> HandleDisableAsync(CommandContext context) => DisableAsync(EmptyParameters.Instance, context);
 
-        internal ValueTask RaiseAsync(CommandContext context)
+        internal ValueTask RaiseAsync()
         {
             var entry = new LogEntry
             {
@@ -123,7 +130,7 @@ public class DomainLifecycleTests
                 Timestamp = 1,
             };
 
-            return EmitAsync(LogEvents.EntryAdded(new EntryAddedEvent { Entry = entry }), context);
+            return EmitAsync(LogEvents.EntryAdded(new EntryAddedEvent { Entry = entry }));
         }
 
         protected override async ValueTask<EmptyResult> EnableAsync(EmptyParameters parameters, CommandContext context)

--- a/Jint.Tests.DevTools/Jint.Tests.DevTools.csproj
+++ b/Jint.Tests.DevTools/Jint.Tests.DevTools.csproj
@@ -28,6 +28,12 @@
 
   <ItemGroup>
     <PackageReference Include="AwesomeAssertions" />
+    <!--
+      The .NET client the recorded handshake in tools/devtools-protocol/handshakes/ came from, at the very
+      version it was recorded with. It is what turns "the protocol looks right" into "a client library
+      connects, lists the target, opens a session and gets 42 back"; no in-process test can make that claim.
+    -->
+    <PackageReference Include="PuppeteerSharp" />
     <PackageReference Include="GitHubActionsTestLogger" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
@@ -61,6 +67,14 @@
       per test case, and fixtures parallel with each other. See the file for what each decision restores.
     -->
     <Compile Include="..\Jint.Tests\TestFrameworkConventions.cs" Link="TestFrameworkConventions.cs" />
+    <!--
+      And the switch that turns the host-contract verifiers on for a Release run, so that
+      JINT_HOST_CONTRACT_VERIFICATION=1 means the same thing here as it does in the other two suites. It has
+      to be a module initializer in *this* assembly: the gate Jint reads is a static readonly bool settled at
+      type initialization, and a fixture would arm it far too late. It is what makes the thread rule exact
+      rather than asserted: a JsValue touched from a transport thread fails loudly under it.
+    -->
+    <Compile Include="..\Jint.Tests\HostContractVerificationSwitch.cs" Link="HostContractVerificationSwitch.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jint.Tests.DevTools/Protocol/HandshakeReplayTests.cs
+++ b/Jint.Tests.DevTools/Protocol/HandshakeReplayTests.cs
@@ -1,0 +1,256 @@
+using System.Text.Json;
+using Jint.DevTools;
+using Jint.DevTools.Protocol;
+using Jint.Tests.DevTools.Session;
+
+namespace Jint.Tests.DevTools.Protocol;
+
+/// <summary>
+/// Every method a real client was recorded sending is sent at this server, and what comes back is checked
+/// against what the manifest claims.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The recordings in <c>tools/devtools-protocol/handshakes/</c> are what Puppeteer for .NET and the DevTools
+/// front end actually put on the wire while driving one Chrome through one scenario — not what a
+/// compatibility table says, and not what the protocol describes. Replaying them is the only test in this
+/// suite that can fail because of something a client does that nobody here thought of.
+/// </para>
+/// <para>
+/// Two properties, and both matter:
+/// </para>
+/// <list type="bullet">
+/// <item>
+/// A method the manifest names is <b>answered</b> — never <c>-32601</c>. Two of them answer a stated
+/// refusal rather than a value (see <see cref="RefusedByDesign"/>), which is a different thing from not
+/// being there: a client is told why.
+/// </item>
+/// <item>
+/// Every other method answers <b>exactly <c>-32601</c></b>. Not <c>-32602</c>, which would tell a client it
+/// called a command wrongly when the command does not exist here; and not an exception, which would reach
+/// the client as <c>-32000</c> and read as a server that broke rather than one that does not implement it.
+/// </item>
+/// </list>
+/// <para>
+/// The second property needs the tolerance to be deliberate rather than blanket, so <see cref="Absent"/>
+/// names every recorded method that is expected to answer <c>-32601</c> and says why. A recorded method that
+/// is neither implemented nor listed there fails: a new client release, or a re-recording, then arrives as a
+/// decision somebody makes rather than as a silently widened test.
+/// </para>
+/// </remarks>
+public class HandshakeReplayTests
+{
+    /// <summary>
+    /// Why each recorded method this server does not implement is expected to answer <c>-32601</c>.
+    /// </summary>
+    /// <remarks>
+    /// Three reasons, and they are not interchangeable. A <b>page</b> entry belongs to a target that has a
+    /// document — <c>Jint.Browser</c>, which is AngleSharp plus Jint — and would be wrong to answer here
+    /// whatever the implementation state, because an engine target has no page to answer about. A
+    /// <b>later</b> entry is engine-level and simply not written yet. A <b>none</b> entry is one Chrome
+    /// itself answered <c>-32601</c> to in the very recording.
+    /// </remarks>
+    private static readonly Dictionary<string, string> Absent = new(StringComparer.Ordinal)
+    {
+        // Page-level: a document, its frames, its network, its input, its storage. Jint.Browser's, and an
+        // engine target has nothing to answer about.
+        ["Page.enable"] = "page",
+        ["Page.getFrameTree"] = "page",
+        ["Page.setLifecycleEventsEnabled"] = "page",
+        ["Page.addScriptToEvaluateOnNewDocument"] = "page",
+        ["Page.createIsolatedWorld"] = "page",
+        ["Page.navigate"] = "page",
+        ["Page.getNavigationHistory"] = "page",
+        ["Page.navigateToHistoryEntry"] = "page",
+        ["Page.captureScreenshot"] = "page",
+        ["Page.printToPDF"] = "page",
+        ["DOM.describeNode"] = "page",
+        ["DOM.resolveNode"] = "page",
+        ["Network.enable"] = "page",
+        ["Network.setCacheDisabled"] = "page",
+        ["Emulation.setDeviceMetricsOverride"] = "page",
+        ["Emulation.setTouchEmulationEnabled"] = "page",
+        ["Input.dispatchMouseEvent"] = "page",
+        ["Input.dispatchKeyEvent"] = "page",
+        ["Fetch.enable"] = "page",
+        ["Fetch.disable"] = "page",
+        ["Fetch.continueRequest"] = "page",
+        ["Storage.getCookies"] = "page",
+        ["Storage.setCookies"] = "page",
+        ["IO.read"] = "page",
+        ["IO.close"] = "page",
+        ["Audits.enable"] = "page",
+        ["Performance.enable"] = "page",
+        ["Log.enable"] = "page",
+
+        // Engine-level and not written yet. Each needs the remote-object table, the debugger seam or the
+        // profiler seam, and half of any of those is worse than none.
+        ["Runtime.getProperties"] = "later",
+        ["Runtime.callFunctionOn"] = "later",
+        ["Runtime.releaseObject"] = "later",
+        ["Runtime.addBinding"] = "later",
+        ["Debugger.enable"] = "later",
+        ["Debugger.setPauseOnExceptions"] = "later",
+        ["Debugger.setAsyncCallStackDepth"] = "later",
+        ["Debugger.setBlackboxPatterns"] = "later",
+        ["Profiler.enable"] = "later",
+
+        // Chrome answered -32601 to these in the recording itself, so a client that sends one already
+        // handles not getting it.
+        ["WebMCP.enable"] = "none",
+        ["Network.setAttachDebugStack"] = "none",
+        ["Network.setBlockedURLs"] = "none",
+        ["Network.emulateNetworkConditionsByRule"] = "none",
+        ["Network.overrideNetworkState"] = "none",
+        ["Network.clearAcceptedEncodingsOverride"] = "none",
+    };
+
+    /// <summary>
+    /// The two implemented commands whose answer is a refusal with a reason, which is not the same as not
+    /// being implemented: a client is told what is missing rather than that the command is unknown.
+    /// </summary>
+    private static readonly HashSet<string> RefusedByDesign = new(StringComparer.Ordinal)
+    {
+        "Target.createBrowserContext",
+        "Target.disposeBrowserContext",
+    };
+
+    /// <summary>
+    /// What one replay addresses: the target and attachment under test, plus a spare of each so that the
+    /// two destructive commands do not pull the ground out from under the rest of the run.
+    /// </summary>
+    private sealed record Fixture(string TargetId, string SpareTargetId, string SpareSessionId);
+
+    /// <summary>Parameters for the recorded methods that need them to get past deserialization.</summary>
+    /// <remarks>
+    /// Only for the implemented ones: an unimplemented command is method-not-found before its parameters are
+    /// looked at, which is the very property the second assertion pins.
+    /// </remarks>
+    private static string? Parameters(string method, Fixture fixture) => method switch
+    {
+        "Target.getTargetInfo" or "Target.activateTarget" => $$"""{"targetId":"{{fixture.TargetId}}"}""",
+        "Target.attachToTarget" => $$"""{"targetId":"{{fixture.TargetId}}","flatten":true}""",
+        "Target.closeTarget" => $$"""{"targetId":"{{fixture.SpareTargetId}}"}""",
+        "Target.detachFromTarget" => $$"""{"sessionId":"{{fixture.SpareSessionId}}"}""",
+        "Target.setAutoAttach" => """{"autoAttach":false,"waitForDebuggerOnStart":false,"flatten":true}""",
+        "Target.setDiscoverTargets" => """{"discover":false}""",
+        "Target.createTarget" => """{"url":"about:blank"}""",
+        "Target.disposeBrowserContext" => """{"browserContextId":"X"}""",
+        "Runtime.evaluate" => """{"expression":"1"}""",
+        _ => null,
+    };
+
+    [TestCase("puppeteersharp-dotnet")]
+    [TestCase("devtools-frontend")]
+    public async Task EveryRecordedMethodIsEitherAnsweredOrExactlyMethodNotFound(string client)
+    {
+        var methods = RecordedMethods(client);
+        methods.Should().NotBeEmpty("the recording is the manifest these tests are written against");
+
+        await using var session = ProtocolSession.Create(options: new DevToolsServerOptions
+        {
+            EngineFactory = () => new Engine(),
+        });
+
+        var target = session.AddTarget(
+            new EngineTargetOptions { ThreadMode = ThreadMode.LibraryOwned },
+            new Engine(options => options.UseDevTools()));
+
+        var attachment = await session.AttachAsync(target);
+
+        var spare = session.AddTarget(new EngineTargetOptions { ThreadMode = ThreadMode.LibraryOwned });
+        var fixture = new Fixture(target.TargetId, spare.TargetId, await session.AttachAsync(spare));
+
+        var unexpected = new List<string>();
+
+        foreach (var method in methods)
+        {
+            var reply = await BestAnswerAsync(session, method, fixture, attachment);
+            var implemented = ProtocolManifest.ImplementedMethods.Contains(method, StringComparer.Ordinal);
+            var error = reply.TryGetProperty("error", out var value) ? value : (JsonElement?) null;
+            var code = error?.GetProperty("code").GetInt32();
+
+            if (implemented)
+            {
+                if (RefusedByDesign.Contains(method))
+                {
+                    code.Should().Be(-32000, "'{0}' is implemented and refuses with a reason", method);
+                    continue;
+                }
+
+                code.Should().BeNull("'{0}' is in the manifest, so a client that sends it is answered", method);
+                continue;
+            }
+
+            code.Should().Be(-32601, "'{0}' is not implemented, and every other answer misleads the client", method);
+            error!.Value.GetProperty("message").GetString().Should().Be($"'{method}' wasn't found");
+
+            if (!Absent.ContainsKey(method))
+            {
+                unexpected.Add(method);
+            }
+        }
+
+        Assert.That(
+            unexpected.Count == 0,
+            $"""
+            {unexpected.Count} method(s) the '{client}' recording sends answer -32601 and are not accounted
+            for in HandshakeReplayTests.Absent. Add each with the reason it is absent — a page-level command
+            that belongs to Jint.Browser, an engine-level one that is not written yet, or one Chrome itself
+            answered -32601 to — so that the tolerance stays a decision rather than a blanket:
+
+            {string.Join(Environment.NewLine, unexpected.Select(method => "  " + method))}
+            """);
+    }
+
+    /// <summary>
+    /// The recording and the manifest agree about what a client that only ever spoke to an engine target
+    /// would find missing.
+    /// </summary>
+    [Test]
+    public void NothingIsExcusedThatIsAlreadyImplemented()
+    {
+        var stale = Absent.Keys.Where(method => ProtocolManifest.ImplementedMethods.Contains(method, StringComparer.Ordinal)).ToArray();
+
+        Assert.That(
+            stale.Length == 0,
+            $"""
+            {stale.Length} method(s) are listed in HandshakeReplayTests.Absent and are now implemented, so
+            the excuse is stale and the list no longer says anything:
+
+            {string.Join(Environment.NewLine, stale.Select(method => "  " + method))}
+            """);
+    }
+
+    /// <summary>
+    /// Sends <paramref name="method"/> where it belongs: the browser conversation first, and the attachment
+    /// when the conversation does not carry that domain.
+    /// </summary>
+    /// <remarks>
+    /// A real client knows which session each command belongs on, because the protocol tells it. A replay
+    /// does not, so it tries both and keeps the better answer — which is exactly the question being asked:
+    /// is this method reachable at all?
+    /// </remarks>
+    private static async Task<JsonElement> BestAnswerAsync(ProtocolSession session, string method, Fixture fixture, string attachment)
+    {
+        var parameters = Parameters(method, fixture);
+
+        var onBrowser = await session.SendAsync(method, parameters).ConfigureAwait(false);
+        if (!onBrowser.TryGetProperty("error", out _))
+        {
+            return onBrowser;
+        }
+
+        var onAttachment = await session.SendAsync(method, parameters, attachment).ConfigureAwait(false);
+        return onAttachment.TryGetProperty("error", out _) ? onBrowser : onAttachment;
+    }
+
+    private static IReadOnlyList<string> RecordedMethods(string client)
+    {
+        var path = Path.Combine(RepositoryPaths.ProtocolDirectory, "handshakes", client + ".json");
+        File.Exists(path).Should().BeTrue("the recorded handshakes are checked in at {0}", path);
+
+        using var document = JsonDocument.Parse(File.ReadAllBytes(path));
+        return document.RootElement.GetProperty("allMethods").EnumerateArray().Select(method => method.GetString()!).ToArray();
+    }
+}

--- a/Jint.Tests.DevTools/Protocol/ProtocolManifestTests.cs
+++ b/Jint.Tests.DevTools/Protocol/ProtocolManifestTests.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Reflection;
+using Jint.DevTools;
 using Jint.DevTools.Domains;
 using Jint.DevTools.Protocol;
 using Jint.DevTools.Session;
@@ -27,7 +28,30 @@ namespace Jint.Tests.DevTools.Protocol;
 /// </remarks>
 public class ProtocolManifestTests
 {
-    private static readonly DevToolsSession _session = BuiltInDomains.RegisterOn(new DevToolsSession(new InProcessConnection()));
+    /// <summary>
+    /// Every domain a client can reach, across both kinds of session.
+    /// </summary>
+    /// <remarks>
+    /// There are two kinds and the manifest covers both: the browser conversation answers about the server,
+    /// and an attachment answers about one engine. Reading only one of them would let half the manifest go
+    /// unchecked -- which is exactly the shape of the mistake these tests exist to catch.
+    /// </remarks>
+    private static readonly IReadOnlyCollection<DevToolsDomain> _domains = RegisteredDomains();
+
+    private static IReadOnlyCollection<DevToolsDomain> RegisteredDomains()
+    {
+        var server = new DevToolsServer();
+        var target = new EngineTarget(new Engine());
+        server.AddTarget(target);
+
+        var browser = server.OpenBrowserSession(new InProcessConnection());
+        var attachment = browser.Session.CreateChild("S1");
+        BuiltInDomains.RegisterTargetDomains(attachment, target, browser);
+
+        var domains = new List<DevToolsDomain>(browser.Session.Domains);
+        domains.AddRange(attachment.Domains);
+        return domains;
+    }
 
     [Test]
     public void EveryImplementedMethodTheManifestNamesIsOverridden()
@@ -51,7 +75,8 @@ public class ProtocolManifestTests
     {
         var undeclared = new List<string>();
 
-        foreach (var domain in _session.Domains)
+
+        foreach (var domain in _domains)
         {
             foreach (var method in domain.GetType().GetMethods(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.DeclaredOnly))
             {
@@ -91,7 +116,7 @@ public class ProtocolManifestTests
     {
         foreach (var reported in ProtocolManifest.ReportedDomains)
         {
-            _session.Domains.Should().Contain(
+            _domains.Should().Contain(
                 domain => domain.Name == reported.Name,
                 "Schema.getDomains reports '{0}', so a session has to have it registered",
                 reported.Name);
@@ -109,14 +134,21 @@ public class ProtocolManifestTests
         var domainName = qualified.Substring(0, separator);
         var expected = Naming(qualified.Substring(separator + 1)) + "Async";
 
-        var domain = _session.Domains.FirstOrDefault(candidate => string.Equals(candidate.Name, domainName, StringComparison.Ordinal));
-        if (domain is null)
+        foreach (var domain in _domains)
         {
-            return false;
+            if (!string.Equals(domain.Name, domainName, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var method = domain.GetType().GetMethod(expected, BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
+            if (method is not null && method.GetBaseDefinition() != method)
+            {
+                return true;
+            }
         }
 
-        var method = domain.GetType().GetMethod(expected, BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
-        return method is not null && method.GetBaseDefinition() != method;
+        return false;
     }
 
     private static string Command(string domainName, string methodName)

--- a/Jint.Tests.DevTools/Session/InProcessProtocolTests.cs
+++ b/Jint.Tests.DevTools/Session/InProcessProtocolTests.cs
@@ -17,20 +17,22 @@ public class InProcessProtocolTests
     [Test]
     public async Task SchemaGetDomainsAnswersTheManifest()
     {
-        var result = await ProtocolSession.Create().ResultOfAsync("""{"id":1,"method":"Schema.getDomains"}""");
+        await using var session = ProtocolSession.Create();
+        var result = await session.ResultOfAsync("""{"id":1,"method":"Schema.getDomains"}""");
 
         var domains = result.GetProperty("domains").EnumerateArray()
             .Select(domain => domain.GetProperty("name").GetString())
             .ToArray();
 
-        domains.Should().BeEquivalentTo(["Browser", "Schema"]);
+        domains.Should().BeEquivalentTo(["Browser", "Runtime", "Schema", "Target"]);
         result.GetProperty("domains")[0].GetProperty("version").GetString().Should().Be("1.3");
     }
 
     [Test]
     public async Task BrowserGetVersionNamesJintRatherThanAChromeBuild()
     {
-        var result = await ProtocolSession.Create().ResultOfAsync("""{"id":7,"method":"Browser.getVersion"}""");
+        await using var session = ProtocolSession.Create();
+        var result = await session.ResultOfAsync("""{"id":7,"method":"Browser.getVersion"}""");
 
         result.GetProperty("protocolVersion").GetString().Should().Be("1.3");
         result.GetProperty("product").GetString().Should().StartWith("Jint/");
@@ -43,7 +45,8 @@ public class InProcessProtocolTests
     public async Task BrowserCloseReachesTheHostAndAnswersAnEmptyResult()
     {
         var closed = 0;
-        var result = await ProtocolSession.Create(() => closed++).ResultOfAsync("""{"id":2,"method":"Browser.close"}""");
+        await using var session = ProtocolSession.Create(() => closed++);
+        var result = await session.ResultOfAsync("""{"id":2,"method":"Browser.close"}""");
 
         closed.Should().Be(1);
         result.ValueKind.Should().Be(JsonValueKind.Object);
@@ -53,7 +56,8 @@ public class InProcessProtocolTests
     [Test]
     public async Task BrowserCloseWithoutAHostCallbackStillSucceeds()
     {
-        var result = await ProtocolSession.Create().ResultOfAsync("""{"id":2,"method":"Browser.close"}""");
+        await using var session = ProtocolSession.Create();
+        var result = await session.ResultOfAsync("""{"id":2,"method":"Browser.close"}""");
 
         result.GetRawText().Should().Be("{}");
     }
@@ -61,23 +65,32 @@ public class InProcessProtocolTests
     [Test]
     public async Task TheResponseEchoesTheRequestIdentifier()
     {
-        var reply = await ProtocolSession.Create().RoundTripAsync("""{"id":4294967296,"method":"Browser.getVersion"}""");
+        await using var session = ProtocolSession.Create();
+        var reply = await session.RoundTripAsync("""{"id":4294967296,"method":"Browser.getVersion"}""");
 
         reply.GetProperty("id").GetInt64().Should().Be(4294967296, "identifiers are 64-bit, and a client that ran long enough to overflow an int is one that gets wrong answers");
     }
 
+    /// <summary>
+    /// A <c>sessionId</c> nothing answers to is <c>-32001</c> in Chrome's wording, and the failure still
+    /// echoes the identifier so the client can tell which of its attachments went away.
+    /// </summary>
     [Test]
-    public async Task TheResponseEchoesTheSessionIdentifier()
+    public async Task AMessageNamingAnUnknownSessionIsSessionNotFound()
     {
-        var reply = await ProtocolSession.Create().RoundTripAsync("""{"id":1,"method":"Browser.getVersion","sessionId":"AB12"}""");
+        await using var session = ProtocolSession.Create();
+        var reply = await session.RoundTripAsync("""{"id":1,"method":"Browser.getVersion","sessionId":"AB12"}""");
 
         reply.GetProperty("sessionId").GetString().Should().Be("AB12");
+        reply.GetProperty("error").GetProperty("code").GetInt32().Should().Be(-32001);
+        reply.GetProperty("error").GetProperty("message").GetString().Should().Be("Session with given id not found.");
     }
 
     [Test]
     public async Task AResponseWithoutASessionIdentifierCarriesNone()
     {
-        var reply = await ProtocolSession.Create().RoundTripAsync("""{"id":1,"method":"Browser.getVersion"}""");
+        await using var session = ProtocolSession.Create();
+        var reply = await session.RoundTripAsync("""{"id":1,"method":"Browser.getVersion"}""");
 
         reply.TryGetProperty("sessionId", out _).Should().BeFalse();
     }
@@ -94,7 +107,8 @@ public class InProcessProtocolTests
     [TestCase("nodot", TestName = "A method that is not qualified at all")]
     public async Task AnUnansweredMethodIsMethodNotFoundInChromesWording(string method)
     {
-        var error = await ProtocolSession.Create().ErrorOfAsync($$"""{"id":11,"method":"{{method}}"}""");
+        await using var session = ProtocolSession.Create();
+        var error = await session.ErrorOfAsync($$"""{"id":11,"method":"{{method}}"}""");
 
         error.GetProperty("code").GetInt32().Should().Be(-32601);
         error.GetProperty("message").GetString().Should().Be($"'{method}' wasn't found");
@@ -107,7 +121,8 @@ public class InProcessProtocolTests
     [Test]
     public async Task AnUnansweredMethodIsMethodNotFoundEvenWhenItsParametersAreUnusable()
     {
-        var error = await ProtocolSession.Create().ErrorOfAsync(
+        await using var session = ProtocolSession.Create();
+        var error = await session.ErrorOfAsync(
             """{"id":5,"method":"Browser.setWindowBounds","params":{"windowId":"not a number"}}""");
 
         error.GetProperty("code").GetInt32().Should().Be(
@@ -118,7 +133,8 @@ public class InProcessProtocolTests
     [Test]
     public async Task AnErrorResponseCarriesTheRequestIdentifier()
     {
-        var reply = await ProtocolSession.Create().RoundTripAsync("""{"id":99,"method":"Runtime.evaluate"}""");
+        await using var session = ProtocolSession.Create();
+        var reply = await session.RoundTripAsync("""{"id":99,"method":"Runtime.evaluate"}""");
 
         reply.GetProperty("id").GetInt64().Should().Be(99, "a client is waiting on that identifier, and an error it cannot match up is a hang");
     }
@@ -126,7 +142,8 @@ public class InProcessProtocolTests
     [Test]
     public async Task MalformedJsonIsAParseError()
     {
-        var error = await ProtocolSession.Create().ErrorOfAsync("{\"id\":1,\"method\":");
+        await using var session = ProtocolSession.Create();
+        var error = await session.ErrorOfAsync("{\"id\":1,\"method\":");
 
         error.GetProperty("code").GetInt32().Should().Be(-32700);
         error.GetProperty("message").GetString().Should().Be("Message must be a valid JSON");
@@ -135,7 +152,8 @@ public class InProcessProtocolTests
     [Test]
     public async Task AMessageWithNoIdentifierIsAnErrorNotification()
     {
-        var reply = await ProtocolSession.Create().RoundTripAsync("""{"method":"Browser.getVersion"}""");
+        await using var session = ProtocolSession.Create();
+        var reply = await session.RoundTripAsync("""{"method":"Browser.getVersion"}""");
 
         reply.TryGetProperty("id", out _).Should().BeFalse("there is no identifier to address the failure to, so Chrome sends a notification rather than a response");
         reply.GetProperty("error").GetProperty("code").GetInt32().Should().Be(-32600);
@@ -147,7 +165,8 @@ public class InProcessProtocolTests
     [TestCase("[]", TestName = "A message that is not an object")]
     public async Task AMessageThatIsNotARequestIsAnInvalidRequest(string message)
     {
-        var error = await ProtocolSession.Create().ErrorOfAsync(message);
+        await using var session = ProtocolSession.Create();
+        var error = await session.ErrorOfAsync(message);
 
         error.GetProperty("code").GetInt32().Should().Be(-32600);
     }
@@ -155,7 +174,8 @@ public class InProcessProtocolTests
     [Test]
     public async Task AMessageWithoutAMethodIsAnInvalidRequest()
     {
-        var reply = await ProtocolSession.Create().RoundTripAsync("""{"id":3}""");
+        await using var session = ProtocolSession.Create();
+        var reply = await session.RoundTripAsync("""{"id":3}""");
 
         reply.GetProperty("id").GetInt64().Should().Be(3);
         reply.GetProperty("error").GetProperty("code").GetInt32().Should().Be(-32600);
@@ -165,7 +185,8 @@ public class InProcessProtocolTests
     [Test]
     public async Task NonObjectParametersAreAnInvalidRequest()
     {
-        var error = await ProtocolSession.Create().ErrorOfAsync("""{"id":3,"method":"Browser.getVersion","params":[1,2]}""");
+        await using var session = ProtocolSession.Create();
+        var error = await session.ErrorOfAsync("""{"id":3,"method":"Browser.getVersion","params":[1,2]}""");
 
         error.GetProperty("code").GetInt32().Should().Be(-32600);
         error.GetProperty("message").GetString().Should().Be("Message has property 'params' of type other than object");
@@ -174,7 +195,8 @@ public class InProcessProtocolTests
     [Test]
     public async Task ParametersACommandDoesNotDeclareAreIgnored()
     {
-        var result = await ProtocolSession.Create().ResultOfAsync("""{"id":3,"method":"Browser.getVersion","params":{"whatIsThis":true}}""");
+        await using var session = ProtocolSession.Create();
+        var result = await session.ResultOfAsync("""{"id":3,"method":"Browser.getVersion","params":{"whatIsThis":true}}""");
 
         result.GetProperty("protocolVersion").GetString().Should().Be("1.3");
     }
@@ -212,7 +234,7 @@ public class InProcessProtocolTests
     [Test]
     public async Task EachMessageIsAnsweredOnceAndInOrder()
     {
-        var session = ProtocolSession.Create();
+        await using var session = ProtocolSession.Create();
 
         await session.RoundTripAsync("""{"id":1,"method":"Browser.getVersion"}""");
         await session.RoundTripAsync("""{"id":2,"method":"Schema.getDomains"}""");

--- a/Jint.Tests.DevTools/Session/ProtocolSession.cs
+++ b/Jint.Tests.DevTools/Session/ProtocolSession.cs
@@ -1,31 +1,71 @@
 using System.Text.Json;
-using Jint.DevTools.Domains;
+using Jint.DevTools;
 using Jint.DevTools.Session;
 using Jint.DevTools.Transport;
 
 namespace Jint.Tests.DevTools.Session;
 
 /// <summary>
-/// A session with the built-in domains on an in-process connection, plus the one operation every protocol
-/// test performs: send a message, read what came back.
+/// A conversation with the browser endpoint over an in-process connection, plus the one operation every
+/// protocol test performs: send a message, read what came back.
 /// </summary>
-internal sealed class ProtocolSession
+/// <remarks>
+/// The server is real and simply never started, which is what makes these tests worth writing: they drive
+/// exactly the code a socket drives, minus the socket.
+/// </remarks>
+internal sealed class ProtocolSession : IAsyncDisposable
 {
     private readonly InProcessConnection _connection = new();
+    private readonly DevToolsServer _server;
+    private int _nextId = 1000;
 
-    private ProtocolSession(Action? closeRequested)
+    private ProtocolSession(DevToolsServerOptions options, Action? closeRequested)
     {
-        Session = BuiltInDomains.RegisterOn(new DevToolsSession(_connection), closeRequested);
+        _server = new DevToolsServer(options);
+        Browser = _server.OpenBrowserSession(_connection, closeRequested);
     }
 
-    /// <summary>The session under test.</summary>
-    internal DevToolsSession Session { get; }
+    /// <summary>The conversation under test.</summary>
+    internal BrowserSession Browser { get; }
+
+    /// <summary>The server whose targets the conversation sees.</summary>
+    internal DevToolsServer Server => _server;
 
     /// <summary>Every message the session has sent, oldest first.</summary>
     internal IReadOnlyList<string> Sent => _connection.Sent;
 
-    /// <summary>Builds a session carrying the domains this package answers.</summary>
-    internal static ProtocolSession Create(Action? closeRequested = null) => new(closeRequested);
+    /// <summary>Builds a session carrying the domains a browser endpoint answers.</summary>
+    internal static ProtocolSession Create(Action? closeRequested = null, DevToolsServerOptions? options = null)
+        => new(options ?? new DevToolsServerOptions(), closeRequested);
+
+    /// <summary>Publishes a host-pumped engine target on the server.</summary>
+    internal EngineTarget AddTarget(EngineTargetOptions? options = null, Engine? engine = null)
+    {
+        var target = new EngineTarget(engine ?? new Engine(), options);
+        _server.AddTarget(target);
+        return target;
+    }
+
+    /// <summary>Sends one command, addressed to a session or to the conversation itself.</summary>
+    internal Task<JsonElement> SendAsync(string method, string? parameters = null, string? sessionId = null)
+    {
+        var identifier = Interlocked.Increment(ref _nextId);
+        var payload = parameters is null ? "" : ",\"params\":" + parameters;
+        var session = sessionId is null ? "" : ",\"sessionId\":\"" + sessionId + "\"";
+
+        return RoundTripAsync($$"""{"id":{{identifier}},"method":"{{method}}"{{payload}}{{session}}}""");
+    }
+
+    /// <summary>Attaches to <paramref name="target"/> the way a client does, and hands back the session identifier.</summary>
+    internal async Task<string> AttachAsync(EngineTarget target)
+    {
+        var reply = await SendAsync(
+            "Target.attachToTarget",
+            $$"""{"targetId":"{{target.TargetId}}","flatten":true}""").ConfigureAwait(false);
+
+        reply.TryGetProperty("error", out var error).Should().BeFalse("attaching was expected to succeed, and it answered {0}", error);
+        return reply.GetProperty("result").GetProperty("sessionId").GetString()!;
+    }
 
     /// <summary>Sends one message and hands back the reply, parsed.</summary>
     internal async Task<JsonElement> RoundTripAsync(string message)
@@ -34,10 +74,19 @@ internal sealed class ProtocolSession
         await _connection.PostAsync(message).ConfigureAwait(false);
 
         var sent = _connection.Sent;
-        sent.Count.Should().Be(before + 1, "a session answers every message with exactly one reply, or the client hangs");
+        sent.Count.Should().BeGreaterThan(before, "a session answers every message with exactly one reply, or the client hangs");
 
-        // Parsed into a JsonDocument that outlives this call: the whole document is cloned so the caller can
-        // read it after the document is disposed.
+        var identifier = Identifier(message);
+        for (var i = sent.Count - 1; i >= before; i--)
+        {
+            using var candidate = JsonDocument.Parse(sent[i]);
+            if (candidate.RootElement.TryGetProperty("id", out var id) && id.GetInt64() == identifier)
+            {
+                return candidate.RootElement.Clone();
+            }
+        }
+
+        // A message with no readable identifier is answered with an error notification, which carries none.
         using var document = JsonDocument.Parse(sent[^1]);
         return document.RootElement.Clone();
     }
@@ -56,5 +105,50 @@ internal sealed class ProtocolSession
         var reply = await RoundTripAsync(message).ConfigureAwait(false);
         reply.TryGetProperty("error", out var error).Should().BeTrue("the command was expected to fail, and it answered {0}", reply);
         return error;
+    }
+
+    /// <summary>Every event of <paramref name="method"/> the session has sent, oldest first.</summary>
+    internal IReadOnlyList<JsonElement> EventsOf(string method)
+    {
+        var events = new List<JsonElement>();
+        foreach (var message in _connection.Sent)
+        {
+            using var document = JsonDocument.Parse(message);
+            if (document.RootElement.TryGetProperty("method", out var name) && name.GetString() == method)
+            {
+                events.Add(document.RootElement.Clone());
+            }
+        }
+
+        return events;
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask DisposeAsync()
+    {
+        foreach (var target in _server.Targets)
+        {
+            await target.DisposeAsync().ConfigureAwait(false);
+        }
+
+        await _server.DisposeAsync().ConfigureAwait(false);
+    }
+
+    private static long Identifier(string message)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(message);
+            return document.RootElement.ValueKind == JsonValueKind.Object &&
+                   document.RootElement.TryGetProperty("id", out var id) &&
+                   id.ValueKind == JsonValueKind.Number &&
+                   id.TryGetInt64(out var value)
+                ? value
+                : long.MinValue;
+        }
+        catch (JsonException)
+        {
+            return long.MinValue;
+        }
     }
 }

--- a/Jint.Tests.DevTools/Session/RuntimeSessionTests.cs
+++ b/Jint.Tests.DevTools/Session/RuntimeSessionTests.cs
@@ -1,0 +1,366 @@
+using System.Text.Json;
+using Jint.DevTools;
+
+namespace Jint.Tests.DevTools.Session;
+
+/// <summary>
+/// What one attachment can do with an engine: hear about its execution context, and evaluate in it.
+/// </summary>
+/// <remarks>
+/// Every target here is <see cref="ThreadMode.LibraryOwned"/>, because that is what makes the test a test:
+/// the command is answered on a thread that is not this one, which is the arrangement every real client is in
+/// and the one a mistake in the mailbox shows up in.
+/// </remarks>
+public class RuntimeSessionTests
+{
+    [Test]
+    public async Task EnableReplaysTheOneExecutionContext()
+    {
+        await using var session = await AttachedAsync();
+
+        var reply = await session.SendAsync("Runtime.enable", sessionId: session.SessionId);
+        reply.TryGetProperty("error", out _).Should().BeFalse();
+
+        var created = session.EventsOf("Runtime.executionContextCreated");
+        created.Should().HaveCount(1);
+        created[0].GetProperty("sessionId").GetString().Should().Be(session.SessionId);
+
+        var context = created[0].GetProperty("params").GetProperty("context");
+        context.GetProperty("id").GetInt32().Should().Be(1);
+        context.GetProperty("origin").GetString().Should().BeEmpty();
+        context.GetProperty("name").GetString().Should().BeEmpty();
+        context.GetProperty("uniqueId").GetString().Should().Be(session.Target.TargetId + ".1");
+        context.GetProperty("auxData").GetProperty("isDefault").GetBoolean().Should().BeTrue();
+        context.GetProperty("auxData").GetProperty("type").GetString().Should().Be("default");
+    }
+
+    [Test]
+    public async Task EnablingTwiceAnnouncesTheContextOnce()
+    {
+        await using var session = await AttachedAsync();
+
+        await session.SendAsync("Runtime.enable", sessionId: session.SessionId);
+        await session.SendAsync("Runtime.enable", sessionId: session.SessionId);
+
+        session.EventsOf("Runtime.executionContextCreated").Should().HaveCount(1);
+    }
+
+    [Test]
+    public async Task DisableSucceedsAndSaysNothing()
+    {
+        await using var session = await AttachedAsync();
+
+        await session.SendAsync("Runtime.enable", sessionId: session.SessionId);
+        var reply = await session.SendAsync("Runtime.disable", sessionId: session.SessionId);
+
+        reply.GetProperty("result").GetRawText().Should().Be("{}");
+    }
+
+    [Test]
+    public async Task EvaluateAnswersANumber()
+    {
+        await using var session = await AttachedAsync();
+
+        var result = await session.EvaluateAsync("6 * 7");
+
+        result.GetProperty("type").GetString().Should().Be("number");
+        result.GetProperty("value").GetInt32().Should().Be(42);
+        result.GetProperty("description").GetString().Should().Be("42");
+    }
+
+    [TestCase("undefined", "undefined", null, TestName = "undefined")]
+    [TestCase("null", "object", "null", TestName = "null")]
+    [TestCase("true", "boolean", null, TestName = "a boolean")]
+    [TestCase("'text'", "string", null, TestName = "a string")]
+    [TestCase("({ a: 1 })", "object", null, TestName = "a plain object")]
+    [TestCase("[1, 2]", "object", "array", TestName = "an array")]
+    [TestCase("(function f() {})", "function", null, TestName = "a function")]
+    [TestCase("new Date(0)", "object", "date", TestName = "a date")]
+    [TestCase("/x/g", "object", "regexp", TestName = "a regular expression")]
+    [TestCase("new Map()", "object", "map", TestName = "a map")]
+    [TestCase("new Error('boom')", "object", "error", TestName = "an error object")]
+    [TestCase("Promise.resolve(1)", "object", "promise", TestName = "a promise")]
+    public async Task EvaluateNamesTheTypeAndSubtypeTheProtocolUses(string expression, string type, string? subtype)
+    {
+        await using var session = await AttachedAsync();
+
+        var result = await session.EvaluateAsync(expression);
+
+        result.GetProperty("type").GetString().Should().Be(type);
+
+        if (subtype is null)
+        {
+            result.TryGetProperty("subtype", out _).Should().BeFalse();
+        }
+        else
+        {
+            result.GetProperty("subtype").GetString().Should().Be(subtype);
+        }
+    }
+
+    [TestCase("NaN", "NaN")]
+    [TestCase("Infinity", "Infinity")]
+    [TestCase("-Infinity", "-Infinity")]
+    [TestCase("-0", "-0")]
+    public async Task ANumberWithNoJsonFormIsUnserializable(string expression, string expected)
+    {
+        await using var session = await AttachedAsync();
+
+        var result = await session.EvaluateAsync(expression);
+
+        result.GetProperty("unserializableValue").GetString().Should().Be(expected);
+        result.TryGetProperty("value", out _).Should().BeFalse("a client that read 0 back for -0 has been told something false");
+    }
+
+    [Test]
+    public async Task EvaluateWithoutReturnByValueDescribesAnObjectAndHandsOutNoHandle()
+    {
+        await using var session = await AttachedAsync();
+
+        var result = await session.EvaluateAsync("({ a: 1, b: [1, 2] })");
+
+        result.GetProperty("type").GetString().Should().Be("object");
+        result.GetProperty("className").GetString().Should().Be("Object");
+        result.GetProperty("description").GetString().Should().Be("Object");
+        result.TryGetProperty("objectId", out _).Should().BeFalse(
+            "a handle is a promise to keep the value alive, and there is no table keeping it yet");
+    }
+
+    [Test]
+    public async Task EvaluateWithReturnByValueSerializesTheValue()
+    {
+        await using var session = await AttachedAsync();
+
+        var result = await session.EvaluateAsync("({ a: 1, b: [1, 2], c: 'x', d: null, e: undefined, f: function () {} })", returnByValue: true);
+
+        result.GetProperty("type").GetString().Should().Be("object");
+
+        var value = result.GetProperty("value");
+        value.GetProperty("a").GetInt32().Should().Be(1);
+        value.GetProperty("b").EnumerateArray().Select(item => item.GetInt32()).Should().Equal(1, 2);
+        value.GetProperty("c").GetString().Should().Be("x");
+        value.GetProperty("d").ValueKind.Should().Be(JsonValueKind.Null);
+        value.TryGetProperty("e", out _).Should().BeFalse("JSON.stringify omits an undefined member and so does this");
+        value.TryGetProperty("f", out _).Should().BeFalse("JSON.stringify omits a function member and so does this");
+    }
+
+    [Test]
+    public async Task ByValueRefusesAValueThatRefersToItself()
+    {
+        await using var session = await AttachedAsync();
+
+        var reply = await session.SendAsync(
+            "Runtime.evaluate",
+            """{"expression":"(function () { const a = {}; a.self = a; return a; })()","returnByValue":true}""",
+            session.SessionId);
+
+        var error = reply.GetProperty("error");
+        error.GetProperty("code").GetInt32().Should().Be(-32000);
+        error.GetProperty("message").GetString().Should().Be("Object couldn't be returned by value");
+        error.GetProperty("data").GetString().Should().Be("the value refers to itself");
+    }
+
+    [Test]
+    public async Task AThrownErrorBecomesExceptionDetailsAndNotAProtocolError()
+    {
+        await using var session = await AttachedAsync();
+
+        var reply = await session.SendAsync(
+            "Runtime.evaluate",
+            """{"expression":"\n\nthrow new TypeError('boom')"}""",
+            session.SessionId);
+
+        reply.TryGetProperty("error", out _).Should().BeFalse("the command was answered; it is the expression that failed");
+
+        var details = reply.GetProperty("result").GetProperty("exceptionDetails");
+        details.GetProperty("text").GetString().Should().Be("Uncaught");
+        details.GetProperty("lineNumber").GetInt32().Should().Be(2, "the protocol counts lines from zero and the parser counts them from one");
+        details.GetProperty("executionContextId").GetInt32().Should().Be(1);
+        details.GetProperty("exception").GetProperty("subtype").GetString().Should().Be("error");
+        details.GetProperty("exception").GetProperty("description").GetString().Should().Contain("boom");
+
+        reply.GetProperty("result").GetProperty("result").GetProperty("subtype").GetString().Should().Be("error");
+    }
+
+    /// <summary>
+    /// A compile failure travels the same path as a throw, because the engine raises a <c>SyntaxError</c>
+    /// for one with the location filled in. There is one path rather than two, and neither is a protocol
+    /// error: the command was well formed and it is the client's expression that was not.
+    /// </summary>
+    [Test]
+    public async Task ASyntaxErrorBecomesExceptionDetailsToo()
+    {
+        await using var session = await AttachedAsync();
+
+        var reply = await session.SendAsync("Runtime.evaluate", """{"expression":"function ("}""", session.SessionId);
+
+        reply.TryGetProperty("error", out _).Should().BeFalse();
+
+        var details = reply.GetProperty("result").GetProperty("exceptionDetails");
+        details.GetProperty("text").GetString().Should().Be("Uncaught");
+        details.GetProperty("exception").GetProperty("className").GetString().Should().Be("SyntaxError");
+        reply.GetProperty("result").GetProperty("result").GetProperty("subtype").GetString().Should().Be("error");
+    }
+
+    /// <summary>
+    /// The promise is awaited by attaching reactions, never by draining: the command runs inside an
+    /// event-loop job and a nested drain is exactly what the pump's re-entrancy guard refuses.
+    /// </summary>
+    [Test]
+    public async Task AwaitPromiseAnswersWhatThePromiseSettledWith()
+    {
+        await using var session = await AttachedAsync();
+
+        var result = await session.EvaluateAsync("Promise.resolve(41 + 1)", returnByValue: true, awaitPromise: true);
+
+        result.GetProperty("type").GetString().Should().Be("number");
+        result.GetProperty("value").GetInt32().Should().Be(42);
+    }
+
+    [Test]
+    public async Task AwaitPromiseWaitsForOneThatSettlesOnALaterTurn()
+    {
+        await using var session = await AttachedAsync();
+
+        var result = await session.EvaluateAsync(
+            "new Promise(function (resolve) { Promise.resolve().then(function () { resolve('later'); }); })",
+            returnByValue: true,
+            awaitPromise: true);
+
+        result.GetProperty("value").GetString().Should().Be("later");
+    }
+
+    [Test]
+    public async Task AwaitPromiseReportsARejectionAsExceptionDetails()
+    {
+        await using var session = await AttachedAsync();
+
+        var reply = await session.SendAsync(
+            "Runtime.evaluate",
+            """{"expression":"Promise.reject(new RangeError('nope'))","awaitPromise":true}""",
+            session.SessionId);
+
+        reply.TryGetProperty("error", out _).Should().BeFalse();
+
+        var details = reply.GetProperty("result").GetProperty("exceptionDetails");
+        details.GetProperty("text").GetString().Should().Be("Uncaught (in promise)");
+        details.GetProperty("exception").GetProperty("subtype").GetString().Should().Be("error");
+        details.GetProperty("exception").GetProperty("className").GetString().Should().Be("RangeError");
+    }
+
+    [Test]
+    public async Task WithoutAwaitPromiseAPromiseIsDescribedRatherThanWaitedFor()
+    {
+        await using var session = await AttachedAsync();
+
+        var result = await session.EvaluateAsync("Promise.resolve(1)");
+
+        result.GetProperty("subtype").GetString().Should().Be("promise");
+        result.TryGetProperty("value", out _).Should().BeFalse();
+    }
+
+    [Test]
+    public async Task EvaluateInAContextThatIsNotThereIsRefusedInChromesWording()
+    {
+        await using var session = await AttachedAsync();
+
+        var reply = await session.SendAsync("Runtime.evaluate", """{"expression":"1","contextId":7}""", session.SessionId);
+
+        reply.GetProperty("error").GetProperty("code").GetInt32().Should().Be(-32000);
+        reply.GetProperty("error").GetProperty("message").GetString().Should().Be("Cannot find context with specified id");
+    }
+
+    [Test]
+    public async Task EvaluateSeesWhatTheHostPutOnTheEngine()
+    {
+        await using var session = await AttachedAsync(engine =>
+        {
+            engine.SetValue("answer", 42);
+        });
+
+        var result = await session.EvaluateAsync("answer + 1");
+        result.GetProperty("value").GetInt32().Should().Be(43);
+    }
+
+    [Test]
+    public async Task GetIsolateIdIsStableForOneEngine()
+    {
+        await using var session = await AttachedAsync();
+
+        var first = (await session.SendAsync("Runtime.getIsolateId", sessionId: session.SessionId)).GetProperty("result").GetProperty("id").GetString();
+        var second = (await session.SendAsync("Runtime.getIsolateId", sessionId: session.SessionId)).GetProperty("result").GetProperty("id").GetString();
+
+        first.Should().NotBeNullOrEmpty();
+        second.Should().Be(first);
+    }
+
+    [Test]
+    public async Task DiscardConsoleEntriesSucceeds()
+    {
+        await using var session = await AttachedAsync();
+
+        var reply = await session.SendAsync("Runtime.discardConsoleEntries", sessionId: session.SessionId);
+        reply.GetProperty("result").GetRawText().Should().Be("{}");
+    }
+
+    /// <summary>
+    /// The <c>Runtime</c> commands that need the object table are not answered yet, and say so with the one
+    /// error a client feature-detects on rather than with a made-up success.
+    /// </summary>
+    [TestCase("Runtime.getProperties")]
+    [TestCase("Runtime.callFunctionOn")]
+    [TestCase("Runtime.awaitPromise")]
+    [TestCase("Runtime.releaseObject")]
+    public async Task TheCommandsThatNeedAnObjectTableAreMethodNotFound(string method)
+    {
+        await using var session = await AttachedAsync();
+
+        var error = (await session.SendAsync(method, "{}", session.SessionId)).GetProperty("error");
+        error.GetProperty("code").GetInt32().Should().Be(-32601);
+        error.GetProperty("message").GetString().Should().Be($"'{method}' wasn't found");
+    }
+
+    private static async Task<AttachedSession> AttachedAsync(Action<Engine>? configure = null)
+    {
+        var session = ProtocolSession.Create();
+        var engine = new Engine(options => options.UseDevTools());
+        configure?.Invoke(engine);
+
+        var target = session.AddTarget(new EngineTargetOptions { ThreadMode = ThreadMode.LibraryOwned }, engine);
+        var sessionId = await session.AttachAsync(target).ConfigureAwait(false);
+
+        return new AttachedSession(session, target, sessionId);
+    }
+
+    /// <summary>One conversation, one engine, and the identifier that addresses the second through the first.</summary>
+    private sealed class AttachedSession(ProtocolSession session, EngineTarget target, string sessionId) : IAsyncDisposable
+    {
+        internal EngineTarget Target { get; } = target;
+
+        internal string SessionId { get; } = sessionId;
+
+        internal Task<JsonElement> SendAsync(string method, string? parameters = null, string? sessionId = null)
+            => session.SendAsync(method, parameters, sessionId);
+
+        internal IReadOnlyList<JsonElement> EventsOf(string method) => session.EventsOf(method);
+
+        internal async Task<JsonElement> EvaluateAsync(string expression, bool returnByValue = false, bool awaitPromise = false)
+        {
+            var parameters = JsonSerializer.Serialize(new Dictionary<string, object>
+            {
+                ["expression"] = expression,
+                ["returnByValue"] = returnByValue,
+                ["awaitPromise"] = awaitPromise,
+            });
+
+            var reply = await SendAsync("Runtime.evaluate", parameters, SessionId).ConfigureAwait(false);
+            reply.TryGetProperty("error", out var error).Should().BeFalse("evaluating was expected to succeed, and it answered {0}", error);
+
+            var result = reply.GetProperty("result");
+            result.TryGetProperty("exceptionDetails", out var details).Should().BeFalse("the expression was expected to succeed, and it threw {0}", details);
+            return result.GetProperty("result");
+        }
+
+        public ValueTask DisposeAsync() => session.DisposeAsync();
+    }
+}

--- a/Jint.Tests.DevTools/Session/TargetSessionTests.cs
+++ b/Jint.Tests.DevTools/Session/TargetSessionTests.cs
@@ -1,0 +1,322 @@
+using System.Text.Json;
+using Jint.DevTools;
+
+namespace Jint.Tests.DevTools.Session;
+
+/// <summary>
+/// The <c>Target</c> state machine, which is what every client walks before it can evaluate anything.
+/// </summary>
+/// <remarks>
+/// Written against the wire rather than against the domain, for the reason the rest of this suite is: what a
+/// client acts on is the JSON, and the recorded handshakes in <c>tools/devtools-protocol/handshakes/</c> say
+/// exactly which parts of it each one reads.
+/// </remarks>
+public class TargetSessionTests
+{
+    [Test]
+    public async Task GetTargetsListsEveryPublishedEngine()
+    {
+        await using var session = ProtocolSession.Create();
+        var first = session.AddTarget(new EngineTargetOptions { Title = "first" });
+        var second = session.AddTarget(new EngineTargetOptions { Title = "second", Url = "app://second" });
+
+        var reply = await session.SendAsync("Target.getTargets");
+        var infos = reply.GetProperty("result").GetProperty("targetInfos").EnumerateArray().ToArray();
+
+        infos.Select(info => info.GetProperty("targetId").GetString()).Should().Equal(first.TargetId, second.TargetId);
+        infos.Select(info => info.GetProperty("type").GetString()).Should().AllBe("node");
+        infos[1].GetProperty("title").GetString().Should().Be("second");
+        infos[1].GetProperty("url").GetString().Should().Be("app://second");
+        infos[0].GetProperty("attached").GetBoolean().Should().BeFalse();
+    }
+
+    [Test]
+    public async Task GetTargetInfoAnswersOneTargetAndRefusesAnUnknownIdentifier()
+    {
+        await using var session = ProtocolSession.Create();
+        var target = session.AddTarget();
+
+        var found = await session.SendAsync("Target.getTargetInfo", $$"""{"targetId":"{{target.TargetId}}"}""");
+        found.GetProperty("result").GetProperty("targetInfo").GetProperty("targetId").GetString().Should().Be(target.TargetId);
+
+        var missing = await session.SendAsync("Target.getTargetInfo", """{"targetId":"NOPE"}""");
+        missing.GetProperty("error").GetProperty("code").GetInt32().Should().Be(-32000);
+        missing.GetProperty("error").GetProperty("message").GetString().Should().Be("No target with given id found");
+    }
+
+    /// <summary>
+    /// Discovery replays what already exists and then reports what arrives, which is what makes it usable by
+    /// a client that connected after the targets did.
+    /// </summary>
+    [Test]
+    public async Task SetDiscoverTargetsReplaysAndThenReports()
+    {
+        await using var session = ProtocolSession.Create();
+        var existing = session.AddTarget();
+
+        await session.SendAsync("Target.setDiscoverTargets", """{"discover":true}""");
+
+        var created = session.EventsOf("Target.targetCreated");
+        created.Should().HaveCount(1);
+        created[0].GetProperty("params").GetProperty("targetInfo").GetProperty("targetId").GetString().Should().Be(existing.TargetId);
+
+        var later = session.AddTarget();
+        session.EventsOf("Target.targetCreated").Should().HaveCount(2);
+
+        session.Server.RemoveTarget(later).Should().BeTrue();
+        var destroyed = session.EventsOf("Target.targetDestroyed");
+        destroyed.Should().HaveCount(1);
+        destroyed[0].GetProperty("params").GetProperty("targetId").GetString().Should().Be(later.TargetId);
+    }
+
+    [Test]
+    public async Task ATargetIsNotReportedBeforeDiscoveryIsAskedFor()
+    {
+        await using var session = ProtocolSession.Create();
+        session.AddTarget();
+
+        session.EventsOf("Target.targetCreated").Should().BeEmpty("a client is told about targets when it asks to be, and not before");
+    }
+
+    /// <summary>
+    /// Auto-attach is what Puppeteer uses instead of <c>attachToTarget</c>, and the filter it sends is the
+    /// recorded one: exclude pages, include everything else.
+    /// </summary>
+    [Test]
+    public async Task SetAutoAttachAttachesEveryExistingTargetThePuppeteerFilterAdmits()
+    {
+        await using var session = ProtocolSession.Create();
+        var target = session.AddTarget(new EngineTargetOptions { WaitForDebuggerOnStart = true });
+
+        var reply = await session.SendAsync(
+            "Target.setAutoAttach",
+            """{"autoAttach":true,"waitForDebuggerOnStart":true,"flatten":true,"filter":[{"type":"page","exclude":true},{}]}""");
+
+        reply.TryGetProperty("error", out _).Should().BeFalse();
+
+        var attached = session.EventsOf("Target.attachedToTarget");
+        attached.Should().HaveCount(1);
+
+        var parameters = attached[0].GetProperty("params");
+        parameters.GetProperty("targetInfo").GetProperty("targetId").GetString().Should().Be(target.TargetId);
+        parameters.GetProperty("targetInfo").GetProperty("attached").GetBoolean().Should().BeTrue();
+        parameters.GetProperty("waitingForDebugger").GetBoolean().Should().BeTrue();
+        parameters.GetProperty("sessionId").GetString().Should().NotBeNullOrEmpty();
+
+        attached[0].TryGetProperty("sessionId", out _).Should().BeFalse("the attachment is announced on the conversation that made it, not inside it");
+    }
+
+    [Test]
+    public async Task SetAutoAttachAttachesTargetsThatArriveLater()
+    {
+        await using var session = ProtocolSession.Create();
+        await session.SendAsync("Target.setAutoAttach", """{"autoAttach":true,"waitForDebuggerOnStart":false,"flatten":true}""");
+
+        session.EventsOf("Target.attachedToTarget").Should().BeEmpty();
+
+        var target = session.AddTarget();
+        var attached = session.EventsOf("Target.attachedToTarget");
+        attached.Should().HaveCount(1);
+        attached[0].GetProperty("params").GetProperty("targetInfo").GetProperty("targetId").GetString().Should().Be(target.TargetId);
+    }
+
+    /// <summary>
+    /// A filter that excludes everything attaches nothing, which is what makes the filter worth honouring
+    /// rather than ignoring.
+    /// </summary>
+    [Test]
+    public async Task AFilterThatExcludesTheTypeAttachesNothing()
+    {
+        await using var session = ProtocolSession.Create();
+        session.AddTarget();
+
+        await session.SendAsync(
+            "Target.setAutoAttach",
+            """{"autoAttach":true,"waitForDebuggerOnStart":false,"flatten":true,"filter":[{"type":"node","exclude":true},{}]}""");
+
+        session.EventsOf("Target.attachedToTarget").Should().BeEmpty();
+    }
+
+    [TestCase("Target.setAutoAttach", """{"autoAttach":true,"waitForDebuggerOnStart":false,"flatten":false}""")]
+    [TestCase("Target.attachToTarget", """{"targetId":"ANY","flatten":false}""")]
+    public async Task TheWrappedSessionModelIsRefused(string method, string parameters)
+    {
+        await using var session = ProtocolSession.Create();
+        var error = (await session.SendAsync(method, parameters)).GetProperty("error");
+
+        error.GetProperty("code").GetInt32().Should().Be(-32000);
+        error.GetProperty("message").GetString().Should().Be("Only flatten protocol is supported");
+    }
+
+    [Test]
+    public async Task AttachingTwiceAnswersTheSameSession()
+    {
+        await using var session = ProtocolSession.Create();
+        var target = session.AddTarget();
+
+        var first = await session.AttachAsync(target);
+        var second = await session.AttachAsync(target);
+
+        second.Should().Be(first, "a client that attaches twice has one attachment, and two would double every event");
+        session.EventsOf("Target.attachedToTarget").Should().HaveCount(1);
+    }
+
+    [Test]
+    public async Task DetachingReleasesTheSessionAndAnnouncesIt()
+    {
+        await using var session = ProtocolSession.Create();
+        var target = session.AddTarget(new EngineTargetOptions { ThreadMode = ThreadMode.LibraryOwned });
+        var sessionId = await session.AttachAsync(target);
+
+        (await session.SendAsync("Runtime.enable", sessionId: sessionId)).TryGetProperty("error", out _).Should().BeFalse();
+
+        var detached = await session.SendAsync("Target.detachFromTarget", $$"""{"sessionId":"{{sessionId}}"}""");
+        detached.TryGetProperty("error", out _).Should().BeFalse();
+
+        var announced = session.EventsOf("Target.detachedFromTarget");
+        announced.Should().HaveCount(1);
+        announced[0].GetProperty("params").GetProperty("sessionId").GetString().Should().Be(sessionId);
+        announced[0].GetProperty("params").GetProperty("targetId").GetString().Should().Be(target.TargetId);
+
+        var after = await session.SendAsync("Runtime.enable", sessionId: sessionId);
+        after.GetProperty("error").GetProperty("code").GetInt32().Should().Be(-32001);
+        after.GetProperty("error").GetProperty("message").GetString().Should().Be("Session with given id not found.");
+    }
+
+    [Test]
+    public async Task RemovingAnAttachedTargetDetachesFirst()
+    {
+        await using var session = ProtocolSession.Create();
+        var target = session.AddTarget();
+        var sessionId = await session.AttachAsync(target);
+
+        await session.SendAsync("Target.setDiscoverTargets", """{"discover":true}""");
+        session.Server.RemoveTarget(target).Should().BeTrue();
+
+        session.EventsOf("Target.detachedFromTarget").Should().HaveCount(1);
+        session.EventsOf("Target.targetDestroyed").Should().HaveCount(1);
+
+        var after = await session.SendAsync("Runtime.enable", sessionId: sessionId);
+        after.GetProperty("error").GetProperty("code").GetInt32().Should().Be(-32001);
+    }
+
+    /// <summary>
+    /// Clients walk down the target tree by sending <c>setAutoAttach</c> on every session they are handed.
+    /// An engine target has no children, so the answer is a success with nothing in it.
+    /// </summary>
+    [Test]
+    public async Task SetAutoAttachOnAnAttachedSessionSucceedsAndAttachesNothing()
+    {
+        // Library-owned, because a command addressed to an attached session crosses to the engine thread
+        // whatever the command is -- there is one rule about where a session's domains run, not one per
+        // domain -- so an unpumped host-owned target would answer this only when somebody pumped it.
+        await using var session = ProtocolSession.Create();
+        var target = session.AddTarget(new EngineTargetOptions { ThreadMode = ThreadMode.LibraryOwned });
+        var sessionId = await session.AttachAsync(target);
+
+        var reply = await session.SendAsync(
+            "Target.setAutoAttach",
+            """{"autoAttach":true,"waitForDebuggerOnStart":true,"flatten":true}""",
+            sessionId);
+
+        reply.TryGetProperty("error", out _).Should().BeFalse();
+        reply.GetProperty("result").GetRawText().Should().Be("{}");
+        session.EventsOf("Target.attachedToTarget").Should().HaveCount(1, "the nested call attaches nothing of its own");
+    }
+
+    [Test]
+    public async Task BrowserContextsAreEmptyAndCannotBeMade()
+    {
+        await using var session = ProtocolSession.Create();
+
+        var contexts = await session.SendAsync("Target.getBrowserContexts");
+        contexts.GetProperty("result").GetProperty("browserContextIds").GetArrayLength().Should().Be(0);
+
+        foreach (var method in new[] { "Target.createBrowserContext", "Target.disposeBrowserContext" })
+        {
+            var error = (await session.SendAsync(method, """{"browserContextId":"X"}""")).GetProperty("error");
+            error.GetProperty("code").GetInt32().Should().Be(-32000);
+            error.GetProperty("message").GetString().Should().Be("Browser contexts are not supported");
+        }
+    }
+
+    [Test]
+    public async Task CreateTargetRefusesWithoutAnEngineFactory()
+    {
+        await using var session = ProtocolSession.Create();
+        var error = (await session.SendAsync("Target.createTarget", """{"url":"about:blank"}""")).GetProperty("error");
+
+        error.GetProperty("code").GetInt32().Should().Be(-32000);
+        error.GetProperty("message").GetString().Should().Be("No engine factory is configured");
+    }
+
+    [Test]
+    public async Task CreateTargetBuildsAndPublishesAnEngineWhenAFactoryIsConfigured()
+    {
+        await using var session = ProtocolSession.Create(options: new DevToolsServerOptions { EngineFactory = () => new Engine() });
+
+        var created = await session.SendAsync("Target.createTarget", """{"url":"about:blank"}""");
+        var targetId = created.GetProperty("result").GetProperty("targetId").GetString();
+
+        session.Server.Targets.Should().ContainSingle(target => target.TargetId == targetId);
+        session.Server.Targets[0].ThreadMode.Should().Be(
+            ThreadMode.LibraryOwned,
+            "no host thread ever agreed to pump a target a client asked for, so the package runs it");
+
+        var closed = await session.SendAsync("Target.closeTarget", $$"""{"targetId":"{{targetId}}"}""");
+        closed.GetProperty("result").GetProperty("success").GetBoolean().Should().BeTrue();
+        session.Server.Targets.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task ActivateTargetSucceedsForAKnownTargetAndRefusesAnUnknownOne()
+    {
+        await using var session = ProtocolSession.Create();
+        var target = session.AddTarget();
+
+        var activated = await session.SendAsync("Target.activateTarget", $$"""{"targetId":"{{target.TargetId}}"}""");
+        activated.GetProperty("result").GetRawText().Should().Be("{}");
+
+        var missing = await session.SendAsync("Target.activateTarget", """{"targetId":"NOPE"}""");
+        missing.GetProperty("error").GetProperty("code").GetInt32().Should().Be(-32000);
+    }
+
+    /// <summary>
+    /// The pre-flattened routing command, which stays unimplemented on purpose: no client recorded in the
+    /// handshakes sends it, and answering it would mean a second routing path kept alive for nobody.
+    /// </summary>
+    [Test]
+    public async Task SendMessageToTargetIsMethodNotFound()
+    {
+        await using var session = ProtocolSession.Create();
+        var error = (await session.SendAsync("Target.sendMessageToTarget", """{"message":"{}","sessionId":"X"}""")).GetProperty("error");
+
+        error.GetProperty("code").GetInt32().Should().Be(-32601);
+        error.GetProperty("message").GetString().Should().Be("'Target.sendMessageToTarget' wasn't found");
+    }
+
+    [Test]
+    public async Task ADetachedSessionsCommandsAreRefusedButTheConversationSurvives()
+    {
+        await using var session = ProtocolSession.Create();
+        var target = session.AddTarget();
+        var sessionId = await session.AttachAsync(target);
+
+        await session.SendAsync("Target.detachFromTarget", $$"""{"sessionId":"{{sessionId}}"}""");
+
+        var stale = await session.SendAsync("Runtime.getIsolateId", sessionId: sessionId);
+        stale.GetProperty("error").GetProperty("code").GetInt32().Should().Be(-32001);
+
+        var browserLevel = await session.SendAsync("Browser.getVersion");
+        browserLevel.GetProperty("result").GetProperty("protocolVersion").GetString().Should().Be("1.3");
+    }
+
+    [Test]
+    public async Task DetachingASessionThatIsNotThereIsSessionNotFound()
+    {
+        await using var session = ProtocolSession.Create();
+        var error = (await session.SendAsync("Target.detachFromTarget", """{"sessionId":"NOPE"}""")).GetProperty("error");
+
+        error.GetProperty("code").GetInt32().Should().Be(-32001);
+    }
+}

--- a/Jint.Tests.DevTools/Session/ThreadModeTests.cs
+++ b/Jint.Tests.DevTools/Session/ThreadModeTests.cs
@@ -1,0 +1,202 @@
+using Jint.DevTools;
+
+namespace Jint.Tests.DevTools.Session;
+
+/// <summary>
+/// Which thread runs a target's engine, and what a client is told when nothing does.
+/// </summary>
+public class ThreadModeTests
+{
+    /// <summary>
+    /// What a wait is allowed to take before the test calls it a hang. Generous on purpose — see
+    /// <see cref="Transport.DevToolsClient"/> for why a tight bound here measures the runner, not the server.
+    /// </summary>
+    private static readonly TimeSpan Bound = TimeSpan.FromSeconds(120);
+
+    /// <summary>
+    /// The diagnostic a host that forgot to pump needs. Everything else about a host-owned target looks
+    /// exactly like a slow one, so the message is what tells the two apart.
+    /// </summary>
+    [Test]
+    public async Task ACommandOnAnUnpumpedHostOwnedTargetSaysTheEngineIsNotBeingPumped()
+    {
+        await using var session = ProtocolSession.Create(options: new DevToolsServerOptions
+        {
+            CommandTimeout = TimeSpan.FromMilliseconds(300),
+        });
+
+        var target = session.AddTarget();
+        target.ThreadMode.Should().Be(ThreadMode.HostOwned, "that is the default, and the shape most embedders are already in");
+
+        var sessionId = await session.AttachAsync(target);
+        var error = (await session.SendAsync("Runtime.getIsolateId", sessionId: sessionId)).GetProperty("error");
+
+        error.GetProperty("code").GetInt32().Should().Be(-32000);
+        error.GetProperty("message").GetString().Should().Be("Engine is not being pumped");
+        error.GetProperty("data").GetString().Should().Contain("ProcessTasks");
+    }
+
+    /// <summary>
+    /// A command that timed out is still queued, so the host's next turn answers it — the timeout bounds the
+    /// client's wait rather than cancelling the work.
+    /// </summary>
+    [Test]
+    public async Task AHostOwnedTargetAnswersOnceItIsPumped()
+    {
+        await using var session = ProtocolSession.Create();
+        var target = session.AddTarget();
+        var sessionId = await session.AttachAsync(target);
+
+        var pending = session.SendAsync("Runtime.evaluate", """{"expression":"6*7","returnByValue":true}""", sessionId);
+
+        var deadline = DateTime.UtcNow + Bound;
+        while (!pending.IsCompleted && DateTime.UtcNow < deadline)
+        {
+            target.Pump();
+            await Task.Delay(5);
+        }
+
+        var reply = await pending.WaitAsync(Bound);
+        reply.GetProperty("result").GetProperty("result").GetProperty("value").GetInt32().Should().Be(42);
+    }
+
+    [Test]
+    public async Task PumpIsRefusedOnALibraryOwnedTarget()
+    {
+        await using var target = new EngineTarget(new Engine(), new EngineTargetOptions { ThreadMode = ThreadMode.LibraryOwned });
+
+        var thrown = Assert.Throws<InvalidOperationException>(() => target.Pump());
+        thrown!.Message.Should().Contain("pumps itself");
+    }
+
+    [Test]
+    public async Task PostAsyncRunsHostWorkOnTheEnginesOwnThread()
+    {
+        await using var target = new EngineTarget(new Engine(), new EngineTargetOptions { ThreadMode = ThreadMode.LibraryOwned });
+
+        var answer = await target.PostAsync(engine => engine.Evaluate("1 + 1").AsNumber()).WaitAsync(Bound);
+        answer.Should().Be(2);
+
+        var thread = await target.PostAsync(_ => Environment.CurrentManagedThreadId).WaitAsync(Bound);
+        thread.Should().NotBe(Environment.CurrentManagedThreadId, "the whole point of the mode is that the library owns the thread");
+    }
+
+    [Test]
+    public async Task PostAsyncSurfacesWhatTheWorkThrew()
+    {
+        await using var target = new EngineTarget(new Engine(), new EngineTargetOptions { ThreadMode = ThreadMode.LibraryOwned });
+
+        var thrown = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await target.PostAsync(_ => throw new InvalidOperationException("from the host")).WaitAsync(Bound));
+
+        thrown!.Message.Should().Be("from the host");
+    }
+
+    /// <summary>
+    /// A library-owned target that has to wait for a debugger holds host work and answers protocol commands,
+    /// which is the only arrangement in which the command that ends the wait can ever be answered.
+    /// </summary>
+    [Test]
+    public async Task WaitForDebuggerOnStartHoldsHostWorkUntilAClientReleasesIt()
+    {
+        await using var session = ProtocolSession.Create();
+        var target = session.AddTarget(new EngineTargetOptions
+        {
+            ThreadMode = ThreadMode.LibraryOwned,
+            WaitForDebuggerOnStart = true,
+        });
+
+        var ran = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        target.Post(_ => ran.TrySetResult(1));
+
+        target.IsWaitingForDebugger.Should().BeTrue();
+        await Task.Delay(150);
+        ran.Task.IsCompleted.Should().BeFalse("the first posted work is held until a client says to run it");
+
+        var sessionId = await session.AttachAsync(target);
+        session.EventsOf("Target.attachedToTarget")[0]
+            .GetProperty("params").GetProperty("waitingForDebugger").GetBoolean()
+            .Should().BeFalse("attachToTarget carries no waitForDebuggerOnStart flag; only auto-attach asks for one");
+
+        var released = await session.SendAsync("Runtime.runIfWaitingForDebugger", sessionId: sessionId);
+        released.GetProperty("result").GetRawText().Should().Be("{}");
+
+        (await ran.Task.WaitAsync(Bound)).Should().Be(1);
+        target.IsWaitingForDebugger.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// A host-owned target waits by pumping, because the command that ends the wait is answered on the very
+    /// thread that is waiting.
+    /// </summary>
+    [Test]
+    public async Task WaitForDebuggerPumpsSoThatTheReleaseCanArrive()
+    {
+        await using var session = ProtocolSession.Create();
+        var target = session.AddTarget(new EngineTargetOptions { WaitForDebuggerOnStart = true });
+        var sessionId = await session.AttachAsync(target);
+
+        var waiting = Task.Run(() => target.WaitForDebugger(Bound));
+
+        var released = await session.SendAsync("Runtime.runIfWaitingForDebugger", sessionId: sessionId);
+        released.TryGetProperty("error", out _).Should().BeFalse();
+
+        (await waiting.WaitAsync(Bound)).Should().BeTrue();
+        target.IsWaitingForDebugger.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task WaitForDebuggerGivesUpWhenNobodyEverConnects()
+    {
+        await using var target = new EngineTarget(new Engine(), new EngineTargetOptions { WaitForDebuggerOnStart = true });
+
+        var waited = await Task.Run(() => target.WaitForDebugger(TimeSpan.FromMilliseconds(200)));
+
+        waited.Should().BeFalse("a host that would otherwise block forever needs the bound it passed to mean something");
+        target.IsWaitingForDebugger.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task AutoAttachReportsWaitingForDebuggerWhenBothSidesAskedForIt()
+    {
+        await using var session = ProtocolSession.Create();
+        session.AddTarget(new EngineTargetOptions
+        {
+            ThreadMode = ThreadMode.LibraryOwned,
+            WaitForDebuggerOnStart = true,
+        });
+
+        await session.SendAsync(
+            "Target.setAutoAttach",
+            """{"autoAttach":true,"waitForDebuggerOnStart":true,"flatten":true}""");
+
+        session.EventsOf("Target.attachedToTarget")[0]
+            .GetProperty("params").GetProperty("waitingForDebugger").GetBoolean()
+            .Should().BeTrue();
+    }
+
+    [Test]
+    public async Task ATargetThatIsNotHoldingAnythingIsNotReportedAsWaiting()
+    {
+        await using var session = ProtocolSession.Create();
+        session.AddTarget(new EngineTargetOptions { ThreadMode = ThreadMode.LibraryOwned });
+
+        await session.SendAsync(
+            "Target.setAutoAttach",
+            """{"autoAttach":true,"waitForDebuggerOnStart":true,"flatten":true}""");
+
+        session.EventsOf("Target.attachedToTarget")[0]
+            .GetProperty("params").GetProperty("waitingForDebugger").GetBoolean()
+            .Should().BeFalse();
+    }
+
+    [Test]
+    public async Task ADisposedTargetRefusesEverything()
+    {
+        var target = new EngineTarget(new Engine(), new EngineTargetOptions { ThreadMode = ThreadMode.LibraryOwned });
+        await target.DisposeAsync();
+
+        Assert.Throws<ObjectDisposedException>(() => target.Post(_ => { }));
+        Assert.Throws<ObjectDisposedException>(() => target.Pump());
+    }
+}

--- a/Jint.Tests.DevTools/Transport/DevToolsClient.cs
+++ b/Jint.Tests.DevTools/Transport/DevToolsClient.cs
@@ -1,0 +1,210 @@
+using System.Net.Http;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+
+namespace Jint.Tests.DevTools.Transport;
+
+/// <summary>
+/// The client half of the socket tests: a <see cref="ClientWebSocket"/> with an identifier counter and a
+/// bounded wait for each reply.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every wait is bounded, without exception. A protocol test that can hang is a CI leg that can hang, and
+/// the thing most likely to be wrong in this area is exactly the thing that makes a reply never arrive.
+/// </para>
+/// <para>
+/// <b>The bound is generous on purpose.</b> It exists to stop a hang, not to assert a speed: this suite
+/// finishes in under a second unloaded, and on a two-core CI runner sharing the machine with four other
+/// test processes it has been seen to take four and a half minutes. A bound tight enough to be interesting
+/// is a bound that fails on a busy runner and says nothing about the server.
+/// </para>
+/// </remarks>
+internal sealed class DevToolsClient : IAsyncDisposable
+{
+    private static readonly TimeSpan Bound = TimeSpan.FromSeconds(120);
+
+    private readonly ClientWebSocket _socket = new();
+    private readonly List<JsonElement> _received = [];
+    private readonly CancellationTokenSource _stopping = new();
+
+    private Task? _reader;
+    private int _nextId;
+
+    private DevToolsClient()
+    {
+    }
+
+    /// <summary>Connects to <paramref name="url"/> and starts reading.</summary>
+    internal static async Task<DevToolsClient> ConnectAsync(string url)
+    {
+        var client = new DevToolsClient();
+
+        using var connecting = new CancellationTokenSource(Bound);
+        await client._socket.ConnectAsync(new Uri(url), connecting.Token).ConfigureAwait(false);
+
+        client._reader = Task.Run(() => client.ReadAsync(client._stopping.Token), CancellationToken.None);
+        return client;
+    }
+
+    /// <summary>Fetches one of the server's discovery documents.</summary>
+    internal static async Task<(int Status, string Body)> GetAsync(string url)
+    {
+        using var http = new HttpClient { Timeout = Bound };
+        using var response = await http.GetAsync(new Uri(url)).ConfigureAwait(false);
+        var body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        return ((int) response.StatusCode, body);
+    }
+
+    /// <summary>Sends one command and waits for its reply.</summary>
+    internal async Task<JsonElement> SendAsync(string method, string? parameters = null, string? sessionId = null)
+    {
+        var identifier = Interlocked.Increment(ref _nextId);
+        var payload = parameters is null ? "" : ",\"params\":" + parameters;
+        var session = sessionId is null ? "" : ",\"sessionId\":\"" + sessionId + "\"";
+        var message = $$"""{"id":{{identifier}},"method":"{{method}}"{{payload}}{{session}}}""";
+
+        using var sending = new CancellationTokenSource(Bound);
+        await _socket.SendAsync(Encoding.UTF8.GetBytes(message), WebSocketMessageType.Text, endOfMessage: true, sending.Token).ConfigureAwait(false);
+
+        return await WaitAsync(candidate =>
+            candidate.TryGetProperty("id", out var id) && id.ValueKind == JsonValueKind.Number && id.GetInt32() == identifier).ConfigureAwait(false);
+    }
+
+    /// <summary>Sends one command and hands back its <c>result</c>, failing the test when it errored.</summary>
+    internal async Task<JsonElement> ResultOfAsync(string method, string? parameters = null, string? sessionId = null)
+    {
+        var reply = await SendAsync(method, parameters, sessionId).ConfigureAwait(false);
+        reply.TryGetProperty("error", out var error).Should().BeFalse("'{0}' was expected to succeed, and it answered {1}", method, error);
+        return reply.GetProperty("result");
+    }
+
+    /// <summary>Waits for the first event of <paramref name="method"/>, whenever it arrives.</summary>
+    internal Task<JsonElement> WaitForEventAsync(string method)
+    {
+        return WaitAsync(candidate => candidate.TryGetProperty("method", out var name) && name.GetString() == method);
+    }
+
+    /// <summary>Sends a raw message, for the cases where the point is that it is not well formed.</summary>
+    internal async Task SendRawAsync(string message)
+    {
+        using var sending = new CancellationTokenSource(Bound);
+        await _socket.SendAsync(Encoding.UTF8.GetBytes(message), WebSocketMessageType.Text, endOfMessage: true, sending.Token).ConfigureAwait(false);
+    }
+
+    /// <summary>Sends a binary frame, which the protocol has no use for and the server refuses.</summary>
+    internal async Task SendBinaryAsync()
+    {
+        using var sending = new CancellationTokenSource(Bound);
+        await _socket.SendAsync(new byte[] { 1, 2, 3 }, WebSocketMessageType.Binary, endOfMessage: true, sending.Token).ConfigureAwait(false);
+    }
+
+    /// <summary>Waits until the server has closed the connection.</summary>
+    internal async Task<WebSocketCloseStatus?> WaitForCloseAsync()
+    {
+        var deadline = DateTime.UtcNow + Bound;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (_socket.State is WebSocketState.Closed or WebSocketState.CloseReceived or WebSocketState.Aborted)
+            {
+                return _socket.CloseStatus;
+            }
+
+            await Task.Delay(20).ConfigureAwait(false);
+        }
+
+        throw new TimeoutException("the server did not close the connection");
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask DisposeAsync()
+    {
+        await _stopping.CancelAsync().ConfigureAwait(false);
+
+        try
+        {
+            if (_socket.State == WebSocketState.Open)
+            {
+                using var closing = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+                await _socket.CloseAsync(WebSocketCloseStatus.NormalClosure, statusDescription: null, closing.Token).ConfigureAwait(false);
+            }
+        }
+        catch (Exception exception) when (exception is WebSocketException or OperationCanceledException)
+        {
+        }
+
+        if (_reader is { } reader)
+        {
+            try
+            {
+                await reader.ConfigureAwait(false);
+            }
+            catch (Exception exception) when (exception is WebSocketException or OperationCanceledException)
+            {
+            }
+        }
+
+        _socket.Dispose();
+        _stopping.Dispose();
+    }
+
+    private async Task<JsonElement> WaitAsync(Func<JsonElement, bool> matches)
+    {
+        var deadline = DateTime.UtcNow + Bound;
+        var seen = 0;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            lock (_received)
+            {
+                for (; seen < _received.Count; seen++)
+                {
+                    if (matches(_received[seen]))
+                    {
+                        return _received[seen];
+                    }
+                }
+            }
+
+            await Task.Delay(10).ConfigureAwait(false);
+        }
+
+        throw new TimeoutException("no matching message arrived within " + Bound);
+    }
+
+    private async Task ReadAsync(CancellationToken cancellationToken)
+    {
+        var buffer = new byte[16 * 1024];
+        var message = new List<byte>();
+
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested && _socket.State == WebSocketState.Open)
+            {
+                var received = await _socket.ReceiveAsync(new ArraySegment<byte>(buffer), cancellationToken).ConfigureAwait(false);
+                if (received.MessageType == WebSocketMessageType.Close)
+                {
+                    return;
+                }
+
+                message.AddRange(buffer.AsSpan(0, received.Count).ToArray());
+                if (!received.EndOfMessage)
+                {
+                    continue;
+                }
+
+                using var document = JsonDocument.Parse(Encoding.UTF8.GetString(message.ToArray()));
+                message.Clear();
+
+                lock (_received)
+                {
+                    _received.Add(document.RootElement.Clone());
+                }
+            }
+        }
+        catch (Exception exception) when (exception is WebSocketException or OperationCanceledException)
+        {
+        }
+    }
+}

--- a/Jint.Tests.DevTools/Transport/WebSocketServerTests.cs
+++ b/Jint.Tests.DevTools/Transport/WebSocketServerTests.cs
@@ -1,0 +1,396 @@
+using System.Globalization;
+using System.Net.WebSockets;
+using System.Text.Json;
+using Jint.DevTools;
+
+namespace Jint.Tests.DevTools.Transport;
+
+/// <summary>
+/// The server as a client actually reaches it: a real socket, a real HTTP upgrade, real frames.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every server here binds <c>127.0.0.1</c> port 0, so nothing collides with a port a developer is using and
+/// nothing is reachable from off the machine. Every wait is bounded — see <see cref="DevToolsClient"/>.
+/// </para>
+/// <para>
+/// These are the tests the in-process ones cannot replace. The envelope and the state machine are the same
+/// code either way; the upgrade handshake, the frame handling and the single writer are not exercised at all
+/// without a socket, and they are exactly where a protocol server goes wrong.
+/// </para>
+/// </remarks>
+[NonParallelizable]
+public class WebSocketServerTests
+{
+    [Test]
+    public async Task VersionNamesTheBrowserEndpointAClientThenConnectsTo()
+    {
+        await using var server = await StartedAsync();
+
+        var (status, body) = await DevToolsClient.GetAsync($"http://127.0.0.1:{server.BoundPort}/json/version");
+
+        status.Should().Be(200);
+
+        using var document = JsonDocument.Parse(body);
+        var version = document.RootElement;
+
+        version.GetProperty("Browser").GetString().Should().StartWith("Jint/");
+        version.GetProperty("Protocol-Version").GetString().Should().Be("1.3");
+        version.GetProperty("User-Agent").GetString().Should().StartWith("Jint/");
+        version.GetProperty("V8-Version").GetString().Should().NotBeNullOrEmpty();
+        version.GetProperty("WebKit-Version").GetString().Should().Be("0");
+        version.GetProperty("webSocketDebuggerUrl").GetString().Should().Be(server.BrowserWebSocketUrl);
+    }
+
+    [Test]
+    public async Task ListNamesOneEntryPerTargetWithBothUrlsAClientReads()
+    {
+        await using var server = await StartedAsync();
+        var target = new EngineTarget(new Engine(), new EngineTargetOptions { Title = "worker", Url = "app://worker" });
+        server.AddTarget(target);
+
+        foreach (var path in new[] { "/json", "/json/list" })
+        {
+            var (status, body) = await DevToolsClient.GetAsync($"http://127.0.0.1:{server.BoundPort}{path}");
+            status.Should().Be(200);
+
+            using var document = JsonDocument.Parse(body);
+            var entries = document.RootElement.EnumerateArray().ToArray();
+
+            entries.Should().HaveCount(1);
+            entries[0].GetProperty("id").GetString().Should().Be(target.TargetId);
+            entries[0].GetProperty("type").GetString().Should().Be("node");
+            entries[0].GetProperty("title").GetString().Should().Be("worker");
+            entries[0].GetProperty("url").GetString().Should().Be("app://worker");
+            entries[0].GetProperty("description").GetString().Should().BeEmpty();
+            entries[0].GetProperty("webSocketDebuggerUrl").GetString()
+                .Should().Be(string.Create(CultureInfo.InvariantCulture, $"ws://127.0.0.1:{server.BoundPort}/devtools/page/{target.TargetId}"));
+            entries[0].GetProperty("devtoolsFrontendUrl").GetString()
+                .Should().Contain("v8only=true").And.Contain($"ws=127.0.0.1:{server.BoundPort}/devtools/page/{target.TargetId}");
+        }
+
+        await target.DisposeAsync();
+    }
+
+    [Test]
+    public async Task ProtocolDescribesWhatThisServerAnswersAndNothingElse()
+    {
+        await using var server = await StartedAsync();
+
+        var (status, body) = await DevToolsClient.GetAsync($"http://127.0.0.1:{server.BoundPort}/json/protocol");
+        status.Should().Be(200);
+
+        using var document = JsonDocument.Parse(body);
+        document.RootElement.GetProperty("version").GetProperty("major").GetString().Should().Be("1");
+        document.RootElement.GetProperty("version").GetProperty("minor").GetString().Should().Be("3");
+
+        var domains = document.RootElement.GetProperty("domains").EnumerateArray().ToArray();
+        domains.Select(domain => domain.GetProperty("domain").GetString()).Should().BeEquivalentTo(["Browser", "Runtime", "Schema", "Target"]);
+
+        var runtime = domains.Single(domain => domain.GetProperty("domain").GetString() == "Runtime");
+        runtime.GetProperty("commands").EnumerateArray().Select(command => command.GetProperty("name").GetString())
+            .Should().Contain("evaluate").And.NotContain("getProperties");
+        runtime.GetProperty("events").EnumerateArray().Select(name => name.GetProperty("name").GetString())
+            .Should().Contain("executionContextCreated");
+    }
+
+    [Test]
+    public async Task NewRefusesWithoutAnEngineFactoryAndBuildsATargetWithOne()
+    {
+        await using var refusing = await StartedAsync();
+        var (refused, _) = await DevToolsClient.GetAsync($"http://127.0.0.1:{refusing.BoundPort}/json/new");
+        refused.Should().Be(501);
+
+        await using var making = await StartedAsync(new DevToolsServerOptions { EngineFactory = () => new Engine() });
+        var (status, body) = await DevToolsClient.GetAsync($"http://127.0.0.1:{making.BoundPort}/json/new");
+
+        status.Should().Be(200);
+        using var document = JsonDocument.Parse(body);
+        making.Targets.Should().ContainSingle(target => target.TargetId == document.RootElement.GetProperty("id").GetString());
+    }
+
+    [Test]
+    public async Task ActivateAndCloseAddressATargetByIdentifier()
+    {
+        await using var server = await StartedAsync();
+        var target = new EngineTarget(new Engine());
+        server.AddTarget(target);
+
+        var (activated, activatedBody) = await DevToolsClient.GetAsync($"http://127.0.0.1:{server.BoundPort}/json/activate/{target.TargetId}");
+        activated.Should().Be(200);
+        activatedBody.Should().Be("Target activated");
+
+        var (missing, _) = await DevToolsClient.GetAsync($"http://127.0.0.1:{server.BoundPort}/json/activate/NOPE");
+        missing.Should().Be(404);
+
+        var (closed, closedBody) = await DevToolsClient.GetAsync($"http://127.0.0.1:{server.BoundPort}/json/close/{target.TargetId}");
+        closed.Should().Be(200);
+        closedBody.Should().Be("Target is closing");
+        server.Targets.Should().BeEmpty();
+
+        await target.DisposeAsync();
+    }
+
+    [Test]
+    public async Task AnUnknownPathIsNotFound()
+    {
+        await using var server = await StartedAsync();
+
+        var (status, _) = await DevToolsClient.GetAsync($"http://127.0.0.1:{server.BoundPort}/nope");
+        status.Should().Be(404);
+    }
+
+    [TestCase(ThreadMode.HostOwned)]
+    [TestCase(ThreadMode.LibraryOwned)]
+    public async Task AClientConnectsAutoAttachesAndEvaluates(ThreadMode mode)
+    {
+        await using var server = await StartedAsync();
+        await using var target = new EngineTarget(new Engine(options => options.UseDevTools()), new EngineTargetOptions { ThreadMode = mode });
+        server.AddTarget(target);
+
+        using var pumping = new CancellationTokenSource();
+        var pump = mode == ThreadMode.HostOwned ? Pump(target, pumping.Token) : Task.CompletedTask;
+
+        try
+        {
+            await using var client = await DevToolsClient.ConnectAsync(server.BrowserWebSocketUrl);
+
+            var version = await client.ResultOfAsync("Browser.getVersion");
+            version.GetProperty("product").GetString().Should().StartWith("Jint/");
+
+            await client.ResultOfAsync("Target.setDiscoverTargets", """{"discover":true}""");
+            await client.ResultOfAsync(
+                "Target.setAutoAttach",
+                """{"autoAttach":true,"waitForDebuggerOnStart":true,"flatten":true,"filter":[{"type":"page","exclude":true},{}]}""");
+
+            var attached = await client.WaitForEventAsync("Target.attachedToTarget");
+            var sessionId = attached.GetProperty("params").GetProperty("sessionId").GetString()!;
+            attached.GetProperty("params").GetProperty("targetInfo").GetProperty("targetId").GetString().Should().Be(target.TargetId);
+
+            await client.ResultOfAsync("Runtime.runIfWaitingForDebugger", sessionId: sessionId);
+            await client.ResultOfAsync("Runtime.enable", sessionId: sessionId);
+
+            var context = await client.WaitForEventAsync("Runtime.executionContextCreated");
+            context.GetProperty("sessionId").GetString().Should().Be(sessionId);
+
+            var evaluated = await client.ResultOfAsync(
+                "Runtime.evaluate",
+                """{"expression":"6*7","returnByValue":true}""",
+                sessionId);
+
+            evaluated.GetProperty("result").GetProperty("value").GetInt32().Should().Be(42);
+        }
+        finally
+        {
+            await pumping.CancelAsync();
+            await pump;
+        }
+    }
+
+    [Test]
+    public async Task ADirectPageConnectionCarriesNoSessionIdentifier()
+    {
+        await using var server = await StartedAsync();
+        await using var target = new EngineTarget(new Engine(), new EngineTargetOptions { ThreadMode = ThreadMode.LibraryOwned });
+        server.AddTarget(target);
+
+        var url = string.Create(CultureInfo.InvariantCulture, $"ws://127.0.0.1:{server.BoundPort}/devtools/page/{target.TargetId}");
+        await using var client = await DevToolsClient.ConnectAsync(url);
+
+        var evaluated = await client.ResultOfAsync("Runtime.evaluate", """{"expression":"1+1","returnByValue":true}""");
+        evaluated.GetProperty("result").GetProperty("value").GetInt32().Should().Be(2);
+
+        await client.ResultOfAsync("Runtime.enable");
+        var context = await client.WaitForEventAsync("Runtime.executionContextCreated");
+        context.TryGetProperty("sessionId", out _).Should().BeFalse("a direct connection is the session, so nothing addresses it");
+
+        // The target tree is the browser endpoint's business; a direct connection is one engine and no more.
+        var error = (await client.SendAsync("Target.getTargets")).GetProperty("error");
+        error.GetProperty("code").GetInt32().Should().Be(-32601);
+    }
+
+    [Test]
+    public async Task TwoClientsAreServedAtOnceAndSeeTheirOwnSessions()
+    {
+        await using var server = await StartedAsync();
+        await using var target = new EngineTarget(new Engine(), new EngineTargetOptions { ThreadMode = ThreadMode.LibraryOwned });
+        server.AddTarget(target);
+
+        await using var first = await DevToolsClient.ConnectAsync(server.BrowserWebSocketUrl);
+        await using var second = await DevToolsClient.ConnectAsync(server.BrowserWebSocketUrl);
+
+        var firstSession = (await first.ResultOfAsync("Target.attachToTarget", $$"""{"targetId":"{{target.TargetId}}","flatten":true}"""))
+            .GetProperty("sessionId").GetString()!;
+        var secondSession = (await second.ResultOfAsync("Target.attachToTarget", $$"""{"targetId":"{{target.TargetId}}","flatten":true}"""))
+            .GetProperty("sessionId").GetString()!;
+
+        secondSession.Should().NotBe(firstSession, "each conversation mints its own attachments");
+
+        var evaluated = await second.ResultOfAsync("Runtime.evaluate", """{"expression":"1+2","returnByValue":true}""", secondSession);
+        evaluated.GetProperty("result").GetProperty("value").GetInt32().Should().Be(3);
+
+        // One client's session identifier is meaningless on the other's connection, which is what keeps two
+        // clients from reaching into each other's attachments.
+        var crossed = (await first.SendAsync("Runtime.evaluate", """{"expression":"1"}""", secondSession)).GetProperty("error");
+        crossed.GetProperty("code").GetInt32().Should().Be(-32001);
+    }
+
+    [Test]
+    public async Task AnUnknownEndpointIsRefusedBeforeTheUpgrade()
+    {
+        await using var server = await StartedAsync();
+
+        var url = string.Create(CultureInfo.InvariantCulture, $"ws://127.0.0.1:{server.BoundPort}/devtools/page/NOPE");
+
+        var thrown = Assert.ThrowsAsync<WebSocketException>(async () => await DevToolsClient.ConnectAsync(url));
+        thrown.Should().NotBeNull("a client that guessed a path is told so rather than left holding an open socket");
+    }
+
+    [Test]
+    public async Task ABinaryFrameClosesTheConnection()
+    {
+        await using var server = await StartedAsync();
+        await using var client = await DevToolsClient.ConnectAsync(server.BrowserWebSocketUrl);
+
+        await client.SendBinaryAsync();
+
+        (await client.WaitForCloseAsync()).Should().Be(WebSocketCloseStatus.InvalidMessageType);
+    }
+
+    [Test]
+    public async Task AMessageOverTheBoundClosesTheConnection()
+    {
+        await using var server = await StartedAsync(new DevToolsServerOptions { MaxMessageBytes = 1024 });
+        await using var client = await DevToolsClient.ConnectAsync(server.BrowserWebSocketUrl);
+
+        var padding = new string('x', 4096);
+        await client.SendRawAsync("{\"id\":1,\"method\":\"Browser.getVersion\",\"params\":{\"pad\":\"" + padding + "\"}}");
+
+        (await client.WaitForCloseAsync()).Should().Be(WebSocketCloseStatus.MessageTooBig);
+    }
+
+    /// <summary>
+    /// A client that disappears mid-command must not take the engine thread with it: the command was already
+    /// on the mailbox, so it runs, and the reply goes nowhere.
+    /// </summary>
+    [Test]
+    public async Task AClientClosingMidCommandLeavesTheEngineRunning()
+    {
+        await using var server = await StartedAsync();
+        await using var target = new EngineTarget(new Engine(), new EngineTargetOptions { ThreadMode = ThreadMode.LibraryOwned });
+        server.AddTarget(target);
+
+        var client = await DevToolsClient.ConnectAsync(server.BrowserWebSocketUrl);
+        var sessionId = (await client.ResultOfAsync("Target.attachToTarget", $$"""{"targetId":"{{target.TargetId}}","flatten":true}"""))
+            .GetProperty("sessionId").GetString()!;
+
+        await client.SendRawAsync($$"""{"id":99,"method":"Runtime.evaluate","params":{"expression":"globalThis.marker = 7"},"sessionId":"{{sessionId}}"}""");
+        await client.DisposeAsync();
+
+        var marker = await target.PostAsync(engine => engine.Evaluate("globalThis.marker").AsNumber()).WaitAsync(TimeSpan.FromSeconds(120));
+        marker.Should().Be(7, "the command was already queued when the socket went, and the engine is still the host's");
+
+        await using var second = await DevToolsClient.ConnectAsync(server.BrowserWebSocketUrl);
+        (await second.ResultOfAsync("Browser.getVersion")).GetProperty("product").GetString().Should().StartWith("Jint/");
+    }
+
+    [Test]
+    public async Task BrowserCloseEndsTheClientRatherThanTheHost()
+    {
+        await using var server = await StartedAsync();
+        await using var client = await DevToolsClient.ConnectAsync(server.BrowserWebSocketUrl);
+
+        await client.ResultOfAsync("Browser.close");
+        await client.WaitForCloseAsync();
+
+        await using var second = await DevToolsClient.ConnectAsync(server.BrowserWebSocketUrl);
+        (await second.ResultOfAsync("Browser.getVersion")).GetProperty("product").GetString().Should().StartWith("Jint/");
+    }
+
+    /// <summary>
+    /// What the host called itself is what both a client and a browser-endpoint command are told, because
+    /// the two are the same answer read twice.
+    /// </summary>
+    [Test]
+    public async Task TheHostsOwnProductNameReachesBothAnswers()
+    {
+        await using var server = await StartedAsync(new DevToolsServerOptions { Product = "Contoso Workflow/3.1" });
+
+        var (_, body) = await DevToolsClient.GetAsync($"http://127.0.0.1:{server.BoundPort}/json/version");
+        using var document = JsonDocument.Parse(body);
+        document.RootElement.GetProperty("Browser").GetString().Should().Be("Contoso Workflow/3.1");
+        document.RootElement.GetProperty("User-Agent").GetString().Should().Be("Contoso Workflow/3.1");
+
+        await using var client = await DevToolsClient.ConnectAsync(server.BrowserWebSocketUrl);
+        var version = await client.ResultOfAsync("Browser.getVersion");
+        version.GetProperty("product").GetString().Should().Be("Contoso Workflow/3.1");
+        version.GetProperty("jsVersion").GetString().Should().NotBe("Contoso Workflow/3.1", "the engine version is Jint's whatever the host calls itself");
+    }
+
+    /// <summary>
+    /// A host whose whole purpose is the endpoint turns the disconnect off and decides for itself what
+    /// <c>Browser.close</c> means; the command still succeeds, because a client that fails on the way out
+    /// reports a failure it cannot act on.
+    /// </summary>
+    [Test]
+    public async Task BrowserCloseLeavesTheConnectionOpenWhenTheHostSaysSo()
+    {
+        await using var server = await StartedAsync(new DevToolsServerOptions { CloseIsDisconnect = false });
+        await using var client = await DevToolsClient.ConnectAsync(server.BrowserWebSocketUrl);
+
+        (await client.ResultOfAsync("Browser.close")).GetRawText().Should().Be("{}");
+
+        var version = await client.ResultOfAsync("Browser.getVersion");
+        version.GetProperty("product").GetString().Should().StartWith("Jint/");
+    }
+
+    /// <summary>
+    /// Stopping the server ends the conversations it was holding, rather than leaving a client waiting on a
+    /// socket nothing is reading any more.
+    /// </summary>
+    [Test]
+    public async Task DisposingTheServerClosesTheClientsThatWereConnected()
+    {
+        var server = await StartedAsync();
+        await using var client = await DevToolsClient.ConnectAsync(server.BrowserWebSocketUrl);
+
+        await client.ResultOfAsync("Browser.getVersion");
+        await server.DisposeAsync();
+
+        await client.WaitForCloseAsync();
+    }
+
+    [Test]
+    public async Task StartingTwiceIsRefusedAndAnUnstartedServerHasNoAddress()
+    {
+        await using var server = new DevToolsServer();
+
+        Assert.Throws<InvalidOperationException>(() => _ = server.BrowserWebSocketUrl);
+        server.BoundPort.Should().Be(0);
+
+        server.Start();
+        server.BoundPort.Should().BeGreaterThan(0);
+        Assert.Throws<InvalidOperationException>(() => server.Start());
+    }
+
+    private static async Task<DevToolsServer> StartedAsync(DevToolsServerOptions? options = null)
+    {
+        var server = new DevToolsServer(options ?? new DevToolsServerOptions());
+        await server.StartAsync();
+        return server;
+    }
+
+    private static Task Pump(EngineTarget target, CancellationToken cancellationToken)
+    {
+        return Task.Run(
+            () =>
+            {
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    target.Pump();
+                    target.Engine.Tasks.WaitForScheduledWork(TimeSpan.FromMilliseconds(20));
+                }
+            },
+            CancellationToken.None);
+    }
+}

--- a/Jint.Tests.DevTools/Verify/PublicApiTest.verified.txt
+++ b/Jint.Tests.DevTools/Verify/PublicApiTest.verified.txt
@@ -1,1 +1,68 @@
 ﻿[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+namespace Jint.DevTools
+{
+    public sealed class DevToolsEngineOptions
+    {
+        public DevToolsEngineOptions() { }
+        public bool Coverage { get; set; }
+    }
+    public static class DevToolsOptionsExtensions
+    {
+        public static Jint.Options UseDevTools(this Jint.Options options, System.Action<Jint.DevTools.DevToolsEngineOptions>? configure = null) { }
+    }
+    public sealed class DevToolsServer : System.IAsyncDisposable
+    {
+        public DevToolsServer(Jint.DevTools.DevToolsServerOptions? options = null) { }
+        public int BoundPort { get; }
+        public string BrowserId { get; }
+        public string BrowserWebSocketUrl { get; }
+        public System.Collections.Generic.IReadOnlyList<Jint.DevTools.EngineTarget> Targets { get; }
+        public void AddTarget(Jint.DevTools.EngineTarget target) { }
+        public System.Threading.Tasks.ValueTask DisposeAsync() { }
+        public bool RemoveTarget(Jint.DevTools.EngineTarget target) { }
+        public void Start() { }
+        public System.Threading.Tasks.Task StartAsync(System.Threading.CancellationToken cancellationToken = default) { }
+    }
+    public sealed class DevToolsServerOptions
+    {
+        public DevToolsServerOptions() { }
+        public bool CloseIsDisconnect { get; set; }
+        public System.TimeSpan CommandTimeout { get; set; }
+        public System.Func<Jint.Engine>? EngineFactory { get; set; }
+        public string Host { get; set; }
+        public int MaxMessageBytes { get; set; }
+        public System.TimeSpan PauseTimeout { get; set; }
+        public int Port { get; set; }
+        public string? Product { get; set; }
+    }
+    public sealed class EngineTarget : System.IAsyncDisposable
+    {
+        public EngineTarget(Jint.Engine engine, Jint.DevTools.EngineTargetOptions? options = null) { }
+        public Jint.Engine Engine { get; }
+        public bool IsWaitingForDebugger { get; }
+        public string TargetId { get; }
+        public Jint.DevTools.ThreadMode ThreadMode { get; }
+        public string Title { get; }
+        public string Type { get; }
+        public string Url { get; }
+        public System.Threading.Tasks.ValueTask DisposeAsync() { }
+        public void Post(System.Action<Jint.Engine> work) { }
+        public System.Threading.Tasks.Task PostAsync(System.Action<Jint.Engine> work) { }
+        public System.Threading.Tasks.Task<T> PostAsync<T>(System.Func<Jint.Engine, T> work) { }
+        public void Pump() { }
+        public bool WaitForDebugger(System.TimeSpan timeout) { }
+    }
+    public sealed class EngineTargetOptions
+    {
+        public EngineTargetOptions() { }
+        public Jint.DevTools.ThreadMode ThreadMode { get; set; }
+        public string Title { get; set; }
+        public string Url { get; set; }
+        public bool WaitForDebuggerOnStart { get; set; }
+    }
+    public enum ThreadMode
+    {
+        HostOwned = 0,
+        LibraryOwned = 1,
+    }
+}

--- a/README.md
+++ b/README.md
@@ -2092,6 +2092,52 @@ itself: that is where a size limit, an eviction policy and a per-tenant partitio
 
 
 
+## Chrome DevTools Protocol (opt-in package)
+
+The `Jint.DevTools` package lets a debugging client attach to an engine your host is already running. It
+speaks the [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/) over a WebSocket,
+so a Jint engine appears to a client the way a Node process does — a target it can list, attach to and
+evaluate in — with no browser anywhere in the picture.
+
+```csharp
+// dotnet add package Jint.DevTools   (net8.0 and later)
+using Jint.DevTools;
+
+var engine = new Engine(options => options.UseDevTools());
+
+await using var server = new DevToolsServer(new DevToolsServerOptions { Port = 9222 });
+server.AddTarget(new EngineTarget(engine));
+server.Start();
+
+// The host's own loop is what runs the engine AND answers the protocol.
+while (running)
+{
+    engine.Tasks.ProcessTasks();
+    engine.Tasks.WaitForScheduledWork(TimeSpan.FromMilliseconds(50));
+}
+```
+
+Point a client at `http://127.0.0.1:9222` — `chrome://inspect` lists it, PuppeteerSharp's
+`Puppeteer.ConnectAsync(new ConnectOptions { BrowserURL = "http://127.0.0.1:9222" })` connects to it, and
+`server.BrowserWebSocketUrl` is the address for a client that wants the socket directly. Leave
+`DevToolsServerOptions.Port` at its default of `0` for an ephemeral port and read `server.BoundPort`.
+
+**Which thread answers a command is yours to choose.** `ThreadMode.HostOwned`, the default, means your own
+loop does: every command waits for your next `ProcessTasks`, and one that waits longer than
+`DevToolsServerOptions.CommandTimeout` is refused with a message saying the engine is not being pumped.
+`ThreadMode.LibraryOwned` gives the target its own thread instead, and you hand it work with
+`target.Post(engine => …)` or `await target.PostAsync(engine => …)` — the engine's own rules are unchanged,
+so touching it from anywhere else still fails fast rather than corrupting anything.
+
+Today a client can list targets, attach, hear about the execution context and evaluate — including
+`returnByValue` and awaiting a promise. `Debugger` (breakpoints, stepping, scopes), `Profiler` and the
+console and log domains arrive in later releases; until then each answers `'Domain.method' wasn't found`,
+which is what a client feature-detects on. Page-level domains are not this package's business at all.
+
+**The endpoint is unauthenticated**, exactly as it is in Chrome: anything that can reach it can evaluate
+arbitrary script in your process. `DevToolsServerOptions.Host` therefore defaults to `127.0.0.1`; do not
+bind it to a routable address.
+
 ## Performance
 
 - Because Jint neither generates any .NET bytecode nor uses the DLR it runs relatively small scripts really fast

--- a/tools/devtools-protocol/manifest.json
+++ b/tools/devtools-protocol/manifest.json
@@ -19,20 +19,54 @@
   // The commands Jint.DevTools actually answers. Every entry is checked against the vendored protocol,
   // and ProtocolManifestTests checks each one is overridden on a registered domain - and that nothing
   // else is. An unlisted command is not a silent success; it is 'Domain.method' wasn't found.
+  //
+  // Target.sendMessageToTarget is deliberately absent: it is the pre-flattened session model, no client
+  // recorded in tools/devtools-protocol/handshakes/ sends it, and answering it would mean a second
+  // routing path kept alive forever. Runtime.awaitPromise is absent because it addresses a promise by
+  // objectId and remote-object handles arrive with the Runtime work; the awaitPromise *parameter* of
+  // Runtime.evaluate is answered today.
   "implementedMethods": [
     "Browser.close",
     "Browser.getVersion",
-    "Schema.getDomains"
+    "Runtime.disable",
+    "Runtime.discardConsoleEntries",
+    "Runtime.enable",
+    "Runtime.evaluate",
+    "Runtime.getIsolateId",
+    "Runtime.runIfWaitingForDebugger",
+    "Schema.getDomains",
+    "Target.activateTarget",
+    "Target.attachToTarget",
+    "Target.closeTarget",
+    "Target.createBrowserContext",
+    "Target.createTarget",
+    "Target.detachFromTarget",
+    "Target.disposeBrowserContext",
+    "Target.getBrowserContexts",
+    "Target.getTargetInfo",
+    "Target.getTargets",
+    "Target.setAutoAttach",
+    "Target.setDiscoverTargets"
   ],
 
-  // The events Jint.DevTools emits. None yet: Runtime.consoleAPICalled and the Debugger pause events
-  // arrive with the domains that raise them.
-  "implementedEvents": [],
+  // The events Jint.DevTools emits. Target.targetInfoChanged is deliberately not among them: an engine
+  // target's title and location are fixed when the host makes it, so there is nothing that could change
+  // and claiming the event would be a claim nothing ever honours. Runtime.consoleAPICalled and the
+  // Debugger pause events arrive with the domains that raise them.
+  "implementedEvents": [
+    "Runtime.executionContextCreated",
+    "Target.attachedToTarget",
+    "Target.detachedFromTarget",
+    "Target.targetCreated",
+    "Target.targetDestroyed"
+  ],
 
   // What Schema.getDomains answers. A domain reaches this list only once it has an implemented command,
   // so a client feature-detecting through it is never told about a domain that answers nothing.
   "reportedDomains": [
     { "name": "Browser", "version": "1.3" },
-    { "name": "Schema", "version": "1.3" }
+    { "name": "Runtime", "version": "1.3" },
+    { "name": "Schema", "version": "1.3" },
+    { "name": "Target", "version": "1.3" }
   ]
 }


### PR DESCRIPTION
Part of the headless-browser and DevTools campaign (#3575), phase 1 track A, item **P2**. It sits on the
protocol skeleton (#3586) and the `engine.Tasks.Post` door (#3587), and it is what makes both mean
something: a client can now reach a Jint engine.

```csharp
var engine = new Engine(options => options.UseDevTools());

await using var server = new DevToolsServer(new DevToolsServerOptions { Port = 9222 });
server.AddTarget(new EngineTarget(engine));
server.Start();

// the host's own loop, which is what runs the engine AND answers the protocol
while (running)
{
    engine.Tasks.ProcessTasks();
    engine.Tasks.WaitForScheduledWork(TimeSpan.FromMilliseconds(50));
}
```

`chrome://inspect` lists it, `Puppeteer.ConnectAsync` connects to it, and `Runtime.evaluate("6*7")`
answers 42.

## The mailbox

The whole design is one mechanism. A transport thread parses a message, resolves the session, and hands
the request to `EngineDispatcher`, which enqueues it and calls `engine.Tasks.Post` — the one engine entry
a thread that does not own the engine may call. The drain runs **on the engine thread, inside an ordinary
event-loop job**, answers the command, and completes the waiting task with the finished JSON. **No
`JsValue` ever crosses.**

Running inside a job is also what a command may not undo: nothing may drain, because the pump's
re-entrancy guard forbids it. So `Runtime.evaluate` with `awaitPromise` attaches reactions and answers
from the job that runs them — which is V8's shape too — rather than pumping for a settlement.

Three properties that follow, and that the tests pin:

- **The drain never throws.** It is a job on the host's own pump, and an exception there erupts out of
  `ProcessTasks` into the host. Every queued item catches everything and answers with it; so do the
  promise reactions.
- **A command that times out is answered, not cancelled.** `CommandTimeout` bounds the *client's* wait;
  the item stays queued and runs when the engine is next pumped. Its parameters are cloned out of the
  caller's `JsonDocument` for exactly that reason — the caller disposes it on the way out, and the engine
  thread would otherwise later read pooled buffers somebody else owns.
- **The two timeouts are told apart.** An item nothing ever dequeued answers `Engine is not being
  pumped` with the fix in `data`; one that started and did not finish answers `Command timed out`. A host
  reading the wrong one debugs the wrong thing.

## Thread modes

`ThreadMode.HostOwned` is the default and the shape every existing embedder is already in: the host's own
loop answers commands, through `ProcessTasks` or the `target.Pump()` convenience over it.
`ThreadMode.LibraryOwned` gives the target one thread running drain → `ProcessTasks` →
`WaitForScheduledWork`, and the host submits work with `target.Post` / `target.PostAsync`; the engine's
own single-drainer guard still fails fast on anything else.

`WaitForDebuggerOnStart` is Node's `--inspect-brk`: host work is held, protocol commands are **not** —
otherwise the command that ends the wait could never be answered — and a host-owned target waits by
*pumping* (`target.WaitForDebugger`), because that command is answered on the very thread that is waiting.

## Sessions, and three refusals with reasons

A session is a tree node. The root owns the connection and parses every envelope; a child is one
attachment and carries the `sessionId` that reaches it. `/devtools/browser/<id>` opens a browser
conversation — `Schema`, `Browser`, `Target`, none of which touches an engine, so it answers on the
transport thread with no mailbox in between. `/devtools/page/<targetId>` is one engine directly, with no
`sessionId` on any message. A `sessionId` nothing answers to is `-32001 "Session with given id not
found."`, Chrome's wording.

- **`flatten: false` is `-32000`.** The wrapped model routes every message through
  `Target.sendMessageToTarget`, no client in `tools/devtools-protocol/handshakes/` asks for it, and
  answering both would buy a second routing path for nobody. That command stays `-32601`.
- **A browser context is `-32000`.** An engine target has no cookies, storage or cache to partition;
  minting an identifier would tell a client its next target was isolated when it is not. `Jint.Browser`
  is where contexts start meaning something.
- **`Runtime.evaluate` mints no `objectId`.** A handle is a promise to keep a value alive until the
  client releases it, and half a table is worse than none — a client handed an identifier nothing keeps
  alive is worse off than one told the value by description. So a value that cannot be sent by value is
  described (type, subtype, class name, one line) through the engine's own getter-free `ValueInspector`.
  The table, `getProperties`, `callFunctionOn` and previews are the next PR.

## What it answers

`Target`: `getTargets`, `getTargetInfo`, `setDiscoverTargets`, `setAutoAttach`, `attachToTarget`,
`detachFromTarget`, `createTarget`, `closeTarget`, `activateTarget`, `getBrowserContexts`,
`createBrowserContext`, `disposeBrowserContext`, plus `targetCreated` / `targetDestroyed` /
`attachedToTarget` / `detachedFromTarget`.

`Runtime`: `enable` (replaying `executionContextCreated`), `disable`, `runIfWaitingForDebugger`,
`evaluate` (`returnByValue`, `awaitPromise`, `exceptionDetails`), `discardConsoleEntries`, `getIsolateId`.

`Browser.getVersion` answers what the host called itself; `Browser.close` closes the client's connection
rather than the host, behind the reply to that very command, unless `CloseIsDisconnect` says otherwise.

Over HTTP on the same port: `/json/version`, `/json`, `/json/list`, `/json/protocol` (what this server
implements, derived from the manifest — the pinned document is two megabytes of mostly `-32601`),
`/json/new`, `/json/activate/<id>`, `/json/close/<id>`.

## Verification

**Against what clients actually send.** `HandshakeReplayTests` replays every method in the
`puppeteersharp-dotnet` and `devtools-frontend` recordings from #3599: a manifest method must be
answered, every other must be *exactly* `-32601` — never `-32602`, which would tell a client it called a
command wrongly when the command does not exist here. Each of those is named in an `Absent` table with
its reason (a page-level command that is `Jint.Browser`'s, an engine-level one not written yet, or one
Chrome itself answered `-32601` to), so a re-recording or a client release arrives as a decision somebody
makes rather than a silently widened test.

**Against a real client.** `PuppeteerSharpTests` connects both ways a client can — `BrowserWSEndpoint`
and `BrowserURL` through `/json/version` — lists the target, opens a CDP session and evaluates, including
two engines behind one endpoint each reaching only its own. No browser is downloaded and none is
launched. It is the only test here that can claim client compatibility at all.

**Over a real socket.** The upgrade handshake, frame handling, the single writer, the close ordering and
two concurrent connections are exercised by nothing without one — including a client that disappears
mid-command, which must leave the engine running.

131 tests in `Jint.Tests.DevTools` (129 on the `net8.0` leg, which does not run the API baseline), green
also under `JINT_HOST_CONTRACT_VERIFICATION=1` — the suite now compiles the switch that arms it, so that
variable means the same thing here as in the other two suites. Full solution green.

## Deliberately not here

The public surface — `DevToolsServer`, `DevToolsServerOptions`, `EngineTarget`, `EngineTargetOptions`,
`ThreadMode`, `UseDevTools` — carries **no `[Experimental]`**. `JINTDT001` says "the shape of this member
follows a living upstream document", which is true of a generated protocol type and false of a server and
an options bag; putting it on the entry point would make every host write a `#pragma` to use the package
at all and leave the identifier meaning nothing. `Jint.DevTools/AGENTS.md` now says so.

`Runtime.awaitPromise` the *command* is absent because it addresses a promise by `objectId`; the
`awaitPromise` *parameter* of `Runtime.evaluate` is answered today. `Debugger`, `Profiler`, `Console` and
`Log` are later PRs, and each answers `'Domain.method' wasn't found` until then, which is what a client
feature-detects on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
