### PR TITLE
WPT: the server answers for a file the way wptserve does, so a later browser lane has a page to load

### DIFF
--- a/Jint.Tests/Jint.Tests.csproj
+++ b/Jint.Tests/Jint.Tests.csproj
@@ -27,7 +27,13 @@
     already contain, and "wpt.url.url-constructor.any.js" cannot be turned back into a path.
   -->
   <ItemGroup>
-    <EmbeddedResource Include="Wpt\Vendor\**\*.js;Wpt\Vendor\**\*.json;Wpt\Vendor\**\*.txt;Wpt\Vendor\**\*.xml;Wpt\Vendor\**\*.asis">
+    <!--
+      Text extensions only, and that is a property the corpus has rather than an oversight: WptCorpus hands
+      every file back as a string, so a .png or a .webm could not survive the round trip. wptserve's own
+      content-type table names those types and WptServer answers with them, but nothing binary is vendored -
+      a suite that needs one is a not-vendored row in Vendor/README.md with that as its reason.
+    -->
+    <EmbeddedResource Include="Wpt\Vendor\**\*.js;Wpt\Vendor\**\*.mjs;Wpt\Vendor\**\*.json;Wpt\Vendor\**\*.txt;Wpt\Vendor\**\*.xml;Wpt\Vendor\**\*.asis;Wpt\Vendor\**\*.html;Wpt\Vendor\**\*.htm;Wpt\Vendor\**\*.xhtml;Wpt\Vendor\**\*.xht;Wpt\Vendor\**\*.css;Wpt\Vendor\**\*.svg;Wpt\Vendor\**\*.headers">
       <LogicalName>wpt/%(RecursiveDir)%(Filename)%(Extension)</LogicalName>
     </EmbeddedResource>
     <EmbeddedResource Include="Wpt\Prelude\*.js">

--- a/Jint.Tests/Wpt/AGENTS.md
+++ b/Jint.Tests/Wpt/AGENTS.md
@@ -48,7 +48,7 @@ without. `url/urlencoded-parser.any.js` reaches the urlencoded parser through `R
 three interfaces and nothing else, which is what let that half of the fetch corpus be vendored years before
 there was anything for the other half to talk to. **That other half is `WptServer`** — an in-process HTTP/1.1
 origin on the loopback interface, a raw `TcpListener` on port 0, serving the *vendored* corpus plus a C# port
-of six wptserve `.py` handlers, which `WptServerTests` holds to the upstream source at the pin. Only the
+of the wptserve `.py` handlers those suites name, which `WptServerTests` holds to the upstream source at the pin. Only the
 twenty-nine files in that list get `WebApiFeatures.Fetch`, their `Options.WebApi.Fetch.UrlFilter` is the
 server's own port re-checked on every redirect hop, and `TheServerLaneHoldsExactlyTheFilesItNames` pins the
 list in both directions — so *no suite can reach the network*, which is the promise the driver has always
@@ -94,3 +94,21 @@ the answer is the regression — an engine defect, or a corpus entry whose outco
 never re-censusing, which is what
 [#3339](https://github.com/sebastienros/jint/issues/3339) records three unrelated pull requests being invited
 to do. The other four columns are equalities in both directions, because none of them counts an outcome.
+
+A ninth, which nothing in the `.any.js` lane can reach and which every `.html` test will. `WptServer` has a
+second half, `WptServerFiles`: wptserve's content-type table, its `.headers` sidecars and its `.sub.` template
+language, ported from `tools/wptserve/wptserve/` at the pin and held to it by `WptServerTests` the same way
+the `.py` handlers are. Three things about it decide where a divergence goes. **There is one origin** — one
+loopback host, one port, no TLS — so every host-shaped token (`{{host}}`, `{{domains[www2]}}`,
+`{{hosts[alt][]}}`) answers the same address and every `{{ports[…][…]}}` the same port; a file whose subject
+is a *second* origin therefore reads as same-origin, which makes it un-runnable rather than merely different
+and puts it in `_notVendored` or the exclusion table, never in a green run. **Anything unresolvable is a 500,
+never a placeholder left in place**: an undefined variable, a `?pipe=` other than `sub`, a `{{ host }}` whose
+spaces wptserve's own tokenizer rejects. Serving the file as though the query were not there is how a server
+limitation becomes a failing assertion about the engine three layers away — which is exactly what
+`xhr/abort-after-timeout.any.js`'s `?pipe=trickle(d1)` was. And **`resources/` and `common/` are helper roots,
+never suites**: `WptCorpus.TestFiles` refuses to be asked about them, because a `.any.js` under one would be
+the harness testing itself. `Vendor/resources/testharness.js` is upstream's real harness for a page to load,
+`Prelude/testharness-shim.js` remains Jint's own for the `.any.js` lane, and `resources/testharnessreport.js`
+is deliberately **not** vendored — upstream's is a stub that exists to be replaced, so Jint's lives in
+`Prelude/` and `WptServer` takes an overlay for it per instance.

--- a/Jint.Tests/Wpt/Prelude/testharnessreport.js
+++ b/Jint.Tests/Wpt/Prelude/testharnessreport.js
@@ -1,0 +1,32 @@
+/*
+ * Jint's `resources/testharnessreport.js`.
+ *
+ * This is *not* a vendored file, and it is deliberately the one harness file that is not. Upstream ships a
+ * stub whose whole purpose is to be replaced: "this file is intended for vendors to implement code needed to
+ * integrate testharness.js tests with their own test systems". Vendoring the stub and then overwriting it at
+ * serve time would make `Vendor/` hold bytes the server never sends, which is the one thing the vendored-and-
+ * byte-verified model is for. So the stub's behaviour is reproduced here instead, in Jint's own file, and
+ * `Vendor/resources/` holds only the files the server really serves verbatim.
+ *
+ * The browser lane overlays this. `WptServer` takes an overlay string per instance and answers
+ * `/resources/testharnessreport.js` with it, so the lane can install `add_result_callback` /
+ * `add_completion_callback` handlers that post a page's results back to the driver without touching either
+ * `Vendor/` or this file. Until that lane arrives nothing supplies an overlay, and what a page gets is what
+ * upstream's stub does — which, in an engine with no `window.opener`, is nothing at all.
+ *
+ * Upstream: resources/testharnessreport.js at the commit named in Vendor/README.md.
+ */
+
+/* global setup */
+
+/* If the parent window has a testharness_properties object, we use this to provide the test settings. This is
+ * used by the default in-browser runner to configure the timeout and the rendering of results. There is no
+ * opener here, so the guard is always false and the try/catch is what upstream's is: the property access
+ * itself can throw across a browsing-context boundary.
+ */
+try {
+    if (window.opener && "testharness_properties" in window.opener) {
+        setup(JSON.parse(JSON.stringify(window.opener.testharness_properties)));
+    }
+} catch (e) {
+}

--- a/Jint.Tests/Wpt/Vendor/README.md
+++ b/Jint.Tests/Wpt/Vendor/README.md
@@ -221,6 +221,134 @@ filed separately (see `WptDivergence.NeedsTriage`) and the fifth of which is not
 that transport limit — see [what the fetch *network* corpus says](#what-the-fetch-network-corpus-says-about-this-engine)
 below for the arithmetic.
 
+## Serving a file: content types, `.headers` sidecars and `.sub.` substitution
+
+The server lane above is a set of `.py` handler ports and a static reader that knew four extensions. That is
+all an `.any.js` file ever asks for, because the driver hands it to an engine directly and the server is only
+there to answer its `fetch`. A **`.html`** test is different: a page is *loaded* from the server, and everything
+about how wptserve turns a file on disk into a response then matters — its media type, the `.headers` sidecar
+beside it, and the `{{…}}` substitution its name may ask for. This section is that half, added ahead of the
+browser lane by [the headless-browser campaign](https://github.com/sebastienros/jint/issues/3575) so that the
+lane can be about the lane. Nothing script-side changed with it: no vendored file was a `.sub.` file, had a
+sidecar or passed a `?pipe=` before, so the corpus's own results are byte-identical either side.
+
+`WptServerFiles` is the port, and `WptServerTests` holds it to `tools/wptserve/wptserve/` at the pin the same
+way the handler tests hold the `.py` ports.
+
+**Content types come from `constants.py`'s own table**, reproduced entire rather than trimmed to what is
+vendored, because a trimmed copy would quietly stop being a copy. The fallback is
+`application/octet-stream`, upstream's, where the old reader's was `text/plain`; only one vendored file
+changed type as a result, `xhr/resources/well-formed.xml`, from `text/plain` to `application/xml`, and the
+census is identical across that change. **wptserve adds no charset anywhere** — nothing under `tools/wptserve`
+appends one to a guessed type — so the `charset=utf-8` a browser sees on `testharness.js` is not the table's
+doing at all. It comes from a sidecar.
+
+**`.headers` sidecars** are `load_headers` followed by `FileHandler.get_headers`, and four of their rules are
+easy to get subtly wrong, so each has a case: the directory's `__dir__.headers` is applied *before* the file's
+own; a repeated name is kept rather than overwritten and takes the position of its first appearance
+(`ResponseHeaders.update` appends); a `Content-Type` in either sidecar suppresses the guess, which is
+otherwise inserted *first* rather than appended; and a `.sub.headers` wins outright over a plain `.headers` of
+the same base name and is substituted with escaping off. Three headers are the server's own framing and a
+sidecar naming one is dropped — `Content-Length`, `Connection` and `Transfer-Encoding` — because every
+response here writes its own and is delimited by its close. A file whose subject *is* a wrong framing uses
+`.asis` instead, which bypasses all of this and puts the response on the wire byte for byte; that is what the
+six the xhr corpus vendors are for.
+
+**`.sub.` substitution** is `pipes.py`'s `template`, tokenizer included. Its grammar is four patterns tried in
+order at each position with a *stop* — not a skip — at the first character none of them match, which is why
+`{{ host }}` is a 500 upstream and is one here: a tokenizer that skipped whitespace would accept a spelling
+wptserve rejects, and a corpus file written against it would then only work here. The extension picks the
+escaping, exactly as `wrap_pipeline` does: `.html`, `.htm`, `.xht`, `.xhtml`, `.xml` and `.svg` get
+`html.escape(…, quote=True)` — five characters and no more, which is why it is written by hand rather than
+handed to `WebUtility.HtmlEncode` — and everything else, a `.sub.js` included, gets none.
+
+**There is exactly one origin, and that is the whole of what substitution cannot reproduce.** wptserve runs on
+two http ports and two https ports across several hostnames because a large part of the corpus is about what
+happens *between* origins. This is one `TcpListener` on one loopback port with no TLS, so:
+
+| Token | What it answers here |
+| --- | --- |
+| `{{host}}`, `{{domains[www]}}`, `{{domains[]}}`, `{{hosts[alt][www2]}}` | `127.0.0.1` — every host-shaped spelling, because there is one host |
+| `{{ports[http][0]}}`, `{{ports[http][1]}}`, `{{ports[https][0]}}`, `{{ports[ws][0]}}` | the one port the listener bound, for every protocol and every index |
+| `{{location[…]}}` | `server`, `scheme`, `host`, `hostname`, `port`, `path`/`pathname`, `query` — the request's own, undecoded |
+| `{{GET[name]}}` | the first value for that parameter, or the empty string; the one lookup here that does not fail on a miss |
+| `{{headers[name]}}` | the request header, and a 500 for a name the request did not send |
+| `{{header_or_default(name, default)}}` | the header, or the default |
+| `{{uuid()}}`, `{{$id:uuid()}}` … `{{$id}}` | a fresh UUID, and the variable form that lets a file use the same one twice |
+| `{{url_base}}` | `/` |
+| `{{file_hash(…)}}`, `{{fs_path(…)}}` | nothing: a 500 naming the variable. Both read the document root, and there is no document root — the corpus is embedded resources |
+
+A file whose subject is a *second* origin therefore reads as same-origin here, which makes it un-runnable
+rather than merely different: it belongs in the exclusion table or in the table above when a lane brings it
+in, and never in a green run. Substitution is still faithful for the many files that only want *an* origin,
+and `common/get-host-info.sub.js` — which 68 files of the browser lane's suites include — is the reason this
+exists at all.
+
+**`?pipe=` is parsed and exactly one pipe is implemented.** wptserve has fourteen; only `sub` is needed to
+load an `.html` test, and an unknown one is a **500 naming itself** rather than a file served as though the
+query were not there. That is the difference between a server that says it cannot do something and a test that
+fails an assertion about the engine: `xhr/abort-after-timeout.any.js` is a not-vendored row precisely because
+it asks for `?pipe=trickle(d1)`, and with this it would say so on the wire.
+
+Three smaller things the browser lane needs and the `.any.js` lane never did. The query and the fragment take
+no part in finding a file — `filesystem_path` reads `url_parts.path` alone — and a percent-escape in the path
+is decoded before the lookup, as `unquote` does. A `HEAD` carries the headers a `GET` would, `Content-Length`
+included, and no body. And a path the corpus does not hold is a 404 with the same status line, content type
+and empty body whatever its extension, so a missing `.html` fails the way a missing `.txt` always has.
+
+## The harness itself, and the one file that is not vendored
+
+`resources/` and `common/` are the wpt tree's two shared roots: the harness a page loads, and what every
+standard's suites share. Neither is ever a **suite** — `WptCorpus.TestFiles` refuses to be asked about them
+and `EveryVendoredFileIsAccountedFor` fails if either ever holds a `.any.js` — because a test case there
+would be the harness testing itself. The rule for what lives in them is the rule for every other directory:
+vendor what something references, and say why for the rest.
+
+What the browser lane's five target directories (`dom/`, `html/dom/`,
+`html/semantics/scripting-1/the-script-element/`, `xhr/`, `html/webappapis/`) reference, and which of it is
+here:
+
+| Vendored | Referrers at the pin | What it is |
+| --- | --- | --- |
+| `resources/testharness.js` (+ `.headers`) | 1764 | The real upstream harness — see the two-file note below |
+| `resources/testdriver.js` (+ `.headers`) | 98 | The automation API a test drives input through |
+| `resources/testdriver-vendor.js` (+ `.headers`) | 98 | Upstream's **empty** vendor hook, which `testdriver.js` expects to be replaced |
+| `resources/testdriver-actions.js` (+ `.headers`) | 85 | The action-sequence builder `testdriver.js` layers on top |
+| `common/get-host-info.sub.js` | 68 | The origins helper, and the corpus's most-used `.sub.` file |
+| `common/utils.js` | 37 | Already vendored: `token()`, the stash key generator |
+| `common/blank.html` | 26 | An empty document, navigated to and framed |
+| `common/subset-tests-by-key.js`, `common/subset-tests.js`, `common/gc.js`, `common/sab.js` | — | Already vendored for the `.any.js` lane |
+| `common/dummy.xml`, `common/dummy.xhtml` | 6 | Two-line XML fixtures the parsing tests load |
+
+The four `.headers` files are upstream's own, vendored beside the files they belong to, and they are what
+gives the harness `Content-Type: text/javascript; charset=utf-8` — the answer to "where does wptserve add a
+charset": in a sidecar, for those files, and nowhere else.
+
+**`resources/testharness.css` is not here because it does not exist**: the pin has no such file, and
+`testharness.js` loads no stylesheet. It is named in older wpt documentation and in a good deal of prose about
+the harness, which is the only reason it is worth a sentence.
+
+### Two harnesses, on purpose
+
+There are now two implementations of `testharness.js` in this directory tree and they do not compete.
+
+* `Prelude/testharness-shim.js` is **Jint's own**, and it stays. It implements the slice of upstream's harness
+  the `.any.js` lane uses, runs in an engine with no DOM, and `WptHarnessTests` exercises every assertion in it
+  from both sides. Nothing about that lane changes.
+* `Vendor/resources/testharness.js` is **upstream's, verbatim**, and it is what a `.html` test loads through a
+  `<script src>` when the browser lane arrives. A page has a document, a `<div id=log>` and an `onload`, so it
+  can run the real thing, and running the real thing is most of what makes a browser lane's result mean
+  something.
+
+The file that bridges them is `resources/testharnessreport.js`, and it is **the one harness file deliberately
+not vendored**. Upstream's is a stub whose whole purpose is to be replaced — *"intended for vendors to
+implement code needed to integrate testharness.js tests with their own test systems"* — so vendoring it would
+put bytes in this tree that the server never sends, which is the one thing the vendored-and-byte-verified
+model is for. Jint's copy is `Prelude/testharnessreport.js`, beside the shim, and `WptServer` takes an overlay
+string per instance and answers `/resources/testharnessreport.js` with it. The browser lane fills that slot
+with the script that posts a page's results back to the driver; until then what a page gets is what upstream's
+stub does, which in an engine with no `window.opener` is nothing at all.
+
 ## Deliberately not vendored
 
 The driver enforces this list (`WptTestRunner._notVendored`): a re-vendor that brings one of these back
@@ -254,7 +382,7 @@ without revisiting the reason fails rather than quietly adding a red suite.
 | `workers/modules/dedicated-worker-import-blob-url.any.js`, `workers/modules/dedicated-worker-import-data-url.any.js`, `workers/modules/resources/*data-url*`, `workers/modules/resources/*block-cross-origin*` | Need `URL.createObjectURL`, a `data:` module loader, and a second origin. |
 | `workers/SharedWorker-*.any.js`, `workers/semantics/interface-objects/*` | `SharedWorker` and `SharedWorkerGlobalScope`, which Jint does not have — the design records it as still open, needing a cross-engine name registry of the shape `BroadcastChannelBroker` has. A `global=sharedworker` file cannot even be run in the worker lane: there is no shared worker to be the global of. |
 | `workers/examples/*` | Upstream's own tutorial for writing worker tests, and it teaches wpt rather than testing an engine: `general.any.js` is two tests, the second asserting `location.pathname === "/workers/examples/general.any.worker.js"` — the path of the glue script the wpt server generates for a `.any.js` file. There is no server here to generate one. `onconnect.any.js` beside it is `global=sharedworker`. |
-| `workers/Worker-location.sub.any.js`, `workers/interfaces/WorkerUtils/importScripts/*`, `workers/importscripts_mime*.any.js` | `.sub.` is wptserve's server-side substitution: it rewrites `{{host}}` and `{{ports[…]}}` into a real origin before serving the file, so a vendored copy carries the placeholders verbatim. The `importScripts` families are classic-worker script loading on top of that, over server-chosen MIME types and cross-origin redirects. `Worker-location.sub.any.js` additionally asserts every member of a `WorkerLocation`, which is declined below. |
+| `workers/Worker-location.sub.any.js`, `workers/interfaces/WorkerUtils/importScripts/*`, `workers/importscripts_mime*.any.js` | `.sub.` is wptserve's server-side substitution, which `WptServer` now performs — but over one origin, and these want a second. The `importScripts` families are classic-worker script loading on top of that, over server-chosen MIME types and cross-origin redirects. `Worker-location.sub.any.js` additionally asserts every member of a `WorkerLocation`, which is declined below. |
 | `workers/interfaces/WorkerGlobalScope/location/*` | The whole assertion of `returns-same-object.any.js` is `location === location`. The harness shim installs a stub `location` of its own — `/common/subset-tests.js` reads `location.search` to pick a shard — so a vendored copy would pass **against the shim** while Jint deliberately has no `WorkerLocation` at all. A test that can only assert the harness is worse than no test, which is why this is a row here and not an exclusion. |
 | `user-timing/supported-usertiming-types.any.js` | Reads `PerformanceObserver.supportedEntryTypes` at *file scope* to decide which promise tests to register, so on an engine with no `PerformanceObserver` it throws before the first test exists. The rows that reach for an observer from inside a test body are excluded one by one instead, under `NeedsPerformanceObserver`. |
 | `html/webappapis/timers/evil-spec-example.any.js` | `setTimeout`'s string handler, which `TimerFunctions` documents declining: compiling the string is `eval` by another name and reachable even where a host disabled string compilation, so it is a `TypeError` here as it is in Node. The file's whole subject is that form, and it uses it at file scope. |
@@ -286,12 +414,17 @@ without revisiting the reason fails rather than quietly adding a red suite.
 | `fetch/api/body/textstream.any.js` | `Response.prototype.textStream`, a Fetch pull the standard has not merged. The directory's other two files are vendored: they build their own `Request` and `Response` and never ask for a URL, which is what made the old glob wrong about them. |
 | `fetch/api/redirect/redirect-back-to-original-origin.any.js`, `redirect-mode.any.js`, `redirect-origin.any.js` | A second origin, and for `redirect-mode` the opaque filtered response as well. |
 | `fetch/api/redirect/redirect-schemes.any.js` | Redirects to `blob:` and other schemes, and `get-host-info` substitution. |
-| `fetch/api/*/*.sub.any.js` | `.sub.` is wptserve rewriting `{{host}}` and `{{ports[…]}}` into a real origin before serving the file, so a vendored copy carries the placeholders verbatim. |
+| `fetch/api/*/*.sub.any.js` | `.sub.` is wptserve rewriting `{{host}}` and `{{ports[…]}}` into a **second** origin before serving the file. `WptServer` substitutes now — see [serving a file](#serving-a-file-content-types-headers-sidecars-and-sub-substitution) — but it has one origin to substitute, so every one of these would read as same-origin and assert nothing. |
 | `fetch/api/*/*.h2.any.js` | Needs an HTTP/2 server. `WptServer` speaks HTTP/1.1 on a raw socket, which is what lets it trickle a body. |
 | `fetch/api/*/*keepalive*` | The `keepalive` init member, and a window creating iframes. |
 | `fetch/api/headers/headers-no-cors.any.js` | The `"no-cors"` request mode. The rest of that directory is vendored. |
 | `fetch/api/response/json.any.js` | Fetches a `data:` url and `/xhr/resources/utf16-bom.json`. |
 | `fetch/api/response/response-blob-realm.any.js` | Needs a document and a second realm: it builds an `iframe` to obtain one. |
+| `resources/idlharness.js` | The WebIDL conformance harness, out for the reason its `.any.js` files are. Its three companions (`webidl2/`, `test-only-api.js`, `sriharness.js`) are out with it. |
+| `common/slow.py`, `common/redirect.py` | wptserve handlers, which are Python and not files to serve. Port them the way the seven above were ported if a lane needs one. |
+| `common/reftest-wait.js` | A reftest's rendering handshake, and there is nothing here to render. |
+| `common/dispatcher/*` | A cross-context message bus built on a wptserve stash handler. |
+| `common/security-features/*` | The referrer-policy and mixed-content generators, and a second origin to be insecure from. |
 
 Every vendored file was timed at the pin; the slowest is
 `derive_bits_keys/pbkdf2.https.any.js` at ~20 s for 8,632 cases (it is `// META: timeout=long` and sharded

--- a/Jint.Tests/Wpt/Vendor/common/dummy.xhtml
+++ b/Jint.Tests/Wpt/Vendor/common/dummy.xhtml
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"><head><title>Dummy XHTML document</title></head><body /></html>

--- a/Jint.Tests/Wpt/Vendor/common/dummy.xml
+++ b/Jint.Tests/Wpt/Vendor/common/dummy.xml
@@ -1,0 +1,1 @@
+<foo>Dummy XML document</foo>

--- a/Jint.Tests/Wpt/Vendor/common/get-host-info.sub.js
+++ b/Jint.Tests/Wpt/Vendor/common/get-host-info.sub.js
@@ -1,0 +1,68 @@
+/**
+ * Host information for cross-origin tests.
+ * @returns {Object} with properties for different host information.
+ */
+function get_host_info() {
+
+  var HTTP_PORT = '{{ports[http][0]}}';
+  var HTTP_PORT2 = '{{ports[http][1]}}';
+  var HTTPS_PORT = '{{ports[https][0]}}';
+  var HTTPS_PORT2 = '{{ports[https][1]}}';
+  var PROTOCOL = self.location.protocol;
+  var IS_HTTPS = (PROTOCOL == "https:");
+  var PORT = IS_HTTPS ? HTTPS_PORT : HTTP_PORT;
+  var PORT2 = IS_HTTPS ? HTTPS_PORT2 : HTTP_PORT2;
+  var HTTP_PORT_ELIDED = HTTP_PORT == "80" ? "" : (":" + HTTP_PORT);
+  var HTTP_PORT2_ELIDED = HTTP_PORT2 == "80" ? "" : (":" + HTTP_PORT2);
+  var HTTPS_PORT_ELIDED = HTTPS_PORT == "443" ? "" : (":" + HTTPS_PORT);
+  var PORT_ELIDED = IS_HTTPS ? HTTPS_PORT_ELIDED : HTTP_PORT_ELIDED;
+  var ORIGINAL_HOST = '{{host}}';
+  var REMOTE_HOST = (ORIGINAL_HOST === 'localhost') ? '127.0.0.1' : ('www1.' + ORIGINAL_HOST);
+  var OTHER_HOST = '{{domains[www2]}}';
+  var NOTSAMESITE_HOST = (ORIGINAL_HOST === 'localhost') ? '127.0.0.1' : ('{{hosts[alt][]}}');
+  var OTHER_NOTSAMESITE_HOST = '{{hosts[alt][www2]}}';
+
+  return {
+    HTTP_PORT: HTTP_PORT,
+    HTTP_PORT2: HTTP_PORT2,
+    HTTPS_PORT: HTTPS_PORT,
+    HTTPS_PORT2: HTTPS_PORT2,
+    HTTP_PORT_ELIDED: HTTP_PORT_ELIDED,
+    HTTPS_PORT_ELIDED: HTTPS_PORT_ELIDED,
+    PORT: PORT,
+    PORT2: PORT2,
+    ORIGINAL_HOST: ORIGINAL_HOST,
+    REMOTE_HOST: REMOTE_HOST,
+    NOTSAMESITE_HOST,
+
+    ORIGIN: PROTOCOL + "//" + ORIGINAL_HOST + PORT_ELIDED,
+    HTTP_ORIGIN: 'http://' + ORIGINAL_HOST + HTTP_PORT_ELIDED,
+    HTTPS_ORIGIN: 'https://' + ORIGINAL_HOST + HTTPS_PORT_ELIDED,
+    HTTPS_ORIGIN_WITH_CREDS: 'https://foo:bar@' + ORIGINAL_HOST + HTTPS_PORT_ELIDED,
+    HTTP_ORIGIN_WITH_DIFFERENT_PORT: 'http://' + ORIGINAL_HOST + HTTP_PORT2_ELIDED,
+    REMOTE_ORIGIN: PROTOCOL + "//" + REMOTE_HOST + PORT_ELIDED,
+    OTHER_ORIGIN: PROTOCOL + "//" + OTHER_HOST + PORT_ELIDED,
+    HTTP_REMOTE_ORIGIN: 'http://' + REMOTE_HOST + HTTP_PORT_ELIDED,
+    HTTP_NOTSAMESITE_ORIGIN: 'http://' + NOTSAMESITE_HOST + HTTP_PORT_ELIDED,
+    HTTP_REMOTE_ORIGIN_WITH_DIFFERENT_PORT: 'http://' + REMOTE_HOST + HTTP_PORT2_ELIDED,
+    HTTPS_REMOTE_ORIGIN: 'https://' + REMOTE_HOST + HTTPS_PORT_ELIDED,
+    HTTPS_REMOTE_ORIGIN_WITH_CREDS: 'https://foo:bar@' + REMOTE_HOST + HTTPS_PORT_ELIDED,
+    HTTPS_NOTSAMESITE_ORIGIN: 'https://' + NOTSAMESITE_HOST + HTTPS_PORT_ELIDED,
+    HTTPS_OTHER_NOTSAMESITE_ORIGIN: 'https://' + OTHER_NOTSAMESITE_HOST + HTTPS_PORT_ELIDED,
+    UNAUTHENTICATED_ORIGIN: 'http://' + OTHER_HOST + HTTP_PORT_ELIDED,
+    AUTHENTICATED_ORIGIN: 'https://' + OTHER_HOST + HTTPS_PORT_ELIDED
+  };
+}
+
+/**
+ * When a default port is used, location.port returns the empty string.
+ * This function attempts to provide an exact port, assuming we are running under wptserve.
+ * @param {*} loc - can be Location/<a>/<area>/URL, but assumes http/https only.
+ * @returns {string} The port number.
+ */
+function get_port(loc) {
+  if (loc.port) {
+    return loc.port;
+  }
+  return loc.protocol === 'https:' ? '443' : '80';
+}

--- a/Jint.Tests/Wpt/Vendor/resources/testdriver-actions.js
+++ b/Jint.Tests/Wpt/Vendor/resources/testdriver-actions.js
@@ -1,0 +1,607 @@
+(function() {
+  let sourceNameIdx = 0;
+
+  /**
+   * @class
+   * Builder for creating a sequence of actions
+   *
+   *
+   * The actions are dispatched once
+   * :js:func:`test_driver.Actions.send` is called. This returns a
+   * promise which resolves once the actions are complete.
+   *
+   * The other methods on :js:class:`test_driver.Actions` object are
+   * used to build the sequence of actions that will be sent. These
+   * return the `Actions` object itself, so the actions sequence can
+   * be constructed by chaining method calls.
+   *
+   * Internally :js:func:`test_driver.Actions.send` invokes
+   * :js:func:`test_driver.action_sequence`.
+   *
+   * @example
+   * let text_box = document.getElementById("text");
+   *
+   * let actions = new test_driver.Actions()
+   *    .pointerMove(0, 0, {origin: text_box})
+   *    .pointerDown()
+   *    .pointerUp()
+   *    .addTick()
+   *    .keyDown("p")
+   *    .keyUp("p");
+   *
+   * await actions.send();
+   *
+   * @param {number} [defaultTickDuration] - The default duration of a
+   * tick. Be default this is set ot 16ms, which is one frame time
+   * based on 60Hz display.
+   */
+  function Actions(defaultTickDuration=16) {
+    this.sourceTypes = new Map([["key", KeySource],
+                                ["pointer", PointerSource],
+                                ["wheel", WheelSource],
+                                ["none", GeneralSource]]);
+    this.sources = new Map();
+    this.sourceOrder = [];
+    for (let sourceType of this.sourceTypes.keys()) {
+      this.sources.set(sourceType, new Map());
+    }
+    this.currentSources = new Map();
+    for (let sourceType of this.sourceTypes.keys()) {
+      this.currentSources.set(sourceType, null);
+    }
+    this.createSource("none");
+    this.tickIdx = 0;
+    this.defaultTickDuration = defaultTickDuration;
+    this.context = null;
+  }
+
+  Actions.prototype = {
+    ButtonType: {
+      LEFT: 0,
+      MIDDLE: 1,
+      RIGHT: 2,
+      BACK: 3,
+      FORWARD: 4,
+    },
+
+    /**
+     * Generate the action sequence suitable for passing to
+     * test_driver.action_sequence
+     *
+     * @returns {Array} Array of WebDriver-compatible actions sequences
+     */
+    serialize: function() {
+      let actions = [];
+      for (let [sourceType, sourceName] of this.sourceOrder) {
+        let source = this.sources.get(sourceType).get(sourceName);
+        let serialized = source.serialize(this.tickIdx + 1, this.defaultTickDuration);
+        if (serialized) {
+          serialized.id = sourceName;
+          actions.push(serialized);
+        }
+      }
+      return actions;
+    },
+
+    /**
+     * Generate and send the action sequence
+     *
+     * @returns {Promise} fulfilled after the sequence is executed,
+     *                    rejected if any actions fail.
+     */
+    send: function() {
+      let actions;
+      try {
+        actions = this.serialize();
+      } catch(e) {
+        return Promise.reject(e);
+      }
+      return test_driver.action_sequence(actions, this.context);
+    },
+
+    /**
+     * Set the context for the actions
+     *
+     * @param {WindowProxy} context - Context in which to run the action sequence
+     */
+    setContext: function(context) {
+      this.context = context;
+      return this;
+    },
+
+    /**
+     * Get the action source with a particular source type and name.
+     * If no name is passed, a new source with the given type is
+     * created.
+     *
+     * @param {String} type - Source type ('none', 'key', 'pointer', or 'wheel')
+     * @param {String?} name - Name of the source
+     * @returns {Source} Source object for that source.
+     */
+    getSource: function(type, name) {
+      if (!this.sources.has(type)) {
+        throw new Error(`${type} is not a valid action type`);
+      }
+      if (name === null || name === undefined) {
+        name = this.currentSources.get(type);
+      }
+      if (name === null || name === undefined) {
+        return this.createSource(type, null);
+      }
+      return this.sources.get(type).get(name);
+    },
+
+    setSource: function(type, name) {
+      if (!this.sources.has(type)) {
+        throw new Error(`${type} is not a valid action type`);
+      }
+      if (!this.sources.get(type).has(name)) {
+        throw new Error(`${name} is not a valid source for ${type}`);
+      }
+      this.currentSources.set(type, name);
+      return this;
+    },
+
+    /**
+     * Add a new key input source with the given name
+     *
+     * @param {String} name - Name of the key source
+     * @param {Bool} set - Set source as the default key source
+     * @returns {Actions}
+     */
+    addKeyboard: function(name, set=true) {
+      this.createSource("key", name);
+      if (set) {
+        this.setKeyboard(name);
+      }
+      return this;
+    },
+
+    /**
+     * Set the current default key source
+     *
+     * @param {String} name - Name of the key source
+     * @returns {Actions}
+     */
+    setKeyboard: function(name) {
+      this.setSource("key", name);
+      return this;
+    },
+
+    /**
+     * Add a new pointer input source with the given name
+     *
+     * @param {String} type - Name of the pointer source
+     * @param {String} pointerType - Type of pointing device
+     * @param {Bool} set - Set source as the default pointer source
+     * @returns {Actions}
+     */
+    addPointer: function(name, pointerType="mouse", set=true) {
+      this.createSource("pointer", name, {pointerType: pointerType});
+      if (set) {
+        this.setPointer(name);
+      }
+      return this;
+    },
+
+    /**
+     * Set the current default pointer source
+     *
+     * @param {String} name - Name of the pointer source
+     * @returns {Actions}
+     */
+    setPointer: function(name) {
+      this.setSource("pointer", name);
+      return this;
+    },
+
+    /**
+     * Add a new wheel input source with the given name
+     *
+     * @param {String} type - Name of the wheel source
+     * @param {Bool} set - Set source as the default wheel source
+     * @returns {Actions}
+     */
+    addWheel: function(name, set=true) {
+      this.createSource("wheel", name);
+      if (set) {
+        this.setWheel(name);
+      }
+      return this;
+    },
+
+    /**
+     * Set the current default wheel source
+     *
+     * @param {String} name - Name of the wheel source
+     * @returns {Actions}
+     */
+    setWheel: function(name) {
+      this.setSource("wheel", name);
+      return this;
+    },
+
+    createSource: function(type, name, parameters={}) {
+      if (!this.sources.has(type)) {
+        throw new Error(`${type} is not a valid action type`);
+      }
+      let sourceNames = new Set();
+      for (let [_, name] of this.sourceOrder) {
+        sourceNames.add(name);
+      }
+      if (!name) {
+        do {
+          name = "" + sourceNameIdx++;
+        } while (sourceNames.has(name))
+      } else {
+        if (sourceNames.has(name)) {
+          throw new Error(`Alreay have a source of type ${type} named ${name}.`);
+        }
+      }
+      this.sources.get(type).set(name, new (this.sourceTypes.get(type))(parameters));
+      this.currentSources.set(type, name);
+      this.sourceOrder.push([type, name]);
+      return this.sources.get(type).get(name);
+    },
+
+    /**
+     * Insert a new actions tick
+     *
+     * @param {Number?} duration - Minimum length of the tick in ms.
+     * @returns {Actions}
+     */
+    addTick: function(duration) {
+      this.tickIdx += 1;
+      if (duration !== undefined && duration !== null) {
+        this.pause(duration);
+      }
+      return this;
+    },
+
+    /**
+     * Add a pause to the current tick
+     *
+     * @param {Number?} duration - Minimum length of the tick in ms.
+     * @param {String} sourceType - source type
+     * @param {String?} sourceName - Named key, pointer or wheel source to use
+     *                               or null for the default key, pointer or
+     *                               wheel source
+     * @returns {Actions}
+     */
+    pause: function(duration=0, sourceType="none", {sourceName=null}={}) {
+      if (sourceType=="none")
+        this.getSource("none").addPause(this, duration);
+      else
+        this.getSource(sourceType, sourceName).addPause(this, duration);
+      return this;
+    },
+
+    /**
+     * Create a keyDown event for the current default key source
+     *
+     * To send special keys, send the respective key's codepoint,
+     * as defined by `WebDriver
+     * <https://w3c.github.io/webdriver/#keyboard-actions>`_.
+     *
+     * @param {String} key - Key to press
+     * @param {String?} sourceName - Named key source to use or null for the default key source
+     * @returns {Actions}
+     */
+    keyDown: function(key, {sourceName=null}={}) {
+      let source = this.getSource("key", sourceName);
+      source.keyDown(this, key);
+      return this;
+    },
+
+    /**
+     * Create a keyUp event for the current default key source
+     *
+     * To send special keys, send the respective key's codepoint,
+     * as defined by `WebDriver
+     * <https://w3c.github.io/webdriver/#keyboard-actions>`_.
+     *
+     * @param {String} key - Key to release
+     * @param {String?} sourceName - Named key source to use or null for the default key source
+     * @returns {Actions}
+     */
+    keyUp: function(key, {sourceName=null}={}) {
+      let source = this.getSource("key", sourceName);
+      source.keyUp(this, key);
+      return this;
+    },
+
+    /**
+     * Create a pointerDown event for the current default pointer source
+     *
+     * @param {String} button - Button to press
+     * @param {String?} sourceName - Named pointer source to use or null for the default
+     *                               pointer source
+     * @returns {Actions}
+     */
+    pointerDown: function({button=this.ButtonType.LEFT, sourceName=null,
+                           width, height, pressure, tangentialPressure,
+                           tiltX, tiltY, twist, altitudeAngle, azimuthAngle}={}) {
+      let source = this.getSource("pointer", sourceName);
+      source.pointerDown(this, button, width, height, pressure, tangentialPressure,
+                         tiltX, tiltY, twist, altitudeAngle, azimuthAngle);
+      return this;
+    },
+
+    /**
+     * Create a pointerUp event for the current default pointer source
+     *
+     * @param {String} button - Button to release
+     * @param {String?} sourceName - Named pointer source to use or null for the default pointer
+     *                               source
+     * @returns {Actions}
+     */
+    pointerUp: function({button=this.ButtonType.LEFT, sourceName=null}={}) {
+      let source = this.getSource("pointer", sourceName);
+      source.pointerUp(this, button);
+      return this;
+    },
+
+    /**
+     * Create a move event for the current default pointer source
+     *
+     * @param {Number} x - Destination x coordinate
+     * @param {Number} y - Destination y coordinate
+     * @param {String|Element} origin - Origin of the coordinate system.
+     *                                  Either "pointer", "viewport" or an Element
+     * @param {Number?} duration - Time in ms for the move
+     * @param {String?} sourceName - Named pointer source to use or null for the default pointer
+     *                               source
+     * @returns {Actions}
+     */
+    pointerMove: function(x, y,
+                          {origin="viewport", duration, sourceName=null,
+                           width, height, pressure, tangentialPressure,
+                           tiltX, tiltY, twist, altitudeAngle, azimuthAngle}={}) {
+      let source = this.getSource("pointer", sourceName);
+      source.pointerMove(this, x, y, duration, origin, width, height, pressure,
+                         tangentialPressure, tiltX, tiltY, twist, altitudeAngle,
+                         azimuthAngle);
+      return this;
+    },
+
+    /**
+     * Create a scroll event for the current default wheel source
+     *
+     * @param {Number} x - mouse cursor x coordinate
+     * @param {Number} y - mouse cursor y coordinate
+     * @param {Number} deltaX - scroll delta value along the x-axis in pixels
+     * @param {Number} deltaY - scroll delta value along the y-axis in pixels
+     * @param {String|Element} origin - Origin of the coordinate system.
+     *                                  Either "viewport" or an Element
+     * @param {Number?} duration - Time in ms for the scroll
+     * @param {String?} sourceName - Named wheel source to use or null for the
+     *                               default wheel source
+     * @returns {Actions}
+     */
+    scroll: function(x, y, deltaX, deltaY,
+                     {origin="viewport", duration, sourceName=null}={}) {
+      let source = this.getSource("wheel", sourceName);
+      source.scroll(this, x, y, deltaX, deltaY, duration, origin);
+      return this;
+    },
+  };
+
+  function GeneralSource() {
+    this.actions = new Map();
+  }
+
+  GeneralSource.prototype = {
+    serialize: function(tickCount, defaultTickDuration) {
+      let actions = [];
+      let data = {"type": "none", "actions": actions};
+      for (let i=0; i<tickCount; i++) {
+        if (this.actions.has(i)) {
+          actions.push(this.actions.get(i));
+        } else {
+          actions.push({"type": "pause", duration: defaultTickDuration});
+        }
+      }
+      return data;
+    },
+
+    addPause: function(actions, duration) {
+      let tick = actions.tickIdx;
+      if (this.actions.has(tick)) {
+        throw new Error(`Already have a pause action for the current tick`);
+      }
+      this.actions.set(tick, {type: "pause", duration: duration});
+    },
+  };
+
+  function KeySource() {
+    this.actions = new Map();
+  }
+
+  KeySource.prototype = {
+    serialize: function(tickCount) {
+      if (!this.actions.size) {
+        return undefined;
+      }
+      let actions = [];
+      let data = {"type": "key", "actions": actions};
+      for (let i=0; i<tickCount; i++) {
+        if (this.actions.has(i)) {
+          actions.push(this.actions.get(i));
+        } else {
+          actions.push({"type": "pause"});
+        }
+      }
+      return data;
+    },
+
+    keyDown: function(actions, key) {
+      let tick = actions.tickIdx;
+      if (this.actions.has(tick)) {
+        tick = actions.addTick().tickIdx;
+      }
+      this.actions.set(tick, {type: "keyDown", value: key});
+    },
+
+    keyUp: function(actions, key) {
+      let tick = actions.tickIdx;
+      if (this.actions.has(tick)) {
+        tick = actions.addTick().tickIdx;
+      }
+      this.actions.set(tick, {type: "keyUp", value: key});
+    },
+
+    addPause: function(actions, duration) {
+      let tick = actions.tickIdx;
+      if (this.actions.has(tick)) {
+        tick = actions.addTick().tickIdx;
+      }
+      this.actions.set(tick, {type: "pause", duration: duration});
+    },
+  };
+
+  function PointerSource(parameters={pointerType: "mouse"}) {
+    let pointerType = parameters.pointerType || "mouse";
+    if (!["mouse", "pen", "touch"].includes(pointerType)) {
+      throw new Error(`Invalid pointerType ${pointerType}`);
+    }
+    this.type = pointerType;
+    this.actions = new Map();
+  }
+
+  function setPointerProperties(action, width, height, pressure, tangentialPressure,
+                                tiltX, tiltY, twist, altitudeAngle, azimuthAngle) {
+    if (width) {
+      action.width = width;
+    }
+    if (height) {
+      action.height = height;
+    }
+    if (pressure) {
+      action.pressure = pressure;
+    }
+    if (tangentialPressure) {
+      action.tangentialPressure = tangentialPressure;
+    }
+    if (tiltX) {
+      action.tiltX = tiltX;
+    }
+    if (tiltY) {
+      action.tiltY = tiltY;
+    }
+    if (twist) {
+      action.twist = twist;
+    }
+    if (altitudeAngle) {
+      action.altitudeAngle = altitudeAngle;
+    }
+    if (azimuthAngle) {
+      action.azimuthAngle = azimuthAngle;
+    }
+    return action;
+  }
+
+  PointerSource.prototype = {
+    serialize: function(tickCount) {
+      if (!this.actions.size) {
+        return undefined;
+      }
+      let actions = [];
+      let data = {"type": "pointer", "actions": actions, "parameters": {"pointerType": this.type}};
+      for (let i=0; i<tickCount; i++) {
+        if (this.actions.has(i)) {
+          actions.push(this.actions.get(i));
+        } else {
+          actions.push({"type": "pause"});
+        }
+      }
+      return data;
+    },
+
+    pointerDown: function(actions, button, width, height, pressure, tangentialPressure,
+                          tiltX, tiltY, twist, altitudeAngle, azimuthAngle) {
+      let tick = actions.tickIdx;
+      if (this.actions.has(tick)) {
+        tick = actions.addTick().tickIdx;
+      }
+      let actionProperties = setPointerProperties({type: "pointerDown", button}, width, height,
+                                                  pressure, tangentialPressure, tiltX, tiltY,
+                                                  twist, altitudeAngle, azimuthAngle);
+      this.actions.set(tick, actionProperties);
+    },
+
+    pointerUp: function(actions, button) {
+      let tick = actions.tickIdx;
+      if (this.actions.has(tick)) {
+        tick = actions.addTick().tickIdx;
+      }
+      this.actions.set(tick, {type: "pointerUp", button});
+    },
+
+    pointerMove: function(actions, x, y, duration, origin, width, height, pressure,
+                          tangentialPressure, tiltX, tiltY, twist, altitudeAngle, azimuthAngle) {
+      let tick = actions.tickIdx;
+      if (this.actions.has(tick)) {
+        tick = actions.addTick().tickIdx;
+      }
+      let moveAction = {type: "pointerMove", x, y, origin};
+      if (duration !== undefined && duration !== null) {
+        moveAction.duration = duration;
+      }
+      let actionProperties = setPointerProperties(moveAction, width, height, pressure,
+                                                  tangentialPressure, tiltX, tiltY, twist,
+                                                  altitudeAngle, azimuthAngle);
+      this.actions.set(tick, actionProperties);
+    },
+
+    addPause: function(actions, duration) {
+      let tick = actions.tickIdx;
+      if (this.actions.has(tick)) {
+        tick = actions.addTick().tickIdx;
+      }
+      this.actions.set(tick, {type: "pause", duration: duration});
+    },
+  };
+
+  function WheelSource() {
+    this.actions = new Map();
+  }
+
+  WheelSource.prototype = {
+    serialize: function(tickCount) {
+      if (!this.actions.size) {
+        return undefined;
+      }
+      let actions = [];
+      let data = {"type": "wheel", "actions": actions};
+      for (let i=0; i<tickCount; i++) {
+        if (this.actions.has(i)) {
+          actions.push(this.actions.get(i));
+        } else {
+          actions.push({"type": "pause"});
+        }
+      }
+      return data;
+    },
+
+    scroll: function(actions, x, y, deltaX, deltaY, duration, origin) {
+      let tick = actions.tickIdx;
+      if (this.actions.has(tick)) {
+        tick = actions.addTick().tickIdx;
+      }
+      this.actions.set(tick, {type: "scroll", x, y, deltaX, deltaY, origin});
+      if (duration !== undefined && duration !== null) {
+        this.actions.get(tick).duration = duration;
+      }
+    },
+
+    addPause: function(actions, duration) {
+      let tick = actions.tickIdx;
+      if (this.actions.has(tick)) {
+        tick = actions.addTick().tickIdx;
+      }
+      this.actions.set(tick, {type: "pause", duration: duration});
+    },
+  };
+
+  test_driver.Actions = Actions;
+})();

--- a/Jint.Tests/Wpt/Vendor/resources/testdriver-actions.js.headers
+++ b/Jint.Tests/Wpt/Vendor/resources/testdriver-actions.js.headers
@@ -1,0 +1,2 @@
+Content-Type: text/javascript; charset=utf-8
+Cache-Control: max-age=3600

--- a/Jint.Tests/Wpt/Vendor/resources/testdriver-vendor.js.headers
+++ b/Jint.Tests/Wpt/Vendor/resources/testdriver-vendor.js.headers
@@ -1,0 +1,2 @@
+Content-Type: text/javascript; charset=utf-8
+Cache-Control: max-age=3600

--- a/Jint.Tests/Wpt/Vendor/resources/testdriver.js
+++ b/Jint.Tests/Wpt/Vendor/resources/testdriver.js
@@ -1,0 +1,2782 @@
+(function() {
+    "use strict";
+    var idCounter = 0;
+    let testharness_context = null;
+
+    const features = (() => {
+        function getFeatures(scriptSrc) {
+            try {
+                const url = new URL(scriptSrc);
+                return url.searchParams.getAll('feature');
+            } catch (e) {
+                return [];
+            }
+        }
+
+        return getFeatures(document?.currentScript?.src ?? '');
+    })();
+
+    function assertBidiIsEnabled(){
+        if (!features.includes('bidi')) {
+            throw new Error(
+                "`?feature=bidi` is missing when importing testdriver.js but the test is using WebDriver BiDi APIs");
+        }
+    }
+
+    function assertTestIsTentative(){
+        const testPath = location.pathname;
+        const tentative = testPath.includes('.tentative.') || testPath.includes('/tentative/');
+        if (!tentative) {
+            throw new Error("Method in testdriver.js intended for tentative tests used in non-tentative test");
+        }
+    }
+
+    function getInViewCenterPoint(rect) {
+        var left = Math.max(0, rect.left);
+        var right = Math.min(window.innerWidth, rect.right);
+        var top = Math.max(0, rect.top);
+        var bottom = Math.min(window.innerHeight, rect.bottom);
+
+        var x = 0.5 * (left + right);
+        var y = 0.5 * (top + bottom);
+
+        return [x, y];
+    }
+
+    function getPointerInteractablePaintTree(element) {
+        let elementDocument = element.ownerDocument;
+        if (!elementDocument.contains(element)) {
+            return [];
+        }
+
+        var rectangles = element.getClientRects();
+
+        if (rectangles.length === 0) {
+            return [];
+        }
+
+        var centerPoint = getInViewCenterPoint(rectangles[0]);
+
+        if ("elementsFromPoint" in elementDocument) {
+            return elementDocument.elementsFromPoint(centerPoint[0], centerPoint[1]);
+        } else if ("msElementsFromPoint" in elementDocument) {
+            var rv = elementDocument.msElementsFromPoint(centerPoint[0], centerPoint[1]);
+            return Array.prototype.slice.call(rv ? rv : []);
+        } else {
+            throw new Error("document.elementsFromPoint unsupported");
+        }
+    }
+
+    function inView(element) {
+        var pointerInteractablePaintTree = getPointerInteractablePaintTree(element);
+        return pointerInteractablePaintTree.indexOf(element) !== -1;
+    }
+
+
+    /**
+     * @namespace {test_driver}
+     */
+    window.test_driver = {
+        /**
+         Represents `WebDriver BiDi <https://w3c.github.io/webdriver-bidi>`_ protocol.
+         */
+        bidi: {
+            /**
+             * @typedef {(String|WindowProxy)} Context A browsing context. Can
+             * be specified by its ID (a string) or using a `WindowProxy`
+             * object.
+             */
+            /**
+             * `bluetooth <https://webbluetoothcg.github.io/web-bluetooth>`_ module.
+             */
+            bluetooth: {
+                /**
+                 * Handle a bluetooth device prompt with the given params. Matches the
+                 * `bluetooth.handleRequestDevicePrompt
+                 * <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-handlerequestdeviceprompt-command>`_
+                 * WebDriver BiDi command.
+                 *
+                 * @example
+                 * await test_driver.bidi.bluetooth.handleRequestDevicePrompt({
+                 *     prompt: "pmt-e0a234b",
+                 *     accept: true,
+                 *     device: "dvc-9b3b872"
+                 * });
+                 *
+                 * @param {object} params - Parameters for the command.
+                 * @param {string} params.prompt - The id of a bluetooth device prompt.
+                 * Matches the
+                 * `bluetooth.HandleRequestDevicePromptParameters:prompt <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-handlerequestdeviceprompt-command>`_
+                 * value.
+                 * @param {bool} params.accept - Whether to accept a bluetooth device prompt.
+                 * Matches the
+                 * `bluetooth.HandleRequestDevicePromptAcceptParameters:accept <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-handlerequestdeviceprompt-command>`_
+                 * value.
+                 * @param {string} params.device - The device id from a bluetooth device
+                 * prompt to be accepted. Matches the
+                 * `bluetooth.HandleRequestDevicePromptAcceptParameters:device <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-handlerequestdeviceprompt-command>`_
+                 * value.
+                 * @param {Context} [params.context] The optional context parameter specifies in
+                 * which browsing context the bluetooth device prompt should be handled. If not
+                 * provided, the current browsing context is used.
+                 * @returns {Promise} fulfilled after the bluetooth device prompt
+                 * is handled, or rejected if the operation fails.
+                 */
+                handle_request_device_prompt: function(params) {
+                    return window.test_driver_internal.bidi.bluetooth
+                        .handle_request_device_prompt(params);
+                },
+                /**
+                 * Creates a simulated bluetooth adapter with the given params. Matches the
+                 * `bluetooth.simulateAdapter <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-simulateAdapter-command>`_
+                 * WebDriver BiDi command.
+                 *
+                 * @example
+                 * await test_driver.bidi.bluetooth.simulate_adapter({
+                 *     state: "powered-on"
+                 * });
+                 *
+                 * @param {object} params - Parameters for the command.
+                 * @param {string} params.state The state of the simulated bluetooth adapter.
+                 * Matches the
+                 * `bluetooth.SimulateAdapterParameters:state <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-simulateAdapter-command>`_
+                 * value.
+                 * @param {Context} [params.context] The optional context parameter specifies in
+                 * which browsing context the simulated bluetooth adapter should be set. If not
+                 * provided, the current browsing context is used.
+                 * @returns {Promise} fulfilled after the simulated bluetooth adapter is created
+                 * and set, or rejected if the operation fails.
+                 */
+                simulate_adapter: function (params) {
+                    return window.test_driver_internal.bidi.bluetooth.simulate_adapter(params);
+                },
+                /**
+                 * Disables the bluetooth simulation with the given params. Matches the
+                 * `bluetooth.disableSimulation <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-disableSimulation-command>`_
+                 * WebDriver BiDi command.
+                 *
+                 * @example
+                 * await test_driver.bidi.bluetooth.disable_simulation();
+                 *
+                 * @param {object} params - Parameters for the command.
+                 * @param {Context} [params.context] The optional context parameter specifies in
+                 * which browsing context to disable the simulation for. If not provided, the
+                 * current browsing context is used.
+                 * @returns {Promise} fulfilled after the simulation is disabled, or rejected if
+                 * the operation fails.
+                 */
+                disable_simulation: function (params) {
+                    return window.test_driver_internal.bidi.bluetooth.disable_simulation(params);
+                },
+                /**
+                 * Creates a simulated bluetooth peripheral with the given params.
+                 * Matches the
+                 * `bluetooth.simulatePreconnectedPeripheral <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-simulateconnectedperipheral-command>`_
+                 * WebDriver BiDi command.
+                 *
+                 * @example
+                 * await test_driver.bidi.bluetooth.simulatePreconnectedPeripheral({
+                 *     "address": "09:09:09:09:09:09",
+                 *     "name": "Some Device",
+                 *     "manufacturerData": [{key: 17, data: "AP8BAX8="}],
+                 *     "knownServiceUuids": [
+                 *          "12345678-1234-5678-9abc-def123456789",
+                 *     ],
+                 * });
+                 *
+                 * @param {object} params - Parameters for the command.
+                 * @param {string} params.address - The address of the simulated
+                 * bluetooth peripheral. Matches the
+                 * `bluetooth.SimulatePreconnectedPeripheralParameters:address <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-simulateconnectedperipheral-command>`_
+                 * value.
+                 * @param {string} params.name - The name of the simulated bluetooth
+                 * peripheral. Matches the
+                 * `bluetooth.SimulatePreconnectedPeripheralParameters:name <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-simulateconnectedperipheral-command>`_
+                 * value.
+                 * @param {Array.ManufacturerData} params.manufacturerData - The manufacturerData of the
+                 * simulated bluetooth peripheral. Matches the
+                 * `bluetooth.SimulatePreconnectedPeripheralParameters:manufacturerData <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-simulateconnectedperipheral-command>`_
+                 * value.
+                 * @param {string} params.knownServiceUuids - The knownServiceUuids of
+                 * the simulated bluetooth peripheral. Matches the
+                 * `bluetooth.SimulatePreconnectedPeripheralParameters:knownServiceUuids <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-simulateconnectedperipheral-command>`_
+                 * value.
+                 * @param {Context} [params.context] The optional context parameter
+                 * specifies in which browsing context the simulated bluetooth peripheral should be
+                 * set. If not provided, the current browsing context is used.
+                 * @returns {Promise} fulfilled after the simulated bluetooth peripheral is created
+                 * and set, or rejected if the operation fails.
+                 */
+                simulate_preconnected_peripheral: function(params) {
+                    return window.test_driver_internal.bidi.bluetooth
+                        .simulate_preconnected_peripheral(params);
+                },
+                /**
+                 * Simulates a GATT connection response for a given peripheral.
+                 * Matches the `bluetooth.simulateGattConnectionResponse
+                 * <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-simulategattconnectionresponse-command>`_
+                 * WebDriver BiDi command.
+                 *
+                 * @example
+                 * await test_driver.bidi.bluetooth.simulate_gatt_connection_response({
+                 *     "address": "09:09:09:09:09:09",
+                 *     "code": 0x0
+                 * });
+                 *
+                 * @param {object} params - Parameters for the command.
+                 * @param {string} params.address - The address of the simulated
+                 * bluetooth peripheral. Matches the
+                 * `bluetooth.SimulateGattConnectionResponseParameters:peripheral <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-simulategattconnectionresponse-command>`_
+                 * value.
+                 * @param {number} params.code - The response code for a GATT connection attempted.
+                 * Matches the
+                 * `bluetooth.SimulateGattConnectionResponseParameters:code <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-simulategattconnectionresponse-command>`_
+                 * value.
+                 * @param {Context} [params.context] The optional context parameter specifies in
+                 * which browsing context the GATT connection response should be simulated. If not
+                 * provided, the current browsing context is used.
+                 * @returns {Promise} fulfilled after the GATT connection response
+                 * is simulated, or rejected if the operation fails.
+                 */
+                simulate_gatt_connection_response: function(params) {
+                    return window.test_driver_internal.bidi.bluetooth
+                        .simulate_gatt_connection_response(params);
+                },
+                /**
+                 * Simulates a GATT disconnection for a given peripheral.
+                 * Matches the `bluetooth.simulateGattDisconnection
+                 * <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-simulategattdisconnection-command>`_
+                 * WebDriver BiDi command.
+                 *
+                 * @example
+                 * await test_driver.bidi.bluetooth.simulate_gatt_disconnection({
+                 *     "address": "09:09:09:09:09:09",
+                 * });
+                 *
+                 * @param {object} params - Parameters for the command.
+                 * @param {string} params.address - The address of the simulated
+                 * bluetooth peripheral. Matches the
+                 * `bluetooth.SimulateGattDisconnectionParameters:address <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-simulategattdisconnection-command>`_
+                 * value.
+                 * @param {Context} [params.context] The optional context parameter specifies in
+                 * which browsing context the GATT disconnection should be simulated. If not
+                 * provided, the current browsing context is used.
+                 * @returns {Promise} fulfilled after the GATT disconnection
+                 * is simulated, or rejected if the operation fails.
+                 */
+                simulate_gatt_disconnection: function(params) {
+                    return window.test_driver_internal.bidi.bluetooth
+                        .simulate_gatt_disconnection(params);
+                },
+                /**
+                 * Simulates a GATT service.
+                 * Matches the `bluetooth.simulateService
+                 * <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-simulateservice-command>`_
+                 * WebDriver BiDi command.
+                 *
+                 * @example
+                 * await test_driver.bidi.bluetooth.simulate_service({
+                 *     "address": "09:09:09:09:09:09",
+                 *     "uuid": "0000180d-0000-1000-8000-00805f9b34fb",
+                 *     "type": "add"
+                 * });
+                 *
+                 * @param {object} params - Parameters for the command.
+                 * @param {string} params.address - The address of the simulated bluetooth peripheral this service belongs to.
+                 * Matches the
+                 * `bluetooth.SimulateServiceParameters:address <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-simulateservice-command>`_
+                 * value.
+                 * @param {string} params.uuid - The uuid of the simulated GATT service.
+                 * Matches the
+                 * `bluetooth.SimulateServiceParameters:address <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-simulateservice-command>`_
+                 * value.
+                 * @param {string} params.type - The type of the GATT service simulation, either "add" or "remove".
+                 * Matches the
+                 * `bluetooth.SimulateServiceParameters:address <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-simulateservice-command>`_
+                 * value.
+                 * @param {Context} [params.context] The optional context parameter specifies in
+                 * which browsing context the GATT service should be simulated. If not
+                 * provided, the current browsing context is used.
+                 * @returns {Promise} fulfilled after the GATT service
+                 * is simulated, or rejected if the operation fails.
+                 */
+                simulate_service: function(params) {
+                    return window.test_driver_internal.bidi.bluetooth
+                        .simulate_service(params);
+                },
+                /**
+                 * Simulates a GATT characteristic.
+                 * Matches the `bluetooth.simulateCharacteristic
+                 * <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-simulatecharacteristic-command>`_
+                 * WebDriver BiDi command.
+                 *
+                 * @example
+                 * await test_driver.bidi.bluetooth.simulate_characteristic({
+                 *     "address": "09:09:09:09:09:09",
+                 *    "serviceUuid": "0000180d-0000-1000-8000-00805f9b34fb",
+                 *    "characteristicUuid": "00002a21-0000-1000-8000-00805f9b34fb",
+                 *    "characteristicProperties": {
+                 *      "read": true,
+                 *      "write": true,
+                 *      "notify": true
+                 *    },
+                 *    "type": "add"
+                 * });
+                 *
+                 * @param {object} params - Parameters for the command.
+                 * @param {string} params.address - The address of the simulated bluetooth peripheral the characterisitc belongs to.
+                 * Matches the
+                 * `bluetooth.SimulateCharacteristicParameters:address <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-simulatecharacteristic-command>`_
+                 * value.
+                 * @param {string} params.serviceUuid - The uuid of the simulated GATT service the characterisitc belongs to.
+                 * Matches the
+                 * `bluetooth.SimulateCharacteristicParameters:address <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-simulatecharacteristic-command>`_
+                 * value.
+                * @param {string} params.characteristicUuid - The uuid of the simulated GATT characteristic.
+                * Matches the
+                * `bluetooth.SimulateCharacteristicParameters:address <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-simulatecharacteristic-command>`_
+                * value.
+                * @param {string} params.characteristicProperties - The properties of the simulated GATT characteristic.
+                * Matches the
+                * `bluetooth.SimulateCharacteristicParameters:address <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-simulatecharacteristic-command>`_
+                * value.
+                * @param {string} params.type - The type of the GATT characterisitc simulation, either "add" or "remove".
+                * Matches the
+                * `bluetooth.SimulateCharacteristicParameters:address <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-simulatecharacteristic-command>`_
+                * value.
+                * @param {Context} [params.context] The optional context parameter specifies in
+                * which browsing context the GATT characteristic should be simulated. If not
+                * provided, the current browsing context is used.
+                * @returns {Promise} fulfilled after the GATT characteristic
+                * is simulated, or rejected if the operation fails.
+                */
+                simulate_characteristic: function(params) {
+                    return window.test_driver_internal.bidi.bluetooth
+                        .simulate_characteristic(params);
+                },
+                /**
+                 * Simulates a GATT characteristic response.
+                 * Matches the `bluetooth.simulateCharacteristicResponse
+                 * <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-simulatecharacteristicresponse-command>`_
+                 * WebDriver BiDi command.
+                 *
+                 * @example
+                 * await test_driver.bidi.bluetooth.simulate_characteristic({
+                 *     "address": "09:09:09:09:09:09",
+                 *    "serviceUuid": "0000180d-0000-1000-8000-00805f9b34fb",
+                 *    "characteristicUuid": "00002a21-0000-1000-8000-00805f9b34fb",
+                 *    "type": "read",
+                 *    "code": 0,
+                 *    "data": [1, 2]
+                 * });
+                 *
+                 * @param {object} params - Parameters for the command.
+                 * @param {string} params.address - The address of the simulated
+                 * bluetooth peripheral. Matches the
+                 * `bluetooth.SimulateCharacteristicResponseParameters:address <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-simulatecharacteristicresponse-command>`_
+                 * value.
+                 * @param {string} params.serviceUuid - The uuid of the simulated GATT service the characterisitc belongs to.
+                 * Matches the
+                 * `bluetooth.SimulateCharacteristicResponseParameters:address <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-simulatecharacteristicresponse-command>`_
+                 * value.
+                * @param {string} params.characteristicUuid - The uuid of the simulated characteristic.
+                * Matches the
+                * `bluetooth.SimulateCharacteristicResponseParameters:address <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-simulatecharacteristicresponse-command>`_
+                * value.
+                * @param {string} params.type - The type of the simulated GATT characteristic operation."
+                * Can be "read", "write", "subscribe-to-notifications" or "unsubscribe-from-notifications".
+                * Matches the
+                * `bluetooth.SimulateCharacteristicResponseParameters:address <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-simulatecharacteristicresponse-command>`_
+                * value.
+                * @param {string} params.code - The simulated GATT characteristic response code.
+                * Matches the
+                * `bluetooth.SimulateCharacteristicResponseParameters:address <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-simulatecharacteristicresponse-command>`_
+                * value.*
+                * @param {string} params.data - The data along with the simulated GATT characteristic response.
+                * Matches the
+                * `bluetooth.SimulateCharacteristicResponseParameters:address <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-simulatecharacteristicresponse-command>`_
+                * value.**
+                * @param {Context} [params.context] The optional context parameter specifies in
+                * which browsing context the GATT characteristic belongs to. If not
+                * provided, the current browsing context is used.
+                * @returns {Promise} fulfilled after the GATT characteristic
+                * is simulated, or rejected if the operation fails.
+                */
+                simulate_characteristic_response: function(params) {
+                    return window.test_driver_internal.bidi.bluetooth
+                        .simulate_characteristic_response(params);
+                },
+                /**
+                 * Simulates a GATT descriptor.
+                 * Matches the `bluetooth.simulateDescriptor
+                 * <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-simulatedescriptor-command>`_
+                 * WebDriver BiDi command.
+                 *
+                 * @example
+                 * await test_driver.bidi.bluetooth.simulate_descriptor({
+                 *     "address": "09:09:09:09:09:09",
+                 *    "serviceUuid": "0000180d-0000-1000-8000-00805f9b34fb",
+                 *    "characteristicUuid": "00002a21-0000-1000-8000-00805f9b34fb",
+                 *    "descriptorUuid": "00002901-0000-1000-8000-00805f9b34fb",
+                 *    "type": "add"
+                 * });
+                 *
+                 * @param {object} params - Parameters for the command.
+                 * @param {string} params.address - The address of the simulated bluetooth peripheral the descriptor belongs to.
+                 * Matches the
+                 * `bluetooth.SimulateDescriptorParameters:address <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-simulatedescriptor-command>`_
+                 * value.
+                 * @param {string} params.serviceUuid - The uuid of the simulated GATT service the descriptor belongs to.
+                 * Matches the
+                 * `bluetooth.SimulateDescriptorParameters:address <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-simulatedescriptor-command>`_
+                 * value.
+                * @param {string} params.characteristicUuid - The uuid of the simulated GATT characterisitc the descriptor belongs to.
+                 * Matches the
+                * `bluetooth.SimulateDescriptorParameters:address <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-simulatedescriptor-command>`_
+                * value.
+                * @param {string} params.descriptorUuid - The uuid of the simulated GATT descriptor.
+                *  Matches the
+                * `bluetooth.SimulateDescriptorParameters:address <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-simulatedescriptor-command>`_
+                * value.*
+                * @param {string} params.type - The type of the GATT descriptor simulation, either "add" or "remove".
+                * Matches the
+                * `bluetooth.SimulateDescriptorParameters:address <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-simulatedescriptor-command>`_
+                * value.
+                * @param {Context} [params.context] The optional context parameter specifies in
+                * which browsing context the GATT descriptor should be simulated. If not
+                * provided, the current browsing context is used.
+                * @returns {Promise} fulfilled after the GATT descriptor
+                * is simulated, or rejected if the operation fails.
+                */
+                simulate_descriptor: function(params) {
+                    return window.test_driver_internal.bidi.bluetooth
+                        .simulate_descriptor(params);
+                },
+                /**
+                 * Simulates a GATT descriptor response.
+                 * Matches the `bluetooth.simulateDescriptorResponse
+                 * <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-simulatedescriptorresponse-command>`_
+                 * WebDriver BiDi command.
+                 *
+                 * @example
+                 * await test_driver.bidi.bluetooth.simulate_descriptor_response({
+                 *     "address": "09:09:09:09:09:09",
+                 *    "serviceUuid": "0000180d-0000-1000-8000-00805f9b34fb",
+                 *    "characteristicUuid": "00002a21-0000-1000-8000-00805f9b34fb",
+                 *    "descriptorUuid": "00002901-0000-1000-8000-00805f9b34fb",
+                 *    "type": "read",
+                 *    "code": 0,
+                 *    "data": [1, 2]
+                 * });
+                 *
+                 * @param {object} params - Parameters for the command.
+                 * @param {string} params.address - The address of the simulated bluetooth peripheral the descriptor belongs to.
+                 * Matches the
+                 * `bluetooth.SimulateDescriptorResponseParameters:address <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-simulatedescriptorresponse-command>`_
+                 * value.
+                 * @param {string} params.serviceUuid - The uuid of the simulated GATT service the descriptor belongs to.
+                 * Matches the
+                 * `bluetooth.SimulateDescriptorResponseParameters:address <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-simulatedescriptorresponse-command>`_
+                 * value.
+                 * @param {string} params.characteristicUuid - The uuid of the simulated GATT characterisitc the descriptor belongs to.
+                 * Matches the
+                 * `bluetooth.SimulateDescriptorResponseParameters:address <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-simulatedescriptorresponse-command>`_
+                 * value.
+                * @param {string} params.descriptorUuid - The uuid of the simulated GATT descriptor.
+                * Matches the
+                * `bluetooth.SimulateDescriptorResponseParameters:address <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-simulatedescriptorresponse-command>`_
+                * value.
+                * @param {string} params.type - The type of the simulated GATT descriptor operation.
+                * Matches the
+                * `bluetooth.SimulateDescriptorResponseParameters:address <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-simulatedescriptorresponse-command>`_
+                * value.
+                * @param {string} params.code - The simulated GATT descriptor response code.
+                * Matches the
+                * `bluetooth.SimulateDescriptorResponseParameters:address <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-simulatedescriptorresponse-command>`_
+                * value.*
+                * @param {string} params.data - The data along with the simulated GATT descriptor response.
+                * Matches the
+                * `bluetooth.SimulateDescriptorResponseParameters:address <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-simulatedescriptorresponse-command>`_
+                * value.**
+                * @param {Context} [params.context] The optional context parameter specifies in
+                * which browsing context the GATT descriptor belongs to. If not
+                * provided, the current browsing context is used.
+                * @returns {Promise} fulfilled after the GATT descriptor response
+                * is simulated, or rejected if the operation fails.
+                */
+                simulate_descriptor_response: function(params) {
+                    return window.test_driver_internal.bidi.bluetooth
+                        .simulate_descriptor_response(params);
+                },
+                /**
+                 * `bluetooth.RequestDevicePromptUpdatedParameters <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-requestdevicepromptupdated-event>`_
+                 * event.
+                 */
+                request_device_prompt_updated: {
+                    /**
+                     * @typedef {object} RequestDevicePromptUpdated
+                     * `bluetooth.RequestDevicePromptUpdatedParameters <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-requestdevicepromptupdated-event>`_
+                     * event.
+                     */
+
+                    /**
+                     * Subscribes to the event. Events will be emitted only if
+                     * there is a subscription for the event. This method does
+                     * not add actual listeners. To listen to the event, use the
+                     * `on` or `once` methods. The buffered events will be
+                     * emitted before the command promise is resolved.
+                     *
+                     * @param {object} [params] Parameters for the subscription.
+                     * @param {null|Array.<(Context)>} [params.contexts] The
+                     * optional contexts parameter specifies which browsing
+                     * contexts to subscribe to the event on. It should be
+                     * either an array of Context objects, or null. If null, the
+                     * event will be subscribed to globally. If omitted, the
+                     * event will be subscribed to on the current browsing
+                     * context.
+                     * @returns {Promise<(function(): Promise<void>)>} Callback
+                     * for unsubscribing from the created subscription.
+                     */
+                    subscribe: async function(params = {}) {
+                        assertBidiIsEnabled();
+                        return window.test_driver_internal.bidi.bluetooth
+                            .request_device_prompt_updated.subscribe(params);
+                    },
+                    /**
+                     * Adds an event listener for the event.
+                     *
+                     * @param {function(RequestDevicePromptUpdated): void} callback The
+                     * callback to be called when the event is emitted. The
+                     * callback is called with the event object as a parameter.
+                     * @returns {function(): void} A function that removes the
+                     * added event listener when called.
+                     */
+                    on: function(callback) {
+                        assertBidiIsEnabled();
+                        return window.test_driver_internal.bidi.bluetooth
+                            .request_device_prompt_updated.on(callback);
+                    },
+                    /**
+                     * Adds an event listener for the event that is only called
+                     * once and removed afterward.
+                     *
+                     * @return {Promise<RequestDevicePromptUpdated>} The promise which
+                     * is resolved with the event object when the event is emitted.
+                     */
+                    once: function() {
+                        assertBidiIsEnabled();
+                        return new Promise(resolve => {
+                            const remove_handler =
+                                window.test_driver_internal.bidi.bluetooth
+                                    .request_device_prompt_updated.on(event => {
+                                    resolve(event);
+                                    remove_handler();
+                                });
+                        });
+                    },
+                },
+                /**
+                 * `bluetooth.GattConnectionAttemptedParameters <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-gattConnectionAttempted-event>`_
+                 * event.
+                 */
+                gatt_connection_attempted: {
+                    /**
+                     * @typedef {object} GattConnectionAttempted
+                     * `bluetooth.GattConnectionAttempted <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-gattConnectionAttempted-event>`_
+                     * event.
+                     */
+
+                    /**
+                     * Subscribes to the event. Events will be emitted only if
+                     * there is a subscription for the event. This method does
+                     * not add actual listeners. To listen to the event, use the
+                     * `on` or `once` methods. The buffered events will be
+                     * emitted before the command promise is resolved.
+                     *
+                     * @param {object} [params] Parameters for the subscription.
+                     * @param {null|Array.<(Context)>} [params.contexts] The
+                     * optional contexts parameter specifies which browsing
+                     * contexts to subscribe to the event on. It should be
+                     * either an array of Context objects, or null. If null, the
+                     * event will be subscribed to globally. If omitted, the
+                     * event will be subscribed to on the current browsing
+                     * context.
+                     * @returns {Promise<(function(): Promise<void>)>} Callback
+                     * for unsubscribing from the created subscription.
+                     */
+                    subscribe: async function(params = {}) {
+                        assertBidiIsEnabled();
+                        return window.test_driver_internal.bidi.bluetooth
+                            .gatt_connection_attempted.subscribe(params);
+                    },
+                    /**
+                     * Adds an event listener for the event.
+                     *
+                     * @param {function(GattConnectionAttempted): void} callback The
+                     * callback to be called when the event is emitted. The
+                     * callback is called with the event object as a parameter.
+                     * @returns {function(): void} A function that removes the
+                     * added event listener when called.
+                     */
+                    on: function(callback) {
+                        assertBidiIsEnabled();
+                        return window.test_driver_internal.bidi.bluetooth
+                            .gatt_connection_attempted.on(callback);
+                    },
+                    /**
+                     * Adds an event listener for the event that is only called
+                     * once and removed afterward.
+                     *
+                     * @return {Promise<GattConnectionAttempted>} The promise which
+                     * is resolved with the event object when the event is emitted.
+                     */
+                    once: function() {
+                        assertBidiIsEnabled();
+                        return new Promise(resolve => {
+                            const remove_handler =
+                                window.test_driver_internal.bidi.bluetooth
+                                    .gatt_connection_attempted.on(event => {
+                                    resolve(event);
+                                    remove_handler();
+                                });
+                        });
+                    },
+                },
+                /**
+                 * `bluetooth.CharacteristicEventGeneratedParameters <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-characteristiceventgenerated-event>`_
+                 * event.
+                 */
+                characteristic_event_generated: {
+                    /**
+                     * @typedef {object} CharacteristicEventGenerated
+                     * `bluetooth.CharacteristicEventGenerated <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-characteristiceventgenerated-event>`_
+                     * event.
+                     */
+
+                    /**
+                     * Subscribes to the event. Events will be emitted only if
+                     * there is a subscription for the event. This method does
+                     * not add actual listeners. To listen to the event, use the
+                     * `on` or `once` methods. The buffered events will be
+                     * emitted before the command promise is resolved.
+                     *
+                     * @param {object} [params] Parameters for the subscription.
+                     * @param {null|Array.<(Context)>} [params.contexts] The
+                     * optional contexts parameter specifies which browsing
+                     * contexts to subscribe to the event on. It should be
+                     * either an array of Context objects, or null. If null, the
+                     * event will be subscribed to globally. If omitted, the
+                     * event will be subscribed to on the current browsing
+                     * context.
+                     * @returns {Promise<(function(): Promise<void>)>} Callback
+                     * for unsubscribing from the created subscription.
+                     */
+                    subscribe: async function(params = {}) {
+                        assertBidiIsEnabled();
+                        return window.test_driver_internal.bidi.bluetooth
+                            .characteristic_event_generated.subscribe(params);
+                    },
+                    /**
+                     * Adds an event listener for the event.
+                     *
+                     * @param {function(CharacteristicEventGenerated): void} callback The
+                     * callback to be called when the event is emitted. The
+                     * callback is called with the event object as a parameter.
+                     * @returns {function(): void} A function that removes the
+                     * added event listener when called.
+                     */
+                    on: function(callback) {
+                        assertBidiIsEnabled();
+                        return window.test_driver_internal.bidi.bluetooth
+                            .characteristic_event_generated.on(callback);
+                    },
+                    /**
+                     * Adds an event listener for the event that is only called
+                     * once and removed afterward.
+                     *
+                     * @return {Promise<CharacteristicEventGenerated>} The promise which
+                     * is resolved with the event object when the event is emitted.
+                     */
+                    once: function() {
+                        assertBidiIsEnabled();
+                        return new Promise(resolve => {
+                            const remove_handler =
+                                window.test_driver_internal.bidi.bluetooth
+                                    .characteristic_event_generated.on(event => {
+                                    resolve(event);
+                                    remove_handler();
+                                });
+                        });
+                    },
+                },
+                /**
+                 * `bluetooth.DescriptorEventGeneratedParameters <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-descriptoreventgenerated-event>`_
+                 * event.
+                 */
+                descriptor_event_generated: {
+                    /**
+                     * @typedef {object} DescriptorEventGenerated
+                     * `bluetooth.DescriptorEventGenerated <https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-descriptoreventgenerated-event>`_
+                     * event.
+                     */
+
+                    /**
+                     * Subscribes to the event. Events will be emitted only if
+                     * there is a subscription for the event. This method does
+                     * not add actual listeners. To listen to the event, use the
+                     * `on` or `once` methods. The buffered events will be
+                     * emitted before the command promise is resolved.
+                     *
+                     * @param {object} [params] Parameters for the subscription.
+                     * @param {null|Array.<(Context)>} [params.contexts] The
+                     * optional contexts parameter specifies which browsing
+                     * contexts to subscribe to the event on. It should be
+                     * either an array of Context objects, or null. If null, the
+                     * event will be subscribed to globally. If omitted, the
+                     * event will be subscribed to on the current browsing
+                     * context.
+                     * @returns {Promise<(function(): Promise<void>)>} Callback
+                     * for unsubscribing from the created subscription.
+                     */
+                    subscribe: async function(params = {}) {
+                        assertBidiIsEnabled();
+                        return window.test_driver_internal.bidi.bluetooth
+                            .descriptor_event_generated.subscribe(params);
+                    },
+                    /**
+                     * Adds an event listener for the event.
+                     *
+                     * @param {function(DescriptorEventGenerated): void} callback The
+                     * callback to be called when the event is emitted. The
+                     * callback is called with the event object as a parameter.
+                     * @returns {function(): void} A function that removes the
+                     * added event listener when called.
+                     */
+                    on: function(callback) {
+                        assertBidiIsEnabled();
+                        return window.test_driver_internal.bidi.bluetooth
+                            .descriptor_event_generated.on(callback);
+                    },
+                    /**
+                     * Adds an event listener for the event that is only called
+                     * once and removed afterward.
+                     *
+                     * @return {Promise<DescriptorEventGenerated>} The promise which
+                     * is resolved with the event object when the event is emitted.
+                     */
+                    once: function() {
+                        assertBidiIsEnabled();
+                        return new Promise(resolve => {
+                            const remove_handler =
+                                window.test_driver_internal.bidi.bluetooth
+                                    .descriptor_event_generated.on(event => {
+                                    resolve(event);
+                                    remove_handler();
+                                });
+                        });
+                    },
+                }
+            },
+            /**
+             * `speculation <https://wicg.github.io/nav-speculation/prefetch.html>`_ module.
+             */
+            speculation: {
+                /**
+                 * `speculation.PrefetchStatusUpdated <https://wicg.github.io/nav-speculation/prefetch.html#speculation-prefetchstatusupdated-event>`_
+                 * event.
+                 */
+                prefetch_status_updated: {
+                    /**
+                     * @typedef {object} PrefetchStatusUpdated
+                     * `speculation.PrefetchStatusUpdatedParameters <https://wicg.github.io/nav-speculation/prefetch.html#cddl-type-speculationprefetchstatusupdatedparameters>`_
+                     * event.
+                     */
+
+                    /**
+                     * Subscribes to the event. Events will be emitted only if
+                     * there is a subscription for the event. This method does
+                     * not add actual listeners. To listen to the event, use the
+                     * `on` or `once` methods. The buffered events will be
+                     * emitted before the command promise is resolved.
+                     *
+                     * @param {object} [params] Parameters for the subscription.
+                     * @param {null|Array.<(Context)>} [params.contexts] The
+                     * optional contexts parameter specifies which browsing
+                     * contexts to subscribe to the event on. It should be
+                     * either an array of Context objects, or null. If null, the
+                     * event will be subscribed to globally. If omitted, the
+                     * event will be subscribed to on the current browsing
+                     * context.
+                     * @returns {Promise<(function(): Promise<void>)>} Callback
+                     * for unsubscribing from the created subscription.
+                     */
+                    subscribe: async function(params = {}) {
+                        assertBidiIsEnabled();
+                        return window.test_driver_internal.bidi.speculation
+                            .prefetch_status_updated.subscribe(params);
+                    },
+                    /**
+                     * Adds an event listener for the event.
+                     *
+                     * @param {function(PrefetchStatusUpdated): void} callback The
+                     * callback to be called when the event is emitted. The
+                     * callback is called with the event object as a parameter.
+                     * @returns {function(): void} A function that removes the
+                     * added event listener when called.
+                     */
+                    on: function(callback) {
+                        assertBidiIsEnabled();
+                        return window.test_driver_internal.bidi.speculation
+                            .prefetch_status_updated.on(callback);
+                    },
+                    /**
+                     * Adds an event listener for the event that is only called
+                     * once and removed afterward.
+                     *
+                     * @return {Promise<PrefetchStatusUpdated>} The promise which
+                     * is resolved with the event object when the event is emitted.
+                     */
+                    once: function() {
+                        assertBidiIsEnabled();
+                        return new Promise(resolve => {
+                            const remove_handler =
+                                window.test_driver_internal.bidi.speculation
+                                    .prefetch_status_updated.on(event => {
+                                    resolve(event);
+                                    remove_handler();
+                                });
+                        });
+                    }
+                }
+            },
+            /**
+             * `emulation <https://www.w3.org/TR/webdriver-bidi/#module-emulation>`_ module.
+             */
+            emulation: {
+                /**
+                 * Overrides the geolocation coordinates for the specified
+                 * browsing contexts.
+                 * Matches the `emulation.setGeolocationOverride
+                 * <https://w3c.github.io/webdriver-bidi/#command-emulation-setGeolocationOverride>`_
+                 * WebDriver BiDi command.
+                 *
+                 * @example
+                 * await test_driver.bidi.emulation.set_geolocation_override({
+                 *     coordinates: {
+                 *         latitude: 52.51,
+                 *         longitude: 13.39,
+                 *         accuracy: 0.5,
+                 *         altitude: 34,
+                 *         altitudeAccuracy: 0.75,
+                 *         heading: 180,
+                 *         speed: 2.77
+                 *     }
+                 * });
+                 *
+                 * @param {object} params - Parameters for the command.
+                 * @param {null|object} params.coordinates - The optional
+                 * geolocation coordinates to set. Matches the
+                 * `emulation.GeolocationCoordinates <https://w3c.github.io/webdriver-bidi/#commands-emulationsetgeolocationoverride>`_
+                 * value. If null or omitted and the `params.error` is set, the
+                 * emulation will be removed. Mutually exclusive with
+                 * `params.error`.
+                 * @param {object} params.error - The optional
+                 * geolocation error to emulate. Matches the
+                 * `emulation.GeolocationPositionError <https://w3c.github.io/webdriver-bidi/#commands-emulationsetgeolocationoverride>`_
+                 * value. Mutually exclusive with `params.coordinates`.
+                 * @param {null|Array.<(Context)>} [params.contexts] The
+                 * optional contexts parameter specifies which browsing contexts
+                 * to set the geolocation override on. It should be either an
+                 * array of Context objects (window or browsing context id), or
+                 * null. If null or omitted, the override will be set on the
+                 * current browsing context.
+                 * @returns {Promise<void>} Resolves when the geolocation
+                 * override is successfully set.
+                 */
+                set_geolocation_override: function (params) {
+                    // Ensure the bidi feature is enabled before calling the internal method
+                    assertBidiIsEnabled();
+                    return window.test_driver_internal.bidi.emulation.set_geolocation_override(
+                        params);
+                },
+                /**
+                 * Overrides the locale for the specified browsing contexts.
+                 * Matches the `emulation.setLocaleOverride
+                 * <https://www.w3.org/TR/webdriver-bidi/#commands-emulationsetlocaleoverride>`_
+                 * WebDriver BiDi command.
+                 *
+                 * @example
+                 * await test_driver.bidi.emulation.set_locale_override({
+                 *     locale: 'de-DE'
+                 * });
+                 *
+                 * @param {object} params - Parameters for the command.
+                 * @param {null|string} params.locale - The optional
+                 * locale to set.
+                 * @param {null|Array.<(Context)>} [params.contexts] The
+                 * optional contexts parameter specifies which browsing contexts
+                 * to set the locale override on. It should be either an array
+                 * of Context objects (window or browsing context id), or null.
+                 * If null or omitted, the override will be set on the current
+                 * browsing context.
+                 * @returns {Promise<void>} Resolves when the locale override
+                 * is successfully set.
+                 */
+                set_locale_override: function (params) {
+                    assertBidiIsEnabled();
+                    return window.test_driver_internal.bidi.emulation.set_locale_override(
+                        params);
+                },
+                /**
+                 * Overrides the screen orientation for the specified browsing
+                 * contexts.
+                 * Matches the `emulation.setScreenOrientationOverride
+                 * <https://www.w3.org/TR/webdriver-bidi/#commands-emulationsetscreenorientationoverride>`_
+                 * WebDriver BiDi command.
+                 *
+                 * @example
+                 * await test_driver.bidi.emulation.set_screen_orientation_override({
+                 *     screenOrientation: {
+                 *         natural: 'portrait',
+                 *         type: 'landscape-secondary'
+                 *     }
+                 * });
+                 *
+                 * @param {object} params - Parameters for the command.
+                 * @param {null|object} params.screenOrientation - The optional
+                 * screen orientation. Matches the
+                 * `emulation.ScreenOrientation <https://www.w3.org/TR/webdriver-bidi/#cddl-type-emulationscreenorientation>`_
+                 * type. If null or omitted, the override will be removed.
+                 * @param {null|Array.<(Context)>} [params.contexts] The
+                 * optional contexts parameter specifies which browsing contexts
+                 * to set the screen orientation override on. It should be
+                 * either an array of Context objects (window or browsing
+                 * context id), or null. If null or omitted, the override will
+                 * be set on the current browsing context.
+                 * @returns {Promise<void>} Resolves when the screen orientation
+                 * override is successfully set.
+                 */
+                set_screen_orientation_override: function (params) {
+                    // Ensure the bidi feature is enabled before calling the internal method
+                    assertBidiIsEnabled();
+                    return window.test_driver_internal.bidi.emulation.set_screen_orientation_override(
+                        params);
+                },
+                /**
+                 * Overrides the touch configuration for the specified browsing
+                 * contexts.
+                 * Matches the `emulation.setTouchOverride
+                 * <https://w3c.github.io/webdriver-bidi/#command-emulation-setTouchOverride>`_
+                 * WebDriver BiDi command.
+                 *
+                 * @example
+                 * await test_driver.bidi.emulation.set_touch_override({
+                 *     maxTouchPoints: 5
+                 * });
+                 *
+                 * @param {object} params - Parameters for the command.
+                 * @param {null|number} params.maxTouchPoints - The
+                 * maximum number of simultaneous touch points to support.
+                 * If null or omitted, the override will be removed.
+                 * @param {null|Array.<(Context)>} [params.contexts] The
+                 * optional contexts parameter specifies which browsing contexts
+                 * to set the touch override on. It should be either an array of
+                 * Context objects (window or browsing context id), or null. If
+                 * null or omitted, the override will be set on the current
+                 * browsing context.
+                 * @returns {Promise<void>} Resolves when the touch
+                 * override is successfully set.
+                 */
+                set_touch_override: function (params) {
+                    assertBidiIsEnabled();
+                    return window.test_driver_internal.bidi.emulation.set_touch_override(
+                        params);
+                },
+            },
+            /**
+             * `user_agent_client_hints <https://wicg.github.io/ua-client-hints/#automation>`_ module.
+             */
+            user_agent_client_hints: {
+                /**
+                 * Overrides the user agent client hints configuration for the specified browsing
+                 * contexts. Matches the `userAgentClientHints.setClientHintsOverride
+                 * <https://wicg.github.io/ua-client-hints/#emulation-setclienthintsoverride>`_
+                 * WebDriver BiDi command.
+                 *
+                 * @param {object} params - Parameters for the command.
+                 * @param {null|object} params.clientHints - The client hints to override.
+                 * Matches the `userAgentClientHints.ClientHints` type.
+                 * If null or omitted, the override will be removed.
+                 * @param {null|Array.<(Context)>} [params.contexts] The
+                 * optional contexts parameter specifies which browsing contexts
+                 * to set the override on.
+                 * @returns {Promise<void>} Resolves when the override is successfully set.
+                 */
+                set_client_hints_override: function (params) {
+                    assertBidiIsEnabled();
+                    return window.test_driver_internal.bidi.user_agent_client_hints.set_client_hints_override(
+                        params);
+                }
+            },
+            /**
+             * `log <https://www.w3.org/TR/webdriver-bidi/#module-log>`_ module.
+             */
+            log: {
+                entry_added: {
+                    /**
+                     * @typedef {object} LogEntryAdded `log.entryAdded <https://www.w3.org/TR/webdriver-bidi/#event-log-entryAdded>`_ event.
+                     */
+
+                    /**
+                     * Subscribes to the event. Events will be emitted only if
+                     * there is a subscription for the event. This method does
+                     * not add actual listeners. To listen to the event, use the
+                     * `on` or `once` methods. The buffered events will be
+                     * emitted before the command promise is resolved.
+                     *
+                     * @param {object} [params] Parameters for the subscription.
+                     * @param {null|Array.<(Context)>} [params.contexts] The
+                     * optional contexts parameter specifies which browsing
+                     * contexts to subscribe to the event on. It should be
+                     * either an array of Context objects, or null. If null, the
+                     * event will be subscribed to globally. If omitted, the
+                     * event will be subscribed to on the current browsing
+                     * context.
+                     * @returns {Promise<(function(): Promise<void>)>} Callback
+                     * for unsubscribing from the created subscription.
+                     */
+                    subscribe: async function (params = {}) {
+                        assertBidiIsEnabled();
+                        return window.test_driver_internal.bidi.log.entry_added.subscribe(params);
+                    },
+                    /**
+                     * Adds an event listener for the event.
+                     *
+                     * @param {function(LogEntryAdded): void} callback The
+                     * callback to be called when the event is emitted. The
+                     * callback is called with the event object as a parameter.
+                     * @returns {function(): void} A function that removes the
+                     * added event listener when called.
+                     */
+                    on: function (callback) {
+                        assertBidiIsEnabled();
+                        return window.test_driver_internal.bidi.log.entry_added.on(callback);
+                    },
+                    /**
+                     * Adds an event listener for the event that is only called
+                     * once and removed afterward.
+                     *
+                     * @return {Promise<LogEntryAdded>} The promise which is resolved
+                     * with the event object when the event is emitted.
+                     */
+                    once: function () {
+                        assertBidiIsEnabled();
+                        return new Promise(resolve => {
+                            const remove_handler = window.test_driver_internal.bidi.log.entry_added.on(
+                                event => {
+                                    resolve(event);
+                                    remove_handler();
+                                });
+                        });
+                    },
+                }
+            },
+            /**
+             * `permissions <https://www.w3.org/TR/permissions/>`_ module.
+             */
+            permissions: {
+                /**
+                 * Sets the state of a permission
+                 *
+                 * This function causes permission requests and queries for the status
+                 * of a certain permission type (e.g. "push", or "background-fetch") to
+                 * always return ``state`` for the specific origin.
+                 *
+                 * Matches the `permissions.setPermission <https://w3c.github.io/permissions/#webdriver-bidi-command-permissions-setPermission>`_
+                 * WebDriver BiDi command.
+                 *
+                 * @example
+                 * await test_driver.bidi.permissions.set_permission({
+                 *     {name: "geolocation"},
+                 *     state: "granted",
+                 * });
+                 *
+                 * @param {object} params - Parameters for the command.
+                 * @param {PermissionDescriptor} params.descriptor - a `PermissionDescriptor
+                 *                               <https://w3c.github.io/permissions/#dom-permissiondescriptor>`_
+                 *                               or derived object.
+                 * @param {PermissionState} params.state - a `PermissionState
+                 *                          <https://w3c.github.io/permissions/#dom-permissionstate>`_
+                 *                          value.
+                 * @param {string} [params.origin] - an optional top-level `origin` string to set the
+                 *                 permission for. If omitted, the permission is set for the
+                 *                 current window's origin.
+                 * @param {string} [params.embeddedOrigin] - an optional embedded `origin` string to set the
+                 *                 permission for. If omitted, the top-level `origin` is used as the
+                 *                 embedded origin.
+                 * @returns {Promise} fulfilled after the permission is set, or rejected if setting
+                 *                    the permission fails.
+                 */
+                set_permission: function (params) {
+                    assertBidiIsEnabled();
+                    return window.test_driver_internal.bidi.permissions.set_permission(
+                        params);
+                }
+            }
+        },
+
+        /**
+         * Set the context in which testharness.js is loaded
+         *
+         * @param {WindowProxy} context - the window containing testharness.js
+         **/
+        set_test_context: function(context) {
+          if (window.test_driver_internal.set_test_context) {
+            window.test_driver_internal.set_test_context(context);
+          }
+          testharness_context = context;
+        },
+
+        /**
+         * postMessage to the context containing testharness.js
+         *
+         * @param {Object} msg - the data to POST
+         **/
+        message_test: function(msg) {
+            let target = testharness_context;
+            if (testharness_context === null) {
+                target = window;
+            }
+            target.postMessage(msg, "*");
+        },
+
+        /**
+         * Trigger user interaction in order to grant additional privileges to
+         * a provided function.
+         *
+         * See `Tracking user activation
+         * <https://html.spec.whatwg.org/multipage/interaction.html#tracking-user-activation>`_.
+         *
+         * @example
+         * var mediaElement = document.createElement('video');
+         *
+         * test_driver.bless('initiate media playback', function () {
+         *   mediaElement.play();
+         * });
+         *
+         * @param {String} intent - a description of the action which must be
+         *                          triggered by user interaction
+         * @param {Function} action - code requiring escalated privileges
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null for the current
+         *                                browsing context.
+         *
+         * @returns {Promise} fulfilled following user interaction and
+         *                    execution of the provided `action` function;
+         *                    rejected if interaction fails or the provided
+         *                    function throws an error
+         */
+        bless: function(intent, action, context=null) {
+            let contextDocument = context ? context.document : document;
+            var button = contextDocument.createElement("button");
+            button.innerHTML = "This test requires user interaction.<br />" +
+                "Please click here to allow " + intent + ".";
+            button.id = "wpt-test-driver-bless-" + (idCounter += 1);
+            const elem = contextDocument.body || contextDocument.documentElement;
+            elem.appendChild(button);
+
+            let wait_click = new Promise(resolve => button.addEventListener("click", resolve));
+
+            return test_driver.click(button)
+                .then(() => wait_click)
+                .then(() => {
+                    button.remove();
+
+                    if (typeof action === "function") {
+                        return action();
+                    }
+                    return null;
+                });
+        },
+
+        /**
+         * Triggers a user-initiated mouse click.
+         *
+         * If ``element`` isn't inside the viewport, it will be
+         * scrolled into view before the click occurs.
+         *
+         * If ``element`` is from a different browsing context, the
+         * command will be run in that context.
+         *
+         * Matches the behaviour of the `Element Click
+         * <https://w3c.github.io/webdriver/#element-click>`_
+         * WebDriver command.
+         *
+         * **Note:** If the element to be clicked does not have a
+         * unique ID, the document must not have any DOM mutations
+         * made between the function being called and the promise
+         * settling.
+         *
+         * @param {Element} element - element to be clicked
+         * @returns {Promise} fulfilled after click occurs, or rejected in
+         *                    the cases the WebDriver command errors
+         */
+        click: function(element) {
+            if (!inView(element)) {
+                element.scrollIntoView({behavior: "instant",
+                                        block: "end",
+                                        inline: "nearest"});
+            }
+
+            var pointerInteractablePaintTree = getPointerInteractablePaintTree(element);
+            if (pointerInteractablePaintTree.length === 0 ||
+                !element.contains(pointerInteractablePaintTree[0])) {
+                return Promise.reject(new Error("element click intercepted error"));
+            }
+
+            var rect = element.getClientRects()[0];
+            var centerPoint = getInViewCenterPoint(rect);
+            return window.test_driver_internal.click(element,
+                                                     {x: centerPoint[0],
+                                                      y: centerPoint[1]});
+        },
+
+        /**
+         * Deletes all cookies.
+         *
+         * Matches the behaviour of the `Delete All Cookies
+         * <https://w3c.github.io/webdriver/#delete-all-cookies>`_
+         * WebDriver command.
+         *
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null for the current
+         *                                browsing context.
+         *
+         * @returns {Promise} fulfilled after cookies are deleted, or rejected in
+         *                    the cases the WebDriver command errors
+         */
+        delete_all_cookies: function(context=null) {
+            return window.test_driver_internal.delete_all_cookies(context);
+        },
+
+        /**
+         * Get details for all cookies in the current context.
+         * See https://w3c.github.io/webdriver/#get-all-cookies
+         *
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null for the current
+         *                                browsing context.
+         *
+         * @returns {Promise} Returns an array of cookies objects as defined in the spec:
+         *                    https://w3c.github.io/webdriver/#cookies
+         */
+        get_all_cookies: function(context=null) {
+            return window.test_driver_internal.get_all_cookies(context);
+        },
+
+        /**
+         * Get details for a cookie in the current context by name if it exists.
+         * See https://w3c.github.io/webdriver/#get-named-cookie
+         *
+         * @param {String} name - The name of the cookie to get.
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null for the current
+         *                                browsing context.
+         *
+         * @returns {Promise} Returns the matching cookie as defined in the spec:
+         *                    https://w3c.github.io/webdriver/#cookies
+         *                    Rejected if no such cookie exists.
+         */
+         get_named_cookie: async function(name, context=null) {
+            let cookie = await window.test_driver_internal.get_named_cookie(name, context);
+            if (!cookie) {
+                throw new Error("no such cookie");
+            }
+            return cookie;
+        },
+
+        /**
+         * Get Computed Label for an element.
+         *
+         * This matches the behaviour of the
+         * `Get Computed Label
+         * <https://w3c.github.io/webdriver/#dfn-get-computed-label>`_
+         * WebDriver command.
+         *
+         * @param {Element} element
+         * @returns {Promise} fulfilled after the computed label is returned, or
+         *                    rejected in the cases the WebDriver command errors
+         */
+        get_computed_label: async function(element) {
+            let label = await window.test_driver_internal.get_computed_label(element);
+            return label;
+        },
+
+        /**
+         * Get Computed Role for an element.
+         *
+         * This matches the behaviour of the
+         * `Get Computed Label
+         * <https://w3c.github.io/webdriver/#dfn-get-computed-role>`_
+         * WebDriver command.
+         *
+         * @param {Element} element
+         * @returns {Promise} fulfilled after the computed role is returned, or
+         *                    rejected in the cases the WebDriver command errors
+         */
+        get_computed_role: async function(element) {
+            let role = await window.test_driver_internal.get_computed_role(element);
+            return role;
+        },
+
+        /**
+         * Get accessibility properties for a DOM element.
+         *
+         * @param {Element} element
+         * @returns {Promise} fulfilled after the accessibility properties are
+         *                    returned, or rejected in the cases the WebDriver
+         *                    command errors
+         */
+        get_accessibility_properties_for_element: async function(element) {
+            assertTestIsTentative();
+            let acc = await window.test_driver_internal.get_accessibility_properties_for_element(element);
+            return acc;
+        },
+
+        /**
+         * Get properties for an accessibility node.
+         *
+         * @param {String} accId
+         * @returns {Promise} fulfilled after the accessibility properties are
+         *                    returned, or rejected in the cases the WebDriver
+         *                    command errors
+         */
+        get_accessibility_properties_for_accessibility_node: async function(accId) {
+            assertTestIsTentative();
+            let acc = await window.test_driver_internal.get_accessibility_properties_for_accessibility_node(accId);
+            return acc;
+        },
+
+        /**
+         * Send keys to an element.
+         *
+         * If ``element`` isn't inside the
+         * viewport, it will be scrolled into view before the click
+         * occurs.
+         *
+         * If ``element`` is from a different browsing context, the
+         * command will be run in that context. The test must not depend
+         * on the ``window.name`` property being unset on the target
+         * window.
+         *
+         * To send special keys, send the respective key's codepoint,
+         * as defined by `WebDriver
+         * <https://w3c.github.io/webdriver/#keyboard-actions>`_.  For
+         * example, the "tab" key is represented as "``\uE004``".
+         *
+         * **Note:** these special-key codepoints are not necessarily
+         * what you would expect. For example, <kbd>Esc</kbd> is the
+         * invalid Unicode character ``\uE00C``, not the ``\u001B`` Escape
+         * character from ASCII.
+         *
+         * This matches the behaviour of the
+         * `Send Keys
+         * <https://w3c.github.io/webdriver/#element-send-keys>`_
+         * WebDriver command.
+         *
+         * **Note:** If the element to be clicked does not have a
+         * unique ID, the document must not have any DOM mutations
+         * made between the function being called and the promise
+         * settling.
+         *
+         * @param {Element} element - element to send keys to
+         * @param {String} keys - keys to send to the element
+         * @returns {Promise} fulfilled after keys are sent, or rejected in
+         *                    the cases the WebDriver command errors
+         */
+        send_keys: function(element, keys) {
+            if (!inView(element)) {
+                element.scrollIntoView({behavior: "instant",
+                                        block: "end",
+                                        inline: "nearest"});
+            }
+
+            return window.test_driver_internal.send_keys(element, keys);
+        },
+
+        /**
+         * Freeze the current page
+         *
+         * The freeze function transitions the page from the HIDDEN state to
+         * the FROZEN state as described in `Lifecycle API for Web Pages
+         * <https://github.com/WICG/page-lifecycle/blob/master/README.md>`_.
+         *
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null for the current
+         *                                browsing context.
+         *
+         * @returns {Promise} fulfilled after the freeze request is sent, or rejected
+         *                    in case the WebDriver command errors
+         */
+        freeze: function(context=null) {
+            return window.test_driver_internal.freeze();
+        },
+
+        /**
+         * Minimizes the browser window.
+         *
+         * Matches the behaviour of the `Minimize
+         * <https://www.w3.org/TR/webdriver/#minimize-window>`_
+         * WebDriver command
+         *
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null for the current
+         *                                browsing context.
+         *
+         * @returns {Promise} fulfilled with the previous `WindowRect
+         *                    <https://www.w3.org/TR/webdriver/#dfn-windowrect-object>`_
+         *                    value, after the window is minimized.
+         */
+        minimize_window: function(context=null) {
+            return window.test_driver_internal.minimize_window(context);
+        },
+
+        /**
+         * Restore the window from minimized/maximized state to a given rect.
+         *
+         * Matches the behaviour of the `Set Window Rect
+         * <https://www.w3.org/TR/webdriver/#set-window-rect>`_
+         * WebDriver command
+         *
+         * @param {Object} rect - A `WindowRect
+         *                        <https://www.w3.org/TR/webdriver/#dfn-windowrect-object>`_
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null for the current
+         *                                browsing context.
+         *
+         * @returns {Promise} fulfilled after the window is restored to the given rect.
+         */
+        set_window_rect: function(rect, context=null) {
+            return window.test_driver_internal.set_window_rect(rect, context);
+        },
+
+        /**
+         * Gets a rect with the size and position on the screen from the current window state.
+         *
+         * Matches the behaviour of the `Get Window Rect
+         * <https://www.w3.org/TR/webdriver/#get-window-rect>`_
+         * WebDriver command
+         *
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null for the current
+         *                                browsing context.
+         *
+         * @returns {Promise} fulfilled after the window rect is returned, or rejected
+         * in cases the WebDriver command returns errors. Returns a
+         * `WindowRect <https://www.w3.org/TR/webdriver/#dfn-windowrect-object>`_
+         */
+        get_window_rect: function(context=null) {
+            return window.test_driver_internal.get_window_rect(context);
+        },
+
+        /**
+         * Send a sequence of actions
+         *
+         * This function sends a sequence of actions to perform.
+         *
+         * Matches the behaviour of the `Actions
+         * <https://w3c.github.io/webdriver/#actions>`_ feature in
+         * WebDriver.
+         *
+         * Authors are encouraged to use the
+         * :js:class:`test_driver.Actions` builder rather than
+         * invoking this API directly.
+         *
+         * @param {Array} actions - an array of actions. The format is
+         *                          the same as the actions property
+         *                          of the `Perform Actions
+         *                          <https://w3c.github.io/webdriver/#perform-actions>`_
+         *                          WebDriver command. Each element is
+         *                          an object representing an input
+         *                          source and each input source
+         *                          itself has an actions property
+         *                          detailing the behaviour of that
+         *                          source at each timestep (or
+         *                          tick). Authors are not expected to
+         *                          construct the actions sequence by
+         *                          hand, but to use the builder api
+         *                          provided in testdriver-actions.js
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null for the current
+         *                                browsing context.
+         *
+         * @returns {Promise} fulfilled after the actions are performed, or rejected in
+         *                    the cases the WebDriver command errors
+         */
+        action_sequence: function(actions, context=null) {
+            return window.test_driver_internal.action_sequence(actions, context);
+        },
+
+        /**
+         * Generates a test report on the current page
+         *
+         * The generate_test_report function generates a report (to be
+         * observed by ReportingObserver) for testing purposes.
+         *
+         * Matches the `Generate Test Report
+         * <https://w3c.github.io/reporting/#generate-test-report-command>`_
+         * WebDriver command.
+         *
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null for the current
+         *                                browsing context.
+         *
+         * @returns {Promise} fulfilled after the report is generated, or
+         *                    rejected if the report generation fails
+         */
+        generate_test_report: function(message, context=null) {
+            return window.test_driver_internal.generate_test_report(message, context);
+        },
+
+        /**
+         * Sets the state of a permission
+         *
+         * This function causes permission requests and queries for the status
+         * of a certain permission type (e.g. "push", or "background-fetch") to
+         * always return ``state``.
+         *
+         * Matches the `Set Permission
+         * <https://w3c.github.io/permissions/#set-permission-command>`_
+         * WebDriver command.
+         *
+         * @example
+         * await test_driver.set_permission({ name: "background-fetch" }, "denied");
+         * await test_driver.set_permission({ name: "push", userVisibleOnly: true }, "granted");
+         *
+         * @param {PermissionDescriptor} descriptor - a `PermissionDescriptor
+         *                              <https://w3c.github.io/permissions/#dom-permissiondescriptor>`_
+         *                              or derived object.
+         * @param {PermissionState} state - a `PermissionState
+         *                          <https://w3c.github.io/permissions/#dom-permissionstate>`_
+         *                          value.
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null for the current
+         *                                browsing context.
+         * @returns {Promise} fulfilled after the permission is set, or rejected if setting the
+         *                    permission fails
+         */
+        set_permission: function(descriptor, state, context=null) {
+            let permission_params = {
+              descriptor,
+              state,
+            };
+            return window.test_driver_internal.set_permission(permission_params, context);
+        },
+
+        /**
+         * Creates a virtual authenticator
+         *
+         * This function creates a virtual authenticator for use with
+         * the U2F and WebAuthn APIs.
+         *
+         * Matches the `Add Virtual Authenticator
+         * <https://w3c.github.io/webauthn/#sctn-automation-add-virtual-authenticator>`_
+         * WebDriver command.
+         *
+         * @param {Object} config - an `Authenticator Configuration
+         *                          <https://w3c.github.io/webauthn/#authenticator-configuration>`_
+         *                          object
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null for the current
+         *                                browsing context.
+         *
+         * @returns {Promise} fulfilled after the authenticator is added, or
+         *                    rejected in the cases the WebDriver command
+         *                    errors. Returns the ID of the authenticator
+         */
+        add_virtual_authenticator: function(config, context=null) {
+            return window.test_driver_internal.add_virtual_authenticator(config, context);
+        },
+
+        /**
+         * Removes a virtual authenticator
+         *
+         * This function removes a virtual authenticator that has been
+         * created by :js:func:`add_virtual_authenticator`.
+         *
+         * Matches the `Remove Virtual Authenticator
+         * <https://w3c.github.io/webauthn/#sctn-automation-remove-virtual-authenticator>`_
+         * WebDriver command.
+         *
+         * @param {String} authenticator_id - the ID of the authenticator to be
+         *                                    removed.
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null for the current
+         *                                browsing context.
+         *
+         * @returns {Promise} fulfilled after the authenticator is removed, or
+         *                    rejected in the cases the WebDriver command
+         *                    errors
+         */
+        remove_virtual_authenticator: function(authenticator_id, context=null) {
+            return window.test_driver_internal.remove_virtual_authenticator(authenticator_id, context);
+        },
+
+        /**
+         * Adds a credential to a virtual authenticator
+         *
+         * Matches the `Add Credential
+         * <https://w3c.github.io/webauthn/#sctn-automation-add-credential>`_
+         * WebDriver command.
+         *
+         * @param {String} authenticator_id - the ID of the authenticator
+         * @param {Object} credential - A `Credential Parameters
+         *                              <https://w3c.github.io/webauthn/#credential-parameters>`_
+         *                              object
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null for the current
+         *                                browsing context.
+         *
+         * @returns {Promise} fulfilled after the credential is added, or
+         *                    rejected in the cases the WebDriver command
+         *                    errors
+         */
+        add_credential: function(authenticator_id, credential, context=null) {
+            return window.test_driver_internal.add_credential(authenticator_id, credential, context);
+        },
+
+        /**
+         * Gets all the credentials stored in an authenticator
+         *
+         * This function retrieves all the credentials (added via the U2F API,
+         * WebAuthn, or the add_credential function) stored in a virtual
+         * authenticator
+         *
+         * Matches the `Get Credentials
+         * <https://w3c.github.io/webauthn/#sctn-automation-get-credentials>`_
+         * WebDriver command.
+         *
+         * @param {String} authenticator_id - the ID of the authenticator
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null for the current
+         *                                browsing context.
+         *
+         * @returns {Promise} fulfilled after the credentials are
+         *                    returned, or rejected in the cases the
+         *                    WebDriver command errors. Returns an
+         *                    array of `Credential Parameters
+         *                    <https://w3c.github.io/webauthn/#credential-parameters>`_
+         */
+        get_credentials: function(authenticator_id, context=null) {
+            return window.test_driver_internal.get_credentials(authenticator_id, context=null);
+        },
+
+        /**
+         * Remove a credential stored in an authenticator
+         *
+         * Matches the `Remove Credential
+         * <https://w3c.github.io/webauthn/#sctn-automation-remove-credential>`_
+         * WebDriver command.
+         *
+         * @param {String} authenticator_id - the ID of the authenticator
+         * @param {String} credential_id - the ID of the credential
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null for the current
+         *                                browsing context.
+         *
+         * @returns {Promise} fulfilled after the credential is removed, or
+         *                    rejected in the cases the WebDriver command
+         *                    errors.
+         */
+        remove_credential: function(authenticator_id, credential_id, context=null) {
+            return window.test_driver_internal.remove_credential(authenticator_id, credential_id, context);
+        },
+
+        /**
+         * Removes all the credentials stored in a virtual authenticator
+         *
+         * Matches the `Remove All Credentials
+         * <https://w3c.github.io/webauthn/#sctn-automation-remove-all-credentials>`_
+         * WebDriver command.
+         *
+         * @param {String} authenticator_id - the ID of the authenticator
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null for the current
+         *                                browsing context.
+         *
+         * @returns {Promise} fulfilled after the credentials are removed, or
+         *                    rejected in the cases the WebDriver command
+         *                    errors.
+         */
+        remove_all_credentials: function(authenticator_id, context=null) {
+            return window.test_driver_internal.remove_all_credentials(authenticator_id, context);
+        },
+
+        /**
+         * Sets the User Verified flag on an authenticator
+         *
+         * Sets whether requests requiring user verification will succeed or
+         * fail on a given virtual authenticator
+         *
+         * Matches the `Set User Verified
+         * <https://w3c.github.io/webauthn/#sctn-automation-set-user-verified>`_
+         * WebDriver command.
+         *
+         * @param {String} authenticator_id - the ID of the authenticator
+         * @param {boolean} uv - the User Verified flag
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null for the current
+         *                                browsing context.
+         */
+        set_user_verified: function(authenticator_id, uv, context=null) {
+            return window.test_driver_internal.set_user_verified(authenticator_id, uv, context);
+        },
+
+        /**
+         * Sets the storage access rule for an origin when embedded
+         * in a third-party context.
+         *
+         * Matches the `Set Storage Access
+         * <https://privacycg.github.io/storage-access/#set-storage-access-command>`_
+         * WebDriver command.
+         *
+         * @param {String} origin - A third-party origin to block or allow.
+         *                          May be "*" to indicate all origins.
+         * @param {String} embedding_origin - an embedding (first-party) origin
+         *                                    on which {origin}'s access should
+         *                                    be blocked or allowed.
+         *                                    May be "*" to indicate all origins.
+         * @param {String} state - The storage access setting.
+         *                         Must be either "allowed" or "blocked".
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null for the current
+         *                                browsing context.
+         *
+         * @returns {Promise} Fulfilled after the storage access rule has been
+         *                    set, or rejected if setting the rule fails.
+         */
+        set_storage_access: function(origin, embedding_origin, state, context=null) {
+            if (state !== "allowed" && state !== "blocked") {
+                throw new Error("storage access status must be 'allowed' or 'blocked'");
+            }
+            const blocked = state === "blocked";
+            return window.test_driver_internal.set_storage_access(origin, embedding_origin, blocked, context);
+        },
+
+        /**
+         * Sets the current transaction automation mode for Secure Payment
+         * Confirmation.
+         *
+         * This function places `Secure Payment
+         * Confirmation <https://w3c.github.io/secure-payment-confirmation>`_ into
+         * an automated 'autoAccept' or 'autoReject' mode, to allow testing
+         * without user interaction with the transaction UX prompt.
+         *
+         * Matches the `Set SPC Transaction Mode
+         * <https://w3c.github.io/secure-payment-confirmation/#sctn-automation-set-spc-transaction-mode>`_
+         * WebDriver command.
+         *
+         * @example
+         * await test_driver.set_spc_transaction_mode("autoaccept");
+         * test.add_cleanup(() => {
+         *   return test_driver.set_spc_transaction_mode("none");
+         * });
+         *
+         * // Assumption: `request` is a PaymentRequest with a secure-payment-confirmation
+         * // payment method.
+         * const response = await request.show();
+         *
+         * @param {String} mode - The `transaction mode
+         *                        <https://w3c.github.io/secure-payment-confirmation/#enumdef-transactionautomationmode>`_
+         *                        to set. Must be one of "``none``",
+         *                        "``autoAccept``", or
+         *                        "``autoReject``".
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null for the current
+         *                                browsing context.
+         *
+         * @returns {Promise} Fulfilled after the transaction mode has been set,
+         *                    or rejected if setting the mode fails.
+         */
+        set_spc_transaction_mode: function(mode, context=null) {
+          return window.test_driver_internal.set_spc_transaction_mode(mode, context);
+        },
+
+        /**
+         * Sets the current registration automation mode for Register Protocol Handlers.
+         *
+         * This function places `Register Protocol Handlers
+         * <https://html.spec.whatwg.org/multipage/system-state.html#custom-handlers>`_ into
+         * an automated 'autoAccept' or 'autoReject' mode, to allow testing
+         * without user interaction with the transaction UX prompt.
+         *
+         * Matches the `Set Register Protocol Handler Mode
+         * <https://html.spec.whatwg.org/multipage/system-state.html#set-rph-registration-mode>`_
+         * WebDriver command.
+         *
+         * @example
+         * await test_driver.set_rph_registration_mode("autoAccept");
+         * test.add_cleanup(() => {
+         *   return test_driver.set_rph_registration_mode("none");
+         * });
+         *
+         * navigator.registerProtocolHandler('web+soup', 'soup?url=%s');
+         *
+         * @param {String} mode - The `registration mode
+         *                        <https://html.spec.whatwg.org/multipage/system-state.html#registerprotocolhandler()-automation-mode>`_
+         *                        to set. Must be one of "``none``",
+         *                        "``autoAccept``", or
+         *                        "``autoReject``".
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null for the current
+         *                                browsing context.
+         *
+         * @returns {Promise} Fulfilled after the transaction mode has been set,
+         *                    or rejected if setting the mode fails.
+         */
+        set_rph_registration_mode: function(mode, context=null) {
+          return window.test_driver_internal.set_rph_registration_mode(mode, context);
+        },
+
+        /**
+         * Cancels the Federated Credential Management dialog
+         *
+         * Matches the `Cancel dialog
+         * <https://fedidcg.github.io/FedCM/#webdriver-canceldialog>`_
+         * WebDriver command.
+         *
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null for the current
+         *                                browsing context.
+         *
+         * @returns {Promise} Fulfilled after the dialog is canceled, or rejected
+         *                    in case the WebDriver command errors
+         */
+        cancel_fedcm_dialog: function(context=null) {
+            return window.test_driver_internal.cancel_fedcm_dialog(context);
+        },
+
+        /**
+         * Clicks a button on the Federated Credential Management dialog
+         *
+         * Matches the `Click dialog button
+         * <https://fedidcg.github.io/FedCM/#webdriver-clickdialogbutton>`_
+         * WebDriver command.
+         *
+         * @param {String} dialog_button - String enum representing the dialog button to click.
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null for the current
+         *                                browsing context.
+         *
+         * @returns {Promise} Fulfilled after the button is clicked,
+         *                    or rejected in case the WebDriver command errors
+         */
+        click_fedcm_dialog_button: function(dialog_button, context=null) {
+          return window.test_driver_internal.click_fedcm_dialog_button(dialog_button, context);
+        },
+
+        /**
+         * Selects an account from the Federated Credential Management dialog
+         *
+         * Matches the `Select account
+         * <https://fedidcg.github.io/FedCM/#webdriver-selectaccount>`_
+         * WebDriver command.
+         *
+         * @param {number} account_index - Index of the account to select.
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null for the current
+         *                                browsing context.
+         *
+         * @returns {Promise} Fulfilled after the account is selected,
+         *                    or rejected in case the WebDriver command errors
+         */
+        select_fedcm_account: function(account_index, context=null) {
+          return window.test_driver_internal.select_fedcm_account(account_index, context);
+        },
+
+        /**
+         * Gets the account list from the Federated Credential Management dialog
+         *
+         * Matches the `Account list
+         * <https://fedidcg.github.io/FedCM/#webdriver-accountlist>`_
+         * WebDriver command.
+         *
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null for the current
+         *                                browsing context.
+         *
+         * @returns {Promise} fulfilled after the account list is returned, or
+         *                    rejected in case the WebDriver command errors
+         */
+        get_fedcm_account_list: function(context=null) {
+          return window.test_driver_internal.get_fedcm_account_list(context);
+        },
+
+        /**
+         * Gets the title of the Federated Credential Management dialog
+         *
+         * Matches the `Get title
+         * <https://fedidcg.github.io/FedCM/#webdriver-gettitle>`_
+         * WebDriver command.
+         *
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null for the current
+         *                                browsing context.
+         *
+         * @returns {Promise} Fulfilled after the title is returned, or rejected
+         *                    in case the WebDriver command errors
+         */
+        get_fedcm_dialog_title: function(context=null) {
+          return window.test_driver_internal.get_fedcm_dialog_title(context);
+        },
+
+        /**
+         * Gets the type of the Federated Credential Management dialog
+         *
+         * Matches the `Get dialog type
+         * <https://fedidcg.github.io/FedCM/#webdriver-getdialogtype>`_
+         * WebDriver command.
+         *
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null for the current
+         *                                browsing context.
+         *
+         * @returns {Promise} Fulfilled after the dialog type is returned, or
+         *                    rejected in case the WebDriver command errors
+         */
+        get_fedcm_dialog_type: function(context=null) {
+          return window.test_driver_internal.get_fedcm_dialog_type(context);
+        },
+
+        /**
+         * Sets whether promise rejection delay is enabled for the Federated Credential Management dialog
+         *
+         * Matches the `Set delay enabled
+         * <https://fedidcg.github.io/FedCM/#webdriver-setdelayenabled>`_
+         * WebDriver command.
+         *
+         * @param {boolean} enabled - Whether to delay FedCM promise rejection.
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null for the current
+         *                                browsing context.
+         *
+         * @returns {Promise} Fulfilled after the delay has been enabled or disabled,
+         *                    or rejected in case the WebDriver command errors
+         */
+        set_fedcm_delay_enabled: function(enabled, context=null) {
+          return window.test_driver_internal.set_fedcm_delay_enabled(enabled, context);
+        },
+
+        /**
+         * Resets the Federated Credential Management dialog's cooldown
+         *
+         * Matches the `Reset cooldown
+         * <https://fedidcg.github.io/FedCM/#webdriver-resetcooldown>`_
+         * WebDriver command.
+         *
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null for the current
+         *                                browsing context.
+         *
+         * @returns {Promise} Fulfilled after the cooldown has been reset,
+         *                    or rejected in case the WebDriver command errors
+         */
+        reset_fedcm_cooldown: function(context=null) {
+          return window.test_driver_internal.reset_fedcm_cooldown(context);
+        },
+
+        /**
+         * Sets the behavior for the virtual wallet.
+         *
+         * Matches the `Set Virtual Wallet Behavior
+         * <https://w3c-fedid.github.io/digital-credentials/#automated-testing>`_
+         * WebDriver command.
+         *
+         * @param {String} action - The action to take ("decline", "respond", "wait", "clear").
+         * @param {String} [protocol=null] - The protocol requested (required for "respond").
+         * @param {Object} [response=null] - The response data (optional for "respond").
+         * @param {WindowProxy} [context=null] - Browsing context in which to run the call.
+         *
+         * @returns {Promise} Fulfilled after the behavior has been set.
+         */
+        set_virtual_wallet_behavior: function(action, protocol=null, response=null, context=null) {
+          return window.test_driver_internal.set_virtual_wallet_behavior(action, protocol, response, context);
+        },
+
+
+        /**
+         * Creates a virtual sensor for use with the Generic Sensors APIs.
+         *
+         * Matches the `Create Virtual Sensor
+         * <https://w3c.github.io/sensors/#create-virtual-sensor-command>`_
+         * WebDriver command.
+         *
+         * Once created, a virtual sensor is available to all navigables under
+         * the same top-level traversable (i.e. all frames in the same page,
+         * regardless of origin).
+         *
+         * @param {String} sensor_type - A `virtual sensor type
+         *                               <https://w3c.github.io/sensors/#virtual-sensor-metadata-virtual-sensor-type>`_
+         *                               such as "accelerometer".
+         * @param {Object} [sensor_params={}] - Optional parameters described
+         *                                     in `Create Virtual Sensor
+         *                                     <https://w3c.github.io/sensors/#create-virtual-sensor-command>`_.
+         * @param {WindowProxy} [context=null] - Browsing context in which to
+         *                                       run the call, or null for the
+         *                                       current browsing context.
+         *
+         * @returns {Promise} Fulfilled when virtual sensor is created.
+         *                    Rejected in case the WebDriver command errors out
+         *                    (including if a virtual sensor of the same type
+         *                    already exists).
+         */
+        create_virtual_sensor: function(sensor_type, sensor_params={}, context=null) {
+          return window.test_driver_internal.create_virtual_sensor(sensor_type, sensor_params, context);
+        },
+
+        /**
+         * Causes a virtual sensor to report a new reading to any connected
+         * platform sensor.
+         *
+         * Matches the `Update Virtual Sensor Reading
+         * <https://w3c.github.io/sensors/#update-virtual-sensor-reading-command>`_
+         * WebDriver command.
+         *
+         * Note: The ``Promise`` it returns may fulfill before or after a
+         * "reading" event is fired. When using
+         * :js:func:`EventWatcher.wait_for`, it is necessary to take this into
+         * account:
+         *
+         * Note: New values may also be discarded due to the checks in `update
+         * latest reading
+         * <https://w3c.github.io/sensors/#update-latest-reading>`_.
+         *
+         * @example
+         * // Avoid races between EventWatcher and update_virtual_sensor().
+         * // This assumes you are sure this reading will be processed (see
+         * // the example below otherwise).
+         * const reading = { x: 1, y: 2, z: 3 };
+         * await Promise.all([
+         *   test_driver.update_virtual_sensor('gyroscope', reading),
+         *   watcher.wait_for('reading')
+         * ]);
+         *
+         * @example
+         * // Do not wait forever if you are not sure the reading will be
+         * // processed.
+         * const readingPromise = watcher.wait_for('reading');
+         * const timeoutPromise = new Promise(resolve => {
+         *     t.step_timeout(() => resolve('TIMEOUT', 3000))
+         * });
+         *
+         * const reading = { x: 1, y: 2, z: 3 };
+         * await test_driver.update_virtual_sensor('gyroscope', 'reading');
+         *
+         * const value =
+         *     await Promise.race([timeoutPromise, readingPromise]);
+         * if (value !== 'TIMEOUT') {
+         *   // Do something. The "reading" event was fired.
+         * }
+         *
+         * @param {String} sensor_type - A `virtual sensor type
+         *                               <https://w3c.github.io/sensors/#virtual-sensor-metadata-virtual-sensor-type>`_
+         *                               such as "accelerometer".
+         * @param {Object} reading - An Object describing a reading in a format
+         *                           dependent on ``sensor_type`` (e.g. ``{x:
+         *                           1, y: 2, z: 3}`` or ``{ illuminance: 42
+         *                           }``).
+         * @param {WindowProxy} [context=null] - Browsing context in which to
+         *                                       run the call, or null for the
+         *                                       current browsing context.
+         *
+         * @returns {Promise} Fulfilled after the reading update reaches the
+         *                    virtual sensor. Rejected in case the WebDriver
+         *                    command errors out (including if a virtual sensor
+         *                    of the given type does not exist).
+         */
+        update_virtual_sensor: function(sensor_type, reading, context=null) {
+          return window.test_driver_internal.update_virtual_sensor(sensor_type, reading, context);
+        },
+
+        /**
+         * Triggers the removal of a virtual sensor if it exists.
+         *
+         * Matches the `Delete Virtual Sensor
+         * <https://w3c.github.io/sensors/#delete-virtual-sensor-command>`_
+         * WebDriver command.
+         *
+         * @param {String} sensor_type - A `virtual sensor type
+         *                               <https://w3c.github.io/sensors/#virtual-sensor-metadata-virtual-sensor-type>`_
+         *                               such as "accelerometer".
+         * @param {WindowProxy} [context=null] - Browsing context in which to
+         *                                       run the call, or null for the
+         *                                       current browsing context.
+         *
+         * @returns {Promise} Fulfilled after the virtual sensor has been
+         *                    removed or if a sensor of the given type does not
+         *                    exist. Rejected in case the WebDriver command
+         *                    errors out.
+
+         */
+        remove_virtual_sensor: function(sensor_type, context=null) {
+          return window.test_driver_internal.remove_virtual_sensor(sensor_type, context);
+        },
+
+        /**
+         * Returns information about a virtual sensor.
+         *
+         * Matches the `Get Virtual Sensor Information
+         * <https://w3c.github.io/sensors/#get-virtual-sensor-information-command>`_
+         * WebDriver command.
+         *
+         * @param {String} sensor_type - A `virtual sensor type
+         *                               <https://w3c.github.io/sensors/#virtual-sensor-metadata-virtual-sensor-type>`_
+         *                               such as "accelerometer".
+         * @param {WindowProxy} [context=null] - Browsing context in which to
+         *                                       run the call, or null for the
+         *                                       current browsing context.
+         *
+         * @returns {Promise} Fulfilled with an Object with the properties
+         *                    described in `Get Virtual Sensor Information
+         *                    <https://w3c.github.io/sensors/#get-virtual-sensor-information-command>`_.
+         *                    Rejected in case the WebDriver command errors out
+         *                    (including if a virtual sensor of the given type
+         *                    does not exist).
+         */
+        get_virtual_sensor_information: function(sensor_type, context=null) {
+            return window.test_driver_internal.get_virtual_sensor_information(sensor_type, context);
+        },
+
+        /**
+         * Overrides device posture set by hardware.
+         *
+         * Matches the `Set device posture
+         * <https://w3c.github.io/device-posture/#set-device-posture>`_
+         * WebDriver command.
+         *
+         * @param {String} posture - A `DevicePostureType
+         *                           <https://w3c.github.io/device-posture/#dom-deviceposturetype>`_
+         *                           either "continuous" or "folded".
+         * @param {WindowProxy} [context=null] - Browsing context in which to
+         *                                       run the call, or null for the
+         *                                       current browsing context.
+         *
+         * @returns {Promise} Fulfilled when device posture is set.
+         *                    Rejected in case the WebDriver command errors out
+         *                    (including if a device posture of the given type
+         *                    does not exist).
+         */
+        set_device_posture: function(posture, context=null) {
+            return window.test_driver_internal.set_device_posture(posture, context);
+        },
+
+        /**
+         * Removes device posture override and returns device posture control
+         * back to hardware.
+         *
+         * Matches the `Clear device posture
+         * <https://w3c.github.io/device-posture/#clear-device-posture>`_
+         * WebDriver command.
+         *
+         * @param {WindowProxy} [context=null] - Browsing context in which to
+         *                                       run the call, or null for the
+         *                                       current browsing context.
+         *
+         * @returns {Promise} Fulfilled after the device posture override has
+         *                    been removed. Rejected in case the WebDriver
+         *                    command errors out.
+         */
+        clear_device_posture: function(context=null) {
+            return window.test_driver_internal.clear_device_posture(context);
+        },
+
+        /**
+         * Runs the `bounce tracking timer algorithm
+         * <https://privacycg.github.io/nav-tracking-mitigations/#bounce-tracking-timer>`_,
+         * which removes all hosts from the stateful bounce tracking map, without
+         * regard for the bounce tracking grace period and returns a list of the
+         * deleted hosts.
+         *
+         * Matches the `Run Bounce Tracking Mitigations
+         * <https://privacycg.github.io/nav-tracking-mitigations/#run-bounce-tracking-mitigations-command>`_
+         * WebDriver command.
+         *
+         * @param {WindowProxy} [context=null] - Browsing context in which to
+         *                                       run the call, or null for the
+         *                                       current browsing context.
+         * @returns {Promise} Fulfilled after the bounce tracking timer
+         *                    algorithm has finished running. Returns an array
+         *                    of all hosts that were in the stateful bounce
+         *                    tracking map before deletion occurred.
+         */
+        run_bounce_tracking_mitigations: function (context = null) {
+            return window.test_driver_internal.run_bounce_tracking_mitigations(context);
+        },
+
+        /**
+         * Creates a virtual pressure source.
+         *
+         * Matches the `Create virtual pressure source
+         * <https://w3c.github.io/compute-pressure/#create-virtual-pressure-source>`_
+         * WebDriver command.
+         *
+         * @param {String} source_type - A `virtual pressure source type
+         *                               <https://w3c.github.io/compute-pressure/#dom-pressuresource>`_
+         *                               such as "cpu".
+         * @param {Object} [metadata={}] - Optional parameters described
+         *                                 in `Create virtual pressure source
+         *                                 <https://w3c.github.io/compute-pressure/#create-virtual-pressure-source>`_.
+         * @param {WindowProxy} [context=null] - Browsing context in which to
+         *                                       run the call, or null for the
+         *                                       current browsing context.
+         *
+         * @returns {Promise} Fulfilled when virtual pressure source is created.
+         *                    Rejected in case the WebDriver command errors out
+         *                    (including if a virtual pressure source of the
+         *                    same type already exists).
+         */
+        create_virtual_pressure_source: function(source_type, metadata={}, context=null) {
+            return window.test_driver_internal.create_virtual_pressure_source(source_type, metadata, context);
+        },
+
+        /**
+         * Causes a virtual pressure source to report a new reading.
+         *
+         * Matches the `Update virtual pressure source
+         * <https://w3c.github.io/compute-pressure/?experimental=1#update-virtual-pressure-source>`_
+         * WebDriver command.
+         *
+         * @param {String} source_type - A `virtual pressure source type
+         *                               <https://w3c.github.io/compute-pressure/#dom-pressuresource>`_
+         *                               such as "cpu".
+         * @param {String} sample - A `virtual pressure state
+         *                          <https://w3c.github.io/compute-pressure/#dom-pressurestate>`_
+         *                          such as "critical".
+         * @param {number} own_contribution_estimate - Optional, A `virtual own contribution estimate`
+         *                          <https://w3c.github.io/compute-pressure/?experimental=1#the-owncontributionestimate-attribute>`_
+         * @param {WindowProxy} [context=null] - Browsing context in which to
+         *                                       run the call, or null for the
+         *                                       current browsing context.
+         *
+         * @returns {Promise} Fulfilled after the reading update reaches the
+         *                    virtual pressure source. Rejected in case the
+         *                    WebDriver command errors out (including if a
+         *                    virtual pressure source of the given type does not
+         *                    exist).
+         */
+        update_virtual_pressure_source: function(source_type, sample, own_contribution_estimate, context=null) {
+            return window.test_driver_internal.update_virtual_pressure_source(source_type, sample, own_contribution_estimate, context);
+        },
+
+        /**
+         * Removes created virtual pressure source.
+         *
+         * Matches the `Delete virtual pressure source
+         * <https://w3c.github.io/compute-pressure/#delete-virtual-pressure-source>`_
+         * WebDriver command.
+         *
+         * @param {String} source_type - A `virtual pressure source type
+         *                               <https://w3c.github.io/compute-pressure/#dom-pressuresource>`_
+         *                               such as "cpu".
+         * @param {WindowProxy} [context=null] - Browsing context in which to
+         *                                       run the call, or null for the
+         *                                       current browsing context.
+         *
+         * @returns {Promise} Fulfilled after the virtual pressure source has
+         *                    been removed or if a pressure source of the given
+         *                    type does not exist. Rejected in case the
+         *                    WebDriver command errors out.
+         */
+        remove_virtual_pressure_source: function(source_type, context=null) {
+            return window.test_driver_internal.remove_virtual_pressure_source(source_type, context);
+        },
+
+        /**
+         * Sets which hashes are considered k-anonymous for the Protected
+         * Audience interest group with specified `owner` and `name`.
+         *
+         * Matches the `Set Protected Audience K-Anonymity
+         * <https://wicg.github.io/turtledove/#sctn-automation-set-protected-audience-k-anonymity>
+         * WebDriver command.
+         *
+         *  @param {String} owner - Origin of the owner of the interest group
+         *                          to modify
+         *  @param {String} name -  Name of the interest group to modify
+         *  @param {Array} hashes - An array of strings, each of which is a
+         *                          base64 ecoded hash to consider k-anonymous.
+         *
+         *  @returns {Promise} Fulfilled after the k-anonymity status for the
+         *                     specified Protected Audience interest group has
+         *                     been updated.
+         *
+         */
+        set_protected_audience_k_anonymity: function(owner, name, hashes, context = null) {
+            return window.test_driver_internal.set_protected_audience_k_anonymity(owner, name, hashes, context);
+        },
+
+        /**
+         * Overrides the display features provided by the hardware so the viewport segments
+         * can be emulated.
+         *
+         * Matches the `Set display features
+         * <https://drafts.csswg.org/css-viewport/#set-display-features>`_
+         * WebDriver command.
+         *
+         * @param {Array} features - An array of `DisplayFeatureOverride
+         *                           <https://drafts.csswg.org/css-viewport/#display-feature-override>`.
+         * @param {WindowProxy} [context=null] - Browsing context in which to
+         *                                       run the call, or null for the
+         *                                       current browsing context.
+         *
+         * @returns {Promise} Fulfilled when the display features are set.
+         *                    Rejected in case the WebDriver command errors out
+         *                    (including if the array is malformed).
+         */
+        set_display_features: function(features, context=null) {
+            return window.test_driver_internal.set_display_features(features, context);
+        },
+
+        /**
+         * Removes display features override and returns the control
+         * back to hardware.
+         *
+         * Matches the `Clear display features
+         * <https://drafts.csswg.org/css-viewport/#clear-display-features>`_
+         * WebDriver command.
+         *
+         * @param {WindowProxy} [context=null] - Browsing context in which to
+         *                                       run the call, or null for the
+         *                                       current browsing context.
+         *
+         * @returns {Promise} Fulfilled after the display features override has
+         *                    been removed. Rejected in case the WebDriver
+         *                    command errors out.
+         */
+        clear_display_features: function(context=null) {
+            return window.test_driver_internal.clear_display_features(context);
+        },
+
+        /**
+         * Gets the current globally-applied privacy control status
+         *
+         * @returns {Promise} Fulfils with an object with boolean property `gpc`
+         *                    that encodes the current "do not sell or share"
+         *                    signal the browser is configured to convey.
+         */
+        get_global_privacy_control: function() {
+            return window.test_driver_internal.get_global_privacy_control();
+        },
+
+        /**
+         * Gets the current globally-applied privacy control status
+         *
+         * @param {bool} newValue - The a boolean that is true if the browers
+         *                          should convey a "do not sell or share" signal
+         *                          and false otherwise
+         *
+         * @returns {Promise} Fulfils with an object with boolean property `gpc`
+         *                    that encodes the new "do not sell or share"
+         *                    after applying the new value.
+         */
+        set_global_privacy_control: function(newValue) {
+            return window.test_driver_internal.set_global_privacy_control(newValue);
+        },
+
+        /**
+         * Installs a WebExtension.
+         *
+         * Matches the `Install WebExtension
+         * <https://github.com/w3c/webextensions/blob/main/specification/webdriver-classic.bs>`_
+         * WebDriver command.
+         *
+         * @param {Object} params - Parameters for loading the extension.
+         * @param {String} params.type - A type such as "path", "archivePath", or "base64".
+         *
+         * @param {String} params.path - The path to the extension's resources if type "path" or "archivePath" is specified.
+         *
+         * @param {String} params.value - The base64 encoded value of the extension's resources if type "base64" is specified.
+         *
+         * @returns {Promise} Returns the extension identifier as defined in the spec.
+         *                    Rejected if the extension fails to load.
+         */
+        install_web_extension: function(params) {
+            return window.test_driver_internal.install_web_extension(params);
+        },
+
+        /**
+         * Uninstalls a WebExtension.
+         *
+         * Matches the `Uninstall WebExtension
+         * <https://github.com/w3c/webextensions/blob/main/specification/webdriver-classic.bs>`_
+         * WebDriver command.
+         *
+         * @param {String} extension_id - The extension identifier.
+         *
+         * @returns {Promise} Fulfilled after the extension has been removed.
+         *                    Rejected in case the WebDriver command errors out.
+         */
+        uninstall_web_extension: function(extension_id) {
+            return window.test_driver_internal.uninstall_web_extension(extension_id);
+        }
+    };
+
+    window.test_driver_internal = {
+        /**
+         * This flag should be set to `true` by any code which implements the
+         * internal methods defined below for automation purposes. Doing so
+         * allows the library to signal failure immediately when an automated
+         * implementation of one of the methods is not available.
+         */
+        in_automation: false,
+
+        bidi: {
+            bluetooth: {
+                handle_request_device_prompt: function() {
+                    throw new Error(
+                        'bidi.bluetooth.handle_request_device_prompt is not implemented by testdriver-vendor.js');
+                },
+                simulate_adapter: function () {
+                    throw new Error(
+                        "bidi.bluetooth.simulate_adapter is not implemented by testdriver-vendor.js");
+                },
+                disable_simulation: function () {
+                    throw new Error(
+                        "bidi.bluetooth.disable_simulation is not implemented by testdriver-vendor.js");
+                },
+                simulate_preconnected_peripheral: function() {
+                    throw new Error(
+                        'bidi.bluetooth.simulate_preconnected_peripheral is not implemented by testdriver-vendor.js');
+                },
+                request_device_prompt_updated: {
+                    async subscribe() {
+                        throw new Error(
+                            'bidi.bluetooth.request_device_prompt_updated.subscribe is not implemented by testdriver-vendor.js');
+                    },
+                    on() {
+                        throw new Error(
+                            'bidi.bluetooth.request_device_prompt_updated.on is not implemented by testdriver-vendor.js');
+                    }
+                },
+                gatt_connection_attempted: {
+                    async subscribe() {
+                        throw new Error(
+                            'bidi.bluetooth.gatt_connection_attempted.subscribe is not implemented by testdriver-vendor.js');
+                    },
+                    on() {
+                        throw new Error(
+                            'bidi.bluetooth.gatt_connection_attempted.on is not implemented by testdriver-vendor.js');
+                    }
+                },
+                characteristic_event_generated: {
+                    async subscribe() {
+                        throw new Error(
+                            'bidi.bluetooth.characteristic_event_generated.subscribe is not implemented by testdriver-vendor.js');
+                    },
+                    on() {
+                        throw new Error(
+                            'bidi.bluetooth.characteristic_event_generated.on is not implemented by testdriver-vendor.js');
+                    }
+                },
+                descriptor_event_generated: {
+                    async subscribe() {
+                        throw new Error(
+                            'bidi.bluetooth.descriptor_event_generated.subscribe is not implemented by testdriver-vendor.js');
+                    },
+                    on() {
+                        throw new Error(
+                            'bidi.bluetooth.descriptor_event_generated.on is not implemented by testdriver-vendor.js');
+                    }
+                }
+            },
+            emulation: {
+                set_geolocation_override: function (params) {
+                    throw new Error(
+                        "bidi.emulation.set_geolocation_override is not implemented by testdriver-vendor.js");
+                },
+                set_locale_override: function (params) {
+                    throw new Error(
+                        "bidi.emulation.set_locale_override is not implemented by testdriver-vendor.js");
+                },
+                set_screen_orientation_override: function (params) {
+                    throw new Error(
+                        "bidi.emulation.set_screen_orientation_override is not implemented by testdriver-vendor.js");
+                },
+                set_touch_override: function (params) {
+                    throw new Error(
+                        "bidi.emulation.set_touch_override is not implemented by testdriver-vendor.js");
+                }
+            },
+            user_agent_client_hints: {
+                set_client_hints_override: function (params) {
+                    throw new Error(
+                        "bidi.user_agent_client_hints.set_client_hints_override is not implemented by testdriver-vendor.js");
+                }
+            },
+            log: {
+                entry_added: {
+                    async subscribe() {
+                        throw new Error(
+                            "bidi.log.entry_added.subscribe is not implemented by testdriver-vendor.js");
+                    },
+                    on() {
+                        throw new Error(
+                            "bidi.log.entry_added.on is not implemented by testdriver-vendor.js");
+                    }
+                }
+            },
+            permissions: {
+                async set_permission() {
+                    throw new Error(
+                        "bidi.permissions.set_permission() is not implemented by testdriver-vendor.js");
+                }
+            },
+            speculation: {
+                prefetch_status_updated: {
+                    async subscribe() {
+                        throw new Error(
+                            'bidi.speculation.prefetch_status_updated.subscribe is not implemented by testdriver-vendor.js');
+                    },
+                    on() {
+                        throw new Error(
+                            'bidi.speculation.prefetch_status_updated.on is not implemented by testdriver-vendor.js');
+                    }
+                },
+            }
+        },
+
+        async click(element, coords) {
+            if (this.in_automation) {
+                throw new Error("click() is not implemented by testdriver-vendor.js");
+            }
+
+            return new Promise(function(resolve, reject) {
+                element.addEventListener("click", resolve);
+            });
+        },
+
+        async delete_all_cookies(context=null) {
+            throw new Error("delete_all_cookies() is not implemented by testdriver-vendor.js");
+        },
+
+        async get_all_cookies(context=null) {
+            throw new Error("get_all_cookies() is not implemented by testdriver-vendor.js");
+        },
+
+        async get_named_cookie(name, context=null) {
+            throw new Error("get_named_cookie() is not implemented by testdriver-vendor.js");
+        },
+
+        async get_computed_role(element) {
+            throw new Error("get_computed_role is a testdriver.js function which cannot be run in this context.");
+        },
+
+        async get_computed_name(element) {
+            throw new Error("get_computed_name is a testdriver.js function which cannot be run in this context.");
+        },
+
+        async get_accessibility_properties_for_element(element) {
+            throw new Error("get_accessibility_properties_for_element is a testdriver.js function which cannot be run in this context.");
+        },
+
+        async get_accessibility_properties_for_accessibility_node(accId) {
+            throw new Error("get_accessibility_properties_for_accessibility_node is a testdriver.js function which cannot be run in this context.");
+        },
+
+        async send_keys(element, keys) {
+            if (this.in_automation) {
+                throw new Error("send_keys() is not implemented by testdriver-vendor.js");
+            }
+
+            return new Promise(function(resolve, reject) {
+                var seen = "";
+
+                function remove() {
+                    element.removeEventListener("keydown", onKeyDown);
+                }
+
+                function onKeyDown(event) {
+                    if (event.key.length > 1) {
+                        return;
+                    }
+
+                    seen += event.key;
+
+                    if (keys.indexOf(seen) !== 0) {
+                        reject(new Error("Unexpected key sequence: " + seen));
+                        remove();
+                    } else if (seen === keys) {
+                        resolve();
+                        remove();
+                    }
+                }
+
+                element.addEventListener("keydown", onKeyDown);
+            });
+        },
+
+        async freeze(context=null) {
+            throw new Error("freeze() is not implemented by testdriver-vendor.js");
+        },
+
+        async minimize_window(context=null) {
+            throw new Error("minimize_window() is not implemented by testdriver-vendor.js");
+        },
+
+        async set_window_rect(rect, context=null) {
+            throw new Error("set_window_rect() is not implemented by testdriver-vendor.js");
+        },
+
+        async get_window_rect(context=null) {
+            throw new Error("get_window_rect() is not implemented by testdriver-vendor.js");
+        },
+
+        async action_sequence(actions, context=null) {
+            throw new Error("action_sequence() is not implemented by testdriver-vendor.js");
+        },
+
+        async generate_test_report(message, context=null) {
+            throw new Error("generate_test_report() is not implemented by testdriver-vendor.js");
+        },
+
+        async set_permission(permission_params, context=null) {
+            throw new Error("set_permission() is not implemented by testdriver-vendor.js");
+        },
+
+        async add_virtual_authenticator(config, context=null) {
+            throw new Error("add_virtual_authenticator() is not implemented by testdriver-vendor.js");
+        },
+
+        async remove_virtual_authenticator(authenticator_id, context=null) {
+            throw new Error("remove_virtual_authenticator() is not implemented by testdriver-vendor.js");
+        },
+
+        async add_credential(authenticator_id, credential, context=null) {
+            throw new Error("add_credential() is not implemented by testdriver-vendor.js");
+        },
+
+        async get_credentials(authenticator_id, context=null) {
+            throw new Error("get_credentials() is not implemented by testdriver-vendor.js");
+        },
+
+        async remove_credential(authenticator_id, credential_id, context=null) {
+            throw new Error("remove_credential() is not implemented by testdriver-vendor.js");
+        },
+
+        async remove_all_credentials(authenticator_id, context=null) {
+            throw new Error("remove_all_credentials() is not implemented by testdriver-vendor.js");
+        },
+
+        async set_user_verified(authenticator_id, uv, context=null) {
+            throw new Error("set_user_verified() is not implemented by testdriver-vendor.js");
+        },
+
+        async set_storage_access(origin, embedding_origin, blocked, context=null) {
+            throw new Error("set_storage_access() is not implemented by testdriver-vendor.js");
+        },
+
+        async set_spc_transaction_mode(mode, context=null) {
+            throw new Error("set_spc_transaction_mode() is not implemented by testdriver-vendor.js");
+        },
+
+        set_rph_registration_mode: function(mode, context=null) {
+            return Promise.reject(new Error("unimplemented"));
+        },
+
+        async cancel_fedcm_dialog(context=null) {
+            throw new Error("cancel_fedcm_dialog() is not implemented by testdriver-vendor.js");
+        },
+
+        async click_fedcm_dialog_button(dialog_button, context=null) {
+            throw new Error("click_fedcm_dialog_button() is not implemented by testdriver-vendor.js");
+        },
+
+        async select_fedcm_account(account_index, context=null) {
+            throw new Error("select_fedcm_account() is not implemented by testdriver-vendor.js");
+        },
+
+        async get_fedcm_account_list(context=null) {
+            throw new Error("get_fedcm_account_list() is not implemented by testdriver-vendor.js");
+        },
+
+        async get_fedcm_dialog_title(context=null) {
+            throw new Error("get_fedcm_dialog_title() is not implemented by testdriver-vendor.js");
+        },
+
+        async get_fedcm_dialog_type(context=null) {
+            throw new Error("get_fedcm_dialog_type() is not implemented by testdriver-vendor.js");
+        },
+
+        async set_fedcm_delay_enabled(enabled, context=null) {
+            throw new Error("set_fedcm_delay_enabled() is not implemented by testdriver-vendor.js");
+        },
+
+        async reset_fedcm_cooldown(context=null) {
+            throw new Error("reset_fedcm_cooldown() is not implemented by testdriver-vendor.js");
+        },
+
+        async set_virtual_wallet_behavior(action, protocol=null, response=null, context=null) {
+            throw new Error("set_virtual_wallet_behavior() is not implemented by testdriver-vendor.js");
+        },
+
+
+        async create_virtual_sensor(sensor_type, sensor_params, context=null) {
+            throw new Error("create_virtual_sensor() is not implemented by testdriver-vendor.js");
+        },
+
+        async update_virtual_sensor(sensor_type, reading, context=null) {
+            throw new Error("update_virtual_sensor() is not implemented by testdriver-vendor.js");
+        },
+
+        async remove_virtual_sensor(sensor_type, context=null) {
+            throw new Error("remove_virtual_sensor() is not implemented by testdriver-vendor.js");
+        },
+
+        async get_virtual_sensor_information(sensor_type, context=null) {
+            throw new Error("get_virtual_sensor_information() is not implemented by testdriver-vendor.js");
+        },
+
+        async set_device_posture(posture, context=null) {
+            throw new Error("set_device_posture() is not implemented by testdriver-vendor.js");
+        },
+
+        async clear_device_posture(context=null) {
+            throw new Error("clear_device_posture() is not implemented by testdriver-vendor.js");
+        },
+
+        async run_bounce_tracking_mitigations(context=null) {
+            throw new Error("run_bounce_tracking_mitigations() is not implemented by testdriver-vendor.js");
+        },
+
+        async create_virtual_pressure_source(source_type, metadata={}, context=null) {
+            throw new Error("create_virtual_pressure_source() is not implemented by testdriver-vendor.js");
+        },
+
+        async update_virtual_pressure_source(source_type, sample, own_contribution_estimate, context=null) {
+            throw new Error("update_virtual_pressure_source() is not implemented by testdriver-vendor.js");
+        },
+
+        async remove_virtual_pressure_source(source_type, context=null) {
+            throw new Error("remove_virtual_pressure_source() is not implemented by testdriver-vendor.js");
+        },
+
+        async set_protected_audience_k_anonymity(owner, name, hashes, context=null) {
+            throw new Error("set_protected_audience_k_anonymity() is not implemented by testdriver-vendor.js");
+        },
+
+        async set_display_features(features, context=null) {
+            throw new Error("set_display_features() is not implemented by testdriver-vendor.js");
+        },
+
+        async clear_display_features(context=null) {
+            throw new Error("clear_display_features() is not implemented by testdriver-vendor.js");
+        },
+
+        async set_global_privacy_control(newValue) {
+            throw new Error("set_global_privacy_control() is not implemented by testdriver-vendor.js");
+        },
+
+        async get_global_privacy_control() {
+            throw new Error("get_global_privacy_control() is not implemented by testdriver-vendor.js");
+        }
+    };
+})();

--- a/Jint.Tests/Wpt/Vendor/resources/testdriver.js.headers
+++ b/Jint.Tests/Wpt/Vendor/resources/testdriver.js.headers
@@ -1,0 +1,2 @@
+Content-Type: text/javascript; charset=utf-8
+Cache-Control: max-age=3600

--- a/Jint.Tests/Wpt/Vendor/resources/testharness.js
+++ b/Jint.Tests/Wpt/Vendor/resources/testharness.js
@@ -1,0 +1,5207 @@
+/*global self*/
+/*jshint latedef: nofunc*/
+
+/* Documentation: https://web-platform-tests.org/writing-tests/testharness-api.html
+ * (../docs/_writing-tests/testharness-api.md) */
+
+(function (global_scope)
+{
+    // default timeout is 10 seconds, test can override if needed
+    var settings = {
+        output:true,
+        harness_timeout:{
+            "normal":10000,
+            "long":60000
+        },
+        test_timeout:null,
+        message_events: ["start", "test_state", "result", "completion"],
+        debug: false,
+    };
+
+    var xhtml_ns = "http://www.w3.org/1999/xhtml";
+
+    /*
+     * TestEnvironment is an abstraction for the environment in which the test
+     * harness is used. Each implementation of a test environment has to provide
+     * the following interface:
+     *
+     * interface TestEnvironment {
+     *   // Invoked after the global 'tests' object has been created and it's
+     *   // safe to call add_*_callback() to register event handlers.
+     *   void on_tests_ready();
+     *
+     *   // Invoked after setup() has been called to notify the test environment
+     *   // of changes to the test harness properties.
+     *   void on_new_harness_properties(object properties);
+     *
+     *   // Should return a new unique default test name.
+     *   DOMString next_default_test_name();
+     *
+     *   // Should return the test harness timeout duration in milliseconds.
+     *   float test_timeout();
+     * };
+     */
+
+    /*
+     * A test environment with a DOM. The global object is 'window'. By default
+     * test results are displayed in a table. Any parent windows receive
+     * callbacks or messages via postMessage() when test events occur. See
+     * apisample11.html and apisample12.html.
+     */
+    function WindowTestEnvironment() {
+        this.name_counter = 0;
+        this.window_cache = null;
+        this.output_handler = null;
+        this.all_loaded = false;
+        var this_obj = this;
+        this.message_events = [];
+        this.dispatched_messages = [];
+
+        this.message_functions = {
+            start: [add_start_callback, remove_start_callback,
+                    function (properties) {
+                        this_obj._dispatch("start_callback", [properties],
+                                           {type: "start", properties: properties});
+                    }],
+
+            test_state: [add_test_state_callback, remove_test_state_callback,
+                         function(test) {
+                             this_obj._dispatch("test_state_callback", [test],
+                                                {type: "test_state",
+                                                 test: test.structured_clone()});
+                         }],
+            result: [add_result_callback, remove_result_callback,
+                     function (test) {
+                         this_obj.output_handler.show_status();
+                         this_obj._dispatch("result_callback", [test],
+                                            {type: "result",
+                                             test: test.structured_clone()});
+                     }],
+            completion: [add_completion_callback, remove_completion_callback,
+                         function (tests, harness_status, asserts) {
+                             var cloned_tests = map(tests, function(test) {
+                                 return test.structured_clone();
+                             });
+                             this_obj._dispatch("completion_callback", [tests, harness_status],
+                                                {type: "complete",
+                                                 tests: cloned_tests,
+                                                 status: harness_status.structured_clone(),
+                                                 asserts: asserts.map(assert => assert.structured_clone())});
+                         }]
+        };
+
+        on_event(window, 'load', function() {
+          setTimeout(() => {
+            this_obj.all_loaded = true;
+            if (tests.all_done()) {
+              tests.complete();
+            }
+          },0);
+        });
+
+        on_event(window, 'message', function(event) {
+            if (event.data && event.data.type === "getmessages" && event.source) {
+                // A window can post "getmessages" to receive a duplicate of every
+                // message posted by this environment so far. This allows subscribers
+                // from fetch_tests_from_window to 'catch up' to the current state of
+                // this environment.
+                for (var i = 0; i < this_obj.dispatched_messages.length; ++i)
+                {
+                    event.source.postMessage(this_obj.dispatched_messages[i], "*");
+                }
+            }
+        });
+    }
+
+    WindowTestEnvironment.prototype._dispatch = function(selector, callback_args, message_arg) {
+        this.dispatched_messages.push(message_arg);
+        this._forEach_windows(
+                function(w, same_origin) {
+                    if (same_origin) {
+                        try {
+                            var has_selector = selector in w;
+                        } catch(e) {
+                            // If document.domain was set at some point same_origin can be
+                            // wrong and the above will fail.
+                            has_selector = false;
+                        }
+                        if (has_selector) {
+                            try {
+                                w[selector].apply(undefined, callback_args);
+                            } catch (e) {}
+                        }
+                    }
+                    if (w !== self) {
+                        w.postMessage(message_arg, "*");
+                    }
+                });
+    };
+
+    WindowTestEnvironment.prototype._forEach_windows = function(callback) {
+        // Iterate over the windows [self ... top, opener]. The callback is passed
+        // two objects, the first one is the window object itself, the second one
+        // is a boolean indicating whether or not it's on the same origin as the
+        // current window.
+        var cache = this.window_cache;
+        if (!cache) {
+            cache = [[self, true]];
+            var w = self;
+            var i = 0;
+            var so;
+            while (w != w.parent) {
+                w = w.parent;
+                so = is_same_origin(w);
+                cache.push([w, so]);
+                i++;
+            }
+            w = window.opener;
+            if (w) {
+                cache.push([w, is_same_origin(w)]);
+            }
+            this.window_cache = cache;
+        }
+
+        forEach(cache,
+                function(a) {
+                    callback.apply(null, a);
+                });
+    };
+
+    WindowTestEnvironment.prototype.on_tests_ready = function() {
+        var output = new Output();
+        this.output_handler = output;
+
+        var this_obj = this;
+
+        add_start_callback(function (properties) {
+            this_obj.output_handler.init(properties);
+        });
+
+        add_test_state_callback(function(test) {
+            this_obj.output_handler.show_status();
+        });
+
+        add_result_callback(function (test) {
+            this_obj.output_handler.show_status();
+        });
+
+        add_completion_callback(function (tests, harness_status, asserts_run) {
+            this_obj.output_handler.show_results(tests, harness_status, asserts_run);
+        });
+        this.setup_messages(settings.message_events);
+    };
+
+    WindowTestEnvironment.prototype.setup_messages = function(new_events) {
+        var this_obj = this;
+        forEach(settings.message_events, function(x) {
+            var current_dispatch = this_obj.message_events.indexOf(x) !== -1;
+            var new_dispatch = new_events.indexOf(x) !== -1;
+            if (!current_dispatch && new_dispatch) {
+                this_obj.message_functions[x][0](this_obj.message_functions[x][2]);
+            } else if (current_dispatch && !new_dispatch) {
+                this_obj.message_functions[x][1](this_obj.message_functions[x][2]);
+            }
+        });
+        this.message_events = new_events;
+    };
+
+    WindowTestEnvironment.prototype.next_default_test_name = function() {
+        var suffix = this.name_counter > 0 ? " " + this.name_counter : "";
+        this.name_counter++;
+        return get_title() + suffix;
+    };
+
+    WindowTestEnvironment.prototype.on_new_harness_properties = function(properties) {
+        this.output_handler.setup(properties);
+        if (properties.hasOwnProperty("message_events")) {
+            this.setup_messages(properties.message_events);
+        }
+    };
+
+    WindowTestEnvironment.prototype.add_on_loaded_callback = function(callback) {
+        on_event(window, 'load', callback);
+    };
+
+    WindowTestEnvironment.prototype.test_timeout = function() {
+        var metas = document.getElementsByTagName("meta");
+        for (var i = 0; i < metas.length; i++) {
+            if (metas[i].name === "timeout") {
+                if (metas[i].content === "long") {
+                    return settings.harness_timeout.long;
+                }
+                break;
+            }
+        }
+        return settings.harness_timeout.normal;
+    };
+
+    /*
+     * Base TestEnvironment implementation for a generic web worker.
+     *
+     * Workers accumulate test results. One or more clients can connect and
+     * retrieve results from a worker at any time.
+     *
+     * WorkerTestEnvironment supports communicating with a client via a
+     * MessagePort.  The mechanism for determining the appropriate MessagePort
+     * for communicating with a client depends on the type of worker and is
+     * implemented by the various specializations of WorkerTestEnvironment
+     * below.
+     *
+     * A client document using testharness can use fetch_tests_from_worker() to
+     * retrieve results from a worker. See apisample16.html.
+     */
+    function WorkerTestEnvironment() {
+        this.name_counter = 0;
+        this.all_loaded = true;
+        this.message_list = [];
+        this.message_ports = [];
+    }
+
+    WorkerTestEnvironment.prototype._dispatch = function(message) {
+        this.message_list.push(message);
+        for (var i = 0; i < this.message_ports.length; ++i)
+        {
+            this.message_ports[i].postMessage(message);
+        }
+    };
+
+    // The only requirement is that port has a postMessage() method. It doesn't
+    // have to be an instance of a MessagePort, and often isn't.
+    WorkerTestEnvironment.prototype._add_message_port = function(port) {
+        this.message_ports.push(port);
+        for (var i = 0; i < this.message_list.length; ++i)
+        {
+            port.postMessage(this.message_list[i]);
+        }
+    };
+
+    WorkerTestEnvironment.prototype.next_default_test_name = function() {
+        var suffix = this.name_counter > 0 ? " " + this.name_counter : "";
+        this.name_counter++;
+        return get_title() + suffix;
+    };
+
+    WorkerTestEnvironment.prototype.on_new_harness_properties = function() {};
+
+    WorkerTestEnvironment.prototype.on_tests_ready = function() {
+        var this_obj = this;
+        add_start_callback(
+                function(properties) {
+                    this_obj._dispatch({
+                        type: "start",
+                        properties: properties,
+                    });
+                });
+        add_test_state_callback(
+                function(test) {
+                    this_obj._dispatch({
+                        type: "test_state",
+                        test: test.structured_clone()
+                    });
+                });
+        add_result_callback(
+                function(test) {
+                    this_obj._dispatch({
+                        type: "result",
+                        test: test.structured_clone()
+                    });
+                });
+        add_completion_callback(
+                function(tests, harness_status, asserts) {
+                    this_obj._dispatch({
+                        type: "complete",
+                        tests: map(tests,
+                            function(test) {
+                                return test.structured_clone();
+                            }),
+                        status: harness_status.structured_clone(),
+                        asserts: asserts.map(assert => assert.structured_clone()),
+                    });
+                });
+    };
+
+    WorkerTestEnvironment.prototype.add_on_loaded_callback = function() {};
+
+    WorkerTestEnvironment.prototype.test_timeout = function() {
+        // Tests running in a worker don't have a default timeout. I.e. all
+        // worker tests behave as if settings.explicit_timeout is true.
+        return null;
+    };
+
+    /*
+     * Dedicated web workers.
+     * https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope
+     *
+     * This class is used as the test_environment when testharness is running
+     * inside a dedicated worker.
+     */
+    function DedicatedWorkerTestEnvironment() {
+        WorkerTestEnvironment.call(this);
+        // self is an instance of DedicatedWorkerGlobalScope which exposes
+        // a postMessage() method for communicating via the message channel
+        // established when the worker is created.
+        this._add_message_port(self);
+    }
+    DedicatedWorkerTestEnvironment.prototype = Object.create(WorkerTestEnvironment.prototype);
+
+    DedicatedWorkerTestEnvironment.prototype.on_tests_ready = function() {
+        WorkerTestEnvironment.prototype.on_tests_ready.call(this);
+        // In the absence of an onload notification, we a require dedicated
+        // workers to explicitly signal when the tests are done.
+        tests.wait_for_finish = true;
+    };
+
+    /*
+     * Shared web workers.
+     * https://html.spec.whatwg.org/multipage/workers.html#sharedworkerglobalscope
+     *
+     * This class is used as the test_environment when testharness is running
+     * inside a shared web worker.
+     */
+    function SharedWorkerTestEnvironment() {
+        WorkerTestEnvironment.call(this);
+        var this_obj = this;
+        // Shared workers receive message ports via the 'onconnect' event for
+        // each connection.
+        self.addEventListener("connect",
+                function(message_event) {
+                    this_obj._add_message_port(message_event.source);
+                }, false);
+    }
+    SharedWorkerTestEnvironment.prototype = Object.create(WorkerTestEnvironment.prototype);
+
+    SharedWorkerTestEnvironment.prototype.on_tests_ready = function() {
+        WorkerTestEnvironment.prototype.on_tests_ready.call(this);
+        // In the absence of an onload notification, we a require shared
+        // workers to explicitly signal when the tests are done.
+        tests.wait_for_finish = true;
+    };
+
+    /*
+     * Service workers.
+     * http://www.w3.org/TR/service-workers/
+     *
+     * This class is used as the test_environment when testharness is running
+     * inside a service worker.
+     */
+    function ServiceWorkerTestEnvironment() {
+        WorkerTestEnvironment.call(this);
+        this.all_loaded = false;
+        this.on_loaded_callback = null;
+        var this_obj = this;
+        self.addEventListener("message",
+                function(event) {
+                    if (event.data && event.data.type && event.data.type === "connect") {
+                        this_obj._add_message_port(event.source);
+                    }
+                }, false);
+
+        // The oninstall event is received after the service worker script and
+        // all imported scripts have been fetched and executed. It's the
+        // equivalent of an onload event for a document. All tests should have
+        // been added by the time this event is received, thus it's not
+        // necessary to wait until the onactivate event. However, tests for
+        // installed service workers need another event which is equivalent to
+        // the onload event because oninstall is fired only on installation. The
+        // onmessage event is used for that purpose since tests using
+        // testharness.js should ask the result to its service worker by
+        // PostMessage. If the onmessage event is triggered on the service
+        // worker's context, that means the worker's script has been evaluated.
+        on_event(self, "install", on_all_loaded);
+        on_event(self, "message", on_all_loaded);
+        function on_all_loaded() {
+            if (this_obj.all_loaded)
+                return;
+            this_obj.all_loaded = true;
+            if (this_obj.on_loaded_callback) {
+              this_obj.on_loaded_callback();
+            }
+        }
+    }
+
+    ServiceWorkerTestEnvironment.prototype = Object.create(WorkerTestEnvironment.prototype);
+
+    ServiceWorkerTestEnvironment.prototype.add_on_loaded_callback = function(callback) {
+        if (this.all_loaded) {
+            callback();
+        } else {
+            this.on_loaded_callback = callback;
+        }
+    };
+
+    /*
+     * Shadow realms.
+     * https://github.com/tc39/proposal-shadowrealm
+     *
+     * This class is used as the test_environment when testharness is running
+     * inside a shadow realm.
+     */
+    function ShadowRealmTestEnvironment() {
+        WorkerTestEnvironment.call(this);
+        this.all_loaded = false;
+        this.on_loaded_callback = null;
+    }
+
+    ShadowRealmTestEnvironment.prototype = Object.create(WorkerTestEnvironment.prototype);
+
+    /**
+     * Signal to the test environment that the tests are ready and the on-loaded
+     * callback should be run.
+     *
+     * Shadow realms are not *really* a DOM context: they have no `onload` or similar
+     * event for us to use to set up the test environment; so, instead, this method
+     * is manually triggered from the incubating realm
+     *
+     * @param {Function} message_destination - a function that receives JSON-serializable
+     * data to send to the incubating realm, in the same format as used by RemoteContext
+     */
+    ShadowRealmTestEnvironment.prototype.begin = function(message_destination) {
+        if (this.all_loaded) {
+            throw new Error("Tried to start a shadow realm test environment after it has already started");
+        }
+        var fakeMessagePort = {};
+        fakeMessagePort.postMessage = message_destination;
+        this._add_message_port(fakeMessagePort);
+        this.all_loaded = true;
+        if (this.on_loaded_callback) {
+            this.on_loaded_callback();
+        }
+    };
+
+    ShadowRealmTestEnvironment.prototype.add_on_loaded_callback = function(callback) {
+        if (this.all_loaded) {
+            callback();
+        } else {
+            this.on_loaded_callback = callback;
+        }
+    };
+
+    /*
+     * JavaScript shells.
+     *
+     * This class is used as the test_environment when testharness is running
+     * inside a JavaScript shell.
+     */
+    function ShellTestEnvironment() {
+        this.name_counter = 0;
+        this.all_loaded = false;
+        this.on_loaded_callback = null;
+        Promise.resolve().then(function() {
+            this.all_loaded = true;
+            if (this.on_loaded_callback) {
+                this.on_loaded_callback();
+            }
+        }.bind(this));
+        this.message_list = [];
+        this.message_ports = [];
+    }
+
+    ShellTestEnvironment.prototype.next_default_test_name = function() {
+        var suffix = this.name_counter > 0 ? " " + this.name_counter : "";
+        this.name_counter++;
+        return get_title() + suffix;
+    };
+
+    ShellTestEnvironment.prototype.on_new_harness_properties = function() {};
+
+    ShellTestEnvironment.prototype.on_tests_ready = function() {};
+
+    ShellTestEnvironment.prototype.add_on_loaded_callback = function(callback) {
+        if (this.all_loaded) {
+            callback();
+        } else {
+            this.on_loaded_callback = callback;
+        }
+    };
+
+    ShellTestEnvironment.prototype.test_timeout = function() {
+        // Tests running in a shell don't have a default timeout, so behave as
+        // if settings.explicit_timeout is true.
+        return null;
+    };
+
+    function create_test_environment() {
+        if ('document' in global_scope) {
+            return new WindowTestEnvironment();
+        }
+        if ('DedicatedWorkerGlobalScope' in global_scope &&
+            global_scope instanceof DedicatedWorkerGlobalScope) {
+            return new DedicatedWorkerTestEnvironment();
+        }
+        if ('SharedWorkerGlobalScope' in global_scope &&
+            global_scope instanceof SharedWorkerGlobalScope) {
+            return new SharedWorkerTestEnvironment();
+        }
+        if ('ServiceWorkerGlobalScope' in global_scope &&
+            global_scope instanceof ServiceWorkerGlobalScope) {
+            return new ServiceWorkerTestEnvironment();
+        }
+        if ('WorkerGlobalScope' in global_scope &&
+            global_scope instanceof WorkerGlobalScope) {
+            return new DedicatedWorkerTestEnvironment();
+        }
+        /* Shadow realm global objects are _ordinary_ objects (i.e. their prototype is
+         * Object) so we don't have a nice `instanceof` test to use; instead, we
+         * check if the there is a GLOBAL.isShadowRealm() property
+         * on the global object. that was set by the test harness when it
+         * created the ShadowRealm.
+         */
+        if (global_scope.GLOBAL && global_scope.GLOBAL.isShadowRealm()) {
+            return new ShadowRealmTestEnvironment();
+        }
+
+        return new ShellTestEnvironment();
+    }
+
+    var test_environment = create_test_environment();
+
+    function is_shared_worker(worker) {
+        return 'SharedWorker' in global_scope && worker instanceof SharedWorker;
+    }
+
+    function is_service_worker(worker) {
+        // The worker object may be from another execution context,
+        // so do not use instanceof here.
+        return 'ServiceWorker' in global_scope &&
+            Object.prototype.toString.call(worker) === '[object ServiceWorker]';
+    }
+
+    var seen_func_name = Object.create(null);
+
+    function get_test_name(func, name)
+    {
+        if (name) {
+            return name;
+        }
+
+        if (func) {
+            var func_code = func.toString();
+
+            // Try and match with brackets, but fallback to matching without
+            var arrow = func_code.match(/^\(\)\s*=>\s*(?:{(.*)}\s*|(.*))$/);
+
+            // Check for JS line separators
+            if (arrow !== null && !/[\u000A\u000D\u2028\u2029]/.test(func_code)) {
+                var trimmed = (arrow[1] !== undefined ? arrow[1] : arrow[2]).trim();
+                // drop trailing ; if there's no earlier ones
+                trimmed = trimmed.replace(/^([^;]*)(;\s*)+$/, "$1");
+
+                if (trimmed) {
+                    let name = trimmed;
+                    if (seen_func_name[trimmed]) {
+                        // This subtest name already exists, so add a suffix.
+                        name += " " + seen_func_name[trimmed];
+                    } else {
+                        seen_func_name[trimmed] = 0;
+                    }
+                    seen_func_name[trimmed] += 1;
+                    return name;
+                }
+            }
+        }
+
+        return test_environment.next_default_test_name();
+    }
+
+    /**
+     * @callback TestFunction
+     * @param {Test} test - The test currnetly being run.
+     * @param {Any[]} args - Additional args to pass to function.
+     *
+     */
+
+    /**
+     * Create a synchronous test
+     *
+     * @param {TestFunction} func - Test function. This is executed
+     * immediately. If it returns without error, the test status is
+     * set to ``PASS``. If it throws an :js:class:`AssertionError`, or
+     * any other exception, the test status is set to ``FAIL``
+     * (typically from an `assert` function).
+     * @param {String} name - Test name. This must be unique in a
+     * given file and must be invariant between runs.
+     */
+    function test(func, name, properties)
+    {
+        if (tests.promise_setup_called) {
+            tests.status.status = tests.status.ERROR;
+            tests.status.message = '`test` invoked after `promise_setup`';
+            tests.complete();
+        }
+        var test_name = get_test_name(func, name);
+        var test_obj = new Test(test_name, properties);
+        var value = test_obj.step(func, test_obj, test_obj);
+
+        if (value !== undefined) {
+            var msg = 'Test named "' + test_name +
+                '" passed a function to `test` that returned a value.';
+
+            try {
+                if (value && typeof value.then === 'function') {
+                    msg += ' Consider using `promise_test` instead when ' +
+                        'using Promises or async/await.';
+                }
+            } catch (err) {}
+
+            tests.status.status = tests.status.ERROR;
+            tests.status.message = msg;
+        }
+
+        if (test_obj.phase === test_obj.phases.STARTED) {
+            test_obj.done();
+        }
+    }
+
+    /**
+     * Create an asynchronous test
+     *
+     * @param {TestFunction|string} funcOrName - Initial step function
+     * to call immediately with the test name as an argument (if any),
+     * or name of the test.
+     * @param {String} name - Test name (if a test function was
+     * provided). This must be unique in a given file and must be
+     * invariant between runs.
+     * @returns {Test} An object representing the ongoing test.
+     */
+    function async_test(func, name, properties)
+    {
+        if (tests.promise_setup_called) {
+            tests.status.status = tests.status.ERROR;
+            tests.status.message = '`async_test` invoked after `promise_setup`';
+            tests.complete();
+        }
+        if (typeof func !== "function") {
+            properties = name;
+            name = func;
+            func = null;
+        }
+        var test_name = get_test_name(func, name);
+        var test_obj = new Test(test_name, properties);
+        if (func) {
+            var value = test_obj.step(func, test_obj, test_obj);
+
+            // Test authors sometimes return values to async_test, expecting us
+            // to handle the value somehow. Make doing so a harness error to be
+            // clear this is invalid, and point authors to promise_test if it
+            // may be appropriate.
+            //
+            // Note that we only perform this check on the initial function
+            // passed to async_test, not on any later steps - we haven't seen a
+            // consistent problem with those (and it's harder to check).
+            if (value !== undefined) {
+                var msg = 'Test named "' + test_name +
+                    '" passed a function to `async_test` that returned a value.';
+
+                try {
+                    if (value && typeof value.then === 'function') {
+                        msg += ' Consider using `promise_test` instead when ' +
+                            'using Promises or async/await.';
+                    }
+                } catch (err) {}
+
+                tests.set_status(tests.status.ERROR, msg);
+                tests.complete();
+            }
+        }
+        return test_obj;
+    }
+
+    /**
+     * Create a promise test.
+     *
+     * Promise tests are tests which are represented by a promise
+     * object. If the promise is fulfilled the test passes, if it's
+     * rejected the test fails, otherwise the test passes.
+     *
+     * @param {TestFunction} func - Test function. This must return a
+     * promise. The test is automatically marked as complete once the
+     * promise settles.
+     * @param {String} name - Test name. This must be unique in a
+     * given file and must be invariant between runs.
+     */
+    function promise_test(func, name, properties) {
+        if (typeof func !== "function") {
+            properties = name;
+            name = func;
+            func = null;
+        }
+        var test_name = get_test_name(func, name);
+        var test = new Test(test_name, properties);
+        test._is_promise_test = true;
+
+        // If there is no promise tests queue make one.
+        if (!tests.promise_tests) {
+            tests.promise_tests = Promise.resolve();
+        }
+        tests.promise_tests = tests.promise_tests.then(function() {
+            return new Promise(function(resolve) {
+                var promise = test.step(func, test, test);
+
+                test.step(function() {
+                    assert(!!promise, "promise_test", null,
+                           "test body must return a 'thenable' object (received ${value})",
+                           {value:promise});
+                    assert(typeof promise.then === "function", "promise_test", null,
+                           "test body must return a 'thenable' object (received an object with no `then` method)",
+                           null);
+                });
+
+                // Test authors may use the `step` method within a
+                // `promise_test` even though this reflects a mixture of
+                // asynchronous control flow paradigms. The "done" callback
+                // should be registered prior to the resolution of the
+                // user-provided Promise to avoid timeouts in cases where the
+                // Promise does not settle but a `step` function has thrown an
+                // error.
+                add_test_done_callback(test, resolve);
+
+                Promise.resolve(promise)
+                    .catch(test.step_func(
+                        function(value) {
+                            if (value instanceof AssertionError) {
+                                throw value;
+                            }
+                            assert(false, "promise_test", null,
+                                   "Unhandled rejection with value: ${value}", {value:value});
+                        }))
+                    .then(function() {
+                        test.done();
+                    });
+                });
+        });
+    }
+
+    /**
+     * Make a copy of a Promise in the current realm.
+     *
+     * @param {Promise} promise the given promise that may be from a different
+     *                          realm
+     * @returns {Promise}
+     *
+     * An arbitrary promise provided by the caller may have originated
+     * in another frame that have since navigated away, rendering the
+     * frame's document inactive. Such a promise cannot be used with
+     * `await` or Promise.resolve(), as microtasks associated with it
+     * may be prevented from being run. See `issue
+     * 5319<https://github.com/whatwg/html/issues/5319>`_ for a
+     * particular case.
+     *
+     * In functions we define here, there is an expectation from the caller
+     * that the promise is from the current realm, that can always be used with
+     * `await`, etc. We therefore create a new promise in this realm that
+     * inherit the value and status from the given promise.
+     */
+
+    function bring_promise_to_current_realm(promise) {
+        return new Promise(promise.then.bind(promise));
+    }
+
+    /**
+     * Assert that a Promise is rejected with the right ECMAScript exception.
+     *
+     * @param {Test} test - the `Test` to use for the assertion.
+     * @param {Function} constructor - The expected exception constructor.
+     * @param {Promise} promise - The promise that's expected to
+     * reject with the given exception.
+     * @param {string} [description] Error message to add to assert in case of
+     *                               failure.
+     */
+    function promise_rejects_js(test, constructor, promise, description) {
+        return bring_promise_to_current_realm(promise)
+            .then(test.unreached_func("Should have rejected: " + description))
+            .catch(function(e) {
+                assert_throws_js_impl(constructor, function() { throw e; },
+                                      description, "promise_rejects_js");
+            });
+    }
+
+    /**
+     * Assert that a Promise is rejected with the right DOMException.
+     *
+     * For the remaining arguments, there are two ways of calling
+     * promise_rejects_dom:
+     *
+     * 1) If the DOMException is expected to come from the current global, the
+     * third argument should be the promise expected to reject, and a fourth,
+     * optional, argument is the assertion description.
+     *
+     * 2) If the DOMException is expected to come from some other global, the
+     * third argument should be the DOMException constructor from that global,
+     * the fourth argument the promise expected to reject, and the fifth,
+     * optional, argument the assertion description.
+     *
+     * @param {Test} test - the `Test` to use for the assertion.
+     * @param {number|string} type - See documentation for
+     * `assert_throws_dom <#assert_throws_dom>`_.
+     * @param {Function} promiseOrConstructor - Either the constructor
+     * for the expected exception (if the exception comes from another
+     * global), or the promise that's expected to reject (if the
+     * exception comes from the current global).
+     * @param {Function|string} descriptionOrPromise - Either the
+     * promise that's expected to reject (if the exception comes from
+     * another global), or the optional description of the condition
+     * being tested (if the exception comes from the current global).
+     * @param {string} [description] - Description of the condition
+     * being tested (if the exception comes from another global).
+     *
+     */
+    function promise_rejects_dom(test, type, promiseOrConstructor, descriptionOrPromise, maybeDescription) {
+        let constructor, promise, description;
+        if (typeof promiseOrConstructor === "function" &&
+            promiseOrConstructor.name === "DOMException") {
+            constructor = promiseOrConstructor;
+            promise = descriptionOrPromise;
+            description = maybeDescription;
+        } else {
+            constructor = self.DOMException;
+            promise = promiseOrConstructor;
+            description = descriptionOrPromise;
+            assert(maybeDescription === undefined,
+                   "Too many args passed to no-constructor version of promise_rejects_dom, or accidentally explicitly passed undefined");
+        }
+        return bring_promise_to_current_realm(promise)
+            .then(test.unreached_func("Should have rejected: " + description))
+            .catch(function(e) {
+                assert_throws_dom_impl(type, function() { throw e; }, description,
+                                       "promise_rejects_dom", constructor);
+            });
+    }
+
+/**
+     * Assert that a `Promise` is rejected with a `QuotaExceededError` with the
+     * expected values.
+     *
+     * For the remaining arguments, there are two ways of calling
+     * `promise_rejects_quotaexceedederror`:
+     *
+     * 1) If the `QuotaExceededError` is expected to come from the
+     *    current global, the second argument should be the promise
+     *    expected to reject, the third and a fourth the expected
+     *    `requested` and `quota` property values, and the fifth,
+     *    optional, argument is the assertion description.
+     *
+     * 2) If the `QuotaExceededError` is expected to come from some
+     *    other global, the second argument should be the
+     *    `QuotaExceededError` constructor from that global, the third
+     *    argument should be the promise expected to reject, the fourth
+     *    and fifth the expected `requested` and `quota` property
+     *    values, and the sixth, optional, argument is the assertion
+     *    description.
+     *
+     */
+    function promise_rejects_quotaexceedederror(test, promiseOrConstructor, requestedOrPromise, quotaOrRequested, descriptionOrQuota, maybeDescription)
+    {
+        let constructor, promise, requested, quota, description;
+        if (typeof promiseOrConstructor === "function" &&
+            promiseOrConstructor.name === "QuotaExceededError") {
+            constructor = promiseOrConstructor;
+            promise = requestedOrPromise;
+            requested = quotaOrRequested;
+            quota = descriptionOrQuota;
+            description = maybeDescription;
+        } else {
+            constructor = self.QuotaExceededError;
+            promise = promiseOrConstructor;
+            requested = requestedOrPromise;
+            quota = quotaOrRequested;
+            description = descriptionOrQuota;
+            assert(maybeDescription === undefined,
+                   "Too many args passed to no-constructor version of promise_rejects_quotaexceedederror");
+        }
+        return bring_promise_to_current_realm(promise)
+            .then(test.unreached_func("Should have rejected: " + description))
+            .catch(function(e) {
+                assert_throws_quotaexceedederror_impl(function() { throw e; }, requested, quota, description, "promise_rejects_quotaexceedederror", constructor);
+            });
+    }
+
+    /**
+     * Assert that a Promise is rejected with the provided value.
+     *
+     * @param {Test} test - the `Test` to use for the assertion.
+     * @param {Any} exception - The expected value of the rejected promise.
+     * @param {Promise} promise - The promise that's expected to
+     * reject.
+     * @param {string} [description] Error message to add to assert in case of
+     *                               failure.
+     */
+    function promise_rejects_exactly(test, exception, promise, description) {
+        return bring_promise_to_current_realm(promise)
+            .then(test.unreached_func("Should have rejected: " + description))
+            .catch(function(e) {
+                assert_throws_exactly_impl(exception, function() { throw e; },
+                                           description, "promise_rejects_exactly");
+            });
+    }
+
+    /**
+     * Allow DOM events to be handled using Promises.
+     *
+     * This can make it a lot easier to test a very specific series of events,
+     * including ensuring that unexpected events are not fired at any point.
+     *
+     * `EventWatcher` will assert if an event occurs while there is no `wait_for`
+     * created Promise waiting to be fulfilled, or if the event is of a different type
+     * to the type currently expected. This ensures that only the events that are
+     * expected occur, in the correct order, and with the correct timing.
+     *
+     * @constructor
+     * @param {Test} test - The `Test` to use for the assertion.
+     * @param {EventTarget} watchedNode - The target expected to receive the events.
+     * @param {string[]} eventTypes - List of events to watch for.
+     * @param {Promise} timeoutPromise - Promise that will cause the
+     * test to be set to `TIMEOUT` once fulfilled.
+     *
+     */
+    function EventWatcher(test, watchedNode, eventTypes, timeoutPromise)
+    {
+        if (typeof eventTypes === 'string') {
+            eventTypes = [eventTypes];
+        }
+
+        var waitingFor = null;
+
+        // This is null unless we are recording all events, in which case it
+        // will be an Array object.
+        var recordedEvents = null;
+
+        var eventHandler = test.step_func(function(evt) {
+            assert_true(!!waitingFor,
+                        'Not expecting event, but got ' + evt.type + ' event');
+            assert_equals(evt.type, waitingFor.types[0],
+                          'Expected ' + waitingFor.types[0] + ' event, but got ' +
+                          evt.type + ' event instead');
+
+            if (Array.isArray(recordedEvents)) {
+                recordedEvents.push(evt);
+            }
+
+            if (waitingFor.types.length > 1) {
+                // Pop first event from array
+                waitingFor.types.shift();
+                return;
+            }
+            // We need to null out waitingFor before calling the resolve function
+            // since the Promise's resolve handlers may call wait_for() which will
+            // need to set waitingFor.
+            var resolveFunc = waitingFor.resolve;
+            waitingFor = null;
+            // Likewise, we should reset the state of recordedEvents.
+            var result = recordedEvents || evt;
+            recordedEvents = null;
+            resolveFunc(result);
+        });
+
+        for (var i = 0; i < eventTypes.length; i++) {
+            watchedNode.addEventListener(eventTypes[i], eventHandler, false);
+        }
+
+        /**
+         * Returns a Promise that will resolve after the specified event or
+         * series of events has occurred.
+         *
+         * @param {Object} options An optional options object. If the 'record' property
+         *                 on this object has the value 'all', when the Promise
+         *                 returned by this function is resolved,  *all* Event
+         *                 objects that were waited for will be returned as an
+         *                 array.
+         *
+         * @example
+         * const watcher = new EventWatcher(t, div, [ 'animationstart',
+         *                                            'animationiteration',
+         *                                            'animationend' ]);
+         * return watcher.wait_for([ 'animationstart', 'animationend' ],
+         *                         { record: 'all' }).then(evts => {
+         *   assert_equals(evts[0].elapsedTime, 0.0);
+         *   assert_equals(evts[1].elapsedTime, 2.0);
+         * });
+         */
+        this.wait_for = function(types, options) {
+            if (waitingFor) {
+                return Promise.reject('Already waiting for an event or events');
+            }
+            if (typeof types === 'string') {
+                types = [types];
+            }
+            if (options && options.record && options.record === 'all') {
+                recordedEvents = [];
+            }
+            return new Promise(function(resolve, reject) {
+                var timeout = test.step_func(function() {
+                    // If the timeout fires after the events have been received
+                    // or during a subsequent call to wait_for, ignore it.
+                    if (!waitingFor || waitingFor.resolve !== resolve)
+                        return;
+
+                    // This should always fail, otherwise we should have
+                    // resolved the promise.
+                    assert_true(waitingFor.types.length === 0,
+                                'Timed out waiting for ' + waitingFor.types.join(', '));
+                    var result = recordedEvents;
+                    recordedEvents = null;
+                    var resolveFunc = waitingFor.resolve;
+                    waitingFor = null;
+                    resolveFunc(result);
+                });
+
+                if (timeoutPromise) {
+                    timeoutPromise().then(timeout);
+                }
+
+                waitingFor = {
+                    types: types,
+                    resolve: resolve,
+                    reject: reject
+                };
+            });
+        };
+
+        /**
+         * Stop listening for events
+         */
+        this.stop_watching = function() {
+            for (var i = 0; i < eventTypes.length; i++) {
+                watchedNode.removeEventListener(eventTypes[i], eventHandler, false);
+            }
+        };
+
+        test._add_cleanup(this.stop_watching);
+
+        return this;
+    }
+    expose(EventWatcher, 'EventWatcher');
+
+    /**
+     * @typedef {Object} SettingsObject
+     * @property {bool} single_test - Use the single-page-test
+     * mode. In this mode the Document represents a single
+     * `async_test`. Asserts may be used directly without requiring
+     * `Test.step` or similar wrappers, and any exceptions set the
+     * status of the test rather than the status of the harness.
+     * @property {bool} allow_uncaught_exception - don't treat an
+     * uncaught exception as an error; needed when e.g. testing the
+     * `window.onerror` handler.
+     * @property {boolean} explicit_done - Wait for a call to `done()`
+     * before declaring all tests complete (this is always true for
+     * single-page tests).
+     * @property hide_test_state - hide the test state output while
+     * the test is running; This is helpful when the output of the test state
+     * may interfere the test results.
+     * @property {bool} explicit_timeout - disable file timeout; only
+     * stop waiting for results when the `timeout()` function is
+     * called This should typically only be set for manual tests, or
+     * by a test runner that providees its own timeout mechanism.
+     * @property {number} timeout_multiplier - Multiplier to apply to
+     * per-test timeouts. This should only be set by a test runner.
+     * @property {Document} output_document - The document to which
+     * results should be logged. By default this is the current
+     * document but could be an ancestor document in some cases e.g. a
+     * SVG test loaded in an HTML wrapper
+     *
+     */
+
+    /**
+     * Configure the harness
+     *
+     * @param {Function|SettingsObject} funcOrProperties - Either a
+     * setup function to run, or a set of properties. If this is a
+     * function that function is run synchronously. Any exception in
+     * the function will set the overall harness status to `ERROR`.
+     * @param {SettingsObject} maybeProperties - An object containing
+     * the settings to use, if the first argument is a function.
+     *
+     */
+    function setup(func_or_properties, maybe_properties)
+    {
+        var func = null;
+        var properties = {};
+        if (arguments.length === 2) {
+            func = func_or_properties;
+            properties = maybe_properties;
+        } else if (func_or_properties instanceof Function) {
+            func = func_or_properties;
+        } else {
+            properties = func_or_properties;
+        }
+        tests.setup(func, properties);
+        test_environment.on_new_harness_properties(properties);
+    }
+
+    /**
+     * Configure the harness, waiting for a promise to resolve
+     * before running any `promise_test` tests.
+     *
+     * @param {Function} func - Function returning a promise that's
+     * run synchronously. Promise tests are not run until after this
+     * function has resolved.
+     * @param {SettingsObject} [properties] - An object containing
+     * the harness settings to use.
+     *
+     */
+    function promise_setup(func, properties={})
+    {
+        if (typeof func !== "function") {
+            tests.set_status(tests.status.ERROR,
+                             "`promise_setup` invoked without a function");
+            tests.complete();
+            return;
+        }
+        tests.promise_setup_called = true;
+
+        if (!tests.promise_tests) {
+            tests.promise_tests = Promise.resolve();
+        }
+
+        tests.promise_tests = tests.promise_tests
+            .then(function()
+                  {
+                      var result;
+
+                      tests.setup(null, properties);
+                      result = func();
+                      test_environment.on_new_harness_properties(properties);
+
+                      if (!result || typeof result.then !== "function") {
+                          throw "Non-thenable returned by function passed to `promise_setup`";
+                      }
+                      return result;
+                  })
+            .catch(function(e)
+                   {
+                       tests.set_status(tests.status.ERROR,
+                                        String(e),
+                                        e && e.stack);
+                       tests.complete();
+                   });
+    }
+
+    /**
+     * Mark test loading as complete.
+     *
+     * Typically this function is called implicitly on page load; it's
+     * only necessary for users to call this when either the
+     * ``explicit_done`` or ``single_test`` properties have been set
+     * via the :js:func:`setup` function.
+     *
+     * For single page tests this marks the test as complete and sets its status.
+     * For other tests, this marks test loading as complete, but doesn't affect ongoing tests.
+     */
+    function done() {
+        if (tests.tests.length === 0) {
+            // `done` is invoked after handling uncaught exceptions, so if the
+            // harness status is already set, the corresponding message is more
+            // descriptive than the generic message defined here.
+            if (tests.status.status === null) {
+                tests.status.status = tests.status.ERROR;
+                tests.status.message = "done() was called without first defining any tests";
+            }
+
+            tests.complete();
+            return;
+        }
+        if (tests.file_is_test) {
+            // file is test files never have asynchronous cleanup logic,
+            // meaning the fully-synchronous `done` function can be used here.
+            tests.tests[0].done();
+        }
+        tests.end_wait();
+    }
+
+    /**
+     * @deprecated generate a list of tests from a function and list of arguments
+     *
+     * This is deprecated because it runs all the tests outside of the test functions
+     * and as a result any test throwing an exception will result in no tests being
+     * run. In almost all cases, you should simply call test within the loop you would
+     * use to generate the parameter list array.
+     *
+     * @param {Function} func - The function that will be called for each generated tests.
+     * @param {Any[][]} args - An array of arrays. Each nested array
+     * has the structure `[testName, ...testArgs]`. For each of these nested arrays
+     * array, a test is generated with name `testName` and test function equivalent to
+     * `func(..testArgs)`.
+     */
+    function generate_tests(func, args, properties) {
+        forEach(args, function(x, i)
+                {
+                    var name = x[0];
+                    test(function()
+                         {
+                             func.apply(this, x.slice(1));
+                         },
+                         name,
+                         Array.isArray(properties) ? properties[i] : properties);
+                });
+    }
+
+    /**
+     * @deprecated
+     *
+     * Register a function as a DOM event listener to the
+     * given object for the event bubbling phase.
+     *
+     * @param {EventTarget} object - Event target
+     * @param {string} event - Event name
+     * @param {Function} callback - Event handler.
+     */
+    function on_event(object, event, callback)
+    {
+        object.addEventListener(event, callback, false);
+    }
+
+    // Internal helper function to provide timeout-like functionality in
+    // environments where there is no setTimeout(). (No timeout ID or
+    // clearTimeout().)
+    function fake_set_timeout(callback, delay) {
+        var p = Promise.resolve();
+        var start = Date.now();
+        var end = start + delay;
+        function check() {
+            if ((end - Date.now()) > 0) {
+                p.then(check);
+            } else {
+                callback();
+            }
+        }
+        p.then(check);
+    }
+
+    /**
+     * Global version of :js:func:`Test.step_timeout` for use in single page tests.
+     *
+     * @param {Function} func - Function to run after the timeout
+     * @param {number} timeout - Time in ms to wait before running the
+     * test step. The actual wait time is ``timeout`` x
+     * ``timeout_multiplier``.
+     */
+    function step_timeout(func, timeout) {
+        var outer_this = this;
+        var args = Array.prototype.slice.call(arguments, 2);
+        var local_set_timeout = typeof global_scope.setTimeout === "undefined" ? fake_set_timeout : setTimeout;
+        return local_set_timeout(function() {
+            func.apply(outer_this, args);
+        }, timeout * tests.timeout_multiplier);
+    }
+
+    expose(test, 'test');
+    expose(async_test, 'async_test');
+    expose(promise_test, 'promise_test');
+    expose(promise_rejects_js, 'promise_rejects_js');
+    expose(promise_rejects_dom, 'promise_rejects_dom');
+    expose(promise_rejects_quotaexceedederror, 'promise_rejects_quotaexceedederror');
+    expose(promise_rejects_exactly, 'promise_rejects_exactly');
+    expose(generate_tests, 'generate_tests');
+    expose(setup, 'setup');
+    expose(promise_setup, 'promise_setup');
+    expose(done, 'done');
+    expose(on_event, 'on_event');
+    expose(step_timeout, 'step_timeout');
+
+    /*
+     * Return a string truncated to the given length, with ... added at the end
+     * if it was longer.
+     */
+    function truncate(s, len)
+    {
+        if (s.length > len) {
+            return s.substring(0, len - 3) + "...";
+        }
+        return s;
+    }
+
+    /*
+     * Return true if object is probably a Node object.
+     */
+    function is_node(object)
+    {
+        // I use duck-typing instead of instanceof, because
+        // instanceof doesn't work if the node is from another window (like an
+        // iframe's contentWindow):
+        // http://www.w3.org/Bugs/Public/show_bug.cgi?id=12295
+        try {
+            var has_node_properties = ("nodeType" in object &&
+                                       "nodeName" in object &&
+                                       "nodeValue" in object &&
+                                       "childNodes" in object);
+        } catch (e) {
+            // We're probably cross-origin, which means we aren't a node
+            return false;
+        }
+
+        if (has_node_properties) {
+            try {
+                object.nodeType;
+            } catch (e) {
+                // The object is probably Node.prototype or another prototype
+                // object that inherits from it, and not a Node instance.
+                return false;
+            }
+            return true;
+        }
+        return false;
+    }
+
+    var replacements = {
+        "0": "0",
+        "1": "x01",
+        "2": "x02",
+        "3": "x03",
+        "4": "x04",
+        "5": "x05",
+        "6": "x06",
+        "7": "x07",
+        "8": "b",
+        "9": "t",
+        "10": "n",
+        "11": "v",
+        "12": "f",
+        "13": "r",
+        "14": "x0e",
+        "15": "x0f",
+        "16": "x10",
+        "17": "x11",
+        "18": "x12",
+        "19": "x13",
+        "20": "x14",
+        "21": "x15",
+        "22": "x16",
+        "23": "x17",
+        "24": "x18",
+        "25": "x19",
+        "26": "x1a",
+        "27": "x1b",
+        "28": "x1c",
+        "29": "x1d",
+        "30": "x1e",
+        "31": "x1f",
+        "0xfffd": "ufffd",
+        "0xfffe": "ufffe",
+        "0xffff": "uffff",
+    };
+
+    const formatEscapeMap = {
+        "\\": "\\\\",
+        '"': '\\"'
+    };
+    for (const p in replacements) {
+        formatEscapeMap[String.fromCharCode(p)] = "\\" + replacements[p];
+    }
+    const formatEscapePattern = new RegExp(`[${Object.keys(formatEscapeMap).map(k => k === "\\" ? "\\\\" : k).join("")}]`, "g");
+
+    /**
+     * Convert a value to a nice, human-readable string
+     *
+     * When many JavaScript Object values are coerced to a String, the
+     * resulting value will be ``"[object Object]"``. This obscures
+     * helpful information, making the coerced value unsuitable for
+     * use in assertion messages, test names, and debugging
+     * statements. `format_value` produces more distinctive string
+     * representations of many kinds of objects, including arrays and
+     * the more important DOM Node types. It also translates String
+     * values containing control characters to include human-readable
+     * representations.
+     *
+     * @example
+     * // "Document node with 2 children"
+     * format_value(document);
+     * @example
+     * // "\"foo\\uffffbar\""
+     * format_value("foo\uffffbar");
+     * @example
+     * // "[-0, Infinity]"
+     * format_value([-0, Infinity]);
+     * @param {Any} val - The value to convert to a string.
+     * @returns {string} - A string representation of ``val``, optimised for human readability.
+     */
+    function format_value(val, seen)
+    {
+        if (!seen) {
+            seen = [];
+        }
+        if (typeof val === "object" && val !== null) {
+            if (seen.indexOf(val) >= 0) {
+                return "[...]";
+            }
+            seen.push(val);
+        }
+        if (Array.isArray(val)) {
+            let output = "[";
+            if (val.beginEllipsis !== undefined) {
+                output += "…, ";
+            }
+            output += val.map(function(x) {return format_value(x, seen);}).join(", ");
+            if (val.endEllipsis !== undefined) {
+                output += ", …";
+            }
+            return output + "]";
+        }
+
+        switch (typeof val) {
+        case "string":
+            return '"' + val.replace(formatEscapePattern, match => formatEscapeMap[match]) + '"';
+        case "boolean":
+        case "undefined":
+            return String(val);
+        case "number":
+            // In JavaScript, -0 === 0 and String(-0) == "0", so we have to
+            // special-case.
+            if (val === -0 && 1/val === -Infinity) {
+                return "-0";
+            }
+            return String(val);
+        case "bigint":
+            return String(val) + 'n';
+        case "object":
+            if (val === null) {
+                return "null";
+            }
+
+            // Special-case Node objects, since those come up a lot in my tests.  I
+            // ignore namespaces.
+            if (is_node(val)) {
+                switch (val.nodeType) {
+                case Node.ELEMENT_NODE:
+                    var ret = "<" + val.localName;
+                    for (var i = 0; i < val.attributes.length; i++) {
+                        ret += " " + val.attributes[i].name + '="' + val.attributes[i].value + '"';
+                    }
+                    ret += ">" + val.innerHTML + "</" + val.localName + ">";
+                    return "Element node " + truncate(ret, 60);
+                case Node.TEXT_NODE:
+                    return 'Text node "' + truncate(val.data, 60) + '"';
+                case Node.PROCESSING_INSTRUCTION_NODE:
+                    return "ProcessingInstruction node with target " + format_value(truncate(val.target, 60)) + " and data " + format_value(truncate(val.data, 60));
+                case Node.COMMENT_NODE:
+                    return "Comment node <!--" + truncate(val.data, 60) + "-->";
+                case Node.DOCUMENT_NODE:
+                    return "Document node with " + val.childNodes.length + (val.childNodes.length === 1 ? " child" : " children");
+                case Node.DOCUMENT_TYPE_NODE:
+                    return "DocumentType node";
+                case Node.DOCUMENT_FRAGMENT_NODE:
+                    return "DocumentFragment node with " + val.childNodes.length + (val.childNodes.length === 1 ? " child" : " children");
+                default:
+                    return "Node object of unknown type";
+                }
+            }
+
+        /* falls through */
+        default:
+            try {
+                return typeof val + ' "' + truncate(String(val), 1000) + '"';
+            } catch(e) {
+                return ("[stringifying object threw " + String(e) +
+                        " with type " + String(typeof e) + "]");
+            }
+        }
+    }
+    expose(format_value, "format_value");
+
+    /*
+     * Assertions
+     */
+
+    function expose_assert(f, name) {
+        function assert_wrapper(...args) {
+            let status = Test.statuses.TIMEOUT;
+            let stack = null;
+            let new_assert_index = null;
+            try {
+                if (settings.debug) {
+                    console.debug("ASSERT", name, tests.current_test && tests.current_test.name, args);
+                }
+                if (tests.output) {
+                    tests.set_assert(name, args);
+                    // Remember the newly pushed assert's index, because `apply`
+                    // below might push new asserts.
+                    new_assert_index = tests.asserts_run.length - 1;
+                }
+                const rv = f.apply(undefined, args);
+                status = Test.statuses.PASS;
+                return rv;
+            } catch(e) {
+                status = Test.statuses.FAIL;
+                stack = e.stack ? e.stack : null;
+                throw e;
+            } finally {
+                if (tests.output && !stack) {
+                    stack = get_stack();
+                }
+                if (tests.output) {
+                    tests.set_assert_status(new_assert_index, status, stack);
+                }
+            }
+        }
+        expose(assert_wrapper, name);
+    }
+
+    /**
+     * Assert that ``actual`` is strictly true
+     *
+     * @param {Any} actual - Value that is asserted to be true
+     * @param {string} [description] - Description of the condition being tested
+     */
+    function assert_true(actual, description)
+    {
+        assert(actual === true, "assert_true", description,
+                                "expected true got ${actual}", {actual:actual});
+    }
+    expose_assert(assert_true, "assert_true");
+
+    /**
+     * Assert that ``actual`` is strictly false
+     *
+     * @param {Any} actual - Value that is asserted to be false
+     * @param {string} [description] - Description of the condition being tested
+     */
+    function assert_false(actual, description)
+    {
+        assert(actual === false, "assert_false", description,
+                                 "expected false got ${actual}", {actual:actual});
+    }
+    expose_assert(assert_false, "assert_false");
+
+    function same_value(x, y) {
+        if (y !== y) {
+            //NaN case
+            return x !== x;
+        }
+        if (x === 0 && y === 0) {
+            //Distinguish +0 and -0
+            return 1/x === 1/y;
+        }
+        return x === y;
+    }
+
+    /**
+     * Assert that ``actual`` is the same value as ``expected``.
+     *
+     * For objects this compares by object identity; for primitives
+     * this distinguishes between 0 and -0, and has correct handling
+     * of NaN.
+     *
+     * @param {Any} actual - Test value.
+     * @param {Any} expected - Expected value.
+     * @param {string} [description] - Description of the condition being tested.
+     */
+    function assert_equals(actual, expected, description)
+    {
+         /*
+          * Test if two primitives are equal or two objects
+          * are the same object
+          */
+        if (typeof actual != typeof expected) {
+            assert(false, "assert_equals", description,
+                          "expected (" + typeof expected + ") ${expected} but got (" + typeof actual + ") ${actual}",
+                          {expected:expected, actual:actual});
+            return;
+        }
+        assert(same_value(actual, expected), "assert_equals", description,
+                                             "expected ${expected} but got ${actual}",
+                                             {expected:expected, actual:actual});
+    }
+    expose_assert(assert_equals, "assert_equals");
+
+    /**
+     * Assert that ``actual`` is not the same value as ``expected``.
+     *
+     * Comparison is as for :js:func:`assert_equals`.
+     *
+     * @param {Any} actual - Test value.
+     * @param {Any} expected - The value ``actual`` is expected to be different to.
+     * @param {string} [description] - Description of the condition being tested.
+     */
+    function assert_not_equals(actual, expected, description)
+    {
+        assert(!same_value(actual, expected), "assert_not_equals", description,
+                                              "got disallowed value ${actual}",
+                                              {actual:actual});
+    }
+    expose_assert(assert_not_equals, "assert_not_equals");
+
+    /**
+     * Assert that ``expected`` is an array and ``actual`` is one of the members.
+     * This is implemented using ``indexOf``, so doesn't handle NaN or ±0 correctly.
+     *
+     * @param {Any} actual - Test value.
+     * @param {Array} expected - An array that ``actual`` is expected to
+     * be a member of.
+     * @param {string} [description] - Description of the condition being tested.
+     */
+    function assert_in_array(actual, expected, description)
+    {
+        assert(expected.indexOf(actual) != -1, "assert_in_array", description,
+                                               "value ${actual} not in array ${expected}",
+                                               {actual:actual, expected:expected});
+    }
+    expose_assert(assert_in_array, "assert_in_array");
+
+    // This function was deprecated in July of 2015.
+    // See https://github.com/web-platform-tests/wpt/issues/2033
+    /**
+     * @deprecated
+     * Recursively compare two objects for equality.
+     *
+     * See `Issue 2033
+     * <https://github.com/web-platform-tests/wpt/issues/2033>`_ for
+     * more information.
+     *
+     * @param {Object} actual - Test value.
+     * @param {Object} expected - Expected value.
+     * @param {string} [description] - Description of the condition being tested.
+     */
+    function assert_object_equals(actual, expected, description)
+    {
+         assert(typeof actual === "object" && actual !== null, "assert_object_equals", description,
+                                                               "value is ${actual}, expected object",
+                                                               {actual: actual});
+         //This needs to be improved a great deal
+         function check_equal(actual, expected, stack)
+         {
+             stack.push(actual);
+
+             var p;
+             for (p in actual) {
+                 assert(expected.hasOwnProperty(p), "assert_object_equals", description,
+                                                    "unexpected property ${p}", {p:p});
+
+                 if (typeof actual[p] === "object" && actual[p] !== null) {
+                     if (stack.indexOf(actual[p]) === -1) {
+                         check_equal(actual[p], expected[p], stack);
+                     }
+                 } else {
+                     assert(same_value(actual[p], expected[p]), "assert_object_equals", description,
+                                                       "property ${p} expected ${expected} got ${actual}",
+                                                       {p:p, expected:expected[p], actual:actual[p]});
+                 }
+             }
+             for (p in expected) {
+                 assert(actual.hasOwnProperty(p),
+                        "assert_object_equals", description,
+                        "expected property ${p} missing", {p:p});
+             }
+             stack.pop();
+         }
+         check_equal(actual, expected, []);
+    }
+    expose_assert(assert_object_equals, "assert_object_equals");
+
+    /**
+     * Assert that ``actual`` and ``expected`` are both arrays, and that the array properties of
+     * ``actual`` and ``expected`` are all the same value (as for :js:func:`assert_equals`).
+     *
+     * @param {Array} actual - Test array.
+     * @param {Array} expected - Array that is expected to contain the same values as ``actual``.
+     * @param {string} [description] - Description of the condition being tested.
+     */
+    function assert_array_equals(actual, expected, description)
+    {
+        const max_array_length = 20;
+        function shorten_array(arr, offset = 0) {
+            // Make ", …" only show up when it would likely reduce the length, not accounting for
+            // fonts.
+            if (arr.length < max_array_length + 2) {
+                return arr;
+            }
+            // By default we want half the elements after the offset and half before
+            // But if that takes us past the end of the array, we have more before, and
+            // if it takes us before the start we have more after.
+            const length_after_offset = Math.floor(max_array_length / 2);
+            let upper_bound = Math.min(length_after_offset + offset, arr.length);
+            const lower_bound = Math.max(upper_bound - max_array_length, 0);
+
+            if (lower_bound === 0) {
+                upper_bound = max_array_length;
+            }
+
+            const output = arr.slice(lower_bound, upper_bound);
+            if (lower_bound > 0) {
+                output.beginEllipsis = true;
+            }
+            if (upper_bound < arr.length) {
+                output.endEllipsis = true;
+            }
+            return output;
+        }
+
+        assert(typeof actual === "object" && actual !== null && "length" in actual,
+               "assert_array_equals", description,
+               "value is ${actual}, expected array",
+               {actual:actual});
+        assert(actual.length === expected.length,
+               "assert_array_equals", description,
+               "lengths differ, expected array ${expected} length ${expectedLength}, got ${actual} length ${actualLength}",
+               {expected:shorten_array(expected, expected.length - 1), expectedLength:expected.length,
+                actual:shorten_array(actual, actual.length - 1), actualLength:actual.length
+               });
+
+        for (var i = 0; i < actual.length; i++) {
+            assert(actual.hasOwnProperty(i) === expected.hasOwnProperty(i),
+                   "assert_array_equals", description,
+                   "expected property ${i} to be ${expected} but was ${actual} (expected array ${arrayExpected} got ${arrayActual})",
+                   {i:i, expected:expected.hasOwnProperty(i) ? "present" : "missing",
+                    actual:actual.hasOwnProperty(i) ? "present" : "missing",
+                    arrayExpected:shorten_array(expected, i), arrayActual:shorten_array(actual, i)});
+            assert(same_value(expected[i], actual[i]),
+                   "assert_array_equals", description,
+                   "expected property ${i} to be ${expected} but got ${actual} (expected array ${arrayExpected} got ${arrayActual})",
+                   {i:i, expected:expected[i], actual:actual[i],
+                    arrayExpected:shorten_array(expected, i), arrayActual:shorten_array(actual, i)});
+        }
+    }
+    expose_assert(assert_array_equals, "assert_array_equals");
+
+    /**
+     * Assert that each array property in ``actual`` is a number within
+     * ± `epsilon` of the corresponding property in `expected`.
+     *
+     * @param {Array} actual - Array of test values.
+     * @param {Array} expected - Array of values expected to be close to the values in ``actual``.
+     * @param {number} epsilon - Magnitude of allowed difference
+     * between each value in ``actual`` and ``expected``.
+     * @param {string} [description] - Description of the condition being tested.
+     */
+    function assert_array_approx_equals(actual, expected, epsilon, description)
+    {
+        /*
+         * Test if two primitive arrays are equal within +/- epsilon
+         */
+        assert(actual.length === expected.length,
+               "assert_array_approx_equals", description,
+               "lengths differ, expected ${expected} got ${actual}",
+               {expected:expected.length, actual:actual.length});
+
+        for (var i = 0; i < actual.length; i++) {
+            assert(actual.hasOwnProperty(i) === expected.hasOwnProperty(i),
+                   "assert_array_approx_equals", description,
+                   "property ${i}, property expected to be ${expected} but was ${actual}",
+                   {i:i, expected:expected.hasOwnProperty(i) ? "present" : "missing",
+                    actual:actual.hasOwnProperty(i) ? "present" : "missing"});
+            assert(typeof actual[i] === "number",
+                   "assert_array_approx_equals", description,
+                   "property ${i}, expected a number but got a ${type_actual}",
+                   {i:i, type_actual:typeof actual[i]});
+            assert(Math.abs(actual[i] - expected[i]) <= epsilon,
+                   "assert_array_approx_equals", description,
+                   "property ${i}, expected ${expected} +/- ${epsilon}, expected ${expected} but got ${actual}",
+                   {i:i, expected:expected[i], actual:actual[i], epsilon:epsilon});
+        }
+    }
+    expose_assert(assert_array_approx_equals, "assert_array_approx_equals");
+
+    /**
+     * Assert that ``actual`` is within ± ``epsilon`` of ``expected``.
+     *
+     * @param {number} actual - Test value.
+     * @param {number} expected - Value number is expected to be close to.
+     * @param {number} epsilon - Magnitude of allowed difference between ``actual`` and ``expected``.
+     * @param {string} [description] - Description of the condition being tested.
+     */
+    function assert_approx_equals(actual, expected, epsilon, description)
+    {
+        /*
+         * Test if two primitive numbers are equal within +/- epsilon
+         */
+        assert(typeof actual === "number",
+               "assert_approx_equals", description,
+               "expected a number but got a ${type_actual}",
+               {type_actual:typeof actual});
+
+        // The epsilon math below does not place nice with NaN and Infinity
+        // But in this case Infinity = Infinity and NaN = NaN
+        if (isFinite(actual) || isFinite(expected)) {
+            assert(Math.abs(actual - expected) <= epsilon,
+                   "assert_approx_equals", description,
+                   "expected ${expected} +/- ${epsilon} but got ${actual}",
+                   {expected:expected, actual:actual, epsilon:epsilon});
+        } else {
+            assert_equals(actual, expected);
+        }
+    }
+    expose_assert(assert_approx_equals, "assert_approx_equals");
+
+    /**
+     * Assert that ``actual`` is a number less than ``expected``.
+     *
+     * @param {number|bigint} actual - Test value.
+     * @param {number|bigint} expected - Value that ``actual`` must be less than.
+     * @param {string} [description] - Description of the condition being tested.
+     */
+    function assert_less_than(actual, expected, description)
+    {
+        /*
+         * Test if a primitive number (or bigint) is less than another
+         */
+        assert(typeof actual === "number" || typeof actual === "bigint",
+               "assert_less_than", description,
+               "expected a number but got a ${type_actual}",
+               {type_actual:typeof actual});
+
+        assert(typeof actual === typeof expected,
+               "assert_less_than", description,
+               "expected a ${type_expected} but got a ${type_actual}",
+               {type_expected:typeof expected, type_actual:typeof actual});
+
+        assert(actual < expected,
+               "assert_less_than", description,
+               "expected a number less than ${expected} but got ${actual}",
+               {expected:expected, actual:actual});
+    }
+    expose_assert(assert_less_than, "assert_less_than");
+
+    /**
+     * Assert that ``actual`` is a number greater than ``expected``.
+     *
+     * @param {number|bigint} actual - Test value.
+     * @param {number|bigint} expected - Value that ``actual`` must be greater than.
+     * @param {string} [description] - Description of the condition being tested.
+     */
+    function assert_greater_than(actual, expected, description)
+    {
+        /*
+         * Test if a primitive number (or bigint) is greater than another
+         */
+        assert(typeof actual === "number" || typeof actual === "bigint",
+               "assert_greater_than", description,
+               "expected a number but got a ${type_actual}",
+               {type_actual:typeof actual});
+
+        assert(typeof actual === typeof expected,
+               "assert_greater_than", description,
+               "expected a ${type_expected} but got a ${type_actual}",
+               {type_expected:typeof expected, type_actual:typeof actual});
+
+        assert(actual > expected,
+               "assert_greater_than", description,
+               "expected a number greater than ${expected} but got ${actual}",
+               {expected:expected, actual:actual});
+    }
+    expose_assert(assert_greater_than, "assert_greater_than");
+
+    /**
+     * Assert that ``actual`` is a number greater than ``lower`` and less
+     * than ``upper`` but not equal to either.
+     *
+     * @param {number|bigint} actual - Test value.
+     * @param {number|bigint} lower - Value that ``actual`` must be greater than.
+     * @param {number|bigint} upper - Value that ``actual`` must be less than.
+     * @param {string} [description] - Description of the condition being tested.
+     */
+    function assert_between_exclusive(actual, lower, upper, description)
+    {
+        /*
+         * Test if a primitive number (or bigint) is between two others
+         */
+        assert(typeof lower === typeof upper,
+               "assert_between_exclusive", description,
+               "expected lower (${type_lower}) and upper (${type_upper}) types to match (test error)",
+               {type_lower:typeof lower, type_upper:typeof upper});
+
+        assert(typeof actual === "number" || typeof actual === "bigint",
+               "assert_between_exclusive", description,
+               "expected a number but got a ${type_actual}",
+               {type_actual:typeof actual});
+
+        assert(typeof actual === typeof lower,
+               "assert_between_exclusive", description,
+               "expected a ${type_lower} but got a ${type_actual}",
+               {type_lower:typeof lower, type_actual:typeof actual});
+
+        assert(actual > lower && actual < upper,
+               "assert_between_exclusive", description,
+               "expected a number greater than ${lower} " +
+               "and less than ${upper} but got ${actual}",
+               {lower:lower, upper:upper, actual:actual});
+    }
+    expose_assert(assert_between_exclusive, "assert_between_exclusive");
+
+    /**
+     * Assert that ``actual`` is a number less than or equal to ``expected``.
+     *
+     * @param {number|bigint} actual - Test value.
+     * @param {number|bigint} expected - Value that ``actual`` must be less
+     * than or equal to.
+     * @param {string} [description] - Description of the condition being tested.
+     */
+    function assert_less_than_equal(actual, expected, description)
+    {
+        /*
+         * Test if a primitive number (or bigint) is less than or equal to another
+         */
+        assert(typeof actual === "number" || typeof actual === "bigint",
+               "assert_less_than_equal", description,
+               "expected a number but got a ${type_actual}",
+               {type_actual:typeof actual});
+
+        assert(typeof actual === typeof expected,
+               "assert_less_than_equal", description,
+               "expected a ${type_expected} but got a ${type_actual}",
+               {type_expected:typeof expected, type_actual:typeof actual});
+
+        assert(actual <= expected,
+               "assert_less_than_equal", description,
+               "expected a number less than or equal to ${expected} but got ${actual}",
+               {expected:expected, actual:actual});
+    }
+    expose_assert(assert_less_than_equal, "assert_less_than_equal");
+
+    /**
+     * Assert that ``actual`` is a number greater than or equal to ``expected``.
+     *
+     * @param {number|bigint} actual - Test value.
+     * @param {number|bigint} expected - Value that ``actual`` must be greater
+     * than or equal to.
+     * @param {string} [description] - Description of the condition being tested.
+     */
+    function assert_greater_than_equal(actual, expected, description)
+    {
+        /*
+         * Test if a primitive number (or bigint) is greater than or equal to another
+         */
+        assert(typeof actual === "number" || typeof actual === "bigint",
+               "assert_greater_than_equal", description,
+               "expected a number but got a ${type_actual}",
+               {type_actual:typeof actual});
+
+        assert(typeof actual === typeof expected,
+               "assert_greater_than_equal", description,
+               "expected a ${type_expected} but got a ${type_actual}",
+               {type_expected:typeof expected, type_actual:typeof actual});
+
+        assert(actual >= expected,
+               "assert_greater_than_equal", description,
+               "expected a number greater than or equal to ${expected} but got ${actual}",
+               {expected:expected, actual:actual});
+    }
+    expose_assert(assert_greater_than_equal, "assert_greater_than_equal");
+
+    /**
+     * Assert that ``actual`` is a number greater than or equal to ``lower`` and less
+     * than or equal to ``upper``.
+     *
+     * @param {number|bigint} actual - Test value.
+     * @param {number|bigint} lower - Value that ``actual`` must be greater than or equal to.
+     * @param {number|bigint} upper - Value that ``actual`` must be less than or equal to.
+     * @param {string} [description] - Description of the condition being tested.
+     */
+    function assert_between_inclusive(actual, lower, upper, description)
+    {
+        /*
+         * Test if a primitive number (or bigint) is between to two others or equal to either of them
+         */
+        assert(typeof lower === typeof upper,
+               "assert_between_inclusive", description,
+               "expected lower (${type_lower}) and upper (${type_upper}) types to match (test error)",
+               {type_lower:typeof lower, type_upper:typeof upper});
+
+        assert(typeof actual === "number" || typeof actual === "bigint",
+               "assert_between_inclusive", description,
+               "expected a number but got a ${type_actual}",
+               {type_actual:typeof actual});
+
+        assert(typeof actual === typeof lower,
+               "assert_between_inclusive", description,
+               "expected a ${type_lower} but got a ${type_actual}",
+               {type_lower:typeof lower, type_actual:typeof actual});
+
+        assert(actual >= lower && actual <= upper,
+               "assert_between_inclusive", description,
+               "expected a number greater than or equal to ${lower} " +
+               "and less than or equal to ${upper} but got ${actual}",
+               {lower:lower, upper:upper, actual:actual});
+    }
+    expose_assert(assert_between_inclusive, "assert_between_inclusive");
+
+    /**
+     * Assert that ``actual`` matches the RegExp ``expected``.
+     *
+     * @param {String} actual - Test string.
+     * @param {RegExp} expected - RegExp ``actual`` must match.
+     * @param {string} [description] - Description of the condition being tested.
+     */
+    function assert_regexp_match(actual, expected, description) {
+        /*
+         * Test if a string (actual) matches a regexp (expected)
+         */
+        assert(expected.test(actual),
+               "assert_regexp_match", description,
+               "expected ${expected} but got ${actual}",
+               {expected:expected, actual:actual});
+    }
+    expose_assert(assert_regexp_match, "assert_regexp_match");
+
+    /**
+     * Assert that the class string of ``object`` as returned in
+     * ``Object.prototype.toString`` is equal to ``class_name``.
+     *
+     * @param {Object} object - Object to stringify.
+     * @param {string} class_string - Expected class string for ``object``.
+     * @param {string} [description] - Description of the condition being tested.
+     */
+    function assert_class_string(object, class_string, description) {
+        var actual = {}.toString.call(object);
+        var expected = "[object " + class_string + "]";
+        assert(same_value(actual, expected), "assert_class_string", description,
+                                             "expected ${expected} but got ${actual}",
+                                             {expected:expected, actual:actual});
+    }
+    expose_assert(assert_class_string, "assert_class_string");
+
+    /**
+     * Assert that ``object`` has an own property with name ``property_name``.
+     *
+     * @param {Object} object - Object that should have the given property.
+     * @param {string} property_name - Expected property name.
+     * @param {string} [description] - Description of the condition being tested.
+     */
+    function assert_own_property(object, property_name, description) {
+        assert(object.hasOwnProperty(property_name),
+               "assert_own_property", description,
+               "expected property ${p} missing", {p:property_name});
+    }
+    expose_assert(assert_own_property, "assert_own_property");
+
+    /**
+     * Assert that ``object`` does not have an own property with name ``property_name``.
+     *
+     * @param {Object} object - Object that should not have the given property.
+     * @param {string} property_name - Property name to test.
+     * @param {string} [description] - Description of the condition being tested.
+     */
+    function assert_not_own_property(object, property_name, description) {
+        assert(!object.hasOwnProperty(property_name),
+               "assert_not_own_property", description,
+               "unexpected property ${p} is found on object", {p:property_name});
+    }
+    expose_assert(assert_not_own_property, "assert_not_own_property");
+
+    function _assert_inherits(name) {
+        return function (object, property_name, description)
+        {
+            assert((typeof object === "object" && object !== null) ||
+                   typeof object === "function" ||
+                   // Or has [[IsHTMLDDA]] slot
+                   String(object) === "[object HTMLAllCollection]",
+                   name, description,
+                   "provided value is not an object");
+
+            assert("hasOwnProperty" in object,
+                   name, description,
+                   "provided value is an object but has no hasOwnProperty method");
+
+            assert(!object.hasOwnProperty(property_name),
+                   name, description,
+                   "property ${p} found on object expected in prototype chain",
+                   {p:property_name});
+
+            assert(property_name in object,
+                   name, description,
+                   "property ${p} not found in prototype chain",
+                   {p:property_name});
+        };
+    }
+
+    /**
+     * Assert that ``object`` does not have an own property with name
+     * ``property_name``, but inherits one through the prototype chain.
+     *
+     * @param {Object} object - Object that should have the given property in its prototype chain.
+     * @param {string} property_name - Expected property name.
+     * @param {string} [description] - Description of the condition being tested.
+     */
+    function assert_inherits(object, property_name, description) {
+        return _assert_inherits("assert_inherits")(object, property_name, description);
+    }
+    expose_assert(assert_inherits, "assert_inherits");
+
+    /**
+     * Alias for :js:func:`insert_inherits`.
+     *
+     * @param {Object} object - Object that should have the given property in its prototype chain.
+     * @param {string} property_name - Expected property name.
+     * @param {string} [description] - Description of the condition being tested.
+     */
+    function assert_idl_attribute(object, property_name, description) {
+        return _assert_inherits("assert_idl_attribute")(object, property_name, description);
+    }
+    expose_assert(assert_idl_attribute, "assert_idl_attribute");
+
+
+    /**
+     * Assert that ``object`` has a property named ``property_name`` and that the property is not writable or has no setter.
+     *
+     * @param {Object} object - Object that should have the given (not necessarily own) property.
+     * @param {string} property_name - Expected property name.
+     * @param {string} [description] - Description of the condition being tested.
+     */
+    function assert_readonly(object, property_name, description)
+    {
+        assert(property_name in object,
+               "assert_readonly", description,
+               "property ${p} not found",
+               {p:property_name});
+
+        let desc;
+        while (object && (desc = Object.getOwnPropertyDescriptor(object, property_name)) === undefined) {
+            object = Object.getPrototypeOf(object);
+        }
+
+        assert(desc !== undefined,
+               "assert_readonly", description,
+               "could not find a descriptor for property ${p}",
+               {p:property_name});
+
+        if (desc.hasOwnProperty("value")) {
+            // We're a data property descriptor
+            assert(desc.writable === false, "assert_readonly", description,
+                   "descriptor [[Writable]] expected false got ${actual}", {actual:desc.writable});
+        } else if (desc.hasOwnProperty("get") || desc.hasOwnProperty("set")) {
+            // We're an accessor property descriptor
+            assert(desc.set === undefined, "assert_readonly", description,
+                   "property ${p} is an accessor property with a [[Set]] attribute, cannot test readonly-ness",
+                   {p:property_name});
+        } else {
+            // We're a generic property descriptor
+            // This shouldn't happen, because Object.getOwnPropertyDescriptor
+            // forwards the return value of [[GetOwnProperty]] (P), which must
+            // be a fully populated Property Descriptor or Undefined.
+            assert(false, "assert_readonly", description,
+                   "Object.getOwnPropertyDescriptor must return a fully populated property descriptor");
+        }
+    }
+    expose_assert(assert_readonly, "assert_readonly");
+
+    /**
+     * Assert a JS Error with the expected constructor is thrown.
+     *
+     * @param {object} constructor The expected exception constructor.
+     * @param {Function} func Function which should throw.
+     * @param {string} [description] Error description for the case that the error is not thrown.
+     */
+    function assert_throws_js(constructor, func, description)
+    {
+        assert_throws_js_impl(constructor, func, description,
+                              "assert_throws_js");
+    }
+    expose_assert(assert_throws_js, "assert_throws_js");
+
+    /**
+     * Like assert_throws_js but allows specifying the assertion type
+     * (assert_throws_js or promise_rejects_js, in practice).
+     */
+    function assert_throws_js_impl(constructor, func, description,
+                                   assertion_type)
+    {
+        try {
+            func.call(this);
+            assert(false, assertion_type, description,
+                   "${func} did not throw", {func:func});
+        } catch (e) {
+            if (e instanceof AssertionError) {
+                throw e;
+            }
+
+            // Basic sanity-checks on the thrown exception.
+            assert(typeof e === "object",
+                   assertion_type, description,
+                   "${func} threw ${e} with type ${type}, not an object",
+                   {func:func, e:e, type:typeof e});
+
+            assert(e !== null,
+                   assertion_type, description,
+                   "${func} threw null, not an object",
+                   {func:func});
+
+            // Basic sanity-check on the passed-in constructor
+            assert(typeof constructor === "function",
+                   assertion_type, description,
+                   "${constructor} is not a constructor",
+                   {constructor:constructor});
+            var obj = constructor;
+            while (obj) {
+                if (typeof obj === "function" &&
+                    obj.name === "Error") {
+                    break;
+                }
+                obj = Object.getPrototypeOf(obj);
+            }
+            assert(obj != null,
+                   assertion_type, description,
+                   "${constructor} is not an Error subtype",
+                   {constructor:constructor});
+
+            // And checking that our exception is reasonable
+            assert(e.constructor === constructor &&
+                   e.name === constructor.name,
+                   assertion_type, description,
+                   "${func} threw ${actual} (${actual_name}) expected instance of ${expected} (${expected_name})",
+                   {func:func, actual:e, actual_name:e.name,
+                    expected:constructor,
+                    expected_name:constructor.name});
+        }
+    }
+
+    // TODO: Figure out how to document the overloads better.
+    // sphinx-js doesn't seem to handle @variation correctly,
+    // and only expects a single JSDoc entry per function.
+    /**
+     * Assert a DOMException with the expected type is thrown.
+     *
+     * There are two ways of calling assert_throws_dom:
+     *
+     * 1) If the DOMException is expected to come from the current global, the
+     * second argument should be the function expected to throw and a third,
+     * optional, argument is the assertion description.
+     *
+     * 2) If the DOMException is expected to come from some other global, the
+     * second argument should be the DOMException constructor from that global,
+     * the third argument the function expected to throw, and the fourth, optional,
+     * argument the assertion description.
+     *
+     * @param {number|string} type - The expected exception name or
+     * code.  See the `table of names and codes
+     * <https://webidl.spec.whatwg.org/#dfn-error-names-table>`_. If a
+     * number is passed it should be one of the numeric code values in
+     * that table (e.g. 3, 4, etc).  If a string is passed it can
+     * either be an exception name (e.g. "HierarchyRequestError",
+     * "WrongDocumentError") or the name of the corresponding error
+     * code (e.g. "``HIERARCHY_REQUEST_ERR``", "``WRONG_DOCUMENT_ERR``").
+     * @param {Function} descriptionOrFunc - The function expected to
+     * throw (if the exception comes from another global), or the
+     * optional description of the condition being tested (if the
+     * exception comes from the current global).
+     * @param {string} [description] - Description of the condition
+     * being tested (if the exception comes from another global).
+     *
+     */
+    function assert_throws_dom(type, funcOrConstructor, descriptionOrFunc, maybeDescription)
+    {
+        let constructor, func, description;
+        if (funcOrConstructor.name === "DOMException") {
+            constructor = funcOrConstructor;
+            func = descriptionOrFunc;
+            description = maybeDescription;
+        } else {
+            constructor = self.DOMException;
+            func = funcOrConstructor;
+            description = descriptionOrFunc;
+            assert(maybeDescription === undefined,
+                   "Too many args passed to no-constructor version of assert_throws_dom, or accidentally explicitly passed undefined");
+        }
+        assert_throws_dom_impl(type, func, description, "assert_throws_dom", constructor);
+    }
+    expose_assert(assert_throws_dom, "assert_throws_dom");
+
+    /**
+     * Similar to assert_throws_dom but allows specifying the assertion type
+     * (assert_throws_dom or promise_rejects_dom, in practice).  The
+     * "constructor" argument must be the DOMException constructor from the
+     * global we expect the exception to come from.
+     */
+    function assert_throws_dom_impl(type, func, description, assertion_type, constructor)
+    {
+        try {
+            func.call(this);
+            assert(false, assertion_type, description,
+                   "${func} did not throw", {func:func});
+        } catch (e) {
+            if (e instanceof AssertionError) {
+                throw e;
+            }
+
+            // Basic sanity-checks on the thrown exception.
+            assert(typeof e === "object",
+                   assertion_type, description,
+                   "${func} threw ${e} with type ${type}, not an object",
+                   {func:func, e:e, type:typeof e});
+
+            assert(e !== null,
+                   assertion_type, description,
+                   "${func} threw null, not an object",
+                   {func:func});
+
+            // Sanity-check our type
+            assert(typeof type === "number" ||
+                   typeof type === "string",
+                   assertion_type, description,
+                   "${type} is not a number or string",
+                   {type:type});
+
+            var codename_name_map = {
+                INDEX_SIZE_ERR: 'IndexSizeError',
+                HIERARCHY_REQUEST_ERR: 'HierarchyRequestError',
+                WRONG_DOCUMENT_ERR: 'WrongDocumentError',
+                INVALID_CHARACTER_ERR: 'InvalidCharacterError',
+                NO_MODIFICATION_ALLOWED_ERR: 'NoModificationAllowedError',
+                NOT_FOUND_ERR: 'NotFoundError',
+                NOT_SUPPORTED_ERR: 'NotSupportedError',
+                INUSE_ATTRIBUTE_ERR: 'InUseAttributeError',
+                INVALID_STATE_ERR: 'InvalidStateError',
+                SYNTAX_ERR: 'SyntaxError',
+                INVALID_MODIFICATION_ERR: 'InvalidModificationError',
+                NAMESPACE_ERR: 'NamespaceError',
+                INVALID_ACCESS_ERR: 'InvalidAccessError',
+                TYPE_MISMATCH_ERR: 'TypeMismatchError',
+                SECURITY_ERR: 'SecurityError',
+                NETWORK_ERR: 'NetworkError',
+                ABORT_ERR: 'AbortError',
+                URL_MISMATCH_ERR: 'URLMismatchError',
+                TIMEOUT_ERR: 'TimeoutError',
+                INVALID_NODE_TYPE_ERR: 'InvalidNodeTypeError',
+                DATA_CLONE_ERR: 'DataCloneError'
+            };
+
+            var name_code_map = {
+                IndexSizeError: 1,
+                HierarchyRequestError: 3,
+                WrongDocumentError: 4,
+                InvalidCharacterError: 5,
+                NoModificationAllowedError: 7,
+                NotFoundError: 8,
+                NotSupportedError: 9,
+                InUseAttributeError: 10,
+                InvalidStateError: 11,
+                SyntaxError: 12,
+                InvalidModificationError: 13,
+                NamespaceError: 14,
+                InvalidAccessError: 15,
+                TypeMismatchError: 17,
+                SecurityError: 18,
+                NetworkError: 19,
+                AbortError: 20,
+                URLMismatchError: 21,
+                TimeoutError: 23,
+                InvalidNodeTypeError: 24,
+                DataCloneError: 25,
+
+                EncodingError: 0,
+                NotReadableError: 0,
+                UnknownError: 0,
+                ConstraintError: 0,
+                DataError: 0,
+                TransactionInactiveError: 0,
+                ReadOnlyError: 0,
+                VersionError: 0,
+                OperationError: 0,
+                NotAllowedError: 0,
+                OptOutError: 0
+            };
+
+            var code_name_map = {};
+            for (var key in name_code_map) {
+                if (name_code_map[key] > 0) {
+                    code_name_map[name_code_map[key]] = key;
+                }
+            }
+
+            var required_props = {};
+            var name;
+
+            if (typeof type === "number") {
+                if (type === 0) {
+                    throw new AssertionError('Test bug: ambiguous DOMException code 0 passed to assert_throws_dom()');
+                }
+                if (type === 22) {
+                    throw new AssertionError('Test bug: QuotaExceededError needs to be tested for using assert_throws_quotaexceedederror()');
+                }
+                if (!(type in code_name_map)) {
+                    throw new AssertionError('Test bug: unrecognized DOMException code "' + type + '" passed to assert_throws_dom()');
+                }
+                name = code_name_map[type];
+                required_props.code = type;
+            } else if (typeof type === "string") {
+                if (name === "QuotaExceededError") {
+                    throw new AssertionError('Test bug: QuotaExceededError needs to be tested for using assert_throws_quotaexceedederror()');
+                }
+                name = type in codename_name_map ? codename_name_map[type] : type;
+                if (!(name in name_code_map)) {
+                    throw new AssertionError('Test bug: unrecognized DOMException code name or name "' + type + '" passed to assert_throws_dom()');
+                }
+
+                required_props.code = name_code_map[name];
+            }
+
+            if (required_props.code === 0 ||
+               ("name" in e &&
+                e.name !== e.name.toUpperCase() &&
+                e.name !== "DOMException")) {
+                // New style exception: also test the name property.
+                required_props.name = name;
+            }
+
+            for (var prop in required_props) {
+                assert(prop in e && e[prop] == required_props[prop],
+                       assertion_type, description,
+                       "${func} threw ${e} that is not a DOMException " + type + ": property ${prop} is equal to ${actual}, expected ${expected}",
+                       {func:func, e:e, prop:prop, actual:e[prop], expected:required_props[prop]});
+            }
+
+            // Check that the exception is from the right global.  This check is last
+            // so more specific, and more informative, checks on the properties can
+            // happen in case a totally incorrect exception is thrown.
+            assert(e.constructor === constructor,
+                   assertion_type, description,
+                   "${func} threw an exception from the wrong global",
+                   {func});
+
+        }
+    }
+
+    /**
+     * Assert a `QuotaExceededError` with the expected values is thrown.
+     *
+     * There are two ways of calling `assert_throws_quotaexceedederror`:
+     *
+     * 1) If the `QuotaExceededError` is expected to come from the
+     *    current global, the first argument should be the function
+     *    expected to throw, the second and a third the expected
+     *    `requested` and `quota` property values, and the fourth,
+     *    optional, argument is the assertion description.
+     *
+     * 2) If the `QuotaExceededError` is expected to come from some
+     *    other global, the first argument should be the
+     *    `QuotaExceededError` constructor from that global, the second
+     *    argument should be the function expected to throw, the third
+     *    and fourth the expected `requested` and `quota` property
+     *    values, and the fifth, optional, argument is the assertion
+     *    description.
+     *
+     * For the `requested` and `quota` values, instead of `null` or a
+     * number, the caller can provide a function which determines
+     * whether the value is acceptable by returning a boolean.
+     *
+     */
+    function assert_throws_quotaexceedederror(funcOrConstructor, requestedOrFunc, quotaOrRequested, descriptionOrQuota, maybeDescription)
+    {
+        let constructor, func, requested, quota, description;
+        if (funcOrConstructor.name === "QuotaExceededError") {
+            constructor = funcOrConstructor;
+            func = requestedOrFunc;
+            requested = quotaOrRequested;
+            quota = descriptionOrQuota;
+            description = maybeDescription;
+        } else {
+            constructor = self.QuotaExceededError;
+            func = funcOrConstructor;
+            requested = requestedOrFunc;
+            quota = quotaOrRequested;
+            description = descriptionOrQuota;
+            assert(maybeDescription === undefined,
+                   "Too many args passed to no-constructor version of assert_throws_quotaexceedederror");
+        }
+        assert_throws_quotaexceedederror_impl(func, requested, quota, description, "assert_throws_quotaexceedederror", constructor);
+    }
+    expose_assert(assert_throws_quotaexceedederror, "assert_throws_quotaexceedederror");
+
+    /**
+     * Similar to `assert_throws_quotaexceedederror` but allows
+     * specifying the assertion type
+     * (`"assert_throws_quotaexceedederror"` or
+     * `"promise_rejects_quotaexceedederror"`, in practice). The
+     * `constructor` argument must be the `QuotaExceededError`
+     * constructor from the global we expect the exception to come from.
+     */
+    function assert_throws_quotaexceedederror_impl(func, requested, quota, description, assertion_type, constructor)
+    {
+        try {
+            func.call(this);
+            assert(false, assertion_type, description, "${func} did not throw",
+                   {func});
+        } catch (e) {
+            if (e instanceof AssertionError) {
+                throw e;
+            }
+
+            // Basic sanity-checks on the thrown exception.
+            assert(typeof e === "object",
+                   assertion_type, description,
+                   "${func} threw ${e} with type ${type}, not an object",
+                   {func, e, type:typeof e});
+
+            assert(e !== null,
+                   assertion_type, description,
+                   "${func} threw null, not an object",
+                   {func});
+
+            // Sanity-check our requested and quota.
+            assert(requested === null ||
+                   typeof requested === "number" ||
+                   typeof requested === "function",
+                   assertion_type, description,
+                   "${requested} is not null, a number, or a function",
+                   {requested});
+            assert(quota === null ||
+                   typeof quota === "number" ||
+                   typeof quota === "function",
+                   assertion_type, description,
+                   "${quota} is not null or a number",
+                   {quota});
+
+            const required_props = {
+                code: 22,
+                name: "QuotaExceededError"
+            };
+            if (typeof requested !== "function") {
+                required_props.requested = requested;
+            }
+            if (typeof quota !== "function") {
+                required_props.quota = quota;
+            }
+
+            for (const [prop, expected] of Object.entries(required_props)) {
+                assert(prop in e && e[prop] == expected,
+                       assertion_type, description,
+                       "${func} threw ${e} that is not a correct QuotaExceededError: property ${prop} is equal to ${actual}, expected ${expected}",
+                       {func, e, prop, actual:e[prop], expected});
+            }
+
+            if (typeof requested === "function") {
+                assert(requested(e.requested),
+                       assertion_type, description,
+                       "${func} threw ${e} that is not a correct QuotaExceededError: requested value ${requested} did not pass the requested predicate",
+                       {func, e, requested});
+            }
+            if (typeof quota === "function") {
+                assert(quota(e.quota),
+                       assertion_type, description,
+                       "${func} threw ${e} that is not a correct QuotaExceededError: quota value ${quota} did not pass the quota predicate",
+                       {func, e, quota});
+            }
+
+            // Check that the exception is from the right global.  This check is last
+            // so more specific, and more informative, checks on the properties can
+            // happen in case a totally incorrect exception is thrown.
+            assert(e.constructor === constructor,
+                   assertion_type, description,
+                   "${func} threw an exception from the wrong global",
+                   {func});
+        }
+    }
+
+    /**
+     * Assert the provided value is thrown.
+     *
+     * @param {value} exception The expected exception.
+     * @param {Function} func Function which should throw.
+     * @param {string} [description] Error description for the case that the error is not thrown.
+     */
+    function assert_throws_exactly(exception, func, description)
+    {
+        assert_throws_exactly_impl(exception, func, description,
+                                   "assert_throws_exactly");
+    }
+    expose_assert(assert_throws_exactly, "assert_throws_exactly");
+
+    /**
+     * Like assert_throws_exactly but allows specifying the assertion type
+     * (assert_throws_exactly or promise_rejects_exactly, in practice).
+     */
+    function assert_throws_exactly_impl(exception, func, description,
+                                        assertion_type)
+    {
+        try {
+            func.call(this);
+            assert(false, assertion_type, description,
+                   "${func} did not throw", {func:func});
+        } catch (e) {
+            if (e instanceof AssertionError) {
+                throw e;
+            }
+
+            assert(same_value(e, exception), assertion_type, description,
+                   "${func} threw ${e} but we expected it to throw ${exception}",
+                   {func:func, e:e, exception:exception});
+        }
+    }
+
+    /**
+     * Asserts if called. Used to ensure that a specific codepath is
+     * not taken e.g. that an error event isn't fired.
+     *
+     * @param {string} [description] - Description of the condition being tested.
+     */
+    function assert_unreached(description) {
+         assert(false, "assert_unreached", description,
+                "Reached unreachable code");
+    }
+    expose_assert(assert_unreached, "assert_unreached");
+
+    /**
+     * @callback AssertFunc
+     * @param {Any} actual
+     * @param {Any} expected
+     * @param {Any[]} args
+     */
+
+    /**
+     * Asserts that ``actual`` matches at least one value of ``expected``
+     * according to a comparison defined by ``assert_func``.
+     *
+     * Note that tests with multiple allowed pass conditions are bad
+     * practice unless the spec specifically allows multiple
+     * behaviours. Test authors should not use this method simply to
+     * hide UA bugs.
+     *
+     * @param {AssertFunc} assert_func - Function to compare actual
+     * and expected. It must throw when the comparison fails and
+     * return when the comparison passes.
+     * @param {Any} actual - Test value.
+     * @param {Array} expected_array - Array of possible expected values.
+     * @param {Any[]} args - Additional arguments to pass to ``assert_func``.
+     */
+    function assert_any(assert_func, actual, expected_array, ...args)
+    {
+        var errors = [];
+        var passed = false;
+        forEach(expected_array,
+                function(expected)
+                {
+                    try {
+                        assert_func.apply(this, [actual, expected].concat(args));
+                        passed = true;
+                    } catch (e) {
+                        errors.push(e.message);
+                    }
+                });
+        if (!passed) {
+            throw new AssertionError(errors.join("\n\n"));
+        }
+    }
+    // FIXME: assert_any cannot use expose_assert, because assert_wrapper does
+    // not support nested assert calls (e.g. to assert_func). We need to
+    // support bypassing assert_wrapper for the inner asserts here.
+    expose(assert_any, "assert_any");
+
+    /**
+     * Assert that a feature is implemented, based on a 'truthy' condition.
+     *
+     * This function should be used to early-exit from tests in which there is
+     * no point continuing without support for a non-optional spec or spec
+     * feature. For example:
+     *
+     *     assert_implements(window.Foo, 'Foo is not supported');
+     *
+     * @param {object} condition The truthy value to test
+     * @param {string} [description] Error description for the case that the condition is not truthy.
+     */
+    function assert_implements(condition, description) {
+        assert(!!condition, "assert_implements", description);
+    }
+    expose_assert(assert_implements, "assert_implements");
+
+    /**
+     * Assert that an optional feature is implemented, based on a 'truthy' condition.
+     *
+     * This function should be used to early-exit from tests in which there is
+     * no point continuing without support for an explicitly optional spec or
+     * spec feature. For example:
+     *
+     *     assert_implements_optional(video.canPlayType("video/webm"),
+     *                                "webm video playback not supported");
+     *
+     * @param {object} condition The truthy value to test
+     * @param {string} [description] Error description for the case that the condition is not truthy.
+     */
+    function assert_implements_optional(condition, description) {
+        if (!condition) {
+            throw new OptionalFeatureUnsupportedError(description);
+        }
+    }
+    expose_assert(assert_implements_optional, "assert_implements_optional");
+
+    /**
+     * @class
+     *
+     * A single subtest. A Test is not constructed directly but via the
+     * :js:func:`test`, :js:func:`async_test` or :js:func:`promise_test` functions.
+     *
+     * @param {string} name - This must be unique in a given file and must be
+     * invariant between runs.
+     *
+     */
+    function Test(name, properties)
+    {
+        if (tests.file_is_test && tests.tests.length) {
+            throw new Error("Tried to create a test with file_is_test");
+        }
+        /** The test name. */
+        this.name = name;
+
+        this.phase = (tests.is_aborted || tests.phase === tests.phases.COMPLETE) ?
+            this.phases.COMPLETE : this.phases.INITIAL;
+
+        /** The test status code.*/
+        this.status = this.NOTRUN;
+        this.timeout_id = null;
+        this.index = null;
+
+        this.properties = properties || {};
+        this.timeout_length = settings.test_timeout;
+        if (this.timeout_length !== null) {
+            this.timeout_length *= tests.timeout_multiplier;
+        }
+
+        /** A message indicating the reason for test failure. */
+        this.message = null;
+        /** Stack trace in case of failure. */
+        this.stack = null;
+
+        this.steps = [];
+        this._is_promise_test = false;
+
+        this.cleanup_callbacks = [];
+        this._user_defined_cleanup_count = 0;
+        this._done_callbacks = [];
+
+        if (typeof AbortController === "function") {
+            this._abortController = new AbortController();
+        }
+
+        // Tests declared following harness completion are likely an indication
+        // of a programming error, but they cannot be reported
+        // deterministically.
+        if (tests.phase === tests.phases.COMPLETE) {
+            return;
+        }
+
+        tests.push(this);
+    }
+
+    /**
+     * Enum of possible test statuses.
+     *
+     * :values:
+     *   - ``PASS``
+     *   - ``FAIL``
+     *   - ``TIMEOUT``
+     *   - ``NOTRUN``
+     *   - ``PRECONDITION_FAILED``
+     */
+    Test.statuses = {
+        PASS:0,
+        FAIL:1,
+        TIMEOUT:2,
+        NOTRUN:3,
+        PRECONDITION_FAILED:4
+    };
+
+    Test.prototype = merge({}, Test.statuses);
+
+    Test.prototype.phases = {
+        INITIAL:0,
+        STARTED:1,
+        HAS_RESULT:2,
+        CLEANING:3,
+        COMPLETE:4
+    };
+
+    Test.prototype.status_formats = {
+        0: "Pass",
+        1: "Fail",
+        2: "Timeout",
+        3: "Not Run",
+        4: "Optional Feature Unsupported",
+    };
+
+    Test.prototype.format_status = function() {
+        return this.status_formats[this.status];
+    };
+
+    Test.prototype.structured_clone = function()
+    {
+        if (!this._structured_clone) {
+            var msg = this.message;
+            msg = msg ? String(msg) : msg;
+            this._structured_clone = merge({
+                name:String(this.name),
+                properties:merge({}, this.properties),
+                phases:merge({}, this.phases)
+            }, Test.statuses);
+        }
+        this._structured_clone.status = this.status;
+        this._structured_clone.message = this.message;
+        this._structured_clone.stack = this.stack;
+        this._structured_clone.index = this.index;
+        this._structured_clone.phase = this.phase;
+        return this._structured_clone;
+    };
+
+    /**
+     * Run a single step of an ongoing test.
+     *
+     * @param {string} func - Callback function to run as a step. If
+     * this throws an :js:func:`AssertionError`, or any other
+     * exception, the :js:class:`Test` status is set to ``FAIL``.
+     * @param {Object} [this_obj] - The object to use as the this
+     * value when calling ``func``. Defaults to the  :js:class:`Test` object.
+     */
+    Test.prototype.step = function(func, this_obj)
+    {
+        if (this.phase > this.phases.STARTED) {
+            return;
+        }
+
+        if (settings.debug && this.phase !== this.phases.STARTED) {
+            console.log("TEST START", this.name);
+        }
+        this.phase = this.phases.STARTED;
+        //If we don't get a result before the harness times out that will be a test timeout
+        this.set_status(this.TIMEOUT, "Test timed out");
+
+        tests.started = true;
+        tests.current_test = this;
+        tests.notify_test_state(this);
+
+        if (this.timeout_id === null) {
+            this.set_timeout();
+        }
+
+        this.steps.push(func);
+
+        if (arguments.length === 1) {
+            this_obj = this;
+        }
+
+        if (settings.debug) {
+            console.debug("TEST STEP", this.name);
+        }
+
+        try {
+            return func.apply(this_obj, Array.prototype.slice.call(arguments, 2));
+        } catch (e) {
+            if (this.phase >= this.phases.HAS_RESULT) {
+                return;
+            }
+            var status = e instanceof OptionalFeatureUnsupportedError ? this.PRECONDITION_FAILED : this.FAIL;
+            var message = String((typeof e === "object" && e !== null) ? e.message : e);
+            var stack = e.stack ? e.stack : null;
+
+            this.set_status(status, message, stack);
+            this.phase = this.phases.HAS_RESULT;
+            this.done();
+        } finally {
+            this.current_test = null;
+        }
+    };
+
+    /**
+     * Wrap a function so that it runs as a step of the current test.
+     *
+     * This allows creating a callback function that will run as a
+     * test step.
+     *
+     * @example
+     * let t = async_test("Example");
+     * onload = t.step_func(e => {
+     *   assert_equals(e.name, "load");
+     *   // Mark the test as complete.
+     *   t.done();
+     * })
+     *
+     * @param {string} func - Function to run as a step. If this
+     * throws an :js:func:`AssertionError`, or any other exception,
+     * the :js:class:`Test` status is set to ``FAIL``.
+     * @param {Object} [this_obj] - The object to use as the this
+     * value when calling ``func``. Defaults to the :js:class:`Test` object.
+     */
+    Test.prototype.step_func = function(func, this_obj)
+    {
+        var test_this = this;
+
+        if (arguments.length === 1) {
+            this_obj = test_this;
+        }
+
+        return function()
+        {
+            return test_this.step.apply(test_this, [func, this_obj].concat(
+                Array.prototype.slice.call(arguments)));
+        };
+    };
+
+    /**
+     * Wrap a function so that it runs as a step of the current test,
+     * and automatically marks the test as complete if the function
+     * returns without error.
+     *
+     * @param {string} func - Function to run as a step. If this
+     * throws an :js:func:`AssertionError`, or any other exception,
+     * the :js:class:`Test` status is set to ``FAIL``. If it returns
+     * without error the status is set to ``PASS``.
+     * @param {Object} [this_obj] - The object to use as the this
+     * value when calling `func`. Defaults to the :js:class:`Test` object.
+     */
+    Test.prototype.step_func_done = function(func, this_obj)
+    {
+        var test_this = this;
+
+        if (arguments.length === 1) {
+            this_obj = test_this;
+        }
+
+        return function()
+        {
+            if (func) {
+                test_this.step.apply(test_this, [func, this_obj].concat(
+                    Array.prototype.slice.call(arguments)));
+            }
+            test_this.done();
+        };
+    };
+
+    /**
+     * Return a function that automatically sets the current test to
+     * ``FAIL`` if it's called.
+     *
+     * @param {string} [description] - Error message to add to assert
+     * in case of failure.
+     *
+     */
+    Test.prototype.unreached_func = function(description)
+    {
+        return this.step_func(function() {
+            assert_unreached(description);
+        });
+    };
+
+    /**
+     * Run a function as a step of the test after a given timeout.
+     *
+     * This multiplies the timeout by the global timeout multiplier to
+     * account for the expected execution speed of the current test
+     * environment. For example ``test.step_timeout(f, 2000)`` with a
+     * timeout multiplier of 2 will wait for 4000ms before calling ``f``.
+     *
+     * In general it's encouraged to use :js:func:`Test.step_wait` or
+     * :js:func:`step_wait_func` in preference to this function where possible,
+     * as they provide better test performance.
+     *
+     * @param {Function} func - Function to run as a test
+     * step.
+     * @param {number} timeout - Time in ms to wait before running the
+     * test step. The actual wait time is ``timeout`` x
+     * ``timeout_multiplier``.
+     *
+     */
+    Test.prototype.step_timeout = function(func, timeout) {
+        var test_this = this;
+        var args = Array.prototype.slice.call(arguments, 2);
+        var local_set_timeout = typeof global_scope.setTimeout === "undefined" ? fake_set_timeout : setTimeout;
+        return local_set_timeout(this.step_func(function() {
+            return func.apply(test_this, args);
+        }), timeout * tests.timeout_multiplier);
+    };
+
+    /**
+     * Poll for a function to return true, and call a callback
+     * function once it does, or assert if a timeout is
+     * reached. This is preferred over a simple step_timeout
+     * whenever possible since it allows the timeout to be longer
+     * to reduce intermittents without compromising test execution
+     * speed when the condition is quickly met.
+     *
+     * @param {Function} cond A function taking no arguments and
+     *                        returning a boolean or a Promise. The callback is
+     *                        called when this function returns true, or the
+     *                        returned Promise is resolved with true.
+     * @param {Function} func A function taking no arguments to call once
+     *                        the condition is met.
+     * @param {string} [description] Error message to add to assert in case of
+     *                               failure.
+     * @param {number} timeout Timeout in ms. This is multiplied by the global
+     *                         timeout_multiplier
+     * @param {number} interval Polling interval in ms
+     *
+     */
+    Test.prototype.step_wait_func = function(cond, func, description,
+                                             timeout=3000, interval=100) {
+        var timeout_full = timeout * tests.timeout_multiplier;
+        var remaining = Math.ceil(timeout_full / interval);
+        var test_this = this;
+        var local_set_timeout = typeof global_scope.setTimeout === 'undefined' ? fake_set_timeout : setTimeout;
+
+        const step = test_this.step_func((result) => {
+            if (result) {
+                func();
+            } else {
+                if (remaining === 0) {
+                    assert(false, "step_wait_func", description,
+                           "Timed out waiting on condition");
+                }
+                remaining--;
+                local_set_timeout(wait_for_inner, interval);
+            }
+        });
+
+        var wait_for_inner = test_this.step_func(() => {
+            Promise.resolve(cond()).then(
+                step,
+                test_this.unreached_func("step_wait_func"));
+        });
+
+        wait_for_inner();
+    };
+
+    /**
+     * Poll for a function to return true, and invoke a callback
+     * followed by this.done() once it does, or assert if a timeout
+     * is reached. This is preferred over a simple step_timeout
+     * whenever possible since it allows the timeout to be longer
+     * to reduce intermittents without compromising test execution speed
+     * when the condition is quickly met.
+     *
+     * @example
+     * async_test(t => {
+     *  const popup = window.open("resources/coop-coep.py?coop=same-origin&coep=&navigate=about:blank");
+     *  t.add_cleanup(() => popup.close());
+     *  assert_equals(window, popup.opener);
+     *
+     *  popup.onload = t.step_func(() => {
+     *    assert_true(popup.location.href.endsWith("&navigate=about:blank"));
+     *    // Use step_wait_func_done as about:blank cannot message back.
+     *    t.step_wait_func_done(() => popup.location.href === "about:blank");
+     *  });
+     * }, "Navigating a popup to about:blank");
+     *
+     * @param {Function} cond A function taking no arguments and
+     *                        returning a boolean or a Promise. The callback is
+     *                        called when this function returns true, or the
+     *                        returned Promise is resolved with true.
+     * @param {Function} func A function taking no arguments to call once
+     *                        the condition is met.
+     * @param {string} [description] Error message to add to assert in case of
+     *                               failure.
+     * @param {number} timeout Timeout in ms. This is multiplied by the global
+     *                         timeout_multiplier
+     * @param {number} interval Polling interval in ms
+     *
+     */
+    Test.prototype.step_wait_func_done = function(cond, func, description,
+                                                  timeout=3000, interval=100) {
+         this.step_wait_func(cond, () => {
+            if (func) {
+                func();
+            }
+            this.done();
+         }, description, timeout, interval);
+    };
+
+    /**
+     * Poll for a function to return true, and resolve a promise
+     * once it does, or assert if a timeout is reached. This is
+     * preferred over a simple step_timeout whenever possible
+     * since it allows the timeout to be longer to reduce
+     * intermittents without compromising test execution speed
+     * when the condition is quickly met.
+     *
+     * @example
+     * promise_test(async t => {
+     *  // …
+     * await t.step_wait(() => frame.contentDocument === null, "Frame navigated to a cross-origin document");
+     * // …
+     * }, "");
+     *
+     * @param {Function} cond A function taking no arguments and
+     *                        returning a boolean or a Promise.
+     * @param {string} [description] Error message to add to assert in case of
+     *                              failure.
+     * @param {number} timeout Timeout in ms. This is multiplied by the global
+     *                         timeout_multiplier
+     * @param {number} interval Polling interval in ms
+     * @returns {Promise} Promise resolved once cond is met.
+     *
+     */
+    Test.prototype.step_wait = function(cond, description, timeout=3000, interval=100) {
+        return new Promise(resolve => {
+            this.step_wait_func(cond, resolve, description, timeout, interval);
+        });
+    };
+
+    /*
+     * Private method for registering cleanup functions. `testharness.js`
+     * internals should use this method instead of the public `add_cleanup`
+     * method in order to hide implementation details from the harness status
+     * message in the case errors.
+     */
+    Test.prototype._add_cleanup = function(callback) {
+        this.cleanup_callbacks.push(callback);
+    };
+
+    /**
+     * Schedule a function to be run after the test result is known, regardless
+     * of passing or failing state.
+     *
+     * The behavior of this function will not
+     * influence the result of the test, but if an exception is thrown, the
+     * test harness will report an error.
+     *
+     * @param {Function} callback - The cleanup function to run. This
+     * is called with no arguments.
+     */
+    Test.prototype.add_cleanup = function(callback) {
+        this._user_defined_cleanup_count += 1;
+        this._add_cleanup(callback);
+    };
+
+    Test.prototype.set_timeout = function()
+    {
+        if (this.timeout_length !== null) {
+            var this_obj = this;
+            this.timeout_id = setTimeout(function()
+                                         {
+                                             this_obj.timeout();
+                                         }, this.timeout_length);
+        }
+    };
+
+    Test.prototype.set_status = function(status, message, stack)
+    {
+        this.status = status;
+        this.message = message;
+        this.stack = stack ? stack : null;
+    };
+
+    /**
+     * Manually set the test status to ``TIMEOUT``.
+     */
+    Test.prototype.timeout = function()
+    {
+        this.timeout_id = null;
+        this.set_status(this.TIMEOUT, "Test timed out");
+        this.phase = this.phases.HAS_RESULT;
+        this.done();
+    };
+
+    /**
+     * Manually set the test status to ``TIMEOUT``.
+     *
+     * Alias for `Test.timeout <#Test.timeout>`_.
+     */
+    Test.prototype.force_timeout = function() {
+        return this.timeout();
+    };
+
+    /**
+     * Mark the test as complete.
+     *
+     * This sets the test status to ``PASS`` if no other status was
+     * already recorded. Any subsequent attempts to run additional
+     * test steps will be ignored.
+     *
+     * After setting the test status any test cleanup functions will
+     * be run.
+     */
+    Test.prototype.done = function()
+    {
+        if (this.phase >= this.phases.CLEANING) {
+            return;
+        }
+
+        if (this.phase <= this.phases.STARTED) {
+            this.set_status(this.PASS, null);
+        }
+
+        if (global_scope.clearTimeout) {
+            clearTimeout(this.timeout_id);
+        }
+
+        if (settings.debug) {
+            console.log("TEST DONE",
+                        this.status,
+                        this.name);
+        }
+
+        this.cleanup();
+    };
+
+    function add_test_done_callback(test, callback)
+    {
+        if (test.phase === test.phases.COMPLETE) {
+            callback();
+            return;
+        }
+
+        test._done_callbacks.push(callback);
+    }
+
+    /*
+     * Invoke all specified cleanup functions. If one or more produce an error,
+     * the context is in an unpredictable state, so all further testing should
+     * be cancelled.
+     */
+    Test.prototype.cleanup = function() {
+        var errors = [];
+        var bad_value_count = 0;
+        function on_error(e) {
+            errors.push(e);
+            // Abort tests immediately so that tests declared within subsequent
+            // cleanup functions are not run.
+            tests.abort();
+        }
+        var this_obj = this;
+        var results = [];
+
+        this.phase = this.phases.CLEANING;
+
+        if (this._abortController) {
+            this._abortController.abort("Test cleanup");
+        }
+
+        forEach(this.cleanup_callbacks,
+                function(cleanup_callback) {
+                    var result;
+
+                    try {
+                        result = cleanup_callback();
+                    } catch (e) {
+                        on_error(e);
+                        return;
+                    }
+
+                    if (!is_valid_cleanup_result(this_obj, result)) {
+                        bad_value_count += 1;
+                        // Abort tests immediately so that tests declared
+                        // within subsequent cleanup functions are not run.
+                        tests.abort();
+                    }
+
+                    results.push(result);
+                });
+
+        if (!this._is_promise_test) {
+            cleanup_done(this_obj, errors, bad_value_count);
+        } else {
+            all_async(results,
+                      function(result, done) {
+                          if (result && typeof result.then === "function") {
+                              result
+                                  .then(null, on_error)
+                                  .then(done);
+                          } else {
+                              done();
+                          }
+                      },
+                      function() {
+                          cleanup_done(this_obj, errors, bad_value_count);
+                      });
+        }
+    };
+
+    /*
+     * Determine if the return value of a cleanup function is valid for a given
+     * test. Any test may return the value `undefined`. Tests created with
+     * `promise_test` may alternatively return "thenable" object values.
+     */
+    function is_valid_cleanup_result(test, result) {
+        if (result === undefined) {
+            return true;
+        }
+
+        if (test._is_promise_test) {
+            return result && typeof result.then === "function";
+        }
+
+        return false;
+    }
+
+    function cleanup_done(test, errors, bad_value_count) {
+        if (errors.length || bad_value_count) {
+            var total = test._user_defined_cleanup_count;
+
+            tests.status.status = tests.status.ERROR;
+            tests.status.stack = null;
+            tests.status.message = "Test named '" + test.name +
+                "' specified " + total +
+                " 'cleanup' function" + (total > 1 ? "s" : "");
+
+            if (errors.length) {
+                tests.status.message += ", and " + errors.length + " failed";
+                tests.status.stack = ((typeof errors[0] === "object" &&
+                                       errors[0].hasOwnProperty("stack")) ?
+                                      errors[0].stack : null);
+            }
+
+            if (bad_value_count) {
+                var type = test._is_promise_test ?
+                   "non-thenable" : "non-undefined";
+                tests.status.message += ", and " + bad_value_count +
+                    " returned a " + type + " value";
+            }
+
+            tests.status.message += ".";
+        }
+
+        test.phase = test.phases.COMPLETE;
+        tests.result(test);
+        forEach(test._done_callbacks,
+                function(callback) {
+                    callback();
+                });
+        test._done_callbacks.length = 0;
+    }
+
+    /**
+     * Gives an AbortSignal that will be aborted when the test finishes.
+     */
+    Test.prototype.get_signal = function() {
+        if (!this._abortController) {
+            throw new Error("AbortController is not supported in this browser");
+        }
+        return this._abortController.signal;
+    };
+
+    /**
+     * A RemoteTest object mirrors a Test object on a remote worker. The
+     * associated RemoteWorker updates the RemoteTest object in response to
+     * received events. In turn, the RemoteTest object replicates these events
+     * on the local document. This allows listeners (test result reporting
+     * etc..) to transparently handle local and remote events.
+     */
+    function RemoteTest(clone) {
+        var this_obj = this;
+        Object.keys(clone).forEach(
+                function(key) {
+                    this_obj[key] = clone[key];
+                });
+        this.index = null;
+        this.phase = this.phases.INITIAL;
+        this.update_state_from(clone);
+        this._done_callbacks = [];
+        tests.push(this);
+    }
+
+    RemoteTest.prototype.structured_clone = function() {
+        var clone = {};
+        Object.keys(this).forEach(
+                (function(key) {
+                    var value = this[key];
+                    // `RemoteTest` instances are responsible for managing
+                    // their own "done" callback functions, so those functions
+                    // are not relevant in other execution contexts. Because of
+                    // this (and because Function values cannot be serialized
+                    // for cross-realm transmittance), the property should not
+                    // be considered when cloning instances.
+                    if (key === '_done_callbacks' ) {
+                        return;
+                    }
+
+                    if (typeof value === "object" && value !== null) {
+                        clone[key] = merge({}, value);
+                    } else {
+                        clone[key] = value;
+                    }
+                }).bind(this));
+        clone.phases = merge({}, this.phases);
+        return clone;
+    };
+
+    /**
+     * `RemoteTest` instances are objects which represent tests running in
+     * another realm. They do not define "cleanup" functions (if necessary,
+     * such functions are defined on the associated `Test` instance within the
+     * external realm). However, `RemoteTests` may have "done" callbacks (e.g.
+     * as attached by the `Tests` instance responsible for tracking the overall
+     * test status in the parent realm). The `cleanup` method delegates to
+     * `done` in order to ensure that such callbacks are invoked following the
+     * completion of the `RemoteTest`.
+     */
+    RemoteTest.prototype.cleanup = function() {
+        this.done();
+    };
+    RemoteTest.prototype.phases = Test.prototype.phases;
+    RemoteTest.prototype.update_state_from = function(clone) {
+        this.status = clone.status;
+        this.message = clone.message;
+        this.stack = clone.stack;
+        if (this.phase === this.phases.INITIAL) {
+            this.phase = this.phases.STARTED;
+        }
+    };
+    RemoteTest.prototype.done = function() {
+        this.phase = this.phases.COMPLETE;
+
+        forEach(this._done_callbacks,
+                function(callback) {
+                    callback();
+                });
+    };
+
+    RemoteTest.prototype.format_status = function() {
+        return Test.prototype.status_formats[this.status];
+    };
+
+    /*
+     * A RemoteContext listens for test events from a remote test context, such
+     * as another window or a worker. These events are then used to construct
+     * and maintain RemoteTest objects that mirror the tests running in the
+     * remote context.
+     *
+     * An optional third parameter can be used as a predicate to filter incoming
+     * MessageEvents.
+     */
+    function RemoteContext(remote, message_target, message_filter) {
+        this.running = true;
+        this.started = false;
+        this.tests = new Array();
+        this.early_exception = null;
+
+        var this_obj = this;
+        // If remote context is cross origin assigning to onerror is not
+        // possible, so silently catch those errors.
+        try {
+          remote.onerror = function(error) { this_obj.remote_error(error); };
+        } catch (e) {
+          // Ignore.
+        }
+
+        // Keeping a reference to the remote object and the message handler until
+        // remote_done() is seen prevents the remote object and its message channel
+        // from going away before all the messages are dispatched.
+        this.remote = remote;
+        this.message_target = message_target;
+        this.message_handler = function(message) {
+            var passesFilter = !message_filter || message_filter(message);
+            // The reference to the `running` property in the following
+            // condition is unnecessary because that value is only set to
+            // `false` after the `message_handler` function has been
+            // unsubscribed.
+            // TODO: Simplify the condition by removing the reference.
+            if (this_obj.running && message.data && passesFilter &&
+                (message.data.type in this_obj.message_handlers)) {
+                this_obj.message_handlers[message.data.type].call(this_obj, message.data);
+            }
+        };
+
+        if (self.Promise) {
+            this.done = new Promise(function(resolve) {
+                this_obj.doneResolve = resolve;
+            });
+        }
+
+        this.message_target.addEventListener("message", this.message_handler);
+    }
+
+    RemoteContext.prototype.remote_error = function(error) {
+        if (error.preventDefault) {
+            error.preventDefault();
+        }
+
+        // Defer interpretation of errors until the testing protocol has
+        // started and the remote test's `allow_uncaught_exception` property
+        // is available.
+        if (!this.started) {
+            this.early_exception = error;
+        } else if (!this.allow_uncaught_exception) {
+            this.report_uncaught(error);
+        }
+    };
+
+    RemoteContext.prototype.report_uncaught = function(error) {
+        var message = error.message || String(error);
+        var filename = (error.filename ? " " + error.filename: "");
+        // FIXME: Display remote error states separately from main document
+        // error state.
+        tests.set_status(tests.status.ERROR,
+                         "Error in remote" + filename + ": " + message,
+                         error.stack);
+    };
+
+    RemoteContext.prototype.start = function(data) {
+        this.started = true;
+        this.allow_uncaught_exception = data.properties.allow_uncaught_exception;
+
+        if (this.early_exception && !this.allow_uncaught_exception) {
+            this.report_uncaught(this.early_exception);
+        }
+    };
+
+    RemoteContext.prototype.test_state = function(data) {
+        var remote_test = this.tests[data.test.index];
+        if (!remote_test) {
+            remote_test = new RemoteTest(data.test);
+            this.tests[data.test.index] = remote_test;
+        }
+        remote_test.update_state_from(data.test);
+        tests.notify_test_state(remote_test);
+    };
+
+    RemoteContext.prototype.test_done = function(data) {
+        var remote_test = this.tests[data.test.index];
+        remote_test.update_state_from(data.test);
+        remote_test.done();
+        tests.result(remote_test);
+    };
+
+    RemoteContext.prototype.remote_done = function(data) {
+        if (tests.status.status === null &&
+            data.status.status !== data.status.OK) {
+            tests.set_status(data.status.status, data.status.message, data.status.stack);
+        }
+
+        for (let assert of data.asserts) {
+            var record = new AssertRecord();
+            record.assert_name = assert.assert_name;
+            record.args = assert.args;
+            record.test = assert.test != null ? this.tests[assert.test.index] : null;
+            record.status = assert.status;
+            record.stack = assert.stack;
+            tests.asserts_run.push(record);
+        }
+
+        this.message_target.removeEventListener("message", this.message_handler);
+        this.running = false;
+
+        // If remote context is cross origin assigning to onerror is not
+        // possible, so silently catch those errors.
+        try {
+          this.remote.onerror = null;
+        } catch (e) {
+          // Ignore.
+        }
+
+        this.remote = null;
+        this.message_target = null;
+        if (this.doneResolve) {
+            this.doneResolve();
+        }
+
+        if (tests.all_done()) {
+            tests.complete();
+        }
+    };
+
+    RemoteContext.prototype.message_handlers = {
+        start: RemoteContext.prototype.start,
+        test_state: RemoteContext.prototype.test_state,
+        result: RemoteContext.prototype.test_done,
+        complete: RemoteContext.prototype.remote_done
+    };
+
+    /**
+     * @class
+     * Status of the overall harness
+     */
+    function TestsStatus()
+    {
+        /** The status code */
+        this.status = null;
+        /** Message in case of failure */
+        this.message = null;
+        /** Stack trace in case of an exception. */
+        this.stack = null;
+    }
+
+    /**
+     * Enum of possible harness statuses.
+     *
+     * :values:
+     *   - ``OK``
+     *   - ``ERROR``
+     *   - ``TIMEOUT``
+     *   - ``PRECONDITION_FAILED``
+     */
+    TestsStatus.statuses = {
+        OK:0,
+        ERROR:1,
+        TIMEOUT:2,
+        PRECONDITION_FAILED:3
+    };
+
+    TestsStatus.prototype = merge({}, TestsStatus.statuses);
+
+    TestsStatus.prototype.formats = {
+        0: "OK",
+        1: "Error",
+        2: "Timeout",
+        3: "Optional Feature Unsupported"
+    };
+
+    TestsStatus.prototype.structured_clone = function()
+    {
+        if (!this._structured_clone) {
+            var msg = this.message;
+            msg = msg ? String(msg) : msg;
+            this._structured_clone = merge({
+                status:this.status,
+                message:msg,
+                stack:this.stack
+            }, TestsStatus.statuses);
+        }
+        return this._structured_clone;
+    };
+
+    TestsStatus.prototype.format_status = function() {
+        return this.formats[this.status];
+    };
+
+    /**
+     * @class
+     * Record of an assert that ran.
+     *
+     * @param {Test} test - The test which ran the assert.
+     * @param {string} assert_name - The function name of the assert.
+     * @param {Any} args - The arguments passed to the assert function.
+     */
+    function AssertRecord(test, assert_name, args = []) {
+        /** Name of the assert that ran */
+        this.assert_name = assert_name;
+        /** Test that ran the assert */
+        this.test = test;
+        // Avoid keeping complex objects alive
+        /** Stringification of the arguments that were passed to the assert function */
+        this.args = args.map(x => format_value(x).replace(/\n/g, " "));
+        /** Status of the assert */
+        this.status = null;
+    }
+
+    AssertRecord.prototype.structured_clone = function() {
+        return {
+            assert_name: this.assert_name,
+            test: this.test ? this.test.structured_clone() : null,
+            args: this.args,
+            status: this.status,
+        };
+    };
+
+    function Tests()
+    {
+        this.tests = [];
+        this.num_pending = 0;
+
+        this.phases = {
+            INITIAL:0,
+            SETUP:1,
+            HAVE_TESTS:2,
+            HAVE_RESULTS:3,
+            COMPLETE:4
+        };
+        this.phase = this.phases.INITIAL;
+
+        this.properties = {};
+
+        this.wait_for_finish = false;
+        this.processing_callbacks = false;
+
+        this.allow_uncaught_exception = false;
+
+        this.file_is_test = false;
+        // This value is lazily initialized in order to avoid introducing a
+        // dependency on ECMAScript 2015 Promises to all tests.
+        this.promise_tests = null;
+        this.promise_setup_called = false;
+
+        this.timeout_multiplier = 1;
+        this.timeout_length = test_environment.test_timeout();
+        this.timeout_id = null;
+
+        this.start_callbacks = [];
+        this.test_state_callbacks = [];
+        this.test_done_callbacks = [];
+        this.all_done_callbacks = [];
+
+        this.hide_test_state = false;
+        this.remotes = [];
+
+        this.current_test = null;
+        this.asserts_run = [];
+
+        // Track whether output is enabled, and thus whether or not we should
+        // track asserts.
+        //
+        // On workers we don't get properties set from testharnessreport.js, so
+        // we don't know whether or not to track asserts. To avoid the
+        // resulting performance hit, we assume we are not meant to. This means
+        // that assert tracking does not function on workers.
+        this.output = settings.output && 'document' in global_scope;
+
+        this.status = new TestsStatus();
+
+        var this_obj = this;
+
+        test_environment.add_on_loaded_callback(function() {
+            if (this_obj.all_done()) {
+                this_obj.complete();
+            }
+        });
+
+        this.set_timeout();
+    }
+
+    Tests.prototype.setup = function(func, properties)
+    {
+        if (this.phase >= this.phases.HAVE_RESULTS) {
+            return;
+        }
+
+        if (this.phase < this.phases.SETUP) {
+            this.phase = this.phases.SETUP;
+        }
+
+        this.properties = properties;
+
+        for (var p in properties) {
+            if (properties.hasOwnProperty(p)) {
+                var value = properties[p];
+                if (p === "allow_uncaught_exception") {
+                    this.allow_uncaught_exception = value;
+                } else if (p === "explicit_done" && value) {
+                    this.wait_for_finish = true;
+                } else if (p === "explicit_timeout" && value) {
+                    this.timeout_length = null;
+                    if (this.timeout_id)
+                    {
+                        clearTimeout(this.timeout_id);
+                    }
+                } else if (p === "single_test" && value) {
+                    this.set_file_is_test();
+                } else if (p === "timeout_multiplier") {
+                    this.timeout_multiplier = value;
+                    if (this.timeout_length) {
+                         this.timeout_length *= this.timeout_multiplier;
+                    }
+                } else if (p === "hide_test_state") {
+                    this.hide_test_state = value;
+                } else if (p === "output") {
+                    this.output = value;
+                } else if (p === "debug") {
+                    settings.debug = value;
+                }
+            }
+        }
+
+        if (func) {
+            try {
+                func();
+            } catch (e) {
+                this.status.status = e instanceof OptionalFeatureUnsupportedError ? this.status.PRECONDITION_FAILED : this.status.ERROR;
+                this.status.message = String(e);
+                this.status.stack = e.stack ? e.stack : null;
+                this.complete();
+            }
+        }
+        this.set_timeout();
+    };
+
+    Tests.prototype.set_file_is_test = function() {
+        if (this.tests.length > 0) {
+            throw new Error("Tried to set file as test after creating a test");
+        }
+        this.wait_for_finish = true;
+        this.file_is_test = true;
+        // Create the test, which will add it to the list of tests
+        tests.current_test = async_test();
+    };
+
+    Tests.prototype.set_status = function(status, message, stack)
+    {
+        this.status.status = status;
+        this.status.message = message;
+        this.status.stack = stack ? stack : null;
+    };
+
+    Tests.prototype.set_timeout = function() {
+        if (global_scope.clearTimeout) {
+            var this_obj = this;
+            clearTimeout(this.timeout_id);
+            if (this.timeout_length !== null) {
+                this.timeout_id = setTimeout(function() {
+                                                 this_obj.timeout();
+                                             }, this.timeout_length);
+            }
+        }
+    };
+
+    Tests.prototype.timeout = function() {
+        var test_in_cleanup = null;
+
+        if (this.status.status === null) {
+            forEach(this.tests,
+                    function(test) {
+                        // No more than one test is expected to be in the
+                        // "CLEANUP" phase at any time
+                        if (test.phase === test.phases.CLEANING) {
+                            test_in_cleanup = test;
+                        }
+
+                        test.phase = test.phases.COMPLETE;
+                    });
+
+            // Timeouts that occur while a test is in the "cleanup" phase
+            // indicate that some global state was not properly reverted. This
+            // invalidates the overall test execution, so the timeout should be
+            // reported as an error and cancel the execution of any remaining
+            // tests.
+            if (test_in_cleanup) {
+                this.status.status = this.status.ERROR;
+                this.status.message = "Timeout while running cleanup for " +
+                    "test named \"" + test_in_cleanup.name + "\".";
+                tests.status.stack = null;
+            } else {
+                this.status.status = this.status.TIMEOUT;
+            }
+        }
+
+        this.complete();
+    };
+
+    Tests.prototype.end_wait = function()
+    {
+        this.wait_for_finish = false;
+        if (this.all_done()) {
+            this.complete();
+        }
+    };
+
+    Tests.prototype.push = function(test)
+    {
+        if (this.phase === this.phases.COMPLETE) {
+            return;
+        }
+        if (this.phase < this.phases.HAVE_TESTS) {
+            this.start();
+        }
+        this.num_pending++;
+        test.index = this.tests.push(test) - 1;
+        this.notify_test_state(test);
+    };
+
+    Tests.prototype.notify_test_state = function(test) {
+        var this_obj = this;
+        forEach(this.test_state_callbacks,
+                function(callback) {
+                    callback(test, this_obj);
+                });
+    };
+
+    Tests.prototype.all_done = function() {
+        return (this.tests.length > 0 || this.remotes.length > 0) &&
+                test_environment.all_loaded &&
+                (this.num_pending === 0 || this.is_aborted) && !this.wait_for_finish &&
+                !this.processing_callbacks &&
+                !this.remotes.some(function(w) { return w.running; });
+    };
+
+    Tests.prototype.start = function() {
+        this.phase = this.phases.HAVE_TESTS;
+        this.notify_start();
+    };
+
+    Tests.prototype.notify_start = function() {
+        var this_obj = this;
+        forEach (this.start_callbacks,
+                 function(callback)
+                 {
+                     callback(this_obj.properties);
+                 });
+    };
+
+    Tests.prototype.result = function(test)
+    {
+        // If the harness has already transitioned beyond the `HAVE_RESULTS`
+        // phase, subsequent tests should not cause it to revert.
+        if (this.phase <= this.phases.HAVE_RESULTS) {
+            this.phase = this.phases.HAVE_RESULTS;
+        }
+        this.num_pending--;
+        this.notify_result(test);
+    };
+
+    Tests.prototype.notify_result = function(test) {
+        var this_obj = this;
+        this.processing_callbacks = true;
+        forEach(this.test_done_callbacks,
+                function(callback)
+                {
+                    callback(test, this_obj);
+                });
+        this.processing_callbacks = false;
+        if (this_obj.all_done()) {
+            this_obj.complete();
+        }
+    };
+
+    Tests.prototype.complete = function() {
+        if (this.phase === this.phases.COMPLETE) {
+            return;
+        }
+        var this_obj = this;
+        var all_complete = function() {
+            this_obj.phase = this_obj.phases.COMPLETE;
+            this_obj.notify_complete();
+        };
+        var incomplete = filter(this.tests,
+                                function(test) {
+                                    return test.phase < test.phases.COMPLETE;
+                                });
+
+        /**
+         * To preserve legacy behavior, overall test completion must be
+         * signaled synchronously.
+         */
+        if (incomplete.length === 0) {
+            all_complete();
+            return;
+        }
+
+        all_async(incomplete,
+                  function(test, testDone)
+                  {
+                      if (test.phase === test.phases.INITIAL) {
+                          test.phase = test.phases.HAS_RESULT;
+                          test.done();
+                          testDone();
+                      } else {
+                          add_test_done_callback(test, testDone);
+                          test.cleanup();
+                      }
+                  },
+                  all_complete);
+    };
+
+    Tests.prototype.set_assert = function(assert_name, args) {
+        this.asserts_run.push(new AssertRecord(this.current_test, assert_name, args));
+    };
+
+    Tests.prototype.set_assert_status = function(index, status, stack) {
+        let assert_record = this.asserts_run[index];
+        assert_record.status = status;
+        assert_record.stack = stack;
+    };
+
+    /**
+     * Update the harness status to reflect an unrecoverable harness error that
+     * should cancel all further testing. Update all previously-defined tests
+     * which have not yet started to indicate that they will not be executed.
+     */
+    Tests.prototype.abort = function() {
+        this.status.status = this.status.ERROR;
+        this.is_aborted = true;
+
+        forEach(this.tests,
+                function(test) {
+                    if (test.phase === test.phases.INITIAL) {
+                        test.phase = test.phases.COMPLETE;
+                    }
+                });
+    };
+
+    /*
+     * Determine if any tests share the same `name` property. Return an array
+     * containing the names of any such duplicates.
+     */
+    Tests.prototype.find_duplicates = function() {
+        var names = Object.create(null);
+        var duplicates = [];
+
+        forEach (this.tests,
+                 function(test)
+                 {
+                     if (test.name in names && duplicates.indexOf(test.name) === -1) {
+                        duplicates.push(test.name);
+                     }
+                     names[test.name] = true;
+                 });
+
+        return duplicates;
+    };
+
+    function code_unit_str(char) {
+        return 'U+' + char.charCodeAt(0).toString(16);
+    }
+
+    function sanitize_unpaired_surrogates(str) {
+        return str.replace(
+            /([\ud800-\udbff]+)(?![\udc00-\udfff])|(^|[^\ud800-\udbff])([\udc00-\udfff]+)/g,
+            function(_, low, prefix, high) {
+                var output = prefix || "";  // prefix may be undefined
+                var string = low || high;  // only one of these alternates can match
+                for (var i = 0; i < string.length; i++) {
+                    output += code_unit_str(string[i]);
+                }
+                return output;
+            });
+    }
+
+    function sanitize_all_unpaired_surrogates(tests) {
+        forEach (tests,
+                 function (test)
+                 {
+                     var sanitized = sanitize_unpaired_surrogates(test.name);
+
+                     if (test.name !== sanitized) {
+                         test.name = sanitized;
+                         delete test._structured_clone;
+                     }
+                 });
+    }
+
+    Tests.prototype.notify_complete = function() {
+        var this_obj = this;
+        var duplicates;
+
+        if (this.status.status === null) {
+            duplicates = this.find_duplicates();
+
+            // Some transports adhere to UTF-8's restriction on unpaired
+            // surrogates. Sanitize the titles so that the results can be
+            // consistently sent via all transports.
+            sanitize_all_unpaired_surrogates(this.tests);
+
+            // Test names are presumed to be unique within test files--this
+            // allows consumers to use them for identification purposes.
+            // Duplicated names violate this expectation and should therefore
+            // be reported as an error.
+            if (duplicates.length) {
+                this.status.status = this.status.ERROR;
+                this.status.message =
+                   duplicates.length + ' duplicate test name' +
+                   (duplicates.length > 1 ? 's' : '') + ': "' +
+                   duplicates.join('", "') + '"';
+            } else {
+                this.status.status = this.status.OK;
+            }
+        }
+
+        forEach (this.all_done_callbacks,
+                 function(callback)
+                 {
+                     callback(this_obj.tests, this_obj.status, this_obj.asserts_run);
+                 });
+    };
+
+    /*
+     * Constructs a RemoteContext that tracks tests from a specific worker.
+     */
+    Tests.prototype.create_remote_worker = function(worker) {
+        var message_port;
+
+        if (is_service_worker(worker)) {
+            message_port = navigator.serviceWorker;
+            worker.postMessage({type: "connect"});
+        } else if (is_shared_worker(worker)) {
+            message_port = worker.port;
+            message_port.start();
+        } else {
+            message_port = worker;
+        }
+
+        return new RemoteContext(worker, message_port);
+    };
+
+    /*
+     * Constructs a RemoteContext that tracks tests from a specific window.
+     */
+    Tests.prototype.create_remote_window = function(remote) {
+        remote.postMessage({type: "getmessages"}, "*");
+        return new RemoteContext(
+            remote,
+            window,
+            function(msg) {
+                return msg.source === remote;
+            }
+        );
+    };
+
+    Tests.prototype.fetch_tests_from_worker = function(worker) {
+        if (this.phase >= this.phases.COMPLETE) {
+            return;
+        }
+
+        var remoteContext = this.create_remote_worker(worker);
+        this.remotes.push(remoteContext);
+        return remoteContext.done;
+    };
+
+    /**
+     * Get test results from a worker and include them in the current test.
+     *
+     * @param {Worker|SharedWorker|ServiceWorker|MessagePort} port -
+     * Either a worker object or a port connected to a worker which is
+     * running tests..
+     * @returns {Promise} - A promise that's resolved once all the remote tests are complete.
+     */
+    function fetch_tests_from_worker(port) {
+        return tests.fetch_tests_from_worker(port);
+    }
+    expose(fetch_tests_from_worker, 'fetch_tests_from_worker');
+
+    Tests.prototype.fetch_tests_from_window = function(remote) {
+        if (this.phase >= this.phases.COMPLETE) {
+            return;
+        }
+
+        var remoteContext = this.create_remote_window(remote);
+        this.remotes.push(remoteContext);
+        return remoteContext.done;
+    };
+
+    /**
+     * Aggregate tests from separate windows or iframes
+     * into the current document as if they were all part of the same test file.
+     *
+     * The document of the second window (or iframe) should include
+     * ``testharness.js``, but not ``testharnessreport.js``, and use
+     * :js:func:`test`, :js:func:`async_test`, and :js:func:`promise_test` in
+     * the usual manner.
+     *
+     * @param {Window} window - The window to fetch tests from.
+     */
+    function fetch_tests_from_window(window) {
+        return tests.fetch_tests_from_window(window);
+    }
+    expose(fetch_tests_from_window, 'fetch_tests_from_window');
+
+    /**
+     * Get test results from a shadow realm and include them in the current test.
+     *
+     * @param {ShadowRealm} realm - A shadow realm also running the test harness
+     * @returns {Promise} - A promise that's resolved once all the remote tests are complete.
+     */
+    function fetch_tests_from_shadow_realm(realm) {
+        var chan = new MessageChannel();
+        function receiveMessage(msg_json) {
+            chan.port1.postMessage(JSON.parse(msg_json));
+        }
+        var done = tests.fetch_tests_from_worker(chan.port2);
+        realm.evaluate("begin_shadow_realm_tests")(receiveMessage);
+        chan.port2.start();
+        return done;
+    }
+    expose(fetch_tests_from_shadow_realm, 'fetch_tests_from_shadow_realm');
+
+    /**
+     * Begin running tests in this shadow realm test harness.
+     *
+     * To be called after all tests have been loaded; it is an error to call
+     * this more than once or in a non-Shadow Realm environment
+     *
+     * @param {Function} postMessage - A function to send test updates to the
+     * incubating realm-- accepts JSON-encoded messages in the format used by
+     * RemoteContext
+     */
+    function begin_shadow_realm_tests(postMessage) {
+        if (!(test_environment instanceof ShadowRealmTestEnvironment)) {
+            throw new Error("begin_shadow_realm_tests called in non-Shadow Realm environment");
+        }
+
+        test_environment.begin(function (msg) {
+            postMessage(JSON.stringify(msg));
+        });
+    }
+    expose(begin_shadow_realm_tests, 'begin_shadow_realm_tests');
+
+    /**
+     * Timeout the tests.
+     *
+     * This only has an effect when ``explicit_timeout`` has been set
+     * in :js:func:`setup`. In other cases any call is a no-op.
+     *
+     */
+    function timeout() {
+        if (tests.timeout_length === null) {
+            tests.timeout();
+        }
+    }
+    expose(timeout, 'timeout');
+
+    /**
+     * Add a callback that's triggered when the first :js:class:`Test` is created.
+     *
+     * @param {Function} callback - Callback function. This is called
+     * without arguments.
+     */
+    function add_start_callback(callback) {
+        tests.start_callbacks.push(callback);
+    }
+
+    /**
+     * Add a callback that's triggered when a test state changes.
+     *
+     * @param {Function} callback - Callback function, called with the
+     * :js:class:`Test` as the only argument.
+     */
+    function add_test_state_callback(callback) {
+        tests.test_state_callbacks.push(callback);
+    }
+
+    /**
+     * Add a callback that's triggered when a test result is received.
+     *
+     * @param {Function} callback - Callback function, called with the
+     * :js:class:`Test` as the only argument.
+     */
+    function add_result_callback(callback) {
+        tests.test_done_callbacks.push(callback);
+    }
+
+    /**
+     * Add a callback that's triggered when all tests are complete.
+     *
+     * @param {Function} callback - Callback function, called with an
+     * array of :js:class:`Test` objects, a :js:class:`TestsStatus`
+     * object and an array of :js:class:`AssertRecord` objects. If the
+     * debug setting is ``false`` the final argument will be an empty
+     * array.
+     *
+     * For performance reasons asserts are only tracked when the debug
+     * setting is ``true``. In other cases the array of asserts will be
+     * empty.
+     */
+    function add_completion_callback(callback) {
+        tests.all_done_callbacks.push(callback);
+    }
+
+    expose(add_start_callback, 'add_start_callback');
+    expose(add_test_state_callback, 'add_test_state_callback');
+    expose(add_result_callback, 'add_result_callback');
+    expose(add_completion_callback, 'add_completion_callback');
+
+    function remove(array, item) {
+        var index = array.indexOf(item);
+        if (index > -1) {
+            array.splice(index, 1);
+        }
+    }
+
+    function remove_start_callback(callback) {
+        remove(tests.start_callbacks, callback);
+    }
+
+    function remove_test_state_callback(callback) {
+        remove(tests.test_state_callbacks, callback);
+    }
+
+    function remove_result_callback(callback) {
+        remove(tests.test_done_callbacks, callback);
+    }
+
+    function remove_completion_callback(callback) {
+       remove(tests.all_done_callbacks, callback);
+    }
+
+    /*
+     * Output listener
+    */
+
+    function Output() {
+        this.output_document = document;
+        this.output_node = null;
+        this.enabled = settings.output;
+        this.phase = this.INITIAL;
+    }
+
+    Output.prototype.INITIAL = 0;
+    Output.prototype.STARTED = 1;
+    Output.prototype.HAVE_RESULTS = 2;
+    Output.prototype.COMPLETE = 3;
+
+    Output.prototype.setup = function(properties) {
+        if (this.phase > this.INITIAL) {
+            return;
+        }
+
+        //If output is disabled in testharnessreport.js the test shouldn't be
+        //able to override that
+        this.enabled = this.enabled && (properties.hasOwnProperty("output") ?
+                                        properties.output : settings.output);
+    };
+
+    Output.prototype.init = function(properties) {
+        if (this.phase >= this.STARTED) {
+            return;
+        }
+        if (properties.output_document) {
+            this.output_document = properties.output_document;
+        } else {
+            this.output_document = document;
+        }
+        this.phase = this.STARTED;
+    };
+
+    Output.prototype.resolve_log = function() {
+        var output_document;
+        if (this.output_node) {
+            return;
+        }
+        if (typeof this.output_document === "function") {
+            output_document = this.output_document.apply(undefined);
+        } else {
+            output_document = this.output_document;
+        }
+        if (!output_document) {
+            return;
+        }
+        var node = output_document.getElementById("log");
+        if (!node) {
+            if (output_document.readyState === "loading") {
+                return;
+            }
+            node = output_document.createElementNS("http://www.w3.org/1999/xhtml", "div");
+            node.id = "log";
+            if (output_document.body) {
+                output_document.body.appendChild(node);
+            } else {
+                var root = output_document.documentElement;
+                var is_html = (root &&
+                               root.namespaceURI === "http://www.w3.org/1999/xhtml" &&
+                               root.localName === "html");
+                var is_svg = (output_document.defaultView &&
+                              "SVGSVGElement" in output_document.defaultView &&
+                              root instanceof output_document.defaultView.SVGSVGElement);
+                if (is_svg) {
+                    var foreignObject = output_document.createElementNS("http://www.w3.org/2000/svg", "foreignObject");
+                    foreignObject.setAttribute("width", "100%");
+                    foreignObject.setAttribute("height", "100%");
+                    root.appendChild(foreignObject);
+                    foreignObject.appendChild(node);
+                } else if (is_html) {
+                    root.appendChild(output_document.createElementNS("http://www.w3.org/1999/xhtml", "body"))
+                        .appendChild(node);
+                } else {
+                    root.appendChild(node);
+                }
+            }
+        }
+        this.output_document = output_document;
+        this.output_node = node;
+    };
+
+    Output.prototype.show_status = function() {
+        if (this.phase < this.STARTED) {
+            this.init({});
+        }
+        if (!this.enabled || this.phase === this.COMPLETE) {
+            return;
+        }
+        this.resolve_log();
+        if (this.phase < this.HAVE_RESULTS) {
+            this.phase = this.HAVE_RESULTS;
+        }
+        var done_count = tests.tests.length - tests.num_pending;
+        if (this.output_node && !tests.hide_test_state) {
+            if (done_count < 100 ||
+                (done_count < 1000 && done_count % 100 === 0) ||
+                done_count % 1000 === 0) {
+                this.output_node.textContent = "Running, " +
+                    done_count + " complete, " +
+                    tests.num_pending + " remain";
+            }
+        }
+    };
+
+    Output.prototype.show_results = function (tests, harness_status, asserts_run) {
+        if (this.phase >= this.COMPLETE) {
+            return;
+        }
+        if (!this.enabled) {
+            return;
+        }
+        if (!this.output_node) {
+            this.resolve_log();
+        }
+        this.phase = this.COMPLETE;
+
+        var log = this.output_node;
+        if (!log) {
+            return;
+        }
+        var output_document = this.output_document;
+
+        while (log.lastChild) {
+            log.removeChild(log.lastChild);
+        }
+
+        var stylesheet = output_document.createElementNS(xhtml_ns, "style");
+        stylesheet.textContent = stylesheetContent;
+        var heads = output_document.getElementsByTagName("head");
+        if (heads.length) {
+            heads[0].appendChild(stylesheet);
+        }
+
+        var status_number = {};
+        forEach(tests,
+                function(test) {
+                    var status = test.format_status();
+                    if (status_number.hasOwnProperty(status)) {
+                        status_number[status] += 1;
+                    } else {
+                        status_number[status] = 1;
+                    }
+                });
+
+        function status_class(status)
+        {
+            return status.replace(/\s/g, '').toLowerCase();
+        }
+
+        var summary_template = ["section", {"id":"summary"},
+                                ["h2", {}, "Summary"],
+                                function()
+                                {
+                                    var status = harness_status.format_status();
+                                    var rv = [["section", {},
+                                               ["p", {},
+                                                "Harness status: ",
+                                                ["span", {"class":status_class(status)},
+                                                 status
+                                                ],
+                                               ],
+                                               ["button", {"id":"rerun"}, "Rerun"]
+                                              ]];
+
+                                    if (harness_status.status === harness_status.ERROR) {
+                                        rv[0].push(["pre", {}, harness_status.message]);
+                                        if (harness_status.stack) {
+                                            rv[0].push(["pre", {}, harness_status.stack]);
+                                        }
+                                    }
+                                    return rv;
+                                },
+                                ["p", {}, "Found ${num_tests} tests"],
+                                function() {
+                                    var rv = [["div", {}]];
+                                    var i = 0;
+                                    while (Test.prototype.status_formats.hasOwnProperty(i)) {
+                                        if (status_number.hasOwnProperty(Test.prototype.status_formats[i])) {
+                                            var status = Test.prototype.status_formats[i];
+                                            rv[0].push(["div", {},
+                                                        ["label", {},
+                                                         ["input", {type:"checkbox", checked:"checked"}],
+                                                         status_number[status] + " ",
+                                                         ["span", {"class":status_class(status)}, status]]]);
+                                        }
+                                        i++;
+                                    }
+                                    return rv;
+                                },
+                               ];
+
+        log.appendChild(render(summary_template, {num_tests:tests.length}, output_document));
+
+        output_document.getElementById("rerun").addEventListener("click",
+            function() {
+                let evt = new Event('__test_restart');
+                let canceled = !window.dispatchEvent(evt);
+                if (!canceled) { location.reload(); }
+            });
+
+        forEach(output_document.querySelectorAll("section#summary label"),
+                function(element)
+                {
+                    on_event(element, "click",
+                             function(e)
+                             {
+                                 if (output_document.getElementById("results") === null) {
+                                     e.preventDefault();
+                                     return;
+                                 }
+                                 var result_class = element.querySelector("span[class]").getAttribute("class");
+                                 var style_element = output_document.querySelector("style#hide-" + result_class);
+                                 var input_element = element.querySelector("input");
+                                 if (!style_element && !input_element.checked) {
+                                     style_element = output_document.createElementNS(xhtml_ns, "style");
+                                     style_element.id = "hide-" + result_class;
+                                     style_element.textContent = "table#results > tbody > tr.overall-"+result_class+"{display:none}";
+                                     output_document.body.appendChild(style_element);
+                                 } else if (style_element && input_element.checked) {
+                                     style_element.parentNode.removeChild(style_element);
+                                 }
+                             });
+                });
+
+        function has_assertions()
+        {
+            for (var i = 0; i < tests.length; i++) {
+                if (tests[i].properties.hasOwnProperty("assert")) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        function get_assertion(test)
+        {
+            if (test.properties.hasOwnProperty("assert")) {
+                if (Array.isArray(test.properties.assert)) {
+                    return test.properties.assert.join(' ');
+                }
+                return test.properties.assert;
+            }
+            return '';
+        }
+
+        var asserts_run_by_test = new Map();
+        asserts_run.forEach(assert => {
+            if (!asserts_run_by_test.has(assert.test)) {
+                asserts_run_by_test.set(assert.test, []);
+            }
+            asserts_run_by_test.get(assert.test).push(assert);
+        });
+
+        function get_asserts_output(test) {
+            const asserts_output = render(
+                ["details", {},
+                    ["summary", {}, "Asserts run"],
+                    ["table", {}, ""] ]);
+
+            var asserts = asserts_run_by_test.get(test);
+            if (!asserts) {
+                asserts_output.querySelector("summary").insertAdjacentText("afterend", "No asserts ran");
+                return asserts_output;
+            }
+
+            const table = asserts_output.querySelector("table");
+            for (const assert of asserts) {
+                const status_class_name = status_class(Test.prototype.status_formats[assert.status]);
+                var output_fn = "(" + assert.args.join(", ") + ")";
+                if (assert.stack) {
+                    output_fn += "\n";
+                    output_fn += assert.stack.split("\n", 1)[0].replace(/@?\w+:\/\/[^ "\/]+(?::\d+)?/g, " ");
+                }
+                table.appendChild(render(
+                    ["tr", {"class":"overall-" + status_class_name},
+                        ["td", {"class":status_class_name}, Test.prototype.status_formats[assert.status]],
+                        ["td", {}, ["pre", {}, ["strong", {}, assert.assert_name], output_fn]] ]));
+            }
+            return asserts_output;
+        }
+
+        var assertions = has_assertions();
+        const section = render(
+            ["section", {},
+                ["h2", {}, "Details"],
+                ["table", {"id":"results", "class":(assertions ? "assertions" : "")},
+                    ["thead", {},
+                        ["tr", {},
+                            ["th", {}, "Result"],
+                            ["th", {}, "Test Name"],
+                            (assertions ? ["th", {}, "Assertion"] : ""),
+                            ["th", {}, "Message" ]]],
+                    ["tbody", {}]]]);
+
+        const tbody = section.querySelector("tbody");
+        for (const test of tests) {
+            const status = test.format_status();
+            const status_class_name = status_class(status);
+            tbody.appendChild(render(
+                ["tr", {"class":"overall-" + status_class_name},
+                    ["td", {"class":status_class_name}, status],
+                    ["td", {}, test.name],
+                    (assertions ? ["td", {}, get_assertion(test)] : ""),
+                    ["td", {},
+                        test.message ?? "",
+                        ["pre", {}, test.stack ?? ""]]]));
+            if (!(test instanceof RemoteTest)) {
+                tbody.lastChild.lastChild.appendChild(get_asserts_output(test));
+            }
+        }
+        log.appendChild(section);
+    };
+
+    /*
+     * Template code
+     *
+     * A template is just a JavaScript structure. An element is represented as:
+     *
+     * [tag_name, {attr_name:attr_value}, child1, child2]
+     *
+     * the children can either be strings (which act like text nodes), other templates or
+     * functions (see below)
+     *
+     * A text node is represented as
+     *
+     * ["{text}", value]
+     *
+     * String values have a simple substitution syntax; ${foo} represents a variable foo.
+     *
+     * It is possible to embed logic in templates by using a function in a place where a
+     * node would usually go. The function must either return part of a template or null.
+     *
+     * In cases where a set of nodes are required as output rather than a single node
+     * with children it is possible to just use a list
+     * [node1, node2, node3]
+     *
+     * Usage:
+     *
+     * render(template, substitutions) - take a template and an object mapping
+     * variable names to parameters and return either a DOM node or a list of DOM nodes
+     *
+     * substitute(template, substitutions) - take a template and variable mapping object,
+     * make the variable substitutions and return the substituted template
+     *
+     */
+
+    function is_single_node(template)
+    {
+        return typeof template[0] === "string";
+    }
+
+    function substitute(template, substitutions)
+    {
+        if (typeof template === "function") {
+            var replacement = template(substitutions);
+            if (!replacement) {
+                return null;
+            }
+
+            return substitute(replacement, substitutions);
+        }
+
+        if (is_single_node(template)) {
+            return substitute_single(template, substitutions);
+        }
+
+        return filter(map(template, function(x) {
+                              return substitute(x, substitutions);
+                          }), function(x) {return x !== null;});
+    }
+
+    function substitute_single(template, substitutions)
+    {
+        var substitution_re = /\$\{([^ }]*)\}/g;
+
+        function do_substitution(input)
+        {
+            var components = input.split(substitution_re);
+            var rv = [];
+            if (components.length === 1) {
+                rv = components;
+            } else if (substitutions) {
+                for (var i = 0; i < components.length; i += 2) {
+                    if (components[i]) {
+                        rv.push(components[i]);
+                    }
+                    if (substitutions[components[i + 1]]) {
+                        rv.push(String(substitutions[components[i + 1]]));
+                    }
+                }
+            }
+            return rv;
+        }
+
+        function substitute_attrs(attrs, rv)
+        {
+            rv[1] = {};
+            for (var name in template[1]) {
+                if (attrs.hasOwnProperty(name)) {
+                    var new_name = do_substitution(name).join("");
+                    var new_value = do_substitution(attrs[name]).join("");
+                    rv[1][new_name] = new_value;
+                }
+            }
+        }
+
+        function substitute_children(children, rv)
+        {
+            for (var i = 0; i < children.length; i++) {
+                if (children[i] instanceof Object) {
+                    var replacement = substitute(children[i], substitutions);
+                    if (replacement !== null) {
+                        if (is_single_node(replacement)) {
+                            rv.push(replacement);
+                        } else {
+                            extend(rv, replacement);
+                        }
+                    }
+                } else {
+                    extend(rv, do_substitution(String(children[i])));
+                }
+            }
+            return rv;
+        }
+
+        var rv = [];
+        rv.push(do_substitution(String(template[0])).join(""));
+
+        if (template[0] === "{text}") {
+            substitute_children(template.slice(1), rv);
+        } else {
+            substitute_attrs(template[1], rv);
+            substitute_children(template.slice(2), rv);
+        }
+
+        return rv;
+    }
+
+    function make_dom_single(template, doc)
+    {
+        var output_document = doc || document;
+        var element;
+        if (template[0] === "{text}") {
+            element = output_document.createTextNode("");
+            for (var i = 1; i < template.length; i++) {
+                element.data += template[i];
+            }
+        } else {
+            element = output_document.createElementNS(xhtml_ns, template[0]);
+            for (var name in template[1]) {
+                if (template[1].hasOwnProperty(name)) {
+                    element.setAttribute(name, template[1][name]);
+                }
+            }
+            for (var i = 2; i < template.length; i++) {
+                if (template[i] instanceof Object) {
+                    var sub_element = make_dom(template[i]);
+                    element.appendChild(sub_element);
+                } else {
+                    var text_node = output_document.createTextNode(template[i]);
+                    element.appendChild(text_node);
+                }
+            }
+        }
+
+        return element;
+    }
+
+    function make_dom(template, substitutions, output_document)
+    {
+        if (is_single_node(template)) {
+            return make_dom_single(template, output_document);
+        }
+
+        return map(template, function(x) {
+                       return make_dom_single(x, output_document);
+                   });
+    }
+
+    function render(template, substitutions, output_document)
+    {
+        return make_dom(substitute(template, substitutions), output_document);
+    }
+
+    /*
+     * Utility functions
+     */
+    function assert(expected_true, function_name, description, error, substitutions)
+    {
+        if (expected_true !== true) {
+            var msg = make_message(function_name, description,
+                                   error, substitutions);
+            throw new AssertionError(msg);
+        }
+    }
+
+    /**
+     * @class
+     * Exception type that represents a failing assert.
+     *
+     * @param {string} message - Error message.
+     */
+    function AssertionError(message)
+    {
+        if (typeof message === "string") {
+            message = sanitize_unpaired_surrogates(message);
+        }
+        this.message = message;
+        this.stack = get_stack();
+    }
+    expose(AssertionError, "AssertionError");
+
+    AssertionError.prototype = Object.create(Error.prototype);
+
+    const get_stack = function() {
+        var stack = new Error().stack;
+
+        // 'Error.stack' is not supported in all browsers/versions
+        if (!stack) {
+            return "(Stack trace unavailable)";
+        }
+
+        var lines = stack.split("\n");
+
+        // Create a pattern to match stack frames originating within testharness.js.  These include the
+        // script URL, followed by the line/col (e.g., '/resources/testharness.js:120:21').
+        // Escape the URL per http://stackoverflow.com/questions/3561493/is-there-a-regexp-escape-function-in-javascript
+        // in case it contains RegExp characters.
+        var script_url = get_script_url();
+        var re_text = script_url ? script_url.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&') : "\\btestharness.js";
+        var re = new RegExp(re_text + ":\\d+:\\d+");
+
+        // Some browsers include a preamble that specifies the type of the error object.  Skip this by
+        // advancing until we find the first stack frame originating from testharness.js.
+        var i = 0;
+        while (!re.test(lines[i]) && i < lines.length) {
+            i++;
+        }
+
+        // Then skip the top frames originating from testharness.js to begin the stack at the test code.
+        while (re.test(lines[i]) && i < lines.length) {
+            i++;
+        }
+
+        // Paranoid check that we didn't skip all frames.  If so, return the original stack unmodified.
+        if (i >= lines.length) {
+            return stack;
+        }
+
+        return lines.slice(i).join("\n");
+    };
+
+    function OptionalFeatureUnsupportedError(message)
+    {
+        AssertionError.call(this, message);
+    }
+    OptionalFeatureUnsupportedError.prototype = Object.create(AssertionError.prototype);
+    expose(OptionalFeatureUnsupportedError, "OptionalFeatureUnsupportedError");
+
+    function make_message(function_name, description, error, substitutions)
+    {
+        for (var p in substitutions) {
+            if (substitutions.hasOwnProperty(p)) {
+                substitutions[p] = format_value(substitutions[p]);
+            }
+        }
+        var node_form = substitute(["{text}", "${function_name}: ${description}" + error],
+                                   merge({function_name:function_name,
+                                          description:(description?description + " ":"")},
+                                          substitutions));
+        return node_form.slice(1).join("");
+    }
+
+    function filter(array, callable, thisObj) {
+        var rv = [];
+        for (var i = 0; i < array.length; i++) {
+            if (array.hasOwnProperty(i)) {
+                var pass = callable.call(thisObj, array[i], i, array);
+                if (pass) {
+                    rv.push(array[i]);
+                }
+            }
+        }
+        return rv;
+    }
+
+    function map(array, callable, thisObj)
+    {
+        var rv = [];
+        rv.length = array.length;
+        for (var i = 0; i < array.length; i++) {
+            if (array.hasOwnProperty(i)) {
+                rv[i] = callable.call(thisObj, array[i], i, array);
+            }
+        }
+        return rv;
+    }
+
+    function extend(array, items)
+    {
+        Array.prototype.push.apply(array, items);
+    }
+
+    function forEach(array, callback, thisObj)
+    {
+        for (var i = 0; i < array.length; i++) {
+            if (array.hasOwnProperty(i)) {
+                callback.call(thisObj, array[i], i, array);
+            }
+        }
+    }
+
+    /**
+     * Immediately invoke a "iteratee" function with a series of values in
+     * parallel and invoke a final "done" function when all of the "iteratee"
+     * invocations have signaled completion.
+     *
+     * If all callbacks complete synchronously (or if no callbacks are
+     * specified), the ``done_callback`` will be invoked synchronously. It is the
+     * responsibility of the caller to ensure asynchronicity in cases where
+     * that is desired.
+     *
+     * @param {array} value Zero or more values to use in the invocation of
+     *                      ``iter_callback``
+     * @param {function} iter_callback A function that will be invoked
+     *                                 once for each of the values min
+     *                                 ``value``. Two arguments will
+     *                                 be available in each
+     *                                 invocation: the value from
+     *                                 ``value`` and a function that
+     *                                 must be invoked to signal
+     *                                 completion
+     * @param {function} done_callback A function that will be invoked after
+     *                                 all operations initiated by the
+     *                                 ``iter_callback`` function have signaled
+     *                                 completion
+     */
+    function all_async(values, iter_callback, done_callback)
+    {
+        var remaining = values.length;
+
+        if (remaining === 0) {
+            done_callback();
+        }
+
+        forEach(values,
+                function(element) {
+                    var invoked = false;
+                    var elDone = function() {
+                        if (invoked) {
+                            return;
+                        }
+
+                        invoked = true;
+                        remaining -= 1;
+
+                        if (remaining === 0) {
+                            done_callback();
+                        }
+                    };
+
+                    iter_callback(element, elDone);
+                });
+    }
+
+    function merge(a,b)
+    {
+        var rv = {};
+        var p;
+        for (p in a) {
+            rv[p] = a[p];
+        }
+        for (p in b) {
+            rv[p] = b[p];
+        }
+        return rv;
+    }
+
+    function expose(object, name)
+    {
+        var components = name.split(".");
+        var target = global_scope;
+        for (var i = 0; i < components.length - 1; i++) {
+            if (!(components[i] in target)) {
+                target[components[i]] = {};
+            }
+            target = target[components[i]];
+        }
+        target[components[components.length - 1]] = object;
+    }
+
+    function is_same_origin(w) {
+        try {
+            'random_prop' in w;
+            return true;
+        } catch (e) {
+            return false;
+        }
+    }
+
+    /** Returns the 'src' URL of the first <script> tag in the page to include the file 'testharness.js'. */
+    function get_script_url()
+    {
+        if (!('document' in global_scope)) {
+            return undefined;
+        }
+
+        var scripts = document.getElementsByTagName("script");
+        for (var i = 0; i < scripts.length; i++) {
+            var src;
+            if (scripts[i].src) {
+                src = scripts[i].src;
+            } else if (scripts[i].href) {
+                //SVG case
+                src = scripts[i].href.baseVal;
+            }
+
+            var matches = src && src.match(/^(.*\/|)testharness\.js$/);
+            if (matches) {
+                return src;
+            }
+        }
+        return undefined;
+    }
+
+    /** Returns the <title> or filename or "Untitled" */
+    function get_title()
+    {
+        if ('document' in global_scope) {
+            //Don't use document.title to work around an Opera/Presto bug in XHTML documents
+            var title = document.getElementsByTagName("title")[0];
+            if (title && title.firstChild && title.firstChild.data) {
+                return title.firstChild.data;
+            }
+        }
+        if ('META_TITLE' in global_scope && META_TITLE) {
+            return META_TITLE;
+        }
+        if ('location' in global_scope && 'pathname' in location) {
+            var filename = location.pathname.substring(location.pathname.lastIndexOf('/') + 1);
+            return filename.substring(0, filename.indexOf('.'));
+        }
+        return "Untitled";
+    }
+
+    /** Fetches a JSON resource and parses it */
+    async function fetch_json(resource) {
+        const response = await fetch(resource);
+        return await response.json();
+    }
+    if (!global_scope.GLOBAL || !global_scope.GLOBAL.isShadowRealm()) {
+        expose(fetch_json, 'fetch_json');
+    }
+
+    /**
+     * Setup globals
+     */
+
+    var tests = new Tests();
+
+    if (global_scope.addEventListener) {
+        var error_handler = function(error, message, stack) {
+            var optional_unsupported = error instanceof OptionalFeatureUnsupportedError;
+            if (tests.file_is_test) {
+                var test = tests.tests[0];
+                if (test.phase >= test.phases.HAS_RESULT) {
+                    return;
+                }
+                var status = optional_unsupported ? test.PRECONDITION_FAILED : test.FAIL;
+                test.set_status(status, message, stack);
+                test.phase = test.phases.HAS_RESULT;
+            } else if (!tests.allow_uncaught_exception) {
+                var status = optional_unsupported ? tests.status.PRECONDITION_FAILED : tests.status.ERROR;
+                tests.status.status = status;
+                tests.status.message = message;
+                tests.status.stack = stack;
+            }
+
+            // Do not transition to the "complete" phase if the test has been
+            // configured to allow uncaught exceptions. This gives the test an
+            // opportunity to define subtests based on the exception reporting
+            // behavior.
+            if (!tests.allow_uncaught_exception) {
+                done();
+            }
+        };
+
+        addEventListener("error", function(e) {
+            var message = e.message;
+            var stack;
+            if (e.error && e.error.stack) {
+                stack = e.error.stack;
+            } else {
+                stack = e.filename + ":" + e.lineno + ":" + e.colno;
+            }
+            error_handler(e.error, message, stack);
+        }, false);
+
+        addEventListener("unhandledrejection", function(e) {
+            var message;
+            if (e.reason && e.reason.message) {
+                message = "Unhandled rejection: " + e.reason.message;
+            } else {
+                message = "Unhandled rejection";
+            }
+            var stack;
+            if (e.reason && e.reason.stack) {
+                stack = e.reason.stack;
+            }
+            error_handler(e.reason, message, stack);
+        }, false);
+    }
+
+    test_environment.on_tests_ready();
+
+    /**
+     * Stylesheet
+     */
+     var stylesheetContent = "\
+html {\
+    font-family:DejaVu Sans, Bitstream Vera Sans, Arial, Sans;\
+}\
+\
+#log .warning,\
+#log .warning a {\
+  color: black;\
+  background: yellow;\
+}\
+\
+#log .error,\
+#log .error a {\
+  color: white;\
+  background: red;\
+}\
+\
+section#summary {\
+    margin-bottom:1em;\
+}\
+\
+table#results {\
+    border-collapse:collapse;\
+    table-layout:fixed;\
+    width:100%;\
+}\
+\
+table#results > thead > tr > th:first-child,\
+table#results > tbody > tr > td:first-child {\
+    width:8em;\
+}\
+\
+table#results > thead > tr > th:last-child,\
+table#results > thead > tr > td:last-child {\
+    width:50%;\
+}\
+\
+table#results.assertions > thead > tr > th:last-child,\
+table#results.assertions > tbody > tr > td:last-child {\
+    width:35%;\
+}\
+\
+table#results > thead > tr > th {\
+    padding:0;\
+    padding-bottom:0.5em;\
+    border-bottom:medium solid black;\
+}\
+\
+table#results > tbody > tr> td {\
+    padding:1em;\
+    padding-bottom:0.5em;\
+    border-bottom:thin solid black;\
+}\
+\
+.pass {\
+    color:green;\
+}\
+\
+.fail {\
+    color:red;\
+}\
+\
+tr.timeout {\
+    color:red;\
+}\
+\
+tr.notrun {\
+    color:blue;\
+}\
+\
+tr.optionalunsupported {\
+    color:blue;\
+}\
+\
+.ok {\
+    color:green;\
+}\
+\
+.error {\
+    color:red;\
+}\
+\
+.pass, .fail, .timeout, .notrun, .optionalunsupported .ok, .timeout, .error {\
+    font-variant:small-caps;\
+}\
+\
+table#results span {\
+    display:block;\
+}\
+\
+table#results span.expected {\
+    font-family:DejaVu Sans Mono, Bitstream Vera Sans Mono, Monospace;\
+    white-space:pre;\
+}\
+\
+table#results span.actual {\
+    font-family:DejaVu Sans Mono, Bitstream Vera Sans Mono, Monospace;\
+    white-space:pre;\
+}\
+";
+
+})(self);
+// vim: set expandtab shiftwidth=4 tabstop=4:

--- a/Jint.Tests/Wpt/Vendor/resources/testharness.js.headers
+++ b/Jint.Tests/Wpt/Vendor/resources/testharness.js.headers
@@ -1,0 +1,2 @@
+Content-Type: text/javascript; charset=utf-8
+Cache-Control: max-age=3600

--- a/Jint.Tests/Wpt/WptCorpus.cs
+++ b/Jint.Tests/Wpt/WptCorpus.cs
@@ -23,6 +23,7 @@ internal static class WptCorpus
 {
     private const string ResourcePrefix = "wpt/";
     private const string PreludeResourceName = "wpt-prelude/testharness-shim.js";
+    private const string HarnessReportResourceName = "wpt-prelude/testharnessreport.js";
 
     private static readonly FrozenDictionary<string, string> _resourceNames = BuildResourceIndex();
 
@@ -33,16 +34,64 @@ internal static class WptCorpus
     internal static string Prelude { get; } = ReadResource(PreludeResourceName);
 
     /// <summary>
+    /// The <c>resources/testharnessreport.js</c> the server answers with, which is Jint's own file rather
+    /// than a vendored one: it is the slot the browser lane overlays to get results out of a page.
+    /// </summary>
+    internal static string HarnessReport { get; } = ReadResource(HarnessReportResourceName);
+
+    /// <summary>
+    /// The two roots of the wpt tree that hold helpers rather than tests: <c>resources/</c>, which is the
+    /// harness itself, and <c>common/</c>, which is what every standard's suites share.
+    /// </summary>
+    /// <remarks>
+    /// Neither is ever a suite. A directory becomes a suite by being named in one of
+    /// <c>WptTestRunner</c>'s suite arrays and reached by a <c>[TestCaseSource]</c>, and these two hold no
+    /// <c>.any.js</c> at all — but "holds none today" is a property of the corpus rather than a rule, and a
+    /// re-vendor that brought one in would otherwise turn the harness's own source into a test case with no
+    /// subject. So <see cref="TestFiles"/> refuses to be asked about them and
+    /// <c>WptTestRunner.EveryVendoredFileIsAccountedFor</c> fails if one ever holds a <c>.any.js</c>.
+    /// </remarks>
+    internal static readonly string[] SharedDirectories = ["common", "resources"];
+
+    /// <summary>
     /// Every vendored path, normalised to forward slashes: <c>url/url-constructor.any.js</c>,
     /// <c>encoding/resources/encodings.js</c>, and so on.
     /// </summary>
     internal static IEnumerable<string> Paths => _resourceNames.Keys;
 
     /// <summary>
+    /// Whether <paramref name="path"/> lives under one of the <see cref="SharedDirectories"/>.
+    /// </summary>
+    internal static bool IsShared(string path)
+    {
+        foreach (var shared in SharedDirectories)
+        {
+            if (path.Length > shared.Length
+                && path.StartsWith(shared, StringComparison.Ordinal)
+                && path[shared.Length] == '/')
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// The <c>.any.js</c> files of one suite directory, ordered by path so the theory's cases are stable.
     /// </summary>
     internal static IReadOnlyList<string> TestFiles(string suite)
     {
+        foreach (var shared in SharedDirectories)
+        {
+            if (string.Equals(suite, shared, StringComparison.Ordinal)
+                || suite.StartsWith(shared + "/", StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"\"{suite}\" is a shared helper directory of the wpt tree, not a suite — see WptCorpus.SharedDirectories.");
+            }
+        }
+
         var prefix = suite + "/";
         var files = new List<string>();
         foreach (var path in _resourceNames.Keys)
@@ -77,6 +126,13 @@ internal static class WptCorpus
 
         return ReadResource(resourceName);
     }
+
+    /// <summary>
+    /// Reads a vendored file, or answers <see langword="null"/> when the corpus does not hold it — which is
+    /// what a <c>.headers</c> sidecar lookup needs, since most files have none.
+    /// </summary>
+    internal static string? TryRead(string path)
+        => _resourceNames.TryGetValue(path, out var resourceName) ? ReadResource(resourceName) : null;
 
     /// <summary>
     /// Resolves a reference made from inside <paramref name="fromDirectory"/> — a <c>// META: script=</c>

--- a/Jint.Tests/Wpt/WptCorpusTests.cs
+++ b/Jint.Tests/Wpt/WptCorpusTests.cs
@@ -26,6 +26,40 @@ public class WptCorpusTests
     public void AReferenceResolvesToAPathInTheTree(string directory, string reference, string expected)
         => WptCorpus.ResolveReference(directory, reference).Should().Be(expected);
 
+    /// <summary>
+    /// <c>resources/</c> and <c>common/</c> are helpers, never suites — asking for their test files is a
+    /// mistake loud enough to throw rather than an empty list.
+    /// </summary>
+    /// <remarks>
+    /// The empty list is what makes this worth pinning. Before the harness files were vendored the two
+    /// directories held four helper scripts between them and <see cref="WptCorpus.TestFiles"/> answered
+    /// nothing for either, so a suite array that named one would have been green and empty — which is the
+    /// exact shape of failure the inventory check exists to catch everywhere else. Now that
+    /// <c>resources/testharness.js</c> is in the tree the mistake would be worse, not better: the harness
+    /// would become a test case with no subject.
+    /// </remarks>
+    [TestCase("resources")]
+    [TestCase("common")]
+    [TestCase("common/dispatcher")]
+    public void ASharedHelperDirectoryIsNeverASuite(string directory)
+    {
+        Invoking(() => WptCorpus.TestFiles(directory))
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage("*shared helper directory*");
+
+        WptCorpus.IsShared(directory + "/anything.js").Should().BeTrue();
+    }
+
+    /// <summary>And a suite whose name merely starts with those letters is not one of them.</summary>
+    [TestCase("url")]
+    [TestCase("commonwealth")]
+    [TestCase("fetch/api/resources")]
+    public void ADirectoryThatOnlyLooksSharedIsNot(string directory)
+    {
+        Invoking(() => WptCorpus.TestFiles(directory)).Should().NotThrow();
+        WptCorpus.IsShared(directory + "/anything.js").Should().BeFalse();
+    }
+
     [Test]
     public void AReferenceCannotClimbOutOfTheVendoredTree()
     {

--- a/Jint.Tests/Wpt/WptServer.cs
+++ b/Jint.Tests/Wpt/WptServer.cs
@@ -30,6 +30,13 @@ namespace Jint.Tests.Wpt;
 /// changes, and the only divergence is the handlers, which are documented one by one on the methods below.
 /// </para>
 /// <para>
+/// <b>There are two halves, and this file is one of them.</b> Everything here answers a named <c>.py</c>
+/// file; <see cref="WptServerFiles"/> is what applies to <i>every</i> file — the content-type table, the
+/// <c>.headers</c> sidecars, the <c>.sub.</c> template language. The split is what the two lanes need: an
+/// <c>.any.js</c> file is handed to an engine directly and only ever asks this server for a <c>fetch</c>,
+/// while a <c>.html</c> test is <i>loaded</i> from it and so meets all of the second half at once.
+/// </para>
+/// <para>
 /// <b>Why a raw <see cref="TcpListener"/> rather than <c>HttpListener</c> or Kestrel.</b> Three reasons, and
 /// each of them is a property the suites actually need. It binds port <b>0</b> and is told which port it got,
 /// so a run can never collide with anything else on the machine — <c>HttpListener</c> takes a URL prefix and
@@ -67,8 +74,24 @@ internal sealed class WptServer : IDisposable
     /// </summary>
     private readonly ConcurrentDictionary<string, int> _stash = new(StringComparer.Ordinal);
 
-    private WptServer()
+    /// <summary>
+    /// What <c>/resources/testharnessreport.js</c> answers with. It is Jint's own file rather than a
+    /// vendored one — see <c>Prelude/testharnessreport.js</c> for why — and it is a constructor parameter so
+    /// that the browser lane can overlay it per server without a vendored file changing.
+    /// </summary>
+    private readonly string _harnessReport;
+
+    /// <summary>
+    /// Starts a server on an ephemeral loopback port.
+    /// </summary>
+    /// <param name="harnessReportOverlay">
+    /// What to answer <c>/resources/testharnessreport.js</c> with, or <see langword="null"/> for the stub in
+    /// <c>Prelude/</c>. The browser lane passes the script that posts a page's results back to its driver;
+    /// upstream's own file exists to be replaced exactly this way.
+    /// </param>
+    internal WptServer(string? harnessReportOverlay = null)
     {
+        _harnessReport = harnessReportOverlay ?? WptCorpus.HarnessReport;
         _listener = new TcpListener(IPAddress.Loopback, 0);
         _listener.Start();
         Port = ((IPEndPoint) _listener.LocalEndpoint).Port;
@@ -212,8 +235,22 @@ internal sealed class WptServer : IDisposable
         // absolute path, and upstream keeps the same handler in both places.
         "fetch/api/resources/bad-chunk-encoding.py" => BadChunkEncoding(stream, request, token),
 
+        // The one harness file that does not come out of Vendor/. Upstream's is a stub whose whole purpose
+        // is to be replaced by whoever is running the tests, so vendoring it would put bytes in the tree
+        // that the server never sends; Jint's copy lives in Prelude/ beside the shim, and a caller can pass
+        // an overlay per server. Answered here rather than in the static path because there is no corpus
+        // entry to find.
+        "resources/testharnessreport.js" => WriteAsync(stream, HarnessReport(), request, token),
+
         _ => StaticAsync(stream, request, token),
     };
+
+    /// <summary>
+    /// <c>resources/testharnessreport.js</c>, with the content type upstream's own
+    /// <c>testharnessreport.js.headers</c> sidecar gives it.
+    /// </summary>
+    private WptServerResponse HarnessReport()
+        => new(200, "OK", [("Content-Type", "text/javascript; charset=utf-8")], Encoding.UTF8.GetBytes(_harnessReport));
 
     // ------------------------------------------------------------------ handlers
 
@@ -536,7 +573,7 @@ internal sealed class WptServer : IDisposable
     /// <see cref="WriteAsync"/> at all — that method frames a response, and this one <i>is</i> the
     /// framing.
     /// </remarks>
-    private static Task StaticAsync(Stream stream, WptServerRequest request, CancellationToken token)
+    private Task StaticAsync(Stream stream, WptServerRequest request, CancellationToken token)
     {
         if (request.Path.EndsWith(".asis", StringComparison.Ordinal) && WptCorpus.Contains(request.Path))
         {
@@ -558,28 +595,114 @@ internal sealed class WptServer : IDisposable
             return WriteRawAsync(stream, raw.Replace("\n", "\r\n", StringComparison.Ordinal), token);
         }
 
-        return WriteAsync(stream, StaticFile(request), request, token);
+        WptServerResponse response;
+        try
+        {
+            response = StaticFile(request, Port);
+        }
+        catch (WptServerFileException e)
+        {
+            // wptserve turns a raise inside a pipe into a 500, and so does this. The alternative — serving
+            // the file with its placeholders intact, or with a pipe silently skipped — fails a test
+            // somewhere far away from the cause, which is the failure mode this whole port exists to avoid.
+            response = new WptServerResponse(500, "Internal Server Error",
+                [("content-type", "text/plain")], Bytes(e.Message));
+        }
+
+        return WriteAsync(stream, response, request, token);
     }
 
-    private static WptServerResponse StaticFile(WptServerRequest request)
+    /// <summary>
+    /// wptserve's <c>FileHandler</c>: the file's bytes, the headers its <c>.headers</c> sidecars ask for,
+    /// and the <c>sub</c> pipe where the name or the query calls for it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The query and the fragment take no part in finding the file — <c>filesystem_path</c> reads
+    /// <c>url_parts.path</c> alone — which is what lets <c>?pipe=</c> and <c>{{GET[…]}}</c> exist at all,
+    /// and it is why <see cref="WptServerRequest.Path"/> is already stripped of both.
+    /// </para>
+    /// <para>
+    /// A path the corpus does not hold is a 404 rather than a CLR exception, because unlike the shim's
+    /// resource reader this one is answering a request the corpus itself composed, and several suites fetch
+    /// a URL precisely to see it fail.
+    /// </para>
+    /// </remarks>
+    private static WptServerResponse StaticFile(WptServerRequest request, int port)
     {
         if (!WptCorpus.Contains(request.Path))
         {
             return new WptServerResponse(404, "Not Found", [("content-type", "text/plain")], []);
         }
 
-        var extension = request.Path.AsSpan(request.Path.LastIndexOf('.') + 1);
-        var type = extension switch
-        {
-            "js" => "text/javascript",
-            "json" => "application/json",
-            "html" => "text/html",
-            _ => "text/plain",
-        };
+        var context = new WptSubstitutionContext(port, request);
+        var headers = WptServerFiles.LoadHeaders(request.Path, context, WptCorpus.TryRead);
 
-        // The corpus is held as text, so its bytes are the UTF-8 of that text — which is how it was vendored.
-        return new WptServerResponse(200, "OK", [("content-type", type)],
-            Encoding.UTF8.GetBytes(WptCorpus.Read(request.Path)));
+        // The corpus is held as text, so its bytes are the UTF-8 of that text — which is how it was
+        // vendored, and why nothing binary is in the tree.
+        var content = WptCorpus.Read(request.Path);
+
+        if (WptServerFiles.WantsSubstitution(request.Path))
+        {
+            content = WptServerFiles.Substitute(context, content, WptServerFiles.EscapesAsHtml(request.Path));
+        }
+
+        content = ApplyQueryPipes(request, context, content);
+
+        return new WptServerResponse(200, "OK", headers, Encoding.UTF8.GetBytes(content));
+    }
+
+    /// <summary>
+    /// The <c>?pipe=</c> half of <c>wrap_pipeline</c>, of which one pipe is implemented and every other one
+    /// is refused out loud.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// wptserve has fourteen pipes: <c>status</c>, <c>header</c>, <c>slice</c>, <c>trickle</c>, <c>sub</c>,
+    /// <c>gzip</c> and the rest. Implementing them on demand is right; implementing <i>none</i> of them and
+    /// ignoring the query is not, because a file that asks for <c>?pipe=status(404)</c> and gets a 200 fails
+    /// an assertion about the engine instead of reporting that the server does not do that yet. So an
+    /// unknown pipe is a 500 naming itself, which is the same shape as an unknown substitution.
+    /// </para>
+    /// <para>
+    /// Nothing in the vendored corpus passes <c>?pipe=</c> today. This exists because the browser lane's
+    /// suites do, and because the decision of what happens when they do should not be made by whichever
+    /// file gets there first.
+    /// </para>
+    /// </remarks>
+    private static string ApplyQueryPipes(WptServerRequest request, in WptSubstitutionContext context, string content)
+    {
+        if (!request.TryGetLastQuery("pipe", out var pipes) || pipes.Length == 0)
+        {
+            return content;
+        }
+
+        foreach (var pipe in pipes.Split('|'))
+        {
+            var open = pipe.IndexOf('(');
+            var name = (open < 0 ? pipe : pipe.Substring(0, open)).Trim();
+            var arguments = open < 0
+                ? ""
+                : pipe.Substring(open + 1).TrimEnd().TrimEnd(')');
+
+            if (!string.Equals(name, "sub", StringComparison.Ordinal))
+            {
+                throw new WptServerFileException(
+                    $"the wptserve pipe \"{name}\" is not implemented by this server; see WptServer.ApplyQueryPipes");
+            }
+
+            var escaping = arguments.Trim();
+            var escapeAsHtml = escaping switch
+            {
+                "" or "html" => true,
+                "none" => false,
+                _ => throw new WptServerFileException($"\"{escaping}\" is not an escape type the sub pipe takes"),
+            };
+
+            content = WptServerFiles.Substitute(context, content, escapeAsHtml);
+        }
+
+        return content;
     }
 
     // ------------------------------------------------------------------ wire
@@ -701,8 +824,20 @@ internal sealed class WptServerRequest
 
     internal string Method { get; }
 
-    /// <summary>The request target with its leading slash and its query removed: <c>fetch/api/resources/top.txt</c>.</summary>
+    /// <summary>
+    /// The request target with its leading slash and its query removed, percent-decoded:
+    /// <c>fetch/api/resources/top.txt</c>. This is the key the corpus is looked up by, which is why it is
+    /// decoded — <c>filesystem_path</c> unquotes before it joins the document root, so
+    /// <c>/common/blank%2Ehtml</c> is the same file as <c>/common/blank.html</c>.
+    /// </summary>
     internal string Path { get; }
+
+    /// <summary>
+    /// The path component of the request target exactly as it arrived — leading slash, percent-escapes and
+    /// all. wptserve's <c>request.url_parts.path</c>, which is what <c>{{location[path]}}</c> substitutes
+    /// and which <see cref="Path"/> is the decoded form of.
+    /// </summary>
+    internal string RawPath { get; private set; } = "/";
 
     internal IReadOnlyDictionary<string, string> Query { get; }
 
@@ -736,6 +871,28 @@ internal sealed class WptServerRequest
     /// none — wptserve's <c>request.url_parts.query</c>.
     /// </summary>
     internal string RawQuery { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// The <b>last</b> value given for a query parameter, which is what <c>wrap_pipeline</c> reads
+    /// <c>?pipe=</c> with (<c>query["pipe"][-1]</c>) — the one place upstream deliberately does not take the
+    /// first.
+    /// </summary>
+    internal bool TryGetLastQuery(string name, out string value)
+    {
+        value = "";
+        var found = false;
+
+        foreach (var (candidate, candidateValue) in _queryPairs)
+        {
+            if (string.Equals(candidate, name, StringComparison.Ordinal))
+            {
+                value = candidateValue;
+                found = true;
+            }
+        }
+
+        return found;
+    }
 
     /// <summary>
     /// wptserve's <c>request.POST</c>, reduced to the two forms the corpus posts: an urlencoded body and
@@ -935,12 +1092,24 @@ internal sealed class WptServerRequest
 
         var body = await ReadBodyAsync(stream, headers, token).ConfigureAwait(false);
 
+        // A fragment never reaches a server — a client strips it before it writes the request line — so
+        // this is defence rather than a rule of HTTP. It is here because the browser lane composes its own
+        // URLs and a "#frag" that leaked through would look like a file the corpus does not hold, which is
+        // a 404 several layers away from the mistake.
+        var hash = target.IndexOf('#');
+        if (hash >= 0)
+        {
+            target = target.Substring(0, hash);
+        }
+
         var question = target.IndexOf('?');
-        var path = (question < 0 ? target : target.Substring(0, question)).TrimStart('/');
+        var rawPath = question < 0 ? target : target.Substring(0, question);
+        var path = DecodePath(rawPath.TrimStart('/'));
         var queryPairs = ParseQuery(question < 0 ? "" : target.Substring(question + 1));
 
         return new WptServerRequest(method, path, queryPairs, headers, body)
         {
+            RawPath = rawPath.Length == 0 ? "/" : rawPath,
             RawQuery = question < 0 ? string.Empty : target.Substring(question + 1),
         };
     }
@@ -1098,6 +1267,41 @@ internal sealed class WptServerRequest
         }
 
         return decoded.ToString();
+    }
+
+    /// <summary>
+    /// Percent-decoding for the <i>path</i>, which is a different job from <see cref="Decode"/> in two ways
+    /// and both matter. A <c>+</c> is a plus and not a space — that rule belongs to the query string's
+    /// urlencoded form and to nothing else — and the decoded bytes are text rather than a byte string,
+    /// because what they become is a key into the corpus and the corpus is keyed by UTF-8 paths.
+    /// </summary>
+    private static string DecodePath(string value)
+    {
+        if (value.IndexOf('%') < 0)
+        {
+            return value;
+        }
+
+        var bytes = new List<byte>(value.Length);
+
+        for (var i = 0; i < value.Length; i++)
+        {
+            var c = value[i];
+
+            if (c == '%' && i + 2 < value.Length
+                && Uri.IsHexDigit(value[i + 1]) && Uri.IsHexDigit(value[i + 2]))
+            {
+                bytes.Add((byte) int.Parse(value.AsSpan(i + 1, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture));
+                i += 2;
+            }
+            else
+            {
+                // The request line arrived as Latin-1, one char to one byte, so this is that byte back.
+                bytes.Add((byte) c);
+            }
+        }
+
+        return Encoding.UTF8.GetString(bytes.ToArray());
     }
 }
 

--- a/Jint.Tests/Wpt/WptServerFiles.cs
+++ b/Jint.Tests/Wpt/WptServerFiles.cs
@@ -1,0 +1,660 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using System.Collections.Frozen;
+using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Jint.Tests.Wpt;
+
+/// <summary>
+/// The static-file half of <see cref="WptServer"/>: the content-type guess, the <c>.headers</c> sidecars and
+/// the <c>.sub.</c> template language, ported from <c>tools/wptserve/wptserve/</c> at the pinned commit.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why this is separate from the handlers.</b> Everything in <see cref="WptServer"/> answers one named
+/// <c>.py</c> file; everything here applies to <i>every</i> file the server serves, which is what the browser
+/// lane needs and what the <c>.any.js</c> lane never asked for. Its three pieces are
+/// <c>handlers.py</c>'s <c>guess_content_type</c> and <c>load_headers</c>, and <c>pipes.py</c>'s
+/// <c>template</c>, and each is held to that source by a test in <c>WptServerTests</c> in the same way the
+/// handler ports are.
+/// </para>
+/// <para>
+/// <b>There is exactly one origin, and that is the whole of what this cannot reproduce.</b> wptserve runs on
+/// two http ports and two https ports across several hostnames — <c>{{host}}</c>, <c>{{domains[www1]}}</c>,
+/// <c>{{hosts[alt][]}}</c> — because a large part of the corpus is about what happens <i>between</i> origins.
+/// <see cref="WptServer"/> is one <c>TcpListener</c> on one loopback port with no TLS, so every host token
+/// answers <see cref="LoopbackHost"/> and every port token answers that one port. A file whose subject is a
+/// second origin therefore reads as same-origin here, which makes it un-runnable rather than merely
+/// different: it belongs in the exclusion table or the not-vendored table when a lane brings it in, and never
+/// in a green run. Substitution is still faithful for the many files that only want <i>an</i> origin —
+/// <c>common/get-host-info.sub.js</c>, which 68 files in the browser lane's suites include, is the reason
+/// this exists at all.
+/// </para>
+/// <para>
+/// <b>Nothing here is reachable from the <c>.any.js</c> lane.</b> No vendored file was a <c>.sub.</c> file, had
+/// a <c>.headers</c> sidecar or asked for a <c>?pipe=</c> before this change, so the only behaviour the
+/// existing corpus can see is the content-type table — which used to be four extensions with
+/// <c>text/plain</c> underneath and is now wptserve's own, with <c>application/octet-stream</c> underneath.
+/// </para>
+/// </remarks>
+internal static class WptServerFiles
+{
+    /// <summary>
+    /// The one host every host-shaped substitution answers. It is the address
+    /// <see cref="WptServer"/> binds, so a substituted URL really does reach the server.
+    /// </summary>
+    internal const string LoopbackHost = "127.0.0.1";
+
+    /// <summary>
+    /// <c>tools/wptserve/wptserve/constants.py</c>'s <c>content_types</c>, inverted the way
+    /// <c>utils.invert_dict</c> inverts it: extension to media type.
+    /// </summary>
+    /// <remarks>
+    /// Reproduced entire rather than trimmed to what is vendored, because the table is the artefact a
+    /// corpus bump can change and a trimmed copy would silently stop being a copy. Nothing binary is
+    /// vendored — see <c>Jint.Tests.csproj</c> — so the image, audio and video rows are here to be checked
+    /// against upstream, not to be served.
+    /// </remarks>
+    private static readonly FrozenDictionary<string, string> _contentTypes = new Dictionary<string, string>(StringComparer.Ordinal)
+    {
+        ["json"] = "application/json",
+        ["wasm"] = "application/wasm",
+        ["xht"] = "application/xhtml+xml",
+        ["xhtm"] = "application/xhtml+xml",
+        ["xhtml"] = "application/xhtml+xml",
+        ["xml"] = "application/xml",
+        ["xpi"] = "application/x-xpinstall",
+        ["m4a"] = "audio/mp4",
+        ["mp3"] = "audio/mpeg",
+        ["oga"] = "audio/ogg",
+        ["weba"] = "audio/webm",
+        ["wav"] = "audio/x-wav",
+        ["avif"] = "image/avif",
+        ["bmp"] = "image/bmp",
+        ["gif"] = "image/gif",
+        ["jpg"] = "image/jpeg",
+        ["jpeg"] = "image/jpeg",
+        ["jxl"] = "image/jxl",
+        ["png"] = "image/png",
+        ["svg"] = "image/svg+xml",
+        ["manifest"] = "text/cache-manifest",
+        ["css"] = "text/css",
+        ["event_stream"] = "text/event-stream",
+        ["htm"] = "text/html",
+        ["html"] = "text/html",
+        ["js"] = "text/javascript",
+        ["mjs"] = "text/javascript",
+        ["txt"] = "text/plain",
+        ["md"] = "text/plain",
+        ["vtt"] = "text/vtt",
+        ["mp4"] = "video/mp4",
+        ["m4v"] = "video/mp4",
+        ["webm"] = "video/webm",
+    }.ToFrozenDictionary(StringComparer.Ordinal);
+
+    /// <summary>What <c>guess_content_type</c> answers when the extension is not in the table.</summary>
+    internal const string DefaultContentType = "application/octet-stream";
+
+    /// <summary>
+    /// The extensions <c>wrap_pipeline</c> calls markup, and so escapes substituted values for.
+    /// </summary>
+    private static readonly string[] _markupExtensions = [".html", ".htm", ".xht", ".xhtml", ".xml", ".svg"];
+
+    private static readonly Regex _template = new(@"\{\{([^}]*)\}\}", RegexOptions.Compiled);
+
+    /// <summary>
+    /// <c>handlers.py</c>'s <c>guess_content_type</c>: the media type for a path's extension, or
+    /// <see cref="DefaultContentType"/>.
+    /// </summary>
+    /// <remarks>
+    /// Case-sensitive, as upstream's dictionary lookup is, and over the <i>last</i> extension only — so
+    /// <c>get-host-info.sub.js</c> is a <c>.js</c> and <c>a.tar.gz</c> would be neither a <c>.tar</c> nor a
+    /// known type.
+    /// </remarks>
+    internal static string GuessContentType(string path)
+    {
+        var extension = ExtensionOf(path);
+        return extension.Length > 0 && _contentTypes.TryGetValue(extension, out var type)
+            ? type
+            : DefaultContentType;
+    }
+
+    /// <summary>
+    /// Whether <c>wrap_pipeline</c> would apply the <c>sub</c> pipe to this path: <c>.sub.</c> anywhere in
+    /// it, which is how <c>get-host-info.sub.js</c> and every <c>.sub.html</c> ask for substitution.
+    /// </summary>
+    internal static bool WantsSubstitution(string path) => path.Contains(".sub.", StringComparison.Ordinal);
+
+    /// <summary>
+    /// The escaping <c>wrap_pipeline</c> chooses for a path: HTML for a markup extension, none otherwise.
+    /// </summary>
+    internal static bool EscapesAsHtml(string path)
+    {
+        var extension = ExtensionOf(path);
+        foreach (var markup in _markupExtensions)
+        {
+            if (string.Equals("." + extension, markup, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// <c>handlers.py</c>'s <c>load_headers</c> followed by <c>FileHandler.get_headers</c>: the
+    /// directory-level sidecar's lines, then the file's own, and a guessed <c>Content-Type</c> in front of
+    /// both only if neither named one.
+    /// </summary>
+    /// <param name="path">The path in the tree whose headers are wanted.</param>
+    /// <param name="context">What a <c>.sub.headers</c> sidecar substitutes against.</param>
+    /// <param name="read">Reads a sidecar, or answers <see langword="null"/> when there is none.</param>
+    /// <remarks>
+    /// <para>
+    /// Two details are upstream's and are easy to get wrong. The <c>.sub.headers</c> spelling <b>wins over</b>
+    /// the plain one for the same base name rather than adding to it, and it is substituted with escaping
+    /// <i>off</i> — a header value is not markup. And the guess is inserted at the front, not appended, so a
+    /// sidecar that names anything at all still leaves <c>Content-Type</c> first.
+    /// </para>
+    /// <para>
+    /// Duplicates are kept: <c>load_headers</c> returns a list and <c>ResponseHeaders.update</c> appends each
+    /// pair, so two <c>Set-Cookie</c> lines are two response headers. What <c>update</c> also does is group
+    /// them — a repeated name keeps the position of its <i>first</i> appearance and collects its values there
+    /// — which is what <see cref="Group"/> reproduces.
+    /// </para>
+    /// </remarks>
+    internal static List<(string Name, string Value)> LoadHeaders(
+        string path,
+        in WptSubstitutionContext context,
+        Func<string, string?> read)
+    {
+        var headers = new List<(string Name, string Value)>();
+
+        var directory = WptCorpus.DirectoryOf(path);
+        Load(headers, directory.Length == 0 ? "__dir__" : directory + "/__dir__", context, read);
+        Load(headers, path, context, read);
+
+        var hasContentType = false;
+        foreach (var (name, _) in headers)
+        {
+            if (string.Equals(name, "content-type", StringComparison.OrdinalIgnoreCase))
+            {
+                hasContentType = true;
+                break;
+            }
+        }
+
+        if (!hasContentType)
+        {
+            headers.Insert(0, ("Content-Type", GuessContentType(path)));
+        }
+
+        headers.RemoveAll(static header => IsFraming(header.Name));
+
+        return Group(headers);
+
+        static void Load(
+            List<(string Name, string Value)> into,
+            string basePath,
+            in WptSubstitutionContext context,
+            Func<string, string?> read)
+        {
+            var data = read(basePath + ".sub.headers");
+            if (data is not null)
+            {
+                data = Substitute(context, data, escapeAsHtml: false);
+            }
+            else
+            {
+                data = read(basePath + ".headers");
+                if (data is null)
+                {
+                    return;
+                }
+            }
+
+            foreach (var line in data.Split('\n'))
+            {
+                var trimmed = line.TrimEnd('\r');
+                if (trimmed.Length == 0)
+                {
+                    continue;
+                }
+
+                var colon = trimmed.IndexOf(':');
+                if (colon < 0)
+                {
+                    // Upstream builds a one-element tuple here and then crashes unpacking it, so a
+                    // colon-less line is a 500 there and nothing anybody writes on purpose. Skipping it is
+                    // the one place this port is deliberately kinder than its source.
+                    continue;
+                }
+
+                into.Add((trimmed.Substring(0, colon).Trim(), trimmed.Substring(colon + 1).Trim()));
+            }
+        }
+    }
+
+    /// <summary>
+    /// The three headers that are this server's framing rather than the file's, and which a sidecar
+    /// therefore cannot set.
+    /// </summary>
+    /// <remarks>
+    /// Every response here is delimited by its own close and writes its own <c>Content-Length</c> and
+    /// <c>Connection</c>, so a sidecar naming one would put two of it on the wire and a client would read
+    /// the wrong body length or leave the socket open. wptserve has the same headers under its own control
+    /// and simply serves from a real socket per response; here the honest answer is to drop them and say so.
+    /// A vendored file whose whole subject <i>is</i> a wrong <c>Content-Length</c> uses <c>.asis</c>
+    /// instead, which bypasses all of this and puts the response on the wire byte for byte — that is what
+    /// the six the xhr corpus vendors are for.
+    /// </remarks>
+    private static bool IsFraming(string name)
+        => string.Equals(name, "Content-Length", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(name, "Connection", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(name, "Transfer-Encoding", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// <c>ResponseHeaders.update</c>'s ordering: a name keeps the position of its first appearance and every
+    /// value for it follows there, whatever order the lines arrived in.
+    /// </summary>
+    internal static List<(string Name, string Value)> Group(List<(string Name, string Value)> headers)
+    {
+        var order = new List<string>();
+        var grouped = new Dictionary<string, List<(string Name, string Value)>>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var header in headers)
+        {
+            if (!grouped.TryGetValue(header.Name, out var values))
+            {
+                values = [];
+                grouped[header.Name] = values;
+                order.Add(header.Name);
+            }
+
+            values.Add(header);
+        }
+
+        var result = new List<(string Name, string Value)>(headers.Count);
+        foreach (var name in order)
+        {
+            result.AddRange(grouped[name]);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// <c>pipes.py</c>'s <c>template</c>: every <c>{{…}}</c> in <paramref name="content"/> replaced by what
+    /// this server can say about itself and about the request.
+    /// </summary>
+    /// <exception cref="WptServerFileException">
+    /// For anything upstream raises on — an undefined variable, a token where an identifier was expected, an
+    /// index into something that has none. Upstream turns such a raise into a 500 and so does
+    /// <see cref="WptServer"/>: a placeholder that silently stayed a placeholder would reach script as a
+    /// literal <c>{{host}}</c> and fail the test somewhere else entirely.
+    /// </exception>
+    internal static string Substitute(in WptSubstitutionContext context, string content, bool escapeAsHtml)
+    {
+        var variables = new Dictionary<string, string>(StringComparer.Ordinal);
+        var local = context;
+
+        return _template.Replace(content, match =>
+        {
+            var value = Resolve(local, match.Groups[1].Value, variables);
+            return escapeAsHtml ? EscapeHtml(value) : value;
+        });
+    }
+
+    /// <summary>
+    /// One <c>{{…}}</c>, resolved the way <c>config_replacement</c> resolves it: an optional
+    /// <c>$name:</c> assignment prefix, then an identifier, then any number of index and argument tokens.
+    /// </summary>
+    private static string Resolve(in WptSubstitutionContext context, string body, Dictionary<string, string> variables)
+    {
+        var tokens = Tokenize(body);
+        if (tokens.Count == 0)
+        {
+            throw new WptServerFileException($"nothing to substitute in \"{{{{{body}}}}}\"");
+        }
+
+        var next = 0;
+        string? assignTo = null;
+        if (tokens[0].Kind == WptTemplateTokenKind.Variable)
+        {
+            assignTo = tokens[0].Text;
+            next++;
+        }
+
+        if (next >= tokens.Count || tokens[next].Kind != WptTemplateTokenKind.Identifier)
+        {
+            throw new WptServerFileException($"expected an identifier in \"{{{{{body}}}}}\"");
+        }
+
+        var identifier = tokens[next].Text;
+        next++;
+
+        var value = variables.TryGetValue(identifier, out var assigned)
+            ? Indexed(assigned, identifier, tokens, ref next, body)
+            : ResolveIdentifier(context, identifier, tokens, ref next, body);
+
+        if (next != tokens.Count)
+        {
+            throw new WptServerFileException($"unexpected trailing token in \"{{{{{body}}}}}\"");
+        }
+
+        if (assignTo is not null)
+        {
+            variables[assignTo] = value;
+        }
+
+        return value;
+    }
+
+    private static string ResolveIdentifier(
+        in WptSubstitutionContext context,
+        string identifier,
+        List<WptTemplateToken> tokens,
+        ref int next,
+        string body)
+    {
+        switch (identifier)
+        {
+            // SubFunctions.uuid: a fresh UUID per call, which is what a stash key is made of.
+            case "uuid":
+                RequireArguments(tokens, ref next, 0, body);
+                return Guid.NewGuid().ToString();
+
+            // SubFunctions.header_or_default(name, default).
+            case "header_or_default":
+            {
+                var arguments = RequireArguments(tokens, ref next, 2, body);
+                return context.Request is not null && context.Request.TryGetHeader(arguments[0], out var header)
+                    ? header
+                    : arguments[1];
+            }
+
+            // request.headers, indexed by name. Upstream's dictionary raises KeyError for a name the request
+            // did not send, which wptserve reports as a 500; the same is loud here.
+            case "headers":
+            {
+                var name = RequireIndex(tokens, ref next, body);
+                if (context.Request is null || !context.Request.TryGetHeader(name, out var value))
+                {
+                    throw new WptServerFileException($"the request has no \"{name}\" header, asked for by \"{{{{{body}}}}}\"");
+                }
+
+                return value;
+            }
+
+            // FirstWrapper(request.GET): the first value for a name, and the empty string for a name that
+            // was not passed at all — which is the one lookup here that deliberately does not raise.
+            case "GET":
+            {
+                var name = RequireIndex(tokens, ref next, body);
+                return context.Request is not null && context.Request.Query.TryGetValue(name, out var value) ? value : "";
+            }
+
+            // config.all_domains — {alternate host: {subdomain: host}} — and all_domains[""] under it. There
+            // is one host here, so every spelling answers it; see the class remarks for what that costs.
+            case "hosts":
+                RequireIndex(tokens, ref next, body);
+                RequireIndex(tokens, ref next, body);
+                return LoopbackHost;
+
+            case "domains":
+                RequireIndex(tokens, ref next, body);
+                return LoopbackHost;
+
+            case "host":
+            case "browser_host":
+            case "server_host":
+                return LoopbackHost;
+
+            // config["ports"]: {protocol: [port, …]}. One listener, no TLS and no WebSocket origin, so every
+            // protocol and every index answer the one port. A file that wants two distinct ports gets two
+            // identical ones, which is a divergence a lane records rather than a substitution that fails.
+            case "ports":
+                RequireIndex(tokens, ref next, body);
+                RequireIndex(tokens, ref next, body);
+                return context.Port.ToString(CultureInfo.InvariantCulture);
+
+            case "url_base":
+                return "/";
+
+            // The parts of the request URL, undecoded, exactly as urlsplit hands them over.
+            case "location":
+            {
+                var key = RequireIndex(tokens, ref next, body);
+                var authority = LoopbackHost + ":" + context.Port.ToString(CultureInfo.InvariantCulture);
+                return key switch
+                {
+                    "server" => "http://" + authority,
+                    "scheme" => "http",
+                    "host" => authority,
+                    "hostname" => LoopbackHost,
+                    "port" => context.Port.ToString(CultureInfo.InvariantCulture),
+                    "path" or "pathname" => context.Request?.RawPath ?? "/",
+                    "query" => "?" + (context.Request?.RawQuery ?? ""),
+                    _ => throw new WptServerFileException($"\"{key}\" is not a part of the request URL, asked for by \"{{{{{body}}}}}\""),
+                };
+            }
+
+            default:
+                throw new WptServerFileException(
+                    $"undefined template variable \"{identifier}\" in \"{{{{{body}}}}}\"");
+        }
+    }
+
+    private static string Indexed(string value, string identifier, List<WptTemplateToken> tokens, ref int next, string body)
+    {
+        if (next < tokens.Count)
+        {
+            throw new WptServerFileException($"\"{identifier}\" is a string and cannot be indexed, in \"{{{{{body}}}}}\"");
+        }
+
+        return value;
+    }
+
+    private static string RequireIndex(List<WptTemplateToken> tokens, ref int next, string body)
+    {
+        if (next >= tokens.Count || tokens[next].Kind != WptTemplateTokenKind.Index)
+        {
+            throw new WptServerFileException($"expected an index in \"{{{{{body}}}}}\"");
+        }
+
+        return tokens[next++].Text;
+    }
+
+    private static string[] RequireArguments(List<WptTemplateToken> tokens, ref int next, int count, string body)
+    {
+        if (next >= tokens.Count || tokens[next].Kind != WptTemplateTokenKind.Arguments)
+        {
+            throw new WptServerFileException($"expected a call in \"{{{{{body}}}}}\"");
+        }
+
+        var arguments = tokens[next++].Arguments!;
+        if (arguments.Length != count)
+        {
+            throw new WptServerFileException(
+                $"expected {count.ToString(CultureInfo.InvariantCulture)} arguments in \"{{{{{body}}}}}\"");
+        }
+
+        return arguments;
+    }
+
+    /// <summary>
+    /// <c>ReplacementTokenizer</c>'s scanner, whose four patterns are tried in order at each position and
+    /// which stops — rather than skipping — at the first character none of them match.
+    /// </summary>
+    /// <remarks>
+    /// The stopping is the part worth reproducing. <c>{{ host }}</c> tokenizes to nothing at all upstream,
+    /// because a space matches no pattern, and the caller then fails on an empty token list; a tokenizer that
+    /// skipped whitespace would quietly accept a spelling wptserve rejects and let a corpus file be written
+    /// that only works here.
+    /// </remarks>
+    internal static List<WptTemplateToken> Tokenize(string body)
+    {
+        var tokens = new List<WptTemplateToken>();
+        var i = 0;
+
+        while (i < body.Length)
+        {
+            // \$\w+:
+            if (body[i] == '$')
+            {
+                var end = i + 1;
+                while (end < body.Length && IsWord(body[end]))
+                {
+                    end++;
+                }
+
+                if (end > i + 1 && end < body.Length && body[end] == ':')
+                {
+                    // Upstream's `var` keeps the dollar — it is `token[:-1]`, the colon and nothing else
+                    // removed — and its `ident` keeps it too, which is exactly why a later `{{$id}}` finds
+                    // what `{{$id:uuid()}}` stored.
+                    tokens.Add(new WptTemplateToken(WptTemplateTokenKind.Variable, body.Substring(i, end - i), null));
+                    i = end + 1;
+                    continue;
+                }
+            }
+
+            // \$?\w+
+            if (body[i] == '$' || IsWord(body[i]))
+            {
+                var end = body[i] == '$' ? i + 1 : i;
+                while (end < body.Length && IsWord(body[end]))
+                {
+                    end++;
+                }
+
+                if (end > i)
+                {
+                    // `ident` decodes the whole match, dollar included, so "$id" is the identifier "$id".
+                    tokens.Add(new WptTemplateToken(WptTemplateTokenKind.Identifier, body.Substring(i, end - i), null));
+                    i = end;
+                    continue;
+                }
+            }
+
+            // \[[^\]]*\]
+            if (body[i] == '[')
+            {
+                var close = body.IndexOf(']', i);
+                if (close >= 0)
+                {
+                    tokens.Add(new WptTemplateToken(WptTemplateTokenKind.Index, body.Substring(i + 1, close - i - 1), null));
+                    i = close + 1;
+                    continue;
+                }
+            }
+
+            // \([^)]*\)
+            if (body[i] == '(')
+            {
+                var close = body.IndexOf(')', i);
+                if (close >= 0)
+                {
+                    var inner = body.Substring(i + 1, close - i - 1);
+                    tokens.Add(new WptTemplateToken(WptTemplateTokenKind.Arguments, inner, SplitArguments(inner)));
+                    i = close + 1;
+                    continue;
+                }
+            }
+
+            break;
+        }
+
+        return tokens;
+    }
+
+    /// <summary><c>re.split(r",\s*", …)</c>, with the empty argument list an empty string produces.</summary>
+    private static string[] SplitArguments(string inner)
+    {
+        if (inner.Length == 0)
+        {
+            return [];
+        }
+
+        var arguments = new List<string>();
+        var start = 0;
+        for (var i = 0; i < inner.Length; i++)
+        {
+            if (inner[i] != ',')
+            {
+                continue;
+            }
+
+            arguments.Add(inner.Substring(start, i - start));
+            start = i + 1;
+            while (start < inner.Length && char.IsWhiteSpace(inner[start]))
+            {
+                start++;
+            }
+
+            i = start - 1;
+        }
+
+        arguments.Add(inner.Substring(start));
+        return arguments.ToArray();
+    }
+
+    /// <summary>
+    /// Python's <c>html.escape(x, quote=True)</c>: the three markup characters and both quotes, and
+    /// pointedly nothing else — <c>WebUtility.HtmlEncode</c> would also turn every non-ASCII character into a
+    /// numeric entity, which upstream does not.
+    /// </summary>
+    internal static string EscapeHtml(string value)
+    {
+        var builder = new StringBuilder(value.Length);
+        foreach (var c in value)
+        {
+            switch (c)
+            {
+                case '&': builder.Append("&amp;"); break;
+                case '<': builder.Append("&lt;"); break;
+                case '>': builder.Append("&gt;"); break;
+                case '"': builder.Append("&quot;"); break;
+                case '\'': builder.Append("&#x27;"); break;
+                default: builder.Append(c); break;
+            }
+        }
+
+        return builder.ToString();
+    }
+
+    private static string ExtensionOf(string path)
+    {
+        var slash = path.LastIndexOf('/');
+        var dot = path.LastIndexOf('.');
+        return dot > slash && dot >= 0 ? path.Substring(dot + 1) : "";
+    }
+
+    private static bool IsWord(char c) => char.IsAsciiLetterOrDigit(c) || c == '_';
+}
+
+/// <summary>What a <c>{{…}}</c> is resolved against: this server's port, and the request being answered.</summary>
+internal readonly record struct WptSubstitutionContext(int Port, WptServerRequest? Request);
+
+internal enum WptTemplateTokenKind
+{
+    Variable,
+    Identifier,
+    Index,
+    Arguments,
+}
+
+/// <summary>One token of a <c>{{…}}</c> body.</summary>
+internal readonly record struct WptTemplateToken(WptTemplateTokenKind Kind, string Text, string[]? Arguments);
+
+/// <summary>
+/// A request this server understands the shape of and cannot answer: an undefined substitution, a pipe it
+/// does not implement. It becomes a 500 with the message as its body, because the alternative — serving the
+/// file with its placeholders intact — fails the test somewhere far away from the cause.
+/// </summary>
+internal sealed class WptServerFileException(string message) : Exception(message);
+#endif

--- a/Jint.Tests/Wpt/WptServerTests.cs
+++ b/Jint.Tests/Wpt/WptServerTests.cs
@@ -1,8 +1,10 @@
 #if NET8_0_OR_GREATER
 #nullable enable
 
+using System.Globalization;
 using System.Net;
 using System.Net.Http;
+using System.Net.Sockets;
 using System.Text;
 
 namespace Jint.Tests.Wpt;
@@ -470,6 +472,516 @@ public class WptServerTests
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         (await response.Content.ReadAsStringAsync()).Should().NotBeEmpty();
+    }
+
+    // ================================================================ the static-file half
+
+    /// <summary>
+    /// <c>handlers.py</c>'s <c>guess_content_type</c> over <c>constants.py</c>'s <c>content_types</c>, one
+    /// case per extension the table names.
+    /// </summary>
+    /// <remarks>
+    /// The whole table, not the part the corpus exercises. Only a handful of these extensions are vendored —
+    /// nothing binary is, because <c>WptCorpus</c> hands every file back as a string — so the rows that
+    /// cannot be served are here precisely so that a corpus bump which changes one of them fails against
+    /// upstream's source rather than going unnoticed until a lane needs it.
+    /// </remarks>
+    [TestCase("x.json", "application/json")]
+    [TestCase("x.wasm", "application/wasm")]
+    [TestCase("x.xht", "application/xhtml+xml")]
+    [TestCase("x.xhtm", "application/xhtml+xml")]
+    [TestCase("x.xhtml", "application/xhtml+xml")]
+    [TestCase("x.xml", "application/xml")]
+    [TestCase("x.xpi", "application/x-xpinstall")]
+    [TestCase("x.m4a", "audio/mp4")]
+    [TestCase("x.mp3", "audio/mpeg")]
+    [TestCase("x.oga", "audio/ogg")]
+    [TestCase("x.weba", "audio/webm")]
+    [TestCase("x.wav", "audio/x-wav")]
+    [TestCase("x.avif", "image/avif")]
+    [TestCase("x.bmp", "image/bmp")]
+    [TestCase("x.gif", "image/gif")]
+    [TestCase("x.jpg", "image/jpeg")]
+    [TestCase("x.jpeg", "image/jpeg")]
+    [TestCase("x.jxl", "image/jxl")]
+    [TestCase("x.png", "image/png")]
+    [TestCase("x.svg", "image/svg+xml")]
+    [TestCase("x.manifest", "text/cache-manifest")]
+    [TestCase("x.css", "text/css")]
+    [TestCase("x.event_stream", "text/event-stream")]
+    [TestCase("x.htm", "text/html")]
+    [TestCase("x.html", "text/html")]
+    [TestCase("x.js", "text/javascript")]
+    [TestCase("x.mjs", "text/javascript")]
+    [TestCase("x.txt", "text/plain")]
+    [TestCase("x.md", "text/plain")]
+    [TestCase("x.vtt", "text/vtt")]
+    [TestCase("x.mp4", "video/mp4")]
+    [TestCase("x.m4v", "video/mp4")]
+    [TestCase("x.webm", "video/webm")]
+    // The fallback, and the two rules `os.path.splitext` and a dictionary lookup impose on top of the table:
+    // the last extension only, and no case folding.
+    [TestCase("x.asis", "application/octet-stream")]
+    [TestCase("x.headers", "application/octet-stream")]
+    [TestCase("x", "application/octet-stream")]
+    [TestCase("a/b.c/x", "application/octet-stream")]
+    [TestCase("x.HTML", "application/octet-stream")]
+    [TestCase("get-host-info.sub.js", "text/javascript")]
+    [TestCase("x.tar.gz", "application/octet-stream")]
+    public void TheContentTypeIsTheOneWptservesTableNames(string path, string expected)
+        => WptServerFiles.GuessContentType(path).Should().Be(expected);
+
+    /// <summary>
+    /// And a real file really is served with it. wptserve adds <b>no</b> charset here: nothing in
+    /// <c>tools/wptserve/</c> appends one to a guessed type, so a <c>.js</c> is <c>text/javascript</c> flat
+    /// and the <c>charset=utf-8</c> a browser sees on the harness comes from a <c>.headers</c> sidecar
+    /// instead — see <see cref="AHeadersSidecarReplacesTheGuessedContentType"/>.
+    /// </summary>
+    [TestCase("/common/utils.js", "text/javascript")]
+    [TestCase("/common/blank.html", "text/html")]
+    [TestCase("/common/dummy.xml", "application/xml")]
+    [TestCase("/common/dummy.xhtml", "application/xhtml+xml")]
+    [TestCase("/fetch/api/resources/top.txt", "text/plain")]
+    [TestCase("/url/resources/urltestdata.json", "application/json")]
+    public async Task AStaticFileCarriesTheTypeItsExtensionNames(string path, string expected)
+    {
+        using var response = await GetAsync(path);
+
+        ((int) response.StatusCode).Should().Be(200);
+        response.Content.Headers.ContentType!.ToString().Should().Be(expected);
+    }
+
+    /// <summary>
+    /// <c>handlers.py</c>'s <c>load_headers</c>: a file's <c>.headers</c> sidecar is applied to the response,
+    /// and a <c>Content-Type</c> in it replaces the guess rather than joining it.
+    /// </summary>
+    /// <remarks>
+    /// <c>resources/testharness.js.headers</c> is upstream's own, vendored beside the file it belongs to, and
+    /// it is two lines: the content type <i>with</i> a charset, and a cache directive. It is the answer to
+    /// "where does wptserve add <c>charset=utf-8</c>" — in a sidecar, for six files, and nowhere else.
+    /// </remarks>
+    [Test]
+    public async Task AHeadersSidecarReplacesTheGuessedContentType()
+    {
+        using var response = await GetAsync("/resources/testharness.js");
+
+        ((int) response.StatusCode).Should().Be(200);
+        response.Content.Headers.ContentType!.ToString().Should().Be("text/javascript; charset=utf-8");
+        response.Headers.CacheControl!.MaxAge.Should().Be(TimeSpan.FromHours(1));
+        (await response.Content.ReadAsStringAsync()).Should().Be(WptCorpus.Read("resources/testharness.js"));
+    }
+
+    /// <summary>
+    /// The four rules <c>load_headers</c> and <c>get_headers</c> impose between them, checked against a
+    /// synthetic tree because the vendored one has one sidecar shape and there are four.
+    /// </summary>
+    /// <remarks>
+    /// In order: the directory's <c>__dir__.headers</c> comes before the file's own; a repeated name is kept
+    /// rather than overwritten, and takes the position of its first appearance; a <c>Content-Type</c> in
+    /// either sidecar suppresses the guess, which is otherwise inserted <i>first</i>; and a
+    /// <c>.sub.headers</c> wins over a plain <c>.headers</c> of the same base name and is substituted with
+    /// escaping off.
+    /// </remarks>
+    [Test]
+    public void SidecarHeadersAreAppliedInWptservesOrder()
+    {
+        var context = new WptSubstitutionContext(8080, null);
+
+        // The guess goes in front of whatever the sidecars said, and __dir__ comes before the file.
+        Load("a/b.txt", context, new Dictionary<string, string>
+        {
+            ["a/__dir__.headers"] = "X-Dir: one\n",
+            ["a/b.txt.headers"] = "X-File: two\n",
+        }).Should().Equal(("Content-Type", "text/plain"), ("X-Dir", "one"), ("X-File", "two"));
+
+        // A content type anywhere in the sidecars suppresses the guess entirely — even in __dir__, and even
+        // spelled in another case, because `get_headers` compares lowered.
+        Load("a/b.txt", context, new Dictionary<string, string>
+        {
+            ["a/__dir__.headers"] = "content-type: text/x-dir\n",
+            ["a/b.txt.headers"] = "X-File: two\n",
+        }).Should().Equal(("content-type", "text/x-dir"), ("X-File", "two"));
+
+        // A repeated name is two headers, and they sit where the first one did.
+        Load("a/b.txt", context, new Dictionary<string, string>
+        {
+            ["a/b.txt.headers"] = "Set-Cookie: a=1\nX-Other: x\nSet-Cookie: b=2\n",
+        }).Should().Equal(
+            ("Content-Type", "text/plain"),
+            ("Set-Cookie", "a=1"),
+            ("Set-Cookie", "b=2"),
+            ("X-Other", "x"));
+
+        // The .sub. spelling wins outright over the plain one, and its values are substituted.
+        Load("a/b.txt", context, new Dictionary<string, string>
+        {
+            ["a/b.txt.headers"] = "X-Which: plain\n",
+            ["a/b.txt.sub.headers"] = "X-Which: {{host}}:{{ports[http][0]}}\n",
+        }).Should().Equal(("Content-Type", "text/plain"), ("X-Which", "127.0.0.1:8080"));
+
+        // Content-Length, Connection and Transfer-Encoding are this server's framing rather than the file's,
+        // so a sidecar naming one is dropped: two Content-Lengths on the wire is a client reading the wrong
+        // body length. A file whose subject *is* a wrong framing uses .asis, which bypasses all of this.
+        Load("a/b.txt", context, new Dictionary<string, string>
+        {
+            ["a/b.txt.headers"] = "Content-Length: 99\nConnection: keep-alive\nTransfer-Encoding: chunked\nX-Kept: yes\n",
+        }).Should().Equal(("Content-Type", "text/plain"), ("X-Kept", "yes"));
+
+        // Blank lines are skipped, values are stripped, and CRLF is a line ending like any other.
+        Load("a/b.txt", context, new Dictionary<string, string>
+        {
+            ["a/b.txt.headers"] = "\r\nX-Space:   padded  \r\n\r\n",
+        }).Should().Equal(("Content-Type", "text/plain"), ("X-Space", "padded"));
+
+        static List<(string Name, string Value)> Load(
+            string path,
+            in WptSubstitutionContext context,
+            Dictionary<string, string> tree)
+            => WptServerFiles.LoadHeaders(path, context, name => tree.GetValueOrDefault(name));
+    }
+
+    /// <summary>
+    /// <c>pipes.py</c>'s <c>ReplacementTokenizer</c>: four patterns tried in order at each position, and a
+    /// <b>stop</b> — not a skip — at the first character none of them match.
+    /// </summary>
+    /// <remarks>
+    /// The stop is the half a reimplementation gets wrong. <c>{{ host }}</c> tokenizes to nothing upstream
+    /// and is a 500; a tokenizer that skipped the spaces would accept a spelling wptserve rejects, and a
+    /// corpus file written against it would then only work here.
+    /// </remarks>
+    [Test]
+    public void TheTemplateGrammarIsTheOneUpstreamsScannerAccepts()
+    {
+        Kinds("host").Should().Equal("Identifier:host");
+        Kinds("ports[http][0]").Should().Equal("Identifier:ports", "Index:http", "Index:0");
+        Kinds("domains[]").Should().Equal("Identifier:domains", "Index:");
+        Kinds("uuid()").Should().Equal("Identifier:uuid", "Arguments:");
+        Kinds("header_or_default(X-Test, fallback)")
+            .Should().Equal("Identifier:header_or_default", "Arguments:X-Test, fallback");
+
+        // The $ stays in both the assignment's name and a later reference's, which is the only reason the
+        // two ever meet.
+        Kinds("$id:uuid()").Should().Equal("Variable:$id", "Identifier:uuid", "Arguments:");
+        Kinds("$id").Should().Equal("Identifier:$id");
+
+        // And the scanner stops rather than skipping: a space, a stray brace, an unterminated index.
+        Kinds(" host").Should().BeEmpty();
+        Kinds("host ports").Should().Equal("Identifier:host");
+        Kinds("ports[http").Should().Equal("Identifier:ports");
+
+        // `re.split(r",\s*", …)`: the whitespace after a comma is consumed and the whitespace before it is
+        // not, which is a difference a Trim() would erase.
+        Arguments("(a, b)").Should().Equal("a", "b");
+        Arguments("(a ,b)").Should().Equal("a ", "b");
+        Arguments("()").Should().BeEmpty();
+
+        static List<string> Kinds(string body)
+        {
+            var kinds = new List<string>();
+            foreach (var token in WptServerFiles.Tokenize(body))
+            {
+                kinds.Add(token.Kind + ":" + token.Text);
+            }
+
+            return kinds;
+        }
+
+        static string[] Arguments(string body) => WptServerFiles.Tokenize(body)[0].Arguments!;
+    }
+
+    /// <summary>
+    /// Every substitution the corpus spells, as a <c>.sub.html</c> gets it — one case per token, which is
+    /// what the browser lane's files are made of.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The values say what this server is: one loopback host and one port, so <c>{{host}}</c>,
+    /// <c>{{domains[www]}}</c> and <c>{{hosts[alt][www2]}}</c> all answer <c>127.0.0.1</c>, and every
+    /// protocol and index of <c>{{ports[…][…]}}</c> answers the one port <see cref="WptServer"/> bound.
+    /// <c>{{ports[https][0]}}</c> included: there is no TLS here, so a file that composes an
+    /// <c>https://</c> origin out of it composes one that cannot be reached — which is the honest answer,
+    /// and a reason such a file is un-runnable rather than merely different.
+    /// </para>
+    /// <para>
+    /// <c>{{GET[…]}}</c> is the one lookup that answers the empty string for something absent instead of
+    /// failing; <c>FirstWrapper.__getitem__</c> catches its own <c>KeyError</c>, and nothing else here does.
+    /// </para>
+    /// </remarks>
+    [TestCase("{{host}}", "127.0.0.1")]
+    [TestCase("{{domains[www]}}", "127.0.0.1")]
+    [TestCase("{{domains[]}}", "127.0.0.1")]
+    [TestCase("{{domains[www2]}}", "127.0.0.1")]
+    [TestCase("{{hosts[alt][]}}", "127.0.0.1")]
+    [TestCase("{{hosts[alt][www2]}}", "127.0.0.1")]
+    [TestCase("{{ports[http][0]}}", "8080")]
+    [TestCase("{{ports[http][1]}}", "8080")]
+    [TestCase("{{ports[https][0]}}", "8080")]
+    [TestCase("{{ports[ws][0]}}", "8080")]
+    [TestCase("{{url_base}}", "/")]
+    [TestCase("{{location[server]}}", "http://127.0.0.1:8080")]
+    [TestCase("{{location[scheme]}}", "http")]
+    [TestCase("{{location[host]}}", "127.0.0.1:8080")]
+    [TestCase("{{location[hostname]}}", "127.0.0.1")]
+    [TestCase("{{location[port]}}", "8080")]
+    [TestCase("{{location[path]}}", "/a/page.sub.html")]
+    [TestCase("{{location[pathname]}}", "/a/page.sub.html")]
+    // Escaped, because these cases are a .sub.html's: the "&" between two query parameters is a "&"
+    // in the source and "&amp;" in the markup, and upstream escapes it for exactly the same reason.
+    [TestCase("{{location[query]}}", "?name=v%20alue&amp;empty=")]
+    [TestCase("{{GET[name]}}", "v alue")]
+    [TestCase("{{GET[empty]}}", "")]
+    [TestCase("{{GET[absent]}}", "")]
+    [TestCase("{{headers[x-probe]}}", "probed")]
+    [TestCase("{{header_or_default(x-probe, fallback)}}", "probed")]
+    [TestCase("{{header_or_default(x-absent, fallback)}}", "fallback")]
+    // Text either side of a token is untouched, and two tokens in one line both resolve.
+    [TestCase("http://{{host}}:{{ports[http][0]}}/x", "http://127.0.0.1:8080/x")]
+    public async Task EverySubstitutionTokenTheCorpusUsesResolves(string template, string expected)
+    {
+        var request = await RequestAsync("GET /a/page.sub.html?name=v%20alue&empty= HTTP/1.1\r\nx-probe: probed\r\n\r\n");
+
+        WptServerFiles.Substitute(new WptSubstitutionContext(8080, request), template, escapeAsHtml: true)
+            .Should().Be(expected);
+    }
+
+    /// <summary>
+    /// <c>wrap_pipeline</c> picks the escaping from the extension: markup gets
+    /// <c>html.escape(…, quote=True)</c> and everything else — a <c>.sub.js</c>, a <c>.sub.headers</c> — gets
+    /// none.
+    /// </summary>
+    /// <remarks>
+    /// Python's escape is five characters and stops there. <c>WebUtility.HtmlEncode</c> would also turn every
+    /// non-ASCII character into a numeric entity, so a substituted value carrying one would differ from what
+    /// a browser running the real server sees — which is why this is written by hand.
+    /// </remarks>
+    [Test]
+    public async Task AMarkupFileEscapesWhatItSubstitutesAndAScriptDoesNot()
+    {
+        var request = await RequestAsync("GET /a/page.sub.html?v=%3Cb%26%22%27%C3%A5 HTTP/1.1\r\n\r\n");
+        var context = new WptSubstitutionContext(8080, request);
+
+        WptServerFiles.Substitute(context, "{{GET[v]}}", escapeAsHtml: true)
+            .Should().Be("&lt;b&amp;&quot;&#x27;Ã¥", "the five characters and no more");
+        WptServerFiles.Substitute(context, "{{GET[v]}}", escapeAsHtml: false)
+            .Should().Be("<b&\"'Ã¥");
+
+        WptServerFiles.WantsSubstitution("a/page.sub.html").Should().BeTrue();
+        WptServerFiles.WantsSubstitution("a/page.html").Should().BeFalse();
+        WptServerFiles.EscapesAsHtml("a/page.sub.html").Should().BeTrue();
+        WptServerFiles.EscapesAsHtml("a/page.sub.xhtml").Should().BeTrue();
+        WptServerFiles.EscapesAsHtml("a/page.sub.svg").Should().BeTrue();
+        WptServerFiles.EscapesAsHtml("a/page.sub.xml").Should().BeTrue();
+        WptServerFiles.EscapesAsHtml("a/page.sub.js").Should().BeFalse();
+    }
+
+    /// <summary>
+    /// <c>{{uuid()}}</c> is fresh per call, and <c>{{$name:…}}</c> is how a file uses the same one twice.
+    /// </summary>
+    [Test]
+    public async Task AUuidIsFreshAndAVariableRemembersOne()
+    {
+        var request = await RequestAsync("GET /a/page.sub.js HTTP/1.1\r\n\r\n");
+        var context = new WptSubstitutionContext(8080, request);
+
+        var pair = WptServerFiles.Substitute(context, "{{uuid()}}|{{uuid()}}", escapeAsHtml: false).Split('|');
+        pair[0].Should().NotBe(pair[1]);
+        Guid.TryParse(pair[0], out _).Should().BeTrue();
+
+        var remembered = WptServerFiles.Substitute(context, "{{$id:uuid()}}|{{$id}}", escapeAsHtml: false).Split('|');
+        remembered[0].Should().Be(remembered[1]);
+    }
+
+    /// <summary>
+    /// A substitution this server cannot make is a failure and never a placeholder left in place.
+    /// </summary>
+    /// <remarks>
+    /// Upstream raises and wptserve answers 500. The alternative — serving <c>{{file_hash(md5, x)}}</c>
+    /// verbatim — puts the failure in the test's assertions, several layers from the cause, which is exactly
+    /// how the corpus's own unrunnable files used to be discovered.
+    /// </remarks>
+    [TestCase("{{nonesuch}}", "undefined template variable")]
+    [TestCase("{{file_hash(md5, dom/interfaces.html)}}", "undefined template variable")]
+    [TestCase("{{fs_path(x)}}", "undefined template variable")]
+    [TestCase("{{ host }}", "nothing to substitute")]
+    [TestCase("{{host[0]}}", "unexpected trailing token")]
+    [TestCase("{{ports[http]}}", "expected an index")]
+    [TestCase("{{location[nonesuch]}}", "not a part of the request URL")]
+    [TestCase("{{headers[x-absent]}}", "has no \"x-absent\" header")]
+    [TestCase("{{uuid}}", "expected a call")]
+    [TestCase("{{header_or_default(only-one)}}", "expected 2 arguments")]
+    public async Task AnUnresolvableSubstitutionFailsLoudly(string template, string expected)
+    {
+        var request = await RequestAsync("GET /a/page.sub.html HTTP/1.1\r\n\r\n");
+
+        Invoking(() => WptServerFiles.Substitute(new WptSubstitutionContext(8080, request), template, escapeAsHtml: true))
+            .Should().Throw<WptServerFileException>()
+            .WithMessage("*" + expected + "*");
+    }
+
+    /// <summary>
+    /// And the vendored <c>.sub.</c> file really is substituted on its way out: 68 files of the browser
+    /// lane's suites include <c>common/get-host-info.sub.js</c>, and it is the reason the template language
+    /// is here at all.
+    /// </summary>
+    [Test]
+    public async Task TheVendoredSubstitutionFileIsServedSubstituted()
+    {
+        using var response = await GetAsync("/common/get-host-info.sub.js");
+
+        ((int) response.StatusCode).Should().Be(200);
+        var body = await response.Content.ReadAsStringAsync();
+
+        body.Should().NotContain("{{", "every placeholder is resolved before the file is written");
+        body.Should().Contain("var ORIGINAL_HOST = '127.0.0.1';");
+        body.Should().Contain(
+            "var HTTP_PORT = '" + WptServer.Instance.Port.ToString(CultureInfo.InvariantCulture) + "';");
+
+        // Escaping is off for a .sub.js, so the quotes the file writes around each value stay quotes.
+        body.Should().NotContain("&#x27;");
+    }
+
+    /// <summary>
+    /// A <c>?pipe=</c> this server does not implement is a 500 that names itself, not a file served as if
+    /// the query were not there.
+    /// </summary>
+    /// <remarks>
+    /// wptserve has fourteen pipes. Only <c>sub</c> is ported, because only <c>sub</c> is needed to load an
+    /// <c>.html</c> test — but a file asking for <c>?pipe=status(404)</c> and getting a 200 would fail an
+    /// assertion about the engine, and one asking for <c>?pipe=trickle(d1)</c> is why
+    /// <c>xhr/abort-after-timeout.any.js</c> is a not-vendored row. Both should say so.
+    /// </remarks>
+    [Test]
+    public async Task AnUnimplementedPipeIsA500ThatNamesIt()
+    {
+        using var response = await GetAsync("/common/blank.html?pipe=trickle(d1)");
+
+        ((int) response.StatusCode).Should().Be(500);
+        (await response.Content.ReadAsStringAsync()).Should().Contain("trickle");
+
+        using var supported = await GetAsync("/common/utils.js?pipe=sub(none)");
+        ((int) supported.StatusCode).Should().Be(200);
+    }
+
+    /// <summary>
+    /// The query and the fragment take no part in finding the file, and a percent-escape in the path is
+    /// decoded before the lookup — all three of which the browser lane needs and none of which the
+    /// <c>.any.js</c> lane ever asked for.
+    /// </summary>
+    /// <remarks>
+    /// A fragment never reaches a real server, so the one here is written straight onto the socket:
+    /// <c>HttpClient</c> strips it, which is the correct behaviour and the reason it cannot be the thing
+    /// under test.
+    /// </remarks>
+    [Test]
+    public async Task AQueryAFragmentAndAPercentEscapeAllResolveToTheSameFile()
+    {
+        var expected = WptCorpus.Read("common/utils.js");
+
+        using var withQuery = await GetAsync("/common/utils.js?some=thing");
+        (await withQuery.Content.ReadAsStringAsync()).Should().Be(expected);
+
+        using var withEscape = await GetAsync("/common/utils%2Ejs");
+        (await withEscape.Content.ReadAsStringAsync()).Should().Be(expected);
+
+        var raw = await RawAsync("GET /common/utils.js?some=thing#fragment HTTP/1.1\r\nhost: x\r\n\r\n");
+        raw.Should().StartWith("HTTP/1.1 200 OK");
+        raw.Should().Contain(expected);
+    }
+
+    /// <summary>
+    /// <c>HEAD</c> of a static file is the headers a <c>GET</c> would have carried, <c>Content-Length</c>
+    /// included, and no body.
+    /// </summary>
+    [Test]
+    public async Task HeadOfAStaticFileIsItsHeadersWithNoBody()
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Head, WptServer.Instance.Origin + "/resources/testharness.js");
+        using var response = await _client.SendAsync(request);
+
+        ((int) response.StatusCode).Should().Be(200);
+        response.Content.Headers.ContentType!.ToString().Should().Be("text/javascript; charset=utf-8");
+        response.Content.Headers.ContentLength
+            .Should().Be(Encoding.UTF8.GetByteCount(WptCorpus.Read("resources/testharness.js")));
+        (await response.Content.ReadAsByteArrayAsync()).Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// A path the corpus does not hold is a 404 whatever it looks like, with the status line and the content
+    /// type every other answer here has.
+    /// </summary>
+    [TestCase("/dom/nodes/there-is-no-such-file.html")]
+    [TestCase("/resources/testharness.css")]
+    [TestCase("/common/nothing.sub.html")]
+    public async Task APathTheCorpusDoesNotHoldIsA404WhateverItsExtension(string path)
+    {
+        using var response = await GetAsync(path);
+
+        ((int) response.StatusCode).Should().Be(404);
+        response.ReasonPhrase.Should().Be("Not Found");
+        response.Content.Headers.ContentType!.ToString().Should().Be("text/plain");
+        response.Content.Headers.ContentLength.Should().Be(0);
+    }
+
+    /// <summary>
+    /// <c>/resources/testharnessreport.js</c> comes from <c>Prelude/</c> rather than from <c>Vendor/</c>, and
+    /// a server can be given an overlay to answer with instead.
+    /// </summary>
+    /// <remarks>
+    /// Upstream's file is a stub that exists to be replaced — "intended for vendors to implement code needed
+    /// to integrate testharness.js tests with their own test systems" — so vendoring it would put bytes in
+    /// the tree the server never sends. The overlay is the slot the browser lane fills with the script that
+    /// posts a page's results back to the driver; nothing supplies one yet, which is why this test starts
+    /// its own server.
+    /// </remarks>
+    [Test]
+    public async Task TheHarnessReportComesFromThePreludeAndCanBeOverlaid()
+    {
+        using var response = await GetAsync("/resources/testharnessreport.js");
+
+        ((int) response.StatusCode).Should().Be(200);
+        response.Content.Headers.ContentType!.ToString().Should().Be("text/javascript; charset=utf-8");
+        (await response.Content.ReadAsStringAsync()).Should().Be(WptCorpus.HarnessReport);
+
+        // It is Jint's file, and it says so; and it is not in the vendored tree at all.
+        WptCorpus.HarnessReport.Should().Contain("Jint's `resources/testharnessreport.js`");
+        WptCorpus.Contains("resources/testharnessreport.js").Should().BeFalse();
+
+        using var overlaid = new WptServer("window.__jintReport = true;");
+        using var fromOverlay = await _client.GetAsync(overlaid.Origin + "/resources/testharnessreport.js");
+        (await fromOverlay.Content.ReadAsStringAsync()).Should().Be("window.__jintReport = true;");
+
+        // And the overlay is per server: the shared one is untouched.
+        using var again = await GetAsync("/resources/testharnessreport.js");
+        (await again.Content.ReadAsStringAsync()).Should().Be(WptCorpus.HarnessReport);
+    }
+
+    /// <summary>
+    /// Parses one request off a raw byte stream, which is how the substitution cases get a
+    /// <see cref="WptServerRequest"/> to resolve <c>{{GET[…]}}</c> and <c>{{location[…]}}</c> against.
+    /// </summary>
+    private static async Task<WptServerRequest> RequestAsync(string raw)
+    {
+        using var stream = new MemoryStream(Encoding.Latin1.GetBytes(raw));
+        return (await WptServerRequest.ReadAsync(stream, CancellationToken.None))!;
+    }
+
+    /// <summary>
+    /// Writes a request onto the socket verbatim and reads the whole answer back, for the shapes an
+    /// <see cref="HttpClient"/> corrects on the way out.
+    /// </summary>
+    private static async Task<string> RawAsync(string request)
+    {
+        using var client = new TcpClient();
+        await client.ConnectAsync(IPAddress.Loopback, WptServer.Instance.Port);
+        await using var stream = client.GetStream();
+
+        var bytes = Encoding.Latin1.GetBytes(request);
+        await stream.WriteAsync(bytes);
+        await stream.FlushAsync();
+
+        using var answer = new MemoryStream();
+        await stream.CopyToAsync(answer);
+        return Encoding.UTF8.GetString(answer.ToArray());
     }
 }
 #endif

--- a/Jint.Tests/Wpt/WptTestRunner.cs
+++ b/Jint.Tests/Wpt/WptTestRunner.cs
@@ -196,11 +196,12 @@ public class WptTestRunner
         // beside it is global=sharedworker.
         ("workers/examples/*", "upstream's tutorial: asserts the wpt server's own generated glue, and a SharedWorker"),
 
-        // `.sub.` is server-side substitution: wptserve rewrites {{host}}/{{ports[…]}} into a real origin
-        // before serving the file. Nothing here serves anything, so a vendored copy would carry the
-        // placeholders verbatim. Worker-location.sub.any.js additionally asserts every member of a
-        // WorkerLocation, which is the declined feature below.
-        ("workers/Worker-location.sub.any.js", "needs wptserve substitution and a WorkerLocation"),
+        // `.sub.` is server-side substitution: wptserve rewrites {{host}}/{{ports[…]}} into a *second* origin
+        // before serving the file. WptServer performs the substitution now — see WptServerFiles — but it has
+        // one loopback origin to substitute, so these read as same-origin and assert nothing.
+        // Worker-location.sub.any.js additionally asserts every member of a WorkerLocation, which is the
+        // declined feature below.
+        ("workers/Worker-location.sub.any.js", "needs a second origin substituted into it, and a WorkerLocation"),
         ("workers/interfaces/WorkerUtils/importScripts/*", "classic-worker importScripts, most of it .sub. as well"),
         ("workers/importscripts_mime*.any.js", "classic-worker importScripts, over server-chosen MIME types"),
 
@@ -337,9 +338,10 @@ public class WptTestRunner
         ("fetch/api/redirect/redirect-to-dataurl.any.js", "a data: URL redirect target"),
 
         // ---- what the ".sub." and ".h2." spellings mean, wherever they appear under fetch/
-        // `.sub.` is wptserve rewriting {{host}} and {{ports[…]}} into a real origin before serving the file;
-        // a vendored copy carries the placeholders verbatim. `.h2.` needs an HTTP/2 server, which this one is
-        // not — it speaks HTTP/1.1 on a raw socket, which is what lets it trickle a body.
+        // `.sub.` is wptserve rewriting {{host}} and {{ports[…]}} into a *second* origin before serving the
+        // file, and one origin is all this server has however faithfully it substitutes. `.h2.` needs an
+        // HTTP/2 server, which this one is not — it speaks HTTP/1.1 on a raw socket, which is what lets it
+        // trickle a body.
         ("fetch/api/*/*.sub.any.js", "wptserve substitutes a second origin into the file before serving it"),
         ("fetch/api/*/*.h2.any.js", "needs an HTTP/2 server"),
         ("fetch/api/*/*keepalive*", "the keepalive init member, and a window creating iframes"),
@@ -363,6 +365,18 @@ public class WptTestRunner
         ("xhr/json.any.js", "its first test fetches a data: URL, which the transport has no scheme for, so that test never settles and the file stalls"),
         ("xhr/abort-after-timeout.any.js", "its one test asks for /common/blank.html?pipe=trickle(d1), a wptserve pipe directive the driver's server does not implement"),
         ("xhr/xhr-timeout-longtask.any.js", "its outcome depends on the machine: a browser's timeout timer is a task and cannot fire during the 200 ms busy-wait the file runs, while this one is a wall-clock deadline on a cancellation token — see XhrOperation on why it is CLR-side — so a body read the runner is too busy to finish inside 150 ms times out where the file asserts it must not"),
+
+        // ---------------------------------------------------------------- resources/ and common/
+        // The two shared roots hold helpers rather than tests, and the rule for them is the rule for every
+        // other directory: vendor what something references, and say why for the rest. What is vendored is
+        // the harness a page loads (testharness.js, testdriver.js and its two companions), the host-info
+        // helper 68 of the browser lane's files include, and three fixtures. These are the referenced files
+        // that are still out.
+        ("resources/idlharness.js", "the WebIDL conformance harness, out for the reason its .any.js files are"),
+        ("common/*.py", "a wptserve handler — slow.py and redirect.py are Python, not files to serve"),
+        ("common/reftest-wait.js", "a reftest's rendering handshake; there is nothing to render"),
+        ("common/dispatcher/*", "a cross-context message bus built on a wptserve stash handler"),
+        ("common/security-features/*", "the referrer-policy and mixed-content generators, and a second origin"),
     ];
 
     /// <summary>
@@ -1596,6 +1610,15 @@ public class WptTestRunner
             if (path.EndsWith(".any.js", StringComparison.Ordinal) && !_minimumTests.ContainsKey(path))
             {
                 problems.Add($"{path} is vendored but has no entry in the minimum-test table, so nothing runs it");
+            }
+
+            // resources/ is the harness itself and common/ is what every standard shares, so neither is ever
+            // a suite — a .any.js under one would be the harness testing itself, and WptCorpus.TestFiles
+            // refuses to be asked about them at all. Checked here rather than left to that refusal because
+            // nothing asks: a corpus bump that dropped one in would simply never run it.
+            if (WptCorpus.IsShared(path) && path.EndsWith(".any.js", StringComparison.Ordinal))
+            {
+                problems.Add($"{path} is under a shared helper root, which is never a suite — see WptCorpus.SharedDirectories");
             }
         }
 


### PR DESCRIPTION
Part of the headless-browser campaign (#3575), work package **B6**. **Nothing script-side changes**: every
new behaviour here is reachable only from `WptServerTests` until the browser lane arrives.

## Why

`WptServer` today is a set of `.py` handler ports plus a static reader that knew four extensions, and that is
all an `.any.js` file ever asks for — the driver hands that file to an engine directly, and the server is only
there to answer its `fetch`. A `.html` test is *loaded* from the server, so everything about how wptserve
turns a file on disk into a response starts to matter at once: its media type, the `.headers` sidecar beside
it, and the `{{…}}` substitution its name may ask for. That is this PR, ported from
`tools/wptserve/wptserve/` at the pinned commit and held to it by tests in `WptServerTests`, the same way the
handler ports are.

## What it ports

`WptServerFiles`, a new file, because everything in `WptServer` answers one *named* `.py` file and everything
here applies to *every* file:

* **`constants.py`'s content-type table, entire** rather than trimmed to what is vendored — a trimmed copy
  would quietly stop being a copy — with upstream's `application/octet-stream` underneath where the old reader
  had `text/plain`. wptserve adds **no** charset anywhere: nothing under `tools/wptserve` appends one to a
  guessed type, so the `charset=utf-8` a browser sees on `testharness.js` comes from a sidecar instead.
* **`handlers.py`'s `load_headers` and `get_headers`**, whose four orderings are each a case:
  `__dir__.headers` before the file's own; a repeated name kept rather than overwritten and grouped at its
  first appearance (`ResponseHeaders.update` appends); a sidecar `Content-Type` suppressing a guess that is
  otherwise inserted *first*; and `.sub.headers` winning outright over `.headers` of the same base name and
  substituted with escaping off.
* **`pipes.py`'s `template`**, tokenizer included. Its grammar is four patterns tried in order at each
  position with a **stop**, not a skip, at the first character none of them match — which is why `{{ host }}`
  is a 500 upstream and is one here. The extension picks the escaping exactly as `wrap_pipeline` does, and the
  HTML escape is written by hand because `WebUtility.HtmlEncode` would also turn every non-ASCII character
  into an entity and upstream's `html.escape` does not.

## The two decisions worth reviewing

**There is exactly one origin.** One loopback host, one port, no TLS — so every host-shaped token
(`{{host}}`, `{{domains[www2]}}`, `{{hosts[alt][]}}`) answers `127.0.0.1` and every `{{ports[…][…]}}` answers
the one port, `https` and `ws` included. A file whose subject is a *second* origin therefore reads as
same-origin here, which makes it **un-runnable rather than merely different**: it belongs in the exclusion
table or the not-vendored table when a lane brings it in, and never in a green run. `Vendor/README.md` says
this in a table, and the `_notVendored` rows whose stated reason used to be "nothing here substitutes" are
corrected to say what the reason actually is now.

**Anything unresolvable is a 500 and never a placeholder left in place** — an undefined variable, a `?pipe=`
other than `sub`, an escape type `sub` does not take. wptserve has fourteen pipes; only `sub` is needed to
load an `.html` test, but a file that asks for `?pipe=status(404)` and gets a 200 fails an assertion about the
*engine* instead of reporting that the server does not do that yet. `xhr/abort-after-timeout.any.js` is a
not-vendored row today precisely because it asks for `?pipe=trickle(d1)`; with this it would say so on the
wire.

Three smaller things the browser lane needs: the query and the fragment take no part in finding a file
(`filesystem_path` reads `url_parts.path` alone) and a percent-escape in the path is decoded before the
lookup; `HEAD` carries the headers a `GET` would with no body; and a missing file is a 404 with the same
status line, content type and empty body whatever its extension.

## Vendored

Everything the five suites the lane targets (`dom/`, `html/dom/`,
`html/semantics/scripting-1/the-script-element/`, `xhr/`, `html/webappapis/`) reference from `resources/` and
`common/` and that is in scope, enumerated by grepping the upstream tree at the pin. Referrer counts are from
that grep.

| Path | Referrers | What it is |
| --- | --- | --- |
| `resources/testharness.js` (+`.headers`) | 1764 | The real upstream harness |
| `resources/testdriver.js` (+`.headers`) | 98 | The automation API |
| `resources/testdriver-vendor.js` (+`.headers`) | 98 | Upstream's **empty** vendor hook |
| `resources/testdriver-actions.js` (+`.headers`) | 85 | The action-sequence builder |
| `common/get-host-info.sub.js` | 68 | The origins helper — the corpus's most-used `.sub.` file, and the reason the template language is here |
| `common/blank.html` | 26 | An empty document |
| `common/dummy.xhtml`, `common/dummy.xml` | 6 | Two-line XML fixtures |

`common/utils.js` (37 referrers) and `common/{gc,sab,subset-tests,subset-tests-by-key}.js` were already
vendored. **`resources/testharness.css` is not vendored because the pin has no such file** — it is named in a
good deal of prose about the harness, but `resources/` does not contain it and `testharness.js` loads no
stylesheet.

Not vendored, each now a `_notVendored` row with its reason: `resources/idlharness.js` (the WebIDL harness,
out for the reason its `.any.js` files are), `common/slow.py` and `common/redirect.py` (wptserve handlers, to
be ported like the others if a lane needs one), `common/reftest-wait.js`, `common/dispatcher/*`,
`common/security-features/*`.

## Two harnesses, on purpose

`Prelude/testharness-shim.js` stays exactly as it is: it is Jint's own, it implements the slice the `.any.js`
lane uses, and `WptHarnessTests` exercises every assertion in it. `Vendor/resources/testharness.js` is
upstream's, verbatim, for a page to load through a `<script src>`.

`resources/testharnessreport.js` is **the one harness file deliberately not vendored**. Upstream's is a stub
whose whole purpose is to be replaced — *"intended for vendors to implement code needed to integrate
testharness.js tests with their own test systems"* — so vendoring it would put bytes in `Vendor/` the server
never sends. Jint's copy is `Prelude/testharnessreport.js`, and `WptServer` now takes an overlay string **per
instance** and answers `/resources/testharnessreport.js` with it. The browser lane fills that slot with the
script that posts a page's results back to the driver.

`resources/` and `common/` are helper roots and never suites: `WptCorpus.TestFiles` refuses to be asked about
them and `EveryVendoredFileIsAccountedFor` fails if either ever holds a `.any.js`, because a test case there
would be the harness testing itself.

## Verification

* `--filter Wpt` on net8.0: **536 → 637** passing (1 skipped either side, 0 failed). The whole delta is new
  cases; no existing corpus result moves.
* `JINT_WPT_CENSUS=1` green across the change — the inventory table's five columns, "Not passing" included,
  are identical, which is what says the 29 server-backed files produce the same results they did.
* Full `Jint.Tests`: net8.0 12054, net10.0 12054, net472 8432 passing, 0 failed.
* Whole solution green in Release.

The only behaviour the existing corpus can see at all is the content-type table, because no vendored file was
a `.sub.` file, had a sidecar or passed a `?pipe=` before this. The one file it moves is
`xhr/resources/well-formed.xml`, from `text/plain` to `application/xml`, which is what wptserve serves it as;
the census is identical across that change.

## Follow-ups for the lane, not for this PR

* The `?pipe=` pipes beyond `sub` — `status`, `header`, `trickle`, `slice` — each when a vendored file needs
  one. Until then they are a legible 500.
* `common/slow.py` and `common/redirect.py`, ported the way the other handlers were.
* A binary fixture (`.png`, `.gif`, `.webm`) cannot be vendored while `WptCorpus` hands every file back as a
  string; a lane needing one needs a bytes accessor first.
* A second origin is the one thing substitution cannot fake. A second listener would satisfy
  `{{ports[http][1]}}`, but not a second *hostname*, which is what the cross-origin suites actually want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
