### PR TITLE
Debugger: stopping on caught exceptions is a mode, declining a pause no longer cancels a step, and DevTools maps onto both

### DIFF
--- a/Jint.DevTools/Domains/AGENTS.md
+++ b/Jint.DevTools/Domains/AGENTS.md
@@ -174,13 +174,12 @@ too, and `hitBreakpoints` is what tells a breakpoint apart. The other is `except
 through `Break` with `PauseType.Exception`. The domain reads `DebugInformation.ThrownValue` and
 `IsUncaught` there. Four things about the mapping are decisions:
 
-- **`caught` is not an engine mode.** `ExceptionPauseMode` is `None`, `Uncaught` or `All`, so the client's
-  `caught` asks the engine for `All` and the pause decision drops the uncaught half. Inverting it — asking
-  for `Uncaught` and keeping what it did not raise — cannot work, because the engine does not raise a pause
-  at all for a throw it was not asked about.
-- **Filtering one out cancels a step in flight**, because the delegate's return value *is* the next step mode
-  and there is no way to say "unchanged". It is tolerable in this one case and nowhere else: the throw being
-  filtered is an uncaught one, and the frames a step was walking are about to be unwound by it anyway.
+- **Each of the protocol's four states is one engine mode**, `caught` included since
+  [#3631](https://github.com/sebastienros/jint/issues/3631), so this domain filters nothing: a throw that
+  reaches the `Break` handler is one the client asked to stop on. **Deciding it here instead is what must not
+  come back.** Declining a pause means returning a `StepMode`, and every one of those but
+  `StepMode.Unchanged` *sets* the mode — so a filter here cancels a step the client had in flight. Where a
+  future filter genuinely has no engine mode behind it, `StepMode.Unchanged` is the answer.
 - **`data` is the thrown value's `RemoteObject` with `uncaught` written onto it**, which is V8's shape
   exactly. The front end reads both halves — the object to render, and the flag to choose its wording — and
   the handle is billed to the backtrace group, so it dies with the frames. `hitBreakpoints` is an empty

--- a/Jint.DevTools/Domains/DebuggerDomain.Pause.cs
+++ b/Jint.DevTools/Domains/DebuggerDomain.Pause.cs
@@ -317,15 +317,9 @@ internal sealed partial class DebuggerDomain
 
         if (information.PauseType == PauseType.Exception)
         {
-            // `caught` is the one state the engine has no mode for: it is asked for every throw, and the half
-            // the client did not ask for is dropped here. Returning None cancels a step that was in flight,
-            // which is the only answer the delegate can give — and harmless in this one case, because the
-            // frames a step was walking are about to be unwound by the throw anyway.
-            if (information.IsUncaught && string.Equals(_pauseOnExceptions, SetPauseOnExceptionsRequestStateValues.Caught, StringComparison.Ordinal))
-            {
-                return StepMode.None;
-            }
-
+            // Nothing is filtered here: the protocol's four states are four engine modes, so a throw that
+            // reaches this handler is one the client asked to stop on. Deciding it here instead would mean
+            // declining with a StepMode, and every one of those but Unchanged sets the mode.
             return RunPauseLoop(information, new PauseCause
             {
                 Reason = PausedEventReasonValues.Exception,

--- a/Jint.DevTools/Domains/DebuggerDomain.cs
+++ b/Jint.DevTools/Domains/DebuggerDomain.cs
@@ -303,15 +303,12 @@ internal sealed partial class DebuggerDomain : DebuggerDomainBase
         _target.Engine.Debugger.PauseOnExceptions = IsEnabled ? EnginePauseMode(_pauseOnExceptions) : ExceptionPauseMode.None;
     }
 
-    /// <summary>The engine mode that answers a client's state, which for <c>caught</c> is a superset.</summary>
+    /// <summary>The engine mode that answers a client's state, which the protocol's four map onto one each.</summary>
     private static ExceptionPauseMode EnginePauseMode(string state) => state switch
     {
         SetPauseOnExceptionsRequestStateValues.Uncaught => ExceptionPauseMode.Uncaught,
-
-        // `caught` and `all` both need every throw reported; the pause decision keeps the half that was asked
-        // for. Asking for Uncaught and inverting the test would be wrong, not merely inefficient: the engine
-        // does not raise the pause at all for a throw it was not asked about.
-        SetPauseOnExceptionsRequestStateValues.Caught or SetPauseOnExceptionsRequestStateValues.All => ExceptionPauseMode.All,
+        SetPauseOnExceptionsRequestStateValues.Caught => ExceptionPauseMode.Caught,
+        SetPauseOnExceptionsRequestStateValues.All => ExceptionPauseMode.All,
         _ => ExceptionPauseMode.None,
     };
 

--- a/Jint.Tests.DevTools/Session/DebuggerExceptionPauseTests.cs
+++ b/Jint.Tests.DevTools/Session/DebuggerExceptionPauseTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Jint.DevTools;
+using Jint.Runtime.Debugger;
 
 namespace Jint.Tests.DevTools.Session;
 
@@ -84,8 +85,8 @@ public class DebuggerExceptionPauseTests
     }
 
     /// <summary>
-    /// <c>caught</c> is the mirror image, and the engine has no mode for it: it is <c>all</c> with the
-    /// uncaught half filtered out inside the pause decision.
+    /// <c>caught</c> is the mirror image, and it is an engine mode of its own: the engine decides it at the
+    /// throw, so a throw nobody will catch never reaches the pause handler at all.
     /// </summary>
     [Test]
     public async Task CaughtStopsOnlyAtTheThrowSomethingCatches()
@@ -97,7 +98,34 @@ public class DebuggerExceptionPauseTests
         Uncaught(paused).Should().BeFalse();
 
         (await RunAsync(session, "unguarded()")).Should().Be("threw boom");
-        session.EventsOf("Debugger.paused").Should().HaveCount(1, "the uncaught throw is filtered out, not stopped at");
+        session.EventsOf("Debugger.paused").Should().HaveCount(1, "the engine was never asked about the uncaught throw");
+    }
+
+    /// <summary>
+    /// Each of the protocol's four states is one engine mode, so no throw is raised for this domain to
+    /// decline — which it could only do by answering with a <c>StepMode</c>, and every one of those but
+    /// <c>Unchanged</c> sets the mode and cancels a step in flight.
+    /// </summary>
+    [Test]
+    public async Task EachProtocolStateIsAnEngineModeOfItsOwn()
+    {
+        await using var session = await CreateAsync();
+
+        var states = new (string State, ExceptionPauseMode Mode)[]
+        {
+            ("none", ExceptionPauseMode.None),
+            ("caught", ExceptionPauseMode.Caught),
+            ("uncaught", ExceptionPauseMode.Uncaught),
+            ("all", ExceptionPauseMode.All),
+        };
+
+        foreach (var (state, mode) in states)
+        {
+            await session.ResultAsync("Debugger.setPauseOnExceptions", $$"""{"state":"{{state}}"}""");
+
+            (await session.Target.PostAsync(engine => engine.Debugger.PauseOnExceptions))
+                .Should().Be(mode, "'{0}' is what the client asked the engine for", state);
+        }
     }
 
     /// <summary>

--- a/Jint.Tests.PublicInterface/HostExceptionPauseTests.cs
+++ b/Jint.Tests.PublicInterface/HostExceptionPauseTests.cs
@@ -236,4 +236,119 @@ public class HostExceptionPauseTests
 
         reported.Should().Contain("caught", "the event reports every throw, caught or not");
     }
+
+    // ---- caught, which is the fourth state a tool offers ----
+
+    /// <summary>
+    /// The complement of <see cref="ExceptionPauseMode.Uncaught"/>: a throw something will catch stops the
+    /// engine, and one nothing will catch does not.
+    /// </summary>
+    [Test]
+    public void CaughtStopsOnTheThrowsThatUncaughtLetsThrough()
+    {
+        var pauses = Run("""
+            function thrower() { throw new Error('handled'); }
+            try { thrower(); } catch (e) {}
+            undefined.foo;
+            """, ExceptionPauseMode.Caught);
+
+        pauses.Should().ContainSingle("only the throw a catch clause will land in");
+        pauses[0].ThrownValue.Should().Be("handled");
+        pauses[0].IsUncaught.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// The four modes partition the throws of one script, which is the property a tool's four-state control
+    /// is built on.
+    /// </summary>
+    [Test]
+    public void TheFourModesPartitionTheThrows()
+    {
+        const string Script = """
+            try { throw new Error('caught'); } catch (e) {}
+            undefined.foo;
+            """;
+
+        Run(Script, ExceptionPauseMode.None).Should().BeEmpty();
+        Run(Script, ExceptionPauseMode.Caught).Select(pause => pause.ThrownValue).Should().Equal("caught");
+        Run(Script, ExceptionPauseMode.Uncaught).Should().ContainSingle().Which.IsUncaught.Should().BeTrue();
+        Run(Script, ExceptionPauseMode.All).Should().HaveCount(2);
+    }
+
+    /// <summary>
+    /// <see cref="StepMode.Unchanged"/> is what a handler that declines to decide answers, and it is the
+    /// only answer that leaves a step in flight alone.
+    /// </summary>
+    [Test]
+    public void UnchangedLeavesAStepInFlightArmed()
+    {
+        static int StepsAfterTheThrow(StepMode declined)
+        {
+            var engine = new Engine(options =>
+            {
+                options.Debugger.Enabled = true;
+                options.Debugger.InitialStepMode = StepMode.Into;
+            });
+
+            engine.Debugger.PauseOnExceptions = ExceptionPauseMode.All;
+
+            var thrown = false;
+            var afterwards = 0;
+
+            engine.Debugger.Break += (sender, info) =>
+            {
+                // The exception pause, which this handler wants no part of.
+                thrown = true;
+                return declined;
+            };
+
+            engine.Debugger.Step += (sender, info) =>
+            {
+                if (thrown)
+                {
+                    afterwards++;
+                }
+
+                return StepMode.Into;
+            };
+
+            engine.Execute("""
+                var before = 1;
+                try { throw new Error('x'); } catch (e) {}
+                var first = 2;
+                var second = 3;
+                """);
+
+            thrown.Should().BeTrue("the throw was raised to the handler");
+            return afterwards;
+        }
+
+        StepsAfterTheThrow(StepMode.Unchanged).Should().BeGreaterThan(0, "the step was still armed");
+        StepsAfterTheThrow(StepMode.None).Should().Be(0, "None is a decision, and it cancelled the step");
+    }
+
+    /// <summary>
+    /// As an engine's initial mode it means <see cref="StepMode.None"/>: there is no mode yet to keep, and
+    /// an engine that quietly started stepping would stop on its first statement.
+    /// </summary>
+    [Test]
+    public void UnchangedAsTheInitialModeIsNoStepping()
+    {
+        var engine = new Engine(options =>
+        {
+            options.Debugger.Enabled = true;
+            options.Debugger.InitialStepMode = StepMode.Unchanged;
+        });
+
+        var steps = 0;
+        engine.Debugger.Step += (sender, info) =>
+        {
+            steps++;
+            return StepMode.Unchanged;
+        };
+
+        engine.Execute("var a = 1; var b = 2;");
+
+        steps.Should().Be(0);
+    }
 }

--- a/Jint.Tests.PublicInterface/UndocumentedPublicApi.txt
+++ b/Jint.Tests.PublicInterface/UndocumentedPublicApi.txt
@@ -12,7 +12,7 @@
 #
 # The names are ISO documentation comment ids, which is what the compiler writes into Jint.xml.
 #
-undocumented: 628
+undocumented: 622
 F:Jint.ModuleParsingOptions.Default
 F:Jint.ModulePreparationOptions.Default
 F:Jint.Native.Function.Function._length
@@ -56,10 +56,6 @@ F:Jint.Runtime.Debugger.PauseType.Break
 F:Jint.Runtime.Debugger.PauseType.DebuggerStatement
 F:Jint.Runtime.Debugger.PauseType.Skip
 F:Jint.Runtime.Debugger.PauseType.Step
-F:Jint.Runtime.Debugger.StepMode.Into
-F:Jint.Runtime.Debugger.StepMode.None
-F:Jint.Runtime.Debugger.StepMode.Out
-F:Jint.Runtime.Debugger.StepMode.Over
 F:Jint.Runtime.Descriptors.PropertyDescriptor.Undefined
 F:Jint.Runtime.Descriptors.PropertyFlag.AllForbidden
 F:Jint.Runtime.Descriptors.PropertyFlag.Configurable
@@ -608,12 +604,10 @@ T:Jint.Runtime.Debugger.CallFrame
 T:Jint.Runtime.Debugger.DebugCallStack
 T:Jint.Runtime.Debugger.DebugHandler
 T:Jint.Runtime.Debugger.DebugHandler.BeforeEvaluateEventHandler
-T:Jint.Runtime.Debugger.DebugHandler.DebugEventHandler
 T:Jint.Runtime.Debugger.DebugHandler.ExceptionThrownEventHandler
 T:Jint.Runtime.Debugger.DebugInformation
 T:Jint.Runtime.Debugger.DebugScopes
 T:Jint.Runtime.Debugger.PauseType
-T:Jint.Runtime.Debugger.StepMode
 T:Jint.Runtime.DefaultTimeSystem
 T:Jint.Runtime.Descriptors.GetSetPropertyDescriptor
 T:Jint.Runtime.Descriptors.PropertyDescriptor

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
@@ -2321,6 +2321,7 @@ namespace Jint.Runtime.Debugger
         None = 0,
         Uncaught = 1,
         All = 2,
+        Caught = 3,
     }
     public sealed class ExceptionThrownEventArgs : System.EventArgs
     {
@@ -2357,6 +2358,7 @@ namespace Jint.Runtime.Debugger
         Over = 1,
         Into = 2,
         Out = 3,
+        Unchanged = 4,
     }
 }
 namespace Jint.Runtime.Descriptors

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net472.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net472.verified.txt
@@ -2134,6 +2134,7 @@ namespace Jint.Runtime.Debugger
         None = 0,
         Uncaught = 1,
         All = 2,
+        Caught = 3,
     }
     public sealed class ExceptionThrownEventArgs : System.EventArgs
     {
@@ -2170,6 +2171,7 @@ namespace Jint.Runtime.Debugger
         Over = 1,
         Into = 2,
         Out = 3,
+        Unchanged = 4,
     }
 }
 namespace Jint.Runtime.Descriptors

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
@@ -2321,6 +2321,7 @@ namespace Jint.Runtime.Debugger
         None = 0,
         Uncaught = 1,
         All = 2,
+        Caught = 3,
     }
     public sealed class ExceptionThrownEventArgs : System.EventArgs
     {
@@ -2357,6 +2358,7 @@ namespace Jint.Runtime.Debugger
         Over = 1,
         Into = 2,
         Out = 3,
+        Unchanged = 4,
     }
 }
 namespace Jint.Runtime.Descriptors

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.0.verified.txt
@@ -2134,6 +2134,7 @@ namespace Jint.Runtime.Debugger
         None = 0,
         Uncaught = 1,
         All = 2,
+        Caught = 3,
     }
     public sealed class ExceptionThrownEventArgs : System.EventArgs
     {
@@ -2170,6 +2171,7 @@ namespace Jint.Runtime.Debugger
         Over = 1,
         Into = 2,
         Out = 3,
+        Unchanged = 4,
     }
 }
 namespace Jint.Runtime.Descriptors

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.1.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.1.verified.txt
@@ -2134,6 +2134,7 @@ namespace Jint.Runtime.Debugger
         None = 0,
         Uncaught = 1,
         All = 2,
+        Caught = 3,
     }
     public sealed class ExceptionThrownEventArgs : System.EventArgs
     {
@@ -2170,6 +2171,7 @@ namespace Jint.Runtime.Debugger
         Over = 1,
         Into = 2,
         Out = 3,
+        Unchanged = 4,
     }
 }
 namespace Jint.Runtime.Descriptors

--- a/Jint/Runtime/Debugger/DebugHandler.cs
+++ b/Jint/Runtime/Debugger/DebugHandler.cs
@@ -21,7 +21,26 @@ public enum PauseType
 public class DebugHandler
 {
     public delegate void BeforeEvaluateEventHandler(object sender, Program ast);
+
+    /// <summary>
+    /// Handles one execution point the engine stopped at, and answers what it does next.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>The return value is the next step mode, not an acknowledgement.</b> Returning
+    /// <see cref="StepMode.None"/> from a handler that only meant "not this one" cancels a step the host
+    /// armed earlier; <see cref="StepMode.Unchanged"/> is how a handler declines without deciding.
+    /// </para>
+    /// <para>
+    /// It runs on the engine's own thread, inside the execution point: returning is what resumes the script,
+    /// so a handler that services a user interface has to do it before it returns.
+    /// </para>
+    /// </remarks>
+    /// <param name="sender">The <see cref="Engine"/> that stopped.</param>
+    /// <param name="e">Where it stopped, and what the call stack looks like there.</param>
+    /// <returns>How the engine should continue.</returns>
     public delegate StepMode DebugEventHandler(object sender, DebugInformation e);
+
     public delegate void ExceptionThrownEventHandler(object sender, ExceptionThrownEventArgs e);
 
     private readonly Engine _engine;
@@ -82,7 +101,10 @@ public class DebugHandler
     {
         _engine = engine;
         BreakPoints = new BreakPointCollection();
-        HandleNewStepMode(initialStepMode);
+
+        // There is no mode yet to keep, and leaving the stepping depth at its default would arm a step at
+        // top level rather than arm nothing.
+        HandleNewStepMode(initialStepMode == StepMode.Unchanged ? StepMode.None : initialStepMode);
     }
 
     private bool IsStepping => _engine.CallStack.Count <= _steppingDepth;
@@ -121,12 +143,13 @@ public class DebugHandler
     /// </para>
     /// <para>
     /// <see cref="ExceptionPauseMode.Uncaught"/> means no <c>catch</c> clause is executing on the stack — a
-    /// <c>finally</c>-only <c>try</c> does not count, a <c>catch</c> in a calling function does. Two
-    /// boundaries end that search, because a throw crossing either becomes something other than an exception:
-    /// a host entry, whose caller receives a <see cref="JavaScriptException"/>, and an async function body,
-    /// whose throw becomes a rejection of its own promise. So an async function that throws is uncaught even
-    /// when its caller wrapped the call in <c>try</c>/<c>catch</c>, which is what a user asking to stop on
-    /// uncaught exceptions wants and what a rejection nobody handles turns out to be.
+    /// <c>finally</c>-only <c>try</c> does not count, a <c>catch</c> in a calling function does — and
+    /// <see cref="ExceptionPauseMode.Caught"/> is its complement. Two boundaries end that search, because a
+    /// throw crossing either becomes something other than an exception: a host entry, whose caller receives a
+    /// <see cref="JavaScriptException"/>, and an async function body, whose throw becomes a rejection of its
+    /// own promise. So an async function that throws is uncaught even when its caller wrapped the call in
+    /// <c>try</c>/<c>catch</c>, which is what a user asking to stop on uncaught exceptions wants and what a
+    /// rejection nobody handles turns out to be.
     /// </para>
     /// <para>
     /// A rejection with no throw behind it — <c>Promise.reject(x)</c> — never stops the engine. Nothing here
@@ -539,7 +562,18 @@ public class DebugHandler
         // Nothing on the CLR stack between the throw and here has popped a call frame, so the engine's
         // count of executing try-with-catch blocks is still the one the throw was raised under.
         var uncaught = _engine._tryCatchDepth == 0;
-        if (pauseMode == ExceptionPauseMode.Uncaught && !uncaught)
+
+        // The four modes partition the throws, so the decision is made here and a handler is never raised
+        // for one it would have to decline.
+        var asked = pauseMode switch
+        {
+            ExceptionPauseMode.All => true,
+            ExceptionPauseMode.Uncaught => uncaught,
+            ExceptionPauseMode.Caught => !uncaught,
+            _ => false,
+        };
+
+        if (!asked)
         {
             return;
         }
@@ -665,9 +699,14 @@ public class DebugHandler
         HandleNewStepMode(result);
     }
 
+    /// <summary>
+    /// Applies what a notification's handler decided. Null is what no subscriber answers, and
+    /// <see cref="StepMode.Unchanged"/> is what a subscriber that declined to pause answers; both leave the
+    /// mode alone, so a step a client armed before the notification is still armed after it.
+    /// </summary>
     private void HandleNewStepMode(StepMode? newStepMode)
     {
-        if (newStepMode != null)
+        if (newStepMode is not null and not StepMode.Unchanged)
         {
             _steppingDepth = newStepMode switch
             {

--- a/Jint/Runtime/Debugger/ExceptionPauseMode.cs
+++ b/Jint/Runtime/Debugger/ExceptionPauseMode.cs
@@ -18,5 +18,16 @@ public enum ExceptionPauseMode
     /// <summary>
     /// Every exception stops the engine, whether or not something will catch it.
     /// </summary>
-    All
+    All,
+
+    /// <summary>
+    /// Only an exception a <c>catch</c> clause on the stack will land in stops the engine, which is the
+    /// complement of <see cref="Uncaught"/>.
+    /// </summary>
+    /// <remarks>
+    /// What a tool offers as "pause on caught exceptions". The engine decides it where the throw happens, so
+    /// a handler is never raised for a throw it would have to decline — which it could only do by returning a
+    /// <see cref="StepMode"/>, and every one but <see cref="StepMode.Unchanged"/> cancels a step in flight.
+    /// </remarks>
+    Caught,
 }

--- a/Jint/Runtime/Debugger/StepMode.cs
+++ b/Jint/Runtime/Debugger/StepMode.cs
@@ -1,9 +1,45 @@
 namespace Jint.Runtime.Debugger;
 
+/// <summary>
+/// What the engine does after a <see cref="DebugHandler.DebugEventHandler"/> returns, which is how a handler
+/// steps.
+/// </summary>
 public enum StepMode
 {
+    /// <summary>
+    /// Run on. Nothing stops the engine until a breakpoint, a <c>debugger</c> statement or a thrown
+    /// exception <see cref="DebugHandler.PauseOnExceptions"/> asked for.
+    /// </summary>
     None,
+
+    /// <summary>
+    /// Stop at the next execution point of this frame, running any call it makes to completion.
+    /// </summary>
     Over,
+
+    /// <summary>
+    /// Stop at the next execution point anywhere, including the first one inside a call.
+    /// </summary>
     Into,
-    Out
+
+    /// <summary>
+    /// Run on until this frame returns, and stop at the next execution point of its caller.
+    /// </summary>
+    Out,
+
+    /// <summary>
+    /// Leave the step mode as it is, which is what a handler that declined to pause has to say.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Every other member <em>sets</em> the mode, so a handler that only meant "not this one" and answered
+    /// <see cref="None"/> cancelled a step that was in flight. This one changes nothing: a step the client
+    /// asked for before the notification is still armed after it.
+    /// </para>
+    /// <para>
+    /// As the initial mode of an engine (<c>Options.Debugger.InitialStepMode</c>) it means
+    /// <see cref="None"/>, there being no mode yet to keep.
+    /// </para>
+    /// </remarks>
+    Unchanged,
 }

--- a/docs/design/devtools-protocol.md
+++ b/docs/design/devtools-protocol.md
@@ -126,23 +126,20 @@ the vendored JSON by `ProtocolCitationTests`.
 | Domain | What it maps onto | Engine change |
 | --- | --- | --- |
 | `Runtime` | `engine.Evaluate` (running) or `DebugHandler.Evaluate` (paused); `getProperties` over `GetOwnPropertyKeys` + descriptors, accessors reported and never invoked; `awaitPromise` by reactions; `consoleAPICalled`; `exceptionThrown`/`exceptionRevoked` from `Tasks.PromiseRejectionTracker`; `getHeapUsage` from `Diagnostics.GetMemoryReport` | **E5** ([#3597](https://github.com/sebastienros/jint/pull/3597)) structured `ConsoleRecord` sink overload + public `ValueInspector` (previews that never run script, promoted from `ConsoleFormatter`) |
-| `Debugger` | `ScriptRegistry` on `DebugHandler.BeforeEvaluate` keyed by `Program` identity (a cached `Prepared<Script>` is announced once); breakpoints as `DevToolsBreakPoint : BreakPoint` (the class is unsealed for this); `pause` as a flag checked in `Skip`; scopes from `DebugScopeType` 1:1 | **E1** ([#3587](https://github.com/sebastienros/jint/pull/3587)) `TryGetSourceText(Program)` for `getScriptSource`; **E2** ([#3614](https://github.com/sebastienros/jint/pull/3614)) `GetStepLocations(Program)` for `getPossibleBreakpoints` and column snapping; **E3** ([#3623](https://github.com/sebastienros/jint/pull/3623)) pause on exceptions with caught/uncaught; **E4** ([#3622](https://github.com/sebastienros/jint/pull/3622)) evaluate on any call frame; **E6** ([#3632](https://github.com/sebastienros/jint/issues/3632)) `CallFrame.Program`, a profile frame's `Program` and `CoverageSource.Program`, so a position is matched to a script by identity rather than by source name |
+| `Debugger` | `ScriptRegistry` on `DebugHandler.BeforeEvaluate` keyed by `Program` identity (a cached `Prepared<Script>` is announced once); breakpoints as `DevToolsBreakPoint : BreakPoint` (the class is unsealed for this); `pause` as a flag checked in `Skip`; scopes from `DebugScopeType` 1:1 | **E1** ([#3587](https://github.com/sebastienros/jint/pull/3587)) `TryGetSourceText(Program)` for `getScriptSource`; **E2** ([#3614](https://github.com/sebastienros/jint/pull/3614)) `GetStepLocations(Program)` for `getPossibleBreakpoints` and column snapping; **E3** ([#3623](https://github.com/sebastienros/jint/pull/3623)) pause on exceptions with caught/uncaught; **E4** ([#3622](https://github.com/sebastienros/jint/pull/3622)) evaluate on any call frame; **E6** ([#3632](https://github.com/sebastienros/jint/issues/3632)) `CallFrame.Program`, a profile frame's `Program` and `CoverageSource.Program`, so a position is matched to a script by identity rather than by source name ; **E8** ([#3631](https://github.com/sebastienros/jint/issues/3631)) `ExceptionPauseMode.Caught` and `StepMode.Unchanged`, so the four protocol states are four engine modes and declining a pause cannot cancel a step |
 | `Profiler` | `Profiler.Profile` synthesized behind an `IProfileSource` seam from either of the engine's profilers (`Jint/Profiling/`) — the sampler by default, the evented one when the host is already sampling — one weighted sample per interval between two activations, so the time deltas add up to the recording rather than approximating it; precise/best-effort coverage from `CoverageReport` (`Jint/Runtime/Coverage/`), with the uncovered set derived from the script registry's abstract syntax tree so an unused function is reported with `count: 0` | **E7** ([#3630](https://github.com/sebastienros/jint/issues/3630)) public read-only accessors on `SampledProfile`'s sample, stack, frame and function tables, so the sampler of [#3608](https://github.com/sebastienros/jint/pull/3608) is consumable without writing its document and parsing it back |
 | `Console`, `Log` | the structured record | E5 |
 | `Target`, `Browser`, `Schema` | the session core and the manifest | none |
 
-**All seven engine seams are merged**, and every one is additive and public — so that a third party (AngleSharp.Js,
+**All eight engine seams are merged**, and every one is additive and public — so that a third party (AngleSharp.Js,
 a DAP adapter, a host's own tooling) can build the same thing without `InternalsVisibleTo`. `Jint.DevTools`
 itself consumes only public Jint API; that is deliberate, and it is what proves the seams are reachable.
 
-One seam the build wanted and did not get is an open issue rather than a silent workaround, and it is
-named where it bites:
-
-- [#3631](https://github.com/sebastienros/jint/issues/3631) — **`caught` is not an engine mode.**
-  `ExceptionPauseMode` is `None`/`Uncaught`/`All`, so the client's `caught` asks for `All` and drops the
-  uncaught half in the `Break` handler — and declining a pause there means returning a `StepMode`, whose value
-  *is* the next step mode, so it cancels a step in flight. Harmless only because those frames are about to be
-  unwound; a trap for every other host that filters pauses.
+Every seam the build wanted it now has; the three it was missing at design time are
+[#3630](https://github.com/sebastienros/jint/issues/3630),
+[#3631](https://github.com/sebastienros/jint/issues/3631) and
+[#3632](https://github.com/sebastienros/jint/issues/3632), and each is named in the table above under the
+domain it was blocking.
 
 ## 6. Costs, stated up front
 

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -5593,6 +5593,29 @@ foreach (var sample in profile.Samples)          // when it was taken, and which
 `JINT0002`; a table is a view over what the session recorded rather than a copy, so reading one costs nothing
 until a row is asked for. Nothing that existed changed.
 
+### 5.19 A debugger can stop on caught exceptions, and decline a pause without cancelling a step ([#3631](https://github.com/sebastienros/jint/issues/3631))
+
+A tool's "pause on exceptions" control has four states and `ExceptionPauseMode` had three, so a host wanting
+the fourth asked for `All` and dropped the uncaught half in its own handler — and the only way a handler can
+decline a pause is to return a `StepMode`, whose value *is* the next step mode. Declining therefore cancelled
+a step the host had armed. Both halves are closed:
+
+```csharp
+engine.Debugger.PauseOnExceptions = ExceptionPauseMode.Caught;   // the complement of Uncaught
+
+engine.Debugger.Break += (sender, info) => info.PauseType == PauseType.Exception
+    ? StepMode.Unchanged                                          // not this one; leave the mode alone
+    : StepMode.Into;
+```
+
+`ExceptionPauseMode.Caught` stops only where a `catch` clause on the stack will land, decided at the throw —
+so the engine never raises a pause the handler would have to skip. `StepMode.Unchanged` is the general form:
+every other member sets the mode, and this one keeps it. As an engine's initial mode
+(`Options.Debugger.InitialStepMode`) it means `None`, there being no mode yet to keep.
+
+Both are new members of existing enums, so nothing that compiled stops compiling — but a `switch` *expression*
+over either that listed every member and had no discard arm will now warn that it is not exhaustive.
+
 ## 6. AOT and trimming
 
 Jint 4.16 asserted Native AOT compatibility with the `IsAotCompatible` property and nothing else. In


### PR DESCRIPTION
Rebased onto `main` at 7462c8a63 — on top of both #3654 and #3653 — and folded: this is the engine seam **and** its `Jint.DevTools` consumer in one commit. The DevTools half was #3663, which is closed in favour of this. It is no longer stacked on anything.

A tool's "pause on exceptions" control has four states — none, caught, uncaught, all — and `ExceptionPauseMode` had three. A host wanting the fourth asks the engine for `All` and drops the half it did not want in its own `Break` handler, which is what `Jint.DevTools` did. But the only way a handler can decline a pause is to return a `StepMode`, and a `StepMode`'s value **is** the next step mode: declining cancels whatever step was in flight. It was harmless where this package did it — the frames a step was walking are about to be unwound by the throw anyway — and a trap for every other host.

Both halves are closed, and both are additive members of existing enums.

## `ExceptionPauseMode.Caught`

The complement of `Uncaught`, decided at the throw in the same place and from the same state, so the engine never raises a pause a handler would have to skip:

```csharp
engine.Debugger.PauseOnExceptions = ExceptionPauseMode.Caught;
```

The four modes partition the throws of a script, which is the property a four-state control is built on, and `TheFourModesPartitionTheThrows` asserts exactly that over one script with one caught and one uncaught throw.

## `StepMode.Unchanged`

The general form, and the one the issue asks for: every other member sets the mode, and this one keeps it.

```csharp
engine.Debugger.Break += (sender, info) => info.PauseType == PauseType.Exception
    ? StepMode.Unchanged      // not this one; leave the step in flight alone
    : StepMode.Into;
