### PR TITLE
Debugger, profiling and coverage: a frame names the program it belongs to, not the name it was parsed under

### DIFF
--- a/Jint.Tests.PublicInterface/CodeCoverageTests.cs
+++ b/Jint.Tests.PublicInterface/CodeCoverageTests.cs
@@ -29,10 +29,17 @@ public class CodeCoverageTests
     private static string Text(string code, CoverageEntry entry)
         => code.Substring(entry.Start.Index, entry.End.Index - entry.Start.Index);
 
+    /// <summary>
+    /// Every entry counted under the one source name, totalled by construct. A source is one parse, so a
+    /// host that runs the same text twice reads two of them and adds them up exactly like this.
+    /// </summary>
     private static List<(string Text, CoverageEntryKind Kind, long Hits)> Rows(string code, CoverageReport report)
         => report.Sources
-            .Single(s => s.Name == Source).Entries
-            .Select(e => (Text(code, e), e.Kind, e.HitCount))
+            .Where(s => s.Name == Source)
+            .SelectMany(s => s.Entries)
+            .GroupBy(e => (Start: e.Start.Index, End: e.End.Index, e.Kind))
+            .OrderBy(g => g.Key.Start).ThenBy(g => g.Key.End).ThenBy(g => g.Key.Kind)
+            .Select(g => (Text(code, g.First()), g.Key.Kind, g.Sum(e => e.HitCount)))
             .ToList();
 
     // ---- reachability ----
@@ -165,6 +172,50 @@ public class CodeCoverageTests
 
         engine.Diagnostics.GetCoverage().Sources.Select(s => s.Name)
             .Should().Equal("<anonymous>", "alpha.js", "beta.js");
+    }
+
+    /// <summary>
+    /// A source is one parse, named by the program it came from — which is what a coverage tool maps back to
+    /// the script it prepared, and what a source name cannot answer once two parses share one.
+    /// </summary>
+    [Test]
+    public void EachParseIsASourceOfItsOwnNamingItsProgram()
+    {
+        const string Code = "var a = 1;";
+
+        var engine = CreateEngine();
+        engine.Execute(Code);
+        engine.Execute(Code);
+
+        var sources = engine.Diagnostics.GetCoverage().Sources;
+
+        sources.Should().HaveCount(2);
+        sources.Select(s => s.Name).Should().AllBe("<anonymous>");
+        sources.Select(s => s.Program).Should().OnlyHaveUniqueItems();
+        sources.Should().AllSatisfy(s => s.Program.Should().NotBeNull());
+
+        // and the total under one name is the reader's to add up
+        sources.SelectMany(s => s.Entries).Sum(e => e.HitCount).Should().Be(2L);
+    }
+
+    /// <summary>
+    /// A prepared script is one program however often a host runs it, which is the shape an embedder that
+    /// caches its scripts actually reads.
+    /// </summary>
+    [Test]
+    public void APreparedScriptIsOneSourceHoweverOftenItRuns()
+    {
+        var prepared = Engine.PrepareScript("var a = 1;", Source);
+
+        var engine = CreateEngine();
+        engine.Execute(prepared);
+        engine.Execute(prepared);
+
+        var sources = engine.Diagnostics.GetCoverage().Sources;
+
+        sources.Should().ContainSingle();
+        sources[0].Program.Should().BeSameAs(prepared.Program);
+        sources[0].Entries.Single().HitCount.Should().Be(2L);
     }
 
     // ---- engine isolation, which is what makes the feature usable at all ----

