### PR TITLE
Test262: twelve intl402 exclusions name tests that pass, and the thirteenth candidate keeps its entry

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -162,12 +162,6 @@
     "intl402/Collator/prototype/compare/non-normative-phonebook.js",
     "intl402/Collator/usage-de.js",
 
-    // DateTimeFormat - Chinese/Dangi calendar date range issues (.NET ChineseLunisolarCalendar limitations)
-    "intl402/DateTimeFormat/prototype/formatRangeToParts/chinese-calendar-dates.js",
-    "intl402/DateTimeFormat/prototype/formatRangeToParts/dangi-calendar-dates.js",
-    "intl402/DateTimeFormat/prototype/formatToParts/chinese-calendar-dates.js",
-    "intl402/DateTimeFormat/prototype/formatToParts/dangi-calendar-dates.js",
-
     // DurationFormat - precision formatting requires exact sub-second arithmetic
     "intl402/DurationFormat/prototype/format/precision-exact-mathematical-values.js",
     // Requires Spanish unit patterns (ICU4N doesn't include unit data, only core locale data)
@@ -215,32 +209,26 @@
 
     // Remaining intl402/Temporal calendar failures
     "intl402/DateTimeFormat/prototype/formatToParts/compare-to-temporal-lunisolar.js",
-    "intl402/Temporal/PlainDate/from/roundtrip-from-property-bag.js",
     "intl402/Temporal/PlainDate/prototype/daysInMonth/basic-islamic-umalqura.js",
     "intl402/Temporal/PlainDate/prototype/daysInYear/basic-islamic-umalqura.js",
     "intl402/Temporal/PlainDate/prototype/inLeapYear/basic-islamic-umalqura.js",
-    "intl402/Temporal/PlainDate/prototype/with/basic-islamic-umalqura.js",
     "intl402/Temporal/PlainDate/prototype/withCalendar/extreme-dates.js",
     "intl402/Temporal/PlainDateTime/from/extreme-dates.js",
-    "intl402/Temporal/PlainDateTime/from/roundtrip-from-property-bag.js",
     "intl402/Temporal/PlainDateTime/prototype/daysInMonth/basic-islamic-umalqura.js",
     "intl402/Temporal/PlainDateTime/prototype/daysInYear/basic-islamic-umalqura.js",
     "intl402/Temporal/PlainDateTime/prototype/inLeapYear/basic-islamic-umalqura.js",
-    "intl402/Temporal/PlainDateTime/prototype/with/basic-islamic-umalqura.js",
     "intl402/Temporal/PlainDateTime/prototype/withCalendar/extreme-dates.js",
     "intl402/Temporal/PlainMonthDay/from/islamic-umalqura-month-codes.js",
-    "intl402/Temporal/PlainYearMonth/from/extreme-dates.js",
     "intl402/Temporal/PlainYearMonth/from/extreme-unsupported-dates.js",
-    "intl402/Temporal/PlainYearMonth/from/roundtrip-from-property-bag.js",
     "intl402/Temporal/PlainYearMonth/prototype/daysInMonth/basic-islamic-umalqura.js",
     "intl402/Temporal/PlainYearMonth/prototype/daysInYear/basic-islamic-umalqura.js",
     "intl402/Temporal/PlainYearMonth/prototype/inLeapYear/basic-islamic-umalqura.js",
     "intl402/Temporal/ZonedDateTime/from/extreme-dates.js",
-    "intl402/Temporal/ZonedDateTime/from/roundtrip-from-property-bag.js",
     "intl402/Temporal/ZonedDateTime/prototype/daysInMonth/basic-islamic-umalqura.js",
     "intl402/Temporal/ZonedDateTime/prototype/daysInYear/basic-islamic-umalqura.js",
     "intl402/Temporal/ZonedDateTime/prototype/inLeapYear/basic-islamic-umalqura.js",
-    "intl402/Temporal/ZonedDateTime/prototype/with/basic-islamic-umalqura.js",
+    // Only the persian minimum date still fails here, on eraYear alone: -272443 for the -272442
+    // the file asserts, while its `year` of -272442 is already right.
     "intl402/Temporal/ZonedDateTime/prototype/withCalendar/extreme-dates.js"
 
   ],


### PR DESCRIPTION
`Jint.Tests.Test262/AGENTS.md` says an `ExcludedFiles` entry must match a failing test and no passing one. Twelve `intl402` entries no longer did. A thirteenth candidate the issue named still fails, and keeps its entry.

### What was measured

