### PR TITLE
DevTools: the REPL serves the protocol, the front end is driven, and the native binary is a client

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,6 +111,19 @@ jobs:
         ./artifacts/publish/Jint.AotExample/release/Jint.AotExample | tee aot-run.log
         grep -q '^ALL PROBES PASSED' aot-run.log
 
+    # Jint.DevTools is referenced by the example and deliberately NOT rooted, so ILC re-derives its whole
+    # diagnostic set over the closed program here. Unlike Jint's own inventory - a tracked backlog the step
+    # below merely summarises - this one gates at zero: everything the protocol serializes goes through a
+    # source-generated System.Text.Json context, and the first reflective member would raise IL2026 or
+    # IL3050 in this log and nowhere else. No test can see it, and an embedder publishing Native AOT would.
+    - name: No trim or AOT diagnostic is attributed to Jint.DevTools
+      run: |
+        if grep -E 'IL[0-9]{4}' aot-publish.log | grep -E 'Jint\.DevTools'; then
+          echo '::error::a trim or AOT analysis diagnostic names Jint.DevTools; the lines above say which'
+          exit 1
+        fi
+        echo 'no IL2xxx/IL3xxx diagnostic names Jint.DevTools'
+
     - name: Summarise the trim and AOT analysis warnings
       if: always()
       run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -164,6 +164,19 @@ jobs:
         ./artifacts/publish/Jint.AotExample/release/Jint.AotExample | tee aot-run.log
         grep -q '^ALL PROBES PASSED' aot-run.log
 
+    # Jint.DevTools is referenced by the example and deliberately NOT rooted, so ILC re-derives its whole
+    # diagnostic set over the closed program here. Unlike Jint's own inventory - a tracked backlog the step
+    # below merely summarises - this one gates at zero: everything the protocol serializes goes through a
+    # source-generated System.Text.Json context, and the first reflective member would raise IL2026 or
+    # IL3050 in this log and nowhere else. No test can see it, and an embedder publishing Native AOT would.
+    - name: No trim or AOT diagnostic is attributed to Jint.DevTools
+      run: |
+        if grep -E 'IL[0-9]{4}' aot-publish.log | grep -E 'Jint\.DevTools'; then
+          echo '::error::a trim or AOT analysis diagnostic names Jint.DevTools; the lines above say which'
+          exit 1
+        fi
+        echo 'no IL2xxx/IL3xxx diagnostic names Jint.DevTools'
+
     # if: always() so the inventory is still written when the run step above went red, which is exactly when
     # someone wants to read it. Every command here therefore has to survive a missing log.
     - name: Summarise the trim and AOT analysis warnings

--- a/Jint.AotExample/Jint.AotExample.csproj
+++ b/Jint.AotExample/Jint.AotExample.csproj
@@ -46,6 +46,14 @@
     <ProjectReference Include="..\Jint\Jint.csproj" />
 
     <!--
+      The DevTools protocol server, referenced but NOT rooted below, and that absence is the measurement.
+      The package speaks JSON in both directions through a source-generated System.Text.Json context and
+      reaches its domains through a generated switch, so what preserves a domain is that switch or nothing
+      at all. Rooting it would make the probe pass whether or not either of those is true.
+    -->
+    <ProjectReference Include="..\Jint.DevTools\Jint.DevTools.csproj" />
+
+    <!--
       The unrooted half. Deliberately absent from the TrimmerRootAssembly list below, and that absence is
       the whole measurement: every host type declared beside Program.cs is rooted wholesale, so a probe
       over one cannot tell "the annotation preserved this member" from "the root did". The types in this

--- a/Jint.AotExample/Program.cs
+++ b/Jint.AotExample/Program.cs
@@ -48,7 +48,11 @@
 // script's arguments will produce, and rooting a guessed set would cost every AOT consumer binary size
 // for instantiations they never use.
 
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
 using Jint;
+using Jint.DevTools;
 using Jint.Native;
 using Jint.Runtime.Interop;
 using UnrootedAotProbe;
@@ -557,6 +561,18 @@ Probe("promise and async function", static () =>
     Expect(42, engine.Evaluate("(async function () { return 42; })()").UnwrapIfPromise());
 });
 
+// The DevTools protocol server, natively compiled and driven over a real socket by a client that is not
+// PuppeteerSharp and not this package: attach, evaluate, stop the engine at a breakpoint, resume.
+//
+// It is here because the claim "Jint.DevTools is AOT-safe" is exactly as unfounded as the one this whole
+// project exists to check. Two things could have made it false and neither is visible from a JIT run: the
+// protocol is JSON in both directions, which is where a reflection-based serializer would raise IL2026 and
+// IL3050 at every call and then fail at run time under a trimmer (the package uses a source-generated
+// System.Text.Json context, which is what makes this pass); and Jint.DevTools is deliberately NOT rooted in
+// this project's TrimmerRootAssembly list, so a domain reachable only through the generated dispatch is
+// preserved by that switch or by nothing at all.
+Probe("DevTools protocol over a socket: attach, evaluate, break, resume", static () => DevToolsProbe.Run());
+
 Console.WriteLine();
 if (failures == 0)
 {
@@ -784,6 +800,219 @@ public sealed class ReadOnlyDoubles : IReadOnlyList<double>
     public int Count => _items.Count;
     public IEnumerator<double> GetEnumerator() => _items.GetEnumerator();
     System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => _items.GetEnumerator();
+}
+
+/// <summary>
+/// The DevTools half of the probe: a WebSocket client of its own, so that what is being checked is the
+/// published server and not a client library's ability to talk to it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Deliberately hand-rolled rather than PuppeteerSharp. Adding a client package here would put that
+/// package's Native AOT behaviour into the measurement, and a failure would then be ambiguous. Everything
+/// below is <see cref="System.Net.WebSockets.ClientWebSocket"/> plus <see cref="JsonDocument"/>, both of
+/// which are AOT-clean, and every JSON body it sends is a constant with an identifier interpolated into it.
+/// </para>
+/// <para>
+/// The target is <see cref="ThreadMode.LibraryOwned"/> because this thread is the client: the engine needs
+/// a thread of its own to be paused on while this one reads <c>Debugger.paused</c> off the socket and sends
+/// the resume.
+/// </para>
+/// </remarks>
+public static class DevToolsProbe
+{
+    /// <summary>Long enough that a loaded machine does not fail the run, short enough not to be a hang.</summary>
+    private static readonly TimeSpan Bound = TimeSpan.FromSeconds(60);
+
+    private const string Source = """
+        function twice(n) {
+            var doubled = n * 2;
+            return doubled;
+        }
+        """;
+
+    /// <summary>Runs the probe, throwing whatever went wrong so the caller reports it as a failure.</summary>
+    public static void Run() => RunAsync().GetAwaiter().GetResult();
+
+    private static async Task RunAsync()
+    {
+        await using var server = new DevToolsServer(new DevToolsServerOptions { Port = 0 });
+        await server.StartAsync().ConfigureAwait(false);
+
+        await using var target = new EngineTarget(
+            new Engine(static options => options.UseDevTools()),
+            new EngineTargetOptions { Title = "aot", Url = "jint://aot", ThreadMode = ThreadMode.LibraryOwned });
+
+        server.AddTarget(target);
+        await target.PostAsync(static engine => engine.Execute(Source, "twice.js")).ConfigureAwait(false);
+
+        using var deadline = new CancellationTokenSource(Bound);
+        using var socket = new ClientWebSocket();
+        await socket.ConnectAsync(new Uri(server.BrowserWebSocketUrl), deadline.Token).ConfigureAwait(false);
+
+        var client = new ProtocolClient(socket, deadline.Token);
+
+        // Target.getTargets, then attach flattened - the two commands every recorded client sends before it
+        // can address an engine at all.
+        using (var targets = await client.CallAsync("Target.getTargets", null, "{}").ConfigureAwait(false))
+        {
+            var listed = targets.RootElement.GetProperty("result").GetProperty("targetInfos");
+            if (listed.GetArrayLength() != 1 || listed[0].GetProperty("targetId").GetString() != target.TargetId)
+            {
+                throw new InvalidOperationException("Target.getTargets did not list the one engine this server was given");
+            }
+        }
+
+        string session;
+        using (var attached = await client.CallAsync("Target.attachToTarget", null, $$"""{"targetId":"{{target.TargetId}}","flatten":true}""").ConfigureAwait(false))
+        {
+            session = attached.RootElement.GetProperty("result").GetProperty("sessionId").GetString()
+                ?? throw new InvalidOperationException("Target.attachToTarget answered no sessionId");
+        }
+
+        using (var evaluated = await client.CallAsync("Runtime.evaluate", session, """{"expression":"6 * 7","returnByValue":true}""").ConfigureAwait(false))
+        {
+            var value = evaluated.RootElement.GetProperty("result").GetProperty("result").GetProperty("value").GetInt32();
+            if (value != 42)
+            {
+                throw new InvalidOperationException($"Runtime.evaluate answered {value} rather than 42");
+            }
+        }
+
+        (await client.CallAsync("Runtime.enable", session, "{}").ConfigureAwait(false)).Dispose();
+        (await client.CallAsync("Debugger.enable", session, "{}").ConfigureAwait(false)).Dispose();
+
+        string breakpoint;
+        using (var set = await client.CallAsync("Debugger.setBreakpointByUrl", session, """{"url":"twice.js","lineNumber":2}""").ConfigureAwait(false))
+        {
+            var result = set.RootElement.GetProperty("result");
+            breakpoint = result.GetProperty("breakpointId").GetString()
+                ?? throw new InvalidOperationException("Debugger.setBreakpointByUrl answered no breakpointId");
+
+            if (result.GetProperty("locations").GetArrayLength() != 1)
+            {
+                throw new InvalidOperationException("the script is already parsed, so the breakpoint should have been placed at once");
+            }
+        }
+
+        // Not awaited: this evaluation is what pauses, so waiting for its reply before resuming would be
+        // waiting for this probe to answer itself.
+        var pending = client.SendAsync("Runtime.evaluate", session, """{"expression":"twice(21)","returnByValue":true}""");
+
+        using (var paused = await client.EventAsync("Debugger.paused").ConfigureAwait(false))
+        {
+            var parameters = paused.RootElement.GetProperty("params");
+            var hit = parameters.GetProperty("hitBreakpoints");
+            if (hit.GetArrayLength() != 1 || hit[0].GetString() != breakpoint)
+            {
+                throw new InvalidOperationException("the engine paused somewhere other than on the breakpoint that was set");
+            }
+
+            var frame = parameters.GetProperty("callFrames")[0].GetProperty("functionName").GetString();
+            if (frame != "twice")
+            {
+                throw new InvalidOperationException($"the top call frame was '{frame}' rather than 'twice'");
+            }
+        }
+
+        (await client.CallAsync("Debugger.resume", session, "{}").ConfigureAwait(false)).Dispose();
+
+        using (var resumed = await client.ResponseAsync(await pending.ConfigureAwait(false)).ConfigureAwait(false))
+        {
+            var value = resumed.RootElement.GetProperty("result").GetProperty("result").GetProperty("value").GetInt32();
+            if (value != 42)
+            {
+                throw new InvalidOperationException($"the resumed evaluation answered {value} rather than 42");
+            }
+        }
+
+        await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, "done", deadline.Token).ConfigureAwait(false);
+    }
+
+    /// <summary>The smallest thing that can be called a Chrome DevTools Protocol client.</summary>
+    private sealed class ProtocolClient(ClientWebSocket socket, CancellationToken token)
+    {
+        private readonly byte[] _buffer = new byte[16 * 1024];
+        private int _id;
+
+        /// <summary>Sends one command and answers with the identifier its reply will carry.</summary>
+        internal async Task<int> SendAsync(string method, string? session, string parameters)
+        {
+            var id = Interlocked.Increment(ref _id);
+            var envelope = session is null
+                ? $$"""{"id":{{id}},"method":"{{method}}","params":{{parameters}}}"""
+                : $$"""{"id":{{id}},"method":"{{method}}","params":{{parameters}},"sessionId":"{{session}}"}""";
+
+            await socket.SendAsync(Encoding.UTF8.GetBytes(envelope), WebSocketMessageType.Text, endOfMessage: true, token).ConfigureAwait(false);
+            return id;
+        }
+
+        /// <summary>Sends one command and reads until its reply arrives, skipping the events in between.</summary>
+        internal async Task<JsonDocument> CallAsync(string method, string? session, string parameters)
+            => await ResponseAsync(await SendAsync(method, session, parameters).ConfigureAwait(false)).ConfigureAwait(false);
+
+        /// <summary>Reads until the reply to <paramref name="id"/> arrives, and fails on a protocol error.</summary>
+        internal async Task<JsonDocument> ResponseAsync(int id)
+        {
+            while (true)
+            {
+                var message = await ReadAsync().ConfigureAwait(false);
+                if (!message.RootElement.TryGetProperty("id", out var answered) || answered.GetInt32() != id)
+                {
+                    message.Dispose();
+                    continue;
+                }
+
+                if (message.RootElement.TryGetProperty("error", out var error))
+                {
+                    var reported = error.GetProperty("message").GetString();
+                    message.Dispose();
+                    throw new InvalidOperationException($"the server answered {id} with an error: {reported}");
+                }
+
+                return message;
+            }
+        }
+
+        /// <summary>Reads until <paramref name="method"/> is raised, skipping everything else.</summary>
+        internal async Task<JsonDocument> EventAsync(string method)
+        {
+            while (true)
+            {
+                var message = await ReadAsync().ConfigureAwait(false);
+                if (message.RootElement.TryGetProperty("method", out var raised) && raised.GetString() == method)
+                {
+                    return message;
+                }
+
+                message.Dispose();
+            }
+        }
+
+        /// <summary>Reads one whole message, however many frames it took.</summary>
+        private async Task<JsonDocument> ReadAsync()
+        {
+            using var message = new MemoryStream();
+
+            while (true)
+            {
+                var frame = await socket.ReceiveAsync(_buffer, token).ConfigureAwait(false);
+                if (frame.MessageType == WebSocketMessageType.Close)
+                {
+                    throw new InvalidOperationException("the server closed the socket before the probe was finished");
+                }
+
+                message.Write(_buffer, 0, frame.Count);
+                if (frame.EndOfMessage)
+                {
+                    break;
+                }
+            }
+
+            message.Position = 0;
+            return JsonDocument.Parse(message);
+        }
+    }
 }
 
 namespace AotProbe

