### PR TITLE
Interop: an operator overload is chosen by the arguments in hand (backport of #3578)

### DIFF
--- a/Jint.Tests.PublicInterface/OperatorOverloadResolutionCacheTests.cs
+++ b/Jint.Tests.PublicInterface/OperatorOverloadResolutionCacheTests.cs
@@ -181,4 +181,87 @@ public class OperatorOverloadResolutionCacheTests
     }
 
     #endregion
+
+    #region value-decided resolution
+
+    /// <summary>
+    /// A host type carrying a narrow overload beside a catch-all one. Which of the two applies is decided by
+    /// the <em>value</em> on the right - <c>5</c> fits a <see cref="byte"/> and <c>300</c> does not - so the
+    /// pair of CLR types the two arguments have does not determine the answer, both numbers arriving as
+    /// <see cref="double"/>.
+    /// </summary>
+    public sealed class RangedA
+    {
+        public static string operator +(RangedA left, byte right) => "byte:" + right;
+        public static string operator +(RangedA left, object right) => "object:" + right;
+    }
+
+    public sealed class RangedB
+    {
+        public static string operator +(RangedB left, byte right) => "byte:" + right;
+        public static string operator +(RangedB left, object right) => "object:" + right;
+    }
+
+    public sealed class RangedC
+    {
+        public static string operator +(RangedC left, byte right) => "byte:" + right;
+        public static string operator +(RangedC left, object right) => "object:" + right;
+    }
+
+    public sealed class RangedD
+    {
+        public static string operator +(RangedD left, byte right) => "byte:" + right;
+        public static string operator +(RangedD left, object right) => "object:" + right;
+    }
+
+    public sealed class RangedE
+    {
+        public static string operator +(RangedE left, byte right) => "byte:" + right;
+        public static string operator +(RangedE left, object right) => "object:" + right;
+    }
+
+    private static string AddNumber(Engine engine, object host, string expression)
+    {
+        engine.SetValue("m", host);
+        return engine.Evaluate(expression).AsString();
+    }
+
+    [Fact]
+    public void ASmallNumberAloneTakesTheNarrowOverload()
+    {
+        AddNumber(StockEngine(), new RangedA(), "m + 5").Should().Be("byte:5");
+    }
+
+    [Fact]
+    public void ALargeNumberAloneTakesTheCatchAllOverload()
+    {
+        AddNumber(StockEngine(), new RangedB(), "m + 300").Should().Be("object:300");
+    }
+
+    [Fact]
+    public void ASmallNumberDoesNotDecideForALargeOne()
+    {
+        AddNumber(StockEngine(), new RangedC(), "m + 5").Should().Be("byte:5");
+        AddNumber(StockEngine(), new RangedC(), "m + 300").Should().Be("object:300");
+    }
+
+    [Fact]
+    public void ALargeNumberDoesNotDecideForASmallOne()
+    {
+        AddNumber(StockEngine(), new RangedD(), "m + 300").Should().Be("object:300");
+        AddNumber(StockEngine(), new RangedD(), "m + 5").Should().Be("byte:5");
+    }
+
+    [Fact]
+    public void OneEngineSelectsPerEvaluationToo()
+    {
+        var engine = StockEngine();
+        engine.SetValue("m", new RangedE());
+
+        engine.Evaluate("m + 5").AsString().Should().Be("byte:5");
+        engine.Evaluate("m + 300").AsString().Should().Be("object:300");
+        engine.Evaluate("m + 5").AsString().Should().Be("byte:5");
+    }
+
+    #endregion
 }

--- a/Jint.Tests/Runtime/OperatorOverloadResolutionCacheTests.cs
+++ b/Jint.Tests/Runtime/OperatorOverloadResolutionCacheTests.cs
@@ -1,19 +1,33 @@
 #nullable enable
 
 using Jint.Runtime.Interop;
+using Jint.Runtime.Interpreter.Expressions;
 
 namespace Jint.Tests.Runtime;
 
 /// <summary>