Every one of the thirteen candidates was removed together, then run on its own, both parse modes, against this branch's engine. Twelve passed 2/2; one failed 2/2 and went back in.

| exclusion removed | result | closed by |
| --- | --- | --- |
| `DateTimeFormat/prototype/formatRangeToParts/chinese-calendar-dates.js` | 0 failed, 2 passed | #3507 |
| `DateTimeFormat/prototype/formatToParts/chinese-calendar-dates.js` | 0 failed, 2 passed | #3507 |
| `DateTimeFormat/prototype/formatRangeToParts/dangi-calendar-dates.js` | 0 failed, 2 passed | already passing before #3405 |
| `DateTimeFormat/prototype/formatToParts/dangi-calendar-dates.js` | 0 failed, 2 passed | already passing before #3405 |
| `Temporal/PlainDate/from/roundtrip-from-property-bag.js` | 0 failed, 2 passed | #3482 |
| `Temporal/PlainDateTime/from/roundtrip-from-property-bag.js` | 0 failed, 2 passed | #3482 |
| `Temporal/PlainYearMonth/from/roundtrip-from-property-bag.js` | 0 failed, 2 passed | #3482 |
| `Temporal/ZonedDateTime/from/roundtrip-from-property-bag.js` | 0 failed, 2 passed | #3482 |
| `Temporal/PlainYearMonth/from/extreme-dates.js` | 0 failed, 2 passed | #3482 |
| `Temporal/PlainDate/prototype/with/basic-islamic-umalqura.js` | 0 failed, 2 passed | already passing before #3405 |
| `Temporal/PlainDateTime/prototype/with/basic-islamic-umalqura.js` | 0 failed, 2 passed | already passing before #3405 |
| `Temporal/ZonedDateTime/prototype/with/basic-islamic-umalqura.js` | 0 failed, 2 passed | already passing before #3405 |
| `Temporal/ZonedDateTime/prototype/withCalendar/extreme-dates.js` | **2 failed, 0 passed — kept** | — |

Attribution is bisected, not inferred. Each row's fix was pinned by running the same twelve-removal against the commit and its parent:

- **#3482** (*a date past a lunisolar calendar's table is still reckoned in that calendar*) — the five `roundtrip-from-property-bag` / `extreme-dates` files fail 2/2 at its parent `5b2f8f12` and pass 2/2 at `d8ab98c3`. Both commits sit on the same pinned suite SHA, so the flip is the fix and not the `#3277` corpus bump, which lands after it.
- **#3507** (*chinese and dangi read the same on every target framework*) — the two `chinese-calendar-dates` files fail 2/2 at its parent `9f0afc3f` (#3502) and pass 2/2 at `eb3bf010`.
- The two `dangi-calendar-dates` files and the three `with/basic-islamic-umalqura` files already passed at `a487ee06` (#3405), before the recent calendar work began. They are simply stale — added by #2260 and #2344 respectively and never re-checked.

### The one that stays

`intl402/Temporal/ZonedDateTime/prototype/withCalendar/extreme-dates.js` fails deterministically, on one assertion:

```
persian minimum supported date: eraYear result: Expected SameValue(«-272443», «-272442») to be true
```

Its `year` of `-272442` is already right; only `eraYear` is off by one, and the whole file is `"UTC"`, so no time zone or ICU data is involved. The issue scored it as passing; `Jint/Native/Temporal/` is byte-identical between the issue's base `0b44c60a` and `main`, so it was failing there too — the file is one of three near-identical `withCalendar/extreme-dates.js` siblings and its two neighbours stay excluded. Its entry now carries a comment naming the assertion, so the next reading of the group does not have to re-derive it.

### The ICU question the four `calendar-dates` files raise

[#3591's comment](https://github.com/sebastienros/jint/issues/3591#issuecomment-5502341196) flags that whether `chinese`/`dangi` pass may depend on the machine's ICU data, which is why they were kept out of #3594 and want a PR whose cross-platform matrix decides them. That is this PR: linux, linux-ARM, macos and windows are the arbiter. If any leg reddens on those four, they come back out and the other eight stand on their own.

### Verification

**test262: 102,573 / 0 failed / 115 skipped of 102,688**, up 24 passes from `main`'s 102,549 / 0 / 139 at `1df62639` — exactly the twelve files × two parse modes, with the total unchanged. Full `dotnet build -c Release` and `dotnet test -c Release` are green on net472, net8.0 and net10.0, `Jint.Tests.PublicInterface` included.

Test-only: no engine change, so no migration-guide entry and no 4.x backport to consider.

Closes #3591

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014W5mbjGhyvgAS4pivXoc4S
