### PR TITLE
Intl: a calendar counting Gregorian months writes their names (backport of #3589)

### DIFF
--- a/Jint.Tests/Runtime/IntlCalendarMonthNameTests.cs
+++ b/Jint.Tests/Runtime/IntlCalendarMonthNameTests.cs
@@ -1,0 +1,307 @@
+#nullable enable
+
+using Jint.Native.Intl;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// https://tc39.es/ecma402/#table-datetimeformat-components makes <c>"long"</c>, <c>"short"</c> and
+/// <c>"narrow"</c> textual month formats, so a formatter answering one of them with a number is answering a
+/// different format. Which name it writes depends on what the resolved calendar counts months in, and there
+/// are two answers rather than one.
+/// </summary>
+public class IntlCalendarMonthNameTests
+{
+    private readonly Engine _engine = new();
+
+    /// <summary>2024-01-15 is 5 Shevat 5784, 4 Rajab 1445, 25 Dey 1402, 6 Toba 1740 and 25 Pausa 1945.</summary>
+    private const string January15 = "Date.UTC(2024, 0, 15)";
+
+    /// <summary>2024-09-08 is the third of the thirteenth month in both the Coptic and the Ethiopic year.</summary>
+    private const string September8 = "Date.UTC(2024, 8, 8)";
+
+    private string Month(string calendar, string style, string locale = "en-US", string date = January15)
+        => MonthOn(_engine, calendar, style, locale, date);
+
+    private static string MonthOn(Engine engine, string calendar, string style, string locale, string date)
+        => engine.Evaluate(
+                $"new Intl.DateTimeFormat('{locale}-u-ca-{calendar}', {{ month: '{style}', timeZone: 'UTC' }}).format({date})")
+            .AsString();
+
+    /// <summary>
+    /// The defect this pins: every calendar but <c>gregory</c> wrote a bare number for all three textual
+    /// styles. <c>buddhist</c>, <c>japanese</c> and <c>roc</c> differ from <c>gregory</c> in era and year
+    /// only - ICU writes "January" for all four - so the locale's own month name is the one to write.
+    /// </summary>
+    /// <remarks>
+    /// The expected <c>narrow</c> value is the abbreviated name rather than a single letter because that is
+    /// what this branch writes for <c>gregory</c>; narrow month names are a separate gap, and the point here
+    /// is that these three calendars write whatever <c>gregory</c> writes.
+    /// </remarks>
+    [Theory]
+    [InlineData("buddhist", "long", "January")]
+    [InlineData("buddhist", "short", "Jan")]
+    [InlineData("buddhist", "narrow", "Jan")]
+    [InlineData("japanese", "long", "January")]
+    [InlineData("japanese", "short", "Jan")]
+    [InlineData("japanese", "narrow", "Jan")]
+    [InlineData("roc", "long", "January")]
+    [InlineData("roc", "short", "Jan")]
+    [InlineData("roc", "narrow", "Jan")]
+    public void ACalendarCountingGregorianMonthsWritesTheGregorianName(string calendar, string style, string expected)
+    {
+        Month(calendar, style).Should().Be(expected);
+    }
+
+    /// <summary>
+    /// The same rule without a literal: whatever a locale writes for a Gregorian month, these three write for
+    /// the same month, in every style and in a locale whose own names are not English.
+    /// </summary>
+    [Theory]
+    [InlineData("buddhist")]
+    [InlineData("japanese")]
+    [InlineData("roc")]
+    public void SuchACalendarAgreesWithGregoryOnEveryMonthStyle(string calendar)
+    {
+        foreach (var style in new[] { "long", "short", "narrow", "numeric", "2-digit" })
+        {
+            foreach (var locale in new[] { "en-US", "de-DE", "th-TH", "ja-JP" })
+            {
+                Month(calendar, style, locale).Should().Be(
+                    Month("gregory", style, locale),
+                    "{0} counts the Gregorian months, for {1} in {2}", calendar, style, locale);
+            }
+        }
+    }
+
+    /// <summary>
+    /// A calendar counting months of its own is the other case, and the number is what the engine has: Jint
+    /// ships no month-name data for one, and a number is never a wrong name. ICU itself writes the number for
+    /// <c>"narrow"</c> on every one of these.
+    /// </summary>
+    [Theory]
+    [InlineData("islamic-civil", "7")]
+    [InlineData("islamic-tbla", "7")]
+    [InlineData("islamic-umalqura", "7")]
+    [InlineData("hebrew", "5")]
+    [InlineData("persian", "10")]
+    [InlineData("coptic", "5")]
+    [InlineData("ethiopic", "5")]
+    [InlineData("ethioaa", "5")]
+    [InlineData("indian", "10")]
+    [InlineData("chinese", "12")]
+    [InlineData("dangi", "12")]
+    public void ACalendarWithMonthsOfItsOwnKeepsTheNumberWithNoDataForIt(string calendar, string expected)
+    {
+        foreach (var style in new[] { "long", "short", "narrow" })
+        {
+            Month(calendar, style).Should().Be(expected, "{0} has no {1} month names to write", calendar, style);
+        }
+    }
+
+    /// <summary>
+    /// <see cref="ICldrProvider.GetMonthNames"/> takes the calendar for exactly this, and had no reachable
+    /// effect through <c>Intl</c> at all: a host supplying Hebrew month names had nowhere for them to be
+    /// written.
+    /// </summary>
+    [Theory]
+    [InlineData("long", "Shevat")]
+    [InlineData("short", "Sh")]
+    [InlineData("narrow", "S")]
+    public void AHostsMonthNamesForTheCalendarAreWritten(string style, string expected)
+    {
+        var engine = new Engine(options => options.Intl.CldrProvider = new HebrewMonths());
+
+        MonthOn(engine, "hebrew", style, "en-US", January15).Should().Be(expected);
+    }
+
+    /// <summary>
+    /// A thirteenth month is a month, and the calendars that have one carry a name for it. The
+    /// <see cref="System.Globalization.DateTimeFormatInfo"/> arrays the shipped provider reads carry twelve
+    /// names, which is why the calendar's own names are read from the provider rather than out of them.
+    /// </summary>
+    [Fact]
+    public void AThirteenthMonthHasAName()
+    {
+        var engine = new Engine(options => options.Intl.CldrProvider = new CopticMonths());
+
+        MonthOn(engine, "coptic", "long", "en-US", September8).Should().Be("Nasie");
+        MonthOn(engine, "coptic", "long", "en-US", January15).Should().Be("Toba");
+    }
+
+    /// <summary>The calendar the formatter resolved is the one the provider is asked about.</summary>
+    [Fact]
+    public void TheProviderIsAskedWithTheResolvedCalendar()
+    {
+        var provider = new RecordsWhatItWasAsked();
+        var engine = new Engine(options => options.Intl.CldrProvider = provider);
+
+        MonthOn(engine, "persian", "long", "en-US", January15);
+
+        provider.Calendars.Should().Contain("persian");
+    }
+
+    /// <summary><c>format</c> is the concatenation of the parts <c>formatToParts</c> walks, name included.</summary>
+    [Fact]
+    public void FormatAndFormatToPartsWriteTheSameName()
+    {
+        var engine = new Engine(options => options.Intl.CldrProvider = new HebrewMonths());
+
+        var script = $$"""
+            (function () {
+                var f = new Intl.DateTimeFormat('en-US-u-ca-hebrew', { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' });
+                var parts = f.formatToParts({{January15}}).map(function (p) { return p.value; }).join('');
+                return [f.format({{January15}}), parts].join('~');
+            })()
+            """;
+
+        var pieces = engine.Evaluate(script).AsString().Split('~');
+        pieces[0].Should().Contain("Shevat");
+        pieces[1].Should().Be(pieces[0]);
+    }
+
+    /// <summary>The numeric styles are untouched: they were never the defect.</summary>
+    [Theory]
+    [InlineData("buddhist", "numeric", "1")]
+    [InlineData("buddhist", "2-digit", "01")]
+    [InlineData("hebrew", "numeric", "5")]
+    [InlineData("hebrew", "2-digit", "05")]
+    [InlineData("coptic", "numeric", "5")]
+    [InlineData("coptic", "2-digit", "05")]
+    public void ANumericMonthStaysANumber(string calendar, string style, string expected)
+    {
+        Month(calendar, style).Should().Be(expected);
+    }
+
+    /// <summary>
+    /// The shipped provider reads month names out of <see cref="System.Globalization.CultureInfo"/>, and those
+    /// are the Gregorian ones. Answering with them for <c>hebrew</c> would be a wrong name rather than no name,
+    /// and the engine would write "May" for Shevat.
+    /// </summary>
+    [Theory]
+    [InlineData("gregory")]
+    [InlineData("iso8601")]
+    [InlineData("buddhist")]
+    [InlineData("japanese")]
+    [InlineData("roc")]
+    [InlineData(null)]
+    public void TheShippedProviderAnswersForTheCalendarsItsNamesAreFor(string? calendar)
+    {
+        DefaultCldrProvider.Instance.GetMonthNames("en-US", "long", calendar).Should().HaveCount(12);
+    }
+
+    [Theory]
+    [InlineData("hebrew")]
+    [InlineData("persian")]
+    [InlineData("islamic-civil")]
+    [InlineData("coptic")]
+    [InlineData("chinese")]
+    [InlineData("mayan")]
+    public void TheShippedProviderHasNoNamesForACalendarCountingItsOwnMonths(string calendar)
+    {
+        DefaultCldrProvider.Instance.GetMonthNames("en-US", "long", calendar).Should().BeNull();
+    }
+}
+
+/// <summary>
+/// A host provider that answers one question of its own and delegates the rest.
+/// <see cref="DefaultCldrProvider"/> is sealed on this branch, so a host writes the delegation itself, which
+/// is what <c>Jint.Tests.Test262</c>'s ICU provider does too.
+/// </summary>
+file abstract class DelegatingCldrProvider : ICldrProvider
+{
+    private static readonly DefaultCldrProvider Fallback = DefaultCldrProvider.Instance;
+
+    public virtual string[]? GetMonthNames(string locale, string style, string? calendar)
+        => Fallback.GetMonthNames(locale, style, calendar);
+
+    protected static string[]? Delegated(string locale, string style, string? calendar)
+        => Fallback.GetMonthNames(locale, style, calendar);
+
+    public ListPatterns? GetListPatterns(string locale, string type, string style) => Fallback.GetListPatterns(locale, type, style);
+    public RelativeTimePatterns? GetRelativeTimePatterns(string locale, string unit, string style) => Fallback.GetRelativeTimePatterns(locale, unit, style);
+    public string? GetRelativeTimeSpecialPhrase(string locale, string unit, int value, bool past, string style) => Fallback.GetRelativeTimeSpecialPhrase(locale, unit, value, past, style);
+    public string? GetNumberingSystemDigits(string numberingSystem) => Fallback.GetNumberingSystemDigits(numberingSystem);
+    public string? GetDefaultNumberingSystem(string locale) => Fallback.GetDefaultNumberingSystem(locale);
+    public CompactPatterns? GetCompactPatterns(string locale, string style) => Fallback.GetCompactPatterns(locale, style);
+    public CurrencyData? GetCurrencyData(string locale, string currencyCode) => Fallback.GetCurrencyData(locale, currencyCode);
+    public UnitPatterns? GetUnitPatterns(string locale, string unit, string style) => Fallback.GetUnitPatterns(locale, unit, style);
+    public DateTimePatterns? GetDateTimePatterns(string locale, string? dateStyle, string? timeStyle) => Fallback.GetDateTimePatterns(locale, dateStyle, timeStyle);
+    public string[]? GetWeekdayNames(string locale, string style) => Fallback.GetWeekdayNames(locale, style);
+    public string[]? GetDayPeriods(string locale, string style, string? calendar) => Fallback.GetDayPeriods(locale, style, calendar);
+    public string[]? GetEraNames(string locale, string style, string? calendar) => Fallback.GetEraNames(locale, style, calendar);
+    public string? GetCurrencyDisplayName(string locale, string code) => Fallback.GetCurrencyDisplayName(locale, code);
+    public string? GetLikelySubtags(string locale) => Fallback.GetLikelySubtags(locale);
+    public WeekInfo? GetWeekInfo(string locale) => Fallback.GetWeekInfo(locale);
+    public string SelectPluralCategory(string locale, double value, string type) => Fallback.SelectPluralCategory(locale, value, type);
+    public IReadOnlyCollection<string> GetSupportedCalendars() => Fallback.GetSupportedCalendars();
+    public IReadOnlyCollection<string> GetSupportedCollations() => Fallback.GetSupportedCollations();
+    public IReadOnlyCollection<string> GetSupportedCurrencies() => Fallback.GetSupportedCurrencies();
+    public IReadOnlyCollection<string> GetSupportedNumberingSystems() => Fallback.GetSupportedNumberingSystems();
+    public IReadOnlyCollection<string> GetSupportedTimeZones() => Fallback.GetSupportedTimeZones();
+    public IReadOnlyCollection<string> GetSupportedUnits() => Fallback.GetSupportedUnits();
+}
+
+/// <summary>A host with the thirteen Hebrew month names Jint ships none of, and no other datum.</summary>
+file sealed class HebrewMonths : DelegatingCldrProvider
+{
+    private static readonly string[] Wide =
+    [
+        "Tishri", "Heshvan", "Kislev", "Tevet", "Shevat", "Adar I", "Adar II",
+        "Nisan", "Iyar", "Sivan", "Tammuz", "Av", "Elul"
+    ];
+
+    public override string[]? GetMonthNames(string locale, string style, string? calendar)
+    {
+        if (!string.Equals(calendar, "hebrew", StringComparison.Ordinal))
+        {
+            return Delegated(locale, style, calendar);
+        }
+
+        return style switch
+        {
+            "long" => Wide,
+            "short" => Abbreviate(2),
+            "narrow" => Abbreviate(1),
+            _ => null
+        };
+    }
+
+    private static string[] Abbreviate(int length)
+    {
+        var result = new string[Wide.Length];
+        for (var i = 0; i < Wide.Length; i++)
+        {
+            result[i] = Wide[i].Substring(0, Math.Min(length, Wide[i].Length));
+        }
+
+        return result;
+    }
+}
+
+/// <summary>A host answering for the thirteen months of the Coptic year.</summary>
+file sealed class CopticMonths : DelegatingCldrProvider
+{
+    private static readonly string[] Wide =
+    [
+        "Tout", "Baba", "Hator", "Kiahk", "Toba", "Amshir", "Baramhat",
+        "Baramouda", "Bashans", "Paona", "Epep", "Mesra", "Nasie"
+    ];
+
+    public override string[]? GetMonthNames(string locale, string style, string? calendar)
+        => string.Equals(calendar, "coptic", StringComparison.Ordinal) && string.Equals(style, "long", StringComparison.Ordinal)
+            ? Wide
+            : Delegated(locale, style, calendar);
+}
+
+/// <summary>A host that adds nothing and remembers what it was asked.</summary>
+file sealed class RecordsWhatItWasAsked : DelegatingCldrProvider
+{
+    public List<string> Calendars { get; } = [];
+
+    public override string[]? GetMonthNames(string locale, string style, string? calendar)
+    {
+        Calendars.Add(calendar ?? "<null>");
+        return Delegated(locale, style, calendar);
+    }
+}

--- a/Jint/Native/Intl/DefaultCldrProvider.cs
+++ b/Jint/Native/Intl/DefaultCldrProvider.cs
@@ -335,8 +335,25 @@ public sealed class DefaultCldrProvider : ICldrProvider
         return null;
     }
 
