### PR TITLE
Function: a bound function is a Function, so everything that asks by type gets the right answer

### DIFF
--- a/Jint.Tests.DevTools/Session/RemoteObjectTests.cs
+++ b/Jint.Tests.DevTools/Session/RemoteObjectTests.cs
@@ -244,6 +244,22 @@ public class RemoteObjectTests
         result.TryGetProperty("preview", out _).Should().BeFalse("a function's declaration is already its description");
     }
 
+    /// <summary>
+    /// A bound function is a function to the front end — Chrome sends <c>type: "function"</c> and the
+    /// nameless native placeholder for one, never <c>type: "object"</c>.
+    /// </summary>
+    [Test]
+    public async Task ABoundFunctionIsAFunctionAndNotAnObject()
+    {
+        await using var session = await AttachedSession.CreateAsync();
+
+        var result = await session.EvaluateAsync("(function named(a) { return a; }).bind(null)");
+
+        result.GetProperty("type").GetString().Should().Be("function");
+        result.GetProperty("className").GetString().Should().Be("Function");
+        result.GetProperty("description").GetString().Should().Be("function () { [native code] }");
+    }
+
     [Test]
     public async Task AFunctionWithNoSourceIsThePlaceholderChromeSends()
     {

--- a/Jint.Tests.PublicInterface/ValueInspectorTests.cs
+++ b/Jint.Tests.PublicInterface/ValueInspectorTests.cs
@@ -180,6 +180,30 @@ public class ValueInspectorTests
     }
 
     [Test]