--- a/Jint.Tests.PublicInterface/HostFrameProgramTests.cs
+++ b/Jint.Tests.PublicInterface/HostFrameProgramTests.cs
@@ -1,0 +1,176 @@
+#nullable enable
+
+using System.Collections.Generic;
+using System.Linq;
+using Jint.Runtime.Debugger;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// The program a debugger frame and a profile frame belong to, which is the identity a tooling protocol
+/// answers "which script is this?" with.
+/// </summary>
+/// <remarks>
+/// A location carries a source <em>name</em>, and every <c>Execute</c> given no source is
+/// <c>&lt;anonymous&gt;</c>, so a host matching positions against names collapses every such script into one.
+/// The reference on the frame is the one <c>DebugHandler.BeforeEvaluate</c> hands over, which is what makes
+/// the two answerable apart.
+/// </remarks>
+public class HostFrameProgramTests
+{
+    private const string Script = """
+        function work() {
+            debugger;
+            return 1;
+        }
+        work();
+        """;
+
+    private static Engine CreateDebuggerEngine() => new(options =>
+    {
+        options.Debugger.Enabled = true;
+        options.Debugger.StatementHandling = DebuggerStatementHandling.Script;
+    });
+
+    /// <summary>
+    /// The case a name cannot answer: two programs parsed under one name, at the very same positions.
+    /// </summary>
+    [Test]
+    public void TwoScriptsParsedUnderOneNameAreToldApartByTheirFramesProgram()
+    {
+        var engine = CreateDebuggerEngine();
+
+        var parsed = new List<Program>();
+        engine.Debugger.BeforeEvaluate += (sender, ast) => parsed.Add(ast);
+
+        var paused = new List<Program?>();
+        engine.Debugger.Break += (sender, info) =>
+        {
+            paused.Add(info.CallStack[0].Program);
+            return StepMode.None;
+        };
+
+        engine.Execute(Script);
+        engine.Execute(Script);
+
+        parsed.Should().HaveCount(2);
+        parsed[0].Should().NotBeSameAs(parsed[1]);
+
+        paused.Should().HaveCount(2);
+        paused[0].Should().BeSameAs(parsed[0]);
+        paused[1].Should().BeSameAs(parsed[1]);
+    }
+
+    /// <summary>
+    /// Every frame of the stack answers, the top-level one included — it is the frame a sourceless
+    /// <c>Execute</c> spends most of its time in.
+    /// </summary>
+    [Test]
+    public void EveryFrameOfThePauseNamesTheProgramItIsRunning()
+    {
+        var engine = CreateDebuggerEngine();
+
+        var prepared = Engine.PrepareScript(Script, "host.js");
+
+        DebugCallStack? stack = null;
+        engine.Debugger.Break += (sender, info) =>
+        {
+            stack = info.CallStack;
+            return StepMode.None;
+        };
+
+        engine.Execute(prepared);
+
+        stack.Should().NotBeNull();
+        stack!.Should().HaveCount(2);
+        stack.Should().AllSatisfy(frame => frame.Program.Should().BeSameAs(prepared.Program));
+    }
+
+    /// <summary>
+    /// A shared <c>Prepared&lt;Script&gt;</c> is one program however often it runs, which is what makes the
+    /// identity worth keying a script table on.
+    /// </summary>
+    [Test]
+    public void RunningOnePreparedScriptTwiceNamesTheOneProgram()
+    {
+        var engine = CreateDebuggerEngine();
+        var prepared = Engine.PrepareScript(Script, "host.js");
+
+        var paused = new List<Program?>();
+        engine.Debugger.Break += (sender, info) =>
+        {
+            paused.Add(info.CallStack[0].Program);
+            return StepMode.None;
+        };
+
+        engine.Execute(prepared);
+        engine.Execute(prepared);
+
+        paused.Should().HaveCount(2);
+        paused.Should().AllSatisfy(program => program.Should().BeSameAs(prepared.Program));
+    }
+
+    /// <summary>
+    /// Code the engine reached through <c>eval</c> is a program no execution context names, so the frame
+    /// answers with none rather than with the script that ran the <c>eval</c>.
+    /// </summary>
+    [Test]
+    public void AFrameInsideEvalNamesNoProgram()
+    {
+        var engine = CreateDebuggerEngine();
+
+        var paused = new List<Program?>();
+        engine.Debugger.Break += (sender, info) =>
+        {
+            paused.Add(info.CallStack[0].Program);
+            return StepMode.None;
+        };
+
+        engine.Execute("eval('debugger;');", "host.js");
+
+        paused.Should().ContainSingle();
+        paused[0].Should().BeNull();
+    }
+
+    /// <summary>
+    /// The profiler's frame table answers the same question for a function, so a profile's frames map onto
+    /// the same script table a pause does.
+    /// </summary>
+    [Test]
+    public void AProfileFrameNamesTheProgramItsFunctionWasParsedFrom()
+    {
+        var engine = new Engine(options => options.Profiling.Enabled = true);
+
+        var first = Engine.PrepareScript("function alpha() { return 1; } alpha();");
+        var second = Engine.PrepareScript("function beta() { return 2; } beta();");
+
+        engine.Diagnostics.StartProfiling();
+        engine.Execute(first);
+        engine.Execute(second);
+        var profile = engine.Diagnostics.StopProfiling();
+
+        profile.Frames.Single(f => f.Name == "alpha").Program.Should().BeSameAs(first.Program);
+        profile.Frames.Single(f => f.Name == "beta").Program.Should().BeSameAs(second.Program);
+
+        // both were parsed under the one name every sourceless script gets, which is the collision
+        profile.Frames.Select(f => f.File).Distinct().Should().ContainSingle();
+    }
+
+    /// <summary>
+    /// A built-in and a host callable have no source, so they name no program either — the answer is
+    /// <see langword="null"/> rather than the script that happened to be running when they were created.
+    /// </summary>
+    [Test]
+    public void AFunctionWithNoSourceNamesNoProgram()
+    {
+        var engine = new Engine(options => options.Profiling.Enabled = true);
+        engine.SetValue("host", new System.Func<int>(() => 1));
+
+        engine.Diagnostics.StartProfiling();
+        engine.Execute("[3, 1, 2].sort(function (a, b) { return a - b; }); host();", "host.js");
+        var profile = engine.Diagnostics.StopProfiling();
+
+        profile.Frames.Should().NotBeEmpty();
+        profile.Frames.Should().OnlyContain(f => f.File != null || f.Program == null);
+    }
+}

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
@@ -1934,11 +1934,12 @@ namespace Jint.Profiling
     }
     public readonly struct ScriptProfileFrame : System.IEquatable<Jint.Profiling.ScriptProfileFrame>
     {
-        public ScriptProfileFrame(string Name, string? File, int? Line, int? Column) { }
+        public ScriptProfileFrame(string Name, string? File, int? Line, int? Column, Acornima.Ast.Program? Program = null) { }
         public int? Column { get; init; }
         public string? File { get; init; }
         public int? Line { get; init; }
         public string Name { get; init; }
+        public Acornima.Ast.Program? Program { get; init; }
     }
 }
 namespace Jint.Runtime
@@ -2157,6 +2158,7 @@ namespace Jint.Runtime.Coverage
     {
         public System.Collections.Generic.IReadOnlyList<Jint.Runtime.Coverage.CoverageEntry> Entries { get; }
         public string Name { get; }
+        public Acornima.Ast.Program? Program { get; }
     }
 }
 namespace Jint.Runtime.Debugger
@@ -2194,6 +2196,7 @@ namespace Jint.Runtime.Debugger
         public string FunctionName { get; }
         public int Index { get; }
         public Acornima.SourceLocation& Location { get; }
+        public Acornima.Ast.Program? Program { get; }
         public Jint.Native.JsValue? ReturnValue { get; }
         public Jint.Runtime.Debugger.DebugScopes ScopeChain { get; }
         public Jint.Native.JsValue This { get; }

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net472.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net472.verified.txt
@@ -1751,11 +1751,12 @@ namespace Jint.Profiling
     }
     public readonly struct ScriptProfileFrame : System.IEquatable<Jint.Profiling.ScriptProfileFrame>
     {
-        public ScriptProfileFrame(string Name, string? File, int? Line, int? Column) { }
+        public ScriptProfileFrame(string Name, string? File, int? Line, int? Column, Acornima.Ast.Program? Program = null) { }
         public int? Column { get; init; }
         public string? File { get; init; }
         public int? Line { get; init; }
         public string Name { get; init; }
+        public Acornima.Ast.Program? Program { get; init; }
     }
 }
 namespace Jint.Runtime
@@ -1974,6 +1975,7 @@ namespace Jint.Runtime.Coverage
     {
         public System.Collections.Generic.IReadOnlyList<Jint.Runtime.Coverage.CoverageEntry> Entries { get; }
         public string Name { get; }
+        public Acornima.Ast.Program? Program { get; }
     }
 }
 namespace Jint.Runtime.Debugger
@@ -2011,6 +2013,7 @@ namespace Jint.Runtime.Debugger
         public string FunctionName { get; }
         public int Index { get; }
         public Acornima.SourceLocation& Location { get; }
+        public Acornima.Ast.Program? Program { get; }
         public Jint.Native.JsValue? ReturnValue { get; }
         public Jint.Runtime.Debugger.DebugScopes ScopeChain { get; }
         public Jint.Native.JsValue This { get; }

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
@@ -1934,11 +1934,12 @@ namespace Jint.Profiling
     }
     public readonly struct ScriptProfileFrame : System.IEquatable<Jint.Profiling.ScriptProfileFrame>
     {
-        public ScriptProfileFrame(string Name, string? File, int? Line, int? Column) { }
+        public ScriptProfileFrame(string Name, string? File, int? Line, int? Column, Acornima.Ast.Program? Program = null) { }
         public int? Column { get; init; }
         public string? File { get; init; }
         public int? Line { get; init; }
         public string Name { get; init; }
+        public Acornima.Ast.Program? Program { get; init; }
     }
 }
 namespace Jint.Runtime
