### PR TITLE
Debugger: an expression can be evaluated in any call frame, not only the innermost one

### DIFF
--- a/Jint.Tests.PublicInterface/HostFrameEvaluationTests.cs
+++ b/Jint.Tests.PublicInterface/HostFrameEvaluationTests.cs
@@ -1,0 +1,238 @@
+#nullable enable
+
+using Jint.Native;
+using Jint.Runtime;
+using Jint.Runtime.Debugger;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// <c>DebugHandler.Evaluate(…, CallFrame)</c> from the outside: running a watch expression, or a console
+/// input, in the environment of a call frame other than the innermost one.
+/// </summary>
+/// <remarks>
+/// This is what a tooling protocol answers <c>Debugger.evaluateOnCallFrame</c> with, and a debugger front
+/// end asks for it every time a user selects a frame in the call-stack pane. A host reaches it through the
+/// <see cref="CallFrame"/> instances of the pause it is handling, and through nothing else: a frame kept
+/// past its pause names environments the engine has left.
+/// </remarks>
+public class HostFrameEvaluationTests
+{
+    private const string Script = """
+        function outer(tag)
+        {
+            const scoped = 'outer';
+            let written = 'before';
+            inner();
+            return written + '/' + scoped + '/' + tag;
+        }
+
+        function inner()
+        {
+            const scoped = 'inner';
+            debugger;
+        }
+
+        outer('tag');
+        """;
+
+    private static Engine CreateEngine() => new(options =>
+    {
+        options.Debugger.Enabled = true;
+        options.Debugger.StatementHandling = DebuggerStatementHandling.Script;
+    });
+
+    /// <summary>
+    /// The frame's own scope chain answers, so a binding the innermost frame shadows is read as the chosen
+    /// frame sees it — the whole point of selecting a frame.
+    /// </summary>
+    [Test]
+    public void AFrameEvaluationReadsThatFramesBindings()
+    {
+        var engine = CreateEngine();
+        var seen = new List<string>();
+
+        engine.Debugger.Break += (sender, info) =>
+        {
+            seen.Add(engine.Debugger.Evaluate("scoped").AsString());
+            seen.Add(engine.Debugger.Evaluate("scoped", info.CallStack[0]).AsString());
+            seen.Add(engine.Debugger.Evaluate("scoped", info.CallStack[1]).AsString());
+            return StepMode.None;
+        };
+
+        engine.Execute(Script);
+
+        seen.Should().Equal("inner", "inner", "outer");
+    }
+
+    /// <summary>
+    /// Writing is the half a watch pane alone would not need and a console input does: the assignment lands
+    /// in the frame's binding, and the script sees it when it resumes.
+    /// </summary>
+    [Test]
+    public void AFrameEvaluationWritesThatFramesBindings()
+    {
+        var engine = CreateEngine();
+
+        engine.Debugger.Break += (sender, info) =>
+        {
+            engine.Debugger.Evaluate("written = 'after'", info.CallStack[1]);
+            return StepMode.None;
+        };
+
+        engine.Evaluate(Script).AsString().Should().Be("after/outer/tag");
+    }
+
+    /// <summary>
+    /// The frame supplies <c>this</c> and <c>arguments</c> too, because both are resolved out of the same
+    /// environment chain rather than passed alongside it.
+    /// </summary>
+    [Test]
+    public void AFrameEvaluationSeesThatFramesThisAndArguments()
+    {
+        var engine = CreateEngine();
+        JsValue? name = null;
+        JsValue? argument = null;
+
+        engine.Debugger.Break += (sender, info) =>
+        {
+            name = engine.Debugger.Evaluate("this.name", info.CallStack[1]);
+            argument = engine.Debugger.Evaluate("arguments[0]", info.CallStack[1]);
+            return StepMode.None;
+        };
+
+        engine.Execute("""
+            const host = { name: 'host', run(value) { inner(); } };
+            function inner() { debugger; }
+            host.run(42);
+            """);
+
+        name!.AsString().Should().Be("host");
+        argument!.AsNumber().Should().Be(42);
+    }
+
+    /// <summary>
+    /// The last frame is the global one, and evaluating there is what a protocol's plain
+    /// <c>Runtime.evaluate</c> does while a page is paused.
+    /// </summary>
+    [Test]
+    public void TheLastFrameIsTheGlobalScope()
+    {
+        var engine = CreateEngine();
+        var results = new List<string>();
+
+        engine.Debugger.Break += (sender, info) =>
+        {
+            var global = info.CallStack[info.CallStack.Count - 1];
+            global.Index.Should().Be(info.CallStack.Count - 1);
+            results.Add(engine.Debugger.Evaluate("globalBinding", global).AsString());
+            results.Add(engine.Debugger.Evaluate("typeof scoped", global).AsString());
+            return StepMode.None;
+        };
+
+        engine.Execute("var globalBinding = 'global';\n" + Script);
+
+        results.Should().Equal("global", "undefined");
+    }
+
+    /// <summary>
+    /// A throw inside the evaluated expression is reported as a failed evaluation and nothing else: the
+    /// pause is still running afterwards and every frame still answers.
+    /// </summary>
+    [Test]
+    public void AThrowInAFrameEvaluationLeavesThePauseUsable()
+    {
+        var engine = CreateEngine();
+        var recovered = false;
+
+        engine.Debugger.Break += (sender, info) =>
+        {
+            var thrown = Caught.Exception(() => engine.Debugger.Evaluate("missingFunction()", info.CallStack[1]));
+            thrown.Should().BeOfType<DebugEvaluationException>();
+            thrown!.InnerException.Should().BeOfType<JavaScriptException>();
+
+            recovered = engine.Debugger.Evaluate("scoped", info.CallStack[1]).AsString() == "outer";
+            return StepMode.None;
+        };
+
+        engine.Execute(Script);
+
+        recovered.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// A frame is only good for the pause it came from. Keeping one and using it later would evaluate
+    /// against environments the engine has left, so it is refused instead.
+    /// </summary>
+    [Test]
+    public void AFrameKeptPastItsPauseIsRefused()
+    {
+        var engine = CreateEngine();
+        CallFrame? kept = null;
+        Exception? refusal = null;
+
+        engine.Debugger.Break += (sender, info) =>
+        {
+            kept ??= info.CallStack[1];
+            return StepMode.None;
+        };
+
+        engine.Execute(Script);
+
+        kept.Should().NotBeNull();
+        refusal = Caught.Exception(() => engine.Debugger.Evaluate("scoped", kept!));
+        refusal.Should().BeOfType<InvalidOperationException>();
+    }
+
+    /// <summary>
+    /// Frames carry their engine, and a value never crosses engines in Jint, so a frame taken from one is
+    /// refused by another rather than resolved against the wrong realm.
+    /// </summary>
+    [Test]
+    public void AFrameFromAnotherEngineIsRefused()
+    {
+        CallFrame? foreign = null;
+        var source = CreateEngine();
+        source.Debugger.Break += (sender, info) =>
+        {
+            foreign ??= info.CallStack[1];
+            return StepMode.None;
+        };
+        source.Execute(Script);
+
+        var engine = CreateEngine();
+        Exception? refusal = null;
+        engine.Debugger.Break += (sender, info) =>
+        {
+            refusal = Caught.Exception(() => engine.Debugger.Evaluate("scoped", foreign!));
+            return StepMode.None;
+        };
+
+        engine.Execute(Script);
+
+        refusal.Should().BeOfType<InvalidOperationException>();
+        refusal!.Message.Should().Contain("different engine");
+    }
+
+    /// <summary>
+    /// A prepared script is accepted for a frame too, which is what a front end caches when the same watch
+    /// expression is re-evaluated at every stop.
+    /// </summary>
+    [Test]
+    public void APreparedScriptEvaluatesInAFrame()
+    {
+        var engine = CreateEngine();
+        var prepared = Engine.PrepareScript("scoped");
+        JsValue? result = null;
+
+        engine.Debugger.Break += (sender, info) =>
+        {
+            result = engine.Debugger.Evaluate(prepared, info.CallStack[1]);
+            return StepMode.None;
+        };
+
+        engine.Execute(Script);
+
+        result!.AsString().Should().Be("outer");
+    }
+}

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
@@ -2183,6 +2183,7 @@ namespace Jint.Runtime.Debugger
     {
         public Acornima.SourceLocation? FunctionLocation { get; }
         public string FunctionName { get; }
+        public int Index { get; }
         public Acornima.SourceLocation& Location { get; }
         public Jint.Native.JsValue? ReturnValue { get; }
         public Jint.Runtime.Debugger.DebugScopes ScopeChain { get; }
@@ -2209,7 +2210,9 @@ namespace Jint.Runtime.Debugger
         public event Jint.Runtime.Debugger.DebugHandler.DebugEventHandler? Skip;
         public event Jint.Runtime.Debugger.DebugHandler.DebugEventHandler? Step;
         public Jint.Native.JsValue Evaluate(in Jint.Prepared<Acornima.Ast.Script> preparedScript) { }
+        public Jint.Native.JsValue Evaluate(in Jint.Prepared<Acornima.Ast.Script> preparedScript, Jint.Runtime.Debugger.CallFrame frame) { }
         public Jint.Native.JsValue Evaluate(string sourceText, Jint.ScriptParsingOptions? parsingOptions = null) { }
+        public Jint.Native.JsValue Evaluate(string sourceText, Jint.Runtime.Debugger.CallFrame frame, Jint.ScriptParsingOptions? parsingOptions = null) { }
         public static Jint.Runtime.Debugger.StepLocation? FindStepLocation(Acornima.Ast.Program program, int line, int column) { }
         public static System.Collections.Generic.IReadOnlyList<Jint.Runtime.Debugger.StepLocation> GetStepLocations(Acornima.Ast.Program program) { }
         public static System.Collections.Generic.IReadOnlyList<Jint.Runtime.Debugger.StepLocation> GetStepLocations(Acornima.Ast.Program program, int startLine, int startColumn, int endLine, int endColumn) { }

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net472.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net472.verified.txt
@@ -2008,6 +2008,7 @@ namespace Jint.Runtime.Debugger
     {
         public Acornima.SourceLocation? FunctionLocation { get; }
         public string FunctionName { get; }
+        public int Index { get; }
         public Acornima.SourceLocation& Location { get; }
         public Jint.Native.JsValue? ReturnValue { get; }
         public Jint.Runtime.Debugger.DebugScopes ScopeChain { get; }
@@ -2034,7 +2035,9 @@ namespace Jint.Runtime.Debugger
         public event Jint.Runtime.Debugger.DebugHandler.DebugEventHandler? Skip;
         public event Jint.Runtime.Debugger.DebugHandler.DebugEventHandler? Step;
         public Jint.Native.JsValue Evaluate(in Jint.Prepared<Acornima.Ast.Script> preparedScript) { }
+        public Jint.Native.JsValue Evaluate(in Jint.Prepared<Acornima.Ast.Script> preparedScript, Jint.Runtime.Debugger.CallFrame frame) { }
         public Jint.Native.JsValue Evaluate(string sourceText, Jint.ScriptParsingOptions? parsingOptions = null) { }
+        public Jint.Native.JsValue Evaluate(string sourceText, Jint.Runtime.Debugger.CallFrame frame, Jint.ScriptParsingOptions? parsingOptions = null) { }
         public static Jint.Runtime.Debugger.StepLocation? FindStepLocation(Acornima.Ast.Program program, int line, int column) { }
         public static System.Collections.Generic.IReadOnlyList<Jint.Runtime.Debugger.StepLocation> GetStepLocations(Acornima.Ast.Program program) { }
         public static System.Collections.Generic.IReadOnlyList<Jint.Runtime.Debugger.StepLocation> GetStepLocations(Acornima.Ast.Program program, int startLine, int startColumn, int endLine, int endColumn) { }

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
@@ -2183,6 +2183,7 @@ namespace Jint.Runtime.Debugger
     {
         public Acornima.SourceLocation? FunctionLocation { get; }
         public string FunctionName { get; }
+        public int Index { get; }
         public Acornima.SourceLocation& Location { get; }
         public Jint.Native.JsValue? ReturnValue { get; }
         public Jint.Runtime.Debugger.DebugScopes ScopeChain { get; }
@@ -2209,7 +2210,9 @@ namespace Jint.Runtime.Debugger
         public event Jint.Runtime.Debugger.DebugHandler.DebugEventHandler? Skip;
         public event Jint.Runtime.Debugger.DebugHandler.DebugEventHandler? Step;
         public Jint.Native.JsValue Evaluate(in Jint.Prepared<Acornima.Ast.Script> preparedScript) { }
+        public Jint.Native.JsValue Evaluate(in Jint.Prepared<Acornima.Ast.Script> preparedScript, Jint.Runtime.Debugger.CallFrame frame) { }
         public Jint.Native.JsValue Evaluate(string sourceText, Jint.ScriptParsingOptions? parsingOptions = null) { }
+        public Jint.Native.JsValue Evaluate(string sourceText, Jint.Runtime.Debugger.CallFrame frame, Jint.ScriptParsingOptions? parsingOptions = null) { }
         public static Jint.Runtime.Debugger.StepLocation? FindStepLocation(Acornima.Ast.Program program, int line, int column) { }
         public static System.Collections.Generic.IReadOnlyList<Jint.Runtime.Debugger.StepLocation> GetStepLocations(Acornima.Ast.Program program) { }
         public static System.Collections.Generic.IReadOnlyList<Jint.Runtime.Debugger.StepLocation> GetStepLocations(Acornima.Ast.Program program, int startLine, int startColumn, int endLine, int endColumn) { }

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.0.verified.txt
@@ -2008,6 +2008,7 @@ namespace Jint.Runtime.Debugger
     {
         public Acornima.SourceLocation? FunctionLocation { get; }
         public string FunctionName { get; }
+        public int Index { get; }
         public Acornima.SourceLocation& Location { get; }
         public Jint.Native.JsValue? ReturnValue { get; }
         public Jint.Runtime.Debugger.DebugScopes ScopeChain { get; }
@@ -2034,7 +2035,9 @@ namespace Jint.Runtime.Debugger
         public event Jint.Runtime.Debugger.DebugHandler.DebugEventHandler? Skip;
         public event Jint.Runtime.Debugger.DebugHandler.DebugEventHandler? Step;
         public Jint.Native.JsValue Evaluate(in Jint.Prepared<Acornima.Ast.Script> preparedScript) { }
+        public Jint.Native.JsValue Evaluate(in Jint.Prepared<Acornima.Ast.Script> preparedScript, Jint.Runtime.Debugger.CallFrame frame) { }
         public Jint.Native.JsValue Evaluate(string sourceText, Jint.ScriptParsingOptions? parsingOptions = null) { }
+        public Jint.Native.JsValue Evaluate(string sourceText, Jint.Runtime.Debugger.CallFrame frame, Jint.ScriptParsingOptions? parsingOptions = null) { }
         public static Jint.Runtime.Debugger.StepLocation? FindStepLocation(Acornima.Ast.Program program, int line, int column) { }
         public static System.Collections.Generic.IReadOnlyList<Jint.Runtime.Debugger.StepLocation> GetStepLocations(Acornima.Ast.Program program) { }
         public static System.Collections.Generic.IReadOnlyList<Jint.Runtime.Debugger.StepLocation> GetStepLocations(Acornima.Ast.Program program, int startLine, int startColumn, int endLine, int endColumn) { }

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.1.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.1.verified.txt
@@ -2008,6 +2008,7 @@ namespace Jint.Runtime.Debugger
     {
         public Acornima.SourceLocation? FunctionLocation { get; }
         public string FunctionName { get; }
+        public int Index { get; }
         public Acornima.SourceLocation& Location { get; }
         public Jint.Native.JsValue? ReturnValue { get; }
         public Jint.Runtime.Debugger.DebugScopes ScopeChain { get; }
@@ -2034,7 +2035,9 @@ namespace Jint.Runtime.Debugger
         public event Jint.Runtime.Debugger.DebugHandler.DebugEventHandler? Skip;
         public event Jint.Runtime.Debugger.DebugHandler.DebugEventHandler? Step;
         public Jint.Native.JsValue Evaluate(in Jint.Prepared<Acornima.Ast.Script> preparedScript) { }
+        public Jint.Native.JsValue Evaluate(in Jint.Prepared<Acornima.Ast.Script> preparedScript, Jint.Runtime.Debugger.CallFrame frame) { }
         public Jint.Native.JsValue Evaluate(string sourceText, Jint.ScriptParsingOptions? parsingOptions = null) { }
+        public Jint.Native.JsValue Evaluate(string sourceText, Jint.Runtime.Debugger.CallFrame frame, Jint.ScriptParsingOptions? parsingOptions = null) { }
         public static Jint.Runtime.Debugger.StepLocation? FindStepLocation(Acornima.Ast.Program program, int line, int column) { }
         public static System.Collections.Generic.IReadOnlyList<Jint.Runtime.Debugger.StepLocation> GetStepLocations(Acornima.Ast.Program program) { }
         public static System.Collections.Generic.IReadOnlyList<Jint.Runtime.Debugger.StepLocation> GetStepLocations(Acornima.Ast.Program program, int startLine, int startColumn, int endLine, int endColumn) { }

--- a/Jint.Tests/Runtime/Debugger/EvaluateTests.cs
+++ b/Jint.Tests/Runtime/Debugger/EvaluateTests.cs
@@ -111,4 +111,280 @@ public class EvaluateTests
             frameAfter.Function.Should().Be(frameBefore.Function);
         });
     }
+
+    private const string ShadowingScript = @"
+        function outer()
+        {
+            const shadowed = 'outer';
+            let written = 'before';
+            inner();
+            return written;
+        }
+
+        function inner()
+        {
+            const shadowed = 'inner';
+            debugger;
+        }
+
+        outer();
+        ";
+
+    [Test]
+    public void FramesAreIndexedFromTheTop()
+    {
+        TestHelpers.TestAtBreak(ShadowingScript, (engine, info) =>
+        {
+            var stack = info.CallStack;
+            for (var i = 0; i < stack.Count; i++)
+            {
+                stack[i].Index.Should().Be(i);
+            }
+
+            stack[0].FunctionName.Should().Be("inner");
+            stack[1].FunctionName.Should().Be("outer");
+        });
+    }
+
+    [Test]
+    public void EvaluatesInTheEnvironmentOfTheRequestedFrame()
+    {
+        TestHelpers.TestAtBreak(ShadowingScript, (engine, info) =>
+        {
+            engine.Debugger.Evaluate("shadowed").AsString().Should().Be("inner");
+            engine.Debugger.Evaluate("shadowed", info.CallStack[0]).AsString().Should().Be("inner");
+            engine.Debugger.Evaluate("shadowed", info.CallStack[1]).AsString().Should().Be("outer");
+        });
+    }
+
+    [Test]
+    public void WritesBindingsOfTheRequestedFrame()
+    {
+        var engine = new Engine(options =>
+        {
+            options.Debugger.Enabled = true;
+            options.Debugger.StatementHandling = DebuggerStatementHandling.Script;
+        });
+
+        engine.Debugger.Break += (sender, info) =>
+        {
+            engine.Debugger.Evaluate("written = 'after'", info.CallStack[1]);
+            return StepMode.None;
+        };
+
+        engine.Evaluate(ShadowingScript).AsString().Should().Be("after");
+    }
+
+    [Test]
+    public void EvaluatesThisOfTheRequestedFrame()
+    {
+        var script = @"
+            const host = {
+                name: 'host',
+                run() { helper(); }
+            };
+
+            function helper()
+            {
+                debugger;
+            }
+
+            host.run();
+            ";
+
+        TestHelpers.TestAtBreak(script, (engine, info) =>
+        {
+            // helper is called as a plain function, so its own `this` is undefined in strict mode and the
+            // global object otherwise - either way it is not the object whose method is one frame down.
+            engine.Debugger.Evaluate("this.name", info.CallStack[1]).AsString().Should().Be("host");
+        });
+    }
+
+    [Test]
+    public void EvaluatesArgumentsOfTheRequestedFrame()
+    {
+        var script = @"
+            function outer(a, b)
+            {
+                inner();
+            }
+
+            function inner()
+            {
+                debugger;
+            }
+
+            outer(11, 22);
+            ";
+
+        TestHelpers.TestAtBreak(script, (engine, info) =>
+        {
+            engine.Debugger.Evaluate("arguments.length", info.CallStack[1]).AsNumber().Should().Be(2);
+            engine.Debugger.Evaluate("arguments[1]", info.CallStack[1]).AsNumber().Should().Be(22);
+        });
+    }
+
+    [Test]
+    public void EvaluatesInTheGlobalFrame()
+    {
+        var script = @"
+            var globalBinding = 'global';
+
+            function outer()
+            {
+                const shadowed = 'outer';
+                inner();
+            }
+
+            function inner()
+            {
+                const shadowed = 'inner';
+                debugger;
+            }
+
+            outer();
+            ";
+
+        TestHelpers.TestAtBreak(script, (engine, info) =>
+        {
+            var globalFrame = info.CallStack[info.CallStack.Count - 1];
+            globalFrame.FunctionName.Should().Be("(anonymous)");
+            engine.Debugger.Evaluate("globalBinding", globalFrame).AsString().Should().Be("global");
+            engine.Debugger.Evaluate("typeof shadowed", globalFrame).AsString().Should().Be("undefined");
+        });
+    }
+
+    [Test]
+    public void AcceptsAPreparedScriptForAFrame()
+    {
+        var prepared = Engine.PrepareScript("shadowed");
+
+        TestHelpers.TestAtBreak(ShadowingScript, (engine, info) =>
+        {
+            engine.Debugger.Evaluate(prepared, info.CallStack[1]).AsString().Should().Be("outer");
+        });
+    }
+
+    [Test]
+    public void FrameEvaluationErrorLeavesThePauseIntact()
+    {
+        TestHelpers.TestAtBreak(ShadowingScript, (engine, info) =>
+        {
+            var callStackSize = engine.CallStack.Count;
+
+            var exception = Invoking(() => engine.Debugger.Evaluate("undefinedFunction()", info.CallStack[1]))
+                .Should().ThrowExactly<DebugEvaluationException>().Which;
+            exception.InnerException.Should().BeOfType<JavaScriptException>();
+
+            engine.CallStack.Count.Should().Be(callStackSize);
+            engine.Debugger.Evaluate("shadowed", info.CallStack[1]).AsString().Should().Be("outer");
+            engine.Debugger.Evaluate("shadowed").AsString().Should().Be("inner");
+        });
+    }
+
+    [Test]
+    public void RefusesAFrameFromAnEarlierPause()
+    {
+        var engine = new Engine(options =>
+        {
+            options.Debugger.Enabled = true;
+            options.Debugger.StatementHandling = DebuggerStatementHandling.Script;
+        });
+
+        CallFrame staleFrame = null;
+        var breaks = 0;
+        engine.Debugger.Break += (sender, info) =>
+        {
+            breaks++;
+            if (staleFrame is null)
+            {
+                staleFrame = info.CallStack[1];
+                // The frame is usable while the pause it came from is still running.
+                engine.Debugger.Evaluate("1", staleFrame).AsNumber().Should().Be(1);
+            }
+            else
+            {
+                Invoking(() => engine.Debugger.Evaluate("1", staleFrame))
+                    .Should().Throw<InvalidOperationException>()
+                    .WithMessage("*already left*");
+            }
+
+            return StepMode.None;
+        };
+
+        engine.Execute(@"
+            function inner() { debugger; }
+            function outer() { inner(); }
+            outer();
+            outer();
+        ");
+
+        breaks.Should().Be(2);
+    }
+
+    [Test]
+    public void RefusesAFrameFromAnotherEngine()
+    {
+        CallFrame foreignFrame = null;
+        TestHelpers.TestAtBreak(ShadowingScript, (engine, info) => foreignFrame = info.CallStack[1]);
+
+        TestHelpers.TestAtBreak(ShadowingScript, (engine, info) =>
+        {
+            Invoking(() => engine.Debugger.Evaluate("1", foreignFrame))
+                .Should().Throw<InvalidOperationException>()
+                .WithMessage("*different engine*");
+        });
+    }
+
+    [Test]
+    public void RefusesANullFrame()
+    {
+        TestHelpers.TestAtBreak(ShadowingScript, (engine, info) =>
+        {
+            Invoking(() => engine.Debugger.Evaluate("1", (CallFrame) null))
+                .Should().Throw<ArgumentNullException>();
+        });
+    }
+
+    [Test]
+    public void EvaluatesInAFrameSuspendedAtAnAwait()
+    {
+        var engine = new Engine(options =>
+        {
+            options.Debugger.Enabled = true;
+            options.Debugger.StatementHandling = DebuggerStatementHandling.Script;
+        });
+        var gate = engine.Tasks.RegisterPromise();
+        engine.SetValue("gate", gate.Promise);
+
+        var breaks = 0;
+        engine.Debugger.Break += (sender, info) =>
+        {
+            breaks++;
+            engine.Debugger.Evaluate("captured").AsString().Should().Be("from-helper");
+            engine.Debugger.Evaluate("captured", info.CallStack[1]).AsString().Should().Be("from-async");
+            return StepMode.None;
+        };
+
+        engine.Execute(@"
+            async function run(gate) {
+                const captured = 'from-async';
+                await gate;
+                helper();
+            }
+
+            function helper() {
+                const captured = 'from-helper';
+                debugger;
+            }
+
+            run(gate);
+        ");
+
+        breaks.Should().Be(0, "execution is still suspended at the await");
+
+        gate.Resolve(JsValue.Undefined);
+
+        breaks.Should().Be(1);
+    }
 }

--- a/Jint/Runtime/Debugger/CallFrame.cs
+++ b/Jint/Runtime/Debugger/CallFrame.cs
@@ -1,4 +1,5 @@
 using Jint.Native;
+using Jint.Native.Function;
 using Jint.Runtime.CallStack;
 using Environment = Jint.Runtime.Environments.Environment;
 
@@ -11,25 +12,60 @@ public sealed class CallFrame
     private readonly CallStackElement? _element;
     private readonly Lazy<DebugScopes> _scopeChain;
     private readonly Engine _engine;
+    private readonly long _generation;
 
     internal CallFrame(
         CallStackElement? element,
         in CallStackExecutionContext context,
         in SourceLocation location,
-        JsValue? returnValue)
+        JsValue? returnValue,
+        int index,
+        long generation)
     {
         _element = element;
         _context = context;
         _engine = context.LexicalEnvironment._engine;
         _location = location;
         ReturnValue = returnValue;
+        Index = index;
+        _generation = generation;
 
         _scopeChain = new Lazy<DebugScopes>(() => new DebugScopes(Environment));
     }
 
     private Environment Environment => _context.LexicalEnvironment;
 
-    // TODO: CallFrameId
+    /// <summary>
+    /// The engine this frame was taken from.
+    /// </summary>
+    internal Engine Engine => _engine;
+
+    /// <summary>
+    /// The lexical environment that was active in this frame when the debugger stopped.
+    /// </summary>
+    internal Environment LexicalEnvironment => _context.LexicalEnvironment;
+
+    /// <summary>
+    /// The function whose activation this frame is, or <see langword="null"/> for the global frame.
+    /// </summary>
+    internal Function? Function => _element?.Function;
+
+    /// <summary>
+    /// The value <see cref="DebugHandler"/> stamped on the notification this frame was taken from, so
+    /// that a frame outliving its pause can be told apart from a live one.
+    /// </summary>
+    internal long Generation => _generation;
+
+    /// <summary>
+    /// Position of this call frame in the call stack, counting from zero at the currently executing frame.
+    /// </summary>
+    /// <remarks>
+    /// The last frame is the global (or module) frame, so a frame's index also says how many calls deep
+    /// it is. Indices belong to the pause they were taken in: the same function occupies a different
+    /// index the next time the debugger stops.
+    /// </remarks>
+    public int Index { get; }
+
     /// <summary>
     /// Name of the function of this call frame. For global scope, this will be "(anonymous)".
     /// </summary>

--- a/Jint/Runtime/Debugger/DebugCallStack.cs
+++ b/Jint/Runtime/Debugger/DebugCallStack.cs
@@ -8,19 +8,19 @@ public sealed class DebugCallStack : IReadOnlyList<CallFrame>
 {
     private readonly List<CallFrame> _stack;
 
-    internal DebugCallStack(Engine engine, SourceLocation location, JintCallStack callStack, JsValue? returnValue)
+    internal DebugCallStack(Engine engine, SourceLocation location, JintCallStack callStack, JsValue? returnValue, long generation)
     {
         _stack = new List<CallFrame>(callStack.Count + 1);
         var executionContext = new CallStackExecutionContext(engine.ExecutionContext);
         foreach (var element in callStack.Stack)
         {
-            _stack.Add(new CallFrame(element, in executionContext, in location, returnValue));
+            _stack.Add(new CallFrame(element, in executionContext, in location, returnValue, _stack.Count, generation));
             location = element.Location;
             returnValue = null;
             executionContext = element.CallingExecutionContext;
         }
         // Add root location
-        _stack.Add(new CallFrame(null, in executionContext, in location, returnValue: null));
+        _stack.Add(new CallFrame(null, in executionContext, in location, returnValue: null, _stack.Count, generation));
     }
 
     public CallFrame this[int index] => _stack[index];

--- a/Jint/Runtime/Debugger/DebugHandler.cs
+++ b/Jint/Runtime/Debugger/DebugHandler.cs
@@ -1,5 +1,7 @@
 using Jint.Native;
+using Jint.Runtime.Environments;
 using Jint.Runtime.Interpreter;
+using Environment = Jint.Runtime.Environments.Environment;
 
 namespace Jint.Runtime.Debugger;
 
@@ -21,6 +23,13 @@ public class DebugHandler
     private bool _paused;
     private int _steppingDepth;
     private SourceLocation? _currentLocation;
+
+    /// <summary>
+    /// Stamped on every <see cref="DebugCallStack"/> this handler hands out and bumped when the
+    /// notification that produced it returns, so that <see cref="Evaluate(string, CallFrame, ScriptParsingOptions)"/>
+    /// can tell a frame of the current pause from one a host kept past it.
+    /// </summary>
+    private long _generation;
 
     /// <summary>
     /// Triggered before the engine executes/evaluates the parsed AST of a script or module.
@@ -100,12 +109,53 @@ public class DebugHandler
     /// Internally, this is used for evaluating breakpoint conditions, but may also be used for e.g. watch lists
     /// in a debugger.
     /// </remarks>
-    public JsValue Evaluate(in Prepared<Script> preparedScript)
+    public JsValue Evaluate(in Prepared<Script> preparedScript) => EvaluateCore(in preparedScript, frame: null);
+
+    /// <summary>
+    /// Evaluates a script (expression) in the environment of <paramref name="frame"/> rather than in the
+    /// innermost one.
+    /// </summary>
+    /// <param name="preparedScript">The prepared expression or statement list to run.</param>
+    /// <param name="frame">A frame of the call stack the debugger is currently stopped in.</param>
+    /// <exception cref="InvalidOperationException">
+    /// <paramref name="frame"/> belongs to another engine, or to a pause this engine has already left.
+    /// </exception>
+    /// <remarks>
+    /// <para>
+    /// The frame's scope chain is what the expression resolves against, so a binding the innermost frame
+    /// shadows is read — and written — as that frame sees it, and <c>this</c> and <c>arguments</c> are the
+    /// frame's own. Passing <see cref="DebugInformation.CurrentCallFrame"/> is exactly
+    /// <see cref="Evaluate(in Prepared{Script})"/>.
+    /// </para>
+    /// <para>
+    /// Frames belong to the pause they were taken in. One kept past the <see cref="Break"/>,
+    /// <see cref="Step"/> or <see cref="ExceptionThrown"/> handler that produced it names environments the
+    /// engine has since left, so it is refused rather than evaluated against.
+    /// </para>
+    /// </remarks>
+    public JsValue Evaluate(in Prepared<Script> preparedScript, CallFrame frame)
+    {
+        if (frame is null)
+        {
+            Throw.ArgumentNullException(nameof(frame));
+        }
+
+        return EvaluateCore(in preparedScript, frame);
+    }
+
+    private JsValue EvaluateCore(in Prepared<Script> preparedScript, CallFrame? frame)
     {
         using var ownership = _engine.EnterHostCall();
         if (!preparedScript.IsValid)
         {
             Throw.InvalidPreparedScriptArgumentException(nameof(preparedScript));
+        }
+
+        // Before the evaluation-context test, so that a frame the engine has moved past is always reported
+        // as the misuse it is, rather than as "no active evaluation context" once the run is over.
+        if (frame is not null)
+        {
+            VerifyFrameBelongsToCurrentPause(frame);
         }
 
         if (!_engine.IsEvaluationInProgress)
@@ -117,20 +167,32 @@ public class DebugHandler
         var callStackSize = _engine.CallStack.Count;
         var parsingConstraints = _engine.GetActiveParsingConstraints().Combine(preparedScript.ParsingConstraints);
         ref readonly var activeContext = ref _engine.ExecutionContext;
+
+        // The top frame IS the active execution context (DebugCallStack builds it from exactly that), so
+        // taking the active one keeps the frame overload observably identical to the frameless one there.
+        var target = frame is null || frame.Index == 0
+            ? new FrameEnvironments(
+                activeContext.LexicalEnvironment,
+                activeContext.VariableEnvironment,
+                activeContext.PrivateEnvironment,
+                activeContext.Realm,
+                activeContext.Strict)
+            : DescribeFrame(frame, in activeContext);
+
         var scriptRecord = new ScriptRecord(
-            activeContext.Realm,
+            target.Realm,
             preparedScript.Program,
             preparedScript.Program.Location.SourceFile,
             parsingConstraints,
             preparedScript.ParserOptions);
         var debuggerExecutionContext = new Environments.ExecutionContext(
             scriptRecord,
-            activeContext.LexicalEnvironment,
-            activeContext.VariableEnvironment,
-            activeContext.PrivateEnvironment,
-            activeContext.Realm,
+            target.LexicalEnvironment,
+            target.VariableEnvironment,
+            target.PrivateEnvironment,
+            target.Realm,
             parserOptions: preparedScript.ParserOptions,
-            strict: activeContext.Strict);
+            strict: target.Strict);
 
         var list = new JintStatementList(null, preparedScript.Program.Body);
         Completion result;
@@ -178,6 +240,23 @@ public class DebugHandler
 
     /// <inheritdoc cref="Evaluate(in Prepared{Script})" />
     public JsValue Evaluate(string sourceText, ScriptParsingOptions? parsingOptions = null)
+        => EvaluateCore(sourceText, frame: null, parsingOptions);
+
+    /// <inheritdoc cref="Evaluate(in Prepared{Script}, CallFrame)" />
+    /// <param name="sourceText">The expression or statement list to parse and run.</param>
+    /// <param name="frame">A frame of the call stack the debugger is currently stopped in.</param>
+    /// <param name="parsingOptions">Parsing options, or <see langword="null"/> for the engine's own.</param>
+    public JsValue Evaluate(string sourceText, CallFrame frame, ScriptParsingOptions? parsingOptions = null)
+    {
+        if (frame is null)
+        {
+            Throw.ArgumentNullException(nameof(frame));
+        }
+
+        return EvaluateCore(sourceText, frame, parsingOptions);
+    }
+
+    private JsValue EvaluateCore(string sourceText, CallFrame? frame, ScriptParsingOptions? parsingOptions)
     {
         using var ownership = _engine.EnterHostCall();
         var parser = parsingOptions is null
@@ -196,7 +275,7 @@ public class DebugHandler
             _engine._parsingConstraintsOverride = parser.Constraints;
             try
             {
-                return Evaluate(in prepared);
+                return EvaluateCore(in prepared, frame);
             }
             finally
             {
@@ -207,6 +286,73 @@ public class DebugHandler
         catch (ParseErrorException ex)
         {
             throw new DebugEvaluationException("An error occurred during debugger expression parsing", ex);
+        }
+    }
+
+    /// <summary>
+    /// The parts of an <see cref="Environments.ExecutionContext"/> a debugger evaluation has to establish
+    /// to run as if it were code of one particular call frame.
+    /// </summary>
+    private readonly record struct FrameEnvironments(
+        Environment LexicalEnvironment,
+        Environment VariableEnvironment,
+        PrivateEnvironment? PrivateEnvironment,
+        Realm Realm,
+        bool Strict);
+
+    /// <summary>
+    /// Reconstructs a non-top frame's execution context. Only the lexical environment is recorded per
+    /// frame; the rest is derived from it and from the frame's function, which is where the caller's
+    /// context took them from in the first place.
+    /// </summary>
+    private static FrameEnvironments DescribeFrame(CallFrame frame, in Environments.ExecutionContext activeContext)
+    {
+        var lexicalEnvironment = frame.LexicalEnvironment;
+        var variableEnvironment = FindVariableEnvironment(lexicalEnvironment);
+        var function = frame.Function;
+
+        // A function's [[PrivateEnvironment]] and [[Realm]] are exactly what PrepareForOrdinaryCall puts
+        // on its execution context. The global frame has no function, so it keeps the running realm, and
+        // its code is strict only when it is a module's.
+        return new FrameEnvironments(
+            lexicalEnvironment,
+            variableEnvironment,
+            function?._privateEnvironment,
+            function?._realm ?? activeContext.Realm,
+            function?._functionDefinition?.Strict ?? variableEnvironment is ModuleEnvironment);
+    }
+
+    /// <summary>
+    /// Walks out of block, <c>catch</c> and <c>with</c> scopes to the environment a <c>var</c> declaration
+    /// of the frame would land in.
+    /// </summary>
+    private static Environment FindVariableEnvironment(Environment lexicalEnvironment)
+    {
+        var environment = lexicalEnvironment;
+        while (environment is not null)
+        {
+            if (environment is FunctionEnvironment or GlobalEnvironment or ModuleEnvironment)
+            {
+                return environment;
+            }
+
+            environment = environment._outerEnv;
+        }
+
+        return lexicalEnvironment;
+    }
+
+    private void VerifyFrameBelongsToCurrentPause(CallFrame frame)
+    {
+        if (!ReferenceEquals(frame.Engine, _engine))
+        {
+            Throw.InvalidOperationException("The call frame belongs to a different engine");
+        }
+
+        if (frame.Generation != _generation)
+        {
+            Throw.InvalidOperationException(
+                "The call frame belongs to an execution point this engine has already left, and the environments it names are no longer on the stack");
         }
     }
 
@@ -323,8 +469,9 @@ public class DebugHandler
             return;
         }
 
-        var args = new ExceptionThrownEventArgs(_engine, thrownValue, in location);
+        var args = new ExceptionThrownEventArgs(_engine, thrownValue, in location, _generation);
         ExceptionThrown.Invoke(_engine, args);
+        _generation++;
     }
 
     internal void OnBeforeEvaluate(Program ast)
@@ -398,6 +545,9 @@ public class DebugHandler
 
         Pause(pauseType, node, in location, returnValue, breakPoint);
 
+        // Whatever the handler kept — a DebugInformation, a CallFrame — names environments that are about
+        // to be left, so a frame handed back later can be told apart from one of the pause still running.
+        _generation++;
         _paused = false;
     }
 
@@ -415,7 +565,8 @@ public class DebugHandler
             returnValue: returnValue,
             currentMemoryUsage: _engine.CurrentMemoryUsage,
             pauseType: type,
-            breakPoint: breakPoint
+            breakPoint: breakPoint,
+            generation: _generation
         );
 
         StepMode? result = type switch

--- a/Jint/Runtime/Debugger/DebugInformation.cs
+++ b/Jint/Runtime/Debugger/DebugInformation.cs
@@ -7,6 +7,7 @@ public sealed class DebugInformation : EventArgs
     private readonly Engine _engine;
     private readonly SourceLocation _currentLocation;
     private readonly JsValue? _returnValue;
+    private readonly long _generation;
 
     private DebugCallStack? _callStack;
 
@@ -17,9 +18,11 @@ public sealed class DebugInformation : EventArgs
         JsValue? returnValue,
         long currentMemoryUsage,
         PauseType pauseType,
-        BreakPoint? breakPoint)
+        BreakPoint? breakPoint,
+        long generation)
     {
         _engine = engine;
+        _generation = generation;
         CurrentNode = currentNode;
         _currentLocation = currentLocation;
         _returnValue = returnValue;
@@ -47,7 +50,7 @@ public sealed class DebugInformation : EventArgs
         get
         {
             using var ownership = _engine.EnterHostCall();
-            return _callStack ??= new DebugCallStack(_engine, _currentLocation, _engine.CallStack, _returnValue);
+            return _callStack ??= new DebugCallStack(_engine, _currentLocation, _engine.CallStack, _returnValue, _generation);
         }
     }
 

