### PR TITLE
Fetch: a Request built from another Request proxies its body, so the input is disturbed

### DIFF
--- a/Jint.Tests/Runtime/WebApi/BodyCloneTeeTests.cs
+++ b/Jint.Tests/Runtime/WebApi/BodyCloneTeeTests.cs
@@ -225,6 +225,10 @@ public class BodyCloneTeeTests
         // https://streams.spec.whatwg.org/#readablestream-create-a-proxy defines as a pipe through an
         // identity TransformStream — chunks pass through unchanged. It is not the clone-a-body algorithm,
         // so it must not start cloning.
+        //
+        // Only the proxy is read here, and that is the other half of the same algorithm: the input's stream
+        // "becomes immediately locked and disturbed", so `source.body.getReader()` is a TypeError from the
+        // moment the proxy exists. RequestTests.ProxyingLeavesTheInputsOwnStreamInPlace pins that half.
         var engine = FetchEngine();
         engine.Execute(Fixture);
 
@@ -238,9 +242,8 @@ public class BodyCloneTeeTests
               });
               const proxy = new Request(source);
 
-              const a = (await source.body.getReader().read()).value;
-              const b = (await proxy.body.getReader().read()).value;
-              return (a === initial) + ',' + (b === initial);
+              const chunk = (await proxy.body.getReader().read()).value;
+              return (chunk === initial) + ',' + source.bodyUsed;
             })()
             """).UnwrapIfPromise().AsString().Should().Be("true,true");
     }

--- a/Jint.Tests/Runtime/WebApi/RequestTests.cs
+++ b/Jint.Tests/Runtime/WebApi/RequestTests.cs
@@ -155,18 +155,85 @@ public class RequestTests
     public void CopiesFromAnotherRequest()
     {
         var engine = WebEngine();
-        engine.Execute("var a = new Request('https://example.org/a', { method: 'POST', body: 'hi', headers: { 'x-a': '1' } });");
 
-        engine.Evaluate("new Request(a).method").AsString().Should().Be("POST");
-        engine.Evaluate("new Request(a).url").AsString().Should().Be("https://example.org/a");
-        engine.Evaluate("new Request(a).headers.get('x-a')").AsString().Should().Be("1");
-        engine.Evaluate("new Request(a).text()").UnwrapIfPromise().AsString().Should().Be("hi");
+        // A fresh input per probe, because a copy disturbs the one it was built from — see
+        // ProxyingAnotherRequestDisturbsIt.
+        engine.Execute("function a() { return new Request('https://example.org/a', { method: 'POST', body: 'hi', headers: { 'x-a': '1' } }); }");
 
-        // Copying does not consume the original.
-        engine.Evaluate("a.bodyUsed").AsBoolean().Should().BeFalse();
+        engine.Evaluate("new Request(a()).method").AsString().Should().Be("POST");
+        engine.Evaluate("new Request(a()).url").AsString().Should().Be("https://example.org/a");
+        engine.Evaluate("new Request(a()).headers.get('x-a')").AsString().Should().Be("1");
+        engine.Evaluate("new Request(a()).text()").UnwrapIfPromise().AsString().Should().Be("hi");
 
         // An explicit headers member replaces the copied list wholesale rather than adding to it.
-        engine.Evaluate("new Request(a, { headers: { 'x-b': '2' } }).headers.has('x-a')").AsBoolean().Should().BeFalse();
+        engine.Evaluate("new Request(a(), { headers: { 'x-b': '2' } }).headers.has('x-a')").AsBoolean().Should().BeFalse();
+    }
+
+    /// <summary>
+    /// https://fetch.spec.whatwg.org/#dom-request step 42 — "set finalBody to the result of creating a proxy
+    /// for inputBody", and https://streams.spec.whatwg.org/#readablestream-create-a-proxy says what that
+    /// leaves behind: the input's stream "becomes immediately locked and disturbed".
+    /// </summary>
+    [Test]
+    public void ProxyingAnotherRequestDisturbsIt()
+    {
+        var engine = WebEngine();
+        engine.Execute("var a = new Request('https://example.org/a', { method: 'POST', body: 'hi' });");
+        engine.GetValue("a").Get("bodyUsed").AsBoolean().Should().BeFalse();
+
+        engine.Execute("var b = new Request(a);");
+
+        // The input is consumed even though nothing has read a byte of it, and the copy still carries them.
+        engine.GetValue("a").Get("bodyUsed").AsBoolean().Should().BeTrue();
+        engine.Evaluate("b.text()").UnwrapIfPromise().AsString().Should().Be("hi");
+
+        // ... so a second copy is the TypeError step 42.1 raises for an unusable input.
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new Request(a)"))!
+            .Message.Should().Contain("already used");
+    }
+
+    /// <summary>
+    /// The same construction on an input whose <c>body</c> has been asked for, which is the arm that has a
+    /// stream to proxy. A proxy is not a tee: the input keeps the very stream object a script already holds.
+    /// </summary>
+    [Test]
+    public void ProxyingLeavesTheInputsOwnStreamInPlace()
+    {
+        var engine = WebEngine();
+        engine.Execute("""
+            var a = new Request('https://example.org/a', { method: 'POST', body: 'hi' });
+            var before = a.body;
+            var b = new Request(a);
+            """);
+
+        engine.Evaluate("a.body === before").AsBoolean().Should().BeTrue();
+        engine.Evaluate("b.body === before").AsBoolean().Should().BeFalse();
+        engine.GetValue("a").Get("bodyUsed").AsBoolean().Should().BeTrue();
+
+        // Locked as well as disturbed, so nothing can read the input behind the proxy's back.
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("before.getReader()"));
+
+        // The bytes still arrive through the proxy, which is what makes it a proxy rather than a discard.
+        engine.Evaluate("b.text()").UnwrapIfPromise().AsString().Should().Be("hi");
+    }
+
+    /// <summary>
+    /// The other half of that step's condition: "if initBody is null <b>and</b> inputBody is non-null". An
+    /// init body means no proxy is created, so nothing reads the input and it stays usable — which is what
+    /// <c>fetch/api/request/request-disturbed.any.js</c>'s one excluded row asks for the opposite of.
+    /// </summary>
+    [Test]
+    public void AnInitBodyReplacesTheInputsWithoutDisturbingIt()
+    {
+        var engine = WebEngine();
+        engine.Execute("""
+            var a = new Request('https://example.org/a', { method: 'POST', body: 'hi' });
+            var b = new Request(a, { body: 'other' });
+            """);
+
+        engine.GetValue("a").Get("bodyUsed").AsBoolean().Should().BeFalse();
+        engine.Evaluate("b.text()").UnwrapIfPromise().AsString().Should().Be("other");
+        engine.Evaluate("a.text()").UnwrapIfPromise().AsString().Should().Be("hi");
     }
 
     [Test]
@@ -354,10 +421,11 @@ public class RequestTests
         engine.Evaluate("new Request('https://example.org', { method: 'POST', body: 'hi' }).method").AsString().Should().Be("POST");
         engine.Evaluate("new Request('https://example.org', { method: 'POST', body: 'hi', duplex: 'half' }).method").AsString().Should().Be("POST");
 
-        // Copying a request whose body is a stream: initBody is null, so the step does not apply.
-        engine.Execute("var streamed = new Request('https://example.org', { method: 'POST', body: stream(), duplex: 'half' });");
-        engine.Evaluate("new Request(streamed).method").AsString().Should().Be("POST");
-        engine.Evaluate("streamed.clone().method").AsString().Should().Be("POST");
+        // Copying a request whose body is a stream: initBody is null, so the step does not apply. One input
+        // apiece, because a proxy disturbs the request it was built from and a clone does not.
+        engine.Execute("function streamed() { return new Request('https://example.org', { method: 'POST', body: stream(), duplex: 'half' }); }");
+        engine.Evaluate("new Request(streamed()).method").AsString().Should().Be("POST");
+        engine.Evaluate("streamed().clone().method").AsString().Should().Be("POST");
     }
 
     /// <summary>

--- a/Jint.Tests/Wpt/AGENTS.md
+++ b/Jint.Tests/Wpt/AGENTS.md
@@ -30,9 +30,12 @@ non-zero count there means the corpus has found something and somebody still owe
 empty until [#3260](https://github.com/sebastienros/jint/issues/3260) gave the fetch corpus a server, which
 found five things the moment it could make a real request; they were filed as #3279–#3283, they are all fixed,
 and the category went **empty again**, which is the state that makes the next non-zero count mean something.
-It is non-zero now: vendoring `fetch/api/request/` found that `new Request(anotherRequest)` leaves the input
-undisturbed, because `FetchBodyObject.ProxyBody` shares the source for a buffered body where the standard tees
-the stream, so `bodyUsed` stays false on the input. Three rows of `request-disturbed.any.js` name it.
+It went non-zero once more and is empty again: vendoring `fetch/api/request/` found that
+`new Request(anotherRequest)` left the input undisturbed, because `FetchBodyObject.ProxyBody` teed the stream
+(and shared the source for a buffered body) where the standard *proxies* it, and a proxy disturbs what it
+reads. Three rows of `request-disturbed.any.js` named it; [#3618](https://github.com/sebastienros/jint/issues/3618)
+fixed two and moved the third — which asks for a disturbance the constructor's own step makes conditional on
+there being no init body — to `AssertsWhatNothingRequires`, which is the shape the pair of categories is for.
 A row that turns out not to be a defect at all leaves for `AssertsWhatNothingRequires`, the
 analogue of test262's `PERMANENT EXCLUSIONS` banner, earned the same way: a normative citation and an argued
 decision, never a to-do. **The engine supplies its own `setTimeout`** — unlike the test262 harness, which has no web APIs to

--- a/Jint.Tests/Wpt/Vendor/README.md
+++ b/Jint.Tests/Wpt/Vendor/README.md
@@ -42,7 +42,7 @@ Thirteen standards are vendored: `url/`, `encoding/`, `compression/`, `urlpatter
 `dom/` as **two** (events, abort), `fetch/api/` as **six** (basic, body, headers, redirect, request,
 response), `WebCryptoAPI/` as **eight** and `streams/` as **seven** — their root files plus one suite per
 sub-directory, because `WptCorpus.TestFiles` lists a directory's own files and never descends. That is 347
-theory cases over 41,417 assertions, of which 2,941 do not pass and every one is named in the driver's
+theory cases over 41,417 assertions, of which 2,939 do not pass and every one is named in the driver's
 table; the whole driver runs in about two minutes.
 
 Those three figures are a census taken at the pin rather than a running tally, so they are restated whenever a
@@ -1158,6 +1158,46 @@ citation and an argued decision, never a to-do — and the rule that age alone n
    already reached the walk through a proxy while `new Headers({ [Symbol.toStringTag]: 'x' })` on a plain
    object was silently accepted where a browser throws.
 
+## What `fetch/api/request/` says about this engine
+
+`request/` was vendored last, once `Options.WebApi.Fetch.BaseUrl` gave `new Request('')` a base to resolve
+against, and it found one defect: **`new Request(anotherRequest)` left the input undisturbed**. Three rows of
+`request-disturbed.any.js` named it, they were the corpus's `NeedsTriage` debt, and
+[#3618](https://github.com/sebastienros/jint/issues/3618) is the change that paid it.
+
+[The `Request` constructor](https://fetch.spec.whatwg.org/#dom-request) step 42 is "set *finalBody* to the
+result of [creating a proxy](https://streams.spec.whatwg.org/#readablestream-create-a-proxy) for
+*inputBody*", and the Streams Standard states that operation's observable consequence in its own prose: the
+result "pulls its data from *stream*, while *stream* itself becomes immediately **locked and disturbed**".
+Both halves were missing, for two different reasons. A body that had materialized a stream was **teed** — so
+the input's `body` was replaced by a branch, changing an object identity a script already held, and a tee
+disturbs nothing until something reads it. A body that had not — `new Request(url, { method: 'POST', body:
+'hi' })`, which keeps its bytes and builds no stream — simply **shared its source**, which is right for
+`clone()` and wrong here, because it too disturbs nothing.
+
+The fix is the algorithm as written for the stream arm — pipe through an identity `TransformStream`, which
+locks and disturbs by construction because [piping](https://streams.spec.whatwg.org/#readable-stream-pipe-to)
+acquires a reader and sets `disturbed` before it has read anything — and, for the buffered arm, the source
+shared as before plus the disturbance marked on it. That second half is what keeps the common
+`new Request(other)` free of a stream, a controller and a pipe: `GetOrCreateStream` already answers a
+disturbed source with the cancelled, locked stream a consumed body has, so the two halves agree without one
+being built.
+
+### The one row of it that is not debt
+
+The third row, *"Input request used for creating new request became disturbed even if body is not used"*,
+asks that `new Request(input, { body })` disturb `input` as well. The constructor does not: step 42 creates
+the proxy **"if *initBody* is null and *inputBody* is non-null"**, so an init body means nothing ever reads
+the input, and `bodyUsed` stays false. undici answers the same way, following the same step.
+
+Nor does any browser pass the row, which is the empirical half. Chromium's own baseline for this file
+(`request-disturbed.any-expected.txt`) records two rows failing, this one and its sibling, and it fails them
+on the *next* assertion — `assert_equals: body should not change expected object "[object ReadableStream]"
+but got object "[object ReadableStream]"` — because Chrome replaces the input's stream where a proxy leaves
+it in place. Firefox's expectation metadata marks four rows of the file `FAIL`, including both. So the row is
+`AssertsWhatNothingRequires` rather than debt: no change to this engine that keeps step 42's condition would
+move it, and abandoning the condition would mean disturbing a body the constructor never reads.
+
 ## What the fetch *network* corpus says about this engine
 
 326 assertions across the twenty files [the server lane](#the-server-lane) added, of which **69 do not pass**,
@@ -1308,9 +1348,9 @@ their exclusions without revisiting this table.
 | HTML — workers | `workers/` ×4 | 12 | 24 | 8 |
 | HTML — timers, microtasks, structured clone | `html/webappapis/` ×3 | 11 | 154 | 3 |
 | DOM | `dom/` ×2 | 13 | 76 | 0 |
-| Fetch | `fetch/api/` ×6 | 61 | 888 | 118 |
+| Fetch | `fetch/api/` ×6 | 61 | 888 | 116 |
 | XMLHttpRequest | `xhr/` | 42 | 260 | 9 |
-| **total** | **40** | **347** | **41,417** | **2,941** |
+| **total** | **40** | **347** | **41,417** | **2,939** |
 
 Re-censused whole rather than adjusted row by row, because several rows had gone stale between the changes
 that moved them: before [#3195](https://github.com/sebastienros/jint/issues/3195) the true figures were

--- a/Jint.Tests/Wpt/WptExclusions.cs
+++ b/Jint.Tests/Wpt/WptExclusions.cs
@@ -568,7 +568,19 @@ internal enum WptDivergence
     /// arrived, whereas here the divergence is in the test and no change to this engine would move it.
     /// </para>
     /// <para>
-    /// One entry today, moved out of <see cref="NeedsTriage"/> by
+    /// Two divergences today. The second is <c>fetch/api/request/request-disturbed.any.js</c>, "Input request
+    /// used for creating new request became disturbed even if body is not used", which asks that
+    /// <c>new Request(input, { body })</c> disturb <c>input</c>. https://fetch.spec.whatwg.org/#dom-request
+    /// creates the proxy that disturbs it only "if initBody is null and inputBody is non-null", so with an
+    /// init body nothing reads the input and <c>bodyUsed</c> stays false — the answer undici gives as well.
+    /// Neither engine that satisfies the assertion passes the row: Chrome and Firefox both fail this file's
+    /// two "became disturbed" rows, Chrome on the very next assertion because it replaces the input's stream
+    /// where a proxy leaves it in place. Its siblings were the <see cref="NeedsTriage"/> debt
+    /// https://github.com/sebastienros/jint/issues/3618 paid, which is the shape to keep: the rows that were
+    /// a defect left the table, and the row that is the test's own divergence moved here.
+    /// </para>
+    /// <para>
+    /// The first was moved out of <see cref="NeedsTriage"/> by
     /// https://github.com/sebastienros/jint/issues/3261 — <c>fetch/api/response/response-consume-empty.any.js</c>,
     /// "Consume empty FormData response body as text", which asks that
     /// <c>await new Response(new FormData()).text()</c> have length 0 and gets the 50-byte closing boundary

--- a/Jint.Tests/Wpt/WptTestRunner.cs
+++ b/Jint.Tests/Wpt/WptTestRunner.cs
@@ -1,4 +1,4 @@
-#if NET8_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 #nullable enable
 
 using System.Reflection;
@@ -1175,12 +1175,18 @@ public class WptTestRunner
         new("fetch/api/request/request-error.any.js", "Bad mode init parameter value", WptDivergence.NeedsBrowserRequestModel),
         new("fetch/api/request/request-error.any.js", "Bad cache init parameter value", WptDivergence.NeedsBrowserRequestModel),
 
-        // Constructing a Request from another one must leave the input disturbed. Jint's proxy shares the
-        // source for a buffered body instead of teeing it, so the input's bodyUsed stays false — a defect the
-        // corpus found the moment this file could run, recorded rather than fixed in the same change.
-        new("fetch/api/request/request-disturbed.any.js", "Input request used for creating new request became disturbed", WptDivergence.NeedsTriage),
-        new("fetch/api/request/request-disturbed.any.js", "Input request used for creating new request became disturbed even if body is not used", WptDivergence.NeedsTriage),
-        new("fetch/api/request/request-disturbed.any.js", "Request construction failure should not set \"bodyUsed\"", WptDivergence.NeedsTriage),
+        // The one row of request-disturbed.any.js that no conforming implementation passes. Its two siblings
+        // — "…became disturbed" and "Request construction failure should not set bodyUsed" — were the
+        // corpus's NeedsTriage debt and are fixed (#3618); this one asks that `new Request(input, {body})`
+        // disturb `input` as well, and https://fetch.spec.whatwg.org/#dom-request creates the proxy that
+        // disturbs it only "if initBody is null and inputBody is non-null". With an init body there is no
+        // proxy, nothing reads the input's body, and bodyUsed stays false — which is what undici answers too.
+        // Chrome satisfies this row's bodyUsed assertion and still fails the row on the next line
+        // ("body should not change"), because it replaces the input's stream where a proxy leaves it in
+        // place; Firefox fails both rows outright. See WptDivergence.AssertsWhatNothingRequires.
+        new("fetch/api/request/request-disturbed.any.js",
+            "Input request used for creating new request became disturbed even if body is not used",
+            WptDivergence.AssertsWhatNothingRequires),
 
         // https://fetch.spec.whatwg.org/#concept-bodyinit-extract runs the multipart/form-data encoding
         // algorithm over an empty entry list, which is the closing boundary and not nothing. The file says so

--- a/Jint/WebApi/Fetch/FetchBodyObject.cs
+++ b/Jint/WebApi/Fetch/FetchBodyObject.cs
@@ -329,37 +329,16 @@ internal static class FetchBody
     /// <see cref="ProxyBody"/>, and it is a property a script can observe directly:
     /// <c>(await original.body.getReader().read()).value !== (await clone.body.getReader().read()).value</c>.
     /// </para>
-    /// </remarks>
-    internal static void CloneBody(FetchBodyObject source, FetchBodyObject target)
-        => TeeInto(source, target, cloneForBranch2: true);
-
-    /// <summary>
-    /// https://streams.spec.whatwg.org/#readablestream-create-a-proxy, as
-    /// https://fetch.spec.whatwg.org/#dom-request step 42 asks for it: the body a <c>Request</c> built from
-    /// another <c>Request</c> gets.
-    /// </summary>
-    /// <remarks>
-    /// The standard pipes the input's stream through an identity <c>TransformStream</c>, which passes each
-    /// chunk on <b>unchanged</b>; Jint reaches the same observable result with a tee whose
-    /// <i>cloneForBranch2</i> is unset. Sharing the flag's <see langword="false"/> with <c>tee()</c> is the
-    /// point of the split: a proxy that structured-cloned would diverge from the standard in the other
-    /// direction, and quietly refuse a chunk an identity transform is happy to forward.
-    /// </remarks>
-    internal static void ProxyBody(FetchBodyObject source, FetchBodyObject target)
-        => TeeInto(source, target, cloneForBranch2: false);
-
-    /// <summary>
-    /// The shared tail of the two: keep the first branch, hand the second to <paramref name="target"/>.
-    /// </summary>
-    /// <remarks>
+    /// <para>
     /// The tee goes through <see cref="ReadableStreamOperations.Tee"/> rather than straight to the default
     /// algorithm, because https://streams.spec.whatwg.org/#readable-stream-tee dispatches on the kind of
     /// controller the stream has: a body's own stream is a byte stream, and its two branches have to be byte
-    /// streams too or a clone would quietly lose BYOB reading. A byte stream's tee ignores
-    /// <paramref name="cloneForBranch2"/> and clones every chunk regardless, which is why a network
-    /// response's <c>clone()</c> never shared a buffer even before this flag existed.
+    /// streams too or a clone would quietly lose BYOB reading. A byte stream's tee clones every chunk
+    /// regardless of the flag, which is why a network response's <c>clone()</c> never shared a buffer even
+    /// before the flag existed.
+    /// </para>
     /// </remarks>
-    private static void TeeInto(FetchBodyObject source, FetchBodyObject target, bool cloneForBranch2)
+    internal static void CloneBody(FetchBodyObject source, FetchBodyObject target)
     {
         if (!source.HasBody)
         {
@@ -372,9 +351,51 @@ internal static class FetchBody
             return;
         }
 
-        var (branch1, branch2) = ReadableStreamOperations.Tee(stream, cloneForBranch2);
+        var (branch1, branch2) = ReadableStreamOperations.Tee(stream, cloneForBranch2: true);
         source.ReplaceStream(branch1);
         target.SetStreamBody(branch2);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readablestream-create-a-proxy, as
+    /// https://fetch.spec.whatwg.org/#dom-request step 42 asks for it: the body a <c>Request</c> built from
+    /// another <c>Request</c> gets.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>A proxy disturbs its input, and a clone does not</b> — that is what the two are for. The standard
+    /// pipes the input's stream through an identity <c>TransformStream</c>, and says what the caller can then
+    /// observe: the input's stream "becomes immediately locked and disturbed", so <c>bodyUsed</c> is true on
+    /// the request that was handed in and reading it a second time is the <c>TypeError</c> step 42.1 raises
+    /// on the next construction. It keeps its identity too, which is why this is not a tee: a tee would
+    /// replace <c>input.body</c> with a branch, and the object a script already held would no longer be the
+    /// one the request has.
+    /// </para>
+    /// <para>
+    /// A body that has not materialized a stream is proxied by <i>sharing its source</i> and marking that
+    /// source disturbed. Sharing is safe because every arm of
+    /// <see cref="Extract"/> copies the bytes it was given, so no script can reach them again; and marking is
+    /// what makes the two halves agree, since the stream
+    /// <see cref="FetchBodyObject.GetOrCreateStream"/> hands over afterwards is the cancelled, locked one a
+    /// consumed body has. So the common <c>new Request(other)</c> still builds no stream, no controller and
+    /// no pipe, and is observably the proxy all the same.
+    /// </para>
+    /// </remarks>
+    internal static void ProxyBody(FetchBodyObject source, FetchBodyObject target)
+    {
+        if (!source.HasBody)
+        {
+            return;
+        }
+
+        if (source.Stream is not { } stream)
+        {
+            target.SetBufferedBody(source.Source!.Value);
+            source.MarkSourceDisturbed();
+            return;
+        }
+
+        target.SetStreamBody(ReadableStreamPipe.CreateProxy(stream));
     }
 
     /// <summary>

--- a/Jint/WebApi/Streams/ReadableStreamPipe.cs
+++ b/Jint/WebApi/Streams/ReadableStreamPipe.cs
@@ -133,6 +133,29 @@ internal sealed class ReadableStreamPipe
         return transform.Readable;
     }
 
+    /// <summary>
+    /// "Create a proxy for <paramref name="stream"/>" —
+    /// https://streams.spec.whatwg.org/#readablestream-create-a-proxy: pipe it through an identity transform
+    /// and hand back the readable end.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The standard states the observable consequence itself: the result "pulls its data from
+    /// <i>stream</i>, while <i>stream</i> itself becomes immediately locked and disturbed". Both halves come
+    /// from the pipe rather than from anything written here — it acquires a reader, which locks, and sets
+    /// <c>disturbed</c> before it has read anything. <b>The proxied stream keeps its identity</b>, which is
+    /// the difference from <see cref="ReadableStreamOperations.Tee"/>: a tee replaces the stream its caller
+    /// held with a branch, and a proxy does not.
+    /// </para>
+    /// <para>
+    /// The result is a default stream even when the source is a byte stream, because the identity transform's
+    /// readable side is one — so BYOB reading does not survive a proxy, exactly as it does not in the
+    /// algorithm this implements.
+    /// </para>
+    /// </remarks>
+    internal static JsReadableStream CreateProxy(JsReadableStream stream)
+        => PipeThrough(stream, TransformStreamOperations.CreateIdentity(stream.Engine, stream.Realm));
+
     private void Start()
     {
         if (_signal is { } signal)

--- a/Jint/WebApi/Streams/TransformStreamOperations.cs
+++ b/Jint/WebApi/Streams/TransformStreamOperations.cs
@@ -107,6 +107,22 @@ internal static class TransformStreamOperations
     }
 
     /// <summary>
+    /// https://streams.spec.whatwg.org/#create-an-identity-transformstream — "set up transformStream with
+    /// transformAlgorithm set to an algorithm which, given chunk, enqueues chunk in transformStream".
+    /// </summary>
+    /// <remarks>
+    /// The chunk is enqueued as it arrived, so the pair is a queue with a readable end rather than a
+    /// conversion: what makes it useful is that the readable side is a <i>different</i> stream object, which
+    /// is the whole of <see cref="ReadableStreamPipe.CreateProxy"/>.
+    /// </remarks>
+    internal static JsTransformStream CreateIdentity(Engine engine, Realm realm)
+    {
+        JsTransformStream? identity = null;
+        identity = SetUp(engine, realm, chunk => Enqueue(identity!, chunk));
+        return identity;
+    }
+
+    /// <summary>
     /// "Enqueue <paramref name="chunk"/> into <paramref name="stream"/>" —
     /// https://streams.spec.whatwg.org/#transformstream-enqueue.
     /// </summary>

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -4801,6 +4801,36 @@ host `Invoke`. There is one more frame in the first case and a name where there 
 nothing about a frame a call expression created has changed. `Options.Interop.BuildCallStackHandler` is
 handed the same frames the renderer walks, so a host that overrides the rendering sees the new one too.
 
+### 4.109 A `Request` built from another `Request` consumes it ([#3618](https://github.com/sebastienros/jint/issues/3618))
+
+[The `Request` constructor](https://fetch.spec.whatwg.org/#dom-request) step 42 sets the new request's body
+to "the result of [creating a proxy](https://streams.spec.whatwg.org/#readablestream-create-a-proxy) for
+*inputBody*", and the Streams Standard says what a proxy leaves behind: the input's stream "becomes
+immediately **locked and disturbed**". Jint teed the stream instead — which replaced the object `input.body`
+had been answering with, and disturbed nothing — and, for a body still held as bytes, shared the source
+without disturbing it at all. So the input stayed usable, and one request could be copied any number of
+times:
+
+```js
+const source = new Request('https://example.org/', { method: 'POST', body: 'hi' });
+const before = source.body;
+const copy = new Request(source);
+
+source.bodyUsed;            // 5.0: false          5.x: true
+source.body === before;     // 5.0: false          5.x: true  (a proxy keeps the input's stream)
+new Request(source);        // 5.0: another copy   5.x: TypeError - body is already used
+```
+
+`fetch(request)` goes through that constructor, so it consumes the request object it is handed, exactly as it
+does in a browser and in Node. `request.clone()` is unchanged and is still the way to keep a second copy —
+[cloning a body](https://fetch.spec.whatwg.org/#concept-body-clone) tees, which is a different algorithm with
+a different purpose.
+
+**What could break:** host or script code that builds several requests from one input, or that reads a
+request's body after handing it to `fetch`. Call `clone()` before the copy that consumes it — the clone is
+what the standard provides for exactly this — or build each request from the same `RequestInit` rather than
+from a previous `Request`.
+
 ### 4.110 A module a host loader supplied honours `RetainFunctionSourceText` ([#3588](https://github.com/sebastienros/jint/issues/3588))
 
 `Options.RetainFunctionSourceText` retained function source for everything the engine parsed itself, and for


### PR DESCRIPTION
Fixes #3618.

[The `Request` constructor](https://fetch.spec.whatwg.org/#dom-request) step 42 sets the new request's body to
"the result of [creating a proxy](https://streams.spec.whatwg.org/#readablestream-create-a-proxy) for
*inputBody*", and the Streams Standard states that operation's observable consequence in its own prose: the
result "pulls its data from *stream*, while *stream* itself becomes immediately **locked and disturbed**".

Jint did neither half.

* A body that had materialized a stream was **teed**, which replaced the object `input.body` had been
  answering with — so a stream a script already held stopped being the request's — and a tee disturbs nothing
  until something reads through it.
* A body still held as bytes — `new Request(url, { method: 'POST', body: 'hi' })`, which builds no stream at
  all — simply **shared its source**. That is right for `clone()` and wrong here, because it too disturbs
  nothing.

So `new Request(other)` left `other` fully usable, and `fetch(request)` did not consume the request it was
handed.

## The fix

`FetchBody.ProxyBody` is the algorithm now, per arm:

* **Stream arm** — `ReadableStreamPipe.CreateProxy`, which is the standard's own composition: pipe through an
  identity `TransformStream` and hand back its readable end. Both halves fall out of the pipe rather than
  being written here, because
  [`ReadableStreamPipeTo`](https://streams.spec.whatwg.org/#readable-stream-pipe-to) acquires a reader (which
  locks) and sets `disturbed` before it has read anything. The input keeps the very stream object it had.
* **Buffered arm** — the source is shared as before *and marked disturbed*. Sharing is safe because every arm
  of `FetchBody.Extract` already copies the bytes it was given; marking is what makes the two halves agree,
  since `GetOrCreateStream` already answers a disturbed source with the cancelled, locked stream a consumed
  body has. So the common `new Request(other)` still builds no stream, no controller and no pipe, and is
  observably the proxy all the same.

`CloneBody` is untouched apart from absorbing the helper the two used to share: `clone()` really is a tee, it
really does replace the original's stream with a branch
([clone a body](https://fetch.spec.whatwg.org/#concept-body-clone) step 2), and it must not start disturbing.
Two new internal operations carry the streams half — `TransformStreamOperations.CreateIdentity`
([create an identity TransformStream](https://streams.spec.whatwg.org/#create-an-identity-transformstream))
and `ReadableStreamPipe.CreateProxy`.

## The corpus

`WptDivergence.NeedsTriage` is **empty again**, which is the state that makes the next non-zero count mean
something. Two of the three `request-disturbed.any.js` rows it held now pass. The third —
*"Input request used for creating new request became disturbed even if body is not used"* — moves to
`AssertsWhatNothingRequires`, with the argument in `Vendor/README.md` and in the category's own
documentation: step 42 creates the proxy **"if *initBody* is null and *inputBody* is non-null"**, so an init
body means nothing ever reads the input and `bodyUsed` stays false, which is undici's answer too. No browser
passes that row either — Chromium's own baseline for the file records it failing on the *next* assertion
(`body should not change`, because Chrome replaces the input's stream where a proxy leaves it in place), and
Firefox's expectation metadata marks it `FAIL`. No row of any other file moved; the census is re-run
(`Fetch: 118 -> 116`).

## Testing

* `Jint.Tests.Runtime.WebApi.RequestTests` — three new tests: the buffered arm disturbs and the second copy is
  a `TypeError`; the stream arm leaves `input.body` identical, locked and disturbed while the bytes still
  arrive through the proxy; and an init body replaces the input's body without disturbing it.
* `BodyCloneTeeTests.ARequestBuiltFromARequestProxiesItsBodyAndDoesNotCloneTheChunks` still asserts that a
  proxy forwards the chunk unchanged, reading it through the proxy now that the input is locked.
* Two existing tests copied one request several times over and are rewritten to take a fresh input per probe,
  which is the behaviour change stated as a test.
* `docs/v5-migration.md` §4.108 records it for embedders.

Full `dotnet test -c Release` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
