### PR TITLE
DevTools: a Profiler recording is the engine's sampler, and the exact profiler is the fallback

### DIFF
--- a/Jint.DevTools/Domains/AGENTS.md
+++ b/Jint.DevTools/Domains/AGENTS.md
@@ -219,24 +219,28 @@ snapshots, so a value changed after one was handed out is not reflected in it.
 
 The `Profiler` domain answers two questions with two instruments, and neither is the other's fallback.
 
-**A profile comes through `IProfileSource`, and the shipped source is the *exact* profiler.** The engine has
-two: `Engine.Diagnostics.StartProfiling`, which records every call at the call boundary, and the sampling
-profiler of [#3608](https://github.com/sebastienros/jint/pull/3608), which notes what the stack looks like at
-the engine's own check points. Only the first is usable from here, and the reason is a visibility one rather
-than a design one: `SampledProfile` keeps its sample, frame, stack and function tables as `internal` fields
-and publishes a Firefox Profiler document as its only output, so consuming it would mean serializing to JSON
-and parsing it back. **Making those tables public is an engine change**, and when it lands the sampler becomes
-a second `IProfileSource` rather than an edit to the domain — which is why the seam exists before there is a
-second implementation of it. The seam speaks a function table and a balanced stream of enters and leaves,
-deliberately not the engine's own `ScriptProfileFrame`: a seam that names one profiler's type is a seam only
-that profiler fits through.
+**A profile comes through `IProfileSource`, and both of the engine's profilers fit through it.**
+`SampledProfileSource` notes what the stack looks like at the engine's own check points
+([#3608](https://github.com/sebastienros/jint/pull/3608), readable since
+[#3630](https://github.com/sebastienros/jint/issues/3630)); `EventedProfileSource` records every call at the
+call boundary. The seam speaks a function table and a balanced stream of enters and leaves, deliberately not
+either profiler's own type: a seam that names one instrument is a seam only that instrument fits through. A
+sampler converts into that shape losslessly, because two consecutive samples differ by a suffix of the stack
+and that difference is a run of leaves and enters.
+
+**The sampler is what a recording uses, and the choice is made when it starts.** A CDP `Profile` is what
+V8's sampling profiler produces and what `setSamplingInterval` sets the rate of, so it is the instrument a
+front end is asking for; and unlike the exact one it costs the run nothing per call. There is one sampling
+session per engine, though, and it may be the host's own — a client that arrives then is given the exact
+profiler rather than a refusal. What the sampler cannot show is a call it never sampled: a function entered
+and left between two check points is not in the profile at all.
 
 `ProfileBuilder` turns that stream into the protocol's document, and three things about it are decisions:
 
-- **One sample per interval, not per tick.** The stream says exactly when each call happened, so the top of
-  the stack is known for every instant between two activations, and one weighted sample of that node is what
-  the panel wants. The deltas therefore *add up to* the recording rather than approximating it — the only
-  loss is each interval's truncation to whole microseconds.
+- **One sample per interval, not per tick.** The stream says when each activation happened, so the top of the
+  stack is known for every instant between two of them, and one weighted sample of that node is what the
+  panel wants. The deltas therefore *add up to* the recording rather than approximating it, whichever
+  instrument filled the stream in — the only loss is each interval's truncation to whole microseconds.
 - **A node is a call position, not a function.** One function reached from two places is two nodes, which is
   what lets the panel say where the time went rather than only in what.
 - **`(root)` and `(program)`, and nothing else synthetic.** `(program)` takes the time no script function was

--- a/Jint.DevTools/Domains/AGENTS.md
+++ b/Jint.DevTools/Domains/AGENTS.md
@@ -122,13 +122,19 @@ bearing rather than incidental:
 - **Bounded at `MaxScripts`**, oldest first, because a registry that never forgets holds every abstract
   syntax tree a host ever evaluated. A dropped script's identifier stops resolving and its source stops being
   fetchable; run again, it is announced under a new one.
-- **A location is matched back to a script by *name*, not by identity.** A call frame carries a
-  `SourceLocation` and not the program it came from, so `ScriptRegistry.At` takes the scripts under that
-  source name and picks the one whose range contains the position, newest first. Several programs parsed
-  under one name — every `engine.Execute(code)` with no source argument is `<anonymous>` — therefore share
-  one answer, and a location nothing claims is reported against the identifier `0`, which is Chrome's own
-  sentinel for a location it cannot attribute. This is the one place a frame can name the wrong script, and
-  closing it needs an engine seam that puts the program on the frame.
+- **A running position is matched back to a script by identity, never by name.** `CallFrame.Program`, a
+  profile frame's `Program` and `CoverageSource.Program` are the engine seam that carries it
+  ([#3632](https://github.com/sebastienros/jint/issues/3632)), and `ScriptRegistry.For` is a lookup in the
+  same by-reference map `scriptParsed` was minted from. Matching by name is what this replaced, and it must
+  not come back where a program is in hand: every `engine.Execute(code)` with no source argument is
+  `<anonymous>`, so a name answers for every sourceless script at once. A program the engine names none for —
+  `eval`, the `Function` constructor, and a script evicted past `MaxScripts` — is reported against the
+  identifier `0`, Chrome's own sentinel for a location it cannot attribute.
+- **`ScriptRegistry.At` is the fallback, and only a *rendered* stack frame may use it.** A frame of
+  `Error.stack` and a `ConsoleStackFrame` are text — a source name, a line and a column, and no program —
+  so `Runtime.consoleAPICalled`'s `stackTrace` and the frames parsed out of a thrown error's `stack` match by
+  name and range and cannot tell two sourceless scripts apart. Giving those frames a program is a further
+  engine seam; until then, do not reach for `At` from anywhere that has one.
 
 **A source name becomes a URL here, and nowhere else.** The engine's source names stay exactly what the host
 passed — a stack trace prints them, and `Options.Interop.BuildCallStackHandler` is handed them — so

--- a/Jint.DevTools/Domains/DebuggerDomain.Pause.cs
+++ b/Jint.DevTools/Domains/DebuggerDomain.Pause.cs
@@ -523,7 +523,7 @@ internal sealed partial class DebuggerDomain
     private ProtocolCallFrame Frame(int serial, int index, EngineCallFrame frame)
     {
         var location = frame.Location;
-        var script = _target.Scripts!.At(location.SourceFile, location.Start.Line, location.Start.Column);
+        var script = _target.Scripts!.For(frame.Program);
 
         return new ProtocolCallFrame
         {
@@ -610,6 +610,9 @@ internal sealed partial class DebuggerDomain
         }
     }
 
+    /// <summary>
+    /// Where the frame's own function was declared, which lies in the very program the frame is running.
+    /// </summary>
     private ProtocolLocation? FunctionLocation(EngineCallFrame frame)
     {
         if (frame.FunctionLocation is not { } location)
@@ -617,8 +620,7 @@ internal sealed partial class DebuggerDomain
             return null;
         }
 
-        var script = _target.Scripts!.At(location.SourceFile, location.Start.Line, location.Start.Column);
-        return At(script, location.Start.Line, location.Start.Column);
+        return At(_target.Scripts!.For(frame.Program), location.Start.Line, location.Start.Column);
     }
 
     /// <summary>

--- a/Jint.DevTools/Domains/IProfileSource.cs
+++ b/Jint.DevTools/Domains/IProfileSource.cs
@@ -1,4 +1,5 @@
 using System.Runtime.InteropServices;
+using Acornima.Ast;
 using Jint.Profiling;
 
 namespace Jint.DevTools.Domains;
@@ -21,8 +22,9 @@ namespace Jint.DevTools.Domains;
 /// </para>
 /// <para>
 /// <b>Everything here runs on the engine thread</b>, like every other domain member, and the
-/// <see cref="RecordedProfile"/> it hands back holds strings and numbers only — no <c>JsValue</c>, no
-/// abstract syntax tree, no engine.
+/// <see cref="RecordedProfile"/> it hands back holds no <c>JsValue</c> and no engine — a function names the
+/// program it was parsed from, which is the identity a script identifier is looked up by and nothing to
+/// walk.
 /// </para>
 /// </remarks>
 internal interface IProfileSource
@@ -55,12 +57,16 @@ internal interface IProfileSource
 /// <param name="File">The source name the function was parsed under, or <see langword="null"/> for a built-in.</param>
 /// <param name="Line">One-based line of the function's declaration, or <see langword="null"/> with <paramref name="File"/>.</param>
 /// <param name="Column">One-based column of the function's declaration, or <see langword="null"/> with <paramref name="File"/>.</param>
+/// <param name="Program">
+/// The program the function was parsed as part of, which is what gives it a script identifier, or
+/// <see langword="null"/> for one the engine names no program for.
+/// </param>
 /// <remarks>
-/// Deliberately not the engine's own <see cref="ScriptProfileFrame"/>, even though it is the same four
+/// Deliberately not the engine's own <see cref="ScriptProfileFrame"/>, even though it is the same five
 /// members today: a seam that names one profiler's type is a seam only that profiler fits through.
 /// </remarks>
 [StructLayout(LayoutKind.Auto)]
-internal readonly record struct ProfileFunction(string Name, string? File, int? Line, int? Column);
+internal readonly record struct ProfileFunction(string Name, string? File, int? Line, int? Column, Program? Program);
 
 /// <summary>
 /// One function entering or leaving the stack, timestamped against the start of the recording.
@@ -142,7 +148,7 @@ internal sealed class EventedProfileSource : IProfileSource
         for (var i = 0; i < functions.Length; i++)
         {
             var frame = profile.Frames[i];
-            functions[i] = new ProfileFunction(frame.Name, frame.File, frame.Line, frame.Column);
+            functions[i] = new ProfileFunction(frame.Name, frame.File, frame.Line, frame.Column, frame.Program);
         }
 
         var activations = new ProfileActivation[profile.Events.Count];

--- a/Jint.DevTools/Domains/IProfileSource.cs
+++ b/Jint.DevTools/Domains/IProfileSource.cs
@@ -10,15 +10,14 @@ namespace Jint.DevTools.Domains;
 /// </summary>
 /// <remarks>
 /// <para>
-/// The seam exists because the engine has two profilers and the protocol has one profile. Today's
-/// implementation is <see cref="EventedProfileSource"/> over
-/// <c>Engine.Diagnostics.StartProfiling</c>/<c>StopProfiling</c>, which is the only one whose data model this
-/// package can read: the sampling profiler added in
-/// <see href="https://github.com/sebastienros/jint/pull/3608">#3608</see> publishes its sample, frame and
-/// stack tables as <c>internal</c> fields and its only public output is a Firefox Profiler document, so
-/// consuming it here would mean serializing to JSON and parsing it back. Making those tables public is an
-/// engine change, and when it lands the sampler becomes a second implementation of this interface rather
-/// than an edit to the domain.
+/// The seam exists because the engine has two profilers and the protocol has one profile, and both of them
+/// fit through it: <see cref="SampledProfileSource"/> over
+/// <c>Engine.Diagnostics.StartSampling</c>/<c>StopSampling</c>, which is what a client asking for a
+/// <c>Profile</c> at a <c>samplingInterval</c> means, and <see cref="EventedProfileSource"/> over
+/// <c>StartProfiling</c>/<c>StopProfiling</c>, which records every call instead. <c>ProfilerDomain</c>
+/// chooses per recording. The seam speaks a function table and a balanced stream of enters and leaves
+/// deliberately, rather than either profiler's own type: a seam that names one instrument is a seam only
+/// that instrument fits through.
 /// </para>
 /// <para>
 /// <b>Everything here runs on the engine thread</b>, like every other domain member, and the

--- a/Jint.DevTools/Domains/ProfileBuilder.cs
+++ b/Jint.DevTools/Domains/ProfileBuilder.cs
@@ -181,7 +181,7 @@ internal sealed class ProfileBuilder
         }
 
         var column = function.Column ?? 1;
-        var script = _scripts?.At(file, line, column - 1);
+        var script = _scripts?.For(function.Program);
 
         return new ProtocolCallFrame
         {

--- a/Jint.DevTools/Domains/ProfilerDomain.Coverage.cs
+++ b/Jint.DevTools/Domains/ProfilerDomain.Coverage.cs
@@ -129,16 +129,17 @@ internal sealed partial class ProfilerDomain
 
         foreach (var source in report.Sources)
         {
-            // The engine names a source and the registry names a script, and the two meet on that name. A
-            // source no script claims is still reported, against the unattributable identifier, because a
-            // client can do something with ranges it cannot place and nothing with a source that vanished.
-            var script = _target.Scripts?.At(source.Name, line: 1, column: 0);
+            // A coverage source is one parse and names the program it was counted from, so the script it
+            // belongs to is a lookup rather than a guess from a name. A source no script claims is still
+            // reported, against the unattributable identifier, because a client can do something with
+            // ranges it cannot place and nothing with a source that vanished.
+            var script = _target.Scripts?.For(source.Program);
 
             scripts.Add(new ScriptCoverage
             {
                 ScriptId = script?.ScriptId ?? UnknownScriptId,
                 Url = script?.Url ?? ScriptUrl.From(source.Name),
-                Functions = Functions(source, script?.Program, detailed),
+                Functions = Functions(source, source.Program, detailed),
             });
         }
 

--- a/Jint.DevTools/Domains/ProfilerDomain.cs
+++ b/Jint.DevTools/Domains/ProfilerDomain.cs
@@ -37,7 +37,12 @@ internal sealed partial class ProfilerDomain : ProfilerDomainBase
     private static readonly TimeSpan DefaultInterval = TimeSpan.FromMilliseconds(1);
 
     private readonly EngineTarget _target;
-    private readonly IProfileSource _source;
+
+    /// <summary>The source a caller pinned, or <see langword="null"/> to choose one per recording.</summary>
+    private readonly IProfileSource? _fixed;
+
+    /// <summary>The instrument this attachment is recording with, chosen when the recording starts.</summary>
+    private IProfileSource? _source;
 
     private TimeSpan _interval = DefaultInterval;
     private double _startedAtMicroseconds;
@@ -50,15 +55,39 @@ internal sealed partial class ProfilerDomain : ProfilerDomainBase
     private int _recording;
 
     internal ProfilerDomain(EngineTarget target)
-        : this(target, new EventedProfileSource(target.Engine))
+        : this(target, source: null)
     {
     }
 
     /// <summary>Builds the domain over a source of the caller's choosing, which is what a test needs.</summary>
-    internal ProfilerDomain(EngineTarget target, IProfileSource source)
+    internal ProfilerDomain(EngineTarget target, IProfileSource? source)
     {
         _target = target;
-        _source = source;
+        _fixed = source;
+    }
+
+    /// <summary>
+    /// The instrument to record the next profile with.
+    /// </summary>
+    /// <remarks>
+    /// <b>The sampler, unless the engine is already sampling for somebody else.</b> A CDP <c>Profile</c> is
+    /// what V8's sampling profiler produces and what <c>setSamplingInterval</c> sets the rate of, so that is
+    /// the instrument a front end is asking for. There is one sampling session per engine, though, and it
+    /// may be the host's own — a client that arrives then gets the exact profiler rather than a refusal,
+    /// which costs the run more and misses nothing.
+    /// </remarks>
+    private IProfileSource Choose()
+    {
+        if (_fixed is not null)
+        {
+            return _fixed;
+        }
+
+#pragma warning disable JINT0002 // the sampling profiler is the engine's preview area
+        var sampling = _target.Engine.Diagnostics.IsSampling;
+#pragma warning restore JINT0002
+
+        return sampling ? new EventedProfileSource(_target.Engine) : new SampledProfileSource(_target.Engine);
     }
 
     /// <inheritdoc/>
@@ -107,14 +136,22 @@ internal sealed partial class ProfilerDomain : ProfilerDomainBase
             return;
         }
 
+        var source = _source;
+        if (source is null)
+        {
+            return;
+        }
+
         try
         {
             _target.Post(_ =>
             {
-                if (_source.IsRecording)
+                if (source.IsRecording)
                 {
-                    _source.Stop();
+                    source.Stop();
                 }
+
+                _source = null;
             });
         }
         catch (ObjectDisposedException)
@@ -148,9 +185,11 @@ internal sealed partial class ProfilerDomain : ProfilerDomainBase
             return new ValueTask<EmptyResult>(EmptyResult.Instance);
         }
 
+        var source = Choose();
+
         try
         {
-            _source.Start(_interval);
+            source.Start(_interval);
         }
         catch (InvalidOperationException exception)
         {
@@ -158,6 +197,8 @@ internal sealed partial class ProfilerDomain : ProfilerDomainBase
                 "The engine cannot record a profile",
                 exception.Message);
         }
+
+        _source = source;
 
         _startedAtMicroseconds = EngineTarget.UnixMilliseconds() * MicrosecondsPerMillisecond;
         Volatile.Write(ref _recording, 1);
@@ -182,7 +223,8 @@ internal sealed partial class ProfilerDomain : ProfilerDomainBase
                 "send Profiler.start first; a profile is the engine's and only one is recorded at a time");
         }
 
