### PR TITLE
Profiling: the sampled profile publishes its tables, and DevTools records with it

### DIFF
--- a/Jint.DevTools/Domains/AGENTS.md
+++ b/Jint.DevTools/Domains/AGENTS.md
@@ -219,24 +219,28 @@ snapshots, so a value changed after one was handed out is not reflected in it.
 
 The `Profiler` domain answers two questions with two instruments, and neither is the other's fallback.
 
-**A profile comes through `IProfileSource`, and the shipped source is the *exact* profiler.** The engine has
-two: `Engine.Diagnostics.StartProfiling`, which records every call at the call boundary, and the sampling
-profiler of [#3608](https://github.com/sebastienros/jint/pull/3608), which notes what the stack looks like at
-the engine's own check points. Only the first is usable from here, and the reason is a visibility one rather
-than a design one: `SampledProfile` keeps its sample, frame, stack and function tables as `internal` fields
-and publishes a Firefox Profiler document as its only output, so consuming it would mean serializing to JSON
-and parsing it back. **Making those tables public is an engine change**, and when it lands the sampler becomes
-a second `IProfileSource` rather than an edit to the domain — which is why the seam exists before there is a
-second implementation of it. The seam speaks a function table and a balanced stream of enters and leaves,
-deliberately not the engine's own `ScriptProfileFrame`: a seam that names one profiler's type is a seam only
-that profiler fits through.
+**A profile comes through `IProfileSource`, and both of the engine's profilers fit through it.**
+`SampledProfileSource` notes what the stack looks like at the engine's own check points
+([#3608](https://github.com/sebastienros/jint/pull/3608), readable since
+[#3630](https://github.com/sebastienros/jint/issues/3630)); `EventedProfileSource` records every call at the
+call boundary. The seam speaks a function table and a balanced stream of enters and leaves, deliberately not
+either profiler's own type: a seam that names one instrument is a seam only that instrument fits through. A
+sampler converts into that shape losslessly, because two consecutive samples differ by a suffix of the stack
+and that difference is a run of leaves and enters.
+
+**The sampler is what a recording uses, and the choice is made when it starts.** A CDP `Profile` is what
+V8's sampling profiler produces and what `setSamplingInterval` sets the rate of, so it is the instrument a
+front end is asking for; and unlike the exact one it costs the run nothing per call. There is one sampling
+session per engine, though, and it may be the host's own — a client that arrives then is given the exact
+profiler rather than a refusal. What the sampler cannot show is a call it never sampled: a function entered
+and left between two check points is not in the profile at all.
 
 `ProfileBuilder` turns that stream into the protocol's document, and three things about it are decisions:
 
-- **One sample per interval, not per tick.** The stream says exactly when each call happened, so the top of
-  the stack is known for every instant between two activations, and one weighted sample of that node is what
-  the panel wants. The deltas therefore *add up to* the recording rather than approximating it — the only
-  loss is each interval's truncation to whole microseconds.
+- **One sample per interval, not per tick.** The stream says when each activation happened, so the top of the
+  stack is known for every instant between two of them, and one weighted sample of that node is what the
+  panel wants. The deltas therefore *add up to* the recording rather than approximating it, whichever
+  instrument filled the stream in — the only loss is each interval's truncation to whole microseconds.
 - **A node is a call position, not a function.** One function reached from two places is two nodes, which is
   what lets the panel say where the time went rather than only in what.
 - **`(root)` and `(program)`, and nothing else synthetic.** `(program)` takes the time no script function was

--- a/Jint.DevTools/Domains/IProfileSource.cs
+++ b/Jint.DevTools/Domains/IProfileSource.cs
@@ -10,15 +10,14 @@ namespace Jint.DevTools.Domains;
 /// </summary>
 /// <remarks>
 /// <para>
-/// The seam exists because the engine has two profilers and the protocol has one profile. Today's
-/// implementation is <see cref="EventedProfileSource"/> over
-/// <c>Engine.Diagnostics.StartProfiling</c>/<c>StopProfiling</c>, which is the only one whose data model this
-/// package can read: the sampling profiler added in
-/// <see href="https://github.com/sebastienros/jint/pull/3608">#3608</see> publishes its sample, frame and
-/// stack tables as <c>internal</c> fields and its only public output is a Firefox Profiler document, so
-/// consuming it here would mean serializing to JSON and parsing it back. Making those tables public is an
-/// engine change, and when it lands the sampler becomes a second implementation of this interface rather
-/// than an edit to the domain.
+/// The seam exists because the engine has two profilers and the protocol has one profile, and both of them
+/// fit through it: <see cref="SampledProfileSource"/> over
+/// <c>Engine.Diagnostics.StartSampling</c>/<c>StopSampling</c>, which is what a client asking for a
+/// <c>Profile</c> at a <c>samplingInterval</c> means, and <see cref="EventedProfileSource"/> over
+/// <c>StartProfiling</c>/<c>StopProfiling</c>, which records every call instead. <c>ProfilerDomain</c>
+/// chooses per recording. The seam speaks a function table and a balanced stream of enters and leaves
+/// deliberately, rather than either profiler's own type: a seam that names one instrument is a seam only
+/// that instrument fits through.
 /// </para>
 /// <para>
 /// <b>Everything here runs on the engine thread</b>, like every other domain member, and the

--- a/Jint.DevTools/Domains/ProfilerDomain.cs
+++ b/Jint.DevTools/Domains/ProfilerDomain.cs
@@ -37,7 +37,12 @@ internal sealed partial class ProfilerDomain : ProfilerDomainBase
     private static readonly TimeSpan DefaultInterval = TimeSpan.FromMilliseconds(1);
 
     private readonly EngineTarget _target;
-    private readonly IProfileSource _source;
+
+    /// <summary>The source a caller pinned, or <see langword="null"/> to choose one per recording.</summary>
+    private readonly IProfileSource? _fixed;
+
+    /// <summary>The instrument this attachment is recording with, chosen when the recording starts.</summary>
+    private IProfileSource? _source;
 
     private TimeSpan _interval = DefaultInterval;
     private double _startedAtMicroseconds;
@@ -50,15 +55,39 @@ internal sealed partial class ProfilerDomain : ProfilerDomainBase
     private int _recording;
 
     internal ProfilerDomain(EngineTarget target)
-        : this(target, new EventedProfileSource(target.Engine))
+        : this(target, source: null)
     {
     }
 
     /// <summary>Builds the domain over a source of the caller's choosing, which is what a test needs.</summary>
-    internal ProfilerDomain(EngineTarget target, IProfileSource source)
+    internal ProfilerDomain(EngineTarget target, IProfileSource? source)
     {
         _target = target;
-        _source = source;
+        _fixed = source;
+    }
+
+    /// <summary>
+    /// The instrument to record the next profile with.
+    /// </summary>
+    /// <remarks>
+    /// <b>The sampler, unless the engine is already sampling for somebody else.</b> A CDP <c>Profile</c> is
+    /// what V8's sampling profiler produces and what <c>setSamplingInterval</c> sets the rate of, so that is
+    /// the instrument a front end is asking for. There is one sampling session per engine, though, and it
+    /// may be the host's own — a client that arrives then gets the exact profiler rather than a refusal,
+    /// which costs the run more and misses nothing.
+    /// </remarks>
+    private IProfileSource Choose()
+    {
+        if (_fixed is not null)
+        {
+            return _fixed;
+        }
+
+#pragma warning disable JINT0002 // the sampling profiler is the engine's preview area
+        var sampling = _target.Engine.Diagnostics.IsSampling;
+#pragma warning restore JINT0002
+
+        return sampling ? new EventedProfileSource(_target.Engine) : new SampledProfileSource(_target.Engine);
     }
 
     /// <inheritdoc/>
@@ -107,14 +136,22 @@ internal sealed partial class ProfilerDomain : ProfilerDomainBase
             return;
         }
 
+        var source = _source;
+        if (source is null)
+        {
+            return;
+        }
+
         try
         {
             _target.Post(_ =>
             {
-                if (_source.IsRecording)
+                if (source.IsRecording)
                 {
-                    _source.Stop();
+                    source.Stop();
                 }
+
+                _source = null;
             });
         }
         catch (ObjectDisposedException)
@@ -148,9 +185,11 @@ internal sealed partial class ProfilerDomain : ProfilerDomainBase
             return new ValueTask<EmptyResult>(EmptyResult.Instance);
         }
 
+        var source = Choose();
+
         try
         {
-            _source.Start(_interval);
+            source.Start(_interval);
         }
         catch (InvalidOperationException exception)
         {
@@ -158,6 +197,8 @@ internal sealed partial class ProfilerDomain : ProfilerDomainBase
                 "The engine cannot record a profile",
                 exception.Message);
         }
+
+        _source = source;
 
         _startedAtMicroseconds = EngineTarget.UnixMilliseconds() * MicrosecondsPerMillisecond;
         Volatile.Write(ref _recording, 1);
@@ -182,7 +223,8 @@ internal sealed partial class ProfilerDomain : ProfilerDomainBase
                 "send Profiler.start first; a profile is the engine's and only one is recorded at a time");
         }
 
