### PR TITLE
Web platform tests: fetch/api/abort/request.any.js is vendored, and it needed no engine change

### DIFF
--- a/Jint.Tests/Wpt/AGENTS.md
+++ b/Jint.Tests/Wpt/AGENTS.md
@@ -52,7 +52,7 @@ three interfaces and nothing else, which is what let that half of the fetch corp
 there was anything for the other half to talk to. **That other half is `WptServer`** — an in-process HTTP/1.1
 origin on the loopback interface, a raw `TcpListener` on port 0, serving the *vendored* corpus plus a C# port
 of the wptserve `.py` handlers those suites name, which `WptServerTests` holds to the upstream source at the pin. Only the
-twenty-nine files in that list get `WebApiFeatures.Fetch`, their `Options.WebApi.Fetch.UrlFilter` is the
+thirty files in that list get `WebApiFeatures.Fetch`, their `Options.WebApi.Fetch.UrlFilter` is the
 server's own port re-checked on every redirect hop, and `TheServerLaneHoldsExactlyTheFilesItNames` pins the
 list in both directions — so *no suite can reach the network*, which is the promise the driver has always
 made, while the files that could not produce a test report at all now do. Two things about that lane

--- a/Jint.Tests/Wpt/Vendor/README.md
+++ b/Jint.Tests/Wpt/Vendor/README.md
@@ -20,7 +20,7 @@ output by inflating it with pako rather than with the engine's own `Decompressio
 
 `Jint.Tests/Wpt/WptTestRunner.cs`, one test case per `.any.js` file, on a fresh engine built with
 `UseWebApis(WebApiFeatures.Default)` plus the fetch object model — `Headers`, `Request` and `Response`, and,