--- a/Jint/Runtime/Debugger/ExceptionThrownEventArgs.cs
+++ b/Jint/Runtime/Debugger/ExceptionThrownEventArgs.cs
@@ -9,12 +9,14 @@ public sealed class ExceptionThrownEventArgs : EventArgs
 {
     private readonly Engine _engine;
     private readonly SourceLocation _location;
+    private readonly long _generation;
     private DebugCallStack? _callStack;
 
-    internal ExceptionThrownEventArgs(Engine engine, JsValue thrownValue, in SourceLocation location)
+    internal ExceptionThrownEventArgs(Engine engine, JsValue thrownValue, in SourceLocation location, long generation)
     {
         _engine = engine;
         _location = location;
+        _generation = generation;
         ThrownValue = thrownValue;
     }
 
@@ -36,7 +38,7 @@ public sealed class ExceptionThrownEventArgs : EventArgs
         get
         {
             using var ownership = _engine.EnterHostCall();
-            return _callStack ??= new DebugCallStack(_engine, _location, _engine.CallStack, returnValue: null);
+            return _callStack ??= new DebugCallStack(_engine, _location, _engine.CallStack, returnValue: null, _generation);
         }
     }
 }

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -5241,6 +5241,37 @@ preview surface: `<NoWarn>$(NoWarn);JINT0002</NoWarn>`, or a `#pragma` at the ca
 `new Request(url, { credentials: "nonsense" })` is a `TypeError` where it used to be ignored.
 `mode`, `cache`, `integrity`, `keepalive` and `priority` are still accepted and ignored.
 