-        var recorded = _source.Stop();
+        var recorded = _source!.Stop();
+        _source = null;
 
         return new ValueTask<StopResponse>(new StopResponse
         {

--- a/Jint.DevTools/Domains/SampledProfileSource.cs
+++ b/Jint.DevTools/Domains/SampledProfileSource.cs
@@ -1,0 +1,140 @@
+using Jint.Profiling;
+
+#pragma warning disable JINT0002 // the sampling profiler is the engine's preview area; this is what it is for
+
+namespace Jint.DevTools.Domains;
+
+/// <summary>
+/// The engine's sampling profiler, which notes what the call stack looks like at the engine's own check
+/// points.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the instrument a Performance panel asks for: a client sets a rate with
+/// <c>Profiler.setSamplingInterval</c> and gets back where the time went, at a cost the recording does not
+/// change. What it cannot show is a call it never sampled — a function entered and left between two check
+/// points is not in the profile at all, where <see cref="EventedProfileSource"/> records every one of them
+/// and charges the run for it.
+/// </para>
+/// <para>
+/// <b>Samples become a balanced stream of enters and leaves</b>, which is what
+/// <see cref="RecordedProfile"/> speaks and what makes the seam fit both instruments. The direction is
+/// lossless: two consecutive samples differ by a suffix of the stack, so the difference between them is a
+/// run of leaves followed by a run of enters, all at the later sample's timestamp. Time between two samples
+/// therefore belongs to the stack observed at the earlier one, which is exactly what the sampler saw.
+/// </para>
+/// <para>
+/// The sampler's own synthetic <c>(program)</c> root is dropped rather than carried through, because
+/// <see cref="ProfileBuilder"/> has one of its own and takes the time no script function was on the stack.
+/// Two would be a tree with the node twice in it.
+/// </para>
+/// </remarks>
+internal sealed class SampledProfileSource : IProfileSource
+{
+    /// <summary>
+    /// The function index of the sampler's synthetic root, which every sampled stack hangs off.
+    /// </summary>
+    private const int ProgramFunction = 0;
+
+    private const long NanosecondsPerTick = 100;
+
+    private readonly Engine _engine;
+
+    internal SampledProfileSource(Engine engine)
+    {
+        _engine = engine;
+    }
+
+    /// <inheritdoc/>
+    public bool IsRecording => _engine.Diagnostics.IsSampling;
+
+    /// <inheritdoc/>
+    public void Start(TimeSpan interval)
+        => _engine.Diagnostics.StartSampling(new SamplingOptions { Interval = interval });
+
+    /// <inheritdoc/>
+    public RecordedProfile Stop()
+    {
+        var profile = _engine.Diagnostics.StopSampling();
+
+        var functions = new ProfileFunction[profile.Functions.Count];
+        for (var i = 0; i < functions.Length; i++)
+        {
+            var function = profile.Functions[i];
+            functions[i] = new ProfileFunction(function.Name, function.File, function.Line, function.Column, function.Program);
+        }
+
+        var activations = new List<ProfileActivation>();
+        var previous = new List<int>();
+        var current = new List<int>();
+
+        foreach (var sample in profile.Samples)
+        {
+            Read(profile, sample.Stack, current);
+
+            var at = Nanoseconds(sample.Time);
+            var shared = SharedPrefix(previous, current);
+
+            for (var i = previous.Count - 1; i >= shared; i--)
+            {
+                activations.Add(new ProfileActivation(Entered: false, previous[i], at));
+            }
+
+            for (var i = shared; i < current.Count; i++)
+            {
+                activations.Add(new ProfileActivation(Entered: true, current[i], at));
+            }
+
+            (previous, current) = (current, previous);
+        }
+
+        // Whatever was on the stack at the last sample was there until the session ended.
+        var duration = Nanoseconds(profile.Duration);
+        for (var i = previous.Count - 1; i >= 0; i--)
+        {
+            activations.Add(new ProfileActivation(Entered: false, previous[i], duration));
+        }
+
+        // A session that reached MaxSamples describes the beginning of the run and says nothing about the
+        // rest of it, which is what a client reads Truncated for.
+        return new RecordedProfile(functions, activations, duration, profile.DroppedSampleCount > 0);
+    }
+
+    /// <summary>
+    /// Reads one sampled stack into <paramref name="stack"/>, outermost function first and without the
+    /// sampler's synthetic root.
+    /// </summary>
+    private static void Read(SampledProfile profile, int node, List<int> stack)
+    {
+        stack.Clear();
+
+        // The tree is parent-linked, so the walk is innermost first and the order is put right afterwards.
+        for (var index = node; index >= 0; index = profile.Stacks[index].Parent)
+        {
+            var function = profile.Frames[profile.Stacks[index].Frame].Function;
+            if (function != ProgramFunction)
+            {
+                stack.Add(function);
+            }
+        }
+
+        stack.Reverse();
+    }
+
+    /// <summary>How much of two consecutive stacks is the same run of calls, which stays open across them.</summary>
+    private static int SharedPrefix(List<int> previous, List<int> current)
+    {
+        var length = Math.Min(previous.Count, current.Count);
+        for (var i = 0; i < length; i++)
+        {
+            if (previous[i] != current[i])
+            {
+                return i;
+            }
+        }
+
+        return length;
+    }
+
+    private static long Nanoseconds(TimeSpan value) => value.Ticks * NanosecondsPerTick;
+}

--- a/Jint.Tests.DevTools/Session/ProfilerSessionTests.cs
+++ b/Jint.Tests.DevTools/Session/ProfilerSessionTests.cs
@@ -2,37 +2,51 @@ using System.Text.Json;
 using Jint.DevTools.Protocol;
 using Jint.DevTools.Protocol.Profiler;
 
+#pragma warning disable JINT0002 // the sampling profiler is the engine's preview area
+
 namespace Jint.Tests.DevTools.Session;
 
 /// <summary>
 /// <c>Profiler.start</c> and <c>Profiler.stop</c>: the document a front end's Performance panel loads.
 /// </summary>
 /// <remarks>
+/// <para>
 /// The assertions are about the two halves the panel reads — a tree of nodes, and a series of samples with
 /// the time between them — plus the one property that makes the second half meaningful: the deltas add up to
 /// the recording. A profile whose tree is right and whose deltas are not renders as an empty flame chart.
+/// </para>
+/// <para>
+/// The instrument behind them is the engine's <em>sampler</em>, so the script is written to be sampled: the
+/// call it should be caught in is the one it spends its time in, and every recording asks for the fastest
+/// rate the protocol can name so that a run this short is observed more than once.
+/// </para>
 /// </remarks>
 [NonParallelizable]
 public class ProfilerSessionTests
 {
     private const string Source = """
         function inner(n) {
-            return n * 2;
+            var total = 0;
+            for (var i = 0; i < n; i++) { total += i % 7; }
+            return total;
         }
 
         function outer(n) {
-            return inner(n) + inner(n + 1);
+            return inner(n) + inner(n);
         }
 
         function work(times) {
             var total = 0;
             for (var i = 0; i < times; i++) {
-                total = total + outer(i);
+                total = total + outer(50);
             }
 
             return total;
         }
         """;
+
+    /// <summary>Enough work to be sampled many times over, and short enough to be a unit test.</summary>
+    private const string Workload = "work(200)";
 
     [Test]
     public async Task AProfileHasANodeForEveryFunctionThatRan()
@@ -43,7 +57,7 @@ public class ProfilerSessionTests
 
         var scriptId = (await session.EventAsync("Debugger.scriptParsed")).GetProperty("scriptId").GetString();
 
-        var profile = await RecordAsync(session, "work(50)");
+        var profile = await RecordAsync(session, Workload);
 
         var byName = profile.Nodes.ToDictionary(node => node.CallFrame.FunctionName, node => node);
 
@@ -72,15 +86,16 @@ public class ProfilerSessionTests
         await using var session = await AttachedSession.CreateAsync();
         await session.Target.PostAsync(engine => engine.Execute(Source, "main.js"));
 
-        var profile = await RecordAsync(session, "work(200)");
+        var profile = await RecordAsync(session, Workload);
 
         profile.Samples.Should().NotBeNull();
         profile.TimeDeltas.Should().NotBeNull();
         profile.Samples!.Length.Should().Be(profile.TimeDeltas!.Length, "the panel reads them as one series");
         profile.EndTime.Should().BeGreaterThanOrEqualTo(profile.StartTime);
 
-        // The source records when every call happened rather than sampling for it, so this is an equality
-        // and not an approximation: the only loss is the truncation of each interval to whole microseconds.
+        // The deltas are the intervals between the moments the source observed, so they telescope: whatever
+        // the instrument was, they cover the recording rather than approximating it. The only loss is the
+        // truncation of each interval to whole microseconds.
         var total = profile.TimeDeltas.Sum(delta => (long) delta);
         var recorded = (long) (profile.EndTime - profile.StartTime);
 
@@ -129,7 +144,7 @@ public class ProfilerSessionTests
 
         await session.ResultAsync("Profiler.enable");
         await session.ResultAsync("Profiler.start");
-        await session.Target.PostAsync(engine => engine.Evaluate("work(10)"));
+        await session.Target.PostAsync(engine => engine.Evaluate(Workload));
         await session.ResultAsync("Profiler.start");
 
         var profile = await StopAsync(session);
@@ -137,7 +152,7 @@ public class ProfilerSessionTests
     }
 
     /// <summary>
-    /// The rate a client asks for is accepted, because every front end sends it before every recording.
+    /// The rate a client asks for is what the sampler is armed with, which is what the command is for.
     /// </summary>
     [Test]
     public async Task ASamplingIntervalIsAccepted()
@@ -148,8 +163,55 @@ public class ProfilerSessionTests
         await session.ResultAsync("Profiler.setSamplingInterval", """{"interval":100}""");
         await session.ResultAsync("Profiler.start");
 
+        (await session.Target.PostAsync(engine => engine.Diagnostics.IsSampling)).Should().BeTrue();
+
         var profile = await StopAsync(session);
-        profile.Nodes.Should().NotBeEmpty("the profiler answers whatever rate it was told, having none of its own");
+        profile.Nodes.Should().NotBeEmpty();
+    }
+
+    /// <summary>
+    /// What a Performance panel is opened for: a script that spends its time in one function is a profile
+    /// that says so.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The assertion is on the time deltas rather than on the count of samples, because that is what the
+    /// panel adds up per node — and it is what makes this a statement about where the time went rather than
+    /// about how often the instrument happened to fire.
+    /// </para>
+    /// <para>
+    /// It is about the <em>script's</em> time. A recording is bracketed by two protocol commands, so the
+    /// wall clock between them includes the round trips that carried them, and that time belongs to
+    /// <c>(program)</c> — correctly, and in a proportion no test can pin.
+    /// </para>
+    /// </remarks>
+    [Test]
+    public async Task ACpuBoundScriptAttributesMostOfItsTimeToItsHotFunction()
+    {
+        await using var session = await AttachedSession.CreateAsync();
+        await session.Target.PostAsync(engine => engine.Execute(Source, "main.js"));
+
+        var profile = await RecordAsync(session, Workload);
+
+        var byId = profile.Nodes.ToDictionary(node => node.Id, node => node.CallFrame.FunctionName);
+        var byFunction = new Dictionary<string, long>(StringComparer.Ordinal);
+
+        for (var i = 0; i < profile.Samples!.Length; i++)
+        {
+            var name = byId[profile.Samples[i]];
+            byFunction[name] = byFunction.GetValueOrDefault(name) + profile.TimeDeltas![i];
+        }
+
+        var script = byFunction
+            .Where(entry => entry.Key is not "(program)" and not "(root)")
+            .OrderByDescending(entry => entry.Value)
+            .ToList();
+
+        var total = script.Sum(entry => entry.Value);
+        total.Should().BeGreaterThan(0, "the script ran, so some of the recording is its");
+
+        script[0].Key.Should().Be("inner", "that is the function the loop is in");
+        script[0].Value.Should().BeGreaterThan(total / 2, "most of the script's time was spent there");
     }
 
     /// <summary>
@@ -164,16 +226,44 @@ public class ProfilerSessionTests
         await session.ResultAsync("Profiler.start");
         await session.ResultAsync("Profiler.disable");
 
-        (await session.Target.PostAsync(engine => engine.Diagnostics.IsProfiling)).Should().BeFalse();
+        (await session.Target.PostAsync(engine => engine.Diagnostics.IsSampling)).Should().BeFalse();
 
         var error = await session.ErrorAsync("Profiler.stop");
         error.GetProperty("message").GetString().Should().Be("No profile is being recorded");
     }
 