-/// Which table an engine remembers its operator-overload resolutions in. The public-interface suite pins the
-/// answers two engines must not take from each other; this pins the mechanism that keeps them apart, since
-/// "both engines were right" is also what a cache that was never consulted looks like.
+/// What an engine is allowed to remember about an operator overload. The public-interface suite pins the
+/// answers two engines, and two argument values, must not take from each other; this pins the mechanism that
+/// keeps them apart, since "every answer was right" is also what a cache that was never consulted looks like.
 /// </summary>
 public class OperatorOverloadResolutionCacheTests
 {
     public sealed class Amount
     {
         public static string operator +(Amount left, Amount right) => "operator";
+    }
+
+    /// <summary>Declares no operator at all, so every pair it takes part in has an empty candidate set.</summary>
+    public sealed class Plain
+    {
+        public override string ToString() => "plain";
+    }
+
+    /// <summary>Carries two <c>+</c> overloads only an argument's value can choose between.</summary>
+    public sealed class Ranged
+    {
+        public static string operator +(Ranged left, byte right) => "byte:" + right;
+        public static string operator +(Ranged left, object right) => "object:" + right;
     }
 
     /// <summary>Behaves exactly like the stock converter but is not it, which is what makes it a host one.</summary>
@@ -24,51 +38,72 @@ public class OperatorOverloadResolutionCacheTests
         }
     }
 
-    private static Engine Evaluate(Action<Options>? configure = null)
+    private static Engine NewEngine(Action<Options>? configure = null) => new(options =>
     {
-        var engine = new Engine(options =>
-        {
-            options.Interop.AllowOperatorOverloading = true;
-            configure?.Invoke(options);
-        });
+        options.Interop.AllowOperatorOverloading = true;
+        configure?.Invoke(options);
+    });
 
+    private static MethodDescriptor[]? CandidatesFor(Type left, Type right)
+    {
+        var key = new JintBinaryExpression.OperatorKey("op_Addition", left, right);
+        return JintBinaryExpression._operatorCandidates.TryGetValue(key, out var candidates) ? candidates : null;
+    }
+
+    [Fact]
+    public void WhatIsRememberedIsTheCandidateSetAndNotTheSelection()
+    {
+        var engine = NewEngine();
+        engine.SetValue("m", new Ranged());
+
+        engine.Evaluate("m + 5").AsString().Should().Be("byte:5");
+
+        CandidatesFor(typeof(Ranged), typeof(double)).Should().NotBeNull().And.HaveCount(2,
+            "the overload this value did not select has to stay available to the next evaluation");
+    }
+
+    [Fact]
+    public void TheSetIsScannedOnceAndSharedByEveryEngine()
+    {
+        var stock = NewEngine();
+        stock.SetValue("a", new Amount());
+        stock.SetValue("b", new Amount());
+        stock.Evaluate("a + b");
+
+        var first = CandidatesFor(typeof(Amount), typeof(Amount));
+
+        // A converter of its own used to give an engine a resolution table of its own, because a resolution
+        // was scored against that converter. A candidate set is not, so there is one table again.
+        var withConverter = NewEngine(options => options.SetTypeConverter(e => new WrappingTypeConverter(e)));
+        withConverter.SetValue("a", new Amount());
+        withConverter.SetValue("b", new Amount());
+        withConverter.Evaluate("a + b");
+
+        CandidatesFor(typeof(Amount), typeof(Amount)).Should().BeSameAs(first,
+            "a reflection scan of two types is the same answer for every engine in the process");
+    }
+
+    [Fact]
+    public void APairWithNoOperatorIsRememberedAsHavingNone()
+    {
+        var engine = NewEngine();
+        engine.SetValue("p", new Plain());
+
+        engine.Evaluate("p + 'x'").AsString().Should().Be("plainx");
+
+        CandidatesFor(typeof(Plain), typeof(string)).Should().NotBeNull().And.BeEmpty(
+            "an empty set is what lets the next evaluation of the same pair leave without allocating anything");
+    }
+
+    [Fact]
+    public void ACandidateIsListedOnceEvenWhenBothOperandsDeclareIt()
+    {
+        var engine = NewEngine();
         engine.SetValue("a", new Amount());
         engine.SetValue("b", new Amount());
-        engine.Evaluate("a + b").AsString().Should().Be("operator");
-        return engine;
-    }
+        engine.Evaluate("a + b");
 