-        var recorded = _source.Stop();
+        var recorded = _source!.Stop();
+        _source = null;
 
         return new ValueTask<StopResponse>(new StopResponse
         {

--- a/Jint.DevTools/Domains/SampledProfileSource.cs
+++ b/Jint.DevTools/Domains/SampledProfileSource.cs
@@ -1,0 +1,140 @@
+using Jint.Profiling;
+
+#pragma warning disable JINT0002 // the sampling profiler is the engine's preview area; this is what it is for
+
+namespace Jint.DevTools.Domains;
+
+/// <summary>
+/// The engine's sampling profiler, which notes what the call stack looks like at the engine's own check
+/// points.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the instrument a Performance panel asks for: a client sets a rate with
+/// <c>Profiler.setSamplingInterval</c> and gets back where the time went, at a cost the recording does not
+/// change. What it cannot show is a call it never sampled — a function entered and left between two check
+/// points is not in the profile at all, where <see cref="EventedProfileSource"/> records every one of them
+/// and charges the run for it.
+/// </para>
+/// <para>
+/// <b>Samples become a balanced stream of enters and leaves</b>, which is what
+/// <see cref="RecordedProfile"/> speaks and what makes the seam fit both instruments. The direction is
+/// lossless: two consecutive samples differ by a suffix of the stack, so the difference between them is a
+/// run of leaves followed by a run of enters, all at the later sample's timestamp. Time between two samples
+/// therefore belongs to the stack observed at the earlier one, which is exactly what the sampler saw.
+/// </para>
+/// <para>
+/// The sampler's own synthetic <c>(program)</c> root is dropped rather than carried through, because
+/// <see cref="ProfileBuilder"/> has one of its own and takes the time no script function was on the stack.
+/// Two would be a tree with the node twice in it.
+/// </para>
+/// </remarks>
+internal sealed class SampledProfileSource : IProfileSource
+{
+    /// <summary>
+    /// The function index of the sampler's synthetic root, which every sampled stack hangs off.
+    /// </summary>
+    private const int ProgramFunction = 0;
+
+    private const long NanosecondsPerTick = 100;
+
+    private readonly Engine _engine;
+
+    internal SampledProfileSource(Engine engine)
+    {
+        _engine = engine;
+    }
+
+    /// <inheritdoc/>
+    public bool IsRecording => _engine.Diagnostics.IsSampling;
+
+    /// <inheritdoc/>
+    public void Start(TimeSpan interval)
+        => _engine.Diagnostics.StartSampling(new SamplingOptions { Interval = interval });
+
+    /// <inheritdoc/>
+    public RecordedProfile Stop()
+    {
+        var profile = _engine.Diagnostics.StopSampling();
+
+        var functions = new ProfileFunction[profile.Functions.Count];
+        for (var i = 0; i < functions.Length; i++)
+        {
+            var function = profile.Functions[i];
+            functions[i] = new ProfileFunction(function.Name, function.File, function.Line, function.Column, function.Program);
+        }
+
+        var activations = new List<ProfileActivation>();
+        var previous = new List<int>();
+        var current = new List<int>();
+
+        foreach (var sample in profile.Samples)
+        {
+            Read(profile, sample.Stack, current);
+
+            var at = Nanoseconds(sample.Time);
+            var shared = SharedPrefix(previous, current);
+
+            for (var i = previous.Count - 1; i >= shared; i--)
+            {
+                activations.Add(new ProfileActivation(Entered: false, previous[i], at));
+            }
+
+            for (var i = shared; i < current.Count; i++)
+            {
+                activations.Add(new ProfileActivation(Entered: true, current[i], at));
+            }
+
+            (previous, current) = (current, previous);
+        }
+
+        // Whatever was on the stack at the last sample was there until the session ended.
+        var duration = Nanoseconds(profile.Duration);
+        for (var i = previous.Count - 1; i >= 0; i--)
+        {
+            activations.Add(new ProfileActivation(Entered: false, previous[i], duration));
+        }
+
+        // A session that reached MaxSamples describes the beginning of the run and says nothing about the
+        // rest of it, which is what a client reads Truncated for.
+        return new RecordedProfile(functions, activations, duration, profile.DroppedSampleCount > 0);
+    }
+
+    /// <summary>
+    /// Reads one sampled stack into <paramref name="stack"/>, outermost function first and without the
+    /// sampler's synthetic root.
+    /// </summary>
+    private static void Read(SampledProfile profile, int node, List<int> stack)
+    {
+        stack.Clear();
+
+        // The tree is parent-linked, so the walk is innermost first and the order is put right afterwards.
+        for (var index = node; index >= 0; index = profile.Stacks[index].Parent)
+        {
+            var function = profile.Frames[profile.Stacks[index].Frame].Function;
+            if (function != ProgramFunction)
+            {
+                stack.Add(function);
+            }
+        }
+
+        stack.Reverse();
+    }
+
+    /// <summary>How much of two consecutive stacks is the same run of calls, which stays open across them.</summary>
+    private static int SharedPrefix(List<int> previous, List<int> current)
+    {
+        var length = Math.Min(previous.Count, current.Count);
+        for (var i = 0; i < length; i++)
+        {
+            if (previous[i] != current[i])
+            {
+                return i;
+            }
+        }
+
+        return length;
+    }
+
+    private static long Nanoseconds(TimeSpan value) => value.Ticks * NanosecondsPerTick;
+}

--- a/Jint.DevTools/Domains/ScriptRegistry.cs
+++ b/Jint.DevTools/Domains/ScriptRegistry.cs
@@ -106,14 +106,38 @@ internal sealed class ScriptRegistry
     }
 
     /// <summary>
-    /// Answers which script a running location belongs to, or <see langword="null"/> when none is known.
+    /// Answers which script a program is, or <see langword="null"/> when none is known.
     /// </summary>
     /// <remarks>
-    /// A call frame carries a <c>SourceLocation</c> and not the program it came from, so the answer is
-    /// reconstructed: among the scripts parsed under that source name, the one whose own range contains the
-    /// position, and failing that the most recently parsed. Several unnamed scripts therefore share one
-    /// source name and the newest wins, which is a divergence from Chrome — where every frame carries the
-    /// script identifier the engine recorded for it.
+    /// The engine hands the program itself to a call frame, a profile frame and a coverage source, so the
+    /// answer is a lookup by reference rather than a guess from a source name — which is what keeps two
+    /// scripts parsed under one name (every sourceless <c>Execute</c> is <c>&lt;anonymous&gt;</c>) apart.
+    /// Null for a program the engine reached another way — <c>eval</c>, the <c>Function</c> constructor —
+    /// and for one this registry has forgotten.
+    /// </remarks>
+    internal RegisteredScript? For(Program? program)
+    {
+        if (program is null)
+        {
+            return null;
+        }
+
+        lock (_gate)
+        {
+            return _byProgram.GetValueOrDefault(program);
+        }
+    }
+
+    /// <summary>
+    /// Answers which script a rendered stack frame belongs to, or <see langword="null"/> when none is known.
+    /// </summary>
+    /// <remarks>
+    /// <b>The name-and-range fallback, and the only place left that needs one.</b> A frame of a rendered
+    /// stack trace — a <c>ConsoleStackFrame</c>, a line of <c>Error.stack</c> — is text, so all it carries
+    /// is a source name and a position: among the scripts registered under that name, the one whose own
+    /// range contains the position, and failing that the most recently parsed. Several programs parsed under
+    /// one name therefore share one answer. Anything that has the program itself resolves through
+    /// <see cref="For"/> instead, and must: this cannot tell two sourceless scripts apart.
     /// </remarks>
     internal RegisteredScript? At(string? sourceFile, int line, int column)
     {

--- a/Jint.DevTools/Jint.DevTools.csproj
+++ b/Jint.DevTools/Jint.DevTools.csproj
@@ -51,9 +51,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- The AST reaches this assembly in exactly one place — `Prepared<Script>`, which is what a compiled
-         script is — so the repository-wide Acornima global usings would be noise. That one file names the
-         namespace itself, which is also how a reader sees that the dependency is one type deep. -->
+    <!-- The AST reaches this assembly as one type — the `Program` a script registry is keyed on, which is
+         also what a `Prepared<Script>` carries — so the repository-wide Acornima global usings would be
+         noise. The few files that name it name the namespace themselves, which is also how a reader sees
+         that the dependency is one type deep. -->
     <Using Remove="Acornima" />
     <Using Remove="Acornima.Ast" />
   </ItemGroup>

--- a/Jint.Tests.DevTools/Session/DebuggerScriptIdentityTests.cs
+++ b/Jint.Tests.DevTools/Session/DebuggerScriptIdentityTests.cs
@@ -1,0 +1,150 @@
+using System.Text.Json;
+using Jint.DevTools.Protocol;
+using Jint.DevTools.Protocol.Profiler;
+
+namespace Jint.Tests.DevTools.Session;
+
+/// <summary>
+/// Which script a position belongs to, when the source name cannot say.
+/// </summary>
+/// <remarks>
+/// Every <c>engine.Execute(code)</c> given no source argument is parsed under one name, so a server matching
+/// a position back to a script by name answers for all of them at once. The engine hands the program itself
+/// to a call frame, a profile frame and a coverage source, and this suite is what says the registry looks it
+/// up rather than guessing.
+/// </remarks>
+[NonParallelizable]
+public class DebuggerScriptIdentityTests
+{
+    /// <summary>
+    /// Declares the function and stops in it, without calling it — so the pause happens later, while a
+    /// second script of the same name is the newest one.
+    /// </summary>
+    private const string Definition = """
+        function work() {
+            debugger;
+            return 1;
+        }
+        """;
+
+    /// <summary>
+    /// The caller, parsed under the same name and <em>longer</em> than the definition, so the position the
+    /// pause happens at lies inside this script's range as well. That is the whole of what a name-and-range
+    /// match has to go on, and it picks the newest.
+    /// </summary>
+    private const string Caller = """
+        // A second script under the one name every sourceless Execute is parsed with.
+        // It is deliberately taller and wider than the definition above, so that every
+        // position in that one is inside this one's range too.
+        work();
+        """;
+
+    [Test]
+    public async Task TwoSourcelessScriptsWithOverlappingPositionsKeepTheirOwnScriptIds()
+    {
+        await using var session = await AttachedSession.CreateAsync();
+        await session.EnableDebuggerAsync();
+
+        var running = session.Target.PostAsync(engine =>
+        {
+            engine.Execute(Definition);
+            engine.Execute(Caller);
+        });
+
+        var paused = await session.EventAsync("Debugger.paused");
+        await session.ResultAsync("Debugger.resume");
+        await running;
+
+        var parsed = session.EventsOf("Debugger.scriptParsed")
+            .Select(sent => sent.GetProperty("params"))
+            .ToList();
+
+        var announced = parsed.Select(script => script.GetProperty("scriptId").GetString()).ToList();
+
+        announced.Should().HaveCount(2, "two parses are two scripts, whatever they were named");
+        announced.Should().OnlyHaveUniqueItems();
+
+        parsed.Select(script => script.GetProperty("url").GetString())
+            .Distinct().Should().ContainSingle("both were parsed under the one name a sourceless Execute gets");
+
+        var frames = paused.GetProperty("callFrames").EnumerateArray().ToList();
+        frames.Should().HaveCount(2);
+
+        // The two frames of one pause belong to two different scripts of one name, which is the answer a
+        // match on that name cannot give.
+        ScriptIdOf(frames[0]).Should().Be(announced[0], "the function it stopped in was declared in the first script");
+        ScriptIdOf(frames[1]).Should().Be(announced[1], "the top-level frame is running the second");
+
+        // the frame's function was declared in the program the frame is running
+        FunctionScriptIdOf(frames[0]).Should().Be(announced[0]);
+    }
+
+    /// <summary>
+    /// The other half of the same seam: a cached program is one script however often it runs, so a client
+    /// stepping through a second run addresses the frames by the identifier it already has.
+    /// </summary>
+    [Test]
+    public async Task APreparedScriptRunTwiceIsOneScriptInEveryPause()
+    {
+        await using var session = await AttachedSession.CreateAsync();
+        await session.EnableDebuggerAsync();
+
+        var prepared = Engine.PrepareScript(Definition + "\nwork();");
+
+        var running = session.Target.PostAsync(engine =>
+        {
+            engine.Execute(prepared);
+            engine.Execute(prepared);
+        });
+
+        var first = await session.EventAsync("Debugger.paused");
+        await session.ResultAsync("Debugger.resume");
+
+        var second = await session.EventAsync("Debugger.paused", index: 1);
+        await session.ResultAsync("Debugger.resume");
+
+        await running;
+
+        session.EventsOf("Debugger.scriptParsed").Should().HaveCount(1);
+        ScriptIdOf(TopFrame(second)).Should().Be(ScriptIdOf(TopFrame(first)));
+    }
+
+    /// <summary>
+    /// Coverage names the parse it counted, so two runs of one text are two scripts in the Coverage panel
+    /// rather than one whose counts are the sum.
+    /// </summary>
+    [Test]
+    public async Task CoverageReportsEachParseUnderItsOwnScript()
+    {
+        await using var session = await AttachedSession.CreateAsync(
+            configureOptions: options => options.Coverage.Enabled = true);
+
+        await session.ResultAsync("Profiler.startPreciseCoverage", """{"callCount":true,"detailed":false}""");
+        await session.Target.PostAsync(engine =>
+        {
+            engine.Execute("function used() { return 1; } used();");
+            engine.Execute("function used() { return 1; } used();");
+        });
+
+        var result = await session.ResultAsync("Profiler.takePreciseCoverage");
+        var scripts = result.GetProperty("result").Deserialize(ProtocolJsonContext.Default.ProfilerScriptCoverageArray)!;
+
+        var unattributed = scripts.Where(script => script.ScriptId == "0").ToList();
+        unattributed.Should().BeEmpty("every parse was announced, so every source resolves");
+
+        scripts.Should().HaveCount(2);
+        scripts.Select(script => script.ScriptId).Should().OnlyHaveUniqueItems();
+        scripts.Select(script => script.Url).Distinct().Should().ContainSingle();
+        scripts.Should().AllSatisfy(script =>
+            script.Functions.Single(function => function.FunctionName == "used").Ranges[0].Count.Should().Be(1));
+    }
+
+    private static string? ScriptIdOf(JsonElement frame)
+        => frame.GetProperty("location").GetProperty("scriptId").GetString();
+
+    private static string? FunctionScriptIdOf(JsonElement frame)
+        => frame.GetProperty("functionLocation").GetProperty("scriptId").GetString();
+
+    private static JsonElement TopFrame(JsonElement paused)
+        => paused.GetProperty("callFrames").EnumerateArray().First();
+}

--- a/Jint.Tests.DevTools/Session/ProfilerSessionTests.cs
+++ b/Jint.Tests.DevTools/Session/ProfilerSessionTests.cs
@@ -2,37 +2,51 @@ using System.Text.Json;
 using Jint.DevTools.Protocol;
 using Jint.DevTools.Protocol.Profiler;
 
+#pragma warning disable JINT0002 // the sampling profiler is the engine's preview area
+
 namespace Jint.Tests.DevTools.Session;
 
 /// <summary>
 /// <c>Profiler.start</c> and <c>Profiler.stop</c>: the document a front end's Performance panel loads.
 /// </summary>
 /// <remarks>
+/// <para>
 /// The assertions are about the two halves the panel reads — a tree of nodes, and a series of samples with
 /// the time between them — plus the one property that makes the second half meaningful: the deltas add up to
 /// the recording. A profile whose tree is right and whose deltas are not renders as an empty flame chart.
+/// </para>
+/// <para>
+/// The instrument behind them is the engine's <em>sampler</em>, so the script is written to be sampled: the
+/// call it should be caught in is the one it spends its time in, and every recording asks for the fastest
+/// rate the protocol can name so that a run this short is observed more than once.
+/// </para>
 /// </remarks>
 [NonParallelizable]
 public class ProfilerSessionTests
 {
     private const string Source = """
         function inner(n) {
-            return n * 2;
+            var total = 0;
+            for (var i = 0; i < n; i++) { total += i % 7; }
+            return total;
         }
 
         function outer(n) {
-            return inner(n) + inner(n + 1);
+            return inner(n) + inner(n);
         }
 
         function work(times) {
             var total = 0;
             for (var i = 0; i < times; i++) {
-                total = total + outer(i);
+                total = total + outer(50);
             }
 
             return total;
         }
         """;
+
+    /// <summary>Enough work to be sampled many times over, and short enough to be a unit test.</summary>
+    private const string Workload = "work(200)";
 
     [Test]
     public async Task AProfileHasANodeForEveryFunctionThatRan()
@@ -43,7 +57,7 @@ public class ProfilerSessionTests
 
         var scriptId = (await session.EventAsync("Debugger.scriptParsed")).GetProperty("scriptId").GetString();
 
-        var profile = await RecordAsync(session, "work(50)");
+        var profile = await RecordAsync(session, Workload);
 
         var byName = profile.Nodes.ToDictionary(node => node.CallFrame.FunctionName, node => node);
 
@@ -72,15 +86,16 @@ public class ProfilerSessionTests
         await using var session = await AttachedSession.CreateAsync();
         await session.Target.PostAsync(engine => engine.Execute(Source, "main.js"));
 
-        var profile = await RecordAsync(session, "work(200)");
+        var profile = await RecordAsync(session, Workload);
 
         profile.Samples.Should().NotBeNull();
         profile.TimeDeltas.Should().NotBeNull();
         profile.Samples!.Length.Should().Be(profile.TimeDeltas!.Length, "the panel reads them as one series");
         profile.EndTime.Should().BeGreaterThanOrEqualTo(profile.StartTime);
 
-        // The source records when every call happened rather than sampling for it, so this is an equality
-        // and not an approximation: the only loss is the truncation of each interval to whole microseconds.
+        // The deltas are the intervals between the moments the source observed, so they telescope: whatever
+        // the instrument was, they cover the recording rather than approximating it. The only loss is the
+        // truncation of each interval to whole microseconds.
         var total = profile.TimeDeltas.Sum(delta => (long) delta);
         var recorded = (long) (profile.EndTime - profile.StartTime);
 
@@ -129,7 +144,7 @@ public class ProfilerSessionTests
 
         await session.ResultAsync("Profiler.enable");
         await session.ResultAsync("Profiler.start");
-        await session.Target.PostAsync(engine => engine.Evaluate("work(10)"));
+        await session.Target.PostAsync(engine => engine.Evaluate(Workload));
         await session.ResultAsync("Profiler.start");
 
         var profile = await StopAsync(session);
@@ -137,7 +152,7 @@ public class ProfilerSessionTests
     }
 
     /// <summary>
-    /// The rate a client asks for is accepted, because every front end sends it before every recording.
+    /// The rate a client asks for is what the sampler is armed with, which is what the command is for.
     /// </summary>
     [Test]
     public async Task ASamplingIntervalIsAccepted()
@@ -148,8 +163,55 @@ public class ProfilerSessionTests
         await session.ResultAsync("Profiler.setSamplingInterval", """{"interval":100}""");
         await session.ResultAsync("Profiler.start");
 
+        (await session.Target.PostAsync(engine => engine.Diagnostics.IsSampling)).Should().BeTrue();
+
         var profile = await StopAsync(session);
-        profile.Nodes.Should().NotBeEmpty("the profiler answers whatever rate it was told, having none of its own");
+        profile.Nodes.Should().NotBeEmpty();
+    }
+
+    /// <summary>
+    /// What a Performance panel is opened for: a script that spends its time in one function is a profile
+    /// that says so.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The assertion is on the time deltas rather than on the count of samples, because that is what the
+    /// panel adds up per node — and it is what makes this a statement about where the time went rather than
+    /// about how often the instrument happened to fire.
+    /// </para>
+    /// <para>
+    /// It is about the <em>script's</em> time. A recording is bracketed by two protocol commands, so the
+    /// wall clock between them includes the round trips that carried them, and that time belongs to
+    /// <c>(program)</c> — correctly, and in a proportion no test can pin.
+    /// </para>
+    /// </remarks>
+    [Test]
+    public async Task ACpuBoundScriptAttributesMostOfItsTimeToItsHotFunction()
+    {
+        await using var session = await AttachedSession.CreateAsync();
+        await session.Target.PostAsync(engine => engine.Execute(Source, "main.js"));
+
+        var profile = await RecordAsync(session, Workload);
+
+        var byId = profile.Nodes.ToDictionary(node => node.Id, node => node.CallFrame.FunctionName);
+        var byFunction = new Dictionary<string, long>(StringComparer.Ordinal);
+
+        for (var i = 0; i < profile.Samples!.Length; i++)
+        {
+            var name = byId[profile.Samples[i]];
+            byFunction[name] = byFunction.GetValueOrDefault(name) + profile.TimeDeltas![i];
+        }
+
+        var script = byFunction
+            .Where(entry => entry.Key is not "(program)" and not "(root)")
+            .OrderByDescending(entry => entry.Value)
+            .ToList();
+
+        var total = script.Sum(entry => entry.Value);
+        total.Should().BeGreaterThan(0, "the script ran, so some of the recording is its");
+
+        script[0].Key.Should().Be("inner", "that is the function the loop is in");
+        script[0].Value.Should().BeGreaterThan(total / 2, "most of the script's time was spent there");
     }
 
     /// <summary>
@@ -164,16 +226,44 @@ public class ProfilerSessionTests
         await session.ResultAsync("Profiler.start");
         await session.ResultAsync("Profiler.disable");
 
-        (await session.Target.PostAsync(engine => engine.Diagnostics.IsProfiling)).Should().BeFalse();
+        (await session.Target.PostAsync(engine => engine.Diagnostics.IsSampling)).Should().BeFalse();
 
         var error = await session.ErrorAsync("Profiler.stop");
         error.GetProperty("message").GetString().Should().Be("No profile is being recorded");
     }
 