--- a/Jint.DevTools/AGENTS.md
+++ b/Jint.DevTools/AGENTS.md
@@ -357,6 +357,15 @@ everything it tests is `internal`.
   tolerance a decision, and
   [`Domains/AGENTS.md`](Domains/AGENTS.md#the-absent-table-and-how-a-command-leaves-it) says what an entry
   means and how one is retired.
-- **What is not here yet**: the manual checklist for attaching
-  `devtools://devtools/bundled/js_app.html?v8only=true&ws=`, which is how the front end's own behaviour is
-  claimed and which nothing automated replaces.
+- **The front end is claimed by driving it, not by asserting against it.**
+  [`docs/manual-checklist.md`](docs/manual-checklist.md) is the walk — `chrome://inspect` → Configure → the
+  port, then what each panel should show and what is expected to be empty — and
+  [`tools/devtools-frontend-smoke/`](../tools/devtools-frontend-smoke/README.md) automates most of it against a real
+  Chrome and a real Jint process. That tool downloads a browser and reaches the network, so it is **not in
+  CI**; run it when the protocol surface changes, and run the checklist by hand for the steps it reports as
+  not driven.
+- **The published binary is a claim too.** `Jint.AotExample` references this package without rooting it and
+  probes it over a real socket — attach, evaluate, break, resume — so the `aot` leg's own run is what says
+  Native AOT works here. That leg additionally fails if any `IL2xxx`/`IL3xxx` diagnostic is attributed to a
+  file in this package: everything it serializes goes through a source-generated `System.Text.Json` context,
+  and the first reflective one would show up there rather than in a test.

--- a/Jint.DevTools/Jint.DevTools.csproj
+++ b/Jint.DevTools/Jint.DevTools.csproj
@@ -32,9 +32,12 @@
 
       Nothing here is suppressed, and that is the point of the design: every payload crosses through the
       source-generated ProtocolJsonContext, so no protocol type is reached by reflection and the assembly
-      produces no IL2xxx or IL3050 of its own. The AOT probe that turns the claim into evidence arrives
-      with the end-to-end pull request (campaign P7); until then this property says "analysed clean",
-      not "measured".
+      produces no IL2xxx or IL3050 of its own.
+
+      That is now measured rather than analysed. Jint.AotExample references this package and deliberately
+      does NOT root it, then drives the published native binary over a real socket - attach, evaluate,
+      break, resume - and the same CI leg fails if any IL2xxx/IL3xxx diagnostic ILC re-derives over the
+      closed program is attributed to a file in here.
     -->
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
   </PropertyGroup>

--- a/Jint.DevTools/docs/manual-checklist.md
+++ b/Jint.DevTools/docs/manual-checklist.md
@@ -1,0 +1,64 @@
+# Attaching the Chrome DevTools front end by hand
+
+The front end is a user interface, and what it does with a target is its own business rather than this
+server's. So this is the one claim in the package that a test cannot make on its own: everything under
+`Jint.Tests.DevTools/` asserts what *this server answers*, and none of it asserts what *Chrome shows*.
+
+Most of the walk below is now driven automatically by
+[`tools/devtools-frontend-smoke/`](../../tools/devtools-frontend-smoke/README.md), which launches Chrome for
+Testing, loads the hosted front end against a real Jint process and asserts against the front end's own
+DOM. That tool is not in CI — it downloads a browser and reaches the network — so run it when the protocol
+surface changes, and run this checklist when you want to see it with your own eyes, or when the tool says a
+step could not be driven.
+
+## Start something to attach to
+
+```bash
+dotnet run --project Jint.Repl -c Release -- --inspect -f script.js -t 60
+```
+
+The REPL prints three things: the WebSocket endpoint, the `devtools://` address of the front end, and what
+to type into `chrome://inspect`. `--inspect=0` takes an ephemeral port and the banner says which one;
+`--inspect-brk` runs nothing until a client has attached and sent `Runtime.runIfWaitingForDebugger`, which
+is what you want when the interesting thing happens in the first line of the script.
+
+A host embedding the package does the same with a `DevToolsServer` and an `EngineTarget`; the REPL is only
+the shortest way to have one.
+
+## Attach
+
+Either address works and they are worth knowing apart:
+
+- **`chrome://inspect`** — click **Configure…**, add `127.0.0.1:9229` (or whichever port the banner named),
+  close the dialog, and the engine appears under **Remote Target** with the title the host gave it. Click
+  **inspect**. This is the path that reads `/json/list` off the server, so a target that does not appear
+  here is a discovery-document problem rather than a protocol one.
+- **`devtools://devtools/bundled/js_app.html?experiments=true&v8only=true&ws=127.0.0.1:9229/devtools/page/<targetId>`**
+  — paste it into the address bar of a Chrome tab. `v8only=true` is what makes the front end open its
+  JavaScript-only layout rather than asking for a page that does not exist. Chrome refuses to navigate to
+  `devtools://` from a link or from automation, so this one has to be typed.
+
+## What each panel should show
+
+| Panel | What answers, and what it proves |
+| --- | --- |
+| **Sources** → navigator | Every script the engine has parsed, by the name the host passed to `Execute`/`Evaluate`. An empty tree means `Debugger.enable` was refused — check the engine was built with `UseDevTools()`. |
+| **Sources** → editor | The script's own text, from `Debugger.getScriptSource`. Text that reads `// source not available` means `Options.RetainFunctionSourceText` is off. |
+| **Sources** → gutter | Clicking a line number sets a breakpoint, and the marker snaps to the nearest position the engine will stop at. A marker that lands on a blank line or a comment is a `getPossibleBreakpoints` defect. |
+| **Sources** → paused | Run something that reaches the line. Execution stops, the line highlights, and the **Call Stack**, **Scope** and **Watch** panes fill. The Scope pane is a snapshot: it lists the bindings but never calls a getter, and a binding still in its temporal dead zone is absent rather than `undefined`. |
+| **Sources** → step and resume | The three step buttons and Resume all move the engine on. While it is paused the host process is held on the thread that owns the engine, which is why `DevToolsServerOptions.PauseTimeout` exists. |
+| **Sources** → pause on exceptions | The ⏸ button stops the engine **at** the throw, before anything unwinds, with the thrown value in the sidebar; both "uncaught" and "caught" work. Two divergences from Chrome are the engine's rather than this package's: a throw crossing an `async` function's body boundary counts as uncaught whatever the caller wrapped it in, and `Promise.reject(value)` stops nothing because nothing was thrown. Filtering a throw out in `caught` mode also cancels a step that was in flight — [#3631](https://github.com/sebastienros/jint/issues/3631). |
+| **Console** | What the script logged, as it logged it: an object arrives as an expandable preview rather than as a string, and expanding it asks the server for the properties. Nothing here runs script that the script did not run. |
+| **Console** → prompt | Typing an expression evaluates it in the engine — including while it is paused, where it evaluates in the selected call frame. The eager-evaluation preview above the prompt stays empty on purpose: it asks for `throwOnSideEffect`, which this server refuses rather than answers by running the code the front end asked not to run. |
+| **Performance** | **Start profiling and reload** does not apply; use the record button. The profile is the engine's own sampler, so the flame chart is JavaScript frames and nothing else. |
+| **Coverage** | Answers only if the engine was built with `UseDevTools(o => o.Coverage = true)`; the REPL's `--inspect` turns it on. A function the script never called is listed with a zero count rather than being absent. |
+| **Memory** | Nothing. There is no `HeapProfiler` here and there deliberately never will be; the heap is the CLR's, and what a host wants instead is `engine.Diagnostics` and `Options.Constraints`. |
+
+## What is expected to be missing
+
+Not defects, and not worth reporting again: **Elements**, **Network**, **Application** and **Lighthouse**
+have no page behind them — that is what `Jint.Browser` is for — and the front end shows them empty rather
+than erroring. **Async call stacks** are absent because the engine retains no stack across a promise
+reaction, and **blackboxing** and **source maps** are accepted and ignored. Editing a paused program
+(**Save**, "Restart frame") is refused: the interpreter is standing inside an abstract syntax tree it has
+already walked into. `Jint.DevTools/AGENTS.md` carries the full list and the reason for each.

--- a/Jint.Repl/Jint.Repl.csproj
+++ b/Jint.Repl/Jint.Repl.csproj
@@ -9,6 +9,9 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Jint\Jint.csproj" />
+    <!-- The engine-level DevTools protocol, which is what the inspector flags serve. It is net8.0;net10.0, and this
+         project is net10.0. -->
+    <ProjectReference Include="..\Jint.DevTools\Jint.DevTools.csproj" />
     <TrimmerRootAssembly Include="Jint" />
   </ItemGroup>
 </Project>

--- a/Jint.Repl/Program.cs
+++ b/Jint.Repl/Program.cs
@@ -1,7 +1,9 @@
 ﻿#nullable enable
 
+using System.Globalization;
 using System.Reflection;
 using Jint;
+using Jint.DevTools;
 using Jint.Native;
 using Jint.Native.Json;
 using Jint.Runtime;
@@ -17,6 +19,10 @@ string? inputFile = null;
 int? timeoutSeconds = null;
 bool runAsModule = false;
 bool enableFetch = false;
+bool inspect = false;
+bool inspectBreak = false;
+string inspectHost = "127.0.0.1";
+int inspectPort = 9229;
 
 for (int i = 0; i < args.Length; i++)
 {
@@ -58,6 +64,23 @@ for (int i = 0; i < args.Length; i++)
             PrintHelp();
             return 0;
         default:
+            // --inspect and --inspect-brk carry their endpoint in the same argument, the way Node spells it,
+            // so they are matched by prefix rather than by a case label.
+            if (args[i] is "--inspect" or "--inspect-brk" || args[i].StartsWith("--inspect=", StringComparison.Ordinal) || args[i].StartsWith("--inspect-brk=", StringComparison.Ordinal))
+            {
+                inspect = true;
+                inspectBreak = args[i].StartsWith("--inspect-brk", StringComparison.Ordinal);
+
+                var equals = args[i].IndexOf('=');
+                if (equals >= 0 && !TryReadEndpoint(args[i].Substring(equals + 1), ref inspectHost, ref inspectPort))
+                {
+                    Console.Error.WriteLine($"Error: {args[i]} is not [host:]port");
+                    return 1;
+                }
+
+                break;
+            }
+
             // For backwards compatibility, treat first positional arg as filename
             if (!args[i].StartsWith("-") && inputFile == null)
             {
@@ -96,6 +119,14 @@ var engine = new Engine(cfg =>
         cfg.LimitExecutionTime(TimeSpan.FromSeconds(timeoutSeconds.Value));
     }
 
+    // An attachable engine is built for it: debugging, retained source text, profiling and coverage are all
+    // construction-time, so --inspect has to be known here rather than when a client connects. Last of the
+    // web-API calls, because the console sink it wraps is the one UseConsole installed above.
+    if (inspect)
+    {
+        cfg.UseDevTools(devTools => devTools.Coverage = true);
+    }
+
     // Even if the script is not a module, modules still need to be enabled
     // for dynamic import to work.
     var basePath = inputFile != null
@@ -114,6 +145,47 @@ var test262 = Test262Object.Install(engine);
 
 var agentManager = new Test262AgentManager();
 agentManager.InstallAgent(engine, test262);
+
+DevToolsServer? inspector = null;
+EngineTarget? inspected = null;
+
+if (inspect)
+{
+    try
+    {
+        inspector = new DevToolsServer(new DevToolsServerOptions { Host = inspectHost, Port = inspectPort, Product = $"Jint/{Assembly.GetExecutingAssembly().GetName().Version}" });
+        inspector.Start();
+    }
+    catch (Exception e)
+    {
+        // A port already in use and an address that is not one are the two ways this fails, and both are
+        // the command line's fault rather than the script's. Node says so and stops; so does this.
+        Console.Error.WriteLine($"Error: cannot listen on {inspectHost}:{inspectPort}: {e.Message}");
+        return 1;
+    }
+
+    inspected = new EngineTarget(engine, new EngineTargetOptions
+    {
+        Title = inputFile is null ? "Jint REPL" : Path.GetFileName(inputFile),
+        Url = inputFile is null ? "jint://repl" : new Uri(Path.GetFullPath(inputFile)).AbsoluteUri,
+
+        // The REPL owns its loop: it evaluates on this thread, so this thread is also the one that answers
+        // the protocol. A LibraryOwned target would be a second thread in the same engine.
+        ThreadMode = ThreadMode.HostOwned,
+        WaitForDebuggerOnStart = inspectBreak,
+    });
+
+    inspector.AddTarget(inspected);
+    PrintInspectorBanner(inspectHost, inspector.BoundPort, inspected.TargetId, inspectBreak);
+
+    if (inspectBreak)
+    {
+        // Node's --inspect-brk: nothing the host queued runs until a client has attached and sent
+        // Runtime.runIfWaitingForDebugger. The wait pumps rather than blocks, because that very command is
+        // answered on this thread.
+        inspected.WaitForDebugger(Timeout.InfiniteTimeSpan);
+    }
+}
 
 // Execute file if provided via -f
 if (!string.IsNullOrEmpty(inputFile))
@@ -140,13 +212,16 @@ if (!string.IsNullOrEmpty(inputFile))
                 Console.WriteLine(result);
             }
         }
-        return 0;
+        return KeepInspecting(inspected);
     }
     catch (JavaScriptException je)
     {
+        // An attached client hears the throw the way it hears one from a timer: as Runtime.exceptionThrown,
+        // so the Console panel shows it rather than only this terminal.
+        inspected?.ReportUncaughtException(je);
         Console.Error.WriteLine(FormatJavaScriptException(je));
         Console.Error.WriteLine(je.JavaScriptStackTrace);
-        return 1;
+        return KeepInspecting(inspected, 1);
     }
     catch (ModuleResolutionException mre)
     {
@@ -184,13 +259,14 @@ if (Console.IsInputRedirected)
                 Console.WriteLine(result);
             }
         }
-        return 0;
+        return KeepInspecting(inspected);
     }
     catch (JavaScriptException je)
     {
+        inspected?.ReportUncaughtException(je);
         Console.Error.WriteLine(FormatJavaScriptException(je));
         Console.Error.WriteLine(je.JavaScriptStackTrace);
-        return 1;
+        return KeepInspecting(inspected, 1);
     }
     catch (ModuleResolutionException mre)
     {
@@ -229,7 +305,7 @@ while (true)
 {
     Console.ForegroundColor = defaultColor;
     Console.Write("jint> ");
-    var input = Console.ReadLine();
+    var input = inspected is null ? Console.ReadLine() : ReadLineWhilePumping(inspected);
     if (input is null or "exit" or ".exit")
     {
         return 0;
@@ -276,6 +352,111 @@ while (true)
         Console.ForegroundColor = ConsoleColor.Red;
         Console.WriteLine(e.Message);
     }
+
+    // Between inputs, which is what a HostOwned target means: the commands a client sent while the prompt
+    // was waiting were already answered by the read above, and this runs whatever the evaluation queued.
+    if (inspected is not null)
+    {
+        PumpInspector(inspected);
+    }
+}
+
+/// <summary>Reads one line while the engine keeps answering an attached client.</summary>
+static string? ReadLineWhilePumping(EngineTarget target)
+{
+    // The console read is the one thing that leaves this thread. It touches no engine state, and moving it
+    // off is what makes a client's commands answered while the prompt waits rather than only after the next
+    // line is typed.
+    var line = Task.Run(Console.ReadLine);
+    while (!line.IsCompleted)
+    {
+        PumpInspector(target);
+        ((IAsyncResult) line).AsyncWaitHandle.WaitOne(25);
+    }
+
+    // A read that failed rather than returned is end of input, which is what the caller does with a null
+    // anyway. Waiting on the task instead would throw the console's exception out of the REPL's loop.
+    return line.IsCompletedSuccessfully ? line.Result : null;
+}
+
+/// <summary>Gives the engine one turn, and reports whatever the turn threw rather than dying of it.</summary>
+static void PumpInspector(EngineTarget target)
+{
+    try
+    {
+        target.Pump();
+    }
+    catch (JavaScriptException je)
+    {
+        target.ReportUncaughtException(je);
+        Console.Error.WriteLine(FormatJavaScriptException(je));
+    }
+    catch (Exception e)
+    {
+        Console.Error.WriteLine($"Error: {e.Message}");
+    }
+}
+
+/// <summary>
+/// Keeps a --inspect engine attachable after the script it was given has finished, so a client can still
+/// read it, and so a timer the script scheduled still fires.
+/// </summary>
+static int KeepInspecting(EngineTarget? target, int exitCode = 0)
+{
+    if (target is null)
+    {
+        return exitCode;
+    }
+
+    Console.WriteLine("The script has finished; the engine stays attached. Press Ctrl+C to exit.");
+
+    var stopping = 0;
+    Console.CancelKeyPress += (_, e) =>
+    {
+        e.Cancel = true;
+        Interlocked.Exchange(ref stopping, 1);
+    };
+
+    while (Volatile.Read(ref stopping) == 0)
+    {
+        PumpInspector(target);
+
+        // The mailbox wakes this through Engine.Tasks.Post, so a command a client sends is answered on the
+        // next turn rather than after the wait.
+        target.Engine.Tasks.WaitForScheduledWork(TimeSpan.FromMilliseconds(50));
+    }
+
+    return exitCode;
+}
+
+/// <summary>Reads a <c>--inspect=</c> endpoint, which is a port or a host and a port.</summary>
+static bool TryReadEndpoint(string endpoint, ref string host, ref int port)
+{
+    var colon = endpoint.LastIndexOf(':');
+    if (colon >= 0)
+    {
+        host = endpoint.Substring(0, colon);
+        endpoint = endpoint.Substring(colon + 1);
+    }
+
+    return host.Length > 0 && int.TryParse(endpoint, NumberStyles.None, CultureInfo.InvariantCulture, out port) && port <= 65535;
+}
+
+/// <summary>Says where a client attaches, in the three forms one is reached from.</summary>
+static void PrintInspectorBanner(string host, int port, string targetId, bool waiting)
+{
+    var endpoint = string.Create(CultureInfo.InvariantCulture, $"{host}:{port}/devtools/page/{targetId}");
+
+    Console.WriteLine($"Debugger listening on ws://{endpoint}");
+    Console.WriteLine($"  front end: devtools://devtools/bundled/js_app.html?experiments=true&v8only=true&ws={endpoint}");
+    Console.WriteLine($"  or open chrome://inspect, click Configure..., add {host}:{port}, and the target appears under Remote Target");
+
+    if (waiting)
+    {
+        Console.WriteLine("Waiting for the debugger to attach; nothing runs until a client sends Runtime.runIfWaitingForDebugger.");
+    }
+
+    Console.WriteLine();
 }
 
 static string FormatJavaScriptException(JavaScriptException je)
@@ -314,7 +495,19 @@ static void PrintHelp()
     Console.WriteLine("  -m, --module          Run script as ES6 module");
     Console.WriteLine("  -t, --timeout <secs>  Set execution timeout in seconds");
     Console.WriteLine("      --fetch           Allow the script to make network requests");
+    Console.WriteLine("      --inspect[=[host:]port]      Serve the Chrome DevTools protocol (default 127.0.0.1:9229)");
+    Console.WriteLine("      --inspect-brk[=[host:]port]  The same, but run nothing until a client attaches");
     Console.WriteLine("  -h, --help            Show this help message");
+    Console.WriteLine();
+    Console.WriteLine("Inspecting:");
+    Console.WriteLine("  --inspect prints the endpoint, the devtools:// front-end address and what to type into");
+    Console.WriteLine("  chrome://inspect. The engine is the one this process runs, so it is pumped between inputs:");
+    Console.WriteLine("  a command sent while the prompt is waiting is answered there and then, and a script run with");
+    Console.WriteLine("  -f keeps the engine attached after it finishes so a timer still fires and the client can still");
+    Console.WriteLine("  read it - Ctrl+C exits. Port 0 asks the operating system for one and the banner says which.");
+    Console.WriteLine("  It also turns on coverage counting, so the front end's Coverage panel answers.");
+    Console.WriteLine("  -t still bounds execution, and it keeps counting while the debugger has the engine paused,");
+    Console.WriteLine("  so a timeout short enough to matter and a breakpoint do not go together.");
     Console.WriteLine();
     Console.WriteLine("Web APIs:");
     Console.WriteLine("  console, timers, TextEncoder/TextDecoder, atob/btoa, structuredClone, crypto,");
@@ -331,6 +524,8 @@ static void PrintHelp()
     Console.WriteLine("  jint -m module.js             Execute module.js as ES6 module");
     Console.WriteLine("  jint -f script.js -t 10       Execute with 10 second timeout");
     Console.WriteLine("  jint -f script.js --fetch     Execute with network access enabled");
+    Console.WriteLine("  jint --inspect                Start the REPL with DevTools on 127.0.0.1:9229");
+    Console.WriteLine("  jint -f app.js --inspect-brk=0  Attach before app.js runs, on a port the banner names");
     Console.WriteLine("  echo \"1+1\" | jint             Execute from stdin");
     Console.WriteLine("  echo \"1+1\" | jint -t 5        Execute from stdin with timeout");
 }