+### 5.11 A debugger can evaluate in any call frame ([#3622](https://github.com/sebastienros/jint/pull/3622))
+
+`DebugHandler.Evaluate` ran in the innermost frame and only there, so selecting a frame in a call-stack pane
+changed what a debugger *displayed* and nothing about what a watch expression or a console input resolved
+against. Both spellings now take the frame:
+
+```csharp
+engine.Debugger.Break += (sender, info) =>
+{
+    var caller = info.CallStack[1];
+
+    // reads and writes the caller's bindings, not the innermost frame's
+    var value = engine.Debugger.Evaluate("shadowed", caller);
+    engine.Debugger.Evaluate("shadowed = 'patched'", caller);
+
+    // the same, with a prepared expression a front end caches across stops
+    engine.Debugger.Evaluate(prepared, caller);
+
+    return StepMode.None;
+};
+```
+
+The frame's own scope chain is what resolves, so `this`, `arguments` and any binding the innermost frame
+shadows are the frame's; the last frame is the global (or module) one, which is what a protocol's plain
+`Runtime.evaluate` uses while a page is paused. Passing `info.CurrentCallFrame` is exactly the frameless
+overload. `CallFrame.Index` names a frame's position, counting from zero at the innermost.
+
+A frame belongs to the pause it was taken in. One kept past the `Break`, `Step` or `ExceptionThrown` handler
+that produced it names environments the engine has since left, and so does one from another engine; both are
+refused with `InvalidOperationException` rather than evaluated against.
+
 ## 6. AOT and trimming
 
 Jint 4.16 asserted Native AOT compatibility with the `IsAotCompatible` property and nothing else. In