+    /// <summary>
+    /// The engine allows one sampling session, and it may be the host's own — a client that arrives then is
+    /// given the exact profiler rather than a refusal.
+    /// </summary>
+    [Test]
+    public async Task AHostAlreadySamplingLeavesTheClientTheOtherInstrument()
+    {
+        await using var session = await AttachedSession.CreateAsync();
+        await session.Target.PostAsync(engine => engine.Execute(Source, "main.js"));
+        await session.Target.PostAsync(engine => engine.Diagnostics.StartSampling());
+
+        await session.ResultAsync("Profiler.enable");
+        await session.ResultAsync("Profiler.start");
+        await session.Target.PostAsync(engine => engine.Evaluate(Workload));
+
+        var profile = await StopAsync(session);
+        profile.Nodes.Select(node => node.CallFrame.FunctionName).Should().Contain("inner");
+
+        // the host's own session is untouched by the one the client asked for
+        (await session.Target.PostAsync(engine => engine.Diagnostics.IsSampling)).Should().BeTrue();
+        await session.Target.PostAsync(engine => engine.Diagnostics.StopSampling());
+    }
+
     /// <summary>Records <paramref name="expression"/> and hands back the profile of it.</summary>
+    /// <remarks>
+    /// The rate is the fastest the protocol can name — a client's zero means "as fast as you can" — because
+    /// a workload short enough for a unit test has to be observed more than once.
+    /// </remarks>
     private static async Task<Profile> RecordAsync(AttachedSession session, string expression)
     {
         await session.ResultAsync("Profiler.enable").ConfigureAwait(false);
+        await session.ResultAsync("Profiler.setSamplingInterval", """{"interval":0}""").ConfigureAwait(false);
         await session.ResultAsync("Profiler.start").ConfigureAwait(false);
         await session.Target.PostAsync(engine => engine.Evaluate(expression)).ConfigureAwait(false);
 

--- a/Jint.Tests.PublicInterface/CodeCoverageTests.cs
+++ b/Jint.Tests.PublicInterface/CodeCoverageTests.cs
@@ -29,10 +29,17 @@ public class CodeCoverageTests
     private static string Text(string code, CoverageEntry entry)
         => code.Substring(entry.Start.Index, entry.End.Index - entry.Start.Index);
 
+    /// <summary>
+    /// Every entry counted under the one source name, totalled by construct. A source is one parse, so a
+    /// host that runs the same text twice reads two of them and adds them up exactly like this.
+    /// </summary>
     private static List<(string Text, CoverageEntryKind Kind, long Hits)> Rows(string code, CoverageReport report)
         => report.Sources
-            .Single(s => s.Name == Source).Entries
-            .Select(e => (Text(code, e), e.Kind, e.HitCount))
+            .Where(s => s.Name == Source)
+            .SelectMany(s => s.Entries)
+            .GroupBy(e => (Start: e.Start.Index, End: e.End.Index, e.Kind))
+            .OrderBy(g => g.Key.Start).ThenBy(g => g.Key.End).ThenBy(g => g.Key.Kind)
+            .Select(g => (Text(code, g.First()), g.Key.Kind, g.Sum(e => e.HitCount)))
             .ToList();
 
     // ---- reachability ----
@@ -165,6 +172,50 @@ public class CodeCoverageTests
 
         engine.Diagnostics.GetCoverage().Sources.Select(s => s.Name)
             .Should().Equal("<anonymous>", "alpha.js", "beta.js");
+    }
+
+    /// <summary>
+    /// A source is one parse, named by the program it came from — which is what a coverage tool maps back to
+    /// the script it prepared, and what a source name cannot answer once two parses share one.
+    /// </summary>
+    [Test]
+    public void EachParseIsASourceOfItsOwnNamingItsProgram()
+    {
+        const string Code = "var a = 1;";
+
+        var engine = CreateEngine();
+        engine.Execute(Code);
+        engine.Execute(Code);
+
+        var sources = engine.Diagnostics.GetCoverage().Sources;
+
+        sources.Should().HaveCount(2);
+        sources.Select(s => s.Name).Should().AllBe("<anonymous>");
+        sources.Select(s => s.Program).Should().OnlyHaveUniqueItems();
+        sources.Should().AllSatisfy(s => s.Program.Should().NotBeNull());
+
+        // and the total under one name is the reader's to add up
+        sources.SelectMany(s => s.Entries).Sum(e => e.HitCount).Should().Be(2L);
+    }
+
+    /// <summary>
+    /// A prepared script is one program however often a host runs it, which is the shape an embedder that
+    /// caches its scripts actually reads.
+    /// </summary>
+    [Test]
+    public void APreparedScriptIsOneSourceHoweverOftenItRuns()
+    {
+        var prepared = Engine.PrepareScript("var a = 1;", Source);
+
+        var engine = CreateEngine();
+        engine.Execute(prepared);
+        engine.Execute(prepared);
+
+        var sources = engine.Diagnostics.GetCoverage().Sources;
+
+        sources.Should().ContainSingle();
+        sources[0].Program.Should().BeSameAs(prepared.Program);
+        sources[0].Entries.Single().HitCount.Should().Be(2L);
     }
 
     // ---- engine isolation, which is what makes the feature usable at all ----

--- a/Jint.Tests.PublicInterface/HostFrameProgramTests.cs
+++ b/Jint.Tests.PublicInterface/HostFrameProgramTests.cs
@@ -1,0 +1,176 @@
+#nullable enable
+
+using System.Collections.Generic;
+using System.Linq;
+using Jint.Runtime.Debugger;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// The program a debugger frame and a profile frame belong to, which is the identity a tooling protocol
+/// answers "which script is this?" with.
+/// </summary>
+/// <remarks>
+/// A location carries a source <em>name</em>, and every <c>Execute</c> given no source is
+/// <c>&lt;anonymous&gt;</c>, so a host matching positions against names collapses every such script into one.
+/// The reference on the frame is the one <c>DebugHandler.BeforeEvaluate</c> hands over, which is what makes
+/// the two answerable apart.
+/// </remarks>
+public class HostFrameProgramTests
+{
+    private const string Script = """
+        function work() {
+            debugger;
+            return 1;
+        }
+        work();
+        """;
+
+    private static Engine CreateDebuggerEngine() => new(options =>
+    {
+        options.Debugger.Enabled = true;
+        options.Debugger.StatementHandling = DebuggerStatementHandling.Script;
+    });
+
+    /// <summary>
+    /// The case a name cannot answer: two programs parsed under one name, at the very same positions.
+    /// </summary>
+    [Test]
+    public void TwoScriptsParsedUnderOneNameAreToldApartByTheirFramesProgram()
+    {
+        var engine = CreateDebuggerEngine();
+
+        var parsed = new List<Program>();
+        engine.Debugger.BeforeEvaluate += (sender, ast) => parsed.Add(ast);
+
+        var paused = new List<Program?>();
+        engine.Debugger.Break += (sender, info) =>
+        {
+            paused.Add(info.CallStack[0].Program);
+            return StepMode.None;
+        };
+
+        engine.Execute(Script);
+        engine.Execute(Script);
+
+        parsed.Should().HaveCount(2);
+        parsed[0].Should().NotBeSameAs(parsed[1]);
+
+        paused.Should().HaveCount(2);
+        paused[0].Should().BeSameAs(parsed[0]);
+        paused[1].Should().BeSameAs(parsed[1]);
+    }
+
+    /// <summary>
+    /// Every frame of the stack answers, the top-level one included — it is the frame a sourceless
+    /// <c>Execute</c> spends most of its time in.
+    /// </summary>
+    [Test]
+    public void EveryFrameOfThePauseNamesTheProgramItIsRunning()
+    {
+        var engine = CreateDebuggerEngine();
+
+        var prepared = Engine.PrepareScript(Script, "host.js");
+
+        DebugCallStack? stack = null;
+        engine.Debugger.Break += (sender, info) =>
+        {
+            stack = info.CallStack;
+            return StepMode.None;
+        };
+
+        engine.Execute(prepared);
+
+        stack.Should().NotBeNull();
+        stack!.Should().HaveCount(2);
+        stack.Should().AllSatisfy(frame => frame.Program.Should().BeSameAs(prepared.Program));
+    }
+
+    /// <summary>
+    /// A shared <c>Prepared&lt;Script&gt;</c> is one program however often it runs, which is what makes the
+    /// identity worth keying a script table on.
+    /// </summary>
+    [Test]
+    public void RunningOnePreparedScriptTwiceNamesTheOneProgram()
+    {
+        var engine = CreateDebuggerEngine();
+        var prepared = Engine.PrepareScript(Script, "host.js");
+
+        var paused = new List<Program?>();
+        engine.Debugger.Break += (sender, info) =>
+        {
+            paused.Add(info.CallStack[0].Program);
+            return StepMode.None;
+        };
+
+        engine.Execute(prepared);
+        engine.Execute(prepared);
+
+        paused.Should().HaveCount(2);
+        paused.Should().AllSatisfy(program => program.Should().BeSameAs(prepared.Program));
+    }
+
+    /// <summary>
+    /// Code the engine reached through <c>eval</c> is a program no execution context names, so the frame
+    /// answers with none rather than with the script that ran the <c>eval</c>.
+    /// </summary>
+    [Test]
+    public void AFrameInsideEvalNamesNoProgram()
+    {
+        var engine = CreateDebuggerEngine();
+
+        var paused = new List<Program?>();
+        engine.Debugger.Break += (sender, info) =>
+        {
+            paused.Add(info.CallStack[0].Program);
+            return StepMode.None;
+        };
+
+        engine.Execute("eval('debugger;');", "host.js");
+
+        paused.Should().ContainSingle();
+        paused[0].Should().BeNull();
+    }
+
+    /// <summary>
+    /// The profiler's frame table answers the same question for a function, so a profile's frames map onto
+    /// the same script table a pause does.
+    /// </summary>
+    [Test]
+    public void AProfileFrameNamesTheProgramItsFunctionWasParsedFrom()
+    {
+        var engine = new Engine(options => options.Profiling.Enabled = true);
+
+        var first = Engine.PrepareScript("function alpha() { return 1; } alpha();");
+        var second = Engine.PrepareScript("function beta() { return 2; } beta();");
+
+        engine.Diagnostics.StartProfiling();
+        engine.Execute(first);
+        engine.Execute(second);
+        var profile = engine.Diagnostics.StopProfiling();
+
+        profile.Frames.Single(f => f.Name == "alpha").Program.Should().BeSameAs(first.Program);
+        profile.Frames.Single(f => f.Name == "beta").Program.Should().BeSameAs(second.Program);
+
+        // both were parsed under the one name every sourceless script gets, which is the collision
+        profile.Frames.Select(f => f.File).Distinct().Should().ContainSingle();
+    }
+
+    /// <summary>
+    /// A built-in and a host callable have no source, so they name no program either — the answer is
+    /// <see langword="null"/> rather than the script that happened to be running when they were created.
+    /// </summary>
+    [Test]
+    public void AFunctionWithNoSourceNamesNoProgram()
+    {
+        var engine = new Engine(options => options.Profiling.Enabled = true);
+        engine.SetValue("host", new System.Func<int>(() => 1));
+
+        engine.Diagnostics.StartProfiling();
+        engine.Execute("[3, 1, 2].sort(function (a, b) { return a - b; }); host();", "host.js");
+        var profile = engine.Diagnostics.StopProfiling();
+
+        profile.Frames.Should().NotBeEmpty();
+        profile.Frames.Should().OnlyContain(f => f.File != null || f.Program == null);
+    }
+}

