### PR TITLE
Intl: a `-u-` extension carrying more than one key is read whole (backport of #3594)

### DIFF
--- a/Jint.Tests/Runtime/IntlUnicodeExtensionTests.cs
+++ b/Jint.Tests/Runtime/IntlUnicodeExtensionTests.cs
@@ -1,0 +1,230 @@
+#nullable enable
+
+using Jint.Native.Intl;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// A locale's <c>-u-</c> sequence carries as many keys as it likes, and every formatter that reads one
+/// reads all of them. https://unicode.org/reports/tr35/#unicode_locale_extensions is the grammar: a key
+/// is two characters, a value is the 3-to-8-character subtags that follow it, and both end at the next
+/// key or the next singleton.
+/// </summary>
+/// <remarks>
+/// The defect (#3573) was a hand-rolled scanner per constructor, each of which consumed the next key into
+/// the current key's value — so <c>en-US-u-ca-buddhist-nu-arab</c> read <c>ca</c> back as "buddhist-nu",
+/// resolved to no calendar at all, and came back as bare <c>en-US</c> with <c>gregory</c> and
+/// <c>latn</c>. Either key alone worked, which is why it survived. Every expectation below is what V8
+/// (Node 24, full ICU) answers for the same tag.
+/// </remarks>
+public class IntlUnicodeExtensionTests
+{
+    private static Engine Engine() => new();
+
+    private static string Resolved(Engine engine, string expression) => engine.Evaluate(expression).AsString();
+
+    /// <summary>
+    /// The table from the issue: two keys in either order, and neither of them lost.
+    /// </summary>
+    [Theory]
+    [InlineData("en-US-u-ca-buddhist", "en-US-u-ca-buddhist", "buddhist", "latn", "h12")]
+    [InlineData("en-US-u-nu-arab", "en-US-u-nu-arab", "gregory", "arab", "h12")]
+    [InlineData("en-US-u-ca-buddhist-nu-arab", "en-US-u-ca-buddhist-nu-arab", "buddhist", "arab", "h12")]
+    [InlineData("en-US-u-nu-arab-ca-buddhist", "en-US-u-ca-buddhist-nu-arab", "buddhist", "arab", "h12")]
+    [InlineData("en-US-u-ca-buddhist-hc-h23", "en-US-u-ca-buddhist-hc-h23", "buddhist", "latn", "h23")]
+    [InlineData("en-US-u-hc-h23-ca-buddhist", "en-US-u-ca-buddhist-hc-h23", "buddhist", "latn", "h23")]
+    [InlineData("en-US-u-hc-h23-nu-arab-ca-buddhist", "en-US-u-ca-buddhist-hc-h23-nu-arab", "buddhist", "arab", "h23")]
+    public void DateTimeFormatReadsEveryKeyOfTheExtension(
+        string requested, string locale, string calendar, string numberingSystem, string hourCycle)
+    {
+        var engine = Engine();
+        var resolved = $"new Intl.DateTimeFormat('{requested}', {{ hour: 'numeric' }}).resolvedOptions()";
+
+        Resolved(engine, $"{resolved}.locale").Should().Be(locale);
+        Resolved(engine, $"{resolved}.calendar").Should().Be(calendar);
+        Resolved(engine, $"{resolved}.numberingSystem").Should().Be(numberingSystem);
+        Resolved(engine, $"{resolved}.hourCycle").Should().Be(hourCycle);
+    }
+
+    /// <summary>
+    /// https://tc39.es/ecma402/#sec-resolvelocale step 12 builds the resolved locale from the relevant
+    /// extension keys only, so a NumberFormat keeps <c>nu</c> and drops the <c>ca</c> beside it.
+    /// </summary>
+    [Theory]
+    [InlineData("en-US-u-ca-buddhist", "en-US", "latn")]
+    [InlineData("en-US-u-nu-arab", "en-US-u-nu-arab", "arab")]
+    [InlineData("en-US-u-ca-buddhist-nu-arab", "en-US-u-nu-arab", "arab")]
+    [InlineData("en-US-u-nu-arab-ca-buddhist", "en-US-u-nu-arab", "arab")]
+    [InlineData("en-US-u-hc-h23-nu-arab-ca-buddhist", "en-US-u-nu-arab", "arab")]
+    public void NumberFormatReadsTheNumberingSystemBesideAnotherKey(string requested, string locale, string numberingSystem)
+    {
+        var engine = Engine();
+        var resolved = $"new Intl.NumberFormat('{requested}').resolvedOptions()";
+
+        Resolved(engine, $"{resolved}.locale").Should().Be(locale);
+        Resolved(engine, $"{resolved}.numberingSystem").Should().Be(numberingSystem);
+    }
+
+    /// <summary>
+    /// The two formatters the issue does not measure share the same relevant key, and answer the same.
+    /// </summary>
+    [Theory]
+    [InlineData("RelativeTimeFormat")]
+    [InlineData("DurationFormat")]
+    public void TheOtherNumberingSystemCarriersReadItToo(string formatter)
+    {
+        var engine = Engine();
+
+        Resolved(engine, $"new Intl.{formatter}('en-US-u-ca-buddhist-nu-arab').resolvedOptions().numberingSystem")
+            .Should().Be("arab");
+        Resolved(engine, $"new Intl.{formatter}('en-US-u-ca-buddhist-nu-arab').resolvedOptions().locale")
+            .Should().Be("en-US-u-nu-arab");
+    }
+
+    /// <summary>
+    /// Collator's three keys, read from one sequence.
+    /// </summary>
+    [Fact]
+    public void CollatorReadsAllThreeOfItsKeys()
+    {
+        var engine = Engine();
+        var resolved = "new Intl.Collator('de-DE-u-co-phonebk-kf-upper-kn').resolvedOptions()";
+
+        Resolved(engine, $"{resolved}.collation").Should().Be("phonebk");
+        Resolved(engine, $"{resolved}.caseFirst").Should().Be("upper");
+        engine.Evaluate($"{resolved}.numeric").AsBoolean().Should().BeTrue();
+
+        // …and the same three when kn carries an explicit value that another key follows
+        var withValue = "new Intl.Collator('de-DE-u-kn-false-co-phonebk').resolvedOptions()";
+        Resolved(engine, $"{withValue}.collation").Should().Be("phonebk");
+        engine.Evaluate($"{withValue}.numeric").AsBoolean().Should().BeFalse();
+    }
+
+    /// <summary>
+    /// A value is allowed more than one subtag, and a sequence is allowed attributes ahead of its keys.
+    /// </summary>
+    [Fact]
+    public void AMultiSubtagValueAndALeadingAttributeAreBothRead()
+    {
+        var engine = Engine();
+
+        var multiPart = "new Intl.DateTimeFormat('en-US-u-ca-islamic-civil-nu-arab', { hour: 'numeric' }).resolvedOptions()";
+        Resolved(engine, $"{multiPart}.calendar").Should().Be("islamic-civil");
+        Resolved(engine, $"{multiPart}.numberingSystem").Should().Be("arab");
+        Resolved(engine, $"{multiPart}.locale").Should().Be("en-US-u-ca-islamic-civil-nu-arab");
+
+        var withAttribute = "new Intl.DateTimeFormat('en-US-u-foo-ca-buddhist-nu-arab', { hour: 'numeric' }).resolvedOptions()";
+        Resolved(engine, $"{withAttribute}.calendar").Should().Be("buddhist");
+        Resolved(engine, $"{withAttribute}.numberingSystem").Should().Be("arab");
+    }
+
+    /// <summary>
+    /// The sequence ends at the next singleton, so a private-use or transformed section after it is not
+    /// part of any key's value — and does not stop the keys before it from being read.
+    /// </summary>
+    [Fact]
+    public void ASequenceEndsAtTheNextSingleton()
+    {
+        var engine = Engine();
+
+        Resolved(engine, "new Intl.DateTimeFormat('en-US-u-nu-arab-x-private', { hour: 'numeric' }).resolvedOptions().numberingSystem")
+            .Should().Be("arab");
+        Resolved(engine, "new Intl.NumberFormat('en-US-u-nu-arab-t-en-latn').resolvedOptions().numberingSystem")
+            .Should().Be("arab");
+    }
+
+    /// <summary>
+    /// https://tc39.es/ecma402/#sec-resolvelocale step 13: an option supersedes the tag's own keyword, and
+    /// the keyword then leaves the resolved locale. Reading two keys correctly must not disturb that, so
+    /// the single-key cases are pinned beside the two-key one.
+    /// </summary>
+    [Fact]
+    public void AnOptionStillSupersedesTheExtension()
+    {
+        var engine = Engine();
+
+        // one key: the option wins and the extension goes
+        var overridden = "new Intl.DateTimeFormat('en-US-u-ca-buddhist', { calendar: 'hebrew', hour: 'numeric' }).resolvedOptions()";
+        Resolved(engine, $"{overridden}.calendar").Should().Be("hebrew");
+        Resolved(engine, $"{overridden}.locale").Should().Be("en-US");
+
+        // one key, agreeing: the extension stays
+        var agreeing = "new Intl.DateTimeFormat('en-US-u-ca-buddhist', { calendar: 'buddhist', hour: 'numeric' }).resolvedOptions()";
+        Resolved(engine, $"{agreeing}.calendar").Should().Be("buddhist");
+        Resolved(engine, $"{agreeing}.locale").Should().Be("en-US-u-ca-buddhist");
+
+        // two keys: only the superseded one goes
+        var mixed = "new Intl.DateTimeFormat('en-US-u-ca-buddhist-nu-arab', { calendar: 'hebrew', hour: 'numeric' }).resolvedOptions()";
+        Resolved(engine, $"{mixed}.calendar").Should().Be("hebrew");
+        Resolved(engine, $"{mixed}.numberingSystem").Should().Be("arab");
+        Resolved(engine, $"{mixed}.locale").Should().Be("en-US-u-nu-arab");
+
+        // and the same for NumberFormat's own key
+        var numeric = "new Intl.NumberFormat('en-US-u-nu-arab', { numberingSystem: 'thai' }).resolvedOptions()";
+        Resolved(engine, $"{numeric}.numberingSystem").Should().Be("thai");
+        Resolved(engine, $"{numeric}.locale").Should().Be("en-US");
+    }
+
+    /// <summary>
+    /// Intl.Locale and Intl.getCanonicalLocales always read these tags; the point is that the formatters
+    /// now agree with them rather than answering for a locale the tag never asked for.
+    /// </summary>
+    [Fact]
+    public void TheFormattersAgreeWithLocaleAndGetCanonicalLocales()
+    {
+        var engine = Engine();
+        const string Tag = "en-US-u-ca-buddhist-nu-arab";
+
+        Resolved(engine, $"Intl.getCanonicalLocales(['{Tag}'])[0]").Should().Be(Tag);
+        Resolved(engine, $"new Intl.Locale('{Tag}').calendar").Should().Be("buddhist");
+        Resolved(engine, $"new Intl.Locale('{Tag}').numberingSystem").Should().Be("arab");
+
+        var formatter = $"new Intl.DateTimeFormat('{Tag}', {{ hour: 'numeric' }}).resolvedOptions()";
+        Resolved(engine, $"{formatter}.calendar").Should().Be(Resolved(engine, $"new Intl.Locale('{Tag}').calendar"));
+        Resolved(engine, $"{formatter}.numberingSystem").Should().Be(Resolved(engine, $"new Intl.Locale('{Tag}').numberingSystem"));
+    }
+
+    /// <summary>
+    /// The reader itself, since it is the one definition of the rule the eight scanners each had.
+    /// </summary>
+    [Theory]
+    [InlineData("en-US-u-ca-buddhist-nu-arab", "ca", "buddhist")]
+    [InlineData("en-US-u-ca-buddhist-nu-arab", "nu", "arab")]
+    [InlineData("en-US-u-nu-arab-ca-buddhist", "ca", "buddhist")]
+    [InlineData("en-US-u-ca-islamic-civil-nu-arab", "ca", "islamic-civil")]
+    [InlineData("en-US-u-foo-bar-ca-buddhist", "ca", "buddhist")]
+    [InlineData("en-US-u-nu-arab-x-ca-gregory", "ca", null)]
+    [InlineData("en-US-x-u-ca-gregory", "ca", null)]
+    [InlineData("en-US-u-kn-ca-buddhist", "kn", "")]
+    [InlineData("en-US-u-kn-ca-buddhist", "ca", "buddhist")]
+    [InlineData("en-US-u-CA-BUDDHIST", "ca", "buddhist")]
+    [InlineData("en-US", "ca", null)]
+    public void GetKeywordValueReadsTheKeyAndOnlyTheKey(string locale, string key, string? expected)
+    {
+        UnicodeExtension.GetKeywordValue(locale, key).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("en-US-u-ca-buddhist-nu-arab", "en-US")]
+    [InlineData("en-US-u-nu-arab-x-private", "en-US-x-private")]
+    [InlineData("en-US-t-en-latn-u-nu-arab", "en-US-t-en-latn")]
+    [InlineData("en-US", "en-US")]
+    public void RemoveSequenceKeepsEveryOtherExtension(string locale, string expected)
+    {
+        UnicodeExtension.RemoveSequence(locale).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("en-US", "nu", "arab", "en-US-u-nu-arab")]
+    [InlineData("en-US-u-ca-buddhist", "nu", "arab", "en-US-u-ca-buddhist-nu-arab")]
+    [InlineData("en-US-u-nu-latn-ca-buddhist", "nu", "arab", "en-US-u-ca-buddhist-nu-arab")]
+    [InlineData("en-US-u-ca-buddhist-nu-arab", "nu", null, "en-US-u-ca-buddhist")]
+    [InlineData("en-US-u-nu-arab", "nu", null, "en-US")]
+    [InlineData("en-US-x-private", "nu", "arab", "en-US-u-nu-arab-x-private")]
+    [InlineData("en-US-u-nu-arab-x-private", "nu", null, "en-US-x-private")]
+    [InlineData("en-US-u-foo-nu-arab", "nu", null, "en-US-u-foo")]
+    public void WithKeywordRewritesOneKeyAndKeepsTheRestInOrder(string locale, string key, string? value, string expected)
+    {
+        UnicodeExtension.WithKeyword(locale, key, value).Should().Be(expected);
+    }
+}

--- a/Jint/Extensions/Polyfills.cs
+++ b/Jint/Extensions/Polyfills.cs
@@ -26,6 +26,16 @@ internal static class Polyfills
     }
 #endif
 
