### PR TITLE
Browser: a page's observers fire, and its DOM views answer

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,6 +12,11 @@
          these assemblies' [DomName] surface. Bump both together, regenerate, and read the diff. -->
     <PackageVersion Include="AngleSharp" Version="1.7.2" />
     <PackageVersion Include="AngleSharp.Css" Version="1.0.2" />
+    <!-- AngleSharp.Xml is deliberately NOT in the binding generator's pin: the generator reads AngleSharp and
+         AngleSharp.Css and nothing else, and this package contributes no [DomName] interface to the binding.
+         It is referenced for one thing only — DOMParser's XML content types, which need an XML parser and
+         which this package's own principle says must not be written here. -->
+    <PackageVersion Include="AngleSharp.Xml" Version="1.2.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="BenchmarkDotNet.TestAdapter" Version="0.15.8" />
     <PackageVersion Include="AwesomeAssertions" Version="9.6.0" />

--- a/Jint.Browser/AGENTS.md
+++ b/Jint.Browser/AGENTS.md
@@ -88,6 +88,7 @@ version of AngleSharp nobody references.
 | `manual` | An interface whose shape is hand-written in `DomManualShapes`. Today: `IHtmlCollection<T>`, whose generic invariance keeps a member body from naming its receiver. A manual interface contributes no members to any closure — its children inherit them through the prototype chain. |
 | `skip` | A member a later campaign item owns: navigation (`location.assign`, `location.href`'s setter), activation (`click`, `focus`, `blur`, `form.reset`), the parser (`document.open`/`close`/`load`), and `document.createEvent`, whose AngleSharp `Event` must never reach script. `half: "setter"` skips the write half only. |
 | `hooks` | A member routed through `DomHostHooks` so the parser driver can replace its body: the `innerHTML` and `outerHTML` setters, `insertAdjacentHTML`, `document.write`/`writeln`. The default implementations *are* the AngleSharp call, so the seam costs nothing until R3 uses it. The same class carries `WrapperCreated`, which is the other direction — a member the generator could not emit at all, added to one wrapper. |
+| `additions` | A member the **standard** puts on a generated interface and AngleSharp's metadata cannot express: a callback parameter (`createTreeWalker`, `createNodeIterator`), a stringifier with no `[DomName]` (`Range.toString`), a member AngleSharp spells by its Shadow DOM v0 name (`slot.assignedNodes`), a member whose `[DomName]` is simply missing (`ShadowRoot.mode`), and the two CSSOM View rectangles a page with no layout still calls. The body is one line calling `Dom/Views/DomViewMembers`, and it is the **only** list whose entries name something the pinned assemblies do not have — what is checked is the opposite, that the interface exists and that the member does not, so an addition can never quietly shadow a member AngleSharp grew. An addition whose member AngleSharp *skipped* replaces that skip and removes it from the report. |
 | `nullableStrings` | The members whose IDL type is `DOMString?` rather than `DOMString`. See the conversion table below. |
 | `stringEnums`, `constants` | The two enum decisions the heuristics above cannot make. |
 
@@ -139,6 +140,14 @@ here:
 | `matchMedia(q).matches` | evaluates the query against the viewport | `CssMediaQueryList.ComputeMatched` is `return false`, so **every** query answers `false` — a page asking whether it is on a narrow screen is always told no. `Runtime/MediaQuery` answers the subset a page branches on instead |
 | `document.currentScript` | HTML §4.12.1: the script whose text is running | the head of the *deferred* script queue, so it is `null` for exactly the case a page uses it in |
 | `location.host = …` (and `pathname`, `port`, `protocol`, `search`) | a navigation the page can observe | raises `Location.Changed`, which `Document.LocationChanged` handles in a fire-and-forget `async void` calling `IBrowsingContext.OpenAsync` — on whatever thread the setter ran on. **Unreachable from script**, because `Runtime/LocationInstaller` shadows every `Location` member with an own property over the page's own URL; AngleSharp's location is never written |
+| `observer.disconnect()` | DOM §4.3.3 empties the observer's registered-node list | `MutationObserver.Disconnect` unregisters it from the document but leaves that list populated, so the **next** `observe()` of any node silently re-registers every node it used to watch |
+| `observer.observe(document, …)` | observes the document node | `Connect` silently retargets a `Document` to its `documentElement`, so a `childList` mutation of the document itself is never reported. With `subtree: true` — how nearly every page writes it — nothing else changes |
+| `observe(…)` with bad options | a `TypeError` | a `DomException` (`TypeMismatchError` / `SyntaxError`), and its resolution of the dictionary's optional members differs from the standard's: `{ attributeOldValue: false }` alone is valid in DOM and invalid there |
+| `record.addedNodes` on an attribute record | an empty `NodeList` | `null`, for both `Added` and `Removed` |
+| `IShadowRoot.Mode` | `ShadowRoot.mode` | the one member of the interface with no `[DomName]`, so nothing says it is projected |
+| `slot.assignedNodes()` | DOM §4.2.5 | named `getDistributedNodes`, the Shadow DOM v0 spelling |
+| `getComputedStyle(span).display` | `inline` | the empty string: the cascade reports only what a stylesheet *declared*, and `display: inline` is CSS's initial value, so the user-agent sheet does not declare it. A declared one (`div` → `block`) resolves |
+| the computed style is writable | CSSOM's computed flag makes every write a `NoModificationAllowedError` | an ordinary writable declaration, and a detached one, so a write neither throws nor changes anything readable — see `Dom/Views/ReadOnlyStyleDeclaration` |
 
 The `dataset` one has a visible consequence inside the binding, and the one place a workaround is legitimate:
 the generated `SupportedNames` filters out a `null` value, because the projection's three hooks must agree at
@@ -194,6 +203,56 @@ way, and it is the mistake a generator makes by default.
 and workers are [`Runtime/AGENTS.md`](Runtime/AGENTS.md). The one rule to carry across the boundary without
 opening it: **one thread owns a page's engine and its DOM**, every public `Page` member is a mailbox request,
 and nothing belonging to an engine — a `JsValue`, an AngleSharp node — may be in the task it answers.
+
+### The observers, and when each of them delivers
+
+`Observers/` holds three. **Each delivers on a different lane, and the lane is the design.**
+
+- **`MutationObserver` delivers on the engine's job queue — the microtask checkpoint.** The *records* are
+  AngleSharp's: `DocumentExtensions.QueueMutation` already walks a mutated node's inclusive ancestors, matches
+  each against the registered observer list, honours `subtree` and `attributeFilter`, and clears `oldValue`
+  for an observer that did not ask for it. What it has no answer for is *when*, and the reason is the parser
+  hop above: its `MutationHost` schedules through an `IEventLoop` service, **nothing in AngleSharp implements
+  one**, and `EventLoopExtensions.Enqueue` on a null loop runs the action *inline* — so out of the box the
+  callback fires synchronously inside `appendChild`. Registering an event loop to fix that is precisely what
+  would make a step of the parse asynchronous and take the fallback. So the inline call is used as the
+  **arrival** of a record and nothing else: `JsMutationObserver` parks it and `MutationObserverLane` puts one
+  job on the engine's queue per batch. Ordering then falls out of a plain enqueue, and
+  `Observers/MutationObserverTests` pins it. The notify set is also the only strong reference this package
+  keeps to an observer, which is DOM's own rule that one with a non-empty record queue is reachable.
+- **`IntersectionObserver` and `ResizeObserver` deliver as a *task*** — a zero-delay timer entry
+  (`ObserverTask`) — because both belong to update-the-rendering and a microtask would run before the promises
+  of the same turn. It also makes the delivery visible to `Page.WaitForIdleAsync`.
+- **Both are stubs, and the shape of the lie is the point.** Each observed target is reported exactly once,
+  fully intersecting or at zero size, and never again, because with no layout nothing can change. "Never
+  intersecting" would stop every lazy list and reveal-on-scroll animation dead, and the initial resize
+  notification is the one a component uses to measure itself when it mounts. `root`, `rootMargin` and
+  `thresholds` are parsed, validated and reflected exactly as the specification says and change nothing.
+  Rectangles are `ObserverGeometry` zeros and are **plain objects, not `DOMRectReadOnly`**: there is no
+  rectangle interface in this package yet, and one whose every instance is zeros would be worse than none.
+  The flat-box model (campaign item C4) turns all of it into real numbers.
+
+None of the five interface objects is generated, so they are hand-written `JsObjectShape`s behind
+`HostInterfaceObject`, and `Views/HostInterfaceDisciplineTests` holds them to the same two rules
+`DomPrototypeTests` and `WebIdlPropertyAttributeTests` hold the generated ones to.
+
+`Dom/Views/` is the same story for the interfaces a *browser* supplies rather than the DOM — `DOMParser`,
+`XMLSerializer`, `Selection`, `MediaQueryListEvent` — plus the members that make the generated `Range`,
+`TreeWalker` and `NodeIterator` usable. Three things there are worth knowing:
+
+- **`DOMParser`'s XML half is `AngleSharp.Xml`**, referenced for that and nothing else; writing an XML parser
+  here instead is the one thing this package is not for. It is deliberately **not** in `pin.json` — the
+  generator reads two assemblies and projects no interface from this one. A failed parse answers the
+  `parsererror` document the standard prescribes, which is what a page tests for.
+- **A parsed document cannot run anything**: its parser gets a browsing context of its own with no scripting
+  service and `IsScripting` false, so a `<script>` in the input is an element with text and nothing more.
+- **`Selection` has no direction**, because direction comes from which end a user dragged from: the anchor is
+  always the range's start.
+
+`matchMedia` gained its other half. `PageRuntime.SetViewport` is the seam device emulation (campaign item C5)
+drives, and every `MediaQueryList` the page holds recomputes and fires `change` — a real
+`MediaQueryListEvent`, because `e => e.matches` is how the listener is written — only if its own answer moved.
+No `resize` event fires at the window: HTML fires that from update-the-rendering, and there is none.
 
 ### The seams promoted later
 

--- a/Jint.Browser/AGENTS.md
+++ b/Jint.Browser/AGENTS.md
@@ -218,8 +218,10 @@ and nothing belonging to an engine — a `JsValue`, an AngleSharp node — may b
   would make a step of the parse asynchronous and take the fallback. So the inline call is used as the
   **arrival** of a record and nothing else: `JsMutationObserver` parks it and `MutationObserverLane` puts one
   job on the engine's queue per batch. Ordering then falls out of a plain enqueue, and
-  `Observers/MutationObserverTests` pins it. The notify set is also the only strong reference this package
-  keeps to an observer, which is DOM's own rule that one with a non-empty record queue is reachable.
+  `Observers/MutationObserverTests` pins it. Lifetime falls out too, and it is DOM's own rule: a *connected*
+  observer is held by the document (AngleSharp's `MutationHost` holds the callback, which holds the wrapper),
+  and a disconnected one is held only by the notify set until its records are taken — so an observer a page
+  dropped with nothing queued collects together with its callback.
 - **`IntersectionObserver` and `ResizeObserver` deliver as a *task*** — a zero-delay timer entry
   (`ObserverTask`) — because both belong to update-the-rendering and a microtask would run before the promises
   of the same turn. It also makes the delivery visible to `Page.WaitForIdleAsync`.

--- a/Jint.Browser/AGENTS.md
+++ b/Jint.Browser/AGENTS.md
@@ -211,11 +211,12 @@ and nothing belonging to an engine — a `JsValue`, an AngleSharp node — may b
 - **`MutationObserver` delivers on the engine's job queue — the microtask checkpoint.** The *records* are
   AngleSharp's: `DocumentExtensions.QueueMutation` already walks a mutated node's inclusive ancestors, matches
   each against the registered observer list, honours `subtree` and `attributeFilter`, and clears `oldValue`
-  for an observer that did not ask for it. What it has no answer for is *when*, and the reason is the parser
-  hop above: its `MutationHost` schedules through an `IEventLoop` service, **nothing in AngleSharp implements
-  one**, and `EventLoopExtensions.Enqueue` on a null loop runs the action *inline* — so out of the box the
-  callback fires synchronously inside `appendChild`. Registering an event loop to fix that is precisely what
-  would make a step of the parse asynchronous and take the fallback. So the inline call is used as the
+  for an observer that did not ask for it. What it has no answer for is *when*, and the reason is the
+  [parser hop](Runtime/AGENTS.md#the-parse-and-the-parser-hop): its `MutationHost` schedules through an
+  `IEventLoop` service, **nothing in AngleSharp implements one**, and `EventLoopExtensions.Enqueue` on a null
+  loop runs the action *inline* — so out of the box the callback fires synchronously inside `appendChild`.
+  Registering an event loop to fix that is precisely what would make a step of the parse asynchronous and
+  take that fallback. So the inline call is used as the
   **arrival** of a record and nothing else: `JsMutationObserver` parks it and `MutationObserverLane` puts one
   job on the engine's queue per batch. Ordering then falls out of a plain enqueue, and
   `Observers/MutationObserverTests` pins it. Lifetime falls out too, and it is DOM's own rule: a *connected*

--- a/Jint.Browser/Dom/Generated/DomShapes.Dom.g.cs
+++ b/Jint.Browser/Dom/Generated/DomShapes.Dom.g.cs
@@ -703,6 +703,13 @@ internal static partial class DomInterfaces
                     return self.Realm.WrapNodeValue(self.Target.CreateElement(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Document.createElementNS"), global::Jint.Browser.Dom.DomConvert.RequiredText(args, 1, "Document.createElementNS")));
                 },
                 length: 2)
+            .Method("createNodeIterator",
+                static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.createNodeIterator");
+                    return global::Jint.Browser.Dom.Views.DomViewMembers.CreateNodeIterator(self.Realm, self.Target, args);
+                },
+                length: 1)
             .Method("createProcessingInstruction",
                 static (thisObj, args) =>
                 {
@@ -722,6 +729,13 @@ internal static partial class DomInterfaces
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.createTextNode");
                     return self.Realm.WrapNodeValue(self.Target.CreateTextNode(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Document.createTextNode")));
+                },
+                length: 1)
+            .Method("createTreeWalker",
+                static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.createTreeWalker");
+                    return global::Jint.Browser.Dom.Views.DomViewMembers.CreateTreeWalker(self.Realm, self.Target, args);
                 },
                 length: 1)
             .Accessor("currentScript",
@@ -848,6 +862,13 @@ internal static partial class DomInterfaces
                     return self.Realm.WrapCollection<global::AngleSharp.Dom.IElement>(self.Target.GetElementsByTagName(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Document.getElementsByTagNameNS"), global::Jint.Browser.Dom.DomConvert.RequiredText(args, 1, "Document.getElementsByTagNameNS")));
                 },
                 length: 2)
+            .Method("getSelection",
+                static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.getSelection");
+                    return global::Jint.Browser.Dom.Views.DomViewMembers.GetSelection(self.Realm);
+                },
+                length: 0)
             .Method("hasFocus",
                 static (thisObj, args) =>
                 {
@@ -1677,13 +1698,13 @@ internal static partial class DomInterfaces
                 static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IMutationRecord>(thisObj, "MutationRecord.attributeName");
-                    return global::Jint.Browser.Dom.DomConvert.Text(self.Target.AttributeName);
+                    return global::Jint.Browser.Dom.DomConvert.NullableText(self.Target.AttributeName);
                 })
             .Accessor("attributeNamespace",
                 static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IMutationRecord>(thisObj, "MutationRecord.attributeNamespace");
-                    return global::Jint.Browser.Dom.DomConvert.Text(self.Target.AttributeNamespace);
+                    return global::Jint.Browser.Dom.DomConvert.NullableText(self.Target.AttributeNamespace);
                 })
             .Accessor("nextSibling",
                 static (thisObj, args) =>
@@ -1695,7 +1716,7 @@ internal static partial class DomInterfaces
                 static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IMutationRecord>(thisObj, "MutationRecord.oldValue");
-                    return global::Jint.Browser.Dom.DomConvert.Text(self.Target.PreviousValue);
+                    return global::Jint.Browser.Dom.DomConvert.NullableText(self.Target.PreviousValue);
                 })
             .Accessor("previousSibling",
                 static (thisObj, args) =>
@@ -1797,6 +1818,12 @@ internal static partial class DomInterfaces
             .Constant("SHOW_NOTATION", global::Jint.Native.JsNumber.Create(2048))
             .Constant("SHOW_PROCESSING_INSTRUCTION", global::Jint.Native.JsNumber.Create(64))
             .Constant("SHOW_TEXT", global::Jint.Native.JsNumber.Create(4))
+            .Accessor("filter",
+                static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INodeIterator>(thisObj, "NodeIterator.filter");
+                    return global::Jint.Browser.Dom.Views.DomViewMembers.Filter(self.Target);
+                })
             .Method("nextNode",
                 static (thisObj, args) =>
                 {
@@ -1833,7 +1860,7 @@ internal static partial class DomInterfaces
                 static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INodeIterator>(thisObj, "NodeIterator.whatToShow");
-                    return global::Jint.Browser.Dom.DomConvert.Number((int) (self.Target.Settings));
+                    return global::Jint.Browser.Dom.DomConvert.Number((long) (self.Target.Settings));
                 })
             .Build();
 
@@ -1978,6 +2005,20 @@ internal static partial class DomInterfaces
                     return self.Realm.WrapNodeValue(self.Target.ExtractContent());
                 },
                 length: 0)
+            .Method("getBoundingClientRect",
+                static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IRange>(thisObj, "Range.getBoundingClientRect");
+                    return global::Jint.Browser.Dom.Views.DomViewMembers.RangeRect(self.Realm);
+                },
+                length: 0)
+            .Method("getClientRects",
+                static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IRange>(thisObj, "Range.getClientRects");
+                    return global::Jint.Browser.Dom.Views.DomViewMembers.RangeRects(self.Realm);
+                },
+                length: 0)
             .Method("insertNode",
                 static (thisObj, args) =>
                 {
@@ -2074,6 +2115,13 @@ internal static partial class DomInterfaces
                     self.Target.Surround(global::Jint.Browser.Dom.DomBindings.Argument<global::AngleSharp.Dom.INode>(args, 0, "Range.surroundContents")); return global::Jint.Native.JsValue.Undefined;
                 },
                 length: 1)
+            .Method("toString",
+                static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IRange>(thisObj, "Range.toString");
+                    return global::Jint.Browser.Dom.Views.DomViewMembers.RangeToString(self.Target);
+                },
+                length: 0)
             .Build();
 
     /// <summary>The members of <c>ShadowRoot</c>.</summary>
@@ -2103,6 +2151,12 @@ internal static partial class DomInterfaces
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IShadowRoot>(thisObj, "ShadowRoot.innerHTML");
                     self.Target.InnerHtml = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "ShadowRoot.innerHTML"); return global::Jint.Native.JsValue.Undefined;
+                })
+            .Accessor("mode",
+                static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IShadowRoot>(thisObj, "ShadowRoot.mode");
+                    return global::Jint.Browser.Dom.DomEnums.FromShadowRootMode(self.Target.Mode);
                 })
             .Accessor("styleSheets",
                 static (thisObj, args) =>
@@ -2181,6 +2235,12 @@ internal static partial class DomInterfaces
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ITreeWalker>(thisObj, "TreeWalker.currentNode");
                     self.Target.Current = global::Jint.Browser.Dom.DomBindings.Argument<global::AngleSharp.Dom.INode>(args, 0, "TreeWalker.currentNode"); return global::Jint.Native.JsValue.Undefined;
                 })
+            .Accessor("filter",
+                static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ITreeWalker>(thisObj, "TreeWalker.filter");
+                    return global::Jint.Browser.Dom.Views.DomViewMembers.Filter(self.Target);
+                })
             .Method("firstChild",
                 static (thisObj, args) =>
                 {
@@ -2240,7 +2300,7 @@ internal static partial class DomInterfaces
                 static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ITreeWalker>(thisObj, "TreeWalker.whatToShow");
-                    return global::Jint.Browser.Dom.DomConvert.Number((int) (self.Target.Settings));
+                    return global::Jint.Browser.Dom.DomConvert.Number((long) (self.Target.Settings));
                 })
             .Build();
 }

--- a/Jint.Browser/Dom/Generated/DomShapes.Html.g.cs
+++ b/Jint.Browser/Dom/Generated/DomShapes.Html.g.cs
@@ -3846,6 +3846,20 @@ internal static partial class DomInterfaces
         => new global::Jint.Native.JsObjectShape.Builder()
             .ToStringTag("HTMLSlotElement")
             .PerRealmSlot("constructor", enumerable: false)