+    public void ABoundFunctionIsAFunction()
+    {
+        // A bound function has [[Call]], [[Construct]], a name and a length; V8 reports it as a function and
+        // so does this. It used to fall through to the object walk and describe as `{}`.
+        var bound = Describe("function f(a, b) { return 1; }; f.bind(null, 1)");
+
+        bound.Kind.Should().Be(ValueKind.Function);
+        bound.Description.Should().Be("ƒ bound f()");
+        bound.ClassName.Should().Be("Function");
+    }
+
+    [Test]
+    public void ABoundFunctionsSourceTextNamesNothing()
+    {
+        var engine = new Engine(o => o.RetainFunctionSourceText = true);
+        var options = new ValueInspectorOptions { FunctionSourceText = true };
+
+        // What Function.prototype.toString answers for a bound function, in every engine and here: the
+        // placeholder with no name in it, even though the function's own `name` is "bound f".
+        ValueInspector.Describe(engine.Evaluate("function f(a) { return a; }; f.bind(null)"), options)
+            .Description.Should().Be("function () { [native code] }");
+    }
+
+    [Test]
     public void AFunctionCanBeDescribedByItsSourceInstead()
     {
         var options = new ValueInspectorOptions { FunctionSourceText = true };

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
@@ -1388,11 +1388,12 @@ namespace Jint.Native.Error
 }
 namespace Jint.Native.Function
 {
-    public sealed class BindFunction : Jint.Native.Object.ObjectInstance
+    public sealed class BindFunction : Jint.Native.Function.Function
     {
         public Jint.Native.JsValue[] BoundArguments { get; }
         public Jint.Native.JsValue BoundTargetFunction { get; }
         public Jint.Native.JsValue BoundThis { get; }
+        protected override Jint.Native.JsValue Call(Jint.Native.JsValue thisObject, Jint.Native.JsValue[] arguments) { }
         public override string ToString() { }
     }
     public sealed class EvalFunction : Jint.Native.Function.Function

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net472.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net472.verified.txt
@@ -1211,11 +1211,12 @@ namespace Jint.Native.Error
 }
 namespace Jint.Native.Function
 {
-    public sealed class BindFunction : Jint.Native.Object.ObjectInstance
+    public sealed class BindFunction : Jint.Native.Function.Function
     {
         public Jint.Native.JsValue[] BoundArguments { get; }
         public Jint.Native.JsValue BoundTargetFunction { get; }
         public Jint.Native.JsValue BoundThis { get; }
+        protected override Jint.Native.JsValue Call(Jint.Native.JsValue thisObject, Jint.Native.JsValue[] arguments) { }
         public override string ToString() { }
     }
     public sealed class EvalFunction : Jint.Native.Function.Function

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
@@ -1388,11 +1388,12 @@ namespace Jint.Native.Error
 }
 namespace Jint.Native.Function
 {
-    public sealed class BindFunction : Jint.Native.Object.ObjectInstance
+    public sealed class BindFunction : Jint.Native.Function.Function
     {
         public Jint.Native.JsValue[] BoundArguments { get; }
         public Jint.Native.JsValue BoundTargetFunction { get; }
         public Jint.Native.JsValue BoundThis { get; }
+        protected override Jint.Native.JsValue Call(Jint.Native.JsValue thisObject, Jint.Native.JsValue[] arguments) { }
         public override string ToString() { }
     }
     public sealed class EvalFunction : Jint.Native.Function.Function

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.0.verified.txt
@@ -1211,11 +1211,12 @@ namespace Jint.Native.Error
 }
 namespace Jint.Native.Function
 {
-    public sealed class BindFunction : Jint.Native.Object.ObjectInstance
+    public sealed class BindFunction : Jint.Native.Function.Function
     {
         public Jint.Native.JsValue[] BoundArguments { get; }
         public Jint.Native.JsValue BoundTargetFunction { get; }
         public Jint.Native.JsValue BoundThis { get; }
+        protected override Jint.Native.JsValue Call(Jint.Native.JsValue thisObject, Jint.Native.JsValue[] arguments) { }
         public override string ToString() { }
     }
     public sealed class EvalFunction : Jint.Native.Function.Function

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.1.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.1.verified.txt
@@ -1211,11 +1211,12 @@ namespace Jint.Native.Error
 }
 namespace Jint.Native.Function
 {
-    public sealed class BindFunction : Jint.Native.Object.ObjectInstance
+    public sealed class BindFunction : Jint.Native.Function.Function
     {
         public Jint.Native.JsValue[] BoundArguments { get; }
         public Jint.Native.JsValue BoundTargetFunction { get; }
         public Jint.Native.JsValue BoundThis { get; }
+        protected override Jint.Native.JsValue Call(Jint.Native.JsValue thisObject, Jint.Native.JsValue[] arguments) { }
         public override string ToString() { }
     }
     public sealed class EvalFunction : Jint.Native.Function.Function

--- a/Jint.Tests/Runtime/CallableFlagTests.cs
+++ b/Jint.Tests/Runtime/CallableFlagTests.cs
@@ -22,7 +22,6 @@ public class CallableFlagTests
         var flagSettingRoots = new[]
         {
             typeof(Function),
-            typeof(BindFunction),
             typeof(NamespaceReference),
             // internal: JsProxy and IsHTMLDDA are resolved by name below
         };
@@ -48,27 +47,50 @@ public class CallableFlagTests
 
     /// <summary>
     /// The call path also decides whether a callee gets a call-stack frame from
-    /// <c>InternalTypes.Function</c> rather than <c>is Function</c>, so the flag must be set by
-    /// <see cref="Function"/> and by nothing else. The other <c>ICallable</c> roots must NOT carry it —
-    /// if one did, it would be reinterpreted as a <see cref="Function"/> and pushed onto the call stack.
+    /// <c>InternalTypes.Function</c> rather than <c>is Function</c>, so the flag must agree with the type
+    /// exactly: every <see cref="Function"/> carries it and every other <c>ICallable</c> root does not —
+    /// if one of those did, it would be reinterpreted as a <see cref="Function"/> and pushed onto the call
+    /// stack.
     /// </summary>
     [Test]
     public void OnlyFunctionCarriesTheFunctionFlag()
     {
         var engine = new Engine(options => options.AllowClr(typeof(System.Collections.Generic.List<>).Assembly));
 
-        // a Function: ordinary script function, and a built-in
+        // a Function: ordinary script function, a built-in, and a bound function, which is one too
         AssertFunctionFlag(engine.Evaluate("(function () {})"), expected: true);
         AssertFunctionFlag(engine.Evaluate("String.prototype.charAt"), expected: true);
+        AssertFunctionFlag(engine.Evaluate("(function () {}).bind(null)"), expected: true);   // BindFunction
 
         // ICallable but NOT Function — these must not be reinterpreted as functions
-        AssertFunctionFlag(engine.Evaluate("(function () {}).bind(null)"), expected: false);   // BindFunction
         AssertFunctionFlag(engine.Evaluate("new Proxy(function () {}, {})"), expected: false); // JsProxy
         AssertFunctionFlag(engine.Evaluate("importNamespace('System.Collections.Generic')"), expected: false); // NamespaceReference
 
-        // and calling each of them still works, i.e. the non-Function branch is exercised
+        // and calling each of them still works, i.e. both branches are exercised
         Assert.That(engine.Evaluate("(function (a, b) { return a + b; }).bind(null, 1)(2)").AsNumber(), Is.EqualTo(3d));
         Assert.That(engine.Evaluate("new Proxy(function (a, b) { return a + b; }, {})(1, 2)").AsNumber(), Is.EqualTo(3d));
+    }
+
+    /// <summary>
+    /// What the flag buys, seen from the other side: a bound call now owns a call-stack frame, where before
+    /// the throw inside the target was attributed to the frame of whoever called the bound function.
+    /// </summary>
+    [Test]
+    public void ABoundCallOwnsACallStackFrame()
+    {
+        var engine = new Engine();
+        engine.Execute(
+            """
+            function inner() { return new Error('x'); }
+            function outer() { return inner.bind(null)(); }
+            """,
+            "app.js");
+
+        var stack = engine.Evaluate("outer()").AsObject().Get("stack").AsString();
+        var frames = stack.Split(['\n'], StringSplitOptions.RemoveEmptyEntries).Select(line => line.Trim()).ToArray();
+
+        frames[0].Should().StartWith("at bound inner (app.js:");
+        frames[1].Should().StartWith("at outer (app.js:");
     }
 
     private static void AssertFunctionFlag(Jint.Native.JsValue value, bool expected)

--- a/Jint.Tests/SpecAnchors.txt
+++ b/Jint.Tests/SpecAnchors.txt
@@ -15,7 +15,7 @@
 # resolving here until somebody re-runs that.
 #
 verified: 2026-09-02
-anchors: 1252
+anchors: 1253
 absent: 2
 !proposal-decorators sec-autoaccessordefinitionevaluation  # tc39.es still renders the 2018 descriptor design, which has no such clause
 !proposal-decorators sec-createdecoratorcontextobject  # tc39.es still renders the 2018 descriptor design, which has no such clause
@@ -179,6 +179,7 @@ ecma262 sec-blockdeclarationinstantiation
 ecma262 sec-boolean-constructor-boolean-value
 ecma262 sec-bound-function-exotic-objects
 ecma262 sec-bound-function-exotic-objects-call-thisargument-argumentslist
+ecma262 sec-bound-function-exotic-objects-construct-argumentslist-newtarget
 ecma262 sec-boundfunctioncreate
 ecma262 sec-built-in-function-objects
 ecma262 sec-canbeheldweakly

--- a/Jint/Diagnostics/ValueSlotReader.cs
+++ b/Jint/Diagnostics/ValueSlotReader.cs
@@ -109,6 +109,14 @@ internal static class ValueSlotReader
             return sourceText;
         }
 