--- a/Jint.Tests.PublicInterface/HostSamplingProfilerTests.cs
+++ b/Jint.Tests.PublicInterface/HostSamplingProfilerTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Text;
 using Jint.Profiling;
 
@@ -231,5 +232,107 @@ public class HostSamplingProfilerTests
 
         Assert.Throws<ArgumentNullException>(() => profile.WriteTo((Stream) null!));
         Assert.Throws<ArgumentNullException>(() => profile.WriteTo((TextWriter) null!));
+    }
+
+    // ---- the tables, which is what a tool that is not the Firefox Profiler reads ----
+
+    /// <summary>
+    /// The four tables are the document without the document: a host that renders a profile itself, or
+    /// speaks a protocol of its own, reads them rather than writing JSON and parsing it back.
+    /// </summary>
+    [Test]
+    public void TheTablesAnswerWhatTheDocumentWrites()
+    {
+        var engine = new Engine(options => options.Profiling.Enabled = true);
+
+        engine.Diagnostics.StartSampling(new SamplingOptions { Interval = TimeSpan.Zero });
+        engine.Execute(Script, "host.js");
+        var profile = engine.Diagnostics.StopSampling();
+
+        profile.Samples.Should().HaveCount(profile.SampleCount);
+        profile.Functions.Should().NotBeEmpty();
+        profile.Frames.Should().NotBeEmpty();
+        profile.Stacks.Should().NotBeEmpty();
+
+        // Index 0 is the synthetic program function every stack is rooted at.
+        profile.Functions[0].Name.Should().Be("(program)");
+        profile.Functions.Select(function => function.Name).Should().Contain(["hot", "cold"]);
+
+        // every index is in range, and every stack walk terminates at a root
+        foreach (var sample in profile.Samples)
+        {
+            sample.Time.Should().BeGreaterThanOrEqualTo(TimeSpan.Zero);
+            sample.Stack.Should().BeInRange(0, profile.Stacks.Count - 1);
+
+            var node = sample.Stack;
+            var depth = 0;
+            while (node >= 0)
+            {
+                var stack = profile.Stacks[node];
+                stack.Frame.Should().BeInRange(0, profile.Frames.Count - 1);
+                profile.Frames[stack.Frame].Function.Should().BeInRange(0, profile.Functions.Count - 1);
+
+                node = stack.Parent;
+                (++depth).Should().BeLessThan(1000, "a stack walk terminates");
+            }
+        }
+
+        // the samples are in the order they were taken
+        profile.Samples.Select(sample => sample.Time).Should().BeInAscendingOrder();
+    }
+
+    /// <summary>
+    /// The classification a CLR profiler cannot make, which is half the diagnosis for an embedder: whose
+    /// code was on the stack.
+    /// </summary>
+    [Test]
+    public void AFrameSaysWhoseCodeItIsRunning()
+    {
+        var engine = new Engine(options => options.Profiling.Enabled = true);
+        engine.SetValue("host", new Func<int, int>(value => value + 1));
+
+        engine.Diagnostics.StartSampling(new SamplingOptions { Interval = TimeSpan.Zero });
+        engine.Execute("function work() { var t = 0; for (var i = 0; i < 5000; i++) { t += host(i); } return t; } work();", "host.js");
+        var profile = engine.Diagnostics.StopSampling();
+
+        var categories = profile.Frames.Select(frame => frame.Category).Distinct().ToList();
+        categories.Should().Contain(ProfileFrameCategory.Script);
+
+        // a script function names its position and its program; a native one has neither
+        foreach (var frame in profile.Frames)
+        {
+            var function = profile.Functions[frame.Function];
+            if (frame.Category != ProfileFrameCategory.Script)
+            {
+                function.File.Should().BeNull();
+                function.Program.Should().BeNull();
+                frame.Line.Should().BeNull();
+            }
+        }
+
+        var work = profile.Functions.Single(function => function.Name == "work");
+        work.File.Should().Be("host.js");
+        work.Program.Should().NotBeNull();
+    }
+
+    /// <summary>
+    /// A table is a view over what the session recorded, so reading it twice is reading one thing and costs
+    /// no second copy of it.
+    /// </summary>
+    [Test]
+    public void ATableIsAStableViewRatherThanACopy()
+    {
+        var engine = new Engine(options => options.Profiling.Enabled = true);
+        engine.Diagnostics.StartSampling(new SamplingOptions { Interval = TimeSpan.Zero });
+        engine.Execute(Script);
+        var profile = engine.Diagnostics.StopSampling();
+
+        profile.Samples.Should().BeSameAs(profile.Samples);
+        profile.Frames.Should().BeSameAs(profile.Frames);
+        profile.Stacks.Should().BeSameAs(profile.Stacks);
+        profile.Functions.Should().BeSameAs(profile.Functions);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => _ = profile.Samples[profile.Samples.Count]);
+        Assert.Throws<ArgumentOutOfRangeException>(() => _ = profile.Stacks[-1]);
     }
 }

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
@@ -1934,11 +1934,12 @@ namespace Jint.Profiling
     }
     public readonly struct ScriptProfileFrame : System.IEquatable<Jint.Profiling.ScriptProfileFrame>
     {
-        public ScriptProfileFrame(string Name, string? File, int? Line, int? Column) { }
+        public ScriptProfileFrame(string Name, string? File, int? Line, int? Column, Acornima.Ast.Program? Program = null) { }
         public int? Column { get; init; }
         public string? File { get; init; }
         public int? Line { get; init; }
         public string Name { get; init; }
+        public Acornima.Ast.Program? Program { get; init; }
     }
 }
 namespace Jint.Runtime
@@ -2157,6 +2158,7 @@ namespace Jint.Runtime.Coverage
     {
         public System.Collections.Generic.IReadOnlyList<Jint.Runtime.Coverage.CoverageEntry> Entries { get; }
         public string Name { get; }
+        public Acornima.Ast.Program? Program { get; }
     }
 }
 namespace Jint.Runtime.Debugger
@@ -2194,6 +2196,7 @@ namespace Jint.Runtime.Debugger
         public string FunctionName { get; }
         public int Index { get; }
         public Acornima.SourceLocation& Location { get; }