```

**Why a member and not a nullable return.** `HandleNewStepMode` already takes a `StepMode?` and already treats null as "leave it alone" — that is what an event with no subscriber answers, and it is exactly the meaning wanted. But making the *delegate* return `StepMode?` would break every existing `DebugEventHandler`: a method returning `StepMode` is not assignable to a delegate returning `StepMode?`. A new enum member breaks nobody. The one place it needs care is `Options.Debugger.InitialStepMode`, where there is no mode yet to keep: `Unchanged` there means `None`, because leaving the stepping depth at its default would arm a step at top level rather than arm nothing — pinned by `UnchangedAsTheInitialModeIsNoStepping`.

## DevTools maps onto both

The protocol's four states become four engine modes and `DebuggerDomain.Stop` filters nothing: a throw that reaches the handler is one the client asked to stop on. What a client sees is unchanged, which is what the four existing state tests (each against a throw something catches and a throw nothing catches) say by still passing; `EachProtocolStateIsAnEngineModeOfItsOwn` pins the mapping itself. `Domains/AGENTS.md` now says that deciding a pause in that domain is what must not come back, with `StepMode.Unchanged` named as the answer where a future filter genuinely has no engine mode behind it.

## Hot paths touched

None. `HandleNewStepMode` runs once per debugger notification, on an engine with the debugger enabled, and gains one comparison against a constant; the exception-mode test is the same single comparison it was, rewritten as a four-armed `switch` that states the partition. No benchmark is attached for that reason.

## Tests

`HostExceptionPauseTests` gains four: `caught` stops on the throws `uncaught` lets through, the four modes partition one script's throws, `Unchanged` leaves a step in flight armed **where `None` cancels it** (the two asserted against each other in one test, which is the defect the issue describes), and `Unchanged` as an initial mode is no stepping. `DebuggerExceptionPauseTests` gains the mapping pin.

`DebugEventHandler` and `StepMode` are documented rather than left in `UndocumentedPublicApi.txt`, which shrinks by six — what the return value means is the whole of this change. Five `PublicApiTest` baselines re-accepted (two lines each); `docs/v5-migration.md` §5.19.

Full solution in Release: `Jint.Tests` 12069, `Jint.Tests.PublicInterface` 3551, `Jint.Tests.DevTools` 377, `Jint.Tests.Test262` 102573 — all green.

## Reconciled with #3653

Both now live in `OnExceptionThrown` and they answer different questions. #3653's `reRaisedAtBodyBoundary` returns at the very top, so a throw re-raised at a body boundary raises neither the event nor a pause — one `throw` is reported once, in the frame it was raised in. The mode partition here sits below that, in the pause decision alone, and decides *which* of the throws that are reported stop the engine. Neither guard weakens the other, and the debugger suites of both pull requests pass together (`Jint.Tests` debugger filter 171, `HostExceptionPauseTests` 15).

Fixes #3631

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