+        // A bound function's own name is "bound f", and Function.prototype.toString does not write it: the
+        // representation names nothing, here and in every engine. Reading the name would put a name in this
+        // field that the front end would then parse back out as the function's own.
+        if (function is BindFunction)
+        {
+            return "function () { [native code] }";
+        }
+
         var name = function.GetOwnFunctionNameForDisplay()?.TrimStart('#') ?? "";
         return "function " + name + "() { [native code] }";
     }

--- a/Jint/Native/Function/BindFunction.cs
+++ b/Jint/Native/Function/BindFunction.cs
@@ -6,10 +6,15 @@ namespace Jint.Native.Function;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-bound-function-exotic-objects
 /// </summary>
-public sealed class BindFunction : ObjectInstance, IConstructor, ICallable
+/// <remarks>
+/// A <see cref="Function"/> because that is what it is: a bound function exotic object has
+/// <c>[[Call]]</c>, <c>[[Construct]]</c>, a <c>name</c> and a <c>length</c>, and every describer, console
+/// and debugger protocol that asks "is this a function?" asks it by type. It carries no
+/// <c>[[ECMAScriptCode]]</c>, so it has no source text, no <c>prototype</c> property and no environment;
+/// everything it does it delegates to <see cref="BoundTargetFunction"/>.
+/// </remarks>
+public sealed class BindFunction : Function, IConstructor
 {
-    private readonly Realm _realm;
-
     /// <summary>
     /// Internal because a <see cref="Realm"/> is not something a host can obtain, so nothing outside this
     /// assembly could ever have called it. The way to bind a function is <c>Function.prototype.bind</c>; the
@@ -21,10 +26,8 @@ public sealed class BindFunction : ObjectInstance, IConstructor, ICallable
         ObjectInstance targetFunction,
         JsValue boundThis,
         JsValue[] boundArgs)
