### PR TITLE
Events: an event listener has a call-stack frame of its own

### DIFF
--- a/Jint.Tests/Runtime/CallStackEntryFrameTests.cs
+++ b/Jint.Tests/Runtime/CallStackEntryFrameTests.cs
@@ -26,6 +26,11 @@ public class CallStackEntryFrameTests
         return new Engine(options => options.UseWebApis(WebApiFeatures.Timers | WebApiFeatures.Console));
     }
 
+    private static Engine WithEvents()
+    {
+        return new Engine(options => options.UseWebApis(WebApiFeatures.Events | WebApiFeatures.Console));
+    }
+
     /// <summary>The frames of <c>Error.prototype.stack</c>, one per line, whitespace trimmed.</summary>
     private static string[] StackLines(JsValue error)
     {
@@ -101,6 +106,78 @@ public class CallStackEntryFrameTests
         engine.Tasks.ProcessTasks();
 
         StackLines(_reported!)[0].Should().StartWith("at drain (app.js:");
+    }
+
+    [Test]
+    public void AnEventListenerHasAFrameOfItsOwn()
+    {
+        var engine = WithEvents();
+        engine.SetValue("report", new Action<JsValue>(value => _reported = value));
+        engine.Execute(
+            """
+            var target = new EventTarget();
+            target.addEventListener('ping', function handle() {
+                report(new Error('x'));
+            });
+            target.dispatchEvent(new Event('ping'));
+            """,
+            "app.js");
+
+        StackLines(_reported!)[0].Should().StartWith("at handle (app.js:");
+    }
+
+    [Test]
+    public void AHandleEventListenerHasAFrameOfItsOwn()
+    {
+        var engine = WithEvents();
+        engine.SetValue("report", new Action<JsValue>(value => _reported = value));
+        engine.Execute(
+            """
+            var target = new EventTarget();
+            target.addEventListener('ping', {
+                handleEvent: function receive() { report(new Error('x')); }
+            });
+            target.dispatchEvent(new Event('ping'));
+            """,
+            "app.js");
+
+        // The callback interface's operation is looked up per invocation, and the function it finds owns a
+        // frame just as a directly callable listener does.
+        StackLines(_reported!)[0].Should().StartWith("at receive (app.js:");
+    }
+
+    [Test]
+    public void AnEventHandlerAttributeCallbackHasAFrameOfItsOwn()
+    {
+        var engine = WithEvents();
+        engine.SetValue("report", new Action<JsValue>(value => _reported = value));
+        engine.Execute(
+            """
+            var controller = new AbortController();
+            controller.signal.onabort = function reacted() { report(new Error('x')); };
+            controller.abort();
+            """,
+            "app.js");
+
+        // An event handler IDL attribute is a different algorithm from addEventListener's callback, and takes
+        // the other branch of the invoke — which pushed nothing either.
+        StackLines(_reported!)[0].Should().StartWith("at reacted (app.js:");
+    }
+
+    [Test]
+    public void AnAnonymousEventListenerIsAnonymousRatherThanAbsent()
+    {
+        var engine = WithEvents();
+        engine.SetValue("report", new Action<JsValue>(value => _reported = value));
+        engine.Execute(
+            """
+            var target = new EventTarget();
+            target.addEventListener('ping', function () { report(new Error('x')); });
+            target.dispatchEvent(new Event('ping'));
+            """,
+            "app.js");
+
+        StackLines(_reported!)[0].Should().StartWith("at (anonymous) (app.js:");
     }
 
     [Test]

--- a/Jint.Tests/Runtime/WebApi/ConsoleStackTraceTests.cs
+++ b/Jint.Tests/Runtime/WebApi/ConsoleStackTraceTests.cs
@@ -35,7 +35,9 @@ public class ConsoleStackTraceTests
     private static RecordingSink Run(string script, bool wantsStackTrace, string source = "app.js")
     {
         var sink = new RecordingSink(wantsStackTrace);
-        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Console | WebApiFeatures.Timers).UseConsole(sink));
+        var engine = new Engine(options => options
+            .UseWebApis(WebApiFeatures.Console | WebApiFeatures.Timers | WebApiFeatures.Events)
+            .UseConsole(sink));
         engine.Execute(script, source);
         engine.Tasks.ProcessTasks();
         return sink;
