### PR TITLE
DevTools: what a script logged and what it threw reach a client, with the values still attached

### DIFF
--- a/Jint.DevTools/AGENTS.md
+++ b/Jint.DevTools/AGENTS.md
@@ -138,7 +138,9 @@ descriptor and is listed rather than read.
 — `JSON.stringify`'s own contract, `toJSON` hooks and getters both — because a client that asked for the
 value itself asked for exactly that, and V8 does the same. A cycle, a `toJSON` that threw, and a value with
 no JSON form are all `-32000 "Object couldn't be returned by value"` with the engine's own message as the
-data. Everything else on the path is getter-free; this one call is not.
+data. There is exactly one other place: rendering a *thrown* error's message and stack reads a `stack` a
+script may have defined as an accessor, which is why that render is asked for under the engine's own
+`ResultLimits`. Everything else on the path is getter-free.
 
 **`Domains/RemoteObjectDescriber.cs` is the seam `Jint.Browser` fills in.** It is consulted first for every
 non-primitive value and may answer a subtype, a class name and a description — `subtype: "node"`,
@@ -151,6 +153,48 @@ Two gaps are real rather than pending. `[[PromiseResult]]` is answered as a *des
 because the engine publishes a settled promise's value to nothing outside its own assembly —
 `Runtime.awaitPromise` is what hands the value over, and it does so by attaching reactions. And a host
 object's members are listed without their values, for the reason above.
+
+### What a client hears without asking
+
+Three things reach a domain from *inside* the engine, on the engine thread, with no command to answer:
+a `console` call, an exception that escaped the pump, and a promise rejected with nothing to handle it.
+`ITargetObserver` is the one interface for all three, an attachment's three domains implement the parts
+they care about, and `EngineTarget` fans out to whoever is attached. They go out through
+`DevToolsDomain.EmitDetached`, which queues rather than writes: both connections make a send a channel
+insertion, so nothing blocks the engine and no transport failure erupts out of the host's own pump.
+
+**The console arrives through the sink, and the sink wraps rather than replaces.** `UseDevTools` installs a
+`DevToolsConsoleSink` around whatever `Options.WebApi.Console.Sink` the host had and forwards both overloads
+first, so a host keeps every line it was getting. **One sink speaks for one engine**: the engine reads its
+sink out of `Options` on every emit and `ConsoleRecord` carries no engine, so a sink shared by two could not
+tell which was talking. It binds to the first target over an engine and refuses a second engine's, and
+`UseDevTools` installs a fresh one per call — so a host building two engines from one `Options` and
+attaching to both hears the first. An engine without `WebApiFeatures.Console` reports nothing, having no
+`console` to log through.
+
+**`ConsoleJournal` is the last hundred calls**, replayed on `Runtime.enable` and `Console.enable` as V8
+replays its own store. The bound is a memory bound first: an entry holds its arguments strongly, exactly as
+a handle does, so evicting one releases every handle any attachment minted for it. Console arguments are
+billed to the group `"console"`, which is what a client's "clear console" releases;
+`Runtime.discardConsoleEntries` and `Console.clearMessages` empty the journal, which is the target's rather
+than the session's because the history is the engine's.
+
+**`Console` is the flat half, `Log` the failure half.** `Console.messageAdded` carries the finished line the
+engine's printer produced and no handles, so a call that printed nothing — `groupEnd`, a `time` that started
+a timer — is absent there and present in `Runtime.consoleAPICalled`, which a front end draws a group from.
+`Log.entryAdded` carries the two failures an engine target can have, and **`Log.enable` replays nothing**:
+the journal is the console's and no log store exists.
+
+**A rejection is reported earlier than V8 reports it.** `Tasks.PromiseRejectionTracker` raises `Reject` the
+moment a promise is rejected unhandled, where V8 waits for the end of the microtask checkpoint — so a
+rejection handled on the next line produces `exceptionThrown` then `exceptionRevoked` where Chrome produces
+neither, which is the pair the revocation exists for. The identifier is remembered per attachment (the last
+64) rather than the event delayed, because delaying it would mean this package deciding when a checkpoint
+ended.
+
+**`EngineTarget.ReportUncaughtException` is the host's own door**, called by the `LibraryOwned` loop for
+script that escaped `ProcessTasks` and by a `HostOwned` host from its own `catch`. Reporting is not
+handling: it writes to whoever is attached and returns.
 
 ### The pause loop
 

--- a/Jint.DevTools/DevToolsConsoleSink.cs
+++ b/Jint.DevTools/DevToolsConsoleSink.cs
@@ -1,0 +1,77 @@
+using Jint.WebApi;
+
+namespace Jint.DevTools;
+
+/// <summary>
+/// The sink <see cref="DevToolsOptionsExtensions.UseDevTools"/> installs: it forwards everything to whatever
+/// the host had, and hands the record to the target a client is attached to.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>It wraps rather than replaces.</b> A host that set its own sink keeps every line it was getting, in
+/// the same overload it was getting it in; attaching a client adds a reader and changes nothing about the
+/// existing one.
+/// </para>
+/// <para>
+/// <b>One sink reaches one engine.</b> The engine reads its sink out of <c>Options</c> on every emit and the
+/// record carries no engine, so a sink shared by two engines could not tell which of them was talking. It
+/// therefore binds to the first target built over an engine and refuses a second engine's — and
+/// <c>UseDevTools</c> installs a fresh one per call, so the ordinary
+/// <c>new Engine(options =&gt; options.UseDevTools())</c> gives every engine its own. A host that builds two
+/// engines from one <see cref="Options"/> instance and attaches to both gets console events from the first;
+/// calling <c>UseDevTools</c> per engine is what avoids that.
+/// </para>
+/// <para>
+/// <b>Everything here runs on the engine thread</b>, inside the <c>console</c> call. The values in the
+/// record are the engine's, and what leaves this class is a journal entry that holds them exactly as a
+/// remote-object handle does.
+/// </para>
+/// </remarks>
+internal sealed class DevToolsConsoleSink : ConsoleSink
+{
+    private readonly ConsoleSink _inner;
+
+    private Engine? _engine;
+    private EngineTarget? _target;
+
+    internal DevToolsConsoleSink(ConsoleSink? inner)
+    {
+        _inner = inner ?? Null;
+    }
+
+    /// <summary>Binds this sink to <paramref name="target"/>, unless it already speaks for another engine.</summary>
+    /// <returns><see langword="true"/> when console records from now on reach <paramref name="target"/>.</returns>
+    internal bool TryBind(EngineTarget target)
+    {
+        if (_engine is not null && !ReferenceEquals(_engine, target.Engine))
+        {
+            return false;
+        }
+
+        _engine = target.Engine;
+        _target = target;
+        return true;
+    }
+
+    /// <summary>Stops speaking for <paramref name="target"/>, if it is the one bound.</summary>
+    internal void Unbind(EngineTarget target)
+    {
+        if (ReferenceEquals(_target, target))
+        {
+            _target = null;
+        }
+    }
+
+    /// <inheritdoc/>
+    public override void Write(ConsoleLogLevel level, string message) => _inner.Write(level, message);
+
+    /// <inheritdoc/>
+    public override void Write(in ConsoleRecord record)
+    {
+        // The host's sink first and unconditionally: what it was getting before a client attached is what it
+        // gets after, and a protocol failure must not cost the host a log line.
+        _inner.Write(in record);
+
+        _target?.Record(in record);
+    }
+}

--- a/Jint.DevTools/DevToolsEngineOptions.cs
+++ b/Jint.DevTools/DevToolsEngineOptions.cs
@@ -41,6 +41,16 @@ public static class DevToolsOptionsExtensions
     /// <see cref="DevToolsEngineOptions.Coverage"/> asks for it.
     /// </para>
     /// <para>
+    /// It also wraps <c>Options.WebApi.Console.Sink</c>, so that what a script logs reaches an
+    /// attached client as <c>Runtime.consoleAPICalled</c>. <b>The host's own sink keeps everything it was
+    /// getting</b> — the wrapper forwards both overloads before it does anything else — and an engine that
+    /// never enabled <see cref="WebApiFeatures.Console"/> has no <c>console</c> to log through, so
+    /// this costs it nothing. <b>Call it per engine.</b> The wrapper speaks for the first engine a target is
+    /// built over, because the engine reads its sink out of <see cref="Options"/> on every emit and the
+    /// record carries no engine; two engines built from one <see cref="Options"/> instance therefore report
+    /// console traffic from the first alone.
+    /// </para>
+    /// <para>
     /// <b>All three are construction-time.</b> There is no way to turn them on later, so an engine built
     /// without this can be listed and evaluated in but not paused in, and the domains that need what is
     /// missing say so with an explicit refusal rather than answering something untrue.
@@ -70,6 +80,13 @@ public static class DevToolsOptionsExtensions
         options.Debugger.Enabled = true;
         options.RetainFunctionSourceText = true;
         options.Profiling.Enabled = true;
+
+        // Wrapped rather than replaced, and idempotent: calling UseDevTools twice on one Options must not
+        // build a chain of wrappers each forwarding to the last.
+        if (options.WebApi.Console.Sink is not DevToolsConsoleSink)
+        {
+            options.WebApi.Console.Sink = new DevToolsConsoleSink(options.WebApi.Console.Sink);
+        }
 
         if (devTools.Coverage)
         {

--- a/Jint.DevTools/Domains/BuiltInDomains.cs
+++ b/Jint.DevTools/Domains/BuiltInDomains.cs
@@ -63,7 +63,17 @@ internal static class BuiltInDomains
         }
 
         var runtime = new RuntimeDomain(target);
-        session.Register(runtime);
+        var console = new ConsoleDomain(target);
+        var log = new LogDomain();
+
+        session.Register(runtime).Register(console).Register(log);
+
+        // Registered with the engine's own event sources in one place, so that the three domains that hear
+        // about a console call, an uncaught exception or an unhandled rejection are exactly the three the
+        // attachment releases again when it detaches.
+        target.Observe(runtime);
+        target.Observe(console);
+        target.Observe(log);
 
         if (browser is not null)
         {
@@ -72,7 +82,7 @@ internal static class BuiltInDomains
             session.Register(new TargetDomain(browser, nested: true));
         }
 
-        return new TargetDomains(runtime);
+        return new TargetDomains(target, runtime, console, log);
     }
 }
 
@@ -86,8 +96,15 @@ internal static class BuiltInDomains
 /// nothing releases.
 /// </remarks>
 [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Auto)]
-internal readonly record struct TargetDomains(RuntimeDomain Runtime)
+internal readonly record struct TargetDomains(EngineTarget Target, RuntimeDomain Runtime, ConsoleDomain Console, LogDomain Log)
 {
-    /// <summary>Releases everything this attachment holds of its engine.</summary>
-    internal void Detach() => Runtime.Detach();
+    /// <summary>Releases everything this attachment holds of its engine, and stops it hearing anything.</summary>
+    internal void Detach()
+    {
+        Target.Unobserve(Runtime);
+        Target.Unobserve(Console);
+        Target.Unobserve(Log);
+
+        Runtime.Detach();
+    }
 }