@@ -2157,6 +2158,7 @@ namespace Jint.Runtime.Coverage
     {
         public System.Collections.Generic.IReadOnlyList<Jint.Runtime.Coverage.CoverageEntry> Entries { get; }
         public string Name { get; }
+        public Acornima.Ast.Program? Program { get; }
     }
 }
 namespace Jint.Runtime.Debugger
@@ -2194,6 +2196,7 @@ namespace Jint.Runtime.Debugger
         public string FunctionName { get; }
         public int Index { get; }
         public Acornima.SourceLocation& Location { get; }
+        public Acornima.Ast.Program? Program { get; }
         public Jint.Native.JsValue? ReturnValue { get; }
         public Jint.Runtime.Debugger.DebugScopes ScopeChain { get; }
         public Jint.Native.JsValue This { get; }

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.0.verified.txt
@@ -1751,11 +1751,12 @@ namespace Jint.Profiling
     }
     public readonly struct ScriptProfileFrame : System.IEquatable<Jint.Profiling.ScriptProfileFrame>
     {
-        public ScriptProfileFrame(string Name, string? File, int? Line, int? Column) { }
+        public ScriptProfileFrame(string Name, string? File, int? Line, int? Column, Acornima.Ast.Program? Program = null) { }
         public int? Column { get; init; }
         public string? File { get; init; }
         public int? Line { get; init; }
         public string Name { get; init; }
+        public Acornima.Ast.Program? Program { get; init; }
     }
 }
 namespace Jint.Runtime
@@ -1974,6 +1975,7 @@ namespace Jint.Runtime.Coverage
     {
         public System.Collections.Generic.IReadOnlyList<Jint.Runtime.Coverage.CoverageEntry> Entries { get; }
         public string Name { get; }
+        public Acornima.Ast.Program? Program { get; }
     }
 }
 namespace Jint.Runtime.Debugger
@@ -2011,6 +2013,7 @@ namespace Jint.Runtime.Debugger
         public string FunctionName { get; }
         public int Index { get; }
         public Acornima.SourceLocation& Location { get; }
+        public Acornima.Ast.Program? Program { get; }
         public Jint.Native.JsValue? ReturnValue { get; }
         public Jint.Runtime.Debugger.DebugScopes ScopeChain { get; }
         public Jint.Native.JsValue This { get; }

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.1.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.1.verified.txt
@@ -1751,11 +1751,12 @@ namespace Jint.Profiling
     }
     public readonly struct ScriptProfileFrame : System.IEquatable<Jint.Profiling.ScriptProfileFrame>
     {
-        public ScriptProfileFrame(string Name, string? File, int? Line, int? Column) { }
+        public ScriptProfileFrame(string Name, string? File, int? Line, int? Column, Acornima.Ast.Program? Program = null) { }
         public int? Column { get; init; }
         public string? File { get; init; }
         public int? Line { get; init; }
         public string Name { get; init; }
+        public Acornima.Ast.Program? Program { get; init; }
     }
 }
 namespace Jint.Runtime
@@ -1974,6 +1975,7 @@ namespace Jint.Runtime.Coverage
     {
         public System.Collections.Generic.IReadOnlyList<Jint.Runtime.Coverage.CoverageEntry> Entries { get; }
         public string Name { get; }
+        public Acornima.Ast.Program? Program { get; }
     }
 }
 namespace Jint.Runtime.Debugger
@@ -2011,6 +2013,7 @@ namespace Jint.Runtime.Debugger
         public string FunctionName { get; }
         public int Index { get; }
         public Acornima.SourceLocation& Location { get; }
+        public Acornima.Ast.Program? Program { get; }
         public Jint.Native.JsValue? ReturnValue { get; }
         public Jint.Runtime.Debugger.DebugScopes ScopeChain { get; }
         public Jint.Native.JsValue This { get; }

--- a/Jint.Tests/Runtime/CodeCoverageTests.cs
+++ b/Jint.Tests/Runtime/CodeCoverageTests.cs
@@ -29,8 +29,12 @@ public class CodeCoverageTests
     private static string Text(string code, CoverageEntry entry)
         => code.Substring(entry.Start.Index, entry.End.Index - entry.Start.Index);
 
+    /// <summary>
+    /// Every entry counted under one name. A source is one parse, so a name several parses share has a
+    /// source each and a reader that wants the name's total is the one that adds them up.
+    /// </summary>
     private static IReadOnlyList<CoverageEntry> EntriesOf(CoverageReport report, string source = Source)
-        => report.Sources.Single(s => s.Name == source).Entries;
+        => report.Sources.Where(s => s.Name == source).SelectMany(s => s.Entries).ToList();
 
     private static List<(string Text, CoverageEntryKind Kind, long Hits)> Rows(string code, CoverageReport report)
         => EntriesOf(report).Select(e => (Text(code, e), e.Kind, e.HitCount)).ToList();
@@ -288,13 +292,12 @@ public class CodeCoverageTests
     }
 
     /// <summary>
-    /// The counters key on AST node identity, and <c>Execute(string)</c> re-parses, so the same construct is a
-    /// different node on every call. The report folds those together by position — otherwise a host that does
-    /// not cache a <c>Prepared&lt;Script&gt;</c> would read "ran once" ten times over instead of "ran ten
-    /// times".
+    /// The counters key on AST node identity, and <c>Execute(string)</c> re-parses, so the same construct is
+    /// a different node on every call — and a different program. Each parse is a source of its own, under
+    /// the same name and told apart by its program; a reader that wants the name's total adds them up.
     /// </summary>
     [Test]