@@ -101,6 +103,39 @@ public class ConsoleStackTraceTests
         frames.Should().NotBeNull();
         frames!.Select(frame => frame.FunctionName).Should().Equal("heartbeat", "");
         frames[0].Line.Should().Be(2);
+    }
+
+    [Test]
+    public void AMessageLoggedFromAnEventListenerAnchorsInsideTheListener()
+    {
+        var sink = Run(
+            """
+            var target = new EventTarget();
+            target.addEventListener('ping', function receive() {
+                console.log('got it');
+            });
+            target.dispatchEvent(new Event('ping'));
+            """,
+            wantsStackTrace: true);
+
+        var frames = sink.Records.Should().ContainSingle().Which.StackTrace;
+        frames.Should().NotBeNull();
+        frames![0].FunctionName.Should().Be("receive");
+        frames[0].Line.Should().Be(3);
+    }
+
+    [Test]
+    public void ConsoleTraceInsideAnEventListenerStartsAtTheListener()
+    {
+        var sink = Run(
+            """
+            var target = new EventTarget();
+            target.addEventListener('ping', function receive() { console.trace('why'); });
+            target.dispatchEvent(new Event('ping'));
+            """,
+            wantsStackTrace: false);
+
+        sink.Records.Should().ContainSingle().Which.StackTrace![0].FunctionName.Should().Be("receive");
     }
 
     [Test]

--- a/Jint/WebApi/Events/JsEventTarget.cs
+++ b/Jint/WebApi/Events/JsEventTarget.cs
@@ -536,7 +536,10 @@ internal class JsEventTarget : ObjectInstance
 
         if (callback is ICallable directly)
         {
-            directly.Call(ev.CurrentTarget, ev);
+            // Through Engine.Call rather than ICallable.Call, so the listener owns a call-stack frame: a
+            // dispatch is where the engine is entered, and a frame nothing pushed is a frame absent from
+            // Error.prototype.stack, from console.trace, from the profiler and from the debugger's call stack.
+            _engine.Call(directly, ev.CurrentTarget, [ev], expression: null);
             return;
         }
 
@@ -552,7 +555,7 @@ internal class JsEventTarget : ObjectInstance
             return;
         }
 
-        operation.Call(handler, ev);
+        _engine.Call(operation, handler, [ev], expression: null);
     }
 
     /// <summary>