+            .Method("assignedElements",
+                static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSlotElement>(thisObj, "HTMLSlotElement.assignedElements");
+                    return global::Jint.Browser.Dom.Views.DomViewMembers.AssignedElements(self.Realm, self.Target);
+                },
+                length: 0)
+            .Method("assignedNodes",
+                static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSlotElement>(thisObj, "HTMLSlotElement.assignedNodes");
+                    return global::Jint.Browser.Dom.Views.DomViewMembers.AssignedNodes(self.Realm, self.Target);
+                },
+                length: 0)
             .Method("getDistributedNodes",
                 static (thisObj, args) =>
                 {

--- a/Jint.Browser/Dom/HostInterfaceObject.cs
+++ b/Jint.Browser/Dom/HostInterfaceObject.cs
@@ -1,0 +1,70 @@
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.Browser.Dom;
+
+/// <summary>
+/// The interface object of an interface the runtime owns rather than the generator — <c>MutationObserver</c>,
+/// <c>DOMParser</c>, <c>Selection</c> and their kind.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="DomInterfaceObject"/> is the same thing for a generated interface, and the two are separate
+/// because a generated one takes its prototype, its parent and its constants from a
+/// <see cref="DomInterfaceDefinition"/> and every one of them refuses construction. These are the ones a page
+/// really does call <c>new</c> on, so the constructor body is a delegate, and <see langword="null"/> is what
+/// makes an interface that cannot be constructed — <c>Selection</c>, <c>IntersectionObserverEntry</c> —
+/// answer WebIDL's <c>Illegal constructor</c>.
+/// </para>
+/// <para>
+/// It derives from <c>Constructor</c> for the reason <see cref="DomInterfaceObject"/> does:
+/// <c>x instanceof MutationObserver</c> reads <c>prototype</c> off the interface object and walks the chain.
+/// </para>
+/// </remarks>
+internal sealed class HostInterfaceObject : Constructor
+{
+    private readonly string _name;
+    private readonly Func<JsValue[], ObjectInstance>? _construct;
+
+    internal HostInterfaceObject(
+        Engine engine,
+        Realm realm,
+        string name,
+        ObjectInstance prototype,
+        int length,
+        Func<JsValue[], ObjectInstance>? construct = null,
+        ObjectInstance? parent = null)
+        : base(engine, realm, new JsString(name))
+    {
+        _name = name;
+        _construct = construct;
+        _prototype = parent ?? realm.Intrinsics.Function.PrototypeObject;
+        _length = new PropertyDescriptor(JsNumber.Create(length), PropertyFlag.Configurable);
+
+        // https://webidl.spec.whatwg.org/#interface-object — { writable: false, enumerable: false,
+        // configurable: false }.
+        _prototypeDescriptor = new PropertyDescriptor(prototype, PropertyFlag.AllForbidden);
+    }
+
+    /// <summary>https://webidl.spec.whatwg.org/#es-interface-call — an interface object is never callable.</summary>
+    protected internal override JsValue Call(JsValue thisObject, JsValue[] arguments)
+    {
+        Throw.TypeError(_realm, "Failed to construct '" + _name + "': Please use the 'new' operator, this DOM object constructor cannot be called as a function.");
+        return JsValue.Undefined;
+    }
+
+    /// <inheritdoc />
+    public override ObjectInstance Construct(JsValue[] arguments, JsValue newTarget)
+    {
+        if (_construct is null)
+        {
+            Throw.TypeError(_realm, "Illegal constructor");
+        }
+
+        return _construct!(arguments);
+    }
+
+    public override string ToString() => "function " + _name + "() { [native code] }";
+}

--- a/Jint.Browser/Dom/HostInterfaceObject.cs
+++ b/Jint.Browser/Dom/HostInterfaceObject.cs
@@ -49,9 +49,18 @@ internal sealed class HostInterfaceObject : Constructor
     }
 
     /// <summary>https://webidl.spec.whatwg.org/#es-interface-call — an interface object is never callable.</summary>
+    /// <remarks>
+    /// An interface that cannot be constructed at all says so rather than pointing at <c>new</c>, which would
+    /// only send the caller round a second time.
+    /// </remarks>
     protected internal override JsValue Call(JsValue thisObject, JsValue[] arguments)
     {
-        Throw.TypeError(_realm, "Failed to construct '" + _name + "': Please use the 'new' operator, this DOM object constructor cannot be called as a function.");
+        Throw.TypeError(
+            _realm,
+            _construct is null
+                ? "Illegal constructor"
+                : "Failed to construct '" + _name + "': Please use the 'new' operator, this DOM object constructor cannot be called as a function.");
+
         return JsValue.Undefined;
     }
 

--- a/Jint.Browser/Dom/Views/DomViewMembers.cs
+++ b/Jint.Browser/Dom/Views/DomViewMembers.cs
@@ -1,0 +1,126 @@
+using System.Runtime.CompilerServices;
+using AngleSharp.Dom;
+using AngleSharp.Html.Dom;
+using Jint.Browser.Observers;
+using Jint.Browser.Runtime;
+using Jint.Native;
+using Jint.Runtime;
+
+namespace Jint.Browser.Dom.Views;
+
+/// <summary>
+/// The bodies of the members <c>overrides.json</c>'s <c>additions</c> list adds to a generated interface.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every one of them is a member the DOM standard puts on an interface the generator emits, and that the
+/// generator could not project from AngleSharp: a filter parameter is a CLR delegate, a stringifier has no
+/// <c>[DomName]</c>, and one member AngleSharp simply spells by its Shadow DOM v0 name. Adding them here
+/// rather than hand-writing the whole interface keeps the prototype shaped and keeps the other two hundred
+/// members generated.
+/// </para>
+/// <para>
+/// They are static and take the brand-checked receiver, exactly like a generated body, so nothing about the
+/// call site differs from the member beside it.
+/// </para>
+/// </remarks>
+internal static class DomViewMembers
+{
+    /// <summary>
+    /// The <c>NodeFilter</c> each traversal object was created with, so that <c>walker.filter</c> answers the
+    /// value the page passed rather than the delegate it was converted into.
+    /// </summary>
+    /// <remarks>
+    /// Keyed on the AngleSharp traversal object, which belongs to one engine and one document, so the stored
+    /// value can never be read by an engine it does not belong to. A <see cref="ConditionalWeakTable{TKey,TValue}"/>
+    /// rather than a field on the wrapper, because the wrapper is created lazily by the cache and the filter
+    /// is known here, at creation.
+    /// </remarks>
+    private static readonly ConditionalWeakTable<object, JsValue> _filters = new();
+
+    /// <summary>https://dom.spec.whatwg.org/#dom-document-createtreewalker.</summary>
+    internal static JsValue CreateTreeWalker(DomRealm realm, IDocument document, JsValue[] arguments)
+    {
+        var root = DomBindings.Argument<INode>(arguments, 0, "Document.createTreeWalker");
+        var settings = WhatToShow(arguments);
+        var filter = arguments.At(2);
+
+        var walker = document.CreateTreeWalker(root, settings, NodeFilters.From(realm, filter, "createTreeWalker")!);
+        _filters.AddOrUpdate(walker, filter.IsNullOrUndefined() ? JsValue.Null : filter);
+        return realm.Wrap(walker);
+    }
+
+    /// <summary>https://dom.spec.whatwg.org/#dom-document-createnodeiterator.</summary>
+    internal static JsValue CreateNodeIterator(DomRealm realm, IDocument document, JsValue[] arguments)
+    {
+        var root = DomBindings.Argument<INode>(arguments, 0, "Document.createNodeIterator");
+        var settings = WhatToShow(arguments);
+        var filter = arguments.At(2);
+
+        var iterator = document.CreateNodeIterator(root, settings, NodeFilters.From(realm, filter, "createNodeIterator")!);
+        _filters.AddOrUpdate(iterator, filter.IsNullOrUndefined() ? JsValue.Null : filter);
+        return realm.Wrap(iterator);
+    }
+
+    /// <summary>
+    /// https://dom.spec.whatwg.org/#dom-treewalker-filter and its <c>NodeIterator</c> twin: the value the page
+    /// passed, or <see langword="null"/>.
+    /// </summary>
+    internal static JsValue Filter(object traversal)
+        => _filters.TryGetValue(traversal, out var filter) ? filter : JsValue.Null;
+
+    /// <summary>
+    /// https://dom.spec.whatwg.org/#dom-range-stringifier — the text of every text node the range covers.
+    /// </summary>
+    /// <remarks>
+    /// AngleSharp implements it as <c>Range.ToString()</c> and puts no <c>[DomName]</c> on it, so nothing in
+    /// the metadata says it is the interface's stringifier.
+    /// </remarks>
+    internal static JsValue RangeToString(IRange range) => JsString.Create(range.ToString() ?? "");
+
+    /// <summary>
+    /// https://drafts.csswg.org/cssom-view/#dom-range-getboundingclientrect, at the only size a page with no
+    /// layout can be told.
+    /// </summary>
+    internal static JsValue RangeRect(DomRealm realm) => ObserverGeometry.ZeroRect(realm.Engine);
+
+    /// <summary>
+    /// https://drafts.csswg.org/cssom-view/#dom-range-getclientrects — empty, because a range with no layout
+    /// covers no boxes.
+    /// </summary>
+    internal static JsValue RangeRects(DomRealm realm)
+        => realm.PrincipalRealm.Intrinsics.Array.ConstructFast(System.Array.Empty<JsValue>());
+
+    /// <summary>
+    /// https://dom.spec.whatwg.org/#dom-slot-assignednodes.
+    /// </summary>
+    /// <remarks>
+    /// AngleSharp names it <c>getDistributedNodes</c>, which is the Shadow DOM v0 spelling, and that is the
+    /// name its <c>[DomName]</c> carries — so the generated interface has the old name and not the standard
+    /// one. Both are present: the generated one because it is what the metadata says, this one because it is
+    /// what a page calls.
+    /// </remarks>
+    internal static JsValue AssignedNodes(DomRealm realm, IHtmlSlotElement slot)
+        => DomConvert.NodeSequence(realm, slot.GetDistributedNodes());
+
+    /// <summary>
+    /// https://dom.spec.whatwg.org/#dom-slot-assignedelements — the assigned nodes that are elements.
+    /// </summary>
+    internal static JsValue AssignedElements(DomRealm realm, IHtmlSlotElement slot)
+        => DomConvert.NodeSequence(realm, slot.GetDistributedNodes().OfType<IElement>());
+
+    /// <summary>https://w3c.github.io/selection-api/#dom-document-getselection.</summary>
+    internal static JsValue GetSelection(DomRealm realm)
+    {
+        var runtime = PageRuntime.Find(realm.Engine);
+        return runtime is null ? JsValue.Null : runtime.Views.Selection;
+    }
+
+    /// <summary>
+    /// <c>whatToShow</c>, an <c>unsigned long</c> whose default is <c>0xFFFFFFFF</c>. It is read as a
+    /// <see cref="uint"/> and widened, because <c>FilterSettings</c> is a 64-bit enum and a signed read of
+    /// <c>SHOW_ALL</c> would be <c>-1</c>.
+    /// </summary>
+    private static FilterSettings WhatToShow(JsValue[] arguments)
+        => (FilterSettings) DomConvert.OptionalUInt32(arguments, 1, uint.MaxValue);
+}

--- a/Jint.Browser/Dom/Views/DomViewMembers.cs
+++ b/Jint.Browser/Dom/Views/DomViewMembers.cs
@@ -110,6 +110,13 @@ internal static class DomViewMembers
         => DomConvert.NodeSequence(realm, slot.GetDistributedNodes().OfType<IElement>());
 
     /// <summary>https://w3c.github.io/selection-api/#dom-document-getselection.</summary>
+    /// <remarks>
+    /// The page's selection, whichever document the call was made on: a selection belongs to a document's
+    /// browsing context, and a document a <c>DOMParser</c> produced has none. So
+    /// <c>parsed.getSelection()</c> answers the page's rather than a second empty one, where a browser gives
+    /// the parsed document its own. Nothing can select inside a parsed document, so the difference is what
+    /// the object is rather than what it holds.
+    /// </remarks>
     internal static JsValue GetSelection(DomRealm realm)
     {
         var runtime = PageRuntime.Find(realm.Engine);

--- a/Jint.Browser/Dom/Views/JsDomParser.cs
+++ b/Jint.Browser/Dom/Views/JsDomParser.cs
@@ -86,7 +86,7 @@ internal sealed class JsDomParser : ObjectInstance
         {
             "text/html" => ParseHtml(source),
             "text/xml" or "application/xml" or "application/xhtml+xml" or "image/svg+xml" => ParseXml(source),
-            _ => Unsupported(type),
+            _ => Unsupported(_runtime.Engine, type),
         };
 
         return _runtime.Dom.WrapNode(document);
@@ -126,9 +126,14 @@ internal sealed class JsDomParser : ObjectInstance
         return new XmlParser(new XmlParserOptions { IsSuppressingErrors = true }, NewContext()).ParseDocument(markup);
     }
 
-    private static IDocument Unsupported(string type)
+    /// <summary>
+    /// https://webidl.spec.whatwg.org/#es-enumeration — a value outside the enumeration is a
+    /// <c>TypeError</c>, built in the page's own realm.
+    /// </summary>
+    private static IDocument Unsupported(Engine engine, string type)
     {
-        Throw.TypeErrorNoEngine(
+        Throw.TypeError(
+            engine._mainRealm,
             "Failed to execute 'parseFromString' on 'DOMParser': The provided value '" + type
             + "' is not a valid enum value of type SupportedType.");
         return null!;

--- a/Jint.Browser/Dom/Views/JsDomParser.cs
+++ b/Jint.Browser/Dom/Views/JsDomParser.cs
@@ -1,0 +1,191 @@
+using AngleSharp;
+using AngleSharp.Dom;
+using AngleSharp.Html.Parser;
+using AngleSharp.Xhtml;
+using AngleSharp.Xml.Parser;
+using Jint.Browser.Runtime;
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+
+namespace Jint.Browser.Dom.Views;
+
+/// <summary>
+/// <c>DOMParser</c>: markup in, a document out, with nothing in it allowed to run.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Scripting is off for the document this produces</b>, which
+/// <a href="https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-domparser-parsefromstring">
+/// DOM Parsing</a> requires: the parsed document is "not a browsing context" and its scripts never run. That
+/// falls out of two things here rather than being enforced by one — the parser is given a browsing context of
+/// its own that carries no scripting service, and <c>IsScripting</c> is false so the parse itself treats
+/// <c>&lt;noscript&gt;</c> as markup. A <c>&lt;script&gt;</c> in the input becomes an element in the tree,
+/// with its text, and nothing else happens.
+/// </para>
+/// <para>
+/// <b>The XML half is AngleSharp's XML parser</b>, which is a separate package (<c>AngleSharp.Xml</c>, MIT,
+/// same project) referenced for exactly this. Writing an XML parser here instead would be the one thing this
+/// package is not for. A parse that fails answers the
+/// <a href="https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-domparser-parsefromstring">
+/// <c>parsererror</c> document</a> the standard prescribes, which is what a page tests for, rather than
+/// throwing.
+/// </para>
+/// <para>
+/// Each parse gets a fresh browsing context. The context is what a document's services hang off, and sharing
+/// one across parses would make every document this ever produced reachable from the last one.
+/// </para>
+/// </remarks>
+internal sealed class JsDomParser : ObjectInstance
+{
+    /// <summary>
+    /// The namespace a <c>parsererror</c> element is in. It is Mozilla's, which every engine copied and
+    /// which the HTML standard now names.
+    /// </summary>
+    private const string ParserErrorNamespace = "http://www.mozilla.org/newlayout/xml/parsererror.xml";
+
+    private readonly PageRuntime _runtime;
+
+    internal JsDomParser(PageRuntime runtime, ObjectInstance prototype) : base(runtime.Engine)
+    {
+        _runtime = runtime;
+        Prototype = prototype;
+    }
+
+    /// <inheritdoc />
+    public override string ToString() => "[object DOMParser]";
+
+    /// <summary>The receiver check the one member starts with.</summary>
+    internal static JsDomParser Brand(JsValue thisObject, string member)
+    {
+        if (thisObject is JsDomParser parser)
+        {
+            return parser;
+        }
+
+        var message = "Failed to execute '" + member + "' on 'DOMParser': Illegal invocation";
+
+        if (thisObject is ObjectInstance instance)
+        {
+            Throw.TypeError(instance.Engine.Realm, message);
+        }
+
+        Throw.TypeErrorNoEngine(message);
+        return null!;
+    }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-domparser-parsefromstring
+    /// </summary>
+    internal JsValue ParseFromString(JsValue[] arguments)
+    {
+        var source = DomConvert.RequiredText(arguments, 0, "DOMParser.parseFromString");
+        var type = DomConvert.RequiredText(arguments, 1, "DOMParser.parseFromString");
+
+        var document = type switch
+        {
+            "text/html" => ParseHtml(source),
+            "text/xml" or "application/xml" or "application/xhtml+xml" or "image/svg+xml" => ParseXml(source),
+            _ => Unsupported(type),
+        };
+
+        return _runtime.Dom.WrapNode(document);
+    }
+
+    private static IDocument ParseHtml(string source)
+        => new HtmlParser(new HtmlParserOptions { IsScripting = false }, NewContext()).ParseDocument(source);
+
+    private static IDocument ParseXml(string source)
+    {
+        try
+        {
+            return new XmlParser(default, NewContext()).ParseDocument(source);
+        }
+        catch (Exception exception) when (exception is not JavaScriptException)
+        {
+            return ErrorDocument(exception.Message);
+        }
+    }
+
+    /// <summary>
+    /// The document a failed XML parse answers: a <c>parsererror</c> element carrying the message, which is
+    /// what a page looks for with <c>doc.querySelector('parsererror')</c>.
+    /// </summary>
+    private static IDocument ErrorDocument(string message)
+    {
+        var text = message
+            .Replace("&", "&amp;", StringComparison.Ordinal)
+            .Replace("<", "&lt;", StringComparison.Ordinal)
+            .Replace(">", "&gt;", StringComparison.Ordinal);
+
+        var markup =
+            "<html xmlns=\"http://www.w3.org/1999/xhtml\"><body><parsererror xmlns=\"" + ParserErrorNamespace + "\">"
+            + text
+            + "</parsererror></body></html>";
+
+        return new XmlParser(new XmlParserOptions { IsSuppressingErrors = true }, NewContext()).ParseDocument(markup);
+    }
+
+    private static IDocument Unsupported(string type)
+    {
+        Throw.TypeErrorNoEngine(
+            "Failed to execute 'parseFromString' on 'DOMParser': The provided value '" + type
+            + "' is not a valid enum value of type SupportedType.");
+        return null!;
+    }
+
+    /// <summary>
+    /// A browsing context with the CSS services and nothing else: no requester, so a parsed document reaches
+    /// no network, and no scripting service, so its scripts are inert.
+    /// </summary>
+    private static IBrowsingContext NewContext() => BrowsingContext.New(ViewInstaller.ParserConfiguration);
+}
+
+/// <summary>
+/// <c>XMLSerializer</c>: a node out as XML-shaped markup.
+/// </summary>
+/// <remarks>
+/// AngleSharp's <c>XhtmlMarkupFormatter</c> is the
+/// <a href="https://w3c.github.io/DOM-Parsing/#dfn-xml-serialization">XML serialization</a> algorithm's
+/// practical equivalent: every element is closed, an empty element is self-closed, and text is escaped for
+/// XML rather than for HTML. What it does not do is the standard's namespace-prefix invention for a tree
+/// whose prefixes conflict, so a document built by hand out of two namespaces with one prefix serializes to
+/// markup that does not round-trip. Every document this package can produce — parsed, not hand-assembled —
+/// serializes correctly.
+/// </remarks>
+internal sealed class JsXmlSerializer : ObjectInstance
+{
+    internal JsXmlSerializer(PageRuntime runtime, ObjectInstance prototype) : base(runtime.Engine)
+    {
+        Prototype = prototype;
+    }
+
+    /// <inheritdoc />
+    public override string ToString() => "[object XMLSerializer]";
+
+    /// <summary>The receiver check the one member starts with.</summary>
+    internal static JsXmlSerializer Brand(JsValue thisObject, string member)
+    {
+        if (thisObject is JsXmlSerializer serializer)
+        {
+            return serializer;
+        }
+
+        var message = "Failed to execute '" + member + "' on 'XMLSerializer': Illegal invocation";
+
+        if (thisObject is ObjectInstance instance)
+        {
+            Throw.TypeError(instance.Engine.Realm, message);
+        }
+
+        Throw.TypeErrorNoEngine(message);
+        return null!;
+    }
+
+    /// <summary>https://w3c.github.io/DOM-Parsing/#dom-xmlserializer-serializetostring.</summary>
+    internal static JsValue SerializeToString(JsValue[] arguments)
+    {
+        var node = DomBindings.Argument<INode>(arguments, 0, "XMLSerializer.serializeToString");
+        return JsString.Create(node.ToHtml(XhtmlMarkupFormatter.Instance));
+    }
+}

--- a/Jint.Browser/Dom/Views/JsMediaQueryListEvent.cs
+++ b/Jint.Browser/Dom/Views/JsMediaQueryListEvent.cs
@@ -1,0 +1,50 @@
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.WebApi.Events;
+
+namespace Jint.Browser.Dom.Views;
+
+/// <summary>
+/// The <c>change</c> event a <c>MediaQueryList</c> fires: the query, and whether it now matches.
+/// </summary>
+/// <remarks>
+/// <a href="https://drafts.csswg.org/cssom-view/#mediaquerylistevent">CSSOM View</a> gives the event its own
+/// interface because <c>mql.addEventListener('change', e =&gt; e.matches)</c> is the idiomatic read — the
+/// listener is usually written without a reference to the list. Both members are also readable off the list
+/// itself, and they agree, because the list recomputes rather than caching.
+/// </remarks>
+internal sealed class JsMediaQueryListEvent : JsEvent
+{
+    internal JsMediaQueryListEvent(Engine engine, JsString type, EventInit init, double timeStamp, string media, bool matches)
+        : base(engine, type, init, timeStamp)
+    {
+        Media = media;
+        Matches = matches;
+    }
+
+    /// <summary>https://drafts.csswg.org/cssom-view/#dom-mediaquerylistevent-media.</summary>
+    internal string Media { get; }
+
+    /// <summary>https://drafts.csswg.org/cssom-view/#dom-mediaquerylistevent-matches.</summary>
+    internal bool Matches { get; }
+
+    /// <summary>The receiver check the two members start with.</summary>
+    internal static JsMediaQueryListEvent Brand(JsValue thisObject, string member)
+    {
+        if (thisObject is JsMediaQueryListEvent ev)
+        {
+            return ev;
+        }
+
+        var message = "Failed to read the '" + member + "' property from 'MediaQueryListEvent': Illegal invocation";
+
+        if (thisObject is ObjectInstance instance)
+        {
+            Throw.TypeError(instance.Engine.Realm, message);
+        }
+
+        Throw.TypeErrorNoEngine(message);
+        return null!;
+    }
+}

--- a/Jint.Browser/Dom/Views/JsSelection.cs
+++ b/Jint.Browser/Dom/Views/JsSelection.cs
@@ -1,0 +1,192 @@
+using AngleSharp.Dom;
+using Jint.Browser.Runtime;
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+
+namespace Jint.Browser.Dom.Views;
+
+/// <summary>
+/// The document's <c>Selection</c>: at most one range, and no user to move it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <a href="https://w3c.github.io/selection-api/">Selection API</a> models a selection as a list of ranges
+/// that every browser caps at one, and this caps it at one too. What it cannot have is a <em>direction</em>:
+/// direction comes from which end the user dragged from, and there is no user, so the anchor is always the
+/// range's start and the focus always its end. A page that calls <c>extend</c> backwards and then reads
+/// <c>anchorNode</c> gets the earlier boundary where a browser gives it the later one.
+/// </para>
+/// <para>
+/// Nothing renders, so nothing is highlighted and no <c>selectionchange</c> event is fired: the selection is
+/// a place to put a range and read it back — which is what <c>window.getSelection().toString()</c>, the one
+/// call a text-extracting agent makes, needs.
+/// </para>
+/// </remarks>
+internal sealed class JsSelection : ObjectInstance
+{
+    private readonly PageRuntime _runtime;
+    private IRange? _range;
+
+    internal JsSelection(PageRuntime runtime, ObjectInstance prototype) : base(runtime.Engine)
+    {
+        _runtime = runtime;
+        Prototype = prototype;
+    }
+
+    /// <inheritdoc />
+    public override string ToString() => _range?.ToString() ?? "";
+
+    /// <summary>The receiver check every member of the interface starts with.</summary>
+    internal static JsSelection Brand(JsValue thisObject, string member)
+    {
+        if (thisObject is JsSelection selection)
+        {
+            return selection;
+        }
+
+        var message = "Failed to execute '" + member + "' on 'Selection': Illegal invocation";
+
+        if (thisObject is ObjectInstance instance)
+        {
+            Throw.TypeError(instance.Engine.Realm, message);
+        }
+
+        Throw.TypeErrorNoEngine(message);
+        return null!;
+    }
+
+    /// <summary>https://w3c.github.io/selection-api/#dom-selection-rangecount.</summary>
+    internal int RangeCount => _range is null ? 0 : 1;
+
+    /// <summary>https://w3c.github.io/selection-api/#dom-selection-anchornode.</summary>
+    internal JsValue AnchorNode => _range is null ? JsValue.Null : _runtime.Dom.WrapNodeValue(_range.Head);
+
+    /// <summary>https://w3c.github.io/selection-api/#dom-selection-anchoroffset.</summary>
+    internal int AnchorOffset => _range?.Start ?? 0;
+
+    /// <summary>https://w3c.github.io/selection-api/#dom-selection-focusnode.</summary>
+    internal JsValue FocusNode => _range is null ? JsValue.Null : _runtime.Dom.WrapNodeValue(_range.Tail);
+
+    /// <summary>https://w3c.github.io/selection-api/#dom-selection-focusoffset.</summary>
+    internal int FocusOffset => _range?.End ?? 0;
+
+    /// <summary>https://w3c.github.io/selection-api/#dom-selection-iscollapsed.</summary>
+    internal bool IsCollapsed => _range is null || _range.IsCollapsed;
+
+    /// <summary>
+    /// https://w3c.github.io/selection-api/#dom-selection-type — <c>None</c>, <c>Caret</c> or <c>Range</c>.
+    /// </summary>
+    internal string SelectionType => _range is null ? "None" : _range.IsCollapsed ? "Caret" : "Range";
+
+    /// <summary>https://w3c.github.io/selection-api/#dom-selection-getrangeat.</summary>
+    internal JsValue GetRangeAt(JsValue[] arguments)
+    {
+        var index = DomConvert.RequiredInt32(arguments, 0, "Selection.getRangeAt");
+
+        if (_range is null || index != 0)
+        {
+            Throw.RangeError(_runtime.Engine._mainRealm, "Failed to execute 'getRangeAt' on 'Selection': " + index + " is not a valid index.");
+        }
+
+        return _runtime.Dom.Wrap(_range!);
+    }
+
+    /// <summary>https://w3c.github.io/selection-api/#dom-selection-addrange — the second range is ignored.</summary>
+    internal JsValue AddRange(JsValue[] arguments)
+    {
+        var range = DomBindings.Argument<IRange>(arguments, 0, "Selection.addRange");
+
+        // "If the selection's range list is not empty, abort these steps": a browser keeps the first range
+        // and drops the second rather than replacing it, and a page that meant to replace calls
+        // removeAllRanges() first.
+        _range ??= range;
+        return JsValue.Undefined;
+    }
+
+    /// <summary>https://w3c.github.io/selection-api/#dom-selection-removerange.</summary>
+    internal JsValue RemoveRange(JsValue[] arguments)
+    {
+        var range = DomBindings.Argument<IRange>(arguments, 0, "Selection.removeRange");
+
+        if (ReferenceEquals(_range, range))
+        {
+            _range = null;
+        }
+
+        return JsValue.Undefined;
+    }
+
+    /// <summary>https://w3c.github.io/selection-api/#dom-selection-removeallranges.</summary>
+    internal JsValue RemoveAllRanges()
+    {
+        _range = null;
+        return JsValue.Undefined;
+    }
+
+    /// <summary>https://w3c.github.io/selection-api/#dom-selection-collapse, which is also <c>setPosition</c>.</summary>
+    internal JsValue Collapse(JsValue[] arguments)
+    {
+        if (arguments.At(0).IsNull())
+        {
+            return RemoveAllRanges();
+        }
+
+        var node = DomBindings.Argument<INode>(arguments, 0, "Selection.collapse");
+        var offset = DomConvert.OptionalInt32(arguments, 1, 0);
+
+        var range = NewRange("collapse");
+        range.StartWith(node, offset);
+        range.Collapse(true);
+        _range = range;
+        return JsValue.Undefined;
+    }
+
+    /// <summary>https://w3c.github.io/selection-api/#dom-selection-collapsetostart.</summary>
+    internal JsValue CollapseTo(bool toStart, string member)
+    {
+        if (_range is null)
+        {
+            Throw.TypeError(_runtime.Engine._mainRealm, "Failed to execute '" + member + "' on 'Selection': There is no selection.");
+        }
+
+        _range!.Collapse(toStart);
+        return JsValue.Undefined;
+    }
+
+    /// <summary>https://w3c.github.io/selection-api/#dom-selection-selectallchildren.</summary>
+    internal JsValue SelectAllChildren(JsValue[] arguments)
+    {
+        var node = DomBindings.Argument<INode>(arguments, 0, "Selection.selectAllChildren");
+        var range = NewRange("selectAllChildren");
+        range.SelectContent(node);
+        _range = range;
+        return JsValue.Undefined;
+    }
+
+    /// <summary>https://w3c.github.io/selection-api/#dom-selection-containsnode.</summary>
+    internal JsValue ContainsNode(JsValue[] arguments)
+    {
+        var node = DomBindings.Argument<INode>(arguments, 0, "Selection.containsNode");
+        return _range is not null && _range.Intersects(node) ? JsBoolean.True : JsBoolean.False;
+    }
+
+    /// <summary>https://w3c.github.io/selection-api/#dom-selection-deletefromdocument.</summary>
+    internal JsValue DeleteFromDocument()
+    {
+        _range?.ClearContent();
+        return JsValue.Undefined;
+    }
+
+    private IRange NewRange(string member)
+    {
+        var document = _runtime.Document;
+
+        if (document is null)
+        {
+            Throw.TypeError(_runtime.Engine._mainRealm, "Failed to execute '" + member + "' on 'Selection': the page has no document.");
+        }
+
+        return document!.CreateRange();
+    }
+}

--- a/Jint.Browser/Dom/Views/NodeFilters.cs
+++ b/Jint.Browser/Dom/Views/NodeFilters.cs
@@ -1,0 +1,89 @@
+using AngleSharp.Dom;
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+
+namespace Jint.Browser.Dom.Views;
+
+/// <summary>
+/// Turns a script's <c>NodeFilter</c> into the delegate AngleSharp's traversal takes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <a href="https://dom.spec.whatwg.org/#interface-nodefilter">DOM §6.3</a> declares <c>NodeFilter</c> as a
+/// <em>legacy callback interface</em>, which means two accepted shapes: a bare function, and an object whose
+/// <c>acceptNode</c> property is one. Both are common — a function in modern code, the object form in code
+/// written against the original API — so both are handled here, and the object's <c>acceptNode</c> is read on
+/// every call rather than captured, because WebIDL invokes a callback-interface operation by looking the
+/// property up each time.
+/// </para>
+/// <para>
+/// The generator could not project <c>createTreeWalker</c> and <c>createNodeIterator</c> at all: their filter
+/// parameter is a CLR delegate, which the conversion table has no entry for and deliberately no general one —
+/// a delegate parameter is a callback whose IDL shape only the standard knows. That is why they arrive
+/// through <c>overrides.json</c>'s additions with a hand-written body instead.
+/// </para>
+/// <para>
+/// A filter that throws propagates out of <c>nextNode()</c>, which is what the standard requires, and the
+/// exception unwinds through AngleSharp's traversal on its way — safe because the traversal holds no state it
+/// has to unwind and the walker is left where the filter found it.
+/// </para>
+/// </remarks>
+internal static class NodeFilters
+{
+    /// <summary>https://dom.spec.whatwg.org/#dom-nodefilter-filter_accept.</summary>
+    internal const int Accept = 1;
+
+    /// <summary>https://dom.spec.whatwg.org/#dom-nodefilter-filter_reject.</summary>
+    internal const int Reject = 2;
+
+    /// <summary>https://dom.spec.whatwg.org/#dom-nodefilter-filter_skip.</summary>
+    internal const int Skip = 3;
+
+    /// <summary>
+    /// The filter argument, or <see langword="null"/> when it was absent — which the traversal reads as
+    /// "accept everything <c>whatToShow</c> let through".
+    /// </summary>
+    internal static NodeFilter? From(DomRealm realm, JsValue value, string member)
+    {
+        if (value.IsNullOrUndefined())
+        {
+            return null;
+        }
+
+        if (value is ICallable or ObjectInstance)
+        {
+            return node => Invoke(realm, value, node);
+        }
+
+        Throw.TypeError(
+            realm.PrincipalRealm,
+            "Failed to execute '" + member + "' on 'Document': parameter 3 is not of type 'NodeFilter'.");
+        return null;
+    }
+
+    private static FilterResult Invoke(DomRealm realm, JsValue filter, INode node)
+    {
+        var callable = filter is ICallable ? filter : (filter as ObjectInstance)?.Get("acceptNode");
+
+        if (callable is not ICallable)
+        {
+            // WebIDL: an object with no callable operation is a TypeError at call time, not at conversion
+            // time, which is exactly when a page notices it passed the wrong thing.
+            Throw.TypeError(realm.PrincipalRealm, "Failed to execute 'acceptNode' on 'NodeFilter': the filter is neither a function nor an object with an acceptNode method.");
+        }
+
+        var answer = realm.Engine.Call(callable!, filter, [realm.WrapNode(node)]);
+
+        return TypeConverter.ToUint32(answer) switch
+        {
+            Reject => FilterResult.Reject,
+            Skip => FilterResult.Skip,
+            Accept => FilterResult.Accept,
+
+            // https://dom.spec.whatwg.org/#concept-node-filter step 5: anything but FILTER_ACCEPT and
+            // FILTER_REJECT is FILTER_SKIP, so an unknown number does not accept by accident.
+            _ => FilterResult.Skip,
+        };
+    }
+}

--- a/Jint.Browser/Dom/Views/ReadOnlyStyleDeclaration.cs
+++ b/Jint.Browser/Dom/Views/ReadOnlyStyleDeclaration.cs
@@ -1,0 +1,116 @@
+using System.Collections;
+using AngleSharp;
+using AngleSharp.Css.Dom;
+using Jint.Runtime;
+using Jint.WebApi.DomException;
+
+namespace Jint.Browser.Dom.Views;
+
+/// <summary>
+/// What <c>getComputedStyle</c> answers: the cascade's declarations, with every way of writing to them
+/// refused.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <a href="https://drafts.csswg.org/cssom/#dom-window-getcomputedstyle">CSSOM</a> gives the returned
+/// declaration a <i>computed flag</i>, and a declaration carrying it throws a
+/// <c>NoModificationAllowedError</c> from <c>setProperty</c>, <c>removeProperty</c>, the <c>cssText</c> setter
+/// and every CSS property setter. AngleSharp's <c>ComputeCurrentStyle()</c> hands back an ordinary writable
+/// declaration that is also <em>detached</em> — a fresh object per call, not the element's style — so writing
+/// to it in a browser throws and here would silently change nothing anybody can read. Refusing the write is
+/// the difference between a page learning it has a bug and a page not.
+/// </para>
+/// <para>
+/// The refusal is a real <c>DOMException</c> thrown as the error value, so <c>catch (e) { e.name }</c>
+/// answers <c>"NoModificationAllowedError"</c>. That is only possible because this object is reachable from
+/// script alone: nothing inside AngleSharp ever calls it, so a JavaScript exception can never unwind through
+/// AngleSharp's own frames from here.
+/// </para>
+/// <para>
+/// Reads pass straight through, and what they can answer is the cascade with no layout behind it: a property
+/// the stylesheets, the inline style or the user-agent defaults settled resolves, and a used value that would
+/// need a box — <c>width</c>, <c>height</c>, anything resolved against a containing block — is the empty
+/// string. <c>display</c> resolves, because it comes from the cascade and not from layout.
+/// </para>
+/// </remarks>
+internal sealed class ReadOnlyStyleDeclaration : ICssStyleDeclaration
+{
+    private readonly ICssStyleDeclaration _computed;
+    private readonly Engine _engine;
+
+    internal ReadOnlyStyleDeclaration(Engine engine, ICssStyleDeclaration computed)
+    {
+        _engine = engine;
+        _computed = computed;
+    }
+
+    /// <inheritdoc />
+    public string this[int index] => _computed[index];
+
+    /// <inheritdoc />
+    public string this[string name] => _computed[name];
+
+    /// <inheritdoc />
+    public int Length => _computed.Length;
+
+    /// <inheritdoc />
+    public ICssRule? Parent => _computed.Parent;
+
+    /// <inheritdoc />
+    public string CssText
+    {
+        get => _computed.CssText;
+        set => Refuse("cssText");
+    }
+
+    /// <inheritdoc />
+    public event Action<string>? Changed
+    {
+        add { }
+        remove { }
+    }
+
+    /// <inheritdoc />
+    public string GetPropertyValue(string propertyName) => _computed.GetPropertyValue(propertyName);
+
+    /// <inheritdoc />
+    public ICssProperty GetProperty(string propertyName) => _computed.GetProperty(propertyName)!;
+
+    /// <inheritdoc />
+    public string GetPropertyPriority(string propertyName) => _computed.GetPropertyPriority(propertyName);
+
+    /// <inheritdoc />
+    public void SetProperty(string propertyName, string propertyValue, string? priority = null) => Refuse("setProperty");
+
+    /// <inheritdoc />
+    public string RemoveProperty(string propertyName)
+    {
+        Refuse("removeProperty");
+        return "";
+    }
+
+    /// <inheritdoc />
+    public void SetParent(ICssRule? rule)
+    {
+    }
+
+    /// <inheritdoc />
+    public void Update(string value) => Refuse("cssText");
+
+    /// <inheritdoc />
+    public void ToCss(TextWriter writer, IStyleFormatter formatter) => _computed.ToCss(writer, formatter);
+
+    /// <inheritdoc />
+    public IEnumerator<ICssProperty> GetEnumerator() => _computed.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    private void Refuse(string member)
+    {
+        var error = _engine._mainRealm.Intrinsics.DomException.CreateException(
+            DomExceptionNames.NoModificationAllowed,
+            "Failed to execute '" + member + "' on 'CSSStyleDeclaration': These styles are computed, and therefore read-only.");
+
+        Throw.JavaScriptException(_engine, error, _engine.GetLastSyntaxElement()?.Location ?? default);
+    }
+}

--- a/Jint.Browser/Dom/Views/ViewInstaller.cs
+++ b/Jint.Browser/Dom/Views/ViewInstaller.cs
@@ -1,0 +1,183 @@
+using AngleSharp;
+using Jint.Browser.Runtime;
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.WebApi.Events;
+
+namespace Jint.Browser.Dom.Views;
+
+/// <summary>
+/// The interfaces the runtime owns rather than the generator: <c>DOMParser</c>, <c>XMLSerializer</c>,
+/// <c>NodeFilter</c>, <c>Selection</c> and <c>MediaQueryListEvent</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// None of the five exists in AngleSharp — three of them are host objects a browser supplies rather than DOM
+/// objects, <c>NodeFilter</c> is a callback interface with constants and no instances, and
+/// <c>MediaQueryListEvent</c> is CSSOM View's. Everything else in this folder is a <em>view</em> onto the DOM
+/// that AngleSharp does have and that the generator already emits: <c>Range</c>, <c>TreeWalker</c> and
+/// <c>NodeIterator</c> are generated, and only the members whose signatures the conversion table could not
+/// cross arrive from <c>overrides.json</c>'s additions.
+/// </para>
+/// <para>
+/// Each global is lazy and non-clobbering, and the shapes are process-shared with the prototypes per engine,
+/// which is what every other installer in this package does.
+/// </para>
+/// </remarks>
+internal static class ViewInstaller
+{
+    private static readonly JsObjectShape _domParser = BuildDomParserShape();
+    private static readonly JsObjectShape _xmlSerializer = BuildXmlSerializerShape();
+    private static readonly JsObjectShape _selection = BuildSelectionShape();
+    private static readonly JsObjectShape _nodeFilter = BuildNodeFilterShape();
+    private static readonly JsObjectShape _mediaQueryListEvent = BuildMediaQueryListEventShape();
+
+    /// <summary>
+    /// The configuration a <c>DOMParser</c> document is parsed with: the CSS services, so that
+    /// <c>element.style</c> answers on the result, and nothing else — no requester, no scripting.
+    /// </summary>
+    internal static IConfiguration ParserConfiguration { get; } = Configuration.Default.WithCss();
+
+    /// <summary>Installs the five globals on <paramref name="runtime"/>'s engine. Called once, at construction.</summary>
+    internal static void Install(PageRuntime runtime)
+    {
+        var engine = runtime.Engine;
+
+        Add(engine, "DOMParser", static realm => realm.DomParser);
+        Add(engine, "XMLSerializer", static realm => realm.XmlSerializer);
+        Add(engine, "Selection", static realm => realm.SelectionInterface);
+        Add(engine, "NodeFilter", static realm => realm.NodeFilter);
+        Add(engine, "MediaQueryListEvent", static realm => realm.MediaQueryListEvent);
+    }
+
+    private static void Add(Engine engine, string name, Func<ViewRealm, JsValue> factory)
+        => engine.AddLazyGlobal(
+            name,
+            factory,
+            static (e, f) => f(PageRuntime.Find(e)!.Views),
+            PropertyFlag.NonEnumerable);
+
+    internal static JsObjectShape DomParserShape => _domParser;
+
+    internal static JsObjectShape XmlSerializerShape => _xmlSerializer;
+
+    internal static JsObjectShape SelectionShape => _selection;
+
+    internal static JsObjectShape NodeFilterShape => _nodeFilter;
+
+    internal static JsObjectShape MediaQueryListEventShape => _mediaQueryListEvent;
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#the-domparser-interface
+    /// </summary>
+    private static JsObjectShape BuildDomParserShape() => new JsObjectShape.Builder()
+        .PerRealmSlot("constructor")
+        .ToStringTag("DOMParser")
+        .Method("parseFromString", static (t, args) => JsDomParser.Brand(t, "parseFromString").ParseFromString(args), length: 2)
+        .Build();
+
+    /// <summary>https://w3c.github.io/DOM-Parsing/#the-xmlserializer-interface</summary>
+    private static JsObjectShape BuildXmlSerializerShape() => new JsObjectShape.Builder()
+        .PerRealmSlot("constructor")
+        .ToStringTag("XMLSerializer")
+        .Method("serializeToString", static (t, args) =>
+        {
+            JsXmlSerializer.Brand(t, "serializeToString");
+            return JsXmlSerializer.SerializeToString(args);
+        }, length: 1)
+        .Build();
+
+    /// <summary>https://w3c.github.io/selection-api/#selection-interface</summary>
+    private static JsObjectShape BuildSelectionShape() => new JsObjectShape.Builder()
+        .PerRealmSlot("constructor")
+        .ToStringTag("Selection")
+        .Accessor("anchorNode", static (t, _) => JsSelection.Brand(t, "anchorNode").AnchorNode)
+        .Accessor("anchorOffset", static (t, _) => JsNumber.Create(JsSelection.Brand(t, "anchorOffset").AnchorOffset))
+        .Accessor("focusNode", static (t, _) => JsSelection.Brand(t, "focusNode").FocusNode)
+        .Accessor("focusOffset", static (t, _) => JsNumber.Create(JsSelection.Brand(t, "focusOffset").FocusOffset))
+        .Accessor("isCollapsed", static (t, _) => JsSelection.Brand(t, "isCollapsed").IsCollapsed ? JsBoolean.True : JsBoolean.False)
+        .Accessor("rangeCount", static (t, _) => JsNumber.Create(JsSelection.Brand(t, "rangeCount").RangeCount))
+        .Accessor("type", static (t, _) => JsString.Create(JsSelection.Brand(t, "type").SelectionType))
+        .Method("getRangeAt", static (t, args) => JsSelection.Brand(t, "getRangeAt").GetRangeAt(args), length: 1)
+        .Method("addRange", static (t, args) => JsSelection.Brand(t, "addRange").AddRange(args), length: 1)
+        .Method("removeRange", static (t, args) => JsSelection.Brand(t, "removeRange").RemoveRange(args), length: 1)
+        .Method("removeAllRanges", static (t, _) => JsSelection.Brand(t, "removeAllRanges").RemoveAllRanges())
+        .Method("empty", static (t, _) => JsSelection.Brand(t, "empty").RemoveAllRanges())
+        .Method("collapse", static (t, args) => JsSelection.Brand(t, "collapse").Collapse(args), length: 1)
+        .Method("setPosition", static (t, args) => JsSelection.Brand(t, "setPosition").Collapse(args), length: 1)
+        .Method("collapseToStart", static (t, _) => JsSelection.Brand(t, "collapseToStart").CollapseTo(true, "collapseToStart"))
+        .Method("collapseToEnd", static (t, _) => JsSelection.Brand(t, "collapseToEnd").CollapseTo(false, "collapseToEnd"))
+        .Method("selectAllChildren", static (t, args) => JsSelection.Brand(t, "selectAllChildren").SelectAllChildren(args), length: 1)
+        .Method("containsNode", static (t, args) => JsSelection.Brand(t, "containsNode").ContainsNode(args), length: 1)
+        .Method("deleteFromDocument", static (t, _) => JsSelection.Brand(t, "deleteFromDocument").DeleteFromDocument())
+        .Method("toString", static (t, _) => JsString.Create(JsSelection.Brand(t, "toString").ToString()))
+        .Build();
+
+    /// <summary>
+    /// https://dom.spec.whatwg.org/#interface-nodefilter — a callback interface, so its interface object is
+    /// a plain object carrying the constants and nothing callable.
+    /// </summary>
+    private static JsObjectShape BuildNodeFilterShape() => new JsObjectShape.Builder()
+        .ToStringTag("NodeFilter")
+        .Constant("FILTER_ACCEPT", JsNumber.Create(NodeFilters.Accept))
+        .Constant("FILTER_REJECT", JsNumber.Create(NodeFilters.Reject))
+        .Constant("FILTER_SKIP", JsNumber.Create(NodeFilters.Skip))
+        .Constant("SHOW_ALL", JsNumber.Create(4294967295))
+        .Constant("SHOW_ATTRIBUTE", JsNumber.Create(2))
+        .Constant("SHOW_CDATA_SECTION", JsNumber.Create(8))
+        .Constant("SHOW_COMMENT", JsNumber.Create(128))
+        .Constant("SHOW_DOCUMENT", JsNumber.Create(256))
+        .Constant("SHOW_DOCUMENT_FRAGMENT", JsNumber.Create(1024))
+        .Constant("SHOW_DOCUMENT_TYPE", JsNumber.Create(512))
+        .Constant("SHOW_ELEMENT", JsNumber.Create(1))
+        .Constant("SHOW_ENTITY", JsNumber.Create(32))
+        .Constant("SHOW_ENTITY_REFERENCE", JsNumber.Create(16))
+        .Constant("SHOW_NOTATION", JsNumber.Create(2048))
+        .Constant("SHOW_PROCESSING_INSTRUCTION", JsNumber.Create(64))
+        .Constant("SHOW_TEXT", JsNumber.Create(4))
+        .Build();
+
+    /// <summary>https://drafts.csswg.org/cssom-view/#mediaquerylistevent</summary>
+    private static JsObjectShape BuildMediaQueryListEventShape() => new JsObjectShape.Builder()
+        .PerRealmSlot("constructor")
+        .ToStringTag("MediaQueryListEvent")
+        .Accessor("media", static (t, _) => JsString.Create(JsMediaQueryListEvent.Brand(t, "media").Media))
+        .Accessor("matches", static (t, _) => JsMediaQueryListEvent.Brand(t, "matches").Matches ? JsBoolean.True : JsBoolean.False)
+        .Build();
+
+    /// <summary>
+    /// Builds an interface prototype and its interface object together, filling the per-realm
+    /// <c>constructor</c> slot the way every shaped prototype in this package does.
+    /// </summary>
+    internal static ObjectInstance Instantiate(
+        Engine engine,
+        JsObjectShape shape,
+        string name,
+        int length,
+        Func<JsValue[], ObjectInstance>? construct,
+        ObjectInstance? parentPrototype,
+        ObjectInstance? parentInterface,
+        out HostInterfaceObject interfaceObject)
+    {
+        var realm = engine._mainRealm;
+        var prototype = shape.Instantiate(engine, parentPrototype ?? realm.Intrinsics.Object.PrototypeObject);
+        interfaceObject = new HostInterfaceObject(engine, realm, name, prototype, length, construct, parentInterface);
+
+        prototype.DefineOwnPropertyUnchecked(
+            "constructor",
+            new PropertyDescriptor(interfaceObject, PropertyFlag.NonEnumerable));
+
+        return prototype;
+    }
+
+    /// <summary>The <c>Event.prototype</c> a <c>MediaQueryListEvent</c> inherits from.</summary>
+    internal static ObjectInstance EventPrototype(Engine engine) => engine._mainRealm.Intrinsics.Event.PrototypeObject;
+
+    /// <summary>The <c>Event</c> interface object a <c>MediaQueryListEvent</c>'s own inherits from.</summary>
+    internal static ObjectInstance EventInterface(Engine engine) => engine._mainRealm.Intrinsics.Event;
+
+    /// <summary>The timestamp an event the runtime fires carries.</summary>
+    internal static double TimeStamp(Engine engine) => EventConstructor.TimeStampNow(engine);
+}

--- a/Jint.Browser/Dom/Views/ViewRealm.cs
+++ b/Jint.Browser/Dom/Views/ViewRealm.cs
@@ -1,0 +1,170 @@
+using Jint.Browser.Runtime;
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.WebApi.Events;
+
+namespace Jint.Browser.Dom.Views;
+
+/// <summary>
+/// The view interfaces of one engine: each prototype and its interface object, built on first use, plus the
+/// document's one <c>Selection</c>.
+/// </summary>
+/// <remarks>
+/// The observers' <c>ObserverRealm</c> is the same thing for the same reason, and they are separate so that a
+/// page using neither pays for neither: an engine that never mentions <c>DOMParser</c> never builds its
+/// prototype.
+/// </remarks>
+internal sealed class ViewRealm
+{
+    private readonly PageRuntime _runtime;
+
+    private ObjectInstance? _domParserPrototype;
+    private HostInterfaceObject? _domParser;
+    private ObjectInstance? _xmlSerializerPrototype;
+    private HostInterfaceObject? _xmlSerializer;
+    private ObjectInstance? _selectionPrototype;
+    private HostInterfaceObject? _selectionInterface;
+    private ObjectInstance? _mediaQueryListEventPrototype;
+    private HostInterfaceObject? _mediaQueryListEvent;
+    private ObjectInstance? _nodeFilter;
+    private JsSelection? _selection;
+
+    internal ViewRealm(PageRuntime runtime)
+    {
+        _runtime = runtime;
+    }
+
+    /// <summary>The global <c>DOMParser</c>.</summary>
+    internal HostInterfaceObject DomParser
+    {
+        get
+        {
+            if (_domParser is null)
+            {
+                _domParserPrototype = ViewInstaller.Instantiate(
+                    _runtime.Engine,
+                    ViewInstaller.DomParserShape,
+                    "DOMParser",
+                    length: 0,
+                    _ => new JsDomParser(_runtime, _domParserPrototype!),
+                    parentPrototype: null,
+                    parentInterface: null,
+                    out var interfaceObject);
+
+                _domParser = interfaceObject;
+            }
+
+            return _domParser;
+        }
+    }
+
+    /// <summary>The global <c>XMLSerializer</c>.</summary>
+    internal HostInterfaceObject XmlSerializer
+    {
+        get
+        {
+            if (_xmlSerializer is null)
+            {
+                _xmlSerializerPrototype = ViewInstaller.Instantiate(
+                    _runtime.Engine,
+                    ViewInstaller.XmlSerializerShape,
+                    "XMLSerializer",
+                    length: 0,
+                    _ => new JsXmlSerializer(_runtime, _xmlSerializerPrototype!),
+                    parentPrototype: null,
+                    parentInterface: null,
+                    out var interfaceObject);
+
+                _xmlSerializer = interfaceObject;
+            }
+
+            return _xmlSerializer;
+        }
+    }
+
+    /// <summary>The global <c>Selection</c>, which is not constructible.</summary>
+    internal HostInterfaceObject SelectionInterface
+    {
+        get
+        {
+            if (_selectionInterface is null)
+            {
+                _selectionPrototype = ViewInstaller.Instantiate(
+                    _runtime.Engine,
+                    ViewInstaller.SelectionShape,
+                    "Selection",
+                    length: 0,
+                    construct: null,
+                    parentPrototype: null,
+                    parentInterface: null,
+                    out var interfaceObject);
+
+                _selectionInterface = interfaceObject;
+            }
+
+            return _selectionInterface;
+        }
+    }
+
+    /// <summary>The global <c>MediaQueryListEvent</c>, whose prototype chains to <c>Event.prototype</c>.</summary>
+    internal HostInterfaceObject MediaQueryListEvent
+    {
+        get
+        {
+            if (_mediaQueryListEvent is null)
+            {
+                var engine = _runtime.Engine;
+
+                _mediaQueryListEventPrototype = ViewInstaller.Instantiate(
+                    engine,
+                    ViewInstaller.MediaQueryListEventShape,
+                    "MediaQueryListEvent",
+                    length: 1,
+                    construct: null,
+                    ViewInstaller.EventPrototype(engine),
+                    ViewInstaller.EventInterface(engine),
+                    out var interfaceObject);
+
+                _mediaQueryListEvent = interfaceObject;
+            }
+
+            return _mediaQueryListEvent;
+        }
+    }
+
+    /// <summary>
+    /// The global <c>NodeFilter</c>: a plain object carrying the constants, because DOM declares it as a
+    /// callback interface and a callback interface has no instances to construct.
+    /// </summary>
+    internal ObjectInstance NodeFilter
+        => _nodeFilter ??= ViewInstaller.NodeFilterShape.Instantiate(
+            _runtime.Engine,
+            _runtime.Engine._mainRealm.Intrinsics.Object.PrototypeObject);
+
+    /// <summary>
+    /// The document's one <c>Selection</c>, which <c>window.getSelection()</c> and
+    /// <c>document.getSelection()</c> both answer and which stays the same object for the life of the
+    /// document — as the Selection API requires.
+    /// </summary>
+    internal JsSelection Selection
+    {
+        get
+        {
+            _ = SelectionInterface;
+            return _selection ??= new JsSelection(_runtime, _selectionPrototype!);
+        }
+    }
+
+    /// <summary>The <c>change</c> event a media query list fires when its answer moves.</summary>
+    internal JsEvent CreateMediaQueryListEvent(string media, bool matches)
+    {
+        var engine = _runtime.Engine;
+        _ = MediaQueryListEvent;
+
+        return new JsMediaQueryListEvent(engine, JsString.Create("change"), default, ViewInstaller.TimeStamp(engine), media, matches)
+        {
+            IsTrusted = true,
+            Prototype = _mediaQueryListEventPrototype!,
+        };
+    }
+}

--- a/Jint.Browser/Jint.Browser.csproj
+++ b/Jint.Browser/Jint.Browser.csproj
@@ -48,6 +48,9 @@
     <!-- Pinned centrally in Directory.Packages.props, which is also the binding generator's pin. -->
     <PackageReference Include="AngleSharp" />
     <PackageReference Include="AngleSharp.Css" />
+    <!-- AngleSharp's XML parser, for DOMParser's four XML content types and nothing else. It is not a
+         generator input: no interface is projected from it, so the pin stays two assemblies. -->
+    <PackageReference Include="AngleSharp.Xml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jint.Browser/Observers/JsIntersectionObserver.cs
+++ b/Jint.Browser/Observers/JsIntersectionObserver.cs
@@ -191,20 +191,20 @@ internal sealed class JsIntersectionObserver : ObjectInstance
 
         var margin = options?.Get("rootMargin") is { } m && !m.IsUndefined() ? TypeConverter.ToString(m) : "0px";
 
-        return (root, SerializeMargin(realm, margin), ReadThresholds(realm, options?.Get("threshold")));
+        return (root, SerializeMargin(engine, margin), ReadThresholds(realm, options?.Get("threshold")));
     }
 
     /// <summary>
     /// The margin is one to four <c>&lt;length-percentage&gt;</c> components, serialized back as four. Only
     /// <c>px</c> and <c>%</c> are units a margin may carry, and a zero may be written bare.
     /// </summary>
-    private static string SerializeMargin(Realm realm, string margin)
+    private static string SerializeMargin(Engine engine, string margin)
     {
         var parts = margin.Split((char[]?) null, StringSplitOptions.RemoveEmptyEntries);
 
         if (parts.Length is 0 or > 4)
         {
-            Throw.TypeError(realm, "Failed to construct 'IntersectionObserver': rootMargin must be one to four length or percentage components.");
+            BadMargin(engine, "rootMargin must be one to four length or percentage components");
         }
 
         // CSS's one-to-four shorthand expansion, in the order top, right, bottom, left.
@@ -219,13 +219,13 @@ internal sealed class JsIntersectionObserver : ObjectInstance
                 _ => i,
             };
 
-            components[i] = Component(realm, parts[source]);
+            components[i] = Component(engine, parts[source]);
         }
 
         return string.Join(" ", components);
     }
 