-    [Fact]
-    public void AStockEngineRemembersInTheProcessWideTable()
-    {
-        var engine = Evaluate();
-
-        engine._engineOperatorOverloads.Should().BeNull(
-            "the stock converter resolves what every other stock engine would, so the answer is shareable");
-    }
-
-    [Fact]
-    public void AnEngineWithItsOwnConverterRemembersOnItself()
-    {
-        var engine = Evaluate(options => options.SetTypeConverter(e => new WrappingTypeConverter(e)));
-
-        engine._engineOperatorOverloads.Should().NotBeNull().And.HaveCount(1,
-            "this engine's converter answers overload scoring's last rule, so its resolution is its own");
-
-        // and it really is a cache: a second evaluation of the same pair adds nothing
-        engine.Evaluate("a + b").AsString().Should().Be("operator");
-        engine._engineOperatorOverloads.Should().HaveCount(1);
-    }
-
-    [Fact]
-    public void SwappingTheConverterDropsWhatTheOldOneDecided()
-    {
-        var engine = Evaluate(options => options.SetTypeConverter(e => new WrappingTypeConverter(e)));
-        engine._engineOperatorOverloads.Should().HaveCount(1);
-
-        engine.TypeConverter = new WrappingTypeConverter(engine);
-
-        engine._engineOperatorOverloads.Should().BeEmpty(
-            "every entry was scored against the converter that has just been replaced");
+        CandidatesFor(typeof(Amount), typeof(Amount)).Should().NotBeNull().And.HaveCount(1,
+            "both operand types are scanned, and `T + T` finds the same operator on each");
     }
 }

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -347,24 +347,6 @@ public sealed partial class Engine : IDisposable
     // one Options instance be shared by engines that are already running.
     internal readonly bool _operatorOverloadingAllowed;
 
-    // Snapshot of Options.Interop.ValueCoercion, read the same way and for the same reason. It steers
-    // overload scoring's gray-zone rule, so it is part of the key JintBinaryExpression remembers an
-    // operator-overload resolution under: two engines that coerce differently can rank the same candidates
-    // differently, and must not answer from one another's entries.
-    internal readonly ValueCoercionType _valueCoercion;
-
-    /// <summary>
-    /// Operator-overload resolutions belonging to this engine alone, created on first use and only by an
-    /// engine whose <see cref="TypeConverter"/> is not the stock one.
-    /// </summary>
-    /// <remarks>
-    /// Such an engine's converter answers overload scoring's last rule, so its resolutions are not the ones a
-    /// stock engine would reach and cannot go in the process-wide table - nor could that table be keyed on the
-    /// converter, which is a host object handed this engine by its factory and would pin both for the life of
-    /// the process. The <see cref="TypeConverter"/> setter drops these when the converter changes.
-    /// </remarks>
-    internal ConcurrentDictionary<JintBinaryExpression.OperatorKey, MethodDescriptor?>? _engineOperatorOverloads;
-
     internal readonly ReferencePool _referencePool;
     internal readonly ArgumentsInstancePool _argumentsInstancePool;
     internal readonly JsValueArrayPool _jsValueArrayPool;
@@ -385,11 +367,6 @@ public sealed partial class Engine : IDisposable
         {
             _typeConverter = value;
             _typeConverterIsDefault = value.GetType() == typeof(DefaultTypeConverter);
-
-            // Every operator-overload resolution this engine remembered was scored against the converter
-            // being replaced, and the stock table it may now be entitled to was not. Nothing is resolved
-            // before the first assignment, so this is a no-op during construction.
-            _engineOperatorOverloads?.Clear();
         }
     }
 
@@ -535,7 +512,6 @@ public sealed partial class Engine : IDisposable
         // documented place to finish configuring an engine, and enabling operator overloading from
         // one has to reach the expressions that consult it.
         _operatorOverloadingAllowed = Options.Interop.AllowOperatorOverloading;