@@ -596,13 +599,17 @@ internal class JsEventTarget : ObjectInstance
             && IsGlobalScope
             && string.Equals(ev.TypeName, GlobalEventNames.ErrorName, StringComparison.Ordinal))
         {
-            var legacy = handler.Call(
+            var legacy = _engine.Call(
+                handler,
                 ev.CurrentTarget,
-                JsString.Create(errorEvent.Message),
-                JsString.Create(errorEvent.Filename),
-                JsNumber.Create(errorEvent.Lineno),
-                JsNumber.Create(errorEvent.Colno),
-                errorEvent.Error);
+                [
+                    JsString.Create(errorEvent.Message),
+                    JsString.Create(errorEvent.Filename),
+                    JsNumber.Create(errorEvent.Lineno),
+                    JsNumber.Create(errorEvent.Colno),
+                    errorEvent.Error
+                ],
+                expression: null);
 
             if (legacy is JsBoolean && legacy.AsBoolean())
             {
@@ -612,7 +619,7 @@ internal class JsEventTarget : ObjectInstance
             return;
         }
 
-        var result = handler.Call(ev.CurrentTarget, ev);
+        var result = _engine.Call(handler, ev.CurrentTarget, [ev], expression: null);
 
         if (result is JsBoolean && !result.AsBoolean())
         {

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -4921,6 +4921,31 @@ with a shallower call stack. The one event it now gets is the deepest of the one
 value, same location, and the call stack it was thrown on — so a subscriber that only read the first event
 of a run sees no change at all.
 
+### 4.113 An event listener has a call-stack frame of its own ([#3644](https://github.com/sebastienros/jint/issues/3644))
+
+The same defect [4.108](#4108-a-frame-the-engine-was-entered-at-is-named-and-a-timer-callback-has-one-3635)
+fixed for a timer callback held for an event listener: `JsEventTarget` reached every callback through
+`ICallable.Call`, which pushes nothing onto the call stack, so a listener invoked by `dispatchEvent`, by
+`controller.abort()` or by any engine-fired event was absent from `Error.prototype.stack`, from
+`console.trace`, from the profiler and from the debugger's call stack. All four invocation sites — a callable
+listener, a callback object's `handleEvent`, an event handler IDL attribute (`onabort`, `onmessage`, …) and
+the global scope's legacy five-argument `onerror` — now go through `Engine.Call`, the same entry a call
+expression and `engine.Invoke` use.
+
+```js
+var target = new EventTarget();
+target.addEventListener('ping', function handle() { throw new Error('boom'); });
+target.dispatchEvent(new Event('ping'));
+// 5.0:  "    at dispatchEvent (app.js:3:8)"
+// 5.x:  "    at handle (app.js:2:52)" and the dispatchEvent frame under it
+```
+
+**What could break:** a test comparing a stack trace against a hard-coded string for code an event listener
+entered — there is one more frame in it — and a host that sets `Options.Constraints.MaxRecursionDepth` low
+enough that one extra frame per listener matters. Nothing about what a listener is passed, what its `this`
+is, what a throwing listener does (report and continue with a `DiagnosticsSink`, erupt without one), or
+whether a handler's return value cancels the event has changed.
+
 ## 5. New in v5
 
 Everything in the table below is opt-in: nothing in it is installed unless the host asks for it, so


### PR DESCRIPTION
The defect [#3635](https://github.com/sebastienros/jint/pull/3635) fixed for a timer callback held for an
event listener too. `JsEventTarget` reached every callback through `ICallable.Call`, which pushes nothing
onto `JintCallStack`, so a listener invoked by `dispatchEvent`, by `controller.abort()` or by any
engine-fired event was absent from `Error.prototype.stack`, from `console.trace`, from the profiler and from
the debugger's call stack. The outermost row a front end drew for a listener was the native `dispatchEvent`
frame that reached it:

```js
var target = new EventTarget();
target.addEventListener('ping', function handle() { throw new Error('boom'); });
target.dispatchEvent(new Event('ping'));
// before:  "    at dispatchEvent (app.js:3:8)"
// after:   "    at handle (app.js:2:52)" and the dispatchEvent frame under it
```

All four invocation sites now go through `Engine.Call(callback, thisValue, arguments, expression: null)` —
the same entry a call expression and `engine.Invoke` already use, and the same change #3635 made to
`TimerEntry.Fire`, `TimerFunctions.InvokeMicrotask`, `IdleCallbackQueue.InvokeCallback` and
`SchedulerTask.Run`:

- a directly callable `addEventListener` listener;
- a callback object's `handleEvent` operation, which is still looked up per invocation;
- an event handler IDL attribute (`onabort`, `onmessage`, `onload`, …);
- the global scope's legacy five-argument `onerror`, which is a worker global's and nothing else — its
  behaviour (five arguments, cancel by returning `true`) is already pinned by
  `WorkerMechanismTests.TheWorkerGlobalOnErrorTakesFiveArgumentsAndCancelsByReturningTrue`, which still
  passes unchanged.

Nothing else about the invocation moves: the `this`, the arguments, the return-value cancellation, and what a
throwing listener does — reported to the `DiagnosticsSink` and the dispatch continues, or erupts when there
is no sink — are all where they were. `DiagnosticsTests.AThrowingListenerIsReportedAndTheDispatchContinues`
and `AThrowingListenerEruptsWithoutASink` are unchanged and pass.

**Hot paths touched:** `JsEventTarget.InvokeCallback` / `InvokeEventHandler` — one dispatch per event
listener invocation, now pushing and popping a `JintCallStack` frame as every call expression already does.
No benchmark: the whole point is that a listener costs what a called function costs.

### Tests

`Jint.Tests/Runtime/CallStackEntryFrameTests.cs` gains four cases (a named listener, a `handleEvent` object,
an `onabort` handler attribute, and an anonymous listener naming itself `(anonymous)` rather than nothing),
and `Jint.Tests/Runtime/WebApi/ConsoleStackTraceTests.cs` two (`console.log` under
`ConsoleSink.WantsStackTrace`, and `console.trace`, both anchoring inside the listener). All six fail on
`main` with the native `dispatchEvent` / `abort` frame at the top.

Full solution: green on net472/net8.0/net10.0 (`Jint.Tests` 11 972, `Jint.Tests.PublicInterface` 3 531,
`Jint.Tests.DevTools` 337, test262 102 573).

Fixes #3644

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