-    private static string Component(Realm realm, string part)
+    private static string Component(Engine engine, string part)
     {
         var value = part;
         var unit = "px";
@@ -242,10 +242,24 @@ internal sealed class JsIntersectionObserver : ObjectInstance
 
         if (!double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var number))
         {
-            Throw.TypeError(realm, "Failed to construct 'IntersectionObserver': rootMargin component '" + part + "' is not a length or a percentage.");
+            BadMargin(engine, "rootMargin component '" + part + "' is not a length or a percentage");
         }
 
         return number.ToString("0.####", CultureInfo.InvariantCulture) + unit;
+    }
+
+    /// <summary>
+    /// A malformed <c>rootMargin</c> is a <c>SyntaxError</c> <c>DOMException</c> rather than a
+    /// <c>TypeError</c>: the value crossed WebIDL's <c>DOMString</c> conversion cleanly and failed the
+    /// interface's own parse, which is the distinction the two error types carry.
+    /// </summary>
+    private static void BadMargin(Engine engine, string what)
+    {
+        var error = engine._mainRealm.Intrinsics.DomException.CreateException(
+            Jint.WebApi.DomException.DomExceptionNames.Syntax,
+            "Failed to construct 'IntersectionObserver': " + what + ".");
+
+        Throw.JavaScriptException(engine, error, engine.GetLastSyntaxElement()?.Location ?? default);
     }
 
     private static double[] ReadThresholds(Realm realm, JsValue? value)

--- a/Jint.Browser/Observers/JsIntersectionObserver.cs
+++ b/Jint.Browser/Observers/JsIntersectionObserver.cs
@@ -1,0 +1,326 @@
+using System.Globalization;
+using AngleSharp.Dom;
+using Jint.Browser.Dom;
+using Jint.Browser.Runtime;
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+
+namespace Jint.Browser.Observers;
+
+/// <summary>
+/// An <c>IntersectionObserver</c> with no viewport to intersect against: every target it is given is reported
+/// once, fully intersecting.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>This is a stub, and the shape of the lie is the point.</b>
+/// <a href="https://w3c.github.io/IntersectionObserver/">Intersection Observer</a> is a layout question, and
+/// there is no layout. The two possible answers are "never intersecting", which stops every lazy-loading list,
+/// infinite scroller and reveal-on-scroll animation on the web dead, and "always intersecting", which loads
+/// everything at once — which is what a headless agent reading a page wants anyway. So each observed target
+/// gets exactly one entry, with <c>isIntersecting: true</c> and <c>intersectionRatio: 1</c>, delivered as a
+/// task after <c>observe()</c> returns; nothing is reported afterwards, because with no layout nothing can
+/// change.
+/// </para>
+/// <para>
+/// <c>root</c>, <c>rootMargin</c> and <c>thresholds</c> are parsed, validated and reflected exactly as the
+/// specification requires, because a page reads them back and because a wrong value is a page bug worth
+/// reporting. They have no effect on what is delivered. The rectangles are
+/// <see cref="ObserverGeometry">zeros</see>.
+/// </para>
+/// </remarks>
+internal sealed class JsIntersectionObserver : ObjectInstance
+{
+    private readonly PageRuntime _runtime;
+    private readonly ICallable _callback;
+    private readonly List<INode> _targets = [];
+    private readonly List<JsIntersectionObserverEntry> _queue = [];
+    private readonly ObjectInstance _entryPrototype;
+    private bool _scheduled;
+
+    internal JsIntersectionObserver(
+        PageRuntime runtime,
+        ObjectInstance prototype,
+        ObjectInstance entryPrototype,
+        ICallable callback,
+        JsValue root,
+        string rootMargin,
+        double[] thresholds)
+        : base(runtime.Engine)
+    {
+        _runtime = runtime;
+        _callback = callback;
+        _entryPrototype = entryPrototype;
+        Root = root;
+        RootMargin = rootMargin;
+        Thresholds = thresholds;
+        Prototype = prototype;
+    }
+
+    /// <summary>https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-root.</summary>
+    internal JsValue Root { get; }
+
+    /// <summary>https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-rootmargin, serialized.</summary>
+    internal string RootMargin { get; }
+
+    /// <summary>https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-thresholds, sorted.</summary>
+    internal double[] Thresholds { get; }
+
+    /// <inheritdoc />
+    public override string ToString() => "[object IntersectionObserver]";
+
+    /// <summary>The receiver check every member of the interface starts with.</summary>
+    internal static JsIntersectionObserver Brand(JsValue thisObject, string member)
+        => ObserverGeometry.Brand<JsIntersectionObserver>(thisObject, "IntersectionObserver", member);
+
+    /// <summary>https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-observe.</summary>
+    internal JsValue Observe(JsValue[] arguments)
+    {
+        var target = Target(arguments, "observe");
+
+        if (_targets.Contains(target))
+        {
+            return JsValue.Undefined;
+        }
+
+        _targets.Add(target);
+        _queue.Add(new JsIntersectionObserverEntry(_runtime, _entryPrototype, target));
+        Schedule();
+        return JsValue.Undefined;
+    }
+
+    /// <summary>https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-unobserve.</summary>
+    internal JsValue Unobserve(JsValue[] arguments)
+    {
+        var target = Target(arguments, "unobserve");
+        _targets.Remove(target);
+        _queue.RemoveAll(entry => ReferenceEquals(entry.Node, target));
+        return JsValue.Undefined;
+    }
+
+    /// <summary>https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-disconnect.</summary>
+    internal JsValue Disconnect()
+    {
+        _targets.Clear();
+        _queue.Clear();
+        return JsValue.Undefined;
+    }
+
+    /// <summary>https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-takerecords.</summary>
+    internal JsValue TakeRecords() => Drain();
+
+    private void Schedule()
+    {
+        if (_scheduled)
+        {
+            return;
+        }
+
+        _scheduled = true;
+        ObserverTask.Post(_runtime, Deliver);
+    }
+
+    private void Deliver()
+    {
+        _scheduled = false;
+
+        if (_queue.Count == 0)
+        {
+            return;
+        }
+
+        var entries = Drain();
+
+        try
+        {
+            _callback.Call(this, [entries, this]);
+        }
+        catch (JavaScriptException exception)
+        {
+            _runtime.Recorder.Add(new PageError(
+                PageErrorKind.UncaughtCallbackError,
+                PageRecorder.Diagnostics.Describe(exception.Error, exception),
+                "IntersectionObserver"));
+        }
+    }
+
+    private JsArray Drain()
+    {
+        var values = new JsValue[_queue.Count];
+        for (var i = 0; i < _queue.Count; i++)
+        {
+            values[i] = _queue[i];
+        }
+
+        _queue.Clear();
+        return _runtime.Engine._mainRealm.Intrinsics.Array.ConstructFast(values);
+    }
+
+    private INode Target(JsValue[] arguments, string member)
+    {
+        if (arguments.At(0) is IDomWrapper { DomTarget: IElement element })
+        {
+            return element;
+        }
+
+        Throw.TypeError(
+            _runtime.Engine._mainRealm,
+            "Failed to execute '" + member + "' on 'IntersectionObserver': parameter 1 is not of type 'Element'.");
+        return null!;
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-intersectionobserver — the
+    /// options dictionary, validated the way the constructor's steps 1-6 validate it.
+    /// </summary>
+    internal static (JsValue Root, string RootMargin, double[] Thresholds) ReadOptions(Engine engine, JsValue value)
+    {
+        var realm = engine._mainRealm;
+        var options = value as ObjectInstance;
+
+        var root = options?.Get("root") ?? JsValue.Undefined;
+        if (root.IsUndefined())
+        {
+            root = JsValue.Null;
+        }
+        else if (!root.IsNull() && root is not IDomWrapper { DomTarget: IElement or IDocument })
+        {
+            Throw.TypeError(realm, "Failed to construct 'IntersectionObserver': member root is not of type Element or Document.");
+        }
+
+        var margin = options?.Get("rootMargin") is { } m && !m.IsUndefined() ? TypeConverter.ToString(m) : "0px";
+
+        return (root, SerializeMargin(realm, margin), ReadThresholds(realm, options?.Get("threshold")));
+    }
+
+    /// <summary>
+    /// The margin is one to four <c>&lt;length-percentage&gt;</c> components, serialized back as four. Only
+    /// <c>px</c> and <c>%</c> are units a margin may carry, and a zero may be written bare.
+    /// </summary>
+    private static string SerializeMargin(Realm realm, string margin)
+    {
+        var parts = margin.Split((char[]?) null, StringSplitOptions.RemoveEmptyEntries);
+
+        if (parts.Length is 0 or > 4)
+        {
+            Throw.TypeError(realm, "Failed to construct 'IntersectionObserver': rootMargin must be one to four length or percentage components.");
+        }
+
+        // CSS's one-to-four shorthand expansion, in the order top, right, bottom, left.
+        var components = new string[4];
+        for (var i = 0; i < 4; i++)
+        {
+            var source = parts.Length switch
+            {
+                1 => 0,
+                2 => i % 2,
+                3 => i == 3 ? 1 : i,
+                _ => i,
+            };
+
+            components[i] = Component(realm, parts[source]);
+        }
+
+        return string.Join(" ", components);
+    }
+
+    private static string Component(Realm realm, string part)
+    {
+        var value = part;
+        var unit = "px";
+
+        if (value.EndsWith('%'))
+        {
+            unit = "%";
+            value = value[..^1];
+        }
+        else if (value.EndsWith("px", StringComparison.OrdinalIgnoreCase))
+        {
+            value = value[..^2];
+        }
+
+        if (!double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var number))
+        {
+            Throw.TypeError(realm, "Failed to construct 'IntersectionObserver': rootMargin component '" + part + "' is not a length or a percentage.");
+        }
+
+        return number.ToString("0.####", CultureInfo.InvariantCulture) + unit;
+    }
+
+    private static double[] ReadThresholds(Realm realm, JsValue? value)
+    {
+        if (value is null || value.IsUndefined())
+        {
+            return [0];
+        }
+
+        var thresholds = new List<double>();
+
+        if (value is ObjectInstance sequence && !value.IsNumber())
+        {
+            var length = (int) TypeConverter.ToUint32(sequence.Get("length"));
+            for (var i = 0; i < length; i++)
+            {
+                thresholds.Add(TypeConverter.ToNumber(sequence.Get(i.ToString(CultureInfo.InvariantCulture))));
+            }
+        }
+        else
+        {
+            thresholds.Add(TypeConverter.ToNumber(value));
+        }
+
+        if (thresholds.Count == 0)
+        {
+            thresholds.Add(0);
+        }
+
+        foreach (var threshold in thresholds)
+        {
+            if (threshold is < 0 or > 1 || double.IsNaN(threshold))
+            {
+                Throw.RangeError(realm, "Failed to construct 'IntersectionObserver': Threshold values must be numbers between 0 and 1.");
+            }
+        }
+
+        thresholds.Sort();
+        return [.. thresholds];
+    }
+}
+
+/// <summary>
+/// One <c>IntersectionObserverEntry</c>: the target, the moment it was reported, and the zero rectangles a
+/// page with no layout has.
+/// </summary>
+internal sealed class JsIntersectionObserverEntry : ObjectInstance
+{
+    private readonly PageRuntime _runtime;
+
+    internal JsIntersectionObserverEntry(PageRuntime runtime, ObjectInstance prototype, INode node)
+        : base(runtime.Engine)
+    {
+        _runtime = runtime;
+        Node = node;
+        Time = runtime.Now;
+        Prototype = prototype;
+    }
+
+    /// <summary>The element this entry reports on.</summary>
+    internal INode Node { get; }
+
+    /// <summary>https://w3c.github.io/IntersectionObserver/#dom-intersectionobserverentry-time.</summary>
+    internal double Time { get; }
+
+    /// <summary>The wrapper for <see cref="Node"/>, which is what <c>entry.target</c> answers.</summary>
+    internal JsValue TargetValue => _runtime.Dom.WrapNode(Node);
+
+    /// <summary>A fresh zero rectangle; a page may keep or mutate the one it is given.</summary>
+    internal JsValue Rect() => ObserverGeometry.ZeroRect(Engine);
+
+    /// <inheritdoc />
+    public override string ToString() => "[object IntersectionObserverEntry]";
+
+    /// <summary>The receiver check every member of the interface starts with.</summary>
+    internal static JsIntersectionObserverEntry Brand(JsValue thisObject, string member)
+        => ObserverGeometry.Brand<JsIntersectionObserverEntry>(thisObject, "IntersectionObserverEntry", member);
+}