### PR DESCRIPTION
`DebugHandler.Evaluate` ran in the innermost frame and only there. A debugger front end that lets a
user select a frame in the call-stack pane therefore changed what it *displayed* and nothing about
what a watch expression or a console input resolved against, and `Debugger.evaluateOnCallFrame` — the
protocol method that exists for exactly this — could only be answered for the top frame. This is **E4**
of the engine seams named in `docs/design/devtools-protocol.md` §5.

## What is added

```csharp
engine.Debugger.Break += (sender, info) =>
{
    var caller = info.CallStack[1];

    engine.Debugger.Evaluate("shadowed", caller);            // reads the caller's binding
    engine.Debugger.Evaluate("shadowed = 'patched'", caller); // and writes it
    engine.Debugger.Evaluate(prepared, caller);               // prepared form, for a cached watch

    return StepMode.None;
};
```

- `DebugHandler.Evaluate(string sourceText, CallFrame frame, ScriptParsingOptions? parsingOptions = null)`
- `DebugHandler.Evaluate(in Prepared<Script> preparedScript, CallFrame frame)`
- `CallFrame.Index` — the frame's position, counting from zero at the innermost frame. It also
  replaces the `// TODO: CallFrameId` comment the file carried: a protocol identifier stays in
  `Jint.DevTools`, and the index is what it is minted from.

