### PR TITLE
Fix bug in JavaScriptException.cs handling of new error-stack-accessor style stacks

### DIFF
--- a/Jint.Tests/Runtime/ErrorTests.cs
+++ b/Jint.Tests/Runtime/ErrorTests.cs
@@ -231,6 +231,45 @@ var wrap = function(v) {
         engine.Evaluate(@"typeof Error().stack").AsString().Should().Be("string");
     }
 
+    [Test]
+    public void ThrowingErrorPrototypeDerivedObjectWithoutErrorDataSurfacesAsJavaScriptException()
+    {
+        // A hand-rolled subclass in the pre-ES6 style inherits the Error.prototype "stack" accessor but has
+        // no [[ErrorData]], so the getter returns undefined. Building the host exception must not turn that
+        // undefined into a CLR ArgumentException — it must fall through to the engine-built call stack.
+        // (This is exactly how WPT's idlharness.js declares IdlHarnessError.)
+        var engine = new Engine();
+        engine.Execute(@"
+function CustomError(message) { this.message = message; }
+CustomError.prototype = Object.create(Error.prototype);
+function thrower() { throw new CustomError('custom boom'); }
+", "custom.js");
+
+        var e = Invoking(() => engine.Execute("thrower();", "main.js")).Should().ThrowExactly<JavaScriptException>().Which;
+
+        e.Message.Should().Be("custom boom");
+        EqualIgnoringNewLineDifferences(@"    at thrower (custom.js:4:28)
+    at main.js:1:1", e.JavaScriptStackTrace);
+
+        // The engine-built stack is installed as an own data property, so the script can read it too.
+        engine.Evaluate(@"
+try { thrower(); } catch (err) { typeof err.stack; }").AsString().Should().Be("string");
+    }
+
+    [Test]
+    public void ThrowingObjectWithNonStringStackPropertyKeepsAuthorValueAndDoesNotFault()
+    {
+        var engine = new Engine();
+
+        var e = Invoking(() => engine.Execute("throw { message: 'plain', stack: 42 };", "main.js"))
+            .Should().ThrowExactly<JavaScriptException>().Which;
+
+        e.Message.Should().Be("plain");
+        // The author's non-string "stack" is left untouched; the host side falls back to its own call stack.
+        e.JavaScriptStackTrace.Should().Be("    at main.js:1:7");
+        engine.Evaluate("(function(){ try { throw { stack: 42 }; } catch (x) { return x.stack; } })()").AsNumber().Should().Be(42);
+    }
+
     private class Folder
     {
         public Folder Parent { get; set; }

--- a/Jint/Runtime/JavaScriptException.cs
+++ b/Jint/Runtime/JavaScriptException.cs
@@ -206,10 +206,18 @@ public class JavaScriptException : JintException
                 return;
             }
 
-            // Does the Error object already have a stack property?
-            if (errObj.HasProperty(CommonProperties.Stack) && !overwriteExisting)
+            // Does the Error object already carry a usable stack? HasProperty walks the prototype chain, and
+            // %Error.prototype% exposes "stack" as an accessor (error-stack-accessor proposal) that returns
+            // undefined for receivers without [[ErrorData]] — e.g. `Object.create(Error.prototype)` subclasses
+            // such as WPT idlharness's IdlHarnessError. Only a string value counts as an existing stack;
+            // anything else falls through to building one, instead of failing AsString() with a CLR
+            // ArgumentException escaping out of an ordinary JavaScript `throw`.
+            var existingStack = !overwriteExisting && errObj.HasProperty(CommonProperties.Stack)
+                ? errObj.Get(CommonProperties.Stack)
+                : JsValue.Undefined;
+            if (existingStack.IsString())
             {
-                _callStack = errObj.Get(CommonProperties.Stack).AsString();
+                _callStack = existingStack.AsString();
             }
             else
             {


### PR DESCRIPTION
## Summary

Jint was updated to error-stack-accessor proposal, but this code in JavaScriptException.cs:191-195 was missed and still assuming the old string 'stack' only.

## Details

`JavaScriptException.SetCallstack` still assumed the legacy model where `stack` is an own data
property written by the `Error` constructor (so `HasProperty("stack")` implied a string is there).
That model was superseded by the error-stack-accessor implementation: `stack` is now a getter on
`%Error.prototype%`, `HasProperty` walks the chain and answers true for *every* `Error.prototype`
descendant, and the getter returns `undefined` for receivers without `[[ErrorData]]`. The
follow-up `Get("stack").AsString()` is a typed unwrap, not `ToString`, so it faulted with a CLR
`ArgumentException: Expected string but got Undefined` from inside `Throw.JavaScriptException` —
an ordinary JavaScript `throw` escaped to the host as `ArgumentException` instead of
`JavaScriptException`, bypassing script-level `catch`.

This PR makes "pre-existing stack" mean *resolves to a string*. Anything else falls through to the
engine-built call stack, installed as an own data property — the same thing the
`Error.prototype.stack` setter does for such a receiver. Decorator-written string stacks behave
exactly as before; an author's non-string own `stack` is left untouched.

## How we hit it

Running web-platform-tests through Jint. WPT's `resources/idlharness.js` declares its error type in
the pre-class style:

```js
function IdlHarnessError(message) { this.message = message; }
IdlHarnessError.prototype = Object.create(Error.prototype);
```

Every `throw new IdlHarnessError(...)` that reached the host took the fault above, killing the
page as a harness error rather than a JS exception. Any code using `util.inherits(MyError, Error)`
or the same `Object.create(Error.prototype)` idiom is affected identically.

## Change

- `Jint/Runtime/JavaScriptException.cs` — `SetCallstack`: read `stack` only when `HasProperty` and
  `!overwriteExisting`; take it as the pre-existing stack only if `IsString()`, else build.
- `Jint.Tests/Runtime/ErrorTests.cs` — two tests:
  `ThrowingErrorPrototypeDerivedObjectWithoutErrorDataSurfacesAsJavaScriptException` (the
  idlharness shape: surfaces as `JavaScriptException`, engine stack installed and readable from
  script) and `ThrowingObjectWithNonStringStackPropertyKeepsAuthorValueAndDoesNotFault`
  (`throw { stack: 42 }` keeps `42`, host falls back to its own trace).

## References

- Error stack accessor proposal — getter step 3, "If E does not have an [[ErrorData]] internal slot, return undefined":
  https://tc39.es/proposal-error-stacks/#sec-get-error.prototype-stack
- ECMA-262 `[[HasProperty]]` walks the prototype chain: https://tc39.es/ecma262/#sec-ordinaryhasproperty
- WPT `idlharness.js` `IdlHarnessError`: https://github.com/web-platform-tests/wpt/blob/master/resources/idlharness.js
- Jint's accessor implementation: `Jint/Native/Error/ErrorPrototype.cs` (`StackGet`)

## Test plan

Unit test included.

## Breaking change?

No API change.