### PR TITLE
Browser: the accessibility tree and the extraction payloads are computed from the DOM alone, because there is no layout to ask

### DIFF
--- a/Jint.Browser/AGENTS.md
+++ b/Jint.Browser/AGENTS.md
@@ -284,3 +284,54 @@ until the protocol layer has settled what a host actually holds. `DomBindings`, 
 with XML docs and a `docs/v5-migration.md` row. Until then `Jint.Tests.Browser` is the only consumer, which is
 why it is named in `InternalsVisibleTo` and why every test of the binding is written against the internal
 surface rather than around it.
+
+### Accessibility and extraction have no layout
+
+`Accessibility/` computes an accessibility tree over AngleSharp's DOM and `Extraction/` renders the same
+document as text or CommonMark. Both are pure C# over `IDocument`/`IElement`; neither touches an engine, and
+that is why they were built before the page runtime existed. The consumers are the CDP `Accessibility` domain,
+the custom `Jint.getMarkdown`/`getText`/`getAccessibilitySnapshot` domain, and the MCP server's `snapshot`.
+
+**Three things a browser answers from its layout tree are answered from somewhere else, and every one is a
+place where this can be wrong.**
+
+- **Hidden** is `ElementVisibility`: the `hidden` content attribute, `aria-hidden="true"`, and `display:none`
+  / `visibility:hidden|collapse` from the cascade — `IElement.ComputeCurrentStyle()`, which resolves author
+  sheets and the UA sheet — falling back to the `style` content attribute alone when `AngleSharp.Css` is not
+  registered. It cannot know that an element is off screen, clipped, covered or zero-sized. Two asymmetries
+  are deliberate: `display:none` takes its subtree with it while `visibility:hidden` does not (CSS inherits
+  `visibility`, so a `visibility:visible` descendant comes back), and `aria-hidden` removes a node from the
+  accessibility tree while changing nothing about the rendering — so the extractors ask
+  `RenderingReasonFor`, which ignores it, and only the tree asks `ReasonFor`, which does not.
+- **Block-level** is `HtmlDisplay`, HTML's suggested rendering rather than a used display, and it is the
+  table that decides — not the cascade. The cascade only wins where it *differs* from the table, which is
+  what makes `<span style="display:block">` a block and stops AngleSharp's incomplete default sheet from
+  calling every `<section>` inline.
+- **`innerText`** is therefore the text of the document, not the text of a rendering of it: the required
+  line breaks, the `<br>`s, the cell tabs and the white-space processing are all there, but nothing wraps,
+  so a paragraph is one line however wide it would have been.
+
+Three simplifications in the name computation are worth knowing before reading a wrong name as a bug: CSS
+generated content (`::before`, `::after`, `::marker`) contributes nothing, `text-transform` is not applied,
+and SVG `<title>`/`<desc>` children are not read. Everything else of accname 1.2 — 2A through 2I, the
+recursion, the visited guard, the flattening — is the algorithm as written. HTML-AAM's mapping table is
+implemented in full with one blanket simplification: where it names a computed role that is not a WAI-ARIA
+role (`html-abbr`, `html-audio`, `keyboard`, `variable` and their kind) the element maps to `generic`.
+
+`AccessibilityOptions` has three presets and they are not interchangeable: `Default` is the pruned tree,
+`Snapshot` adds the text between the nodes (which is what `AccessibilitySnapshot.Render` needs to say
+anything at all), and `Full` is what `Accessibility.getFullAXTree` answers with. A snapshot states each
+string once — text that is already a node's accessible name is not published again as a text node.
+
+The four fixture pages under `Jint.Tests.Browser/Accessibility/Golden/` are rendered three ways each and the
+output is checked in. **`JINT_BROWSER_GOLDEN=update` rewrites them**, the same discipline `JINT_SPEC_ANCHORS`
+and `JINT_DOM_BINDINGS` use: the diff is the artefact, so a change to what an agent reads has to be looked at.
+
+Divergences that are **AngleSharp's**, found by this work, to be reported upstream rather than patched here:
+
+| What | The standard | AngleSharp.Css 1.0.2 |
+| --- | --- | --- |
+| `el.ComputeCurrentStyle()` without the CSS services | an empty declaration, or a documented failure | throws `InvalidOperationException("Sequence contains no elements")`, which is why every call here is guarded and the guard latches |
+| the default style sheet's `display` rules | HTML's rendering section gives `display: block` to `section`, `article`, `nav`, `aside`, `header`, `footer`, `main`, `figure`, `figcaption`, `details`, `summary`, `dialog`, `hgroup` | no rule at all, so every one of them computes to nothing and reads as inline |
+| `[hidden] { display: none }` | in HTML's rendering section | absent, so `<div hidden>` computes `display: block` |
+| `textarea { white-space: pre-wrap }` | in HTML's rendering section | absent, though `pre { white-space: pre }` is there |

--- a/Jint.Browser/Accessibility/AccessibilityOptions.cs
+++ b/Jint.Browser/Accessibility/AccessibilityOptions.cs
@@ -1,0 +1,55 @@
+namespace Jint.Browser.Accessibility;
+
+/// <summary>
+/// What a call to <see cref="AccessibilityTree.Build(AngleSharp.Dom.IDocument, AccessibilityOptions?)"/>
+/// keeps and what it prunes.
+/// </summary>
+/// <remarks>
+/// The defaults are the agent-facing tree: no generic wrappers, no text nodes, no ignored subtrees — the
+/// smallest thing that still says what is on the page. <see cref="Full"/> is the other end, and is what a
+/// Chrome DevTools Protocol <c>Accessibility.getFullAXTree</c> answers with.
+/// </remarks>
+internal sealed record AccessibilityOptions
+{
+    /// <summary>The agent-facing tree: interesting nodes only.</summary>
+    internal static AccessibilityOptions Default { get; } = new();
+
+    /// <summary>
+    /// The agent-facing tree plus the text between its nodes, which is what a compact snapshot renders.
+    /// </summary>
+    /// <remarks>
+    /// The text a node's own accessible name already carries is left out — a button's label, a
+    /// <c>&lt;label&gt;</c>'s text, a <c>&lt;legend&gt;</c>, a <c>&lt;caption&gt;</c> — so a snapshot states
+    /// each string once.
+    /// </remarks>
+    internal static AccessibilityOptions Snapshot { get; } = new() { IncludeText = true };
+
+    /// <summary>Everything the walk saw, ignored nodes and text nodes included.</summary>
+    internal static AccessibilityOptions Full { get; } = new()
+    {
+        IncludeGeneric = true,
+        IncludeText = true,
+        IncludeIgnored = true,
+    };
+
+    /// <summary>Whether nodes whose role is <c>generic</c>, <c>none</c> or <c>presentation</c> are kept.</summary>
+    /// <remarks>
+    /// A pruned node is replaced by its children rather than dropped with them, so the tree stays complete.
+    /// A generic node that carries an accessible name or can take focus is kept either way.
+    /// </remarks>
+    internal bool IncludeGeneric { get; init; }
+
+    /// <summary>Whether text nodes become <c>StaticText</c> nodes.</summary>
+    internal bool IncludeText { get; init; }
+
+    /// <summary>Whether hidden subtrees are kept as ignored nodes rather than dropped.</summary>
+    internal bool IncludeIgnored { get; init; }
+
+    /// <summary>Whether the CSS cascade is consulted for <c>display</c> and <c>visibility</c>.</summary>
+    /// <remarks>
+    /// It needs <c>AngleSharp.Css</c> registered on the browsing context. When it is not, the computation
+    /// falls back to the <c>style</c> content attribute and the <c>hidden</c> attribute, once, and stays
+    /// there for the life of the walk rather than throwing per element.
+    /// </remarks>
+    internal bool UseComputedStyle { get; init; } = true;
+}