+#if !NET8_0_OR_GREATER
+    // The span overloads of string.Concat arrived in .NET Core 2.1 and were never exposed by
+    // netstandard2.1, so every target below net8.0 needs them. The fallback materializes both slices,
+    // which is what a call site's own #else branch already did.
+    extension(string)
+    {
+        public static string Concat(ReadOnlySpan<char> str0, ReadOnlySpan<char> str1) => str0.ToString() + str1.ToString();
+    }
+#endif
+
 #if NETFRAMEWORK
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
     internal static bool Contains(this ReadOnlySpan<string> source, string c) => source.IndexOf(c) != -1;

--- a/Jint/Native/Intl/CollatorConstructor.cs
+++ b/Jint/Native/Intl/CollatorConstructor.cs
@@ -330,53 +330,23 @@ internal sealed partial class CollatorConstructor : Constructor
         numeric = null;
         caseFirst = null;
 
-        // Only search for -u- before the private-use section (-x-)
-        var xIndex = locale.IndexOf("-x-", StringComparison.OrdinalIgnoreCase);
-        var searchRange = xIndex >= 0 ? locale.Substring(0, xIndex) : locale;
-        var uIndex = searchRange.IndexOf("-u-", StringComparison.Ordinal);
-        if (uIndex < 0)
+        // https://tc39.es/ecma402/#sec-intl-collator-internal-slots lists co, kf and kn as this
+        // constructor's relevant extension keys, and UnicodeExtension answers for all three in one walk.
+        // Duplicate keys are not canonical, and the first occurrence is the one that counts.
+        foreach (var keyword in UnicodeExtension.EnumerateKeywords(locale))
         {
-            return;
-        }
-
-        // Extract the -u- extension content (up to private-use or next singleton)
-        var extensionContent = (xIndex >= 0 ? locale.Substring(uIndex + 3, xIndex - uIndex - 3) : locale.Substring(uIndex + 3));
-        var parts = extensionContent.Split('-');
-        for (var i = 0; i < parts.Length; i++)
-        {
-            var key = parts[i];
-            // Keys are exactly 2 characters, values are 3+ characters (or "true"/"false" which are special)
-            // If the next part is also 2 characters, it's another key, not a value
-            if (key.Length == 2)
+            if (collation is null && keyword.KeyIs("co"))
             {
-                // Check if there's a value (3+ chars or special 2-char values that aren't keys)
-                string? value = null;
-                if (i + 1 < parts.Length && parts[i + 1].Length >= 3)
-                {
-                    value = parts[i + 1];
-                    i++;
-                }
-
-                switch (key)
-                {
-                    case "co":
-                        collation = value;
-                        break;
-                    case "kn":
-                        // -u-kn without value or with any non-false value means true
-                        if (value == null)
-                        {
-                            numeric = true;
-                        }
-                        else
-                        {
-                            numeric = !string.Equals(value, "false", StringComparison.OrdinalIgnoreCase);
-                        }
-                        break;
-                    case "kf":
-                        caseFirst = value;
-                        break;
-                }
+                collation = keyword.Value.IsEmpty ? null : keyword.Value.ToString();
+            }
+            else if (!numeric.HasValue && keyword.KeyIs("kn"))
+            {
+                // -u-kn without a value, or with any value other than "false", means true.
+                numeric = keyword.Value.IsEmpty || !keyword.Value.Equals("false".AsSpan(), StringComparison.OrdinalIgnoreCase);
+            }
+            else if (caseFirst is null && keyword.KeyIs("kf"))
+            {
+                caseFirst = keyword.Value.IsEmpty ? null : keyword.Value.ToString();
             }
         }
     }