-        _valueCoercion = Options.Interop.ValueCoercion;
 
         // likewise after Apply, which is where a custom ITypeConverter gets installed
         _interopResolutionProfile = new InteropResolutionProfile(

--- a/Jint/Runtime/Interop/InteropHelper.cs
+++ b/Jint/Runtime/Interop/InteropHelper.cs
@@ -456,7 +456,14 @@ internal sealed class InteropHelper
         Func<MethodDescriptor, TState, JsValue[]> argumentProvider,
         TState state)
     {
+        // The first surviving candidate is held here rather than in a list, because there is nothing to sort
+        // until a second one survives — and one survivor is the usual outcome, not an edge case. It matters
+        // most on the operator lane, where scoring runs on every evaluation (JintBinaryExpression's candidate
+        // set is cached; which of them applies is not, since the argument values decide it).
+        MethodMatch survivor = default;
+        var haveSurvivor = false;
         List<MethodMatch>? matchingByParameterCount = null;
+
         foreach (var method in methods)
         {
             var parameterInfos = method.Parameters;
@@ -477,21 +484,30 @@ internal sealed class InteropHelper
                     continue;
                 }
 
-                matchingByParameterCount ??= [];
-                matchingByParameterCount.Add(new MethodMatch(method, arguments, score));
+                var match = new MethodMatch(method, arguments, score);
+                if (!haveSurvivor)
+                {
+                    survivor = match;
+                    haveSurvivor = true;
+                    continue;
+                }
+
+                matchingByParameterCount ??= [survivor];
+                matchingByParameterCount.Add(match);
             }
         }
 
-        if (matchingByParameterCount == null)
+        if (!haveSurvivor)
         {
             return MethodMatches.Empty;
         }
 
-        if (matchingByParameterCount.Count > 1)
+        if (matchingByParameterCount is null)
         {
-            matchingByParameterCount.Sort();
+            return MethodMatches.Single(in survivor);
         }
 
+        matchingByParameterCount.Sort();
         return MethodMatches.Sorted(matchingByParameterCount);
     }
 }

--- a/Jint/Runtime/Interop/MethodDescriptor.cs
+++ b/Jint/Runtime/Interop/MethodDescriptor.cs
@@ -198,7 +198,7 @@ internal sealed class MethodDescriptor
     // Trade-off: a static cache keyed by MethodBase pins that MethodBase - and therefore its
     // declaring assembly - for the lifetime of the process. That matches the precedent already set
     // by this codebase's other process-wide reflection caches (TypeDescriptor._cache,
-    // TypeReference._memberAccessors, JintBinaryExpression._knownOperators,
+    // TypeReference._memberAccessors, JintBinaryExpression._operatorCandidates,
     // DefaultTypeConverter._knownCastOperators).
     //
     // A concurrent duplicate build for the same key is benign (both produce equivalent invokers and

--- a/Jint/Runtime/Interop/Reflection/CompiledMemberAccessor.cs
+++ b/Jint/Runtime/Interop/Reflection/CompiledMemberAccessor.cs
@@ -47,7 +47,7 @@ namespace Jint.Runtime.Interop.Reflection;
 /// cache lives on <see cref="TypeResolver"/>, so engines configured with resolvers of their own
 /// would otherwise recompile every member each time. The trade-off is the same one the other
 /// process-wide reflection caches in this assembly make (<see cref="TypeDescriptor"/>,
-/// <see cref="TypeReference"/>, <c>JintBinaryExpression._knownOperators</c>): the cached
+/// <see cref="TypeReference"/>, <c>JintBinaryExpression._operatorCandidates</c>): the cached
 /// <see cref="MemberInfo"/> keeps its declaring assembly alive for the process lifetime.
 /// </para>
 /// </summary>

