### PR TITLE
Engine: a frame the engine was entered at has a name, and a timer callback has a frame

### DIFF
--- a/Jint.Tests.PublicInterface/ValueInspectorTests.cs
+++ b/Jint.Tests.PublicInterface/ValueInspectorTests.cs
@@ -180,6 +180,55 @@ public class ValueInspectorTests
     }
 
     [Test]
+    public void AFunctionCanBeDescribedByItsSourceInstead()
+    {
+        var options = new ValueInspectorOptions { FunctionSourceText = true };
+        var engine = new Engine(o => o.RetainFunctionSourceText = true);
+
+        // What Function.prototype.toString returns, which is what a debugger protocol's client parses.
+        ValueInspector.Describe(engine.Evaluate("function f(a, b) { return 1; }; f"), options)
+            .Description.Should().Be("function f(a, b) { return 1; }");
+        ValueInspector.Describe(engine.Evaluate("(function () {})"), options)
+            .Description.Should().Be("function () {}");
+        ValueInspector.Describe(engine.Evaluate("class C { m() {} }; C"), options)
+            .Description.Should().Be("class C { m() {} }");
+
+        // Nothing the parser built a declaration for falls back to the placeholder, exactly as toString does.
+        ValueInspector.Describe(engine.Evaluate("Math.max"), options)
+            .Description.Should().Be("function max() { [native code] }");
+    }
+
+    [Test]
+    public void ASourceTextDescriptionStillRunsNothing()
+    {
+        var engine = new Engine(o => o.RetainFunctionSourceText = true);
+        var value = engine.Evaluate(
+            """
+            (function () {
+                var f = Math.min;
+                Object.defineProperty(f, 'name', { get: function () { throw new Error('read'); } });
+                return f;
+            })()
+            """);
+
+        // A native function whose name a script replaced with an accessor: the name is left out rather
+        // than read, which is the same answer bind's own result gives.
+        ValueInspector.Describe(value, new ValueInspectorOptions { FunctionSourceText = true })
+            .Description.Should().Be("function () { [native code] }");
+    }
+
+    [Test]
+    public void WithoutSourceTextRetainedEvenAScriptFunctionIsThePlaceholder()
+    {
+        var engine = new Engine();
+
+        ValueInspector.Describe(
+                engine.Evaluate("function f(a) { return a; }; f"),
+                new ValueInspectorOptions { FunctionSourceText = true })
+            .Description.Should().Be("function f() { [native code] }");
+    }
+
+    [Test]
     public void ThePlainCollectionsCarryTheirSizeAndTheirEntries()
     {
         var array = Describe("[1, 'x', null]");

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
@@ -907,6 +907,7 @@ namespace Jint.Diagnostics
     public sealed class ValueInspectorOptions
     {
         public ValueInspectorOptions() { }
+        public bool FunctionSourceText { get; init; }
         public int MaxDepth { get; init; }
         public int MaxEntries { get; init; }
         public int MaxStringLength { get; init; }
@@ -2823,6 +2824,7 @@ namespace Jint.WebApi
     public abstract class ConsoleSink
     {
         protected ConsoleSink() { }
+        public virtual bool WantsStackTrace { get; }
         public static Jint.WebApi.ConsoleSink Null { get; }
         public virtual void Write(in Jint.WebApi.ConsoleRecord record) { }
         public abstract void Write(Jint.WebApi.ConsoleLogLevel level, string message);

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net472.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net472.verified.txt
@@ -733,6 +733,7 @@ namespace Jint.Diagnostics
     public sealed class ValueInspectorOptions
     {
         public ValueInspectorOptions() { }
+        public bool FunctionSourceText { get; init; }
         public int MaxDepth { get; init; }
         public int MaxEntries { get; init; }
         public int MaxStringLength { get; init; }

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
@@ -907,6 +907,7 @@ namespace Jint.Diagnostics
     public sealed class ValueInspectorOptions
     {
         public ValueInspectorOptions() { }
+        public bool FunctionSourceText { get; init; }
         public int MaxDepth { get; init; }
         public int MaxEntries { get; init; }
         public int MaxStringLength { get; init; }
@@ -2823,6 +2824,7 @@ namespace Jint.WebApi
     public abstract class ConsoleSink
     {
         protected ConsoleSink() { }
+        public virtual bool WantsStackTrace { get; }
         public static Jint.WebApi.ConsoleSink Null { get; }
         public virtual void Write(in Jint.WebApi.ConsoleRecord record) { }
         public abstract void Write(Jint.WebApi.ConsoleLogLevel level, string message);

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.0.verified.txt
@@ -733,6 +733,7 @@ namespace Jint.Diagnostics
     public sealed class ValueInspectorOptions
     {
         public ValueInspectorOptions() { }
+        public bool FunctionSourceText { get; init; }
         public int MaxDepth { get; init; }
         public int MaxEntries { get; init; }
         public int MaxStringLength { get; init; }

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.1.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.1.verified.txt
@@ -733,6 +733,7 @@ namespace Jint.Diagnostics
     public sealed class ValueInspectorOptions
     {
         public ValueInspectorOptions() { }
+        public bool FunctionSourceText { get; init; }
         public int MaxDepth { get; init; }
         public int MaxEntries { get; init; }
         public int MaxStringLength { get; init; }

--- a/Jint.Tests.PublicInterface/WebApiConsoleRecordTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiConsoleRecordTests.cs
@@ -44,6 +44,26 @@ public class WebApiConsoleRecordTests
         public override void Write(ConsoleLogLevel level, string message) => Lines.Add(message);
     }
 
+    /// <summary>A sink that asks for the call site of every record, not just <c>console.trace</c>'s.</summary>
+    private sealed class FrameHungrySink : ConsoleSink
+    {
+        internal List<ConsoleRecordSnapshot> Records { get; } = new();
+
+        public override bool WantsStackTrace => true;
+
+        public override void Write(ConsoleLogLevel level, string message)
+        {
+        }
+
+        public override void Write(in ConsoleRecord record)
+        {
+            Records.Add(new ConsoleRecordSnapshot(record.Method, record.StackTrace));
+        }
+    }
+
+    /// <summary>What a sink may keep of a record, since the record itself is only valid during the call.</summary>
+    private sealed record ConsoleRecordSnapshot(ConsoleMethod Method, IReadOnlyList<ConsoleStackFrame>? StackTrace);
+
     /// <summary>A sink written before the record overload existed, which must not notice that it does.</summary>
     private sealed class StringOnlySink : ConsoleSink
     {
@@ -198,9 +218,25 @@ public class WebApiConsoleRecordTests
     }
 
     [Test]
-    public void OnlyTraceCarriesFrames()
+    public void ASinkThatDoesNotAskForFramesGetsThemForTraceAlone()
     {
         Run("console.log('x')").Records.Should().ContainSingle().Which.StackTrace.Should().BeNull();
+    }
+
+    [Test]
+    public void ASinkThatAsksForFramesGetsTheCallSiteOfEveryMethod()
+    {
+        var sink = new FrameHungrySink();
+        var engine = new Engine(options => options.UseConsole(sink));
+        engine.Execute("function speak() { console.log('x'); } speak();", "app.js");
+
+        var frames = sink.Records.Should().ContainSingle().Which.StackTrace;
+        frames.Should().NotBeNull();
+
+        // The console method's own frame is not one of them: the trace starts where the script called it.
+        frames![0].FunctionName.Should().Be("speak");
+        frames[0].Source.Should().Be("app.js");
+        frames[0].Line.Should().Be(1);
     }
 
     [Test]

--- a/Jint.Tests/Runtime/CallStackEntryFrameTests.cs
+++ b/Jint.Tests/Runtime/CallStackEntryFrameTests.cs
@@ -1,0 +1,200 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using Jint.Native;
+using Jint.Runtime;
+using Jint.Runtime.Debugger;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// The frame the engine was <i>entered</i> at — a host <c>Invoke</c>, a timer callback, a microtask — and
+/// what it is called in a stack trace and in the debugger's call stack.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every other frame is created by a call expression, which carries a callee expression the engine can name
+/// a frame after. An entry frame has none: nothing in script called it. Until this suite, that showed up as
+/// a frame with the empty string for a name, and — for the timer callbacks, which reached the function
+/// through <c>ICallable.Call</c> and pushed nothing — as no frame at all.
+/// </para>
+/// </remarks>
+public class CallStackEntryFrameTests
+{
+    private static Engine WithTimers()
+    {
+        return new Engine(options => options.UseWebApis(WebApiFeatures.Timers | WebApiFeatures.Console));
+    }
+
+    /// <summary>The frames of <c>Error.prototype.stack</c>, one per line, whitespace trimmed.</summary>
+    private static string[] StackLines(JsValue error)
+    {
+        var stack = error.AsObject().Get("stack").AsString();
+        return stack.Split('\n', StringSplitOptions.RemoveEmptyEntries).Select(line => line.Trim()).ToArray();
+    }
+
+    [Test]
+    public void AHostInvokedNamedFunctionNamesItsOwnFrame()
+    {
+        var engine = new Engine();
+        engine.Execute("function declared() { return new Error('x'); }", "app.js");
+
+        var error = engine.Invoke("declared");
+
+        // The trailing line is the top-level program frame every rendered trace ends with.
+        StackLines(error)[0].Should().StartWith("at declared (app.js:");
+    }
+
+    [Test]
+    public void AHostInvokedAnonymousFunctionIsAnonymousRatherThanNameless()
+    {
+        var engine = new Engine();
+        var callable = engine.Evaluate("(function () { return new Error('x'); })", "app.js");
+
+        var error = engine.Invoke(callable);
+
+        // The call site gave no name and the function has none of its own, so the frame is anonymous — the
+        // same word an immediately invoked function expression already got, rather than an empty one.
+        StackLines(error)[0].Should().StartWith("at (anonymous) (app.js:");
+    }
+
+    [Test]
+    public void ATimerCallbackHasAFrameOfItsOwn()
+    {
+        var engine = WithTimers();
+        engine.SetValue("report", new Action<JsValue>(value => _reported = value));
+        engine.Execute(
+            """
+            setTimeout(function reconcile() {
+                report(new Error('x'));
+            }, 0);
+            """,
+            "app.js");
+
+        engine.Tasks.ProcessTasks();
+
+        _reported.Should().NotBeNull();
+        StackLines(_reported!).Should().SatisfyRespectively(
+            frame => frame.Should().StartWith("at reconcile (app.js:"),
+            frame => frame.Should().StartWith("at app.js:"));
+    }
+
+    [Test]
+    public void AnAnonymousTimerCallbackIsAnonymousRatherThanAbsent()
+    {
+        var engine = WithTimers();
+        engine.SetValue("report", new Action<JsValue>(value => _reported = value));
+        engine.Execute("setTimeout(function () { report(new Error('x')); }, 0);", "app.js");
+
+        engine.Tasks.ProcessTasks();
+
+        StackLines(_reported!)[0].Should().StartWith("at (anonymous) (app.js:");
+    }
+
+    [Test]
+    public void AMicrotaskCallbackHasAFrameOfItsOwn()
+    {
+        var engine = WithTimers();
+        engine.SetValue("report", new Action<JsValue>(value => _reported = value));
+        engine.Execute("queueMicrotask(function drain() { report(new Error('x')); });", "app.js");
+
+        engine.Tasks.ProcessTasks();
+
+        StackLines(_reported!)[0].Should().StartWith("at drain (app.js:");
+    }
+
+    [Test]
+    public void TheNameIsTheFunctionsOwnAndIsNotReadThroughAGetter()
+    {
+        var engine = new Engine();
+        var callable = engine.Evaluate(
+            """
+            (function () {
+                var f = function () { return new Error('x'); };
+                Object.defineProperty(f, 'name', { get: function () { throw new Error('read'); } });
+                return f;
+            })()
+            """,
+            "app.js");
+
+        // Naming a frame must never run script: an accessor `name` leaves the frame anonymous rather than
+        // hijacking the stack trace of an error being constructed.
+        var error = engine.Invoke(callable);
+
+        StackLines(error)[0].Should().StartWith("at (anonymous) (app.js:");
+    }
+
+    [Test]
+    public void TheDebuggerNamesAndLocatesTheFrameATimerCallbackEntered()
+    {
+        var engine = new Engine(options =>
+        {
+            options.UseWebApis(WebApiFeatures.Timers);
+            options.Debugger.Enabled = true;
+            options.Debugger.StatementHandling = DebuggerStatementHandling.Script;
+        });
+
+        DebugCallStack? stack = null;
+        engine.Debugger.Break += (_, info) =>
+        {
+            stack = info.CallStack;
+            return StepMode.None;
+        };
+
+        engine.Execute(
+            """
+            function inner() {
+                debugger;
+            }
+
+            setTimeout(function reconcile() {
+                inner();
+            }, 0);
+            """,
+            "app.js");
+
+        engine.Tasks.ProcessTasks();
+
+        stack.Should().NotBeNull();
+        stack!.Select(frame => frame.FunctionName).Should().Equal("inner", "reconcile", "(anonymous)");
+
+        // The row a front end makes clickable. The callback's declaration is on line 5 of the fixture.
+        stack[1].FunctionLocation.Should().NotBeNull();
+        stack[1].FunctionLocation!.Value.Start.Line.Should().Be(5);
+    }
+
+    [Test]
+    public void TheDebuggerNamesAndLocatesTheFrameAHostInvokeEntered()
+    {
+        var engine = new Engine(options =>
+        {
+            options.Debugger.Enabled = true;
+            options.Debugger.StatementHandling = DebuggerStatementHandling.Script;
+        });
+
+        DebugCallStack? stack = null;
+        engine.Debugger.Break += (_, info) =>
+        {
+            stack = info.CallStack;
+            return StepMode.None;
+        };
+
+        engine.Execute(
+            """
+            function entered() {
+                debugger;
+            }
+            """,
+            "app.js");
+
+        engine.Invoke("entered");
+
+        stack.Should().NotBeNull();
+        stack!.Select(frame => frame.FunctionName).Should().Equal("entered", "(anonymous)");
+        stack[0].FunctionLocation.Should().NotBeNull();
+        stack[0].FunctionLocation!.Value.Start.Line.Should().Be(1);
+    }
+
+    private JsValue? _reported;
+}
+#endif

--- a/Jint.Tests/Runtime/WebApi/ConsoleStackTraceTests.cs
+++ b/Jint.Tests/Runtime/WebApi/ConsoleStackTraceTests.cs
@@ -1,0 +1,118 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using Jint.WebApi;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// <see cref="ConsoleSink.WantsStackTrace"/>: the call site a console message came from, which a debugger
+/// protocol anchors the message to and no other sink pays for.
+/// </summary>
+/// <remarks>
+/// The frames are only readable while the call is still on the stack, so the engine either captures them
+/// before the sink is reached or not at all — which is why this is a question asked of the sink rather than
+/// something a sink could compute for itself once it has the record.
+/// </remarks>
+public class ConsoleStackTraceTests
+{
+    private sealed class RecordingSink(bool wantsStackTrace) : ConsoleSink
+    {
+        internal List<(ConsoleMethod Method, IReadOnlyList<ConsoleStackFrame>? StackTrace)> Records { get; } = [];
+
+        public override bool WantsStackTrace => wantsStackTrace;
+
+        public override void Write(ConsoleLogLevel level, string message)
+        {
+        }
+
+        public override void Write(in ConsoleRecord record)
+        {
+            Records.Add((record.Method, record.StackTrace));
+        }
+    }
+
+    private static RecordingSink Run(string script, bool wantsStackTrace, string source = "app.js")
+    {
+        var sink = new RecordingSink(wantsStackTrace);
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Console | WebApiFeatures.Timers).UseConsole(sink));
+        engine.Execute(script, source);
+        engine.Tasks.ProcessTasks();
+        return sink;
+    }
+
+    [Test]
+    public void ASinkThatDoesNotAskGetsNoFramesAndPaysForNone()
+    {
+        var sink = Run("console.log('hello');", wantsStackTrace: false);
+
+        sink.Records.Should().ContainSingle().Which.StackTrace.Should().BeNull();
+    }
+
+    [Test]
+    public void ASinkThatAsksGetsTheCallSiteOfEveryMethod()
+    {
+        var sink = Run(
+            """
+            function inner() {
+                console.log('hello');
+            }
+
+            function outer() {
+                inner();
+            }
+
+            outer();
+            """,
+            wantsStackTrace: true);
+
+        var frames = sink.Records.Should().ContainSingle().Which.StackTrace;
+        frames.Should().NotBeNull();
+
+        // Innermost first, and the console method's own frame is not one of them — the trace starts where
+        // the script called it.
+        frames!.Select(frame => frame.FunctionName).Should().Equal("inner", "outer", "");
+        frames[0].Source.Should().Be("app.js");
+        frames[0].Line.Should().Be(2);
+        frames[0].Column.Should().BeGreaterThan(0);
+    }
+
+    [Test]
+    public void ConsoleTraceStillCarriesItsOwnFramesWithoutBeingAsked()
+    {
+        var sink = Run("function f() { console.trace('why'); } f();", wantsStackTrace: false);
+
+        sink.Records.Should().ContainSingle().Which.StackTrace.Should().NotBeNull();
+        sink.Records[0].StackTrace![0].FunctionName.Should().Be("f");
+    }
+
+    [Test]
+    public void AMessageLoggedFromATimerCallbackAnchorsInsideTheCallback()
+    {
+        var sink = Run(
+            """
+            setTimeout(function heartbeat() {
+                console.log('tick');
+            }, 0);
+            """,
+            wantsStackTrace: true);
+
+        var frames = sink.Records.Should().ContainSingle().Which.StackTrace;
+        frames.Should().NotBeNull();
+        frames!.Select(frame => frame.FunctionName).Should().Equal("heartbeat", "");
+        frames[0].Line.Should().Be(2);
+    }
+
+    [Test]
+    public void AMethodThatPrintsNothingStillCarriesItsCallSite()
+    {
+        // groupEnd prints nothing, so it exists only as a record — and a front end that draws a group from
+        // the record still wants to know where it came from.
+        var sink = Run("console.group('g'); console.groupEnd();", wantsStackTrace: true);
+
+        sink.Records.Should().HaveCount(2);
+        sink.Records[1].Method.Should().Be(ConsoleMethod.GroupEnd);
+        sink.Records[1].StackTrace.Should().NotBeNull();
+    }
+}
+#endif

--- a/Jint/Diagnostics/ValueDescription.cs
+++ b/Jint/Diagnostics/ValueDescription.cs
@@ -266,4 +266,25 @@ public sealed class ValueInspectorOptions
 
     /// <summary>Gets how long a string may be before it is truncated with an ellipsis. Defaults to 100.</summary>
     public int MaxStringLength { get; init; } = 100;
+
+    /// <summary>
+    /// Gets whether a function is described by its source text rather than by a short label. Defaults to
+    /// <see langword="false"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The short label is <c>ƒ name()</c>, which is what a console prints. The source text is what
+    /// <c>Function.prototype.toString</c> returns — the declaration itself when
+    /// <see cref="Options.RetainFunctionSourceText"/> kept it, and
+    /// <c>function name() { [native code] }</c> otherwise — which is what a debugger protocol's client
+    /// parses a function out of.
+    /// </para>
+    /// <para>
+    /// Either way the answer is produced without running script: a <c>name</c> a script replaced with an
+    /// accessor is reported as absent rather than read, so a function described while the engine is paused
+    /// stays exactly as it was. The host's <c>Options.Host.FunctionToStringHandler</c> is not consulted
+    /// either, for the same reason.
+    /// </para>
+    /// </remarks>
+    public bool FunctionSourceText { get; init; }
 }

--- a/Jint/Diagnostics/ValueInspector.cs
+++ b/Jint/Diagnostics/ValueInspector.cs
@@ -75,6 +75,7 @@ public static class ValueInspector
         private readonly int _maxEntries;
         private readonly int _maxDepth;
         private readonly int _maxStringLength;
+        private readonly bool _functionSourceText;
         private List<ObjectInstance>? _path;
 
         internal Walker(ValueInspectorOptions options)
@@ -82,6 +83,7 @@ public static class ValueInspector
             _maxEntries = System.Math.Max(0, options.MaxEntries);
             _maxDepth = System.Math.Clamp(options.MaxDepth, 0, DepthCeiling);
             _maxStringLength = System.Math.Max(0, options.MaxStringLength);
+            _functionSourceText = options.FunctionSourceText;
             _path = null;
         }
 
@@ -134,7 +136,11 @@ public static class ValueInspector
 
             if (obj is Function function)
             {
-                return new ValueDescription(ValueKind.Function, FunctionText(function), ValueSlotReader.ConstructorName(obj));
+                var text = _functionSourceText
+                    ? ValueSlotReader.FunctionSourceText(function)
+                    : FunctionText(function);
+
+                return new ValueDescription(ValueKind.Function, text, ValueSlotReader.ConstructorName(obj));
             }
 
             // Everything below may carry entries, so it takes part in both the cycle and the depth bound.

--- a/Jint/Diagnostics/ValueSlotReader.cs
+++ b/Jint/Diagnostics/ValueSlotReader.cs
@@ -91,6 +91,28 @@ internal static class ValueSlotReader
         return declaration.Generator ? "GeneratorFunction" : "Function";
     }
 
+    /// <summary>
+    /// What <c>Function.prototype.toString</c> answers for a function, produced without running script.
+    /// </summary>
+    /// <remarks>
+    /// The declaration itself when the parser retained the source text, and
+    /// <c>function name() { [native code] }</c> otherwise — the same two answers
+    /// <see cref="Function.ToString"/> gives, minus the two things a describing path may not do: it neither
+    /// calls the host's <c>FunctionToStringHandler</c> nor coerces a <c>name</c> a script replaced with an
+    /// accessor. A name that cannot be read that way is left out, which is what
+    /// <c>Function.prototype.bind</c>'s own result already looks like.
+    /// </remarks>
+    internal static string FunctionSourceText(Function function)
+    {
+        if (function.TryGetOwnSourceText(out var sourceText))
+        {
+            return sourceText;
+        }
+
+        var name = function.GetOwnFunctionNameForDisplay()?.TrimStart('#') ?? "";
+        return "function " + name + "() { [native code] }";
+    }
+
     /// <summary>The half of an accessor property a renderer may report, since it may call neither.</summary>
     internal static string AccessorLabel(PropertyDescriptor descriptor)
     {

--- a/Jint/Native/Error/ErrorConstructor.cs
+++ b/Jint/Native/Error/ErrorConstructor.cs
@@ -78,18 +78,28 @@ public sealed partial class ErrorConstructor : Constructor
     /// </summary>
     internal static ErrorStackCapture? BuildStackTraceCapture(Engine engine, JsValue constructor)
     {
+        var callStack = engine.CallStack;
+        var currentFunction = callStack.TryPeek(out var element) ? element.Function : null;
+
+        // If the current function is the error constructor itself (i.e. "throw new Error(...)" was called
+        // from script), exclude it from the stack trace, because the trace should begin at the throw point.
+        return BuildStackTraceCapture(engine, currentFunction == constructor ? 1 : 0);
+    }
+
+    /// <summary>
+    /// Captures a deferred snapshot of the call stack with the top <paramref name="excludeTop"/> frames left
+    /// out, so a dispatcher that is itself on the stack can report the call site rather than itself.
+    /// </summary>
+    /// <remarks>Returns <see langword="null"/> when there is no active script location.</remarks>
+    internal static ErrorStackCapture? BuildStackTraceCapture(Engine engine, int excludeTop)
+    {
         var lastSyntaxNode = engine.GetLastSyntaxElement();
         if (lastSyntaxNode == null)
         {
             return null;
         }
 
-        var callStack = engine.CallStack;
-        var currentFunction = callStack.TryPeek(out var element) ? element.Function : null;
-
-        // If the current function is the error constructor itself (i.e. "throw new Error(...)" was called
-        // from script), exclude it from the stack trace, because the trace should begin at the throw point.
-        var frames = callStack.SnapshotFrames(currentFunction == constructor ? 1 : 0);
+        var frames = engine.CallStack.SnapshotFrames(excludeTop);
         return new ErrorStackCapture(engine, lastSyntaxNode.Location, frames);
     }
 

--- a/Jint/Native/Function/Function.cs
+++ b/Jint/Native/Function/Function.cs
@@ -609,6 +609,21 @@ public abstract partial class Function : ObjectInstance, ICallable
     }
 
     /// <summary>
+    /// The retained source text of this function's declaration, for a describing path that may not run
+    /// script and may not call the host's <c>FunctionToStringHandler</c>.
+    /// </summary>
+    /// <remarks>
+    /// The same text <see cref="ToString"/> returns when <see cref="Options.RetainFunctionSourceText"/> kept
+    /// it. False for every function the parser did not build one for — a <c>ClrFunction</c>, a bound
+    /// function, anything native — and for a program parsed with retention off.
+    /// </remarks>
+    internal bool TryGetOwnSourceText([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out string? sourceText)
+    {
+        sourceText = _functionDefinition?.GetSourceText();
+        return sourceText is not null;
+    }
+
+    /// <summary>
     /// The function's own <c>name</c> as a string, or the empty string when it has none. Resolved off the
     /// descriptor field rather than through <c>Get</c> so the answer is the function's
     /// own name and not something inherited, and a pending descriptor stands for the definition's

--- a/Jint/Runtime/CallStack/CallStackElement.cs
+++ b/Jint/Runtime/CallStack/CallStackElement.cs
@@ -36,19 +36,35 @@ internal readonly struct CallStackElement : IEquatable<CallStackElement>
 
     public NodeList<Node>? Arguments => Function._functionDefinition?.Function.Params;
 
+    /// <summary>
+    /// What the frame is called in a stack trace and in the debugger's call stack: the function's own
+    /// <c>name</c>, the call-site expression when it has none, and <c>(anonymous)</c> when neither says
+    /// anything.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The name is read as a descriptor rather than through <c>[[Get]]</c>. <c>name</c> is configurable on
+    /// every function, so a script may replace it with an accessor — and naming a frame happens while an
+    /// error's stack trace is being built, where running script would let that accessor hijack the error.
+    /// A name that cannot be read without running something is treated as absent.
+    /// </para>
+    /// <para>
+    /// A frame the engine was <i>entered</i> at — a host <c>Invoke</c>, a timer callback — has no call-site
+    /// expression, because nothing in script called it. Falling out of both sources therefore has to answer
+    /// <c>(anonymous)</c>, the word an immediately invoked function expression already got, rather than the
+    /// empty string, which renders as a frame with no name at all.
+    /// </para>
+    /// </remarks>
     public override string ToString()
     {
-        var name = TypeConverter.ToString(Function.Get(CommonProperties.Name));
+        var name = Function.GetOwnFunctionNameForDisplay();
 
-        if (string.IsNullOrWhiteSpace(name))
+        if (string.IsNullOrWhiteSpace(name) && Expression is not null)
         {
-            if (Expression is not null)
-            {
-                name = JintExpression.ToString(Expression._expression);
-            }
+            name = JintExpression.ToString(Expression._expression);
         }
 
-        return name ?? "(anonymous)";
+        return string.IsNullOrWhiteSpace(name) ? "(anonymous)" : name!;
     }
 
     public bool Equals(CallStackElement other)

--- a/Jint/WebApi/Console/ConsoleInstance.cs
+++ b/Jint/WebApi/Console/ConsoleInstance.cs
@@ -474,6 +474,15 @@ internal sealed partial class ConsoleInstance : BuiltinShapeObject
         ConsoleStackFrame[]? stackTrace = null)
     {
         var sink = _engine.Options.WebApi.Console.Sink ?? ConsoleSink.Null;
+
+        if (stackTrace is null && sink.WantsStackTrace)
+        {
+            // The frame on top of the stack is the console method the script called, and a trace has to
+            // start at the call site below it — which is what console.trace gets by naming its own function
+            // object, and what every other method reaches here without one to name.
+            stackTrace = StackFrames(ErrorConstructor.BuildStackTraceCapture(_engine, excludeTop: 1));
+        }
+
         var record = new ConsoleRecord(
             method,
             level,

--- a/Jint/WebApi/ConsoleRecord.cs
+++ b/Jint/WebApi/ConsoleRecord.cs
@@ -145,18 +145,23 @@ public readonly struct ConsoleRecord
     public int GroupDepth { get; }
 
     /// <summary>
-    /// Gets the captured call stack for a <c>console.trace</c> record, or <see langword="null"/> for every
-    /// other method.
+    /// Gets the call stack the console method was called from, innermost frame first, or
+    /// <see langword="null"/> when none was captured.
     /// </summary>
     /// <remarks>
-    /// The frames are the ones rendered into <see cref="Message"/>, innermost first, read from the same
-    /// capture — so the two describe the same call stack.
+    /// <para>
+    /// A <c>console.trace</c> record always carries them, and they are the frames rendered into
+    /// <see cref="Message"/> — read from the same capture, so the two describe one call stack. Every other
+    /// method carries them only when the sink asked, through
+    /// <see cref="ConsoleSink.WantsStackTrace"/>: walking the stack for each call costs something, and a
+    /// host that never reads the frames should not pay it.
+    /// </para>
     /// </remarks>
     public IReadOnlyList<ConsoleStackFrame>? StackTrace { get; }
 }
 
 /// <summary>
-/// One frame of a <c>console.trace</c> record's call stack. Requires .NET 8 or higher.
+/// One frame of a console record's call stack. Requires .NET 8 or higher.
 /// </summary>
 [StructLayout(LayoutKind.Auto)]
 public readonly struct ConsoleStackFrame

--- a/Jint/WebApi/ConsoleSink.cs
+++ b/Jint/WebApi/ConsoleSink.cs
@@ -22,10 +22,11 @@ namespace Jint.WebApi;
 /// </para>
 /// <para>
 /// <b>A sink may take the record instead of the line.</b> <see cref="Write(in ConsoleRecord)"/> carries the
-/// method that was called, its raw arguments as <see cref="Native.JsValue"/>s, the group depth and, for
-/// <c>console.trace</c>, the captured frames — everything a structured log or a debugger protocol needs and
-/// a finished string has already thrown away. It is what the engine calls, for every invocation including
-/// the ones that print nothing, and it forwards to the string overload by default.
+/// method that was called, its raw arguments as <see cref="Native.JsValue"/>s, the group depth and the
+/// captured frames — everything a structured log or a debugger protocol needs and a finished string has
+/// already thrown away. It is what the engine calls, for every invocation including the ones that print
+/// nothing, and it forwards to the string overload by default. Frames reach a method other than
+/// <c>console.trace</c> only when <see cref="WantsStackTrace"/> asks for them.
 /// </para>
 /// </remarks>
 public abstract class ConsoleSink
@@ -90,6 +91,23 @@ public abstract class ConsoleSink
             Write(record.Level, message);
         }
     }
+
+    /// <summary>
+    /// Whether every record should carry <see cref="ConsoleRecord.StackTrace"/>, not just <c>console.trace</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A call site is what a debugger protocol anchors a console message to, and the frames are only readable
+    /// while the call is still on the stack — so the engine has to capture them before the sink is reached,
+    /// or not at all. Walking the call stack for every <c>console.log</c> is not free, so it is off unless a
+    /// sink says it reads them.
+    /// </para>
+    /// <para>
+    /// The value is read once per record, so a sink may change its mind between calls. A sink that answers
+    /// <see langword="true"/> and never reads <see cref="ConsoleRecord.StackTrace"/> is paying for nothing.
+    /// </para>
+    /// </remarks>
+    public virtual bool WantsStackTrace => false;
 
     private sealed class NullConsoleSink : ConsoleSink
     {

--- a/Jint/WebApi/Idle/IdleCallbackQueue.cs
+++ b/Jint/WebApi/Idle/IdleCallbackQueue.cs
@@ -338,7 +338,8 @@ internal sealed class IdleCallbackQueue
     {
         try
         {
-            entry.Callback.Call(JsValue.Undefined, [deadline]);
+            // Through Engine.Call, so the callback owns a call-stack frame: see TimerEntry.Fire.
+            _engine.Call(entry.Callback, JsValue.Undefined, [deadline], expression: null);
         }
         catch (JavaScriptException exception) when (_engine._webApi?.Diagnostics is { } diagnostics)
         {

--- a/Jint/WebApi/Scheduling/SchedulerQueue.cs
+++ b/Jint/WebApi/Scheduling/SchedulerQueue.cs
@@ -526,7 +526,8 @@ internal sealed class SchedulerTask
             JsValue result;
             try
             {
-                result = _callback.Call(JsValue.Undefined);
+                // Through Engine.Call, so the callback owns a call-stack frame: see TimerEntry.Fire.
+                result = _scheduler.Engine.Call(_callback, JsValue.Undefined, Arguments.Empty, expression: null);
             }
             catch (JavaScriptException ex)
             {

--- a/Jint/WebApi/Timers/TimerFunctions.cs
+++ b/Jint/WebApi/Timers/TimerFunctions.cs
@@ -203,7 +203,8 @@ internal sealed class TimerFunctions
     {
         try
         {
-            callback.Call(JsValue.Undefined);
+            // Through Engine.Call, so the callback owns a call-stack frame: see TimerEntry.Fire.
+            _engine.Call(callback, JsValue.Undefined, Arguments.Empty, expression: null);
         }
         catch (JavaScriptException exception) when (_engine._webApi?.Diagnostics is { } diagnostics)
         {

--- a/Jint/WebApi/Timers/TimerQueue.cs
+++ b/Jint/WebApi/Timers/TimerQueue.cs
@@ -52,9 +52,10 @@ internal sealed class TimerQueue
     }
 
     /// <summary>
-    /// The engine these timers belong to. Reached from <see cref="TimerEntry.Fire"/> alone, and only on the
-    /// path where a callback threw — the web-API state it leads to is where HTML's <i>report an exception</i>
-    /// finds a global <c>error</c> listener, if there is one.
+    /// The engine these timers belong to. Reached from <see cref="TimerEntry.Fire"/> alone: to call the
+    /// callback through <c>Engine.Call</c>, so it gets a call-stack frame of its own, and — where one threw
+    /// — to reach the web-API state where HTML's <i>report an exception</i> finds a global <c>error</c>
+    /// listener, if there is one.
     /// </summary>
     internal Engine Engine { get; }
 
@@ -366,7 +367,11 @@ internal sealed class TimerEntry
             // Step 8.4: "If handler is a Function, then invoke handler given arguments and "report"". WebIDL's
             // "report" exception behavior is to report the exception and return undefined, which is what the
             // catch below does whenever the host gave the engine somewhere to report to.
-            _callback.Call(JsValue.Undefined, _arguments);
+            //
+            // Through Engine.Call rather than ICallable.Call, so the callback gets a call-stack frame of its
+            // own: this is where the engine is entered, and a frame nothing pushed is a frame absent from
+            // every stack trace, from console.trace and from the debugger's call stack.
+            _queue.Engine.Call(_callback, JsValue.Undefined, _arguments, expression: null);
         }
         catch (JavaScriptException exception) when (_queue.Diagnostics is { } diagnostics)
         {

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -4771,6 +4771,36 @@ string. There is no option to restore the old output. To write a year beside a m
 year-month, name the fields instead of the style — `{ year: 'numeric', month: 'long', day: 'numeric' }` — and
 supply the value that should stand in the field the type does not have.
 
+### 4.108 A frame the engine was entered at is named, and a timer callback has one ([#3635](https://github.com/sebastienros/jint/pull/3635))
+
+Every frame in a stack trace but one is created by a call expression, and a call expression carries a callee
+the engine can name the frame after. A frame the engine was *entered* at has no such expression — nothing in
+script called it — and two things followed from that. A host `Invoke` of a function with no name of its own
+produced a frame with the empty string for a name, which renders as a frame with no name at all; and a
+`setTimeout`, `setInterval`, `queueMicrotask`, `requestIdleCallback` or `scheduler.postTask` callback reached
+its function through `ICallable.Call`, which pushes nothing, so the callback had no frame in any stack trace,
+in `console.trace`, or in the debugger's call stack.
+
+```js
+setTimeout(function reconcile() {
+    throw new Error('late');
+}, 0);
+// 5.0:  "    at app.js:2:11"
+// 5.x:  "    at reconcile (app.js:2:11)" and the program frame under it
+```
+
+The name is now read from the function's own `name` **as a descriptor**, and only then from the call site,
+and falls back to `(anonymous)` — the word an immediately invoked function expression already produced —
+when neither says anything. Reading it as a descriptor means naming a frame can no longer run script: a
+`name` a script replaced with an accessor leaves the frame anonymous instead of running that accessor while
+an error's stack trace is being built.
+
+**What could break:** a test comparing `Error.prototype.stack`, `JavaScriptException.JavaScriptStackTrace` or
+`DebugInformation.CallStack` against a hard-coded string for code the engine entered from a timer or from a
+host `Invoke`. There is one more frame in the first case and a name where there was none in the second;
+nothing about a frame a call expression created has changed. `Options.Interop.BuildCallStackHandler` is
+handed the same frames the renderer walks, so a host that overrides the rendering sees the new one too.
+
 ## 5. New in v5
 
 Everything in the table below is opt-in: nothing in it is installed unless the host asks for it, so
@@ -5343,6 +5373,48 @@ host loop; it holds the thread for as long as `Options.WebApi.Fetch.Timeout` and
 `Func<Engine, string, string, JsValue?>` handed the engine, the decoded body and the final MIME
 type's essence. Without it `responseXML` and `responseType = "document"` answer `null`, because Jint
 parses no markup.
+
+### 5.14 A console sink can ask where each message was logged from ([#3635](https://github.com/sebastienros/jint/pull/3635))
+
+`ConsoleRecord.StackTrace` used to carry frames for `console.trace` and nothing else. A sink that overrides
+the new `ConsoleSink.WantsStackTrace` and answers `true` now gets them for every method:
+
+```csharp
+sealed class AnchoringSink : ConsoleSink
+{
+    public override bool WantsStackTrace => true;
+
+    public override void Write(in ConsoleRecord record)
+    {
+        var site = record.StackTrace?[0];   // innermost frame: FunctionName, Source, Line, Column
+        // ...
+    }
+
+    public override void Write(ConsoleLogLevel level, string message) { }
+}
+```
+
+The frames start at the call site — the console method's own frame is left out — and a method that prints
+nothing, such as `groupEnd`, carries them too. **A sink that does not override it is unchanged**, and pays
+nothing: the capture is a call-stack walk per record, so it happens only when a sink says it reads the
+result. The property is read once per record, so a sink may answer differently from one call to the next.
+
+### 5.15 A described function can carry its source instead of a label ([#3635](https://github.com/sebastienros/jint/pull/3635))
+
+`ValueInspector` describes a function as `ƒ name()`, which is what a console prints and what a debugger
+protocol's client cannot parse: the front end reads that field as `Function.prototype.toString` output.
+`ValueInspectorOptions.FunctionSourceText` asks for that instead:
+
+```csharp
+var described = ValueInspector.Describe(value, new ValueInspectorOptions { FunctionSourceText = true });
+// "function computeTotal(items) { … }", or "function max() { [native code] }"
+```
+
+The declaration when `Options.RetainFunctionSourceText` kept it, and the `[native code]` placeholder
+otherwise — the same two answers `Function.prototype.toString` gives, minus the two things a describing path
+may not do: it neither calls the host's `Options.Host.FunctionToStringHandler` nor coerces a `name` a script
+replaced with an accessor. **The default is unchanged**, so a caller that does not name the option gets the
+label it always did.
 
 ## 6. AOT and trimming
 


### PR DESCRIPTION
Driving the real Chrome DevTools front end against a Jint target — the smoke tool
[#3633](https://github.com/sebastienros/jint/pull/3633) added — surfaced four defects no protocol test
caught. Two of them are the engine's, and this is those two plus the seam the third needs. The package half
is stacked on top.

## The Call Stack pane's outermost row had no name and was not clickable

`Debugger.paused` reported the outermost call frame with `functionName: ""` and no `functionLocation`,
however the callback was written — a function declaration, a named function expression or an inline one.
Every inner frame was named correctly, which looks like the name being taken from the call site. It is two
defects wearing one symptom.

**A frame the engine was entered at has no call site.** `CallStackElement.ToString()` already preferred the
function's own `name`, but it read it through `[[Get]]` and, when that came back empty,
`TypeConverter.ToString` handed back `""` rather than `null` — so the `?? "(anonymous)"` at the end never
fired for the one case it was written for, and `engine.Invoke` of an anonymous function produced a frame
with no name at all. The name is now read as a **descriptor**
(`Function.GetOwnFunctionNameForDisplay()`), then from the call-site expression, and falls back to
`(anonymous)` when neither says anything — the word an immediately invoked function expression already
produced.

Reading it as a descriptor closes something else: naming a frame happens while an error's stack trace is
being built, and `name` is configurable on every function, so a script could install an accessor there and
have it run — and throw — inside `new Error()`. `TheNameIsTheFunctionsOwnAndIsNotReadThroughAGetter` fails
on `main` with that accessor's own exception.

**A timer callback had no frame at all.** `TimerEntry.Fire`, `TimerFunctions.InvokeMicrotask`,
`IdleCallbackQueue.InvokeCallback` and `SchedulerTask.Run` each reached their callback through
`ICallable.Call`, which goes straight to `ScriptFunction.Call` and pushes nothing onto `JintCallStack`. So
the callback was absent from `Error.prototype.stack`, from `console.trace`, from the profiler and from
`DebugInformation.CallStack`, and the outermost row a front end drew was the synthetic program frame that
`DebugCallStack` appends. All four now go through `Engine.Call(ICallable, …)` — the same entry
`engine.Invoke`, `Engine.Call` and every call expression already use, which pushes the frame, counts it
against `MaxRecursionDepth` and takes the `CallWithStackFrame` route a tail call needs.

Event listeners (`JsEventTarget`) reach their callbacks the same way and are deliberately **not** changed
here: a listener is never an entry frame — `dispatchEvent` is itself called from script or from one of these
queues — so it is a separate question with a wider blast radius.

## `Runtime.consoleAPICalled` had no source anchor

V8 attaches the call site to every console message; Jint populated `ConsoleRecord.StackTrace` for
`console.trace` and nothing else, so no console line in the front end had a `app.js:NN` link on the right.

The frames are only readable while the call is still on the stack, so the engine either captures them before
the sink is reached or not at all — a sink cannot work them out once it has the record. That is what makes
this a question asked of the sink rather than a property of it:

```csharp
sealed class AnchoringSink : ConsoleSink
{
    public override bool WantsStackTrace => true;

    public override void Write(in ConsoleRecord record)
    {
        var site = record.StackTrace?[0];   // FunctionName, Source, Line, Column
    }

    public override void Write(ConsoleLogLevel level, string message) { }
}
```

**A sink that does not override it is unchanged and pays nothing** — no walk happens. The frames start at the
call site, the console method's own frame excluded, which is what `console.trace` already got by naming its
own function object and what every other method reaches `Emit` without one to name;
`ErrorConstructor.BuildStackTraceCapture` gains an `excludeTop` overload for it and the existing one is
written in terms of it. A method that prints nothing, `groupEnd`, carries frames too, because a front end
draws its group from the record rather than from a line.

## A function in the Scope pane rendered as `ƒ undefined()`

The front end reads `RemoteObject.description` for a function as `Function.prototype.toString` output and
parses the name back out of it; Jint sent the console's short label, `ƒ computeTotal()`. The fix belongs in
the package, but the *source* of that string is `Jint.Diagnostics.ValueInspector`, and it is the engine's —
so `ValueInspectorOptions.FunctionSourceText` is the seam:

```csharp
ValueInspector.Describe(value, new ValueInspectorOptions { FunctionSourceText = true }).Description;
// "function computeTotal(items) { … }", or "function max() { [native code] }"
```

It is computed *inside* the engine rather than by the package calling `value.ToString()`, and that is the
whole point: `Function.prototype.toString` consults the host's `FunctionToStringHandler` and, with no
retained source text, coerces `name` through `[[Get]]` — which for a `name` a script replaced with an
accessor would run script from a describing path, while the engine is paused. The seam does neither.
`ASourceTextDescriptionStillRunsNothing` pins that. The default is unchanged, so `ƒ name()` is still what a
console gets.

## Existing stack-trace expectations

**Unchanged — none of them encoded the defect.** All 11 966 tests in `Jint.Tests` pass on `net472`, `net8.0`
and `net10.0` with no expected string edited, `ErrorTests`' hard-coded traces included: every one of them is
a frame a call expression created, which is the case this does not touch. `at (anonymous) (get-item.js:9:16)`
already proved the `(anonymous)` spelling was the established one for a frame nothing could name.

## Verification

- `Jint.Tests/Runtime/CallStackEntryFrameTests.cs` — 8 tests: `engine.Invoke` named and anonymous, a
  `setTimeout` and a `queueMicrotask` callback, the accessor-`name` case, and `DebugHandler`'s `CallStack` at
  a breakpoint reached through a timer and through a host `Invoke`, asserting the name *and* the
  `FunctionLocation` the front end makes the row clickable with. Seven of the eight fail on `main`.
- `Jint.Tests/Runtime/WebApi/ConsoleStackTraceTests.cs` — 5 tests, including the negative case: a sink that
  does not ask still gets `null` for everything but `trace`.
- `Jint.Tests.PublicInterface/WebApiConsoleRecordTests.cs` — the new member exercised from the one project
  with no `InternalsVisibleTo`. `OnlyTraceCarriesFrames` is renamed
  `ASinkThatDoesNotAskForFramesGetsThemForTraceAlone`; its assertion is unchanged.
- `Jint.Tests.PublicInterface/ValueInspectorTests.cs` — three tests for the new option, including that it
  still runs nothing and that a function whose source was not retained falls back to the placeholder.
- Full runs, all green: `Jint.Tests` (11 966 / 11 966 / 8 432), `Jint.Tests.PublicInterface` (3 521 / 3 531 /
  2 830), `Jint.Tests.DevTools` (335 / 337), `Jint.Tests.CommonScripts` (28 / 28), `Jint.Tests.Test262`
  (102 573).
- `docs/v5-migration.md` §4.108 (the behaviour change), §5.14 and §5.15 (the two new members); public API
  baselines re-accepted, one added line each.

## One thing found on the way and deliberately left alone

`Function.prototype.bind` returns a `BindFunction`, which derives from `ObjectInstance` rather than from
`Function` — so `ValueInspector` describes it as an ordinary object and `Jint.DevTools` reports it as
`type: "object"` where V8 reports `type: "function"`. That is a describer gap of its own rather than part of
this, and it is reported separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