-for every file but the twenty-nine the [server lane](#the-server-lane) names, pointedly not `fetch`, so no suite
+for every file but the thirty the [server lane](#the-server-lane) names, pointedly not `fetch`, so no suite
 gets outbound network access — and a `DiagnosticsSink`, which is what makes
 an exception escaping a timer callback, an event listener or a `queueMicrotask` callback report-and-continue
 rather than erupt from the pump. `WptDiagnosticsSink` says why the driver needs one and why it records the
@@ -39,11 +39,11 @@ before there was anything for the other half to talk to).
 Thirteen standards are vendored: `url/`, `encoding/`, `compression/`, `urlpattern/`, `hr-time/`,
 `user-timing/` and `xhr/` as one suite each, `FileAPI/` as **three** (its root, `blob/` and `file/`),
 `workers/` as **four**, `html/webappapis/` as **three** (timers, microtask-queuing, structured-clone),
-`dom/` as **two** (events, abort), `fetch/api/` as **six** (basic, body, headers, redirect, request,
-response), `WebCryptoAPI/` as **eight** and `streams/` as **seven** — their root files plus one suite per
-sub-directory, because `WptCorpus.TestFiles` lists a directory's own files and never descends. That is 347
-theory cases over 41,417 assertions, of which 2,939 do not pass and every one is named in the driver's
-table; the whole driver runs in about two minutes.
+`dom/` as **two** (events, abort), `fetch/api/` as **seven** (abort, basic, body, headers, redirect,
+request, response), `WebCryptoAPI/` as **eight** and `streams/` as **seven** — their root files plus one
+suite per sub-directory, because `WptCorpus.TestFiles` lists a directory's own files and never descends.
+That is 348 theory cases over 41,435 assertions, of which 2,939 do not pass and every one is named in the
+driver's table; the whole driver runs in about two minutes.
 
 Those three figures are a census taken at the pin rather than a running tally, so they are restated whenever a
 change moves them; the counts before the `xhr/` corpus arrived were 305 / 41,157 / 2,966, before
@@ -124,8 +124,8 @@ leave a permanent exemption behind — the run fails until the table is brought 
 
 ## The server lane
 
-A third lane, added by [#3260](https://github.com/sebastienros/jint/issues/3260). Seventy-one files —
-`WptHarness._serverBackedFiles` names twenty-nine and the whole of `xhr/` is the rest — run on an engine
+A third lane, added by [#3260](https://github.com/sebastienros/jint/issues/3260). Seventy-two files —
+`WptHarness._serverBackedFiles` names thirty and the whole of `xhr/` is the rest — run on an engine
 that has the shipped `fetch` and the shipped `XMLHttpRequest`, against `WptServer`: an in-process
 HTTP/1.1 origin on the loopback interface, started once per test run.
 
@@ -399,7 +399,6 @@ without revisiting the reason fails rather than quietly adding a red suite.
 | `fetch/api/policies/*` | Not one `.any.js` file: the directory is `.html` documents, their `.headers` sidecars and the `.js` they load. It is Content-Security-Policy and Referrer-Policy applied to a *document*. This row is the clearest example of how much the old "needs a wpt server" glob overstated itself — it was parking nothing runnable at all. |
 | `fetch/api/abort/general.any.js` | Opens by including `/common/get-host-info.sub.js` — wptserve's server-side substitution — at file scope, so it cannot register a test here at all. |
 | `fetch/api/abort/cache.https.any.js` | The Cache API, which the driver's engine does not enable. |
-| `fetch/api/abort/request.any.js` | Consuming the body of a request whose signal is already aborted must reject with the abort reason; this engine resolves instead. Five of its rows say so, and it is a candidate once that is fixed — the relative-url reason the whole directory used to give is gone with `Options.WebApi.Fetch.BaseUrl`. |
 | `fetch/api/basic/conditional-get.any.js` | An HTTP cache: `ETag` revalidation through `cache.py`. |
 | `fetch/api/basic/error-after-response.any.js` | `bad-chunk-encoding.py`: a deliberately malformed chunked body, which needs a server writing bytes no framing layer would emit. |
 | `fetch/api/basic/header-value-combining.any.js`, `header-value-null-byte.any.js`, `request-headers-case.any.js` | `/xhr/resources/`: `.asis` files served byte for byte, and two `.py` handlers in a directory nothing else here reaches. |
@@ -1198,6 +1197,31 @@ it in place. Firefox's expectation metadata marks four rows of the file `FAIL`, 
 `AssertsWhatNothingRequires` rather than debt: no change to this engine that keeps step 42's condition would
 move it, and abandoning the condition would mean disturbing a body the constructor never reads.
 
+### The same defect again, in `abort/`
+
+`fetch/api/abort/request.any.js` was in the not-vendored table above with a reason of its own — *"consuming
+the body of a request whose signal is already aborted must reject with the abort reason; this engine resolves
+instead. Five of its rows say so"* — filed as
+[#3619](https://github.com/sebastienros/jint/issues/3619). The reason was wrong twice over, and the file is
+vendored now with **no exclusion at all**.
+
+Wrong about the standard first. There is no step anywhere in
+[the `Request` constructor](https://fetch.spec.whatwg.org/#dom-request) that errors a body stream with a
+signal's abort reason; the only algorithm that touches a body because of an abort is
+[the `fetch()` method](https://fetch.spec.whatwg.org/#dom-global-fetch)'s *abort the `fetch()` call*, which
+cancels the body of the request **`fetch` itself built**. The file says as much: ten of its eighteen rows
+assert that consuming an aborted request's body **resolves**, so an engine that had implemented the reason as
+written would have turned five red rows into ten.
+
+Wrong about the defect second. The five rows that really did fail are the *"Calling …() on an aborted consumed
+nonempty request"* group, and what each of them does is `fetch(request)` — with the comment *"consuming
+happens synchronously, so don't wait"* — and then require `request.text()` to reject. That is
+[#3618](https://github.com/sebastienros/jint/issues/3618), the very defect the `request/` corpus found:
+`fetch(request)` runs the `Request` constructor, and the constructor was not disturbing its input. Measured
+both ways on the same tree — with the proxy fix reverted the same five rows fail with *"Should have rejected"*
+and nothing else does; with it in place the file passes whole. The abort in those rows is not what makes the
+body unusable; being consumed is.
+
 ## What the fetch *network* corpus says about this engine
 
 326 assertions across the twenty files [the server lane](#the-server-lane) added, of which **69 do not pass**,
@@ -1348,9 +1372,9 @@ their exclusions without revisiting this table.
 | HTML — workers | `workers/` ×4 | 12 | 24 | 8 |
 | HTML — timers, microtasks, structured clone | `html/webappapis/` ×3 | 11 | 154 | 3 |
 | DOM | `dom/` ×2 | 13 | 76 | 0 |
-| Fetch | `fetch/api/` ×6 | 61 | 888 | 116 |
+| Fetch | `fetch/api/` ×7 | 62 | 906 | 116 |
 | XMLHttpRequest | `xhr/` | 42 | 260 | 9 |
-| **total** | **40** | **347** | **41,417** | **2,939** |
+| **total** | **41** | **348** | **41,435** | **2,939** |
 
 Re-censused whole rather than adjusted row by row, because several rows had gone stale between the changes
 that moved them: before [#3195](https://github.com/sebastienros/jint/issues/3195) the true figures were
@@ -1360,7 +1384,7 @@ carrying a number a later fix had already improved. That class of drift is what 
 rows were arithmetic the driver already did, and nothing checked the prose against it.
 
 Three of those rows are worth a caveat. The Fetch row is the only one whose files reach a socket at all — the
-twenty-nine [server-lane](#the-server-lane) files, over the loopback interface to a server in this same
+thirty [server-lane](#the-server-lane) files, over the loopback interface to a server in this same
 process — so it is the only row whose figures could in principle depend on the machine. They do not: the
 suite was run five times over and reported the same 458 cases every time, and the driver's own idle rule
 is reset by a test settling rather than by a wall clock. The Encoding figure is dominated by
@@ -1382,14 +1406,16 @@ the one corpus that mostly does not run in the driver's own engine —
 [#3195](https://github.com/sebastienros/jint/issues/3195), is the exception, because its subject is a page
 creating workers rather than the worker global itself. The rest of `fetch/api/` — `basic/`, `body/` and
 `redirect/` — came next, with [the server](#the-server-lane)
-([#3260](https://github.com/sebastienros/jint/issues/3260)), and `request/` last, once
-`Options.WebApi.Fetch.BaseUrl` gave a relative url something to resolve against. This file records what each
-of them says about the engine.
+([#3260](https://github.com/sebastienros/jint/issues/3260)), then `request/`, once
+`Options.WebApi.Fetch.BaseUrl` gave a relative url something to resolve against, and last the one file of
+`abort/` that neither wptserve substitution nor the Cache API keeps out
+([#3619](https://github.com/sebastienros/jint/issues/3619)). This file records what each of them says about
+the engine.
 
 What remains deliberately unvendored, in one place: everything in the "Deliberately not vendored" table
 above, plus every upstream file that is not a `.any.js` — `.window.js`, `.html`, `.xhtml`, `.worker.js` and
 `.sub.html` are all for a browsing context or a classic worker. Of the WHATWG standards Jint implements, the
-directories with no vendored file at all are `fetch/api/abort/`, `cors/`, `credentials/` and `policies/`
+directories with no vendored file at all are `fetch/api/cors/`, `credentials/` and `policies/`
 (each for the reason its row gives, and none of them for want of a server), the parts of the `workers/` tree
 listed above, the `WebCryptoAPI` directories listed above, and
 `xhr/` (there is no `XMLHttpRequest` in the engine — the shim's is a vendored-corpus reader for the suites

--- a/Jint.Tests/Wpt/Vendor/fetch/api/abort/request.any.js
+++ b/Jint.Tests/Wpt/Vendor/fetch/api/abort/request.any.js
@@ -1,0 +1,85 @@
+// META: timeout=long
+// META: global=window,worker
+
+const BODY_FUNCTION_AND_DATA = {
+  arrayBuffer: null,
+  blob: null,
+  formData: new FormData(),
+  json: new Blob(["{}"]),
+  text: null,
+};
+
+for (const [bodyFunction, body] of Object.entries(BODY_FUNCTION_AND_DATA)) {
+  promise_test(async () => {
+    const controller = new AbortController();
+    const signal = controller.signal;
+    const request = new Request("../resources/data.json", {
+      method: "post",
+      signal,
+      body,
+    });
+
+    controller.abort();
+    await request[bodyFunction]();
+    assert_true(
+      true,
+      `An aborted request should still be able to run ${bodyFunction}()`
+    );
+  }, `Calling ${bodyFunction}() on an aborted request`);
+
+  promise_test(async () => {
+    const controller = new AbortController();
+    const signal = controller.signal;
+    const request = new Request("../resources/data.json", {
+      method: "post",
+      signal,
+      body,
+    });
+
+    const p = request[bodyFunction]();
+    controller.abort();
+    await p;
+    assert_true(
+      true,
+      `An aborted request should still be able to run ${bodyFunction}()`
+    );
+  }, `Aborting a request after calling ${bodyFunction}()`);
+
+  if (!body) {
+    promise_test(async () => {
+      const controller = new AbortController();
+      const signal = controller.signal;
+      const request = new Request("../resources/data.json", {
+        method: "post",
+        signal,
+        body,
+      });
+
+      // consuming happens synchronously, so don't wait
+      fetch(request).catch(() => {});
+
+      controller.abort();
+      await request[bodyFunction]();
+      assert_true(
+        true,
+        `An aborted consumed request should still be able to run ${bodyFunction}() when empty`
+      );
+    }, `Calling ${bodyFunction}() on an aborted consumed empty request`);
+  }
+
+  promise_test(async t => {
+    const controller = new AbortController();
+    const signal = controller.signal;
+    const request = new Request("../resources/data.json", {
+      method: "post",
+      signal,
+      body: body || new Blob(["foo"]),
+    });
+
+    // consuming happens synchronously, so don't wait
+    fetch(request).catch(() => {});
+
+    controller.abort();
+    await promise_rejects_js(t, TypeError, request[bodyFunction]());
+  }, `Calling ${bodyFunction}() on an aborted consumed nonempty request`);
+}

--- a/Jint.Tests/Wpt/WptHarness.cs
+++ b/Jint.Tests/Wpt/WptHarness.cs
@@ -274,6 +274,10 @@ internal static class WptHarness
     /// </remarks>
     private static readonly HashSet<string> _serverBackedFiles = new(StringComparer.Ordinal)
     {
+        // The only vendored file of fetch/api/abort/: it builds its Requests from a relative url, and two of
+        // its four groups hand one to fetch() to have the body consumed.
+        "fetch/api/abort/request.any.js",
+
         "fetch/api/basic/accept-header.any.js",
         "fetch/api/basic/request-head.any.js",
         "fetch/api/basic/request-headers-nonascii.any.js",

--- a/Jint.Tests/Wpt/WptTestRunner.cs
+++ b/Jint.Tests/Wpt/WptTestRunner.cs
@@ -297,10 +297,11 @@ public class WptTestRunner
 
         // ---- abort/
         // The relative-url reason this directory used to give is gone with Options.WebApi.Fetch.BaseUrl, so
-        // each file now says what it actually needs. All three were run to find out.
+        // each file now says what it actually needs. All three were run to find out, and the third —
+        // request.any.js — is vendored (#3619): the five rows it could not pass were #3618's defect rather
+        // than anything about aborting, and it needs no exclusion now that they are fixed.
         ("fetch/api/abort/general.any.js", "/common/get-host-info.sub.js at file scope: wptserve's server-side substitution"),
         ("fetch/api/abort/cache.https.any.js", "the Cache API, which the driver's engine does not enable"),
-        ("fetch/api/abort/request.any.js", "consuming the body of a request whose signal is already aborted must reject, which this engine does not do"),
         ("fetch/api/abort/*.html", "a document"),
         ("fetch/api/abort/*.window.js", "a browsing context"),
         ("fetch/api/abort/*.sub.any.js", "wptserve substitutes a second origin into the file before serving it"),
@@ -668,6 +669,8 @@ public class WptTestRunner
         ["dom/abort/abort-signal-any.any.js"] = 14,
         ["dom/abort/event.any.js"] = 16,
         ["dom/abort/timeout.any.js"] = 3,
+
+        ["fetch/api/abort/request.any.js"] = 18,
 
         ["fetch/api/basic/accept-header.any.js"] = 4,
         ["fetch/api/basic/historical.any.js"] = 3,
@@ -1431,6 +1434,7 @@ public class WptTestRunner
     /// </summary>
     private static readonly string[] _fetchSuites =
     [
+        "fetch/api/abort",
         "fetch/api/basic",
         "fetch/api/body",
         "fetch/api/headers",
@@ -1452,6 +1456,8 @@ public class WptTestRunner
     public static IEnumerable<object[]> DomEventsSuiteFiles() => Cases("dom/events");
 
     public static IEnumerable<object[]> DomAbortSuiteFiles() => Cases("dom/abort");
+
+    public static IEnumerable<object[]> FetchAbortSuiteFiles() => Cases("fetch/api/abort");
 
     public static IEnumerable<object[]> FetchBasicSuiteFiles() => Cases("fetch/api/basic");
 
@@ -1565,6 +1571,9 @@ public class WptTestRunner
 
     [TestCaseSource(nameof(DomAbortSuiteFiles))]
     public void RunsTheDomAbortSuite(string file) => RunSuiteFile(file);
+
+    [TestCaseSource(nameof(FetchAbortSuiteFiles))]
+    public void RunsTheFetchAbortSuite(string file) => RunSuiteFile(file);
 
     [TestCaseSource(nameof(FetchBasicSuiteFiles))]
     public void RunsTheFetchBasicSuite(string file) => RunSuiteFile(file);


### PR DESCRIPTION
Fixes #3619.

**Stacked on #3618** (`fix/request-body-tee`), which is what makes the file pass. Review the second commit;
merge that one first.

`fetch/api/abort/request.any.js` sat in `Vendor/README.md`'s not-vendored table with a reason of its own —
*"consuming the body of a request whose signal is already aborted must reject with the abort reason; this
engine resolves instead. Five of its rows say so"*. Vendoring the file shows the reason was wrong twice over,
and the file goes in with **no exclusion at all**: all eighteen rows pass.

## Wrong about the standard

There is no step anywhere in [the `Request` constructor](https://fetch.spec.whatwg.org/#dom-request) that
errors a body stream with a signal's abort reason. The only algorithm that touches a body because of an abort
is [the `fetch()` method](https://fetch.spec.whatwg.org/#dom-global-fetch)'s *abort the `fetch()` call*, which
cancels the body of the request **`fetch` itself built**.

The file says the same thing out loud: ten of its eighteen rows assert that consuming an aborted request's
body **resolves** —

```js
const request = new Request("../resources/data.json", { method: "post", signal, body });
controller.abort();
await request[bodyFunction]();          // "An aborted request should still be able to run text()"
```

— so an engine that had implemented the issue's fix as written would have turned five red rows into ten.

## Wrong about the defect

The five rows that really did fail are the *"Calling …() on an aborted consumed nonempty request"* group, and
what each of them does is hand the request to `fetch` — with the comment *"consuming happens synchronously,
so don't wait"* — before requiring `request.text()` to reject:

```js
fetch(request).catch(() => {});
controller.abort();
await promise_rejects_js(t, TypeError, request[bodyFunction]());
```

`fetch(request)` runs the `Request` constructor, and the constructor was not disturbing its input. That is
#3618, the same defect the `request/` corpus found from the other side. Measured both ways on this tree: with
the proxy fix reverted the same five rows fail with *"Should have rejected"* and nothing else does; with it in
place the file passes whole. The abort in those rows is not what makes the body unusable — being consumed is.

## What this changes

* Vendors `fetch/api/abort/request.any.js` at the pin, and retires its not-vendored row.
* `fetch/api/abort` becomes the seventh `fetch/api/` suite (`RunsTheFetchAbortSuite`), with a minimum-test
  entry of 18.
* It joins `WptHarness._serverBackedFiles`, because it builds its `Request`s from a relative url and two of
  its four groups hand one to `fetch()`. That list is thirty files now; the counts stating it are updated in
  `Vendor/README.md` and `Jint.Tests/Wpt/AGENTS.md`.
* `Vendor/README.md` gets the analysis above and a re-run census (`Fetch: 61 files / 888 assertions -> 62 /
  906`, not passing unchanged at 116).

No engine change, and no `WptDivergence` entry: the corpus is eighteen rows greener and its exclusion table is
untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