--- a/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
@@ -1,6 +1,5 @@
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Numerics;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -16,20 +15,18 @@ namespace Jint.Runtime.Interpreter.Expressions;
 internal abstract class JintBinaryExpression : JintExpression
 {
     /// <summary>
-    /// Identifies one operator-overload resolution. <see cref="Coercion"/> is part of it because
-    /// <c>InteropHelper.CalculateMethodParameterScore</c>'s gray-zone rule reads it, so two engines
-    /// configured differently can rank the same candidates differently - and, with a single candidate, can
-    /// disagree about whether it survives scoring at all.
+    /// Identifies the set of operator methods a pair of CLR operand types offers under one operator name.
     /// </summary>
     [StructLayout(LayoutKind.Auto)]
-    internal readonly record struct OperatorKey(string? OperatorName, Type Left, Type Right, ValueCoercionType Coercion);
+    internal readonly record struct OperatorKey(string? OperatorName, Type Left, Type Right);
 
     /// <summary>
-    /// Resolutions every engine agrees on, and therefore the ones that may be remembered for the process.
-    /// Only an engine running the stock <see cref="DefaultTypeConverter"/> reads or writes this; see
-    /// <see cref="TryOperatorOverloading"/> for why, and for where the others keep theirs.
+    /// The candidates each key offers, which is what a reflection scan of the two types answers and nothing
+    /// more - no engine, no configuration and no argument value takes part in building one, so it is the same
+    /// answer for every engine in the process. Choosing between them is <see cref="TryOperatorOverloading"/>'s
+    /// job, per evaluation.
     /// </summary>
-    private static readonly ConcurrentDictionary<OperatorKey, MethodDescriptor?> _knownOperators = new();
+    internal static readonly ConcurrentDictionary<OperatorKey, MethodDescriptor[]> _operatorCandidates = new();
 
     private protected readonly JintExpression _left;
     private protected readonly JintExpression _right;
@@ -763,24 +760,33 @@ internal abstract class JintBinaryExpression : JintExpression
     private readonly record struct MethodResolverState(JsCallArguments Arguments);
 
     /// <summary>
-    /// The operator this pair of CLR operand types selects, resolved once and remembered.
+    /// Calls the CLR operator this pair of operands selects, if there is one.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// The resolution runs <see cref="InteropHelper.FindBestMatch"/>, which reads two things the embedder
-    /// configures: <c>Options.Interop.ValueCoercion</c>, which the gray-zone scoring rule consults, and the
-    /// installed <see cref="ITypeConverter"/>, whose answer is the last rule outright - a conversion it
-    /// confirms keeps the candidate, one it refuses scores -1 and discards it. So the answer is not a
-    /// property of the operator name and the two types alone, and a process-wide cache keyed on those let
-    /// whichever engine evaluated first decide for every engine after it (#3424).
+    /// What is remembered is the <em>candidate set</em> - the operator methods the two types declare under
+    /// this name - and choosing between them runs on every evaluation. Selection is
+    /// <see cref="InteropHelper.FindBestMatch"/>, which scores each candidate against the actual arguments,
+    /// and several of its rules read the argument's <em>value</em>: a number is a perfect fit for a
+    /// <c>byte</c> parameter when it lands inside that range and no match at all when it does not. Every
+    /// JavaScript number reaches a cache key as <see cref="double"/>, so a resolution keyed on the two CLR
+    /// types answered <c>m + 300</c> with whatever <c>m + 5</c> had selected - an
+    /// <see cref="OverflowException"/> out of <c>Execute</c> in one order and the wrong overload, silently,
+    /// in the other (#3567).
     /// </para>
     /// <para>
-    /// The coercion setting is a value, so it goes in the key and engines that share it share their entries.
-    /// The converter is an object a host builds - <c>Options.SetTypeConverter</c> hands its factory the
-    /// <see cref="Engine"/> - so keying a process-lived static on it would pin every such converter, and any
-    /// engine it captured, for the life of the process. It gates the choice of cache instead: an engine
-    /// running the stock converter resolves what every other stock engine would and shares the static one,
-    /// and an engine with a converter of its own keeps its resolutions on itself, where they die with it.
+    /// Scoring also reads two things the embedder configures - <c>Options.Interop.ValueCoercion</c>, which
+    /// the gray-zone rule consults, and the installed <see cref="ITypeConverter"/>, whose answer is the
+    /// last rule outright - so neither belongs to a shared cache either (#3424). Running selection per
+    /// evaluation is what keeps all three out of it: the candidate set is a pure function of the operator
+    /// name and the two types, so one process-wide table serves every engine, and nothing an engine or an
+    /// argument decides is stored anywhere.
+    /// </para>
+    /// <para>
+    /// The scan the table saves is the expensive half; scoring one or two candidates is not. A pair with no
+    /// operator at all - the common case for a binary expression over host objects - leaves through the
+    /// empty candidate set without allocating the argument array, and a single candidate is scored without
+    /// allocating a candidate list.
     /// </para>
     /// </remarks>
     internal static bool TryOperatorOverloading(
@@ -795,46 +801,38 @@ internal abstract class JintBinaryExpression : JintExpression
 
         if (left != null && right != null)
         {
-            var leftType = left.GetType();
-            var rightType = right.GetType();
-            var arguments = new[] { leftValue, rightValue };
-
-            var engine = context.Engine;
-            var key = new OperatorKey(clrName, leftType, rightType, engine._valueCoercion);
-            var cache = engine._typeConverterIsDefault
-                ? _knownOperators
-                : engine._engineOperatorOverloads ??= new ConcurrentDictionary<OperatorKey, MethodDescriptor?>();
-
-            if (!cache.TryGetValue(key, out var method))
+            var candidates = GetOperatorCandidates(clrName, left.GetType(), right.GetType());
+            if (candidates.Length > 0)
             {
-                method = ResolveOperatorOverload(engine, clrName, leftType, rightType, arguments);
+                var engine = context.Engine;
+                var arguments = new[] { leftValue, rightValue };
+                var method = InteropHelper
+                    .FindBestMatch(engine, candidates, static (_, state) => state.Arguments, new MethodResolverState(arguments))
+                    .FirstOrDefault().Method;
 
-                // racy, we don't care: both racers resolved the same operator the same way
-                cache.TryAdd(key, method);
-            }
-
-            if (method != null)
-            {
-                try
+                if (method != null)
                 {
-                    result = method.Call(context.Engine, null, arguments);
-                }
-                catch (Exception e)
-                {
-                    // The same normalization every other interop call site uses. Wrapping e.InnerException
-                    // instead reported the wrong exception twice over: MethodDescriptor.Call has already
-                    // unwrapped the invoke, so `e` is the host's own exception and its InnerException is
-                    // that exception's cause - null for the common case, which left MeaningfulException
-                    // with a contentless TargetInvocationException to report.
-                    Throw.MeaningfulException(context.Engine, e as TargetInvocationException ?? new TargetInvocationException(e));
-                    result = null;
-                    return false;
-                }
+                    try
+                    {
+                        result = method.Call(engine, null, arguments);
+                    }
+                    catch (Exception e)
+                    {
+                        // The same normalization every other interop call site uses. Wrapping e.InnerException
+                        // instead reported the wrong exception twice over: MethodDescriptor.Call has already
+                        // unwrapped the invoke, so `e` is the host's own exception and its InnerException is
+                        // that exception's cause - null for the common case, which left MeaningfulException
+                        // with a contentless TargetInvocationException to report.
+                        Throw.MeaningfulException(engine, e as TargetInvocationException ?? new TargetInvocationException(e));
+                        result = null;
+                        return false;
+                    }
 
-                // outside the catch-all above so a constraint exception is not laundered into
-                // a TargetInvocationException
-                context.Engine.CheckAmortizedConstraintsAtHostBoundary();
-                return true;
+                    // outside the catch-all above so a constraint exception is not laundered into
+                    // a TargetInvocationException
+                    engine.CheckAmortizedConstraintsAtHostBoundary();
+                    return true;
+                }
             }
         }
 
@@ -842,20 +840,58 @@ internal abstract class JintBinaryExpression : JintExpression
         return false;
     }
 
