### PR TITLE
Generated protocol and DOM binding files are marked linguist-generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -42,3 +42,9 @@ Jint.Tests/Wpt/Vendor/** text eol=lf
 tools/devtools-protocol/js_protocol.json text eol=lf
 tools/devtools-protocol/browser_protocol.json text eol=lf
 tools/devtools-protocol/devtools-protocol-LICENSE text eol=lf
+
+# Generated from the vendored protocol JSON and from AngleSharp's [DomName] attributes, checked in on purpose
+# (a pin bump is a diff to read, and the serializer context has to be generated over the DTOs), and
+# collapsed in pull-request review and excluded from language statistics for the same reason.
+Jint.DevTools/Protocol/Generated/*.g.cs linguist-generated=true
+Jint.Browser/Dom/Generated/*.g.cs linguist-generated=true


### PR DESCRIPTION
Follow-up to the review of #3586: the generated protocol DTOs and DOM bindings stay checked in (a pin bump is a diff a reviewer reads; the System.Text.Json context has to be generated over the DTOs, which a Roslyn generator cannot do over another generator's output; a currency test fails on drift), but GitHub should collapse them in review and leave them out of language statistics. Two `linguist-generated` rules do that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