## How a frame's context is rebuilt

`CallStackExecutionContext` records one thing per frame, the lexical environment, and nothing was
added to it — it is pushed on every call and two more reference fields there is a cost every engine
would pay for a debugger nobody has attached. Everything else is derived from what is already
reachable:

| | |
| --- | --- |
| lexical environment | the frame's own, as recorded |
| variable environment | the nearest function, global or module environment on its chain — what a `var` of that frame lands in |
| private environment | the frame's function's `[[PrivateEnvironment]]`, which is exactly what `PrepareForOrdinaryCall` put on its context |
| realm | the frame's function's `[[Realm]]`; the global frame keeps the running one |
| strictness | the frame's function definition's; the global frame is strict only when it is a module's |
| `this`, `arguments` | neither is passed: both resolve out of the lexical chain the evaluation is given |

**Frame 0 is not rebuilt.** `DebugCallStack` builds the top frame from `engine.ExecutionContext`
itself, so the frame overload takes that context verbatim there and is identical to the frameless
overload by construction rather than by agreement. `AFrameEvaluationReadsThatFramesBindings` pins the
two against each other anyway.

## A frame belongs to its pause

`DebugHandler` stamps a generation on every `DebugCallStack` it hands out and bumps it when the
notification that produced it returns. A frame kept past its `Break`, `Step` or `ExceptionThrown`
handler names environments the engine has left, and a frame from another engine names another
engine's, so both are refused with `InvalidOperationException` — checked before the "no active
evaluation context" test, so that a stale frame is reported as the misuse it is even after the run is
over.

## Hot paths

None. The only engine-side change outside `Jint/Runtime/Debugger/` is that `CallFrame` and
`DebugCallStack` carry two more fields, and both are allocated only when a debug notification's call
stack is actually read.

## Tests

- `Jint.Tests/Runtime/Debugger/EvaluateTests.cs`: 12 new cases — frame indices, reading and writing a
  shadowed binding in frame N, `this` and `arguments` of frame N, the global frame, the prepared
  overload, a throw leaving the pause usable, the two refusals, a null frame, and a frame suspended at
  an `await` (the resumed async frame is the one below a synchronous callee, and its locals are what
  frame 1 answers with).
- `Jint.Tests.PublicInterface/HostFrameEvaluationTests.cs`: 8 cases proving the same surface is
  reachable without `InternalsVisibleTo`.

Verified failing first: with the frame's environments ignored (frame 0's context used for every
frame) 8 of the 12 fail; with the generation bump removed, `RefusesAFrameFromAnEarlierPause` fails and
nothing else does.

Five `PublicApiTest` baselines re-accepted (three added lines each); one migration-guide section,
§5.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