-    private static MethodDescriptor? ResolveOperatorOverload(
-        Engine engine,
+    /// <summary>
+    /// The two-parameter operator methods named <paramref name="clrName"/> that either operand type declares,
+    /// scanned once per triple and shared by every engine in the process.
+    /// </summary>
+    private static MethodDescriptor[] GetOperatorCandidates(
         string? clrName,
-        Type leftType,
-        Type rightType,
-        JsCallArguments arguments)
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type leftType,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type rightType)
     {
-        var leftMethods = leftType.GetOperatorOverloadMethods();
-        var rightMethods = rightType.GetOperatorOverloadMethods();
+        var key = new OperatorKey(clrName, leftType, rightType);
+        if (_operatorCandidates.TryGetValue(key, out var candidates))
+        {
+            return candidates;
+        }
 
-        var methods = leftMethods.Concat(rightMethods).Where(x => string.Equals(x.Name, clrName, StringComparison.Ordinal) && x.GetParameters().Length == 2);
-        var methodDescriptors = MethodDescriptor.Build(methods.ToArray());
+        // Written out rather than passed to GetOrAdd's factory because a lambda parameter cannot carry
+        // [DynamicallyAccessedMembers]: the annotation the caller already promised would be dropped on the
+        // way into the closure and every trimming build would report the scan as unannotated.
+        List<MethodInfo>? matching = null;
+        CollectOperatorMethods(leftType, clrName, ref matching);
+        CollectOperatorMethods(rightType, clrName, ref matching);
 
-        return InteropHelper.FindBestMatch(engine, methodDescriptors, static (_, state) => state.Arguments, new MethodResolverState(arguments)).FirstOrDefault().Method;
+        candidates = matching is null ? [] : MethodDescriptor.Build(matching);
+
+        // racy, we don't care: both racers scanned the same two types for the same name
+        _operatorCandidates.TryAdd(key, candidates);
+        return candidates;
+    }
+
+    private static void CollectOperatorMethods(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type type,
+        string? clrName,
+        ref List<MethodInfo>? matching)
+    {
+        foreach (var method in type.GetOperatorOverloadMethods())
+        {
+            if (string.Equals(method.Name, clrName, StringComparison.Ordinal) && method.GetParameters().Length == 2)
+            {
+                matching ??= [];
+
+                // The two operand types are scanned separately and the same operator can be on both lists -
+                // `T + T`, or a derived operand whose FlattenHierarchy scan reports the base's operator
+                // alongside the base itself. A duplicate candidate is scored a second time on every
+                // evaluation and, being a second survivor, costs the single-candidate lane its list-free
+                // path. The lists are two or three entries long, so the linear scan is the cheap way to say
+                // it, and it is paid once per key.
+                if (!matching.Contains(method))
+                {
+                    matching.Add(method);
+                }
+            }
+        }
     }
 
     internal static JintExpression Build(NonLogicalBinaryExpression expression)