-    public void ReParsingTheSameSourceAddsToTheSameEntry()
+    public void ReParsingTheSameSourceIsOneSourcePerParse()
     {
         const string Code = "function f() { return 1; } f(); f();";
 
@@ -302,11 +305,55 @@ public class CodeCoverageTests
         engine.Execute(Code, Source);
         engine.Execute(Code, Source);
 
-        var rows = Rows(Code, engine.Diagnostics.GetCoverage());
+        var sources = engine.Diagnostics.GetCoverage().Sources.Where(s => s.Name == Source).ToList();
 
-        rows.Count(r => r.Text == "return 1;").Should().Be(1);
-        rows.Should().Contain(("return 1;", CoverageEntryKind.Statement, 4L));
-        rows.Should().Contain(("{ return 1; }", CoverageEntryKind.Function, 4L));
+        sources.Should().HaveCount(2);
+        sources.Select(s => s.Program).Should().OnlyHaveUniqueItems();
+        sources.Should().AllSatisfy(s => s.Program.Should().NotBeNull());
+
+        foreach (var source in sources)
+        {
+            source.Entries.Select(e => (Text(Code, e), e.Kind, e.HitCount))
+                .Should().Contain(("return 1;", CoverageEntryKind.Statement, 2L));
+        }
+
+        Rows(Code, engine.Diagnostics.GetCoverage())
+            .Where(r => r.Text == "return 1;").Sum(r => r.Hits).Should().Be(4L);
+    }
+
+    /// <summary>
+    /// The identity a host maps a source back to the script it prepared by, which is what a name cannot
+    /// answer once several parses share one.
+    /// </summary>
+    [Test]
+    public void ASourceNamesTheProgramItWasParsedFrom()
+    {
+        var prepared = Engine.PrepareScript("var a = 1;", Source);
+
+        var engine = CreateEngine();
+        engine.Execute(prepared);
+        engine.Execute(prepared);
+
+        var sources = engine.Diagnostics.GetCoverage().Sources.Where(s => s.Name == Source).ToList();
+
+        sources.Should().ContainSingle();
+        sources[0].Program.Should().BeSameAs(prepared.Program);
+    }
+
+    /// <summary>
+    /// Code the engine reached through <c>eval</c> belongs to a program no execution context names, so it is
+    /// reported with none rather than against the script that ran it.
+    /// </summary>
+    [Test]
+    public void EvaluatedCodeIsReportedWithNoProgram()
+    {
+        var engine = CreateEngine();
+        engine.Execute("eval('var a = 1;');", Source);
+
+        var report = engine.Diagnostics.GetCoverage();
+
+        report.Sources.Should().Contain(s => s.Program == null);
+        report.Sources.Where(s => s.Name == Source).Should().AllSatisfy(s => s.Program.Should().NotBeNull());
     }
 
     [Test]

--- a/Jint/Engine.Coverage.cs
+++ b/Jint/Engine.Coverage.cs
@@ -36,12 +36,12 @@ public partial class Engine
         /// not double-counted by a resumption; execution picks up where it suspended.
         /// </para>
         /// <para>
-        /// <b>Re-parsing the same source.</b> The counters are keyed on AST node identity, so a host calling
-        /// <see cref="Engine.Execute(string, string, ScriptParsingOptions)"/> with the same text twice counts two different node
-        /// sets for one construct. The report folds those together by source name and position, so such a host
-        /// reads the total rather than one entry per parse — and a host that caches a
-        /// <see cref="Prepared{TProgram}"/> (which it should) never creates the situation in the first place.
-        /// The corollary is that two genuinely different sources must not share a name.
+        /// <b>Re-parsing the same source.</b> A source is one parse, so a host calling
+        /// <see cref="Engine.Execute(string, string, ScriptParsingOptions)"/> with the same text twice reads two
+        /// <see cref="CoverageSource"/>s of one name, told apart by <see cref="CoverageSource.Program"/> — and a
+        /// host that caches a <see cref="Prepared{TProgram}"/> (which it should) never creates the situation in
+        /// the first place. Only entries of a program the engine cannot name — <c>eval</c>, the <c>Function</c>
+        /// constructor — are folded together by name and position.
         /// </para>
         /// <para>
         /// <b>What is not in the report.</b> Only constructs that actually ran. A statement with zero hits has

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -3196,7 +3196,7 @@ public sealed partial class Engine : IDisposable
         // After the constraints on purpose: a statement a constraint refused is a statement that never ran.
         if (_coverage is not null && statement is not null)
         {
-            _coverage.Record(statement);
+            _coverage.Record(statement, this);
         }
 
         if (_isDebugMode && statement != null && statement.Type != NodeType.BlockStatement)

--- a/Jint/Profiling/ProfileFrames.cs
+++ b/Jint/Profiling/ProfileFrames.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using Jint.Native;
 using Jint.Native.Function;
+using Jint.Runtime;
 using Jint.Runtime.Descriptors;
 using Jint.Runtime.Interop;
 using Jint.Runtime.Interpreter;
@@ -34,7 +35,7 @@ internal static class ProfileFrames
     internal static readonly IEqualityComparer<object> FunctionIdentity = new IdentityComparer();
 
     /// <summary>
-    /// The name, file and declaration position to show for <paramref name="function"/>.
+    /// The name, file, declaration position and owning program to show for <paramref name="function"/>.
     /// </summary>
     internal static ScriptProfileFrame Describe(Function function, JintFunctionDefinition? definition)
     {
@@ -56,7 +57,15 @@ internal static class ProfileFrames
 
         // Column is reported one-based, matching the column Jint puts in a stack trace; the parser's is an
         // index.
-        return new ScriptProfileFrame(name, file, location.Start.Line, location.Start.Column + 1);
+        // The function's [[ScriptOrModule]] is the script that was active when it was created, which is the
+        // program its body belongs to for everything but eval and the Function constructor — and those two
+        // are what OwningProgramOf declines rather than mis-attributing.
+        return new ScriptProfileFrame(
+            name,
+            file,
+            location.Start.Line,
+            location.Start.Column + 1,
+            function._scriptOrModule.OwningProgramOf(node));
     }
 
     /// <summary>

--- a/Jint/Profiling/SampledProfile.cs
+++ b/Jint/Profiling/SampledProfile.cs
@@ -11,9 +11,10 @@ namespace Jint.Profiling;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Immutable, engine-independent and safe to hand to another thread: it holds strings and numbers only. In
-/// particular it retains no <c>Function</c>, no AST and no <see cref="Engine"/>, so keeping a profile around
-/// does not keep the engine that produced it alive.
+/// Immutable and engine-independent: it retains no <c>Function</c>, no <c>JsValue</c> and no
+/// <see cref="Engine"/>, so keeping a profile around does not keep the engine that produced it alive. A
+/// frame does name the <see cref="ScriptProfileFrame.Program"/> it was parsed from, which is an identity to
+/// compare and not a tree to walk from another thread.
 /// </para>
 /// <para>
 /// <b>What a sample weighs.</b> The sampler fires at the engine's check points rather than on a timer, so

--- a/Jint/Profiling/ScriptProfile.cs
+++ b/Jint/Profiling/ScriptProfile.cs
@@ -12,9 +12,10 @@ namespace Jint.Profiling;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Immutable, engine-independent and safe to hand to another thread: it holds strings and numbers only.
-/// In particular it retains no <c>Function</c>, no AST and no <see cref="Engine"/>, so keeping a profile
-/// around does not keep the engine that produced it alive.
+/// Immutable and engine-independent: it retains no <c>Function</c>, no <c>JsValue</c> and no
+/// <see cref="Engine"/>, so keeping a profile around does not keep the engine that produced it alive. A
+/// frame does name the <see cref="ScriptProfileFrame.Program"/> it was parsed from, which is an identity to
+/// compare and not a tree to walk from another thread.
 /// </para>
 /// <para>
 /// <see cref="WriteSpeedscopeJson(TextWriter)"/> renders it in the