+        public Acornima.Ast.Program? Program { get; }
         public Jint.Native.JsValue? ReturnValue { get; }
         public Jint.Runtime.Debugger.DebugScopes ScopeChain { get; }
         public Jint.Native.JsValue This { get; }

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
@@ -1893,14 +1893,49 @@ namespace Jint.NodeCompat
 namespace Jint.Profiling
 {
     [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
+    public enum ProfileFrameCategory
+    {
+        Other = 0,
+        Script = 1,
+        BuiltIn = 2,
+        HostInterop = 3,
+    }
+    [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
     public sealed class SampledProfile
     {
         public int DroppedSampleCount { get; }
         public System.TimeSpan Duration { get; }
+        public System.Collections.Generic.IReadOnlyList<Jint.Profiling.SampledProfileFrame> Frames { get; }
+        public System.Collections.Generic.IReadOnlyList<Jint.Profiling.ScriptProfileFrame> Functions { get; }
         public System.TimeSpan Interval { get; }
         public int SampleCount { get; }
+        public System.Collections.Generic.IReadOnlyList<Jint.Profiling.SampledProfileSample> Samples { get; }
+        public System.Collections.Generic.IReadOnlyList<Jint.Profiling.SampledProfileStack> Stacks { get; }
         public void WriteTo(System.IO.Stream stream) { }
         public void WriteTo(System.IO.TextWriter writer) { }
+    }
+    [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
+    public readonly struct SampledProfileFrame : System.IEquatable<Jint.Profiling.SampledProfileFrame>
+    {
+        public SampledProfileFrame(int Function, Jint.Profiling.ProfileFrameCategory Category, int? Line, int? Column) { }
+        public Jint.Profiling.ProfileFrameCategory Category { get; init; }
+        public int? Column { get; init; }
+        public int Function { get; init; }
+        public int? Line { get; init; }
+    }
+    [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
+    public readonly struct SampledProfileSample : System.IEquatable<Jint.Profiling.SampledProfileSample>
+    {
+        public SampledProfileSample(System.TimeSpan Time, int Stack) { }
+        public int Stack { get; init; }
+        public System.TimeSpan Time { get; init; }
+    }
+    [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
+    public readonly struct SampledProfileStack : System.IEquatable<Jint.Profiling.SampledProfileStack>
+    {
+        public SampledProfileStack(int Parent, int Frame) { }
+        public int Frame { get; init; }
+        public int Parent { get; init; }
     }
     [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
     public sealed class SamplingOptions

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net472.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net472.verified.txt
@@ -1751,11 +1751,12 @@ namespace Jint.Profiling
     }
     public readonly struct ScriptProfileFrame : System.IEquatable<Jint.Profiling.ScriptProfileFrame>
     {
-        public ScriptProfileFrame(string Name, string? File, int? Line, int? Column) { }
+        public ScriptProfileFrame(string Name, string? File, int? Line, int? Column, Acornima.Ast.Program? Program = null) { }
         public int? Column { get; init; }
         public string? File { get; init; }
         public int? Line { get; init; }
         public string Name { get; init; }
+        public Acornima.Ast.Program? Program { get; init; }
     }
 }
 namespace Jint.Runtime
@@ -1974,6 +1975,7 @@ namespace Jint.Runtime.Coverage
     {
         public System.Collections.Generic.IReadOnlyList<Jint.Runtime.Coverage.CoverageEntry> Entries { get; }
         public string Name { get; }
+        public Acornima.Ast.Program? Program { get; }
     }
 }
 namespace Jint.Runtime.Debugger
@@ -2011,6 +2013,7 @@ namespace Jint.Runtime.Debugger
         public string FunctionName { get; }
         public int Index { get; }
         public Acornima.SourceLocation& Location { get; }
+        public Acornima.Ast.Program? Program { get; }
         public Jint.Native.JsValue? ReturnValue { get; }
         public Jint.Runtime.Debugger.DebugScopes ScopeChain { get; }
         public Jint.Native.JsValue This { get; }

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net472.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net472.verified.txt
@@ -1711,14 +1711,45 @@ namespace Jint.NodeCompat
 }
 namespace Jint.Profiling
 {
+    public enum ProfileFrameCategory
+    {
+        Other = 0,
+        Script = 1,
+        BuiltIn = 2,
+        HostInterop = 3,
+    }
     public sealed class SampledProfile
     {
         public int DroppedSampleCount { get; }
         public System.TimeSpan Duration { get; }
+        public System.Collections.Generic.IReadOnlyList<Jint.Profiling.SampledProfileFrame> Frames { get; }
+        public System.Collections.Generic.IReadOnlyList<Jint.Profiling.ScriptProfileFrame> Functions { get; }
         public System.TimeSpan Interval { get; }
         public int SampleCount { get; }
+        public System.Collections.Generic.IReadOnlyList<Jint.Profiling.SampledProfileSample> Samples { get; }
+        public System.Collections.Generic.IReadOnlyList<Jint.Profiling.SampledProfileStack> Stacks { get; }
         public void WriteTo(System.IO.Stream stream) { }
         public void WriteTo(System.IO.TextWriter writer) { }
+    }
+    public readonly struct SampledProfileFrame : System.IEquatable<Jint.Profiling.SampledProfileFrame>
+    {
+        public SampledProfileFrame(int Function, Jint.Profiling.ProfileFrameCategory Category, int? Line, int? Column) { }
+        public Jint.Profiling.ProfileFrameCategory Category { get; init; }
+        public int? Column { get; init; }
+        public int Function { get; init; }
+        public int? Line { get; init; }
+    }
+    public readonly struct SampledProfileSample : System.IEquatable<Jint.Profiling.SampledProfileSample>
+    {
+        public SampledProfileSample(System.TimeSpan Time, int Stack) { }
+        public int Stack { get; init; }
+        public System.TimeSpan Time { get; init; }
+    }
+    public readonly struct SampledProfileStack : System.IEquatable<Jint.Profiling.SampledProfileStack>
+    {
+        public SampledProfileStack(int Parent, int Frame) { }
+        public int Frame { get; init; }
+        public int Parent { get; init; }
     }
     public sealed class SamplingOptions
     {

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
@@ -1934,11 +1934,12 @@ namespace Jint.Profiling
     }
     public readonly struct ScriptProfileFrame : System.IEquatable<Jint.Profiling.ScriptProfileFrame>
     {
-        public ScriptProfileFrame(string Name, string? File, int? Line, int? Column) { }
+        public ScriptProfileFrame(string Name, string? File, int? Line, int? Column, Acornima.Ast.Program? Program = null) { }
         public int? Column { get; init; }
         public string? File { get; init; }
         public int? Line { get; init; }
         public string Name { get; init; }
+        public Acornima.Ast.Program? Program { get; init; }
     }
 }
 namespace Jint.Runtime
@@ -2157,6 +2158,7 @@ namespace Jint.Runtime.Coverage
     {
         public System.Collections.Generic.IReadOnlyList<Jint.Runtime.Coverage.CoverageEntry> Entries { get; }
         public string Name { get; }
+        public Acornima.Ast.Program? Program { get; }
     }
 }
 namespace Jint.Runtime.Debugger
@@ -2194,6 +2196,7 @@ namespace Jint.Runtime.Debugger
         public string FunctionName { get; }
         public int Index { get; }
         public Acornima.SourceLocation& Location { get; }
+        public Acornima.Ast.Program? Program { get; }
         public Jint.Native.JsValue? ReturnValue { get; }
         public Jint.Runtime.Debugger.DebugScopes ScopeChain { get; }
         public Jint.Native.JsValue This { get; }

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
@@ -1893,14 +1893,49 @@ namespace Jint.NodeCompat
 namespace Jint.Profiling
 {
     [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
+    public enum ProfileFrameCategory
+    {
+        Other = 0,
+        Script = 1,
+        BuiltIn = 2,
+        HostInterop = 3,
+    }
+    [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
     public sealed class SampledProfile
     {
         public int DroppedSampleCount { get; }
         public System.TimeSpan Duration { get; }
+        public System.Collections.Generic.IReadOnlyList<Jint.Profiling.SampledProfileFrame> Frames { get; }
+        public System.Collections.Generic.IReadOnlyList<Jint.Profiling.ScriptProfileFrame> Functions { get; }
         public System.TimeSpan Interval { get; }
         public int SampleCount { get; }
+        public System.Collections.Generic.IReadOnlyList<Jint.Profiling.SampledProfileSample> Samples { get; }
+        public System.Collections.Generic.IReadOnlyList<Jint.Profiling.SampledProfileStack> Stacks { get; }
         public void WriteTo(System.IO.Stream stream) { }
         public void WriteTo(System.IO.TextWriter writer) { }
+    }
+    [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
+    public readonly struct SampledProfileFrame : System.IEquatable<Jint.Profiling.SampledProfileFrame>
+    {
+        public SampledProfileFrame(int Function, Jint.Profiling.ProfileFrameCategory Category, int? Line, int? Column) { }
+        public Jint.Profiling.ProfileFrameCategory Category { get; init; }
+        public int? Column { get; init; }
+        public int Function { get; init; }
+        public int? Line { get; init; }
+    }
+    [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
+    public readonly struct SampledProfileSample : System.IEquatable<Jint.Profiling.SampledProfileSample>
+    {
+        public SampledProfileSample(System.TimeSpan Time, int Stack) { }
+        public int Stack { get; init; }
+        public System.TimeSpan Time { get; init; }
+    }
+    [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
+    public readonly struct SampledProfileStack : System.IEquatable<Jint.Profiling.SampledProfileStack>
+    {
+        public SampledProfileStack(int Parent, int Frame) { }
+        public int Frame { get; init; }
+        public int Parent { get; init; }
     }
     [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
     public sealed class SamplingOptions

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.0.verified.txt
@@ -1751,11 +1751,12 @@ namespace Jint.Profiling
     }
     public readonly struct ScriptProfileFrame : System.IEquatable<Jint.Profiling.ScriptProfileFrame>
     {
-        public ScriptProfileFrame(string Name, string? File, int? Line, int? Column) { }
+        public ScriptProfileFrame(string Name, string? File, int? Line, int? Column, Acornima.Ast.Program? Program = null) { }
         public int? Column { get; init; }
         public string? File { get; init; }
         public int? Line { get; init; }
         public string Name { get; init; }
+        public Acornima.Ast.Program? Program { get; init; }
     }
 }
 namespace Jint.Runtime
@@ -1974,6 +1975,7 @@ namespace Jint.Runtime.Coverage
     {
         public System.Collections.Generic.IReadOnlyList<Jint.Runtime.Coverage.CoverageEntry> Entries { get; }
         public string Name { get; }
+        public Acornima.Ast.Program? Program { get; }
     }
 }
 namespace Jint.Runtime.Debugger
@@ -2011,6 +2013,7 @@ namespace Jint.Runtime.Debugger
         public string FunctionName { get; }
         public int Index { get; }
         public Acornima.SourceLocation& Location { get; }
+        public Acornima.Ast.Program? Program { get; }
         public Jint.Native.JsValue? ReturnValue { get; }
         public Jint.Runtime.Debugger.DebugScopes ScopeChain { get; }
         public Jint.Native.JsValue This { get; }

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.0.verified.txt
@@ -1711,14 +1711,45 @@ namespace Jint.NodeCompat
 }
 namespace Jint.Profiling
 {
+    public enum ProfileFrameCategory
+    {
+        Other = 0,
+        Script = 1,
+        BuiltIn = 2,
+        HostInterop = 3,
+    }
     public sealed class SampledProfile
     {
         public int DroppedSampleCount { get; }
         public System.TimeSpan Duration { get; }
+        public System.Collections.Generic.IReadOnlyList<Jint.Profiling.SampledProfileFrame> Frames { get; }
+        public System.Collections.Generic.IReadOnlyList<Jint.Profiling.ScriptProfileFrame> Functions { get; }
         public System.TimeSpan Interval { get; }
         public int SampleCount { get; }
+        public System.Collections.Generic.IReadOnlyList<Jint.Profiling.SampledProfileSample> Samples { get; }
+        public System.Collections.Generic.IReadOnlyList<Jint.Profiling.SampledProfileStack> Stacks { get; }
         public void WriteTo(System.IO.Stream stream) { }
         public void WriteTo(System.IO.TextWriter writer) { }
+    }
+    public readonly struct SampledProfileFrame : System.IEquatable<Jint.Profiling.SampledProfileFrame>
+    {
+        public SampledProfileFrame(int Function, Jint.Profiling.ProfileFrameCategory Category, int? Line, int? Column) { }
+        public Jint.Profiling.ProfileFrameCategory Category { get; init; }
+        public int? Column { get; init; }
+        public int Function { get; init; }
+        public int? Line { get; init; }
+    }
+    public readonly struct SampledProfileSample : System.IEquatable<Jint.Profiling.SampledProfileSample>
+    {
+        public SampledProfileSample(System.TimeSpan Time, int Stack) { }
+        public int Stack { get; init; }
+        public System.TimeSpan Time { get; init; }
+    }
+    public readonly struct SampledProfileStack : System.IEquatable<Jint.Profiling.SampledProfileStack>
+    {
+        public SampledProfileStack(int Parent, int Frame) { }
+        public int Frame { get; init; }
+        public int Parent { get; init; }
     }
     public sealed class SamplingOptions
     {

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.1.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.1.verified.txt
@@ -1751,11 +1751,12 @@ namespace Jint.Profiling
     }
     public readonly struct ScriptProfileFrame : System.IEquatable<Jint.Profiling.ScriptProfileFrame>
     {
-        public ScriptProfileFrame(string Name, string? File, int? Line, int? Column) { }
+        public ScriptProfileFrame(string Name, string? File, int? Line, int? Column, Acornima.Ast.Program? Program = null) { }
         public int? Column { get; init; }
         public string? File { get; init; }
         public int? Line { get; init; }
         public string Name { get; init; }
+        public Acornima.Ast.Program? Program { get; init; }
     }
 }
 namespace Jint.Runtime
@@ -1974,6 +1975,7 @@ namespace Jint.Runtime.Coverage
     {
         public System.Collections.Generic.IReadOnlyList<Jint.Runtime.Coverage.CoverageEntry> Entries { get; }
         public string Name { get; }
+        public Acornima.Ast.Program? Program { get; }
     }
 }
 namespace Jint.Runtime.Debugger
@@ -2011,6 +2013,7 @@ namespace Jint.Runtime.Debugger
         public string FunctionName { get; }
         public int Index { get; }
         public Acornima.SourceLocation& Location { get; }
+        public Acornima.Ast.Program? Program { get; }
         public Jint.Native.JsValue? ReturnValue { get; }
         public Jint.Runtime.Debugger.DebugScopes ScopeChain { get; }
         public Jint.Native.JsValue This { get; }

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.1.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.1.verified.txt
@@ -1711,14 +1711,45 @@ namespace Jint.NodeCompat
 }
 namespace Jint.Profiling
 {
+    public enum ProfileFrameCategory
+    {
+        Other = 0,
+        Script = 1,
+        BuiltIn = 2,
+        HostInterop = 3,
+    }
     public sealed class SampledProfile
     {
         public int DroppedSampleCount { get; }
         public System.TimeSpan Duration { get; }
+        public System.Collections.Generic.IReadOnlyList<Jint.Profiling.SampledProfileFrame> Frames { get; }
+        public System.Collections.Generic.IReadOnlyList<Jint.Profiling.ScriptProfileFrame> Functions { get; }
         public System.TimeSpan Interval { get; }
         public int SampleCount { get; }
+        public System.Collections.Generic.IReadOnlyList<Jint.Profiling.SampledProfileSample> Samples { get; }
+        public System.Collections.Generic.IReadOnlyList<Jint.Profiling.SampledProfileStack> Stacks { get; }
         public void WriteTo(System.IO.Stream stream) { }
         public void WriteTo(System.IO.TextWriter writer) { }
+    }
+    public readonly struct SampledProfileFrame : System.IEquatable<Jint.Profiling.SampledProfileFrame>
+    {
+        public SampledProfileFrame(int Function, Jint.Profiling.ProfileFrameCategory Category, int? Line, int? Column) { }
+        public Jint.Profiling.ProfileFrameCategory Category { get; init; }
+        public int? Column { get; init; }
+        public int Function { get; init; }
+        public int? Line { get; init; }
+    }
+    public readonly struct SampledProfileSample : System.IEquatable<Jint.Profiling.SampledProfileSample>
+    {
+        public SampledProfileSample(System.TimeSpan Time, int Stack) { }
+        public int Stack { get; init; }
+        public System.TimeSpan Time { get; init; }
+    }
+    public readonly struct SampledProfileStack : System.IEquatable<Jint.Profiling.SampledProfileStack>
+    {
+        public SampledProfileStack(int Parent, int Frame) { }
+        public int Frame { get; init; }
+        public int Parent { get; init; }
     }
     public sealed class SamplingOptions
     {

--- a/Jint.Tests/Runtime/CodeCoverageTests.cs
+++ b/Jint.Tests/Runtime/CodeCoverageTests.cs
@@ -29,8 +29,12 @@ public class CodeCoverageTests
     private static string Text(string code, CoverageEntry entry)
         => code.Substring(entry.Start.Index, entry.End.Index - entry.Start.Index);
 
+    /// <summary>
+    /// Every entry counted under one name. A source is one parse, so a name several parses share has a
+    /// source each and a reader that wants the name's total is the one that adds them up.
+    /// </summary>
     private static IReadOnlyList<CoverageEntry> EntriesOf(CoverageReport report, string source = Source)
-        => report.Sources.Single(s => s.Name == source).Entries;
+        => report.Sources.Where(s => s.Name == source).SelectMany(s => s.Entries).ToList();
 
     private static List<(string Text, CoverageEntryKind Kind, long Hits)> Rows(string code, CoverageReport report)
         => EntriesOf(report).Select(e => (Text(code, e), e.Kind, e.HitCount)).ToList();
@@ -288,13 +292,12 @@ public class CodeCoverageTests
     }
 
     /// <summary>
-    /// The counters key on AST node identity, and <c>Execute(string)</c> re-parses, so the same construct is a
-    /// different node on every call. The report folds those together by position — otherwise a host that does
-    /// not cache a <c>Prepared&lt;Script&gt;</c> would read "ran once" ten times over instead of "ran ten
-    /// times".
+    /// The counters key on AST node identity, and <c>Execute(string)</c> re-parses, so the same construct is
+    /// a different node on every call — and a different program. Each parse is a source of its own, under
+    /// the same name and told apart by its program; a reader that wants the name's total adds them up.
     /// </summary>
     [Test]
-    public void ReParsingTheSameSourceAddsToTheSameEntry()
+    public void ReParsingTheSameSourceIsOneSourcePerParse()
     {
         const string Code = "function f() { return 1; } f(); f();";
 
@@ -302,11 +305,55 @@ public class CodeCoverageTests
         engine.Execute(Code, Source);
         engine.Execute(Code, Source);
 
-        var rows = Rows(Code, engine.Diagnostics.GetCoverage());
+        var sources = engine.Diagnostics.GetCoverage().Sources.Where(s => s.Name == Source).ToList();
 
-        rows.Count(r => r.Text == "return 1;").Should().Be(1);
-        rows.Should().Contain(("return 1;", CoverageEntryKind.Statement, 4L));
-        rows.Should().Contain(("{ return 1; }", CoverageEntryKind.Function, 4L));
+        sources.Should().HaveCount(2);
+        sources.Select(s => s.Program).Should().OnlyHaveUniqueItems();
+        sources.Should().AllSatisfy(s => s.Program.Should().NotBeNull());
+
+        foreach (var source in sources)
+        {
+            source.Entries.Select(e => (Text(Code, e), e.Kind, e.HitCount))
+                .Should().Contain(("return 1;", CoverageEntryKind.Statement, 2L));
+        }
+
+        Rows(Code, engine.Diagnostics.GetCoverage())
+            .Where(r => r.Text == "return 1;").Sum(r => r.Hits).Should().Be(4L);
+    }
+
+    /// <summary>
+    /// The identity a host maps a source back to the script it prepared by, which is what a name cannot
+    /// answer once several parses share one.
+    /// </summary>
+    [Test]
+    public void ASourceNamesTheProgramItWasParsedFrom()
+    {
+        var prepared = Engine.PrepareScript("var a = 1;", Source);
+
+        var engine = CreateEngine();
+        engine.Execute(prepared);
+        engine.Execute(prepared);
+
+        var sources = engine.Diagnostics.GetCoverage().Sources.Where(s => s.Name == Source).ToList();
+
+        sources.Should().ContainSingle();
+        sources[0].Program.Should().BeSameAs(prepared.Program);
+    }
+
+    /// <summary>
+    /// Code the engine reached through <c>eval</c> belongs to a program no execution context names, so it is
+    /// reported with none rather than against the script that ran it.
+    /// </summary>
+    [Test]
+    public void EvaluatedCodeIsReportedWithNoProgram()
+    {
+        var engine = CreateEngine();
+        engine.Execute("eval('var a = 1;');", Source);
+
+        var report = engine.Diagnostics.GetCoverage();
+
+        report.Sources.Should().Contain(s => s.Program == null);
+        report.Sources.Where(s => s.Name == Source).Should().AllSatisfy(s => s.Program.Should().NotBeNull());
     }
 
     [Test]

--- a/Jint/Engine.Coverage.cs
+++ b/Jint/Engine.Coverage.cs
@@ -36,12 +36,12 @@ public partial class Engine
         /// not double-counted by a resumption; execution picks up where it suspended.
         /// </para>
         /// <para>
-        /// <b>Re-parsing the same source.</b> The counters are keyed on AST node identity, so a host calling
-        /// <see cref="Engine.Execute(string, string, ScriptParsingOptions)"/> with the same text twice counts two different node
-        /// sets for one construct. The report folds those together by source name and position, so such a host
-        /// reads the total rather than one entry per parse — and a host that caches a
-        /// <see cref="Prepared{TProgram}"/> (which it should) never creates the situation in the first place.
-        /// The corollary is that two genuinely different sources must not share a name.
+        /// <b>Re-parsing the same source.</b> A source is one parse, so a host calling
+        /// <see cref="Engine.Execute(string, string, ScriptParsingOptions)"/> with the same text twice reads two
+        /// <see cref="CoverageSource"/>s of one name, told apart by <see cref="CoverageSource.Program"/> — and a
+        /// host that caches a <see cref="Prepared{TProgram}"/> (which it should) never creates the situation in
+        /// the first place. Only entries of a program the engine cannot name — <c>eval</c>, the <c>Function</c>
+        /// constructor — are folded together by name and position.
         /// </para>
         /// <para>
         /// <b>What is not in the report.</b> Only constructs that actually ran. A statement with zero hits has

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -3196,7 +3196,7 @@ public sealed partial class Engine : IDisposable
         // After the constraints on purpose: a statement a constraint refused is a statement that never ran.
         if (_coverage is not null && statement is not null)
         {
-            _coverage.Record(statement);
+            _coverage.Record(statement, this);
         }
 
         if (_isDebugMode && statement != null && statement.Type != NodeType.BlockStatement)

--- a/Jint/Profiling/ProfileFrameCategory.cs
+++ b/Jint/Profiling/ProfileFrameCategory.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Jint.Profiling;
 
 /// <summary>
@@ -5,10 +7,18 @@ namespace Jint.Profiling;
 /// classification a native profiler cannot make, since at the CLR level all three are Jint frames.
 /// </summary>
 /// <remarks>
+/// <para>
 /// The values are the category indices the Firefox Profiler document declares in <c>meta.categories</c>,
 /// so a frame's category is written out as-is.
+/// </para>
+/// <para>
+/// This type is in a preview area, declared to the compiler as <c>JINT0002</c>; see
+/// <see cref="JintDiagnosticIds"/>. New members may be added, so treat an unrecognized value as "some other
+/// kind of code" rather than switching exhaustively without a default arm.
+/// </para>
 /// </remarks>
-internal enum ProfileFrameCategory
+[Experimental(JintDiagnosticIds.PreviewDiagnostic)]
+public enum ProfileFrameCategory
 {
     /// <summary>
     /// Nothing else fits. Index 0 is the profiler format's default category and must stay the grey one.

--- a/Jint/Profiling/ProfileFrames.cs
+++ b/Jint/Profiling/ProfileFrames.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using Jint.Native;
 using Jint.Native.Function;
+using Jint.Runtime;
 using Jint.Runtime.Descriptors;
 using Jint.Runtime.Interop;
 using Jint.Runtime.Interpreter;
@@ -34,7 +35,7 @@ internal static class ProfileFrames
     internal static readonly IEqualityComparer<object> FunctionIdentity = new IdentityComparer();
 
     /// <summary>
-    /// The name, file and declaration position to show for <paramref name="function"/>.
+    /// The name, file, declaration position and owning program to show for <paramref name="function"/>.
     /// </summary>
     internal static ScriptProfileFrame Describe(Function function, JintFunctionDefinition? definition)
     {
@@ -56,7 +57,15 @@ internal static class ProfileFrames
 
         // Column is reported one-based, matching the column Jint puts in a stack trace; the parser's is an
         // index.
-        return new ScriptProfileFrame(name, file, location.Start.Line, location.Start.Column + 1);
+        // The function's [[ScriptOrModule]] is the script that was active when it was created, which is the
+        // program its body belongs to for everything but eval and the Function constructor — and those two
+        // are what OwningProgramOf declines rather than mis-attributing.
+        return new ScriptProfileFrame(
+            name,
+            file,
+            location.Start.Line,
+            location.Start.Column + 1,
+            function._scriptOrModule.OwningProgramOf(node));
     }
 
     /// <summary>

--- a/Jint/Profiling/SampledProfile.cs
+++ b/Jint/Profiling/SampledProfile.cs
@@ -1,5 +1,7 @@
+using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Text;
 using Jint.Runtime;
 
@@ -76,12 +78,75 @@ public sealed class SampledProfile
 
         DroppedSampleCount = droppedSampleCount;
         Interval = interval;
+
+        // Views rather than copies: a session of a hundred thousand samples publishes its tables without
+        // allocating a second set of them, and the rows are made as a reader asks for them.
+        Functions = new ProfileTableView<ScriptProfileFrame>(funcs.Length, index => funcs[index]);
+        Frames = new ProfileTableView<SampledProfileFrame>(frames.Length, index =>
+        {
+            var frame = frames[index];
+            return new SampledProfileFrame(
+                frame.Func,
+                funcCategories[frame.Func],
+                frame.Line < 0 ? null : frame.Line,
+                frame.Column < 0 ? null : frame.Column);
+        });
+        Stacks = new ProfileTableView<SampledProfileStack>(stacks.Length, index =>
+        {
+            var stack = stacks[index];
+            return new SampledProfileStack(stack.Prefix, stack.Frame);
+        });
+        Samples = new ProfileTableView<SampledProfileSample>(
+            sampleStacks.Length,
+            index => new SampledProfileSample(TimeSpan.FromMilliseconds(sampleTimes[index]), sampleStacks[index]));
     }
 
     /// <summary>
     /// How many samples the session recorded.
     /// </summary>
     public int SampleCount => _sampleStacks.Length;
+
+    /// <summary>
+    /// Gets the distinct functions the session saw, which <see cref="SampledProfileFrame.Function"/> indexes
+    /// into.
+    /// </summary>
+    /// <remarks>
+    /// Index <c>0</c> is the synthetic <c>(program)</c> function every sampled stack is rooted at: the
+    /// program itself, which is not on the call stack because only function activations are.
+    /// </remarks>
+    public IReadOnlyList<ScriptProfileFrame> Functions { get; }
+
+    /// <summary>
+    /// Gets the positions the session observed, which <see cref="SampledProfileStack.Frame"/> indexes into.
+    /// </summary>
+    public IReadOnlyList<SampledProfileFrame> Frames { get; }
+
+    /// <summary>
+    /// Gets the stack tree as parent links, which <see cref="SampledProfileSample.Stack"/> indexes into.
+    /// </summary>
+    /// <remarks>
+    /// A node names its frame and the node it hangs off, so a stack is read by walking
+    /// <see cref="SampledProfileStack.Parent"/> to <c>-1</c>, which yields the frames innermost first.
+    /// Two stacks sharing a prefix share every node of it, which is what makes a long session's table small.
+    /// </remarks>
+    public IReadOnlyList<SampledProfileStack> Stacks { get; }
+
+    /// <summary>
+    /// Gets what the stack looked like at each sample point, oldest first.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A sample's time is measured from the start of the session, and the gap to the next one — to
+    /// <see cref="Duration"/> for the last — is how long that stack was observed for. The gaps vary, because
+    /// the sampler fires at the engine's own check points rather than on a timer, so a reader that weights
+    /// samples equally under-reports exactly the stacks the engine could not be interrupted in.
+    /// </para>
+    /// <para>
+    /// The document <see cref="WriteTo(TextWriter)"/> writes carries that as a weight of
+    /// <c>round(gap / <see cref="Interval"/>)</c>, at least one.
+    /// </para>
+    /// </remarks>
+    public IReadOnlyList<SampledProfileSample> Samples { get; }
 
     /// <summary>
     /// How many sample points were refused because <see cref="SamplingOptions.MaxSamples"/> had been
@@ -141,4 +206,98 @@ public sealed class SampledProfile
         using var writer = new StreamWriter(stream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), 1024, leaveOpen: true);
         WriteTo(writer);
     }
+}
+
+/// <summary>
+/// One row of a sampled profile's frame table: a function, and the position inside it that was executing.
+/// </summary>
+/// <param name="Function">Index into <see cref="SampledProfile.Functions"/> of the function this is a position in.</param>
+/// <param name="Category">Whose code that function is, which is the classification a CLR profiler cannot make.</param>
+/// <param name="Line">One-based line the frame was executing, or <see langword="null"/> when there is none.</param>
+/// <param name="Column">One-based column the frame was executing, or <see langword="null"/> with <paramref name="Line"/>.</param>
+/// <remarks>
+/// <para>
+/// One function appears as several frames when it was observed at several positions, so a reader building a
+/// tree of functions groups by <see cref="Function"/> and a reader showing where the time went inside one
+/// does not.
+/// </para>
+/// <para>
+/// Only a function parsed from source has a position, so <see cref="Line"/> is <see langword="null"/> for a
+/// built-in and for a host callable. The one for the synthetic <c>(program)</c> function is the call site of
+/// the outermost frame on the stack, or the node the engine last prepared for when nothing is on it.
+/// </para>
+/// <para>
+/// This type is in a preview area, declared to the compiler as <c>JINT0002</c>; see
+/// <see cref="JintDiagnosticIds"/>.
+/// </para>
+/// </remarks>
+[Experimental(JintDiagnosticIds.PreviewDiagnostic)]
+[StructLayout(LayoutKind.Auto)]
+public readonly record struct SampledProfileFrame(int Function, ProfileFrameCategory Category, int? Line, int? Column);
+
+/// <summary>
+/// One node of a sampled profile's stack tree: a frame, and the node it hangs off.
+/// </summary>
+/// <param name="Parent">Index into <see cref="SampledProfile.Stacks"/> of the calling node, or <c>-1</c> for a root.</param>
+/// <param name="Frame">Index into <see cref="SampledProfile.Frames"/> of the position this node is.</param>
+/// <remarks>
+/// This type is in a preview area, declared to the compiler as <c>JINT0002</c>; see
+/// <see cref="JintDiagnosticIds"/>.
+/// </remarks>
+[Experimental(JintDiagnosticIds.PreviewDiagnostic)]
+[StructLayout(LayoutKind.Auto)]
+public readonly record struct SampledProfileStack(int Parent, int Frame);
+
+/// <summary>
+/// One sample: when it was taken, and what the stack looked like.
+/// </summary>
+/// <param name="Time">How long after the session started the sample was taken.</param>
+/// <param name="Stack">Index into <see cref="SampledProfile.Stacks"/> of the stack that was observed.</param>
+/// <remarks>
+/// This type is in a preview area, declared to the compiler as <c>JINT0002</c>; see
+/// <see cref="JintDiagnosticIds"/>.
+/// </remarks>
+[Experimental(JintDiagnosticIds.PreviewDiagnostic)]
+[StructLayout(LayoutKind.Auto)]
+public readonly record struct SampledProfileSample(TimeSpan Time, int Stack);
+
+/// <summary>
+/// A read-only view over one of a profile's columnar tables, projecting a row as it is asked for so that
+/// publishing a table copies nothing.
+/// </summary>
+internal sealed class ProfileTableView<T> : IReadOnlyList<T>
+{
+    private readonly int _count;
+    private readonly Func<int, T> _row;
+
+    internal ProfileTableView(int count, Func<int, T> row)
+    {
+        _count = count;
+        _row = row;
+    }
+
+    public T this[int index]
+    {
+        get
+        {
+            if ((uint) index >= (uint) _count)
+            {
+                Throw.ArgumentOutOfRangeException(nameof(index), "Index was out of range of the profile's table.");
+            }
+
+            return _row(index);
+        }
+    }
+
+    public int Count => _count;
+
+    public IEnumerator<T> GetEnumerator()
+    {
+        for (var i = 0; i < _count; i++)
+        {
+            yield return _row(i);
+        }
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/Jint/Profiling/SampledProfile.cs
+++ b/Jint/Profiling/SampledProfile.cs
@@ -11,9 +11,10 @@ namespace Jint.Profiling;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Immutable, engine-independent and safe to hand to another thread: it holds strings and numbers only. In
-/// particular it retains no <c>Function</c>, no AST and no <see cref="Engine"/>, so keeping a profile around
-/// does not keep the engine that produced it alive.
+/// Immutable and engine-independent: it retains no <c>Function</c>, no <c>JsValue</c> and no
+/// <see cref="Engine"/>, so keeping a profile around does not keep the engine that produced it alive. A
+/// frame does name the <see cref="ScriptProfileFrame.Program"/> it was parsed from, which is an identity to
+/// compare and not a tree to walk from another thread.
 /// </para>
 /// <para>
 /// <b>What a sample weighs.</b> The sampler fires at the engine's check points rather than on a timer, so

--- a/Jint/Profiling/ScriptProfile.cs
+++ b/Jint/Profiling/ScriptProfile.cs
@@ -12,9 +12,10 @@ namespace Jint.Profiling;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Immutable, engine-independent and safe to hand to another thread: it holds strings and numbers only.
-/// In particular it retains no <c>Function</c>, no AST and no <see cref="Engine"/>, so keeping a profile
-/// around does not keep the engine that produced it alive.
+/// Immutable and engine-independent: it retains no <c>Function</c>, no <c>JsValue</c> and no
+/// <see cref="Engine"/>, so keeping a profile around does not keep the engine that produced it alive. A
+/// frame does name the <see cref="ScriptProfileFrame.Program"/> it was parsed from, which is an identity to
+/// compare and not a tree to walk from another thread.
 /// </para>
 /// <para>
 /// <see cref="WriteSpeedscopeJson(TextWriter)"/> renders it in the

--- a/Jint/Profiling/ScriptProfileFrame.cs
+++ b/Jint/Profiling/ScriptProfileFrame.cs
@@ -16,6 +16,11 @@ namespace Jint.Profiling;
 /// </param>
 /// <param name="Line">One-based line of the function's declaration, or <see langword="null"/> with <see cref="File"/>.</param>
 /// <param name="Column">One-based column of the function's declaration, or <see langword="null"/> with <see cref="File"/>.</param>
+/// <param name="Program">
+/// The abstract syntax tree the function was parsed as part of — the reference
+/// <c>DebugHandler.BeforeEvaluate</c> hands over — or <see langword="null"/> for a function with no source,
+/// and for one the engine reached through <c>eval</c> or the <c>Function</c> constructor.
+/// </param>
 /// <remarks>
 /// <para>
 /// Frames are interned by <em>definition</em>, not by function object: every closure instantiated from one
@@ -27,6 +32,12 @@ namespace Jint.Profiling;
 /// <see cref="Column"/> is one-based to match the column Jint reports in a stack trace, where the underlying
 /// parser position is a zero-based index.
 /// </para>
+/// <para>
+/// <see cref="Program"/> identifies the script two frames share where <see cref="File"/> only names it, so
+/// several programs parsed under one name — every <c>Execute</c> given no source is <c>&lt;anonymous&gt;</c>
+/// — stay apart. Hold it as an identity: the tree itself is the engine's, and reading it from another thread
+/// while that engine runs is not supported.
+/// </para>
 /// </remarks>
 [StructLayout(LayoutKind.Auto)]
-public readonly record struct ScriptProfileFrame(string Name, string? File, int? Line, int? Column);
+public readonly record struct ScriptProfileFrame(string Name, string? File, int? Line, int? Column, Program? Program = null);

--- a/Jint/Runtime/CallStack/JintCallStack.cs
+++ b/Jint/Runtime/CallStack/JintCallStack.cs
@@ -18,9 +18,17 @@ internal readonly record struct CallStackExecutionContext
     public CallStackExecutionContext(in ExecutionContext context)
     {
         LexicalEnvironment = context.LexicalEnvironment;
+        ScriptOrModule = context.ScriptOrModule;
     }
 
     internal readonly Environment LexicalEnvironment;
+
+    /// <summary>
+    /// The script or module whose code runs in this context, which is what tells a debugger's
+    /// <c>CallFrame</c> which program its position belongs to. One reference copied per pushed frame,
+    /// read by nothing else.
+    /// </summary>
+    internal readonly IScriptOrModule? ScriptOrModule;
 
     internal Environment GetThisEnvironment()
     {

--- a/Jint/Runtime/Coverage/CoverageCollector.cs
+++ b/Jint/Runtime/Coverage/CoverageCollector.cs
@@ -35,13 +35,20 @@ internal sealed class CoverageCollector
 {
     private sealed class Counter
     {
-        internal Counter(CoverageEntryKind kind, bool reported)
+        internal Counter(CoverageEntryKind kind, bool reported, Program? program)
         {
             Kind = kind;
             Reported = reported;
+            Program = program;
         }
 
         internal readonly CoverageEntryKind Kind;
+
+        /// <summary>
+        /// The program the node was parsed as part of, read once when the counter is made: a node belongs
+        /// to one program for as long as it exists, so this never has to be re-asked.
+        /// </summary>
+        internal readonly Program? Program;
 
         /// <summary>
         /// False for a node the granularity excludes. Such a node still gets an entry here so the
@@ -75,7 +82,7 @@ internal sealed class CoverageCollector
     /// one of the three things that arms it, so this runs for every executed statement and every function-body
     /// entry.
     /// </summary>
-    internal void Record(StatementOrExpression node)
+    internal void Record(StatementOrExpression node, Engine engine)
     {
         if (_counters.TryGetValue(node, out var counter))
         {
@@ -83,14 +90,19 @@ internal sealed class CoverageCollector
             return;
         }
 
-        AddCounter(node);
+        AddCounter(node, engine);
     }
 
+    /// <summary>
+    /// Makes the counter for a node seen for the first time, and settles which program it belongs to while
+    /// the context that is running it is still the top of the stack.
+    /// </summary>
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private void AddCounter(Node node)
+    private void AddCounter(Node node, Engine engine)
     {
         var reported = TryClassify(node, out var kind);
-        _counters[node] = new Counter(kind, reported) { Hits = 1 };
+        var program = engine.ExecutionContext.ScriptOrModule.OwningProgramOf(node);
+        _counters[node] = new Counter(kind, reported, program) { Hits = 1 };
     }
 
     /// <summary>
@@ -134,7 +146,7 @@ internal sealed class CoverageCollector
 
     internal CoverageReport BuildReport()
     {
-        var bySource = new Dictionary<string, List<Raw>>(StringComparer.Ordinal);
+        var bySource = new Dictionary<SourceKey, Group>(SourceKeyComparer.Instance);
 
         foreach (var pair in _counters)
         {
@@ -146,39 +158,87 @@ internal sealed class CoverageCollector
 
             var node = pair.Key;
             var location = node.Location;
-            var name = location.SourceFile ?? string.Empty;
+            var key = new SourceKey(counter.Program, location.SourceFile ?? string.Empty);
 
-            if (!bySource.TryGetValue(name, out var raws))
+            if (!bySource.TryGetValue(key, out var group))
             {
-                bySource[name] = raws = new List<Raw>();
+                bySource[key] = group = new Group(bySource.Count);
             }
 
-            raws.Add(new Raw(
+            group.Raws.Add(new Raw(
                 counter.Kind,
                 new CoveragePosition(location.Start.Line, location.Start.Column, node.Start),
                 new CoveragePosition(location.End.Line, location.End.Column, node.End),
                 counter.Hits));
         }
 
-        var sources = new List<CoverageSource>(bySource.Count);
+        var sources = new List<(SourceKey Key, Group Group)>(bySource.Count);
         foreach (var pair in bySource)
         {
-            sources.Add(new CoverageSource(pair.Key, Coalesce(pair.Value)));
+            sources.Add((pair.Key, pair.Value));
         }
 
-        sources.Sort(static (a, b) => string.CompareOrdinal(a.Name, b.Name));
-        return new CoverageReport(sources);
+        // By name first, which is the order that reads; several programs parsed under one name are then in
+        // the order they were first counted, so the report stays reproducible without inventing an order
+        // between two trees that have none.
+        sources.Sort(static (a, b) =>
+        {
+            var result = string.CompareOrdinal(a.Key.Name, b.Key.Name);
+            return result != 0 ? result : a.Group.Ordinal.CompareTo(b.Group.Ordinal);
+        });
+
+        var reported = new List<CoverageSource>(sources.Count);
+        foreach (var source in sources)
+        {
+            reported.Add(new CoverageSource(source.Key.Name, source.Key.Program, Coalesce(source.Group.Raws)));
+        }
+
+        return new CoverageReport(reported);
+    }
+
+    /// <summary>
+    /// What one <see cref="CoverageSource"/> is made of: the program the nodes were parsed as part of, and
+    /// the name they carry. Both, because a program the engine cannot name still has a source name to
+    /// report under, and two such parses must not be folded into one.
+    /// </summary>
+    [StructLayout(LayoutKind.Auto)]
+    private readonly record struct SourceKey(Program? Program, string Name);
+
+    private sealed class Group(int ordinal)
+    {
+        internal readonly int Ordinal = ordinal;
+        internal readonly List<Raw> Raws = new();
+    }
+
+    /// <summary>
+    /// Reference identity for the program half of a key, spelt out rather than left to the default
+    /// comparer: two abstract syntax trees with identical contents are two parses, and one source name
+    /// covering both is exactly the case this key exists to keep apart.
+    /// </summary>
+    private sealed class SourceKeyComparer : IEqualityComparer<SourceKey>
+    {
+        internal static readonly SourceKeyComparer Instance = new();
+
+        public bool Equals(SourceKey x, SourceKey y)
+            => ReferenceEquals(x.Program, y.Program) && string.Equals(x.Name, y.Name, StringComparison.Ordinal);
+
+        public int GetHashCode(SourceKey obj)
+        {
+            var program = obj.Program is null ? 0 : RuntimeHelpers.GetHashCode(obj.Program);
+            return (program * 397) ^ StringComparer.Ordinal.GetHashCode(obj.Name);
+        }
     }
 
     /// <summary>
     /// Orders the raw counts and sums the ones that name the same construct.
     /// </summary>
     /// <remarks>
-    /// The counters are keyed on AST node identity, and a host that re-parses the same text — every
-    /// <c>engine.Execute(code)</c> does — gets a fresh node per parse for the same construct. Reporting those
-    /// separately would answer "this statement ran once, ten times over" instead of "ten times", so a source
-    /// position counted through several parses is folded into one entry here. Within a single parse the fold
-    /// is a no-op: no two distinct nodes of the same kind share a range.
+    /// The counters are keyed on AST node identity, and several parses can land in one group: the entries of
+    /// every program the engine cannot name — <c>eval</c> and the <c>Function</c> constructor — are grouped
+    /// by source name alone, and a host evaluating the same string twice there gets a fresh node per parse
+    /// for the same construct. Reporting those separately would answer "this statement ran once, twice over"
+    /// instead of "twice". Within one program the fold is a no-op: no two distinct nodes of the same kind
+    /// share a range.
     /// </remarks>
     private static List<CoverageEntry> Coalesce(List<Raw> raws)
     {

--- a/Jint/Runtime/Coverage/CoverageReport.cs
+++ b/Jint/Runtime/Coverage/CoverageReport.cs
@@ -70,16 +70,24 @@ public sealed record CoverageEntry
 }
 
 /// <summary>
-/// The entries collected for one source, identified by the name that source was parsed under.
+/// The entries collected for one parsed program, under the name that program was parsed with.
 /// </summary>
 /// <remarks>
+/// <para>
+/// <b>One source is one parse, not one name.</b> Several programs parsed under one name — every
+/// <c>Execute</c> given no source is <c>&lt;anonymous&gt;</c> — are reported as one source each, told apart
+/// by <see cref="Program"/>.
+/// </para>
+/// <para>
 /// <b>Forward-extensible.</b> This type may gain members in any release; it has no public constructor.
+/// </para>
 /// </remarks>
 public sealed record CoverageSource
 {
-    internal CoverageSource(string name, IReadOnlyList<CoverageEntry> entries)
+    internal CoverageSource(string name, Program? program, IReadOnlyList<CoverageEntry> entries)
     {
         Name = name;
+        Program = program;
         Entries = entries;
     }
 
@@ -90,6 +98,23 @@ public sealed record CoverageSource
     /// name is reported as the empty string.
     /// </summary>
     public string Name { get; }
+
+    /// <summary>
+    /// Gets the program these entries were parsed as part of, or <see langword="null"/> when the engine
+    /// knows of none.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The same reference <see cref="Runtime.Debugger.DebugHandler.BeforeEvaluate"/> hands over and
+    /// <see cref="Engine.AdvancedOperations.TryGetSourceText"/> is keyed by, so a host maps a source to the
+    /// script it announced by reference rather than by matching <see cref="Name"/>.
+    /// </para>
+    /// <para>
+    /// Null for code the engine reached another way — <c>eval</c> and the <c>Function</c> constructor are
+    /// programs no script names — and those entries are grouped by <see cref="Name"/> alone.
+    /// </para>
+    /// </remarks>
+    public Program? Program { get; }
 
     /// <summary>
     /// The executed constructs, ordered by <see cref="CoveragePosition.Index"/> of their start.
@@ -113,7 +138,7 @@ public sealed record CoverageReport
 
     /// <summary>
     /// The sources that contributed at least one executed construct, ordered by
-    /// <see cref="CoverageSource.Name"/> (ordinal).
+    /// <see cref="CoverageSource.Name"/> (ordinal), then by when each parse was first counted.
     /// </summary>
     public IReadOnlyList<CoverageSource> Sources { get; }
 }

--- a/Jint/Runtime/Debugger/CallFrame.cs
+++ b/Jint/Runtime/Debugger/CallFrame.cs
@@ -72,6 +72,23 @@ public sealed class CallFrame
     public string FunctionName => _element?.ToString() ?? "(anonymous)";
 
     /// <summary>
+    /// Gets the program this frame's code was parsed from, or <see langword="null"/> when the engine knows
+    /// of none.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The same reference <see cref="DebugHandler.BeforeEvaluate"/> hands over and
+    /// <see cref="Engine.AdvancedOperations.TryGetSourceText"/> is keyed by, so a host maps a frame to the
+    /// script it announced by reference rather than by matching <see cref="Location"/>'s source name.
+    /// </para>
+    /// <para>
+    /// Null for code the engine reached another way: a frame inside <c>eval</c> or a <c>Function</c>
+    /// constructor body, a host callable, and a module record with no source of its own.
+    /// </para>
+    /// </remarks>
+    public Program? Program => _context.ScriptOrModule?.Program;
+
+    /// <summary>
     /// Source location of function of this call frame.
     /// </summary>
     /// <remarks>For top level (global) call frames, as well as functions not defined in script, this will be null.</remarks>

--- a/Jint/Runtime/IScriptOrModule.Extensions.cs
+++ b/Jint/Runtime/IScriptOrModule.Extensions.cs
@@ -13,4 +13,30 @@ internal static class ScriptOrModuleExtensions
         }
         return module;
     }
+
+    /// <summary>
+    /// The program <paramref name="node"/> was parsed as part of, or <see langword="null"/> when
+    /// <paramref name="scriptOrModule"/> is not the one the node came from.
+    /// </summary>
+    /// <remarks>
+    /// An execution context names the script or module whose code it runs, but code the engine reaches
+    /// through <c>eval</c> or the <c>Function</c> constructor is a program of its own that no context names
+    /// — so a node from such a program would otherwise be attributed to whichever script ran it, at a
+    /// position that script does not have. The node has to lie in the program, by source name and by range,
+    /// before the answer is given at all.
+    /// </remarks>
+    internal static Program? OwningProgramOf(this IScriptOrModule? scriptOrModule, Node node)
+    {
+        if (scriptOrModule?.Program is not { } program)
+        {
+            return null;
+        }
+
+        if (!string.Equals(node.Location.SourceFile, program.Location.SourceFile, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        return node.Start >= program.Start && node.End <= program.End ? program : null;
+    }
 }

--- a/Jint/Runtime/IScriptOrModule.cs
+++ b/Jint/Runtime/IScriptOrModule.cs
@@ -5,4 +5,11 @@ internal interface IScriptOrModule
     public string? Location { get; }
     public ParsingConstraints ParsingConstraints { get; }
     public ParserOptions? ParserOptions { get; }
+
+    /// <summary>
+    /// The abstract syntax tree this script or module was parsed into, which is the identity a host maps a
+    /// running position back to a script by. Null for a module that has no source of its own — a synthetic
+    /// or builder module.
+    /// </summary>
+    public Program? Program { get; }
 }

--- a/Jint/Runtime/Modules/ModuleRecord.cs
+++ b/Jint/Runtime/Modules/ModuleRecord.cs
@@ -25,8 +25,15 @@ public abstract class ModuleRecord : JsValue, IScriptOrModule
 
     ParsingConstraints IScriptOrModule.ParsingConstraints => ParsingConstraints;
     ParserOptions IScriptOrModule.ParserOptions => ParserOptions;
+    Program IScriptOrModule.Program => Source;
     internal virtual ParsingConstraints ParsingConstraints => default;
     internal virtual ParserOptions ParserOptions => null;
+
+    /// <summary>
+    /// The parsed module body, or null for a module with no source of its own — a synthetic module, a
+    /// builder module, and any host record that is not text.
+    /// </summary>
+    internal virtual Module Source => null;
 
     /// <summary>
     /// [[LoadedModules]] — the module records this one has already resolved a specifier to. Per

--- a/Jint/Runtime/Modules/SourceTextModuleRecord.cs
+++ b/Jint/Runtime/Modules/SourceTextModuleRecord.cs
@@ -60,6 +60,7 @@ internal class SourceTextModuleRecord : CyclicModuleRecord
     private readonly ParsingConstraints _parsingConstraints;
     internal override ParsingConstraints ParsingConstraints => _parsingConstraints;
     internal override ParserOptions ParserOptions => _parserOptions;
+    internal override Module Source => _source;
     private ExecutionContext _context;
     private ObjectInstance? _importMeta;
     private readonly List<ImportEntry>? _importEntries;

--- a/Jint/Runtime/ScriptRecord.cs
+++ b/Jint/Runtime/ScriptRecord.cs
@@ -5,4 +5,7 @@ internal sealed record ScriptRecord(
     Script EcmaScriptCode,
     string? Location,
     ParsingConstraints ParsingConstraints,
-    ParserOptions? ParserOptions) : IScriptOrModule;
+    ParserOptions? ParserOptions) : IScriptOrModule
+{
+    Program IScriptOrModule.Program => EcmaScriptCode;
+}

--- a/README.md
+++ b/README.md
@@ -2782,9 +2782,9 @@ profile.WriteSpeedscopeJson(file);
 
 Drop the file onto [speedscope.app](https://www.speedscope.app) — it is written in that tool's
 [evented profile format](https://www.speedscope.app/file-format-schema.json), in nanoseconds. The
-`ScriptProfile` is also readable directly: `Frames` (name, file, line, column), `Events` (open/close plus a
-timestamp), `Truncated` and `Duration`. It holds strings and numbers only, so keeping a profile does not keep
-the engine that produced it alive.
+`ScriptProfile` is also readable directly: `Frames` (name, file, line, column, and the `Program` the function
+was parsed from), `Events` (open/close plus a timestamp), `Truncated` and `Duration`. It holds no `JsValue`
+and no engine, so keeping a profile does not keep the engine that produced it alive.
 
 Worth knowing before you read a profile:
 
@@ -4135,6 +4135,11 @@ engine.Diagnostics.ResetCoverage(); // start a fresh measurement
   them are.
 - Counters are per engine, so a `Prepared<Script>` shared across a pool of engines keeps a separate count per
   engine and the shared AST is untouched. `Options` stays shareable.
+- A source is one *parse*, not one name: `source.Program` is the abstract syntax tree it was counted from —
+  the same reference `DebugHandler.BeforeEvaluate` hands over — so two `Execute(text)` calls under one name
+  are two sources. Add them up if you want the name's total; a host that caches a `Prepared<Script>` reads
+  one source either way. It is `null` for code reached through `eval` or the `Function` constructor, whose
+  entries are grouped by name.
 - `GetCoverage()` and `ResetCoverage()` throw `InvalidOperationException` on an engine that did not enable
   collection, rather than reporting an empty result that looks like a script which never ran.
 

--- a/README.md
+++ b/README.md
@@ -2739,6 +2739,26 @@ script's own functions, **Built-in** for Jint's, and **Host interop** for your c
 a CLR method reached through interop, or a `ClrFunction` you built. Seeing script time apart from time
 inside your own callbacks is usually half the diagnosis.
 
+The document is not the only way to read a profile. Its four tables are public, so a host that renders its
+own view — or speaks a protocol of its own — reads them instead of writing JSON and parsing it back:
+
+```csharp
+foreach (var sample in profile.Samples)          // when, and which stack
+{
+    for (var node = sample.Stack; node >= 0; node = profile.Stacks[node].Parent)
+    {
+        var frame = profile.Frames[profile.Stacks[node].Frame];   // executing line/column, category
+        var function = profile.Functions[frame.Function];         // name, file, declaration, Program
+        Console.WriteLine($"{sample.Time}  {function.Name}  {frame.Category}");
+    }
+}
+```
+
+They are views over what the session recorded rather than copies of it, so reading a table costs nothing
+until a row is asked for. A sample's time is measured from the start of the session and the gap to the next
+one is how long that stack was observed — the weight the document writes is that gap over the interval, at
+least one.
+
 Worth knowing before you read a sampled profile:
 
 - **Samples are taken at the engine's check points**, the same once-per-64-statements cadence a timeout

--- a/docs/design/devtools-protocol.md
+++ b/docs/design/devtools-protocol.md
@@ -127,22 +127,17 @@ the vendored JSON by `ProtocolCitationTests`.
 | --- | --- | --- |
 | `Runtime` | `engine.Evaluate` (running) or `DebugHandler.Evaluate` (paused); `getProperties` over `GetOwnPropertyKeys` + descriptors, accessors reported and never invoked; `awaitPromise` by reactions; `consoleAPICalled`; `exceptionThrown`/`exceptionRevoked` from `Tasks.PromiseRejectionTracker`; `getHeapUsage` from `Diagnostics.GetMemoryReport` | **E5** ([#3597](https://github.com/sebastienros/jint/pull/3597)) structured `ConsoleRecord` sink overload + public `ValueInspector` (previews that never run script, promoted from `ConsoleFormatter`) |
 | `Debugger` | `ScriptRegistry` on `DebugHandler.BeforeEvaluate` keyed by `Program` identity (a cached `Prepared<Script>` is announced once); breakpoints as `DevToolsBreakPoint : BreakPoint` (the class is unsealed for this); `pause` as a flag checked in `Skip`; scopes from `DebugScopeType` 1:1 | **E1** ([#3587](https://github.com/sebastienros/jint/pull/3587)) `TryGetSourceText(Program)` for `getScriptSource`; **E2** ([#3614](https://github.com/sebastienros/jint/pull/3614)) `GetStepLocations(Program)` for `getPossibleBreakpoints` and column snapping; **E3** ([#3623](https://github.com/sebastienros/jint/pull/3623)) pause on exceptions with caught/uncaught; **E4** ([#3622](https://github.com/sebastienros/jint/pull/3622)) evaluate on any call frame; **E6** ([#3632](https://github.com/sebastienros/jint/issues/3632)) `CallFrame.Program`, a profile frame's `Program` and `CoverageSource.Program`, so a position is matched to a script by identity rather than by source name |
-| `Profiler` | `Profiler.Profile` synthesized from the evented `ScriptProfile` (`Jint/Profiling/`) behind an `IProfileSource` seam — one weighted sample per interval between two activations, so the time deltas add up to the recording rather than approximating it; precise/best-effort coverage from `CoverageReport` (`Jint/Runtime/Coverage/`), with the uncovered set derived from the script registry's abstract syntax tree so an unused function is reported with `count: 0` | none. The sampling profiler that landed as [#3608](https://github.com/sebastienros/jint/pull/3608) is **not** the source: `SampledProfile` publishes its sample, frame and stack tables as `internal` and a Firefox Profiler document as its only output, so it plugs into the same seam once those tables are public — an additive engine change ([#3630](https://github.com/sebastienros/jint/issues/3630)), not an edit to the domain |
+| `Profiler` | `Profiler.Profile` synthesized behind an `IProfileSource` seam from either of the engine's profilers (`Jint/Profiling/`) — the sampler by default, the evented one when the host is already sampling — one weighted sample per interval between two activations, so the time deltas add up to the recording rather than approximating it; precise/best-effort coverage from `CoverageReport` (`Jint/Runtime/Coverage/`), with the uncovered set derived from the script registry's abstract syntax tree so an unused function is reported with `count: 0` | **E7** ([#3630](https://github.com/sebastienros/jint/issues/3630)) public read-only accessors on `SampledProfile`'s sample, stack, frame and function tables, so the sampler of [#3608](https://github.com/sebastienros/jint/pull/3608) is consumable without writing its document and parsing it back |
 | `Console`, `Log` | the structured record | E5 |
 | `Target`, `Browser`, `Schema` | the session core and the manifest | none |
 
-**All six engine seams are merged**, and every one is additive and public — so that a third party (AngleSharp.Js,
+**All seven engine seams are merged**, and every one is additive and public — so that a third party (AngleSharp.Js,
 a DAP adapter, a host's own tooling) can build the same thing without `InternalsVisibleTo`. `Jint.DevTools`
 itself consumes only public Jint API; that is deliberate, and it is what proves the seams are reachable.
 
-Two seams the build wanted and did not get are open issues rather than silent workarounds, and each is
+One seam the build wanted and did not get is an open issue rather than a silent workaround, and it is
 named where it bites:
 
-- [#3630](https://github.com/sebastienros/jint/issues/3630) — **the sampler is not the profile's source.**
-  `SampledProfile` publishes its sample, frame and stack tables as `internal` and a Firefox Profiler document
-  as its only output, so `Profiler.start`/`stop` samples on its own activations behind `IProfileSource` and
-  reports `(root)`/`(program)` frames. Public read-only accessors on those tables make the sampler a second
-  `IProfileSource`, with no edit to the domain.
 - [#3631](https://github.com/sebastienros/jint/issues/3631) — **`caught` is not an engine mode.**
   `ExceptionPauseMode` is `None`/`Uncaught`/`All`, so the client's `caught` asks for `All` and drops the
   uncaught half in the `Break` handler — and declining a pause there means returning a `StepMode`, whose value

--- a/docs/design/devtools-protocol.md
+++ b/docs/design/devtools-protocol.md
@@ -126,16 +126,16 @@ the vendored JSON by `ProtocolCitationTests`.
 | Domain | What it maps onto | Engine change |
 | --- | --- | --- |
 | `Runtime` | `engine.Evaluate` (running) or `DebugHandler.Evaluate` (paused); `getProperties` over `GetOwnPropertyKeys` + descriptors, accessors reported and never invoked; `awaitPromise` by reactions; `consoleAPICalled`; `exceptionThrown`/`exceptionRevoked` from `Tasks.PromiseRejectionTracker`; `getHeapUsage` from `Diagnostics.GetMemoryReport` | **E5** ([#3597](https://github.com/sebastienros/jint/pull/3597)) structured `ConsoleRecord` sink overload + public `ValueInspector` (previews that never run script, promoted from `ConsoleFormatter`) |
-| `Debugger` | `ScriptRegistry` on `DebugHandler.BeforeEvaluate` keyed by `Program` identity (a cached `Prepared<Script>` is announced once); breakpoints as `DevToolsBreakPoint : BreakPoint` (the class is unsealed for this); `pause` as a flag checked in `Skip`; scopes from `DebugScopeType` 1:1 | **E1** ([#3587](https://github.com/sebastienros/jint/pull/3587)) `TryGetSourceText(Program)` for `getScriptSource`; **E2** ([#3614](https://github.com/sebastienros/jint/pull/3614)) `GetStepLocations(Program)` for `getPossibleBreakpoints` and column snapping; **E3** ([#3623](https://github.com/sebastienros/jint/pull/3623)) pause on exceptions with caught/uncaught; **E4** ([#3622](https://github.com/sebastienros/jint/pull/3622)) evaluate on any call frame |
+| `Debugger` | `ScriptRegistry` on `DebugHandler.BeforeEvaluate` keyed by `Program` identity (a cached `Prepared<Script>` is announced once); breakpoints as `DevToolsBreakPoint : BreakPoint` (the class is unsealed for this); `pause` as a flag checked in `Skip`; scopes from `DebugScopeType` 1:1 | **E1** ([#3587](https://github.com/sebastienros/jint/pull/3587)) `TryGetSourceText(Program)` for `getScriptSource`; **E2** ([#3614](https://github.com/sebastienros/jint/pull/3614)) `GetStepLocations(Program)` for `getPossibleBreakpoints` and column snapping; **E3** ([#3623](https://github.com/sebastienros/jint/pull/3623)) pause on exceptions with caught/uncaught; **E4** ([#3622](https://github.com/sebastienros/jint/pull/3622)) evaluate on any call frame; **E6** ([#3632](https://github.com/sebastienros/jint/issues/3632)) `CallFrame.Program`, a profile frame's `Program` and `CoverageSource.Program`, so a position is matched to a script by identity rather than by source name |
 | `Profiler` | `Profiler.Profile` synthesized from the evented `ScriptProfile` (`Jint/Profiling/`) behind an `IProfileSource` seam — one weighted sample per interval between two activations, so the time deltas add up to the recording rather than approximating it; precise/best-effort coverage from `CoverageReport` (`Jint/Runtime/Coverage/`), with the uncovered set derived from the script registry's abstract syntax tree so an unused function is reported with `count: 0` | none. The sampling profiler that landed as [#3608](https://github.com/sebastienros/jint/pull/3608) is **not** the source: `SampledProfile` publishes its sample, frame and stack tables as `internal` and a Firefox Profiler document as its only output, so it plugs into the same seam once those tables are public — an additive engine change ([#3630](https://github.com/sebastienros/jint/issues/3630)), not an edit to the domain |
 | `Console`, `Log` | the structured record | E5 |
 | `Target`, `Browser`, `Schema` | the session core and the manifest | none |
 
-**All five engine seams are merged**, and every one is additive and public — so that a third party (AngleSharp.Js,
+**All six engine seams are merged**, and every one is additive and public — so that a third party (AngleSharp.Js,
 a DAP adapter, a host's own tooling) can build the same thing without `InternalsVisibleTo`. `Jint.DevTools`
 itself consumes only public Jint API; that is deliberate, and it is what proves the seams are reachable.
 
-Three seams the build wanted and did not get are open issues rather than silent workarounds, and each is
+Two seams the build wanted and did not get are open issues rather than silent workarounds, and each is
 named where it bites:
 
 - [#3630](https://github.com/sebastienros/jint/issues/3630) — **the sampler is not the profile's source.**
@@ -148,10 +148,6 @@ named where it bites:
   uncaught half in the `Break` handler — and declining a pause there means returning a `StepMode`, whose value
   *is* the next step mode, so it cancels a step in flight. Harmless only because those frames are about to be
   unwound; a trap for every other host that filters pauses.
-- [#3632](https://github.com/sebastienros/jint/issues/3632) — **a frame carries a source name, not a
-  `Program`.** `ScriptRegistry.At` therefore matches by name and range, which collapses every sourceless
-  `Execute` into one `<anonymous>` script. It limits paused frames, profile frames and coverage sources at
-  once, and one seam closes all three.
 
 ## 6. Costs, stated up front
 

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -4837,6 +4837,34 @@ promised, but a host that wants the old answer for loader-loaded modules can say
 `new ModuleParsingOptions { RetainFunctionSourceText = false }` to
 `ModuleFactory.BuildSourceTextModule`.
 
+### 4.111 A coverage source is one parse, not one name ([#3632](https://github.com/sebastienros/jint/issues/3632))
+
+`CoverageReport.Sources` used to hold one `CoverageSource` per source *name*, folding the counts of every
+parse that shared one — so a host calling `Execute(text)` twice read one source whose hit counts were the
+sum. It holds one source per parsed program now, told apart by the new `CoverageSource.Program`, because a
+name cannot tell two scripts apart and every `Execute` given no source is named `<anonymous>`.
+
+```csharp
+engine.Execute("var a = 1;");
+engine.Execute("var a = 1;");
+// 5.0:  Sources = [ <anonymous> ], one entry, HitCount 2
+// 5.x:  Sources = [ <anonymous>, <anonymous> ], one entry each, HitCount 1
+```
+
+**What could break:** a reader that indexes `Sources` by name — `Sources.Single(s => s.Name == "app.js")`
+throws where it used to answer. Group and add up to restore the old shape:
+
+```csharp
+var total = report.Sources.Where(s => s.Name == "app.js")
+    .SelectMany(s => s.Entries)
+    .GroupBy(e => (e.Start.Index, e.End.Index, e.Kind))
+    .Select(g => (g.Key, Hits: g.Sum(e => e.HitCount)));
+```
+
+A host that caches a `Prepared<Script>` — which it should — never had several parses in the first place and
+reads exactly what it read before. Entries of a program the engine cannot name (`eval`, the `Function`
+constructor) are still folded together by name and position.
+
 ## 5. New in v5
 
 Everything in the table below is opt-in: nothing in it is installed unless the host asks for it, so
@@ -5467,6 +5495,25 @@ new EngineTargetOptions { Url = Path.GetFullPath("app.js") }   // /json/list say
 `Options.Interop.BuildCallStackHandler` is handed, and they stay exactly what the host passed;
 `Debugger.setBreakpointByUrl` accepts either form. A `Url` that is not a path — `jint://repl`,
 `https://…`, the empty string — is unchanged.
+
+### 5.17 A frame, a profile frame and a coverage source name the program they belong to ([#3632](https://github.com/sebastienros/jint/issues/3632))
+
+A `SourceLocation` carries a source *name*, and every `Execute` given no source is named `<anonymous>`, so a
+host mapping a position back to the script it announced through `DebugHandler.BeforeEvaluate` had to guess.
+Three types now carry the program itself — the same reference `BeforeEvaluate` hands over and
+`Engine.Advanced.TryGetSourceText` is keyed by:
+
+```csharp
+CallFrame frame = information.CallStack[0];
+Program? running = frame.Program;                       // the program this frame executes
+Program? declared = profile.Frames[0].Program;          // where a profiled function was parsed
+Program? covered = report.Sources[0].Program;           // which parse a coverage source is of
+```
+
+All three are `null` for code the engine reached another way — `eval` and the `Function` constructor are
+programs no execution context names, and a built-in or host callable has no source at all — rather than
+being attributed to whichever script was running. `ScriptProfileFrame`'s primary constructor gained the
+optional parameter that carries it, so a profile a host keeps now retains the abstract syntax trees it names.
 
 ## 6. AOT and trimming
 

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -5515,6 +5515,28 @@ programs no execution context names, and a built-in or host callable has no sour
 being attributed to whichever script was running. `ScriptProfileFrame`'s primary constructor gained the
 optional parameter that carries it, so a profile a host keeps now retains the abstract syntax trees it names.
 
+### 5.18 A sampled profile is readable, not only writable ([#3630](https://github.com/sebastienros/jint/issues/3630))
+
+`SampledProfile` published a Firefox Profiler document and nothing else, so a host rendering its own view —
+or speaking a protocol of its own — had to write that JSON and parse it back. Its four tables are now public,
+in the same shape the document is built from:
+
+```csharp
+foreach (var sample in profile.Samples)          // when it was taken, and which stack
+{
+    for (var node = sample.Stack; node >= 0; node = profile.Stacks[node].Parent)
+    {
+        var frame = profile.Frames[profile.Stacks[node].Frame];   // executing line/column, and a category
+        var function = profile.Functions[frame.Function];         // name, file, declaration, Program
+    }
+}
+```
+
+`ProfileFrameCategory` becomes public with them, and `SampledProfileFrame`, `SampledProfileStack` and
+`SampledProfileSample` are new. All of it is in the same preview area the sampler already was, so it carries
+`JINT0002`; a table is a view over what the session recorded rather than a copy, so reading one costs nothing
+until a row is asked for. Nothing that existed changed.
+
 ## 6. AOT and trimming
 
 Jint 4.16 asserted Native AOT compatibility with the `IsAotCompatible` property and nothing else. In


### PR DESCRIPTION
**Stacked on #3651, #3652 and #3654**; review the top commit only, and merge those three first.

A CDP `Profile` is what V8's *sampling* profiler produces and what `Profiler.setSamplingInterval` sets the rate of, so a sampler is the instrument a front end is asking for. This package could not use the engine's one, because `SampledProfile` published a Firefox Profiler document and nothing else — which is what #3654 fixes. With its tables public it becomes a second `IProfileSource`, and the domain does not change shape: that is what the seam was written for before there was a second implementation of it.

## Samples as a balanced stream

`SampledProfileSource.Stop` converts the sample table into the enters and leaves `RecordedProfile` speaks, which is lossless in that direction: two consecutive samples differ by a *suffix* of the stack, so the difference between them is a run of leaves and a run of enters at the later sample's time, and the interval between two samples belongs to the stack observed at the earlier one. `ProfileBuilder` then does exactly what it did.

Two decisions in it:

- **The sampler's synthetic `(program)` root is dropped.** `ProfileBuilder` has one of its own and gives it the time no script function was on the stack; carrying both would put the node in the tree twice. `(idle)` stays unemitted for the reason it always was — an engine target has no idle state to report, and a host that is not running script is doing something this package cannot see.
- **`DroppedSampleCount > 0` becomes `Truncated`**, which is what a client reads to know the profile describes the beginning of a run and nothing about the rest.

## Which instrument, and when

Chosen when a recording starts: the sampler, unless the engine is already sampling for the host — there is one sampling session per engine — in which case the client gets the exact profiler rather than a refusal. That costs the run more and misses nothing, which is the right way round for a fallback. `AHostAlreadySamplingLeavesTheClientTheOtherInstrument` pins it, including that the host's own session is untouched.

## What it costs the engine

Nothing an engine pays unless a client records. A sampling session is one `Stopwatch.GetTimestamp` and one comparison at the check points the amortized constraints already ride, where the exact profiler pays a frame lookup and a 16-byte event on *every call*; so the instrument this switches to is the cheaper of the two, and neither is armed until `Profiler.start`. No path in this package runs while script does.

## What this changes for a client, and for the tests

A sampler cannot show a call it never sampled: a function entered and left between two check points is not in the profile at all, where the exact profiler recorded every one of them. So `ProfilerSessionTests` now profiles a script that spends its time where it says it does, and asks for the fastest rate the protocol can name (`setSamplingInterval: 0`, "as fast as you can") because a workload short enough for a unit test has to be observed more than once. Ten consecutive runs of the file were green on both target frameworks.

The new one is the pin the issue asks for: `ACpuBoundScriptAttributesMostOfItsTimeToItsHotFunction` adds up the time deltas per node and requires the hottest to be the function the loop is in, with more than half the run. It asserts on the deltas rather than on the count of samples, because that is what the panel adds up per node.

`Jint.Tests.DevTools`: 376 on net10.0, 374 on net8.0, all green. No public surface changes here, so no baseline and no migration row; #3654 carries both.

`Domains/AGENTS.md`'s profiling section and `docs/design/devtools-protocol.md` now say the sampler is the source; the design doc moves #3630 out of the open-seams list and names it E7.

Fixes #3630

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