--- a/Jint.Tests.DevTools/Clients/PuppeteerSharpTests.cs
+++ b/Jint.Tests.DevTools/Clients/PuppeteerSharpTests.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+using System.Globalization;
 using System.Text.Json;
 using Jint.DevTools;
 using Jint.DevTools.Protocol;
@@ -509,6 +511,259 @@ public class PuppeteerSharpTests
         profile.EndTime.Should().BeGreaterThan(profile.StartTime);
 
         await session.DetachAsync().WaitAsync(Bound);
+    }
+
+    /// <summary>
+    /// Which of the engine's code ran, taken over a real socket in the shape a front end's Coverage panel
+    /// draws.
+    /// </summary>
+    /// <remarks>
+    /// The assertion that matters is the second one. Coverage is a <i>covered set</i> — a function that
+    /// never ran has no entry anywhere in the engine — so a client is told about it only because the domain
+    /// derives the uncovered functions from the script's abstract syntax tree. A panel that shaded nothing
+    /// red would look exactly like a passing test without it.
+    /// </remarks>
+    [Test]
+    public async Task PuppeteerTakesCoverageAndIsToldWhatNeverRan()
+    {
+        await using var server = new DevToolsServer();
+        await server.StartAsync();
+
+        await using var target = new EngineTarget(
+            new Engine(options => options.UseDevTools(devTools => devTools.Coverage = true)),
+            new EngineTargetOptions { Url = "jint://coverage", ThreadMode = ThreadMode.LibraryOwned });
+
+        server.AddTarget(target);
+
+        await using var browser = await ConnectAsync(new ConnectOptions { BrowserWSEndpoint = server.BrowserWebSocketUrl });
+        var session = await SessionForAsync(browser, "jint://coverage", target.TargetId);
+
+        await session.SendAsync("Profiler.enable").WaitAsync(Bound);
+        await session.SendAsync("Profiler.startPreciseCoverage", new { callCount = true, detailed = false }).WaitAsync(Bound);
+
+        // Executed after the recording started, which is the order a client uses: what ran before it began
+        // is not what the panel is asking about.
+        await target.PostAsync(engine => engine.Execute(
+            """
+            function counted(n) {
+                return n + 1;
+            }
+
+            function skipped(n) {
+                return n - 1;
+            }
+
+            var total = counted(1);
+            """,
+            "coverage.js")).WaitAsync(Bound);
+
+        var taken = await session.SendAsync("Profiler.takePreciseCoverage").WaitAsync(Bound);
+        var scripts = taken!.Value.GetProperty("result").Deserialize(ProtocolJsonContext.Default.ProfilerScriptCoverageArray);
+
+        scripts.Should().NotBeNull();
+        var script = scripts!.Single(candidate => candidate.Url == "coverage.js");
+
+        var functions = script.Functions.ToDictionary(function => function.FunctionName, function => function);
+        functions.Should().ContainKeys("counted", "skipped");
+        functions["counted"].Ranges.Single().Count.Should().Be(1);
+        functions["skipped"].Ranges.Single().Count.Should().Be(0, "it is declared and never called, which is what the panel shades");
+
+        await session.SendAsync("Profiler.stopPreciseCoverage").WaitAsync(Bound);
+        await session.DetachAsync().WaitAsync(Bound);
+    }
+
+    /// <summary>
+    /// The REPL's <c>--inspect</c>, from the outside: a separate process, its own port, and a client that
+    /// reaches the engine that process ran its script in.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Everything else in this suite builds its own server in this process, so nothing else would notice if
+    /// the flag stopped serving a target — the wiring the flag does is a host's wiring, and a host is the
+    /// one thing an in-process test cannot be. It also pins the two halves of a
+    /// <see cref="ThreadMode.HostOwned"/> host that are easy to get wrong: the banner has to name the port
+    /// the operating system actually chose, and the engine has to keep being pumped after the script it was
+    /// given has finished, or every command a client sends times out.
+    /// </para>
+    /// <para>
+    /// The script arrives on standard input rather than in a file, because a redirected standard input is
+    /// what the REPL reads when it is not given <c>-f</c>, and a test that wrote a temporary file would be
+    /// testing the file path instead of the flag.
+    /// </para>
+    /// </remarks>
+    [Test]
+    public async Task PuppeteerReachesTheEngineTheReplsInspectFlagServes()
+    {
+        using var repl = ReplProcess.Start("--inspect=0");
+
+        var port = await repl.ListeningPortAsync();
+        port.Should().BeGreaterThan(0, "port 0 asks the operating system for one, and the banner has to name what it chose");
+
+        await repl.RunAsync("function twice(n) { return n * 2; }");
+        await repl.Finished.WaitAsync(Bound);
+
+        await using var browser = await ConnectAsync(new ConnectOptions { BrowserURL = $"http://127.0.0.1:{port}" });
+        var target = browser.Targets().Single(candidate => candidate.Url == "jint://repl");
+
+        var session = await target.CreateCDPSessionAsync().WaitAsync(Bound);
+        var evaluated = await session.SendAsync("Runtime.evaluate", new { expression = "twice(21)", returnByValue = true }).WaitAsync(Bound);
+
+        Value(evaluated).GetInt32().Should().Be(42, "the client reached the engine that process ran its script in, and that engine is still being pumped");
+
+        await session.DetachAsync().WaitAsync(Bound);
+    }
+
+    /// <summary>
+    /// <c>--inspect-brk</c>: the script the REPL was given does not run until a client has attached and said
+    /// so.
+    /// </summary>
+    /// <remarks>
+    /// The half of the flag that cannot be checked by seeing something happen, because what it promises is
+    /// that nothing does. The negative is asserted with a bounded wait rather than a sleep and a poll: if the
+    /// hold were broken the script would run within milliseconds of standard input closing, so a wait that
+    /// times out is the assertion, and the positive half immediately after it is what stops that timeout from
+    /// passing for a REPL that never got as far as reading its input at all.
+    /// </remarks>
+    [Test]
+    public async Task TheReplHoldsItsScriptUntilAClientSaysToRunIt()
+    {
+        using var repl = ReplProcess.Start("--inspect-brk=0");
+
+        var port = await repl.ListeningPortAsync();
+        await repl.RunAsync("globalThis.ran = true;");
+
+        var held = async () => await repl.Finished.WaitAsync(TimeSpan.FromSeconds(2));
+        await held.Should().ThrowAsync<TimeoutException>("nothing the host queued runs until a client releases the target");
+
+        await using var browser = await ConnectAsync(new ConnectOptions { BrowserURL = $"http://127.0.0.1:{port}" });
+        var target = browser.Targets().Single(candidate => candidate.Url == "jint://repl");
+        var session = await target.CreateCDPSessionAsync().WaitAsync(Bound);
+
+        await session.SendAsync("Runtime.runIfWaitingForDebugger").WaitAsync(Bound);
+        await repl.Finished.WaitAsync(Bound);
+
+        var evaluated = await session.SendAsync("Runtime.evaluate", new { expression = "ran === true", returnByValue = true }).WaitAsync(Bound);
+        Value(evaluated).GetBoolean().Should().BeTrue("the held script ran once the client released it, and it ran in the engine this session reaches");
+
+        await session.DetachAsync().WaitAsync(Bound);
+    }
+
+    /// <summary>
+    /// The REPL as a separate process, which is the only way an inspector flag can be checked: the wiring it
+    /// does is a host's wiring, and a host is the one thing an in-process test cannot be.
+    /// </summary>
+    private sealed class ReplProcess : IDisposable
+    {
+        private const string Banner = "Debugger listening on ws://";
+
+        private readonly Process _process = new();
+        private readonly TaskCompletionSource<string> _listening = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<bool> _finished = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly List<string> _printed = [];
+
+        private ReplProcess()
+        {
+        }
+
+        /// <summary>Completes when the REPL says the script it was given has finished.</summary>
+        internal Task Finished => _finished.Task;
+
+        internal static ReplProcess Start(params string[] arguments)
+        {
+            var assembly = RepositoryPaths.ReplAssembly;
+            assembly.Should().NotBeNull("Jint.Repl has to be built for this test; run `dotnet build -c Release Jint.Repl/Jint.Repl.csproj`");
+
+            var repl = new ReplProcess();
+
+            // A framework-dependent assembly is run by the .NET host, and the one running this test is the
+            // host to use: it is the runtime this build was verified against rather than whichever `dotnet`
+            // a PATH happens to name first.
+            var host = Environment.ProcessPath is { } path && Path.GetFileNameWithoutExtension(path).Equals("dotnet", StringComparison.OrdinalIgnoreCase)
+                ? path
+                : "dotnet";
+
+            repl._process.StartInfo = new ProcessStartInfo(host)
+            {
+                ArgumentList = { assembly!, "-t", "60" },
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = RepositoryPaths.Root,
+            };
+
+            foreach (var argument in arguments)
+            {
+                repl._process.StartInfo.ArgumentList.Add(argument);
+            }
+
+            repl._process.OutputDataReceived += repl.OnOutput;
+            repl._process.ErrorDataReceived += repl.OnOutput;
+
+            repl._process.Start();
+            repl._process.BeginOutputReadLine();
+            repl._process.BeginErrorReadLine();
+
+            return repl;
+        }
+
+        /// <summary>The port the banner named, which is what port 0 makes worth reading.</summary>
+        internal async Task<int> ListeningPortAsync()
+        {
+            var banner = await _listening.Task.WaitAsync(Bound);
+            var authority = banner.Substring(Banner.Length).Split('/')[0];
+
+            return int.Parse(authority.Split(':')[1], CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>Hands the REPL a script on standard input, which is what it reads when given no file.</summary>
+        internal async Task RunAsync(string script)
+        {
+            await _process.StandardInput.WriteAsync(script + "\n");
+            _process.StandardInput.Close();
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                _process.Kill(entireProcessTree: true);
+                _process.WaitForExit((int) Bound.TotalMilliseconds);
+            }
+            catch (InvalidOperationException)
+            {
+                // Already gone, which is the outcome the kill was for.
+            }
+
+            lock (_printed)
+            {
+                TestContext.Out.WriteLine(string.Join(Environment.NewLine, _printed));
+            }
+
+            _process.Dispose();
+        }
+
+        private void OnOutput(object sender, DataReceivedEventArgs line)
+        {
+            if (line.Data is not { } text)
+            {
+                return;
+            }
+
+            lock (_printed)
+            {
+                _printed.Add(text);
+            }
+
+            if (text.StartsWith(Banner, StringComparison.Ordinal))
+            {
+                _listening.TrySetResult(text);
+            }
+            else if (text.StartsWith("The script has finished", StringComparison.Ordinal))
+            {
+                _finished.TrySetResult(true);
+            }
+        }
     }
 
     /// <summary>The <c>result.value</c> of a <c>Runtime.evaluate</c> reply the client handed back.</summary>

--- a/Jint.Tests.DevTools/Jint.Tests.DevTools.csproj
+++ b/Jint.Tests.DevTools/Jint.Tests.DevTools.csproj
@@ -24,6 +24,18 @@
       unreferenceable from the lower one.
     -->
     <ProjectReference Include="..\tools\devtools-protocol\Jint.DevTools.ProtocolGenerator\Jint.DevTools.ProtocolGenerator.csproj" />
+    <!--
+      The REPL, referenced so that it is built rather than so that it is used: one test spawns it as a
+      process to check that the inspector flag really serves a target, and a test that passed because nobody
+      had built the thing it spawns would be worse than no test. ReferenceOutputAssembly=false because there
+      is nothing here to call into it - and because it is net10.0 while this suite also runs on net8.0, which
+      is what SkipGetTargetFrameworkProperties tells MSBuild not to reconcile.
+    -->
+    <ProjectReference Include="..\Jint.Repl\Jint.Repl.csproj"
+                      ReferenceOutputAssembly="false"
+                      SkipGetTargetFrameworkProperties="true"
+                      UndefineProperties="TargetFramework"
+                      PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jint.Tests.DevTools/RepositoryPaths.cs
+++ b/Jint.Tests.DevTools/RepositoryPaths.cs
@@ -25,6 +25,36 @@ internal static class RepositoryPaths
     /// <summary>The package's own sources.</summary>
     internal static string SourceDirectory => Path.Combine(Root, "Jint.DevTools");
 
+    /// <summary>
+    /// The compiled REPL, which is what <c>--inspect</c> is served from, or <see langword="null"/> when the
+    /// build that produced this assembly did not produce it.
+    /// </summary>
+    /// <remarks>
+    /// Found rather than configured, because the one thing that must not happen is a test that quietly
+    /// passes by testing nothing. <c>Jint.Tests.DevTools.csproj</c> takes a build-only reference on
+    /// <c>Jint.Repl</c> so this is always there; the search is what keeps the failure legible if it is not.
+    /// </remarks>
+    internal static string? ReplAssembly { get; } = FindRepl();
+
+    private static string? FindRepl()
+    {
+        var output = Path.Combine(Root, "artifacts", "bin", "Jint.Repl");
+        if (!Directory.Exists(output))
+        {
+            return null;
+        }
+
+        // This assembly's own output directory is `<configuration>_<targetFramework>`, and the REPL has one
+        // target framework so its is `<configuration>`. Preferring that over the first match is what stops a
+        // Release test run from spawning a Debug REPL left over from somebody's last build.
+        var configuration = new DirectoryInfo(AppContext.BaseDirectory).Name.Split('_')[0];
+        var preferred = Path.Combine(output, configuration, "Jint.Repl.dll");
+
+        return File.Exists(preferred)
+            ? preferred
+            : Directory.EnumerateFiles(output, "Jint.Repl.dll", SearchOption.AllDirectories).FirstOrDefault();
+    }
+
     /// <summary>Line endings as the emitter writes them, so a Windows checkout compares equal.</summary>
     internal static string NormalizeNewlines(string text) => text.Replace("\r\n", "\n", StringComparison.Ordinal);
 

--- a/README.md
+++ b/README.md
@@ -2168,14 +2168,52 @@ loop does: every command waits for your next `ProcessTasks`, and one that waits 
 `target.Post(engine => …)` or `await target.PostAsync(engine => …)` — the engine's own rules are unchanged,
 so touching it from anywhere else still fails fast rather than corrupting anything.
 
-Today a client can list targets, attach, hear about the execution context and evaluate — including
-`returnByValue` and awaiting a promise. `Debugger` (breakpoints, stepping, scopes), `Profiler` and the
-console and log domains arrive in later releases; until then each answers `'Domain.method' wasn't found`,
-which is what a client feature-detects on. Page-level domains are not this package's business at all.
-
 **The endpoint is unauthenticated**, exactly as it is in Chrome: anything that can reach it can evaluate
 arbitrary script in your process. `DevToolsServerOptions.Host` therefore defaults to `127.0.0.1`; do not
 bind it to a routable address.
+
+### What answers today
+
+- **`Runtime`** — list targets, attach, hear about the execution context, and evaluate, including
+  `returnByValue`, object handles you can walk with `getProperties`, `callFunctionOn`, bindings and awaiting
+  a promise.
+- **`Debugger`** — breakpoints by URL or script, the three steps, `continueToLocation`, call frames, scopes
+  (a getter-free snapshot, with a binding still in its temporal dead zone absent rather than `undefined`),
+  `setVariableValue`, evaluation in any frame, and **pausing where a script throws**.
+- **`Profiler`** — a sampled CPU profile in the document the Performance panel loads, and precise coverage in
+  which a function that never ran is reported with a zero count rather than being absent. Coverage is the
+  one switch with a running cost, so it is opt-in: `options.UseDevTools(devTools => devTools.Coverage = true)`.
+- **`Console`, `Log`** — what a script logged, with its values still attached, and what it threw.
+- **`Target`, `Browser`, `Schema`** — the session core, flattened sessions only.
+
+Everything else answers `'Domain.method' wasn't found`, which is what a client feature-detects on, and the
+package's `AGENTS.md` says why for each. Page-level domains are not this package's business.
+
+### Trying it without writing a host
+
+The REPL serves the protocol over `--inspect`:
+
+```bash
+dotnet run --project Jint.Repl -c Release -- --inspect -f script.js -t 60
+```
+
+It prints the WebSocket endpoint, the `devtools://` front-end address and what to type into
+`chrome://inspect`. `--inspect=[host:]port` chooses where to listen — `0` takes an ephemeral port and the
+banner names it — and `--inspect-brk` runs nothing until a client has attached and sent
+`Runtime.runIfWaitingForDebugger`. The engine stays attached after the script finishes, so a timer still
+fires and a client can still read it.
+
+`Jint.DevTools/docs/manual-checklist.md` is what each panel should show, and
+`tools/devtools-frontend-smoke/` drives most of that walk against a real Chrome automatically.
+
+### Native AOT
+
+**Measured rather than claimed.** `Jint.AotExample` references this package *without* rooting it and, in the
+published native binary, opens a real socket to it: `Target.getTargets`, a flattened attach, an evaluation,
+a breakpoint that pauses the engine, and a resume. The CI leg that publishes and runs that binary also fails
+if any trim or AOT analysis diagnostic is attributed to a file in `Jint.DevTools` — everything the protocol
+serializes goes through a source-generated `System.Text.Json` context, and the first reflective member would
+show up there and nowhere else.
 
 ## Performance
 

--- a/docs/design/devtools-protocol.md
+++ b/docs/design/devtools-protocol.md
@@ -125,15 +125,33 @@ the vendored JSON by `ProtocolCitationTests`.
 
 | Domain | What it maps onto | Engine change |
 | --- | --- | --- |
-| `Runtime` | `engine.Evaluate` (running) or `DebugHandler.Evaluate` (paused); `getProperties` over `GetOwnPropertyKeys` + descriptors, accessors reported and never invoked; `awaitPromise` by reactions; `consoleAPICalled`; `exceptionThrown`/`exceptionRevoked` from `Tasks.PromiseRejectionTracker`; `getHeapUsage` from `Diagnostics.GetMemoryReport` | **E5** structured `ConsoleRecord` sink overload + public `ValueInspector` (previews that never run script, promoted from `ConsoleFormatter`) |
-| `Debugger` | `ScriptRegistry` on `DebugHandler.BeforeEvaluate` keyed by `Program` identity (a cached `Prepared<Script>` is announced once); breakpoints as `DevToolsBreakPoint : BreakPoint` (the class is unsealed for this); `pause` as a flag checked in `Skip`; scopes from `DebugScopeType` 1:1 | **E1** `TryGetSourceText(Program)` for `getScriptSource`; **E2** `GetStepLocations(Program)` for `getPossibleBreakpoints` and column snapping; **E3** pause on exceptions with caught/uncaught; **E4** evaluate on any call frame |
-| `Profiler` | `Profiler.Profile` synthesized from the evented `ScriptProfile` (`Jint/Profiling/`) behind an `IProfileSource` seam — one weighted sample per interval between two activations, so the time deltas add up to the recording rather than approximating it; precise/best-effort coverage from `CoverageReport` (`Jint/Runtime/Coverage/`), with the uncovered set derived from the script registry's abstract syntax tree so an unused function is reported with `count: 0` | none. The sampling profiler that landed as [#3608](https://github.com/sebastienros/jint/pull/3608) is **not** the source: `SampledProfile` publishes its sample, frame and stack tables as `internal` and a Firefox Profiler document as its only output, so it plugs into the same seam once those tables are public — an additive engine change, not an edit to the domain |
+| `Runtime` | `engine.Evaluate` (running) or `DebugHandler.Evaluate` (paused); `getProperties` over `GetOwnPropertyKeys` + descriptors, accessors reported and never invoked; `awaitPromise` by reactions; `consoleAPICalled`; `exceptionThrown`/`exceptionRevoked` from `Tasks.PromiseRejectionTracker`; `getHeapUsage` from `Diagnostics.GetMemoryReport` | **E5** ([#3597](https://github.com/sebastienros/jint/pull/3597)) structured `ConsoleRecord` sink overload + public `ValueInspector` (previews that never run script, promoted from `ConsoleFormatter`) |
+| `Debugger` | `ScriptRegistry` on `DebugHandler.BeforeEvaluate` keyed by `Program` identity (a cached `Prepared<Script>` is announced once); breakpoints as `DevToolsBreakPoint : BreakPoint` (the class is unsealed for this); `pause` as a flag checked in `Skip`; scopes from `DebugScopeType` 1:1 | **E1** ([#3587](https://github.com/sebastienros/jint/pull/3587)) `TryGetSourceText(Program)` for `getScriptSource`; **E2** ([#3614](https://github.com/sebastienros/jint/pull/3614)) `GetStepLocations(Program)` for `getPossibleBreakpoints` and column snapping; **E3** ([#3623](https://github.com/sebastienros/jint/pull/3623)) pause on exceptions with caught/uncaught; **E4** ([#3622](https://github.com/sebastienros/jint/pull/3622)) evaluate on any call frame |
+| `Profiler` | `Profiler.Profile` synthesized from the evented `ScriptProfile` (`Jint/Profiling/`) behind an `IProfileSource` seam — one weighted sample per interval between two activations, so the time deltas add up to the recording rather than approximating it; precise/best-effort coverage from `CoverageReport` (`Jint/Runtime/Coverage/`), with the uncovered set derived from the script registry's abstract syntax tree so an unused function is reported with `count: 0` | none. The sampling profiler that landed as [#3608](https://github.com/sebastienros/jint/pull/3608) is **not** the source: `SampledProfile` publishes its sample, frame and stack tables as `internal` and a Firefox Profiler document as its only output, so it plugs into the same seam once those tables are public — an additive engine change ([#3630](https://github.com/sebastienros/jint/issues/3630)), not an edit to the domain |
 | `Console`, `Log` | the structured record | E5 |
 | `Target`, `Browser`, `Schema` | the session core and the manifest | none |
 
-The five engine PRs are additive and public, so that a third party — AngleSharp.Js, a DAP adapter, a host's own
-tooling — can build the same thing without `InternalsVisibleTo`. `Jint.DevTools` itself consumes only public
-Jint API; that is deliberate, and it is what proves the seams are reachable.
+**All five engine seams are merged**, and every one is additive and public — so that a third party (AngleSharp.Js,
+a DAP adapter, a host's own tooling) can build the same thing without `InternalsVisibleTo`. `Jint.DevTools`
+itself consumes only public Jint API; that is deliberate, and it is what proves the seams are reachable.
+
+Three seams the build wanted and did not get are open issues rather than silent workarounds, and each is
+named where it bites:
+
+- [#3630](https://github.com/sebastienros/jint/issues/3630) — **the sampler is not the profile's source.**
+  `SampledProfile` publishes its sample, frame and stack tables as `internal` and a Firefox Profiler document
+  as its only output, so `Profiler.start`/`stop` samples on its own activations behind `IProfileSource` and
+  reports `(root)`/`(program)` frames. Public read-only accessors on those tables make the sampler a second
+  `IProfileSource`, with no edit to the domain.
+- [#3631](https://github.com/sebastienros/jint/issues/3631) — **`caught` is not an engine mode.**
+  `ExceptionPauseMode` is `None`/`Uncaught`/`All`, so the client's `caught` asks for `All` and drops the
+  uncaught half in the `Break` handler — and declining a pause there means returning a `StepMode`, whose value
+  *is* the next step mode, so it cancels a step in flight. Harmless only because those frames are about to be
+  unwound; a trap for every other host that filters pauses.
+- [#3632](https://github.com/sebastienros/jint/issues/3632) — **a frame carries a source name, not a
+  `Program`.** `ScriptRegistry.At` therefore matches by name and range, which collapses every sourceless
+  `Execute` into one `<anonymous>` script. It limits paused frames, profile frames and coverage sources at
+  once, and one seam closes all three.
 
 ## 6. Costs, stated up front
 
@@ -154,8 +172,24 @@ Each is a follow-up issue if a client turns out to need it.
 
 ## 8. Verification
 
-In-process protocol tests over `InProcessConnection` (no sockets); recorded handshake fixtures of PuppeteerSharp
-and the DevTools frontend replayed as tests (no `-32601` for a manifest method, no unhandled exception for any
-other); a PuppeteerSharp end-to-end suite over a real WebSocket; a documented manual checklist for attaching the
-Chrome DevTools frontend; an AOT probe in `Jint.AotExample`; the host-contract verification leg with
-`JINT_HOST_CONTRACT_VERIFICATION=1`, which makes the thread rule exact.
+All of it is in place, and each layer claims something the one below it cannot:
+
+- **In-process protocol tests** over `InProcessConnection`, no sockets, asserting the envelope as text — `id`,
+  `error.code` and the wording a client feature-detects on.
+- **Socket tests**, which are not a duplicate of those: the upgrade handshake, the frame handling, the single
+  writer, the close ordering, and whether the read loop keeps reading while a command is outstanding.
+- **Recorded handshake fixtures** of PuppeteerSharp, Puppeteer, Playwright, Playwright for .NET and the DevTools
+  front end, in `tools/devtools-protocol/handshakes/`, replayed as tests: a manifest method must be answered,
+  and every other must be *exactly* `-32601`.
+- **A PuppeteerSharp suite over a real WebSocket**, the only test that can claim client compatibility: connect,
+  handles, bindings, console, breakpoints, exception pauses, a profile, a coverage round trip, and the Jint
+  REPL's `--inspect` spawned as a separate process and reached through the port its banner named.
+- **The Chrome DevTools front end, driven.** `tools/devtools-frontend-smoke/` launches Chrome for Testing,
+  loads the hosted front end against a real Jint process and asserts against the front end's own DOM;
+  `Jint.DevTools/docs/manual-checklist.md` is the same walk by hand. Neither runs in CI — one downloads a
+  browser, the other is a person — which is why the layers above it exist.
+- **A Native AOT probe in `Jint.AotExample`**, which references `Jint.DevTools` *without* rooting it and drives
+  the published native binary over a real socket: attach, evaluate, break, resume. The same CI leg fails if any
+  `IL2xxx`/`IL3xxx` diagnostic is attributed to a file in the package.
+- **The host-contract verification leg** with `JINT_HOST_CONTRACT_VERIFICATION=1`, which makes the thread rule
+  exact rather than asserted: a `JsValue` touched from a transport thread fails loudly under it.

--- a/tools/devtools-frontend-smoke/.gitignore
+++ b/tools/devtools-frontend-smoke/.gitignore
@@ -1,0 +1,4 @@
+# Everything this tool downloads or produces on the way to a run's verdict.
+node_modules/
+package-lock.json
+out/

--- a/tools/devtools-frontend-smoke/README.md
+++ b/tools/devtools-frontend-smoke/README.md
@@ -1,0 +1,191 @@
+# DevTools front-end smoke test
+
+Everything else in this repository that claims Chrome DevTools works against Jint claims it from the
+protocol side: a test sends a command and asserts the answer. That proves the server answers. It does not
+prove that a person who opens DevTools sees anything.
+
+This drives the other half. It launches `Jint.Repl --inspect`, loads the **real Chrome DevTools front
+end** — unmodified, at the revision that shipped in the Chrome being driven — points it at that Jint
+process, and then reads the panels: the Sources navigator, the editor, the Console, the Scope pane, the
+call stack. Every assertion is made against what the front end rendered, through its own shadow roots.
+
+It is [`Jint.DevTools/docs/manual-checklist.md`](../../Jint.DevTools/docs/manual-checklist.md) minus the
+manual part. Run this when the protocol surface changes; walk the checklist by hand for the steps the table
+below says are not driven.
+
+## Running it
+
+```bash
+cd tools/devtools-frontend-smoke
+npm install                 # also downloads Chrome for Testing (puppeteer's postinstall)
+node smoke.mjs
+```
+
+Puppeteer is pinned to the same version [`tools/cdp-histogram`](../cdp-histogram/) pins, so both tools use
+one Chrome for Testing download and neither one's evidence is a different browser's.
+
+The Jint side has to be built first — this tool never builds anything, because a second MSBuild in a working
+tree somebody else is building is its own kind of flake:
+
+```bash
+dotnet build -c Release Jint.Repl/Jint.Repl.csproj
+```
+
+It looks for `artifacts/bin/Jint.Repl/release/Jint.Repl.exe`, then the extensionless apphost, then
+`Jint.Repl.dll` (run through `dotnet`), and says all three plus the build command when it finds none.
+
+| Environment variable | What it does |
+| --- | --- |
+| `JINT_REPL` | Use this binary instead of the built one. A `.dll` is run through `dotnet`. |
+| `CDP_FRONTEND_REVISION` | Load this devtools-frontend commit instead of the one Chromium's DEPS names. |
+| `CDP_FRONTEND_URL` | Load this `js_app.html` instead, skipping the lookup entirely. |
+| `SMOKE_HEADED=1` | Show the browser, which is how you watch it drive. |
+
+The recording proxy is `tools/cdp-histogram/proxy.mjs`, **imported rather than copied**. Node resolves that
+file's `import 'ws'` from *its* directory, not from this one, so it needs a copy of `ws` next door:
+
+```bash
+node -e "await (await import('node:fs/promises')).cp('node_modules/ws', '../cdp-histogram/node_modules/ws', { recursive: true })"
+```
+
+Both paths are gitignored, so this changes nothing that is checked in, and `smoke.mjs` prints exactly that
+command if the import fails. A full `npm install` in `tools/cdp-histogram` works too and does more.
+
+One thing is **not** imported: the devtools-frontend revision lookup. It lives in
+`tools/cdp-histogram/scenarios/devtools-frontend.mjs`, which is a script that runs a whole capture on import
+and exports nothing, so `frontend.mjs` re-derives it — same DEPS file, same rule, same two overrides.
+
+## What it drives
+
+`fixture/app.js` is what the engine runs, and it is short on purpose. It logs a string and an object, so the
+Console has an object preview to render; it declares named functions, so the editor and the gutter have
+something worth looking at; and a `setTimeout` inside a one-second `setInterval` throws, so an uncaught
+exception is reachable.
+
+The heartbeat re-arms rather than firing once, and that is deliberate. The script itself finishes in
+milliseconds while the front end needs seconds to download and connect, so a single `setTimeout` would have
+thrown before anybody was listening. The same heartbeat is what makes a breakpoint hittable at all:
+`computeTotal` is called once a second forever, so the front end can set a breakpoint whenever it likes and
+be paused within a second of doing it.
+
+## The steps, and what each one proves
+
+Each step gets a 60-second budget, a screenshot, a DOM dump, and a row in `out/summary.json` carrying what it
+observed. A step that could not be driven is recorded as `not-driven` with what was seen instead — never as a
+pass, and never as a weaker assertion wearing the strong one's name.
+
+| # | Step | What a pass means |
+| --- | --- | --- |
+| 1 | `frontend-connected` | The hosted front end loaded, opened a socket to Jint, and the handshake completed: `Runtime.enable` was answered and `Debugger.scriptParsed` arrived. |
+| 2 | `sources-lists-script` | The Sources navigator has a **visible** entry for the running script — the folder is expanded first, because a collapsed tree keeps its children in the document and asserting on one of those would be reporting the DOM rather than the panel. |
+| 3 | `sources-shows-source-text` | Clicking that entry opens the editor and the retained source is in it: `lineTotal`, `computeTotal`, `describeOrders`, `heartbeat` and `reconcile` are all read back out of the CodeMirror content. That is `Debugger.getScriptSource` end to end. |
+| 4 | `console-shows-log-with-object-preview` | The Console shows `console.log('order book ready', …)` **with its object preview expanded into properties**, not as a bare `Object`. |
+| 5 | `console-evaluates-expression` | `1+1` typed at the Console prompt and submitted comes back as `2` in a result row. |
+| 6 | `breakpoint-set-in-the-gutter-is-hit` | A breakpoint set by clicking the editor gutter — the front end's own `Debugger.setBreakpointByUrl` — stops the engine, and the front end says "Paused on breakpoint". |
+| 7 | `scope-pane-populated` | The Scope pane lists the frame's scopes and the bindings inside them, with values. |
+| 8 | `resume-continues-execution` | The breakpoint is cleared from the gutter, Resume is clicked, and **the heartbeat in the Console advances past the tick it was paused on**. Execution continuing is what proves a resume; the paused indicator going away only proves the indicator went away. |
+
+## How it reads a user interface
+
+DevTools is built out of custom elements, and nothing interesting is reachable from
+`document.querySelector`. `frontend.mjs` installs one helper, `window.__smoke`, before the page loads; it
+walks every open shadow root and answers four questions — which elements match a selector, what they say,
+their whole text, and where one is on screen. Everything else goes through it, and clicks are real mouse
+events at the coordinates it returns rather than synthetic `el.click()` calls, because the gutter and the
+tree both listen for the real thing.
+
+The `UI` table at the top of `smoke.mjs` is every selector the tool bets on. When DevTools' markup moves,
+that table is the list to read.
+
+Three things make loading the front end possible at all, and all three are inherited from
+[`tools/cdp-histogram`](../cdp-histogram/README.md#the-best-effort-capture):
+
+- **Chrome refuses to navigate an ordinary page to `devtools://`**, so the front end comes from
+  `chrome-devtools-frontend.appspot.com`.
+- **That host serves by devtools-frontend commit and only serves commits that were rolled into a Chromium
+  release**, so the revision is read from the DEPS file of the exact Chrome being driven rather than from the
+  tip of the front-end repository.
+- **Chrome blocks a request from a public origin to a loopback one**, and the front end's socket to Jint is
+  exactly that request, so the browser runs with Local Network Access checks disabled. Without it the page
+  loads, connects to nothing, and every assertion fails for a reason that has nothing to do with Jint.
+
+## What a run leaves behind
+
+`out/` is gitignored; a run is evidence for a human, not an artefact to check in.
+
+- `out/NN-<step>.png` — a screenshot after every step, pass or fail.
+- `out/dom/NN-<step>.txt` — a compact outline of the whole rendered tree, shadow roots included. This is what
+  to read when a selector stops matching.
+- `out/summary.json` — the environment (Chrome version, front-end revision, the front end's own console
+  errors, Jint's stdout), every step's verdict and what it observed, and the protocol traffic sliced per step.
+- `out/protocol.jsonl` — every frame between the front end and Jint, one JSON line each, written by
+  `tools/cdp-histogram/proxy.mjs`. Step boundaries are in the same log, because each step marks itself on the
+  proxy's `/__mark` endpoint before it runs.
+
+## Honesty: what these passes are not
+
+Every step in the checked-in run drove the real user interface and none was faked. What follows is the list
+of places where a pass means something narrower than its name, and the things that were not attempted.
+
+- **The navigator lists the script by its whole filesystem path, not by `app.js`.** Step 2 asserts "an entry
+  ending in `fixture/app.js`", and records the text it actually read. The path is there because Jint
+  publishes a bare filesystem path as `Debugger.scriptParsed.url`; see the defects below.
+- **The Console's message list is virtualized.** Only the visible tail is in the DOM, and the heartbeat
+  pushes everything else off it, so the message logged *before* the front end connected cannot be read
+  directly. Step 4 types it into the Console's Filter box first. That is still driving the UI, and it has a
+  bonus: a filtered-in message that arrived before the socket existed is proof that the console journal Jint
+  replays on `Runtime.enable` reached the front end.
+- **The editor is virtualized too**, though not at this file's size. `deepTexts` truncates each entry at 400
+  characters for readability; the editor is read with `deepFullText`, which does not. A step that asserts on
+  a long text and uses the wrong one silently reads a prefix — that is how the first run of step 3 failed.
+- **Step 7 asserts that the Scope pane is populated; it does not assert that everything in it is right.** The
+  same pane renders eleven function-valued bindings as `ƒ undefined()`. That is recorded in `summary.json`
+  under `functionValuedBindings` rather than asserted, and it is a Jint defect — below.
+- **`--inspect-brk`, stepping (over / into / out), watch expressions, conditional breakpoints, `Debugger.pause`,
+  the Profiler and coverage, and the Memory and Performance panels are not driven at all.** Nothing here says
+  anything about them.
+- **The screenshots are of a headless Chrome.** `SMOKE_HEADED=1` renders it in a window instead.
+- **The protocol recording names methods, result keys and errors — not argument values.** That is
+  `proxy.mjs`'s deliberate design, and it is enough to show that a command was sent, answered or refused. It
+  is not enough to see *what* a command carried, so the defect notes below that turn on a value were
+  confirmed with a direct protocol client rather than by this tool.
+- **Reading a user interface by class name is a bet on somebody else's markup.** This is why the tool is not
+  in CI: a DevTools release can break it without Jint changing, and a failure here is a prompt to look, not a
+  regression by itself.
+
+## What this run found in Jint's DevTools server
+
+All four are visible in the checked-in screenshots and reproduce on demand.
+
+- **A frame the engine was entered at has no name and no `functionLocation`.** The Call Stack pane shows
+  `computeTotal` over `(anonymous)`, where V8 would show the timer callback's own name. In
+  `Debugger.paused`, the outermost call frame — the one a `setInterval` / `setTimeout` callback entered —
+  comes back with `functionName: ""` and no `functionLocation` at all, whether the callback is a function
+  declaration, a named function expression or an inline one. Every inner frame is named correctly, including
+  named function expressions, so the name is being taken from the call site rather than from the function.
+  Without `functionLocation` that call-stack row is also not clickable.
+- **`RemoteObject.description` for a function is a rendered label where the front end expects source text.**
+  Jint sends `description: "ƒ computeTotal()"`. The front end treats that field as
+  `Function.prototype.toString` output and parses the name back out of it, so every function in the Scope
+  pane and in `Runtime.getProperties` renders as **`ƒ undefined()`** — 47 of them in one screenshot.
+  `console.log`'s *previews* are unaffected, because a preview's value string is shown verbatim; it is the
+  full property path that breaks. The fix is to send the function's source text.
+- **`Runtime.consoleAPICalled` carries no `stackTrace`**, so no console message has a source anchor. In the
+  screenshots the uncaught errors link to `app.js:48` (from `exceptionDetails`) while every `console.log`
+  line has nothing on the right, where V8 puts the file and line the call came from.
+- **The front end calls `Runtime.getExceptionDetails` once per uncaught exception, and is refused every
+  time** (`-32601`). `Jint.DevTools/AGENTS.md` lists that command as deliberately absent on the grounds that
+  nothing retains an exception's details past the command that reported them — which is a decision, not an
+  oversight, but the recorded handshakes had no client asking for it and this one does, continuously. The
+  console still renders the error, so it degrades rather than fails.
+
+Two more refusals show up in the recording and are working as designed, listed so a reader does not file them
+twice: `Network.*` is `-32601` because an engine target has no Network domain, and `Runtime.evaluate` with
+`throwOnSideEffect` is `-32000 "Side-effect free evaluation is not supported"`, which costs the Console
+prompt its eager-evaluation preview and nothing else.
+
+One inconsistency worth a decision rather than a fix: `/json/list` reports the target's `url` as
+`file:///D:/…/app.js` while `Debugger.scriptParsed` reports the same file as `D:/…/app.js`. The second is
+what `Jint.Repl` passes as the source name; V8 emits a `file://` URL for both. It is why the Sources
+navigator files the script under "(no domain)" with its whole path as the name, and why a breakpoint's
+identifier reads `1:29:0:D:/Work/…/app.js`.

--- a/tools/devtools-frontend-smoke/fixture/app.js
+++ b/tools/devtools-frontend-smoke/fixture/app.js
@@ -1,0 +1,50 @@
+// The script the Jint REPL runs under --inspect while the smoke test drives DevTools against it.
+//
+// Three things have to be true of it and nothing else here is deliberate:
+//
+//   * it logs a string *and* an object, so the Console panel has an object preview to render rather than
+//     a bare string;
+//   * it declares named functions, so the Sources panel has recognisable text to show and the editor's
+//     gutter has a line worth putting a breakpoint on;
+//   * a timer throws, so an uncaught exception is reachable.
+//
+// The last one is why the failing timer re-arms instead of firing once. The script itself finishes in
+// milliseconds and the frontend needs seconds to download and connect, so a single `setTimeout` would have
+// thrown before anybody was listening; the heartbeat gives every step after the connection something to
+// catch. The heartbeat is also what makes a breakpoint hittable: `computeTotal` is called once per second
+// forever, so the frontend can set a breakpoint at any time and be paused within a second.
+
+var orders = [
+    { sku: 'widget', quantity: 3, price: 4.5 },
+    { sku: 'gasket', quantity: 1, price: 12 },
+    { sku: 'flange', quantity: 7, price: 0.75 },
+];
+
+function lineTotal(order) {
+    return order.quantity * order.price;
+}
+
+function computeTotal(items) {
+    var total = 0;
+    for (var i = 0; i < items.length; i++) {
+        total += lineTotal(items[i]);
+    }
+    return total;
+}
+
+function describeOrders(items) {
+    return { count: items.length, total: computeTotal(items), first: items[0].sku };
+}
+
+console.log('order book ready', describeOrders(orders));
+
+var ticks = 0;
+
+setInterval(function heartbeat() {
+    ticks++;
+    console.log('heartbeat', { tick: ticks, total: computeTotal(orders) });
+
+    setTimeout(function reconcile() {
+        throw new Error('reconciliation failed on tick ' + ticks);
+    }, 50);
+}, 1000);

--- a/tools/devtools-frontend-smoke/frontend.mjs
+++ b/tools/devtools-frontend-smoke/frontend.mjs
@@ -1,0 +1,292 @@
+// The Chrome DevTools front end: where to get one that matches the browser, how to host it, and how to
+// read anything out of it.
+//
+// Two things make loading it possible at all, and both are lifted from `tools/cdp-histogram`'s best-effort
+// capture, whose README explains them at length:
+//
+//   * Chrome refuses to navigate an ordinary page to `devtools://`, so the front end is loaded from
+//     chrome-devtools-frontend.appspot.com. That host serves *by devtools-frontend commit* and only serves
+//     commits that were rolled into a Chromium release, so the revision is read from the DEPS file of the
+//     exact Chrome being driven rather than from the tip of the front-end repository.
+//   * Chrome blocks a request from a public origin to a loopback one, and the front end's socket to Jint is
+//     exactly that request. The browser that hosts the front-end page therefore runs with Local Network
+//     Access checks disabled. Without it the page loads, connects to nothing, and every assertion below
+//     fails for a reason that has nothing to do with Jint.
+//
+// The revision lookup is re-derived here rather than imported: it lives in
+// `tools/cdp-histogram/scenarios/devtools-frontend.mjs`, which is a script that runs a whole capture on
+// import and exports nothing. `proxy.mjs` next door *is* a module with an export, and is imported.
+
+import puppeteer from 'puppeteer';
+
+/** The devtools-frontend commit that shipped in this exact Chrome, read from Chromium's DEPS. */
+export async function revisionFromChromiumDeps(chromeVersion) {
+    const tag = /\d+\.\d+\.\d+\.\d+/.exec(chromeVersion)?.[0];
+    if (!tag) {
+        return { revisions: [], how: `could not read a Chromium tag out of "${chromeVersion}"` };
+    }
+    try {
+        const response = await fetch(`https://chromium.googlesource.com/chromium/src/+/refs/tags/${tag}/DEPS?format=TEXT`);
+        if (!response.ok) {
+            return { revisions: [], how: `chromium.googlesource.com answered ${response.status} for tag ${tag}` };
+        }
+        const deps = Buffer.from(await response.text(), 'base64').toString('utf8');
+        const match = /'devtools_frontend_revision':\s*'([0-9a-f]{40})'/.exec(deps);
+        return match
+            ? { revisions: [match[1]], how: `devtools_frontend_revision from Chromium DEPS at tag ${tag}` }
+            : { revisions: [], how: `no devtools_frontend_revision in Chromium DEPS at tag ${tag}` };
+    } catch (error) {
+        return { revisions: [], how: `could not reach chromium.googlesource.com: ${error.message}` };
+    }
+}
+
+async function firstReachable(urls) {
+    for (const url of urls) {
+        try {
+            const response = await fetch(url, { redirect: 'follow' });
+            if (response.ok && (await response.text()).includes('<script')) {
+                return url;
+            }
+        } catch {
+            // Next candidate.
+        }
+    }
+    return null;
+}
+
+/** Picks the front-end build to load, honouring CDP_FRONTEND_REVISION and CDP_FRONTEND_URL. */
+export async function resolveFrontend(chromeVersion) {
+    if (process.env.CDP_FRONTEND_URL) {
+        return { base: process.env.CDP_FRONTEND_URL, revision: 'from CDP_FRONTEND_URL', how: 'CDP_FRONTEND_URL environment variable' };
+    }
+
+    const { revisions, how } = process.env.CDP_FRONTEND_REVISION
+        ? { revisions: [process.env.CDP_FRONTEND_REVISION], how: 'CDP_FRONTEND_REVISION environment variable' }
+        : await revisionFromChromiumDeps(chromeVersion);
+
+    const base = await firstReachable(revisions.map((sha) => `https://chrome-devtools-frontend.appspot.com/serve_rev/@${sha}/js_app.html`));
+    if (!base) {
+        throw new Error(
+            `No hosted DevTools front-end build answered (${how}).\n`
+            + 'Set CDP_FRONTEND_URL to a js_app.html that does, or CDP_FRONTEND_REVISION to a devtools-frontend commit.');
+    }
+    return { base, revision: revisions[0], how };
+}
+
+/** Launches the throwaway browser that hosts the front-end page. */
+export async function launchHostBrowser() {
+    return puppeteer.launch({
+        headless: process.env.SMOKE_HEADED === '1' ? false : true,
+        defaultViewport: { width: 1680, height: 1050 },
+        args: [
+            '--no-first-run',
+            '--no-default-browser-check',
+            '--disable-gpu',
+            '--mute-audio',
+            '--disable-background-networking',
+            '--disable-component-update',
+            // The front end lives on a public origin and its socket goes to loopback. Without this the
+            // connection is refused with ERR_BLOCKED_BY_LOCAL_NETWORK_ACCESS_CHECKS and nothing says so.
+            '--disable-features=LocalNetworkAccessChecks,PrivateNetworkAccessSendPreflights,PrivateNetworkAccessRespectPreflightResults',
+        ],
+    });
+}
+
+// --- reading the front end, which means piercing its shadow roots ------------------------------------------
+//
+// DevTools is built out of custom elements with closed-ish shadow trees; nothing interesting is reachable
+// from `document.querySelector`. One helper is installed into the page before it loads and everything else
+// here goes through it: `window.__smoke`, which walks every open shadow root and answers three questions —
+// which elements match a selector, what their text says, and where one of them is on screen so the real
+// mouse can be pointed at it.
+
+/** Installs `window.__smoke` into every document the page loads. */
+export async function installShadowDomHelper(page) {
+    await page.evaluateOnNewDocument(() => {
+        const normalize = (text) => (text || '').replace(/\s+/g, ' ').trim();
+
+        // Containment across a shadow boundary: Node.contains stops at the host, so walk hosts by hand.
+        const containsDeep = (ancestor, node) => {
+            let current = node;
+            while (current) {
+                if (current === ancestor) {
+                    return true;
+                }
+                current = current.parentNode || current.host || null;
+            }
+            return false;
+        };
+
+        const collect = () => {
+            const out = [];
+            const stack = [document];
+            while (stack.length) {
+                const root = stack.pop();
+                let elements;
+                try {
+                    elements = root.querySelectorAll('*');
+                } catch {
+                    continue;
+                }
+                for (const element of elements) {
+                    out.push(element);
+                    if (element.shadowRoot) {
+                        stack.push(element.shadowRoot);
+                    }
+                }
+            }
+            return out;
+        };
+
+        const describe = (element) => ({
+            tag: element.tagName.toLowerCase(),
+            class: element.getAttribute('class') || '',
+            role: element.getAttribute('role') || '',
+            label: element.getAttribute('aria-label') || element.getAttribute('title') || '',
+            text: normalize(element.textContent).slice(0, 300),
+        });
+
+        window.__smoke = {
+            /** Every element matching `selector`, in every open shadow root. */
+            matching(selector) {
+                return collect().filter((element) => {
+                    try {
+                        return element.matches(selector);
+                    } catch {
+                        return false;
+                    }
+                });
+            },
+
+            /**
+             * The innermost elements matching `selector` and, when given, containing `text`. Innermost,
+             * because every ancestor of a match also "contains" the text and clicking one is a coin toss.
+             */
+            deepest(selector, text, exact) {
+                const wanted = normalize(text);
+                let candidates = this.matching(selector);
+                if (wanted) {
+                    candidates = candidates.filter((element) => {
+                        const actual = normalize(element.textContent);
+                        return exact ? actual === wanted : actual.includes(wanted);
+                    });
+                }
+                return candidates.filter((element) => !candidates.some((other) => other !== element && containsDeep(element, other)));
+            },
+
+            /**
+             * What the matching elements say, deduplicated and capped. `visibleOnly` skips elements that
+             * have no box — a collapsed tree keeps its children in the document, and reporting one of
+             * those as "the panel shows it" would be a lie.
+             */
+            texts(selector, limit, visibleOnly) {
+                const seen = new Set();
+                for (const element of this.matching(selector)) {
+                    if (visibleOnly && element.getClientRects().length === 0) {
+                        continue;
+                    }
+                    const text = normalize(element.textContent);
+                    if (text) {
+                        seen.add(text.slice(0, 400));
+                    }
+                    if (seen.size >= (limit || 400)) {
+                        break;
+                    }
+                }
+                return [...seen];
+            },
+
+            /**
+             * The whole text of the first match, untruncated. `texts` caps each entry so a dump stays
+             * readable; an editor's contents are the one thing that has to come back in full.
+             */
+            full(selector) {
+                const element = this.matching(selector)[0];
+                return element ? normalize(element.textContent) : null;
+            },
+
+            /** Where to point the mouse for the first visible match, after scrolling it into view. */
+            locate(selector, text, exact, index) {
+                const matches = this.deepest(selector, text, exact).filter((element) => element.getClientRects().length > 0);
+                const element = matches[index || 0];
+                if (!element) {
+                    return null;
+                }
+                element.scrollIntoView({ block: 'center', inline: 'nearest' });
+                const box = element.getBoundingClientRect();
+                return {
+                    x: box.x + box.width / 2,
+                    y: box.y + box.height / 2,
+                    width: box.width,
+                    height: box.height,
+                    count: matches.length,
+                    ...describe(element),
+                };
+            },
+
+            /** A compact dump of the whole rendered tree, for working out what to select next. */
+            outline(limit) {
+                return collect()
+                    .filter((element) => element.getAttribute('class') || element.getAttribute('role') || element.getAttribute('aria-label'))
+                    .slice(0, limit || 4000)
+                    .map((element) => {
+                        const d = describe(element);
+                        return `${d.tag}${d.class ? `.${d.class.split(/\s+/).join('.')}` : ''}${d.role ? `[role=${d.role}]` : ''}${d.label ? `[label=${d.label}]` : ''} :: ${d.text.slice(0, 120)}`;
+                    });
+            },
+        };
+    });
+}
+
+/** What the elements matching `selector` say; `visibleOnly` counts only what is actually on screen. */
+export function deepTexts(page, selector, limit, visibleOnly = false) {
+    return page.evaluate((s, l, v) => window.__smoke.texts(s, l, v), selector, limit ?? 400, visibleOnly);
+}
+
+/** The whole text of the first element matching `selector`, or null. */
+export function deepFullText(page, selector) {
+    return page.evaluate((s) => window.__smoke.full(s), selector);
+}
+
+/** Where the innermost match is, or null. */
+export function deepLocate(page, selector, { text = '', exact = false, index = 0 } = {}) {
+    return page.evaluate((s, t, e, i) => window.__smoke.locate(s, t, e, i), selector, text, exact, index);
+}
+
+/** Points the real mouse at the innermost match and clicks it. Returns what it clicked, or null. */
+export async function deepClick(page, selector, options = {}) {
+    const found = await deepLocate(page, selector, options);
+    if (!found) {
+        return null;
+    }
+    await page.mouse.click(found.x, found.y);
+    return found;
+}
+
+/** A compact dump of everything on screen, shadow roots included. */
+export function deepOutline(page, limit) {
+    return page.evaluate((l) => window.__smoke.outline(l), limit ?? 4000);
+}
+
+/**
+ * Polls `probe` until it answers something truthy, then returns it. A timeout says what it was waiting for,
+ * because "timed out" on its own is the least useful failure a tool like this can produce.
+ */
+export async function waitFor(label, probe, { timeoutMs = 60000, intervalMs = 250 } = {}) {
+    const deadline = Date.now() + timeoutMs;
+    let lastError = null;
+    for (;;) {
+        try {
+            const value = await probe();
+            if (value) {
+                return value;
+            }
+        } catch (error) {
+            lastError = error;
+        }
+        if (Date.now() > deadline) {
+            throw new Error(`timed out after ${Math.round(timeoutMs / 1000)}s waiting for ${label}${lastError ? ` (last error: ${lastError.message})` : ''}`);
+        }
+        await new Promise((r) => setTimeout(r, intervalMs));
+    }
+}

--- a/tools/devtools-frontend-smoke/jint.mjs
+++ b/tools/devtools-frontend-smoke/jint.mjs
@@ -1,0 +1,127 @@
+// Spawns the Jint REPL under --inspect and reads the endpoint back out of its banner.
+//
+// The banner is the contract this file depends on. `Jint.Repl` prints
+//
+//     Debugger listening on ws://127.0.0.1:54796/devtools/page/5EB8F253FFCD410A8AC91A0D00000002
+//
+// on stdout before it evaluates anything, so the host, the port and the target identifier are all readable
+// without asking the server anything. `/json/list` carries the same three, and is read afterwards as a
+// cross-check: a banner that disagrees with the discovery document is a defect worth failing on rather than
+// a detail to paper over.
+
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..', '..');
+
+/** Where a Release build of the REPL lands, in the order they are tried. */
+const CANDIDATES = [
+    join(repoRoot, 'artifacts', 'bin', 'Jint.Repl', 'release', 'Jint.Repl.exe'),
+    join(repoRoot, 'artifacts', 'bin', 'Jint.Repl', 'release', 'Jint.Repl'),
+    join(repoRoot, 'artifacts', 'bin', 'Jint.Repl', 'release', 'Jint.Repl.dll'),
+];
+
+const BUILD_COMMAND = `dotnet build -c Release ${join(repoRoot, 'Jint.Repl', 'Jint.Repl.csproj')}`;
+
+const BANNER = /Debugger listening on ws:\/\/([^\s:]+):(\d+)(\/devtools\/page\/(\S+))/;
+
+/** Resolves the binary to run, honouring JINT_REPL, and says how to produce it when there is none. */
+function resolveBinary() {
+    const override = process.env.JINT_REPL;
+    const candidates = override ? [override] : CANDIDATES;
+    const found = candidates.find((path) => existsSync(path));
+
+    if (!found) {
+        const tried = candidates.map((path) => `  ${path}`).join('\n');
+        throw new Error(
+            `No Jint REPL binary found. Tried:\n${tried}\n\n`
+            + `Build one with:\n  ${BUILD_COMMAND}\n\n`
+            + 'or point JINT_REPL at an existing Jint.Repl.exe / Jint.Repl.dll.');
+    }
+
+    // A .dll is the portable form and needs the muxer; anything else is an apphost.
+    return found.endsWith('.dll')
+        ? { command: 'dotnet', args: [found], described: `dotnet ${found}` }
+        : { command: found, args: [], described: found };
+}
+
+/**
+ * Starts `Jint.Repl --inspect=0 -f <script> -t <timeoutSeconds>` and waits for its banner.
+ *
+ * @param {object} options
+ * @param {string} options.script            Absolute path to the script the engine runs.
+ * @param {number} [options.timeoutSeconds]  What -t is given; the REPL's per-entry execution-time limit.
+ * @param {number} [options.startupTimeoutMs]
+ */
+export async function launchJint({ script, timeoutSeconds = 60, startupTimeoutMs = 30000 }) {
+    const binary = resolveBinary();
+    const argv = [...binary.args, '--inspect=0', '-f', script, '-t', String(timeoutSeconds)];
+    const child = spawn(binary.command, argv, { cwd: here, stdio: ['ignore', 'pipe', 'pipe'] });
+
+    const stdout = [];
+    const stderr = [];
+    let banner = '';
+    let exited = null;
+
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk) => { banner += chunk; stdout.push(chunk); });
+    child.stderr.on('data', (chunk) => { stderr.push(chunk); });
+    child.on('exit', (code) => { exited = code; });
+
+    const deadline = Date.now() + startupTimeoutMs;
+    let match = null;
+    for (;;) {
+        match = BANNER.exec(banner);
+        if (match) {
+            break;
+        }
+        if (exited !== null) {
+            throw new Error(
+                `${binary.described} exited with ${exited} before printing a debugger banner.\n`
+                + `stdout:\n${stdout.join('')}\nstderr:\n${stderr.join('')}`);
+        }
+        if (Date.now() > deadline) {
+            child.kill();
+            throw new Error(
+                `${binary.described} printed no debugger banner within ${startupTimeoutMs} ms.\n`
+                + `stdout so far:\n${stdout.join('')}\nstderr so far:\n${stderr.join('')}`);
+        }
+        await new Promise((r) => setTimeout(r, 50));
+    }
+
+    const [, host, port, wsPath, targetId] = match;
+    const httpUrl = `http://${host}:${port}`;
+
+    // The discovery document has to agree with the banner, because the two are produced by different code
+    // and a client reaches the target through either.
+    const targets = await (await fetch(`${httpUrl}/json/list`)).json();
+    const target = targets.find((entry) => entry.id === targetId);
+    if (!target) {
+        child.kill();
+        throw new Error(`${httpUrl}/json/list does not list the target the banner named (${targetId}): ${JSON.stringify(targets)}`);
+    }
+
+    return {
+        command: binary.described,
+        argv,
+        host,
+        port: Number(port),
+        httpUrl,
+        wsPath,
+        targetId,
+        target,
+        output: () => stdout.join(''),
+        errors: () => stderr.join(''),
+        exitCode: () => exited,
+        kill() {
+            // Only ever the process this module spawned, and only by handle.
+            if (exited === null) {
+                try { child.kill(); } catch { /* already gone */ }
+            }
+        },
+    };
+}

--- a/tools/devtools-frontend-smoke/package.json
+++ b/tools/devtools-frontend-smoke/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "devtools-frontend-smoke",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Drives the real Chrome DevTools frontend against a real Jint REPL under --inspect and asserts through the frontend's own shadow DOM.",
+  "scripts": {
+    "start": "node smoke.mjs"
+  },
+  "dependencies": {
+    "puppeteer": "^24.29.0",
+    "ws": "^8.19.0"
+  }
+}

--- a/tools/devtools-frontend-smoke/smoke.mjs
+++ b/tools/devtools-frontend-smoke/smoke.mjs
@@ -1,0 +1,491 @@
+// Drives the real Chrome DevTools front end against a real Jint process, and asserts through the front
+// end's own DOM.
+//
+//   node smoke.mjs
+//
+// Everything else in this repository that claims DevTools works claims it from the protocol side: a test
+// sends a command and reads the answer. That proves the server answers; it does not prove a human opening
+// DevTools sees anything. This walks the other half — Chrome's own front end, unmodified, loaded from the
+// build that shipped in the Chrome being driven, pointed at `Jint.Repl --inspect` — and reads the panels.
+//
+// It is deliberately not in CI. It downloads a front-end build over the network, drives a user interface
+// through its shadow roots, and depends on DevTools' own markup; any of those can change without Jint
+// changing. What it produces is evidence for a human: screenshots, a per-step verdict, and a full recording
+// of the protocol traffic between the front end and Jint.
+//
+// The one rule that makes the output worth reading: **a step that could not be driven says so.** It is
+// recorded as `not-driven` with what was observed instead, never as a pass and never as a weaker assertion
+// wearing the strong one's name. Where the UI could not be driven, the recording of what the front end
+// actually sent and what Jint answered stands in for it.
+
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { launchJint } from './jint.mjs';
+import {
+    deepClick, deepFullText, deepLocate, deepOutline, deepTexts, installShadowDomHelper,
+    launchHostBrowser, resolveFrontend, waitFor,
+} from './frontend.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const outDir = join(here, 'out');
+const fixture = join(here, 'fixture', 'app.js');
+
+// The step budget. Generous, because the front end downloads a few megabytes before it connects, and the
+// engine only reaches a breakpoint on the next turn of a one-second timer.
+const STEP_TIMEOUT = 60000;
+
+// Selectors, all of them piercing shadow roots through `window.__smoke`. Named rather than inlined because
+// every one of them is a bet on DevTools' markup, and when one stops matching this is the list to read.
+const UI = {
+    panelTab: '.tabbed-pane-header-tab',
+    navigatorFolder: 'li.navigator-folder-tree-item',
+    navigatorFile: 'li.navigator-file-tree-item',
+    editorContent: '.cm-content:not([aria-label="Console prompt"])',
+    gutterLine: '.cm-lineNumbers .cm-gutterElement, .cm-gutterElement',
+    consoleFilter: '[role="textbox"][aria-label="Filter"]',
+    consolePrompt: '.cm-content[aria-label="Console prompt"]',
+    consoleMessage: '.console-message-text',
+    consoleResult: '.console-user-command-result',
+    callFrame: '.call-frame-item-title, .call-frame-title-text',
+    scopeSection: '.scope-chain-sidebar-pane-section-title',
+    scopeBinding: '.object-properties-section span.name-and-value',
+    infoMessage: '.gray-info-message',
+    resumeButton: 'button[aria-label*="Resume script execution"]',
+    pausedStatus: '.paused-status, .paused-message',
+};
+
+const results = [];
+let stepIndex = 0;
+
+/** The line the breakpoint goes on, found in the fixture rather than hard-coded. */
+async function breakpointLine() {
+    const lines = (await readFile(fixture, 'utf8')).split(/\r?\n/);
+    const index = lines.findIndex((line) => line.includes('total += lineTotal'));
+    if (index < 0) {
+        throw new Error(`fixture/app.js no longer holds the accumulator line the breakpoint step needs`);
+    }
+    return { number: index + 1, text: lines[index].trim() };
+}
+
+/**
+ * Runs one step, screenshots it, and records the verdict.
+ *
+ * `body` returns what it observed. It may return `{ status: 'not-driven', observed, instead }` to say the
+ * UI could not be driven; anything it throws is a failure, and the message says what was being waited for.
+ */
+async function step(page, proxy, name, proves, body) {
+    stepIndex++;
+    const label = `${String(stepIndex).padStart(2, '0')}-${name}`;
+    await fetch(`${proxy.httpUrl}/__mark?name=${encodeURIComponent(name)}`).catch(() => { /* recording only */ });
+    process.stdout.write(`\n[${label}] ${proves}\n`);
+
+    const started = Date.now();
+    const entry = { step: name, proves, status: 'fail', observed: null, elapsedMs: 0, screenshot: `${label}.png` };
+    try {
+        const outcome = await body();
+        if (outcome && outcome.status === 'not-driven') {
+            entry.status = 'not-driven';
+            entry.observed = outcome.observed ?? null;
+            entry.instead = outcome.instead ?? null;
+            process.stdout.write(`  NOT DRIVEN: ${outcome.instead ?? ''}\n`);
+        } else {
+            entry.status = 'pass';
+            entry.observed = outcome ?? null;
+            process.stdout.write(`  PASS\n`);
+        }
+    } catch (error) {
+        entry.error = error.message;
+        process.stdout.write(`  FAIL: ${error.message}\n`);
+    }
+    entry.elapsedMs = Date.now() - started;
+
+    await page.screenshot({ path: join(outDir, `${label}.png`) }).catch(() => { /* the page may be gone */ });
+    const outline = await deepOutline(page).catch(() => null);
+    if (outline) {
+        await writeFile(join(outDir, 'dom', `${label}.txt`), outline.join('\n'));
+    }
+    results.push(entry);
+    return entry;
+}
+
+/** Reads the recording back, sliced by the marks each step wrote. */
+async function readProtocol(logPath) {
+    const rows = (await readFile(logPath, 'utf8'))
+        .split('\n')
+        .filter(Boolean)
+        .map((line) => { try { return JSON.parse(line); } catch { return null; } })
+        .filter(Boolean);
+
+    const slices = [];
+    let current = { step: '(before the first step)', commands: [], events: [], errors: [] };
+    for (const row of rows) {
+        if (row.direction === 'mark') {
+            slices.push(current);
+            current = { step: row.step, commands: [], events: [], errors: [] };
+            continue;
+        }
+        if (row.direction === 'c2b' && row.method) {
+            current.commands.push(row.method);
+        } else if (row.event && row.method) {
+            current.events.push(row.method);
+        }
+        if (row.error) {
+            current.errors.push(`${row.method}: ${row.error.code} ${row.error.message}`);
+        }
+    }
+    slices.push(current);
+
+    const distinct = (values) => [...new Set(values)];
+    return {
+        rows: rows.length,
+        slices: slices.map((slice) => ({
+            step: slice.step,
+            commands: distinct(slice.commands),
+            events: distinct(slice.events),
+            errors: distinct(slice.errors),
+        })),
+        allCommands: distinct(rows.filter((r) => r.direction === 'c2b' && r.method).map((r) => r.method)),
+        allEvents: distinct(rows.filter((r) => r.event && r.method).map((r) => r.method)),
+        allErrors: distinct(rows.filter((r) => r.error).map((r) => `${r.method}: ${r.error.code} ${r.error.message}`)),
+    };
+}
+
+/** Whichever tick the heartbeat has reached, according to what the Console is rendering. */
+async function latestTick(page) {
+    const texts = await deepTexts(page, UI.consoleMessage, 300);
+    const ticks = texts
+        .map((text) => /heartbeat \{tick: (\d+)/.exec(text))
+        .filter(Boolean)
+        .map((match) => Number(match[1]));
+    return ticks.length ? Math.max(...ticks) : null;
+}
+
+/** Clicks a main panel tab by its name and waits for it to be the selected one. */
+async function openPanel(page, panel) {
+    const clicked = await deepClick(page, UI.panelTab, { text: panel, exact: true });
+    if (!clicked) {
+        throw new Error(`no main panel tab reading "${panel}"`);
+    }
+    await waitFor(`the ${panel} panel to become the selected tab`, async () => {
+        const selected = await deepTexts(page, `${UI.panelTab}.selected`, 10);
+        return selected.includes(panel);
+    }, { timeoutMs: 15000 });
+}
+
+/** Types into one of the front end's contenteditable prompts, replacing whatever was in it. */
+async function typeInto(page, selector, text) {
+    const found = await waitFor(`an editable element matching ${selector}`,
+        () => deepLocate(page, selector), { timeoutMs: 30000 });
+    await page.mouse.click(found.x, found.y);
+    await page.keyboard.down('Control');
+    await page.keyboard.press('KeyA');
+    await page.keyboard.up('Control');
+    await page.keyboard.press('Backspace');
+    if (text) {
+        await page.keyboard.type(text, { delay: 20 });
+    }
+}
+
+async function main() {
+    await rm(outDir, { recursive: true, force: true }).catch(() => { /* first run */ });
+    await mkdir(join(outDir, 'dom'), { recursive: true });
+
+    if (!existsSync(fixture)) {
+        throw new Error(`the fixture is missing: ${fixture}`);
+    }
+
+    // The recording proxy is `tools/cdp-histogram/proxy.mjs`, imported rather than copied. It resolves `ws`
+    // from its own directory, so the import is dynamic and the failure is explained rather than raw.
+    let startProxy;
+    try {
+        ({ startProxy } = await import('../cdp-histogram/proxy.mjs'));
+    } catch (error) {
+        throw new Error(
+            `could not load the recording proxy from tools/cdp-histogram/proxy.mjs: ${error.message}\n`
+            + 'It imports "ws", which Node resolves from *its* directory. Run:\n'
+            + '  node -e "await (await import(\'node:fs/promises\')).cp(\'node_modules/ws\', \'../cdp-histogram/node_modules/ws\', { recursive: true })"\n'
+            + 'from tools/devtools-frontend-smoke after npm install.');
+    }
+
+    const line = await breakpointLine();
+    const environment = { startedAt: new Date().toISOString() };
+
+    const jint = await launchJint({ script: fixture.replace(/\\/g, '/'), timeoutSeconds: 60 });
+    environment.jint = { command: jint.command, argv: jint.argv, port: jint.port, targetId: jint.targetId, target: jint.target };
+    console.log(`jint:     ${jint.command}\n          ${jint.httpUrl}${jint.wsPath}`);
+
+    const logPath = join(outDir, 'protocol.jsonl');
+    const proxy = await startProxy({ upstreamHttp: jint.httpUrl, logPath, client: 'devtools-frontend-smoke' });
+    console.log(`proxy:    ${proxy.httpUrl} (recording to out/protocol.jsonl)`);
+
+    const browser = await launchHostBrowser();
+    let page = null;
+    try {
+        const chromeVersion = await browser.version();
+        const frontend = await resolveFrontend(chromeVersion);
+        environment.chrome = chromeVersion;
+        environment.frontend = { revision: frontend.revision, how: frontend.how, base: frontend.base };
+        console.log(`chrome:   ${chromeVersion}`);
+        console.log(`frontend: ${frontend.revision} (${frontend.how})`);
+
+        const url = `${frontend.base}?v8only=true&panel=sources&ws=${proxy.httpUrl.replace('http://', '')}${jint.wsPath}`;
+        environment.frontendUrl = url;
+
+        page = await browser.newPage();
+        await installShadowDomHelper(page);
+
+        // The front end reports its own protocol failures to its console, and that is the cheapest place to
+        // see a command Jint refused: "Request <Method> failed. {code, message}".
+        const frontendErrors = [];
+        page.on('console', (message) => { if (message.type() === 'error') { frontendErrors.push(message.text().slice(0, 400)); } });
+        page.on('pageerror', (error) => frontendErrors.push(String(error).slice(0, 400)));
+
+        // --- 1 -------------------------------------------------------------------------------------------
+        await step(page, proxy, 'frontend-connected',
+            'the real DevTools front end loads and completes a handshake with Jint',
+            async () => {
+                await page.goto(url, { waitUntil: 'domcontentloaded', timeout: STEP_TIMEOUT });
+                const tabs = await waitFor('the DevTools panel tabs to render', async () => {
+                    const found = await deepTexts(page, UI.panelTab, 20);
+                    return found.length ? found : null;
+                }, { timeoutMs: STEP_TIMEOUT });
+
+                const protocol = await waitFor('Runtime.enable and Debugger.scriptParsed on the wire', async () => {
+                    const read = await readProtocol(logPath);
+                    return read.allCommands.includes('Runtime.enable') && read.allEvents.includes('Debugger.scriptParsed') ? read : null;
+                }, { timeoutMs: STEP_TIMEOUT });
+
+                return { panelTabs: tabs, handshakeCommands: protocol.allCommands, handshakeEvents: protocol.allEvents };
+            });
+
+        // --- 2 -------------------------------------------------------------------------------------------
+        let scriptEntry = null;
+        await step(page, proxy, 'sources-lists-script',
+            'the Sources navigator lists the script the engine is running',
+            async () => {
+                // The navigator groups scripts under a folder node and starts collapsed, so the file is in
+                // the document before it is on screen. Expanding is part of the step: an assertion that read
+                // the collapsed subtree would be reporting the DOM rather than the panel.
+                const folders = await waitFor('a folder node in the Sources navigator', async () => {
+                    const found = await deepTexts(page, UI.navigatorFolder, 20, true);
+                    return found.length ? found : null;
+                }, { timeoutMs: STEP_TIMEOUT });
+
+                const folder = await deepClick(page, UI.navigatorFolder, { text: folders[0], exact: true });
+                await page.keyboard.press('ArrowRight');
+
+                const entries = await waitFor('a visible file entry in the Sources navigator', async () => {
+                    const found = await deepTexts(page, UI.navigatorFile, 50, true);
+                    return found.length ? found : null;
+                }, { timeoutMs: STEP_TIMEOUT });
+
+                scriptEntry = entries.find((text) => text.replace(/\\/g, '/').endsWith('fixture/app.js'));
+                if (!scriptEntry) {
+                    throw new Error(`the navigator shows ${JSON.stringify(entries)}, none of which ends with fixture/app.js`);
+                }
+                return {
+                    folder: folder?.text ?? folders[0],
+                    navigatorEntries: entries,
+                    matched: scriptEntry,
+                    note: scriptEntry === 'app.js'
+                        ? 'listed by file name'
+                        : 'listed by its whole path under a "(no domain)" folder, because Jint publishes a bare '
+                            + 'filesystem path as Debugger.scriptParsed.url rather than a file:// URL',
+                };
+            });
+
+        // --- 3 -------------------------------------------------------------------------------------------
+        await step(page, proxy, 'sources-shows-source-text',
+            'opening the script shows the source text the engine retained',
+            async () => {
+                if (!scriptEntry) {
+                    throw new Error('the previous step never found the script, so there is nothing to open');
+                }
+                await waitFor(`the navigator entry ${JSON.stringify(scriptEntry)} to be clickable`,
+                    () => deepClick(page, UI.navigatorFile, { text: scriptEntry, exact: true }), { timeoutMs: 30000 });
+
+                const wanted = ['lineTotal', 'computeTotal', 'describeOrders', 'heartbeat', 'reconcile'];
+                const editor = await waitFor(`the editor to show ${wanted.join(', ')}`, async () => {
+                    const body = await deepFullText(page, UI.editorContent);
+                    return body && wanted.every((name) => body.includes(name)) ? body : null;
+                }, { timeoutMs: STEP_TIMEOUT });
+
+                return {
+                    functionsFound: wanted,
+                    editorLength: editor.length,
+                    declarationsRead: editor.match(/function \w+\([^)]*\)/g) ?? [],
+                };
+            });
+
+        // --- 4 -------------------------------------------------------------------------------------------
+        await step(page, proxy, 'console-shows-log-with-object-preview',
+            'the Console panel shows the console.log, object preview and all',
+            async () => {
+                await openPanel(page, 'Console');
+                // The console viewport only keeps the visible tail in the DOM, and the heartbeat pushes
+                // everything else off it. Filtering is how the message from before the front end connected
+                // is brought back — which also proves the journal Jint replays on Runtime.enable arrived.
+                await typeInto(page, UI.consoleFilter, 'order book ready');
+
+                const message = await waitFor('a console message reading "order book ready"', async () => {
+                    const texts = await deepTexts(page, UI.consoleMessage, 50);
+                    return texts.find((text) => text.includes('order book ready')) ?? null;
+                }, { timeoutMs: STEP_TIMEOUT });
+
+                const preview = ['count', 'total', 'first', '30.75', 'widget'].filter((part) => message.includes(part));
+                if (preview.length !== 5) {
+                    throw new Error(`the message is "${message}", which is missing ${['count', 'total', 'first', '30.75', 'widget'].filter((p) => !message.includes(p)).join(', ')} from the object preview`);
+                }
+                return { message, previewParts: preview };
+            });
+
+        // --- 5 -------------------------------------------------------------------------------------------
+        await step(page, proxy, 'console-evaluates-expression',
+            'typing an expression at the Console prompt evaluates it in the engine',
+            async () => {
+                await typeInto(page, UI.consoleFilter, '');
+                await typeInto(page, UI.consolePrompt, '1+1');
+                await page.keyboard.press('Enter');
+
+                const result = await waitFor('the console to show the result of 1+1', async () => {
+                    const texts = await deepTexts(page, UI.consoleResult, 20);
+                    return texts.find((text) => text.trim() === '2') ?? null;
+                }, { timeoutMs: STEP_TIMEOUT });
+
+                return { typed: '1+1', result };
+            });
+
+        // --- 6 -------------------------------------------------------------------------------------------
+        let tickBeforeResume = null;
+        let pausedForReal = false;
+        await step(page, proxy, 'breakpoint-set-in-the-gutter-is-hit',
+            'a breakpoint the front end set by clicking the gutter pauses the engine',
+            async () => {
+                await openPanel(page, 'Sources');
+                // The drawer console, so the heartbeat stays readable while the Sources panel is in front:
+                // that is how the resume step proves the engine really continued.
+                await page.keyboard.press('Escape');
+
+                const gutter = await waitFor(`the editor gutter to show line ${line.number}`,
+                    () => deepLocate(page, UI.gutterLine, { text: String(line.number), exact: true }),
+                    { timeoutMs: STEP_TIMEOUT });
+                await page.mouse.click(gutter.x, gutter.y);
+
+                const paused = await waitFor(`the debugger to pause on line ${line.number} (${line.text})`, async () => {
+                    const status = await deepTexts(page, UI.pausedStatus, 5, true);
+                    const info = await deepTexts(page, UI.infoMessage, 10, true);
+                    const resume = await deepLocate(page, UI.resumeButton);
+                    return (status.length || resume) && !info.includes('Not paused')
+                        ? { status, resumeButton: resume?.label ?? null }
+                        : null;
+                }, { timeoutMs: STEP_TIMEOUT });
+
+                pausedForReal = true;
+                tickBeforeResume = await latestTick(page);
+                return {
+                    breakpointLine: `${line.number}: ${line.text}`,
+                    pausedIndicator: paused.status,
+                    resumeButton: paused.resumeButton,
+                    callStackSays: await deepTexts(page, UI.callFrame, 20, true),
+                    tickWhenPaused: tickBeforeResume,
+                };
+            });
+
+        // --- 7 -------------------------------------------------------------------------------------------
+        await step(page, proxy, 'scope-pane-populated',
+            'the Scope pane shows the paused frame\'s bindings',
+            async () => {
+                if (!pausedForReal) {
+                    return { status: 'not-driven', instead: 'the engine never paused, so there was no frame to show scopes for' };
+                }
+                const scope = await waitFor('the Scope pane to list a scope and the bindings of the paused frame', async () => {
+                    const scopes = await deepTexts(page, UI.scopeSection, 20, true);
+                    const all = await deepTexts(page, UI.scopeBinding, 200, true);
+                    const bindings = all.filter((text) => /^(total|items|i|this|arguments):/.test(text));
+                    return scopes.length && bindings.length ? { scopes, bindings, all } : null;
+                }, { timeoutMs: STEP_TIMEOUT });
+
+                // Not an assertion — a recording. Every function-valued binding renders as "ƒ undefined()",
+                // because Jint sends a rendered label as RemoteObject.description where the front end
+                // expects the function's source text and parses the name back out of it. The README says so;
+                // this keeps the evidence in the artefact rather than only in a human's memory.
+                const functionValues = scope.all.filter((text) => text.includes(': ƒ '));
+                return {
+                    scopes: scope.scopes,
+                    bindings: scope.bindings,
+                    functionValuedBindings: {
+                        count: functionValues.length,
+                        rendered: [...new Set(functionValues.map((text) => text.replace(/^[^:]+: /, '')))].slice(0, 6),
+                    },
+                };
+            });
+
+        // --- 8 -------------------------------------------------------------------------------------------
+        await step(page, proxy, 'resume-continues-execution',
+            'Resume lets the engine run on, which the heartbeat advancing proves',
+            async () => {
+                if (!pausedForReal) {
+                    return { status: 'not-driven', instead: 'the engine never paused, so there was nothing to resume' };
+                }
+                // Take the breakpoint back off first, or the next heartbeat pauses again a second later and
+                // "did it resume" becomes a race with the answer.
+                const gutter = await deepLocate(page, UI.gutterLine, { text: String(line.number), exact: true });
+                if (gutter) {
+                    await page.mouse.click(gutter.x, gutter.y);
+                }
+
+                const resumed = await deepClick(page, UI.resumeButton);
+                if (!resumed) {
+                    throw new Error('no Resume button in the debugger toolbar');
+                }
+
+                const advanced = await waitFor(`the heartbeat to pass tick ${tickBeforeResume}`, async () => {
+                    const tick = await latestTick(page);
+                    return tick !== null && tickBeforeResume !== null && tick > tickBeforeResume ? tick : null;
+                }, { timeoutMs: STEP_TIMEOUT });
+
+                const info = await deepTexts(page, UI.infoMessage, 10, true);
+                return {
+                    tickWhenPaused: tickBeforeResume,
+                    tickAfterResume: advanced,
+                    callStackSays: info.find((text) => text === 'Not paused') ?? info.slice(0, 3),
+                };
+            });
+
+        environment.frontendConsoleErrors = frontendErrors;
+    } finally {
+        // Always, and only ever what this process started.
+        if (page) {
+            await page.close().catch(() => { /* already gone */ });
+        }
+        await browser.close().catch(() => { /* already gone */ });
+        await proxy.close();
+        jint.kill();
+    }
+
+    const protocol = await readProtocol(logPath);
+    environment.finishedAt = new Date().toISOString();
+    environment.jintOutputTail = jint.output().split(/\r?\n/).slice(-12);
+    environment.jintErrorTail = jint.errors().split(/\r?\n/).slice(-6);
+
+    const summary = { environment, steps: results, protocol };
+    await writeFile(join(outDir, 'summary.json'), `${JSON.stringify(summary, null, 2)}\n`);
+
+    console.log('\n--- verdict ------------------------------------------------------------------');
+    for (const entry of results) {
+        console.log(`${entry.status.toUpperCase().padEnd(11)} ${entry.step}${entry.error ? ` — ${entry.error}` : ''}`);
+    }
+    console.log(`\nout/summary.json, out/protocol.jsonl (${protocol.rows} frames), ${results.length} screenshots in out/.`);
+    if (environment.frontendConsoleErrors?.length) {
+        console.log(`\nthe front end's own console reported ${environment.frontendConsoleErrors.length} errors; summary.json has them all.`);
+    }
+
+    return results.some((entry) => entry.status === 'fail') ? 1 : 0;
+}
+
+process.exitCode = await main().catch((error) => {
+    console.error(`\n${error.message}`);
+    return 1;
+});


### PR DESCRIPTION
The engine-level DevTools protocol has been complete since #3629 and had never been reached by a host that
was not a test. This is the end-to-end pull request of the campaign (#3575): a way to attach to Jint without
writing a host, evidence that the package works in a published Native AOT binary, the Chrome front end
driven rather than described, and the documentation brought level with what landed.

## `Jint.Repl --inspect` and `--inspect-brk`

```
$ jint --inspect=0 -f demo.js -t 30
Debugger listening on ws://127.0.0.1:54796/devtools/page/5EB8F253FFCD410A8AC91A0D00000002
  front end: devtools://devtools/bundled/js_app.html?experiments=true&v8only=true&ws=127.0.0.1:54796/devtools/page/5EB8F253FFCD410A8AC91A0D00000002
  or open chrome://inspect, click Configure..., add 127.0.0.1:54796, and the target appears under Remote Target
```

The REPL owns its loop, so the target is `HostOwned` and the REPL pumps it. Three places that matters:

- **Between prompt inputs.** `Console.ReadLine` moves to another thread while the engine stays on this one,
  so a command a client sends while the prompt is waiting is answered there and then rather than after the
  next line is typed. The console read is the only thing that leaves the engine thread, and it touches no
  engine state.
- **After a `-f` script or a piped one finishes**, the engine stays attached: a timer still fires and a
  client can still read it. Ctrl+C exits.
- **`--inspect-brk` holds everything the host queued** until a client sends
  `Runtime.runIfWaitingForDebugger`, and the wait *pumps* rather than blocks, because that command is
  answered on the waiting thread.

`--inspect=[host:]port` chooses where to listen, `0` takes an ephemeral port and the banner names it, and a
port already in use is an error message rather than an unhandled exception. `-t` still bounds, and `--help`
says so along with the one interaction worth knowing: the timeout keeps counting while the debugger has the
engine paused.

## Native AOT, measured

`Jint.AotExample` now references `Jint.DevTools` and **deliberately does not root it** — a rooted subject
cannot measure anything, which is this project's own rule. The probe starts a server on an ephemeral port and
drives it with a hand-rolled `ClientWebSocket` client (a client package would put *that* package's AOT
behaviour into the measurement): `Target.getTargets`, a flattened `Target.attachToTarget`,
`Runtime.evaluate("6 * 7")` = 42, `Debugger.enable`, a breakpoint that pauses the engine with `twice` on top
of the stack, `Debugger.resume`, and the held evaluation answering 42.

Measured on a published `win-x64` native binary:

```
PASS  DevTools protocol over a socket: attach, evaluate, break, resume
ALL PROBES PASSED (32 probes, 4 known AOT gaps, 2 known trimming gaps)
```

ILC re-derived **69** IL diagnostics over the closed program, every one of them in a file under `Jint/`
(interop dataflow, the #3305 backlog) and **zero** attributed to `Jint.DevTools` or to the probe itself.
Both the `aot` legs now fail if that stops being true — unlike Jint's own inventory, which is summarised
rather than gated, this one gates at zero, because everything the protocol serializes goes through a
source-generated `System.Text.Json` context and the first reflective member would show up in that log and
nowhere else.

## The Chrome DevTools front end, driven

`tools/devtools-frontend-smoke/` launches Chrome for Testing, loads the **real** DevTools front end at the
revision that shipped in that Chrome (`6efd6eb1d…`, read from Chromium's DEPS at tag 148.0.7778.97, served
from `chrome-devtools-frontend.appspot.com` because Chrome refuses to navigate a page to `devtools://`),
points it at `Jint.Repl --inspect=0`, and asserts against what the front end *rendered*, through its own
shadow roots. It is not in CI — it downloads a browser and reads somebody else's markup, so a failure there
is a prompt to look rather than a regression by itself.

**Eight steps, eight passes, three consecutive clean runs.** What was read out of the DOM:

| # | Step | What the panel said |
| --- | --- | --- |
| 1 | front end connected | handshake completed, `Runtime.enable` answered, `Debugger.scriptParsed` arrived |
| 2 | Sources navigator lists the script | `…/tools/devtools-frontend-smoke/fixture/app.js` — the folder is expanded first, because a collapsed tree keeps its children in the document and asserting on one of those reports the DOM rather than the panel |
| 3 | the editor shows the retained source | `lineTotal`, `computeTotal`, `describeOrders`, `heartbeat`, `reconcile` all read back out of the CodeMirror content — `Debugger.getScriptSource` end to end |
| 4 | Console shows the log with its object preview | `order book ready {count: 3, total: 30.75, first: 'widget'}` — and that message was logged *before* the front end connected, so reading it back also proves the console journal Jint replays on `Runtime.enable` arrived |
| 5 | Console evaluates | `1+1` typed at the prompt, result row `2` |
| 6 | a gutter click sets a breakpoint that is hit | `Paused on breakpoint` at `30: total += lineTotal(items[i]);`, Call Stack `computeTotal` / `(anonymous)` |
| 7 | Scope pane populated | `Local`, `Global`; `this: Object`, `arguments: Arguments {0: Array(3)}`, `i: 0`, `items: (3) [{…}, {…}, {…}]`, `total: 0` |
| 8 | Resume continues | heartbeat tick 4 → 5 in the drawer console, Call Stack back to `Not paused` — execution continuing is what proves a resume; the indicator disappearing only proves the indicator disappeared |

Screenshots, a full shadow-DOM outline per step, `summary.json` and 87 frames of `protocol.jsonl` (recorded
by `tools/cdp-histogram/proxy.mjs`, imported rather than copied) land in a git-ignored `out/`. The README
carries an *Honesty* section naming every place a pass means something narrower than its name, and what was
not attempted at all (`--inspect-brk`, stepping, watch expressions, conditional breakpoints, the Profiler and
coverage panels, Memory and Performance).

### What driving the front end found

Four things no protocol test could have caught, all reproduced on demand and none of them fixed here:

1. **The frame the engine was entered at has `functionName: ""` and no `functionLocation`.** For a stack
   `declared ← named ← anonymous ← <interval callback>`, `Debugger.paused` names the first three correctly
   and the outermost not at all — whether it was written as a declaration, a named function expression or
   inline — so the name looks to be taken from the call site rather than from the function. Missing
   `functionLocation` also makes that call-stack row unclickable; V8 always sends it.
2. **`RemoteObject.description` for a function is a rendered label where the front end expects source text.**
   Jint sends `"ƒ computeTotal()"`; the front end treats that field as `Function.prototype.toString` output
   and parses the name back out of it, so every function in the Scope pane and in `Runtime.getProperties`
   renders as **`ƒ undefined()`** — 47 in one screenshot. Object *previews* are unaffected.
3. **`Runtime.consoleAPICalled` carries no `stackTrace`**, so no console message has a source anchor: the
   uncaught errors link to `app.js:48` from `exceptionDetails` while every `console.log` row has nothing
   where V8 puts the file and line.
4. **The front end calls `Runtime.getExceptionDetails` once per uncaught exception and is refused every
   time.** `Jint.DevTools/AGENTS.md` lists it as deliberately absent, which is a decision — but its premise
   was that no recorded client sends it, and those recordings never threw. It degrades rather than fails.

Two refusals are working as designed and are listed so nobody files them twice: `Network.*` is `-32601`
because an engine target has no Network domain, and `throwOnSideEffect` is `-32000`, which costs the Console
prompt its eager-evaluation preview and nothing else. One inconsistency wants a decision rather than a fix:
`/json/list` reports the target `url` as `file:///…/app.js` while `Debugger.scriptParsed` reports the same
file as the bare path `Jint.Repl` passed as its source name, which is why the navigator files it under
"(no domain)" with its whole path as the display name.

## Tests

`Jint.Tests.DevTools/Clients/PuppeteerSharpTests.cs` gains three:

- **a coverage round trip** — `startPreciseCoverage` → run → `takePreciseCoverage`, where the assertion that
  matters is the *second* one: coverage is a covered set, so a function that never ran has no entry anywhere
  in the engine and is reported with a zero count only because the domain derives it from the script's
  abstract syntax tree;
- **the REPL's `--inspect` from the outside** — spawned as a process, its port parsed out of its banner, and
  the engine that process ran its script in reached through it;
- **the REPL's `--inspect-brk`** — the negative half asserted as a bounded wait that must time out, then
  released with `Runtime.runIfWaitingForDebugger` and the script observed to have run. Checked in the other
  direction: with `--inspect=0` in place of `--inspect-brk=0` the test fails, which is what makes the
  timeout an assertion rather than a sleep.

`Jint.Tests.DevTools` takes a build-only `ProjectReference` on `Jint.Repl` so those two cannot silently pass
by spawning nothing.

## Documentation

- **`Jint.DevTools/docs/manual-checklist.md`** — `chrome://inspect` → Configure → the port, what each panel
  should show, and what is expected to be empty and why. Referenced from the package's `AGENTS.md`, which
  previously said this checklist was the thing that did not exist yet.
- **README** — the DevTools section said `Debugger`, `Profiler`, `Console` and `Log` "arrive in later
  releases". They arrived. It now says what answers, how to try it without writing a host, and states the
  AOT claim as the measurement above rather than as a property.
- **`docs/design/devtools-protocol.md`** — §5 records that engine seams E1–E5 are all merged (#3587, #3614,
  #3623, #3622, #3597) and names the three seams the build wanted and did not get: #3630 (the sampler
  publishes no public tables, so the profile is not its samples), #3631 (`ExceptionPauseMode` has no
  `Caught`, and declining a pause cancels a step in flight), #3632 (a frame carries a source name rather
  than the `Program`). §8 describes the verification that exists rather than the verification that was
  intended.

## Verification

Full solution green in Release: `Jint.Tests` 11873/11879 on net10.0, net8.0 and net472 (5 skipped),
`Jint.Tests.DevTools` 337/337 on both legs and **green again under `JINT_HOST_CONTRACT_VERIFICATION=1`**,
`Jint.Tests.PublicInterface` 3517/3538 on all three legs, `Jint.Tests.Test262` 102573/102688,
`Jint.Tests.CommonScripts` 28/28, `Jint.Tests.SourceGenerators` 71/71.

Part of #3575.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