-        : base(engine, ObjectClass.Function)
+        : base(engine, realm, name: null)
     {
-        _type |= InternalTypes.Callable;
-        _realm = realm;
         _prototype = proto;
         BoundTargetFunction = targetFunction;
         BoundThis = boundThis;
@@ -46,7 +49,10 @@ public sealed class BindFunction : ObjectInstance, IConstructor, ICallable
     /// </summary>
     public JsValue[] BoundArguments { get; }
 
-    JsValue ICallable.Call(JsValue thisObject, params JsCallArguments arguments)
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-bound-function-exotic-objects-call-thisargument-argumentslist
+    /// </summary>
+    protected internal override JsValue Call(JsValue thisObject, JsCallArguments arguments)
     {
         // Per https://tc39.es/ecma262/#sec-bound-function-exotic-objects-call-thisargument-argumentslist
         // the [[BoundTargetFunction]] only needs to be callable — it is not necessarily a
@@ -67,6 +73,9 @@ public sealed class BindFunction : ObjectInstance, IConstructor, ICallable
         return value;
     }
 
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-bound-function-exotic-objects-construct-argumentslist-newtarget
+    /// </summary>
     ObjectInstance IConstructor.Construct(JsCallArguments arguments, JsValue newTarget)
     {
         var target = BoundTargetFunction as IConstructor;
@@ -118,5 +127,9 @@ public sealed class BindFunction : ObjectInstance, IConstructor, ICallable
 
     internal override bool IsConstructor => BoundTargetFunction.IsConstructor;
 
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-function.prototype.tostring — a bound function is not the function it
+    /// wraps, so the representation names nothing, which is what every engine writes for one.
+    /// </summary>
     public override string ToString() => "function () { [native code] }";
 }

--- a/Jint/Native/Function/Function.cs
+++ b/Jint/Native/Function/Function.cs
@@ -438,14 +438,16 @@ public abstract partial class Function : ObjectInstance, ICallable
     /// </summary>
     internal Realm GetFunctionRealm(JsValue obj)
     {
-        if (obj is Function functionInstance && functionInstance._realm is not null)
-        {
-            return functionInstance._realm;
-        }
-
+        // Step 2 before step 3: a bound function is a Function too, and its own realm is not the answer —
+        // the specification asks its [[BoundTargetFunction]], which is what a cross-realm bind depends on.
         if (obj is BindFunction bindFunctionInstance)
         {
             return GetFunctionRealm(bindFunctionInstance.BoundTargetFunction);
+        }
+
+        if (obj is Function functionInstance && functionInstance._realm is not null)
+        {
+            return functionInstance._realm;
         }
 
         if (obj is JsProxy proxyInstance)

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -4945,6 +4945,51 @@ enough that one extra frame per listener matters. Nothing about what a listener 
 is, what a throwing listener does (report and continue with a `DiagnosticsSink`, erupt without one), or
 whether a handler's return value cancels the event has changed.
 
+### 4.114 `BindFunction` is a `Function` ([#3645](https://github.com/sebastienros/jint/issues/3645))
+
+A bound function exotic object has `[[Call]]`, `[[Construct]]`, a `name` and a `length`, and script always
+saw one as a function — `typeof` answered `"function"` and `Object.prototype.toString` answered
+`[object Function]`. The CLR type did not: `BindFunction` derived from `ObjectInstance`, so everything in
+and around the engine that asks "is this a function?" by type answered no. `Jint.Diagnostics.ValueInspector`
+described `f.bind(null)` as `{}` with `ValueKind.Object`, the console printed it as an empty object, and a
+Chrome DevTools client was sent `type: "object"` for it. It now derives from `Jint.Native.Function.Function`:
+
+```csharp
+// 5.0:  BindFunction : ObjectInstance
+// 5.x:  BindFunction : Function
+var bound = engine.Evaluate("(function f() {}).bind(null)");
+bound.Should().BeAssignableTo<Function>();
+ValueInspector.Describe(bound).Kind;   // was ValueKind.Object, now ValueKind.Function
+```
+
+Three consequences beyond the description.
+
+- **A bound call has a call-stack frame.** The frame is pushed for a `Function` and nothing else, so calling
+  a bound function used to push none — the throw site inside the target was attributed to the *caller's*
+  frame. It is now a frame of its own, named by the bound function's own `name`:
+
+  ```js
+  function inner() { throw new Error('boom'); }
+  function outer() { inner.bind(null)(); }
+  outer();
+  // 5.0:  "at outer (<the throw's location>)"      — one frame, carrying the caller's name
+  // 5.x:  "at bound inner (<the throw's location>)" and "at outer (<the call's location>)"
+  ```
+
+  V8 elides the wrapper and names the frame `inner`; Jint names it after the function that owns it. Either
+  way there is a frame where there was none. It counts against `Options.Constraints.MaxRecursionDepth`, so a
+  host that bounded a deeply recursive bound-function chain to the exact limit has one level less headroom.
+- **`ToObject()` returns a delegate.** Converting a bound function to a CLR value produced a property bag;
+  it now produces the `JsCallDelegate` every other function produces, which is what a host asking for one
+  wanted.
+- **`Function.prototype.toString` is unchanged**, and so is the source text the inspector reports for a
+  bound function: `function () { [native code] }`, with no name in it, exactly as before and as V8 writes
+  it — even though the function's own `name` is `"bound f"`.
+
+**What could break:** a host switching on `is ObjectInstance` before `is Function` (the bound function now
+matches the second), a test comparing a stack trace that crosses a bound call, and a host converting a bound
+function with `ToObject()` and expecting a property bag.
+
 ### 4.115 `performance` is an `EventTarget`, and asking for it brings the events ([#3660](https://github.com/sebastienros/jint/pull/3660))
 
 [HR-Time](https://w3c.github.io/hr-time/#sec-performance) declares `interface Performance : EventTarget`, and


### PR DESCRIPTION
A bound function exotic object has `[[Call]]`, `[[Construct]]`, a `name` and a `length`, and script always
saw one as a function: `typeof` answers `"function"` and `Object.prototype.toString` answers
`[object Function]`. The CLR type did not — `BindFunction` derived from `ObjectInstance` — so everything in
and around the engine that asks "is this a function?" by type answered no:

```csharp
ValueInspector.Describe(engine.Evaluate("(function f() {}).bind(null)")).Kind;
// before: ValueKind.Object, described as "{}"
// after:  ValueKind.Function, described as "ƒ bound f()"
```

The console printed a bound function as an empty object, and a Chrome DevTools client was sent
`type: "object"` where V8 sends `function`.

Of the two fixes the issue offered, this is the first: `BindFunction` now derives from `Function`. It is the
honest shape, and it fixes the inspector, the console formatter and the DevTools mapper at once rather than
teaching each describer a second question. The alternative — keying the describers on `IsCallable()` —
would also have swept in `NamespaceReference`, which is callable and is not a function, so it fixes one
wrong answer by inventing another.

Three things follow, and each is deliberate:

- **`GetFunctionRealm` reorders its two branches.** A bound function is now a `Function` with a realm of its
  own, and https://tc39.es/ecma262/#sec-getfunctionrealm asks its `[[BoundTargetFunction]]` instead — so the
  bound branch has to be tested first, or a cross-realm bind answers with the wrong realm. test262's
  cross-realm bind tests cover it.
- **A bound call owns a call-stack frame**, because the frame is pushed for a `Function` and nothing else. It
  had none, so the throw site inside the target was attributed to the frame of whoever called the bound
  function:

  ```js
  function inner() { throw new Error('boom'); }
  function outer() { inner.bind(null)(); }
  outer();
  // before: one frame, "at outer (<the throw's location>)"
  // after:  "at bound inner (<the throw's location>)" then "at outer (<the call's location>)"
  ```

  V8 elides the wrapper and names the frame `inner`; Jint names it after the function that owns it. Either
  way there is now a frame where there was none, and the location is no longer attributed to the wrong one.
- **`Function.prototype.toString` is unchanged** and so is the source text a debugger protocol is sent:
  `function () { [native code] }`, with no name in it, even though the function's own `name` is `"bound f"`.
  `ValueSlotReader.FunctionSourceText` builds its placeholder from the name, so it now answers for a bound
  function the way `BindFunction.ToString` already did.

**Hot paths touched:** `BindFunction.Call` and `IConstructor.Construct` — a bound call now pushes and pops a
`JintCallStack` frame, as every ordinary call already does, and pays `MaxRecursionDepth` for it. Construction
of a bound function additionally reads `Engine.GetActiveScriptOrModule()` once, from `Function`'s
constructor. No benchmark: the cost is the frame, and the frame is the fix.

### Tests

- `Jint.Tests.PublicInterface/ValueInspectorTests.cs`: a bound function describes as
  `ValueKind.Function` / `ƒ bound f()` / `className: "Function"`, and its source text names nothing. Both
  fail on `main` (`ValueKind.Object`).
- `Jint.Tests.DevTools/Session/RemoteObjectTests.cs`: `Runtime.evaluate` on a bound function sends
  `type: "function"`. Fails on `main`.
- `Jint.Tests/Runtime/CallableFlagTests.cs`: `OnlyFunctionCarriesTheFunctionFlag` moves the bound function
  from the "callable but not a function" list to the "function" list — the test that pinned the old design
  is the test that states the new one — and a new case pins the call-stack frame.
- The public API snapshots are re-accepted; the diff is two lines per target framework (the base class, and
  the `Call` override every other `Function` subclass already shows).
- test262 `built-ins/Function/prototype/bind` and every other suite naming `bind`: 832 tests, all green.

Full solution: green on net472/net8.0/net10.0 (`Jint.Tests` 12 068, `Jint.Tests.PublicInterface` 3 538,
`Jint.Tests.DevTools` 372, test262 102 573).

Fixes #3645

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