--- a/Jint/Runtime/Interpreter/Expressions/JintUnaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintUnaryExpression.cs
@@ -20,10 +20,11 @@ internal sealed class JintUnaryExpression : JintExpression
     /// <see cref="Jint.Runtime.Interop.ITypeConverter"/> is consulted.
     /// </summary>
     /// <remarks>
-    /// That is what makes it different from <see cref="JintBinaryExpression"/>'s table, whose key carries the
-    /// coercion setting and whose choice of table carries the converter (#3424). Anything that gives this one
-    /// a scoring step - a second candidate to choose between, <see cref="Jint.Runtime.Interop.InteropHelper.FindBestMatch"/>
-    /// - inherits those rules with it.
+    /// That is what makes it different from <see cref="JintBinaryExpression"/>, which remembers the candidate
+    /// set alone and scores it on every evaluation, because the argument values and those two embedder inputs
+    /// all take part in choosing (#3424, #3567). Anything that gives this one a scoring step - a second
+    /// candidate to choose between, <see cref="Jint.Runtime.Interop.InteropHelper.FindBestMatch"/> - inherits
+    /// those rules with it, and this table would have to become a candidate set too.
     /// </remarks>
     private readonly record struct OperatorKey(string OperatorName, Type Operand);
     private static readonly ConcurrentDictionary<OperatorKey, MethodDescriptor?> _knownOperators = new();


### PR DESCRIPTION
Backport of #3578 (main squash `381dbb961`), which closed #3567. Its follow-up #3585 is deliberately **not** included: it was ruled out for 4.x separately.

## The defect, live on 4.x

`JintBinaryExpression` cached the *selected* `MethodDescriptor` under `(operator name, left CLR type, right CLR type, ValueCoercion)`. Selection is `InteropHelper.FindBestMatch`, and several of its scoring rules read the argument **value** rather than its type: a number is a perfect fit for a `byte` parameter inside that range and no match at all outside it. Every JavaScript number reaches the key as `System.Double`, so `5` and `300` share one entry and whichever arrives first decides for the other.

Both halves reproduce on 4.x today, in the same process:

* `m + 5` then `m + 300` — `System.OverflowException : Value was either too large or too small for an unsigned byte.` thrown out of `Engine.Evaluate` (the cached `operator +(RangedC, byte)` is called with 300).
* `m + 300` then `m + 5` — no exception, the wrong answer: `"object:5"` where ICU-equivalent selection gives `"byte:5"`.

Two fresh, identically configured engines disagree for the same reason, the table being process-wide.

## The fix