+    /// <summary>
+    /// The engine allows one sampling session, and it may be the host's own — a client that arrives then is
+    /// given the exact profiler rather than a refusal.
+    /// </summary>
+    [Test]
+    public async Task AHostAlreadySamplingLeavesTheClientTheOtherInstrument()
+    {
+        await using var session = await AttachedSession.CreateAsync();
+        await session.Target.PostAsync(engine => engine.Execute(Source, "main.js"));
+        await session.Target.PostAsync(engine => engine.Diagnostics.StartSampling());
+
+        await session.ResultAsync("Profiler.enable");
+        await session.ResultAsync("Profiler.start");
+        await session.Target.PostAsync(engine => engine.Evaluate(Workload));
+
+        var profile = await StopAsync(session);
+        profile.Nodes.Select(node => node.CallFrame.FunctionName).Should().Contain("inner");
+
+        // the host's own session is untouched by the one the client asked for
+        (await session.Target.PostAsync(engine => engine.Diagnostics.IsSampling)).Should().BeTrue();
+        await session.Target.PostAsync(engine => engine.Diagnostics.StopSampling());
+    }
+
     /// <summary>Records <paramref name="expression"/> and hands back the profile of it.</summary>
+    /// <remarks>
+    /// The rate is the fastest the protocol can name — a client's zero means "as fast as you can" — because
+    /// a workload short enough for a unit test has to be observed more than once.
+    /// </remarks>
     private static async Task<Profile> RecordAsync(AttachedSession session, string expression)
     {
         await session.ResultAsync("Profiler.enable").ConfigureAwait(false);
+        await session.ResultAsync("Profiler.setSamplingInterval", """{"interval":0}""").ConfigureAwait(false);
         await session.ResultAsync("Profiler.start").ConfigureAwait(false);
         await session.Target.PostAsync(engine => engine.Evaluate(expression)).ConfigureAwait(false);
 

--- a/Jint.Tests.PublicInterface/HostSamplingProfilerTests.cs
+++ b/Jint.Tests.PublicInterface/HostSamplingProfilerTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Text;
 using Jint.Profiling;
 
@@ -231,5 +232,107 @@ public class HostSamplingProfilerTests
 
         Assert.Throws<ArgumentNullException>(() => profile.WriteTo((Stream) null!));
         Assert.Throws<ArgumentNullException>(() => profile.WriteTo((TextWriter) null!));
+    }
+
+    // ---- the tables, which is what a tool that is not the Firefox Profiler reads ----
+
+    /// <summary>
+    /// The four tables are the document without the document: a host that renders a profile itself, or
+    /// speaks a protocol of its own, reads them rather than writing JSON and parsing it back.
+    /// </summary>
+    [Test]
+    public void TheTablesAnswerWhatTheDocumentWrites()
+    {
+        var engine = new Engine(options => options.Profiling.Enabled = true);
+
+        engine.Diagnostics.StartSampling(new SamplingOptions { Interval = TimeSpan.Zero });
+        engine.Execute(Script, "host.js");
+        var profile = engine.Diagnostics.StopSampling();
+
+        profile.Samples.Should().HaveCount(profile.SampleCount);
+        profile.Functions.Should().NotBeEmpty();
+        profile.Frames.Should().NotBeEmpty();
+        profile.Stacks.Should().NotBeEmpty();
+
+        // Index 0 is the synthetic program function every stack is rooted at.
+        profile.Functions[0].Name.Should().Be("(program)");
+        profile.Functions.Select(function => function.Name).Should().Contain(["hot", "cold"]);
+
+        // every index is in range, and every stack walk terminates at a root
+        foreach (var sample in profile.Samples)
+        {
+            sample.Time.Should().BeGreaterThanOrEqualTo(TimeSpan.Zero);
+            sample.Stack.Should().BeInRange(0, profile.Stacks.Count - 1);
+
+            var node = sample.Stack;
+            var depth = 0;
+            while (node >= 0)
+            {
+                var stack = profile.Stacks[node];
+                stack.Frame.Should().BeInRange(0, profile.Frames.Count - 1);
+                profile.Frames[stack.Frame].Function.Should().BeInRange(0, profile.Functions.Count - 1);
+
+                node = stack.Parent;
+                (++depth).Should().BeLessThan(1000, "a stack walk terminates");
+            }
+        }
+
+        // the samples are in the order they were taken
+        profile.Samples.Select(sample => sample.Time).Should().BeInAscendingOrder();
+    }
+
+    /// <summary>
+    /// The classification a CLR profiler cannot make, which is half the diagnosis for an embedder: whose
+    /// code was on the stack.
+    /// </summary>
+    [Test]
+    public void AFrameSaysWhoseCodeItIsRunning()
+    {
+        var engine = new Engine(options => options.Profiling.Enabled = true);
+        engine.SetValue("host", new Func<int, int>(value => value + 1));
+
+        engine.Diagnostics.StartSampling(new SamplingOptions { Interval = TimeSpan.Zero });
+        engine.Execute("function work() { var t = 0; for (var i = 0; i < 5000; i++) { t += host(i); } return t; } work();", "host.js");
+        var profile = engine.Diagnostics.StopSampling();
+
+        var categories = profile.Frames.Select(frame => frame.Category).Distinct().ToList();
+        categories.Should().Contain(ProfileFrameCategory.Script);
+
+        // a script function names its position and its program; a native one has neither
+        foreach (var frame in profile.Frames)
+        {
+            var function = profile.Functions[frame.Function];
+            if (frame.Category != ProfileFrameCategory.Script)
+            {
+                function.File.Should().BeNull();
+                function.Program.Should().BeNull();
+                frame.Line.Should().BeNull();
+            }
+        }
+
+        var work = profile.Functions.Single(function => function.Name == "work");
+        work.File.Should().Be("host.js");
+        work.Program.Should().NotBeNull();
+    }
+
+    /// <summary>
+    /// A table is a view over what the session recorded, so reading it twice is reading one thing and costs
+    /// no second copy of it.
+    /// </summary>
+    [Test]
+    public void ATableIsAStableViewRatherThanACopy()
+    {
+        var engine = new Engine(options => options.Profiling.Enabled = true);
+        engine.Diagnostics.StartSampling(new SamplingOptions { Interval = TimeSpan.Zero });
+        engine.Execute(Script);
+        var profile = engine.Diagnostics.StopSampling();
+
+        profile.Samples.Should().BeSameAs(profile.Samples);
+        profile.Frames.Should().BeSameAs(profile.Frames);
+        profile.Stacks.Should().BeSameAs(profile.Stacks);
+        profile.Functions.Should().BeSameAs(profile.Functions);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => _ = profile.Samples[profile.Samples.Count]);
+        Assert.Throws<ArgumentOutOfRangeException>(() => _ = profile.Stacks[-1]);
     }
 }

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
@@ -1893,14 +1893,49 @@ namespace Jint.NodeCompat
 namespace Jint.Profiling
 {
     [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
+    public enum ProfileFrameCategory
+    {
+        Other = 0,
+        Script = 1,
+        BuiltIn = 2,
+        HostInterop = 3,
+    }
+    [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
     public sealed class SampledProfile
     {
         public int DroppedSampleCount { get; }
         public System.TimeSpan Duration { get; }
+        public System.Collections.Generic.IReadOnlyList<Jint.Profiling.SampledProfileFrame> Frames { get; }
+        public System.Collections.Generic.IReadOnlyList<Jint.Profiling.ScriptProfileFrame> Functions { get; }
         public System.TimeSpan Interval { get; }
         public int SampleCount { get; }
+        public System.Collections.Generic.IReadOnlyList<Jint.Profiling.SampledProfileSample> Samples { get; }
+        public System.Collections.Generic.IReadOnlyList<Jint.Profiling.SampledProfileStack> Stacks { get; }
         public void WriteTo(System.IO.Stream stream) { }
         public void WriteTo(System.IO.TextWriter writer) { }
+    }
+    [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
+    public readonly struct SampledProfileFrame : System.IEquatable<Jint.Profiling.SampledProfileFrame>
+    {
+        public SampledProfileFrame(int Function, Jint.Profiling.ProfileFrameCategory Category, int? Line, int? Column) { }
+        public Jint.Profiling.ProfileFrameCategory Category { get; init; }
+        public int? Column { get; init; }
+        public int Function { get; init; }
+        public int? Line { get; init; }
+    }
+    [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
+    public readonly struct SampledProfileSample : System.IEquatable<Jint.Profiling.SampledProfileSample>
+    {
+        public SampledProfileSample(System.TimeSpan Time, int Stack) { }
+        public int Stack { get; init; }
+        public System.TimeSpan Time { get; init; }
+    }
+    [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
+    public readonly struct SampledProfileStack : System.IEquatable<Jint.Profiling.SampledProfileStack>
+    {
+        public SampledProfileStack(int Parent, int Frame) { }
+        public int Frame { get; init; }
+        public int Parent { get; init; }
     }
     [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
     public sealed class SamplingOptions

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net472.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net472.verified.txt
@@ -1711,14 +1711,45 @@ namespace Jint.NodeCompat
 }
 namespace Jint.Profiling
 {
+    public enum ProfileFrameCategory
+    {
+        Other = 0,
+        Script = 1,
+        BuiltIn = 2,
+        HostInterop = 3,
+    }
     public sealed class SampledProfile
     {
         public int DroppedSampleCount { get; }
         public System.TimeSpan Duration { get; }
+        public System.Collections.Generic.IReadOnlyList<Jint.Profiling.SampledProfileFrame> Frames { get; }
+        public System.Collections.Generic.IReadOnlyList<Jint.Profiling.ScriptProfileFrame> Functions { get; }
         public System.TimeSpan Interval { get; }
         public int SampleCount { get; }
+        public System.Collections.Generic.IReadOnlyList<Jint.Profiling.SampledProfileSample> Samples { get; }
+        public System.Collections.Generic.IReadOnlyList<Jint.Profiling.SampledProfileStack> Stacks { get; }
         public void WriteTo(System.IO.Stream stream) { }
         public void WriteTo(System.IO.TextWriter writer) { }
+    }
+    public readonly struct SampledProfileFrame : System.IEquatable<Jint.Profiling.SampledProfileFrame>
+    {
+        public SampledProfileFrame(int Function, Jint.Profiling.ProfileFrameCategory Category, int? Line, int? Column) { }
+        public Jint.Profiling.ProfileFrameCategory Category { get; init; }
+        public int? Column { get; init; }
+        public int Function { get; init; }
+        public int? Line { get; init; }
+    }
+    public readonly struct SampledProfileSample : System.IEquatable<Jint.Profiling.SampledProfileSample>
+    {
+        public SampledProfileSample(System.TimeSpan Time, int Stack) { }
+        public int Stack { get; init; }
+        public System.TimeSpan Time { get; init; }
+    }
+    public readonly struct SampledProfileStack : System.IEquatable<Jint.Profiling.SampledProfileStack>
+    {
+        public SampledProfileStack(int Parent, int Frame) { }
+        public int Frame { get; init; }
+        public int Parent { get; init; }
     }
     public sealed class SamplingOptions
     {

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
@@ -1893,14 +1893,49 @@ namespace Jint.NodeCompat
 namespace Jint.Profiling
 {
     [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
+    public enum ProfileFrameCategory
+    {
+        Other = 0,
+        Script = 1,
+        BuiltIn = 2,
+        HostInterop = 3,
+    }
+    [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
     public sealed class SampledProfile
     {
         public int DroppedSampleCount { get; }
         public System.TimeSpan Duration { get; }
+        public System.Collections.Generic.IReadOnlyList<Jint.Profiling.SampledProfileFrame> Frames { get; }
+        public System.Collections.Generic.IReadOnlyList<Jint.Profiling.ScriptProfileFrame> Functions { get; }
         public System.TimeSpan Interval { get; }
         public int SampleCount { get; }
+        public System.Collections.Generic.IReadOnlyList<Jint.Profiling.SampledProfileSample> Samples { get; }
+        public System.Collections.Generic.IReadOnlyList<Jint.Profiling.SampledProfileStack> Stacks { get; }
         public void WriteTo(System.IO.Stream stream) { }
         public void WriteTo(System.IO.TextWriter writer) { }
+    }
+    [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
+    public readonly struct SampledProfileFrame : System.IEquatable<Jint.Profiling.SampledProfileFrame>
+    {
+        public SampledProfileFrame(int Function, Jint.Profiling.ProfileFrameCategory Category, int? Line, int? Column) { }
+        public Jint.Profiling.ProfileFrameCategory Category { get; init; }
+        public int? Column { get; init; }
+        public int Function { get; init; }
+        public int? Line { get; init; }
+    }
+    [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
+    public readonly struct SampledProfileSample : System.IEquatable<Jint.Profiling.SampledProfileSample>
+    {
+        public SampledProfileSample(System.TimeSpan Time, int Stack) { }
+        public int Stack { get; init; }
+        public System.TimeSpan Time { get; init; }
+    }
+    [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
+    public readonly struct SampledProfileStack : System.IEquatable<Jint.Profiling.SampledProfileStack>
+    {
+        public SampledProfileStack(int Parent, int Frame) { }
+        public int Frame { get; init; }
+        public int Parent { get; init; }
     }
     [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
     public sealed class SamplingOptions

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.0.verified.txt
@@ -1711,14 +1711,45 @@ namespace Jint.NodeCompat
 }
 namespace Jint.Profiling
 {
+    public enum ProfileFrameCategory
+    {
+        Other = 0,
+        Script = 1,
+        BuiltIn = 2,
+        HostInterop = 3,
+    }
     public sealed class SampledProfile
     {
         public int DroppedSampleCount { get; }
         public System.TimeSpan Duration { get; }
+        public System.Collections.Generic.IReadOnlyList<Jint.Profiling.SampledProfileFrame> Frames { get; }
+        public System.Collections.Generic.IReadOnlyList<Jint.Profiling.ScriptProfileFrame> Functions { get; }
         public System.TimeSpan Interval { get; }
         public int SampleCount { get; }
+        public System.Collections.Generic.IReadOnlyList<Jint.Profiling.SampledProfileSample> Samples { get; }
+        public System.Collections.Generic.IReadOnlyList<Jint.Profiling.SampledProfileStack> Stacks { get; }
         public void WriteTo(System.IO.Stream stream) { }
         public void WriteTo(System.IO.TextWriter writer) { }
+    }
+    public readonly struct SampledProfileFrame : System.IEquatable<Jint.Profiling.SampledProfileFrame>
+    {
+        public SampledProfileFrame(int Function, Jint.Profiling.ProfileFrameCategory Category, int? Line, int? Column) { }
+        public Jint.Profiling.ProfileFrameCategory Category { get; init; }
+        public int? Column { get; init; }
+        public int Function { get; init; }
+        public int? Line { get; init; }
+    }
+    public readonly struct SampledProfileSample : System.IEquatable<Jint.Profiling.SampledProfileSample>
+    {
+        public SampledProfileSample(System.TimeSpan Time, int Stack) { }
+        public int Stack { get; init; }
+        public System.TimeSpan Time { get; init; }
+    }
+    public readonly struct SampledProfileStack : System.IEquatable<Jint.Profiling.SampledProfileStack>
+    {
+        public SampledProfileStack(int Parent, int Frame) { }
+        public int Frame { get; init; }
+        public int Parent { get; init; }
     }
     public sealed class SamplingOptions
     {

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.1.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.1.verified.txt
@@ -1711,14 +1711,45 @@ namespace Jint.NodeCompat
 }
 namespace Jint.Profiling
 {
+    public enum ProfileFrameCategory
+    {
+        Other = 0,
+        Script = 1,
+        BuiltIn = 2,
+        HostInterop = 3,
+    }
     public sealed class SampledProfile
     {
         public int DroppedSampleCount { get; }
         public System.TimeSpan Duration { get; }
+        public System.Collections.Generic.IReadOnlyList<Jint.Profiling.SampledProfileFrame> Frames { get; }
+        public System.Collections.Generic.IReadOnlyList<Jint.Profiling.ScriptProfileFrame> Functions { get; }
         public System.TimeSpan Interval { get; }
         public int SampleCount { get; }
+        public System.Collections.Generic.IReadOnlyList<Jint.Profiling.SampledProfileSample> Samples { get; }
+        public System.Collections.Generic.IReadOnlyList<Jint.Profiling.SampledProfileStack> Stacks { get; }
         public void WriteTo(System.IO.Stream stream) { }
         public void WriteTo(System.IO.TextWriter writer) { }
+    }
+    public readonly struct SampledProfileFrame : System.IEquatable<Jint.Profiling.SampledProfileFrame>
+    {
+        public SampledProfileFrame(int Function, Jint.Profiling.ProfileFrameCategory Category, int? Line, int? Column) { }
+        public Jint.Profiling.ProfileFrameCategory Category { get; init; }
+        public int? Column { get; init; }
+        public int Function { get; init; }
+        public int? Line { get; init; }
+    }
+    public readonly struct SampledProfileSample : System.IEquatable<Jint.Profiling.SampledProfileSample>
+    {
+        public SampledProfileSample(System.TimeSpan Time, int Stack) { }
+        public int Stack { get; init; }
+        public System.TimeSpan Time { get; init; }
+    }
+    public readonly struct SampledProfileStack : System.IEquatable<Jint.Profiling.SampledProfileStack>
+    {
+        public SampledProfileStack(int Parent, int Frame) { }
+        public int Frame { get; init; }
+        public int Parent { get; init; }
     }
     public sealed class SamplingOptions
     {

--- a/Jint/Profiling/ProfileFrameCategory.cs
+++ b/Jint/Profiling/ProfileFrameCategory.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Jint.Profiling;
 
 /// <summary>
@@ -5,10 +7,18 @@ namespace Jint.Profiling;
 /// classification a native profiler cannot make, since at the CLR level all three are Jint frames.
 /// </summary>
 /// <remarks>
+/// <para>
 /// The values are the category indices the Firefox Profiler document declares in <c>meta.categories</c>,
 /// so a frame's category is written out as-is.
+/// </para>
+/// <para>
+/// This type is in a preview area, declared to the compiler as <c>JINT0002</c>; see
+/// <see cref="JintDiagnosticIds"/>. New members may be added, so treat an unrecognized value as "some other
+/// kind of code" rather than switching exhaustively without a default arm.
+/// </para>
 /// </remarks>
-internal enum ProfileFrameCategory
+[Experimental(JintDiagnosticIds.PreviewDiagnostic)]
+public enum ProfileFrameCategory
 {
     /// <summary>
     /// Nothing else fits. Index 0 is the profiler format's default category and must stay the grey one.

--- a/Jint/Profiling/SampledProfile.cs
+++ b/Jint/Profiling/SampledProfile.cs
@@ -1,5 +1,7 @@
+using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Text;
 using Jint.Runtime;
 
@@ -76,12 +78,75 @@ public sealed class SampledProfile
 
         DroppedSampleCount = droppedSampleCount;
         Interval = interval;
+
+        // Views rather than copies: a session of a hundred thousand samples publishes its tables without
+        // allocating a second set of them, and the rows are made as a reader asks for them.
+        Functions = new ProfileTableView<ScriptProfileFrame>(funcs.Length, index => funcs[index]);
+        Frames = new ProfileTableView<SampledProfileFrame>(frames.Length, index =>
+        {
+            var frame = frames[index];
+            return new SampledProfileFrame(
+                frame.Func,
+                funcCategories[frame.Func],
+                frame.Line < 0 ? null : frame.Line,
+                frame.Column < 0 ? null : frame.Column);
+        });
+        Stacks = new ProfileTableView<SampledProfileStack>(stacks.Length, index =>
+        {
+            var stack = stacks[index];
+            return new SampledProfileStack(stack.Prefix, stack.Frame);
+        });
+        Samples = new ProfileTableView<SampledProfileSample>(
+            sampleStacks.Length,
+            index => new SampledProfileSample(TimeSpan.FromMilliseconds(sampleTimes[index]), sampleStacks[index]));
     }
 
     /// <summary>
     /// How many samples the session recorded.
     /// </summary>
     public int SampleCount => _sampleStacks.Length;
+
+    /// <summary>
+    /// Gets the distinct functions the session saw, which <see cref="SampledProfileFrame.Function"/> indexes
+    /// into.
+    /// </summary>
+    /// <remarks>
+    /// Index <c>0</c> is the synthetic <c>(program)</c> function every sampled stack is rooted at: the
+    /// program itself, which is not on the call stack because only function activations are.
+    /// </remarks>
+    public IReadOnlyList<ScriptProfileFrame> Functions { get; }
+
+    /// <summary>
+    /// Gets the positions the session observed, which <see cref="SampledProfileStack.Frame"/> indexes into.
+    /// </summary>
+    public IReadOnlyList<SampledProfileFrame> Frames { get; }
+
+    /// <summary>
+    /// Gets the stack tree as parent links, which <see cref="SampledProfileSample.Stack"/> indexes into.
+    /// </summary>
+    /// <remarks>
+    /// A node names its frame and the node it hangs off, so a stack is read by walking
+    /// <see cref="SampledProfileStack.Parent"/> to <c>-1</c>, which yields the frames innermost first.
+    /// Two stacks sharing a prefix share every node of it, which is what makes a long session's table small.
+    /// </remarks>
+    public IReadOnlyList<SampledProfileStack> Stacks { get; }
+
+    /// <summary>
+    /// Gets what the stack looked like at each sample point, oldest first.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A sample's time is measured from the start of the session, and the gap to the next one — to
+    /// <see cref="Duration"/> for the last — is how long that stack was observed for. The gaps vary, because
+    /// the sampler fires at the engine's own check points rather than on a timer, so a reader that weights
+    /// samples equally under-reports exactly the stacks the engine could not be interrupted in.
+    /// </para>
+    /// <para>
+    /// The document <see cref="WriteTo(TextWriter)"/> writes carries that as a weight of
+    /// <c>round(gap / <see cref="Interval"/>)</c>, at least one.
+    /// </para>
+    /// </remarks>
+    public IReadOnlyList<SampledProfileSample> Samples { get; }
 
     /// <summary>
     /// How many sample points were refused because <see cref="SamplingOptions.MaxSamples"/> had been
@@ -141,4 +206,98 @@ public sealed class SampledProfile
         using var writer = new StreamWriter(stream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), 1024, leaveOpen: true);
         WriteTo(writer);
     }
+}
+
+/// <summary>
+/// One row of a sampled profile's frame table: a function, and the position inside it that was executing.
+/// </summary>
+/// <param name="Function">Index into <see cref="SampledProfile.Functions"/> of the function this is a position in.</param>
+/// <param name="Category">Whose code that function is, which is the classification a CLR profiler cannot make.</param>
+/// <param name="Line">One-based line the frame was executing, or <see langword="null"/> when there is none.</param>
+/// <param name="Column">One-based column the frame was executing, or <see langword="null"/> with <paramref name="Line"/>.</param>
+/// <remarks>
+/// <para>
+/// One function appears as several frames when it was observed at several positions, so a reader building a
+/// tree of functions groups by <see cref="Function"/> and a reader showing where the time went inside one
+/// does not.
+/// </para>
+/// <para>
+/// Only a function parsed from source has a position, so <see cref="Line"/> is <see langword="null"/> for a
+/// built-in and for a host callable. The one for the synthetic <c>(program)</c> function is the call site of
+/// the outermost frame on the stack, or the node the engine last prepared for when nothing is on it.
+/// </para>
+/// <para>
+/// This type is in a preview area, declared to the compiler as <c>JINT0002</c>; see
+/// <see cref="JintDiagnosticIds"/>.
+/// </para>
+/// </remarks>
+[Experimental(JintDiagnosticIds.PreviewDiagnostic)]
+[StructLayout(LayoutKind.Auto)]
+public readonly record struct SampledProfileFrame(int Function, ProfileFrameCategory Category, int? Line, int? Column);
+
+/// <summary>
+/// One node of a sampled profile's stack tree: a frame, and the node it hangs off.
+/// </summary>
+/// <param name="Parent">Index into <see cref="SampledProfile.Stacks"/> of the calling node, or <c>-1</c> for a root.</param>
+/// <param name="Frame">Index into <see cref="SampledProfile.Frames"/> of the position this node is.</param>
+/// <remarks>
+/// This type is in a preview area, declared to the compiler as <c>JINT0002</c>; see
+/// <see cref="JintDiagnosticIds"/>.
+/// </remarks>
+[Experimental(JintDiagnosticIds.PreviewDiagnostic)]
+[StructLayout(LayoutKind.Auto)]
+public readonly record struct SampledProfileStack(int Parent, int Frame);
+
+/// <summary>
+/// One sample: when it was taken, and what the stack looked like.
+/// </summary>
+/// <param name="Time">How long after the session started the sample was taken.</param>
+/// <param name="Stack">Index into <see cref="SampledProfile.Stacks"/> of the stack that was observed.</param>
+/// <remarks>
+/// This type is in a preview area, declared to the compiler as <c>JINT0002</c>; see
+/// <see cref="JintDiagnosticIds"/>.
+/// </remarks>
+[Experimental(JintDiagnosticIds.PreviewDiagnostic)]
+[StructLayout(LayoutKind.Auto)]
+public readonly record struct SampledProfileSample(TimeSpan Time, int Stack);
+
+/// <summary>
+/// A read-only view over one of a profile's columnar tables, projecting a row as it is asked for so that
+/// publishing a table copies nothing.
+/// </summary>
+internal sealed class ProfileTableView<T> : IReadOnlyList<T>
+{
+    private readonly int _count;
+    private readonly Func<int, T> _row;
+
+    internal ProfileTableView(int count, Func<int, T> row)
+    {
+        _count = count;
+        _row = row;
+    }
+
+    public T this[int index]
+    {
+        get
+        {
+            if ((uint) index >= (uint) _count)
+            {
+                Throw.ArgumentOutOfRangeException(nameof(index), "Index was out of range of the profile's table.");
+            }
+
+            return _row(index);
+        }
+    }
+
+    public int Count => _count;
+
+    public IEnumerator<T> GetEnumerator()
+    {
+        for (var i = 0; i < _count; i++)
+        {
+            yield return _row(i);
+        }
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/README.md
+++ b/README.md
@@ -2756,6 +2756,26 @@ script's own functions, **Built-in** for Jint's, and **Host interop** for your c
 a CLR method reached through interop, or a `ClrFunction` you built. Seeing script time apart from time
 inside your own callbacks is usually half the diagnosis.
 
+The document is not the only way to read a profile. Its four tables are public, so a host that renders its
+own view — or speaks a protocol of its own — reads them instead of writing JSON and parsing it back:
+
+```csharp
+foreach (var sample in profile.Samples)          // when, and which stack
+{
+    for (var node = sample.Stack; node >= 0; node = profile.Stacks[node].Parent)
+    {
+        var frame = profile.Frames[profile.Stacks[node].Frame];   // executing line/column, category
+        var function = profile.Functions[frame.Function];         // name, file, declaration, Program
+        Console.WriteLine($"{sample.Time}  {function.Name}  {frame.Category}");
+    }
+}
+```
+
+They are views over what the session recorded rather than copies of it, so reading a table costs nothing
+until a row is asked for. A sample's time is measured from the start of the session and the gap to the next
+one is how long that stack was observed — the weight the document writes is that gap over the interval, at
+least one.
+
 Worth knowing before you read a sampled profile:
 
 - **Samples are taken at the engine's check points**, the same once-per-64-statements cadence a timeout

--- a/docs/design/devtools-protocol.md
+++ b/docs/design/devtools-protocol.md
@@ -127,22 +127,17 @@ the vendored JSON by `ProtocolCitationTests`.
 | --- | --- | --- |
 | `Runtime` | `engine.Evaluate` (running) or `DebugHandler.Evaluate` (paused); `getProperties` over `GetOwnPropertyKeys` + descriptors, accessors reported and never invoked; `awaitPromise` by reactions; `consoleAPICalled`; `exceptionThrown`/`exceptionRevoked` from `Tasks.PromiseRejectionTracker`; `getHeapUsage` from `Diagnostics.GetMemoryReport` | **E5** ([#3597](https://github.com/sebastienros/jint/pull/3597)) structured `ConsoleRecord` sink overload + public `ValueInspector` (previews that never run script, promoted from `ConsoleFormatter`) |
 | `Debugger` | `ScriptRegistry` on `DebugHandler.BeforeEvaluate` keyed by `Program` identity (a cached `Prepared<Script>` is announced once); breakpoints as `DevToolsBreakPoint : BreakPoint` (the class is unsealed for this); `pause` as a flag checked in `Skip`; scopes from `DebugScopeType` 1:1 | **E1** ([#3587](https://github.com/sebastienros/jint/pull/3587)) `TryGetSourceText(Program)` for `getScriptSource`; **E2** ([#3614](https://github.com/sebastienros/jint/pull/3614)) `GetStepLocations(Program)` for `getPossibleBreakpoints` and column snapping; **E3** ([#3623](https://github.com/sebastienros/jint/pull/3623)) pause on exceptions with caught/uncaught; **E4** ([#3622](https://github.com/sebastienros/jint/pull/3622)) evaluate on any call frame; **E6** ([#3632](https://github.com/sebastienros/jint/issues/3632)) `CallFrame.Program`, a profile frame's `Program` and `CoverageSource.Program`, so a position is matched to a script by identity rather than by source name |
-| `Profiler` | `Profiler.Profile` synthesized from the evented `ScriptProfile` (`Jint/Profiling/`) behind an `IProfileSource` seam — one weighted sample per interval between two activations, so the time deltas add up to the recording rather than approximating it; precise/best-effort coverage from `CoverageReport` (`Jint/Runtime/Coverage/`), with the uncovered set derived from the script registry's abstract syntax tree so an unused function is reported with `count: 0` | none. The sampling profiler that landed as [#3608](https://github.com/sebastienros/jint/pull/3608) is **not** the source: `SampledProfile` publishes its sample, frame and stack tables as `internal` and a Firefox Profiler document as its only output, so it plugs into the same seam once those tables are public — an additive engine change ([#3630](https://github.com/sebastienros/jint/issues/3630)), not an edit to the domain |
+| `Profiler` | `Profiler.Profile` synthesized behind an `IProfileSource` seam from either of the engine's profilers (`Jint/Profiling/`) — the sampler by default, the evented one when the host is already sampling — one weighted sample per interval between two activations, so the time deltas add up to the recording rather than approximating it; precise/best-effort coverage from `CoverageReport` (`Jint/Runtime/Coverage/`), with the uncovered set derived from the script registry's abstract syntax tree so an unused function is reported with `count: 0` | **E7** ([#3630](https://github.com/sebastienros/jint/issues/3630)) public read-only accessors on `SampledProfile`'s sample, stack, frame and function tables, so the sampler of [#3608](https://github.com/sebastienros/jint/pull/3608) is consumable without writing its document and parsing it back |
 | `Console`, `Log` | the structured record | E5 |
 | `Target`, `Browser`, `Schema` | the session core and the manifest | none |
 
-**All six engine seams are merged**, and every one is additive and public — so that a third party (AngleSharp.Js,
+**All seven engine seams are merged**, and every one is additive and public — so that a third party (AngleSharp.Js,
 a DAP adapter, a host's own tooling) can build the same thing without `InternalsVisibleTo`. `Jint.DevTools`
 itself consumes only public Jint API; that is deliberate, and it is what proves the seams are reachable.
 
-Two seams the build wanted and did not get are open issues rather than silent workarounds, and each is
+One seam the build wanted and did not get is an open issue rather than a silent workaround, and it is
 named where it bites:
 
-- [#3630](https://github.com/sebastienros/jint/issues/3630) — **the sampler is not the profile's source.**
-  `SampledProfile` publishes its sample, frame and stack tables as `internal` and a Firefox Profiler document
-  as its only output, so `Profiler.start`/`stop` samples on its own activations behind `IProfileSource` and
-  reports `(root)`/`(program)` frames. Public read-only accessors on those tables make the sampler a second
-  `IProfileSource`, with no edit to the domain.
 - [#3631](https://github.com/sebastienros/jint/issues/3631) — **`caught` is not an engine mode.**
   `ExceptionPauseMode` is `None`/`Uncaught`/`All`, so the client's `caught` asks for `All` and drops the
   uncaught half in the `Break` handler — and declining a pause there means returning a `StepMode`, whose value

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -5545,6 +5545,28 @@ programs no execution context names, and a built-in or host callable has no sour
 being attributed to whichever script was running. `ScriptProfileFrame`'s primary constructor gained the
 optional parameter that carries it, so a profile a host keeps now retains the abstract syntax trees it names.
 
+### 5.18 A sampled profile is readable, not only writable ([#3630](https://github.com/sebastienros/jint/issues/3630))
+
+`SampledProfile` published a Firefox Profiler document and nothing else, so a host rendering its own view —
+or speaking a protocol of its own — had to write that JSON and parse it back. Its four tables are now public,
+in the same shape the document is built from:
+
+```csharp
+foreach (var sample in profile.Samples)          // when it was taken, and which stack
+{
+    for (var node = sample.Stack; node >= 0; node = profile.Stacks[node].Parent)
+    {
+        var frame = profile.Frames[profile.Stacks[node].Frame];   // executing line/column, and a category
+        var function = profile.Functions[frame.Function];         // name, file, declaration, Program
+    }
+}
+```
+
+`ProfileFrameCategory` becomes public with them, and `SampledProfileFrame`, `SampledProfileStack` and
+`SampledProfileSample` are new. All of it is in the same preview area the sampler already was, so it carries
+`JINT0002`; a table is a view over what the session recorded rather than a copy, so reading one costs nothing
+until a row is asked for. Nothing that existed changed.
+
 ## 6. AOT and trimming
 
 Jint 4.16 asserted Native AOT compatibility with the `IsAotCompatible` property and nothing else. In


### PR DESCRIPTION
Rebased onto `main` at 34113ca1c and folded: this is now the engine seam **and** its `Jint.DevTools` consumer in one commit. The DevTools half was #3659, which is closed in favour of this.

`SampledProfile` kept its sample, frame, stack and function tables `internal` and published a Firefox Profiler document as its only output. A host that renders its own view of a profile — or speaks a protocol of its own, which is what `Jint.DevTools` does — had to write that JSON and parse it back, so the sampler was usable as a file and as nothing else. `docs/design/devtools-protocol.md` §5 named it as one of the seams the protocol server wanted and did not get.

## The tables

```csharp
foreach (var sample in profile.Samples)          // when it was taken, and which stack
{
    for (var node = sample.Stack; node >= 0; node = profile.Stacks[node].Parent)
    {
        var frame = profile.Frames[profile.Stacks[node].Frame];   // executing line/column, and a category
        var function = profile.Functions[frame.Function];         // name, file, declaration, Program
        Console.WriteLine($"{sample.Time}  {function.Name}  {frame.Category}");
    }
}
```

- `Functions` is `ScriptProfileFrame`, the type both profilers already describe a function with, so a reader has one vocabulary for both instruments. Index 0 is the synthetic `(program)` every sampled stack is rooted at.
- `ProfileFrameCategory` becomes public with `SampledProfileFrame`, which is what says whose code a frame is — the classification a CLR profiler cannot make.
- `Stacks` is the tree as parent links, walked to `-1`; two stacks sharing a prefix share every node of it, which is what keeps a long session's table small.
- `Samples` gives each sample's time from the start of the session; the gap to the next one — to `Duration` for the last — is how long that stack was observed, and the weight the document writes is that gap over `Interval`, at least one.

A table is an `IReadOnlyList<T>` over the array the session recorded, projecting a row when a reader asks for one, so publishing them allocates four small objects and no second set of tables — a hundred-thousand-sample session would otherwise pay 1.6 MB to be readable. The four are stable references; an index outside the table is an `ArgumentOutOfRangeException`. Everything new is in the preview area the sampler already declared, so it carries `JINT0002`, and nothing that existed changed.

## DevTools records with it

A CDP `Profile` is what V8's *sampling* profiler produces and what `Profiler.setSamplingInterval` sets the rate of, so a sampler is the instrument a front end is asking for. `SampledProfileSource` converts the sample table into the enters and leaves `IProfileSource` speaks, which is lossless in that direction: two consecutive samples differ by a *suffix* of the stack, so the difference between them is a run of leaves and a run of enters at the later sample's time, and the interval between two samples belongs to the stack observed at the earlier one. `ProfileBuilder` then does exactly what it did.

- **The sampler's synthetic `(program)` root is dropped.** `ProfileBuilder` has one of its own and gives it the time no script function was on the stack; carrying both would put the node in the tree twice. `(idle)` stays unemitted for the reason it always was — an engine target has no idle state to report.
- **`DroppedSampleCount > 0` becomes `Truncated`**, which is what a client reads to know the profile describes the beginning of a run and nothing about the rest.
- **Which instrument is chosen when a recording starts**: the sampler, unless the engine is already sampling for the host — there is one sampling session per engine — in which case the client gets the exact profiler rather than a refusal. `AHostAlreadySamplingLeavesTheClientTheOtherInstrument` pins it, including that the host's own session is untouched.

## What it costs

Nothing an engine pays unless a client records. A sampling session is one `Stopwatch.GetTimestamp` and one comparison at the check points the amortized constraints already ride, where the exact profiler pays a frame lookup and a 16-byte event on *every call* — so the instrument this switches to is the cheaper of the two, and neither is armed until `Profiler.start`. Nothing here runs while script does, which is why no benchmark is attached.

## Tests

`HostSamplingProfilerTests` gains three: the tables answer what the document writes (every index in range, every stack walk terminating at a root, samples in ascending time), a frame says whose code it is running (a native one names neither a file nor a program), and a table is a stable view rather than a copy.

A sampler cannot show a call it never sampled, so `ProfilerSessionTests` now profiles a script that spends its time where it says it does and asks for the fastest rate the protocol can name (`setSamplingInterval: 0`). The new one is the pin the issue asks for: `ACpuBoundScriptAttributesMostOfItsTimeToItsHotFunction` adds up the time deltas per node and requires the hottest to be the function the loop is in, with more than half the *script's* time — the recording is bracketed by two protocol commands, so the round trips that carried them belong to `(program)`, correctly and in a proportion no test can pin. Ten consecutive runs of that file were green on both target frameworks.

Five `PublicApiTest` baselines re-accepted; `docs/v5-migration.md` §5.18; the README's sampling section shows the walk. Full solution in Release: `Jint.Tests` 12069, `Jint.Tests.PublicInterface` 3551, `Jint.Tests.DevTools` 377, `Jint.Tests.Test262` 102573, CommonScripts 28, Browser 57 — all green.

Fixes #3630

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