--- a/Jint/Native/Intl/DateTimeFormatConstructor.cs
+++ b/Jint/Native/Intl/DateTimeFormatConstructor.cs
@@ -116,11 +116,34 @@ internal sealed partial class DateTimeFormatConstructor : Constructor
         var resolved = IntlUtilities.ResolveLocale(_engine, availableLocales, requestedLocales, localeMatcher, []);
         var resolvedLocale = resolved.Locale;
 
-        // Extract unicode extension values from the requested locale
+        // Extract unicode extension values from the requested locale. One walk answers for all three
+        // keys, and UnicodeExtension is the only thing in the engine that knows where a value ends —
+        // reading a key at a time by hand is what cost every tag carrying more than one of them.
         var requestedLocale = requestedLocales.Count > 0 ? requestedLocales[0] : "";
-        var extCalendar = ExtractUnicodeExtensionFromLocale(requestedLocale, "ca");
-        var extHourCycle = ExtractUnicodeExtensionFromLocale(requestedLocale, "hc");
-        var extNumberingSystem = ExtractUnicodeExtensionFromLocale(requestedLocale, "nu");
+        string? extCalendar = null;
+        string? extHourCycle = null;
+        string? extNumberingSystem = null;
+        foreach (var keyword in UnicodeExtension.EnumerateKeywords(requestedLocale))
+        {
+            if (keyword.Value.IsEmpty)
+            {
+                continue;
+            }
+
+            // Duplicate keys are not canonical, and the first occurrence is the one that counts.
+            if (extCalendar is null && keyword.KeyIs("ca"))
+            {
+                extCalendar = keyword.Value.ToString();
+            }
+            else if (extHourCycle is null && keyword.KeyIs("hc"))
+            {
+                extHourCycle = keyword.Value.ToString();
+            }
+            else if (extNumberingSystem is null && keyword.KeyIs("nu"))
+            {
+                extNumberingSystem = keyword.Value.ToString();
+            }
+        }
 
         // Track which extensions should be preserved in the resolved locale
         var preserveCalendarExt = false;
@@ -317,7 +340,7 @@ internal sealed partial class DateTimeFormatConstructor : Constructor
         }
 
         // Build the resolved locale with only preserved extensions
-        resolvedLocale = BuildResolvedLocale(resolvedLocale, requestedLocale,
+        resolvedLocale = BuildResolvedLocale(resolvedLocale,
             preserveCalendarExt ? extCalendar : null,
             preserveHourCycleExt ? extHourCycle : null,
             preserveNumberingSystemExt ? extNumberingSystem : null);
@@ -755,7 +778,7 @@ internal sealed partial class DateTimeFormatConstructor : Constructor
     /// <summary>
     /// Builds the resolved locale string, including only the unicode extensions that should be preserved.
     /// </summary>
-    private static string BuildResolvedLocale(string baseLocale, string requestedLocale,
+    private static string BuildResolvedLocale(string baseLocale,
         string? calendar, string? hourCycle, string? numberingSystem)
     {
         // If no extensions to preserve, return base locale (without any extensions)
@@ -813,83 +836,5 @@ internal sealed partial class DateTimeFormatConstructor : Constructor
             "islamic-rgsa" => "islamic-civil",
             _ => calendar.ToLowerInvariant()
         };
-    }
-
-    /// <summary>
-    /// Extracts a specific unicode extension value from a single locale string.
-    /// </summary>
-    private static string? ExtractUnicodeExtensionFromLocale(string locale, string key)
-    {
-        // Look for -u- marker
-        var uIndex = locale.IndexOf("-u-", StringComparison.OrdinalIgnoreCase);
-        if (uIndex == -1)
-        {
-            return null;
-        }
-
-        // Parse the unicode extension looking for the key
-        var extensionStart = uIndex + 3;
-        var i = extensionStart;
-
-        while (i < locale.Length)
-        {
-            // Find the key (2 characters)
-            var keyStart = i;
-            while (i < locale.Length && locale[i] != '-')
-            {
-                i++;
-            }
-
-            var currentKey = locale.Substring(keyStart, i - keyStart);
-
-            // Move past the '-' if present
-            if (i < locale.Length && locale[i] == '-')
-            {
-                i++;
-            }
-
-            // Check if this is a 2-character key (not a singleton for next extension)
-            if (currentKey.Length == 2)
-            {
-                // Find the value(s) - collect until next key or end
-                var valueStart = i;
-                while (i < locale.Length)
-                {
-                    var partStart = i;
-                    while (i < locale.Length && locale[i] != '-')
-                    {
-                        i++;
-                    }
-
-                    var part = locale.Substring(partStart, i - partStart);
-
-                    // If this part is a 2-char key or 1-char singleton, stop
-                    if (part.Length == 2 || part.Length == 1)
-                    {
-                        break;
-                    }
-
-                    // Move past '-' if present
-                    if (i < locale.Length && locale[i] == '-')
-                    {
-                        i++;
-                    }
-                }
-
-                var value = locale.Substring(valueStart, i - valueStart).TrimEnd('-');
-
-                if (string.Equals(currentKey, key, StringComparison.OrdinalIgnoreCase) && value.Length > 0)
-                {
-                    return value.ToLowerInvariant();
-                }
-            }
-            else if (currentKey.Length == 1)
-            {
-                // This is a singleton starting a new extension type, stop parsing unicode extension
-                break;
-            }
-        }
-
-        return null;
     }
 }

--- a/Jint/Native/Intl/DefaultCldrProvider.cs
+++ b/Jint/Native/Intl/DefaultCldrProvider.cs
@@ -574,11 +574,7 @@ public sealed class DefaultCldrProvider : ICldrProvider
         return locale.StartsWith("en", StringComparison.OrdinalIgnoreCase);
     }
 
-    private static string RemoveExtensions(string locale)
-    {
-        var uIndex = locale.IndexOf("-u-", StringComparison.OrdinalIgnoreCase);
-        return uIndex >= 0 ? locale.Substring(0, uIndex) : locale;
-    }
+    private static string RemoveExtensions(string locale) => UnicodeExtension.RemoveSequence(locale);
 
     private static string GetUnitName(string unit, string style, bool plural)
     {

--- a/Jint/Native/Intl/DurationFormatConstructor.cs
+++ b/Jint/Native/Intl/DurationFormatConstructor.cs
@@ -77,7 +77,7 @@ internal sealed partial class DurationFormatConstructor : Constructor
         string? extensionNu = null;
         if (requestedLocales.Count > 0)
         {
-            extensionNu = ParseNumberingSystemExtension(requestedLocales[0]);
+            extensionNu = UnicodeExtension.GetKeywordValue(requestedLocales[0], "nu");
         }
 
         // Resolve numbering system: option overrides extension; validate both
@@ -87,7 +87,7 @@ internal sealed partial class DurationFormatConstructor : Constructor
         var resolvedLocale = resolved.Locale;
         if (extensionNu != null && string.Equals(numberingSystem, extensionNu, StringComparison.Ordinal))
         {
-            resolvedLocale = resolved.Locale + "-u-nu-" + numberingSystem;
+            resolvedLocale = UnicodeExtension.WithKeyword(resolved.Locale, "nu", numberingSystem);
         }
 
         // Determine base style based on overall style (for date units)
@@ -289,30 +289,11 @@ internal sealed partial class DurationFormatConstructor : Constructor
         return IntlUtilities.CanonicalizeUValue("nu", stringValue);
     }
 