What is cached is now the **candidate set**: the two-parameter operator methods the two types declare under that name, which is a reflection scan and nothing else. Selection runs per evaluation, which also retires the two embedder inputs #3424 had to key on — `Options.Interop.ValueCoercion` and the installed `ITypeConverter` are both read while scoring, so neither is in a shared table any more and `Engine._engineOperatorOverloads` is gone (along with `Engine._valueCoercion`, which existed only to be part of that key).

Three things keep the per-evaluation selection cheap:

* a pair with no operator at all leaves through the empty candidate set without allocating the argument array;
* a candidate found on both operand types (`T + T`, or a derived operand whose `FlattenHierarchy` scan reports the base's operator) is listed once instead of twice;
* `FindBestMatch` holds the first surviving candidate in a local and builds its list only when a second one survives, so a single-candidate resolution allocates nothing — the shape of most operator lanes and of many ordinary method calls too.

`#3424`'s guarantee is not weakened: two engines still cannot decide for each other. It is now guaranteed by *not storing a decision at all* rather than by partitioning the store, so the four converter-decided and four coercion-decided tests in `Jint.Tests.PublicInterface` keep passing unchanged.

## Divergence from the main PR

| main | here | why |
| --- | --- | --- |
| `engine._typeConverterTargetFilter is null`, `ClrTypeConverter`, `InstallTypeConverter` | `engine._typeConverterIsDefault`, `ITypeConverter`, the `TypeConverter` setter | 4.x names; the code being deleted is the same code |
| `docs/v5-migration.md`, `Jint/Runtime/Interpreter/AGENTS.md` | dropped | neither exists on 4.x |
| — | `MethodDescriptor.cs` and `JintUnaryExpression.cs` comment updates | 4.x carries two more references to the renamed table than main did. `MethodDescriptor`'s precedent list named `JintBinaryExpression._knownOperators`, and `JintUnaryExpression`'s remarks explained itself by contrast with "`JintBinaryExpression`'s table, whose key carries the coercion setting and whose choice of table carries the converter" — true before this change, false after it. Both now name `_operatorCandidates` and describe what it holds. **main still has the `JintUnaryExpression` wording, where it is equally stale** — worth a follow-up there. |

Everything else is byte-identical to the main patch: the `Engine.cs` deletion (24 lines, same as main), the `InteropHelper.FindBestMatch` survivor lane (applied with `git apply -3`, clean), and the whole of `JintBinaryExpression`'s new `GetOperatorCandidates` / `CollectOperatorMethods` / `TryOperatorOverloading`.

## Evidence

The five new `Jint.Tests.PublicInterface` cases were run against **unfixed** 4.x first, on both legs:

| leg | before | after |
| --- | --- | --- |
| net472 | **Failed: 3**, Passed: 10, Total: 13 | Failed: 0, Passed: 13 |
| net10.0 | **Failed: 3**, Passed: 10, Total: 13 | Failed: 0, Passed: 13 |

The three that failed are `ASmallNumberDoesNotDecideForALargeOne` (the `OverflowException`), `ALargeNumberDoesNotDecideForASmallOne` (the silent wrong overload) and `OneEngineSelectsPerEvaluationToo`. The two single-evaluation cases passed before and after, which is what makes the other three about ordering rather than about scoring.

`Jint.Tests`' `OperatorOverloadResolutionCacheTests` is rewritten rather than added to: its three cases pinned `Engine._engineOperatorOverloads`, which no longer exists. The four replacing them pin the mechanism — that the set and not the selection is what is stored, that one table serves a stock engine and a converter engine alike, that a pair with no operator is remembered as having none, and that `T + T` is listed once. 4/4 on net472 and net10.0.

Full `dotnet build -c Release`: 0 errors, 0 warnings. Full `dotnet test -c Release`:

* `Jint.Tests` 7000/7000 (net10.0), 6915/6915 (net472)
* `Jint.Tests.PublicInterface` 1825/1825 (net10.0), 1817/1817 (net472)
* `Jint.Tests.CommonScripts` 28/28 both legs, `Jint.Tests.SourceGenerators` 52/52
* `Jint.Tests.Test262` 102,498 passed / 1 failed / 185 skipped of 102,684 — the one failure is `intl402/supportedLocalesOf-unicode-extensions-ignored.js`, the known load flake (31 s under the full run, **passes in 2 s in isolation**, verified). At the 4.x control of 102,499 / 0 / 185; this change cannot reach test262, which has no CLR interop.