--- a/Jint.Browser/Accessibility/AccessibilitySnapshot.cs
+++ b/Jint.Browser/Accessibility/AccessibilitySnapshot.cs
@@ -1,0 +1,113 @@
+using System.Text;
+
+namespace Jint.Browser.Accessibility;
+
+/// <summary>
+/// Renders an accessibility tree as the compact indented text an agent reads, one node per line.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The shape is the one Playwright's <c>ariaSnapshot</c> established — <c>- role "name" [attrs]:</c>, nested
+/// by indentation — because it is what an agent's prompt budget can afford and what the models driving these
+/// pages have already seen. It is a projection, not a serialization: only the properties that change what a
+/// caller would do are printed, and <see cref="AccessibilityTree.ToJson"/> is the lossless form.
+/// </para>
+/// </remarks>
+internal static class AccessibilitySnapshot
+{
+    private static readonly AxPropertyName[] s_printed =
+    [
+        AxPropertyName.Level,
+        AxPropertyName.Checked,
+        AxPropertyName.Pressed,
+        AxPropertyName.Expanded,
+        AxPropertyName.Selected,
+        AxPropertyName.Disabled,
+        AxPropertyName.Required,
+        AxPropertyName.Readonly,
+        AxPropertyName.Focused,
+        AxPropertyName.Multiselectable,
+        AxPropertyName.Invalid,
+    ];
+
+    /// <summary>Renders <paramref name="node"/> and its descendants.</summary>
+    internal static string Render(AxNode node)
+    {
+        ArgumentNullException.ThrowIfNull(node);
+
+        var builder = new StringBuilder();
+        Write(builder, node, depth: 0);
+        return builder.ToString();
+    }
+
+    private static void Write(StringBuilder builder, AxNode node, int depth)
+    {
+        builder.Append(' ', depth * 2).Append("- ");
+
+        if (string.Equals(node.Role, AriaRoles.StaticText, StringComparison.Ordinal))
+        {
+            builder.Append("text: ").Append(node.Name ?? string.Empty).Append('\n');
+            return;
+        }
+
+        builder.Append(node.Role);
+
+        if (node.Name is { Length: > 0 } name)
+        {
+            builder.Append(" \"").Append(Escape(name)).Append('"');
+        }
+
+        foreach (var wanted in s_printed)
+        {
+            foreach (var property in node.Properties)
+            {
+                if (property.Name != wanted)
+                {
+                    continue;
+                }
+
+                var value = property.Value.ToDisplayString();
+                if (string.Equals(value, "false", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                builder.Append(" [").Append(property.ProtocolName);
+                if (!string.Equals(value, "true", StringComparison.Ordinal))
+                {
+                    builder.Append('=').Append(value);
+                }
+
+                builder.Append(']');
+            }
+        }
+
+        // A node whose whole content is one run of text says it on its own line rather than in a child:
+        // `- strong: non-DOM half` instead of two lines, which is the whole point of the compact form.
+        if (node.Children is [{ Role: AriaRoles.StaticText, Name: { Length: > 0 } only }])
+        {
+            builder.Append(": ").Append(only).Append('\n');
+            return;
+        }
+
+        if (node.Children.Count > 0)
+        {
+            builder.Append(":\n");
+            foreach (var child in node.Children)
+            {
+                Write(builder, child, depth + 1);
+            }
+
+            return;
+        }
+
+        if (node.Value is { Length: > 0 } widgetValue)
+        {
+            builder.Append(": ").Append(widgetValue);
+        }
+
+        builder.Append('\n');
+    }
+
+    private static string Escape(string text) => text.Replace("\"", "\\\"", StringComparison.Ordinal);
+}

--- a/Jint.Browser/Accessibility/AccessibilityTree.cs
+++ b/Jint.Browser/Accessibility/AccessibilityTree.cs
@@ -1,0 +1,779 @@
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using AngleSharp.Dom;
+using AngleSharp.Html.Dom;
+
+namespace Jint.Browser.Accessibility;
+
+/// <summary>
+/// Computes an accessibility tree over an AngleSharp document, with no layout and no script engine.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The roles come from <see cref="ImplicitRole"/> (HTML-AAM's mapping table) with an author <c>role</c>
+/// attribute overriding them, the names from <see cref="AccessibleName"/> (accname 1.2), and the hidden
+/// verdict from <see cref="ElementVisibility"/>. What none of them can answer is anything positional — off
+/// screen, clipped, covered, zero-sized — because those are layout facts.
+/// </para>
+/// <para>
+/// Node identifiers are stable for as long as the document and the element live, so two builds of an
+/// unchanged document produce the same identifiers and a protocol client can address a node across calls.
+/// </para>
+/// </remarks>
+internal static class AccessibilityTree
+{
+    private static readonly ConditionalWeakTable<IDocument, NodeIdentifiers> s_identifiers = new();
+
+    private static readonly AxProtocolJsonContext s_indented = new(new JsonSerializerOptions(JsonSerializerDefaults.General)
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+        WriteIndented = true,
+    });
+
+    /// <summary>Builds the accessibility tree of <paramref name="document"/>.</summary>
+    internal static AxNode Build(IDocument document, AccessibilityOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        options ??= AccessibilityOptions.Default;
+        var builder = new Builder(document, options);
+
+        var children = new List<AxNode>();
+        if (document.DocumentElement is not null)
+        {
+            builder.Visit(document.DocumentElement, AxIgnoredReason.None, children, suppressText: false);
+        }
+
+        var properties = new List<AxProperty>();
+        if (!string.IsNullOrEmpty(document.Url))
+        {
+            properties.Add(new AxProperty(AxPropertyName.Url, AxValue.String(document.Url)));
+        }
+
+        var root = new AxNode(IdOf(document, document), AriaRoles.RootWebArea)
+        {
+            Node = document,
+            Name = NullIfEmpty(AccessibleName.Flatten(document.Title ?? string.Empty)),
+            Properties = properties,
+            Children = children,
+        };
+
+        root.AdoptChildren();
+        return root;
+    }
+
+    /// <summary>
+    /// Builds the accessibility tree rooted at <paramref name="element"/>, or <see langword="null"/> when the
+    /// element produces no node at all.
+    /// </summary>
+    /// <remarks>
+    /// This is what a partial tree request answers with. An element whose own node is pruned — a
+    /// <c>&lt;div&gt;</c> with nothing on it — yields its first surviving descendant rather than nothing,
+    /// so a caller always gets the subtree it asked about.
+    /// </remarks>
+    internal static AxNode? Build(IElement element, AccessibilityOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(element);
+
+        options ??= AccessibilityOptions.Default;
+        var document = element.Owner ?? throw new ArgumentException("The element does not belong to a document.", nameof(element));
+        var builder = new Builder(document, options);
+
+        var nodes = new List<AxNode>();
+        builder.Visit(element, InheritedReasonFor(element, builder), nodes, suppressText: false);
+
+        return nodes.Count switch
+        {
+            0 => null,
+            1 => nodes[0],
+            _ => Wrap(document, element, nodes),
+        };
+    }
+
+    /// <summary>Converts one node to the protocol shape, with its children named by identifier.</summary>
+    internal static AxProtocolNode ToProtocol(AxNode node)
+    {
+        ArgumentNullException.ThrowIfNull(node);
+
+        return new AxProtocolNode
+        {
+            NodeId = Identifier(node.Id),
+            Ignored = node.Ignored,
+            IgnoredReasons = node.Ignored ? [IgnoredReasonProperty(node.IgnoredReason)] : null,
+            Role = new AxProtocolValue(node.Ignored ? "internalRole" : "role", AxValue.Role(node.Role)),
+            Name = node.Name is null ? null : new AxProtocolValue("computedString", AxValue.ComputedString(node.Name)),
+            Description = node.Description is null ? null : new AxProtocolValue("computedString", AxValue.ComputedString(node.Description)),
+            Value = node.Value is null ? null : new AxProtocolValue("computedString", AxValue.ComputedString(node.Value)),
+            Properties = node.Properties.Count == 0 ? null : node.Properties.Select(ToProtocol).ToArray(),
+            ParentId = node.Parent is null ? null : Identifier(node.Parent.Id),
+            ChildIds = node.Children.Count == 0 ? null : node.Children.Select(child => Identifier(child.Id)).ToArray(),
+        };
+    }
+
+    /// <summary>Flattens the tree into the node list <c>Accessibility.getFullAXTree</c> answers with.</summary>
+    internal static IReadOnlyList<AxProtocolNode> Flatten(AxNode root)
+    {
+        ArgumentNullException.ThrowIfNull(root);
+
+        var nodes = new List<AxProtocolNode>();
+        Collect(root, nodes);
+        return nodes;
+
+        static void Collect(AxNode node, List<AxProtocolNode> into)
+        {
+            into.Add(ToProtocol(node));
+            foreach (var child in node.Children)
+            {
+                Collect(child, into);
+            }
+        }
+    }
+
+    /// <summary>Writes the flattened tree as the JSON body of a <c>getFullAXTree</c> reply's <c>nodes</c>.</summary>
+    internal static string ToJson(AxNode root, bool indented = false) =>
+        JsonSerializer.Serialize(Flatten(root), indented ? s_indented.IReadOnlyListAxProtocolNode : AxProtocolJsonContext.Default.IReadOnlyListAxProtocolNode);
+
+    /// <summary>The identifier this document gave the node, assigning one when it has none yet.</summary>
+    internal static int IdOf(IDocument document, INode node) => s_identifiers.GetValue(document, static _ => new NodeIdentifiers()).For(node);
+
+    private static string Identifier(int id) => id.ToString(CultureInfo.InvariantCulture);
+
+    private static AxProtocolProperty ToProtocol(AxProperty property) =>
+        new(property.ProtocolName, new AxProtocolValue(TypeName(property.Value.Type), property.Value));
+
+    private static AxProtocolProperty IgnoredReasonProperty(AxIgnoredReason reason)
+    {
+        var name = reason switch
+        {
+            AxIgnoredReason.Hidden => AxPropertyName.Hidden,
+            AxIgnoredReason.NotRendered => AxPropertyName.NotRendered,
+            AxIgnoredReason.NotVisible => AxPropertyName.NotVisible,
+            AxIgnoredReason.AriaHiddenElement => AxPropertyName.AriaHiddenElement,
+            AxIgnoredReason.AriaHiddenSubtree => AxPropertyName.AriaHiddenSubtree,
+            AxIgnoredReason.PresentationalRole => AxPropertyName.PresentationalRole,
+            AxIgnoredReason.EmptyAlt => AxPropertyName.EmptyAlt,
+            AxIgnoredReason.EmptyText => AxPropertyName.EmptyText,
+            _ => AxPropertyName.Uninteresting,
+        };
+
+        var property = new AxProperty(name, AxValue.Boolean(true));
+        return new AxProtocolProperty(property.ProtocolName, new AxProtocolValue("boolean", property.Value));
+    }
+
+    private static string TypeName(AxValueType type) => type switch
+    {
+        AxValueType.Boolean => "boolean",
+        AxValueType.Tristate => "tristate",
+        AxValueType.Integer => "integer",
+        AxValueType.Number => "number",
+        AxValueType.String => "string",
+        AxValueType.ComputedString => "computedString",
+        AxValueType.Token => "token",
+        AxValueType.Role => "role",
+        _ => "string",
+    };
+
+    private static AxIgnoredReason InheritedReasonFor(IElement element, Builder builder)
+    {
+        for (var ancestor = element.ParentElement; ancestor is not null; ancestor = ancestor.ParentElement)
+        {
+            var reason = builder.Visibility.ReasonFor(ancestor);
+            if (reason != AxIgnoredReason.None)
+            {
+                return Inherit(reason);
+            }
+        }
+
+        return AxIgnoredReason.None;
+    }
+
+    private static AxNode Wrap(IDocument document, IElement element, List<AxNode> nodes)
+    {
+        // The element's own node was pruned but several of its descendants survived, so they need a holder.
+        // It takes the element's identifier rather than a fresh one: it stands for that element.
+        var wrapper = new AxNode(IdOf(document, element), AriaRoles.Generic)
+        {
+            Element = element,
+            Node = element,
+            Children = nodes,
+        };
+
+        wrapper.AdoptChildren();
+        return wrapper;
+    }
+
+    private static AxIgnoredReason Inherit(AxIgnoredReason reason) => reason switch
+    {
+        AxIgnoredReason.AriaHiddenElement => AxIgnoredReason.AriaHiddenSubtree,
+        _ => reason,
+    };
+
+    private static string? NullIfEmpty(string text) => text.Length == 0 ? null : text;
+
+    private sealed class Builder
+    {
+        private readonly IDocument _document;
+        private readonly AccessibilityOptions _options;
+        private readonly AccessibleName _names;
+
+        internal Builder(IDocument document, AccessibilityOptions options)
+        {
+            _document = document;
+            _options = options;
+            Visibility = new ElementVisibility(options.UseComputedStyle);
+            _names = new AccessibleName(Visibility);
+        }
+
+        internal ElementVisibility Visibility { get; }
+
+        internal void Visit(INode node, AxIgnoredReason inherited, List<AxNode> output, bool suppressText)
+        {
+            switch (node)
+            {
+                case IText text:
+                    VisitText(text, inherited, output, suppressText);
+                    return;
+
+                case IElement element:
+                    VisitElement(element, inherited, output, suppressText);
+                    return;
+
+                default:
+                    return;
+            }
+        }
+
+        private void VisitText(IText text, AxIgnoredReason inherited, List<AxNode> output, bool suppressText)
+        {
+            if (!_options.IncludeText || (suppressText && !_options.IncludeIgnored))
+            {
+                return;
+            }
+
+            var content = AccessibleName.Flatten(text.Data);
+            var reason = inherited != AxIgnoredReason.None ? inherited
+                : content.Length == 0 ? AxIgnoredReason.EmptyText
+                : AxIgnoredReason.None;
+
+            if (reason != AxIgnoredReason.None && !_options.IncludeIgnored)
+            {
+                return;
+            }
+
+            output.Add(new AxNode(IdOf(_document, text), AriaRoles.StaticText)
+            {
+                Node = text,
+                Name = NullIfEmpty(content),
+                IgnoredReason = reason,
+                Properties = reason == AxIgnoredReason.None ? [] : [new AxProperty(AxPropertyName.Hidden, AxValue.Boolean(true))],
+            });
+        }
+
+        private void VisitElement(IElement element, AxIgnoredReason inherited, List<AxNode> output, bool suppressText)
+        {
+            if (ImplicitRole.IsMetadataContent(element))
+            {
+                return;
+            }
+
+            var reason = Reason(Visibility.ReasonFor(element), inherited);
+
+            // Four of the reasons take the subtree with them: nothing inside a `display: none`, a `hidden`
+            // attribute or an `aria-hidden` can come back. `visibility` is the one that can, because CSS
+            // inherits it and a descendant may set it back to `visible`.
+            var subtreeHidden = reason is AxIgnoredReason.Hidden or AxIgnoredReason.NotRendered
+                or AxIgnoredReason.AriaHiddenElement or AxIgnoredReason.AriaHiddenSubtree;
+            if (subtreeHidden && !_options.IncludeIgnored)
+            {
+                return;
+            }
+
+            var explicitRole = AriaRoles.Explicit(element.GetAttribute("role"));
+            var role = explicitRole ?? ImplicitRole.For(element);
+            if (role is null)
+            {
+                // HTML-AAM maps the element to no role at all: <br>, <wbr>, <input type=hidden>.
+                return;
+            }
+
+            // Text this element's own name already carries is not repeated as a node of its own: a
+            // button's label, a <label>'s text, a <legend>, a <caption>, a <figcaption>.
+            var suppressBelow = suppressText || AriaRoles.NameFromContent.Contains(role) || NamesAnAncestor(element);
+
+            var children = new List<AxNode>();
+            foreach (var child in element.ChildNodes)
+            {
+                Visit(child, reason, children, suppressBelow);
+            }
+
+            if (reason == AxIgnoredReason.None && explicitRole is null && IsEmptyAlt(element))
+            {
+                reason = AxIgnoredReason.EmptyAlt;
+            }
+
+            if (reason == AxIgnoredReason.None && AriaRoles.IsPresentational(role))
+            {
+                reason = AxIgnoredReason.PresentationalRole;
+            }
+
+            var name = _names.Compute(element, role);
+            var disabled = IsDisabled(element);
+            var focusable = reason == AxIgnoredReason.None && IsFocusable(element, disabled);
+
+            if (reason != AxIgnoredReason.None)
+            {
+                if (!_options.IncludeIgnored)
+                {
+                    // An ignored node that did not take its subtree with it is replaced by its children.
+                    output.AddRange(children);
+                    return;
+                }
+            }
+            else if (!_options.IncludeGeneric && children.Count == 0 && name.Length == 0 && NamesAnAncestor(element))
+            {
+                // Everything this element had was its ancestor's accessible name, and it has nothing of its
+                // own: an empty <caption> under a named <figure> states nothing twice over.
+                return;
+            }
+            else if (string.Equals(role, AriaRoles.Generic, StringComparison.Ordinal)
+                     && !_options.IncludeGeneric
+                     && name.Length == 0
+                     && !focusable)
+            {
+                // A generic wrapper with nothing on it is replaced by its children rather than dropped with
+                // them, so the tree stays complete while losing the levels an agent cannot act on.
+                output.AddRange(children);
+                return;
+            }
+
+            var value = ControlValue.For(element, role);
+            var node = new AxNode(IdOf(_document, element), role)
+            {
+                Element = element,
+                Node = element,
+                Name = NullIfEmpty(name),
+                Description = NullIfEmpty(_names.ComputeDescription(element, name)),
+                Value = NullIfEmpty(value),
+                IgnoredReason = reason,
+                Properties = BuildProperties(element, role, reason, disabled, focusable),
+                Children = children,
+            };
+
+            node.AdoptChildren();
+            output.Add(node);
+        }
+
+        private AxIgnoredReason Reason(AxIgnoredReason own, AxIgnoredReason inherited)
+        {
+            if (own != AxIgnoredReason.None)
+            {
+                return own;
+            }
+
+            if (inherited == AxIgnoredReason.None)
+            {
+                return AxIgnoredReason.None;
+            }
+
+            // `visibility` is the one CSS inherits, so with the cascade available the element's own verdict
+            // is the whole answer and a `visibility: visible` child of a hidden parent is visible again.
+            // Without the cascade there is nothing to resolve it against, so the ancestor's verdict stands.
+            if (inherited == AxIgnoredReason.NotVisible && Visibility.CascadeAvailable)
+            {
+                return AxIgnoredReason.None;
+            }
+
+            return Inherit(inherited);
+        }
+
+        private List<AxProperty> BuildProperties(IElement element, string role, AxIgnoredReason reason, bool disabled, bool focusable)
+        {
+            var properties = new List<AxProperty>();
+
+            if (reason != AxIgnoredReason.None)
+            {
+                properties.Add(new AxProperty(AxPropertyName.Hidden, AxValue.Boolean(true)));
+            }
+
+            AddTristate(properties, AxPropertyName.Checked, CheckedState(element, role));
+            AddTristate(properties, AxPropertyName.Pressed, element.GetAttribute("aria-pressed"));
+            AddBoolean(properties, AxPropertyName.Expanded, ExpandedState(element));
+            AddBoolean(properties, AxPropertyName.Selected, SelectedState(element, role));
+
+            if (disabled)
+            {
+                properties.Add(new AxProperty(AxPropertyName.Disabled, AxValue.Boolean(true)));
+            }
+
+            if (IsRequired(element))
+            {
+                properties.Add(new AxProperty(AxPropertyName.Required, AxValue.Boolean(true)));
+            }
+
+            if (IsReadOnly(element))
+            {
+                properties.Add(new AxProperty(AxPropertyName.Readonly, AxValue.Boolean(true)));
+            }
+
+            if (focusable)
+            {
+                properties.Add(new AxProperty(AxPropertyName.Focusable, AxValue.Boolean(true)));
+            }
+
+            if (ReferenceEquals(_document.ActiveElement, element))
+            {
+                properties.Add(new AxProperty(AxPropertyName.Focused, AxValue.Boolean(true)));
+            }
+
+            if (Level(element, role) is { } level)
+            {
+                properties.Add(new AxProperty(AxPropertyName.Level, AxValue.Integer(level)));
+            }
+
+            if (IsMultiline(element, role))
+            {
+                properties.Add(new AxProperty(AxPropertyName.Multiline, AxValue.Boolean(true)));
+            }
+
+            if (IsMultiselectable(element, role))
+            {
+                properties.Add(new AxProperty(AxPropertyName.Multiselectable, AxValue.Boolean(true)));
+            }
+
+            AddToken(properties, AxPropertyName.Orientation, element.GetAttribute("aria-orientation"));
+            AddToken(properties, AxPropertyName.Invalid, Invalid(element));
+            AddToken(properties, AxPropertyName.Autocomplete, Autocomplete(element, role));
+            AddToken(properties, AxPropertyName.HasPopup, element.GetAttribute("aria-haspopup"));
+            AddToken(properties, AxPropertyName.Live, Live(element, role));
+            AddBoolean(properties, AxPropertyName.Atomic, Flag(element.GetAttribute("aria-atomic")));
+            AddBoolean(properties, AxPropertyName.Busy, Flag(element.GetAttribute("aria-busy")));
+            AddBoolean(properties, AxPropertyName.Modal, Flag(element.GetAttribute("aria-modal")));
+
+            var (minimum, maximum) = ControlValue.Range(element, role);
+            if (minimum is { } low)
+            {
+                properties.Add(new AxProperty(AxPropertyName.Valuemin, AxValue.Number(low)));
+            }
+
+            if (maximum is { } high)
+            {
+                properties.Add(new AxProperty(AxPropertyName.Valuemax, AxValue.Number(high)));
+            }
+
+            AddToken(properties, AxPropertyName.Valuetext, element.GetAttribute("aria-valuetext"));
+
+            if (Url(element) is { } url)
+            {
+                properties.Add(new AxProperty(AxPropertyName.Url, AxValue.String(url)));
+            }
+
+            return properties;
+        }
+
+        private static void AddBoolean(List<AxProperty> properties, AxPropertyName name, bool? value)
+        {
+            if (value is { } flag)
+            {
+                properties.Add(new AxProperty(name, AxValue.Boolean(flag)));
+            }
+        }
+
+        private static void AddToken(List<AxProperty> properties, AxPropertyName name, string? value)
+        {
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                properties.Add(new AxProperty(name, AxValue.Token(value)));
+            }
+        }
+
+        private static void AddTristate(List<AxProperty> properties, AxPropertyName name, string? value)
+        {
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                properties.Add(new AxProperty(name, AxValue.Tristate(value)));
+            }
+        }
+
+        private static string? CheckedState(IElement element, string role)
+        {
+            if (role is not ("checkbox" or "radio" or "switch" or "menuitemcheckbox" or "menuitemradio"))
+            {
+                return null;
+            }
+
+            var aria = element.GetAttribute("aria-checked");
+            if (!string.IsNullOrWhiteSpace(aria))
+            {
+                return aria.ToLowerInvariant();
+            }
+
+            if (element is IHtmlInputElement input)
+            {
+                return input.IsIndeterminate ? "mixed" : input.IsChecked ? "true" : "false";
+            }
+
+            return null;
+        }
+
+        private static bool? ExpandedState(IElement element)
+        {
+            var aria = element.GetAttribute("aria-expanded");
+            if (!string.IsNullOrWhiteSpace(aria))
+            {
+                return Flag(aria);
+            }
+
+            if (element is IHtmlDetailsElement details)
+            {
+                return details.IsOpen;
+            }
+
+            if (string.Equals(element.LocalName, "summary", StringComparison.Ordinal)
+                && element.ParentElement is IHtmlDetailsElement parent)
+            {
+                return parent.IsOpen;
+            }
+
+            return null;
+        }
+
+        private static bool? SelectedState(IElement element, string role)
+        {
+            var aria = element.GetAttribute("aria-selected");
+            if (!string.IsNullOrWhiteSpace(aria))
+            {
+                return Flag(aria);
+            }
+
+            if (role is "option" && element is IHtmlOptionElement option)
+            {
+                return option.IsSelected;
+            }
+
+            return null;
+        }
+
+        private static bool IsDisabled(IElement element)
+        {
+            if (string.Equals(element.GetAttribute("aria-disabled"), "true", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            if (element.HasAttribute("disabled"))
+            {
+                return true;
+            }
+
+            // A disabled fieldset disables its descendants, except those inside its first legend.
+            for (var ancestor = element.ParentElement; ancestor is not null; ancestor = ancestor.ParentElement)
+            {
+                if (ancestor is IHtmlFieldSetElement { IsDisabled: true })
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool IsRequired(IElement element) =>
+            string.Equals(element.GetAttribute("aria-required"), "true", StringComparison.OrdinalIgnoreCase)
+            || element.HasAttribute("required");
+
+        private static bool IsReadOnly(IElement element) =>
+            string.Equals(element.GetAttribute("aria-readonly"), "true", StringComparison.OrdinalIgnoreCase)
+            || element.HasAttribute("readonly");
+
+        private static bool IsFocusable(IElement element, bool disabled)
+        {
+            if (disabled)
+            {
+                return false;
+            }
+
+            var tabIndex = element.GetAttribute("tabindex");
+            if (tabIndex is not null && int.TryParse(tabIndex, NumberStyles.Integer, CultureInfo.InvariantCulture, out var index))
+            {
+                return index > int.MinValue;
+            }
+
+            switch (element.LocalName)
+            {
+                case "a":
+                case "area":
+                    return element.HasAttribute("href");
+                case "button":
+                case "select":
+                case "textarea":
+                case "iframe":
+                case "object":
+                case "embed":
+                    return true;
+                case "input":
+                    return !string.Equals((element as IHtmlInputElement)?.Type, "hidden", StringComparison.OrdinalIgnoreCase);
+                case "summary":
+                    return string.Equals(element.ParentElement?.LocalName, "details", StringComparison.Ordinal);
+                case "audio":
+                case "video":
+                    return element.HasAttribute("controls");
+                default:
+                    return element is IHtmlElement { IsContentEditable: true };
+            }
+        }
+
+        private static int? Level(IElement element, string role)
+        {
+            var aria = element.GetAttribute("aria-level");
+            if (int.TryParse(aria, NumberStyles.Integer, CultureInfo.InvariantCulture, out var level))
+            {
+                return level;
+            }
+
+            if (!string.Equals(role, "heading", StringComparison.Ordinal))
+            {
+                return null;
+            }
+
+            return element.LocalName switch
+            {
+                "h1" => 1,
+                "h2" => 2,
+                "h3" => 3,
+                "h4" => 4,
+                "h5" => 5,
+                "h6" => 6,
+                _ => 2,
+            };
+        }
+
+        private static bool IsMultiline(IElement element, string role)
+        {
+            if (Flag(element.GetAttribute("aria-multiline")) is { } aria)
+            {
+                return aria;
+            }
+
+            return role is "textbox" && string.Equals(element.LocalName, "textarea", StringComparison.Ordinal);
+        }
+
+        private static bool IsMultiselectable(IElement element, string role)
+        {
+            if (Flag(element.GetAttribute("aria-multiselectable")) is { } aria)
+            {
+                return aria;
+            }
+
+            return role is "listbox" && element is IHtmlSelectElement { IsMultiple: true };
+        }
+
+        private static string? Invalid(IElement element)
+        {
+            var aria = element.GetAttribute("aria-invalid");
+            if (string.IsNullOrWhiteSpace(aria))
+            {
+                return null;
+            }
+
+            return string.Equals(aria, "false", StringComparison.OrdinalIgnoreCase) ? null : aria.ToLowerInvariant();
+        }
+
+        private static string? Autocomplete(IElement element, string role)
+        {
+            var aria = element.GetAttribute("aria-autocomplete");
+            if (!string.IsNullOrWhiteSpace(aria))
+            {
+                return aria.ToLowerInvariant();
+            }
+
+            return role is "combobox" && element.HasAttribute("list") ? "list" : null;
+        }
+
+        private static string? Live(IElement element, string role)
+        {
+            var aria = element.GetAttribute("aria-live");
+            if (!string.IsNullOrWhiteSpace(aria))
+            {
+                return aria.ToLowerInvariant();
+            }
+
+            return role switch
+            {
+                "alert" => "assertive",
+                "log" or "status" => "polite",
+                _ => null,
+            };
+        }
+
+        private static string? Url(IElement element) => element switch
+        {
+            IHtmlAnchorElement anchor when anchor.HasAttribute("href") => anchor.Href,
+            IHtmlAreaElement area when area.HasAttribute("href") => area.Href,
+            IHtmlImageElement image when image.HasAttribute("src") => image.Source,
+            _ => null,
+        };
+
+        /// <summary>
+        /// Whether the element's text is already an ancestor's accessible name, so publishing it again would
+        /// state the same string twice.
+        /// </summary>
+        /// <remarks>These are exactly HTML-AAM's native-label sources that take their value from content.</remarks>
+        private static bool NamesAnAncestor(IElement element)
+        {
+            var parent = element.ParentElement;
+            if (parent is null)
+            {
+                return false;
+            }
+
+            return element.LocalName switch
+            {
+                "legend" => string.Equals(parent.LocalName, "fieldset", StringComparison.Ordinal),
+                "caption" => parent.LocalName is "table" or "figure",
+                "figcaption" => string.Equals(parent.LocalName, "figure", StringComparison.Ordinal),
+                "label" => LabelsAControl(element),
+                _ => false,
+            };
+        }
+
+        private static bool LabelsAControl(IElement label)
+        {
+            // A `for` that names nothing labels nothing, so its text is ordinary page text and stays.
+            var target = label.GetAttribute("for");
+            if (!string.IsNullOrEmpty(target))
+            {
+                return label.Owner?.GetElementById(target) is not null;
+            }
+
+            return label.QuerySelector("input, select, textarea, button, meter, output, progress") is not null;
+        }
+
+        private static bool IsEmptyAlt(IElement element) =>
+            string.Equals(element.LocalName, "img", StringComparison.Ordinal)
+            && element.HasAttribute("alt")
+            && element.GetAttribute("alt")!.Length == 0;
+
+        private static bool? Flag(string? value) => value switch
+        {
+            null => null,
+            _ when string.Equals(value, "true", StringComparison.OrdinalIgnoreCase) => true,
+            _ when string.Equals(value, "false", StringComparison.OrdinalIgnoreCase) => false,
+            _ => null,
+        };
+    }
+
+    private sealed class NodeIdentifiers
+    {
+        private readonly ConditionalWeakTable<INode, Box> _ids = new();
+        private int _next;
+
+        internal int For(INode node) => _ids.GetValue(node, _ => new Box(Interlocked.Increment(ref _next))).Value;
+
+        private sealed class Box(int value)
+        {
+            internal int Value { get; } = value;
+        }
+    }
+}

--- a/Jint.Browser/Accessibility/AccessibleName.cs
+++ b/Jint.Browser/Accessibility/AccessibleName.cs
@@ -1,0 +1,432 @@
+using System.Text;
+using AngleSharp.Dom;
+using AngleSharp.Html.Dom;
+
+namespace Jint.Browser.Accessibility;
+
+/// <summary>
+/// The accessible name and description computation of
+/// <see href="https://w3c.github.io/accname/">Accessible Name and Description Computation 1.2</see>.
+/// </summary>
+/// <remarks>
+/// Four parts of the algorithm are deliberately simplified, and every one of them needs a layout or a style
+/// resolver this package does not have: CSS generated content (<c>::before</c>, <c>::after</c>,
+/// <c>::marker</c>) contributes nothing; <c>text-transform</c> is not applied; SVG <c>title</c>/<c>desc</c>
+/// children are not read; and the inter-child spacing rule uses HTML's suggested <c>display</c> rather than
+/// a used one. Everything else — 2A through 2I, the recursion, the visited guard and the whitespace
+/// flattening — is the algorithm as written.
+/// </remarks>
+internal sealed class AccessibleName
+{
+    private readonly ElementVisibility _visibility;
+
+    internal AccessibleName(ElementVisibility visibility) => _visibility = visibility;
+
+    /// <summary>Computes the accessible name of <paramref name="element"/>, or the empty string.</summary>
+    internal string Compute(IElement element, string role)
+    {
+        var context = new Context(new HashSet<INode>());
+        var name = Flatten(FromElement(element, role, context, referenced: false, descendant: false));
+
+        // Step 2I: a title is the last resort, and only for the element the computation started on.
+        if (name.Length == 0)
+        {
+            name = Flatten(element.GetAttribute("title") ?? string.Empty);
+        }
+
+        return name;
+    }
+
+    /// <summary>
+    /// Computes the accessible description of <paramref name="element"/>, given the name it already has.
+    /// </summary>
+    /// <remarks>
+    /// <c>aria-describedby</c> first, then the fallbacks HTML-AAM names — a <c>title</c> that the name did
+    /// not consume, and for a text control a <c>placeholder</c> that the name did not consume.
+    /// </remarks>
+    internal string ComputeDescription(IElement element, string name)
+    {
+        var describedBy = References(element, "aria-describedby");
+        if (describedBy.Count > 0)
+        {
+            var context = new Context(new HashSet<INode>());
+            var builder = new StringBuilder();
+            foreach (var target in describedBy)
+            {
+                // A referenced node is traversed for its content the same way step 2B's targets are.
+                Append(builder, FromNode(target, context, referenced: true, descendant: true));
+            }
+
+            var described = Flatten(builder.ToString());
+            if (described.Length > 0)
+            {
+                return described;
+            }
+        }
+
+        var title = Flatten(element.GetAttribute("title") ?? string.Empty);
+        if (title.Length > 0 && !string.Equals(title, name, StringComparison.Ordinal))
+        {
+            return title;
+        }
+
+        var placeholder = Flatten(element.GetAttribute("placeholder") ?? string.Empty);
+        if (placeholder.Length > 0 && !string.Equals(placeholder, name, StringComparison.Ordinal))
+        {
+            return placeholder;
+        }
+
+        return string.Empty;
+    }
+
+    private string FromNode(INode node, Context context, bool referenced, bool descendant)
+    {
+        if (node is IText text)
+        {
+            // Step 2G.
+            return text.Data;
+        }
+
+        if (node is not IElement element)
+        {
+            return string.Empty;
+        }
+
+        return FromElement(element, ResolveRole(element), context, referenced, descendant);
+    }
+
+    private string FromElement(IElement element, string role, Context context, bool referenced, bool descendant)
+    {
+        if (!context.Visited.Add(element))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            // Step 2A. A hidden node contributes nothing unless it is the direct target of the reference
+            // that reached it, which is what makes an off-screen <span id="label" hidden> a legal label.
+            if (!referenced && _visibility.ReasonFor(element) != AxIgnoredReason.None)
+            {
+                return string.Empty;
+            }
+
+            // Step 2B.
+            if (!context.InLabelledBy)
+            {
+                var labelledBy = References(element, "aria-labelledby");
+                if (labelledBy.Count > 0)
+                {
+                    var builder = new StringBuilder();
+                    var nested = context with { InLabelledBy = true };
+                    foreach (var target in labelledBy)
+                    {
+                        Append(builder, FromNode(target, nested, referenced: true, descendant: true));
+                    }
+
+                    var result = Flatten(builder.ToString());
+                    if (result.Length > 0)
+                    {
+                        return result;
+                    }
+                }
+            }
+
+            // Step 2C. Reached from somewhere else, a control contributes its value rather than its label.
+            var embedded = descendant && AriaRoles.EmbeddedControl.Contains(role);
+            if (embedded)
+            {
+                var value = ControlValue.For(element, role);
+                if (!string.IsNullOrEmpty(value))
+                {
+                    return value;
+                }
+            }
+
+            // Step 2D.
+            var ariaLabel = element.GetAttribute("aria-label");
+            if (!string.IsNullOrWhiteSpace(ariaLabel) && !embedded)
+            {
+                return Flatten(ariaLabel);
+            }
+
+            // Step 2E.
+            if (!AriaRoles.IsPresentational(role))
+            {
+                var native = NativeLabel(element, role, context);
+                if (native.Length > 0)
+                {
+                    return native;
+                }
+            }
+
+            // Step 2F and 2H. Name from content, either because the role allows it or because the walk got
+            // here through a reference or a subtree descent.
+            if (descendant || AriaRoles.NameFromContent.Contains(role))
+            {
+                var content = FromContent(element, context);
+                if (content.Length > 0)
+                {
+                    return content;
+                }
+            }
+
+            // Step 2I, for a node the recursion reached rather than the one it started on.
+            if (descendant)
+            {
+                var title = element.GetAttribute("title");
+                if (!string.IsNullOrWhiteSpace(title))
+                {
+                    return Flatten(title);
+                }
+            }
+
+            return string.Empty;
+        }
+        finally
+        {
+            context.Visited.Remove(element);
+        }
+    }
+
+    private string FromContent(IElement element, Context context)
+    {
+        var builder = new StringBuilder();
+        foreach (var child in element.ChildNodes)
+        {
+            if (child is IElement childElement)
+            {
+                if (ImplicitRole.IsMetadataContent(childElement))
+                {
+                    continue;
+                }
+
+                var childRole = ResolveRole(childElement);
+                var contribution = FromElement(childElement, childRole, context, referenced: false, descendant: true);
+
+                // Without a used display there is nothing to measure, so HTML's suggested rendering decides
+                // whether two children run together: "<b>a</b><b>b</b>" is "ab", "<p>a</p><p>b</p>" is "a b".
+                if (!HtmlDisplay.IsInlineLevel(HtmlDisplay.Resolve(childElement, _visibility.Style(childElement).Display)))
+                {
+                    Append(builder, contribution);
+                }
+                else
+                {
+                    builder.Append(contribution);
+                }
+            }
+            else if (child is IText text)
+            {
+                builder.Append(text.Data);
+            }
+        }
+
+        return Flatten(builder.ToString());
+    }
+
+    private string NativeLabel(IElement element, string role, Context context)
+    {
+        switch (element.LocalName)
+        {
+            case "input":
+                return InputLabel(element, role, context);
+
+            case "textarea":
+            case "select":
+            case "progress":
+            case "meter":
+            case "output":
+                return LabelElements(element, context);
+
+            case "img":
+            case "area":
+                return Flatten(element.GetAttribute("alt") ?? string.Empty);
+
+            case "fieldset":
+                return FromFirstChild(element, "legend", context);
+
+            case "table":
+                return FromFirstChild(element, "caption", context);
+
+            case "figure":
+                return FromFirstChild(element, "figcaption", context);
+
+            case "optgroup":
+                return Flatten(element.GetAttribute("label") ?? string.Empty);
+
+            default:
+                return string.Empty;
+        }
+    }
+
+    private string InputLabel(IElement element, string role, Context context)
+    {
+        var type = ((element as IHtmlInputElement)?.Type ?? element.GetAttribute("type") ?? "text").ToLowerInvariant();
+
+        switch (type)
+        {
+            case "button":
+                return Flatten(element.GetAttribute("value") ?? string.Empty);
+
+            case "submit":
+                {
+                    var value = Flatten(element.GetAttribute("value") ?? string.Empty);
+                    return value.Length > 0 ? value : "Submit";
+                }
+
+            case "reset":
+                {
+                    var value = Flatten(element.GetAttribute("value") ?? string.Empty);
+                    return value.Length > 0 ? value : "Reset";
+                }
+
+            case "image":
+                {
+                    var alt = Flatten(element.GetAttribute("alt") ?? string.Empty);
+                    if (alt.Length > 0)
+                    {
+                        return alt;
+                    }
+
+                    var value = Flatten(element.GetAttribute("value") ?? string.Empty);
+                    return value.Length > 0 ? value : "Submit Query";
+                }
+
+            default:
+                {
+                    var label = LabelElements(element, context);
+                    if (label.Length > 0)
+                    {
+                        return label;
+                    }
+
+                    // HTML-AAM's last native fallback for a text control.
+                    return Flatten(element.GetAttribute("placeholder") ?? string.Empty);
+                }
+        }
+    }
+
+    private string LabelElements(IElement element, Context context)
+    {
+        var builder = new StringBuilder();
+
+        var id = element.Id;
+        var document = element.Owner;
+        if (!string.IsNullOrEmpty(id) && document is not null)
+        {
+            foreach (var candidate in document.QuerySelectorAll("label[for]"))
+            {
+                if (string.Equals(candidate.GetAttribute("for"), id, StringComparison.Ordinal))
+                {
+                    Append(builder, FromElement(candidate, AriaRoles.Generic, context, referenced: false, descendant: true));
+                }
+            }
+        }
+
+        for (var ancestor = element.ParentElement; ancestor is not null; ancestor = ancestor.ParentElement)
+        {
+            if (string.Equals(ancestor.LocalName, "label", StringComparison.Ordinal) && !ancestor.HasAttribute("for"))
+            {
+                Append(builder, FromElement(ancestor, AriaRoles.Generic, context, referenced: false, descendant: true));
+                break;
+            }
+        }
+
+        return Flatten(builder.ToString());
+    }
+
+    private string FromFirstChild(IElement element, string localName, Context context)
+    {
+        foreach (var child in element.Children)
+        {
+            if (string.Equals(child.LocalName, localName, StringComparison.Ordinal))
+            {
+                return FromElement(child, AriaRoles.Generic, context, referenced: false, descendant: true);
+            }
+        }
+
+        return string.Empty;
+    }
+
+    private static List<INode> References(IElement element, string attribute)
+    {
+        var value = element.GetAttribute(attribute);
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return [];
+        }
+
+        var document = element.Owner;
+        if (document is null)
+        {
+            return [];
+        }
+
+        var targets = new List<INode>();
+        foreach (var idref in value.Split((char[]?) null, StringSplitOptions.RemoveEmptyEntries))
+        {
+            var target = document.GetElementById(idref);
+            if (target is not null)
+            {
+                targets.Add(target);
+            }
+        }
+
+        return targets;
+    }
+
+    /// <summary>Resolves a role the way the tree builder does, so a name computation agrees with it.</summary>
+    internal static string ResolveRole(IElement element) =>
+        AriaRoles.Explicit(element.GetAttribute("role")) ?? ImplicitRole.For(element) ?? AriaRoles.Generic;
+
+    private static void Append(StringBuilder builder, string text)
+    {
+        if (text.Length == 0)
+        {
+            return;
+        }
+
+        if (builder.Length > 0)
+        {
+            builder.Append(' ');
+        }
+
+        builder.Append(text);
+    }
+
+    /// <summary>Collapses every run of white space to one space and trims the ends, as accname requires.</summary>
+    internal static string Flatten(string text)
+    {
+        if (text.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        var builder = new StringBuilder(text.Length);
+        var pendingSpace = false;
+
+        foreach (var c in text)
+        {
+            if (char.IsWhiteSpace(c))
+            {
+                pendingSpace = builder.Length > 0;
+                continue;
+            }
+
+            if (pendingSpace)
+            {
+                builder.Append(' ');
+                pendingSpace = false;
+            }
+
+            builder.Append(c);
+        }
+
+        return builder.ToString();
+    }
+
+    private readonly record struct Context(HashSet<INode> Visited)
+    {
+        internal bool InLabelledBy { get; init; }
+    }
+}

--- a/Jint.Browser/Accessibility/AriaRoles.cs
+++ b/Jint.Browser/Accessibility/AriaRoles.cs
@@ -1,0 +1,100 @@
+using System.Collections.Frozen;
+
+namespace Jint.Browser.Accessibility;
+
+/// <summary>
+/// The WAI-ARIA role vocabulary: which role names exist, and which of them take a name from their content.
+/// </summary>
+/// <remarks>
+/// From <see href="https://w3c.github.io/aria/">WAI-ARIA 1.2</see>'s "Definition of Roles", plus the 1.3
+/// additions HTML-AAM's element mapping table already names (<c>comment</c>, <c>mark</c>, <c>suggestion</c>,
+/// <c>sectionheader</c>, <c>sectionfooter</c>). Abstract roles are deliberately absent: an author may not
+/// use one, so a <c>role="widget"</c> falls back to the implicit role the same way an unknown name does.
+/// </remarks>
+internal static class AriaRoles
+{
+    internal const string Generic = "generic";
+    internal const string None = "none";
+    internal const string Presentation = "presentation";
+    internal const string StaticText = "StaticText";
+    internal const string RootWebArea = "RootWebArea";
+
+    /// <summary>Every non-abstract role an author may write in a <c>role</c> attribute.</summary>
+    internal static FrozenSet<string> All { get; } = new[]
+    {
+        "alert", "alertdialog", "application", "article", "banner", "blockquote", "button", "caption", "cell",
+        "checkbox", "code", "columnheader", "combobox", "comment", "complementary", "contentinfo", "definition",
+        "deletion", "dialog", "directory", "document", "emphasis", "feed", "figure", "form", "generic", "grid",
+        "gridcell", "group", "heading", "image", "img", "insertion", "link", "list", "listbox", "listitem", "log",
+        "main", "mark", "marquee", "math", "menu", "menubar", "menuitem", "menuitemcheckbox", "menuitemradio",
+        "meter", "navigation", "none", "note", "option", "paragraph", "presentation", "progressbar", "radio",
+        "radiogroup", "region", "row", "rowgroup", "rowheader", "scrollbar", "search", "searchbox",
+        "sectionfooter", "sectionheader", "separator", "slider", "spinbutton", "status", "strong", "subscript",
+        "suggestion", "superscript", "switch", "tab", "table", "tablist", "tabpanel", "term", "textbox", "time",
+        "timer", "toolbar", "tooltip", "tree", "treegrid", "treeitem",
+    }.ToFrozenSet(StringComparer.Ordinal);
+
+    /// <summary>
+    /// The roles whose "Name From" is "author and contents", so that accname step 2F may walk their subtree.
+    /// </summary>
+    internal static FrozenSet<string> NameFromContent { get; } = new[]
+    {
+        "button", "cell", "checkbox", "columnheader", "comment", "gridcell", "heading", "link", "menuitem",
+        "menuitemcheckbox", "menuitemradio", "option", "radio", "row", "rowheader", "switch", "tab", "tooltip",
+        "treeitem",
+    }.ToFrozenSet(StringComparer.Ordinal);
+
+    /// <summary>
+    /// The roles accname step 2C treats as an embedded control, whose value replaces its content when it is
+    /// reached through a name computation that started somewhere else.
+    /// </summary>
+    internal static FrozenSet<string> EmbeddedControl { get; } = new[]
+    {
+        "textbox", "searchbox", "combobox", "listbox", "slider", "spinbutton", "progressbar", "meter",
+    }.ToFrozenSet(StringComparer.Ordinal);
+
+    /// <summary>
+    /// The roles that stop accname's "name from content" descent, because a control inside a label names
+    /// itself rather than the label.
+    /// </summary>
+    internal static FrozenSet<string> Interactive { get; } = new[]
+    {
+        "button", "checkbox", "combobox", "link", "listbox", "menuitem", "menuitemcheckbox", "menuitemradio",
+        "option", "radio", "searchbox", "slider", "spinbutton", "switch", "tab", "textbox", "treeitem",
+    }.ToFrozenSet(StringComparer.Ordinal);
+
+    /// <summary>Whether the role hides a node from an assistive technology while keeping its children.</summary>
+    internal static bool IsPresentational(string role) =>
+        string.Equals(role, None, StringComparison.Ordinal) || string.Equals(role, Presentation, StringComparison.Ordinal);
+
+    /// <summary>Whether the role carries nothing on its own, so the node may be replaced by its children.</summary>
+    internal static bool IsPrunable(string role) =>
+        string.Equals(role, Generic, StringComparison.Ordinal) || IsPresentational(role);
+
+    /// <summary>
+    /// Reads the first token of a <c>role</c> attribute that names a real role, or <see langword="null"/>
+    /// when the attribute is absent, empty or names nothing.
+    /// </summary>
+    /// <remarks>
+    /// ARIA's <c>role</c> is a token list whose first valid token wins, which is what makes
+    /// <c>role="doc-chapter region"</c> a region rather than nothing.
+    /// </remarks>
+    internal static string? Explicit(string? attribute)
+    {
+        if (string.IsNullOrWhiteSpace(attribute))
+        {
+            return null;
+        }
+
+        foreach (var token in attribute.Split((char[]?) null, StringSplitOptions.RemoveEmptyEntries))
+        {
+            var lowered = token.ToLowerInvariant();
+            if (All.Contains(lowered))
+            {
+                return lowered;
+            }
+        }
+
+        return null;
+    }
+}

--- a/Jint.Browser/Accessibility/AxNode.cs
+++ b/Jint.Browser/Accessibility/AxNode.cs
@@ -1,0 +1,102 @@
+using AngleSharp.Dom;
+
+namespace Jint.Browser.Accessibility;
+
+/// <summary>
+/// Why a node is in the tree but not exposed to an assistive technology.
+/// </summary>
+internal enum AxIgnoredReason
+{
+    /// <summary>The node is not ignored.</summary>
+    None,
+
+    /// <summary>The element or an ancestor carries the <c>hidden</c> content attribute.</summary>
+    Hidden,
+
+    /// <summary>The element or an ancestor computes to <c>display: none</c>.</summary>
+    NotRendered,
+
+    /// <summary>The element or an ancestor computes to <c>visibility: hidden</c>.</summary>
+    NotVisible,
+
+    /// <summary>The element carries <c>aria-hidden="true"</c>.</summary>
+    AriaHiddenElement,
+
+    /// <summary>An ancestor carries <c>aria-hidden="true"</c>.</summary>
+    AriaHiddenSubtree,
+
+    /// <summary>The element's role is <c>none</c> or <c>presentation</c>.</summary>
+    PresentationalRole,
+
+    /// <summary>An <c>img</c> whose <c>alt</c> is present and empty.</summary>
+    EmptyAlt,
+
+    /// <summary>A text node whose content collapses to nothing.</summary>
+    EmptyText,
+
+    /// <summary>A generic node carrying nothing an assistive technology would report.</summary>
+    Uninteresting,
+}
+
+/// <summary>
+/// One node of a computed accessibility tree.
+/// </summary>
+/// <remarks>
+/// The shape is the Chrome DevTools Protocol's <c>Accessibility.AXNode</c> in tree rather than flattened form:
+/// <see cref="AccessibilityTree.ToProtocol(AxNode)"/> converts one node and <see cref="AccessibilityTree.Flatten"/>
+/// produces the list <c>getFullAXTree</c> answers with.
+/// </remarks>
+internal sealed class AxNode
+{
+    internal AxNode(int id, string role)
+    {
+        Id = id;
+        Role = role;
+    }
+
+    /// <summary>The node's identifier, stable for as long as its document and this node's element live.</summary>
+    internal int Id { get; }
+
+    /// <summary>The computed role, explicit or implicit.</summary>
+    internal string Role { get; }
+
+    /// <summary>The element this node was computed from, or <see langword="null"/> for a text node.</summary>
+    internal IElement? Element { get; init; }
+
+    /// <summary>The DOM node this node was computed from.</summary>
+    internal INode? Node { get; init; }
+
+    /// <summary>The accessible name, or <see langword="null"/> when the computation produced nothing.</summary>
+    internal string? Name { get; init; }
+
+    /// <summary>The accessible description, or <see langword="null"/> when there is none.</summary>
+    internal string? Description { get; init; }
+
+    /// <summary>The value a widget carries, or <see langword="null"/> when the role has none.</summary>
+    internal string? Value { get; init; }
+
+    /// <summary>Everything else the node states, in a stable order.</summary>
+    internal IReadOnlyList<AxProperty> Properties { get; init; } = [];
+
+    /// <summary>The node's children, already pruned according to the options the tree was built with.</summary>
+    internal IReadOnlyList<AxNode> Children { get; init; } = [];
+
+    /// <summary>Whether an assistive technology would skip this node.</summary>
+    internal bool Ignored => IgnoredReason != AxIgnoredReason.None;
+
+    /// <summary>Why the node is ignored, or <see cref="AxIgnoredReason.None"/> when it is not.</summary>
+    internal AxIgnoredReason IgnoredReason { get; init; }
+
+    /// <summary>The node's parent, or <see langword="null"/> for the root.</summary>
+    internal AxNode? Parent { get; private set; }
+
+    internal void AdoptChildren()
+    {
+        foreach (var child in Children)
+        {
+            child.Parent = this;
+        }
+    }
+
+    public override string ToString() => Name is null ? Role : $"{Role} \"{Name}\"";
+}

--- a/Jint.Browser/Accessibility/AxProtocolNode.cs
+++ b/Jint.Browser/Accessibility/AxProtocolNode.cs
@@ -1,0 +1,119 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Jint.Browser.Accessibility;
+
+/// <summary>
+/// One computed accessibility value in the shape the Chrome DevTools Protocol's
+/// <c>Accessibility.AXValue</c> has on the wire.
+/// </summary>
+/// <remarks>
+/// The value is written as the JSON primitive its type calls for — a boolean for <c>boolean</c>, a number
+/// for <c>integer</c> and <c>number</c>, a string for the rest — because the protocol's <c>value</c> is
+/// <c>any</c> and a DevTools front end reads it as its type says.
+/// </remarks>
+[JsonConverter(typeof(AxProtocolValueConverter))]
+internal sealed record AxProtocolValue(string Type, AxValue Value);
+
+/// <summary>One name-and-value pair in the shape of the protocol's <c>Accessibility.AXProperty</c>.</summary>
+internal sealed record AxProtocolProperty(string Name, AxProtocolValue Value);
+
+/// <summary>
+/// One node in the shape of the Chrome DevTools Protocol's <c>Accessibility.AXNode</c>.
+/// </summary>
+/// <remarks>
+/// It exists here rather than in <c>Jint.DevTools</c> because this package does not reference that one:
+/// the accessibility tree is computed over AngleSharp's DOM alone, and the protocol domain that serves it
+/// maps this record onto its generated <c>AXNode</c> in one statement. <c>backendDOMNodeId</c> is therefore
+/// always <see langword="null"/> here — only a session that owns a DOM node registry can fill it in.
+/// </remarks>
+internal sealed record AxProtocolNode
+{
+    /// <summary>The node's identifier, as the protocol's string-typed <c>AXNodeId</c>.</summary>
+    [JsonPropertyName("nodeId")]
+    public required string NodeId { get; init; }
+
+    /// <summary>Whether an assistive technology skips this node.</summary>
+    [JsonPropertyName("ignored")]
+    public required bool Ignored { get; init; }
+
+    /// <summary>Why the node is ignored, when it is.</summary>
+    [JsonPropertyName("ignoredReasons")]
+    public IReadOnlyList<AxProtocolProperty>? IgnoredReasons { get; init; }
+
+    /// <summary>The computed role.</summary>
+    [JsonPropertyName("role")]
+    public AxProtocolValue? Role { get; init; }
+
+    /// <summary>The computed accessible name.</summary>
+    [JsonPropertyName("name")]
+    public AxProtocolValue? Name { get; init; }
+
+    /// <summary>The computed accessible description.</summary>
+    [JsonPropertyName("description")]
+    public AxProtocolValue? Description { get; init; }
+
+    /// <summary>The widget's value.</summary>
+    [JsonPropertyName("value")]
+    public AxProtocolValue? Value { get; init; }
+
+    /// <summary>Everything else the node states.</summary>
+    [JsonPropertyName("properties")]
+    public IReadOnlyList<AxProtocolProperty>? Properties { get; init; }
+
+    /// <summary>The identifier of this node's parent, absent on the root.</summary>
+    [JsonPropertyName("parentId")]
+    public string? ParentId { get; init; }
+
+    /// <summary>The identifiers of this node's children, in tree order.</summary>
+    [JsonPropertyName("childIds")]
+    public IReadOnlyList<string>? ChildIds { get; init; }
+
+    /// <summary>The DOM node the protocol session knows this node by, which only a session can supply.</summary>
+    [JsonPropertyName("backendDOMNodeId")]
+    public int? BackendDomNodeId { get; init; }
+}
+
+/// <summary>Writes an <see cref="AxProtocolValue"/> as the protocol's <c>{ type, value }</c> object.</summary>
+internal sealed class AxProtocolValueConverter : JsonConverter<AxProtocolValue>
+{
+    public override AxProtocolValue Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+        throw new NotSupportedException("Accessibility values are written, never read.");
+
+    public override void Write(Utf8JsonWriter writer, AxProtocolValue value, JsonSerializerOptions options)
+    {
+        writer.WriteStartObject();
+        writer.WriteString("type", value.Type);
+
+        var inner = value.Value;
+        switch (inner.Type)
+        {
+            case AxValueType.Boolean:
+                writer.WriteBoolean("value", inner.Flag ?? false);
+                break;
+
+            case AxValueType.Integer:
+            case AxValueType.Number:
+                writer.WriteNumber("value", inner.Numeric ?? 0);
+                break;
+
+            default:
+                if (inner.Text is not null)
+                {
+                    writer.WriteString("value", inner.Text);
+                }
+
+                break;
+        }
+
+        writer.WriteEndObject();
+    }
+}
+
+/// <summary>The source-generated serializer for the protocol shape of an accessibility tree.</summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(AxProtocolNode))]
+[JsonSerializable(typeof(IReadOnlyList<AxProtocolNode>))]
+internal sealed partial class AxProtocolJsonContext : JsonSerializerContext;

--- a/Jint.Browser/Accessibility/AxValue.cs
+++ b/Jint.Browser/Accessibility/AxValue.cs
@@ -1,0 +1,261 @@
+using System.Globalization;
+using System.Runtime.InteropServices;
+
+namespace Jint.Browser.Accessibility;
+
+/// <summary>
+/// The type tag a computed accessibility value carries, mirroring the Chrome DevTools Protocol's
+/// <c>Accessibility.AXValueType</c>.
+/// </summary>
+/// <remarks>
+/// Only the members this package produces are listed. The protocol's enumeration is larger — it also carries
+/// the source-tracking types <c>idref</c>, <c>nodeList</c> and <c>domRelation</c> that a real browser fills in
+/// from its layout tree — and a member never produced here would be a name nothing writes.
+/// </remarks>
+internal enum AxValueType
+{
+    /// <summary>A <see langword="true"/>/<see langword="false"/> value.</summary>
+    Boolean,
+
+    /// <summary>A <c>"true"</c>/<c>"false"</c>/<c>"mixed"</c> value, as ARIA's tristate attributes carry.</summary>
+    Tristate,
+
+    /// <summary>An integral value, such as a heading level.</summary>
+    Integer,
+
+    /// <summary>A numeric value, such as <c>aria-valuemin</c>.</summary>
+    Number,
+
+    /// <summary>A literal string, such as a URL.</summary>
+    String,
+
+    /// <summary>A string the algorithm computed rather than read, such as an accessible name.</summary>
+    ComputedString,
+
+    /// <summary>One value out of a closed set, such as <c>aria-orientation</c>'s.</summary>
+    Token,
+
+    /// <summary>A role name.</summary>
+    Role,
+}
+
+/// <summary>
+/// One computed accessibility value: a type tag and the value itself.
+/// </summary>
+/// <remarks>
+/// The value is kept as its CLR primitive rather than as a string so that the protocol writer can emit a JSON
+/// boolean, number or string without re-parsing what the builder already knew.
+/// </remarks>
+[StructLayout(LayoutKind.Auto)]
+internal readonly record struct AxValue
+{
+    private AxValue(AxValueType type, string? text, bool? flag, double? number)
+    {
+        Type = type;
+        Text = text;
+        Flag = flag;
+        Numeric = number;
+    }
+
+    /// <summary>What kind of value this is.</summary>
+    internal AxValueType Type { get; }
+
+    /// <summary>The value, when it is a string, a token, a tristate or a role; otherwise <see langword="null"/>.</summary>
+    internal string? Text { get; }
+
+    /// <summary>The value, when it is a boolean; otherwise <see langword="null"/>.</summary>
+    internal bool? Flag { get; }
+
+    /// <summary>The value, when it is a number or an integer; otherwise <see langword="null"/>.</summary>
+    internal double? Numeric { get; }
+
+    internal static AxValue Boolean(bool value) => new(AxValueType.Boolean, text: null, value, number: null);
+
+    internal static AxValue Tristate(string value) => new(AxValueType.Tristate, value, flag: null, number: null);
+
+    internal static AxValue Integer(int value) => new(AxValueType.Integer, text: null, flag: null, value);
+
+    internal static AxValue Number(double value) => new(AxValueType.Number, text: null, flag: null, value);
+
+    internal static AxValue String(string value) => new(AxValueType.String, value, flag: null, number: null);
+
+    internal static AxValue ComputedString(string value) => new(AxValueType.ComputedString, value, flag: null, number: null);
+
+    internal static AxValue Token(string value) => new(AxValueType.Token, value, flag: null, number: null);
+
+    internal static AxValue Role(string value) => new(AxValueType.Role, value, flag: null, number: null);
+
+    /// <summary>Renders the value the way the compact snapshot prints it.</summary>
+    internal string ToDisplayString() => Type switch
+    {
+        AxValueType.Boolean => Flag == true ? "true" : "false",
+        AxValueType.Integer => ((int) (Numeric ?? 0)).ToString(CultureInfo.InvariantCulture),
+        AxValueType.Number => (Numeric ?? 0).ToString("0.############", CultureInfo.InvariantCulture),
+        _ => Text ?? string.Empty,
+    };
+}
+
+/// <summary>
+/// The name of a computed accessibility property, spelled as the Chrome DevTools Protocol's
+/// <c>Accessibility.AXPropertyName</c> spells it.
+/// </summary>
+/// <remarks>
+/// The protocol's enumeration is closed, so every member here has to be one of its names — which is why
+/// <c>placeholder</c> is absent. HTML-AAM routes a placeholder into the accessible name or, when the element
+/// already has one, into the accessible description, and that is where this builder puts it.
+/// </remarks>
+internal enum AxPropertyName
+{
+    /// <summary>Whether a checkbox, radio or switch is checked, as a tristate.</summary>
+    Checked,
+
+    /// <summary>Whether a toggle button is pressed, as a tristate.</summary>
+    Pressed,
+
+    /// <summary>Whether a disclosure is expanded.</summary>
+    Expanded,
+
+    /// <summary>Whether an option, tab or row is selected.</summary>
+    Selected,
+
+    /// <summary>Whether the element is disabled.</summary>
+    Disabled,
+
+    /// <summary>Whether a form control must be filled in.</summary>
+    Required,
+
+    /// <summary>Whether a form control rejects edits.</summary>
+    Readonly,
+
+    /// <summary>Whether the element can take focus.</summary>
+    Focusable,
+
+    /// <summary>Whether the element currently has focus.</summary>
+    Focused,
+
+    /// <summary>Whether the element is hidden from the accessibility tree.</summary>
+    Hidden,
+
+    /// <summary>Which ancestor made a hidden element hidden.</summary>
+    HiddenRoot,
+
+    /// <summary>A heading's or tree item's level.</summary>
+    Level,
+
+    /// <summary>Whether a textbox accepts more than one line.</summary>
+    Multiline,
+
+    /// <summary>Whether more than one descendant may be selected at a time.</summary>
+    Multiselectable,
+
+    /// <summary>Whether the element is laid out horizontally or vertically.</summary>
+    Orientation,
+
+    /// <summary>Whether the element's value fails validation.</summary>
+    Invalid,
+
+    /// <summary>What kind of completion a text input offers.</summary>
+    Autocomplete,
+
+    /// <summary>What kind of pop-up the element triggers.</summary>
+    HasPopup,
+
+    /// <summary>A range widget's minimum.</summary>
+    Valuemin,
+
+    /// <summary>A range widget's maximum.</summary>
+    Valuemax,
+
+    /// <summary>A range widget's human-readable value.</summary>
+    Valuetext,
+
+    /// <summary>How assertively a live region announces updates.</summary>
+    Live,
+
+    /// <summary>Whether a live region announces itself in full on every update.</summary>
+    Atomic,
+
+    /// <summary>Whether the element is a modal dialog.</summary>
+    Modal,
+
+    /// <summary>The resource a link or image points at.</summary>
+    Url,
+
+    /// <summary>Whether the element's content is being updated.</summary>
+    Busy,
+
+    /// <summary>Whether the element's text can be edited.</summary>
+    Editable,
+
+    /// <summary>An element whose <c>aria-hidden</c> removed the node.</summary>
+    AriaHiddenElement,
+
+    /// <summary>An ancestor whose <c>aria-hidden</c> removed the node.</summary>
+    AriaHiddenSubtree,
+
+    /// <summary>An image whose <c>alt</c> is present and empty.</summary>
+    EmptyAlt,
+
+    /// <summary>A text node that collapses to nothing.</summary>
+    EmptyText,
+
+    /// <summary>An element the flat rendering model would not render.</summary>
+    NotRendered,
+
+    /// <summary>An element rendered but not visible.</summary>
+    NotVisible,
+
+    /// <summary>An element whose role is <c>none</c> or <c>presentation</c>.</summary>
+    PresentationalRole,
+
+    /// <summary>An element carrying nothing an assistive technology would report.</summary>
+    Uninteresting,
+}
+
+/// <summary>
+/// One name-and-value pair on an accessibility node.
+/// </summary>
+[StructLayout(LayoutKind.Auto)]
+internal readonly record struct AxProperty(AxPropertyName Name, AxValue Value)
+{
+    /// <summary>The protocol spelling of <see cref="Name"/>.</summary>
+    internal string ProtocolName => Name switch
+    {
+        AxPropertyName.Checked => "checked",
+        AxPropertyName.Pressed => "pressed",
+        AxPropertyName.Expanded => "expanded",
+        AxPropertyName.Selected => "selected",
+        AxPropertyName.Disabled => "disabled",
+        AxPropertyName.Required => "required",
+        AxPropertyName.Readonly => "readonly",
+        AxPropertyName.Focusable => "focusable",
+        AxPropertyName.Focused => "focused",
+        AxPropertyName.Hidden => "hidden",
+        AxPropertyName.HiddenRoot => "hiddenRoot",
+        AxPropertyName.Level => "level",
+        AxPropertyName.Multiline => "multiline",
+        AxPropertyName.Multiselectable => "multiselectable",
+        AxPropertyName.Orientation => "orientation",
+        AxPropertyName.Invalid => "invalid",
+        AxPropertyName.Autocomplete => "autocomplete",
+        AxPropertyName.HasPopup => "hasPopup",
+        AxPropertyName.Valuemin => "valuemin",
+        AxPropertyName.Valuemax => "valuemax",
+        AxPropertyName.Valuetext => "valuetext",
+        AxPropertyName.Live => "live",
+        AxPropertyName.Atomic => "atomic",
+        AxPropertyName.Modal => "modal",
+        AxPropertyName.Url => "url",
+        AxPropertyName.Busy => "busy",
+        AxPropertyName.Editable => "editable",
+        AxPropertyName.AriaHiddenElement => "ariaHiddenElement",
+        AxPropertyName.AriaHiddenSubtree => "ariaHiddenSubtree",
+        AxPropertyName.EmptyAlt => "emptyAlt",
+        AxPropertyName.EmptyText => "emptyText",
+        AxPropertyName.NotRendered => "notRendered",
+        AxPropertyName.NotVisible => "notVisible",
+        AxPropertyName.PresentationalRole => "presentationalRole",
+        AxPropertyName.Uninteresting => "uninteresting",
+        _ => Name.ToString().ToLowerInvariant(),
+    };
+}

--- a/Jint.Browser/Accessibility/ControlValue.cs
+++ b/Jint.Browser/Accessibility/ControlValue.cs
@@ -1,0 +1,107 @@
+using System.Globalization;
+using AngleSharp.Dom;
+using AngleSharp.Html.Dom;
+
+namespace Jint.Browser.Accessibility;
+
+/// <summary>
+/// The value a widget carries: what accname step 2C substitutes for an embedded control's content, and what
+/// the tree publishes as <see cref="AxNode.Value"/>.
+/// </summary>
+internal static class ControlValue
+{
+    /// <summary>Returns the element's value for its role, or the empty string when the role has none.</summary>
+    internal static string For(IElement element, string role)
+    {
+        var ariaValueText = element.GetAttribute("aria-valuetext");
+        if (!string.IsNullOrEmpty(ariaValueText) && IsRange(role))
+        {
+            return ariaValueText;
+        }
+
+        var ariaValueNow = element.GetAttribute("aria-valuenow");
+        if (!string.IsNullOrEmpty(ariaValueNow) && IsRange(role))
+        {
+            return ariaValueNow;
+        }
+
+        switch (element)
+        {
+            case IHtmlInputElement input when role is "textbox" or "searchbox" or "combobox" or "spinbutton" or "slider":
+                return input.Value ?? string.Empty;
+
+            case IHtmlTextAreaElement textArea:
+                return textArea.Value ?? string.Empty;
+
+            case IHtmlSelectElement select:
+                return SelectedText(select);
+
+            case IHtmlProgressElement progress:
+                return progress.Value.ToString("0.############", CultureInfo.InvariantCulture);
+
+            case IHtmlMeterElement meter:
+                return meter.Value.ToString("0.############", CultureInfo.InvariantCulture);
+
+            case IHtmlOutputElement output:
+                return output.Value ?? string.Empty;
+        }
+
+        if (role is "textbox" && element is IHtmlElement { IsContentEditable: true })
+        {
+            return AccessibleName.Flatten(element.TextContent);
+        }
+
+        return string.Empty;
+    }
+
+    /// <summary>Returns the range a widget spans, when its role has one.</summary>
+    internal static (double? Minimum, double? Maximum) Range(IElement element, string role)
+    {
+        if (!IsRange(role))
+        {
+            return (null, null);
+        }
+
+        var minimum = Parse(element.GetAttribute("aria-valuemin"));
+        var maximum = Parse(element.GetAttribute("aria-valuemax"));
+
+        switch (element)
+        {
+            case IHtmlInputElement input when role is "slider" or "spinbutton":
+                minimum ??= Parse(input.GetAttribute("min"));
+                maximum ??= Parse(input.GetAttribute("max"));
+                break;
+
+            case IHtmlProgressElement progress:
+                minimum ??= 0;
+                maximum ??= progress.Maximum;
+                break;
+
+            case IHtmlMeterElement meter:
+                minimum ??= meter.Minimum;
+                maximum ??= meter.Maximum;
+                break;
+        }
+
+        return (minimum, maximum);
+    }
+
+    private static bool IsRange(string role) =>
+        role is "slider" or "spinbutton" or "progressbar" or "meter" or "scrollbar";
+
+    private static string SelectedText(IHtmlSelectElement select)
+    {
+        foreach (var option in select.Options)
+        {
+            if (option.IsSelected)
+            {
+                return AccessibleName.Flatten(option.Text ?? string.Empty);
+            }
+        }
+
+        return string.Empty;
+    }
+
+    private static double? Parse(string? text) =>
+        double.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out var value) ? value : null;
+}

--- a/Jint.Browser/Accessibility/ElementVisibility.cs
+++ b/Jint.Browser/Accessibility/ElementVisibility.cs
@@ -1,0 +1,155 @@
+using AngleSharp.Css.Dom;
+using AngleSharp.Dom;
+
+namespace Jint.Browser.Accessibility;
+
+/// <summary>
+/// What "hidden" means to a browser that never lays a page out.
+/// </summary>
+/// <remarks>
+/// Two things a real browser answers from its layout tree are answered from the cascade instead:
+/// <c>display: none</c> is walked down from the ancestors because CSS does not inherit it, and
+/// <c>visibility</c> is read per element because CSS does. Nothing here can know that an element is
+/// off-screen, clipped or covered — those are layout facts, and a headless browser does not have them.
+/// </remarks>
+internal sealed class ElementVisibility
+{
+    private readonly bool _useComputedStyle;
+    private bool _cascadeAvailable = true;
+
+    internal ElementVisibility(bool useComputedStyle) => _useComputedStyle = useComputedStyle;
+
+    /// <summary>
+    /// Whether the CSS cascade answered at least once, so a caller can say which source a verdict came from.
+    /// </summary>
+    internal bool CascadeAvailable => _useComputedStyle && _cascadeAvailable;
+
+    /// <summary>
+    /// Returns the reason <paramref name="element"/> is itself hidden, or <see cref="AxIgnoredReason.None"/>.
+    /// </summary>
+    /// <remarks>
+    /// Ancestors are not consulted: the tree walk carries an inherited verdict down, which is both cheaper
+    /// than walking up per node and the only way <c>hiddenRoot</c> can name the ancestor that did it.
+    /// </remarks>
+    internal AxIgnoredReason ReasonFor(IElement element) => ReasonFor(element, ariaHiddenCounts: true);
+
+    /// <summary>
+    /// Returns the reason <paramref name="element"/> is not rendered, or <see cref="AxIgnoredReason.None"/>.
+    /// </summary>
+    /// <remarks>
+    /// The same verdict without <c>aria-hidden</c>, which removes a node from the accessibility tree and
+    /// changes nothing about the rendering. It is what the text and markdown extractors ask, because a
+    /// decorative marker is still text on the page.
+    /// </remarks>
+    internal AxIgnoredReason RenderingReasonFor(IElement element) => ReasonFor(element, ariaHiddenCounts: false);
+
+    private AxIgnoredReason ReasonFor(IElement element, bool ariaHiddenCounts)
+    {
+        if (element.HasAttribute("hidden"))
+        {
+            return AxIgnoredReason.Hidden;
+        }
+
+        if (ariaHiddenCounts && string.Equals(element.GetAttribute("aria-hidden"), "true", StringComparison.OrdinalIgnoreCase))
+        {
+            return AxIgnoredReason.AriaHiddenElement;
+        }
+
+        var (display, visibility) = Style(element);
+
+        if (string.Equals(display, "none", StringComparison.OrdinalIgnoreCase))
+        {
+            return AxIgnoredReason.NotRendered;
+        }
+
+        if (string.Equals(visibility, "hidden", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(visibility, "collapse", StringComparison.OrdinalIgnoreCase))
+        {
+            return AxIgnoredReason.NotVisible;
+        }
+
+        return AxIgnoredReason.None;
+    }
+
+    /// <summary>
+    /// Reads the element's <c>display</c> and <c>visibility</c>, from the cascade when it is available and
+    /// from the <c>style</c> content attribute when it is not.
+    /// </summary>
+    internal (string? Display, string? Visibility) Style(IElement element)
+    {
+        if (_useComputedStyle && _cascadeAvailable)
+        {
+            try
+            {
+                var computed = element.ComputeCurrentStyle();
+                return (computed.GetPropertyValue("display"), computed.GetPropertyValue("visibility"));
+            }
+            catch (Exception exception) when (exception is InvalidOperationException or NullReferenceException)
+            {
+                // AngleSharp.Css's ComputeCurrentStyle throws "Sequence contains no elements" rather than
+                // answering an empty declaration when the CSS service is not registered on the browsing
+                // context. Ask once, then stay on the inline-style path for the rest of the walk.
+                _cascadeAvailable = false;
+            }
+        }
+
+        return InlineStyle(element);
+    }
+
+    /// <summary>
+    /// Reads the element's declared <c>white-space</c>, or <see langword="null"/> when the cascade cannot
+    /// answer.
+    /// </summary>
+    internal string? WhiteSpace(IElement element)
+    {
+        if (!_useComputedStyle || !_cascadeAvailable)
+        {
+            return null;
+        }
+
+        try
+        {
+            return element.ComputeCurrentStyle().GetPropertyValue("white-space");
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or NullReferenceException)
+        {
+            _cascadeAvailable = false;
+            return null;
+        }
+    }
+
+    private static (string? Display, string? Visibility) InlineStyle(IElement element)
+    {
+        var style = element.GetAttribute("style");
+        if (string.IsNullOrEmpty(style))
+        {
+            return (null, null);
+        }
+
+        string? display = null;
+        string? visibility = null;
+
+        foreach (var declaration in style.Split(';'))
+        {
+            var separator = declaration.IndexOf(':', StringComparison.Ordinal);
+            if (separator < 0)
+            {
+                continue;
+            }
+
+            var name = declaration.AsSpan(0, separator).Trim();
+            var value = declaration.AsSpan(separator + 1).Trim();
+
+            if (name.Equals("display", StringComparison.OrdinalIgnoreCase))
+            {
+                display = value.ToString();
+            }
+            else if (name.Equals("visibility", StringComparison.OrdinalIgnoreCase))
+            {
+                visibility = value.ToString();
+            }
+        }
+
+        return (display, visibility);
+    }
+}

--- a/Jint.Browser/Accessibility/HtmlDisplay.cs
+++ b/Jint.Browser/Accessibility/HtmlDisplay.cs
@@ -1,0 +1,156 @@
+using System.Collections.Frozen;
+using AngleSharp.Dom;
+
+namespace Jint.Browser.Accessibility;
+
+/// <summary>
+/// What HTML's suggested rendering gives an element for <c>display</c> and <c>white-space</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This table, and not the cascade, is what decides whether a box is block-level. AngleSharp.Css's default
+/// style sheet has no rules for the HTML5 flow and sectioning elements — <c>section</c>, <c>article</c>,
+/// <c>nav</c>, <c>aside</c>, <c>header</c>, <c>footer</c>, <c>main</c>, <c>figure</c>, <c>figcaption</c>,
+/// <c>details</c>, <c>summary</c>, <c>dialog</c>, <c>hgroup</c> — so asking it would call every one of them
+/// inline.
+/// </para>
+/// <para>
+/// The cascade still wins where it says something this table does not: <see cref="Resolve"/> prefers a
+/// declared value that differs from the default, which is what makes
+/// <c>&lt;span style="display:block"&gt;</c> a block and leaves <c>&lt;section&gt;</c> alone.
+/// </para>
+/// </remarks>
+internal static class HtmlDisplay
+{
+    private static readonly FrozenDictionary<string, string> s_defaults = new Dictionary<string, string>(StringComparer.Ordinal)
+    {
+        ["address"] = "block",
+        ["article"] = "block",
+        ["aside"] = "block",
+        ["blockquote"] = "block",
+        ["body"] = "block",
+        ["caption"] = "table-caption",
+        ["center"] = "block",
+        ["col"] = "table-column",
+        ["colgroup"] = "table-column-group",
+        ["dd"] = "block",
+        ["details"] = "block",
+        ["dialog"] = "block",
+        ["dir"] = "block",
+        ["div"] = "block",
+        ["dl"] = "block",
+        ["dt"] = "block",
+        ["fieldset"] = "block",
+        ["figcaption"] = "block",
+        ["figure"] = "block",
+        ["footer"] = "block",
+        ["form"] = "block",
+        ["h1"] = "block",
+        ["h2"] = "block",
+        ["h3"] = "block",
+        ["h4"] = "block",
+        ["h5"] = "block",
+        ["h6"] = "block",
+        ["header"] = "block",
+        ["hgroup"] = "block",
+        ["hr"] = "block",
+        ["html"] = "block",
+        ["legend"] = "block",
+        ["li"] = "list-item",
+        ["listing"] = "block",
+        ["main"] = "block",
+        ["menu"] = "block",
+        ["nav"] = "block",
+        ["ol"] = "block",
+        ["optgroup"] = "block",
+        ["option"] = "block",
+        ["p"] = "block",
+        ["plaintext"] = "block",
+        ["pre"] = "block",
+        ["search"] = "block",
+        ["section"] = "block",
+        ["summary"] = "block",
+        ["table"] = "table",
+        ["tbody"] = "table-row-group",
+        ["td"] = "table-cell",
+        ["tfoot"] = "table-footer-group",
+        ["th"] = "table-cell",
+        ["thead"] = "table-header-group",
+        ["tr"] = "table-row",
+        ["ul"] = "block",
+        ["xmp"] = "block",
+    }.ToFrozenDictionary(StringComparer.Ordinal);
+
+    private static readonly FrozenSet<string> s_preserveWhitespace = new[]
+    {
+        "pre", "listing", "plaintext", "xmp", "textarea",
+    }.ToFrozenSet(StringComparer.Ordinal);
+
+    /// <summary>Returns HTML's suggested <c>display</c> for the element, or <c>inline</c>.</summary>
+    internal static string DefaultFor(IElement element) =>
+        s_defaults.TryGetValue(element.LocalName, out var display) ? display : "inline";
+
+    /// <summary>
+    /// Returns the element's effective <c>display</c>: the declared value when it differs from HTML's
+    /// suggested rendering, and the suggested rendering otherwise.
+    /// </summary>
+    internal static string Resolve(IElement element, string? declared)
+    {
+        var fallback = DefaultFor(element);
+        if (string.IsNullOrEmpty(declared) || string.Equals(declared, fallback, StringComparison.OrdinalIgnoreCase))
+        {
+            return fallback;
+        }
+
+        return declared;
+    }
+
+    /// <summary>Whether a box with this <c>display</c> is block-level, so it starts and ends a line.</summary>
+    /// <remarks>
+    /// The internal table displays are deliberately absent. A <c>table-row-group</c> or <c>table-cell</c> box
+    /// is not a block-level box, and <c>innerText</c> separates rows and cells with its own line feeds and
+    /// tabs rather than with the required line breaks a block-level box contributes.
+    /// </remarks>
+    internal static bool IsBlockLevel(string display) => display switch
+    {
+        "block" or "flow-root" or "list-item" or "table" or "flex" or "grid" => true,
+        _ => false,
+    };
+
+    /// <summary>Whether a box with this <c>display</c> runs together with the text beside it.</summary>
+    /// <remarks>
+    /// This is the coarser question the name computation asks. A table cell is not a block-level box, but two
+    /// cells still read as two words rather than one, so anything that is not inline-level separates.
+    /// </remarks>
+    internal static bool IsInlineLevel(string display) => display switch
+    {
+        "inline" or "inline-block" or "inline-flex" or "inline-grid" or "inline-table" or "contents"
+            or "ruby" or "ruby-base" or "ruby-text" => true,
+        _ => false,
+    };
+
+    /// <summary>Whether the element's content keeps its white space verbatim.</summary>
+    /// <remarks>
+    /// The element list is HTML's; AngleSharp.Css's default sheet carries <c>pre { white-space: pre }</c> but
+    /// not the <c>textarea</c> rule, so asking the cascade alone would collapse a text area's content.
+    /// </remarks>
+    internal static bool PreservesWhitespace(IElement element, string? declaredWhiteSpace)
+    {
+        if (!string.IsNullOrEmpty(declaredWhiteSpace))
+        {
+            if (declaredWhiteSpace.StartsWith("pre", StringComparison.OrdinalIgnoreCase)
+                || declaredWhiteSpace.StartsWith("break-spaces", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            if (declaredWhiteSpace.StartsWith("normal", StringComparison.OrdinalIgnoreCase)
+                || declaredWhiteSpace.StartsWith("nowrap", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+        }
+
+        return s_preserveWhitespace.Contains(element.LocalName);
+    }
+}

--- a/Jint.Browser/Accessibility/ImplicitRole.cs
+++ b/Jint.Browser/Accessibility/ImplicitRole.cs
@@ -1,0 +1,222 @@
+using AngleSharp.Dom;
+using AngleSharp.Html.Dom;
+
+namespace Jint.Browser.Accessibility;
+
+/// <summary>
+/// HTML-AAM's element-to-role mapping: what role an element has when its <c>role</c> attribute does not say.
+/// </summary>
+/// <remarks>
+/// From <see href="https://w3c.github.io/html-aam/#html-element-role-mappings">HTML-AAM</see>'s "HTML element
+/// role mappings" table. One simplification is deliberate and applies to every row: where the table names a
+/// computed role that is not a WAI-ARIA role — <c>html-abbr</c>, <c>html-audio</c>, <c>keyboard</c>,
+/// <c>variable</c> and their kind — this maps the element to <c>generic</c> instead, which is what a consumer
+/// of this tree can act on and what the pruning rules already understand.
+/// </remarks>
+internal static class ImplicitRole
+{
+    /// <summary>The tags that produce no accessibility node at all, children included.</summary>
+    /// <remarks>
+    /// These are not "ignored" nodes with a reason — an assistive technology never sees a
+    /// <c>&lt;script&gt;</c>'s text, and neither should a snapshot. <c>&lt;template&gt;</c> is here for a
+    /// second reason: its contents live in a separate document fragment, so a child walk never reaches them.
+    /// </remarks>
+    internal static bool IsMetadataContent(IElement element) => element.LocalName switch
+    {
+        "head" or "meta" or "link" or "style" or "script" or "template" or "title" or "base" or "noscript"
+            or "param" or "source" or "track" or "col" or "colgroup" or "slot" => true,
+        _ => false,
+    };
+
+    /// <summary>
+    /// Returns the element's implicit role, or <see langword="null"/> when HTML-AAM maps it to no role at all.
+    /// </summary>
+    internal static string? For(IElement element)
+    {
+        if (!string.Equals(element.NamespaceUri, NamespaceNames.HtmlUri, StringComparison.Ordinal))
+        {
+            return element.LocalName switch
+            {
+                "svg" => "graphics-document",
+                "math" => "math",
+                _ => AriaRoles.Generic,
+            };
+        }
+
+        return element.LocalName switch
+        {
+            "a" or "area" => element.HasAttribute("href") ? "link" : AriaRoles.Generic,
+            "article" => "article",
+            "aside" => Complementary(element),
+            "blockquote" => "blockquote",
+            "button" => "button",
+            "caption" or "figcaption" => "caption",
+            "code" => "code",
+            "datalist" => "listbox",
+            "dd" => "definition",
+            "del" => "deletion",
+            "details" => "group",
+            "dfn" or "dt" => "term",
+            "dialog" => "dialog",
+            "dl" or "menu" or "ol" or "ul" or "dir" => "list",
+            "em" => "emphasis",
+            "address" or "fieldset" or "hgroup" or "optgroup" => "group",
+            "figure" => "figure",
+            "form" => "form",
+            "h1" or "h2" or "h3" or "h4" or "h5" or "h6" => "heading",
+            "header" => IsScopedToBody(element) ? "banner" : "sectionheader",
+            "footer" => IsScopedToBody(element) ? "contentinfo" : "sectionfooter",
+            "hr" => "separator",
+            "img" => Image(element),
+            "input" => Input(element),
+            "ins" => "insertion",
+            "li" => IsListItem(element) ? "listitem" : AriaRoles.Generic,
+            "main" => "main",
+            "mark" => "mark",
+            "math" => "math",
+            "meter" => "meter",
+            "nav" => "navigation",
+            "option" => "option",
+            "output" => "status",
+            "p" => "paragraph",
+            "progress" => "progressbar",
+            "s" => "strikethrough",
+            "search" => "search",
+            "section" => HasNamingAttribute(element) ? "region" : AriaRoles.Generic,
+            "select" => IsListBox(element) ? "listbox" : "combobox",
+            "strong" => "strong",
+            "sub" => "subscript",
+            "summary" => IsDetailsSummary(element) ? "button" : AriaRoles.Generic,
+            "sup" => "superscript",
+            "svg" => "graphics-document",
+            "table" => "table",
+            "tbody" or "tfoot" or "thead" => "rowgroup",
+            "td" => "cell",
+            "textarea" => "textbox",
+            "th" => Header(element),
+            "time" => "time",
+            "tr" => "row",
+            "br" or "wbr" => null,
+            _ => IsMetadataContent(element) ? null : AriaRoles.Generic,
+        };
+    }
+
+    /// <summary>Whether the element carries an attribute that would give it an author-supplied name.</summary>
+    /// <remarks>
+    /// <c>aside</c> and <c>section</c> take their role from whether they are named, and the name computation
+    /// takes its starting point from the role. This breaks that circle the way browsers do, by asking whether
+    /// a naming attribute is present rather than what it computes to.
+    /// </remarks>
+    internal static bool HasNamingAttribute(IElement element) =>
+        !string.IsNullOrWhiteSpace(element.GetAttribute("aria-label"))
+        || !string.IsNullOrWhiteSpace(element.GetAttribute("aria-labelledby"))
+        || !string.IsNullOrWhiteSpace(element.GetAttribute("title"));
+
+    private static string Complementary(IElement element) =>
+        IsScopedToBody(element, mainIsRoot: true) || HasNamingAttribute(element) ? "complementary" : AriaRoles.Generic;
+
+    private static string Image(IElement element) =>
+        element.HasAttribute("alt") && element.GetAttribute("alt")!.Length == 0 ? AriaRoles.None : "image";
+
+    private static string Header(IElement element)
+    {
+        var scope = element.GetAttribute("scope");
+        if (string.Equals(scope, "row", StringComparison.OrdinalIgnoreCase) || string.Equals(scope, "rowgroup", StringComparison.OrdinalIgnoreCase))
+        {
+            return "rowheader";
+        }
+
+        return "columnheader";
+    }
+
+    private static string? Input(IElement element)
+    {
+        var type = (element as IHtmlInputElement)?.Type ?? element.GetAttribute("type") ?? "text";
+        var hasList = element.HasAttribute("list");
+
+        return type.ToLowerInvariant() switch
+        {
+            "hidden" => null,
+            "button" or "image" or "reset" or "submit" => "button",
+            "checkbox" => "checkbox",
+            "radio" => "radio",
+            "number" => "spinbutton",
+            "range" => "slider",
+            "search" => hasList ? "combobox" : "searchbox",
+            "email" or "tel" or "text" or "url" => hasList ? "combobox" : "textbox",
+            // color, date, datetime-local, file, month, password, time and week are HTML-AAM's html-input-*
+            // computed roles, which are not ARIA roles; see the class remarks.
+            "color" or "date" or "datetime-local" or "file" or "month" or "password" or "time" or "week" => AriaRoles.Generic,
+            _ => hasList ? "combobox" : "textbox",
+        };
+    }
+
+    private static bool IsListItem(IElement element) => element.ParentElement?.LocalName switch
+    {
+        "ul" or "ol" or "menu" or "dir" => true,
+        _ => false,
+    };
+
+    private static bool IsListBox(IElement element)
+    {
+        if (element is not IHtmlSelectElement select)
+        {
+            return element.HasAttribute("multiple");
+        }
+
+        // AngleSharp answers 0 for an absent size where HTML's reflected default is 0 too; the rendered
+        // default a browser applies is 1, so anything above 1 is what makes a select a list box.
+        return select.IsMultiple || select.Size > 1;
+    }
+
+    private static bool IsDetailsSummary(IElement element)
+    {
+        var parent = element.ParentElement;
+        if (parent is null || !string.Equals(parent.LocalName, "details", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        foreach (var child in parent.Children)
+        {
+            if (string.Equals(child.LocalName, "summary", StringComparison.Ordinal))
+            {
+                return ReferenceEquals(child, element);
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsScopedToBody(IElement element, bool mainIsRoot = false)
+    {
+        for (var ancestor = element.ParentElement; ancestor is not null; ancestor = ancestor.ParentElement)
+        {
+            switch (ancestor.LocalName)
+            {
+                case "main" when mainIsRoot:
+                case "body":
+                    return true;
+                case "article":
+                case "aside":
+                case "main":
+                case "nav":
+                case "section":
+                    return false;
+            }
+
+            var explicitRole = AriaRoles.Explicit(ancestor.GetAttribute("role"));
+            if (explicitRole is "main" && mainIsRoot)
+            {
+                return true;
+            }
+
+            if (explicitRole is "article" or "complementary" or "main" or "navigation" or "region")
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/Jint.Browser/Extraction/MarkdownExtractor.cs
+++ b/Jint.Browser/Extraction/MarkdownExtractor.cs
@@ -1,0 +1,704 @@
+using System.Globalization;
+using System.Text;
+using AngleSharp.Dom;
+using AngleSharp.Html.Dom;
+using Jint.Browser.Accessibility;
+
+namespace Jint.Browser.Extraction;
+
+/// <summary>
+/// Renders a document or an element as CommonMark, for a reader whose budget is tokens rather than pixels.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The output is CommonMark with GFM pipe tables. Three choices are worth knowing at the call site: a
+/// <c>&lt;br&gt;</c> becomes a backslash hard break rather than two trailing spaces, so no line ends in
+/// invisible white space; a definition list becomes a bold term followed by its definitions; and a
+/// <c>&lt;details&gt;</c> becomes its summary in bold followed by its body, open or not.
+/// </para>
+/// <para>
+/// What is skipped: <c>&lt;script&gt;</c>, <c>&lt;style&gt;</c>, <c>&lt;template&gt;</c>,
+/// <c>&lt;noscript&gt;</c> and everything the hidden rules of <see cref="ElementVisibility"/> exclude.
+/// </para>
+/// </remarks>
+internal static class MarkdownExtractor
+{
+    /// <summary>What a result cut short by <see cref="MarkdownOptions.MaxLength"/> ends with.</summary>
+    internal const string TruncationMarker = "\n\n[truncated]";
+
+    /// <summary>Renders <paramref name="document"/> as CommonMark.</summary>
+    internal static string ToMarkdown(IDocument document, MarkdownOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        options ??= MarkdownOptions.Default;
+        var root = options.MainContentOnly ? MainContentOf(document) : null;
+        root ??= document.Body ?? document.DocumentElement;
+
+        return root is null ? string.Empty : ToMarkdown(root, options);
+    }
+
+    /// <summary>Renders <paramref name="element"/> and its descendants as CommonMark.</summary>
+    internal static string ToMarkdown(IElement element, MarkdownOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(element);
+
+        options ??= MarkdownOptions.Default;
+        var writer = new Writer(options, new ElementVisibility(options.UseComputedStyle));
+        var body = writer.Blocks(element);
+        return Truncate(Normalize(body), options.MaxLength);
+    }
+
+    private static IElement? MainContentOf(IDocument document) =>
+        document.QuerySelector("main")
+        ?? document.QuerySelector("[role=main]")
+        ?? document.QuerySelector("article");
+
+    /// <summary>
+    /// Drops the blank lines at both ends and caps any run of them at one, which is all a block separator
+    /// ever needs.
+    /// </summary>
+    /// <remarks>
+    /// A line that is not blank is emitted as it stands, trailing white space included: inside a fenced code
+    /// block that white space is content, and trimming it here would silently rewrite the page's own text.
+    /// </remarks>
+    private static string Normalize(string text)
+    {
+        var lines = text.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
+        var builder = new StringBuilder(text.Length);
+        var blanks = 0;
+        var started = false;
+
+        foreach (var line in lines)
+        {
+            if (line.AsSpan().Trim().IsEmpty)
+            {
+                blanks++;
+                continue;
+            }
+
+            if (started)
+            {
+                builder.Append('\n', Math.Min(blanks, 1) + 1);
+            }
+
+            builder.Append(line);
+            blanks = 0;
+            started = true;
+        }
+
+        return builder.ToString();
+    }
+
+    private static string Truncate(string text, int maxLength)
+    {
+        if (maxLength <= 0 || text.Length <= maxLength)
+        {
+            return text;
+        }
+
+        var budget = Math.Max(0, maxLength - TruncationMarker.Length);
+        var cut = budget;
+        while (cut > 0 && !char.IsWhiteSpace(text[cut]))
+        {
+            cut--;
+        }
+
+        if (cut == 0)
+        {
+            cut = budget;
+        }
+
+        return string.Concat(text.AsSpan(0, cut).TrimEnd(), TruncationMarker);
+    }
+
+    private sealed class Writer
+    {
+        private readonly MarkdownOptions _options;
+        private readonly ElementVisibility _visibility;
+
+        internal Writer(MarkdownOptions options, ElementVisibility visibility)
+        {
+            _options = options;
+            _visibility = visibility;
+        }
+
+        /// <summary>Renders an element's children as a sequence of blocks separated by a blank line.</summary>
+        internal string Blocks(IElement element)
+        {
+            var blocks = new List<string>();
+            var inline = new StringBuilder();
+
+            foreach (var child in element.ChildNodes)
+            {
+                if (child is IElement childElement)
+                {
+                    if (Skip(childElement))
+                    {
+                        continue;
+                    }
+
+                    if (IsBlock(childElement))
+                    {
+                        Flush(blocks, inline);
+                        var block = Block(childElement);
+                        if (block.Length > 0)
+                        {
+                            blocks.Add(block);
+                        }
+
+                        continue;
+                    }
+                }
+
+                inline.Append(Inline(child));
+            }
+
+            Flush(blocks, inline);
+            return string.Join("\n\n", blocks);
+
+            static void Flush(List<string> blocks, StringBuilder inline)
+            {
+                var text = Collapse(inline.ToString());
+                inline.Clear();
+
+                if (text.Length > 0)
+                {
+                    blocks.Add(text);
+                }
+            }
+        }
+
+        private string Block(IElement element)
+        {
+            switch (element.LocalName)
+            {
+                case "h1":
+                case "h2":
+                case "h3":
+                case "h4":
+                case "h5":
+                case "h6":
+                    {
+                        var level = element.LocalName[1] - '0';
+                        var text = InlineOf(element);
+                        return text.Length == 0 ? string.Empty : new string('#', level) + " " + text;
+                    }
+
+                case "p":
+                    return InlineOf(element);
+
+                case "pre":
+                    return CodeBlock(element);
+
+                case "blockquote":
+                    return Prefix(Blocks(element), "> ", "> ");
+
+                case "ul":
+                case "menu":
+                    return List(element, ordered: false);
+
+                case "ol":
+                    return List(element, ordered: true);
+
+                case "dl":
+                    return DefinitionList(element);
+
+                case "table":
+                    return Table(element);
+
+                case "hr":
+                    return "---";
+
+                case "details":
+                    return Details(element);
+
+                case "figure":
+                    return Blocks(element);
+
+                case "li":
+                    // A list item reached outside a list still renders as one.
+                    return "- " + Prefix(Blocks(element), string.Empty, "  ");
+
+                default:
+                    return Blocks(element);
+            }
+        }
+
+        private string InlineOf(IElement element)
+        {
+            var builder = new StringBuilder();
+            foreach (var child in element.ChildNodes)
+            {
+                builder.Append(Inline(child));
+            }
+
+            return Collapse(builder.ToString());
+        }
+
+        private string Inline(INode node)
+        {
+            if (node is IText text)
+            {
+                return Escape(text.Data);
+            }
+
+            if (node is not IElement element || Skip(element))
+            {
+                return string.Empty;
+            }
+
+            switch (element.LocalName)
+            {
+                case "br":
+                    return "\\\n";
+
+                case "a":
+                    {
+                        var content = InlineOf(element);
+                        var href = element is IHtmlAnchorElement anchor && anchor.HasAttribute("href") ? anchor.Href : null;
+                        if (string.IsNullOrEmpty(href))
+                        {
+                            return content;
+                        }
+
+                        return content.Length == 0 ? $"<{href}>" : $"[{content}]({Link(href)})";
+                    }
+
+                case "img":
+                    {
+                        var alt = element.GetAttribute("alt") ?? string.Empty;
+
+                        // An explicitly empty alt is HTML's way of saying the image is decoration, so it is
+                        // not content and does not belong in a rendering whose whole purpose is content.
+                        if (alt.Length == 0 && element.HasAttribute("alt"))
+                        {
+                            return string.Empty;
+                        }
+
+                        if (!_options.IncludeImages)
+                        {
+                            return Escape(alt);
+                        }
+
+                        var source = element is IHtmlImageElement image && image.HasAttribute("src") ? image.Source : element.GetAttribute("src");
+                        return string.IsNullOrEmpty(source) ? Escape(alt) : $"![{Escape(alt)}]({Link(source)})";
+                    }
+
+                case "strong":
+                case "b":
+                    return Wrap(InlineOf(element), "**");
+
+                case "em":
+                case "i":
+                    return Wrap(InlineOf(element), "*");
+
+                case "del":
+                case "s":
+                    return Wrap(InlineOf(element), "~~");
+
+                case "code":
+                case "kbd":
+                case "samp":
+                    return CodeSpan(Collapse(element.TextContent));
+
+                default:
+                    return IsBlock(element) ? " " + Collapse(Block(element).Replace('\n', ' ')) + " " : InlineOf(element);
+            }
+        }
+
+        /// <summary>
+        /// Wraps <paramref name="content"/> in a code span whose delimiter is longer than any backtick run
+        /// inside it, which is how CommonMark quotes a backtick — doubling one would not.
+        /// </summary>
+        private static string CodeSpan(string content)
+        {
+            if (content.Length == 0)
+            {
+                return string.Empty;
+            }
+
+            var longest = 0;
+            var run = 0;
+            foreach (var c in content)
+            {
+                run = c == '`' ? run + 1 : 0;
+                longest = Math.Max(longest, run);
+            }
+
+            var fence = new string('`', longest + 1);
+            var pad = content.StartsWith('`') || content.EndsWith('`') ? " " : string.Empty;
+            return fence + pad + content + pad + fence;
+        }
+
+        private static string CodeBlock(IElement element)
+        {
+            var code = element.QuerySelector("code");
+            var language = LanguageOf(code ?? element);
+            var content = (code ?? element).TextContent.Replace("\r\n", "\n", StringComparison.Ordinal).TrimEnd('\n');
+
+            var fence = "```";
+            while (content.Contains(fence, StringComparison.Ordinal))
+            {
+                fence += "`";
+            }
+
+            return fence + language + "\n" + content + "\n" + fence;
+        }
+
+        private static string LanguageOf(IElement element)
+        {
+            foreach (var token in element.ClassList)
+            {
+                if (token.StartsWith("language-", StringComparison.Ordinal))
+                {
+                    return token["language-".Length..];
+                }
+
+                if (token.StartsWith("lang-", StringComparison.Ordinal))
+                {
+                    return token["lang-".Length..];
+                }
+            }
+
+            return string.Empty;
+        }
+
+        private string List(IElement element, bool ordered)
+        {
+            var number = ordered && element is IHtmlOrderedListElement { Start: var start } ? start : 1;
+            var lines = new List<string>();
+
+            foreach (var child in element.Children)
+            {
+                if (!string.Equals(child.LocalName, "li", StringComparison.Ordinal) || Skip(child))
+                {
+                    continue;
+                }
+
+                var marker = ordered ? number.ToString(CultureInfo.InvariantCulture) + ". " : "- ";
+                var body = Blocks(child);
+                lines.Add(Prefix(body, marker, new string(' ', marker.Length)));
+                number++;
+            }
+
+            return string.Join("\n", lines);
+        }
+
+        private string DefinitionList(IElement element)
+        {
+            var lines = new List<string>();
+            foreach (var child in element.Children)
+            {
+                if (Skip(child))
+                {
+                    continue;
+                }
+
+                if (string.Equals(child.LocalName, "dt", StringComparison.Ordinal))
+                {
+                    var term = InlineOf(child);
+                    if (term.Length > 0)
+                    {
+                        lines.Add("**" + term + "**\\");
+                    }
+                }
+                else if (string.Equals(child.LocalName, "dd", StringComparison.Ordinal))
+                {
+                    var definition = Blocks(child);
+                    if (definition.Length > 0)
+                    {
+                        lines.Add(Prefix(definition, "  ", "  "));
+                    }
+                }
+            }
+
+            return string.Join("\n", lines);
+        }
+
+        private string Details(IElement element)
+        {
+            var parts = new List<string>();
+            foreach (var child in element.Children)
+            {
+                if (Skip(child))
+                {
+                    continue;
+                }
+
+                if (string.Equals(child.LocalName, "summary", StringComparison.Ordinal))
+                {
+                    var summary = InlineOf(child);
+                    if (summary.Length > 0)
+                    {
+                        parts.Add("**" + summary + "**");
+                    }
+                }
+                else if (IsBlock(child))
+                {
+                    var block = Block(child);
+                    if (block.Length > 0)
+                    {
+                        parts.Add(block);
+                    }
+                }
+                else
+                {
+                    var inline = Inline(child);
+                    if (inline.Trim().Length > 0)
+                    {
+                        parts.Add(Collapse(inline));
+                    }
+                }
+            }
+
+            return string.Join("\n\n", parts);
+        }
+
+        private string Table(IElement element)
+        {
+            var rows = new List<List<string>>();
+            var headerIndex = -1;
+
+            foreach (var row in RowsOf(element))
+            {
+                if (Skip(row))
+                {
+                    continue;
+                }
+
+                var cells = new List<string>();
+                var isHeader = true;
+
+                foreach (var cell in row.Children)
+                {
+                    if (cell.LocalName is not ("td" or "th") || Skip(cell))
+                    {
+                        continue;
+                    }
+
+                    isHeader &= string.Equals(cell.LocalName, "th", StringComparison.Ordinal);
+                    cells.Add(Collapse(InlineOf(cell)).Replace("|", "\\|", StringComparison.Ordinal));
+                }
+
+                if (cells.Count == 0)
+                {
+                    continue;
+                }
+
+                if (isHeader && headerIndex < 0)
+                {
+                    headerIndex = rows.Count;
+                }
+
+                rows.Add(cells);
+            }
+
+            if (rows.Count == 0)
+            {
+                return string.Empty;
+            }
+
+            var width = rows.Max(static row => row.Count);
+            var builder = new StringBuilder();
+
+            var header = headerIndex >= 0 ? rows[headerIndex] : [];
+            builder.Append(Row(header, width)).Append('\n');
+            builder.Append("| ").Append(string.Join(" | ", Enumerable.Repeat("---", width))).Append(" |");
+
+            for (var i = 0; i < rows.Count; i++)
+            {
+                if (i == headerIndex)
+                {
+                    continue;
+                }
+
+                builder.Append('\n').Append(Row(rows[i], width));
+            }
+
+            var caption = CaptionOf(element);
+            if (caption is not null && !Skip(caption))
+            {
+                var text = InlineOf(caption);
+                if (text.Length > 0)
+                {
+                    return "**" + text + "**\n\n" + builder;
+                }
+            }
+
+            return builder.ToString();
+
+            static string Row(IReadOnlyList<string> cells, int width)
+            {
+                var builder = new StringBuilder("|");
+                for (var i = 0; i < width; i++)
+                {
+                    builder.Append(' ').Append(i < cells.Count ? cells[i] : string.Empty).Append(" |");
+                }
+
+                return builder.ToString();
+            }
+        }
+
+        /// <summary>
+        /// The rows of this table and no other: its own <c>tr</c> children and those of its own row groups.
+        /// </summary>
+        /// <remarks>
+        /// A descendant selector would pull a nested table's rows into this one, which is not a shape a
+        /// pipe table has any way to express.
+        /// </remarks>
+        private static IEnumerable<IElement> RowsOf(IElement table)
+        {
+            foreach (var child in table.Children)
+            {
+                if (string.Equals(child.LocalName, "tr", StringComparison.Ordinal))
+                {
+                    yield return child;
+                }
+                else if (child.LocalName is "thead" or "tbody" or "tfoot")
+                {
+                    foreach (var row in child.Children)
+                    {
+                        if (string.Equals(row.LocalName, "tr", StringComparison.Ordinal))
+                        {
+                            yield return row;
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>This table's own caption, which is a child rather than any descendant.</summary>
+        private static IElement? CaptionOf(IElement table)
+        {
+            foreach (var child in table.Children)
+            {
+                if (string.Equals(child.LocalName, "caption", StringComparison.Ordinal))
+                {
+                    return child;
+                }
+            }
+
+            return null;
+        }
+
+        private bool Skip(IElement element) =>
+            ImplicitRole.IsMetadataContent(element)
+            || string.Equals(element.LocalName, "noscript", StringComparison.Ordinal)
+            || _visibility.RenderingReasonFor(element) != AxIgnoredReason.None;
+
+        private bool IsBlock(IElement element) =>
+            HtmlDisplay.IsBlockLevel(HtmlDisplay.Resolve(element, _visibility.Style(element).Display))
+            || element.LocalName is "table" or "dl" or "details";
+
+        private static string Wrap(string content, string marker)
+        {
+            var trimmed = content.Trim();
+            if (trimmed.Length == 0)
+            {
+                return content;
+            }
+
+            var lead = content.StartsWith(' ') ? " " : string.Empty;
+            var tail = content.EndsWith(' ') ? " " : string.Empty;
+            return lead + marker + trimmed + marker + tail;
+        }
+
+        private static string Prefix(string text, string first, string rest)
+        {
+            if (text.Length == 0)
+            {
+                return first.TrimEnd();
+            }
+
+            var lines = text.Split('\n');
+            var builder = new StringBuilder();
+
+            for (var i = 0; i < lines.Length; i++)
+            {
+                if (i > 0)
+                {
+                    builder.Append('\n');
+                }
+
+                var prefix = i == 0 ? first : rest;
+                builder.Append(lines[i].Length == 0 ? prefix.TrimEnd() : prefix + lines[i]);
+            }
+
+            return builder.ToString();
+        }
+
+        private static string Collapse(string text)
+        {
+            var builder = new StringBuilder(text.Length);
+            var space = false;
+
+            foreach (var c in text)
+            {
+                // The only line feed an inline run may carry is the one a <br> wrote, and it always follows
+                // the backslash that makes it a CommonMark hard break. Every other one is white space.
+                if (c is '\n' && builder.Length > 0 && builder[^1] == '\\')
+                {
+                    builder.Append('\n');
+                    space = false;
+                    continue;
+                }
+
+                if (char.IsWhiteSpace(c))
+                {
+                    space = builder.Length > 0 && builder[^1] != '\n';
+                    continue;
+                }
+
+                if (space)
+                {
+                    builder.Append(' ');
+                    space = false;
+                }
+
+                builder.Append(c);
+            }
+
+            return builder.ToString().TrimEnd();
+        }
+
+        private static string Link(string url) => url.Contains(' ', StringComparison.Ordinal) ? "<" + url + ">" : url;
+
+        private static string Escape(string text)
+        {
+            var builder = new StringBuilder(text.Length);
+
+            foreach (var c in text)
+            {
+                switch (c)
+                {
+                    case '\\':
+                    case '`':
+                    case '*':
+                    case '[':
+                    case ']':
+                    case '<':
+                        builder.Append('\\').Append(c);
+                        break;
+
+                    case '_':
+                        // Intra-word underscores are not emphasis in CommonMark, so only a boundary one needs
+                        // escaping; escaping every one would turn snake_case into noise.
+                        if (builder.Length == 0 || char.IsWhiteSpace(builder[^1]))
+                        {
+                            builder.Append('\\');
+                        }
+
+                        builder.Append(c);
+                        break;
+
+                    default:
+                        builder.Append(c);
+                        break;
+                }
+            }
+
+            return builder.ToString();
+        }
+    }
+}

--- a/Jint.Browser/Extraction/MarkdownOptions.cs
+++ b/Jint.Browser/Extraction/MarkdownOptions.cs
@@ -1,0 +1,33 @@
+using Jint.Browser.Accessibility;
+
+namespace Jint.Browser.Extraction;
+
+/// <summary>
+/// What <see cref="MarkdownExtractor"/> keeps, and how much of it.
+/// </summary>
+internal sealed record MarkdownOptions
+{
+    /// <summary>The whole document, images included, unbounded.</summary>
+    internal static MarkdownOptions Default { get; } = new();
+
+    /// <summary>Whether images become <c>![alt](src)</c> rather than their alternative text alone.</summary>
+    /// <remarks>Defaults to <see langword="true"/>.</remarks>
+    internal bool IncludeImages { get; init; } = true;
+
+    /// <summary>The greatest number of characters to return, or zero for no limit.</summary>
+    /// <remarks>
+    /// A truncated result ends at the last white space before the limit and carries
+    /// <see cref="MarkdownExtractor.TruncationMarker"/>, so a reader can tell a short page from a cut one.
+    /// </remarks>
+    internal int MaxLength { get; init; }
+
+    /// <summary>
+    /// Whether to render only the document's main content — the first <c>&lt;main&gt;</c>,
+    /// <c>[role=main]</c> or <c>&lt;article&gt;</c> — when the document has one.
+    /// </summary>
+    internal bool MainContentOnly { get; init; }
+
+    /// <summary>Whether the CSS cascade is consulted for <c>display</c> and <c>visibility</c>.</summary>
+    /// <remarks>Defaults to <see langword="true"/>; see <see cref="AccessibilityOptions.UseComputedStyle"/>.</remarks>
+    internal bool UseComputedStyle { get; init; } = true;
+}

--- a/Jint.Browser/Extraction/TextExtractor.cs
+++ b/Jint.Browser/Extraction/TextExtractor.cs
@@ -1,0 +1,252 @@
+using System.Text;
+using AngleSharp.Dom;
+using Jint.Browser.Accessibility;
+
+namespace Jint.Browser.Extraction;
+
+/// <summary>
+/// HTML's <c>innerText</c> getter, as far as it can be computed without laying the page out.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The algorithm is
+/// <see href="https://html.spec.whatwg.org/multipage/dom.html#the-innertext-idl-attribute">HTML's rendered
+/// text collection steps</see>: text with CSS white-space processing applied, a literal line feed for
+/// <c>&lt;br&gt;</c>, tabs between table cells and line feeds between table rows, two required line breaks
+/// around a <c>&lt;p&gt;</c> and one around any other block-level box, then the runs of required breaks
+/// collapsed to their maximum and trimmed off the ends.
+/// </para>
+/// <para>
+/// Three of its inputs are layout, and this is what replaces them: "being rendered" becomes the hidden
+/// verdict <see cref="ElementVisibility"/> computes, "block-level" becomes HTML's suggested rendering
+/// (<see cref="HtmlDisplay"/>) rather than a used display, and line wrapping does not happen at all — a
+/// paragraph is one line however wide it would have been. So this is the text of the document, not the text
+/// of a rendering of it.
+/// </para>
+/// </remarks>
+internal static class TextExtractor
+{
+    /// <summary>Returns the rendered text of <paramref name="element"/>.</summary>
+    internal static string InnerText(IElement element, bool useComputedStyle = true)
+    {
+        ArgumentNullException.ThrowIfNull(element);
+
+        var collector = new Collector(new ElementVisibility(useComputedStyle));
+        collector.Collect(element, preserveWhitespace: false);
+        return collector.Assemble();
+    }
+
+    /// <summary>Returns the rendered text of <paramref name="document"/>'s body.</summary>
+    internal static string InnerText(IDocument document, bool useComputedStyle = true)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        var root = document.Body ?? document.DocumentElement;
+        return root is null ? string.Empty : InnerText(root, useComputedStyle);
+    }
+
+    private sealed class Collector
+    {
+        private readonly ElementVisibility _visibility;
+        private readonly List<Item> _items = [];
+
+        internal Collector(ElementVisibility visibility) => _visibility = visibility;
+
+        internal void Collect(INode node, bool preserveWhitespace)
+        {
+            switch (node)
+            {
+                case IText text:
+                    _items.Add(Item.Content(text.Data, preserveWhitespace));
+                    return;
+
+                case IElement element:
+                    CollectElement(element, preserveWhitespace);
+                    return;
+            }
+        }
+
+        private void CollectElement(IElement element, bool inheritedPreserve)
+        {
+            if (ImplicitRole.IsMetadataContent(element) || _visibility.RenderingReasonFor(element) != AxIgnoredReason.None)
+            {
+                return;
+            }
+
+            var (declaredDisplay, _) = _visibility.Style(element);
+            var display = HtmlDisplay.Resolve(element, declaredDisplay);
+            var breaks = string.Equals(element.LocalName, "p", StringComparison.Ordinal) ? 2
+                : HtmlDisplay.IsBlockLevel(display) || string.Equals(display, "table-caption", StringComparison.Ordinal) ? 1
+                : 0;
+
+            if (breaks > 0)
+            {
+                _items.Add(Item.Break(breaks));
+            }
+
+            if (string.Equals(element.LocalName, "br", StringComparison.Ordinal))
+            {
+                _items.Add(Item.Separator("\n"));
+            }
+            else
+            {
+                var preserve = inheritedPreserve || HtmlDisplay.PreservesWhitespace(element, _visibility.WhiteSpace(element));
+                foreach (var child in element.ChildNodes)
+                {
+                    Collect(child, preserve);
+                }
+
+                if (string.Equals(display, "table-cell", StringComparison.Ordinal) && element.NextElementSibling is not null)
+                {
+                    _items.Add(Item.Separator("\t"));
+                }
+                else if (string.Equals(display, "table-row", StringComparison.Ordinal) && !IsLastRow(element))
+                {
+                    _items.Add(Item.Separator("\n"));
+                }
+            }
+
+            if (breaks > 0)
+            {
+                _items.Add(Item.Break(breaks));
+            }
+        }
+
+        internal string Assemble()
+        {
+            var builder = new StringBuilder();
+            var pendingBreaks = 0;
+            var pendingSpace = false;
+            var started = false;
+
+            foreach (var item in _items)
+            {
+                if (item.Breaks > 0)
+                {
+                    if (started)
+                    {
+                        pendingBreaks = Math.Max(pendingBreaks, item.Breaks);
+                    }
+
+                    pendingSpace = false;
+                    continue;
+                }
+
+                var text = item.Text!;
+                if (text.Length == 0)
+                {
+                    continue;
+                }
+
+                string core;
+                var leadingSpace = false;
+                var trailingSpace = false;
+
+                if (item.Preserve)
+                {
+                    core = text;
+                }
+                else
+                {
+                    var collapsed = Collapse(text);
+                    if (collapsed.Length == 0)
+                    {
+                        continue;
+                    }
+
+                    if (collapsed == " ")
+                    {
+                        pendingSpace |= started;
+                        continue;
+                    }
+
+                    leadingSpace = collapsed[0] == ' ';
+                    trailingSpace = collapsed[^1] == ' ';
+                    core = collapsed.Trim(' ');
+                }
+
+                if (pendingBreaks > 0)
+                {
+                    builder.Append('\n', pendingBreaks);
+                    pendingBreaks = 0;
+                    pendingSpace = false;
+                    leadingSpace = false;
+                }
+
+                if ((pendingSpace || leadingSpace) && started && builder.Length > 0 && builder[^1] is not ('\n' or '\t'))
+                {
+                    builder.Append(' ');
+                }
+
+                builder.Append(core);
+                started = true;
+                pendingSpace = trailingSpace;
+            }
+
+            return builder.ToString();
+        }
+
+        private static bool IsLastRow(IElement row)
+        {
+            if (row.NextElementSibling is not null)
+            {
+                return false;
+            }
+
+            var group = row.ParentElement;
+            if (group is null || group.LocalName is not ("thead" or "tbody" or "tfoot"))
+            {
+                return true;
+            }
+
+            for (var sibling = group.NextElementSibling; sibling is not null; sibling = sibling.NextElementSibling)
+            {
+                if (sibling.LocalName is "thead" or "tbody" or "tfoot" && sibling.QuerySelector("tr") is not null)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static string Collapse(string text)
+        {
+            var builder = new StringBuilder(text.Length);
+            var space = false;
+
+            foreach (var c in text)
+            {
+                if (c is ' ' or '\t' or '\n' or '\r' or '\f')
+                {
+                    space = true;
+                    continue;
+                }
+
+                if (space)
+                {
+                    builder.Append(' ');
+                    space = false;
+                }
+
+                builder.Append(c);
+            }
+
+            if (space)
+            {
+                builder.Append(' ');
+            }
+
+            return builder.ToString();
+        }
+
+        private readonly record struct Item(string? Text, int Breaks, bool Preserve)
+        {
+            internal static Item Content(string text, bool preserve) => new(text, 0, preserve);
+
+            internal static Item Separator(string text) => new(text, 0, Preserve: true);
+
+            internal static Item Break(int count) => new(null, count, Preserve: false);
+        }
+    }
+}

--- a/Jint.Tests.Browser/Accessibility/AccessibilitySnapshotTests.cs
+++ b/Jint.Tests.Browser/Accessibility/AccessibilitySnapshotTests.cs
@@ -1,0 +1,110 @@
+using Jint.Browser.Accessibility;
+
+namespace Jint.Tests.Browser.Accessibility;
+
+/// <summary>
+/// The compact snapshot, checked against approved output for four whole pages.
+/// </summary>
+/// <remarks>
+/// A golden file rather than an inline assertion, because this is the artefact an agent reads: its size and
+/// its shape are the product, and a diff is the only honest way to review a change to either.
+/// </remarks>
+public sealed class AccessibilitySnapshotTests
+{
+    [TestCase("form")]
+    [TestCase("article")]
+    [TestCase("nav")]
+    [TestCase("todomvc")]
+    public void RendersThePage(string page)
+    {
+        using var document = PageFixture.Parse(GoldenFiles.Page(page), "https://jint.test/" + page + ".html");
+        var snapshot = AccessibilitySnapshot.Render(AccessibilityTree.Build(document, AccessibilityOptions.Snapshot));
+
+        GoldenFiles.Approve(page + ".snapshot.txt", snapshot);
+    }
+
+    [Test]
+    public void RendersARoleANameAndTheAttributesThatChangeWhatACallerWouldDo()
+    {
+        using var document = PageFixture.Parse("<h2>Title</h2><input type=checkbox checked disabled aria-label=Agree>");
+
+        var expected =
+            """
+            - RootWebArea:
+              - heading "Title" [level=2]
+              - checkbox "Agree" [checked] [disabled]
+            """.Replace("\r\n", "\n") + "\n";
+
+        AccessibilitySnapshot.Render(AccessibilityTree.Build(document)).Should().Be(expected);
+    }
+
+    [Test]
+    public void OmitsAPropertyWhoseValueIsFalse()
+    {
+        using var document = PageFixture.Parse("<input type=checkbox aria-label=Agree>");
+
+        AccessibilitySnapshot.Render(AccessibilityTree.Build(document))
+            .Should().Contain("- checkbox \"Agree\"")
+            .And.NotContain("[checked=false]");
+    }
+
+    [Test]
+    public void RendersAWidgetsValueAfterTheColonWhenItHasNoChildren()
+    {
+        using var document = PageFixture.Parse("<label for=t>Name</label><input id=t value=Ada>");
+
+        AccessibilitySnapshot.Render(AccessibilityTree.Build(document)).Should().Contain("- textbox \"Name\": Ada");
+    }
+
+    [Test]
+    public void ANodeWhoseWholeContentIsOneRunOfTextSaysItOnItsOwnLine()
+    {
+        using var document = PageFixture.Parse("<p>Hello there</p>");
+        var tree = AccessibilityTree.Build(document, AccessibilityOptions.Snapshot);
+
+        AccessibilitySnapshot.Render(tree).Should().Contain("- paragraph: Hello there").And.NotContain("- text:");
+    }
+
+    [Test]
+    public void TextBetweenNodesIsItsOwnLine()
+    {
+        using var document = PageFixture.Parse("<p>before <a href='/x'>a link</a> after</p>");
+        var tree = AccessibilityTree.Build(document, AccessibilityOptions.Snapshot);
+
+        AccessibilitySnapshot.Render(tree).Should().Contain("- text: before").And.Contain("- text: after");
+    }
+
+    [Test]
+    public void TextThatIsAlreadyANodesNameIsNotStatedTwice()
+    {
+        using var document = PageFixture.Parse(
+            "<button>Save</button><label for=t>Name</label><input id=t><figure><figcaption>Cap</figcaption></figure>");
+        var tree = AccessibilityTree.Build(document, AccessibilityOptions.Snapshot);
+        var snapshot = AccessibilitySnapshot.Render(tree);
+
+        snapshot.Should().Contain("- button \"Save\"").And.NotContain("text: Save");
+        snapshot.Should().Contain("- textbox \"Name\"").And.NotContain("text: Name");
+        snapshot.Should().Contain("- figure \"Cap\"").And.NotContain("text: Cap");
+    }
+
+    [Test]
+    public void EscapesAQuoteInsideAName()
+    {
+        using var document = PageFixture.Parse("<button aria-label='Say &quot;hello&quot;'>x</button>");
+
+        AccessibilitySnapshot.Render(AccessibilityTree.Build(document)).Should().Contain("- button \"Say \\\"hello\\\"\"");
+    }
+
+    [Test]
+    public void TheSnapshotIsSmallerThanTheProtocolJson()
+    {
+        using var document = PageFixture.Parse(GoldenFiles.Page("todomvc"));
+        var tree = AccessibilityTree.Build(document, AccessibilityOptions.Snapshot);
+
+        var snapshot = AccessibilitySnapshot.Render(tree);
+        var json = AccessibilityTree.ToJson(tree);
+
+        // Not decoration: the snapshot exists because an agent's budget is tokens, and this is the claim.
+        snapshot.Length.Should().BeLessThan(json.Length / 2);
+    }
+}

--- a/Jint.Tests.Browser/Accessibility/AccessibilityTreeTests.cs
+++ b/Jint.Tests.Browser/Accessibility/AccessibilityTreeTests.cs
@@ -1,0 +1,309 @@
+using Jint.Browser.Accessibility;
+
+namespace Jint.Tests.Browser.Accessibility;
+
+/// <summary>
+/// The tree walk itself: what it prunes, what it hides, what it publishes and what it keeps stable.
+/// </summary>
+public sealed class AccessibilityTreeTests
+{
+    [Test]
+    public void TheRootIsAWebAreaNamedByTheDocumentTitle()
+    {
+        using var document = PageFixture.Parse("<html><head><title>  My   page </title></head><body><h1>Hi</h1></body></html>");
+        var root = AccessibilityTree.Build(document);
+
+        root.Role.Should().Be("RootWebArea");
+        root.Name.Should().Be("My page");
+        ImplicitRoleTests.Find(root, "heading").Should().NotBeNull();
+    }
+
+    [Test]
+    public void GenericWrappersArePrunedAndReplacedByTheirChildren()
+    {
+        using var document = PageFixture.Parse("<div><div><span><button>Save</button></span></div></div>");
+        var root = AccessibilityTree.Build(document);
+
+        // html, body and every div and span in between are generic; only the button survives.
+        root.Children.Should().ContainSingle();
+        root.Children[0].Role.Should().Be("button");
+        root.Children[0].Name.Should().Be("Save");
+    }
+
+    [Test]
+    public void IncludeGenericKeepsEveryWrapper()
+    {
+        using var document = PageFixture.Parse("<div><button>Save</button></div>");
+        var root = AccessibilityTree.Build(document, AccessibilityOptions.Default with { IncludeGeneric = true });
+
+        ImplicitRoleTests.FindAll(root, "generic").Should().NotBeEmpty();
+    }
+
+    [Test]
+    public void AGenericElementThatIsNamedOrFocusableSurvivesThePruning()
+    {
+        using var document = PageFixture.Parse("<div aria-label='Named box'>x</div><div tabindex=0>y</div><div>z</div>");
+        var root = AccessibilityTree.Build(document);
+
+        var generics = ImplicitRoleTests.FindAll(root, "generic");
+        generics.Should().HaveCount(2);
+        generics[0].Name.Should().Be("Named box");
+        generics[1].Properties.Should().Contain(p => p.Name == AxPropertyName.Focusable);
+    }
+
+    [Test]
+    public void HiddenSubtreesAreDroppedWholesale()
+    {
+        using var document = PageFixture.Parse(
+            "<button>Visible</button>" +
+            "<div hidden><button>A</button></div>" +
+            "<div style='display:none'><button>B</button></div>" +
+            "<div aria-hidden=true><button>C</button></div>" +
+            "<div style='visibility:hidden'><button>D</button></div>");
+
+        var root = AccessibilityTree.Build(document);
+
+        ImplicitRoleTests.FindAll(root, "button").Select(static n => n.Name).Should().Equal("Visible");
+    }
+
+    [Test]
+    public void AVisibleChildOfAVisibilityHiddenParentComesBack()
+    {
+        // `visibility` is the one CSS inherits, so the cascade — not an ancestor walk — is what answers.
+        using var document = PageFixture.Parse(
+            "<div style='visibility:hidden'><button style='visibility:visible'>Back</button><button>Gone</button></div>");
+
+        var root = AccessibilityTree.Build(document);
+
+        ImplicitRoleTests.FindAll(root, "button").Select(static n => n.Name).Should().Equal("Back");
+    }
+
+    [Test]
+    public void ADisplayNoneFromAStyleSheetHidesTheSubtree()
+    {
+        using var document = PageFixture.Parse("<style>.gone{display:none}</style><div class=gone><button>A</button></div><button>B</button>");
+        var root = AccessibilityTree.Build(document);
+
+        ImplicitRoleTests.FindAll(root, "button").Select(static n => n.Name).Should().Equal("B");
+    }
+
+    [Test]
+    public void WithoutTheCascadeTheInlineStyleAndTheHiddenAttributeStillAnswer()
+    {
+        // AngleSharp.Css's ComputeCurrentStyle throws rather than answering when the CSS service is absent.
+        // The walk asks once, records that, and finishes on the inline-style path instead of failing.
+        using var document = PageFixture.ParseWithoutCss(
+            "<style>.gone{display:none}</style>" +
+            "<div class=gone><button>Sheet</button></div>" +
+            "<div style='display:none'><button>Inline</button></div>" +
+            "<div hidden><button>Attribute</button></div>" +
+            "<button>Visible</button>");
+
+        var root = AccessibilityTree.Build(document);
+
+        // The style sheet is beyond reach without the cascade, and this is what that costs.
+        ImplicitRoleTests.FindAll(root, "button").Select(static n => n.Name).Should().Equal("Sheet", "Visible");
+    }
+
+    [Test]
+    public void HeadScriptStyleAndTemplateContentsNeverReachTheTree()
+    {
+        using var document = PageFixture.Parse(
+            "<head><title>T</title><style>button{color:red}</style></head>" +
+            "<body><script>var x = 1;</script><template><button>In a template</button></template><button>Real</button></body>");
+
+        var root = AccessibilityTree.Build(document, AccessibilityOptions.Full);
+        var text = AccessibilitySnapshot.Render(root);
+
+        text.Should().NotContain("var x").And.NotContain("color:red").And.NotContain("In a template");
+        ImplicitRoleTests.FindAll(root, "button").Select(static n => n.Name).Should().Equal("Real");
+    }
+
+    [Test]
+    public void IncludeIgnoredKeepsTheHiddenNodesAndSaysWhy()
+    {
+        using var document = PageFixture.Parse("<div hidden><button>A</button></div><div aria-hidden=true><span><button>B</button></span></div>");
+        var root = AccessibilityTree.Build(document, AccessibilityOptions.Full);
+
+        var buttons = ImplicitRoleTests.FindAll(root, "button");
+        buttons.Should().HaveCount(2);
+        buttons[0].IgnoredReason.Should().Be(AxIgnoredReason.Hidden);
+        buttons[1].IgnoredReason.Should().Be(AxIgnoredReason.AriaHiddenSubtree);
+        buttons.Should().AllSatisfy(static b => b.Ignored.Should().BeTrue());
+    }
+
+    [Test]
+    public void AnImageWithAnEmptyAltIsIgnoredForBeingPresentational()
+    {
+        using var document = PageFixture.Parse("<img src=a.png alt=''><img src=b.png alt='A cat'>");
+        var full = AccessibilityTree.Build(document, AccessibilityOptions.Full);
+
+        ImplicitRoleTests.Find(full, "none")!.IgnoredReason.Should().Be(AxIgnoredReason.EmptyAlt);
+        ImplicitRoleTests.Find(full, "image")!.Name.Should().Be("A cat");
+
+        var pruned = AccessibilityTree.Build(document);
+        ImplicitRoleTests.Find(pruned, "none").Should().BeNull();
+    }
+
+    [Test]
+    public void TextNodesBecomeStaticTextOnlyWhenAsked()
+    {
+        using var document = PageFixture.Parse("<p>Hello there</p>");
+
+        ImplicitRoleTests.Find(AccessibilityTree.Build(document), "StaticText").Should().BeNull();
+
+        var full = AccessibilityTree.Build(document, AccessibilityOptions.Default with { IncludeText = true });
+        ImplicitRoleTests.Find(full, "StaticText")!.Name.Should().Be("Hello there");
+    }
+
+    [Test]
+    public void IdentifiersAreStableAcrossTwoBuildsOfTheSameDocument()
+    {
+        using var document = PageFixture.Parse("<button>A</button><a href='/x'>B</a><h1>C</h1>");
+
+        var first = Identifiers(AccessibilityTree.Build(document));
+        var second = Identifiers(AccessibilityTree.Build(document));
+
+        second.Should().Equal(first);
+        first.Should().OnlyHaveUniqueItems();
+
+        static List<int> Identifiers(AxNode node)
+        {
+            var ids = new List<int> { node.Id };
+            foreach (var child in node.Children)
+            {
+                ids.AddRange(Identifiers(child));
+            }
+
+            return ids;
+        }
+    }
+
+    [Test]
+    public void TwoDocumentsNumberTheirOwnNodes()
+    {
+        using var first = PageFixture.Parse("<button>A</button>");
+        using var second = PageFixture.Parse("<button>A</button>");
+
+        var a = ImplicitRoleTests.Find(AccessibilityTree.Build(first), "button")!;
+        var b = ImplicitRoleTests.Find(AccessibilityTree.Build(second), "button")!;
+
+        a.Id.Should().Be(b.Id, "each document counts from one, so identifiers are only unique within a document");
+    }
+
+    [Test]
+    public void APartialTreeStartsAtTheElementAndInheritsTheAncestorsHiddenVerdict()
+    {
+        using var document = PageFixture.Parse("<div hidden><section id=s aria-label=S><button>A</button></section></div>");
+
+        AccessibilityTree.Build(document.GetElementById("s")!).Should().BeNull();
+
+        var included = AccessibilityTree.Build(document.GetElementById("s")!, AccessibilityOptions.Full);
+        included!.Role.Should().Be("region");
+        included.IgnoredReason.Should().Be(AxIgnoredReason.Hidden);
+    }
+
+    [Test]
+    public void APartialTreeOfAPrunedElementAnswersItsSurvivingChild()
+    {
+        using var document = PageFixture.Parse("<div id=d><button>A</button></div>");
+        var node = AccessibilityTree.Build(document.GetElementById("d")!);
+
+        node!.Role.Should().Be("button");
+    }
+
+    private static IEnumerable<TestCaseData> Properties()
+    {
+        yield return Property("<input id=t type=checkbox checked>", AxPropertyName.Checked, "true");
+        yield return Property("<input id=t type=checkbox>", AxPropertyName.Checked, "false");
+        yield return Property("<div id=t role=checkbox aria-checked=mixed></div>", AxPropertyName.Checked, "mixed");
+        yield return Property("<button id=t aria-pressed=true>x</button>", AxPropertyName.Pressed, "true");
+        yield return Property("<details id=t open></details>", AxPropertyName.Expanded, "true");
+        yield return Property("<details id=t></details>", AxPropertyName.Expanded, "false");
+        yield return Property("<details open><summary id=t>x</summary></details>", AxPropertyName.Expanded, "true");
+        yield return Property("<select><option id=t selected>x</option></select>", AxPropertyName.Selected, "true");
+        yield return Property("<button id=t disabled>x</button>", AxPropertyName.Disabled, "true");
+        yield return Property("<fieldset disabled><button id=t>x</button></fieldset>", AxPropertyName.Disabled, "true");
+        yield return Property("<div id=t role=button aria-disabled=true>x</div>", AxPropertyName.Disabled, "true");
+        yield return Property("<input id=t required>", AxPropertyName.Required, "true");
+        yield return Property("<input id=t readonly>", AxPropertyName.Readonly, "true");
+        yield return Property("<a id=t href='/x'>x</a>", AxPropertyName.Focusable, "true");
+        yield return Property("<h3 id=t>x</h3>", AxPropertyName.Level, "3");
+        yield return Property("<div id=t role=heading aria-level=5>x</div>", AxPropertyName.Level, "5");
+        yield return Property("<textarea id=t></textarea>", AxPropertyName.Multiline, "true");
+        yield return Property("<select id=t multiple></select>", AxPropertyName.Multiselectable, "true");
+        yield return Property("<div id=t role=slider aria-orientation=vertical></div>", AxPropertyName.Orientation, "vertical");
+        yield return Property("<input id=t aria-invalid=spelling>", AxPropertyName.Invalid, "spelling");
+        yield return Property("<datalist id=d></datalist><input id=t list=d>", AxPropertyName.Autocomplete, "list");
+        yield return Property("<div id=t role=button aria-haspopup=menu>x</div>", AxPropertyName.HasPopup, "menu");
+        yield return Property("<div id=t role=status>x</div>", AxPropertyName.Live, "polite");
+        yield return Property("<div id=t role=alert>x</div>", AxPropertyName.Live, "assertive");
+        yield return Property("<div id=t role=status aria-live=off>x</div>", AxPropertyName.Live, "off");
+        yield return Property("<input id=t type=range min=1 max=9>", AxPropertyName.Valuemin, "1");
+        yield return Property("<input id=t type=range min=1 max=9>", AxPropertyName.Valuemax, "9");
+        yield return Property("<progress id=t value=3 max=10></progress>", AxPropertyName.Valuemax, "10");
+        yield return Property("<div id=t role=slider aria-valuetext='Large'></div>", AxPropertyName.Valuetext, "Large");
+        yield return Property("<dialog id=t open aria-modal=true></dialog>", AxPropertyName.Modal, "true");
+        yield return Property("<div id=t role=status aria-atomic=true aria-busy=true>x</div>", AxPropertyName.Busy, "true");
+    }
+
+    // The case data carries the protocol spelling rather than the enumeration member, because the
+    // enumeration is internal and a public test method may not name it.
+    private static TestCaseData Property(string html, AxPropertyName name, string value) =>
+        new TestCaseData(html, new AxProperty(name, default).ProtocolName, value)
+            .SetArgDisplayNames(html, name.ToString(), value);
+
+    [TestCaseSource(nameof(Properties))]
+    public void PublishesTheProperty(string html, string name, string expected)
+    {
+        using var document = PageFixture.Parse(html);
+        var node = AccessibilityTree.Build(document.GetElementById("t")!, AccessibilityOptions.Full)!;
+
+        var property = node.Properties.FirstOrDefault(p => string.Equals(p.ProtocolName, name, StringComparison.Ordinal));
+        property.Should().NotBe(default(AxProperty), "the node should carry a {0} property", name);
+        property.Value.ToDisplayString().Should().Be(expected);
+    }
+
+    [Test]
+    public void PublishesTheUrlOfALinkAndAnImage()
+    {
+        using var document = PageFixture.Parse("<a id=a href='/page?q=1'>x</a><img id=i src='pic.png' alt=A>", "https://example.com/dir/index.html");
+
+        Url(document, "a").Should().Be("https://example.com/page?q=1");
+        Url(document, "i").Should().Be("https://example.com/dir/pic.png");
+
+        string? Url(AngleSharp.Dom.IDocument doc, string id)
+        {
+            var node = AccessibilityTree.Build(doc.GetElementById(id)!, AccessibilityOptions.Full)!;
+            return node.Properties.FirstOrDefault(p => p.Name == AxPropertyName.Url).Value.Text;
+        }
+    }
+
+    [Test]
+    public void PublishesAWidgetsValue()
+    {
+        using var document = PageFixture.Parse(
+            "<input id=a value='typed'>" +
+            "<textarea id=b>lines</textarea>" +
+            "<select id=c><option>One</option><option selected>Two</option></select>" +
+            "<progress id=d value=4 max=10></progress>");
+
+        Value(document, "a").Should().Be("typed");
+        Value(document, "b").Should().Be("lines");
+        Value(document, "c").Should().Be("Two");
+        Value(document, "d").Should().Be("4");
+
+        string? Value(AngleSharp.Dom.IDocument doc, string id) =>
+            AccessibilityTree.Build(doc.GetElementById(id)!, AccessibilityOptions.Full)!.Value;
+    }
+
+    [Test]
+    public void ARoleThatIsPresentationalKeepsItsChildren()
+    {
+        using var document = PageFixture.Parse("<ul role=presentation><li><a href='/x'>Link</a></li></ul>");
+        var root = AccessibilityTree.Build(document);
+
+        ImplicitRoleTests.Find(root, "list").Should().BeNull();
+        ImplicitRoleTests.Find(root, "link")!.Name.Should().Be("Link");
+    }
+}

--- a/Jint.Tests.Browser/Accessibility/AccessibleNameTests.cs
+++ b/Jint.Tests.Browser/Accessibility/AccessibleNameTests.cs
@@ -1,0 +1,157 @@
+using AngleSharp.Dom;
+using Jint.Browser.Accessibility;
+
+namespace Jint.Tests.Browser.Accessibility;
+
+/// <summary>
+/// The accessible name and description computation, step by step and then by its edge cases.
+/// </summary>
+public sealed class AccessibleNameTests
+{
+    private static IEnumerable<TestCaseData> Names()
+    {
+        // 2B: aria-labelledby wins over everything below it, and joins its targets with a space.
+        yield return Case("<span id=a>Hello</span><span id=b>world</span><button id=t aria-labelledby='a b' aria-label=Ignored>Content</button>", "Hello world");
+        yield return Case("<button id=t aria-labelledby='missing'>Content</button>", "Content");
+
+        // 2B again: a hidden node that is the direct target of the reference still contributes (accname 2A).
+        yield return Case("<span id=a hidden>Hidden label</span><button id=t aria-labelledby=a>Content</button>", "Hidden label");
+        yield return Case("<span id=a style='display:none'>Hidden label</span><button id=t aria-labelledby=a>Content</button>", "Hidden label");
+
+        // 2D: aria-label.
+        yield return Case("<button id=t aria-label='Close dialog'>x</button>", "Close dialog");
+        yield return Case("<button id=t aria-label='   '>Content</button>", "Content");
+
+        // 2E: the native host language label.
+        yield return Case("<label for=t>Full name</label><input id=t>", "Full name");
+        yield return Case("<label>Full name <input id=t></label>", "Full name");
+        yield return Case("<label for=t>A</label><label for=t>B</label><input id=t>", "A B");
+        yield return Case("<input id=t placeholder='Search the docs'>", "Search the docs");
+        yield return Case("<label for=t>Query</label><input id=t placeholder='Search'>", "Query");
+        yield return Case("<input id=t type=submit>", "Submit");
+        yield return Case("<input id=t type=submit value='Send it'>", "Send it");
+        yield return Case("<input id=t type=reset>", "Reset");
+        yield return Case("<input id=t type=button value=Go>", "Go");
+        yield return Case("<input id=t type=image alt='Search'>", "Search");
+        yield return Case("<input id=t type=image>", "Submit Query");
+        yield return Case("<img id=t src=x.png alt='A red cat'>", "A red cat");
+        yield return Case("<fieldset id=t><legend>Shipping</legend></fieldset>", "Shipping");
+        yield return Case("<table id=t><caption>Sales</caption><tr><td>x</td></tr></table>", "Sales");
+        yield return Case("<figure id=t><figcaption>Figure 1</figcaption></figure>", "Figure 1");
+        yield return Case("<select><optgroup id=t label='Group A'><option>x</option></optgroup></select>", "Group A");
+
+        // 2C: an embedded control inside a label contributes its value, not its own label.
+        yield return Case("<label for=q>Search <input id=q value=cats></label><div id=t role=link aria-labelledby=q>x</div>", "cats");
+
+        // 2F: name from content, only for the roles that allow it.
+        yield return Case("<button id=t>Save <b>now</b></button>", "Save now");
+        yield return Case("<a id=t href='/x'>Read <em>more</em></a>", "Read more");
+        yield return Case("<h2 id=t>A <span>nested</span> heading</h2>", "A nested heading");
+        yield return Case("<div id=t>Plain text</div>", "");
+        yield return Case("<p id=t>Plain text</p>", "");
+        yield return Case("<select><option id=t>Choice</option></select>", "Choice");
+
+        // 2F: a button whose content is an image takes the image's alternative text.
+        yield return Case("<button id=t><img src=save.png alt=Save></button>", "Save");
+        yield return Case("<button id=t><img src=deco.png alt=''>Save</button>", "Save");
+        yield return Case("<button id=t><img src=deco.png alt=''></button>", "");
+
+        // 2F: whitespace joins by HTML's suggested display, not by a used one.
+        yield return Case("<button id=t><b>a</b><b>b</b></button>", "ab");
+        yield return Case("<button id=t><div>a</div><div>b</div></button>", "a b");
+        yield return Case("<button id=t>  Save\n  the   file  </button>", "Save the file");
+
+        // 2A inside content: a hidden descendant contributes nothing.
+        yield return Case("<button id=t>Save<span hidden> secretly</span></button>", "Save");
+        yield return Case("<button id=t>Save<span aria-hidden=true> secretly</span></button>", "Save");
+        yield return Case("<button id=t>Save<span style='display:none'> secretly</span></button>", "Save");
+
+        // 2I: a title, but only when everything above produced nothing.
+        yield return Case("<button id=t title='Tooltip only'></button>", "Tooltip only");
+        yield return Case("<button id=t title='Tooltip'>Content</button>", "Content");
+        yield return Case("<div id=t title='Tooltip only'></div>", "Tooltip only");
+    }
+
+    private static TestCaseData Case(string html, string name) => new TestCaseData(html, name).SetArgDisplayNames(html, name.Length == 0 ? "(empty)" : name);
+
+    [TestCaseSource(nameof(Names))]
+    public void ComputesTheNameAccnameSpecifies(string html, string expected)
+    {
+        using var document = PageFixture.Parse(html);
+        Name(document, "t").Should().Be(expected);
+    }
+
+    [Test]
+    public void AnAriaLabelledByCycleTerminates()
+    {
+        using var document = PageFixture.Parse("<div id=t role=button aria-labelledby=b>A</div><div id=b role=button aria-labelledby=t>B</div>");
+
+        // The visited guard stops the recursion; what matters is that it answers at all.
+        Name(document, "t").Should().Be("B");
+    }
+
+    [Test]
+    public void ALabelledControlDoesNotNameItselfThroughItsOwnLabel()
+    {
+        // The control being named is on the visited set before its label is walked, so the label's content
+        // contributes and the control's value does not.
+        using var document = PageFixture.Parse("<label>Name <input id=t value=Bob></label>");
+
+        Name(document, "t").Should().Be("Name");
+    }
+
+    [Test]
+    public void NameFromContentReachesANestedControlsValue()
+    {
+        using var document = PageFixture.Parse("<div id=t role=button>Total <input value='42' readonly></div>");
+
+        Name(document, "t").Should().Be("Total 42");
+    }
+
+    [Test]
+    public void ADescriptionComesFromDescribedByThenTitleThenPlaceholder()
+    {
+        using var document = PageFixture.Parse(
+            "<span id=d>The long help text</span>" +
+            "<input id=a aria-label=A aria-describedby=d title=T placeholder=P>" +
+            "<input id=b aria-label=B title=T placeholder=P>" +
+            "<input id=c aria-label=C placeholder=P>" +
+            "<input id=e placeholder=P>");
+
+        Description(document, "a").Should().Be("The long help text");
+        Description(document, "b").Should().Be("T");
+        Description(document, "c").Should().Be("P");
+
+        // The placeholder became the name, so it cannot also be the description.
+        Name(document, "e").Should().Be("P");
+        Description(document, "e").Should().BeEmpty();
+    }
+
+    [Test]
+    public void FlattenCollapsesEveryRunOfWhitespaceAndTrimsTheEnds()
+    {
+        AccessibleName.Flatten("  a \n\t b  ").Should().Be("a b");
+        AccessibleName.Flatten("   ").Should().BeEmpty();
+        AccessibleName.Flatten("").Should().BeEmpty();
+    }
+
+    private static string Name(IDocument document, string id)
+    {
+        var element = document.GetElementById(id)!;
+        return Computation(document).Compute(element, AccessibleName.ResolveRole(element));
+    }
+
+    private static string Description(IDocument document, string id)
+    {
+        var element = document.GetElementById(id)!;
+        var computation = Computation(document);
+        var name = computation.Compute(element, AccessibleName.ResolveRole(element));
+        return computation.ComputeDescription(element, name);
+    }
+
+    private static AccessibleName Computation(IDocument document)
+    {
+        _ = document;
+        return new AccessibleName(new ElementVisibility(useComputedStyle: true));
+    }
+}

--- a/Jint.Tests.Browser/Accessibility/AxProtocolTests.cs
+++ b/Jint.Tests.Browser/Accessibility/AxProtocolTests.cs
@@ -1,0 +1,116 @@
+using System.Text.Json;
+using Jint.Browser.Accessibility;
+
+namespace Jint.Tests.Browser.Accessibility;
+
+/// <summary>
+/// The Chrome DevTools Protocol shape: what <c>Accessibility.getFullAXTree</c> puts on the wire.
+/// </summary>
+/// <remarks>
+/// The assertions are on the JSON rather than on the record, because the record is a private arrangement
+/// between this package and the protocol domain while the JSON is the contract a DevTools front end and both
+/// .NET clients read. <c>backendDOMNodeId</c> is deliberately absent: only a session that owns a DOM node
+/// registry can fill it in.
+/// </remarks>
+public sealed class AxProtocolTests
+{
+    [Test]
+    public void FlattensTheTreeIntoNodesLinkedByIdentifier()
+    {
+        using var document = PageFixture.Parse("<h1>Title</h1><button>Save</button>");
+        var root = AccessibilityTree.Build(document);
+
+        using var parsed = JsonDocument.Parse(AccessibilityTree.ToJson(root));
+        var nodes = parsed.RootElement.EnumerateArray().ToArray();
+
+        nodes.Should().HaveCount(3);
+
+        var rootNode = nodes[0];
+        rootNode.GetProperty("role").GetProperty("value").GetString().Should().Be("RootWebArea");
+        rootNode.TryGetProperty("parentId", out _).Should().BeFalse("the root has no parent");
+
+        var childIds = rootNode.GetProperty("childIds").EnumerateArray().Select(static id => id.GetString()).ToArray();
+        childIds.Should().Equal(nodes[1].GetProperty("nodeId").GetString(), nodes[2].GetProperty("nodeId").GetString());
+        nodes[1].GetProperty("parentId").GetString().Should().Be(rootNode.GetProperty("nodeId").GetString());
+    }
+
+    [Test]
+    public void EveryValueCarriesTheTypeTagTheProtocolDefines()
+    {
+        using var document = PageFixture.Parse("<h2 id=t aria-describedby=d>Heading</h2><span id=d>Help</span>");
+        var node = AccessibilityTree.Build(document.GetElementById("t")!)!;
+
+        using var parsed = JsonDocument.Parse(JsonSerializer.Serialize(AccessibilityTree.ToProtocol(node), AxProtocolJsonContext.Default.AxProtocolNode));
+        var root = parsed.RootElement;
+
+        root.GetProperty("ignored").GetBoolean().Should().BeFalse();
+        root.GetProperty("role").GetProperty("type").GetString().Should().Be("role");
+        root.GetProperty("role").GetProperty("value").GetString().Should().Be("heading");
+        root.GetProperty("name").GetProperty("type").GetString().Should().Be("computedString");
+        root.GetProperty("name").GetProperty("value").GetString().Should().Be("Heading");
+        root.GetProperty("description").GetProperty("value").GetString().Should().Be("Help");
+
+        var level = root.GetProperty("properties").EnumerateArray().Single(static p => p.GetProperty("name").GetString() == "level");
+        level.GetProperty("value").GetProperty("type").GetString().Should().Be("integer");
+        level.GetProperty("value").GetProperty("value").GetInt32().Should().Be(2);
+    }
+
+    [Test]
+    public void ABooleanPropertyIsAJsonBooleanAndATristateIsAString()
+    {
+        using var document = PageFixture.Parse("<input id=t type=checkbox checked required>");
+        var node = AccessibilityTree.Build(document.GetElementById("t")!)!;
+
+        using var parsed = JsonDocument.Parse(JsonSerializer.Serialize(AccessibilityTree.ToProtocol(node), AxProtocolJsonContext.Default.AxProtocolNode));
+        var properties = parsed.RootElement.GetProperty("properties").EnumerateArray()
+            .ToDictionary(static p => p.GetProperty("name").GetString()!, static p => p.GetProperty("value"));
+
+        properties["checked"].GetProperty("type").GetString().Should().Be("tristate");
+        properties["checked"].GetProperty("value").GetString().Should().Be("true");
+        properties["required"].GetProperty("type").GetString().Should().Be("boolean");
+        properties["required"].GetProperty("value").GetBoolean().Should().BeTrue();
+    }
+
+    [Test]
+    public void AnIgnoredNodeSaysThatItIsAndWhy()
+    {
+        using var document = PageFixture.Parse("<div id=t hidden>x</div>");
+        var node = AccessibilityTree.Build(document.GetElementById("t")!, AccessibilityOptions.Full)!;
+
+        using var parsed = JsonDocument.Parse(JsonSerializer.Serialize(AccessibilityTree.ToProtocol(node), AxProtocolJsonContext.Default.AxProtocolNode));
+
+        parsed.RootElement.GetProperty("ignored").GetBoolean().Should().BeTrue();
+        var reasons = parsed.RootElement.GetProperty("ignoredReasons").EnumerateArray().ToArray();
+        reasons.Should().ContainSingle();
+        reasons[0].GetProperty("name").GetString().Should().Be("hidden");
+        reasons[0].GetProperty("value").GetProperty("value").GetBoolean().Should().BeTrue();
+    }
+
+    [Test]
+    public void NullMembersAreLeftOutRatherThanWrittenAsNull()
+    {
+        using var document = PageFixture.Parse("<hr id=t>");
+        var node = AccessibilityTree.Build(document.GetElementById("t")!)!;
+
+        var json = JsonSerializer.Serialize(AccessibilityTree.ToProtocol(node), AxProtocolJsonContext.Default.AxProtocolNode);
+
+        json.Should().NotContain("null");
+        json.Should().NotContain("backendDOMNodeId", "only a protocol session can supply one");
+        json.Should().NotContain("childIds");
+    }
+
+    [Test]
+    public void TheIndentedFormIsTheSameDocument()
+    {
+        using var document = PageFixture.Parse("<button>Save</button>");
+        var root = AccessibilityTree.Build(document);
+
+        var compact = AccessibilityTree.ToJson(root);
+        var indented = AccessibilityTree.ToJson(root, indented: true);
+
+        indented.Should().Contain("\n");
+        using var a = JsonDocument.Parse(compact);
+        using var b = JsonDocument.Parse(indented);
+        b.RootElement.GetArrayLength().Should().Be(a.RootElement.GetArrayLength());
+    }
+}

--- a/Jint.Tests.Browser/Accessibility/Golden/article.html
+++ b/Jint.Tests.Browser/Accessibility/Golden/article.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>A headless browser on Jint</title>
+</head>
+<body>
+  <header>
+    <p>Jint</p>
+  </header>
+
+  <article>
+    <h1>A headless browser on Jint</h1>
+    <p>Jint already carries the web platform's <strong>non-DOM half</strong>. The only missing layer is
+      the <em>document</em>: parsing, the DOM, the CSSOM, and the runtime that ties them to a
+      <a href="/docs/window">Window</a>.</p>
+
+    <figure>
+      <img src="diagram.png" alt="The parser hands a baton to the page loop">
+      <figcaption>Figure 1: the parser baton.</figcaption>
+    </figure>
+
+    <h2>What v1 delivers</h2>
+    <ul>
+      <li>Full HTML5 parse, with <code>defer</code> and <code>async</code> scripts.</li>
+      <li>Generated DOM and CSSOM bindings.
+        <ul>
+          <li>One shape per interface.</li>
+          <li>One wrapper per node.</li>
+        </ul>
+      </li>
+      <li>Accessibility and markdown snapshots.</li>
+    </ul>
+
+    <h2>What it is not</h2>
+    <ol start="1">
+      <li>A renderer.</li>
+      <li>A rival DOM stack.</li>
+    </ol>
+
+    <blockquote>
+      <p>Jint should add value to AngleSharp without competing too much.</p>
+    </blockquote>
+
+    <h2>Running it</h2>
+    <pre><code class="language-bash">dotnet run --project Jint.Repl -c Release -- -f page.js -t 10</code></pre>
+
+    <table>
+      <caption>Comparison</caption>
+      <thead><tr><th scope="col">Engine</th><th scope="col">Memory</th><th scope="col">Wall</th></tr></thead>
+      <tbody>
+        <tr><td>Chromium</td><td>High</td><td>1x</td></tr>
+        <tr><td>Jint.Browser</td><td>Low</td><td>1.5-3x</td></tr>
+      </tbody>
+    </table>
+
+    <hr>
+
+    <dl>
+      <dt>Baton</dt>
+      <dd>The token that says which side may touch the DOM.</dd>
+      <dt>Census</dt>
+      <dd>The ceiling a conformance lane may not raise.</dd>
+    </dl>
+
+    <details open>
+      <summary>Read the design</summary>
+      <p>The whole design is in <a href="/docs/design">the design document</a>.</p>
+    </details>
+
+    <p>Send corrections<br>to the tracking issue.</p>
+    <p aria-hidden="true">Decorative footnote marker.</p>
+  </article>
+
+  <footer>
+    <p>&copy; 2026</p>
+  </footer>
+</body>
+</html>

--- a/Jint.Tests.Browser/Accessibility/Golden/article.md
+++ b/Jint.Tests.Browser/Accessibility/Golden/article.md
@@ -1,0 +1,56 @@
+Jint
+
+# A headless browser on Jint
+
+Jint already carries the web platform's **non-DOM half**. The only missing layer is the *document*: parsing, the DOM, the CSSOM, and the runtime that ties them to a [Window](https://jint.test/docs/window).
+
+![The parser hands a baton to the page loop](https://jint.test/diagram.png)
+
+Figure 1: the parser baton.
+
+## What v1 delivers
+
+- Full HTML5 parse, with `defer` and `async` scripts.
+- Generated DOM and CSSOM bindings.
+
+  - One shape per interface.
+  - One wrapper per node.
+- Accessibility and markdown snapshots.
+
+## What it is not
+
+1. A renderer.
+2. A rival DOM stack.
+
+> Jint should add value to AngleSharp without competing too much.
+
+## Running it
+
+```bash
+dotnet run --project Jint.Repl -c Release -- -f page.js -t 10
+```
+
+**Comparison**
+
+| Engine | Memory | Wall |
+| --- | --- | --- |
+| Chromium | High | 1x |
+| Jint.Browser | Low | 1.5-3x |
+
+---
+
+**Baton**\
+  The token that says which side may touch the DOM.
+**Census**\
+  The ceiling a conformance lane may not raise.
+
+**Read the design**
+
+The whole design is in [the design document](https://jint.test/docs/design).
+
+Send corrections\
+to the tracking issue.
+
+Decorative footnote marker.
+
+© 2026

--- a/Jint.Tests.Browser/Accessibility/Golden/article.snapshot.txt
+++ b/Jint.Tests.Browser/Accessibility/Golden/article.snapshot.txt
@@ -1,0 +1,69 @@
+- RootWebArea "A headless browser on Jint":
+  - banner:
+    - paragraph: Jint
+  - article:
+    - heading "A headless browser on Jint" [level=1]
+    - paragraph:
+      - text: Jint already carries the web platform's
+      - strong: non-DOM half
+      - text: . The only missing layer is the
+      - emphasis: document
+      - text: : parsing, the DOM, the CSSOM, and the runtime that ties them to a
+      - link "Window"
+      - text: .
+    - figure "Figure 1: the parser baton.":
+      - image "The parser hands a baton to the page loop"
+    - heading "What v1 delivers" [level=2]
+    - list:
+      - listitem:
+        - text: Full HTML5 parse, with
+        - code: defer
+        - text: and
+        - code: async
+        - text: scripts.
+      - listitem:
+        - text: Generated DOM and CSSOM bindings.
+        - list:
+          - listitem: One shape per interface.
+          - listitem: One wrapper per node.
+      - listitem: Accessibility and markdown snapshots.
+    - heading "What it is not" [level=2]
+    - list:
+      - listitem: A renderer.
+      - listitem: A rival DOM stack.
+    - blockquote:
+      - paragraph: Jint should add value to AngleSharp without competing too much.
+    - heading "Running it" [level=2]
+    - code: dotnet run --project Jint.Repl -c Release -- -f page.js -t 10
+    - table "Comparison":
+      - rowgroup:
+        - row "Engine Memory Wall":
+          - columnheader "Engine"
+          - columnheader "Memory"
+          - columnheader "Wall"
+      - rowgroup:
+        - row "Chromium High 1x":
+          - cell "Chromium"
+          - cell "High"
+          - cell "1x"
+        - row "Jint.Browser Low 1.5-3x":
+          - cell "Jint.Browser"
+          - cell "Low"
+          - cell "1.5-3x"
+    - separator
+    - list:
+      - term: Baton
+      - definition: The token that says which side may touch the DOM.
+      - term: Census
+      - definition: The ceiling a conformance lane may not raise.
+    - group [expanded]:
+      - button "Read the design" [expanded]
+      - paragraph:
+        - text: The whole design is in
+        - link "the design document"
+        - text: .
+    - paragraph:
+      - text: Send corrections
+      - text: to the tracking issue.
+  - contentinfo:
+    - paragraph: © 2026

--- a/Jint.Tests.Browser/Accessibility/Golden/article.text.txt
+++ b/Jint.Tests.Browser/Accessibility/Golden/article.text.txt
@@ -1,0 +1,39 @@
+Jint
+
+A headless browser on Jint
+
+Jint already carries the web platform's non-DOM half. The only missing layer is the document: parsing, the DOM, the CSSOM, and the runtime that ties them to a Window.
+
+Figure 1: the parser baton.
+What v1 delivers
+Full HTML5 parse, with defer and async scripts.
+Generated DOM and CSSOM bindings.
+One shape per interface.
+One wrapper per node.
+Accessibility and markdown snapshots.
+What it is not
+A renderer.
+A rival DOM stack.
+
+Jint should add value to AngleSharp without competing too much.
+
+Running it
+dotnet run --project Jint.Repl -c Release -- -f page.js -t 10
+Comparison
+Engine	Memory	Wall
+Chromium	High	1x
+Jint.Browser	Low	1.5-3x
+Baton
+The token that says which side may touch the DOM.
+Census
+The ceiling a conformance lane may not raise.
+Read the design
+
+The whole design is in the design document.
+
+Send corrections
+to the tracking issue.
+
+Decorative footnote marker.
+
+© 2026

--- a/Jint.Tests.Browser/Accessibility/Golden/form.html
+++ b/Jint.Tests.Browser/Accessibility/Golden/form.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Create an account</title>
+  <style>.visually-hidden { display: none }</style>
+</head>
+<body>
+  <main>
+    <h1>Create an account</h1>
+    <form action="/signup" method="post" aria-labelledby="signup-heading" aria-describedby="signup-help">
+      <h2 id="signup-heading">Your details</h2>
+      <p id="signup-help">Everything marked with an asterisk is required.</p>
+
+      <fieldset>
+        <legend>Name</legend>
+        <label for="given">Given name</label>
+        <input id="given" name="given" required value="Ada">
+        <label for="family">Family name</label>
+        <input id="family" name="family" required placeholder="Lovelace">
+      </fieldset>
+
+      <label for="email">Email</label>
+      <input id="email" type="email" placeholder="you@example.com" aria-describedby="email-help">
+      <span id="email-help">We only use this to send the receipt.</span>
+
+      <label for="age">Age</label>
+      <input id="age" type="number" min="13" max="120" value="36">
+
+      <label for="volume">Notification volume</label>
+      <input id="volume" type="range" min="0" max="11" value="7" aria-valuetext="Loud">
+
+      <label for="country">Country</label>
+      <select id="country">
+        <option>Finland</option>
+        <option selected>Ireland</option>
+      </select>
+
+      <label for="tags">Tags</label>
+      <select id="tags" multiple size="4">
+        <option selected>alpha</option>
+        <option>beta</option>
+      </select>
+
+      <label for="bio">About you</label>
+      <textarea id="bio" rows="4" readonly>A short biography.</textarea>
+
+      <input id="terms" type="checkbox" checked>
+      <label for="terms">I accept the terms</label>
+
+      <input id="news" type="checkbox" disabled>
+      <label for="news">Send me the newsletter</label>
+
+      <p role="group" aria-label="Plan">
+        <input id="plan-free" type="radio" name="plan" checked><label for="plan-free">Free</label>
+        <input id="plan-paid" type="radio" name="plan"><label for="plan-paid">Paid</label>
+      </p>
+
+      <p class="visually-hidden"><input id="honeypot" name="website"><label for="honeypot">Leave this empty</label></p>
+      <input type="hidden" name="csrf" value="token">
+
+      <progress id="strength" value="3" max="10"></progress>
+      <output id="summary" aria-live="polite">Ready</output>
+
+      <button type="submit">Create account</button>
+      <button type="button" aria-pressed="false" aria-haspopup="menu">More options</button>
+      <input type="reset">
+    </form>
+  </main>
+</body>
+</html>

--- a/Jint.Tests.Browser/Accessibility/Golden/form.snapshot.txt
+++ b/Jint.Tests.Browser/Accessibility/Golden/form.snapshot.txt
@@ -1,0 +1,30 @@
+- RootWebArea "Create an account":
+  - main:
+    - heading "Create an account" [level=1]
+    - form "Your details":
+      - heading "Your details" [level=2]
+      - paragraph: Everything marked with an asterisk is required.
+      - group "Name":
+        - textbox "Given name" [required]: Ada
+        - textbox "Family name" [required]
+      - textbox "Email"
+      - text: We only use this to send the receipt.
+      - spinbutton "Age": 36
+      - slider "Notification volume": Loud
+      - combobox "Country":
+        - option "Finland"
+        - option "Ireland" [selected]
+      - listbox "Tags" [multiselectable]:
+        - option "alpha" [selected]
+        - option "beta"
+      - textbox "About you" [readonly]: A short biography.
+      - checkbox "I accept the terms" [checked]
+      - checkbox "Send me the newsletter" [disabled]
+      - group "Plan":
+        - radio "Free" [checked]
+        - radio "Paid"
+      - progressbar: 3
+      - status: Ready
+      - button "Create account"
+      - button "More options"
+      - button "Reset"

--- a/Jint.Tests.Browser/Accessibility/Golden/nav.html
+++ b/Jint.Tests.Browser/Accessibility/Golden/nav.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Documentation</title>
+  <style>
+    .sr-only { position: absolute }
+    [aria-current="page"] { font-weight: 700 }
+    .collapsed > ul { display: none }
+  </style>
+</head>
+<body>
+  <a href="#content" class="sr-only">Skip to content</a>
+
+  <header>
+    <a href="/" aria-label="Jint home"><img src="logo.svg" alt=""></a>
+
+    <nav aria-label="Primary">
+      <ul>
+        <li><a href="/docs" aria-current="page">Docs</a></li>
+        <li><a href="/api">API</a></li>
+        <li>
+          <button aria-expanded="false" aria-controls="more-menu" aria-haspopup="menu">More</button>
+          <ul id="more-menu" hidden>
+            <li><a href="/blog">Blog</a></li>
+            <li><a href="/talks">Talks</a></li>
+          </ul>
+        </li>
+      </ul>
+    </nav>
+
+    <form role="search" action="/search">
+      <label for="q">Search the docs</label>
+      <input id="q" type="search" placeholder="Type to search">
+      <button type="submit"><img src="search.svg" alt="Search"></button>
+    </form>
+  </header>
+
+  <nav aria-label="Section" class="collapsed">
+    <h2>On this page</h2>
+    <ul>
+      <li><a href="#install">Install</a></li>
+      <li><a href="#use">Use</a></li>
+    </ul>
+  </nav>
+
+  <main id="content">
+    <h1>Documentation</h1>
+  </main>
+
+  <footer>
+    <nav aria-label="Legal">
+      <a href="/terms">Terms</a>
+      <a href="/privacy">Privacy</a>
+    </nav>
+  </footer>
+</body>
+</html>

--- a/Jint.Tests.Browser/Accessibility/Golden/nav.md
+++ b/Jint.Tests.Browser/Accessibility/Golden/nav.md
@@ -1,0 +1,15 @@
+[Skip to content](https://jint.test/nav.html#content)
+
+<https://jint.test/>
+
+- [Docs](https://jint.test/docs)
+- [API](https://jint.test/api)
+- More
+
+Search the docs ![Search](https://jint.test/search.svg)
+
+## On this page
+
+# Documentation
+
+[Terms](https://jint.test/terms) [Privacy](https://jint.test/privacy)

--- a/Jint.Tests.Browser/Accessibility/Golden/nav.snapshot.txt
+++ b/Jint.Tests.Browser/Accessibility/Golden/nav.snapshot.txt
@@ -1,0 +1,24 @@
+- RootWebArea "Documentation":
+  - link "Skip to content"
+  - banner:
+    - link "Jint home"
+    - navigation "Primary":
+      - list:
+        - listitem:
+          - link "Docs"
+        - listitem:
+          - link "API"
+        - listitem:
+          - button "More"
+    - search:
+      - searchbox "Search the docs"
+      - button "Search":
+        - image "Search"
+  - navigation "Section":
+    - heading "On this page" [level=2]
+  - main:
+    - heading "Documentation" [level=1]
+  - contentinfo:
+    - navigation "Legal":
+      - link "Terms"
+      - link "Privacy"

--- a/Jint.Tests.Browser/Accessibility/Golden/todomvc.html
+++ b/Jint.Tests.Browser/Accessibility/Golden/todomvc.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Jint • TodoMVC</title>
+  <style>
+    .hidden { display: none }
+    .todo-list li.completed label { text-decoration: line-through }
+  </style>
+</head>
+<body>
+  <section class="todoapp">
+    <header class="header">
+      <h1>todos</h1>
+      <label for="new-todo" class="hidden">What needs to be done?</label>
+      <input id="new-todo" class="new-todo" placeholder="What needs to be done?" autofocus>
+    </header>
+
+    <section class="main">
+      <input id="toggle-all" class="toggle-all" type="checkbox">
+      <label for="toggle-all">Mark all as complete</label>
+
+      <ul class="todo-list">
+        <li class="completed">
+          <input id="todo-1" class="toggle" type="checkbox" checked>
+          <label for="todo-1">Write the accessibility tree</label>
+          <button class="destroy" aria-label="Delete Write the accessibility tree"></button>
+        </li>
+        <li>
+          <input id="todo-2" class="toggle" type="checkbox">
+          <label for="todo-2">Render the page as markdown</label>
+          <button class="destroy" aria-label="Delete Render the page as markdown"></button>
+        </li>
+        <li>
+          <input id="todo-3" class="toggle" type="checkbox">
+          <label for="todo-3">Ship the snapshot</label>
+          <button class="destroy" aria-label="Delete Ship the snapshot"></button>
+        </li>
+      </ul>
+    </section>
+
+    <footer class="footer">
+      <span class="todo-count"><strong>2</strong> items left</span>
+      <ul class="filters">
+        <li><a href="#/" aria-current="page">All</a></li>
+        <li><a href="#/active">Active</a></li>
+        <li><a href="#/completed">Completed</a></li>
+      </ul>
+      <button class="clear-completed">Clear completed</button>
+    </footer>
+  </section>
+
+  <footer class="info">
+    <p>Double-click a todo to edit it</p>
+    <p>Created by <a href="https://jint.test/">the Jint campaign</a></p>
+  </footer>
+</body>
+</html>

--- a/Jint.Tests.Browser/Accessibility/Golden/todomvc.md
+++ b/Jint.Tests.Browser/Accessibility/Golden/todomvc.md
@@ -1,0 +1,19 @@
+# todos
+
+Mark all as complete
+
+- Write the accessibility tree
+- Render the page as markdown
+- Ship the snapshot
+
+**2** items left
+
+- [All](https://jint.test/todomvc.html#/)
+- [Active](https://jint.test/todomvc.html#/active)
+- [Completed](https://jint.test/todomvc.html#/completed)
+
+Clear completed
+
+Double-click a todo to edit it
+
+Created by [the Jint campaign](https://jint.test/)

--- a/Jint.Tests.Browser/Accessibility/Golden/todomvc.snapshot.txt
+++ b/Jint.Tests.Browser/Accessibility/Golden/todomvc.snapshot.txt
@@ -1,0 +1,31 @@
+- RootWebArea "Jint • TodoMVC":
+  - sectionheader:
+    - heading "todos" [level=1]
+    - textbox "What needs to be done?"
+  - checkbox "Mark all as complete"
+  - list:
+    - listitem:
+      - checkbox "Write the accessibility tree" [checked]
+      - button "Delete Write the accessibility tree"
+    - listitem:
+      - checkbox "Render the page as markdown"
+      - button "Delete Render the page as markdown"
+    - listitem:
+      - checkbox "Ship the snapshot"
+      - button "Delete Ship the snapshot"
+  - sectionfooter:
+    - strong: 2
+    - text: items left
+    - list:
+      - listitem:
+        - link "All"
+      - listitem:
+        - link "Active"
+      - listitem:
+        - link "Completed"
+    - button "Clear completed"
+  - contentinfo:
+    - paragraph: Double-click a todo to edit it
+    - paragraph:
+      - text: Created by
+      - link "the Jint campaign"

--- a/Jint.Tests.Browser/Accessibility/Golden/todomvc.text.txt
+++ b/Jint.Tests.Browser/Accessibility/Golden/todomvc.text.txt
@@ -1,0 +1,14 @@
+todos
+Mark all as complete
+Write the accessibility tree
+Render the page as markdown
+Ship the snapshot
+2 items left
+All
+Active
+Completed
+Clear completed
+
+Double-click a todo to edit it
+
+Created by the Jint campaign

--- a/Jint.Tests.Browser/Accessibility/GoldenFiles.cs
+++ b/Jint.Tests.Browser/Accessibility/GoldenFiles.cs
@@ -1,0 +1,60 @@
+namespace Jint.Tests.Browser.Accessibility;
+
+/// <summary>
+/// The fixture pages and their approved output, read from the checkout rather than from the test binary.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Setting <c>JINT_BROWSER_GOLDEN=update</c> rewrites the approved file instead of failing, which is the
+/// same discipline <c>JINT_SPEC_ANCHORS</c> and <c>JINT_DOM_BINDINGS</c> already use in this repository: the
+/// diff is what gets reviewed, so a change to a snapshot has to be looked at rather than merely re-run.
+/// </para>
+/// <para>
+/// Line endings are normalized on both sides, because a Windows checkout stores these as CRLF and the
+/// renderers emit LF.
+/// </para>
+/// </remarks>
+internal static class GoldenFiles
+{
+    private static string Directory => Path.Combine(RepositoryPaths.Root, "Jint.Tests.Browser", "Accessibility", "Golden");
+
+    /// <summary>Whether the run was asked to rewrite the approved files.</summary>
+    internal static bool Updating { get; } =
+        string.Equals(Environment.GetEnvironmentVariable("JINT_BROWSER_GOLDEN"), "update", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>Reads the fixture page named <paramref name="name"/>.</summary>
+    internal static string Page(string name) => Read(name + ".html");
+
+    /// <summary>
+    /// Asserts <paramref name="actual"/> against the approved file, or rewrites it when the run was asked to.
+    /// </summary>
+    internal static void Approve(string fileName, string actual)
+    {
+        var normalized = Normalize(actual);
+        var path = Path.Combine(Directory, fileName);
+
+        if (Updating || !File.Exists(path))
+        {
+            File.WriteAllText(path, normalized);
+            if (!Updating)
+            {
+                Assert.Fail($"'{fileName}' did not exist and has been written. Review it, then run again.");
+            }
+
+            return;
+        }
+
+        Normalize(File.ReadAllText(path)).Should().Be(normalized,
+            "the approved snapshot in '{0}' is the reviewed one; rerun with JINT_BROWSER_GOLDEN=update to rewrite it, then read the diff", fileName);
+    }
+
+    private static string Read(string fileName)
+    {
+        var path = Path.Combine(Directory, fileName);
+        return File.Exists(path)
+            ? Normalize(File.ReadAllText(path))
+            : throw new FileNotFoundException($"No fixture '{fileName}' under '{Directory}'.", path);
+    }
+
+    private static string Normalize(string text) => text.Replace("\r\n", "\n", StringComparison.Ordinal).TrimEnd('\n') + "\n";
+}

--- a/Jint.Tests.Browser/Accessibility/ImplicitRoleTests.cs
+++ b/Jint.Tests.Browser/Accessibility/ImplicitRoleTests.cs
@@ -1,0 +1,240 @@
+using AngleSharp.Dom;
+using Jint.Browser.Accessibility;
+
+namespace Jint.Tests.Browser.Accessibility;
+
+/// <summary>
+/// HTML-AAM's element-to-role mapping, one case per row of the table this package claims to implement.
+/// </summary>
+/// <remarks>
+/// Every case names the markup rather than the element, because more than a third of the table's rows are
+/// conditional — <c>a</c> on <c>href</c>, <c>input</c> on <c>type</c> and <c>list</c>, <c>li</c> on its
+/// parent, <c>header</c> and <c>aside</c> on their scope — and a test that only fed a bare element would
+/// pass while every condition was wrong.
+/// </remarks>
+public sealed class ImplicitRoleTests
+{
+    private static IEnumerable<TestCaseData> Rows()
+    {
+        // Anchors, areas and links.
+        yield return Case("<a id=t href='/x'>x</a>", "link");
+        yield return Case("<a id=t>x</a>", "generic");
+        yield return Case("<map><area id=t href='/x'></map>", "link");
+        yield return Case("<map><area id=t></map>", "generic");
+
+        // Document structure.
+        yield return Case("<article id=t></article>", "article");
+        yield return Case("<blockquote id=t></blockquote>", "blockquote");
+        yield return Case("<address id=t></address>", "group");
+        yield return Case("<hgroup id=t></hgroup>", "group");
+        yield return Case("<main id=t></main>", "main");
+        yield return Case("<nav id=t></nav>", "navigation");
+        yield return Case("<search id=t></search>", "search");
+        yield return Case("<hr id=t>", "separator");
+        yield return Case("<p id=t>x</p>", "paragraph");
+        yield return Case("<div id=t></div>", "generic");
+        yield return Case("<span id=t></span>", "generic");
+        yield return Case("<label id=t>x</label>", "generic");
+
+        // Landmarks whose role depends on where they are.
+        yield return Case("<header id=t></header>", "banner");
+        yield return Case("<article><header id=t></header></article>", "sectionheader");
+        yield return Case("<footer id=t></footer>", "contentinfo");
+        yield return Case("<section><footer id=t></footer></section>", "sectionfooter");
+        yield return Case("<aside id=t></aside>", "complementary");
+        yield return Case("<main><aside id=t></aside></main>", "complementary");
+        yield return Case("<article><aside id=t></aside></article>", "generic");
+        yield return Case("<article><aside id=t aria-label=Notes></aside></article>", "complementary");
+        yield return Case("<section id=t></section>", "generic");
+        yield return Case("<section id=t aria-label=Intro></section>", "region");
+
+        // Headings.
+        yield return Case("<h1 id=t>x</h1>", "heading");
+        yield return Case("<h6 id=t>x</h6>", "heading");
+
+        // Lists.
+        yield return Case("<ul id=t></ul>", "list");
+        yield return Case("<ol id=t></ol>", "list");
+        yield return Case("<menu id=t></menu>", "list");
+        yield return Case("<dl id=t></dl>", "list");
+        yield return Case("<ul><li id=t>x</li></ul>", "listitem");
+        yield return Case("<div><li id=t>x</li></div>", "generic");
+        yield return Case("<dl><dt id=t>x</dt></dl>", "term");
+        yield return Case("<dl><dd id=t>x</dd></dl>", "definition");
+
+        // Tables.
+        yield return Case("<table id=t></table>", "table");
+        yield return Case("<table><caption id=t>x</caption></table>", "caption");
+        yield return Case("<table><tbody id=t><tr><td>x</td></tr></tbody></table>", "rowgroup");
+        yield return Case("<table><tr id=t><td>x</td></tr></table>", "row");
+        yield return Case("<table><tr><td id=t>x</td></tr></table>", "cell");
+        yield return Case("<table><tr><th id=t>x</th></tr></table>", "columnheader");
+        yield return Case("<table><tr><th id=t scope=row>x</th></tr></table>", "rowheader");
+
+        // Form controls.
+        yield return Case("<button id=t>x</button>", "button");
+        yield return Case("<fieldset id=t></fieldset>", "group");
+        yield return Case("<fieldset><legend id=t>x</legend></fieldset>", "generic");
+        yield return Case("<form id=t></form>", "form");
+        yield return Case("<textarea id=t></textarea>", "textbox");
+        yield return Case("<select id=t></select>", "combobox");
+        yield return Case("<select id=t multiple></select>", "listbox");
+        yield return Case("<select id=t size=4></select>", "listbox");
+        yield return Case("<select><optgroup id=t label=G></optgroup></select>", "group");
+        yield return Case("<select><option id=t>x</option></select>", "option");
+        yield return Case("<datalist id=t></datalist>", "listbox");
+        yield return Case("<output id=t></output>", "status");
+        yield return Case("<progress id=t></progress>", "progressbar");
+        yield return Case("<meter id=t></meter>", "meter");
+
+        // Inputs, by type and by the presence of a list.
+        yield return Case("<input id=t>", "textbox");
+        yield return Case("<input id=t type=text>", "textbox");
+        yield return Case("<input id=t type=email>", "textbox");
+        yield return Case("<input id=t type=tel>", "textbox");
+        yield return Case("<input id=t type=url>", "textbox");
+        yield return Case("<input id=t type=search>", "searchbox");
+        yield return Case("<datalist id=d></datalist><input id=t list=d>", "combobox");
+        yield return Case("<datalist id=d></datalist><input id=t type=search list=d>", "combobox");
+        yield return Case("<input id=t type=checkbox>", "checkbox");
+        yield return Case("<input id=t type=radio>", "radio");
+        yield return Case("<input id=t type=number>", "spinbutton");
+        yield return Case("<input id=t type=range>", "slider");
+        yield return Case("<input id=t type=button>", "button");
+        yield return Case("<input id=t type=submit>", "button");
+        yield return Case("<input id=t type=reset>", "button");
+        yield return Case("<input id=t type=image>", "button");
+        yield return Case("<input id=t type=password>", "generic");
+        yield return Case("<input id=t type=file>", "generic");
+
+        // Images.
+        yield return Case("<img id=t src=x.png alt='A cat'>", "image");
+        yield return Case("<img id=t src=x.png>", "image");
+        yield return Case("<img id=t src=x.png alt=''>", "none");
+
+        // Disclosure, dialogs and figures.
+        yield return Case("<details id=t></details>", "group");
+        yield return Case("<details><summary id=t>x</summary></details>", "button");
+        yield return Case("<div><summary id=t>x</summary></div>", "generic");
+        yield return Case("<dialog id=t></dialog>", "dialog");
+        yield return Case("<figure id=t></figure>", "figure");
+        yield return Case("<figure><figcaption id=t>x</figcaption></figure>", "caption");
+
+        // Phrasing semantics that do map to a role.
+        yield return Case("<code id=t>x</code>", "code");
+        yield return Case("<del id=t>x</del>", "deletion");
+        yield return Case("<ins id=t>x</ins>", "insertion");
+        yield return Case("<em id=t>x</em>", "emphasis");
+        yield return Case("<strong id=t>x</strong>", "strong");
+        yield return Case("<mark id=t>x</mark>", "mark");
+        yield return Case("<sub id=t>x</sub>", "subscript");
+        yield return Case("<sup id=t>x</sup>", "superscript");
+        yield return Case("<dfn id=t>x</dfn>", "term");
+        yield return Case("<time id=t>x</time>", "time");
+        yield return Case("<b id=t>x</b>", "generic");
+        yield return Case("<i id=t>x</i>", "generic");
+        yield return Case("<q id=t>x</q>", "generic");
+        yield return Case("<small id=t>x</small>", "generic");
+    }
+
+    private static TestCaseData Case(string html, string role) => new TestCaseData(html, role).SetArgDisplayNames(html, role);
+
+    [TestCaseSource(nameof(Rows))]
+    public void MapsTheElementToTheRoleHtmlAamNames(string html, string expected)
+    {
+        using var document = PageFixture.Parse(html);
+        var element = document.GetElementById("t")!;
+
+        ImplicitRole.For(element).Should().Be(expected);
+    }
+
+    [Test]
+    public void MapsBrAndAHiddenInputToNoRoleAtAll()
+    {
+        using var document = PageFixture.Parse("<br id=b><wbr id=w><input id=i type=hidden>");
+
+        ImplicitRole.For(document.GetElementById("b")!).Should().BeNull();
+        ImplicitRole.For(document.GetElementById("w")!).Should().BeNull();
+        ImplicitRole.For(document.GetElementById("i")!).Should().BeNull();
+    }
+
+    [Test]
+    public void TreatsMetadataContentAsProducingNoNode()
+    {
+        using var document = PageFixture.Parse("<head><title>t</title></head><body><script id=s></script><style id=y></style><template id=p></template></body>");
+
+        foreach (var id in new[] { "s", "y", "p" })
+        {
+            ImplicitRole.IsMetadataContent(document.GetElementById(id)!).Should().BeTrue();
+        }
+    }
+
+    [Test]
+    public void AnExplicitRoleOverridesTheImplicitOne()
+    {
+        using var document = PageFixture.Parse("<div id=t role=button>x</div>");
+        var root = AccessibilityTree.Build(document);
+
+        Find(root, "button").Should().NotBeNull();
+    }
+
+    [Test]
+    public void AnUnknownExplicitRoleFallsBackToTheImplicitOne()
+    {
+        AriaRoles.Explicit("nonsense").Should().BeNull();
+        AriaRoles.Explicit("doc-chapter region").Should().Be("region");
+        AriaRoles.Explicit("BUTTON").Should().Be("button");
+        AriaRoles.Explicit(null).Should().BeNull();
+
+        using var document = PageFixture.Parse("<nav id=t role=nonsense></nav>");
+        AccessibleName.ResolveRole(document.GetElementById("t")!).Should().Be("navigation");
+    }
+
+    [Test]
+    public void AnAbstractRoleIsNotAValidExplicitRole()
+    {
+        // ARIA forbids an author from using an abstract role, so `role="widget"` names nothing and the
+        // implicit role stands.
+        AriaRoles.Explicit("widget").Should().BeNull();
+        AriaRoles.Explicit("landmark").Should().BeNull();
+        AriaRoles.Explicit("input").Should().BeNull();
+    }
+
+    internal static AxNode? Find(AxNode node, string role)
+    {
+        if (string.Equals(node.Role, role, StringComparison.Ordinal))
+        {
+            return node;
+        }
+
+        foreach (var child in node.Children)
+        {
+            if (Find(child, role) is { } found)
+            {
+                return found;
+            }
+        }
+
+        return null;
+    }
+
+    internal static IReadOnlyList<AxNode> FindAll(AxNode node, string role)
+    {
+        var found = new List<AxNode>();
+        Collect(node, role, found);
+        return found;
+
+        static void Collect(AxNode node, string role, List<AxNode> into)
+        {
+            if (string.Equals(node.Role, role, StringComparison.Ordinal))
+            {
+                into.Add(node);
+            }
+
+            foreach (var child in node.Children)
+            {
+                Collect(child, role, into);
+            }
+        }
+    }
+}

--- a/Jint.Tests.Browser/Accessibility/PageFixture.cs
+++ b/Jint.Tests.Browser/Accessibility/PageFixture.cs
@@ -1,0 +1,45 @@
+using AngleSharp;
+using AngleSharp.Dom;
+
+namespace Jint.Tests.Browser.Accessibility;
+
+/// <summary>
+/// A parsed document with the CSS cascade available, which is what every test in this area needs and all
+/// that any of them needs.
+/// </summary>
+/// <remarks>
+/// There is no engine here on purpose: the accessibility tree and the extraction payloads are computed over
+/// AngleSharp's DOM alone, so a test that reached for one would be testing something the production path
+/// never does.
+/// </remarks>
+internal static class PageFixture
+{
+    /// <summary>Parses <paramref name="html"/> with <c>AngleSharp.Css</c> registered.</summary>
+    internal static IDocument Parse(string html, string? url = null)
+    {
+        var context = BrowsingContext.New(Configuration.Default.WithCss());
+        return context.OpenAsync(response =>
+        {
+            response.Content(html);
+            if (url is not null)
+            {
+                response.Address(url);
+            }
+        }).GetAwaiter().GetResult();
+    }
+
+    /// <summary>Parses <paramref name="html"/> without the CSS services, so the cascade cannot answer.</summary>
+    internal static IDocument ParseWithoutCss(string html)
+    {
+        var context = BrowsingContext.New(Configuration.Default);
+        return context.OpenAsync(response => response.Content(html)).GetAwaiter().GetResult();
+    }
+
+    /// <summary>Parses <paramref name="html"/> and returns the element with the identifier <c>t</c>.</summary>
+    internal static IElement Target(string html)
+    {
+        var document = Parse(html);
+        return document.GetElementById("t")
+            ?? throw new InvalidOperationException("The fixture has no element with the identifier 't'.");
+    }
+}

--- a/Jint.Tests.Browser/Extraction/ExtractionGoldenTests.cs
+++ b/Jint.Tests.Browser/Extraction/ExtractionGoldenTests.cs
@@ -1,0 +1,59 @@
+using Jint.Browser.Extraction;
+using Jint.Tests.Browser.Accessibility;
+
+namespace Jint.Tests.Browser.Extraction;
+
+/// <summary>
+/// The two extraction payloads over the same whole pages the accessibility snapshot uses.
+/// </summary>
+/// <remarks>
+/// One fixture set, three renderings: an agent picks one of them per task, and having the three approved
+/// side by side is what makes the choice reviewable. <c>JINT_BROWSER_GOLDEN=update</c> rewrites them.
+/// </remarks>
+public sealed class ExtractionGoldenTests
+{
+    [TestCase("article")]
+    [TestCase("todomvc")]
+    [TestCase("nav")]
+    public void RendersThePageAsMarkdown(string page)
+    {
+        using var document = PageFixture.Parse(GoldenFiles.Page(page), "https://jint.test/" + page + ".html");
+
+        GoldenFiles.Approve(page + ".md", MarkdownExtractor.ToMarkdown(document));
+    }
+
+    [TestCase("article")]
+    [TestCase("todomvc")]
+    public void RendersThePageAsText(string page)
+    {
+        using var document = PageFixture.Parse(GoldenFiles.Page(page), "https://jint.test/" + page + ".html");
+
+        GoldenFiles.Approve(page + ".text.txt", TextExtractor.InnerText(document));
+    }
+
+    [Test]
+    public void MainContentOnlyDropsTheChromeOfARealPage()
+    {
+        using var document = PageFixture.Parse(GoldenFiles.Page("article"), "https://jint.test/article.html");
+
+        var whole = MarkdownExtractor.ToMarkdown(document);
+        var main = MarkdownExtractor.ToMarkdown(document, MarkdownOptions.Default with { MainContentOnly = true });
+
+        whole.Should().Contain("© 2026");
+        main.Should().NotContain("© 2026").And.Contain("# A headless browser on Jint");
+        main.Length.Should().BeLessThan(whole.Length);
+    }
+
+    [Test]
+    public void AriaHiddenContentIsStillTextOnThePage()
+    {
+        // aria-hidden removes a node from the accessibility tree and changes nothing about the rendering, so
+        // innerText and the markdown both keep it while the accessibility snapshot does not.
+        using var document = PageFixture.Parse("<p>Kept</p><p aria-hidden=true>Decoration</p><p hidden>Gone</p>");
+
+        var expected = "Kept" + Environment.NewLine + Environment.NewLine + "Decoration";
+
+        TextExtractor.InnerText(document).Replace("\n", Environment.NewLine).Should().Be(expected);
+        MarkdownExtractor.ToMarkdown(document).Replace("\n", Environment.NewLine).Should().Be(expected);
+    }
+}

--- a/Jint.Tests.Browser/Extraction/MarkdownExtractorTests.cs
+++ b/Jint.Tests.Browser/Extraction/MarkdownExtractorTests.cs
@@ -1,0 +1,237 @@
+using Jint.Browser.Extraction;
+using Jint.Tests.Browser.Accessibility;
+
+namespace Jint.Tests.Browser.Extraction;
+
+/// <summary>
+/// The CommonMark rendering, one construct at a time and then the whole-page options.
+/// </summary>
+public sealed class MarkdownExtractorTests
+{
+    private static IEnumerable<TestCaseData> Constructs()
+    {
+        // Headings and paragraphs.
+        yield return Case("<h1>Title</h1>", "# Title");
+        yield return Case("<h3>Sub</h3>", "### Sub");
+        yield return Case("<p>One.</p><p>Two.</p>", "One.\n\nTwo.");
+        yield return Case("<p>  spread   over\n  lines  </p>", "spread over lines");
+
+        // Emphasis and code.
+        yield return Case("<p>a <strong>b</strong> c</p>", "a **b** c");
+        yield return Case("<p>a <b>b</b> c</p>", "a **b** c");
+        yield return Case("<p>a <em>b</em> c</p>", "a *b* c");
+        yield return Case("<p>a <i>b</i> c</p>", "a *b* c");
+        yield return Case("<p>a <del>b</del> c</p>", "a ~~b~~ c");
+        yield return Case("<p>use <code>x = 1</code> here</p>", "use `x = 1` here");
+        // A backtick inside a code span needs a longer delimiter, not a doubled one.
+        yield return Case("<p>use <code>a`b</code> here</p>", "use ``a`b`` here");
+        yield return Case("<p>use <code>`x`</code> here</p>", "use `` `x` `` here");
+        yield return Case("<p>a<strong></strong>b</p>", "ab");
+
+        // Fenced code, with the language from the class.
+        yield return Case("<pre><code class='language-csharp'>var x = 1;</code></pre>", "```csharp\nvar x = 1;\n```");
+        yield return Case("<pre><code>plain</code></pre>", "```\nplain\n```");
+        yield return Case("<pre>  kept  \n  as is</pre>", "```\n  kept  \n  as is\n```");
+
+        // Links and images, resolved against the document's base.
+        yield return Case("<p><a href='/docs'>Docs</a></p>", "[Docs](https://example.com/docs)");
+        yield return Case("<p><a href='https://x.test/'>X</a></p>", "[X](https://x.test/)");
+        yield return Case("<p><a>no href</a></p>", "no href");
+        yield return Case("<p><img src='pic.png' alt='A cat'></p>", "![A cat](https://example.com/dir/pic.png)");
+        yield return Case("<p><a href='/x'><img src='pic.png' alt='Logo'></a></p>", "[![Logo](https://example.com/dir/pic.png)](https://example.com/x)");
+        // An empty alt is HTML's way of saying the image is decoration, so it is not content.
+        yield return Case("<p>a<img src='deco.png' alt=''>b</p>", "ab");
+        yield return Case("<p><img src='pic.png'></p>", "![](https://example.com/dir/pic.png)");
+
+        // Lists.
+        yield return Case("<ul><li>a</li><li>b</li></ul>", "- a\n- b");
+        yield return Case("<ol><li>a</li><li>b</li></ol>", "1. a\n2. b");
+        yield return Case("<ol start=3><li>a</li></ol>", "3. a");
+        yield return Case("<ul><li>a<ul><li>b</li></ul></li></ul>", "- a\n\n  - b");
+        yield return Case("<ul><li><p>a</p><p>b</p></li></ul>", "- a\n\n  b");
+
+        // Block quotes.
+        yield return Case("<blockquote><p>quoted</p></blockquote>", "> quoted");
+        yield return Case("<blockquote><p>a</p><p>b</p></blockquote>", "> a\n>\n> b");
+
+        // Rules and hard breaks.
+        yield return Case("<hr>", "---");
+        yield return Case("<p>a<br>b</p>", "a\\\nb");
+
+        // Definition lists.
+        yield return Case("<dl><dt>Term</dt><dd>Meaning</dd></dl>", "**Term**\\\n  Meaning");
+
+        // Disclosure.
+        yield return Case("<details><summary>More</summary><p>Body</p></details>", "**More**\n\nBody");
+
+        // Escaping.
+        yield return Case("<p>a * b _ c [d] `e`</p>", "a \\* b \\_ c \\[d\\] \\`e\\`");
+        yield return Case("<p>snake_case stays</p>", "snake_case stays");
+        yield return Case("<p>2 &lt; 3</p>", "2 \\< 3");
+
+        // Skipped content.
+        yield return Case("<p>a</p><script>var x=1</script><style>p{color:red}</style><noscript>b</noscript>", "a");
+        yield return Case("<p>a</p><div hidden><p>b</p></div>", "a");
+        yield return Case("<p>a</p><div style='display:none'><p>b</p></div>", "a");
+    }
+
+    private static TestCaseData Case(string html, string expected) =>
+        new TestCaseData(html, expected).SetArgDisplayNames(html, expected.Replace("\n", "\\n"));
+
+    [TestCaseSource(nameof(Constructs))]
+    public void RendersTheConstruct(string html, string expected)
+    {
+        using var document = PageFixture.Parse(html, "https://example.com/dir/index.html");
+        MarkdownExtractor.ToMarkdown(document).Should().Be(expected);
+    }
+
+    [Test]
+    public void RendersAGitHubFlavouredTable()
+    {
+        using var document = PageFixture.Parse(
+            "<table><thead><tr><th>Name</th><th>Qty</th></tr></thead>" +
+            "<tbody><tr><td>Apples</td><td>3</td></tr><tr><td>Pears</td><td>12</td></tr></tbody></table>");
+
+        MarkdownExtractor.ToMarkdown(document).Should().Be(
+            """
+            | Name | Qty |
+            | --- | --- |
+            | Apples | 3 |
+            | Pears | 12 |
+            """.Replace("\r\n", "\n"));
+    }
+
+    [Test]
+    public void ATableWithNoHeaderRowStillGetsTheSeparatorGfmRequires()
+    {
+        using var document = PageFixture.Parse("<table><tr><td>a</td><td>b</td></tr></table>");
+
+        MarkdownExtractor.ToMarkdown(document).Should().Be(
+            """
+            |  |  |
+            | --- | --- |
+            | a | b |
+            """.Replace("\r\n", "\n"));
+    }
+
+    [Test]
+    public void ATableCaptionBecomesABoldLineAboveIt()
+    {
+        using var document = PageFixture.Parse("<table><caption>Stock</caption><tr><th>a</th></tr></table>");
+
+        MarkdownExtractor.ToMarkdown(document).Should().StartWith("**Stock**\n\n| a |");
+    }
+
+    [Test]
+    public void ANestedTablesRowsStayInTheNestedTable()
+    {
+        using var document = PageFixture.Parse("<table><tr><td>outer<table><tr><td>inner</td></tr></table></td></tr></table>");
+
+        var markdown = MarkdownExtractor.ToMarkdown(document);
+
+        markdown.Split('\n').Should().HaveCount(3, "the outer table has one header row, one separator and one body row");
+        markdown.Should().Contain("outer").And.Contain("inner");
+    }
+
+    [Test]
+    public void APipeInACellIsEscaped()
+    {
+        using var document = PageFixture.Parse("<table><tr><td>a|b</td></tr></table>");
+
+        MarkdownExtractor.ToMarkdown(document).Should().Contain("a\\|b");
+    }
+
+    [Test]
+    public void ImagesCanBeReducedToTheirAlternativeText()
+    {
+        using var document = PageFixture.Parse("<p>see <img src=pic.png alt='the cat'> now</p>");
+
+        MarkdownExtractor.ToMarkdown(document, MarkdownOptions.Default with { IncludeImages = false })
+            .Should().Be("see the cat now");
+    }
+
+    [Test]
+    public void MainContentOnlyPrefersMainThenRoleMainThenArticle()
+    {
+        const string Chrome = "<nav><a href='/'>Home</a></nav><footer><p>Footer</p></footer>";
+
+        using var withMain = PageFixture.Parse("<main><p>Main body</p></main>" + Chrome);
+        Markdown(withMain).Should().Be("Main body");
+
+        using var withRole = PageFixture.Parse("<div role=main><p>Role body</p></div>" + Chrome);
+        Markdown(withRole).Should().Be("Role body");
+
+        using var withArticle = PageFixture.Parse("<article><p>Article body</p></article>" + Chrome);
+        Markdown(withArticle).Should().Be("Article body");
+
+        using var withNeither = PageFixture.Parse("<p>Everything</p>" + Chrome);
+        Markdown(withNeither).Should().Contain("Everything").And.Contain("Home").And.Contain("Footer");
+
+        static string Markdown(AngleSharp.Dom.IDocument document) =>
+            MarkdownExtractor.ToMarkdown(document, MarkdownOptions.Default with { MainContentOnly = true });
+    }
+
+    [Test]
+    public void MaxLengthTruncatesAtAWordBoundaryAndSaysSo()
+    {
+        using var document = PageFixture.Parse("<p>" + string.Join(" ", Enumerable.Repeat("word", 200)) + "</p>");
+
+        var full = MarkdownExtractor.ToMarkdown(document);
+        var cut = MarkdownExtractor.ToMarkdown(document, MarkdownOptions.Default with { MaxLength = 100 });
+
+        full.Length.Should().BeGreaterThan(100);
+        cut.Length.Should().BeLessThanOrEqualTo(100);
+        cut.Should().EndWith(MarkdownExtractor.TruncationMarker);
+        cut.Should().StartWith("word word");
+        cut[..^MarkdownExtractor.TruncationMarker.Length].Should().NotEndWith("wor");
+    }
+
+    [Test]
+    public void MaxLengthLeavesAShortDocumentAlone()
+    {
+        using var document = PageFixture.Parse("<p>short</p>");
+
+        MarkdownExtractor.ToMarkdown(document, MarkdownOptions.Default with { MaxLength = 100 }).Should().Be("short");
+    }
+
+    [Test]
+    public void RendersAWholePageInOnePass()
+    {
+        using var document = PageFixture.Parse(
+            """
+            <html><head><title>Release notes</title></head><body>
+            <header><nav><a href="/">Home</a> <a href="/docs">Docs</a></nav></header>
+            <main>
+              <h1>Release notes</h1>
+              <p>The <strong>headline</strong> change is <a href="/pr/1">the parser baton</a>.</p>
+              <h2>Fixed</h2>
+              <ul><li>A <code>null</code> reference.</li><li>A hang under load.</li></ul>
+              <pre><code class="language-bash">dotnet test -c Release</code></pre>
+              <blockquote><p>Upgrade before the next release.</p></blockquote>
+            </main>
+            <footer><p>&copy; 2026</p></footer>
+            </body></html>
+            """,
+            "https://jint.test/notes.html");
+
+        var markdown = MarkdownExtractor.ToMarkdown(document, MarkdownOptions.Default with { MainContentOnly = true });
+
+        markdown.Should().Be(
+            """
+            # Release notes
+
+            The **headline** change is [the parser baton](https://jint.test/pr/1).
+
+            ## Fixed
+
+            - A `null` reference.
+            - A hang under load.
+
+            ```bash
+            dotnet test -c Release
+            ```
+
+            > Upgrade before the next release.
+            """.Replace("\r\n", "\n"));
+    }
+}

--- a/Jint.Tests.Browser/Extraction/TextExtractorTests.cs
+++ b/Jint.Tests.Browser/Extraction/TextExtractorTests.cs
@@ -1,0 +1,120 @@
+using Jint.Browser.Extraction;
+using Jint.Tests.Browser.Accessibility;
+
+namespace Jint.Tests.Browser.Extraction;
+
+/// <summary>
+/// HTML's rendered text collection steps, case by case.
+/// </summary>
+/// <remarks>
+/// The cases are written from the algorithm and from what a browser answers for the same markup, not
+/// vendored from web-platform-tests: the corpus's <c>innerText</c> files are not in this repository's WPT
+/// tree, and its getter tests assert against a real layout, which this has none of.
+/// </remarks>
+public sealed class TextExtractorTests
+{
+    private static IEnumerable<TestCaseData> Cases()
+    {
+        // Collapsing, and the trim at the ends of the root.
+        yield return Case("<div id=t>abc</div>", "abc");
+        yield return Case("<div id=t>  abc  </div>", "abc");
+        yield return Case("<div id=t>a\n  b   c</div>", "a b c");
+        yield return Case("<div id=t>a <b>b</b> c</div>", "a b c");
+        yield return Case("<div id=t>a<b>b</b>c</div>", "abc");
+        yield return Case("<div id=t>a <b> b </b> c</div>", "a b c");
+
+        // <br> is a literal line feed rather than a required line break.
+        yield return Case("<div id=t>abc<br>def</div>", "abc\ndef");
+        yield return Case("<div id=t>abc<br>  def</div>", "abc\ndef");
+        yield return Case("<div id=t>abc<br><br>def</div>", "abc\n\ndef");
+
+        // One required line break around a block-level box, two around a paragraph, then the runs collapse
+        // to their maximum and the ends are trimmed.
+        yield return Case("<div id=t><div>a</div><div>b</div></div>", "a\nb");
+        yield return Case("<div id=t>a<div>b</div>c</div>", "a\nb\nc");
+        yield return Case("<div id=t><p>a</p><p>b</p></div>", "a\n\nb");
+        yield return Case("<div id=t><div>a</div><p>b</p><div>c</div></div>", "a\n\nb\n\nc");
+        yield return Case("<div id=t><h1>Title</h1><p>Body</p></div>", "Title\n\nBody");
+
+        // AngleSharp.Css's default sheet has no rule for the HTML5 flow elements, so this is the table in
+        // HtmlDisplay answering rather than the cascade.
+        yield return Case("<div id=t><section>a</section><article>b</article></div>", "a\nb");
+        yield return Case("<div id=t><nav>a</nav><aside>b</aside><main>c</main></div>", "a\nb\nc");
+        yield return Case("<div id=t><figure>a</figure><figcaption>b</figcaption></div>", "a\nb");
+
+        // Lists.
+        yield return Case("<ul id=t><li>a</li><li>b</li></ul>", "a\nb");
+
+        // Tables: a tab between cells, a line feed between rows, and nothing extra around either.
+        yield return Case("<table id=t><tr><td>a</td><td>b</td></tr><tr><td>c</td><td>d</td></tr></table>", "a\tb\nc\td");
+        yield return Case("<table id=t><thead><tr><th>h</th></tr></thead><tbody><tr><td>a</td></tr></tbody></table>", "h\na");
+        yield return Case("<table id=t><caption>Cap</caption><tr><td>a</td></tr></table>", "Cap\na");
+
+        // White space is preserved where CSS preserves it.
+        yield return Case("<pre id=t>  a  b  </pre>", "  a  b  ");
+        yield return Case("<div id=t><pre>a\n  b</pre></div>", "a\n  b");
+        yield return Case("<textarea id=t>  keep  this  </textarea>", "  keep  this  ");
+        yield return Case("<div id=t style='white-space:pre'>  a  b  </div>", "  a  b  ");
+
+        // Hidden content contributes nothing at all, breaks included.
+        yield return Case("<div id=t>a<span style='display:none'>b</span>c</div>", "ac");
+        // A `display: none` box is not laid out at all, so it contributes no required line break either.
+        yield return Case("<div id=t>a<div hidden>b</div>c</div>", "ac");
+        yield return Case("<div id=t>a<span style='visibility:hidden'>b</span>c</div>", "ac");
+
+        // Metadata content is never text.
+        yield return Case("<div id=t>a<script>var x=1</script><style>p{color:red}</style>b</div>", "ab");
+        yield return Case("<div id=t>a<template>hidden</template>b</div>", "ab");
+
+        // Nothing to say.
+        yield return Case("<div id=t></div>", "");
+        yield return Case("<div id=t>   </div>", "");
+    }
+
+    private static TestCaseData Case(string html, string expected) =>
+        new TestCaseData(html, expected).SetArgDisplayNames(html, Escape(expected));
+
+    private static string Escape(string text) => text.Length == 0 ? "(empty)" : text.Replace("\n", "\\n").Replace("\t", "\\t");
+
+    [TestCaseSource(nameof(Cases))]
+    public void CollectsTheRenderedText(string html, string expected)
+    {
+        using var document = PageFixture.Parse(html);
+        TextExtractor.InnerText(document.GetElementById("t")!).Should().Be(expected);
+    }
+
+    [Test]
+    public void ADocumentWithNoElementIdentifiedAnswersItsBody()
+    {
+        using var document = PageFixture.Parse("<h1>Title</h1><p>Body</p>");
+
+        TextExtractor.InnerText(document).Should().Be("Title\n\nBody");
+    }
+
+    [Test]
+    public void ADisplayNoneFromAStyleSheetIsSkippedToo()
+    {
+        using var document = PageFixture.Parse("<style>.gone{display:none}</style><div id=t>a<span class=gone>b</span>c</div>");
+
+        TextExtractor.InnerText(document.GetElementById("t")!).Should().Be("ac");
+    }
+
+    [Test]
+    public void WithoutTheCascadeTheInlineStyleStillAnswers()
+    {
+        using var document = PageFixture.ParseWithoutCss("<div id=t>a<span style='display:none'>b</span>c<div>d</div></div>");
+
+        // The block break still lands, because HtmlDisplay's table is what supplies it either way.
+        TextExtractor.InnerText(document.GetElementById("t")!).Should().Be("ac\nd");
+    }
+
+    [Test]
+    public void ASpanTurnedIntoABlockByTheAuthorBreaksTheLine()
+    {
+        // The declared value only wins where it differs from HTML's suggested rendering, which is what keeps
+        // AngleSharp's incomplete default sheet from calling every <section> inline.
+        using var document = PageFixture.Parse("<div id=t>a<span style='display:block'>b</span>c</div>");
+
+        TextExtractor.InnerText(document.GetElementById("t")!).Should().Be("a\nb\nc");
+    }
+}


### PR DESCRIPTION
Campaign item **R7** of [#3575](https://github.com/sebastienros/jint/issues/3575): the accessibility tree and
the two extraction payloads an agent actually reads. Everything here is pure C# over AngleSharp's
`IDocument`/`IElement` — no engine, no runtime dependency — which is why it lands before the page runtime does.

## What this adds

**`Jint.Browser/Accessibility/`**

- `AccessibilityTree.Build(IDocument | IElement, AccessibilityOptions)` walks the DOM and answers an `AxNode`
  tree: role, name, description, value, properties, children, an `IElement` back-reference, and an
  `Ignored` verdict with a reason. Identifiers come from a per-document counter in a
  `ConditionalWeakTable<IDocument, …>`, so two builds of an unchanged document agree and a protocol client can
  address a node across calls.
- `ImplicitRole` is HTML-AAM's element-to-role mapping table, implemented in full — every conditional row
  included: `a` on `href`, `input` by `type` and `list`, `li` on its parent, `select` on `multiple`/`size`,
  `th` on `scope`, `summary` on being a `details` summary, `img` on an empty `alt`, and the scope rules that
  make `header`/`footer` a banner or a section header and `aside`/`section` named or generic. An author
  `role` overrides it, validated against the ARIA 1.2 role list, with an unknown or abstract name falling
  back to the implicit role.
- `AccessibleName` is accname 1.2, steps 2A through 2I: `aria-labelledby` with its own traversal rules, the
  embedded-control substitution, `aria-label`, HTML-AAM's native labels (`<label for>` and wrapping labels,
  `alt`, `legend`, `caption`, `figcaption`, `optgroup[label]`, the `input[type=submit]` defaults,
  `placeholder` as the last native fallback), name from content for the roles that allow it, the visited
  guard, and the whitespace flattening. Descriptions follow HTML-AAM: `aria-describedby`, then a `title` the
  name did not consume, then a `placeholder` it did not consume.
- `ElementVisibility` is what "hidden" means without a layout, and `AccessibilitySnapshot.Render` is the
  compact `- role "name" [attrs]:` text Playwright's `ariaSnapshot` established, because agents are judged by
  tokens.

**CDP shape.** `Jint.Browser` does not reference `Jint.DevTools`, so `AxProtocolNode` mirrors
`Accessibility.AXNode` here — `nodeId`, `ignored`, `ignoredReasons`, `role`, `name`, `description`, `value`,
`properties[]`, `parentId`, `childIds` — with a `System.Text.Json` source-generated writer and a converter
that emits each `AXValue` as the JSON primitive its type tag calls for. `ToProtocol` converts one node and
`Flatten` produces the list `getFullAXTree` answers with, so C5 maps it in one statement. `backendDOMNodeId`
stays null: only a session that owns a DOM node registry can fill it in.

**`Jint.Browser/Extraction/`**

- `TextExtractor.InnerText` is HTML's rendered text collection steps — white-space processing, `<br>`, cell
  tabs and row line feeds, two required breaks around a `<p>` and one around any other block-level box, the
  runs collapsed to their maximum and trimmed.
- `MarkdownExtractor.ToMarkdown` renders CommonMark with GFM pipe tables: headings, paragraphs, emphasis,
  inline code, fenced blocks with the language from the class, links and images with URLs resolved against
  the document's base, ordered/unordered/nested lists, block quotes, rules, definition lists,
  `<details>`/`<summary>`, escaping. `MarkdownOptions` carries `IncludeImages`, `MaxLength` (truncated at a
  word boundary with a marker) and `MainContentOnly` — the token-budget feature an agent wants.

## The three things layout would have answered

Stated in the new `Jint.Browser/AGENTS.md` section, and worth repeating here because they are what a reader
will mistake for a bug:

- **Hidden** is the `hidden` attribute, `aria-hidden="true"` and `display:none`/`visibility:hidden` from
  `IElement.ComputeCurrentStyle()`, falling back to the `style` content attribute when `AngleSharp.Css` is
  absent. Nothing here knows that an element is off screen, clipped or covered. `display:none` takes its
  subtree with it and `visibility:hidden` does not, because CSS inherits `visibility` and a
  `visibility:visible` descendant comes back. `aria-hidden` removes a node from the accessibility tree and
  changes nothing about the rendering, so the extractors ignore it and only the tree does not.
- **Block-level** is HTML's suggested rendering, not the cascade — the cascade only wins where it *differs*
  from the table. That is what makes `<span style="display:block">` a block and stops AngleSharp's default
  sheet from calling every `<section>` inline.
- **`innerText`** is therefore the text of the document, not of a rendering of it: nothing wraps, so a
  paragraph is one line however wide it would have been.

## Simplifications, named

Four in accname, each needing a resolver this package does not have: CSS generated content (`::before`,
`::after`, `::marker`) contributes nothing, `text-transform` is not applied, SVG `<title>`/`<desc>` children
are not read, and the inter-child spacing rule uses HTML's suggested display rather than a used one. One
blanket simplification in the role table: where HTML-AAM names a computed role that is not a WAI-ARIA role
(`html-abbr`, `html-audio`, `keyboard`, `variable` and their kind) the element maps to `generic`.

## Tests

310 new cases in `Jint.Tests.Browser`, all table-driven where the thing under test is a table.

- 98 role-mapping cases, one per HTML-AAM row that this implements, each naming the markup rather than the
  element so the conditional rows are actually exercised.
- 41 name-and-description cases covering every accname step, the `aria-labelledby` chain, a hidden referenced
  label (2A's exception), a presentational `alt=""` image, a button naming itself from a nested image, the
  embedded-control substitution, and the visited guard that stops a control naming itself through its own
  label.
- The tree walk: pruning, hidden subtrees, the `visibility:visible` descendant, a style-sheet
  `display:none`, the no-cascade fallback, stable identifiers across two builds, 31 property cases.
- The protocol shape asserted on the JSON rather than on the record, because the JSON is the contract.
- 32 `innerText` cases and 43 markdown cases with exact expected output.
- Four fixture pages — a form, an article, a nav and a TodoMVC-like page — rendered three ways each into
  checked-in golden files. `JINT_BROWSER_GOLDEN=update` rewrites them, the `JINT_SPEC_ANCHORS` discipline:
  the diff is the artefact.

## AngleSharp findings

Recorded in `Jint.Browser/AGENTS.md` rather than worked around silently, per this package's rule. All four are
`AngleSharp.Css` 1.0.2:

| What | The standard | AngleSharp.Css |
| --- | --- | --- |
| `ComputeCurrentStyle()` with no CSS services | an empty declaration, or a documented failure | throws `InvalidOperationException("Sequence contains no elements")` |
| the default sheet's `display` rules | `display: block` for `section`, `article`, `nav`, `aside`, `header`, `footer`, `main`, `figure`, `figcaption`, `details`, `summary`, `dialog`, `hgroup` | no rule at all, so every one reads as inline |
| `[hidden] { display: none }` | in HTML's rendering section | absent, so `<div hidden>` computes `display: block` |
| `textarea { white-space: pre-wrap }` | in HTML's rendering section | absent, though the `pre` rule is there |

The first is why every cascade call here is guarded and the guard latches; the rest are why `HtmlDisplay` is
the authority for layout questions rather than the cascade.

Nothing outside `Jint.Browser/Accessibility/`, `Jint.Browser/Extraction/`,
`Jint.Tests.Browser/Accessibility/`, `Jint.Tests.Browser/Extraction/` and one appended `AGENTS.md` section is
touched. Rebased onto #3648; the only overlap with it was that appended section, and both are kept.
`Jint.Browser/AGENTS.md` now sits at 29,095 bytes against the 32,768 cap, so the next section that lands
there needs a trap/remedy split rather than another append.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