-    private static string? ParseNumberingSystemExtension(string locale)
-    {
-        // Only search for -u- before the private-use section (-x-)
-        var xIndex = locale.IndexOf("-x-", StringComparison.OrdinalIgnoreCase);
-        var searchRange = xIndex >= 0 ? locale.Substring(0, xIndex) : locale;
-        var uIndex = searchRange.IndexOf("-u-", StringComparison.Ordinal);
-        if (uIndex < 0)
-        {
-            return null;
-        }
-
-        var extensionContent = xIndex >= 0 ? locale.Substring(uIndex + 3, xIndex - uIndex - 3) : locale.Substring(uIndex + 3);
-        var parts = extensionContent.Split('-');
-        for (var i = 0; i < parts.Length; i++)
-        {
-            if (string.Equals(parts[i], "nu", StringComparison.Ordinal) && i + 1 < parts.Length && parts[i + 1].Length >= 3)
-            {
-                return parts[i + 1];
-            }
-        }
-
-        return null;
-    }
-
+    /// <summary>
+    /// https://tc39.es/ecma402/#sec-resolvelocale (9.2.7) step 13 for <c>nu</c>, which
+    /// https://tc39.es/proposal-intl-duration-format/#sec-Intl.DurationFormat-internal-slots lists as a
+    /// relevant extension key: the option wins, then the locale's <c>-u-nu-</c> extension, then Latin.
+    /// </summary>
     private static string ResolveNumberingSystem(string? optionValue, string? extensionValue)
     {
         // Options override extension

--- a/Jint/Native/Intl/IntlUtilities.cs
+++ b/Jint/Native/Intl/IntlUtilities.cs
@@ -1403,15 +1403,10 @@ internal static class IntlUtilities
                 {
                     var part = parts[j];
 
-                    // ukey is exactly 2 chars, both alpha
-                    if (part.Length == 2 && char.IsLetter(part[0]) && char.IsLetter(part[1]) && currentKey == null && keywords.Count == 0 && attributes.Count == 0 && j == 1)
+                    // UnicodeExtension owns what a ukey looks like, so canonicalization and the readers the
+                    // formatters use cannot drift apart about where one keyword ends and the next begins.
+                    if (UnicodeExtension.IsKey(part.AsSpan()))
                     {
-                        // Could be first keyword key
-                        currentKey = part;
-                    }
-                    else if (part.Length == 2 && char.IsLetter(part[0]) && char.IsLetter(part[1]))
-                    {
-                        // This is a ukey
                         if (currentKey != null)
                         {
                             keywords.Add(new KeyValueParts { Key = currentKey, Values = currentValues });
@@ -1615,7 +1610,7 @@ internal static class IntlUtilities
             // c. If availableLocale is not undefined, return the Record { [[locale]]: availableLocale, [[extension]]: extension }.
             if (availableLocale != null)
             {
-                return new MatcherResult(availableLocale, ExtractUnicodeExtension(locale));
+                return new MatcherResult(availableLocale, UnicodeExtension.GetSequence(locale));
             }
         }
 
@@ -1720,62 +1715,7 @@ internal static class IntlUtilities
     /// <summary>
     /// Removes Unicode locale extension sequences from a language tag.
     /// </summary>
-    private static string RemoveUnicodeExtensions(string locale)
-    {
-        // Unicode extensions start with "-u-"
-        var extensionIndex = locale.IndexOf("-u-", StringComparison.OrdinalIgnoreCase);
-        if (extensionIndex == -1)
-        {
-            return locale;
-        }
-
-        // Find end of extension (next singleton or end of string)
-        var endIndex = locale.Length;
-        for (var i = extensionIndex + 3; i < locale.Length - 1; i++)
-        {
-            if (locale[i] == '-' && i + 2 < locale.Length && locale[i + 2] == '-')
-            {
-                // Found another singleton
-                endIndex = i;
-                break;
-            }
-        }
-
-        if (endIndex < locale.Length)
-        {
-#if NET8_0_OR_GREATER
-            return string.Concat(locale.AsSpan(0, extensionIndex), locale.AsSpan(endIndex));
-#else
-            return locale.Substring(0, extensionIndex) + locale.Substring(endIndex);
-#endif
-        }
-
-        return locale.Substring(0, extensionIndex);
-    }
-
-    /// <summary>
-    /// Extracts the Unicode extension from a locale tag.
-    /// </summary>
-    private static string? ExtractUnicodeExtension(string locale)
-    {
-        var extensionIndex = locale.IndexOf("-u-", StringComparison.OrdinalIgnoreCase);
-        if (extensionIndex == -1)
-        {
-            return null;
-        }
-
-        var endIndex = locale.Length;
-        for (var i = extensionIndex + 3; i < locale.Length - 1; i++)
-        {
-            if (locale[i] == '-' && i + 2 < locale.Length && locale[i + 2] == '-')
-            {
-                endIndex = i;
-                break;
-            }
-        }
-
-        return locale.Substring(extensionIndex + 1, endIndex - extensionIndex - 1);
-    }
+    private static string RemoveUnicodeExtensions(string locale) => UnicodeExtension.RemoveSequence(locale);
 
     /// <summary>
     /// Converts a BCP 47 language tag to a .NET CultureInfo.

--- a/Jint/Native/Intl/LocaleConstructor.cs
+++ b/Jint/Native/Intl/LocaleConstructor.cs
@@ -617,14 +617,12 @@ internal sealed class LocaleConstructor : Constructor
                     // Unicode extension
                     index++;
 
-                    // First, collect any attributes (3-8 alphanumeric parts before any 2-char key)
-                    while (index < parts.Length && parts[index].Length >= 3 && parts[index].Length <= 8 && parts[index].Length != 1)
+                    // First, collect any attributes (3-8 alphanumeric parts before any key)
+                    while (index < parts.Length
+                           && !UnicodeExtension.IsKey(parts[index].AsSpan())
+                           && parts[index].Length >= 3
+                           && parts[index].Length <= 8)
                     {
-                        // If this is a 2-char part, it's a key, not an attribute
-                        if (parts[index].Length == 2)
-                        {
-                            break;
-                        }
                         result.Attributes.Add(parts[index].ToLowerInvariant());
                         index++;
                     }
@@ -632,8 +630,9 @@ internal sealed class LocaleConstructor : Constructor
                     // Then process key-value pairs
                     while (index < parts.Length && parts[index].Length != 1)
                     {
-                        // Keys are exactly 2 characters
-                        if (parts[index].Length != 2)
+                        // UnicodeExtension owns what a key looks like, so this parser and the readers the
+                        // formatters use cannot drift apart about where one keyword ends and the next begins.
+                        if (!UnicodeExtension.IsKey(parts[index].AsSpan()))
                         {
                             // Unexpected format - skip
                             index++;

--- a/Jint/Native/Intl/NumberFormatConstructor.cs
+++ b/Jint/Native/Intl/NumberFormatConstructor.cs
@@ -292,7 +292,7 @@ internal sealed partial class NumberFormatConstructor : Constructor
         string? localeNumberingSystem = null;
         foreach (var loc in requestedLocales)
         {
-            localeNumberingSystem = ExtractNumberingSystemFromLocale(loc);
+            localeNumberingSystem = UnicodeExtension.GetKeywordValue(loc, "nu");
             if (localeNumberingSystem != null)
             {
                 break;
@@ -326,17 +326,17 @@ internal sealed partial class NumberFormatConstructor : Constructor
             if (numberingSystemFromOptions && !string.Equals(numberingSystem, localeNumberingSystem, StringComparison.OrdinalIgnoreCase))
             {
                 // Options overrode locale extension - remove nu from resolved locale
-                finalResolvedLocale = RemoveNumberingSystemFromLocale(resolvedLocale);
+                finalResolvedLocale = UnicodeExtension.WithKeyword(resolvedLocale, "nu", null);
             }
             else if (!IsSupportedNumberingSystem(localeNumberingSystem))
             {
                 // Locale extension was invalid - remove it
-                finalResolvedLocale = RemoveNumberingSystemFromLocale(resolvedLocale);
+                finalResolvedLocale = UnicodeExtension.WithKeyword(resolvedLocale, "nu", null);
             }
             else
             {
                 // Locale extension is used - ensure it's in the resolved locale
-                finalResolvedLocale = EnsureNumberingSystemInLocale(resolvedLocale, resolvedNumberingSystem);
+                finalResolvedLocale = UnicodeExtension.WithKeyword(resolvedLocale, "nu", resolvedNumberingSystem);
             }
         }
 
@@ -373,204 +373,10 @@ internal sealed partial class NumberFormatConstructor : Constructor
             culture);
     }
 
-    private static string? ExtractNumberingSystemFromLocale(string locale)
-    {
-        // Look for -u-nu-xxx pattern
-        const string marker = "-u-";
-        var uIndex = locale.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
-        if (uIndex == -1)
-        {
-            return null;
-        }
-
-        // Parse the unicode extension to find 'nu' key
-        var extensionStart = uIndex + marker.Length;
-        var i = extensionStart;
-
-        while (i < locale.Length)
-        {
-            // Find the key
-            var keyStart = i;
-            while (i < locale.Length && locale[i] != '-')
-            {
-                i++;
-            }
-            var key = locale.Substring(keyStart, i - keyStart);
-
-            // If we hit another singleton (single char key), we've left the Unicode extension
-            if (key.Length == 1 && key[0] != 'u')
-            {
-                break;
-            }
-
-            // Move past the hyphen
-            if (i < locale.Length && locale[i] == '-')
-            {
-                i++;
-            }
-
-            // Check if this is a 2-letter key (like 'nu', 'ca', etc.)
-            if (key.Length == 2)
-            {
-                // Get the value (continue until we hit a 2-letter key or end)
-                var valueStart = i;
-                var valueEnd = i;
-
-                while (i < locale.Length)
-                {
-                    var partStart = i;
-                    while (i < locale.Length && locale[i] != '-')
-                    {
-                        i++;
-                    }
-                    var part = locale.Substring(partStart, i - partStart);
-
-                    // 2-letter part = next key, single-letter = singleton (end of extension)
-                    if (part.Length == 2 || part.Length == 1)
-                    {
-                        break;
-                    }
-
-                    valueEnd = i;
-                    if (i < locale.Length && locale[i] == '-')
-                    {
-                        i++;
-                    }
-                }
-
-                if (string.Equals(key, "nu", StringComparison.OrdinalIgnoreCase) && valueEnd > valueStart)
-                {
-                    return locale.Substring(valueStart, valueEnd - valueStart).ToLowerInvariant();
-                }
-            }
-        }
-
-        return null;
-    }
-
     private static bool IsSupportedNumberingSystem(string numberingSystem)
     {
         // Check if the numbering system is actually supported (has digit mappings)
         return Data.NumberingSystemData.Digits.ContainsKey(numberingSystem);
-    }
-
-    private static string RemoveNumberingSystemFromLocale(string locale)
-    {
-        // Remove the -u-nu-xxx part from the locale
-        var uIndex = locale.IndexOf("-u-", StringComparison.OrdinalIgnoreCase);
-        if (uIndex == -1)
-        {
-            return locale;
-        }
-
-        // Find and remove the nu key-value pair
-        var extensionStart = uIndex + 3;
-        var result = new ValueStringBuilder();
-        result.Append(locale.AsSpan(0, uIndex));
-        var i = extensionStart;
-        var hasOtherExtensions = false;
-
-        while (i < locale.Length)
-        {
-            var keyStart = i;
-            while (i < locale.Length && locale[i] != '-')
-            {
-                i++;
-            }
-            var key = locale.Substring(keyStart, i - keyStart);
-
-            // Single char means we've hit another singleton extension
-            if (key.Length == 1)
-            {
-                result.Append(locale.AsSpan(keyStart - 1));
-                break;
-            }
-
-            if (i < locale.Length && locale[i] == '-')
-            {
-                i++;
-            }
-
-            if (key.Length == 2)
-            {
-                // Get the value
-                var valueStart = i;
-                while (i < locale.Length)
-                {
-                    var partStart = i;
-                    while (i < locale.Length && locale[i] != '-')
-                    {
-                        i++;
-                    }
-                    var part = locale.Substring(partStart, i - partStart);
-
-                    if (part.Length == 2 || part.Length == 1)
-                    {
-                        break;
-                    }
-
-                    if (i < locale.Length && locale[i] == '-')
-                    {
-                        i++;
-                    }
-                }
-
-                // Skip the nu key, keep others
-                if (!string.Equals(key, "nu", StringComparison.OrdinalIgnoreCase))
-                {
-                    if (!hasOtherExtensions)
-                    {
-                        result.Append("-u-");
-                        hasOtherExtensions = true;
-                    }
-                    else
-                    {
-                        result.Append('-');
-                    }
-                    var len = i - keyStart - (i < locale.Length && locale[i - 1] == '-' ? 1 : 0);
-                    result.Append(locale.AsSpan(keyStart, len));
-                }
-            }
-        }
-
-        return result.ToString();
-    }
-
-    private static string EnsureNumberingSystemInLocale(string locale, string numberingSystem)
-    {
-        // Check if locale already has the numbering system extension
-        var uIndex = locale.IndexOf("-u-", StringComparison.OrdinalIgnoreCase);
-        if (uIndex == -1)
-        {
-            // No Unicode extension - add it
-            return locale + "-u-nu-" + numberingSystem;
-        }
-
-        // Check if nu is already present with the correct value
-        var nuPattern = "-nu-" + numberingSystem;
-        if (locale.Contains(nuPattern, StringComparison.OrdinalIgnoreCase))
-        {
-            return locale;
-        }
-
-        // Has -u- but not nu - add nu
-        var nuIndex = locale.IndexOf("-nu-", StringComparison.OrdinalIgnoreCase);
-        if (nuIndex == -1)
-        {
-            // Insert nu after -u-
-            return locale.Insert(uIndex + 3, "nu-" + numberingSystem + "-");
-        }
-
-        // nu exists with different value - replace it
-        var valueStart = nuIndex + 4;
-        var valueEnd = valueStart;
-        while (valueEnd < locale.Length && locale[valueEnd] != '-')
-        {
-            valueEnd++;
-        }
-#pragma warning disable CA1845
-        return locale.Substring(0, valueStart) + numberingSystem + locale.Substring(valueEnd);
-#pragma warning restore CA1845
     }
 
     private string GetStringOption(ObjectInstance options, string property, string[]? values, string fallback)

--- a/Jint/Native/Intl/RelativeTimeFormatConstructor.cs
+++ b/Jint/Native/Intl/RelativeTimeFormatConstructor.cs
@@ -91,7 +91,7 @@ internal sealed partial class RelativeTimeFormatConstructor : Constructor
         string? localeNumberingSystem = null;
         foreach (var loc in requestedLocales)
         {
-            localeNumberingSystem = ExtractNumberingSystemFromLocale(loc);
+            localeNumberingSystem = UnicodeExtension.GetKeywordValue(loc, "nu");
             if (localeNumberingSystem != null)
             {
                 break;
@@ -130,23 +130,23 @@ internal sealed partial class RelativeTimeFormatConstructor : Constructor
                 string.Equals(numberingSystem, localeNumberingSystem, StringComparison.OrdinalIgnoreCase))
             {
                 // Options matches locale extension - keep the extension
-                finalResolvedLocale = EnsureNumberingSystemInLocale(resolvedLocale, resolvedNumberingSystem);
+                finalResolvedLocale = UnicodeExtension.WithKeyword(resolvedLocale, "nu", resolvedNumberingSystem);
             }
             else
             {
                 // Options overrode locale extension with different value - remove nu from resolved locale
-                finalResolvedLocale = RemoveNumberingSystemFromLocale(resolvedLocale);
+                finalResolvedLocale = UnicodeExtension.WithKeyword(resolvedLocale, "nu", null);
             }
         }
         else if (localeNumberingSystem != null && IsSupportedNumberingSystem(localeNumberingSystem))
         {
             // Locale extension is used - ensure it's in the resolved locale
-            finalResolvedLocale = EnsureNumberingSystemInLocale(resolvedLocale, resolvedNumberingSystem);
+            finalResolvedLocale = UnicodeExtension.WithKeyword(resolvedLocale, "nu", resolvedNumberingSystem);
         }
         else
         {
             // Default is used - remove any unsupported nu extension
-            finalResolvedLocale = RemoveNumberingSystemFromLocale(resolvedLocale);
+            finalResolvedLocale = UnicodeExtension.WithKeyword(resolvedLocale, "nu", null);
         }
 
         // Get CultureInfo for the locale
@@ -170,111 +170,10 @@ internal sealed partial class RelativeTimeFormatConstructor : Constructor
             numberFormat);
     }
 
-    private static string? ExtractNumberingSystemFromLocale(string locale)
-    {
-        // Look for -u-nu-xxx pattern
-        const string marker = "-u-";
-        var uIndex = locale.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
-        if (uIndex == -1) return null;
-
-        // Look for nu- after -u-
-        var extensionPart = locale.Substring(uIndex + marker.Length);
-        var nuIndex = extensionPart.IndexOf("nu-", StringComparison.OrdinalIgnoreCase);
-        if (nuIndex == -1) return null;
-
-        // Extract the value after nu-
-        var valueStart = nuIndex + 3;
-        var valueEnd = valueStart;
-        while (valueEnd < extensionPart.Length && extensionPart[valueEnd] != '-')
-        {
-            valueEnd++;
-        }
-
-        if (valueEnd > valueStart)
-        {
-            return extensionPart.Substring(valueStart, valueEnd - valueStart).ToLowerInvariant();
-        }
-
-        return null;
-    }
-
     private static bool IsSupportedNumberingSystem(string numberingSystem)
     {
         // Check if the numbering system is actually supported (has digit mappings)
         return Data.NumberingSystemData.Digits.ContainsKey(numberingSystem);
-    }
-
-    private static string RemoveNumberingSystemFromLocale(string locale)
-    {
-        // Remove the -u-nu-xxx or -nu-xxx part from the locale
-        var uIndex = locale.IndexOf("-u-", StringComparison.OrdinalIgnoreCase);
-        if (uIndex == -1) return locale;
-
-        var nuIndex = locale.IndexOf("-nu-", StringComparison.OrdinalIgnoreCase);
-        if (nuIndex == -1) return locale;
-
-        // Find the end of the nu value
-        var valueStart = nuIndex + 4;
-        var valueEnd = valueStart;
-        while (valueEnd < locale.Length && locale[valueEnd] != '-')
-        {
-            valueEnd++;
-        }
-
-        // Check if there are other extensions after nu
-        var hasOtherExtensions = valueEnd < locale.Length;
-
-        // Check if there are other extensions before nu (after -u-)
-        var extensionPart = locale.Substring(uIndex + 3);
-        var hasExtensionsBefore = !extensionPart.StartsWith("nu-", StringComparison.OrdinalIgnoreCase);
-
-        if (!hasOtherExtensions && !hasExtensionsBefore)
-        {
-            // nu is the only extension - remove entire -u- section
-            return locale.Substring(0, uIndex);
-        }
-
-        // Remove just the nu-xxx part
-#pragma warning disable CA1845
-        return locale.Substring(0, nuIndex) + locale.Substring(valueEnd);
-#pragma warning restore CA1845
-    }
-
-    private static string EnsureNumberingSystemInLocale(string locale, string numberingSystem)
-    {
-        // Check if locale already has the numbering system extension
-        var uIndex = locale.IndexOf("-u-", StringComparison.OrdinalIgnoreCase);
-        if (uIndex == -1)
-        {
-            // No Unicode extension - add it
-            return locale + "-u-nu-" + numberingSystem;
-        }
-
-        // Check if nu is already present with the correct value
-        var nuPattern = "-nu-" + numberingSystem;
-        if (locale.Contains(nuPattern, StringComparison.OrdinalIgnoreCase))
-        {
-            return locale;
-        }
-
-        // Check if nu is present at all
-        var nuIndex = locale.IndexOf("-nu-", StringComparison.OrdinalIgnoreCase);
-        if (nuIndex == -1)
-        {
-            // Insert nu after -u-
-            return locale.Insert(uIndex + 3, "nu-" + numberingSystem + "-");
-        }
-
-        // nu exists with different value - replace it
-        var valueStart = nuIndex + 4;
-        var valueEnd = valueStart;
-        while (valueEnd < locale.Length && locale[valueEnd] != '-')
-        {
-            valueEnd++;
-        }
-#pragma warning disable CA1845
-        return locale.Substring(0, valueStart) + numberingSystem + locale.Substring(valueEnd);
-#pragma warning restore CA1845
     }
 
     private string GetStringOption(ObjectInstance options, string property, string[]? values, string fallback)

--- a/Jint/Native/Intl/UnicodeExtension.cs
+++ b/Jint/Native/Intl/UnicodeExtension.cs
@@ -1,0 +1,432 @@
+using System.Text;
+
+namespace Jint.Native.Intl;
+
+/// <summary>
+/// Reads and rewrites the Unicode locale extension sequence — the <c>-u-</c> singleton and the
+/// attributes and keywords after it — of a BCP 47 language tag.
+/// </summary>
+/// <remarks>
+/// <para>
+/// One scanner for every Intl consumer, because the subtag rule is easy to write and easy to write
+/// wrong: https://unicode.org/reports/tr35/#unicode_locale_extensions says a keyword is a two-character
+/// key followed by zero or more 3-to-8-character type subtags, so a value ends at the next two-character
+/// subtag and a sequence ends at the next singleton. Reading one key at a time by hand cost every
+/// formatter that did so any tag carrying more than one key.
+/// </para>
+/// <para>
+/// Nothing here validates the tag: the reading entry points answer for whatever a structurally valid tag
+/// carries, and answer nothing for a tag that carries no <c>-u-</c> sequence at all.
+/// </para>
+/// </remarks>
+internal static class UnicodeExtension
+{
+    /// <summary>
+    /// Reads the value of one Unicode extension key, lowercased, or null when the tag has no such key.
+    /// </summary>
+    /// <remarks>
+    /// A key written with no value at all — the <c>kn</c> of <c>de-DE-u-kn</c> — answers with the empty
+    /// string, which is how a caller tells "present, and true by UTS 35 §3.2.1" from "absent".
+    /// </remarks>
+    internal static string? GetKeywordValue(string locale, string key)
+    {
+        foreach (var keyword in EnumerateKeywords(locale))
+        {
+            if (keyword.KeyIs(key))
+            {
+                return ToLowerString(keyword.Value);
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Enumerates the keywords of the tag's Unicode extension sequence, in the order they appear.
+    /// </summary>
+    internal static KeywordEnumerator EnumerateKeywords(string locale)
+    {
+        return TryLocateSequence(locale, out _, out var contentStart, out var contentEnd)
+            ? new KeywordEnumerator(locale.AsSpan(contentStart, contentEnd - contentStart))
+            : default;
+    }
+
+    /// <summary>
+    /// Returns the tag's Unicode extension sequence, from its <c>u</c> singleton to the next one, or null.
+    /// </summary>
+    internal static string? GetSequence(string locale)
+    {
+        return TryLocateSequence(locale, out var sequenceStart, out _, out var contentEnd)
+            ? locale.Substring(sequenceStart + 1, contentEnd - sequenceStart - 1)
+            : null;
+    }
+
+    /// <summary>
+    /// Returns the tag with its whole Unicode extension sequence removed, keeping every other extension.
+    /// </summary>
+    internal static string RemoveSequence(string locale)
+    {
+        if (!TryLocateSequence(locale, out var sequenceStart, out _, out var contentEnd))
+        {
+            return locale;
+        }
+
+        if (contentEnd >= locale.Length)
+        {
+            return locale.Substring(0, sequenceStart);
+        }
+
+        return string.Concat(locale.AsSpan(0, sequenceStart), locale.AsSpan(contentEnd));
+    }
+
+    /// <summary>
+    /// Returns the tag carrying <paramref name="key"/> with <paramref name="value"/>, or without the key
+    /// when the value is null, keeping every other keyword and extension.
+    /// </summary>
+    /// <remarks>
+    /// Keys come back in ascending order, which is the canonical form
+    /// https://unicode.org/reports/tr35/#Canonical_Unicode_Locale_Identifiers asks for; attributes are
+    /// kept ahead of them. Removing the last keyword removes the <c>-u-</c> singleton with it.
+    /// </remarks>
+    internal static string WithKeyword(string locale, string key, string? value)
+    {
+        if (!TryLocateSequence(locale, out var sequenceStart, out var contentStart, out var contentEnd))
+        {
+            // No sequence to merge into: insert one, or leave a tag that already lacks the key alone.
+            if (value is null)
+            {
+                return locale;
+            }
+
+            var keyword = value.Length == 0 ? "-u-" + key : "-u-" + key + "-" + value;
+            var insertAt = SingletonInsertionPoint(locale);
+            return insertAt >= locale.Length
+                ? locale + keyword
+                : locale.Insert(insertAt, keyword);
+        }
+
+        var attributes = new List<string>();
+        var keywords = new List<KeyValuePair<string, string>>();
+        var written = false;
+
+        foreach (var attribute in EnumerateAttributes(locale.AsSpan(contentStart, contentEnd - contentStart)))
+        {
+            attributes.Add(attribute.ToString());
+        }
+
+        foreach (var keyword in new KeywordEnumerator(locale.AsSpan(contentStart, contentEnd - contentStart)))
+        {
+            if (keyword.KeyIs(key))
+            {
+                if (value is not null && !written)
+                {
+                    keywords.Add(new KeyValuePair<string, string>(key, value));
+                    written = true;
+                }
+
+                continue;
+            }
+
+            keywords.Add(new KeyValuePair<string, string>(ToLowerString(keyword.Key), ToLowerString(keyword.Value)));
+        }
+
+        if (value is not null && !written)
+        {
+            keywords.Add(new KeyValuePair<string, string>(key, value));
+        }
+
+        keywords.Sort(static (a, b) => string.CompareOrdinal(a.Key, b.Key));
+
+        var builder = new ValueStringBuilder(stackalloc char[64]);
+        builder.Append(locale.AsSpan(0, sequenceStart));
+
+        if (attributes.Count > 0 || keywords.Count > 0)
+        {
+            builder.Append("-u");
+            foreach (var attribute in attributes)
+            {
+                builder.Append('-');
+                builder.Append(attribute);
+            }
+
+            foreach (var keyword in keywords)
+            {
+                builder.Append('-');
+                builder.Append(keyword.Key);
+                if (keyword.Value.Length > 0)
+                {
+                    builder.Append('-');
+                    builder.Append(keyword.Value);
+                }
+            }
+        }
+
+        if (contentEnd < locale.Length)
+        {
+            builder.Append(locale.AsSpan(contentEnd));
+        }
+
+        return builder.ToString();
+    }
+
+    /// <summary>
+    /// Whether a subtag of a Unicode extension sequence is a key rather than a value or an attribute.
+    /// </summary>
+    /// <remarks>
+    /// https://unicode.org/reports/tr35/#unicode_locale_extensions: <c>key = alphanum alpha</c>, and every
+    /// other subtag of the sequence is 3 to 8 characters, so length alone separates the two — the second
+    /// character is checked because the grammar says so, not because anything hangs on it.
+    /// </remarks>
+    internal static bool IsKey(ReadOnlySpan<char> subtag)
+    {
+        return subtag.Length == 2 && IsAlphanumeric(subtag[0]) && IsAlpha(subtag[1]);
+    }
+
+    /// <summary>
+    /// Locates the tag's Unicode extension sequence: <paramref name="sequenceStart"/> is the index of the
+    /// hyphen before its <c>u</c> singleton, and the content between the other two indexes is everything
+    /// after <c>-u-</c> and before the next singleton.
+    /// </summary>
+    private static bool TryLocateSequence(string locale, out int sequenceStart, out int contentStart, out int contentEnd)
+    {
+        sequenceStart = 0;
+        contentStart = 0;
+        contentEnd = 0;
+
+        var length = locale.Length;
+        var index = 0;
+        while (index < length)
+        {
+            var end = SubtagEnd(locale, index);
+            if (end - index == 1)
+            {
+                var singleton = locale[index];
+
+                // A private-use sequence runs to the end of the tag, so nothing after it is an extension.
+                if (singleton is 'x' or 'X')
+                {
+                    return false;
+                }
+
+                if (singleton is 'u' or 'U')
+                {
+                    // The singleton has to be preceded by a hyphen and followed by content: a tag that
+                    // starts with it is not a tag, and one that ends with it carries no keyword.
+                    if (index == 0 || end >= length)
+                    {
+                        return false;
+                    }
+
+                    sequenceStart = index - 1;
+                    contentStart = end + 1;
+                    contentEnd = SequenceEnd(locale, contentStart);
+                    return contentStart < contentEnd;
+                }
+            }
+
+            index = end + 1;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// The index at which the sequence starting at <paramref name="start"/> ends: the hyphen before the
+    /// next singleton, or the end of the tag.
+    /// </summary>
+    private static int SequenceEnd(string locale, int start)
+    {
+        var length = locale.Length;
+        var index = start;
+        while (index < length)
+        {
+            var end = SubtagEnd(locale, index);
+            if (end - index == 1)
+            {
+                return index - 1;
+            }
+
+            index = end + 1;
+        }
+
+        return length;
+    }
+
+    private static int SubtagEnd(string locale, int start)
+    {
+        var index = locale.IndexOf('-', start);
+        return index < 0 ? locale.Length : index;
+    }
+
+    private static int SubtagEnd(ReadOnlySpan<char> content, int start)
+    {
+        var index = content.Slice(start).IndexOf('-');
+        return index < 0 ? content.Length : start + index;
+    }
+
+    /// <summary>
+    /// Where a new <c>-u-</c> sequence belongs in a tag that has none: ahead of every extension whose
+    /// singleton sorts after <c>u</c>, which is what keeps a private-use sequence last.
+    /// </summary>
+    private static int SingletonInsertionPoint(string locale)
+    {
+        var length = locale.Length;
+        var index = 0;
+        while (index < length)
+        {
+            var end = SubtagEnd(locale, index);
+            if (end - index == 1 && char.ToLowerInvariant(locale[index]) > 'u')
+            {
+                return index - 1;
+            }
+
+            index = end + 1;
+        }
+
+        return length;
+    }
+
+    private static AttributeEnumerator EnumerateAttributes(ReadOnlySpan<char> content) => new(content);
+
+    private static string ToLowerString(ReadOnlySpan<char> value)
+    {
+        foreach (var c in value)
+        {
+            if (c is >= 'A' and <= 'Z')
+            {
+                return value.ToString().ToLowerInvariant();
+            }
+        }
+
+        return value.ToString();
+    }
+
+    private static bool IsAlpha(char c) => (c is >= 'a' and <= 'z') || (c is >= 'A' and <= 'Z');
+
+    private static bool IsAlphanumeric(char c) => IsAlpha(c) || (c is >= '0' and <= '9');
+
+    /// <summary>
+    /// One keyword of a Unicode extension sequence: a key, and the value subtags that follow it.
+    /// </summary>
+    internal readonly ref struct Keyword
+    {
+        internal Keyword(ReadOnlySpan<char> key, ReadOnlySpan<char> value)
+        {
+            Key = key;
+            Value = value;
+        }
+
+        /// <summary>
+        /// The two-character key, as written in the tag.
+        /// </summary>
+        internal ReadOnlySpan<char> Key { get; }
+
+        /// <summary>
+        /// The value subtags, hyphen-joined as written, and empty for a key written without one.
+        /// </summary>
+        internal ReadOnlySpan<char> Value { get; }
+
+        /// <summary>
+        /// Whether this keyword's key is <paramref name="key"/>, which callers pass in lowercase.
+        /// </summary>
+        internal bool KeyIs(string key) => Key.Equals(key.AsSpan(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Walks the keywords of a Unicode extension sequence's content, skipping its leading attributes.
+    /// </summary>
+    internal ref struct KeywordEnumerator
+    {
+        private readonly ReadOnlySpan<char> _content;
+        private int _index;
+
+        internal KeywordEnumerator(ReadOnlySpan<char> content)
+        {
+            _content = content;
+            _index = 0;
+            Current = default;
+        }
+
+        public Keyword Current { get; private set; }
+
+        public readonly KeywordEnumerator GetEnumerator() => this;
+
+        public bool MoveNext()
+        {
+            while (_index < _content.Length)
+            {
+                var keyEnd = SubtagEnd(_content, _index);
+                var key = _content.Slice(_index, keyEnd - _index);
+                _index = keyEnd + 1;
+
+                if (!IsKey(key))
+                {
+                    // An attribute, or a value subtag of a key this walk has already reported.
+                    continue;
+                }
+
+                // The value runs to the next key, so every subtag until then belongs to this one. A key
+                // written last leaves _index one past the content, which is an empty value, not a slice.
+                var valueStart = _index <= _content.Length ? _index : _content.Length;
+                var valueEnd = valueStart;
+                while (_index < _content.Length)
+                {
+                    var subtagEnd = SubtagEnd(_content, _index);
+                    if (IsKey(_content.Slice(_index, subtagEnd - _index)))
+                    {
+                        break;
+                    }
+
+                    valueEnd = subtagEnd;
+                    _index = subtagEnd + 1;
+                }
+
+                Current = new Keyword(key, _content.Slice(valueStart, valueEnd - valueStart));
+                return true;
+            }
+
+            Current = default;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Walks the attributes of a Unicode extension sequence's content — the subtags before its first key.
+    /// </summary>
+    private ref struct AttributeEnumerator
+    {
+        private readonly ReadOnlySpan<char> _content;
+        private int _index;
+
+        internal AttributeEnumerator(ReadOnlySpan<char> content)
+        {
+            _content = content;
+            _index = 0;
+            Current = default;
+        }
+
+        public ReadOnlySpan<char> Current { get; private set; }
+
+        public readonly AttributeEnumerator GetEnumerator() => this;
+
+        public bool MoveNext()
+        {
+            if (_index >= _content.Length)
+            {
+                return false;
+            }
+
+            var end = SubtagEnd(_content, _index);
+            var subtag = _content.Slice(_index, end - _index);
+            if (IsKey(subtag))
+            {
+                _index = _content.Length;
+                return false;
+            }
+
+            _index = end + 1;
+            Current = subtag;
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Backport of #3594 (main squash `53ef37e79`), which closed #3573.

## The defect, live on 4.x

`new Intl.DateTimeFormat('en-US-u-ca-buddhist-nu-arab')` resolves to a bare `en-US` with `gregory` and `latn`, losing both keys. Either key on its own is read; the two together lose both, and the resolved locale loses the extension with them. `Intl.NumberFormat` has it too, while `Intl.Locale` and `Intl.getCanonicalLocales` read the same tag correctly.

Each constructor carried its own scanner, and each ended a key's value by consuming the next key into it — `ca` read back as `"buddhist-nu"`, which resolves to no calendar, so the option was dropped and the extension never made it into the resolved locale. Eight such scanners existed under `Jint/Native/Intl`.

Measured on this branch, before and after. `DTF` is `new Intl.DateTimeFormat(tag, { hour: 'numeric' }).resolvedOptions()`, `NF` is `new Intl.NumberFormat(tag).resolvedOptions()`:

| requested tag | before | after |
| --- | --- | --- |
| `en-US-u-ca-buddhist-nu-arab` | DTF `en-US` / `gregory` / `latn` | DTF `en-US-u-ca-buddhist-nu-arab` / `buddhist` / `arab` |
| `en-US-u-nu-arab-ca-buddhist` | DTF `en-US` / `gregory` / `latn` | DTF `en-US-u-ca-buddhist-nu-arab` / `buddhist` / `arab` |
| `en-US-u-ca-buddhist-hc-h23` | DTF `en-US` / `gregory` / `latn` / `h12` | DTF `en-US-u-ca-buddhist-hc-h23` / `buddhist` / `latn` / `h23` |
| `en-US-u-hc-h23-nu-arab-ca-buddhist` | DTF `en-US-u-nu-arab` / `gregory` / `arab` / `h12` | DTF `en-US-u-ca-buddhist-hc-h23-nu-arab` / `buddhist` / `arab` / `h23` |
| `en-US-u-ca-islamic-civil-nu-arab` | DTF `en-US` / `gregory` / `latn` | DTF `en-US-u-ca-islamic-civil-nu-arab` / `islamic-civil` / `arab` |
| `en-US-u-foo-ca-buddhist-nu-arab` | DTF `en-US` / `gregory` / `latn` | DTF `en-US-u-ca-buddhist-nu-arab` / `buddhist` / `arab` |
| `en-US-u-nu-arab-x-private` | DTF `en-US` / `latn` | DTF `en-US-u-nu-arab` / `arab` |
| `en-US-u-ca-buddhist-nu-arab` | NF `en-US` / `latn` | NF `en-US-u-nu-arab` / `arab` |
| `en-US-u-nu-arab-ca-buddhist` | NF `en-US` / `latn` | NF `en-US-u-nu-arab` / `arab` |

Every "after" value is what ICU — and therefore V8 (Node 24, full ICU) — answers for the same tag.

## This changes what scripts see

Stated plainly, as #3556 did for read-only host collections. A script reading `resolvedOptions()` for a tag that carries **more than one** `-u-` key gets different values than it did: the keys it asked for, and a `locale` that carries them. A tag with **one** key, or none, resolves exactly as before — those lanes are pinned in the new tests precisely so the change stays confined to the case that was broken. Anything downstream that formats through such a formatter (dates in a Buddhist calendar, numbers in Arabic-Indic digits) formats differently as a result, which is the point of the fix.

`ResolveLocale` step 13's precedence is untouched, and now pinned: an option still supersedes the tag's keyword and still removes that keyword from the resolved locale — for one key, and for one key beside another.

## The fix

The eight scanners are replaced by one. `UnicodeExtension` owns the rule https://unicode.org/reports/tr35/#unicode_locale_extensions states — a key is two characters, a value is the 3-to-8-character subtags after it, and both end at the next key or the next singleton — and answers for reading a keyword, enumerating them, removing the sequence, and rewriting one key. `Intl.Locale`'s own whole-tag parser and `CanonicalizeUnicodeLocaleId` take their key test from it as well, so nothing in the engine can drift about where one keyword ends and the next begins.

## Divergence from the main PR

This is not a blind pick; four files needed a merge, and all four for the same reason: main's `Intl` has moved on around this code (the provider chain that is out of scope for 4.x), so `git apply -3` pulled in signature changes that belong to other PRs.

| file | what main's patch wanted | what landed here |
| --- | --- | --- |
| `DurationFormatConstructor` | `private string ResolveNumberingSystem(…, string locale)` reading `IntlUtilities.IsSupportedNumberingSystem` / `GetLocaleDefaultNumberingSystem` | 4.x's `private static string ResolveNumberingSystem(string?, string?)` kept as-is; only `ParseNumberingSystemExtension` is deleted and its call site replaced with `UnicodeExtension.GetKeywordValue`. Main's spec-citation doc comment is kept — it describes step 13 either way. |
| `NumberFormatConstructor`, `RelativeTimeFormatConstructor` | `private bool IsSupportedNumberingSystem(…)` | kept `private static bool`; only `ExtractNumberingSystemFromLocale` is deleted |
| `DateTimeFormatConstructor` | delete a region main no longer has `CanonicalizeCalendar` in | `CanonicalizeCalendar` kept, `ExtractUnicodeExtensionFromLocale` deleted |
| `Polyfills.cs` | insert the `string.Concat(ROS<char>, ROS<char>)` block where 4.x has its `#if NETFRAMEWORK` span-`Contains` block | inserted ahead of it, both intact |

`docs/v5-migration.md` dropped — it does not exist here. `Jint/Native/Intl/UnicodeExtension.cs`, `CollatorConstructor`, `DefaultCldrProvider`, `IntlUtilities` and `LocaleConstructor` applied cleanly and are byte-identical to main's.

**TFM check** (asked for explicitly, since 4.x is `net462;netstandard2.0;netstandard2.1;net8.0;net10.0`):

* The `string.Concat` span polyfill's guard is `#if !NET8_0_OR_GREATER`, which covers `net462`, `netstandard2.0` and `netstandard2.1` here exactly as it covers `net472`, `netstandard2.0` and `netstandard2.1` on main — same three downlevel assets, same reason. 4.x's `Polyfills` already uses the C# 14 `extension(string)` member syntax the block needs (`string.Join(char, …)` right above it). No existing `Concat` polyfill to collide with.
* `UnicodeExtension.IsKey` is shared by `IntlUtilities.CanonicalizeUnicodeLocaleId` and `LocaleConstructor` and uses nothing newer than `ReadOnlySpan<char>`.
* All five assets build with 0 errors and 0 warnings.

## Evidence

`Jint.Tests/Runtime/IntlUnicodeExtensionTests.cs` (42 cases) run against **unfixed** 4.x first. To make the file compile before the fix, `UnicodeExtension.cs` and the polyfill were added on their own — nothing calls the class at that point, so engine behaviour is unchanged and the reader's own unit tests act as a control:

| leg | before | after |
| --- | --- | --- |
| net472 | **Failed: 11**, Passed: 31, Total: 42 | Failed: 0, Passed: 42 |
| net10.0 | **Failed: 11**, Passed: 31, Total: 42 | Failed: 0, Passed: 42 |

The 31 that passed before are the 23 `GetKeywordValue` / `RemoveSequence` / `WithKeyword` cases (the new reader is right before any consumer uses it), plus `Intl.Collator`'s three keys and `RelativeTimeFormat` / `DurationFormat`'s `nu` — those two scanners split the sequence on `-` and looked for a key by name, so they already survived a second key. The 11 failures are `Intl.DateTimeFormat` (7) and `Intl.NumberFormat` (2) losing keys, plus the multi-subtag/attribute case and the option-precedence case.

All 280 `Jint.Tests` Intl cases pass on both legs. Full `dotnet build -c Release`: 0 errors, 0 warnings. Full `dotnet test -c Release`:

* `Jint.Tests` 7041/7041 (net10.0), 6956/6956 (net472)
* `Jint.Tests.PublicInterface` 1820/1820 (net10.0), 1812/1812 (net472)
* `Jint.Tests.CommonScripts` 28/28 both legs, `Jint.Tests.SourceGenerators` 52/52
* `Jint.Tests.Test262` **102,499 passed / 0 failed / 185 skipped of 102,684** — exactly the 4.x control, with not even the usual `supportedLocalesOf` load flake this run. The pass count is unchanged, so no exclusion becomes removable: every test the corpus runs through these constructors was already passing with a single-key tag, and the multi-key tags the defect lost are ones test262 does not exercise here.