--- a/Jint.Browser/Observers/JsMutationObserver.cs
+++ b/Jint.Browser/Observers/JsMutationObserver.cs
@@ -1,0 +1,267 @@
+using AngleSharp.Dom;
+using Jint.Browser.Dom;
+using Jint.Browser.Runtime;
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+
+namespace Jint.Browser.Observers;
+
+/// <summary>
+/// A <c>MutationObserver</c>: the callback, the registrations AngleSharp keeps for it, and the records it has
+/// not delivered yet.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The records are AngleSharp's; the timing is Jint's.</b> AngleSharp does the whole of DOM §4.3.4 —
+/// walking a mutated node's inclusive ancestors, matching each against the registered observer list, honouring
+/// <c>subtree</c> and <c>attributeFilter</c>, and clearing <c>oldValue</c> for an observer that did not ask
+/// for it. What it cannot do is <em>when</em>: with no <c>IEventLoop</c> service registered — and registering
+/// one would make a step of the parse genuinely asynchronous, which is the parser hop
+/// <c>Runtime/PageDocument</c> exists to avoid — AngleSharp's own queue runs inline, so its callback fires
+/// synchronously in the middle of <c>appendChild</c>. That inline call is used as the <em>arrival</em> of a
+/// record and nothing more: the records are parked here, and <see cref="MutationObserverLane"/> queues one
+/// microtask on the engine's job queue to deliver them at the microtask checkpoint, which is where
+/// <a href="https://dom.spec.whatwg.org/#notify-mutation-observers">notify mutation observers</a> belongs.
+/// </para>
+/// <para>
+/// <b>Two AngleSharp behaviours are corrected here rather than worked around silently</b>, and both are in
+/// <c>Jint.Browser/AGENTS.md</c>'s divergence table. Its <c>observe</c> validation raises a
+/// <c>DomException</c> where DOM raises a <c>TypeError</c>, and it resolves the dictionary's optional members
+/// differently from the specification — so the flags are resolved and validated here and handed over already
+/// settled, which leaves AngleSharp's own checks unreachable. And its <c>Disconnect</c> unregisters the
+/// observer from the document but leaves its registration list populated, so a later <c>observe</c> of any
+/// node silently resurrects every node it used to watch; a disconnect therefore throws its AngleSharp
+/// observer away and the next <c>observe</c> starts a new one.
+/// </para>
+/// </remarks>
+internal sealed class JsMutationObserver : ObjectInstance
+{
+    private readonly PageRuntime _runtime;
+    private readonly ICallable _callback;
+    private readonly List<IMutationRecord> _records = [];
+    private AngleSharp.Dom.MutationObserver _source;
+
+    internal JsMutationObserver(PageRuntime runtime, ObjectInstance prototype, ICallable callback)
+        : base(runtime.Engine)
+    {
+        _runtime = runtime;
+        _callback = callback;
+        _source = NewSource();
+        Prototype = prototype;
+    }
+
+    /// <inheritdoc />
+    public override string ToString() => "[object MutationObserver]";
+
+    /// <summary>The receiver check every member of the interface starts with.</summary>
+    internal static JsMutationObserver Brand(JsValue thisObject, string member)
+    {
+        if (thisObject is JsMutationObserver observer)
+        {
+            return observer;
+        }
+
+        var message = "Failed to execute '" + member + "' on 'MutationObserver': Illegal invocation";
+
+        if (thisObject is ObjectInstance instance)
+        {
+            Throw.TypeError(instance.Engine.Realm, message);
+        }
+
+        Throw.TypeErrorNoEngine(message);
+        return null!;
+    }
+
+    /// <summary>
+    /// https://dom.spec.whatwg.org/#dom-mutationobserver-observe — register <paramref name="arguments"/>'s
+    /// node with the options it asks for, replacing any registration this observer already has for it.
+    /// </summary>
+    internal JsValue Observe(JsValue[] arguments)
+    {
+        var realm = _runtime.Engine._mainRealm;
+
+        if (arguments.At(0) is not IDomWrapper { DomTarget: INode node })
+        {
+            Throw.TypeError(realm, "Failed to execute 'observe' on 'MutationObserver': parameter 1 is not of type 'Node'.");
+            return JsValue.Undefined;
+        }
+
+        var options = arguments.At(1) as ObjectInstance;
+        var childList = Flag(options, "childList") ?? false;
+        var subtree = Flag(options, "subtree") ?? false;
+        var attributeOldValue = Flag(options, "attributeOldValue");
+        var characterDataOldValue = Flag(options, "characterDataOldValue");
+        var filter = Filter(options);
+
+        // Steps 2-4: an option that only makes sense with attributes (or with characterData) turns that one
+        // on when the dictionary left it out. "Left out" and "present and false" are different: { attributes:
+        // false, attributeOldValue: false } is a TypeError, { attributeOldValue: false } is not.
+        var attributes = Flag(options, "attributes") ?? (attributeOldValue is not null || filter is not null);
+        var characterData = Flag(options, "characterData") ?? characterDataOldValue is not null;
+
+        if (!childList && !attributes && !characterData)
+        {
+            Throw.TypeError(realm, "Failed to execute 'observe' on 'MutationObserver': The options object must set at least one of 'attributes', 'characterData', or 'childList' to true.");
+        }
+
+        if (attributeOldValue == true && !attributes)
+        {
+            Throw.TypeError(realm, "Failed to execute 'observe' on 'MutationObserver': The options object may only set 'attributeOldValue' to true when 'attributes' is true or not present.");
+        }
+
+        if (filter is not null && !attributes)
+        {
+            Throw.TypeError(realm, "Failed to execute 'observe' on 'MutationObserver': The options object may only set 'attributeFilter' when 'attributes' is true or not present.");
+        }
+
+        if (characterDataOldValue == true && !characterData)
+        {
+            Throw.TypeError(realm, "Failed to execute 'observe' on 'MutationObserver': The options object may only set 'characterDataOldValue' to true when 'characterData' is true or not present.");
+        }
+
+        // Every flag is passed as a settled value, so none of AngleSharp's own defaulting or validation runs.
+        _source.Connect(
+            node,
+            childList,
+            subtree,
+            attributes,
+            characterData,
+            attributeOldValue == true,
+            characterDataOldValue == true,
+            filter);
+
+        return JsValue.Undefined;
+    }
+
+    /// <summary>
+    /// https://dom.spec.whatwg.org/#dom-mutationobserver-disconnect — empty the registration list and the
+    /// record queue.
+    /// </summary>
+    internal JsValue Disconnect()
+    {
+        _source.Disconnect();
+
+        // A fresh one, because AngleSharp's Disconnect leaves its own registration list in place: reusing it
+        // would make the next observe() re-register every node this one used to watch.
+        _source = NewSource();
+        _records.Clear();
+        _runtime.MutationObservers.Withdraw(this);
+        return JsValue.Undefined;
+    }
+
+    /// <summary>
+    /// https://dom.spec.whatwg.org/#dom-mutationobserver-takerecords — the queued records, and the queue is
+    /// emptied.
+    /// </summary>
+    internal JsValue TakeRecords()
+    {
+        var records = Drain();
+        _runtime.MutationObservers.Withdraw(this);
+        return records;
+    }
+
+    /// <summary>
+    /// https://dom.spec.whatwg.org/#notify-mutation-observers, for this observer: hand the queued records to
+    /// the callback, with the observer itself as both the second argument and the receiver.
+    /// </summary>
+    internal void Deliver()
+    {
+        if (_records.Count == 0)
+        {
+            return;
+        }
+
+        var records = Drain();
+
+        try
+        {
+            _callback.Call(this, [records, this]);
+        }
+        catch (JavaScriptException exception)
+        {
+            // WebIDL's "report the exception": the page survives a callback that threw, exactly as it
+            // survives a timer callback that threw.
+            _runtime.Recorder.Add(new PageError(
+                PageErrorKind.UncaughtCallbackError,
+                PageRecorder.Diagnostics.Describe(exception.Error, exception),
+                "MutationObserver"));
+        }
+    }
+
+    private AngleSharp.Dom.MutationObserver NewSource() => new(OnRecords);
+
+    /// <summary>
+    /// What AngleSharp calls, synchronously, from inside the mutation. Nothing but bookkeeping happens here —
+    /// no script runs — so re-entering the DOM operation that is still running is safe.
+    /// </summary>
+    private void OnRecords(IEnumerable<IMutationRecord> records, AngleSharp.Dom.MutationObserver source)
+    {
+        foreach (var record in records)
+        {
+            _records.Add(new DeliveredMutationRecord(record));
+        }
+
+        if (_records.Count > 0)
+        {
+            _runtime.MutationObservers.Enlist(this);
+        }
+    }
+
+    private JsArray Drain()
+    {
+        var realm = _runtime.Engine._mainRealm;
+        var values = new JsValue[_records.Count];
+
+        for (var i = 0; i < _records.Count; i++)
+        {
+            values[i] = _runtime.Dom.Wrap(_records[i]);
+        }
+
+        _records.Clear();
+        return realm.Intrinsics.Array.ConstructFast(values);
+    }
+
+    /// <summary>
+    /// A dictionary member declared <c>boolean</c> with no default: <see langword="null"/> means the member
+    /// was not there, which is what steps 2-4 of <c>observe</c> distinguish from <see langword="false"/>.
+    /// </summary>
+    private static bool? Flag(ObjectInstance? options, string name)
+    {
+        if (options is null)
+        {
+            return null;
+        }
+
+        var value = options.Get(name);
+        return value.IsUndefined() ? null : TypeConverter.ToBoolean(value);
+    }
+
+    /// <summary>
+    /// <c>attributeFilter</c>, a <c>sequence&lt;DOMString&gt;</c>. <see langword="null"/> means absent, which
+    /// is what turns <c>attributes</c> on by itself.
+    /// </summary>
+    private static string[]? Filter(ObjectInstance? options)
+    {
+        if (options?.Get("attributeFilter") is not { } value || value.IsUndefined() || value.IsNull())
+        {
+            return null;
+        }
+
+        if (value is not ObjectInstance list)
+        {
+            Throw.TypeErrorNoEngine("Failed to execute 'observe' on 'MutationObserver': The provided value cannot be converted to a sequence.");
+            return null;
+        }
+
+        var length = (int) TypeConverter.ToUint32(list.Get("length"));
+        var names = new string[length];
+
+        for (var i = 0; i < length; i++)
+        {
+            names[i] = TypeConverter.ToString(list.Get(i.ToString(System.Globalization.CultureInfo.InvariantCulture)));
+        }
+
+        return names;
+    }
+}

--- a/Jint.Browser/Observers/JsResizeObserver.cs
+++ b/Jint.Browser/Observers/JsResizeObserver.cs
@@ -1,0 +1,175 @@
+using AngleSharp.Dom;
+using Jint.Browser.Dom;
+using Jint.Browser.Runtime;
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+
+namespace Jint.Browser.Observers;
+
+/// <summary>
+/// A <c>ResizeObserver</c> with no box to measure: every target it is given is reported once, at zero size.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>A stub, like <see cref="JsIntersectionObserver"/>, and for the same reason.</b>
+/// <a href="https://w3c.github.io/csswg-drafts/resize-observer/">Resize Observer</a> reports a box changing
+/// size, and there are no boxes. What matters to a page is the <em>initial</em> notification the specification
+/// requires — "observe() ... queues an initial observation" — because that is the one a component uses to
+/// measure itself when it mounts, and a component whose observer never fires never finishes mounting. So each
+/// observed target gets exactly one entry, delivered as a task after <c>observe()</c> returns, and nothing
+/// afterwards: with no layout, no size can change.
+/// </para>
+/// <para>
+/// The <c>box</c> option is read and ignored: the three box sizes an entry carries are the same zeros, so
+/// choosing between them would be a distinction without a difference. The flat-box model (campaign item C4)
+/// is what makes them different numbers.
+/// </para>
+/// </remarks>
+internal sealed class JsResizeObserver : ObjectInstance
+{
+    private readonly PageRuntime _runtime;
+    private readonly ICallable _callback;
+    private readonly List<INode> _targets = [];
+    private readonly List<JsResizeObserverEntry> _queue = [];
+    private readonly ObjectInstance _entryPrototype;
+    private bool _scheduled;
+
+    internal JsResizeObserver(PageRuntime runtime, ObjectInstance prototype, ObjectInstance entryPrototype, ICallable callback)
+        : base(runtime.Engine)
+    {
+        _runtime = runtime;
+        _callback = callback;
+        _entryPrototype = entryPrototype;
+        Prototype = prototype;
+    }
+
+    /// <inheritdoc />
+    public override string ToString() => "[object ResizeObserver]";
+
+    /// <summary>The receiver check every member of the interface starts with.</summary>
+    internal static JsResizeObserver Brand(JsValue thisObject, string member)
+        => ObserverGeometry.Brand<JsResizeObserver>(thisObject, "ResizeObserver", member);
+
+    /// <summary>https://w3c.github.io/csswg-drafts/resize-observer/#dom-resizeobserver-observe.</summary>
+    internal JsValue Observe(JsValue[] arguments)
+    {
+        var target = Target(arguments, "observe");
+
+        if (_targets.Contains(target))
+        {
+            return JsValue.Undefined;
+        }
+
+        _targets.Add(target);
+        _queue.Add(new JsResizeObserverEntry(_runtime, _entryPrototype, target));
+        Schedule();
+        return JsValue.Undefined;
+    }
+
+    /// <summary>https://w3c.github.io/csswg-drafts/resize-observer/#dom-resizeobserver-unobserve.</summary>
+    internal JsValue Unobserve(JsValue[] arguments)
+    {
+        var target = Target(arguments, "unobserve");
+        _targets.Remove(target);
+        _queue.RemoveAll(entry => ReferenceEquals(entry.Node, target));
+        return JsValue.Undefined;
+    }
+
+    /// <summary>https://w3c.github.io/csswg-drafts/resize-observer/#dom-resizeobserver-disconnect.</summary>
+    internal JsValue Disconnect()
+    {
+        _targets.Clear();
+        _queue.Clear();
+        return JsValue.Undefined;
+    }
+
+    private void Schedule()
+    {
+        if (_scheduled)
+        {
+            return;
+        }
+
+        _scheduled = true;
+        ObserverTask.Post(_runtime, Deliver);
+    }
+
+    private void Deliver()
+    {
+        _scheduled = false;
+
+        if (_queue.Count == 0)
+        {
+            return;
+        }
+
+        var values = new JsValue[_queue.Count];
+        for (var i = 0; i < _queue.Count; i++)
+        {
+            values[i] = _queue[i];
+        }
+
+        _queue.Clear();
+
+        try
+        {
+            _callback.Call(this, [_runtime.Engine._mainRealm.Intrinsics.Array.ConstructFast(values), this]);
+        }
+        catch (JavaScriptException exception)
+        {
+            _runtime.Recorder.Add(new PageError(
+                PageErrorKind.UncaughtCallbackError,
+                PageRecorder.Diagnostics.Describe(exception.Error, exception),
+                "ResizeObserver"));
+        }
+    }
+
+    private INode Target(JsValue[] arguments, string member)
+    {
+        if (arguments.At(0) is IDomWrapper { DomTarget: IElement element })
+        {
+            return element;
+        }
+
+        Throw.TypeError(
+            _runtime.Engine._mainRealm,
+            "Failed to execute '" + member + "' on 'ResizeObserver': parameter 1 is not of type 'Element'.");
+        return null!;
+    }
+}
+
+/// <summary>
+/// One <c>ResizeObserverEntry</c>: the target, and the three box sizes a page with no layout has.
+/// </summary>
+internal sealed class JsResizeObserverEntry : ObjectInstance
+{
+    private readonly PageRuntime _runtime;
+
+    internal JsResizeObserverEntry(PageRuntime runtime, ObjectInstance prototype, INode node)
+        : base(runtime.Engine)
+    {
+        _runtime = runtime;
+        Node = node;
+        Prototype = prototype;
+    }
+
+    /// <summary>The element this entry reports on.</summary>
+    internal INode Node { get; }
+
+    /// <summary>The wrapper for <see cref="Node"/>, which is what <c>entry.target</c> answers.</summary>
+    internal JsValue TargetValue => _runtime.Dom.WrapNode(Node);
+
+    /// <summary>A fresh zero rectangle; a page may keep or mutate the one it is given.</summary>
+    internal JsValue Rect() => ObserverGeometry.ZeroRect(Engine);
+
+    /// <summary>A fresh one-element array of zero box sizes.</summary>
+    internal JsValue BoxSizes() => ObserverGeometry.BoxSizes(Engine, 0, 0);
+
+    /// <inheritdoc />
+    public override string ToString() => "[object ResizeObserverEntry]";
+
+    /// <summary>The receiver check every member of the interface starts with.</summary>
+    internal static JsResizeObserverEntry Brand(JsValue thisObject, string member)
+        => ObserverGeometry.Brand<JsResizeObserverEntry>(thisObject, "ResizeObserverEntry", member);
+}

--- a/Jint.Browser/Observers/MutationObserverLane.cs
+++ b/Jint.Browser/Observers/MutationObserverLane.cs
@@ -1,0 +1,77 @@
+using Jint.Browser.Runtime;
+
+namespace Jint.Browser.Observers;
+
+/// <summary>
+/// <a href="https://dom.spec.whatwg.org/#queue-a-mutation-observer-microtask">Queue a mutation observer
+/// microtask</a>: one job on the engine's queue per batch of mutations, however many records the batch holds.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The engine's single job queue <em>is</em> the microtask queue, so the ordering DOM asks for comes out of a
+/// plain enqueue: a <c>then</c> callback registered before the first mutation of a turn runs before the
+/// observer's, and one registered after it runs after. The compound-microtask-queue flag is
+/// <see cref="_scheduled"/>, set when the job is queued and cleared when it starts — so a mutation made from
+/// inside a callback queues the next checkpoint rather than joining the one that is running.
+/// </para>
+/// <para>
+/// An observer joins the notify set when a record arrives and leaves it when its records are taken, whether
+/// by delivery, by <c>takeRecords()</c> or by <c>disconnect()</c>. That set is the only strong reference this
+/// package keeps to an observer, which matches DOM's own rule that an observer with a non-empty record queue
+/// is reachable: one that a page dropped and that has nothing queued is collectable together with its
+/// callback.
+/// </para>
+/// </remarks>
+internal sealed class MutationObserverLane
+{
+    private readonly PageRuntime _runtime;
+    private readonly List<JsMutationObserver> _notify = [];
+    private readonly Action _notifyJob;
+    private bool _scheduled;
+
+    internal MutationObserverLane(PageRuntime runtime)
+    {
+        _runtime = runtime;
+        _notifyJob = Notify;
+    }
+
+    /// <summary>Adds <paramref name="observer"/> to the notify set and queues the checkpoint if it is not queued.</summary>
+    internal void Enlist(JsMutationObserver observer)
+    {
+        if (!_notify.Contains(observer))
+        {
+            _notify.Add(observer);
+        }
+
+        if (_scheduled)
+        {
+            return;
+        }
+
+        _scheduled = true;
+        _runtime.Engine.AddToEventLoop(_notifyJob);
+    }
+
+    /// <summary>Takes <paramref name="observer"/> out of the notify set; its queue is empty.</summary>
+    internal void Withdraw(JsMutationObserver observer) => _notify.Remove(observer);
+
+    private void Notify()
+    {
+        _scheduled = false;
+
+        if (_notify.Count == 0)
+        {
+            return;
+        }
+
+        // A copy, because a callback may mutate the DOM and put its own observer straight back into the set;
+        // those records belong to the next checkpoint.
+        var batch = _notify.ToArray();
+        _notify.Clear();
+
+        foreach (var observer in batch)
+        {
+            observer.Deliver();
+        }
+    }
+}