+    /// <summary>
+    /// The month names this provider has for <paramref name="calendar"/>, or null when it has none for it.
+    /// </summary>
+    /// <remarks>
+    /// The names come from <see cref="DateTimeFormatInfo.MonthNames"/>, and those are the twelve Gregorian
+    /// months, so this provider answers for the calendars that count them - <c>gregory</c>, <c>iso8601</c>,
+    /// <c>buddhist</c>, <c>japanese</c> and <c>roc</c>, which differ in era and year only - and answers null
+    /// for a calendar counting months of its own. Writing "May" for Shevat would be a wrong name rather than
+    /// no name. A null calendar is the caller with nothing resolved, and reads the culture's names as before.
+    /// </remarks>
     public string[]? GetMonthNames(string locale, string style, string? calendar)
     {
+        if (!IntlUtilities.UsesGregorianMonths(calendar))
+        {
+            return null;
+        }
+
+        // Every calendar that reaches here answers with the same names, which is why the calendar is not
+        // part of the key.
         var cacheKey = string.Concat(locale, "_", style);
         return _monthNameCache.GetOrAdd(cacheKey, _ =>
         {

--- a/Jint/Native/Intl/ICldrProvider.cs
+++ b/Jint/Native/Intl/ICldrProvider.cs
@@ -98,7 +98,13 @@ public interface ICldrProvider
     /// <param name="locale">The locale identifier.</param>
     /// <param name="style">Style: "long", "short", "narrow", or "numeric".</param>
     /// <param name="calendar">Calendar identifier (e.g., "gregory", "buddhist"), or null for default.</param>
-    /// <returns>Array of 12 month names (January-December) or null if not available.</returns>
+    /// <returns>The calendar's month names in order, or null if none are available for it.</returns>
+    /// <remarks>
+    /// The array is indexed by the calendar's own month number, so it is as long as that calendar's year:
+    /// thirteen for Coptic, Ethiopic and a Hebrew or Chinese leap year, twelve for the Gregorian months.
+    /// Answering null is what leaves the month number standing, and is the right answer for a calendar the
+    /// implementation has no names for - a Gregorian name under a non-Gregorian month number is a wrong name.
+    /// </remarks>
     string[]? GetMonthNames(string locale, string style, string? calendar);
 
     /// <summary>

--- a/Jint/Native/Intl/IntlUtilities.cs
+++ b/Jint/Native/Intl/IntlUtilities.cs
@@ -16,6 +16,47 @@ namespace Jint.Native.Intl;
 internal static class IntlUtilities
 {
     /// <summary>
+    /// The calendars that count the very months <c>gregory</c> counts, so that a month number of one names
+    /// the same month and the locale's own month names are the ones to write for it.
+    /// </summary>
+    /// <remarks>
+    /// <c>buddhist</c>, <c>japanese</c> and <c>roc</c> differ from <c>gregory</c> in era and year only - ICU
+    /// writes "January" for all four and a number for none of them. Every other calendar, this engine's or a
+    /// host's, counts months of its own, and a name for one has to come from data that knows that calendar:
+    /// <see cref="ICldrProvider.GetMonthNames"/>, which takes the calendar for exactly this.
+    /// </remarks>
+    private static readonly string[] GregorianMonthedCalendars = ["gregory", "iso8601", "buddhist", "japanese", "roc"];
+
+    /// <summary>
+    /// Whether <paramref name="calendar"/> counts the Gregorian months. A formatter that resolved one writes
+    /// its months exactly as <c>gregory</c> does, names included; every other calendar needs its own names, or
+    /// keeps the month number.
+    /// </summary>
+    /// <remarks>
+    /// A null calendar is the unresolved case and answers as <c>gregory</c>, so a caller with nothing resolved
+    /// reads the locale's own names rather than none. The comparison is case-insensitive because
+    /// <see cref="ICldrProvider.GetMonthNames"/> is public and its argument has been through no
+    /// canonicalization this class can see.
+    /// </remarks>
+    internal static bool UsesGregorianMonths(string? calendar)
+    {
+        if (calendar is null)
+        {
+            return true;
+        }
+
+        foreach (var candidate in GregorianMonthedCalendars)
+        {
+            if (string.Equals(calendar, candidate, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// The primary language subtag of a BCP 47 tag, so "es" from "es-ES", and the tag itself when it
     /// carries no subtags. Equivalent to <c>tag.Split('-')[0]</c> without the string[] that allocates
     /// to read one element -- including for a leading separator, where Split yields an empty string.

--- a/Jint/Native/Intl/JsDateTimeFormat.cs
+++ b/Jint/Native/Intl/JsDateTimeFormat.cs
@@ -88,6 +88,62 @@ internal sealed class JsDateTimeFormat : ObjectInstance
     private ICldrProvider CldrProvider => _engine.Options.Intl.CldrProvider;
 
     /// <summary>
+    /// The resolved calendar's own month names, one array per textual style, asked for once each and only by
+    /// a formatter that writes one. An empty array is "asked, and there are none".
+    /// </summary>
+    private string[][]? _calendarMonthNames;
+
+    /// <summary>
+    /// The name this formatter writes for month <paramref name="month"/> of the calendar it resolved, or null
+    /// when there is none and the month number stands.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// https://tc39.es/ecma402/#table-datetimeformat-components makes <c>"long"</c>, <c>"short"</c> and
+    /// <c>"narrow"</c> textual, and a formatter is not free to answer one of them with a number. For a
+    /// calendar counting the Gregorian months the name is the locale's own and no lookup happens here - the
+    /// Gregorian lane writes it. For a calendar counting months of its own the name has to come from data that
+    /// knows that calendar, which is what <see cref="ICldrProvider.GetMonthNames"/> takes its <c>calendar</c>
+    /// argument for.
+    /// </para>
+    /// <para>
+    /// The array is indexed by the calendar's month number, so it is as long as that calendar's year: thirteen
+    /// for Coptic, Ethiopic and a Hebrew or Chinese leap year. That is why the answer is read from the provider
+    /// rather than out of <see cref="DateTimeFormatInfo"/>, whose month arrays hold twelve names and a trailing
+    /// empty one. A month the array is too short for keeps its number, and so does an empty name.
+    /// </para>
+    /// <para>
+    /// With no answer the number stands, which is what every release before this one wrote for all three
+    /// styles, and what ICU itself writes for <c>"narrow"</c> on every one of these calendars.
+    /// </para>
+    /// </remarks>
+    private string? CalendarMonthName(int month, string? style)
+    {
+        var index = style switch
+        {
+            "long" => 0,
+            "short" => 1,
+            "narrow" => 2,
+            _ => -1
+        };
+
+        if (index < 0 || month < 1 || IntlUtilities.UsesGregorianMonths(Calendar))
+        {
+            return null;
+        }
+
+        var cache = _calendarMonthNames ??= new string[3][];
+        var names = cache[index];
+        if (names is null)
+        {
+            names = CldrProvider.GetMonthNames(Locale, style!, Calendar) ?? [];
+            cache[index] = names;
+        }
+
+        return month <= names.Length && names[month - 1].Length > 0 ? names[month - 1] : null;
+    }
+
+    /// <summary>
     /// Formats a date according to the formatter's locale and options.
     /// </summary>
     /// <param name="dateTime">The .NET DateTime to format</param>
@@ -602,20 +658,21 @@ internal sealed class JsDateTimeFormat : ObjectInstance
             return;
         }
 
-        // Simple offset calendars: cheap arithmetic without going through NonIsoCalendars.
+        // Simple offset calendars: cheap arithmetic without going through NonIsoCalendars. Only the year is
+        // overridden, because only the year differs - https://tc39.es/ecma402/#table-datetimeformat-components
+        // makes "long", "short" and "narrow" textual month formats, and a month override is what forced them
+        // to a number. Leaving month and day to the Gregorian lane is what makes these calendars write the
+        // very name gregory writes, which is also what ICU does: buddhist, japanese and roc are the Gregorian
+        // months under another era.
         var sourceYear = originalYear ?? dateTime.Year;
         if (string.Equals(Calendar, "buddhist", StringComparison.OrdinalIgnoreCase))
         {
             year = sourceYear + 543;
-            month = dateTime.Month;
-            day = dateTime.Day;
             return;
         }
         if (string.Equals(Calendar, "roc", StringComparison.OrdinalIgnoreCase))
         {
             year = sourceYear - 1911;
-            month = dateTime.Month;
-            day = dateTime.Day;
             return;
         }
         if (string.Equals(Calendar, "japanese", StringComparison.OrdinalIgnoreCase))
@@ -640,8 +697,6 @@ internal sealed class JsDateTimeFormat : ObjectInstance
             if (eraYear.HasValue)
             {
                 year = eraYear;
-                month = dt.Month;
-                day = dt.Day;
             }
             return;
         }
@@ -677,22 +732,21 @@ internal sealed class JsDateTimeFormat : ObjectInstance
             {
                 "numeric" => chineseMonth.ToString(CultureInfo),
                 "2-digit" => chineseMonth.ToString("D2", CultureInfo),
-                // For textual months in lunisolar calendars, we still use numeric
-                // as Chinese month names are not typically used in Intl formatting
-                "long" or "short" or "narrow" => chineseMonth.ToString(CultureInfo),
+                // A lunisolar month has a name - ICU writes "Twelfth Month" - and Jint ships none, so the
+                // number stands unless a host answers for the calendar.
+                "long" or "short" or "narrow" => CalendarMonthName(chineseMonth, Month) ?? chineseMonth.ToString(CultureInfo),
                 _ => chineseMonth.ToString("D2", CultureInfo)
             };
         }
         else if (overrideMonth.HasValue)
         {
-            // Calendar-aware override (e.g. coptic month for the underlying ISO date).
-            // Textual month styles fall back to numeric since we don't have month-name data
-            // for arbitrary non-ISO calendars.
+            // Calendar-aware override (e.g. coptic month for the underlying ISO date). A textual style writes
+            // the calendar's own name for that month where there is one, and the number where there is not.
             monthValue = Month switch
             {
                 "numeric" => overrideMonth.Value.ToString(CultureInfo),
                 "2-digit" => overrideMonth.Value.ToString("D2", CultureInfo),
-                _ => overrideMonth.Value.ToString(CultureInfo)
+                _ => CalendarMonthName(overrideMonth.Value, Month) ?? overrideMonth.Value.ToString(CultureInfo)
             };
         }
         else


### PR DESCRIPTION
Backport of #3589 (main squash `ac083c472`), which closed #3574. **This is the component-lane half only** — see "What is not here" below for the half that has no 4.x counterpart, and for the measured reason the test262 harness change is left out.

## The defect, live on 4.x

`Intl.DateTimeFormat` answers `month: 'long'`, `'short'` and `'narrow'` with a bare number on every calendar but `gregory`. https://tc39.es/ecma402/#table-datetimeformat-components makes those three *textual* formats; a formatter is not free to answer one with a number. Measured on this branch before the change, for `Date.UTC(2024, 0, 15)` in `en-US`:

| calendar | `month:'long'` | `month:'short'` | `month:'narrow'` |
| --- | --- | --- | --- |
| `gregory` | January | Jan | Jan |
| `buddhist` / `japanese` / `roc` | **1** | **1** | **1** |
| `hebrew` | **5** | **5** | **5** |
| `coptic` | **5** | **5** | **5** |
| `islamic-tbla` | **7** | **7** | **7** |
| `persian` | **10** | **10** | **10** |
| `chinese` / `dangi` | **12** | **12** | **12** |

## The fix

There are two cases, not one, and the fix separates them.

**`buddhist`, `japanese` and `roc` differ from `gregory` in era and year only**, so their month number *is* the Gregorian month number. `ResolveCalendarFieldsForFormatting` was overriding month and day with values equal to what the Gregorian lane would write, and that override is what forced the number. It now overrides the year alone, so those three write the very name `gregory` writes — the locale's own, in whatever style. ICU writes "January" for all four. `AddDayPart` falls back to `dateTime.Day` for the same reason and gets the identical value.

**Every other calendar counts months of its own**, and a name for one has to come from data that knows that calendar. That is what `ICldrProvider.GetMonthNames` takes its `calendar` argument for, and on this branch it had no reachable effect through `Intl` at all — nothing in `Jint/Native/Intl` called it. `AddMonthPart` now reads it, once per formatter per style, indexed by the calendar's month number. That is why the answer comes from the provider rather than out of the formatter's own `DateTimeFormatInfo` arrays: a thirteen-month calendar has thirteen names and those arrays hold twelve. With no answer the number stands — Jint ships no such data, a number is never a wrong name, and it is what ICU itself writes for `narrow` on every one of these calendars.

**`DefaultCldrProvider.GetMonthNames` stops answering for a calendar its names are not for.** It reads `CultureInfo.DateTimeFormat`, whose names are the twelve Gregorian months, so it answers for the five calendars that count them and `null` otherwise. Without that early return the new lane would write "May" under the name Shevat, so it is load-bearing rather than cosmetic. It sits ahead of the cache `GetOrAdd`, so the calendar-blind cache key stays correct: every calendar that reaches the cache answers with the same names.

## Divergence from the main PR, and where the predicate lives

* **`UsesGregorianMonths` lives on `IntlUtilities`.** Main put it on `AvailableCalendars`, which does not exist on 4.x. `IntlUtilities` is this namespace's internal static utility class and is already used by both consumers (`DefaultCldrProvider` for `GetCultureInfo`, `JsDateTimeFormat` for `GetLanguageSubtag`), so a new one-file class named after a type that exists nowhere else on the branch would have been the less idiomatic choice. The predicate itself, its list and its documentation are main's.
* **The `narrow` expectations differ.** Main's tests assert `"J"`; this branch writes `"Jan"` for `gregory` itself, narrow month names being main-only (`ApplyNarrowNames`, part of the excluded provider work). The literal test therefore expects `"Jan"`, and the stronger test — that these three calendars agree with `gregory` in *every* style and in `en-US`, `de-DE`, `th-TH` and `ja-JP` — carries the real claim and is framework-independent.
* **Host-provider tests implement `ICldrProvider` instead of deriving from `DefaultCldrProvider`**, which is `sealed` on this branch (main unsealed it in #3335, which is out of scope for 4.x). The test file carries one small delegating base, the same shape `Jint.Tests.Test262`'s ICU provider already uses.
* `docs/v5-migration.md` dropped — it does not exist here.
* `ICldrProvider.GetMonthNames`' doc comment updated: it said "Array of 12 month names", which is now wrong for a thirteen-month calendar and was the reason the arrays could not simply be read out of `DateTimeFormatInfo`.

## What is not here, and why

**The pattern lane.** Main's #3589 also fixed the textual month of a `dateStyle` pattern. That lane does not exist on this branch: `FormatDateStyleToParts` writes a fixed layout out of `dateTime.ToString("MMMM"|"MMM")` and never consults the resolved calendar at all — measured, `new Intl.DateTimeFormat('en-US-u-ca-buddhist', { dateStyle: 'full' })` answers `Monday, January 15, 2024`, with the Gregorian *year* as well as the Gregorian month. So there is no calendar month number to replace with a name there, and closing that gap means porting the locale-pattern machinery main has and this branch does not — a different change, not this one. Main's two `dateStyle` tests are therefore not part of this file.

**The `Jint.Tests.Test262` `IcuCldrProvider` change.** On main it removed four exclusions — the `toLocaleString/dateStyle` tests for `Instant`, `PlainDate`, `PlainDateTime` and `ZonedDateTime`. Those are `dateStyle` tests, and per the paragraph above no month-name data can make them pass here. I ported the ~90-line change anyway and measured it: **test262 was byte-identical with and without it**, 102,498 / 1 / 185 both times. It is left out rather than merged as unexercised harness code; if the pattern lane is ever ported, it is one `git show ac083c472 -- Jint.Tests.Test262/IcuCldrProvider.cs` away.

**No 4.x exclusion comes out.** Checked as asked: the six `intl402/Temporal/*/prototype/toLocaleString/dateStyle.js` entries all stay, for the same reason.

## Evidence

`Jint.Tests/Runtime/IntlCalendarMonthNameTests.cs` (47 cases) run against **unfixed** 4.x first, on both legs:

| leg | before | after |
| --- | --- | --- |
| net472 | **Failed: 24**, Passed: 23, Total: 47 | Failed: 0, Passed: 47 |
| net10.0 | **Failed: 24**, Passed: 23, Total: 47 | Failed: 0, Passed: 47 |

The 23 that passed before are the numeric-style cases (never the defect), the "keeps the number with no data for it" cases (true before *and* after, for different reasons) and the shipped provider answering for the five Gregorian-monthed calendars.

All 285 `Jint.Tests` Intl cases pass on both legs. Full `dotnet build -c Release`: 0 errors, 0 warnings. Full `dotnet test -c Release`:

* `Jint.Tests` 7046/7046 (net10.0), 6961/6961 (net472)
* `Jint.Tests.PublicInterface` 1820/1820 (net10.0), 1812/1812 (net472)
* `Jint.Tests.CommonScripts` 28/28 both legs, `Jint.Tests.SourceGenerators` 52/52
* `Jint.Tests.Test262` 102,498 passed / 1 failed / 185 skipped of 102,684 — the one failure is `intl402/supportedLocalesOf-unicode-extensions-ignored.js`, the known load flake (32 s under the full run, passes in 2 s in isolation, verified on this box in this session). At the 4.x control of 102,499 / 0 / 185.

## Note for embedders

This changes what `Intl.DateTimeFormat` writes: a `buddhist`, `japanese` or `roc` formatter asked for a textual month now answers with the month's name where it answered with its number, and a host that supplies `ICldrProvider.GetMonthNames` for a calendar of its own now sees those names reach the output. The precedent for an output-changing conformance fix on this branch is #3552 (trailing NUL) and #3556 (read-only host collections). A `DefaultCldrProvider` that a host merely reads from now answers `null` for a calendar it has no names for, where it used to answer twelve Gregorian names under any calendar's name.