--- a/Jint/Profiling/ScriptProfileFrame.cs
+++ b/Jint/Profiling/ScriptProfileFrame.cs
@@ -16,6 +16,11 @@ namespace Jint.Profiling;
 /// </param>
 /// <param name="Line">One-based line of the function's declaration, or <see langword="null"/> with <see cref="File"/>.</param>
 /// <param name="Column">One-based column of the function's declaration, or <see langword="null"/> with <see cref="File"/>.</param>
+/// <param name="Program">
+/// The abstract syntax tree the function was parsed as part of — the reference
+/// <c>DebugHandler.BeforeEvaluate</c> hands over — or <see langword="null"/> for a function with no source,
+/// and for one the engine reached through <c>eval</c> or the <c>Function</c> constructor.
+/// </param>
 /// <remarks>
 /// <para>
 /// Frames are interned by <em>definition</em>, not by function object: every closure instantiated from one
@@ -27,6 +32,12 @@ namespace Jint.Profiling;
 /// <see cref="Column"/> is one-based to match the column Jint reports in a stack trace, where the underlying
 /// parser position is a zero-based index.
 /// </para>
+/// <para>
+/// <see cref="Program"/> identifies the script two frames share where <see cref="File"/> only names it, so
+/// several programs parsed under one name — every <c>Execute</c> given no source is <c>&lt;anonymous&gt;</c>
+/// — stay apart. Hold it as an identity: the tree itself is the engine's, and reading it from another thread
+/// while that engine runs is not supported.
+/// </para>
 /// </remarks>
 [StructLayout(LayoutKind.Auto)]
-public readonly record struct ScriptProfileFrame(string Name, string? File, int? Line, int? Column);
+public readonly record struct ScriptProfileFrame(string Name, string? File, int? Line, int? Column, Program? Program = null);

--- a/Jint/Runtime/CallStack/JintCallStack.cs
+++ b/Jint/Runtime/CallStack/JintCallStack.cs
@@ -18,9 +18,17 @@ internal readonly record struct CallStackExecutionContext
     public CallStackExecutionContext(in ExecutionContext context)
     {
         LexicalEnvironment = context.LexicalEnvironment;
+        ScriptOrModule = context.ScriptOrModule;
     }
 
     internal readonly Environment LexicalEnvironment;