--- a/Jint.Browser/Observers/MutationRecords.cs
+++ b/Jint.Browser/Observers/MutationRecords.cs
@@ -1,0 +1,100 @@
+using System.Collections;
+using AngleSharp;
+using AngleSharp.Dom;
+
+namespace Jint.Browser.Observers;
+
+/// <summary>
+/// The record a callback is handed: AngleSharp's, with the two node lists made non-null.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <a href="https://dom.spec.whatwg.org/#interface-mutationrecord">DOM §4.3.3</a> declares
+/// <c>addedNodes</c> and <c>removedNodes</c> as <c>[SameObject] readonly attribute NodeList</c> — never
+/// nullable — so a page may write <c>record.addedNodes.length</c> for a record of any type.
+/// <c>MutationRecord.Attributes</c> and <c>MutationRecord.CharacterData</c> leave AngleSharp's own
+/// <c>Added</c> and <c>Removed</c> <see langword="null"/>, which the binding would project as
+/// <see langword="null"/>; this decorator answers an empty list instead.
+/// </para>
+/// <para>
+/// It is a decorator rather than a patch to the generated <c>MutationRecord</c> binding because the fix
+/// belongs to the record AngleSharp made, not to the projection: everything else — the type string, the
+/// target, the siblings, and <c>oldValue</c> already cleared by <c>MutationRecord.Copy</c> when the observer
+/// did not ask for it — is right, and <c>DomTypeMap</c> matches this on <see cref="IMutationRecord"/> exactly
+/// as it matches AngleSharp's own, so <c>record instanceof MutationRecord</c> still holds.
+/// </para>
+/// </remarks>
+internal sealed class DeliveredMutationRecord : IMutationRecord
+{
+    private readonly IMutationRecord _record;
+
+    internal DeliveredMutationRecord(IMutationRecord record)
+    {
+        _record = record;
+    }
+
+    /// <inheritdoc />
+    public string Type => _record.Type;
+
+    /// <inheritdoc />
+    public INode Target => _record.Target;
+
+    /// <inheritdoc />
+    public INodeList Added => _record.Added ?? EmptyNodeList.Instance;
+
+    /// <inheritdoc />
+    public INodeList Removed => _record.Removed ?? EmptyNodeList.Instance;
+
+    /// <inheritdoc />
+    public INode PreviousSibling => _record.PreviousSibling!;
+
+    /// <inheritdoc />
+    public INode NextSibling => _record.NextSibling!;
+
+    /// <inheritdoc />
+    public string AttributeName => _record.AttributeName!;
+
+    /// <inheritdoc />
+    public string AttributeNamespace => _record.AttributeNamespace!;
+
+    /// <inheritdoc />
+    public string PreviousValue => _record.PreviousValue!;
+}
+
+/// <summary>
+/// The <c>NodeList</c> an attribute or character-data record answers for its added and removed nodes.
+/// </summary>
+/// <remarks>
+/// One process-shared instance, because it holds nothing. That means every such record shares one wrapper in
+/// an engine's wrapper cache, so <c>a.addedNodes === b.addedNodes</c> answers <see langword="true"/> across
+/// two empty records where a browser answers <see langword="false"/>. Nothing a page does with an empty list
+/// can tell the difference except that identity comparison, and the alternative — one allocation per record
+/// per engine, kept alive by the cache — costs more than the divergence is worth.
+/// </remarks>
+internal sealed class EmptyNodeList : INodeList
+{
+    internal static readonly EmptyNodeList Instance = new();
+
+    private EmptyNodeList()
+    {
+    }
+
+    /// <inheritdoc />
+    public INode this[int index] => throw new ArgumentOutOfRangeException(nameof(index));
+
+    /// <inheritdoc />
+    public int Length => 0;
+
+    /// <inheritdoc />
+    public IEnumerator<INode> GetEnumerator()
+    {
+        yield break;
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    /// <inheritdoc />
+    public void ToHtml(TextWriter writer, IMarkupFormatter formatter)
+    {
+    }
+}

--- a/Jint.Browser/Observers/ObserverGeometry.cs
+++ b/Jint.Browser/Observers/ObserverGeometry.cs
@@ -1,0 +1,95 @@
+using Jint.Native;
+using Jint.Native.Object;
+
+namespace Jint.Browser.Observers;
+
+/// <summary>
+/// The boxes an <c>IntersectionObserverEntry</c> and a <c>ResizeObserverEntry</c> carry, at the only size a
+/// page with no layout can honestly be told: zero.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>They are plain objects, not <c>DOMRectReadOnly</c> instances.</b> There is no box model in this version
+/// and therefore no rectangle interface anywhere in the package — <c>Element.getBoundingClientRect</c> does
+/// not exist either — so introducing <c>DOMRectReadOnly</c> here would mean shipping an interface whose only
+/// instances are zeros. The flat-box model (campaign item C4) is what gives every element a deterministic
+/// rectangle; when it lands, these become the real thing and a page reading <c>entry.boundingClientRect.width</c>
+/// starts getting an answer instead of <c>0</c>. Until then the shape of the value is right and the numbers
+/// are not, which is the honest half.
+/// </para>
+/// <para>
+/// One process-shared <see cref="JsObjectLayout"/> per shape, so every rectangle an engine builds shares a
+/// hidden class and a page reading <c>.width</c> across a batch of entries keeps a monomorphic inline cache.
+/// </para>
+/// </remarks>
+internal static class ObserverGeometry
+{
+    /// <summary>
+    /// The eight numbers <c>DOMRectReadOnly</c> declares, in the order the interface lists them, plus the
+    /// <c>toJSON</c> the CSSOM View <c>DOMRect</c> stringifier is spelled as.
+    /// </summary>
+    private static readonly JsObjectLayout _rect = new JsObjectLayout.Builder()
+        .Add("x")
+        .Add("y")
+        .Add("width")
+        .Add("height")
+        .Add("top")
+        .Add("right")
+        .Add("bottom")
+        .Add("left")
+        .Build();
+
+    /// <summary>
+    /// https://drafts.csswg.org/resize-observer/#resizeobserversize — the two writing-mode-relative lengths a
+    /// box size reports.
+    /// </summary>
+    private static readonly JsObjectLayout _boxSize = new JsObjectLayout.Builder()
+        .Add("inlineSize")
+        .Add("blockSize")
+        .Build();
+
+    /// <summary>A rectangle at the origin with no extent.</summary>
+    internal static JsObject ZeroRect(Engine engine) => Rect(engine, 0, 0, 0, 0);
+
+    /// <summary>A rectangle, with the four derived edges filled in from the four given numbers.</summary>
+    internal static JsObject Rect(Engine engine, double x, double y, double width, double height)
+        => JsObject.Create(
+            engine,
+            _rect,
+            [
+                JsNumber.Create(x),
+                JsNumber.Create(y),
+                JsNumber.Create(width),
+                JsNumber.Create(height),
+                JsNumber.Create(y),
+                JsNumber.Create(x + width),
+                JsNumber.Create(y + height),
+                JsNumber.Create(x),
+            ]);
+
+    /// <summary>A one-element array holding the single fragment a box with no layout has.</summary>
+    internal static JsValue BoxSizes(Engine engine, double inlineSize, double blockSize)
+    {
+        var size = JsObject.Create(engine, _boxSize, [JsNumber.Create(inlineSize), JsNumber.Create(blockSize)]);
+        return engine._mainRealm.Intrinsics.Array.ConstructFast(new JsValue[] { size });
+    }
+
+    /// <summary>The receiver check an entry's members start with.</summary>
+    internal static T Brand<T>(JsValue thisObject, string interfaceName, string member) where T : ObjectInstance
+    {
+        if (thisObject is T entry)
+        {
+            return entry;
+        }
+
+        var message = "Failed to read the '" + member + "' property from '" + interfaceName + "': Illegal invocation";
+
+        if (thisObject is ObjectInstance instance)
+        {
+            Jint.Runtime.Throw.TypeError(instance.Engine.Realm, message);
+        }
+
+        Jint.Runtime.Throw.TypeErrorNoEngine(message);
+        return null!;
+    }
+}

--- a/Jint.Browser/Observers/ObserverInstaller.cs
+++ b/Jint.Browser/Observers/ObserverInstaller.cs
@@ -1,0 +1,156 @@
+using Jint.Browser.Dom;
+using Jint.Browser.Runtime;
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.Browser.Observers;
+
+/// <summary>
+/// The five observer interfaces a page reaches through its window: <c>MutationObserver</c>,
+/// <c>IntersectionObserver</c>, <c>IntersectionObserverEntry</c>, <c>ResizeObserver</c> and
+/// <c>ResizeObserverEntry</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Each global is lazy and non-clobbering, exactly as every web-API and DOM-interface global is: a page that
+/// never mentions <c>ResizeObserver</c> must not pay for its prototype, and a name the host's own
+/// configuration already took stays the host's.
+/// </para>
+/// <para>
+/// The shapes are process-shared and the prototypes are per engine, which is the split the whole binding is
+/// built on. Every member below is a static lambda that reaches its state through the receiver, which is what
+/// lets one shape serve every engine — and unlike a <c>Window</c> member, none of these is ever called
+/// unqualified, so a shape method reading <c>thisObj</c> is safe here where it is not there.
+/// </para>
+/// </remarks>
+internal static class ObserverInstaller
+{
+    private static readonly JsObjectShape _mutationObserver = BuildMutationObserverShape();
+    private static readonly JsObjectShape _intersectionObserver = BuildIntersectionObserverShape();
+    private static readonly JsObjectShape _intersectionObserverEntry = BuildIntersectionObserverEntryShape();
+    private static readonly JsObjectShape _resizeObserver = BuildResizeObserverShape();
+    private static readonly JsObjectShape _resizeObserverEntry = BuildResizeObserverEntryShape();
+
+    /// <summary>Installs the five globals on <paramref name="runtime"/>'s engine. Called once, at construction.</summary>
+    internal static void Install(PageRuntime runtime)
+    {
+        var engine = runtime.Engine;
+
+        Add(engine, "MutationObserver", static realm => realm.MutationObserver);
+        Add(engine, "IntersectionObserver", static realm => realm.IntersectionObserver);
+        Add(engine, "IntersectionObserverEntry", static realm => realm.IntersectionObserverEntry);
+        Add(engine, "ResizeObserver", static realm => realm.ResizeObserver);
+        Add(engine, "ResizeObserverEntry", static realm => realm.ResizeObserverEntry);
+    }
+
+    private static void Add(Engine engine, string name, Func<ObserverRealm, JsValue> factory)
+        => engine.AddLazyGlobal(
+            name,
+            factory,
+            static (e, f) => f(PageRuntime.Find(e)!.Observers),
+            PropertyFlag.NonEnumerable);
+
+    /// <summary>
+    /// Builds an interface prototype and its interface object together, filling the prototype's per-realm
+    /// <c>constructor</c> slot with the sanctioned in-place slot replacement so the prototype stays shaped.
+    /// </summary>
+    internal static ObjectInstance Instantiate(
+        Engine engine,
+        JsObjectShape shape,
+        string name,
+        int length,
+        Func<JsValue[], ObjectInstance>? construct,
+        out HostInterfaceObject interfaceObject)
+    {
+        var realm = engine._mainRealm;
+        var prototype = shape.Instantiate(engine, realm.Intrinsics.Object.PrototypeObject);
+        interfaceObject = new HostInterfaceObject(engine, realm, name, prototype, length, construct);
+
+        prototype.DefineOwnPropertyUnchecked(
+            "constructor",
+            new PropertyDescriptor(interfaceObject, PropertyFlag.NonEnumerable));
+
+        return prototype;
+    }
+
+    /// <summary>
+    /// https://dom.spec.whatwg.org/#interface-mutationobserver — <c>observe</c>, <c>disconnect</c> and
+    /// <c>takeRecords</c>, and nothing else: the interface has no attributes at all.
+    /// </summary>
+    private static JsObjectShape BuildMutationObserverShape() => new JsObjectShape.Builder()
+        .PerRealmSlot("constructor")
+        .ToStringTag("MutationObserver")
+        .Method("observe", static (t, args) => JsMutationObserver.Brand(t, "observe").Observe(args), length: 2)
+        .Method("disconnect", static (t, _) => JsMutationObserver.Brand(t, "disconnect").Disconnect())
+        .Method("takeRecords", static (t, _) => JsMutationObserver.Brand(t, "takeRecords").TakeRecords())
+        .Build();
+
+    /// <summary>https://w3c.github.io/IntersectionObserver/#intersection-observer-interface.</summary>
+    private static JsObjectShape BuildIntersectionObserverShape() => new JsObjectShape.Builder()
+        .PerRealmSlot("constructor")
+        .ToStringTag("IntersectionObserver")
+        .Accessor("root", static (t, _) => JsIntersectionObserver.Brand(t, "root").Root)
+        .Accessor("rootMargin", static (t, _) => JsString.Create(JsIntersectionObserver.Brand(t, "rootMargin").RootMargin))
+        .Accessor("scrollMargin", static (_, _) => JsString.Create("0px 0px 0px 0px"))
+        .Accessor("thresholds", static (t, _) =>
+        {
+            var observer = JsIntersectionObserver.Brand(t, "thresholds");
+            var values = new JsValue[observer.Thresholds.Length];
+            for (var i = 0; i < values.Length; i++)
+            {
+                values[i] = JsNumber.Create(observer.Thresholds[i]);
+            }
+
+            return observer.Engine._mainRealm.Intrinsics.Array.ConstructFast(values);
+        })
+        .Method("observe", static (t, args) => JsIntersectionObserver.Brand(t, "observe").Observe(args), length: 1)
+        .Method("unobserve", static (t, args) => JsIntersectionObserver.Brand(t, "unobserve").Unobserve(args), length: 1)
+        .Method("disconnect", static (t, _) => JsIntersectionObserver.Brand(t, "disconnect").Disconnect())
+        .Method("takeRecords", static (t, _) => JsIntersectionObserver.Brand(t, "takeRecords").TakeRecords())
+        .Build();
+
+    /// <summary>https://w3c.github.io/IntersectionObserver/#intersection-observer-entry.</summary>
+    private static JsObjectShape BuildIntersectionObserverEntryShape() => new JsObjectShape.Builder()
+        .PerRealmSlot("constructor")
+        .ToStringTag("IntersectionObserverEntry")
+        .Accessor("boundingClientRect", static (t, _) => JsIntersectionObserverEntry.Brand(t, "boundingClientRect").Rect())
+        .Accessor("intersectionRatio", static (_, _) => JsNumber.Create(1))
+        .Accessor("intersectionRect", static (t, _) => JsIntersectionObserverEntry.Brand(t, "intersectionRect").Rect())
+        .Accessor("isIntersecting", static (_, _) => JsBoolean.True)
+        .Accessor("rootBounds", static (t, _) => JsIntersectionObserverEntry.Brand(t, "rootBounds").Rect())
+        .Accessor("target", static (t, _) => JsIntersectionObserverEntry.Brand(t, "target").TargetValue)
+        .Accessor("time", static (t, _) => JsNumber.Create(JsIntersectionObserverEntry.Brand(t, "time").Time))
+        .Build();
+
+    /// <summary>https://w3c.github.io/csswg-drafts/resize-observer/#resizeobserver.</summary>
+    private static JsObjectShape BuildResizeObserverShape() => new JsObjectShape.Builder()
+        .PerRealmSlot("constructor")
+        .ToStringTag("ResizeObserver")
+        .Method("observe", static (t, args) => JsResizeObserver.Brand(t, "observe").Observe(args), length: 1)
+        .Method("unobserve", static (t, args) => JsResizeObserver.Brand(t, "unobserve").Unobserve(args), length: 1)
+        .Method("disconnect", static (t, _) => JsResizeObserver.Brand(t, "disconnect").Disconnect())
+        .Build();
+
+    /// <summary>https://w3c.github.io/csswg-drafts/resize-observer/#resizeobserverentry.</summary>
+    private static JsObjectShape BuildResizeObserverEntryShape() => new JsObjectShape.Builder()
+        .PerRealmSlot("constructor")
+        .ToStringTag("ResizeObserverEntry")
+        .Accessor("borderBoxSize", static (t, _) => JsResizeObserverEntry.Brand(t, "borderBoxSize").BoxSizes())
+        .Accessor("contentBoxSize", static (t, _) => JsResizeObserverEntry.Brand(t, "contentBoxSize").BoxSizes())
+        .Accessor("contentRect", static (t, _) => JsResizeObserverEntry.Brand(t, "contentRect").Rect())
+        .Accessor("devicePixelContentBoxSize", static (t, _) => JsResizeObserverEntry.Brand(t, "devicePixelContentBoxSize").BoxSizes())
+        .Accessor("target", static (t, _) => JsResizeObserverEntry.Brand(t, "target").TargetValue)
+        .Build();
+
+    internal static JsObjectShape MutationObserverShape => _mutationObserver;
+
+    internal static JsObjectShape IntersectionObserverShape => _intersectionObserver;
+
+    internal static JsObjectShape IntersectionObserverEntryShape => _intersectionObserverEntry;
+
+    internal static JsObjectShape ResizeObserverShape => _resizeObserver;
+
+    internal static JsObjectShape ResizeObserverEntryShape => _resizeObserverEntry;
+}

--- a/Jint.Browser/Observers/ObserverRealm.cs
+++ b/Jint.Browser/Observers/ObserverRealm.cs
@@ -1,0 +1,196 @@
+using Jint.Browser.Dom;
+using Jint.Browser.Runtime;
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+
+namespace Jint.Browser.Observers;
+
+/// <summary>
+/// The observer interfaces of one engine: each prototype and its interface object, built on first use.
+/// </summary>
+/// <remarks>
+/// It is the observers' half of what <see cref="DomRealm"/> is for the generated interfaces, and it is
+/// separate for the same reason <see cref="HostInterfaceObject"/> is separate from
+/// <see cref="DomInterfaceObject"/>: these interfaces have no <see cref="DomInterfaceDefinition"/>, because
+/// AngleSharp's <c>MutationObserver</c> is a class rather than a <c>[DomName]</c> interface and the other four
+/// do not exist in AngleSharp at all.
+/// </remarks>
+internal sealed class ObserverRealm
+{
+    private readonly PageRuntime _runtime;
+
+    private ObjectInstance? _mutationObserverPrototype;
+    private HostInterfaceObject? _mutationObserver;
+    private ObjectInstance? _intersectionObserverPrototype;
+    private HostInterfaceObject? _intersectionObserver;
+    private ObjectInstance? _intersectionObserverEntryPrototype;
+    private HostInterfaceObject? _intersectionObserverEntry;
+    private ObjectInstance? _resizeObserverPrototype;
+    private HostInterfaceObject? _resizeObserver;
+    private ObjectInstance? _resizeObserverEntryPrototype;
+    private HostInterfaceObject? _resizeObserverEntry;
+
+    internal ObserverRealm(PageRuntime runtime)
+    {
+        _runtime = runtime;
+    }
+
+    /// <summary>The global <c>MutationObserver</c>.</summary>
+    internal HostInterfaceObject MutationObserver
+    {
+        get
+        {
+            if (_mutationObserver is null)
+            {
+                _mutationObserverPrototype = ObserverInstaller.Instantiate(
+                    _runtime.Engine,
+                    ObserverInstaller.MutationObserverShape,
+                    "MutationObserver",
+                    length: 1,
+                    ConstructMutationObserver,
+                    out var interfaceObject);
+
+                _mutationObserver = interfaceObject;
+            }
+
+            return _mutationObserver;
+        }
+    }
+
+    /// <summary>The global <c>IntersectionObserver</c>.</summary>
+    internal HostInterfaceObject IntersectionObserver
+    {
+        get
+        {
+            if (_intersectionObserver is null)
+            {
+                _intersectionObserverPrototype = ObserverInstaller.Instantiate(
+                    _runtime.Engine,
+                    ObserverInstaller.IntersectionObserverShape,
+                    "IntersectionObserver",
+                    length: 1,
+                    ConstructIntersectionObserver,
+                    out var interfaceObject);
+
+                _intersectionObserver = interfaceObject;
+            }
+
+            return _intersectionObserver;
+        }
+    }
+
+    /// <summary>The global <c>IntersectionObserverEntry</c>, which is not constructible.</summary>
+    internal HostInterfaceObject IntersectionObserverEntry
+    {
+        get
+        {
+            if (_intersectionObserverEntry is null)
+            {
+                _intersectionObserverEntryPrototype = ObserverInstaller.Instantiate(
+                    _runtime.Engine,
+                    ObserverInstaller.IntersectionObserverEntryShape,
+                    "IntersectionObserverEntry",
+                    length: 0,
+                    construct: null,
+                    out var interfaceObject);
+
+                _intersectionObserverEntry = interfaceObject;
+            }
+
+            return _intersectionObserverEntry;
+        }
+    }
+
+    /// <summary>The global <c>ResizeObserver</c>.</summary>
+    internal HostInterfaceObject ResizeObserver
+    {
+        get
+        {
+            if (_resizeObserver is null)
+            {
+                _resizeObserverPrototype = ObserverInstaller.Instantiate(
+                    _runtime.Engine,
+                    ObserverInstaller.ResizeObserverShape,
+                    "ResizeObserver",
+                    length: 1,
+                    ConstructResizeObserver,
+                    out var interfaceObject);
+
+                _resizeObserver = interfaceObject;
+            }
+
+            return _resizeObserver;
+        }
+    }
+
+    /// <summary>The global <c>ResizeObserverEntry</c>, which is not constructible.</summary>
+    internal HostInterfaceObject ResizeObserverEntry
+    {
+        get
+        {
+            if (_resizeObserverEntry is null)
+            {
+                _resizeObserverEntryPrototype = ObserverInstaller.Instantiate(
+                    _runtime.Engine,
+                    ObserverInstaller.ResizeObserverEntryShape,
+                    "ResizeObserverEntry",
+                    length: 0,
+                    construct: null,
+                    out var interfaceObject);
+
+                _resizeObserverEntry = interfaceObject;
+            }
+
+            return _resizeObserverEntry;
+        }
+    }
+
+    private ObjectInstance ConstructMutationObserver(JsValue[] arguments)
+    {
+        _ = MutationObserver;
+        return new JsMutationObserver(_runtime, _mutationObserverPrototype!, Callback(arguments, "MutationObserver"));
+    }
+
+    private ObjectInstance ConstructIntersectionObserver(JsValue[] arguments)
+    {
+        _ = IntersectionObserver;
+        _ = IntersectionObserverEntry;
+
+        var (root, rootMargin, thresholds) = JsIntersectionObserver.ReadOptions(_runtime.Engine, arguments.At(1));
+
+        return new JsIntersectionObserver(
+            _runtime,
+            _intersectionObserverPrototype!,
+            _intersectionObserverEntryPrototype!,
+            Callback(arguments, "IntersectionObserver"),
+            root,
+            rootMargin,
+            thresholds);
+    }
+
+    private ObjectInstance ConstructResizeObserver(JsValue[] arguments)
+    {
+        _ = ResizeObserver;
+        _ = ResizeObserverEntry;
+
+        return new JsResizeObserver(
+            _runtime,
+            _resizeObserverPrototype!,
+            _resizeObserverEntryPrototype!,
+            Callback(arguments, "ResizeObserver"));
+    }
+
+    private ICallable Callback(JsValue[] arguments, string interfaceName)
+    {
+        if (arguments.At(0) is ICallable callback)
+        {
+            return callback;
+        }
+
+        Throw.TypeError(
+            _runtime.Engine._mainRealm,
+            "Failed to construct '" + interfaceName + "': parameter 1 is not of type 'Function'.");
+        return null!;
+    }
+}

--- a/Jint.Browser/Observers/ObserverTask.cs
+++ b/Jint.Browser/Observers/ObserverTask.cs
@@ -1,0 +1,64 @@
+using Jint.Browser.Runtime;
+using Jint.Native;
+using Jint.WebApi.Timers;
+
+namespace Jint.Browser.Observers;
+
+/// <summary>
+/// Queues work as a <em>task</em> rather than as a microtask: a zero-delay entry on the engine's timer queue.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The intersection and resize observers deliver from the "update the rendering" steps, which are a task and
+/// not a microtask — so a page that observes a target and then awaits a promise sees the promise settle
+/// first, exactly as it does in a browser. A microtask would deliver too early and would let an observer that
+/// re-observes from its own callback starve the queue.
+/// </para>
+/// <para>
+/// The timer queue is the engine's only task queue, so a zero-delay entry is the whole of it. That also makes
+/// the delivery visible to <c>Page.WaitForIdleAsync</c>, which is what lets a test await it without polling.
+/// </para>
+/// </remarks>
+internal static class ObserverTask
+{
+    /// <summary>Runs <paramref name="work"/> on the page's own thread, in a later turn of the loop.</summary>
+    internal static void Post(PageRuntime runtime, Action work)
+    {
+        var engine = runtime.Engine;
+        var timers = engine._webApi?.Timers;
+
+        if (timers is null)
+        {
+            // The timer feature is off, which a host can do through ConfigureEngine. The job queue is then
+            // the only queue there is, so the delivery becomes a microtask: earlier than a browser's, and
+            // still after the script that asked for it.
+            engine.AddToEventLoop(work);
+            return;
+        }
+
+        timers.Schedule(new TimerEntry(
+            timers,
+            new Job(work),
+            [],
+            requestedDelay: 0,
+            repeat: false,
+            engine.CaptureEventLoopRegistration()));
+    }
+
+    /// <summary>What the timer queue calls: a CLR action wearing the queue's callback interface.</summary>
+    private sealed class Job : ICallable
+    {
+        private readonly Action _work;
+
+        internal Job(Action work)
+        {
+            _work = work;
+        }
+
+        public JsValue Call(JsValue thisObject, params JsValue[] arguments)
+        {
+            _work();
+            return JsValue.Undefined;
+        }
+    }
+}

--- a/Jint.Browser/Runtime/AGENTS.md
+++ b/Jint.Browser/Runtime/AGENTS.md
@@ -59,9 +59,9 @@ mean re-installing every intrinsic; the prototype swap costs nothing, and
 reading `thisObject` has no engine to reach the runtime through and can only answer `Illegal invocation`.
 Accessors are unaffected, because a bare identifier *read* goes through the global object's `[[Get]]` with the
 global as receiver. So: **an operation that needs its page is a `PerRealmSlot` holding a `ClrFunction` bound to
-the engine** (`WindowInstaller.Operation`), and only an operation that needs nothing — `scrollTo`,
-`getSelection` — stays a `Method`. Adding a window operation the other way compiles, passes `window.foo()`,
-and fails `foo()`.
+the engine** (`WindowInstaller.Operation`), and only an operation that needs nothing — `scrollTo`, `blur`,
+`open` — stays a `Method`. Adding a window operation the other way compiles, passes `window.foo()`, and fails
+`foo()`. `getSelection` crossed that line the moment it had a selection to answer.
 
 Several members are own properties of their object rather than accessors on a shaped prototype, and each says
 why in place. On `document`: `defaultView` (the binding excludes AngleSharp's `IWindow`), `currentScript`

--- a/Jint.Browser/Runtime/JsMediaQueryList.cs
+++ b/Jint.Browser/Runtime/JsMediaQueryList.cs
@@ -21,6 +21,7 @@ namespace Jint.Browser.Runtime;
 internal sealed class JsMediaQueryList : JsEventTarget
 {
     private readonly PageRuntime _runtime;
+    private bool _lastMatches;
 
     internal JsMediaQueryList(PageRuntime runtime, ObjectInstance prototype, string media)
         : base(runtime.Engine, runtime.Engine._mainRealm)
@@ -28,6 +29,8 @@ internal sealed class JsMediaQueryList : JsEventTarget
         _runtime = runtime;
         Media = media;
         Prototype = prototype;
+        _lastMatches = Matches;
+        runtime.Track(this);
     }
 
     /// <summary>The serialized query, as the page wrote it.</summary>
@@ -38,6 +41,27 @@ internal sealed class JsMediaQueryList : JsEventTarget
 
     /// <summary>The event type a <c>MediaQueryList</c> fires, which is also what <c>onchange</c> keys on.</summary>
     internal const string ChangeEventType = "change";
+
+    /// <summary>
+    /// Recomputes after a viewport change and fires <c>change</c> if the answer moved.
+    /// </summary>
+    /// <remarks>
+    /// <a href="https://drafts.csswg.org/cssom-view/#evaluate-media-queries-and-report-changes">CSSOM View</a>
+    /// fires at a list whose <c>matches</c> changed and at no other, so a page with ten listeners hears from
+    /// the ones whose answer actually moved. The event carries <c>media</c> and <c>matches</c> because that is
+    /// what a listener written without a reference to the list reads.
+    /// </remarks>
+    internal void ViewportChanged()
+    {
+        var matches = Matches;
+        if (matches == _lastMatches)
+        {
+            return;
+        }
+
+        _lastMatches = matches;
+        DispatchEvent(_runtime.Views.CreateMediaQueryListEvent(Media, matches));
+    }
 
     /// <inheritdoc />
     public override string ToString() => "[object MediaQueryList]";

--- a/Jint.Browser/Runtime/PageRuntime.cs
+++ b/Jint.Browser/Runtime/PageRuntime.cs
@@ -30,6 +30,9 @@ internal sealed class PageRuntime
 
     private readonly long _started;
     private IDocument? _document;
+    private Observers.ObserverRealm? _observers;
+    private Dom.Views.ViewRealm? _views;
+    private List<JsMediaQueryList>? _mediaQueryLists;
 
     private PageRuntime(Engine engine, Page page, BrowserOptions options, PageRecorder recorder, string documentUrl, string referrer)
     {
@@ -42,6 +45,7 @@ internal sealed class PageRuntime
         AnimationFrames = new AnimationFrameLane(this);
         DocumentUrl = documentUrl;
         Referrer = referrer;
+        MutationObservers = new Observers.MutationObserverLane(this);
         _started = System.Diagnostics.Stopwatch.GetTimestamp();
     }
 
@@ -58,13 +62,26 @@ internal sealed class PageRuntime
     internal PageRecorder Recorder { get; }
 
     /// <summary>The viewport this page answers dimension and media queries from.</summary>
-    internal Viewport Viewport { get; }
+    /// <remarks>
+    /// Settable through <see cref="SetViewport"/> only, because a change has to be announced: every
+    /// <c>MediaQueryList</c> the page is holding recomputes and fires <c>change</c> if its answer moved.
+    /// </remarks>
+    internal Viewport Viewport { get; private set; }
 
     /// <summary>The DOM binding state of this engine.</summary>
     internal DomRealm Dom { get; }
 
     /// <summary>The <c>requestAnimationFrame</c> lane, run as a batch on the engine's timer queue.</summary>
     internal AnimationFrameLane AnimationFrames { get; }
+
+    /// <summary>Where mutation records wait for the microtask checkpoint that delivers them.</summary>
+    internal Observers.MutationObserverLane MutationObservers { get; }
+
+    /// <summary>The observer interface objects of this engine, built on first use.</summary>
+    internal Observers.ObserverRealm Observers => _observers ??= new Observers.ObserverRealm(this);
+
+    /// <summary>The DOM views of this engine — <c>DOMParser</c>, <c>XMLSerializer</c>, <c>Selection</c>.</summary>
+    internal Dom.Views.ViewRealm Views => _views ??= new Dom.Views.ViewRealm(this);
 
     /// <summary>The document this engine is showing, or <see langword="null"/> before the first parse.</summary>
     /// <remarks>
@@ -149,6 +166,58 @@ internal sealed class PageRuntime
     /// the engine's timer queue either way.
     /// </remarks>
     internal double Now => System.Diagnostics.Stopwatch.GetElapsedTime(_started).TotalMilliseconds;
+
+    /// <summary>
+    /// Replaces the viewport and tells every <c>MediaQueryList</c> the page is holding.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the seam device emulation drives (campaign item C5): the viewport is the only thing a page can
+    /// observe about its window's size, so changing it is the whole of "the window resized" in a browser with
+    /// no window. <a href="https://drafts.csswg.org/cssom-view/#dom-mediaquerylist-onchange">CSSOM View</a>
+    /// fires <c>change</c> at a list whose answer moved and at no other, which is what a page listens for
+    /// rather than polling.
+    /// </para>
+    /// <para>
+    /// It runs on the page loop, like everything else here, and it dispatches synchronously — a listener runs
+    /// before this returns, exactly as it does for any other dispatch. A <c>resize</c> event at the window is
+    /// deliberately not fired yet: HTML fires it from the "run the resize steps" of update-the-rendering, and
+    /// this package has no rendering step to hang it on.
+    /// </para>
+    /// </remarks>
+    internal void SetViewport(Viewport viewport)
+    {
+        if (Viewport == viewport)
+        {
+            return;
+        }
+
+        Viewport = viewport;
+
+        if (_mediaQueryLists is null)
+        {
+            return;
+        }
+
+        // A copy, because a listener may call matchMedia and append to the list being walked; a list created
+        // during the notification cannot have a stale answer to report.
+        foreach (var list in _mediaQueryLists.ToArray())
+        {
+            list.ViewportChanged();
+        }
+    }
+
+    /// <summary>
+    /// Remembers a <c>MediaQueryList</c> so that a viewport change can reach it.
+    /// </summary>
+    /// <remarks>
+    /// A strong reference, held for the life of the engine — which is the life of the document. CSSOM View
+    /// keeps a list alive while it has a listener and this keeps every one alive, so a page calling
+    /// <c>matchMedia</c> in a loop accumulates them. That is bounded by the document rather than unbounded,
+    /// and the alternative — a weak reference per list — would cost a resurrection check on every viewport
+    /// change to save a few objects per page.
+    /// </remarks>
+    internal void Track(JsMediaQueryList list) => (_mediaQueryLists ??= []).Add(list);
 
     /// <summary>Attaches a runtime to a freshly built engine. Called once, on the page loop.</summary>
     internal static PageRuntime Attach(

--- a/Jint.Browser/Runtime/WindowInstaller.cs
+++ b/Jint.Browser/Runtime/WindowInstaller.cs
@@ -129,6 +129,11 @@ internal static class WindowInstaller
         // global names has to be the one the prototype's `constructor` slot already holds.
         engine.AddLazyGlobal("Window", windowInterface, static (_, value) => value, PropertyFlag.NonEnumerable);
         engine.AddLazyGlobal("MediaQueryList", mediaQueryListInterface, static (_, value) => value, PropertyFlag.NonEnumerable);
+
+        // The observers and the views the window carries, each as lazy globals of their own so that a page
+        // touching none of them builds none of their prototypes.
+        Observers.ObserverInstaller.Install(runtime);
+        Dom.Views.ViewInstaller.Install(runtime);
     }
 
     /// <summary>
@@ -312,7 +317,7 @@ internal static class WindowInstaller
             .Method("blur", static (_, _) => JsValue.Undefined)
             .Method("close", static (_, _) => JsValue.Undefined)
             .Method("open", static (_, _) => JsValue.Null, length: 3)
-            .Method("getSelection", static (_, _) => JsValue.Null)
+            .PerRealmSlot("getSelection", Operation("getSelection", 0, static (runtime, _) => runtime.Views.Selection), enumerable: true)
             .PerRealmSlot("alert", Operation("alert", 1, static (runtime, args) =>
             {
                 runtime.Page.RaiseDialog(DialogKind.Alert, Text(args, 0), "");
@@ -447,7 +452,11 @@ internal static class WindowInstaller
         // anything that would need a box — used values, offsetWidth's kind — does not. The pseudo-element
         // argument is ignored, because the extension that takes one needs an AngleSharp IWindow and the
         // window here is Jint's.
-        return runtime.Dom.Wrap(element.ComputeCurrentStyle());
+        //
+        // Wrapped read-only, because CSSOM gives the result a computed flag and AngleSharp's declaration is
+        // an ordinary writable one that is also detached — so an unwrapped write would neither throw nor
+        // change anything a page can read. See Dom/Views/ReadOnlyStyleDeclaration.
+        return runtime.Dom.Wrap(new Dom.Views.ReadOnlyStyleDeclaration(runtime.Engine, element.ComputeCurrentStyle()));
     }
 
     private static JsValue PostMessage(PageRuntime runtime, JsValue[] arguments)

--- a/Jint.Tests.Browser/Observers/MutationObserverTests.cs
+++ b/Jint.Tests.Browser/Observers/MutationObserverTests.cs
@@ -1,0 +1,402 @@
+using Jint.Browser;
+
+namespace Jint.Tests.Browser.Observers;
+
+// The test namespace sits under Jint.Tests.Browser, so the bare name Browser binds to that namespace rather
+// than to the type. The alias belongs inside the namespace declaration, where it wins that lookup.
+using Browser = global::Jint.Browser.Browser;
+
+/// <summary>
+/// <c>MutationObserver</c>: the records AngleSharp produces, delivered at Jint's microtask checkpoint.
+/// </summary>
+public sealed class MutationObserverTests
+{
+    private static async Task<Page> PageWith(Browser browser, string body)
+    {
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync(body);
+        return page;
+    }
+
+    [Test]
+    public async Task AChildListMutationIsReportedWithItsAddedNodes()
+    {
+        await using var browser = new Browser();
+        var page = await PageWith(browser,
+            """
+            <div id="host"></div>
+            <script>
+              window.log = [];
+              const host = document.getElementById('host');
+              new MutationObserver(records => {
+                for (const r of records) {
+                  window.log.push(r.type + ':' + r.addedNodes.length + ':' + r.addedNodes[0].nodeName + ':' + (r.target === host));
+                }
+              }).observe(host, { childList: true });
+              host.appendChild(document.createElement('p'));
+            </script>
+            """);
+
+        (await page.EvaluateAsync<string>("window.log.join('|')")).Should().Be("childList:1:P:true");
+        page.Errors.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task ARemovalReportsRemovedNodesAndTheSiblingsItSatBetween()
+    {
+        await using var browser = new Browser();
+        var page = await PageWith(browser,
+            """
+            <div id="host"><a></a><b></b><i></i></div>
+            <script>
+              window.log = [];
+              const host = document.getElementById('host');
+              new MutationObserver(records => {
+                const r = records[0];
+                window.log.push(r.removedNodes.length, r.removedNodes[0].nodeName, r.previousSibling.nodeName, r.nextSibling.nodeName, r.addedNodes.length);
+              }).observe(host, { childList: true });
+              host.removeChild(host.querySelector('b'));
+            </script>
+            """);
+
+        // addedNodes is a NodeList even for a removal: DOM declares both as non-nullable.
+        (await page.EvaluateAsync<string>("window.log.join('|')")).Should().Be("1|B|A|I|0");
+    }
+
+    [Test]
+    public async Task AnAttributeChangeCarriesTheNameAndTheOldValueWhenItWasAskedFor()
+    {
+        await using var browser = new Browser();
+        var page = await PageWith(browser,
+            """
+            <div id="host" data-x="one"></div>
+            <script>
+              window.log = [];
+              const host = document.getElementById('host');
+              new MutationObserver(records => {
+                for (const r of records) {
+                  window.log.push(r.type + ':' + r.attributeName + ':' + r.oldValue + ':' + r.attributeNamespace);
+                }
+              }).observe(host, { attributes: true, attributeOldValue: true });
+              host.setAttribute('data-x', 'two');
+            </script>
+            """);
+
+        (await page.EvaluateAsync<string>("window.log.join('|')")).Should().Be("attributes:data-x:one:null");
+    }
+
+    [Test]
+    public async Task AnAttributeChangeHasANullOldValueWhenItWasNotAskedFor()
+    {
+        await using var browser = new Browser();
+        var page = await PageWith(browser,
+            """
+            <div id="host" data-x="one"></div>
+            <script>
+              window.log = [];
+              const host = document.getElementById('host');
+              new MutationObserver(records => { window.log.push(String(records[0].oldValue)) }).observe(host, { attributes: true });
+              host.setAttribute('data-x', 'two');
+            </script>
+            """);
+
+        (await page.EvaluateAsync<string>("window.log.join('|')")).Should().Be("null");
+    }
+
+    [Test]
+    public async Task AnAttributeFilterKeepsTheAttributesItNames()
+    {
+        await using var browser = new Browser();
+        var page = await PageWith(browser,
+            """
+            <div id="host"></div>
+            <script>
+              window.log = [];
+              const host = document.getElementById('host');
+              new MutationObserver(records => {
+                for (const r of records) { window.log.push(r.attributeName) }
+              }).observe(host, { attributes: true, attributeFilter: ['data-keep'] });
+              host.setAttribute('data-drop', '1');
+              host.setAttribute('data-keep', '1');
+              host.setAttribute('data-drop', '2');
+            </script>
+            """);
+
+        (await page.EvaluateAsync<string>("window.log.join('|')")).Should().Be("data-keep");
+    }
+
+    [Test]
+    public async Task CharacterDataOnATextNodeIsReportedWithItsOldValue()
+    {
+        await using var browser = new Browser();
+        var page = await PageWith(browser,
+            """
+            <div id="host">before</div>
+            <script>
+              window.log = [];
+              const text = document.getElementById('host').firstChild;
+              new MutationObserver(records => {
+                const r = records[0];
+                window.log.push(r.type, r.oldValue, r.target.nodeName, r.target.data);
+              }).observe(text, { characterData: true, characterDataOldValue: true });
+              text.data = 'after';
+            </script>
+            """);
+
+        (await page.EvaluateAsync<string>("window.log.join('|')")).Should().Be("characterData|before|#text|after");
+    }
+
+    [Test]
+    public async Task SubtreeReachesADescendantAndWithoutItNothingIsReported()
+    {
+        await using var browser = new Browser();
+        var page = await PageWith(browser,
+            """
+            <div id="outer"><div id="inner"></div></div>
+            <script>
+              window.deep = 0;
+              window.shallow = 0;
+              const outer = document.getElementById('outer');
+              const inner = document.getElementById('inner');
+              new MutationObserver(rs => { window.deep += rs.length }).observe(outer, { childList: true, subtree: true });
+              new MutationObserver(rs => { window.shallow += rs.length }).observe(outer, { childList: true });
+              inner.appendChild(document.createElement('p'));
+            </script>
+            """);
+
+        (await page.EvaluateAsync<int>("window.deep")).Should().Be(1);
+        (await page.EvaluateAsync<int>("window.shallow")).Should().Be(0);
+    }
+
+    [Test]
+    public async Task ObservingTheSameNodeTwiceReplacesTheOptions()
+    {
+        await using var browser = new Browser();
+        var page = await PageWith(browser,
+            """
+            <div id="host"></div>
+            <script>
+              window.log = [];
+              const host = document.getElementById('host');
+              const observer = new MutationObserver(records => {
+                for (const r of records) { window.log.push(r.type) }
+              });
+              observer.observe(host, { childList: true });
+              observer.observe(host, { attributes: true });
+              host.appendChild(document.createElement('p'));
+              host.setAttribute('data-x', '1');
+            </script>
+            """);
+
+        // One registration per (observer, node): the second observe() replaced the first's options rather
+        // than adding a second registration, so the childList mutation is not reported at all.
+        (await page.EvaluateAsync<string>("window.log.join('|')")).Should().Be("attributes");
+    }
+
+    [Test]
+    public async Task TwoMutationsInOneTurnAreOneCallbackWithTwoRecords()
+    {
+        await using var browser = new Browser();
+        var page = await PageWith(browser,
+            """
+            <div id="host"></div>
+            <script>
+              window.log = [];
+              const host = document.getElementById('host');
+              new MutationObserver(records => { window.log.push('mo:' + records.length) }).observe(host, { childList: true, attributes: true });
+              host.appendChild(document.createElement('p'));
+              host.setAttribute('data-x', '1');
+              window.log.push('sync');
+            </script>
+            """);
+
+        (await page.EvaluateAsync<string>("window.log.join('|')")).Should().Be("sync|mo:2");
+    }
+
+    [Test]
+    public async Task DeliveryIsAMicrotaskInTheOrderTheCheckpointGivesIt()
+    {
+        await using var browser = new Browser();
+        var page = await PageWith(browser,
+            """
+            <div id="host"></div>
+            <script>
+              window.log = [];
+              const host = document.getElementById('host');
+              new MutationObserver(records => { window.log.push('mo:' + records.length) }).observe(host, { childList: true });
+
+              Promise.resolve().then(() => window.log.push('before'));
+              host.appendChild(document.createElement('p'));
+              host.appendChild(document.createElement('p'));
+              Promise.resolve().then(() => window.log.push('after'));
+
+              window.log.push('sync');
+            </script>
+            """);
+
+        // "Queue a mutation observer microtask" runs at the first mutation of the batch, so the notify job
+        // sits between the two promise reactions: a `then` registered before the mutations runs first, the
+        // observer's callback next with both records, and a `then` registered after the mutations last.
+        (await page.EvaluateAsync<string>("window.log.join('|')")).Should().Be("sync|before|mo:2|after");
+    }
+
+    [Test]
+    public async Task TakeRecordsEmptiesTheQueueAndStopsTheDelivery()
+    {
+        await using var browser = new Browser();
+        var page = await PageWith(browser,
+            """
+            <div id="host"></div>
+            <script>
+              window.log = [];
+              const host = document.getElementById('host');
+              const observer = new MutationObserver(records => { window.log.push('mo:' + records.length) });
+              observer.observe(host, { childList: true });
+              host.appendChild(document.createElement('p'));
+              window.taken = observer.takeRecords().length;
+              window.emptied = observer.takeRecords().length;
+            </script>
+            """);
+
+        (await page.EvaluateAsync<int>("window.taken")).Should().Be(1);
+        (await page.EvaluateAsync<int>("window.emptied")).Should().Be(0);
+        (await page.EvaluateAsync<string>("window.log.join('|')")).Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task DisconnectStopsReportingAndDropsWhatWasQueued()
+    {
+        await using var browser = new Browser();
+        var page = await PageWith(browser,
+            """
+            <div id="host"></div>
+            <script>
+              window.log = [];
+              const host = document.getElementById('host');
+              const observer = new MutationObserver(records => { window.log.push('mo:' + records.length) });
+              observer.observe(host, { childList: true });
+              host.appendChild(document.createElement('p'));
+              observer.disconnect();
+              host.appendChild(document.createElement('p'));
+            </script>
+            """);
+
+        (await page.WaitForIdleAsync(TimeSpan.FromSeconds(5))).Should().BeTrue();
+        (await page.EvaluateAsync<string>("window.log.join('|')")).Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task ObservingAgainAfterADisconnectWatchesOnlyTheNewNode()
+    {
+        await using var browser = new Browser();
+        var page = await PageWith(browser,
+            """
+            <div id="one"></div><div id="two"></div>
+            <script>
+              window.log = [];
+              const one = document.getElementById('one');
+              const two = document.getElementById('two');
+              const observer = new MutationObserver(records => {
+                for (const r of records) { window.log.push(r.target.id) }
+              });
+              observer.observe(one, { childList: true });
+              observer.disconnect();
+              observer.observe(two, { childList: true });
+              one.appendChild(document.createElement('p'));
+              two.appendChild(document.createElement('p'));
+            </script>
+            """);
+
+        // AngleSharp's own MutationObserver.Disconnect leaves its registration list populated, so a later
+        // observe() would resurrect the first node; the wrapper throws the AngleSharp observer away instead.
+        (await page.EvaluateAsync<string>("window.log.join('|')")).Should().Be("two");
+    }
+
+    [Test]
+    public async Task InvalidOptionsAreATypeError()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        var cases = new[]
+        {
+            "{}",
+            "{ childList: false }",
+            "{ attributes: false, attributeOldValue: true }",
+            "{ attributes: false, attributeFilter: ['x'] }",
+            "{ characterData: false, characterDataOldValue: true }",
+        };
+
+        foreach (var options in cases)
+        {
+            var thrown = await page.EvaluateAsync<string>(
+                "(() => { try { new MutationObserver(() => {}).observe(document.body, " + options + "); return 'no throw' } catch (e) { return e.constructor.name } })()");
+
+            thrown.Should().Be("TypeError", "observe({0}) is a TypeError", options);
+        }
+
+        // But an old-value option on its own turns its flag on rather than failing, which is what the
+        // dictionary's "exists" steps say.
+        (await page.EvaluateAsync<string>(
+            "(() => { try { new MutationObserver(() => {}).observe(document.body, { attributeOldValue: false }); return 'ok' } catch (e) { return e.name } })()"))
+            .Should().Be("ok");
+    }
+
+    [Test]
+    public async Task ARecordIsAMutationRecordAndTheObserverIsAMutationObserver()
+    {
+        await using var browser = new Browser();
+        var page = await PageWith(browser,
+            """
+            <div id="host"></div>
+            <script>
+              window.log = [];
+              const host = document.getElementById('host');
+              const observer = new MutationObserver(function (records, self) {
+                window.log.push(records[0] instanceof MutationRecord, self === observer, this === observer, Array.isArray(records));
+              });
+              observer.observe(host, { childList: true });
+              host.appendChild(document.createElement('p'));
+              window.isObserver = observer instanceof MutationObserver;
+            </script>
+            """);
+
+        (await page.EvaluateAsync<bool>("window.isObserver")).Should().BeTrue();
+        (await page.EvaluateAsync<string>("window.log.join('|')")).Should().Be("true|true|true|true");
+    }
+
+    [Test]
+    public async Task ACallbackThatThrowsIsReportedAndTheOtherObserversStillRun()
+    {
+        await using var browser = new Browser();
+        var page = await PageWith(browser,
+            """
+            <div id="host"></div>
+            <script>
+              window.ran = 0;
+              const host = document.getElementById('host');
+              new MutationObserver(() => { throw new Error('from an observer') }).observe(host, { childList: true });
+              new MutationObserver(() => { window.ran++ }).observe(host, { childList: true });
+              host.appendChild(document.createElement('p'));
+            </script>
+            """);
+
+        (await page.EvaluateAsync<int>("window.ran")).Should().Be(1);
+        page.Errors.Should().ContainSingle();
+    }
+
+    [Test]
+    public async Task ObservingANonNodeIsATypeError()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        (await page.EvaluateAsync<string>(
+            "(() => { try { new MutationObserver(() => {}).observe({}, { childList: true }); return 'no throw' } catch (e) { return e.constructor.name } })()"))
+            .Should().Be("TypeError");
+
+        (await page.EvaluateAsync<string>(
+            "(() => { try { new MutationObserver(); return 'no throw' } catch (e) { return e.constructor.name } })()"))
+            .Should().Be("TypeError");
+    }
+}

--- a/Jint.Tests.Browser/Observers/MutationObserverTests.cs
+++ b/Jint.Tests.Browser/Observers/MutationObserverTests.cs
@@ -353,7 +353,13 @@ public sealed class MutationObserverTests
               window.log = [];
               const host = document.getElementById('host');
               const observer = new MutationObserver(function (records, self) {
-                window.log.push(records[0] instanceof MutationRecord, self === observer, this === observer, Array.isArray(records));
+                window.log.push(
+                  records[0] instanceof MutationRecord,
+                  self === observer,
+                  this === observer,
+                  Array.isArray(records),
+                  records[0].addedNodes instanceof NodeList,
+                  Object.prototype.toString.call(records[0]) === '[object MutationRecord]');
               });
               observer.observe(host, { childList: true });
               host.appendChild(document.createElement('p'));
@@ -362,7 +368,7 @@ public sealed class MutationObserverTests
             """);
 
         (await page.EvaluateAsync<bool>("window.isObserver")).Should().BeTrue();
-        (await page.EvaluateAsync<string>("window.log.join('|')")).Should().Be("true|true|true|true");
+        (await page.EvaluateAsync<string>("window.log.join('|')")).Should().Be("true|true|true|true|true|true");
     }
 
     [Test]

--- a/Jint.Tests.Browser/Observers/ViewportObserverTests.cs
+++ b/Jint.Tests.Browser/Observers/ViewportObserverTests.cs
@@ -97,6 +97,15 @@ public sealed class ViewportObserverTests
         (await page.EvaluateAsync<string>(
             "(() => { try { new IntersectionObserver(() => {}, { threshold: 2 }); return 'no throw' } catch (e) { return e.constructor.name } })()"))
             .Should().Be("RangeError");
+
+        // A malformed rootMargin crossed WebIDL's DOMString conversion and failed the interface's own parse,
+        // which is a SyntaxError DOMException rather than a TypeError.
+        (await page.EvaluateAsync<string>(
+            "(() => { try { new IntersectionObserver(() => {}, { rootMargin: '1em' }); return 'no throw' } catch (e) { return e.name } })()"))
+            .Should().Be("SyntaxError");
+        (await page.EvaluateAsync<string>(
+            "(() => { try { new IntersectionObserver(() => {}, { rootMargin: '1px 2px 3px 4px 5px' }); return 'no throw' } catch (e) { return e.name } })()"))
+            .Should().Be("SyntaxError");
     }
 
     [Test]

--- a/Jint.Tests.Browser/Observers/ViewportObserverTests.cs
+++ b/Jint.Tests.Browser/Observers/ViewportObserverTests.cs
@@ -1,0 +1,248 @@
+using Jint.Browser;
+
+namespace Jint.Tests.Browser.Observers;
+
+// The test namespace sits under Jint.Tests.Browser, so the bare name Browser binds to that namespace rather
+// than to the type. The alias belongs inside the namespace declaration, where it wins that lookup.
+using Browser = global::Jint.Browser.Browser;
+
+/// <summary>
+/// <c>IntersectionObserver</c> and <c>ResizeObserver</c>: one notification per observed target, delivered as
+/// a task, with the geometry a page with no layout can honestly be told.
+/// </summary>
+public sealed class ViewportObserverTests
+{
+    [Test]
+    public async Task EveryObservedTargetIntersectsOnce()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync(
+            """
+            <div id="a"></div><div id="b"></div>
+            <script>
+              window.log = [];
+              const observer = new IntersectionObserver(entries => {
+                for (const e of entries) {
+                  window.log.push(e.target.id + ':' + e.isIntersecting + ':' + e.intersectionRatio);
+                }
+              });
+              observer.observe(document.getElementById('a'));
+              observer.observe(document.getElementById('b'));
+              window.duringScript = window.log.length;
+            </script>
+            """);
+
+        // Delivery is a task, not a microtask: nothing has been reported by the time the script ends.
+        (await page.EvaluateAsync<int>("window.duringScript")).Should().Be(0);
+
+        (await page.WaitForIdleAsync(TimeSpan.FromSeconds(5))).Should().BeTrue();
+        (await page.EvaluateAsync<string>("window.log.join('|')")).Should().Be("a:true:1|b:true:1");
+        page.Errors.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task AnEntryCarriesZeroRectanglesAndATimestamp()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync(
+            """
+            <div id="a"></div>
+            <script>
+              window.seen = null;
+              new IntersectionObserver(entries => {
+                const e = entries[0];
+                window.seen = [
+                  e instanceof IntersectionObserverEntry,
+                  e.boundingClientRect.width, e.boundingClientRect.height,
+                  e.intersectionRect.top, e.rootBounds.left,
+                  typeof e.time,
+                ].join('|');
+              }).observe(document.getElementById('a'));
+            </script>
+            """);
+
+        (await page.WaitForIdleAsync(TimeSpan.FromSeconds(5))).Should().BeTrue();
+        (await page.EvaluateAsync<string>("window.seen")).Should().Be("true|0|0|0|0|number");
+    }
+
+    [Test]
+    public async Task RootMarginAndThresholdsAreParsedAndReflected()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync("<div id='a'></div>");
+
+        (await page.EvaluateAsync<string>("new IntersectionObserver(() => {}).rootMargin"))
+            .Should().Be("0px 0px 0px 0px");
+        (await page.EvaluateAsync<string>("new IntersectionObserver(() => {}, { rootMargin: '10px 20%' }).rootMargin"))
+            .Should().Be("10px 20% 10px 20%");
+        (await page.EvaluateAsync<string>("new IntersectionObserver(() => {}, { rootMargin: '1px 2px 3px' }).rootMargin"))
+            .Should().Be("1px 2px 3px 2px");
+        (await page.EvaluateAsync<string>("new IntersectionObserver(() => {}).thresholds.join(',')"))
+            .Should().Be("0");
+        (await page.EvaluateAsync<string>("new IntersectionObserver(() => {}, { threshold: [1, 0.5, 0] }).thresholds.join(',')"))
+            .Should().Be("0,0.5,1");
+        (await page.EvaluateAsync<string>("new IntersectionObserver(() => {}, { threshold: 0.25 }).thresholds.join(',')"))
+            .Should().Be("0.25");
+        (await page.EvaluateAsync("new IntersectionObserver(() => {}).root"))
+            .Should().BeNull();
+        (await page.EvaluateAsync<bool>("new IntersectionObserver(() => {}, { root: document.getElementById('a') }).root.id === 'a'"))
+            .Should().BeTrue();
+
+        (await page.EvaluateAsync<string>(
+            "(() => { try { new IntersectionObserver(() => {}, { threshold: 2 }); return 'no throw' } catch (e) { return e.constructor.name } })()"))
+            .Should().Be("RangeError");
+    }
+
+    [Test]
+    public async Task UnobserveAndDisconnectDropAWaitingNotification()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync(
+            """
+            <div id="a"></div><div id="b"></div><div id="c"></div>
+            <script>
+              window.log = [];
+              const observer = new IntersectionObserver(entries => {
+                for (const e of entries) { window.log.push(e.target.id) }
+              });
+              observer.observe(document.getElementById('a'));
+              observer.observe(document.getElementById('b'));
+              observer.unobserve(document.getElementById('a'));
+
+              const other = new IntersectionObserver(() => { window.log.push('other') });
+              other.observe(document.getElementById('c'));
+              other.disconnect();
+            </script>
+            """);
+
+        (await page.WaitForIdleAsync(TimeSpan.FromSeconds(5))).Should().BeTrue();
+        (await page.EvaluateAsync<string>("window.log.join('|')")).Should().Be("b");
+    }
+
+    [Test]
+    public async Task TakeRecordsEmptiesTheQueueBeforeItIsDelivered()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync(
+            """
+            <div id="a"></div>
+            <script>
+              window.log = [];
+              const observer = new IntersectionObserver(entries => { window.log.push('cb:' + entries.length) });
+              observer.observe(document.getElementById('a'));
+              window.taken = observer.takeRecords().length;
+            </script>
+            """);
+
+        (await page.EvaluateAsync<int>("window.taken")).Should().Be(1);
+        (await page.WaitForIdleAsync(TimeSpan.FromSeconds(5))).Should().BeTrue();
+        (await page.EvaluateAsync<string>("window.log.join('|')")).Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task EveryResizeObservedTargetIsReportedOnce()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync(
+            """
+            <div id="a"></div><div id="b"></div>
+            <script>
+              window.log = [];
+              const observer = new ResizeObserver(entries => {
+                for (const e of entries) {
+                  window.log.push([
+                    e.target.id,
+                    e instanceof ResizeObserverEntry,
+                    e.contentRect.width,
+                    e.borderBoxSize.length,
+                    e.contentBoxSize[0].inlineSize,
+                    e.devicePixelContentBoxSize[0].blockSize,
+                  ].join(':'));
+                }
+              });
+              observer.observe(document.getElementById('a'));
+              observer.observe(document.getElementById('b'), { box: 'border-box' });
+              window.duringScript = window.log.length;
+            </script>
+            """);
+
+        (await page.EvaluateAsync<int>("window.duringScript")).Should().Be(0);
+        (await page.WaitForIdleAsync(TimeSpan.FromSeconds(5))).Should().BeTrue();
+        (await page.EvaluateAsync<string>("window.log.join('|')")).Should().Be("a:true:0:1:0:0|b:true:0:1:0:0");
+    }
+
+    [Test]
+    public async Task AResizeObserverStopsAfterUnobserveAndDisconnect()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync(
+            """
+            <div id="a"></div><div id="b"></div>
+            <script>
+              window.log = [];
+              const observer = new ResizeObserver(entries => {
+                for (const e of entries) { window.log.push(e.target.id) }
+              });
+              observer.observe(document.getElementById('a'));
+              observer.observe(document.getElementById('b'));
+              observer.unobserve(document.getElementById('a'));
+            </script>
+            """);
+
+        (await page.WaitForIdleAsync(TimeSpan.FromSeconds(5))).Should().BeTrue();
+        (await page.EvaluateAsync<string>("window.log.join('|')")).Should().Be("b");
+
+        await page.EvaluateAsync("window.log.length = 0");
+        (await page.WaitForIdleAsync(TimeSpan.FromSeconds(5))).Should().BeTrue();
+
+        // Nothing is reported a second time: with no layout, no size can change.
+        (await page.EvaluateAsync<string>("window.log.join('|')")).Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task NeitherObserverIsConstructibleWithoutACallbackAndTheEntriesAreNotConstructibleAtAll()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        foreach (var source in new[] { "new IntersectionObserver()", "new ResizeObserver()", "new IntersectionObserverEntry()", "new ResizeObserverEntry()" })
+        {
+            (await page.EvaluateAsync<string>(
+                "(() => { try { " + source + "; return 'no throw' } catch (e) { return e.constructor.name } })()"))
+                .Should().Be("TypeError", "{0} is a TypeError", source);
+        }
+    }
+
+    [Test]
+    public async Task ACallbackThatThrowsIsReportedAndThePageSurvives()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync(
+            """
+            <div id="a"></div>
+            <script>
+              new IntersectionObserver(() => { throw new Error('from an observer') }).observe(document.getElementById('a'));
+            </script>
+            """);
+
+        (await page.WaitForIdleAsync(TimeSpan.FromSeconds(5))).Should().BeTrue();
+        page.Errors.Should().ContainSingle();
+        (await page.EvaluateAsync<int>("1 + 1")).Should().Be(2);
+    }
+}

--- a/Jint.Tests.Browser/Runtime/WindowTests.cs
+++ b/Jint.Tests.Browser/Runtime/WindowTests.cs
@@ -233,15 +233,18 @@ public sealed class WindowTests
     }
 
     [Test]
-    public async Task WindowOpenAnswersNullAndGetSelectionIsAStub()
+    public async Task WindowOpenAnswersNull()
     {
         await using var browser = new Browser();
         var page = await browser.NewPageAsync();
 
         (await page.EvaluateAsync("window.open('/other')")).Should().BeNull();
-        (await page.EvaluateAsync("window.getSelection()")).Should().BeNull();
         (await page.EvaluateAsync("window.event")).Should().BeNull();
         (await page.EvaluateAsync<bool>("window.closed")).Should().BeFalse();
+
+        // getSelection() answered null while nothing owned a Selection; campaign item R4 gave the document
+        // one, and Views/SelectionTests is where its behaviour lives.
+        (await page.EvaluateAsync<bool>("window.getSelection() instanceof Selection")).Should().BeTrue();
     }
 
     [Test]

--- a/Jint.Tests.Browser/Views/ComputedStyleTests.cs
+++ b/Jint.Tests.Browser/Views/ComputedStyleTests.cs
@@ -1,0 +1,129 @@
+namespace Jint.Tests.Browser.Views;
+
+// The test namespace sits under Jint.Tests.Browser, so the bare name Browser binds to that namespace rather
+// than to the type. The alias belongs inside the namespace declaration, where it wins that lookup.
+using Browser = global::Jint.Browser.Browser;
+
+/// <summary>
+/// <c>getComputedStyle</c>: AngleSharp.Css's cascade, read-only, with no layout behind it.
+/// </summary>
+public sealed class ComputedStyleTests
+{
+    [Test]
+    public async Task AStyleElementRuleAndAnInlineStyleBothReachTheComputedStyle()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync(
+            """
+            <style>
+              .tinted { color: rgb(0, 128, 0) }
+              #by-id { font-weight: bold }
+            </style>
+            <p id="by-id" class="tinted" style="text-align: center">text</p>
+            """);
+
+        var computed = "getComputedStyle(document.getElementById('by-id'))";
+
+        (await page.EvaluateAsync<string>(computed + ".getPropertyValue('font-weight')")).Should().Be("bold");
+        (await page.EvaluateAsync<string>(computed + ".getPropertyValue('text-align')")).Should().Be("center");
+        (await page.EvaluateAsync<string>(computed + ".color")).Should().Contain("0, 128, 0");
+        (await page.EvaluateAsync<bool>(computed + " instanceof CSSStyleDeclaration")).Should().BeTrue();
+    }
+
+    [Test]
+    public async Task DisplayComesFromTheUserAgentStylesheetWithoutAnyLayout()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync("<div id='block'>a</div><span id='inline'>b</span>");
+
+        (await page.EvaluateAsync<string>("getComputedStyle(document.getElementById('block')).display")).Should().Be("block");
+
+        // A <span> answers the empty string where a browser answers "inline": AngleSharp's cascade reports
+        // the values something declared, and `display: inline` is CSS's initial value, so its user-agent
+        // stylesheet does not declare it. A declared one — the <div>'s — resolves. Recorded as a divergence
+        // in Jint.Browser/AGENTS.md rather than papered over with an initial-value table of our own.
+        (await page.EvaluateAsync<string>("getComputedStyle(document.getElementById('inline')).display")).Should().BeEmpty();
+        (await page.EvaluateAsync<string>("getComputedStyle(document.getElementById('inline')).getPropertyValue('display')")).Should().BeEmpty();
+
+        // Width and height are used values, and a used value needs a box. There is none, so they stay empty
+        // rather than pretending to a number.
+        (await page.EvaluateAsync<string>("getComputedStyle(document.getElementById('block')).getPropertyValue('width')")).Should().BeEmpty();
+        (await page.EvaluateAsync<string>("getComputedStyle(document.getElementById('block')).getPropertyValue('height')")).Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task TheComputedStyleRefusesEveryWrite()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync("<p id='p' style='color: rgb(1, 2, 3)'>text</p>");
+
+        var refusal =
+            """
+            (member => {
+              const style = getComputedStyle(document.getElementById('p'));
+              try {
+                if (member === 'setProperty') { style.setProperty('color', 'blue') }
+                else if (member === 'removeProperty') { style.removeProperty('color') }
+                else if (member === 'cssText') { style.cssText = 'color: blue' }
+                else { style.color = 'blue' }
+                return 'no throw';
+              } catch (e) { return e.name }
+            })
+            """;
+
+        foreach (var member in new[] { "setProperty", "removeProperty", "cssText", "color" })
+        {
+            (await page.EvaluateAsync<string>("(" + refusal + ")('" + member + "')"))
+                .Should().Be("NoModificationAllowedError", "writing {0} on a computed style is refused", member);
+        }
+
+        // And the element's own style is untouched, which is the point of refusing rather than accepting a
+        // write into a detached copy.
+        (await page.EvaluateAsync<string>("document.getElementById('p').style.color")).Should().Contain("1, 2, 3");
+    }
+
+    [Test]
+    public async Task TheInlineStyleIsStillWritable()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync("<p id='p'>text</p>");
+
+        await page.EvaluateAsync("document.getElementById('p').style.setProperty('font-weight', 'bold')");
+
+        (await page.EvaluateAsync<string>("document.getElementById('p').getAttribute('style')")).Should().Contain("font-weight");
+        (await page.EvaluateAsync<string>("getComputedStyle(document.getElementById('p')).getPropertyValue('font-weight')")).Should().Be("bold");
+    }
+
+    [Test]
+    public async Task ThePseudoElementArgumentIsAcceptedAndIgnored()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync("<style>#p::before { content: 'x' }</style><p id='p' style='color: rgb(9, 9, 9)'>text</p>");
+
+        // Documented divergence: the pseudo-element selector is ignored, so the answer is the element's own
+        // computed style rather than the pseudo-element's.
+        (await page.EvaluateAsync<string>("getComputedStyle(document.getElementById('p'), '::before').color"))
+            .Should().Contain("9, 9, 9");
+    }
+
+    [Test]
+    public async Task GetComputedStyleNeedsAnElement()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        (await page.EvaluateAsync<string>(
+            "(() => { try { getComputedStyle({}); return 'no throw' } catch (e) { return e.constructor.name } })()"))
+            .Should().Be("TypeError");
+    }
+}

--- a/Jint.Tests.Browser/Views/DomParserTests.cs
+++ b/Jint.Tests.Browser/Views/DomParserTests.cs
@@ -1,0 +1,174 @@
+namespace Jint.Tests.Browser.Views;
+
+// The test namespace sits under Jint.Tests.Browser, so the bare name Browser binds to that namespace rather
+// than to the type. The alias belongs inside the namespace declaration, where it wins that lookup.
+using Browser = global::Jint.Browser.Browser;
+
+/// <summary>
+/// <c>DOMParser</c> and <c>XMLSerializer</c>: markup into a document that cannot run, and back out again.
+/// </summary>
+public sealed class DomParserTests
+{
+    [Test]
+    public async Task HtmlIsParsedIntoADocumentTheWrapperUnderstands()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync(
+            """
+            <script>
+              const doc = new DOMParser().parseFromString('<p id="x">hi</p>', 'text/html');
+              window.log = [
+                doc instanceof Document,
+                doc.nodeType,
+                doc.getElementById('x').textContent,
+                doc.querySelector('p').tagName,
+                doc.documentElement.tagName,
+                doc !== document,
+              ].join('|');
+            </script>
+            """);
+
+        (await page.EvaluateAsync<string>("window.log")).Should().Be("true|9|hi|P|HTML|true");
+        page.Errors.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task AParsedDocumentDoesNotRunItsScripts()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync(
+            """
+            <script>
+              window.ran = false;
+              const doc = new DOMParser().parseFromString('<script>window.ran = true<\/script><p>after</p>', 'text/html');
+              window.log = [doc.querySelector('script') !== null, doc.querySelector('p').textContent, window.ran].join('|');
+            </script>
+            """);
+
+        // The script element is in the tree with its text, and it never ran: a DOMParser document has no
+        // browsing context, which is what the standard requires.
+        (await page.EvaluateAsync<string>("window.log")).Should().Be("true|after|false");
+        (await page.WaitForIdleAsync(TimeSpan.FromSeconds(5))).Should().BeTrue();
+        (await page.EvaluateAsync<bool>("window.ran")).Should().BeFalse();
+    }
+
+    [Test]
+    public async Task XmlIsParsedWithTheXmlParser()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync(
+            """
+            <script>
+              const doc = new DOMParser().parseFromString('<root><item id="a">one</item></root>', 'text/xml');
+              window.log = [
+                doc.documentElement.tagName,
+                doc.querySelector('item').textContent,
+                doc.querySelector('parsererror') === null,
+              ].join('|');
+            </script>
+            """);
+
+        (await page.EvaluateAsync<string>("window.log")).Should().Be("root|one|true");
+    }
+
+    [Test]
+    public async Task MalformedXmlAnswersAParsererrorDocument()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync(
+            """
+            <script>
+              const doc = new DOMParser().parseFromString('<root><unclosed></root>', 'application/xml');
+              const error = doc.getElementsByTagName('parsererror')[0];
+              window.log = [error !== undefined, error && error.textContent.length > 0].join('|');
+            </script>
+            """);
+
+        (await page.EvaluateAsync<string>("window.log")).Should().Be("true|true");
+        page.Errors.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task AnUnknownContentTypeIsATypeError()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        (await page.EvaluateAsync<string>(
+            "(() => { try { new DOMParser().parseFromString('<p/>', 'text/plain'); return 'no throw' } catch (e) { return e.constructor.name } })()"))
+            .Should().Be("TypeError");
+    }
+
+    [Test]
+    public async Task TheFourXmlContentTypesAreAllAccepted()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        foreach (var type in new[] { "text/xml", "application/xml", "application/xhtml+xml", "image/svg+xml" })
+        {
+            (await page.EvaluateAsync<string>(
+                "new DOMParser().parseFromString('<root/>', '" + type + "').documentElement.tagName"))
+                .Should().Be("root", "{0} is a DOMParserSupportedType", type);
+        }
+    }
+
+    [Test]
+    public async Task ANodeRoundTripsThroughTheSerializerAndTheParser()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync(
+            """
+            <script>
+              const serializer = new XMLSerializer();
+              const first = new DOMParser().parseFromString('<root><item a="1">text</item><empty/></root>', 'text/xml');
+              const markup = serializer.serializeToString(first.documentElement);
+              const second = new DOMParser().parseFromString(markup, 'text/xml');
+              window.markup = markup;
+              window.again = serializer.serializeToString(second.documentElement);
+            </script>
+            """);
+
+        var markup = await page.EvaluateAsync<string>("window.markup");
+        markup.Should().Contain("<item a=\"1\">text</item>");
+        (await page.EvaluateAsync<string>("window.again")).Should().Be(markup);
+    }
+
+    [Test]
+    public async Task TheSerializerWritesTheLivingDocumentToo()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync("<div id='d'><br></div>");
+
+        // XML serialization closes every element, so a void element comes out self-closed rather than bare.
+        (await page.EvaluateAsync<string>("new XMLSerializer().serializeToString(document.getElementById('d'))"))
+            .Should().Be("<div id=\"d\"><br /></div>");
+    }
+
+    [Test]
+    public async Task BothInterfacesAreConstructibleAndBranded()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        (await page.EvaluateAsync<bool>("new DOMParser() instanceof DOMParser")).Should().BeTrue();
+        (await page.EvaluateAsync<bool>("new XMLSerializer() instanceof XMLSerializer")).Should().BeTrue();
+        (await page.EvaluateAsync<string>("Object.prototype.toString.call(new DOMParser())")).Should().Be("[object DOMParser]");
+
+        (await page.EvaluateAsync<string>(
+            "(() => { try { DOMParser.prototype.parseFromString.call({}, '<p/>', 'text/html'); return 'no throw' } catch (e) { return e.constructor.name } })()"))
+            .Should().Be("TypeError");
+    }
+}

--- a/Jint.Tests.Browser/Views/HostInterfaceDisciplineTests.cs
+++ b/Jint.Tests.Browser/Views/HostInterfaceDisciplineTests.cs
@@ -1,0 +1,181 @@
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Native.Symbol;
+
+namespace Jint.Tests.Browser.Views;
+
+// The test namespace sits under Jint.Tests.Browser, so the bare name Browser binds to that namespace rather
+// than to the type. The alias belongs inside the namespace declaration, where it wins that lookup.
+using Browser = global::Jint.Browser.Browser;
+
+/// <summary>
+/// The interfaces the runtime owns rather than the generator, held to the same two rules every generated one
+/// is: the prototype keeps a shared shape, and every member carries WebIDL's attributes for its kind.
+/// </summary>
+/// <remarks>
+/// <c>DomPrototypeTests</c> and <c>WebIdlPropertyAttributeTests</c> walk <c>DomInterfaces.All</c>, which is
+/// the generated registry; none of these five is in it, so they would otherwise be the one part of the
+/// surface nothing checks — and a hand-written shape is exactly where the mistake is easiest to make.
+/// </remarks>
+public sealed class HostInterfaceDisciplineTests
+{
+    private static readonly string[] _interfaces =
+    [
+        "MutationObserver",
+        "IntersectionObserver",
+        "IntersectionObserverEntry",
+        "ResizeObserver",
+        "ResizeObserverEntry",
+        "DOMParser",
+        "XMLSerializer",
+        "Selection",
+        "MediaQueryListEvent",
+        "MediaQueryList",
+        "Window",
+    ];
+
+    [Test]
+    public async Task EveryRuntimeOwnedPrototypeKeepsItsSharedShape()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        var unshaped = await page.RunOnLoopAsync(engine =>
+        {
+            var names = new List<string>();
+
+            foreach (var name in _interfaces)
+            {
+                var prototype = ((ObjectInstance) engine.GetValue(name)).Get("prototype");
+                if (!engine.Advanced.HasSharedShape((ObjectInstance) prototype))
+                {
+                    names.Add(name);
+                }
+            }
+
+            return string.Join(", ", names);
+        });
+
+        unshaped.Should().BeEmpty("a shaped prototype is what makes the prototype-method inline cache valid");
+    }
+
+    [Test]
+    public async Task EveryRuntimeOwnedMemberCarriesItsKindsAttributes()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        var violations = await page.RunOnLoopAsync(engine =>
+        {
+            var found = new List<string>();
+
+            foreach (var name in _interfaces)
+            {
+                var prototype = (ObjectInstance) ((ObjectInstance) engine.GetValue(name)).Get("prototype");
+
+                foreach (var key in prototype.GetOwnPropertyKeys())
+                {
+                    var descriptor = prototype.GetOwnProperty(key);
+                    var member = name + ".prototype[" + key + "]";
+
+                    // Symbol.toStringTag: { writable: false, enumerable: false, configurable: true }.
+                    if (key.IsSymbol())
+                    {
+                        Check(found, member, descriptor.Writable, descriptor.Enumerable, descriptor.Configurable, false, false, true);
+                        continue;
+                    }
+
+                    // https://webidl.spec.whatwg.org/#interface-prototype-object
+                    if (key.AsString() == "constructor")
+                    {
+                        Check(found, member, descriptor.Writable, descriptor.Enumerable, descriptor.Configurable, true, false, true);
+                        continue;
+                    }
+
+                    // https://webidl.spec.whatwg.org/#es-attributes — an accessor, enumerable and configurable.
+                    if (descriptor.Get is not null || descriptor.Set is not null)
+                    {
+                        Check(found, member, null, descriptor.Enumerable, descriptor.Configurable, null, true, true);
+                        continue;
+                    }
+
+                    // https://webidl.spec.whatwg.org/#es-operations — enumerable, which is the opposite of
+                    // ECMAScript's rule for a built-in and the mistake a hand-written shape makes by default.
+                    Check(found, member, descriptor.Writable, descriptor.Enumerable, descriptor.Configurable, true, true, true);
+                }
+            }
+
+            return string.Join("\n", found);
+        });
+
+        violations.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task TheInterfaceObjectsCarryTheirWebIdlAttributesToo()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        foreach (var name in _interfaces)
+        {
+            // https://webidl.spec.whatwg.org/#es-interfaces — an interface object is a non-enumerable,
+            // writable, configurable property of the global, and its `prototype` is none of the three.
+            var descriptor = await page.EvaluateAsync<string>(
+                "(() => { const d = Object.getOwnPropertyDescriptor(globalThis, '" + name + "'); "
+                + "return [d.writable, d.enumerable, d.configurable].join('|') })()");
+
+            descriptor.Should().Be("true|false|true", "{0} is an interface object", name);
+
+            var prototypeDescriptor = await page.EvaluateAsync<string>(
+                "(() => { const d = Object.getOwnPropertyDescriptor(" + name + ", 'prototype'); "
+                + "return [d.writable, d.enumerable, d.configurable].join('|') })()");
+
+            prototypeDescriptor.Should().Be("false|false|false", "{0}.prototype is unforgeable", name);
+        }
+    }
+
+    [Test]
+    public async Task NoneOfTheGlobalsIsForcedIntoExistenceByTheInstaller()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        // Lazy: the property is there, and reading it is what builds the prototype. Enumerating the global's
+        // own keys must not force any of them, which is what makes an engine that never mentions
+        // ResizeObserver pay nothing for it.
+        foreach (var name in _interfaces)
+        {
+            (await page.EvaluateAsync<bool>("Object.getOwnPropertyNames(globalThis).includes('" + name + "')"))
+                .Should().BeTrue("{0} is installed as a global", name);
+        }
+
+        (await page.EvaluateAsync<bool>("Object.keys(globalThis).includes('MutationObserver')")).Should().BeFalse();
+    }
+
+    private static void Check(
+        List<string> found,
+        string member,
+        bool? writable,
+        bool enumerable,
+        bool configurable,
+        bool? expectedWritable,
+        bool expectedEnumerable,
+        bool expectedConfigurable)
+    {
+        if (expectedWritable is not null && writable != expectedWritable)
+        {
+            found.Add(member + ": writable is " + writable + ", expected " + expectedWritable);
+        }
+
+        if (enumerable != expectedEnumerable)
+        {
+            found.Add(member + ": enumerable is " + enumerable + ", expected " + expectedEnumerable);
+        }
+
+        if (configurable != expectedConfigurable)
+        {
+            found.Add(member + ": configurable is " + configurable + ", expected " + expectedConfigurable);
+        }
+    }
+}

--- a/Jint.Tests.Browser/Views/MediaQueryChangeTests.cs
+++ b/Jint.Tests.Browser/Views/MediaQueryChangeTests.cs
@@ -1,0 +1,139 @@
+using Jint.Browser;
+using Jint.Browser.Runtime;
+
+namespace Jint.Tests.Browser.Views;
+
+// The test namespace sits under Jint.Tests.Browser, so the bare name Browser binds to that namespace rather
+// than to the type. The alias belongs inside the namespace declaration, where it wins that lookup.
+using Browser = global::Jint.Browser.Browser;
+
+/// <summary>
+/// <c>matchMedia</c>'s <c>change</c> event: what a page hears when the viewport moves under it.
+/// </summary>
+/// <remarks>
+/// The viewport is set through the internal runtime seam rather than through a public member, because device
+/// emulation (campaign item C5) is what will own the public one. That seam is the whole of "the window
+/// resized" in a browser with no window.
+/// </remarks>
+public sealed class MediaQueryChangeTests
+{
+    private static Task SetViewportAsync(Page page, Viewport viewport)
+        => page.RunOnLoopAsync(engine =>
+        {
+            PageRuntime.Find(engine)!.SetViewport(viewport);
+            return 0;
+        });
+
+    [Test]
+    public async Task AListWhoseAnswerMovedFiresChangeAndOneWhoseDidNotStaysQuiet()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync(
+            """
+            <script>
+              window.log = [];
+              window.narrow = matchMedia('(max-width: 600px)');
+              window.wide = matchMedia('(min-width: 100px)');
+              window.narrow.addEventListener('change', e => window.log.push('narrow:' + e.matches + ':' + e.media));
+              window.wide.addEventListener('change', () => window.log.push('wide'));
+              window.before = window.narrow.matches;
+            </script>
+            """);
+
+        (await page.EvaluateAsync<bool>("window.before")).Should().BeFalse();
+
+        await SetViewportAsync(page, new Viewport(480, 800));
+
+        (await page.EvaluateAsync<bool>("window.narrow.matches")).Should().BeTrue();
+        (await page.EvaluateAsync<string>("window.log.join('|')")).Should().Be("narrow:true:(max-width: 600px)");
+        (await page.EvaluateAsync<int>("innerWidth")).Should().Be(480);
+    }
+
+    [Test]
+    public async Task TheOnchangeAttributeIsFiredToo()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync(
+            """
+            <script>
+              window.seen = null;
+              window.list = matchMedia('(min-width: 1000px)');
+              window.list.onchange = e => { window.seen = [e.type, e.matches, e.isTrusted, e instanceof MediaQueryListEvent, e instanceof Event].join('|') };
+            </script>
+            """);
+
+        await SetViewportAsync(page, new Viewport(320, 640));
+
+        (await page.EvaluateAsync<string>("window.seen")).Should().Be("change|false|true|true|true");
+    }
+
+    [Test]
+    public async Task TheLegacyAddListenerAliasHearsItAsWell()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync(
+            """
+            <script>
+              window.hits = 0;
+              window.list = matchMedia('(orientation: landscape)');
+              window.list.addListener(() => { window.hits++ });
+            </script>
+            """);
+
+        // 1280x720 is landscape; a taller-than-wide viewport is not.
+        await SetViewportAsync(page, new Viewport(400, 900));
+        (await page.EvaluateAsync<int>("window.hits")).Should().Be(1);
+        (await page.EvaluateAsync<bool>("window.list.matches")).Should().BeFalse();
+
+        await SetViewportAsync(page, new Viewport(900, 400));
+        (await page.EvaluateAsync<int>("window.hits")).Should().Be(2);
+        (await page.EvaluateAsync<bool>("window.list.matches")).Should().BeTrue();
+    }
+
+    [Test]
+    public async Task SettingTheSameViewportFiresNothing()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync(
+            """
+            <script>
+              window.hits = 0;
+              window.list = matchMedia('(max-width: 600px)');
+              window.list.addEventListener('change', () => { window.hits++ });
+            </script>
+            """);
+
+        await SetViewportAsync(page, new Viewport(1280, 720, 1));
+        (await page.EvaluateAsync<int>("window.hits")).Should().Be(0);
+
+        // And a change that leaves this query's answer alone is not this list's business either.
+        await SetViewportAsync(page, new Viewport(1400, 900));
+        (await page.EvaluateAsync<int>("window.hits")).Should().Be(0);
+    }
+
+    [Test]
+    public async Task ThePreferenceFeaturesAnswerWhatAHeadlessPageReports()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        (await page.EvaluateAsync<bool>("matchMedia('(prefers-color-scheme: light)').matches")).Should().BeTrue();
+        (await page.EvaluateAsync<bool>("matchMedia('(prefers-color-scheme: dark)').matches")).Should().BeFalse();
+        (await page.EvaluateAsync<bool>("matchMedia('(prefers-reduced-motion: no-preference)').matches")).Should().BeTrue();
+        (await page.EvaluateAsync<bool>("matchMedia('(prefers-reduced-motion: reduce)').matches")).Should().BeFalse();
+        (await page.EvaluateAsync<bool>("matchMedia('(hover: hover)').matches")).Should().BeTrue();
+        (await page.EvaluateAsync<bool>("matchMedia('(any-hover: hover)').matches")).Should().BeTrue();
+        (await page.EvaluateAsync<bool>("matchMedia('(pointer: fine)').matches")).Should().BeTrue();
+        (await page.EvaluateAsync<bool>("matchMedia('(pointer: coarse)').matches")).Should().BeFalse();
+        (await page.EvaluateAsync<bool>("matchMedia('(orientation: landscape)').matches")).Should().BeTrue();
+        (await page.EvaluateAsync<bool>("matchMedia('(orientation: portrait)').matches")).Should().BeFalse();
+    }
+}

--- a/Jint.Tests.Browser/Views/SelectionTests.cs
+++ b/Jint.Tests.Browser/Views/SelectionTests.cs
@@ -1,0 +1,172 @@
+namespace Jint.Tests.Browser.Views;
+
+// The test namespace sits under Jint.Tests.Browser, so the bare name Browser binds to that namespace rather
+// than to the type. The alias belongs inside the namespace declaration, where it wins that lookup.
+using Browser = global::Jint.Browser.Browser;
+
+/// <summary>
+/// <c>Selection</c>: one range, no direction, and no user to move it.
+/// </summary>
+public sealed class SelectionTests
+{
+    [Test]
+    public async Task TheDocumentHasOneSelectionAndBothEntriesAnswerIt()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        (await page.EvaluateAsync<bool>("getSelection() === window.getSelection()")).Should().BeTrue();
+        (await page.EvaluateAsync<bool>("document.getSelection() === window.getSelection()")).Should().BeTrue();
+        (await page.EvaluateAsync<bool>("getSelection() instanceof Selection")).Should().BeTrue();
+        (await page.EvaluateAsync<string>("Object.prototype.toString.call(getSelection())")).Should().Be("[object Selection]");
+
+        (await page.EvaluateAsync<string>(
+            "(() => { try { new Selection(); return 'no throw' } catch (e) { return e.constructor.name } })()"))
+            .Should().Be("TypeError");
+    }
+
+    [Test]
+    public async Task AnEmptySelectionAnswersTheEmptyState()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        (await page.EvaluateAsync<int>("getSelection().rangeCount")).Should().Be(0);
+        (await page.EvaluateAsync("getSelection().anchorNode")).Should().BeNull();
+        (await page.EvaluateAsync("getSelection().focusNode")).Should().BeNull();
+        (await page.EvaluateAsync<bool>("getSelection().isCollapsed")).Should().BeTrue();
+        (await page.EvaluateAsync<string>("getSelection().type")).Should().Be("None");
+        (await page.EvaluateAsync<string>("getSelection().toString()")).Should().BeEmpty();
+        (await page.EvaluateAsync<string>("String(getSelection())")).Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task ARangeCanBeAddedReadBackAndRemoved()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync(
+            """
+            <div id="host"><b>one</b><i>two</i></div>
+            <script>
+              const host = document.getElementById('host');
+              const range = document.createRange();
+              range.selectNodeContents(host);
+
+              const selection = getSelection();
+              selection.removeAllRanges();
+              selection.addRange(range);
+
+              window.after = [
+                selection.rangeCount,
+                selection.getRangeAt(0) === range,
+                selection.anchorNode === host,
+                selection.anchorOffset,
+                selection.focusNode === host,
+                selection.focusOffset,
+                selection.isCollapsed,
+                selection.type,
+                selection.toString(),
+              ].join('|');
+
+              selection.removeAllRanges();
+              window.emptied = [selection.rangeCount, selection.type].join('|');
+            </script>
+            """);
+
+        (await page.EvaluateAsync<string>("window.after")).Should().Be("1|true|true|0|true|2|false|Range|onetwo");
+        (await page.EvaluateAsync<string>("window.emptied")).Should().Be("0|None");
+    }
+
+    [Test]
+    public async Task CollapseAndSelectAllChildrenMoveTheSelection()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync(
+            """
+            <div id="host"><b>one</b><i>two</i></div>
+            <script>
+              const host = document.getElementById('host');
+              const selection = getSelection();
+
+              selection.collapse(host, 1);
+              window.collapsed = [selection.rangeCount, selection.isCollapsed, selection.anchorOffset, selection.type].join('|');
+
+              selection.selectAllChildren(host);
+              window.children = [selection.toString(), selection.isCollapsed, selection.containsNode(host.querySelector('b'))].join('|');
+
+              selection.collapseToStart();
+              window.start = [selection.isCollapsed, selection.anchorOffset].join('|');
+
+              selection.collapse(null);
+              window.cleared = selection.rangeCount;
+            </script>
+            """);
+
+        (await page.EvaluateAsync<string>("window.collapsed")).Should().Be("1|true|1|Caret");
+        (await page.EvaluateAsync<string>("window.children")).Should().Be("onetwo|false|true");
+        (await page.EvaluateAsync<string>("window.start")).Should().Be("true|0");
+        (await page.EvaluateAsync<int>("window.cleared")).Should().Be(0);
+    }
+
+    [Test]
+    public async Task ASecondRangeIsIgnoredAndAnUnknownIndexIsARangeError()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync(
+            """
+            <div id="a">one</div><div id="b">two</div>
+            <script>
+              const selection = getSelection();
+              const first = document.createRange();
+              first.selectNodeContents(document.getElementById('a'));
+              const second = document.createRange();
+              second.selectNodeContents(document.getElementById('b'));
+
+              selection.addRange(first);
+              selection.addRange(second);
+              window.kept = [selection.rangeCount, selection.toString()].join('|');
+
+              selection.removeRange(second);
+              window.stillThere = selection.rangeCount;
+              selection.removeRange(first);
+              window.gone = selection.rangeCount;
+            </script>
+            """);
+
+        // "If the selection's range list is not empty, abort": the first range wins.
+        (await page.EvaluateAsync<string>("window.kept")).Should().Be("1|one");
+        (await page.EvaluateAsync<int>("window.stillThere")).Should().Be(1);
+        (await page.EvaluateAsync<int>("window.gone")).Should().Be(0);
+
+        (await page.EvaluateAsync<string>(
+            "(() => { try { getSelection().getRangeAt(0); return 'no throw' } catch (e) { return e.constructor.name } })()"))
+            .Should().Be("RangeError");
+    }
+
+    [Test]
+    public async Task DeleteFromDocumentRemovesTheSelectedContent()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync(
+            """
+            <div id="host"><b>one</b><i>two</i></div>
+            <script>
+              const host = document.getElementById('host');
+              const selection = getSelection();
+              selection.selectAllChildren(host);
+              selection.deleteFromDocument();
+              window.left = host.innerHTML;
+            </script>
+            """);
+
+        (await page.EvaluateAsync<string>("window.left")).Should().BeEmpty();
+    }
+}

--- a/Jint.Tests.Browser/Views/ShadowDomTests.cs
+++ b/Jint.Tests.Browser/Views/ShadowDomTests.cs
@@ -1,0 +1,189 @@
+namespace Jint.Tests.Browser.Views;
+
+// The test namespace sits under Jint.Tests.Browser, so the bare name Browser binds to that namespace rather
+// than to the type. The alias belongs inside the namespace declaration, where it wins that lookup.
+using Browser = global::Jint.Browser.Browser;
+
+/// <summary>
+/// <c>&lt;template&gt;</c>, shadow roots and slots: the wrappers the generated binding already had, and what
+/// the engine's tree dispatch makes of a shadow boundary.
+/// </summary>
+public sealed class ShadowDomTests
+{
+    [Test]
+    public async Task TemplateContentIsAnInertDocumentFragment()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync(
+            """
+            <div id="anchor"></div>
+            <template id="t"><p class="row">inside</p></template>
+            <script>
+              const template = document.getElementById('t');
+              const content = template.content;
+              window.log = [
+                content instanceof DocumentFragment,
+                content.nodeType,
+                content.childElementCount,
+                content.querySelector('.row').textContent,
+                document.querySelector('.row') === null,
+              ].join('|');
+
+              const clone = content.cloneNode(true);
+              document.body.appendChild(clone);
+              window.afterClone = document.querySelectorAll('.row').length;
+            </script>
+            """);
+
+        // 11 is DOCUMENT_FRAGMENT_NODE, and a template's content is outside the document until it is cloned in.
+        (await page.EvaluateAsync<string>("window.log")).Should().Be("true|11|1|inside|true");
+        (await page.EvaluateAsync<int>("window.afterClone")).Should().Be(1);
+    }
+
+    [Test]
+    public async Task AttachShadowGivesAHostAShadowRoot()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync(
+            """
+            <div id="host"><span slot="body">light</span></div>
+            <script>
+              const host = document.getElementById('host');
+              const root = host.attachShadow({ mode: 'open' });
+              root.innerHTML = '<slot name="body"></slot><em>shadow</em>';
+
+              window.log = [
+                root instanceof ShadowRoot,
+                root instanceof DocumentFragment,
+                root.mode,
+                root.host === host,
+                host.shadowRoot === root,
+                root.querySelector('em').textContent,
+              ].join('|');
+            </script>
+            """);
+
+        (await page.EvaluateAsync<string>("window.log")).Should().Be("true|true|open|true|true|shadow");
+    }
+
+    [Test]
+    public async Task ASlotReportsTheNodesAssignedToIt()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync(
+            """
+            <div id="host"><span slot="body">light</span><b>unslotted</b></div>
+            <script>
+              const host = document.getElementById('host');
+              const root = host.attachShadow({ mode: 'open' });
+              root.innerHTML = '<slot name="body"></slot>';
+              const slot = root.querySelector('slot');
+
+              window.log = [
+                slot.name,
+                slot.assignedNodes().length,
+                slot.assignedNodes()[0].textContent,
+                slot.assignedElements().length,
+                slot.assignedElements()[0].tagName,
+              ].join('|');
+            </script>
+            """);
+
+        (await page.EvaluateAsync<string>("window.log")).Should().Be("body|1|light|1|SPAN");
+    }
+
+    [Test]
+    public async Task AnEventFromInsideAnOpenShadowRootCrossesTheBoundaryWhenItIsComposed()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync(
+            """
+            <div id="host"></div>
+            <script>
+              const host = document.getElementById('host');
+              const root = host.attachShadow({ mode: 'open' });
+              root.innerHTML = '<em id="inner">x</em>';
+              const inner = root.getElementById ? root.querySelector('#inner') : root.querySelector('em');
+
+              window.path = [];
+              window.outside = [];
+              document.body.addEventListener('composed', e => {
+                window.outside.push(e.target === host);
+                window.path = e.composedPath().map(t => t === inner ? 'inner' : t === root ? 'root' : t === host ? 'host' : t === document.body ? 'body' : t === document ? 'document' : t === window ? 'window' : t.nodeName);
+              });
+
+              inner.dispatchEvent(new Event('composed', { bubbles: true, composed: true }));
+            </script>
+            """);
+
+        // The path is the whole composed tree, and retargeting makes the listener outside the shadow root see
+        // the host rather than the element inside it.
+        (await page.EvaluateAsync<string>("window.outside.join('|')")).Should().Be("true");
+        (await page.EvaluateAsync<string>("window.path.join(',')")).Should().Be("inner,root,host,body,HTML,document,window");
+    }
+
+    [Test]
+    public async Task AnUncomposedEventStopsAtTheShadowRoot()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync(
+            """
+            <div id="host"></div>
+            <script>
+              const host = document.getElementById('host');
+              const root = host.attachShadow({ mode: 'open' });
+              root.innerHTML = '<em>x</em>';
+              const inner = root.querySelector('em');
+
+              window.reachedOutside = false;
+              window.reachedRoot = false;
+              document.body.addEventListener('contained', () => { window.reachedOutside = true });
+              root.addEventListener('contained', () => { window.reachedRoot = true });
+
+              inner.dispatchEvent(new Event('contained', { bubbles: true }));
+            </script>
+            """);
+
+        (await page.EvaluateAsync<bool>("window.reachedRoot")).Should().BeTrue();
+        (await page.EvaluateAsync<bool>("window.reachedOutside")).Should().BeFalse();
+    }
+
+    [Test]
+    public async Task AClosedShadowRootHidesItsContentsFromComposedPath()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync(
+            """
+            <div id="host"></div>
+            <script>
+              const host = document.getElementById('host');
+              const root = host.attachShadow({ mode: 'closed' });
+              root.innerHTML = '<em>x</em>';
+              const inner = root.querySelector('em');
+
+              window.path = [];
+              document.body.addEventListener('composed', e => {
+                window.path = e.composedPath().map(t => t === host ? 'host' : t === document.body ? 'body' : t === document ? 'document' : t === window ? 'window' : t.nodeName);
+              });
+
+              inner.dispatchEvent(new Event('composed', { bubbles: true, composed: true }));
+              window.mode = root.mode;
+            </script>
+            """);
+
+        (await page.EvaluateAsync<string>("window.mode")).Should().Be("closed");
+        (await page.EvaluateAsync<string>("window.path.join(',')")).Should().Be("host,body,HTML,document,window");
+    }
+}

--- a/Jint.Tests.Browser/Views/TraversalTests.cs
+++ b/Jint.Tests.Browser/Views/TraversalTests.cs
@@ -1,0 +1,278 @@
+namespace Jint.Tests.Browser.Views;
+
+// The test namespace sits under Jint.Tests.Browser, so the bare name Browser binds to that namespace rather
+// than to the type. The alias belongs inside the namespace declaration, where it wins that lookup.
+using Browser = global::Jint.Browser.Browser;
+
+/// <summary>
+/// <c>Range</c>, <c>TreeWalker</c> and <c>NodeIterator</c>: the generated interfaces, plus the members whose
+/// signatures the binding could not cross.
+/// </summary>
+public sealed class TraversalTests
+{
+    [Test]
+    public async Task ARangeSelectsMovesAndExtracts()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync(
+            """
+            <div id="host"><b>one</b><i>two</i><u>three</u></div>
+            <script>
+              const host = document.getElementById('host');
+              const range = document.createRange();
+              range.selectNodeContents(host);
+
+              window.log = [
+                range instanceof Range,
+                range.startContainer === host,
+                range.startOffset,
+                range.endOffset,
+                range.collapsed,
+                range.commonAncestorContainer === host,
+                range.toString(),
+              ].join('|');
+
+              const fragment = range.extractContents();
+              window.after = [fragment.childNodes.length, host.childNodes.length].join('|');
+            </script>
+            """);
+
+        (await page.EvaluateAsync<string>("window.log")).Should().Be("true|true|0|3|false|true|onetwothree");
+        (await page.EvaluateAsync<string>("window.after")).Should().Be("3|0");
+    }
+
+    [Test]
+    public async Task ARangeClonesInsertsSurroundsAndDeletes()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync(
+            """
+            <div id="host"><b>one</b><i>two</i></div>
+            <script>
+              const host = document.getElementById('host');
+              const range = document.createRange();
+
+              range.selectNode(host.querySelector('b'));
+              window.cloned = range.cloneContents().childNodes.length;
+
+              const wrapper = document.createElement('em');
+              range.surroundContents(wrapper);
+              window.surrounded = host.innerHTML;
+
+              const insertion = document.createRange();
+              insertion.setStart(host, 0);
+              insertion.collapse(true);
+              insertion.insertNode(document.createElement('s'));
+              window.inserted = host.firstChild.tagName;
+
+              const removal = document.createRange();
+              removal.selectNode(host.querySelector('i'));
+              removal.deleteContents();
+              window.deleted = host.querySelector('i') === null;
+            </script>
+            """);
+
+        (await page.EvaluateAsync<int>("window.cloned")).Should().Be(1);
+        (await page.EvaluateAsync<string>("window.surrounded")).Should().Be("<em><b>one</b></em><i>two</i>");
+        (await page.EvaluateAsync<string>("window.inserted")).Should().Be("S");
+        (await page.EvaluateAsync<bool>("window.deleted")).Should().BeTrue();
+    }
+
+    [Test]
+    public async Task ARangeAnswersZeroRectanglesBecauseThereIsNoLayout()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync("<p id='p'>text</p>");
+
+        (await page.EvaluateAsync<string>(
+            """
+            (() => {
+              const range = document.createRange();
+              range.selectNodeContents(document.getElementById('p'));
+              const rect = range.getBoundingClientRect();
+              return [rect.x, rect.y, rect.width, rect.height, range.getClientRects().length].join('|');
+            })()
+            """))
+            .Should().Be("0|0|0|0|0");
+    }
+
+    [Test]
+    public async Task ATreeWalkerTakesAFunctionFilter()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync(
+            """
+            <div id="host"><a></a><b><i></i></b><u></u></div>
+            <script>
+              const host = document.getElementById('host');
+              const walker = document.createTreeWalker(host, NodeFilter.SHOW_ELEMENT, node =>
+                node.tagName === 'B' ? NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT);
+
+              const seen = [];
+              let node;
+              while ((node = walker.nextNode())) { seen.push(node.tagName) }
+
+              window.log = seen.join(',');
+              window.meta = [walker instanceof TreeWalker, walker.root === host, walker.whatToShow].join('|');
+            </script>
+            """);
+
+        // FILTER_REJECT on an element skips its subtree, so <i> never appears.
+        (await page.EvaluateAsync<string>("window.log")).Should().Be("A,U");
+        (await page.EvaluateAsync<string>("window.meta")).Should().Be("true|true|1");
+    }
+
+    [Test]
+    public async Task ATreeWalkerTakesAnObjectFilterAndReportsItBack()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync(
+            """
+            <div id="host"><a></a><b></b><u></u></div>
+            <script>
+              const filter = { acceptNode: node => node.tagName === 'B' ? NodeFilter.FILTER_SKIP : NodeFilter.FILTER_ACCEPT };
+              const walker = document.createTreeWalker(document.getElementById('host'), NodeFilter.SHOW_ELEMENT, filter);
+
+              const seen = [];
+              let node;
+              while ((node = walker.nextNode())) { seen.push(node.tagName) }
+
+              window.log = seen.join(',');
+              window.filterIsTheSameObject = walker.filter === filter;
+            </script>
+            """);
+
+        // FILTER_SKIP passes over the node but keeps its subtree, unlike FILTER_REJECT.
+        (await page.EvaluateAsync<string>("window.log")).Should().Be("A,U");
+        (await page.EvaluateAsync<bool>("window.filterIsTheSameObject")).Should().BeTrue();
+    }
+
+    [Test]
+    public async Task ATreeWalkerWalksInEveryDirection()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync(
+            """
+            <div id="host"><a><i></i></a><b></b></div>
+            <script>
+              const host = document.getElementById('host');
+              const walker = document.createTreeWalker(host, NodeFilter.SHOW_ELEMENT);
+              const seen = [];
+              seen.push(walker.firstChild().tagName);
+              seen.push(walker.firstChild().tagName);
+              seen.push(walker.parentNode().tagName);
+              seen.push(walker.nextSibling().tagName);
+              seen.push(walker.previousSibling().tagName);
+              seen.push(walker.lastChild().tagName);
+              window.log = seen.join(',');
+              window.current = walker.currentNode.tagName;
+            </script>
+            """);
+
+        (await page.EvaluateAsync<string>("window.log")).Should().Be("A,I,A,B,A,I");
+        (await page.EvaluateAsync<string>("window.current")).Should().Be("I");
+    }
+
+    [Test]
+    public async Task ANodeIteratorWalksEveryNodeTypeItWasAskedFor()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync(
+            """
+            <div id="host"><b>one</b><!--note--><i>two</i></div>
+            <script>
+              const host = document.getElementById('host');
+              const iterator = document.createNodeIterator(host);
+              const seen = [];
+              let node;
+              while ((node = iterator.nextNode())) { seen.push(node.nodeName) }
+              window.all = seen.join(',');
+
+              const elements = document.createNodeIterator(host, NodeFilter.SHOW_ELEMENT);
+              const tags = [];
+              while ((node = elements.nextNode())) { tags.push(node.nodeName) }
+              window.elements = tags.join(',');
+              window.meta = [elements instanceof NodeIterator, elements.root === host, elements.whatToShow, elements.filter].join('|');
+            </script>
+            """);
+
+        (await page.EvaluateAsync<string>("window.all")).Should().Be("DIV,B,#text,#comment,I,#text");
+        (await page.EvaluateAsync<string>("window.elements")).Should().Be("DIV,B,I");
+
+        // whatToShow defaults to 0xFFFFFFFF and is an unsigned long: a signed read would answer -1.
+        (await page.EvaluateAsync<string>("document.createNodeIterator(document.body).whatToShow.toString()")).Should().Be("4294967295");
+        (await page.EvaluateAsync<string>("window.meta")).Should().Be("true|true|1|");
+    }
+
+    [Test]
+    public async Task ANodeIteratorGoesBackwards()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync(
+            """
+            <div id="host"><a></a><b></b></div>
+            <script>
+              const iterator = document.createNodeIterator(document.getElementById('host'), NodeFilter.SHOW_ELEMENT);
+              iterator.nextNode();
+              iterator.nextNode();
+              const back = iterator.previousNode();
+              window.log = [back.nodeName, iterator.referenceNode.nodeName, iterator.pointerBeforeReferenceNode].join('|');
+            </script>
+            """);
+
+        // DOM's traverse(previous) moves the *pointer* from after the reference node to before it without
+        // moving the node, so the first previousNode() after a nextNode() answers the same node again.
+        (await page.EvaluateAsync<string>("window.log")).Should().Be("A|A|true");
+    }
+
+    [Test]
+    public async Task AFilterThatThrowsPropagatesOutOfNextNode()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync("<div id='host'><a></a></div>");
+
+        (await page.EvaluateAsync<string>(
+            """
+            (() => {
+              const walker = document.createTreeWalker(document.getElementById('host'), NodeFilter.SHOW_ELEMENT, () => { throw new Error('from a filter') });
+              try { walker.nextNode(); return 'no throw' } catch (e) { return e.message }
+            })()
+            """))
+            .Should().Be("from a filter");
+    }
+
+    [Test]
+    public async Task NodeFilterCarriesItsConstantsAndABadFilterIsATypeError()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        (await page.EvaluateAsync<string>("[NodeFilter.FILTER_ACCEPT, NodeFilter.FILTER_REJECT, NodeFilter.FILTER_SKIP].join(',')"))
+            .Should().Be("1,2,3");
+        (await page.EvaluateAsync<string>("[NodeFilter.SHOW_ALL, NodeFilter.SHOW_ELEMENT, NodeFilter.SHOW_TEXT, NodeFilter.SHOW_COMMENT].join(',')"))
+            .Should().Be("4294967295,1,4,128");
+        (await page.EvaluateAsync<string>("Object.prototype.toString.call(NodeFilter)")).Should().Be("[object NodeFilter]");
+
+        (await page.EvaluateAsync<string>(
+            "(() => { try { document.createTreeWalker(document.body, NodeFilter.SHOW_ALL, 7) } catch (e) { return e.constructor.name } return 'no throw' })()"))
+            .Should().Be("TypeError");
+    }
+}

--- a/README.md
+++ b/README.md
@@ -2361,10 +2361,18 @@ array-like lane, and node wrappers that Jint's tree-aware event dispatcher can w
 runtime: a `Browser` / `BrowserContext` / `Page` API, one engine and one thread per page, a `Window` whose
 prototype the global object inherits (so `window === globalThis`, `window instanceof EventTarget`, and
 `addEventListener` on the window is on a bubbling event's path), `document`, `location`, `screen`,
-`getComputedStyle`, `matchMedia`, `requestAnimationFrame`, `postMessage`, dialogs as a host event, timers
+`getComputedStyle` (read-only, from the cascade, with no layout behind it), `matchMedia` (with `change`
+fired when the viewport moves), `requestAnimationFrame`, `postMessage`, dialogs as a host event, timers
 that fire because the page's thread pumps the engine, and console output and script errors recorded on the
 page. Content from `SetContentAsync`, `about:blank` and `data:text/html`, with classic inline scripts run in
 document order as the parse reaches them, then `readystatechange`, `DOMContentLoaded`, `load` and `pageshow`.
+
+**And the observers and views a page written this decade expects.** A `MutationObserver` whose records come
+from AngleSharp and are delivered at Jint's microtask checkpoint; `IntersectionObserver` and `ResizeObserver`
+as documented stubs that report every observed target once, since there is no layout for either to measure;
+`DOMParser` (HTML, and XML through `AngleSharp.Xml`) and `XMLSerializer`, `Range`, `TreeWalker`,
+`NodeIterator`, `getSelection()`, `<template>` content and `attachShadow`, with events crossing a shadow
+boundary the way the DOM says.
 
 **And the network half.** `Page.NavigateAsync` loads an `http(s)` URL through Jint's own fetch pipeline and
 parses the result into a new engine — the document being left gets `beforeunload`, `pagehide` and `unload`,
@@ -2379,8 +2387,9 @@ and every request share one jar per browser context; `localStorage` is partition
 
 **What does not exist yet.** No external `<script src>` and no module scripts in a document — a page names
 what it could not run in `Page.UnsupportedScripts` — no import maps, no `document.write` during a parse, no
-`MutationObserver`, no iframe scripting (frames are parsed and listed; `contentWindow` is absent), no
-rendering or layout, and no Chrome DevTools page domains. Those are the later items of the same campaign.
+iframe scripting (frames are parsed and listed; `contentWindow` is absent), no rendering or layout — so every
+rectangle is zeros and `getBoundingClientRect` does not exist — and no Chrome DevTools page domains. Those
+are the later items of the same campaign.
 
 The design, including what a v1 will and will not do, is
 [`docs/design/headless-browser.md`](docs/design/headless-browser.md); the tracking issue is

--- a/tools/dom-bindings/Jint.Browser.BindingGenerator/Conversions.cs
+++ b/tools/dom-bindings/Jint.Browser.BindingGenerator/Conversions.cs
@@ -75,9 +75,15 @@ internal sealed class Conversions
 
         if (type.IsEnum)
         {
+            // A numeric enum crosses as its value, cast through a CLR type wide enough to hold it. That
+            // matters for exactly one enum today: FilterSettings is a ulong whose SHOW_ALL is 0xFFFFFFFF, and
+            // an int cast would make TreeWalker.whatToShow answer -1 where DOM says 4294967295.
+            var underlying = type.GetEnumUnderlyingType().Name;
+            var cast = underlying is "Int64" or "UInt64" or "UInt32" ? "long" : "int";
+
             code = _isStringEnum(type)
                 ? "global::Jint.Browser.Dom.DomEnums.From" + type.Name + "(" + value + ")"
-                : "global::Jint.Browser.Dom.DomConvert.Number((int) (" + value + "))";
+                : "global::Jint.Browser.Dom.DomConvert.Number((" + cast + ") (" + value + "))";
             return true;
         }
 

--- a/tools/dom-bindings/Jint.Browser.BindingGenerator/ModelBuilder.cs
+++ b/tools/dom-bindings/Jint.Browser.BindingGenerator/ModelBuilder.cs
@@ -430,6 +430,40 @@ internal sealed class ModelBuilder
             }
         }
 
+        // The curated additions last, and against what was actually emitted rather than against what was
+        // seen: half of them name a member AngleSharp does declare and the generator skipped, which is
+        // exactly the case an addition exists for. A collision with an *emitted* member is a real one — the
+        // pinned assemblies grew a member the table is now shadowing — and is reported.
+        foreach (var addition in _overrides.Additions)
+        {
+            if (addition.Interface != model.DomName)
+            {
+                continue;
+            }
+
+            if (model.Members.Any(m => m.DomName == addition.Member))
+            {
+                _model.Diagnostics.Add(
+                    "overrides.json adds " + model.DomName + "." + addition.Member + " (" + addition.Reason
+                    + "), but the pinned assemblies already project it; the addition is ignored.");
+                continue;
+            }
+
+            // The skip this replaces is no longer a consequence, so it leaves the report: a reader looking
+            // for members that do not cross should not find one that does.
+            _model.Skipped.RemoveAll(s => s.Interface == model.DomName && s.Member == addition.Member);
+
+            model.Members.Add(new MemberModel
+            {
+                DomName = addition.Member,
+                Kind = addition.Kind == "attribute" ? MemberKind.Attribute : MemberKind.Operation,
+                Body = string.Join("\n", addition.Body),
+                SetterBody = addition.Setter is { Count: > 0 } setter ? string.Join("\n", setter) : null,
+                Length = addition.Length,
+                Origin = "overrides.json",
+            });
+        }
+
         model.Members.Sort((a, b) => string.CompareOrdinal(a.DomName, b.DomName));
     }
 
@@ -1136,6 +1170,18 @@ internal sealed class ModelBuilder
         foreach (var entry in _overrides.NullableStrings)
         {
             Check("nullableStrings", entry.Interface, entry.Member, entry.Reason);
+        }
+
+        // The additions are checked the other way round: the interface has to exist, and the member has to
+        // be one AngleSharp does not have — a member it grew is reported by BuildMembers as a collision.
+        foreach (var entry in _overrides.Additions)
+        {
+            if (!_byClrName.Values.Any(m => m.DomName == entry.Interface))
+            {
+                _model.Diagnostics.Add(
+                    "overrides.json's addition '" + entry.Interface + "." + entry.Member + "' (" + entry.Reason
+                    + ") names an interface the pinned assemblies do not project.");
+            }
         }
 
         foreach (var entry in _overrides.ExcludedInterfaces)

--- a/tools/dom-bindings/Jint.Browser.BindingGenerator/Overrides.cs
+++ b/tools/dom-bindings/Jint.Browser.BindingGenerator/Overrides.cs
@@ -26,6 +26,9 @@ internal sealed class Overrides
     [JsonPropertyName("hooks")]
     public List<HookEntry> Hooks { get; init; } = [];
 
+    [JsonPropertyName("additions")]
+    public List<AdditionEntry> Additions { get; init; } = [];
+
     [JsonPropertyName("nullableStrings")]
     public List<NullableStringEntry> NullableStrings { get; init; } = [];
 
@@ -92,6 +95,44 @@ internal sealed class Overrides
         /// <summary>The method on <c>DomHostHooks</c> the generated body calls.</summary>
         [JsonPropertyName("hook")]
         public string Hook { get; init; } = "";
+
+        [JsonPropertyName("reason")]
+        public string Reason { get; init; } = "";
+    }
+
+    /// <summary>
+    /// A member the DOM standard puts on a generated interface and that AngleSharp's metadata cannot express
+    /// — a callback parameter, a stringifier with no <c>[DomName]</c>, a member AngleSharp spells by another
+    /// name. The body is hand-written and lives in <c>Jint.Browser/Dom/Views/DomViewMembers.cs</c>.
+    /// </summary>
+    /// <remarks>
+    /// This is the one list whose entries name something the pinned assemblies do <em>not</em> have; what is
+    /// checked instead is the opposite — that the interface exists and that the member does not, so an entry
+    /// can never quietly shadow a member AngleSharp grew.
+    /// </remarks>
+    internal sealed class AdditionEntry
+    {
+        [JsonPropertyName("interface")]
+        public string Interface { get; init; } = "";
+
+        [JsonPropertyName("member")]
+        public string Member { get; init; } = "";
+
+        /// <summary><c>operation</c> (the default) or <c>attribute</c>.</summary>
+        [JsonPropertyName("kind")]
+        public string Kind { get; init; } = "operation";
+
+        /// <summary>An operation's declared parameter count — its <c>length</c>.</summary>
+        [JsonPropertyName("length")]
+        public int Length { get; init; }
+
+        /// <summary>The C# statements of the operation or of the getter, one entry per line.</summary>
+        [JsonPropertyName("body")]
+        public List<string> Body { get; init; } = [];
+
+        /// <summary>The C# statements of the setter, for a writable attribute.</summary>
+        [JsonPropertyName("setter")]
+        public List<string>? Setter { get; init; }
 
         [JsonPropertyName("reason")]
         public string Reason { get; init; } = "";

--- a/tools/dom-bindings/overrides.json
+++ b/tools/dom-bindings/overrides.json
@@ -127,6 +127,127 @@
     }
   ],
 
+  "additions": [
+    {
+      "interface": "Document",
+      "member": "createTreeWalker",
+      "kind": "operation",
+      "length": 1,
+      "body": [
+        "var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, \"Document.createTreeWalker\");",
+        "return global::Jint.Browser.Dom.Views.DomViewMembers.CreateTreeWalker(self.Realm, self.Target, args);"
+      ],
+      "reason": "DOM §6.1. AngleSharp has it, but its third parameter is a NodeFilter delegate and the conversion table has no entry for a delegate — deliberately, because only the standard knows a callback's IDL shape. Dom/Views/NodeFilters accepts both shapes DOM's legacy callback interface allows."
+    },
+    {
+      "interface": "Document",
+      "member": "createNodeIterator",
+      "kind": "operation",
+      "length": 1,
+      "body": [
+        "var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, \"Document.createNodeIterator\");",
+        "return global::Jint.Browser.Dom.Views.DomViewMembers.CreateNodeIterator(self.Realm, self.Target, args);"
+      ],
+      "reason": "DOM §6.1, and the same delegate parameter as createTreeWalker."
+    },
+    {
+      "interface": "Document",
+      "member": "getSelection",
+      "kind": "operation",
+      "length": 0,
+      "body": [
+        "var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, \"Document.getSelection\");",
+        "return global::Jint.Browser.Dom.Views.DomViewMembers.GetSelection(self.Realm);"
+      ],
+      "reason": "Selection API §3: document.getSelection() answers the same object window.getSelection() does. AngleSharp has no Selection at all, so the interface is the runtime's."
+    },
+    {
+      "interface": "TreeWalker",
+      "member": "filter",
+      "kind": "attribute",
+      "body": [
+        "var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ITreeWalker>(thisObj, \"TreeWalker.filter\");",
+        "return global::Jint.Browser.Dom.Views.DomViewMembers.Filter(self.Target);"
+      ],
+      "reason": "DOM §6.2 `readonly attribute NodeFilter? filter`. AngleSharp's ITreeWalker.Filter is the CLR delegate, which cannot cross back; the value the page passed is remembered at creation instead."
+    },
+    {
+      "interface": "NodeIterator",
+      "member": "filter",
+      "kind": "attribute",
+      "body": [
+        "var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INodeIterator>(thisObj, \"NodeIterator.filter\");",
+        "return global::Jint.Browser.Dom.Views.DomViewMembers.Filter(self.Target);"
+      ],
+      "reason": "DOM §6.1, the same as TreeWalker.filter."
+    },
+    {
+      "interface": "Range",
+      "member": "toString",
+      "kind": "operation",
+      "length": 0,
+      "body": [
+        "var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IRange>(thisObj, \"Range.toString\");",
+        "return global::Jint.Browser.Dom.Views.DomViewMembers.RangeToString(self.Target);"
+      ],
+      "reason": "DOM §5.5 declares Range's stringifier. AngleSharp implements it as Range.ToString() and puts no [DomName] on it, so nothing in the metadata says the member exists."
+    },
+    {
+      "interface": "Range",
+      "member": "getBoundingClientRect",
+      "kind": "operation",
+      "length": 0,
+      "body": [
+        "var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IRange>(thisObj, \"Range.getBoundingClientRect\");",
+        "return global::Jint.Browser.Dom.Views.DomViewMembers.RangeRect(self.Realm);"
+      ],
+      "reason": "CSSOM View extends Range with it and AngleSharp has no layout to answer from. Zeros, honestly, until the flat-box model (campaign item C4) gives every box a deterministic rectangle."
+    },
+    {
+      "interface": "Range",
+      "member": "getClientRects",
+      "kind": "operation",
+      "length": 0,
+      "body": [
+        "var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IRange>(thisObj, \"Range.getClientRects\");",
+        "return global::Jint.Browser.Dom.Views.DomViewMembers.RangeRects(self.Realm);"
+      ],
+      "reason": "The other half of getBoundingClientRect: an empty list, because a range with no layout covers no boxes."
+    },
+    {
+      "interface": "ShadowRoot",
+      "member": "mode",
+      "kind": "attribute",
+      "body": [
+        "var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IShadowRoot>(thisObj, \"ShadowRoot.mode\");",
+        "return global::Jint.Browser.Dom.DomEnums.FromShadowRootMode(self.Target.Mode);"
+      ],
+      "reason": "DOM §4.8 `readonly attribute ShadowRootMode mode`, and the member a page reads to tell an open root from a closed one. AngleSharp has IShadowRoot.Mode but puts no [DomName] on it — the only member of the interface without one — so nothing in the metadata says it is projected."
+    },
+    {
+      "interface": "HTMLSlotElement",
+      "member": "assignedNodes",
+      "kind": "operation",
+      "length": 0,
+      "body": [
+        "var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSlotElement>(thisObj, \"HTMLSlotElement.assignedNodes\");",
+        "return global::Jint.Browser.Dom.Views.DomViewMembers.AssignedNodes(self.Realm, self.Target);"
+      ],
+      "reason": "DOM §4.2.5. AngleSharp's [DomName] is getDistributedNodes, which is the Shadow DOM v0 spelling; both are emitted, because the old one is what the metadata says and the new one is what a page calls."
+    },
+    {
+      "interface": "HTMLSlotElement",
+      "member": "assignedElements",
+      "kind": "operation",
+      "length": 0,
+      "body": [
+        "var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSlotElement>(thisObj, \"HTMLSlotElement.assignedElements\");",
+        "return global::Jint.Browser.Dom.Views.DomViewMembers.AssignedElements(self.Realm, self.Target);"
+      ],
+      "reason": "DOM §4.2.5, the element-only half of assignedNodes."
+    }
+  ],
+
   "nullableStrings": [
     {
       "interface": "Element",
@@ -157,6 +278,21 @@
       "interface": "Attr",
       "member": "prefix",
       "reason": "DOM §4.9.2: `readonly attribute DOMString? prefix`."
+    },
+    {
+      "interface": "MutationRecord",
+      "member": "attributeName",
+      "reason": "DOM §4.3.3: `readonly attribute DOMString? attributeName` — null for every record but an attributes one, which is how a callback tells the types apart without reading `type`."
+    },
+    {
+      "interface": "MutationRecord",
+      "member": "attributeNamespace",
+      "reason": "DOM §4.3.3: `readonly attribute DOMString? attributeNamespace` — null for an attribute in no namespace, which is nearly all of them."
+    },
+    {
+      "interface": "MutationRecord",
+      "member": "oldValue",
+      "reason": "DOM §4.3.3: `readonly attribute DOMString? oldValue` — and null is load-bearing here, because it is also what an observer that did not ask for the old value must see. The empty string would be indistinguishable from an attribute whose previous value really was empty."
     },
     {
       "interface": "Node",


### PR DESCRIPTION
Campaign item **R4** of the headless-browser campaign (#3575): the window miscellany a real page depends on
and that answered nothing before — the three observers, and the DOM views that let the generated `Range`,
`TreeWalker` and `NodeIterator` be used at all.

A page that watches its own DOM, lazily loads a list, measures a component when it mounts or parses markup
does none of those things when the interface is simply absent. It does not fail either: it stops, with
nothing to read.

## The three observers, and the lane each delivers on

**`MutationObserver` delivers at the microtask checkpoint.** The *records* are AngleSharp's —
`DocumentExtensions.QueueMutation` already does the whole of DOM §4.3.4: inclusive ancestors, the registered
observer list, `subtree`, `attributeFilter`, and `oldValue` cleared for an observer that did not ask for it.
What AngleSharp has no answer for is **when**. Its `MutationHost` schedules through an `IEventLoop` service,
*nothing in AngleSharp implements one*, and `EventLoopExtensions.Enqueue` runs the action **inline** when the
loop is null — so out of the box the callback fires synchronously in the middle of `appendChild`. Registering
an event loop to fix that is precisely the thing that would make a step of the parse asynchronous and take
`PageDocument`'s parser-hop fallback.

So the inline call is used as the *arrival* of a record and nothing more: `JsMutationObserver` parks it, and
`MutationObserverLane` puts one job on the engine's queue per batch. The ordering then falls out of a plain
enqueue and is pinned:

```js
Promise.resolve().then(() => log.push('before'));
host.appendChild(p);            // queues "notify mutation observers" here
host.appendChild(p2);           // same batch
Promise.resolve().then(() => log.push('after'));
log.push('sync');
// → sync | before | mo:2 | after
```

**`IntersectionObserver` and `ResizeObserver` deliver as a *task*** (a zero-delay timer entry), because both
belong to update-the-rendering and a microtask would run before the promises of the same turn. Both are
**stubs, and the shape of the lie is stated rather than hidden**: every observed target is reported exactly
once — fully intersecting, or at zero size — and never again, because with no layout nothing can change.
"Never intersecting" would stop every lazy list and reveal-on-scroll animation dead; the initial resize
notification is the one a component uses to measure itself. `root`, `rootMargin` and `thresholds` are parsed,
validated and reflected exactly as the specification says and change nothing. Rectangles are zeros and are
**plain objects rather than `DOMRectReadOnly` instances** — there is no rectangle interface in the package
yet, and one whose every instance is zeros would be worse than none. C4's flat-box model turns them into real
numbers.

## The DOM views

`DOMParser` (HTML, and XML through **`AngleSharp.Xml`**), `XMLSerializer`, `Selection` + `getSelection()`,
`NodeFilter`, `MediaQueryListEvent`, and the members that make `Range` / `TreeWalker` / `NodeIterator` usable:
`createTreeWalker`, `createNodeIterator`, `Range.toString`, `slot.assignedNodes()`, `ShadowRoot.mode`.

- A **parsed document cannot run anything**: its parser gets a browsing context of its own with no scripting
  service and `IsScripting` false, which is what "not a browsing context" means in the standard. Pinned.
- A **failed XML parse answers the `parsererror` document** the standard prescribes, which is what a page
  tests for, rather than throwing.
- **`getComputedStyle` keeps R1's cascade and gains CSSOM's computed flag**: every write is refused with a
  real `NoModificationAllowedError` instead of landing silently in a detached copy nothing can read.
- **`matchMedia` gained its other half**: `PageRuntime.SetViewport` is the seam device emulation (C5) will
  drive, and every `MediaQueryList` the page holds fires `change` — with a real `MediaQueryListEvent`, because
  `e => e.matches` is how the listener is written — only if its own answer moved.

## AngleSharp findings

Recorded in `Jint.Browser/AGENTS.md`'s divergence table and **reported upstream rather than patched around**;
the two places a wrapper corrects one, it says so and says why.

| What | The standard | AngleSharp |
| --- | --- | --- |
| `observer.disconnect()` | empties the registered-node list | unregisters from the document but **leaves that list populated**, so the next `observe()` of any node silently re-registers every node it used to watch |
| `observer.observe(document, …)` | observes the document node | silently retargets a `Document` to its `documentElement` |
| `observe(…)` with bad options | `TypeError` | `DomException`, and the dictionary's optional members resolve differently (`{ attributeOldValue: false }` alone is valid in DOM, invalid there) |
| `record.addedNodes` on an attribute record | an empty `NodeList` | `null`, for both `Added` and `Removed` |
| `IShadowRoot.Mode` | `ShadowRoot.mode` | the one member of the interface carrying no `[DomName]` |
| `slot.assignedNodes()` | DOM §4.2.5 | named `getDistributedNodes` — the Shadow DOM v0 spelling |
| `getComputedStyle(span).display` | `inline` | the empty string: the cascade reports only what was *declared*, and `display: inline` is the initial value |
| the computed style is writable | `NoModificationAllowedError` | an ordinary writable — and detached — declaration |

`MutationObserver` also has **no `IEventLoop` implementation anywhere in AngleSharp**, so its own microtask
scheduling degenerates to a synchronous call inside the mutation. That is the finding the whole design above
turns on.

## The generator

Two changes, both in this area:

- **`overrides.json` gains an `additions` list** — a member the *standard* puts on a generated interface and
  AngleSharp's attributes cannot express: a callback parameter, a stringifier with no `[DomName]`, a name that
  moved. It is the only override list whose entries name something the pinned assemblies do **not** have, so
  what is checked is the opposite: the interface exists and the member does not. An addition whose member the
  generator *skipped* replaces that skip and removes it from the report.
- **A numeric enum crosses through a CLR type wide enough to hold it.** `FilterSettings` is a `ulong` whose
  `SHOW_ALL` is `0xFFFFFFFF`; the `(int)` cast made `TreeWalker.whatToShow` answer `-1`. Two generated lines
  change.

`AngleSharp.Xml` is referenced for `DOMParser`'s four XML content types and nothing else. It is MIT and from
the same project, and writing an XML parser here instead is the one thing this package is not for. **It is
deliberately not in `tools/dom-bindings/pin.json`**: the generator reads two assemblies and projects no
interface from this one, so the pin discipline is untouched. This is the one decision worth a second opinion
before merge.

## Verification

`Jint.Tests.Browser` goes from 107 to 179 tests, all green on both legs, and green again under
`JINT_HOST_CONTRACT_VERIFICATION=1`. Full solution green. No public API change, so
`PublicApiTest.verified.txt` is untouched.

`Views/HostInterfaceDisciplineTests` is new discipline rather than new coverage: `DomPrototypeTests` and
`WebIdlPropertyAttributeTests` walk the *generated* registry, and none of the eleven runtime-owned interfaces
is in it — so it holds every one of them to the same two rules (a shared-shape prototype, WebIDL's attributes
per member kind), which is exactly where a hand-written shape goes wrong.

## Left out, and why

- **`Element.getBoundingClientRect`** and a real `DOMRect` interface: C4 owns the box model, and zeros with no
  interface is more honest than an interface full of zeros.
- **Transient registered observers** are cleared at mutation time rather than at the checkpoint, because
  AngleSharp clears them inside the call this design uses as the record's arrival. A node removed from an
  observed subtree therefore stops being observed one mutation early.
- **`selectionchange`** is not fired and `Selection` has no direction: both need a user, and there is none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
