### PR TITLE
JavaScriptException: only a string "stack" counts as a pre-existing stack (#3607 backport)

### DIFF
--- a/Jint.Tests/Runtime/ErrorTests.cs
+++ b/Jint.Tests/Runtime/ErrorTests.cs
@@ -231,6 +231,45 @@ var wrap = function(v) {
         engine.Evaluate(@"typeof Error().stack").AsString().Should().Be("string");
     }
 
+    [Fact]
+    public void ThrowingErrorPrototypeDerivedObjectWithoutErrorDataSurfacesAsJavaScriptException()
+    {
+        // A hand-rolled subclass in the pre-ES6 style inherits the Error.prototype "stack" accessor but has
+        // no [[ErrorData]], so the getter returns undefined. Building the host exception must not turn that
+        // undefined into a CLR ArgumentException — it must fall through to the engine-built call stack.
+        // (This is exactly how WPT's idlharness.js declares IdlHarnessError.)
+        var engine = new Engine();
+        engine.Execute(@"
+function CustomError(message) { this.message = message; }
+CustomError.prototype = Object.create(Error.prototype);
+function thrower() { throw new CustomError('custom boom'); }
+", "custom.js");
+
+        var e = Invoking(() => engine.Execute("thrower();", "main.js")).Should().ThrowExactly<JavaScriptException>().Which;
+
+        e.Message.Should().Be("custom boom");
+        EqualIgnoringNewLineDifferences(@"    at thrower (custom.js:4:28)
+    at main.js:1:1", e.JavaScriptStackTrace);
+
+        // The engine-built stack is installed as an own data property, so the script can read it too.
+        engine.Evaluate(@"
+try { thrower(); } catch (err) { typeof err.stack; }").AsString().Should().Be("string");
+    }
+
+    [Fact]
+    public void ThrowingObjectWithNonStringStackPropertyKeepsAuthorValueAndDoesNotFault()
+    {
+        var engine = new Engine();
+
+        var e = Invoking(() => engine.Execute("throw { message: 'plain', stack: 42 };", "main.js"))
+            .Should().ThrowExactly<JavaScriptException>().Which;
+
+        e.Message.Should().Be("plain");
+        // The author's non-string "stack" is left untouched; the host side falls back to its own call stack.
+        e.JavaScriptStackTrace.Should().Be("    at main.js:1:7");
+        engine.Evaluate("(function(){ try { throw { stack: 42 }; } catch (x) { return x.stack; } })()").AsNumber().Should().Be(42);
+    }
+
     private class Folder
     {
         public Folder Parent { get; set; }

--- a/Jint/Runtime/JavaScriptException.cs
+++ b/Jint/Runtime/JavaScriptException.cs
@@ -160,10 +160,18 @@ public class JavaScriptException : JintException
                 return;
             }
 
-            // Does the Error object already have a stack property?
-            if (errObj.HasProperty(CommonProperties.Stack) && !overwriteExisting)
+            // Does the Error object already carry a usable stack? HasProperty walks the prototype chain, and
+            // %Error.prototype% exposes "stack" as an accessor (error-stack-accessor proposal) that returns
+            // undefined for receivers without [[ErrorData]] — e.g. `Object.create(Error.prototype)` subclasses
+            // such as WPT idlharness's IdlHarnessError. Only a string value counts as an existing stack;
+            // anything else falls through to building one, instead of failing AsString() with a CLR
+            // ArgumentException escaping out of an ordinary JavaScript `throw`.
+            var existingStack = !overwriteExisting && errObj.HasProperty(CommonProperties.Stack)
+                ? errObj.Get(CommonProperties.Stack)
+                : JsValue.Undefined;
+            if (existingStack.IsString())
             {
-                _callStack = errObj.Get(CommonProperties.Stack).AsString();
+                _callStack = existingStack.AsString();
             }
             else
             {


### PR DESCRIPTION
Backport of #3607 to 4.x: correctness fix, no API or default change. On 4.x `stack` is already the `%Error.prototype%` accessor and `SetCallstack` has the same `HasProperty` line, so an uncaught throw of an `Object.create(Error.prototype)` subclass instance reaches the host as `ArgumentException: Expected string but got Undefined` there too.

Evidence: the two tests from #3607 fail on unfixed 4.x (2 failed / 34 passed in `ErrorTests`) on both net10.0 and net472, and pass with the fix on both. Attributes converted to xUnit, which this branch's `Jint.Tests` still uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