+
+    /// <summary>
+    /// The script or module whose code runs in this context, which is what tells a debugger's
+    /// <c>CallFrame</c> which program its position belongs to. One reference copied per pushed frame,
+    /// read by nothing else.
+    /// </summary>
+    internal readonly IScriptOrModule? ScriptOrModule;
 
     internal Environment GetThisEnvironment()
     {

--- a/Jint/Runtime/Coverage/CoverageCollector.cs
+++ b/Jint/Runtime/Coverage/CoverageCollector.cs
@@ -35,13 +35,20 @@ internal sealed class CoverageCollector
 {
     private sealed class Counter
     {
-        internal Counter(CoverageEntryKind kind, bool reported)
+        internal Counter(CoverageEntryKind kind, bool reported, Program? program)
         {
             Kind = kind;
             Reported = reported;
+            Program = program;
         }
 
         internal readonly CoverageEntryKind Kind;
+
+        /// <summary>
+        /// The program the node was parsed as part of, read once when the counter is made: a node belongs
+        /// to one program for as long as it exists, so this never has to be re-asked.
+        /// </summary>
+        internal readonly Program? Program;
 
         /// <summary>
         /// False for a node the granularity excludes. Such a node still gets an entry here so the
@@ -75,7 +82,7 @@ internal sealed class CoverageCollector
     /// one of the three things that arms it, so this runs for every executed statement and every function-body
     /// entry.
     /// </summary>
-    internal void Record(StatementOrExpression node)
+    internal void Record(StatementOrExpression node, Engine engine)
     {
         if (_counters.TryGetValue(node, out var counter))
         {
@@ -83,14 +90,19 @@ internal sealed class CoverageCollector
             return;
         }
 
-        AddCounter(node);
+        AddCounter(node, engine);
     }
 
+    /// <summary>
+    /// Makes the counter for a node seen for the first time, and settles which program it belongs to while
+    /// the context that is running it is still the top of the stack.
+    /// </summary>
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private void AddCounter(Node node)
+    private void AddCounter(Node node, Engine engine)
     {
         var reported = TryClassify(node, out var kind);
-        _counters[node] = new Counter(kind, reported) { Hits = 1 };
+        var program = engine.ExecutionContext.ScriptOrModule.OwningProgramOf(node);
+        _counters[node] = new Counter(kind, reported, program) { Hits = 1 };
     }
 
     /// <summary>
@@ -134,7 +146,7 @@ internal sealed class CoverageCollector
 
     internal CoverageReport BuildReport()
     {
-        var bySource = new Dictionary<string, List<Raw>>(StringComparer.Ordinal);
+        var bySource = new Dictionary<SourceKey, Group>(SourceKeyComparer.Instance);
 
         foreach (var pair in _counters)
         {
@@ -146,39 +158,87 @@ internal sealed class CoverageCollector
 
             var node = pair.Key;
             var location = node.Location;
-            var name = location.SourceFile ?? string.Empty;
+            var key = new SourceKey(counter.Program, location.SourceFile ?? string.Empty);
 
-            if (!bySource.TryGetValue(name, out var raws))
+            if (!bySource.TryGetValue(key, out var group))
             {
-                bySource[name] = raws = new List<Raw>();
+                bySource[key] = group = new Group(bySource.Count);
             }
 
-            raws.Add(new Raw(
+            group.Raws.Add(new Raw(
                 counter.Kind,
                 new CoveragePosition(location.Start.Line, location.Start.Column, node.Start),
                 new CoveragePosition(location.End.Line, location.End.Column, node.End),
                 counter.Hits));
         }
 
-        var sources = new List<CoverageSource>(bySource.Count);
+        var sources = new List<(SourceKey Key, Group Group)>(bySource.Count);
         foreach (var pair in bySource)
         {
-            sources.Add(new CoverageSource(pair.Key, Coalesce(pair.Value)));
+            sources.Add((pair.Key, pair.Value));
         }
 
-        sources.Sort(static (a, b) => string.CompareOrdinal(a.Name, b.Name));
-        return new CoverageReport(sources);
+        // By name first, which is the order that reads; several programs parsed under one name are then in
+        // the order they were first counted, so the report stays reproducible without inventing an order
+        // between two trees that have none.
+        sources.Sort(static (a, b) =>
+        {
+            var result = string.CompareOrdinal(a.Key.Name, b.Key.Name);
+            return result != 0 ? result : a.Group.Ordinal.CompareTo(b.Group.Ordinal);
+        });
+
+        var reported = new List<CoverageSource>(sources.Count);
+        foreach (var source in sources)
+        {
+            reported.Add(new CoverageSource(source.Key.Name, source.Key.Program, Coalesce(source.Group.Raws)));
+        }
+
+        return new CoverageReport(reported);
+    }
+
+    /// <summary>
+    /// What one <see cref="CoverageSource"/> is made of: the program the nodes were parsed as part of, and
+    /// the name they carry. Both, because a program the engine cannot name still has a source name to
+    /// report under, and two such parses must not be folded into one.
+    /// </summary>
+    [StructLayout(LayoutKind.Auto)]
+    private readonly record struct SourceKey(Program? Program, string Name);
+
+    private sealed class Group(int ordinal)
+    {
+        internal readonly int Ordinal = ordinal;
+        internal readonly List<Raw> Raws = new();
+    }
+
+    /// <summary>
+    /// Reference identity for the program half of a key, spelt out rather than left to the default
+    /// comparer: two abstract syntax trees with identical contents are two parses, and one source name
+    /// covering both is exactly the case this key exists to keep apart.
+    /// </summary>
+    private sealed class SourceKeyComparer : IEqualityComparer<SourceKey>
+    {
+        internal static readonly SourceKeyComparer Instance = new();
+
+        public bool Equals(SourceKey x, SourceKey y)
+            => ReferenceEquals(x.Program, y.Program) && string.Equals(x.Name, y.Name, StringComparison.Ordinal);
+
+        public int GetHashCode(SourceKey obj)
+        {
+            var program = obj.Program is null ? 0 : RuntimeHelpers.GetHashCode(obj.Program);
+            return (program * 397) ^ StringComparer.Ordinal.GetHashCode(obj.Name);
+        }
     }
 
     /// <summary>
     /// Orders the raw counts and sums the ones that name the same construct.
     /// </summary>
     /// <remarks>
-    /// The counters are keyed on AST node identity, and a host that re-parses the same text — every
-    /// <c>engine.Execute(code)</c> does — gets a fresh node per parse for the same construct. Reporting those
-    /// separately would answer "this statement ran once, ten times over" instead of "ten times", so a source
-    /// position counted through several parses is folded into one entry here. Within a single parse the fold
-    /// is a no-op: no two distinct nodes of the same kind share a range.
+    /// The counters are keyed on AST node identity, and several parses can land in one group: the entries of
+    /// every program the engine cannot name — <c>eval</c> and the <c>Function</c> constructor — are grouped
+    /// by source name alone, and a host evaluating the same string twice there gets a fresh node per parse
+    /// for the same construct. Reporting those separately would answer "this statement ran once, twice over"
+    /// instead of "twice". Within one program the fold is a no-op: no two distinct nodes of the same kind
+    /// share a range.
     /// </remarks>
     private static List<CoverageEntry> Coalesce(List<Raw> raws)
     {

--- a/Jint/Runtime/Coverage/CoverageReport.cs
+++ b/Jint/Runtime/Coverage/CoverageReport.cs
@@ -70,16 +70,24 @@ public sealed record CoverageEntry
 }
 
 /// <summary>
-/// The entries collected for one source, identified by the name that source was parsed under.
+/// The entries collected for one parsed program, under the name that program was parsed with.
 /// </summary>
 /// <remarks>
+/// <para>
+/// <b>One source is one parse, not one name.</b> Several programs parsed under one name — every
+/// <c>Execute</c> given no source is <c>&lt;anonymous&gt;</c> — are reported as one source each, told apart
+/// by <see cref="Program"/>.
+/// </para>
+/// <para>
 /// <b>Forward-extensible.</b> This type may gain members in any release; it has no public constructor.
+/// </para>
 /// </remarks>
 public sealed record CoverageSource
 {
-    internal CoverageSource(string name, IReadOnlyList<CoverageEntry> entries)
+    internal CoverageSource(string name, Program? program, IReadOnlyList<CoverageEntry> entries)
     {
         Name = name;
+        Program = program;
         Entries = entries;
     }
 
@@ -90,6 +98,23 @@ public sealed record CoverageSource
     /// name is reported as the empty string.
     /// </summary>
     public string Name { get; }
+
+    /// <summary>
+    /// Gets the program these entries were parsed as part of, or <see langword="null"/> when the engine
+    /// knows of none.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The same reference <see cref="Runtime.Debugger.DebugHandler.BeforeEvaluate"/> hands over and
+    /// <see cref="Engine.AdvancedOperations.TryGetSourceText"/> is keyed by, so a host maps a source to the
+    /// script it announced by reference rather than by matching <see cref="Name"/>.
+    /// </para>
+    /// <para>
+    /// Null for code the engine reached another way — <c>eval</c> and the <c>Function</c> constructor are
+    /// programs no script names — and those entries are grouped by <see cref="Name"/> alone.
+    /// </para>
+    /// </remarks>
+    public Program? Program { get; }
 
     /// <summary>
     /// The executed constructs, ordered by <see cref="CoveragePosition.Index"/> of their start.
@@ -113,7 +138,7 @@ public sealed record CoverageReport
 
     /// <summary>
     /// The sources that contributed at least one executed construct, ordered by
-    /// <see cref="CoverageSource.Name"/> (ordinal).
+    /// <see cref="CoverageSource.Name"/> (ordinal), then by when each parse was first counted.
     /// </summary>
     public IReadOnlyList<CoverageSource> Sources { get; }
 }

--- a/Jint/Runtime/Debugger/CallFrame.cs
+++ b/Jint/Runtime/Debugger/CallFrame.cs
@@ -72,6 +72,23 @@ public sealed class CallFrame
     public string FunctionName => _element?.ToString() ?? "(anonymous)";
 
     /// <summary>
+    /// Gets the program this frame's code was parsed from, or <see langword="null"/> when the engine knows
+    /// of none.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The same reference <see cref="DebugHandler.BeforeEvaluate"/> hands over and
+    /// <see cref="Engine.AdvancedOperations.TryGetSourceText"/> is keyed by, so a host maps a frame to the
+    /// script it announced by reference rather than by matching <see cref="Location"/>'s source name.
+    /// </para>
+    /// <para>
+    /// Null for code the engine reached another way: a frame inside <c>eval</c> or a <c>Function</c>
+    /// constructor body, a host callable, and a module record with no source of its own.
+    /// </para>
+    /// </remarks>
+    public Program? Program => _context.ScriptOrModule?.Program;
+
+    /// <summary>
     /// Source location of function of this call frame.
     /// </summary>
     /// <remarks>For top level (global) call frames, as well as functions not defined in script, this will be null.</remarks>

--- a/Jint/Runtime/IScriptOrModule.Extensions.cs
+++ b/Jint/Runtime/IScriptOrModule.Extensions.cs
@@ -13,4 +13,30 @@ internal static class ScriptOrModuleExtensions
         }
         return module;
     }
+
+    /// <summary>
+    /// The program <paramref name="node"/> was parsed as part of, or <see langword="null"/> when
+    /// <paramref name="scriptOrModule"/> is not the one the node came from.
+    /// </summary>
+    /// <remarks>
+    /// An execution context names the script or module whose code it runs, but code the engine reaches
+    /// through <c>eval</c> or the <c>Function</c> constructor is a program of its own that no context names
+    /// — so a node from such a program would otherwise be attributed to whichever script ran it, at a
+    /// position that script does not have. The node has to lie in the program, by source name and by range,
+    /// before the answer is given at all.
+    /// </remarks>
+    internal static Program? OwningProgramOf(this IScriptOrModule? scriptOrModule, Node node)
+    {
+        if (scriptOrModule?.Program is not { } program)
+        {
+            return null;
+        }
+
+        if (!string.Equals(node.Location.SourceFile, program.Location.SourceFile, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        return node.Start >= program.Start && node.End <= program.End ? program : null;
+    }
 }

--- a/Jint/Runtime/IScriptOrModule.cs
+++ b/Jint/Runtime/IScriptOrModule.cs
@@ -5,4 +5,11 @@ internal interface IScriptOrModule
     public string? Location { get; }
     public ParsingConstraints ParsingConstraints { get; }
     public ParserOptions? ParserOptions { get; }
+
+    /// <summary>
+    /// The abstract syntax tree this script or module was parsed into, which is the identity a host maps a
+    /// running position back to a script by. Null for a module that has no source of its own — a synthetic
+    /// or builder module.
+    /// </summary>
+    public Program? Program { get; }
 }

--- a/Jint/Runtime/Modules/ModuleRecord.cs
+++ b/Jint/Runtime/Modules/ModuleRecord.cs
@@ -25,8 +25,15 @@ public abstract class ModuleRecord : JsValue, IScriptOrModule
 
     ParsingConstraints IScriptOrModule.ParsingConstraints => ParsingConstraints;
     ParserOptions IScriptOrModule.ParserOptions => ParserOptions;
+    Program IScriptOrModule.Program => Source;
     internal virtual ParsingConstraints ParsingConstraints => default;
     internal virtual ParserOptions ParserOptions => null;
+
+    /// <summary>
+    /// The parsed module body, or null for a module with no source of its own — a synthetic module, a
+    /// builder module, and any host record that is not text.
+    /// </summary>
+    internal virtual Module Source => null;
 
     /// <summary>
     /// [[LoadedModules]] — the module records this one has already resolved a specifier to. Per

--- a/Jint/Runtime/Modules/SourceTextModuleRecord.cs
+++ b/Jint/Runtime/Modules/SourceTextModuleRecord.cs
@@ -60,6 +60,7 @@ internal class SourceTextModuleRecord : CyclicModuleRecord
     private readonly ParsingConstraints _parsingConstraints;
     internal override ParsingConstraints ParsingConstraints => _parsingConstraints;
     internal override ParserOptions ParserOptions => _parserOptions;
+    internal override Module Source => _source;
     private ExecutionContext _context;
     private ObjectInstance? _importMeta;
     private readonly List<ImportEntry>? _importEntries;

--- a/Jint/Runtime/ScriptRecord.cs
+++ b/Jint/Runtime/ScriptRecord.cs
@@ -5,4 +5,7 @@ internal sealed record ScriptRecord(
     Script EcmaScriptCode,
     string? Location,
     ParsingConstraints ParsingConstraints,
-    ParserOptions? ParserOptions) : IScriptOrModule;
+    ParserOptions? ParserOptions) : IScriptOrModule
+{
+    Program IScriptOrModule.Program => EcmaScriptCode;
+}

--- a/README.md
+++ b/README.md
@@ -2782,9 +2782,9 @@ profile.WriteSpeedscopeJson(file);
 
 Drop the file onto [speedscope.app](https://www.speedscope.app) — it is written in that tool's
 [evented profile format](https://www.speedscope.app/file-format-schema.json), in nanoseconds. The
-`ScriptProfile` is also readable directly: `Frames` (name, file, line, column), `Events` (open/close plus a
-timestamp), `Truncated` and `Duration`. It holds strings and numbers only, so keeping a profile does not keep
-the engine that produced it alive.
+`ScriptProfile` is also readable directly: `Frames` (name, file, line, column, and the `Program` the function
+was parsed from), `Events` (open/close plus a timestamp), `Truncated` and `Duration`. It holds no `JsValue`
+and no engine, so keeping a profile does not keep the engine that produced it alive.
 
 Worth knowing before you read a profile:
 
@@ -4135,6 +4135,11 @@ engine.Diagnostics.ResetCoverage(); // start a fresh measurement
   them are.
 - Counters are per engine, so a `Prepared<Script>` shared across a pool of engines keeps a separate count per
   engine and the shared AST is untouched. `Options` stays shareable.
+- A source is one *parse*, not one name: `source.Program` is the abstract syntax tree it was counted from —
+  the same reference `DebugHandler.BeforeEvaluate` hands over — so two `Execute(text)` calls under one name
+  are two sources. Add them up if you want the name's total; a host that caches a `Prepared<Script>` reads
+  one source either way. It is `null` for code reached through `eval` or the `Function` constructor, whose
+  entries are grouped by name.
 - `GetCoverage()` and `ResetCoverage()` throw `InvalidOperationException` on an engine that did not enable
   collection, rather than reporting an empty result that looks like a script which never ran.
 

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -4837,6 +4837,34 @@ promised, but a host that wants the old answer for loader-loaded modules can say
 `new ModuleParsingOptions { RetainFunctionSourceText = false }` to
 `ModuleFactory.BuildSourceTextModule`.
 
+### 4.111 A coverage source is one parse, not one name ([#3632](https://github.com/sebastienros/jint/issues/3632))
+
+`CoverageReport.Sources` used to hold one `CoverageSource` per source *name*, folding the counts of every
+parse that shared one — so a host calling `Execute(text)` twice read one source whose hit counts were the
+sum. It holds one source per parsed program now, told apart by the new `CoverageSource.Program`, because a
+name cannot tell two scripts apart and every `Execute` given no source is named `<anonymous>`.
+
+```csharp
+engine.Execute("var a = 1;");
+engine.Execute("var a = 1;");
+// 5.0:  Sources = [ <anonymous> ], one entry, HitCount 2
+// 5.x:  Sources = [ <anonymous>, <anonymous> ], one entry each, HitCount 1
+```
+
+**What could break:** a reader that indexes `Sources` by name — `Sources.Single(s => s.Name == "app.js")`
+throws where it used to answer. Group and add up to restore the old shape:
+
+```csharp
+var total = report.Sources.Where(s => s.Name == "app.js")
+    .SelectMany(s => s.Entries)
+    .GroupBy(e => (e.Start.Index, e.End.Index, e.Kind))
+    .Select(g => (g.Key, Hits: g.Sum(e => e.HitCount)));
+```
+
+A host that caches a `Prepared<Script>` — which it should — never had several parses in the first place and
+reads exactly what it read before. Entries of a program the engine cannot name (`eval`, the `Function`
+constructor) are still folded together by name and position.
+
 ## 5. New in v5
 
 Everything in the table below is opt-in: nothing in it is installed unless the host asks for it, so
@@ -5467,6 +5495,25 @@ new EngineTargetOptions { Url = Path.GetFullPath("app.js") }   // /json/list say
 `Options.Interop.BuildCallStackHandler` is handed, and they stay exactly what the host passed;
 `Debugger.setBreakpointByUrl` accepts either form. A `Url` that is not a path — `jint://repl`,
 `https://…`, the empty string — is unchanged.
+
+### 5.17 A frame, a profile frame and a coverage source name the program they belong to ([#3632](https://github.com/sebastienros/jint/issues/3632))
+
+A `SourceLocation` carries a source *name*, and every `Execute` given no source is named `<anonymous>`, so a
+host mapping a position back to the script it announced through `DebugHandler.BeforeEvaluate` had to guess.
+Three types now carry the program itself — the same reference `BeforeEvaluate` hands over and
+`Engine.Advanced.TryGetSourceText` is keyed by:
+
+```csharp
+CallFrame frame = information.CallStack[0];
+Program? running = frame.Program;                       // the program this frame executes
+Program? declared = profile.Frames[0].Program;          // where a profiled function was parsed
+Program? covered = report.Sources[0].Program;           // which parse a coverage source is of
+```
+
+All three are `null` for code the engine reached another way — `eval` and the `Function` constructor are
+programs no execution context names, and a built-in or host callable has no source at all — rather than
+being attributed to whichever script was running. `ScriptProfileFrame`'s primary constructor gained the
+optional parameter that carries it, so a profile a host keeps now retains the abstract syntax trees it names.
 
 ## 6. AOT and trimming
 


### PR DESCRIPTION
A `SourceLocation` carries a source *name*, and `Engine.Execute(code)` with no source argument names every script `<anonymous>`. So a host mapping a running position back to the script the engine announced through `DebugHandler.BeforeEvaluate` has to guess — take the scripts under that name, pick the one whose range contains the position, newest first — and every sourceless script collapses into one. `Jint.DevTools` does exactly that in `ScriptRegistry.At`, and it limits a debugger's paused frames, a profile's frames and a coverage report at once.

This exposes the identity the engine already has and already keys `Engine.Advanced.TryGetSourceText` on: the `Program` itself.

## The seam

| Member | What it names |
| --- | --- |
| `CallFrame.Program` | the program whose code this frame is executing |
| `ScriptProfileFrame.Program` | the program a profiled function was parsed from — both profilers |
| `CoverageSource.Program` | which parse a coverage source is of |

`CallFrame` reads it from the execution context the frame runs in: `ExecutionContext.ScriptOrModule` already names the script or module whose code a context runs, and `IScriptOrModule` gains an internal `Program` (a `ScriptRecord`'s `EcmaScriptCode`, a `SourceTextModuleRecord`'s body, `null` for a synthetic or builder module).

All three answer `null` for code the engine reached another way, rather than mis-attributing it. A function's `[[ScriptOrModule]]` is the script that was *active* when it was created, so code inside `eval` or a `Function` constructor body — a program no execution context names — would otherwise be reported against whichever script ran it, at a line that script does not have. `ScriptOrModuleExtensions.OwningProgramOf` declines any node whose source name or range does not lie in the program, which is checked once per counter and once per interned function, never per execution.

## The one behaviour change: a coverage source is one parse, not one name

`CoverageReport.Sources` used to hold one source per source *name*, summing the counts of every parse that shared one. It holds one per parsed program now. The fold destroyed exactly the information a client needs and a caller could not undo it; adding it back is a group-and-sum, which is what the two updated tests and `docs/v5-migration.md` §4.109 show. A host that caches a `Prepared<Script>` — which it should — never had several parses in the first place and reads what it always did, and entries of a program the engine names none for (`eval`, `Function`) are still folded by name and position.

Two existing tests pinned the old fold and now pin the new shape: `Jint.Tests/Runtime/CodeCoverageTests.ReParsingTheSameSourceAddsToTheSameEntry` → `…IsOneSourcePerParse`, and the two `Rows` helpers now say that adding up a name's parses is the reader's job.

## Hot paths touched

- **`JintCallStack.Push`** — `CallStackExecutionContext` grows by one reference field (the `IScriptOrModule`), copied on every pushed call frame. No new allocation, no new branch, no new call; the field is read by `CallFrame.Program` and by nothing else.
- **`CoverageCollector.Record`** — the steady-state path is unchanged (dictionary probe, `Hits++`). The program is resolved in `AddCounter`, which is `[MethodImpl(NoInlining)]` and runs once per node ever counted, and only on an engine that asked for coverage.
- **`ProfileFrames.Describe`** — runs once per interned function, on a profiling engine only.

Nothing else changed on any path the interpreter runs, so no benchmark is attached.

## Tests

- `Jint.Tests.PublicInterface/HostFrameProgramTests.cs` (new, 6 tests): two scripts parsed under one name told apart by their frames' programs; every frame of a pause including the top-level one; one prepared script run twice is one program; a frame inside `eval` names none; a profile frame names its function's program; a function with no source names no program.
- `Jint.Tests.PublicInterface/CodeCoverageTests.cs`: a parse is a source of its own naming its program, and a prepared script is one source however often it runs.
- `Jint.Tests/Runtime/CodeCoverageTests.cs`: the per-parse shape, a source naming a prepared program, and `eval` reported with no program.
- Five `PublicApiTest` baselines re-accepted (four lines each), `docs/v5-migration.md` §4.109 and §5.16.

Full solution in Release: `Jint.Tests` 11968, `Jint.Tests.PublicInterface` 3539, `Jint.Tests.Test262` 102573, `Jint.Tests.CommonScripts` 28, `Jint.Tests.Browser` 57, `Jint.Tests.DevTools` 337 — all green.

`Jint.DevTools` is the first consumer and is a follow-up on top of this one, which deletes `ScriptRegistry.At` and the heuristic.

Fixes #3632

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