--- a/Jint.DevTools/Domains/ConsoleDomain.cs
+++ b/Jint.DevTools/Domains/ConsoleDomain.cs
@@ -1,0 +1,113 @@
+using Jint.DevTools.Protocol;
+using Jint.DevTools.Protocol.Console;
+using Jint.DevTools.Session;
+using Jint.WebApi;
+
+namespace Jint.DevTools.Domains;
+
+/// <summary>
+/// The legacy <c>Console</c> domain: the same calls the <c>Runtime</c> domain reports, as the flat lines a
+/// simpler client reads.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Deprecated in the protocol and implemented anyway, because it is what the small clients use.
+/// <c>chrome-remote-interface</c>'s own samples listen to <c>Console.messageAdded</c> and never touch
+/// <c>Runtime.consoleAPICalled</c>, and a <c>ConsoleMessage</c> is one string with a level on it rather than
+/// a list of remote objects — which is the whole of what a log-scraping client wants.
+/// </para>
+/// <para>
+/// It reports what the engine's own printer produced, group indentation included, and mints no handles: a
+/// client on this domain asked for text. The calls that print nothing — <c>groupEnd</c>, a <c>time</c> that
+/// started a timer — are absent from it for the same reason, while <c>Runtime.consoleAPICalled</c> carries
+/// them because a front end draws a group from them.
+/// </para>
+/// <para>
+/// See <see href="https://chromedevtools.github.io/devtools-protocol/tot/Console/"/>.
+/// </para>
+/// </remarks>
+internal sealed class ConsoleDomain : ConsoleDomainBase, ITargetObserver
+{
+    private readonly EngineTarget _target;
+
+    internal ConsoleDomain(EngineTarget target)
+    {
+        _target = target;
+    }
+
+    /// <inheritdoc/>
+    protected override async ValueTask<EmptyResult> EnableAsync(EmptyParameters parameters, CommandContext context)
+    {
+        await MarkEnabledAsync(context).ConfigureAwait(false);
+        return EmptyResult.Instance;
+    }
+
+    /// <inheritdoc/>
+    protected override async ValueTask<EmptyResult> DisableAsync(EmptyParameters parameters, CommandContext context)
+    {
+        await MarkDisabledAsync(context).ConfigureAwait(false);
+        return EmptyResult.Instance;
+    }
+
+    /// <summary>Empties the journal, which is the same history <c>Runtime.discardConsoleEntries</c> discards.</summary>
+    protected override ValueTask<EmptyResult> ClearMessagesAsync(EmptyParameters parameters, CommandContext context)
+    {
+        _target.Console.Clear(_target.RemoteObjects);
+        return new ValueTask<EmptyResult>(EmptyResult.Instance);
+    }
+
+    /// <summary>Sends what was logged before the client asked, which is what the command promises.</summary>
+    protected override async ValueTask OnEnabledAsync(CommandContext context)
+    {
+        foreach (var entry in _target.Console.Snapshot())
+        {
+            if (Message(entry) is { } message)
+            {
+                await EmitAsync(ConsoleEvents.MessageAdded(message), context.CancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    void ITargetObserver.ConsoleRecorded(ConsoleEntry entry)
+    {
+        if (!IsEnabled || Message(entry) is not { } message)
+        {
+            return;
+        }
+
+        EmitDetached(ConsoleEvents.MessageAdded(message));
+    }
+
+    /// <summary>
+    /// One journalled call as a flat message, or <see langword="null"/> for a call that printed nothing.
+    /// </summary>
+    private static MessageAddedEvent? Message(ConsoleEntry entry)
+    {
+        if (entry.Message is not { } text)
+        {
+            return null;
+        }
+
+        return new MessageAddedEvent
+        {
+            Message = new ConsoleMessage
+            {
+                // Everything an engine target logs came through the console object, which is the one source
+                // this domain has: there is no network, no storage and no renderer to attribute a line to.
+                Source = ConsoleMessageSourceValues.ConsoleApi,
+                Level = Level(entry.Level),
+                Text = text,
+            },
+        };
+    }
+
+    private static string Level(ConsoleLogLevel level) => level switch
+    {
+        ConsoleLogLevel.Debug => ConsoleMessageLevelValues.Debug,
+        ConsoleLogLevel.Info => ConsoleMessageLevelValues.Info,
+        ConsoleLogLevel.Warn => ConsoleMessageLevelValues.Warning,
+        ConsoleLogLevel.Error => ConsoleMessageLevelValues.Error,
+        _ => ConsoleMessageLevelValues.Log,
+    };
+}

--- a/Jint.DevTools/Domains/ConsoleJournal.cs
+++ b/Jint.DevTools/Domains/ConsoleJournal.cs
@@ -1,0 +1,228 @@
+using Jint.Native;
+using Jint.Runtime;
+using Jint.WebApi;
+
+namespace Jint.DevTools.Domains;
+
+/// <summary>
+/// One thing that happened in the engine which a client wants to hear about, whether or not anybody was
+/// listening at the time.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Three of them — a <c>console</c> call, an exception nobody caught, a promise rejected with no handler —
+/// and all three arrive on the engine thread from inside the engine, where there is no command to answer and
+/// nothing to <c>await</c> onto.
+/// </para>
+/// <para>
+/// Default implementations throughout, because a domain hears about one of the three and not the others: the
+/// <c>Runtime</c> domain hears all of it, <c>Console</c> hears console calls, <c>Log</c> hears failures.
+/// </para>
+/// </remarks>
+internal interface ITargetObserver
+{
+    /// <summary>One <c>console</c> call, already journalled.</summary>
+    void ConsoleRecorded(ConsoleEntry entry)
+    {
+    }
+
+    /// <summary>One exception that escaped the engine's own pump.</summary>
+    void ExceptionThrown(JavaScriptException exception)
+    {
+    }
+
+    /// <summary>One promise rejected with nothing to handle it.</summary>
+    void RejectionThrown(JsValue promise, JsValue reason)
+    {
+    }
+
+    /// <summary>One previously unhandled rejection that has since been handled.</summary>
+    void RejectionHandled(JsValue promise)
+    {
+    }
+}
+
+/// <summary>
+/// One journalled <c>console</c> call: what the engine saw, plus the handles every attachment has minted for
+/// it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The arguments are copied out of the record.</b> <see cref="ConsoleRecord.Arguments"/> is documented as
+/// valid only for the duration of the sink's call, so what is kept here is an array of this journal's own —
+/// which holds the values strongly, exactly as a remote-object handle does, and is why the journal is
+/// bounded.
+/// </para>
+/// <para>
+/// The identifiers are recorded per entry rather than per session so that evicting an entry releases every
+/// handle any attachment minted for it. Without that a long-running page that logs objects would keep every
+/// one of them alive for as long as a client stayed attached.
+/// </para>
+/// </remarks>
+internal sealed class ConsoleEntry
+{
+    private List<string>? _handles;
+
+    internal ConsoleEntry(in ConsoleRecord record, double timestamp)
+    {
+        Method = record.Method;
+        Level = record.Level;
+        Message = record.Message;
+        GroupDepth = record.GroupDepth;
+        Timestamp = timestamp;
+
+        var arguments = record.Arguments;
+        if (arguments.Count == 0)
+        {
+            Arguments = [];
+        }
+        else
+        {
+            var copy = new JsValue[arguments.Count];
+            for (var i = 0; i < copy.Length; i++)
+            {
+                copy[i] = arguments[i];
+            }
+
+            Arguments = copy;
+        }
+
+        StackTrace = record.StackTrace is { Count: > 0 } frames ? [.. frames] : null;
+    }
+
+    /// <summary>Gets which console method was called.</summary>
+    internal ConsoleMethod Method { get; }
+
+    /// <summary>Gets the severity that method implies.</summary>
+    internal ConsoleLogLevel Level { get; }
+
+    /// <summary>Gets the arguments, held strongly for as long as this entry is in the journal.</summary>
+    internal JsValue[] Arguments { get; }
+
+    /// <summary>Gets the finished line, or <see langword="null"/> when the method printed nothing.</summary>
+    internal string? Message { get; }
+
+    /// <summary>Gets how many <c>console.group</c>s were open.</summary>
+    internal int GroupDepth { get; }
+
+    /// <summary>Gets when the call happened, in milliseconds since the Unix epoch.</summary>
+    internal double Timestamp { get; }
+
+    /// <summary>Gets the captured frames of a <c>console.trace</c>, or <see langword="null"/>.</summary>
+    internal ConsoleStackFrame[]? StackTrace { get; }
+
+    /// <summary>Records that an attachment minted <paramref name="objectId"/> for one of these arguments.</summary>
+    /// <remarks>
+    /// Minting happens on the engine thread and releasing may not — a target disposed from anywhere empties
+    /// the journal — so the one list both touch is locked. It is taken once per console argument.
+    /// </remarks>
+    internal void Minted(string objectId)
+    {
+        lock (this)
+        {
+            (_handles ??= []).Add(objectId);
+        }
+    }
+
+    /// <summary>Releases every handle minted for this entry, which is what falling out of the journal means.</summary>
+    internal void Release(RemoteObjectTable table)
+    {
+        List<string>? handles;
+
+        lock (this)
+        {
+            handles = _handles;
+            _handles = null;
+        }
+
+        if (handles is null)
+        {
+            return;
+        }
+
+        foreach (var objectId in handles)
+        {
+            table.Release(objectId);
+        }
+    }
+}
+
+/// <summary>
+/// The last few <c>console</c> calls, so that a client attaching after the fact is not told there was
+/// silence.
+/// </summary>
+/// <remarks>
+/// <para>
+/// V8 keeps such a store and reports it on <c>Runtime.enable</c> and <c>Console.enable</c>, which is what
+/// makes a front end opened halfway through a run useful rather than empty. This one is the same idea with
+/// the bound stated: <see cref="MaxEntries"/> calls, after which the oldest is dropped and every handle
+/// minted for it released.
+/// </para>
+/// <para>
+/// It lives on the <see cref="EngineTarget"/>, because the values in it belong to the engine and every
+/// attachment replays the same history. <c>Runtime.discardConsoleEntries</c> and
+/// <c>Console.clearMessages</c> both empty it — which is what those commands mean, and why they are not the
+/// no-op they were.
+/// </para>
+/// </remarks>
+internal sealed class ConsoleJournal
+{
+    /// <summary>
+    /// How many calls are kept. Every one of them holds its arguments alive, so this is a memory bound
+    /// before it is a replay bound: a page that logs a large object every second keeps the last hundred.
+    /// </summary>
+    private const int MaxEntries = 100;
+
+    private readonly object _gate = new();
+    private readonly Queue<ConsoleEntry> _entries = new();
+
+    /// <summary>Journals one call and answers the entry, for the caller to hand to the observers.</summary>
+    internal ConsoleEntry Add(in ConsoleRecord record, double timestamp, RemoteObjectTable table)
+    {
+        var entry = new ConsoleEntry(in record, timestamp);
+        ConsoleEntry? evicted = null;
+
+        lock (_gate)
+        {
+            _entries.Enqueue(entry);
+            if (_entries.Count > MaxEntries)
+            {
+                evicted = _entries.Dequeue();
+            }
+        }
+
+        evicted?.Release(table);
+        return entry;
+    }
+
+    /// <summary>Answers what a client enabling after the fact is owed, oldest first.</summary>
+    internal ConsoleEntry[] Snapshot()
+    {
+        lock (_gate)
+        {
+            return _entries.Count == 0 ? [] : [.. _entries];
+        }
+    }
+
+    /// <summary>Empties the journal, releasing every handle any attachment minted for what was in it.</summary>
+    internal void Clear(RemoteObjectTable table)
+    {
+        ConsoleEntry[] cleared;
+
+        lock (_gate)
+        {
+            if (_entries.Count == 0)
+            {
+                return;
+            }
+
+            cleared = [.. _entries];
+            _entries.Clear();
+        }
+
+        foreach (var entry in cleared)
+        {
+            entry.Release(table);
+        }
+    }
+}

--- a/Jint.DevTools/Domains/LogDomain.cs
+++ b/Jint.DevTools/Domains/LogDomain.cs
@@ -1,0 +1,124 @@
+using Jint.DevTools.Protocol;
+using Jint.DevTools.Protocol.Log;
+using Jint.DevTools.Session;
+using Jint.Native;
+using Jint.Runtime;
+
+namespace Jint.DevTools.Domains;
+
+/// <summary>
+/// The <c>Log</c> domain: what went wrong, as the one entry stream a client watches for failures.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every recorded automation client sends <c>Log.enable</c> while connecting — Puppeteer, PuppeteerSharp and
+/// Playwright all do — and then waits for <c>Log.entryAdded</c>. On a page it carries network failures,
+/// deprecations and violations; on an engine target the only thing there is to report is script that failed,
+/// so that is what it reports: an exception that escaped the pump, and a promise rejected with nothing to
+/// handle it.
+/// </para>
+/// <para>
+/// <b>There is no store, and <c>enable</c> replays nothing.</b> The protocol says the command sends the
+/// entries collected so far; an engine target collects none, because the console journal is the history that
+/// exists and it is the <c>Console</c> and <c>Runtime</c> domains that replay it. A client enabling after a
+/// failure hears about the next one.
+/// </para>
+/// <para>
+/// See <see href="https://chromedevtools.github.io/devtools-protocol/tot/Log/"/>.
+/// </para>
+/// </remarks>
+internal sealed class LogDomain : LogDomainBase, ITargetObserver
+{
+    /// <inheritdoc/>
+    protected override async ValueTask<EmptyResult> EnableAsync(EmptyParameters parameters, CommandContext context)
+    {
+        await MarkEnabledAsync(context).ConfigureAwait(false);
+        return EmptyResult.Instance;
+    }
+
+    /// <inheritdoc/>
+    protected override async ValueTask<EmptyResult> DisableAsync(EmptyParameters parameters, CommandContext context)
+    {
+        await MarkDisabledAsync(context).ConfigureAwait(false);
+        return EmptyResult.Instance;
+    }
+
+    /// <summary>Clears a store this target does not keep, which is the success a client expects.</summary>
+    protected override ValueTask<EmptyResult> ClearAsync(EmptyParameters parameters, CommandContext context)
+    {
+        return new ValueTask<EmptyResult>(EmptyResult.Instance);
+    }
+
+    /// <summary>
+    /// Answers the success a client expects and reports no violations.
+    /// </summary>
+    /// <remarks>
+    /// A violation is a rendering or a blocking-call budget — a long task, a forced reflow, a slow event
+    /// handler — measured by a renderer this target does not have. Refusing would read to a client as a
+    /// broken target; reporting nothing is the truth.
+    /// </remarks>
+    protected override ValueTask<EmptyResult> StartViolationsReportAsync(StartViolationsReportRequest parameters, CommandContext context)
+    {
+        return new ValueTask<EmptyResult>(EmptyResult.Instance);
+    }
+
+    /// <inheritdoc cref="StartViolationsReportAsync"/>
+    protected override ValueTask<EmptyResult> StopViolationsReportAsync(EmptyParameters parameters, CommandContext context)
+    {
+        return new ValueTask<EmptyResult>(EmptyResult.Instance);
+    }
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// The text is the error's message and stack, rendered under the engine's own result limits: reading a
+    /// <c>stack</c> a script defined as an accessor runs that script, and a client watching a log stream
+    /// must not be what makes a page's code run unbounded.
+    /// </remarks>
+    void ITargetObserver.ExceptionThrown(JavaScriptException exception)
+    {
+        var location = exception.Location;
+        var limits = (exception.Error as Native.Object.ObjectInstance)?.Engine.Options.ResultLimits;
+
+        var text = limits is null
+            ? exception.GetJavaScriptErrorString()
+            : exception.GetJavaScriptErrorString(limits);
+
+        Report(text, location.SourceFile, location.Start.Line);
+    }
+
+    /// <inheritdoc/>
+    void ITargetObserver.RejectionThrown(JsValue promise, JsValue reason)
+    {
+        // The reason's own text, rendered without running its toString: a rejection reason is any value, and
+        // a client watching a log stream must not be what makes a page's code run.
+        Report("Uncaught (in promise) " + SafeText(reason), url: null, line: 0);
+    }
+
+    private void Report(string text, string? url, int line)
+    {
+        if (!IsEnabled)
+        {
+            return;
+        }
+
+        EmitDetached(LogEvents.EntryAdded(new EntryAddedEvent
+        {
+            Entry = new LogEntry
+            {
+                Source = LogEntrySourceValues.Javascript,
+                Level = LogEntryLevelValues.Error,
+                Text = text,
+                Timestamp = EngineTarget.UnixMilliseconds(),
+                Url = string.IsNullOrEmpty(url) ? null : url,
+
+                // The protocol counts a log entry's line from one, unlike a call frame's; a location the
+                // engine never filled in is left out rather than reported as line zero.
+                LineNumber = line > 0 ? line : null,
+            },
+        }));
+    }
+
+#pragma warning disable JINT0002 // ValueInspector is the engine's getter-free describer; this is what it is for
+    private static string SafeText(JsValue value) => Diagnostics.ValueInspector.Describe(value).Description;
+#pragma warning restore JINT0002
+}

--- a/Jint.DevTools/Domains/RemoteObjectMapper.cs
+++ b/Jint.DevTools/Domains/RemoteObjectMapper.cs
@@ -221,13 +221,20 @@ internal sealed class RemoteObjectMapper
     /// <summary>Releases every handle this mapper minted under <paramref name="objectGroup"/>.</summary>
     internal void ReleaseGroup(string objectGroup) => Table.ReleaseGroup(_owner, objectGroup);
 
+    /// <summary>
+    /// The thrown value, described with the message-and-stack text a front end prints in its console.
+    /// </summary>
+    /// <remarks>
+    /// <b>This is the one place besides <c>returnByValue</c> where script may run.</b> Rendering an error's
+    /// text reads its <c>stack</c>, which a script may have defined as an accessor — so the render is asked
+    /// for under the engine's own <see cref="ResultLimits"/>, which bounds both what it may execute and how
+    /// much it may produce. It is asked for at all because the stack is the whole reason a client is looking
+    /// at the value; the inspector's getter-free one-liner is the class name alone.
+    /// </remarks>
     private RemoteObject ThrownValue(JavaScriptException exception)
     {
         var described = Describe(exception.Error, RemoteObjectRequest.Description);
-
-        // The description a client renders for an error is the message plus the stack, which is what the
-        // engine already renders for its own exception text; the inspector's one-liner is the class name.
-        return described with { Description = exception.GetJavaScriptErrorString() };
+        return described with { Description = exception.GetJavaScriptErrorString(_target.Engine.Options.ResultLimits) };
     }
 
     private static RemoteObject Number(JsValue value)

--- a/Jint.DevTools/Domains/RuntimeDomain.Events.cs
+++ b/Jint.DevTools/Domains/RuntimeDomain.Events.cs
@@ -1,0 +1,243 @@
+using Jint.DevTools.Protocol.Runtime;
+using Jint.DevTools.Session;
+using Jint.Native;
+using Jint.Runtime;
+using Jint.WebApi;
+
+namespace Jint.DevTools.Domains;
+
+/// <summary>
+/// What the <c>Runtime</c> domain says without being asked: what a script logged, and what it threw with
+/// nothing to catch it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every one of these arrives on the engine thread from <i>inside</i> the engine — a <c>console</c> call, a
+/// promise settling, an exception escaping the pump — where there is no command to answer and nothing to
+/// <c>await</c> onto. They go out through <c>EmitDetached</c>, which queues rather than writes and never
+/// lets a transport failure erupt into the host's own loop.
+/// </para>
+/// <para>
+/// A domain that is not enabled says nothing at all, which is the protocol's rule and also what keeps the
+/// engine-side cost of an unattached target at zero.
+/// </para>
+/// </remarks>
+internal sealed partial class RuntimeDomain
+{
+    /// <summary>
+    /// The object group every <c>console</c> argument is billed to, which is the name Chrome uses and the
+    /// one a client sends to <c>releaseObjectGroup</c> when it stops caring about its console history.
+    /// </summary>
+    private const string ConsoleObjectGroup = "console";
+
+    /// <summary>
+    /// How many unhandled rejections are remembered so that a later handler can revoke the right one. A
+    /// rejection older than this is never revoked, which shows in a client as an error that stays on screen.
+    /// </summary>
+    private const int MaxTrackedRejections = 64;
+
+    /// <summary>What Chrome says when a rejection turns out to have a handler after all.</summary>
+    private const string RevokedReason = "Handler added to rejected promise";
+
+    private readonly List<(JsValue Promise, int ExceptionId)> _rejections = [];
+
+    /// <inheritdoc/>
+    void ITargetObserver.ConsoleRecorded(ConsoleEntry entry)
+    {
+        if (!IsEnabled)
+        {
+            return;
+        }
+
+        EmitDetached(RuntimeEvents.ConsoleAPICalled(ConsoleCall(entry)));
+    }
+
+    /// <inheritdoc/>
+    void ITargetObserver.ExceptionThrown(JavaScriptException exception)
+    {
+        if (!IsEnabled)
+        {
+            return;
+        }
+
+        EmitDetached(RuntimeEvents.ExceptionThrown(new ExceptionThrownEvent
+        {
+            Timestamp = EngineTarget.UnixMilliseconds(),
+            ExceptionDetails = _objects.Exception(exception, NextExceptionId(), MainExecutionContextId),
+        }));
+    }
+
+    /// <inheritdoc/>
+    void ITargetObserver.RejectionThrown(JsValue promise, JsValue reason)
+    {
+        if (!IsEnabled)
+        {
+            return;
+        }
+
+        var exceptionId = NextExceptionId();
+        Track(promise, exceptionId);
+
+        EmitDetached(RuntimeEvents.ExceptionThrown(new ExceptionThrownEvent
+        {
+            Timestamp = EngineTarget.UnixMilliseconds(),
+            ExceptionDetails = _objects.Rejection(reason, exceptionId, MainExecutionContextId),
+        }));
+    }
+
+    /// <inheritdoc/>
+    void ITargetObserver.RejectionHandled(JsValue promise)
+    {
+        if (!IsEnabled || !Untrack(promise, out var exceptionId))
+        {
+            return;
+        }
+
+        EmitDetached(RuntimeEvents.ExceptionRevoked(new ExceptionRevokedEvent
+        {
+            Reason = RevokedReason,
+            ExceptionId = exceptionId,
+        }));
+    }
+
+    /// <summary>Replays the journal to a client that enabled the domain after the fact.</summary>
+    /// <remarks>
+    /// V8 does the same, and it is what makes a front end opened halfway through a run useful rather than
+    /// empty. The context announcement goes first, because every one of these names it.
+    /// </remarks>
+    private async ValueTask ReplayConsoleAsync(CommandContext context)
+    {
+        foreach (var entry in _target.Console.Snapshot())
+        {
+            await EmitAsync(RuntimeEvents.ConsoleAPICalled(ConsoleCall(entry)), context.CancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Turns one journalled call into the event, minting a handle per argument in the console group.
+    /// </summary>
+    /// <remarks>
+    /// The identifiers are recorded on the entry, so that the entry falling out of the journal releases
+    /// them. A client may release the whole lot early with
+    /// <c>Runtime.releaseObjectGroup("console")</c>, which is what its own "clear console" does.
+    /// </remarks>
+    private ConsoleAPICalledEvent ConsoleCall(ConsoleEntry entry)
+    {
+        var request = new RemoteObjectRequest
+        {
+            Addressable = true,
+            GeneratePreview = true,
+            ObjectGroup = ConsoleObjectGroup,
+        };
+
+        var arguments = entry.Arguments;
+        var mapped = new RemoteObject[arguments.Length];
+
+        for (var i = 0; i < arguments.Length; i++)
+        {
+            var described = _objects.Describe(arguments[i], request);
+            if (described.ObjectId is { } objectId)
+            {
+                entry.Minted(objectId);
+            }
+
+            mapped[i] = described;
+        }
+
+        return new ConsoleAPICalledEvent
+        {
+            Type = ConsoleType(entry.Method),
+            Args = mapped,
+            ExecutionContextId = MainExecutionContextId,
+            Timestamp = entry.Timestamp,
+            StackTrace = StackTraceOf(entry.StackTrace),
+        };
+    }
+
+    /// <summary>
+    /// Which of the protocol's console types a <see cref="ConsoleMethod"/> is.
+    /// </summary>
+    /// <remarks>
+    /// Four of the engine's methods have no type of their own in the protocol and are folded into the
+    /// nearest one that exists: <c>countReset</c> into <c>count</c>, and the three timer methods into
+    /// <c>timeEnd</c>, which is the only timer type the protocol has. <c>timeStamp</c> is a marker Chrome
+    /// routes to its timeline rather than to its console, so it arrives as an ordinary log line. A method
+    /// the engine adds later reads as <c>log</c> rather than as an error, which is what the enum's own
+    /// documentation asks of a reader.
+    /// </remarks>
+    private static string ConsoleType(ConsoleMethod method) => method switch
+    {
+        ConsoleMethod.Debug => ConsoleAPICalledEventTypeValues.Debug,
+        ConsoleMethod.Info => ConsoleAPICalledEventTypeValues.Info,
+        ConsoleMethod.Warn => ConsoleAPICalledEventTypeValues.Warning,
+        ConsoleMethod.Error => ConsoleAPICalledEventTypeValues.Error,
+        ConsoleMethod.Trace => ConsoleAPICalledEventTypeValues.Trace,
+        ConsoleMethod.Assert => ConsoleAPICalledEventTypeValues.Assert,
+        ConsoleMethod.Dir => ConsoleAPICalledEventTypeValues.Dir,
+        ConsoleMethod.Table => ConsoleAPICalledEventTypeValues.Table,
+        ConsoleMethod.Group => ConsoleAPICalledEventTypeValues.StartGroup,
+        ConsoleMethod.GroupCollapsed => ConsoleAPICalledEventTypeValues.StartGroupCollapsed,
+        ConsoleMethod.GroupEnd => ConsoleAPICalledEventTypeValues.EndGroup,
+        ConsoleMethod.Count or ConsoleMethod.CountReset => ConsoleAPICalledEventTypeValues.Count,
+        ConsoleMethod.Time or ConsoleMethod.TimeLog or ConsoleMethod.TimeEnd => ConsoleAPICalledEventTypeValues.TimeEnd,
+        _ => ConsoleAPICalledEventTypeValues.Log,
+    };
+
+    /// <summary>
+    /// The frames a <c>console.trace</c> captured, in the protocol's own counting.
+    /// </summary>
+    /// <remarks>
+    /// The engine counts lines and columns from one and the protocol counts both from zero. The script
+    /// identifier is empty, because scripts are not registered until the <c>Debugger</c> domain arrives; a
+    /// front end falls back to the URL, which is what an engine target has.
+    /// </remarks>
+    private static StackTrace? StackTraceOf(ConsoleStackFrame[]? frames)
+    {
+        if (frames is null || frames.Length == 0)
+        {
+            return null;
+        }
+
+        var callFrames = new CallFrame[frames.Length];
+        for (var i = 0; i < frames.Length; i++)
+        {
+            var frame = frames[i];
+            callFrames[i] = new CallFrame
+            {
+                FunctionName = frame.FunctionName,
+                ScriptId = "",
+                Url = frame.Source,
+                LineNumber = Math.Max(0, frame.Line - 1),
+                ColumnNumber = Math.Max(0, frame.Column - 1),
+            };
+        }
+
+        return new StackTrace { CallFrames = callFrames };
+    }
+
+    private void Track(JsValue promise, int exceptionId)
+    {
+        if (_rejections.Count >= MaxTrackedRejections)
+        {
+            _rejections.RemoveAt(0);
+        }
+
+        _rejections.Add((promise, exceptionId));
+    }
+
+    private bool Untrack(JsValue promise, out int exceptionId)
+    {
+        for (var i = 0; i < _rejections.Count; i++)
+        {
+            if (ReferenceEquals(_rejections[i].Promise, promise))
+            {
+                exceptionId = _rejections[i].ExceptionId;
+                _rejections.RemoveAt(i);
+                return true;
+            }
+        }
+
+        exceptionId = 0;
+        return false;
+    }
+}

--- a/Jint.DevTools/Domains/RuntimeDomain.cs
+++ b/Jint.DevTools/Domains/RuntimeDomain.cs
@@ -29,7 +29,7 @@ namespace Jint.DevTools.Domains;
 /// See <see href="https://chromedevtools.github.io/devtools-protocol/tot/Runtime/"/>.
 /// </para>
 /// </remarks>
-internal sealed partial class RuntimeDomain : RuntimeDomainBase, IBindingListener
+internal sealed partial class RuntimeDomain : RuntimeDomainBase, IBindingListener, ITargetObserver
 {
     /// <summary>
     /// The one execution context an engine target has. Chrome numbers page contexts from 1 and so does this;
@@ -84,7 +84,7 @@ internal sealed partial class RuntimeDomain : RuntimeDomainBase, IBindingListene
     /// outlives every session, so a client attaching later would otherwise never hear of it. That is V8's
     /// behaviour too.
     /// </remarks>
-    protected override ValueTask OnEnabledAsync(CommandContext context)
+    protected override async ValueTask OnEnabledAsync(CommandContext context)
     {
         var created = new ExecutionContextCreatedEvent
         {
@@ -101,7 +101,8 @@ internal sealed partial class RuntimeDomain : RuntimeDomainBase, IBindingListene
             },
         };
 
-        return EmitAsync(RuntimeEvents.ExecutionContextCreated(created), context.CancellationToken);
+        await EmitAsync(RuntimeEvents.ExecutionContextCreated(created), context.CancellationToken).ConfigureAwait(false);
+        await ReplayConsoleAsync(context).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -112,14 +113,16 @@ internal sealed partial class RuntimeDomain : RuntimeDomainBase, IBindingListene
     }
 
     /// <summary>
-    /// Answers nothing, and truthfully: this package keeps no console buffer to discard.
+    /// Empties the journal every attachment replays, and releases the handles minted for what was in it.
     /// </summary>
     /// <remarks>
-    /// Answered rather than refused because clients send it while tidying up and a <c>-32601</c> there is
-    /// noise in a client's log about a state it does not have.
+    /// The journal is the target's, so this discards for every attachment rather than only for the one that
+    /// asked. That is what the command means — Chrome's console history is the page's and not the session's
+    /// — and it is why a client sends it when a user clears the console.
     /// </remarks>
     protected override ValueTask<EmptyResult> DiscardConsoleEntriesAsync(EmptyParameters parameters, CommandContext context)
     {
+        _target.Console.Clear(_target.RemoteObjects);
         return new ValueTask<EmptyResult>(EmptyResult.Instance);
     }
 

--- a/Jint.DevTools/EngineTarget.cs
+++ b/Jint.DevTools/EngineTarget.cs
@@ -1,5 +1,8 @@
 using Jint.DevTools.Domains;
 using Jint.DevTools.Session;
+using Jint.Native.Promise;
+using Jint.Runtime;
+using Jint.WebApi;
 
 namespace Jint.DevTools;
 
@@ -43,7 +46,10 @@ public sealed class EngineTarget : IAsyncDisposable
     private readonly CancellationTokenSource? _stopping;
     private readonly Thread? _thread;
     private readonly ManualResetEventSlim? _debuggerWaitEnded;
+    private readonly DevToolsConsoleSink? _console;
+    private readonly object _observerLock = new();
 
+    private ITargetObserver[] _observers = [];
     private int _disposed;
 
     /// <summary>Creates a target over <paramref name="engine"/>.</summary>
@@ -68,6 +74,21 @@ public sealed class EngineTarget : IAsyncDisposable
         RemoteObjects = new RemoteObjectTable(Interlocked.Increment(ref _serial));
 
         _dispatcher = new EngineDispatcher(engine, DevToolsServerOptions.DefaultCommandTimeout, options.WaitForDebuggerOnStart);
+
+        // Console records reach a client only if the engine was built with UseDevTools, which is what
+        // installed the sink this binds to. An engine built without it is attachable and evaluable and says
+        // nothing about what its scripts logged, which is stated rather than silently half-true.
+        _console = engine.Options.WebApi.Console.Sink as DevToolsConsoleSink;
+        if (_console?.TryBind(this) == false)
+        {
+            // A second engine built from one Options instance. The first target speaks for that sink; this
+            // one keeps everything else and reports no console traffic.
+            _console = null;
+        }
+
+        // An unhandled rejection is an event rather than a command, so the subscription is the target's and
+        // outlives every attachment. It is taken before the loop thread starts, so nothing is missed.
+        engine.Tasks.PromiseRejectionTracker += OnPromiseRejection;
 
         if (options.WaitForDebuggerOnStart)
         {
@@ -139,6 +160,77 @@ public sealed class EngineTarget : IAsyncDisposable
 
     /// <summary>Gets the global functions <c>Runtime.addBinding</c> installed, and who hears them.</summary>
     internal BindingRegistry Bindings { get; } = new();
+
+    /// <summary>Gets the last few <c>console</c> calls, which a client enabling after the fact is replayed.</summary>
+    internal ConsoleJournal Console { get; } = new();
+
+    /// <summary>
+    /// Reports one exception that escaped the engine, so that every attached client hears about it.
+    /// </summary>
+    /// <param name="exception">What escaped.</param>
+    /// <remarks>
+    /// <para>
+    /// A <see cref="ThreadMode.LibraryOwned"/> target calls this itself, for anything a timer callback, a
+    /// promise reaction or a host job let out of <see cref="Engine.TaskOperations.ProcessTasks"/>. A
+    /// <see cref="ThreadMode.HostOwned"/> host owns its own loop, so it is the one that catches — and this
+    /// is how it tells a client, in the shape a client already understands: <c>Runtime.exceptionThrown</c>
+    /// and <c>Log.entryAdded</c>.
+    /// </para>
+    /// <para>
+    /// <b>Reporting is not handling.</b> It writes to whoever is attached and returns; whether the host
+    /// swallows the exception, rethrows it or ends the run is the host's decision and this changes none of
+    /// it. With no client attached it does nothing at all.
+    /// </para>
+    /// <para>
+    /// Call it on the engine's own thread, like everything else that carries a <see cref="Native.JsValue"/>
+    /// — the exception's error value is one.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ArgumentNullException"><paramref name="exception"/> is <see langword="null"/>.</exception>
+    public void ReportUncaughtException(JavaScriptException exception)
+    {
+        if (exception is null)
+        {
+            Throw.ArgumentNull(nameof(exception));
+        }
+
+        foreach (var observer in Volatile.Read(ref _observers))
+        {
+            observer.ExceptionThrown(exception);
+        }
+    }
+
+    /// <summary>Registers what hears the engine's own events, from the attachment that owns them.</summary>
+    internal void Observe(ITargetObserver observer)
+    {
+        lock (_observerLock)
+        {
+            _observers = [.. _observers, observer];
+        }
+    }
+
+    /// <summary>Stops telling <paramref name="observer"/> anything, which is what detaching means.</summary>
+    internal void Unobserve(ITargetObserver observer)
+    {
+        lock (_observerLock)
+        {
+            _observers = [.. _observers.Where(candidate => !ReferenceEquals(candidate, observer))];
+        }
+    }
+
+    /// <summary>Journals one <c>console</c> call and tells everyone attached, on the engine thread.</summary>
+    internal void Record(in ConsoleRecord record)
+    {
+        var entry = Console.Add(in record, UnixMilliseconds(), RemoteObjects);
+
+        foreach (var observer in Volatile.Read(ref _observers))
+        {
+            observer.ConsoleRecorded(entry);
+        }
+    }
+
+    /// <summary>The protocol's timestamp: milliseconds since the Unix epoch, as a double.</summary>
+    internal static double UnixMilliseconds() => DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
 
     /// <summary>
     /// Gives the engine one turn: answers the protocol commands waiting for it, then runs the event loop.
@@ -300,8 +392,15 @@ public sealed class EngineTarget : IAsyncDisposable
             return;
         }
 
+        // The engine is the host's, before and after: a disposed target stops reaching into it first, so
+        // that nothing arrives after the release below.
+        Engine.Tasks.PromiseRejectionTracker -= OnPromiseRejection;
+        _console?.Unbind(this);
+
         // A handle is a promise to keep a value alive until the client releases it, and there is no client
-        // left to release one. Dropping the references runs no engine code, so it is safe from here.
+        // left to release one. Dropping the references runs no engine code, so it is safe from here, and so
+        // is letting go of the journal that was holding the arguments of the last hundred console calls.
+        Console.Clear(RemoteObjects);
         RemoteObjects.Clear();
 
         if (_stopping is not null)
@@ -334,13 +433,65 @@ public sealed class EngineTarget : IAsyncDisposable
             {
                 return;
             }
+            catch (JavaScriptException exception)
+            {
+                // Script that escaped the pump — a timer callback, a promise reaction, an event listener.
+                // The loop swallows it either way, because the next turn is still owed to every other
+                // client; what changed is that a client now hears about it instead of it vanishing.
+                Report(exception);
+            }
 #pragma warning disable CA1031 // the loop is the last thing between one bad command and a dead target
             catch (Exception)
 #pragma warning restore CA1031
             {
-                // A host callback or a script that threw out of the pump must not end the thread: every
-                // protocol command already answers its own failure, so what reaches here is host work, and
-                // the next turn is still owed to every other client.
+                // Host work that threw. There is no protocol shape for a CLR exception — Runtime.exceptionThrown
+                // carries a JavaScript error — so it is the host's own business, as it was before.
+            }
+        }
+    }
+
+    /// <summary>Reports without letting the report itself end the loop.</summary>
+    private void Report(JavaScriptException exception)
+    {
+        try
+        {
+            ReportUncaughtException(exception);
+        }
+#pragma warning disable CA1031 // a failure to tell a client is not a reason to stop running the engine
+        catch (Exception)
+#pragma warning restore CA1031
+        {
+        }
+    }
+
+    /// <summary>
+    /// The engine's own unhandled-rejection channel, which is where <c>Runtime.exceptionThrown</c> and
+    /// <c>Runtime.exceptionRevoked</c> come from.
+    /// </summary>
+    /// <remarks>
+    /// The engine raises <c>Reject</c> the moment a promise is rejected with nothing to handle it, and
+    /// <c>Handle</c> if something handles it afterwards. V8 waits for the end of the microtask checkpoint
+    /// before deciding, so a rejection handled on the very next line produces a throw and a revoke here
+    /// where Chrome produces neither — which is exactly the pair <c>exceptionRevoked</c> exists for, and is
+    /// why the identifier is remembered rather than the event delayed.
+    /// </remarks>
+    private void OnPromiseRejection(object? sender, PromiseRejectionTrackerEventArgs arguments)
+    {
+        var observers = Volatile.Read(ref _observers);
+        if (observers.Length == 0)
+        {
+            return;
+        }
+
+        foreach (var observer in observers)
+        {
+            if (arguments.Operation == PromiseRejectionOperation.Reject)
+            {
+                observer.RejectionThrown(arguments.Promise, arguments.Value ?? Native.JsValue.Undefined);
+            }
+            else
+            {
+                observer.RejectionHandled(arguments.Promise);
             }
         }
     }

--- a/Jint.DevTools/Protocol/Generated/Console.g.cs
+++ b/Jint.DevTools/Protocol/Generated/Console.g.cs
@@ -140,8 +140,35 @@ namespace Jint.DevTools.Domains
             => global::Jint.DevTools.Throw.MethodNotFound<global::System.Threading.Tasks.ValueTask<global::Jint.DevTools.Protocol.EmptyResult>>("Console.enable");
 
         /// <inheritdoc/>
-        internal sealed override global::System.Threading.Tasks.ValueTask<string> DispatchAsync(string method, global::System.Text.Json.JsonElement? parameters, global::Jint.DevTools.Session.CommandContext context)
-            => global::Jint.DevTools.Throw.MethodNotFound<global::System.Threading.Tasks.ValueTask<string>>("Console." + method);
+        internal sealed override async global::System.Threading.Tasks.ValueTask<string> DispatchAsync(string method, global::System.Text.Json.JsonElement? parameters, global::Jint.DevTools.Session.CommandContext context)
+        {
+            switch (method)
+            {
+                case "clearMessages":
+                {
+                    var result = await ClearMessagesAsync(global::Jint.DevTools.Protocol.ProtocolPayload.Read(parameters, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.EmptyParameters), context).ConfigureAwait(false);
+                    return global::System.Text.Json.JsonSerializer.Serialize(result, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.EmptyResult);
+                }
+
+                case "disable":
+                {
+                    var result = await DisableAsync(global::Jint.DevTools.Protocol.ProtocolPayload.Read(parameters, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.EmptyParameters), context).ConfigureAwait(false);
+                    return global::System.Text.Json.JsonSerializer.Serialize(result, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.EmptyResult);
+                }
+
+                case "enable":
+                {
+                    var result = await EnableAsync(global::Jint.DevTools.Protocol.ProtocolPayload.Read(parameters, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.EmptyParameters), context).ConfigureAwait(false);
+                    return global::System.Text.Json.JsonSerializer.Serialize(result, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.EmptyResult);
+                }
+
+                // A command manifest.json does not list is method-not-found BEFORE its parameters
+                // are looked at, which is the order Chrome answers in: a command a backend does not
+                // implement is not in its dispatch table at all, so its payload is never read.
+                default:
+                    return global::Jint.DevTools.Throw.MethodNotFound<string>("Console." + method);
+            }
+        }
     }
 
     /// <summary>Builds the <c>Console</c> domain's events.</summary>

--- a/Jint.DevTools/Protocol/Generated/Log.g.cs
+++ b/Jint.DevTools/Protocol/Generated/Log.g.cs
@@ -235,8 +235,47 @@ namespace Jint.DevTools.Domains
             => global::Jint.DevTools.Throw.MethodNotFound<global::System.Threading.Tasks.ValueTask<global::Jint.DevTools.Protocol.EmptyResult>>("Log.stopViolationsReport");
 
         /// <inheritdoc/>
-        internal sealed override global::System.Threading.Tasks.ValueTask<string> DispatchAsync(string method, global::System.Text.Json.JsonElement? parameters, global::Jint.DevTools.Session.CommandContext context)
-            => global::Jint.DevTools.Throw.MethodNotFound<global::System.Threading.Tasks.ValueTask<string>>("Log." + method);
+        internal sealed override async global::System.Threading.Tasks.ValueTask<string> DispatchAsync(string method, global::System.Text.Json.JsonElement? parameters, global::Jint.DevTools.Session.CommandContext context)
+        {
+            switch (method)
+            {
+                case "clear":
+                {
+                    var result = await ClearAsync(global::Jint.DevTools.Protocol.ProtocolPayload.Read(parameters, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.EmptyParameters), context).ConfigureAwait(false);
+                    return global::System.Text.Json.JsonSerializer.Serialize(result, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.EmptyResult);
+                }
+
+                case "disable":
+                {
+                    var result = await DisableAsync(global::Jint.DevTools.Protocol.ProtocolPayload.Read(parameters, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.EmptyParameters), context).ConfigureAwait(false);
+                    return global::System.Text.Json.JsonSerializer.Serialize(result, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.EmptyResult);
+                }
+
+                case "enable":
+                {
+                    var result = await EnableAsync(global::Jint.DevTools.Protocol.ProtocolPayload.Read(parameters, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.EmptyParameters), context).ConfigureAwait(false);
+                    return global::System.Text.Json.JsonSerializer.Serialize(result, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.EmptyResult);
+                }
+
+                case "startViolationsReport":
+                {
+                    var result = await StartViolationsReportAsync(global::Jint.DevTools.Protocol.ProtocolPayload.Read(parameters, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.LogStartViolationsReportRequest), context).ConfigureAwait(false);
+                    return global::System.Text.Json.JsonSerializer.Serialize(result, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.EmptyResult);
+                }
+
+                case "stopViolationsReport":
+                {
+                    var result = await StopViolationsReportAsync(global::Jint.DevTools.Protocol.ProtocolPayload.Read(parameters, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.EmptyParameters), context).ConfigureAwait(false);
+                    return global::System.Text.Json.JsonSerializer.Serialize(result, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.EmptyResult);
+                }
+
+                // A command manifest.json does not list is method-not-found BEFORE its parameters
+                // are looked at, which is the order Chrome answers in: a command a backend does not
+                // implement is not in its dispatch table at all, so its payload is never read.
+                default:
+                    return global::Jint.DevTools.Throw.MethodNotFound<string>("Log." + method);
+            }
+        }
     }
 
     /// <summary>Builds the <c>Log</c> domain's events.</summary>

--- a/Jint.DevTools/Protocol/Generated/ProtocolManifest.g.cs
+++ b/Jint.DevTools/Protocol/Generated/ProtocolManifest.g.cs
@@ -44,6 +44,14 @@ namespace Jint.DevTools.Protocol
         [
             "Browser.close",
             "Browser.getVersion",
+            "Console.clearMessages",
+            "Console.disable",
+            "Console.enable",
+            "Log.clear",
+            "Log.disable",
+            "Log.enable",
+            "Log.startViolationsReport",
+            "Log.stopViolationsReport",
             "Runtime.addBinding",
             "Runtime.awaitPromise",
             "Runtime.callFunctionOn",
@@ -80,7 +88,12 @@ namespace Jint.DevTools.Protocol
         /// <summary>The events this assembly emits.</summary>
         internal static global::System.Collections.Generic.IReadOnlyList<string> ImplementedEvents { get; } =
         [
+            "Console.messageAdded",
+            "Log.entryAdded",
             "Runtime.bindingCalled",
+            "Runtime.consoleAPICalled",
+            "Runtime.exceptionRevoked",
+            "Runtime.exceptionThrown",
             "Runtime.executionContextCreated",
             "Target.attachedToTarget",
             "Target.detachedFromTarget",
@@ -92,6 +105,8 @@ namespace Jint.DevTools.Protocol
         internal static global::System.Collections.Generic.IReadOnlyList<global::Jint.DevTools.Protocol.Schema.Domain> ReportedDomains { get; } =
         [
             new global::Jint.DevTools.Protocol.Schema.Domain { Name = "Browser", Version = "1.3" },
+            new global::Jint.DevTools.Protocol.Schema.Domain { Name = "Console", Version = "1.3" },
+            new global::Jint.DevTools.Protocol.Schema.Domain { Name = "Log", Version = "1.3" },
             new global::Jint.DevTools.Protocol.Schema.Domain { Name = "Runtime", Version = "1.3" },
             new global::Jint.DevTools.Protocol.Schema.Domain { Name = "Schema", Version = "1.3" },
             new global::Jint.DevTools.Protocol.Schema.Domain { Name = "Target", Version = "1.3" },

--- a/Jint.Tests.DevTools/Clients/PuppeteerSharpTests.cs
+++ b/Jint.Tests.DevTools/Clients/PuppeteerSharpTests.cs
@@ -226,6 +226,55 @@ public class PuppeteerSharpTests
         await session.DetachAsync().WaitAsync(Bound);
     }
 
+    /// <summary>
+    /// What a script logged, arriving at a real client as the event it listens for.
+    /// </summary>
+    /// <remarks>
+    /// The console is opt-in, so the engine is built with <see cref="WebApiFeatures.Console"/> as a host
+    /// that wants one builds it; an engine without it has no <c>console</c> object and nothing to report.
+    /// </remarks>
+    [Test]
+    public async Task PuppeteerHearsWhatTheScriptLogged()
+    {
+        await using var server = new DevToolsServer();
+        await server.StartAsync();
+
+        await using var target = new EngineTarget(
+            new Engine(options =>
+            {
+                options.WebApi.Features |= WebApiFeatures.Console;
+                options.UseDevTools();
+            }),
+            new EngineTargetOptions { Url = "jint://console", ThreadMode = ThreadMode.LibraryOwned });
+
+        server.AddTarget(target);
+
+        await using var browser = await ConnectAsync(new ConnectOptions { BrowserWSEndpoint = server.BrowserWebSocketUrl });
+        var session = await SessionForAsync(browser, "jint://console", target.TargetId);
+
+        var logged = new TaskCompletionSource<JsonElement>(TaskCreationOptions.RunContinuationsAsynchronously);
+        session.MessageReceived += (_, message) =>
+        {
+            if (message.MessageID == "Runtime.consoleAPICalled")
+            {
+                logged.TrySetResult(message.MessageData.Clone());
+            }
+        };
+
+        await session.SendAsync("Runtime.enable").WaitAsync(Bound);
+        await session.SendAsync("Runtime.evaluate", new { expression = "console.warn('from the script', { a: 1 })" }).WaitAsync(Bound);
+
+        var call = await logged.Task.WaitAsync(Bound);
+        call.GetProperty("type").GetString().Should().Be("warning");
+
+        var args = call.GetProperty("args").EnumerateArray().ToArray();
+        args[0].GetProperty("value").GetString().Should().Be("from the script");
+        args[1].GetProperty("preview").GetProperty("properties").EnumerateArray().Single()
+            .GetProperty("name").GetString().Should().Be("a");
+
+        await session.DetachAsync().WaitAsync(Bound);
+    }
+
     /// <summary>The <c>result.value</c> of a <c>Runtime.evaluate</c> reply the client handed back.</summary>
     private static JsonElement Value(JsonElement? reply) => reply!.Value.GetProperty("result").GetProperty("value");
 

--- a/Jint.Tests.DevTools/Protocol/HandshakeReplayTests.cs
+++ b/Jint.Tests.DevTools/Protocol/HandshakeReplayTests.cs
@@ -81,7 +81,6 @@ public class HandshakeReplayTests
         ["IO.close"] = "page",
         ["Audits.enable"] = "page",
         ["Performance.enable"] = "page",
-        ["Log.enable"] = "page",
 
         // Engine-level and not written yet. Each needs the debugger seam or the profiler seam, and half of
         // either of those is worse than none.

--- a/Jint.Tests.DevTools/Session/AttachedSession.cs
+++ b/Jint.Tests.DevTools/Session/AttachedSession.cs
@@ -32,12 +32,24 @@ internal sealed class AttachedSession : IAsyncDisposable
     internal ProtocolSession Protocol => _session;
 
     /// <summary>Attaches to a target over one engine, built the way a host that means to attach builds one.</summary>
+    /// <param name="configure">What to do to the engine once it is built.</param>
+    /// <param name="options">How the target presents itself, or the defaults.</param>
+    /// <param name="configureOptions">
+    /// What the host asked for before <c>UseDevTools</c> ran, which is the order a host writes: its own
+    /// console sink, its own web-API features, and then the call that makes the engine attachable.
+    /// </param>
     internal static async Task<AttachedSession> CreateAsync(
         Action<Engine>? configure = null,
-        EngineTargetOptions? options = null)
+        EngineTargetOptions? options = null,
+        Action<Options>? configureOptions = null)
     {
         var session = ProtocolSession.Create();
-        var engine = new Engine(o => o.UseDevTools());
+        var engine = new Engine(o =>
+        {
+            configureOptions?.Invoke(o);
+            o.UseDevTools();
+        });
+
         configure?.Invoke(engine);
 
         options ??= new EngineTargetOptions();

--- a/Jint.Tests.DevTools/Session/ConsoleSessionTests.cs
+++ b/Jint.Tests.DevTools/Session/ConsoleSessionTests.cs
@@ -1,0 +1,355 @@
+using System.Text.Json;
+using Jint.DevTools;
+using Jint.WebApi;
+
+namespace Jint.Tests.DevTools.Session;
+
+/// <summary>
+/// What a script logged, as a client hears it: <c>Runtime.consoleAPICalled</c> with handles and previews,
+/// and the legacy <c>Console</c> domain's flat lines.
+/// </summary>
+/// <remarks>
+/// Every engine here is built with <see cref="WebApiFeatures.Console"/>, because without it there is no
+/// <c>console</c> object to call and nothing to report — which is itself one of the tests.
+/// </remarks>
+public class ConsoleSessionTests
+{
+    [Test]
+    public async Task AConsoleCallReachesTheClientWithHandlesAndPreviews()
+    {
+        await using var session = await ConsoleSessionAsync();
+
+        await session.ResultAsync("Runtime.enable");
+        await session.EvaluateAsync("console.log('answer', { a: 1 }, 42)");
+
+        var called = session.EventsOf("Runtime.consoleAPICalled");
+        called.Should().HaveCount(1);
+
+        var parameters = called[0].GetProperty("params");
+        parameters.GetProperty("type").GetString().Should().Be("log");
+        parameters.GetProperty("executionContextId").GetInt32().Should().Be(1);
+        parameters.GetProperty("timestamp").GetDouble().Should().BeGreaterThan(0);
+
+        var args = parameters.GetProperty("args").EnumerateArray().ToArray();
+        args.Should().HaveCount(3);
+
+        args[0].GetProperty("type").GetString().Should().Be("string");
+        args[0].GetProperty("value").GetString().Should().Be("answer");
+        args[0].Optional("objectId").Should().BeNull("a primitive is sent whole, not held");
+
+        args[1].GetProperty("type").GetString().Should().Be("object");
+        args[1].GetProperty("objectId").GetString().Should().NotBeNullOrEmpty();
+        args[1].GetProperty("preview").GetProperty("properties").EnumerateArray().Single()
+            .GetProperty("name").GetString().Should().Be("a");
+
+        args[2].GetProperty("value").GetInt32().Should().Be(42);
+    }
+
+    [Test]
+    public async Task AConsoleArgumentIsAddressableUntilItsGroupIsReleased()
+    {
+        await using var session = await ConsoleSessionAsync();
+
+        await session.ResultAsync("Runtime.enable");
+        await session.EvaluateAsync("console.log({ a: 1 })");
+
+        var objectId = session.EventsOf("Runtime.consoleAPICalled")[0]
+            .GetProperty("params").GetProperty("args").EnumerateArray().Single()
+            .GetProperty("objectId").GetString()!;
+
+        var properties = await session.PropertiesAsync(objectId, ownProperties: true);
+        properties.Property("a").GetProperty("value").GetProperty("value").GetInt32().Should().Be(1);
+
+        // Which is what a client's own "clear console" sends.
+        await session.ResultAsync("Runtime.releaseObjectGroup", """{"objectGroup":"console"}""");
+
+        (await session.ErrorAsync("Runtime.getProperties", $$"""{"objectId":"{{objectId}}"}"""))
+            .GetProperty("message").GetString().Should().Be("Could not find object with given id");
+    }
+
+    [TestCase("console.debug('x')", "debug")]
+    [TestCase("console.info('x')", "info")]
+    [TestCase("console.warn('x')", "warning")]
+    [TestCase("console.error('x')", "error")]
+    [TestCase("console.dir({})", "dir")]
+    [TestCase("console.table([1])", "table")]
+    [TestCase("console.trace('x')", "trace")]
+    [TestCase("console.assert(false, 'x')", "assert")]
+    [TestCase("console.group('x')", "startGroup")]
+    [TestCase("console.groupCollapsed('x')", "startGroupCollapsed")]
+    [TestCase("console.group('x'); console.groupEnd()", "endGroup")]
+    [TestCase("console.count('x')", "count")]
+    [TestCase("console.time('x'); console.timeEnd('x')", "timeEnd")]
+    public async Task EachConsoleMethodArrivesAsTheProtocolsOwnType(string script, string type)
+    {
+        await using var session = await ConsoleSessionAsync();
+
+        await session.ResultAsync("Runtime.enable");
+        await session.EvaluateAsync(script);
+
+        var types = session.EventsOf("Runtime.consoleAPICalled")
+            .Select(called => called.GetProperty("params").GetProperty("type").GetString());
+
+        types.Should().Contain(type);
+    }
+
+    /// <summary>
+    /// <c>console.trace</c> is the one call that carries frames, and the two countings differ: the engine
+    /// counts lines and columns from one and the protocol counts both from zero.
+    /// </summary>
+    [Test]
+    public async Task ConsoleTraceCarriesTheCapturedFrames()
+    {
+        await using var session = await ConsoleSessionAsync();
+
+        await session.ResultAsync("Runtime.enable");
+        await session.EvaluateAsync("(function outer() { (function inner() { console.trace('here'); })(); })()");
+
+        var parameters = session.EventsOf("Runtime.consoleAPICalled")[0].GetProperty("params");
+        parameters.GetProperty("type").GetString().Should().Be("trace");
+
+        var frames = parameters.GetProperty("stackTrace").GetProperty("callFrames").EnumerateArray().ToArray();
+        frames.Should().NotBeEmpty();
+        frames.Select(frame => frame.GetProperty("functionName").GetString()).Should().Contain("inner");
+        frames[0].GetProperty("lineNumber").GetInt32().Should().BeGreaterThanOrEqualTo(0);
+    }
+
+    /// <summary>
+    /// A client that enables the domain after the fact is replayed the journal, which is what makes a front
+    /// end opened halfway through a run useful rather than empty. V8 does the same.
+    /// </summary>
+    [Test]
+    public async Task EnablingAfterTheFactReplaysWhatWasLogged()
+    {
+        await using var session = await ConsoleSessionAsync();
+
+        await session.EvaluateAsync("console.log('before'); console.warn('also before')");
+        session.EventsOf("Runtime.consoleAPICalled").Should().BeEmpty("a domain nobody enabled says nothing");
+
+        await session.ResultAsync("Runtime.enable");
+
+        var replayed = session.EventsOf("Runtime.consoleAPICalled");
+        replayed.Should().HaveCount(2);
+        replayed[0].GetProperty("params").GetProperty("args").EnumerateArray().Single()
+            .GetProperty("value").GetString().Should().Be("before");
+        replayed[1].GetProperty("params").GetProperty("type").GetString().Should().Be("warning");
+    }
+
+    [Test]
+    public async Task DiscardConsoleEntriesEmptiesTheJournalAndReleasesItsHandles()
+    {
+        await using var session = await ConsoleSessionAsync();
+
+        await session.ResultAsync("Runtime.enable");
+        await session.EvaluateAsync("console.log({ a: 1 })");
+
+        session.Target.RemoteObjects.Count.Should().BeGreaterThan(0);
+
+        await session.ResultAsync("Runtime.discardConsoleEntries");
+
+        session.Target.RemoteObjects.Count.Should().Be(0, "the handles the journal minted go with it");
+
+        // And a client enabling now is replayed nothing.
+        await session.ResultAsync("Runtime.disable");
+        var before = session.EventsOf("Runtime.consoleAPICalled").Count;
+        await session.ResultAsync("Runtime.enable");
+        session.EventsOf("Runtime.consoleAPICalled").Should().HaveCount(before);
+    }
+
+    /// <summary>
+    /// The journal is bounded, and the bound is a memory bound before it is a replay bound: every entry
+    /// holds its arguments alive, so falling out of it has to release the handles minted for them.
+    /// </summary>
+    [Test]
+    public async Task TheJournalIsBoundedAndEvictionReleasesWhatItHeld()
+    {
+        await using var session = await ConsoleSessionAsync();
+
+        await session.ResultAsync("Runtime.enable");
+        await session.EvaluateAsync("console.log({ first: true })");
+
+        var first = session.EventsOf("Runtime.consoleAPICalled")[0]
+            .GetProperty("params").GetProperty("args").EnumerateArray().Single()
+            .GetProperty("objectId").GetString()!;
+
+        await session.EvaluateAsync("for (var i = 0; i < 200; i++) { console.log({ i: i }); }");
+
+        session.Target.RemoteObjects.Count.Should().BeLessThan(
+            201,
+            "a page that logs an object every turn must not keep every one of them alive for as long as a client stays attached");
+
+        (await session.ErrorAsync("Runtime.getProperties", $$"""{"objectId":"{{first}}"}"""))
+            .GetProperty("message").GetString().Should().Be("Could not find object with given id");
+    }
+
+    [Test]
+    public async Task TheConsoleDomainCarriesTheFlatLines()
+    {
+        await using var session = await ConsoleSessionAsync();
+
+        await session.EvaluateAsync("console.log('before enabling')");
+        await session.ResultAsync("Console.enable");
+
+        var replayed = session.EventsOf("Console.messageAdded");
+        replayed.Should().HaveCount(1);
+        replayed[0].GetProperty("params").GetProperty("message").GetProperty("text").GetString().Should().Be("before enabling");
+        replayed[0].GetProperty("params").GetProperty("message").GetProperty("source").GetString().Should().Be("console-api");
+        replayed[0].GetProperty("params").GetProperty("message").GetProperty("level").GetString().Should().Be("log");
+
+        await session.EvaluateAsync("console.error('after enabling')");
+        var all = session.EventsOf("Console.messageAdded");
+        all.Should().HaveCount(2);
+        all[1].GetProperty("params").GetProperty("message").GetProperty("level").GetString().Should().Be("error");
+    }
+
+    /// <summary>
+    /// The <c>Console</c> domain reports lines, so a call that printed nothing is absent from it — while
+    /// <c>Runtime.consoleAPICalled</c> carries it, because a front end draws a group from it.
+    /// </summary>
+    [Test]
+    public async Task ACallThatPrintedNothingIsAbsentFromTheFlatLines()
+    {
+        await using var session = await ConsoleSessionAsync();
+
+        await session.ResultAsync("Console.enable");
+        await session.ResultAsync("Runtime.enable");
+        await session.EvaluateAsync("console.group('open'); console.groupEnd()");
+
+        session.EventsOf("Console.messageAdded").Should().HaveCount(1, "groupEnd prints nothing");
+        session.EventsOf("Runtime.consoleAPICalled").Should().HaveCount(2);
+    }
+
+    [Test]
+    public async Task ConsoleClearMessagesEmptiesTheSameJournal()
+    {
+        await using var session = await ConsoleSessionAsync();
+
+        await session.EvaluateAsync("console.log('gone')");
+        await session.ResultAsync("Console.clearMessages");
+        await session.ResultAsync("Console.enable");
+
+        session.EventsOf("Console.messageAdded").Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task DisablingStopsTheEvents()
+    {
+        await using var session = await ConsoleSessionAsync();
+
+        await session.ResultAsync("Runtime.enable");
+        await session.ResultAsync("Console.enable");
+        await session.ResultAsync("Runtime.disable");
+        await session.ResultAsync("Console.disable");
+
+        var runtime = session.EventsOf("Runtime.consoleAPICalled").Count;
+        await session.EvaluateAsync("console.log('nobody is listening')");
+
+        session.EventsOf("Runtime.consoleAPICalled").Should().HaveCount(runtime);
+        session.EventsOf("Console.messageAdded").Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// The wrapper is a wrapper: a host that set its own sink keeps every line it was getting, in the
+    /// overload it was getting it in.
+    /// </summary>
+    [Test]
+    public async Task TheHostsOwnSinkKeepsEverythingItWasGetting()
+    {
+        var recorded = new RecordingSink();
+
+        await using var session = await AttachedSession.CreateAsync(configureOptions: options =>
+        {
+            options.WebApi.Features |= WebApiFeatures.Console;
+            options.WebApi.Console.Sink = recorded;
+        });
+
+        await session.ResultAsync("Runtime.enable");
+        await session.EvaluateAsync("console.log('to both'); console.groupEnd()");
+
+        recorded.Lines.Should().Equal("to both");
+        // The structured overload sees the calls that print nothing too, which is what it is for.
+        recorded.Records.Should().Equal("Log", "GroupEnd");
+        session.EventsOf("Runtime.consoleAPICalled").Should().HaveCount(2);
+    }
+
+    /// <summary>
+    /// An engine that never enabled the console has nothing to log through, so nothing is reported and
+    /// nothing costs anything.
+    /// </summary>
+    [Test]
+    public async Task AnEngineWithoutTheConsoleFeatureReportsNothing()
+    {
+        await using var session = await AttachedSession.CreateAsync();
+
+        await session.ResultAsync("Runtime.enable");
+
+        var typeOf = await session.EvaluateAsync("typeof console", returnByValue: true);
+        typeOf.GetProperty("value").GetString().Should().Be("undefined");
+
+        session.EventsOf("Runtime.consoleAPICalled").Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task DetachingStopsTheConsoleEvents()
+    {
+        await using var session = await ConsoleSessionAsync();
+
+        await session.ResultAsync("Runtime.enable");
+        await session.Protocol.SendAsync("Target.detachFromTarget", $$"""{"sessionId":"{{session.SessionId}}"}""");
+
+        var before = session.EventsOf("Runtime.consoleAPICalled").Count;
+        await session.Target.PostAsync(engine => engine.Execute("console.log('after detaching')"));
+
+        session.EventsOf("Runtime.consoleAPICalled").Should().HaveCount(before);
+    }
+
+    private static Task<AttachedSession> ConsoleSessionAsync()
+        => AttachedSession.CreateAsync(configureOptions: options => options.WebApi.Features |= WebApiFeatures.Console);
+
+    /// <summary>A host's own sink, which the wrapper must keep feeding in both of its overloads.</summary>
+    private sealed class RecordingSink : ConsoleSink
+    {
+        private readonly List<string> _lines = [];
+        private readonly List<string> _records = [];
+
+        internal IReadOnlyList<string> Lines
+        {
+            get
+            {
+                lock (_lines)
+                {
+                    return [.. _lines];
+                }
+            }
+        }
+
+        internal IReadOnlyList<string> Records
+        {
+            get
+            {
+                lock (_lines)
+                {
+                    return [.. _records];
+                }
+            }
+        }
+
+        public override void Write(ConsoleLogLevel level, string message)
+        {
+            lock (_lines)
+            {
+                _lines.Add(message);
+            }
+        }
+
+        public override void Write(in ConsoleRecord record)
+        {
+            lock (_lines)
+            {
+                _records.Add(record.Method.ToString());
+            }
+
+            base.Write(in record);
+        }
+    }
+}

--- a/Jint.Tests.DevTools/Session/ExceptionSessionTests.cs
+++ b/Jint.Tests.DevTools/Session/ExceptionSessionTests.cs
@@ -1,0 +1,248 @@
+using System.Text.Json;
+using Jint.Runtime;
+
+namespace Jint.Tests.DevTools.Session;
+
+/// <summary>
+/// What a client hears about script that failed with nobody to catch it:
+/// <c>Runtime.exceptionThrown</c>, its revocation, and the <c>Log</c> domain's own entry stream.
+/// </summary>
+/// <remarks>
+/// Two sources, and they are different things. An <b>uncaught exception</b> is script that escaped the
+/// engine's own pump — a timer callback, an event listener — which a library-owned target reports itself and
+/// a host-owned one reports through <see cref="Jint.DevTools.EngineTarget.ReportUncaughtException"/>. An
+/// <b>unhandled rejection</b> is the engine's own rejection tracker, which every target subscribes to.
+/// </remarks>
+public class ExceptionSessionTests
+{
+    [Test]
+    public async Task AnUnhandledRejectionIsReportedAsAnException()
+    {
+        await using var session = await AttachedSession.CreateAsync();
+
+        await session.ResultAsync("Runtime.enable");
+        await session.EvaluateAsync("Promise.reject(new RangeError('nope'))");
+
+        var thrown = session.EventsOf("Runtime.exceptionThrown");
+        thrown.Should().HaveCount(1);
+
+        var details = thrown[0].GetProperty("params").GetProperty("exceptionDetails");
+        details.GetProperty("text").GetString().Should().Be("Uncaught (in promise)");
+        details.GetProperty("executionContextId").GetInt32().Should().Be(1);
+        details.GetProperty("exception").GetProperty("className").GetString().Should().Be("RangeError");
+        details.GetProperty("exception").GetProperty("objectId").GetString().Should().NotBeNullOrEmpty(
+            "a client renders the reason and then asks what is inside it");
+
+        thrown[0].GetProperty("params").GetProperty("timestamp").GetDouble().Should().BeGreaterThan(0);
+    }
+
+    /// <summary>
+    /// The engine decides a rejection is unhandled the moment it happens, where V8 waits for the end of the
+    /// microtask checkpoint. A handler attached afterwards therefore produces the pair
+    /// <c>exceptionRevoked</c> exists for, and the identifiers match.
+    /// </summary>
+    [Test]
+    public async Task AHandlerAddedLaterRevokesTheExceptionItReported()
+    {
+        await using var session = await AttachedSession.CreateAsync();
+
+        await session.ResultAsync("Runtime.enable");
+        await session.EvaluateAsync("globalThis.rejected = Promise.reject(new Error('late'))");
+        await session.EvaluateAsync("rejected.catch(function () {})");
+
+        var thrown = session.EventsOf("Runtime.exceptionThrown");
+        thrown.Should().HaveCount(1);
+
+        var revoked = session.EventsOf("Runtime.exceptionRevoked");
+        revoked.Should().HaveCount(1);
+
+        revoked[0].GetProperty("params").GetProperty("reason").GetString().Should().Be("Handler added to rejected promise");
+        revoked[0].GetProperty("params").GetProperty("exceptionId").GetInt32()
+            .Should().Be(thrown[0].GetProperty("params").GetProperty("exceptionDetails").GetProperty("exceptionId").GetInt32());
+    }
+
+    /// <summary>
+    /// A rejection handled on the very same line is reported and immediately revoked, where Chrome reports
+    /// neither. That is the engine's rejection tracker firing at the moment of rejection rather than at the
+    /// end of the microtask checkpoint, and it is why the revocation exists: a client that acts on the pair
+    /// ends up where Chrome's would, one event later.
+    /// </summary>
+    [Test]
+    public async Task ARejectionHandledOnTheSameLineIsReportedAndAtOnceRevoked()
+    {
+        await using var session = await AttachedSession.CreateAsync();
+
+        await session.ResultAsync("Runtime.enable");
+        await session.EvaluateAsync("Promise.reject(new Error('caught')).catch(function () {})", awaitPromise: true);
+
+        var thrown = session.EventsOf("Runtime.exceptionThrown");
+        var revoked = session.EventsOf("Runtime.exceptionRevoked");
+
+        thrown.Should().HaveCount(1);
+        revoked.Should().HaveCount(1);
+        revoked[0].GetProperty("params").GetProperty("exceptionId").GetInt32()
+            .Should().Be(thrown[0].GetProperty("params").GetProperty("exceptionDetails").GetProperty("exceptionId").GetInt32());
+    }
+
+    /// <summary>A promise that never rejects is never reported, which is the base case worth pinning.</summary>
+    [Test]
+    public async Task APromiseThatSettlesWellIsNeverReported()
+    {
+        await using var session = await AttachedSession.CreateAsync();
+
+        await session.ResultAsync("Runtime.enable");
+        await session.EvaluateAsync("Promise.resolve(1).then(function () {})", awaitPromise: true);
+
+        session.EventsOf("Runtime.exceptionThrown").Should().BeEmpty();
+        session.EventsOf("Runtime.exceptionRevoked").Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// The host's own door: a host-owned target catches script that escaped its loop and tells whoever is
+    /// attached, in the shape a client already understands.
+    /// </summary>
+    [Test]
+    public async Task AnUncaughtExceptionTheHostReportsReachesTheClient()
+    {
+        await using var session = await AttachedSession.CreateAsync();
+
+        await session.ResultAsync("Runtime.enable");
+
+        await session.Target.PostAsync(engine =>
+        {
+            try
+            {
+                engine.Execute("\n\nthrow new TypeError('escaped')");
+            }
+            catch (JavaScriptException exception)
+            {
+                session.Target.ReportUncaughtException(exception);
+            }
+        });
+
+        var thrown = session.EventsOf("Runtime.exceptionThrown");
+        thrown.Should().HaveCount(1);
+
+        var details = thrown[0].GetProperty("params").GetProperty("exceptionDetails");
+        details.GetProperty("text").GetString().Should().Be("Uncaught");
+        details.GetProperty("lineNumber").GetInt32().Should().Be(2, "the protocol counts lines from zero and the parser counts them from one");
+        details.GetProperty("exception").GetProperty("description").GetString().Should().Contain("escaped");
+    }
+
+    /// <summary>
+    /// Script that escapes the library-owned loop is reported by the loop itself, which is the whole reason
+    /// that mode exists: nobody else is holding the <c>try</c>.
+    /// </summary>
+    [Test]
+    public async Task ScriptThatEscapesTheLibraryOwnedLoopIsReported()
+    {
+        await using var session = await AttachedSession.CreateAsync();
+
+        await session.ResultAsync("Runtime.enable");
+
+        session.Target.Post(engine => engine.Execute("throw new TypeError('out of the pump')"));
+
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(30);
+        while (session.EventsOf("Runtime.exceptionThrown").Count == 0 && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(25);
+        }
+
+        var thrown = session.EventsOf("Runtime.exceptionThrown");
+        thrown.Should().HaveCount(1);
+        thrown[0].GetProperty("params").GetProperty("exceptionDetails").GetProperty("exception")
+            .GetProperty("description").GetString().Should().Contain("out of the pump");
+    }
+
+    [Test]
+    public async Task ADomainNobodyEnabledReportsNothing()
+    {
+        await using var session = await AttachedSession.CreateAsync();
+
+        await session.EvaluateAsync("Promise.reject(new Error('unheard'))");
+
+        session.EventsOf("Runtime.exceptionThrown").Should().BeEmpty();
+        session.EventsOf("Log.entryAdded").Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task TheLogDomainCarriesTheSameFailures()
+    {
+        await using var session = await AttachedSession.CreateAsync();
+
+        await session.ResultAsync("Log.enable");
+        await session.EvaluateAsync("Promise.reject(new RangeError('logged'))");
+
+        var entries = session.EventsOf("Log.entryAdded");
+        entries.Should().HaveCount(1);
+
+        var entry = entries[0].GetProperty("params").GetProperty("entry");
+        entry.GetProperty("source").GetString().Should().Be("javascript");
+        entry.GetProperty("level").GetString().Should().Be("error");
+        entry.GetProperty("text").GetString().Should().Contain("Uncaught (in promise)").And.Contain("logged");
+        entry.GetProperty("timestamp").GetDouble().Should().BeGreaterThan(0);
+    }
+
+    [Test]
+    public async Task AnUncaughtExceptionCarriesItsLocationIntoTheLog()
+    {
+        await using var session = await AttachedSession.CreateAsync();
+
+        await session.ResultAsync("Log.enable");
+
+        await session.Target.PostAsync(engine =>
+        {
+            try
+            {
+                engine.Execute("throw new TypeError('located')", "somewhere.js");
+            }
+            catch (JavaScriptException exception)
+            {
+                session.Target.ReportUncaughtException(exception);
+            }
+        });
+
+        var entry = session.EventsOf("Log.entryAdded")[0].GetProperty("params").GetProperty("entry");
+        entry.GetProperty("text").GetString().Should().Contain("located");
+        entry.GetProperty("url").GetString().Should().Be("somewhere.js");
+        entry.GetProperty("lineNumber").GetInt32().Should().Be(1, "a log entry counts lines from one, unlike a call frame");
+    }
+
+    [TestCase("Log.clear", null)]
+    [TestCase("Log.disable", null)]
+    [TestCase("Log.startViolationsReport", """{"config":[]}""")]
+    [TestCase("Log.stopViolationsReport", null)]
+    public async Task TheLogCommandsAnEngineTargetHasNothingToDoWithStillSucceed(string method, string? parameters)
+    {
+        await using var session = await AttachedSession.CreateAsync();
+
+        var reply = await session.SendAsync(method, parameters);
+        reply.GetProperty("result").GetRawText().Should().Be("{}");
+    }
+
+    /// <summary>
+    /// A rejection reason is any value, and a client watching a log stream must not be what makes a page's
+    /// code run: the text comes from the engine's getter-free describer.
+    /// </summary>
+    [Test]
+    public async Task ARejectionReasonIsDescribedWithoutRunningItsToString()
+    {
+        await using var session = await AttachedSession.CreateAsync();
+
+        await session.ResultAsync("Log.enable");
+        await session.ResultAsync("Runtime.enable");
+        await session.EvaluateAsync(
+            """
+            (function () {
+                globalThis.reads = 0;
+                const reason = { toString: function () { globalThis.reads++; return 'ran'; } };
+                Promise.reject(reason);
+            })()
+            """);
+
+        session.EventsOf("Log.entryAdded").Should().HaveCount(1);
+
+        var reads = await session.EvaluateAsync("reads", returnByValue: true);
+        reads.GetProperty("value").GetInt32().Should().Be(0);
+    }
+}

--- a/Jint.Tests.DevTools/Session/InProcessProtocolTests.cs
+++ b/Jint.Tests.DevTools/Session/InProcessProtocolTests.cs
@@ -24,7 +24,7 @@ public class InProcessProtocolTests
             .Select(domain => domain.GetProperty("name").GetString())
             .ToArray();
 
-        domains.Should().BeEquivalentTo(["Browser", "Runtime", "Schema", "Target"]);
+        domains.Should().BeEquivalentTo(["Browser", "Console", "Log", "Runtime", "Schema", "Target"]);
         result.GetProperty("domains")[0].GetProperty("version").GetString().Should().Be("1.3");
     }
 

--- a/Jint.Tests.DevTools/Transport/DevToolsClient.cs
+++ b/Jint.Tests.DevTools/Transport/DevToolsClient.cs
@@ -117,36 +117,72 @@ internal sealed class DevToolsClient : IAsyncDisposable
         throw new TimeoutException("the server did not close the connection");
     }
 
-    /// <inheritdoc/>
+    /// <summary>
+    /// Ends the conversation by closing the stream, not by pulling it out from under itself.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>The close goes first, and the order is the whole of it.</b> Cancelling a
+    /// <see cref="ClientWebSocket.ReceiveAsync(ArraySegment{byte}, CancellationToken)"/> does not cancel a
+    /// receive — the class has no way to — it <i>aborts</i> the socket, which resets the connection and lets
+    /// the peer's kernel discard whatever it had not read yet. On a fast machine there is nothing left to
+    /// discard; on a loaded one the last command this client sent is still in the server's receive buffer,
+    /// and it vanishes. That is what made
+    /// <c>WebSocketServerTests.AClientClosingMidCommandLeavesTheEngineRunning</c> fail on the ARM leg with
+    /// <c>Expected number but got Undefined</c>: the command it had just sent was never read, so the marker
+    /// it sets was never set.
+    /// </para>
+    /// <para>
+    /// <see cref="WebSocket.CloseOutputAsync"/> rather than <see cref="WebSocket.CloseAsync"/> because the
+    /// reader task is inside a receive: <c>CloseAsync</c> waits for the reply by receiving, and two
+    /// concurrent receives on one <see cref="ClientWebSocket"/> are not allowed. Sending the close frame and
+    /// letting the reader see the server's answer ends the stream in order.
+    /// </para>
+    /// </remarks>
     public async ValueTask DisposeAsync()
     {
-        await _stopping.CancelAsync().ConfigureAwait(false);
-
         try
         {
             if (_socket.State == WebSocketState.Open)
             {
-                using var closing = new CancellationTokenSource(TimeSpan.FromSeconds(2));
-                await _socket.CloseAsync(WebSocketCloseStatus.NormalClosure, statusDescription: null, closing.Token).ConfigureAwait(false);
+                using var closing = new CancellationTokenSource(Bound);
+                await _socket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, statusDescription: null, closing.Token).ConfigureAwait(false);
             }
         }
-        catch (Exception exception) when (exception is WebSocketException or OperationCanceledException)
+        catch (Exception exception) when (exception is WebSocketException or OperationCanceledException or ObjectDisposedException)
         {
         }
 
-        if (_reader is { } reader)
-        {
-            try
-            {
-                await reader.ConfigureAwait(false);
-            }
-            catch (Exception exception) when (exception is WebSocketException or OperationCanceledException)
-            {
-            }
-        }
+        // Bounded, like every other wait here: a server that never answers the close must end this test
+        // rather than hang it, and the cancellation below is what unblocks the receive when it does not.
+        await SettledAsync(Bound).ConfigureAwait(false);
+
+        await _stopping.CancelAsync().ConfigureAwait(false);
+
+        // And again, briefly, so that the socket is never disposed under a live receive.
+        await SettledAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
 
         _socket.Dispose();
         _stopping.Dispose();
+    }
+
+    /// <summary>Waits for the reader to finish, swallowing every way it can end.</summary>
+    private async Task SettledAsync(TimeSpan bound)
+    {
+        if (_reader is not { } reader)
+        {
+            return;
+        }
+
+        try
+        {
+            await reader.WaitAsync(bound).ConfigureAwait(false);
+        }
+#pragma warning disable CA1031 // a disposing client has nothing left to report a reader's failure to
+        catch (Exception)
+#pragma warning restore CA1031
+        {
+        }
     }
 
     private async Task<JsonElement> WaitAsync(Func<JsonElement, bool> matches)

--- a/Jint.Tests.DevTools/Transport/WebSocketServerTests.cs
+++ b/Jint.Tests.DevTools/Transport/WebSocketServerTests.cs
@@ -270,9 +270,16 @@ public class WebSocketServerTests
     }
 
     /// <summary>
-    /// A client that disappears mid-command must not take the engine thread with it: the command was already
-    /// on the mailbox, so it runs, and the reply goes nowhere.
+    /// A client that goes away mid-command must not take the engine thread with it: the command was already
+    /// on the mailbox, so it runs, and the connection ends around it.
     /// </summary>
+    /// <remarks>
+    /// The client closes its half of the stream rather than aborting it, which is what makes this a test
+    /// rather than a race. An abort resets the connection, and a reset lets the peer's kernel discard
+    /// whatever it had not read yet — including the very command whose effect is asserted below, which is
+    /// how this failed on the ARM leg with <c>Expected number but got Undefined</c>. Closing sends the frame
+    /// in order behind the command, so the server reads the command first, every time.
+    /// </remarks>
     [Test]
     public async Task AClientClosingMidCommandLeavesTheEngineRunning()
     {

--- a/Jint.Tests.DevTools/Transport/WebSocketServerTests.cs
+++ b/Jint.Tests.DevTools/Transport/WebSocketServerTests.cs
@@ -85,7 +85,7 @@ public class WebSocketServerTests
         document.RootElement.GetProperty("version").GetProperty("minor").GetString().Should().Be("3");
 
         var domains = document.RootElement.GetProperty("domains").EnumerateArray().ToArray();
-        domains.Select(domain => domain.GetProperty("domain").GetString()).Should().BeEquivalentTo(["Browser", "Runtime", "Schema", "Target"]);
+        domains.Select(domain => domain.GetProperty("domain").GetString()).Should().BeEquivalentTo(["Browser", "Console", "Log", "Runtime", "Schema", "Target"]);
 
         var runtime = domains.Single(domain => domain.GetProperty("domain").GetString() == "Runtime");
         runtime.GetProperty("commands").EnumerateArray().Select(command => command.GetProperty("name").GetString())

--- a/Jint.Tests.DevTools/Verify/PublicApiTest.verified.txt
+++ b/Jint.Tests.DevTools/Verify/PublicApiTest.verified.txt
@@ -50,6 +50,7 @@ namespace Jint.DevTools
         public System.Threading.Tasks.Task PostAsync(System.Action<Jint.Engine> work) { }
         public System.Threading.Tasks.Task<T> PostAsync<T>(System.Func<Jint.Engine, T> work) { }
         public void Pump() { }
+        public void ReportUncaughtException(Jint.Runtime.JavaScriptException exception) { }
         public bool WaitForDebugger(System.TimeSpan timeout) { }
     }
     public sealed class EngineTargetOptions

--- a/tools/devtools-protocol/manifest.json
+++ b/tools/devtools-protocol/manifest.json
@@ -33,6 +33,14 @@
   "implementedMethods": [
     "Browser.close",
     "Browser.getVersion",
+    "Console.clearMessages",
+    "Console.disable",
+    "Console.enable",
+    "Log.clear",
+    "Log.disable",
+    "Log.enable",
+    "Log.startViolationsReport",
+    "Log.stopViolationsReport",
     "Runtime.addBinding",
     "Runtime.awaitPromise",
     "Runtime.callFunctionOn",
@@ -68,10 +76,16 @@
 
   // The events Jint.DevTools emits. Target.targetInfoChanged is deliberately not among them: an engine
   // target's title and location are fixed when the host makes it, so there is nothing that could change
-  // and claiming the event would be a claim nothing ever honours. Runtime.consoleAPICalled and the
-  // Debugger pause events arrive with the domains that raise them.
+  // and claiming the event would be a claim nothing ever honours. Runtime.executionContextDestroyed and
+  // executionContextsCleared are absent for the same reason: an engine target's one context lives as long
+  // as the engine does. The Debugger pause events arrive with the domain that raises them.
   "implementedEvents": [
+    "Console.messageAdded",
+    "Log.entryAdded",
     "Runtime.bindingCalled",
+    "Runtime.consoleAPICalled",
+    "Runtime.exceptionRevoked",
+    "Runtime.exceptionThrown",
     "Runtime.executionContextCreated",
     "Target.attachedToTarget",
     "Target.detachedFromTarget",
@@ -83,6 +97,8 @@
   // so a client feature-detecting through it is never told about a domain that answers nothing.
   "reportedDomains": [
     { "name": "Browser", "version": "1.3" },
+    { "name": "Console", "version": "1.3" },
+    { "name": "Log", "version": "1.3" },
     { "name": "Runtime", "version": "1.3" },
     { "name": "Schema", "version": "1.3" },
     { "name": "Target", "version": "1.3" }


### PR DESCRIPTION
Campaign [#3575](https://github.com/sebastienros/jint/issues/3575), phase 1, item **P3** — the second of
two pull requests, and **it stacks on [#3605](https://github.com/sebastienros/jint/pull/3605)**. GitHub
shows the combined diff until that one merges; this branch is `headless/devtools-console` on top of
`headless/devtools-runtime`, both rebased onto `main` at 7d879bfe8.

The first pull request is the object model — the handles a client holds values by. This one is the event
streams: what a script logged, and what it threw with nobody to catch it.

## Three things a client hears without asking

They all arrive on the engine thread from *inside* the engine, where there is no command to answer and
nothing to `await` onto: a `console` call, an exception that escaped the pump, a promise rejected with
nothing to handle it. `ITargetObserver` is the one interface for all three; `EngineTarget` fans out to
whoever is attached; and the events go out through `DevToolsDomain.EmitDetached`, which queues rather than
writes — both connections make a send a channel insertion — so nothing blocks the engine and no transport
failure erupts out of the host's own pump.

## The console

`UseDevTools` installs a `DevToolsConsoleSink` around whatever `Options.WebApi.Console.Sink` the host had,
and **wraps rather than replaces**: it forwards both overloads before it does anything else, so a host that
set its own sink keeps every line it was getting, in the overload it was getting it in. A test pins that,
including the structured overload's calls that print nothing.

**One sink speaks for one engine**, and this is the one design decision here worth stating aloud. The
engine reads its sink out of `Options` on every emit and `ConsoleRecord` carries no engine, so a sink shared
by two engines could not tell which was talking — and mapping one engine's values into another's table is
exactly the thing the repository forbids. The sink therefore binds to the first target built over an engine
and refuses a second engine's, and `UseDevTools` installs a fresh one per call so the ordinary
`new Engine(o => o.UseDevTools())` gives every engine its own. A host that builds two engines from one
`Options` instance and attaches to both hears the first; `UseDevTools` per engine is what avoids it, and its
XML docs say so.

An engine without `WebApiFeatures.Console` reports nothing, because it has no `console` object to log
through. That is not a gap to close here — the web APIs are opt-in and this one is theirs.

**`ConsoleJournal` keeps the last hundred calls**, so a client attaching halfway through a run is not told
there was silence: V8 keeps such a store and replays it on `Runtime.enable` and `Console.enable`, and so
does this. The bound is a memory bound before it is a replay bound — an entry holds its arguments strongly,
exactly as a handle does — so **evicting an entry releases every handle any attachment minted for it**, which
is pinned by a test that logs two hundred objects and finds the first handle gone. Console arguments are
billed to the object group `"console"`, which is what a client's own "clear console" releases;
`Runtime.discardConsoleEntries` and `Console.clearMessages` both empty the journal, and it is the target's
rather than the session's because the history is the engine's.

`Runtime.consoleAPICalled` carries handles and previews. `Console.messageAdded` carries the finished line
the engine's own printer produced and no handles, because a client on the deprecated domain asked for text —
which is why a call that printed nothing (`groupEnd`, a `time` that started a timer) is absent from it and
present in the `Runtime` event a front end draws a group from. Four of the engine's console methods have no
protocol type of their own and are folded into the nearest that exists: `countReset` into `count`, the three
timer methods into `timeEnd`, `timeStamp` into `log`.

## The failures

`Runtime.exceptionThrown` comes from two places. An **unhandled rejection** is
`engine.Tasks.PromiseRejectionTracker`, which every target subscribes to. An **uncaught exception** is
`EngineTarget.ReportUncaughtException`, the one new public member: a `LibraryOwned` target calls it from its
own loop for script that escaped `ProcessTasks`, and a `HostOwned` host — which owns the `try` — calls it
itself. Reporting is not handling; it writes to whoever is attached and returns.

**A rejection is reported earlier here than V8 reports it**, and the divergence is deliberate rather than
unnoticed. The engine raises `Reject` the moment a promise is rejected with no handler; V8 waits for the end
of the microtask checkpoint. So a rejection handled on the very next line produces `exceptionThrown` and then
`exceptionRevoked` here where Chrome produces neither — which is exactly the pair the revocation exists for,
and a client acting on both ends up where Chrome's would, one event later. Delaying the event instead would
mean this package deciding when a checkpoint ended. Two tests pin the pair and the matching `exceptionId`.

`Log.entryAdded` carries the same two failures as `source: "javascript"`, `level: "error"`. **`Log.enable`
replays nothing** and says so: the journal is the console's, and an engine target keeps no log store. Every
recorded client sends `Log.enable` while connecting, which is why the domain is here at all.

## One place script now runs that it did not before

Rendering a *thrown* error's message and stack reads its `stack`, which a script may have defined as an
accessor. #3605 inherited `GetJavaScriptErrorString()` from #3602 for that; this pull request switches both
callers to the overload that takes the engine's own `ResultLimits`, so the render runs under the engine's
execution constraints and output bound rather than unbounded. It is asked for at all because the stack is
the whole reason a client is looking at the event. Together with `returnByValue` that is the complete list
of places this package runs script, and `Jint.DevTools/AGENTS.md` names both.

## Manifest delta

`implementedMethods` gains 8, taking it from 33 to 41: `Console.clearMessages`, `Console.disable`, `Console.enable`, `Log.clear`,
`Log.disable`, `Log.enable`, `Log.startViolationsReport`, `Log.stopViolationsReport`.

`implementedEvents` gains 5, taking it from 6 to 11: `Console.messageAdded`, `Log.entryAdded`, `Runtime.consoleAPICalled`,
`Runtime.exceptionRevoked`, `Runtime.exceptionThrown`.

`reportedDomains` gains `Console` and `Log`, so `Schema.getDomains` and `/json/protocol` now answer six
domains. `Runtime.executionContextDestroyed` and `executionContextsCleared` are stated as deliberately
absent in the manifest's own comment: an engine target's one context lives as long as the engine does.

## The `Absent` table after this change

`HandshakeReplayTests.Absent` loses `Log.enable`, the last of the recorded methods that was excused as
page-level but is not. What remains is **27 `page` entries** (`Jint.Browser`'s), **5 `later`** (the four
`Debugger` commands and `Profiler.enable`) and **6 `none`** that Chrome itself answered `-32601` to in the
recording. Every `Runtime` method any recorded client sends is now answered.

## Tests

`Jint.Tests.DevTools` goes from 219 to 260 cases (net10.0; 258 on net8.0). Two new files:

- `ConsoleSessionTests` — handles and previews on the arguments, the `"console"` group, every console method
  as its protocol type, `console.trace`'s frames, replay after `Runtime.enable` and after `Console.enable`,
  the flat-line domain omitting what printed nothing, both clear commands, disabling, the journal's bound
  and its release on eviction, the host's own sink keeping both overloads, an engine without the console
  feature reporting nothing, and detaching stopping the stream;
- `ExceptionSessionTests` — an unhandled rejection as `exceptionThrown`, the revocation and its matching
  identifier, the same-line pair, a promise that settles well, `ReportUncaughtException` from a host loop,
  script escaping the library-owned loop, the `Log` entry with its location, the `Log` no-ops, and a
  rejection reason described without running its `toString`;
- `PuppeteerSharpTests` gains a real client over a real socket hearing `Runtime.consoleAPICalled` with a
  preview through its own `MessageReceived`.

`Jint.Tests.DevTools` is green under `JINT_HOST_CONTRACT_VERIFICATION=1`. The full solution is green apart
from two `intl402/supportedLocalesOf-unicode-extensions-ignored.js` cases that timed out at exactly 30 s on
a loaded machine and pass in 2 s in isolation; nothing under `Jint/` is touched by either pull request.

## A third commit that is not about the console

`WebSocketServerTests.AClientClosingMidCommandLeavesTheEngineRunning` failed twice on the ARM leg — once on
#3605 and once here — with `Expected number but got Undefined`, and it is a real race in the test helper
rather than in anything either pull request adds. `DevToolsClient.DisposeAsync` cancelled its reader
*before* closing; cancelling a `ClientWebSocket.ReceiveAsync` does not cancel the receive (the class has no
way to), it **aborts the socket**, so no close handshake was sent and the connection was reset — and a reset
lets the peer's kernel discard whatever it had not read yet, which on a two-core runner is the very command
the test then asserts the effect of.

The third commit closes the output half first, with `CloseOutputAsync` rather than `CloseAsync` because the
reader task is inside a receive and two concurrent receives on one `ClientWebSocket` are not allowed. It is
in this pull request because that is where the failure showed; say the word and it moves to its own.

## Two notes for the reviewer

`Runtime.getHeapUsage` (in #3605) answers `GC.GetTotalMemory(false)` for both sizes rather than
`Diagnostics.GetMemoryReport`, which the design doc's table suggested: that report counts objects, timers
and cache entries and publishes no byte figure, so there was nothing to convert. The command says so in its
own remarks.

`Jint.DevTools/AGENTS.md` is at 31,879 of 32,768 bytes after this change — 889 to spare. The next section
added to it will need something else shortened first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
