### PR TITLE
DevTools: a target outlives its engine, and a host can mint one

### DIFF
--- a/Jint.DevTools/AGENTS.md
+++ b/Jint.DevTools/AGENTS.md
@@ -102,9 +102,58 @@ Three decisions worth not relitigating:
 - **`setAutoAttach` on an attached session is a success that attaches nothing.** Clients walk the target
   tree by sending it on every session they are handed; an engine has no children, and a refusal there
   reads as a broken target.
-- **A browser context is not something an engine target has.** `getBrowserContexts` answers an empty list;
-  `createBrowserContext` and `disposeBrowserContext` answer `-32000` with the reason, because minting an
-  identifier that partitions nothing would tell a client its next target was isolated when it is not.
+- **A browser context is not something an engine target has.** With no `ITargetHost` registered,
+  `getBrowserContexts` answers an empty list and `createBrowserContext` / `disposeBrowserContext` answer
+  `-32000` with the reason, because minting an identifier that partitions nothing would tell a client its
+  next target was isolated when it is not.
+
+### A target outlives its engine
+
+`DevToolsTarget` is the identity a client keeps addressing; `TargetRuntime` is one engine and everything that
+dies with it. An `EngineTarget` has one runtime for its whole life. A page has one **per navigation**:
+committing a document builds an engine and hands it to `DevToolsTarget.Replace`, which disposes the previous
+runtime, installs the new one, re-installs the bindings and tells every domain through
+`ITargetObserver.RuntimeReplaced`.
+
+What is on which side is the whole of the split, and putting something on the wrong one is how a client is
+answered about a document that has gone:
+
+- **The target**: `TargetId`, `Type`, `Title`, `Url`, `BrowserContextId`, `OpenerId`, the observer list, the
+  `Describer`, the `BindingRegistry` (a `Runtime.addBinding` name is re-installed into every new engine
+  *before* any script of the new document runs), the `WaitingForDebugger` state, the command and pause
+  timeouts, and the execution-context counter.
+- **The runtime**: the `Engine`, the `EngineDispatcher`, the `RemoteObjectTable`, the `ScriptRegistry`, the
+  `CompiledScriptRegistry`, the `ConsoleJournal`, the console-sink binding, the promise-rejection
+  subscription, and the default execution context's identifier.
+
+Four consequences:
+
+- **A domain holds the target and reads `target.Runtime` per command.** A cached engine, object table or
+  script registry is a domain still answering about the last document.
+- **The gateway is the target, not a mailbox.** `TargetSession` calls `UseGateway(target)` and the target
+  forwards to the current runtime's dispatcher, so a command is queued on the engine that is running now. A
+  command already queued on the engine being replaced is answered `-32000 "Execution context was
+  destroyed."` rather than left to the client's own timeout.
+- **The context counter is the target's**, so the second document's default context is `2` and never `1`
+  again. That is what makes a stale `contextId` distinguishable, and `DevToolsTarget.RequireContext` answers
+  one with `-32000 "Cannot find context with specified id"` — Chrome's text, which the recordings show
+  PuppeteerSharp receiving and coping with. Every table is seeded from a process-wide serial for the same
+  reason: an `objectId` or a `scriptId` from two documents ago must fail to resolve rather than land on a
+  value of the new engine.
+- **Isolated worlds are aliases.** `CreateWorldContext(name)` mints an extra context identifier over the
+  *current* realm and announces it with `auxData: { isDefault: false, type: "isolated", frameId }`. There is
+  one realm per document, so a world is a name for it and not an isolate; it buys a client its own
+  identifier to address and none of the isolation the name promises, and it lasts until the next navigation.
+
+`ITargetHost` is what mints a target when a client asks for one. `DevToolsServer.UseHost` registers it, and
+`Target.createTarget` / `closeTarget` / `createBrowserContext` / `disposeBrowserContext` / `getBrowserContexts`
+route through it; with none registered they behave exactly as they did. A target created while the asking
+session had `setAutoAttach(waitForDebuggerOnStart: true)` is created **waiting** — the flag rides
+`TargetCreationRequest` rather than being applied afterwards, because a host that navigates as it creates
+would otherwise have run the first document before anybody could hold it — and
+`attachedToTarget.waitingForDebugger` tells the client it must send `Runtime.runIfWaitingForDebugger`.
+`DevToolsTarget.RegisterDomains` is virtual so a subclass adds its own domains next to the built-in five, and
+`Describe` is the one `TargetInfo` both `/json/list` and `Target.getTargets` are written from.
 
 ### The pause loop
 

--- a/Jint.DevTools/DevToolsConsoleSink.cs
+++ b/Jint.DevTools/DevToolsConsoleSink.cs
@@ -32,7 +32,7 @@ internal sealed class DevToolsConsoleSink : ConsoleSink
     private readonly ConsoleSink _inner;
 
     private Engine? _engine;
-    private EngineTarget? _target;
+    private DevToolsTarget? _target;
 
     internal DevToolsConsoleSink(ConsoleSink? inner)
     {
@@ -40,21 +40,23 @@ internal sealed class DevToolsConsoleSink : ConsoleSink
     }
 
     /// <summary>Binds this sink to <paramref name="target"/>, unless it already speaks for another engine.</summary>
+    /// <param name="target">The target the records reach.</param>
+    /// <param name="engine">The engine this sink was read out of, which is the one it may speak for.</param>
     /// <returns><see langword="true"/> when console records from now on reach <paramref name="target"/>.</returns>
-    internal bool TryBind(EngineTarget target)
+    internal bool TryBind(DevToolsTarget target, Engine engine)
     {
-        if (_engine is not null && !ReferenceEquals(_engine, target.Engine))
+        if (_engine is not null && !ReferenceEquals(_engine, engine))
         {
             return false;
         }
 
-        _engine = target.Engine;
+        _engine = engine;
         _target = target;
         return true;
     }
 
     /// <summary>Stops speaking for <paramref name="target"/>, if it is the one bound.</summary>
-    internal void Unbind(EngineTarget target)
+    internal void Unbind(DevToolsTarget target)
     {
         if (ReferenceEquals(_target, target))
         {

--- a/Jint.DevTools/DevToolsServer.cs
+++ b/Jint.DevTools/DevToolsServer.cs
@@ -44,12 +44,13 @@ namespace Jint.DevTools;
 /// </example>
 public sealed class DevToolsServer : IAsyncDisposable
 {
-    private readonly List<EngineTarget> _targets = [];
-    private readonly List<EngineTarget> _owned = [];
+    private readonly List<DevToolsTarget> _targets = [];
+    private readonly List<DevToolsTarget> _owned = [];
     private readonly List<BrowserSession> _browserSessions = [];
     private readonly object _lock = new();
 
     private WebSocketServerTransport? _transport;
+    private ITargetHost? _host;
     private int _disposed;
 
     /// <summary>Creates a server over <paramref name="options"/>.</summary>
@@ -86,8 +87,25 @@ public sealed class DevToolsServer : IAsyncDisposable
         }
     }
 
-    /// <summary>Gets the targets a client can list and attach to, oldest first.</summary>
+    /// <summary>Gets the engine targets a client can list and attach to, oldest first.</summary>
+    /// <remarks>
+    /// The engine targets only. A package layered on this one publishes targets of its own — a page is one —
+    /// and those are not <see cref="EngineTarget"/>s; a host that wants the whole list asks the package that
+    /// added them, which is the one that knows what they are.
+    /// </remarks>
     public IReadOnlyList<EngineTarget> Targets
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return [.. _targets.OfType<EngineTarget>()];
+            }
+        }
+    }
+
+    /// <summary>Gets every published target, whatever kind, oldest first.</summary>
+    internal IReadOnlyList<DevToolsTarget> AllTargets
     {
         get
         {
@@ -97,6 +115,9 @@ public sealed class DevToolsServer : IAsyncDisposable
             }
         }
     }
+
+    /// <summary>Gets what mints targets and browser contexts at a client's request, or <see langword="null"/>.</summary>
+    internal ITargetHost? Host => _host;
 
     /// <summary>Gets how this server is configured.</summary>
     internal DevToolsServerOptions Options { get; }
@@ -147,7 +168,10 @@ public sealed class DevToolsServer : IAsyncDisposable
     /// </remarks>
     /// <exception cref="ArgumentNullException"><paramref name="target"/> is <see langword="null"/>.</exception>
     /// <exception cref="ObjectDisposedException">The server has been disposed.</exception>
-    public void AddTarget(EngineTarget target)
+    public void AddTarget(EngineTarget target) => AddTarget((DevToolsTarget?) target);
+
+    /// <inheritdoc cref="AddTarget(EngineTarget)"/>
+    internal void AddTarget(DevToolsTarget? target)
     {
         if (target is null)
         {
@@ -168,15 +192,37 @@ public sealed class DevToolsServer : IAsyncDisposable
             sessions = _browserSessions.ToArray();
         }
 
-        // The bound is the server's rather than the target's: a target may well have been built before the
+        // The bounds are the server's rather than the target's: a target may well have been built before the
         // server it ends up on.
-        target.Dispatcher.CommandTimeout = Options.CommandTimeout;
+        target.CommandTimeout = Options.CommandTimeout;
         target.PauseTimeout = Options.PauseTimeout;
+        target.InfoChanged = OnTargetInfoChanged;
 
         foreach (var session in sessions)
         {
             Complete(session.TargetAddedAsync(target, CancellationToken.None));
         }
+    }
+
+    /// <summary>Registers what mints targets and browser contexts when a client asks for one.</summary>
+    /// <param name="host">The package that owns them.</param>
+    /// <remarks>
+    /// One host per server, and registering one changes what <c>Target.createTarget</c>,
+    /// <c>Target.closeTarget</c> and the two browser-context commands mean and nothing else.
+    /// </remarks>
+    internal void UseHost(ITargetHost host)
+    {
+        if (host is null)
+        {
+            Throw.ArgumentNull(nameof(host));
+        }
+
+        if (_host is not null && !ReferenceEquals(_host, host))
+        {
+            Throw.InvalidOperation("The server already has a target host; one server mints targets one way.");
+        }
+
+        _host = host;
     }
 
     /// <summary>Removes a target, telling every connected client that it went away.</summary>
@@ -187,7 +233,10 @@ public sealed class DevToolsServer : IAsyncDisposable
     /// told the target did. The <see cref="EngineTarget"/> itself is not disposed: it is the host's.
     /// </remarks>
     /// <exception cref="ArgumentNullException"><paramref name="target"/> is <see langword="null"/>.</exception>
-    public bool RemoveTarget(EngineTarget target)
+    public bool RemoveTarget(EngineTarget target) => RemoveTarget((DevToolsTarget?) target);
+
+    /// <inheritdoc cref="RemoveTarget(EngineTarget)"/>
+    internal bool RemoveTarget(DevToolsTarget? target)
     {
         if (target is null)
         {
@@ -205,12 +254,29 @@ public sealed class DevToolsServer : IAsyncDisposable
             sessions = _browserSessions.ToArray();
         }
 
+        target.InfoChanged = null;
+
         foreach (var session in sessions)
         {
             Complete(session.TargetRemovedAsync(target, CancellationToken.None));
         }
 
         return true;
+    }
+
+    /// <summary>Tells every conversation that a target's title or location moved.</summary>
+    private void OnTargetInfoChanged(DevToolsTarget target)
+    {
+        BrowserSession[] sessions;
+        lock (_lock)
+        {
+            sessions = _browserSessions.ToArray();
+        }
+
+        foreach (var session in sessions)
+        {
+            Complete(session.TargetInfoChangedAsync(target, CancellationToken.None));
+        }
     }
 
     /// <inheritdoc/>
@@ -226,7 +292,7 @@ public sealed class DevToolsServer : IAsyncDisposable
             await transport.DisposeAsync().ConfigureAwait(false);
         }
 
-        EngineTarget[] owned;
+        DevToolsTarget[] owned;
         lock (_lock)
         {
             owned = _owned.ToArray();
@@ -239,12 +305,12 @@ public sealed class DevToolsServer : IAsyncDisposable
         // stopping its thread would be this package deciding the lifetime of something it does not own.
         foreach (var target in owned)
         {
-            await target.DisposeAsync().ConfigureAwait(false);
+            await target.CloseAsync().ConfigureAwait(false);
         }
     }
 
     /// <summary>Finds a published target by the identifier a client addresses it with.</summary>
-    internal EngineTarget? FindTarget(string targetId)
+    internal DevToolsTarget? FindTarget(string targetId)
     {
         lock (_lock)
         {
@@ -287,8 +353,12 @@ public sealed class DevToolsServer : IAsyncDisposable
         return target;
     }
 
-    /// <summary>Removes a target at a client's request, disposing it when the server made it.</summary>
-    internal async ValueTask CloseTargetAsync(EngineTarget target)
+    /// <summary>Removes a target at a client's request, closing it when this server is what made it.</summary>
+    /// <remarks>
+    /// A target a host registered goes back to that host to close, because the host is what knows how: a page
+    /// has a loop to stop and a document to release, and the server knows about neither.
+    /// </remarks>
+    internal async ValueTask CloseTargetAsync(DevToolsTarget target, CancellationToken cancellationToken = default)
     {
         RemoveTarget(target);
 
@@ -300,7 +370,13 @@ public sealed class DevToolsServer : IAsyncDisposable
 
         if (owned)
         {
-            await target.DisposeAsync().ConfigureAwait(false);
+            await target.CloseAsync().ConfigureAwait(false);
+            return;
+        }
+
+        if (_host is { } host)
+        {
+            await host.CloseTargetAsync(target, cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -321,7 +397,7 @@ public sealed class DevToolsServer : IAsyncDisposable
     }
 
     /// <summary>Opens a conversation with one target over <paramref name="connection"/>, with no sessions in it.</summary>
-    internal static TargetSession OpenTargetSession(IDevToolsConnection connection, EngineTarget target)
+    internal static TargetSession OpenTargetSession(IDevToolsConnection connection, DevToolsTarget target)
     {
         return TargetSession.Direct(new DevToolsSession(connection), target);
     }

--- a/Jint.DevTools/DevToolsTarget.cs
+++ b/Jint.DevTools/DevToolsTarget.cs
@@ -1,0 +1,437 @@
+using System.Globalization;
+using System.Runtime.InteropServices;
+using Jint.DevTools.Domains;
+using Jint.DevTools.Protocol;
+using Jint.DevTools.Protocol.Target;
+using Jint.DevTools.Session;
+using Jint.Runtime;
+using Jint.WebApi;
+
+namespace Jint.DevTools;
+
+/// <summary>
+/// One thing a client can list, attach to and evaluate in — and which may outlive the engine behind it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>A target is an identity; an engine is a document.</b> An <see cref="EngineTarget"/> has one engine for
+/// its whole life, and a page target has one <i>per navigation</i>: committing a document builds a new
+/// engine and hands it to <see cref="Replace"/>. So this class carries what a client keeps addressing across
+/// that — the identifier, the type, the title and location, the browser context, the bindings
+/// <c>Runtime.addBinding</c> installed, whether the target is still waiting for a debugger — and
+/// <see cref="Runtime"/> carries everything that dies with one engine.
+/// </para>
+/// <para>
+/// <b>A domain holds the target and reads <see cref="Runtime"/> per command.</b> A domain that cached the
+/// engine, the object table or the script registry would go on answering about a document that has been
+/// replaced, which is the one mistake this split exists to make impossible.
+/// </para>
+/// <para>
+/// It is also the gateway every command addressed to the target crosses, so that the mailbox a request is
+/// queued on is always the current engine's. The thread rule is unchanged: a <c>JsValue</c> never leaves the
+/// engine thread and a transport thread only ever moves strings.
+/// </para>
+/// </remarks>
+#pragma warning disable CA1001 // the runtime is released through CloseAsync, which a target has instead of Dispose
+public abstract class DevToolsTarget : ICommandGateway
+#pragma warning restore CA1001
+{
+    private readonly object _observerLock = new();
+    private readonly object _worldLock = new();
+    private readonly List<TargetWorld> _worlds = [];
+
+    private ITargetObserver[] _observers = [];
+    private DebuggerDomain? _debugger;
+    private TargetRuntime _runtime = null!;
+    private int _nextExecutionContextId;
+    private int _waitingForDebugger;
+
+    /// <summary>Creates a target of <paramref name="type"/>.</summary>
+    /// <param name="type">The protocol's target type: <c>node</c> for an engine, <c>page</c> for a page.</param>
+    /// <param name="title">The name a client lists the target under.</param>
+    /// <param name="url">The location a client shows for the target.</param>
+    /// <param name="browserContextId">Which context the target belongs to, or <see langword="null"/>.</param>
+    /// <param name="openerId">Which target opened this one, or <see langword="null"/>.</param>
+    /// <param name="describer">What names a value this package does not recognize, or <see langword="null"/>.</param>
+    /// <param name="waitForDebuggerOnStart">Whether the target runs nothing until a client releases it.</param>
+    private protected DevToolsTarget(
+        string type,
+        string title,
+        string url,
+        string? browserContextId,
+        string? openerId,
+        RemoteObjectDescriber? describer,
+        bool waitForDebuggerOnStart)
+    {
+        TargetId = Identifiers.New();
+        Type = type;
+        Title = title;
+        Url = url;
+        BrowserContextId = browserContextId;
+        OpenerId = openerId;
+        Describer = describer;
+        _waitingForDebugger = waitForDebuggerOnStart ? 1 : 0;
+    }
+
+    /// <summary>Raised on the engine thread the first time the wait for a debugger ends.</summary>
+    internal event Action? DebuggerWaitEnded;
+
+    /// <summary>Gets the opaque identifier a client addresses this target by.</summary>
+    internal string TargetId { get; }
+
+    /// <summary>Gets the target's protocol type.</summary>
+    internal string Type { get; }
+
+    /// <summary>Gets the name a client lists the target under.</summary>
+    internal string Title { get; private set; }
+
+    /// <summary>Gets the location a client shows for the target.</summary>
+    internal string Url { get; private set; }
+
+    /// <summary>Gets the browser context this target belongs to, or <see langword="null"/> for none.</summary>
+    /// <remarks>
+    /// An engine target has none and says so: a context partitions cookies, storage and a cache, and an
+    /// engine has none of the three. A page target belongs to exactly one.
+    /// </remarks>
+    internal string? BrowserContextId { get; }
+
+    /// <summary>Gets which target opened this one, or <see langword="null"/>.</summary>
+    internal string? OpenerId { get; }
+
+    /// <summary>Gets what names a value this package does not recognize, or <see langword="null"/>.</summary>
+    internal RemoteObjectDescriber? Describer { get; }
+
+    /// <summary>Gets the global functions <c>Runtime.addBinding</c> installed, and who hears them.</summary>
+    /// <remarks>
+    /// <b>On the target, so that a binding survives a navigation.</b> A client installs one and then expects
+    /// the page it is about to load to be able to call it; re-installing into every new engine before any of
+    /// its script runs is what makes that true, and is what <see cref="Replace"/> does.
+    /// </remarks>
+    internal BindingRegistry Bindings { get; } = new();
+
+    /// <summary>Gets the engine a client is evaluating in, and everything that dies with it.</summary>
+    internal TargetRuntime Runtime => _runtime;
+
+    /// <summary>Gets whether work posted to the target is still held for a client that has not released it.</summary>
+    internal bool IsWaitingForDebugger => Volatile.Read(ref _waitingForDebugger) != 0;
+
+    /// <summary>Gets or sets how long a client waits for one command before it is told nothing is pumping.</summary>
+    /// <remarks>
+    /// The bound belongs to the server a target is published on, and a target may exist before that server
+    /// does — so it is settable, and it lives here rather than on the mailbox because the mailbox is
+    /// replaced with the engine and the bound is not.
+    /// </remarks>
+    internal TimeSpan CommandTimeout { get; set; } = DevToolsServerOptions.DefaultCommandTimeout;
+
+    /// <summary>Gets or sets how long the engine may stay paused with no client saying what to do next.</summary>
+    /// <inheritdoc cref="CommandTimeout" path="/remarks"/>
+    internal TimeSpan PauseTimeout { get; set; } = DevToolsServerOptions.DefaultPauseTimeout;
+
+    /// <summary>Gets the token that is cancelled when the target stops running, if it has one.</summary>
+    internal virtual CancellationToken StoppingToken => CancellationToken.None;
+
+    /// <summary>Gets what to tell when this target's title or location changes, set by the server.</summary>
+    internal Action<DevToolsTarget>? InfoChanged { get; set; }
+
+    /// <summary>Gets everything currently listening to what the engine says without being asked.</summary>
+    internal ITargetObserver[] Observers => Volatile.Read(ref _observers);
+
+    /// <summary>Gets the one attachment that has the <c>Debugger</c> domain enabled, if any.</summary>
+    /// <remarks>
+    /// <b>One at a time, which is a documented divergence from Chrome.</b> Breakpoints and the step mode live
+    /// on the engine's own <c>DebugHandler</c> rather than per session, so a second client enabling the domain
+    /// would silently share the first one's breakpoints and steal its pauses. It is refused instead.
+    /// </remarks>
+    internal DebuggerDomain? ActiveDebugger => Volatile.Read(ref _debugger);
+
+    /// <summary>Gets whether the engine is currently stopped inside the debugger.</summary>
+    internal bool IsPaused => Volatile.Read(ref _debugger)?.IsPaused == true;
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Read per command rather than captured, because the mailbox belongs to the engine and the engine is
+    /// replaced under the target on every navigation.
+    /// </remarks>
+    ValueTask<string> ICommandGateway.DispatchAsync(DevToolsSession session, ProtocolRequest request, CommandContext context)
+        => _runtime.Dispatcher.DispatchAsync(session, request, context);
+
+    /// <summary>Registers what one attachment to this target answers, on <paramref name="session"/>.</summary>
+    /// <param name="session">The session node the attachment answers on.</param>
+    /// <param name="browser">The conversation it belongs to, or <see langword="null"/> for a direct connection.</param>
+    /// <remarks>
+    /// Virtual so that a subclass adds its own domains next to the built-in five: a page target registers
+    /// <c>Page</c>, <c>Emulation</c> and their kind here, over the same session core.
+    /// </remarks>
+    internal virtual TargetDomains RegisterDomains(DevToolsSession session, BrowserSession? browser)
+        => BuiltInDomains.RegisterTargetDomains(session, this, browser);
+
+    /// <summary>Replaces the engine under this target, which is what committing a document means.</summary>
+    /// <param name="engine">The engine the next document runs in.</param>
+    /// <remarks>
+    /// <para>
+    /// In order, and every step of the order matters. The previous runtime is disposed first, so that a
+    /// handle, a script identifier and a queued command of the document that is going all end before the one
+    /// arriving is announced. The isolated worlds go with it, because a world is a name for the realm of the
+    /// document that minted it. The bindings are re-installed <b>before</b> the observers hear about the
+    /// swap, so that a client told about the new context can already call what it added.
+    /// </para>
+    /// <para>
+    /// Runs on the thread that owns both engines — the page loop — like everything else that touches one.
+    /// </para>
+    /// </remarks>
+    internal void Replace(Engine engine)
+    {
+        if (engine is null)
+        {
+            Throw.ArgumentNull(nameof(engine));
+        }
+
+        var previous = _runtime;
+        var next = new TargetRuntime(this, engine, Interlocked.Increment(ref _nextExecutionContextId));
+
+        lock (_worldLock)
+        {
+            _worlds.Clear();
+        }
+
+        _runtime = next;
+        previous?.Dispose();
+
+        Bindings.Reinstall(engine);
+
+        foreach (var observer in Observers)
+        {
+            observer.RuntimeReplaced(next);
+        }
+    }
+
+    /// <summary>Mints a context identifier that names the current document's realm under a name.</summary>
+    /// <param name="worldName">The name a client asked for, which may be empty.</param>
+    /// <returns>The world, whose identifier a client may then evaluate against.</returns>
+    /// <remarks>
+    /// <b>An isolated world here is an alias, and that is a documented divergence.</b> A browser gives a
+    /// world a realm of its own, so a script running in it cannot see the page's globals; there is one realm
+    /// per document here, and a world is a second name for it. It buys a client its own
+    /// <c>executionContextId</c> to address — which is what Puppeteer and Playwright use it for — and it
+    /// buys none of the isolation the name promises. The alias lasts until the next navigation, because the
+    /// realm it names does.
+    /// </remarks>
+    internal TargetWorld CreateWorldContext(string? worldName)
+    {
+        var world = new TargetWorld(
+            Interlocked.Increment(ref _nextExecutionContextId),
+            worldName ?? "",
+            TargetId);
+
+        lock (_worldLock)
+        {
+            _worlds.Add(world);
+        }
+
+        foreach (var observer in Observers)
+        {
+            observer.WorldCreated(world);
+        }
+
+        return world;
+    }
+
+    /// <summary>Answers every isolated world of the current document, oldest first.</summary>
+    internal TargetWorld[] Worlds
+    {
+        get
+        {
+            lock (_worldLock)
+            {
+                return _worlds.Count == 0 ? [] : [.. _worlds];
+            }
+        }
+    }
+
+    /// <summary>
+    /// Refuses a context identifier that is not one of this target's, in Chrome's own wording.
+    /// </summary>
+    /// <param name="contextId">What the client sent, or <see langword="null"/> for "wherever you are".</param>
+    /// <exception cref="ProtocolException">
+    /// <c>-32000 Cannot find context with specified id</c>, which is what a client matches on to decide the
+    /// context it was addressing went away rather than that it called the command wrongly. A navigation is
+    /// exactly that: the identifier a client read off the last <c>executionContextCreated</c> stops meaning
+    /// anything the moment the next document commits.
+    /// </exception>
+    internal void RequireContext(int? contextId)
+    {
+        if (contextId is not { } id || id == _runtime.ExecutionContextId)
+        {
+            return;
+        }
+
+        lock (_worldLock)
+        {
+            foreach (var world in _worlds)
+            {
+                if (world.Id == id)
+                {
+                    return;
+                }
+            }
+        }
+
+        Throw.ServerError("Cannot find context with specified id");
+    }
+
+    /// <summary>Registers what hears the engine's own events, from the attachment that owns them.</summary>
+    internal void Observe(ITargetObserver observer)
+    {
+        lock (_observerLock)
+        {
+            _observers = [.. _observers, observer];
+        }
+    }
+
+    /// <summary>Stops telling <paramref name="observer"/> anything, which is what detaching means.</summary>
+    internal void Unobserve(ITargetObserver observer)
+    {
+        lock (_observerLock)
+        {
+            _observers = [.. _observers.Where(candidate => !ReferenceEquals(candidate, observer))];
+        }
+    }
+
+    /// <summary>Claims the debugger for <paramref name="domain"/>, answering whether it now has it.</summary>
+    internal bool TryClaimDebugger(DebuggerDomain domain)
+    {
+        var existing = Interlocked.CompareExchange(ref _debugger, domain, null);
+        return existing is null || ReferenceEquals(existing, domain);
+    }
+
+    /// <summary>Gives the debugger back, if <paramref name="domain"/> is what held it.</summary>
+    internal void ReleaseDebugger(DebuggerDomain domain)
+    {
+        Interlocked.CompareExchange(ref _debugger, null, domain);
+    }
+
+    /// <summary>Journals one <c>console</c> call and tells everyone attached, on the engine thread.</summary>
+    internal void Record(in ConsoleRecord record)
+    {
+        var runtime = _runtime;
+        var entry = runtime.Console.Add(in record, UnixMilliseconds(), runtime.RemoteObjects);
+
+        foreach (var observer in Observers)
+        {
+            observer.ConsoleRecorded(entry);
+        }
+    }
+
+    /// <summary>Reports one exception that escaped the engine, so that every attached client hears it.</summary>
+    internal void ReportUncaughtException(JavaScriptException exception)
+    {
+        if (exception is null)
+        {
+            Throw.ArgumentNull(nameof(exception));
+        }
+
+        foreach (var observer in Observers)
+        {
+            observer.ExceptionThrown(exception);
+        }
+    }
+
+    /// <summary>
+    /// Ends the wait for a debugger, releasing whatever host work was held. Idempotent, and a no-op on a
+    /// target that was never waiting.
+    /// </summary>
+    internal void ReleaseDebuggerWait()
+    {
+        if (Interlocked.Exchange(ref _waitingForDebugger, 0) == 0)
+        {
+            return;
+        }
+
+        DebuggerWaitEnded?.Invoke();
+        _runtime.Dispatcher.ScheduleDrain();
+    }
+
+    /// <summary>Holds every posted host work until a client sends <c>Runtime.runIfWaitingForDebugger</c>.</summary>
+    /// <remarks>
+    /// What <c>Target.setAutoAttach(waitForDebuggerOnStart: true)</c> followed by <c>Target.createTarget</c>
+    /// means: the target exists and runs nothing. Called before the target is published, so that no work has
+    /// been posted to it yet.
+    /// </remarks>
+    internal void HoldForDebugger() => Interlocked.Exchange(ref _waitingForDebugger, 1);
+
+    /// <summary>Changes what a client is told this target is showing, announcing it if anything moved.</summary>
+    /// <param name="title">The new title, or <see langword="null"/> to leave it.</param>
+    /// <param name="url">The new location, or <see langword="null"/> to leave it.</param>
+    internal void UpdateInfo(string? title = null, string? url = null)
+    {
+        var changed = false;
+
+        if (title is not null && !string.Equals(Title, title, StringComparison.Ordinal))
+        {
+            Title = title;
+            changed = true;
+        }
+
+        if (url is not null && !string.Equals(Url, url, StringComparison.Ordinal))
+        {
+            Url = url;
+            changed = true;
+        }
+
+        if (changed)
+        {
+            InfoChanged?.Invoke(this);
+        }
+    }
+
+    /// <summary>Describes this target the way both <c>/json/list</c> and <c>Target.getTargets</c> do.</summary>
+    /// <param name="attached">Whether the asking conversation is attached to it.</param>
+    /// <remarks>
+    /// One description rather than two, because a client that reads the discovery document and then asks the
+    /// same question over the socket must not be told two different things about one target.
+    /// </remarks>
+    internal TargetInfo Describe(bool attached) => new()
+    {
+        TargetId = TargetId,
+        Type = Type,
+        Title = Title,
+        Url = Url,
+        Attached = attached,
+        BrowserContextId = BrowserContextId,
+        OpenerId = OpenerId,
+        CanAccessOpener = false,
+    };
+
+    /// <summary>Closes the target, releasing what it holds. Idempotent.</summary>
+    internal abstract ValueTask CloseAsync();
+
+    /// <summary>The protocol's timestamp: milliseconds since the Unix epoch, as a double.</summary>
+    internal static double UnixMilliseconds() => DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+
+    /// <summary>Installs the first runtime, which a subclass does once its engine exists.</summary>
+    /// <remarks>
+    /// Separate from the constructor because a subclass may have to build its engine after the target it
+    /// belongs to: a page target is registered, observed and only then given the engine of its first
+    /// document.
+    /// </remarks>
+    private protected void InstallRuntime(Engine engine)
+    {
+        _runtime = new TargetRuntime(this, engine, Interlocked.Increment(ref _nextExecutionContextId));
+    }
+
+    /// <summary>Releases the current runtime, which is what disposing a target means.</summary>
+    private protected void DisposeRuntime() => _runtime?.Dispose();
+}
+
+/// <summary>
+/// One isolated world of the current document: a context identifier and the name a client asked for.
+/// </summary>
+/// <param name="Id">The execution-context identifier a client evaluates against.</param>
+/// <param name="Name">The name the client gave the world, which may be empty.</param>
+/// <param name="TargetId">The target the world belongs to, which its unique identifier is built from.</param>
+[StructLayout(LayoutKind.Auto)]
+internal readonly record struct TargetWorld(int Id, string Name, string TargetId)
+{
+    /// <summary>Gets the opaque identifier a client tells two contexts apart by.</summary>
+    internal string UniqueId => TargetId + "." + Id.ToString(CultureInfo.InvariantCulture);
+}

--- a/Jint.DevTools/Domains/AGENTS.md
+++ b/Jint.DevTools/Domains/AGENTS.md
@@ -18,14 +18,16 @@ A client cannot hold a `JsValue`, so it holds an `objectId` and the server holds
 promise — **the value will still be there when you come back** — is the whole of
 `Domains/RemoteObjectTable.cs`, and everything about handles follows from it:
 
-- **The table is on the `EngineTarget`, ownership is per attachment.** The values belong to the engine, so
+- **The table is on the `TargetRuntime`, ownership is per attachment.** The values belong to the engine, so
   two sessions address the same value by the same identifier; each entry remembers which attachment
-  registered it, so detaching releases that attachment's handles and nobody else's.
+  registered it, so detaching releases that attachment's handles and nobody else's. It is on the runtime and
+  not the target because a navigation replaces the engine and every value in it: a client that comes back
+  with a handle from the document before is told the object cannot be found, which is what Chrome tells it.
 - **Strong, never weak, never deduplicated.** A fresh identifier per wrap, which is V8's behaviour and what
   stops a client's release of one handle invalidating another it still holds.
-- **Four endings**: `releaseObject`, `releaseObjectGroup`, the attachment detaching, and the target being
-  disposed. Nothing expires on its own, and a client that leaks handles leaks engine values — the cost of
-  the promise rather than a defect in it.
+- **Five endings**: `releaseObject`, `releaseObjectGroup`, the attachment detaching, the target being
+  closed, and the engine being replaced under it. Nothing expires on its own, and a client that leaks handles
+  leaks engine values — the cost of the promise rather than a defect in it.
 - **A group is inherited on the way in.** `getProperties` and `callFunctionOn` bill the handles they mint to
   the group the receiver already belongs to, so `releaseObjectGroup` frees the tree a client walked rather
   than only its root. A group name is a client's own vocabulary, so a release is scoped to the attachment:
@@ -81,11 +83,22 @@ object's members are listed without their values, for the reason above.
 
 ### What a client hears without asking
 
-Three things reach a domain from *inside* the engine, on the engine thread, with no command to answer: a
-`console` call, an exception that escaped the pump, and a promise rejected with nothing to handle it.
-`ITargetObserver` is the one interface for all three and `EngineTarget` fans out to whoever is attached.
-They go out through `DevToolsDomain.EmitDetached`, which queues rather than writes, so nothing blocks the
-engine and no transport failure erupts out of the host's own pump.
+Five things reach a domain from *inside* the engine, on the engine thread, with no command to answer: a
+`console` call, an exception that escaped the pump, a promise rejected with nothing to handle it, the engine
+being replaced under the target, and an isolated world being minted over it. `ITargetObserver` is the one
+interface for all five and `DevToolsTarget` fans out to whoever is attached. They go out through
+`DevToolsDomain.EmitDetached`, which queues rather than writes, so nothing blocks the engine and no transport
+failure erupts out of the host's own pump.
+
+**`RuntimeReplaced` is the seam a navigation reaches every domain through**, and each of the five answers it
+differently. `Runtime` emits `executionContextsCleared` and then `executionContextCreated` for the new
+default context — Chrome's order, and the handles are already gone with the table. `Debugger` moves its
+`Break`/`Step` subscriptions onto the new engine, forgets where every request was *placed* (those named
+positions of an engine that no longer exists) and keeps the requests themselves, so a breakpoint set by URL
+is resolved again as the next document's scripts are parsed; the client's pause-on-exceptions state, its
+skip-all-pauses flag and its asynchronous stack depth carry over. `Profiler` ends whatever was recording and
+throws it away, because a profile over two engines answers a question nobody asked. `Console` and `Log` do
+nothing: the journal is the runtime's and went with it.
 
 **The console arrives through the sink, and the sink wraps rather than replaces.** `UseDevTools` installs a
 `DevToolsConsoleSink` around whatever `Options.WebApi.Console.Sink` the host had and forwards both overloads
@@ -125,7 +138,8 @@ handling: it writes to whoever is attached and returns.
 
 ### Scripts, breakpoints, and why one pause happened
 
-`Domains/ScriptRegistry.cs` is every program one engine has parsed, and three of its properties are load
+`Domains/ScriptRegistry.cs` is every program one engine has parsed — the *current* engine, since the
+registry is the `TargetRuntime`'s and a navigation starts a fresh one — and three of its properties are load
 bearing rather than incidental:
 
 - **Keyed on the `Program` by reference**, so a cached `Prepared<Script>` run a thousand times is one script

--- a/Jint.DevTools/Domains/BindingRegistry.cs
+++ b/Jint.DevTools/Domains/BindingRegistry.cs
@@ -53,6 +53,37 @@ internal sealed class BindingRegistry
     private readonly object _gate = new();
     private readonly Dictionary<string, List<IBindingListener>> _listeners = new(StringComparer.Ordinal);
 
+    /// <summary>
+    /// Installs every registered binding on <paramref name="engine"/>, which a navigation owes them.
+    /// </summary>
+    /// <param name="engine">The engine of the document about to run. Called on that engine's thread.</param>
+    /// <remarks>
+    /// <b>Before any script of the new document runs.</b> A client adds a binding and then expects the page
+    /// it is about to load to be able to call it — that is what <c>Runtime.addBinding</c> is for, and it is
+    /// how Puppeteer's <c>exposeFunction</c> survives a navigation. The registry is the target's, so this is
+    /// the one place where the two halves meet.
+    /// </remarks>
+    internal void Reinstall(Engine engine)
+    {
+        string[] names;
+
+        lock (_gate)
+        {
+            if (_listeners.Count == 0)
+            {
+                return;
+            }
+
+            names = new string[_listeners.Count];
+            _listeners.Keys.CopyTo(names, 0);
+        }
+
+        foreach (var name in names)
+        {
+            Install(engine, name);
+        }
+    }
+
     /// <summary>Installs the binding <paramref name="name"/> if it is not there, and subscribes <paramref name="listener"/>.</summary>
     /// <param name="engine">The engine whose global carries the function. Called on that engine's thread.</param>
     /// <param name="name">The function's name.</param>
@@ -76,11 +107,15 @@ internal sealed class BindingRegistry
             }
         }
 
-        if (!install)
+        if (install)
         {
-            return;
+            Install(engine, name);
         }
+    }
 
+    /// <summary>Puts one binding's function on <paramref name="engine"/>'s global.</summary>
+    private void Install(Engine engine, string name)
+    {
         engine.SetValue(name, new ClrFunction(engine, name, (_, arguments) =>
         {
             // Chrome refuses anything but one string here. This coerces instead: minting the realm's own

--- a/Jint.DevTools/Domains/BuiltInDomains.cs
+++ b/Jint.DevTools/Domains/BuiltInDomains.cs
@@ -19,6 +19,11 @@ namespace Jint.DevTools.Domains;
 /// on the transport thread. A target session answers about one engine and every command of it crosses to
 /// that engine's thread first.
 /// </para>
+/// <para>
+/// <b>A target may register more than these.</b> A page target adds <c>Page</c>, <c>Emulation</c> and their
+/// kind through <see cref="DevToolsTarget.RegisterDomains"/>, over the same session core; what this file
+/// settles is the five every target has whatever it is.
+/// </para>
 /// </remarks>
 internal static class BuiltInDomains
 {
@@ -44,9 +49,9 @@ internal static class BuiltInDomains
             .Register(targets);
     }
 
-    /// <summary>Registers what one attachment to one engine answers.</summary>
+    /// <summary>Registers what one attachment to one target answers.</summary>
     /// <param name="session">The session node the attachment answers on.</param>
-    /// <param name="target">The engine it speaks to.</param>
+    /// <param name="target">The target it speaks to.</param>
     /// <param name="browser">
     /// The conversation the attachment belongs to, or <see langword="null"/> for a direct
     /// <c>/devtools/page/</c> connection, which has no browser session and therefore no target tree.
@@ -55,7 +60,7 @@ internal static class BuiltInDomains
     /// The domains that hold engine state, which is what an attachment releases when it detaches: a handle
     /// is a promise to keep a value alive, and the client it was promised to has gone.
     /// </returns>
-    internal static TargetDomains RegisterTargetDomains(DevToolsSession session, EngineTarget target, BrowserSession? browser)
+    internal static TargetDomains RegisterTargetDomains(DevToolsSession session, DevToolsTarget target, BrowserSession? browser)
     {
         if (session is null)
         {
@@ -70,17 +75,19 @@ internal static class BuiltInDomains
 
         session.Register(runtime).Register(console).Register(log).Register(debugger).Register(profiler);
 
-        // Registered with the engine's own event sources in one place, so that the three domains that hear
-        // about a console call, an uncaught exception or an unhandled rejection are exactly the three the
-        // attachment releases again when it detaches.
+        // Registered with the engine's own event sources in one place, so that the domains that hear about a
+        // console call, an uncaught exception, an unhandled rejection or the engine being replaced under the
+        // target are exactly the ones the attachment releases again when it detaches.
         target.Observe(runtime);
         target.Observe(console);
         target.Observe(log);
+        target.Observe(debugger);
+        target.Observe(profiler);
 
         if (browser is not null)
         {
             // Clients walk down the target tree by sending setAutoAttach on every session they are given.
-            // An engine target has no children, so the nested copy answers it as the success it is.
+            // A target here has no children, so the nested copy answers it as the success it is.
             session.Register(new TargetDomain(browser, nested: true));
         }
 
@@ -89,7 +96,21 @@ internal static class BuiltInDomains
 }
 
 /// <summary>
-/// The domains of one attachment that hold state of the engine behind it, so that detaching can give it
+/// One domain of an attachment that holds state of the target behind it, so that detaching can give it back.
+/// </summary>
+/// <remarks>
+/// What a target's own domains implement so that <see cref="TargetDomains.Detach"/> reaches them without
+/// knowing what they are. The built-in five are released by name, because what each of them owns is
+/// different and the order between two of them matters.
+/// </remarks>
+internal interface IDetachableDomain
+{
+    /// <summary>Releases what this attachment holds, from whichever thread noticed the client had gone.</summary>
+    void Detach();
+}
+
+/// <summary>
+/// The domains of one attachment that hold state of the target behind it, so that detaching can give it
 /// back.
 /// </summary>
 /// <remarks>
@@ -99,14 +120,21 @@ internal static class BuiltInDomains
 /// </remarks>
 [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Auto)]
 internal readonly record struct TargetDomains(
-    EngineTarget Target,
+    DevToolsTarget Target,
     RuntimeDomain Runtime,
     ConsoleDomain Console,
     LogDomain Log,
     DebuggerDomain Debugger,
     ProfilerDomain Profiler)
 {
-    /// <summary>Releases everything this attachment holds of its engine, and stops it hearing anything.</summary>
+    /// <summary>Gets whatever the target registered next to the built-in five, or <see langword="null"/>.</summary>
+    /// <remarks>
+    /// Every one of them is observed and released with the rest; the property exists so that a target's own
+    /// domains are part of the attachment rather than a second lifetime nothing tracks.
+    /// </remarks>
+    internal IReadOnlyList<DevToolsDomain>? Extra { get; init; }
+
+    /// <summary>Releases everything this attachment holds of its target, and stops it hearing anything.</summary>
     /// <remarks>
     /// <b>The debugger goes last, and that ordering is load-bearing.</b> Its release resumes an engine that
     /// is paused, and the engine thread comes straight back out of the pause loop into whatever it was
@@ -117,6 +145,21 @@ internal readonly record struct TargetDomains(
         Target.Unobserve(Runtime);
         Target.Unobserve(Console);
         Target.Unobserve(Log);
+        Target.Unobserve(Debugger);
+        Target.Unobserve(Profiler);
+
+        if (Extra is { } extra)
+        {
+            foreach (var domain in extra)
+            {
+                if (domain is ITargetObserver observer)
+                {
+                    Target.Unobserve(observer);
+                }
+
+                (domain as IDetachableDomain)?.Detach();
+            }
+        }
 
         Runtime.Detach();
         Profiler.Detach();

--- a/Jint.DevTools/Domains/CallArguments.cs
+++ b/Jint.DevTools/Domains/CallArguments.cs
@@ -24,7 +24,7 @@ namespace Jint.DevTools.Domains;
 internal static class CallArguments
 {
     /// <summary>Reads a whole argument list, resolving every handle it names.</summary>
-    internal static JsValue[] Resolve(EngineTarget target, CallArgument[]? arguments)
+    internal static JsValue[] Resolve(DevToolsTarget target, CallArgument[]? arguments)
     {
         if (arguments is null || arguments.Length == 0)
         {
@@ -41,11 +41,11 @@ internal static class CallArguments
     }
 
     /// <summary>Reads one argument.</summary>
-    internal static JsValue Resolve(EngineTarget target, CallArgument argument)
+    internal static JsValue Resolve(DevToolsTarget target, CallArgument argument)
     {
         if (argument.ObjectId is { } objectId)
         {
-            return target.RemoteObjects.Resolve(objectId);
+            return target.Runtime.RemoteObjects.Resolve(objectId);
         }
 
         if (argument.UnserializableValue is { } unserializable)
@@ -60,7 +60,7 @@ internal static class CallArguments
             return JsValue.Undefined;
         }
 
-        return new JsonParser(target.Engine).Parse(value.GetRawText());
+        return new JsonParser(target.Runtime.Engine).Parse(value.GetRawText());
     }
 
     private static JsValue Unserializable(string text) => text switch

--- a/Jint.DevTools/Domains/CompiledScriptRegistry.cs
+++ b/Jint.DevTools/Domains/CompiledScriptRegistry.cs
@@ -10,8 +10,8 @@ namespace Jint.DevTools.Domains;
 /// <remarks>
 /// <para>
 /// Two caches rather than one because they end differently. A persisted script is addressed by an
-/// identifier the client holds, so it lives until the target does; a function declaration is addressed by
-/// its own text, so it is a pure cache and evicting one costs a re-parse and nothing else.
+/// identifier the client holds, so it lives as long as the engine it would run in; a function declaration is
+/// addressed by its own text, so it is a pure cache and evicting one costs a re-parse and nothing else.
 /// </para>
 /// <para>
 /// The declaration cache is what makes the client path cheap rather than merely correct: a recorded

--- a/Jint.DevTools/Domains/ConsoleDomain.cs
+++ b/Jint.DevTools/Domains/ConsoleDomain.cs
@@ -28,9 +28,9 @@ namespace Jint.DevTools.Domains;
 /// </remarks>
 internal sealed class ConsoleDomain : ConsoleDomainBase, ITargetObserver
 {
-    private readonly EngineTarget _target;
+    private readonly DevToolsTarget _target;
 
-    internal ConsoleDomain(EngineTarget target)
+    internal ConsoleDomain(DevToolsTarget target)
     {
         _target = target;
     }
@@ -52,14 +52,14 @@ internal sealed class ConsoleDomain : ConsoleDomainBase, ITargetObserver
     /// <summary>Empties the journal, which is the same history <c>Runtime.discardConsoleEntries</c> discards.</summary>
     protected override ValueTask<EmptyResult> ClearMessagesAsync(EmptyParameters parameters, CommandContext context)
     {
-        _target.Console.Clear(_target.RemoteObjects);
+        _target.Runtime.Console.Clear(_target.Runtime.RemoteObjects);
         return new ValueTask<EmptyResult>(EmptyResult.Instance);
     }
 
     /// <summary>Sends what was logged before the client asked, which is what the command promises.</summary>
     protected override async ValueTask OnEnabledAsync(CommandContext context)
     {
-        foreach (var entry in _target.Console.Snapshot())
+        foreach (var entry in _target.Runtime.Console.Snapshot())
         {
             if (Message(entry) is { } message)
             {

--- a/Jint.DevTools/Domains/ConsoleJournal.cs
+++ b/Jint.DevTools/Domains/ConsoleJournal.cs
@@ -40,6 +40,25 @@ internal interface ITargetObserver
     void RejectionHandled(JsValue promise)
     {
     }
+
+    /// <summary>
+    /// The engine under the target has been replaced, which is what committing a document means.
+    /// </summary>
+    /// <param name="runtime">The engine a client is evaluating in from now on, and its fresh state.</param>
+    /// <remarks>
+    /// Every handle, script identifier and console entry of the document that is going has already been
+    /// released by the time this runs, so a domain's job here is to tell the client what it now has — a new
+    /// default execution context, a fresh set of parsed scripts — rather than to tidy up after the old one.
+    /// </remarks>
+    void RuntimeReplaced(TargetRuntime runtime)
+    {
+    }
+
+    /// <summary>An isolated world was minted over the current document's realm.</summary>
+    /// <param name="world">The alias, whose identifier a client may then evaluate against.</param>
+    void WorldCreated(TargetWorld world)
+    {
+    }
 }
 
 /// <summary>
@@ -159,8 +178,9 @@ internal sealed class ConsoleEntry
 /// minted for it released.
 /// </para>
 /// <para>
-/// It lives on the <see cref="EngineTarget"/>, because the values in it belong to the engine and every
-/// attachment replays the same history. <c>Runtime.discardConsoleEntries</c> and
+/// It lives on the <see cref="TargetRuntime"/>, because the values in it belong to <i>that</i> engine and
+/// every attachment replays the same history. A navigation therefore ends it: the next document starts with
+/// a console of its own, which is what a browser shows. <c>Runtime.discardConsoleEntries</c> and
 /// <c>Console.clearMessages</c> both empty it — which is what those commands mean, and why they are not the
 /// no-op they were.
 /// </para>

--- a/Jint.DevTools/Domains/DebuggerDomain.Breakpoints.cs
+++ b/Jint.DevTools/Domains/DebuggerDomain.Breakpoints.cs
@@ -83,7 +83,7 @@ internal sealed partial class DebuggerDomain
         Remember(request);
 
         var locations = new List<ProtocolLocation>();
-        foreach (var script in _target.Scripts!.Snapshot())
+        foreach (var script in _target.Runtime.Scripts!.Snapshot())
         {
             if (Place(request, script) is { } placed)
             {
@@ -147,7 +147,7 @@ internal sealed partial class DebuggerDomain
         // The engine's own switch, which makes every breakpoint fail to match without forgetting any of
         // them. It is the engine's rather than this session's, which is the same thing here: one session
         // debugs one engine.
-        _target.Engine.Debugger.BreakPoints.Active = parameters.Active;
+        _target.Runtime.Engine.Debugger.BreakPoints.Active = parameters.Active;
         return new ValueTask<EmptyResult>(EmptyResult.Instance);
     }
 
@@ -287,7 +287,7 @@ internal sealed partial class DebuggerDomain
             if (!live.Placed.Contains(breakLocation))
             {
                 live.Placed.Add(breakLocation);
-                _target.Engine.Debugger.BreakPoints.Set(new DevToolsBreakPoint(request.Id, breakLocation, request.Condition, request.IsOneShot));
+                _target.Runtime.Engine.Debugger.BreakPoints.Set(new DevToolsBreakPoint(request.Id, breakLocation, request.Condition, request.IsOneShot));
             }
         }
 
@@ -343,6 +343,26 @@ internal sealed partial class DebuggerDomain
         }
     }
 
+    /// <summary>
+    /// Forgets where every request was placed, because the engine that held those positions has gone.
+    /// </summary>
+    /// <remarks>
+    /// The requests themselves stay: a breakpoint is what the client asked for, and it is owed to the next
+    /// document as much as it was to this one. What cannot survive is the record of having placed it, which
+    /// named an engine's own breakpoint collection -- keeping it would make <see cref="Place"/> believe the
+    /// position was already set and leave the new engine with no breakpoint at all.
+    /// </remarks>
+    private void ForgetPlacedBreakpoints()
+    {
+        lock (_breakpointGate)
+        {
+            foreach (var request in _breakpoints.Values)
+            {
+                request.Placed.Clear();
+            }
+        }
+    }
+
     private void RemoveAllBreakpoints()
     {
         lock (_breakpointGate)
@@ -360,7 +380,7 @@ internal sealed partial class DebuggerDomain
     /// <remarks>Called under <c>_breakpointGate</c>, which is what keeps it and <see cref="Place"/> apart.</remarks>
     private void RemovePlaced(BreakpointRequest request)
     {
-        if (request.Placed.Count == 0 || _target.Scripts is null)
+        if (request.Placed.Count == 0 || _target.Runtime.Scripts is null)
         {
             // Nothing was placed, or the engine never had a debugger to place it on. Reaching for
             // Engine.Debugger in either case would claim engine ownership from a transport thread for the
@@ -369,7 +389,7 @@ internal sealed partial class DebuggerDomain
             return;
         }
 
-        var breakpoints = _target.Engine.Debugger.BreakPoints;
+        var breakpoints = _target.Runtime.Engine.Debugger.BreakPoints;
         foreach (var location in request.Placed)
         {
             // Removal is by position, and a later request may have replaced what this one set there: the

--- a/Jint.DevTools/Domains/DebuggerDomain.Pause.cs
+++ b/Jint.DevTools/Domains/DebuggerDomain.Pause.cs
@@ -37,7 +37,7 @@ namespace Jint.DevTools.Domains;
 /// removed.
 /// </para>
 /// <para>
-/// <b>Host work waits.</b> A host's <c>EngineTarget.Post</c> is work for a running engine; the paused drain
+/// <b>Host work waits.</b> A host's <c>Post</c> is work for a running engine; the paused drain
 /// does not touch it, so it runs in order once the engine resumes.
 /// </para>
 /// </remarks>
@@ -162,7 +162,7 @@ internal sealed partial class DebuggerDomain
 
         try
         {
-            var value = _target.Engine.Debugger.Evaluate(parameters.Expression, frame);
+            var value = _target.Runtime.Engine.Debugger.Evaluate(parameters.Expression, frame);
             return new ValueTask<EvaluateOnCallFrameResponse>(new EvaluateOnCallFrameResponse
             {
                 Result = _objects.Describe(value, request),
@@ -239,7 +239,7 @@ internal sealed partial class DebuggerDomain
     private void RequestResume(StepMode mode)
     {
         Interlocked.Exchange(ref _resumeMode, (int) mode);
-        _target.Dispatcher.Wake();
+        _target.Runtime.Dispatcher.Wake();
     }
 
     private ValueTask<EmptyResult> Resuming(StepMode mode)
@@ -263,7 +263,7 @@ internal sealed partial class DebuggerDomain
 
         if (Interlocked.Exchange(ref _skipSubscribed, 1) == 0)
         {
-            _target.Engine.Debugger.Skip += _onSkip;
+            _target.Runtime.Engine.Debugger.Skip += _onSkip;
         }
     }
 
@@ -276,9 +276,9 @@ internal sealed partial class DebuggerDomain
 
     private void UnsubscribeSkip()
     {
-        if (Interlocked.Exchange(ref _skipSubscribed, 0) != 0 && _target.Scripts is not null)
+        if (Interlocked.Exchange(ref _skipSubscribed, 0) != 0 && _target.Runtime.Scripts is not null)
         {
-            _target.Engine.Debugger.Skip -= _onSkip;
+            _target.Runtime.Engine.Debugger.Skip -= _onSkip;
         }
     }
 
@@ -388,7 +388,7 @@ internal sealed partial class DebuggerDomain
     /// </summary>
     private StepMode RunPauseLoop(DebugInformation information, in PauseCause cause)
     {
-        var dispatcher = _target.Dispatcher;
+        var dispatcher = _target.Runtime.Dispatcher;
         var serial = Interlocked.Increment(ref _pauseSerial);
 
         // A pause a client asked for is satisfied by any pause, not only by the one the Skip subscription
@@ -517,7 +517,7 @@ internal sealed partial class DebuggerDomain
     private ProtocolCallFrame Frame(int serial, int index, EngineCallFrame frame)
     {
         var location = frame.Location;
-        var script = _target.Scripts!.For(frame.Program);
+        var script = _target.Runtime.Scripts!.For(frame.Program);
 
         return new ProtocolCallFrame
         {
@@ -583,7 +583,7 @@ internal sealed partial class DebuggerDomain
             }
         }
 
-        return JsObject.CreateFromEntries(_target.Engine, entries);
+        return JsObject.CreateFromEntries(_target.Runtime.Engine, entries);
     }
 
     /// <summary>The value of <c>this</c>, or nothing when the frame has none to give yet.</summary>
@@ -614,7 +614,7 @@ internal sealed partial class DebuggerDomain
             return null;
         }
 
-        return At(_target.Scripts!.For(frame.Program), location.Start.Line, location.Start.Column);
+        return At(_target.Runtime.Scripts!.For(frame.Program), location.Start.Line, location.Start.Column);
     }
 
     /// <summary>

--- a/Jint.DevTools/Domains/DebuggerDomain.cs
+++ b/Jint.DevTools/Domains/DebuggerDomain.cs
@@ -27,9 +27,9 @@ namespace Jint.DevTools.Domains;
 /// See <see href="https://chromedevtools.github.io/devtools-protocol/tot/Debugger/"/>.
 /// </para>
 /// </remarks>
-internal sealed partial class DebuggerDomain : DebuggerDomainBase
+internal sealed partial class DebuggerDomain : DebuggerDomainBase, ITargetObserver
 {
-    private readonly EngineTarget _target;
+    private readonly DevToolsTarget _target;
     private readonly LogDomain _log;
     private readonly RemoteObjectMapper _objects;
     private readonly DebugHandler.DebugEventHandler _onBreak;
@@ -39,7 +39,7 @@ internal sealed partial class DebuggerDomain : DebuggerDomainBase
 
     private int _handlersSubscribed;
 
-    internal DebuggerDomain(EngineTarget target, LogDomain log)
+    internal DebuggerDomain(DevToolsTarget target, LogDomain log)
     {
         _target = target;
         _log = log;
@@ -92,10 +92,10 @@ internal sealed partial class DebuggerDomain : DebuggerDomainBase
     {
         if (Interlocked.Exchange(ref _handlersSubscribed, 1) == 0)
         {
-            var debugger = _target.Engine.Debugger;
+            var debugger = _target.Runtime.Engine.Debugger;
             debugger.Break += _onBreak;
             debugger.Step += _onStep;
-            _target.Scripts!.Parsed += _onScriptParsed;
+            _target.Runtime.Scripts!.Parsed += _onScriptParsed;
         }
 
         ApplyPauseOnExceptions();
@@ -103,7 +103,7 @@ internal sealed partial class DebuggerDomain : DebuggerDomainBase
         // Every script parsed before the client asked, in the order the engine parsed them. A front end's
         // Sources panel is built from this replay and not from what arrives afterwards, so a client that
         // attached to a running engine sees what it is running.
-        foreach (var script in _target.Scripts!.Snapshot())
+        foreach (var script in _target.Runtime.Scripts!.Snapshot())
         {
             await EmitAsync(DebuggerEvents.ScriptParsed(ScriptParsed(script)), context.CancellationToken).ConfigureAwait(false);
         }
@@ -114,6 +114,42 @@ internal sealed partial class DebuggerDomain : DebuggerDomainBase
     {
         Teardown();
         return default;
+    }
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// <para>
+    /// A navigation is a new engine with a new <c>DebugHandler</c>, a new script registry and an empty
+    /// breakpoint collection, so everything <c>enable</c> did has to be done again against it: the
+    /// subscriptions move, and every breakpoint the client set by URL is re-resolved as the new document's
+    /// scripts are parsed -- which is what makes a breakpoint set before a reload still fire after one.
+    /// </para>
+    /// <para>
+    /// <b>The client's own settings carry over and the engine's positions do not.</b> The pause-on-exceptions
+    /// state, the skip-all-pauses flag and the asynchronous stack depth are the attachment's and survive; the
+    /// places a request was placed at named breakpoints of an engine that is gone, so they are forgotten and
+    /// re-earned. The scripts announce themselves: the registry is fresh, so every program the new document
+    /// parses arrives as a <c>scriptParsed</c> of its own with no replay needed.
+    /// </para>
+    /// </remarks>
+    void ITargetObserver.RuntimeReplaced(TargetRuntime runtime)
+    {
+        if (Volatile.Read(ref _handlersSubscribed) == 0)
+        {
+            return;
+        }
+
+        var debugger = runtime.Engine.Debugger;
+        debugger.Break += _onBreak;
+        debugger.Step += _onStep;
+
+        if (runtime.Scripts is { } scripts)
+        {
+            scripts.Parsed += _onScriptParsed;
+        }
+
+        ForgetPlacedBreakpoints();
+        ApplyPauseOnExceptions();
     }
 
     /// <summary>
@@ -295,12 +331,12 @@ internal sealed partial class DebuggerDomain : DebuggerDomainBase
     /// </remarks>
     private void ApplyPauseOnExceptions()
     {
-        if (_target.Scripts is null)
+        if (_target.Runtime.Scripts is null)
         {
             return;
         }
 
-        _target.Engine.Debugger.PauseOnExceptions = IsEnabled ? EnginePauseMode(_pauseOnExceptions) : ExceptionPauseMode.None;
+        _target.Runtime.Engine.Debugger.PauseOnExceptions = IsEnabled ? EnginePauseMode(_pauseOnExceptions) : ExceptionPauseMode.None;
     }
 
     /// <summary>The engine mode that answers a client's state, which the protocol's four map onto one each.</summary>
@@ -329,7 +365,7 @@ internal sealed partial class DebuggerDomain : DebuggerDomainBase
         ResolvePending(script);
     }
 
-    private static ScriptParsedEvent ScriptParsed(RegisteredScript script) => new()
+    private ScriptParsedEvent ScriptParsed(RegisteredScript script) => new()
     {
         ScriptId = script.ScriptId,
         Url = script.Url,
@@ -354,10 +390,15 @@ internal sealed partial class DebuggerDomain : DebuggerDomainBase
     {
         if (Interlocked.Exchange(ref _handlersSubscribed, 0) != 0)
         {
-            var debugger = _target.Engine.Debugger;
+            var runtime = _target.Runtime;
+            var debugger = runtime.Engine.Debugger;
             debugger.Break -= _onBreak;
             debugger.Step -= _onStep;
-            _target.Scripts!.Parsed -= _onScriptParsed;
+
+            if (runtime.Scripts is { } scripts)
+            {
+                scripts.Parsed -= _onScriptParsed;
+            }
         }
 
         DisarmPause();
@@ -376,7 +417,7 @@ internal sealed partial class DebuggerDomain : DebuggerDomainBase
     /// <summary>Refuses an engine the host did not build with the debugger switched on.</summary>
     private void RequireDebuggerEngine()
     {
-        if (_target.Scripts is null)
+        if (_target.Runtime.Scripts is null)
         {
             Throw.ServerError(
                 "The engine was not built with the debugger enabled",
@@ -389,7 +430,7 @@ internal sealed partial class DebuggerDomain : DebuggerDomainBase
     {
         RequireDebuggerEngine();
 
-        return _target.Scripts!.ById(scriptId)
+        return _target.Runtime.Scripts!.ById(scriptId)
             ?? Throw.ServerError<RegisteredScript>("No script with given id");
     }
 
@@ -403,7 +444,7 @@ internal sealed partial class DebuggerDomain : DebuggerDomainBase
     /// </remarks>
     private string RequireSourceText(RegisteredScript script)
     {
-        if (!_target.Scripts!.TryGetSourceText(script, out var sourceText) || sourceText is null)
+        if (!_target.Runtime.Scripts!.TryGetSourceText(script, out var sourceText) || sourceText is null)
         {
             Throw.ServerError(
                 "No source text was retained for this script; enable Options.RetainFunctionSourceText",
@@ -420,7 +461,7 @@ internal sealed partial class DebuggerDomain : DebuggerDomainBase
     private static readonly TimeSpan SearchTimeout = TimeSpan.FromSeconds(1);
 
     /// <summary>
-    /// The one execution context an engine target has, which every location and frame names.
+    /// The identifier of the document's default execution context, which every location and frame names.
     /// </summary>
-    private const int MainExecutionContextId = 1;
+    private int MainExecutionContextId => _target.Runtime.ExecutionContextId;
 }

--- a/Jint.DevTools/Domains/LogDomain.cs
+++ b/Jint.DevTools/Domains/LogDomain.cs
@@ -116,7 +116,7 @@ internal sealed class LogDomain : LogDomainBase, ITargetObserver
                 Source = LogEntrySourceValues.Javascript,
                 Level = LogEntryLevelValues.Error,
                 Text = text,
-                Timestamp = EngineTarget.UnixMilliseconds(),
+                Timestamp = DevToolsTarget.UnixMilliseconds(),
                 Url = string.IsNullOrEmpty(url) ? null : url,
 
                 // The protocol counts a log entry's line from one, unlike a call frame's; a location the

--- a/Jint.DevTools/Domains/ProfilerDomain.Coverage.cs
+++ b/Jint.DevTools/Domains/ProfilerDomain.Coverage.cs
@@ -54,7 +54,7 @@ internal sealed partial class ProfilerDomain
     {
         RequireCoverageEngine();
 
-        _target.Engine.Diagnostics.ResetCoverage();
+        _target.Runtime.Engine.Diagnostics.ResetCoverage();
         _preciseCoverage = true;
         _detailedCoverage = parameters.Detailed == true;
 
@@ -73,7 +73,7 @@ internal sealed partial class ProfilerDomain
         }
 
         var result = Collect(_detailedCoverage);
-        _target.Engine.Diagnostics.ResetCoverage();
+        _target.Runtime.Engine.Diagnostics.ResetCoverage();
 
         return new ValueTask<TakePreciseCoverageResponse>(new TakePreciseCoverageResponse
         {
@@ -111,7 +111,7 @@ internal sealed partial class ProfilerDomain
     /// <summary>Refuses an engine the host did not build with coverage switched on.</summary>
     private void RequireCoverageEngine()
     {
-        if (!_target.Engine.Options.Coverage.Enabled)
+        if (!_target.Runtime.Engine.Options.Coverage.Enabled)
         {
             Throw.ServerError(
                 "The engine was not built with coverage enabled",
@@ -119,12 +119,12 @@ internal sealed partial class ProfilerDomain
         }
     }
 
-    private static double Timestamp() => EngineTarget.UnixMilliseconds() / MillisecondsPerSecond;
+    private static double Timestamp() => DevToolsTarget.UnixMilliseconds() / MillisecondsPerSecond;
 
     /// <summary>Reads the engine's report and answers it in the protocol's shape, script by script.</summary>
     private ScriptCoverage[] Collect(bool detailed)
     {
-        var report = _target.Engine.Diagnostics.GetCoverage();
+        var report = _target.Runtime.Engine.Diagnostics.GetCoverage();
         var scripts = new List<ScriptCoverage>(report.Sources.Count);
 
         foreach (var source in report.Sources)
@@ -133,7 +133,7 @@ internal sealed partial class ProfilerDomain
             // belongs to is a lookup rather than a guess from a name. A source no script claims is still
             // reported, against the unattributable identifier, because a client can do something with
             // ranges it cannot place and nothing with a source that vanished.
-            var script = _target.Scripts?.For(source.Program);
+            var script = _target.Runtime.Scripts?.For(source.Program);
 
             scripts.Add(new ScriptCoverage
             {

--- a/Jint.DevTools/Domains/ProfilerDomain.cs
+++ b/Jint.DevTools/Domains/ProfilerDomain.cs
@@ -31,12 +31,12 @@ namespace Jint.DevTools.Domains;
 /// See <see href="https://chromedevtools.github.io/devtools-protocol/tot/Profiler/"/>.
 /// </para>
 /// </remarks>
-internal sealed partial class ProfilerDomain : ProfilerDomainBase
+internal sealed partial class ProfilerDomain : ProfilerDomainBase, ITargetObserver
 {
     /// <summary>What the protocol's interval means, which is a rate rather than a duration.</summary>
     private static readonly TimeSpan DefaultInterval = TimeSpan.FromMilliseconds(1);
 
-    private readonly EngineTarget _target;
+    private readonly DevToolsTarget _target;
 
     /// <summary>The source a caller pinned, or <see langword="null"/> to choose one per recording.</summary>
     private readonly IProfileSource? _fixed;
@@ -54,13 +54,13 @@ internal sealed partial class ProfilerDomain : ProfilerDomainBase
     /// </remarks>
     private int _recording;
 
-    internal ProfilerDomain(EngineTarget target)
+    internal ProfilerDomain(DevToolsTarget target)
         : this(target, source: null)
     {
     }
 
     /// <summary>Builds the domain over a source of the caller's choosing, which is what a test needs.</summary>
-    internal ProfilerDomain(EngineTarget target, IProfileSource? source)
+    internal ProfilerDomain(DevToolsTarget target, IProfileSource? source)
     {
         _target = target;
         _fixed = source;
@@ -84,10 +84,10 @@ internal sealed partial class ProfilerDomain : ProfilerDomainBase
         }
 
 #pragma warning disable JINT0002 // the sampling profiler is the engine's preview area
-        var sampling = _target.Engine.Diagnostics.IsSampling;
+        var sampling = _target.Runtime.Engine.Diagnostics.IsSampling;
 #pragma warning restore JINT0002
 
-        return sampling ? new EventedProfileSource(_target.Engine) : new SampledProfileSource(_target.Engine);
+        return sampling ? new EventedProfileSource(_target.Runtime.Engine) : new SampledProfileSource(_target.Runtime.Engine);
     }
 
     /// <inheritdoc/>
@@ -117,6 +117,21 @@ internal sealed partial class ProfilerDomain : ProfilerDomainBase
         return default;
     }
 
+    /// <inheritdoc/>
+    /// <remarks>
+    /// <b>A recording ends at the swap, and what it had is thrown away.</b> A profile is a call tree over one
+    /// engine's stacks and a coverage report is one engine's counters; neither has a meaning that spans two,
+    /// and stitching a document's samples onto the next document's would answer a question nobody asked. A
+    /// client whose <c>Profiler.stop</c> arrives after a navigation is told there is no recording running,
+    /// which is the truth rather than a partial profile it would read as the whole run.
+    /// </remarks>
+    void ITargetObserver.RuntimeReplaced(TargetRuntime runtime)
+    {
+        // Nothing is posted: the engine that was being recorded is gone, so there is no thread left to stop
+        // its instrument on and the instrument dies with it.
+        Stop(post: false);
+    }
+
     /// <summary>Releases everything this attachment holds of the engine's profiler and coverage.</summary>
     /// <remarks>
     /// <b>Called from a transport thread when the client goes away, so the stop is queued rather than
@@ -125,7 +140,15 @@ internal sealed partial class ProfilerDomain : ProfilerDomainBase
     /// the rest of the package is built on. A target already being disposed takes its engine with it, and
     /// there is then nothing left to stop.
     /// </remarks>
-    internal void Detach()
+    internal void Detach() => Stop(post: true);
+
+    /// <summary>Ends whatever this attachment had running, on the engine thread or not at all.</summary>
+    /// <param name="post">
+    /// Whether the engine that is recording is still there to be asked. It is not after a navigation: the
+    /// instrument belonged to an engine that has been replaced, and posting the stop would run it against
+    /// the next document's.
+    /// </param>
+    private void Stop(bool post)
     {
         _preciseCoverage = false;
         _detailedCoverage = false;
@@ -137,21 +160,21 @@ internal sealed partial class ProfilerDomain : ProfilerDomainBase
         }
 
         var source = _source;
-        if (source is null)
+        _source = null;
+
+        if (!post || source is null)
         {
             return;
         }
 
         try
         {
-            _target.Post(_ =>
+            _target.Runtime.Dispatcher.Post(_ =>
             {
                 if (source.IsRecording)
                 {
                     source.Stop();
                 }
-
-                _source = null;
             });
         }
         catch (ObjectDisposedException)
@@ -200,7 +223,7 @@ internal sealed partial class ProfilerDomain : ProfilerDomainBase
 
         _source = source;
 
-        _startedAtMicroseconds = EngineTarget.UnixMilliseconds() * MicrosecondsPerMillisecond;
+        _startedAtMicroseconds = DevToolsTarget.UnixMilliseconds() * MicrosecondsPerMillisecond;
         Volatile.Write(ref _recording, 1);
 
         return new ValueTask<EmptyResult>(EmptyResult.Instance);
@@ -228,7 +251,7 @@ internal sealed partial class ProfilerDomain : ProfilerDomainBase
 
         return new ValueTask<StopResponse>(new StopResponse
         {
-            Profile = ProfileBuilder.Build(recorded, _target.Scripts, _startedAtMicroseconds),
+            Profile = ProfileBuilder.Build(recorded, _target.Runtime.Scripts, _startedAtMicroseconds),
         });
     }
 

--- a/Jint.DevTools/Domains/RemoteObjectMapper.cs
+++ b/Jint.DevTools/Domains/RemoteObjectMapper.cs
@@ -67,17 +67,17 @@ internal sealed class RemoteObjectMapper
         new() { MaxDepth = 0, MaxEntries = 0, MaxStringLength = int.MaxValue, FunctionSourceText = true };
 #pragma warning restore JINT0002
 
-    private readonly EngineTarget _target;
+    private readonly DevToolsTarget _target;
     private readonly object _owner;
 
-    internal RemoteObjectMapper(EngineTarget target, object owner)
+    internal RemoteObjectMapper(DevToolsTarget target, object owner)
     {
         _target = target;
         _owner = owner;
     }
 
     /// <summary>Gets the table this mapper mints handles from.</summary>
-    internal RemoteObjectTable Table => _target.RemoteObjects;
+    internal RemoteObjectTable Table => _target.Runtime.RemoteObjects;
 
     /// <summary>Describes <paramref name="value"/> as the protocol's remote object.</summary>
     /// <param name="value">The value to describe.</param>
@@ -432,7 +432,7 @@ internal sealed class RemoteObjectMapper
     private RemoteObject ThrownValue(JavaScriptException exception)
     {
         var described = Describe(exception.Error, RemoteObjectRequest.Description);
-        return described with { Description = exception.GetJavaScriptErrorString(_target.Engine.Options.ResultLimits) };
+        return described with { Description = exception.GetJavaScriptErrorString(_target.Runtime.Engine.Options.ResultLimits) };
     }
 
     private static RemoteObject Number(JsValue value)
@@ -615,7 +615,7 @@ internal sealed class RemoteObjectMapper
 
         try
         {
-            written = new JsJsonSerializer(_target.Engine).Serialize(value, buffer);
+            written = new JsJsonSerializer(_target.Runtime.Engine).Serialize(value, buffer);
         }
         catch (JavaScriptException exception)
         {

--- a/Jint.DevTools/Domains/RemoteObjectTable.cs
+++ b/Jint.DevTools/Domains/RemoteObjectTable.cs
@@ -16,15 +16,17 @@ namespace Jint.DevTools.Domains;
 /// one that was told the value by description.
 /// </para>
 /// <para>
-/// <b>The table belongs to the target, not to a session</b>, because the values in it belong to the engine.
-/// Two sessions attached to one engine therefore mint identifiers from the same sequence, and a handle one
+/// <b>The table belongs to the engine, not to a session</b>, because the values in it are that engine's.
+/// Two sessions attached to one target therefore mint identifiers from the same sequence, and a handle one
 /// session minted is resolvable by the other — which is what makes an identifier meaningful in the
 /// <c>Runtime</c> and <c>Debugger</c> domains of both. Ownership is tracked all the same, so that a session
 /// going away releases what it registered and only that.
 /// </para>
 /// <para>
-/// Four ways a handle ends, and the client controls the first three: <c>Runtime.releaseObject</c>,
-/// <c>Runtime.releaseObjectGroup</c>, and detaching. The fourth is the target being disposed.
+/// Five ways a handle ends, and the client controls the first three: <c>Runtime.releaseObject</c>,
+/// <c>Runtime.releaseObjectGroup</c>, and detaching. The other two are the target being closed and the
+/// engine being replaced under it — a navigation, after which the client is told the object cannot be
+/// found rather than answered about a value of the document that replaced it.
 /// </para>
 /// <para>
 /// <b>Threading.</b> Every registration and every resolution happens on the engine thread, because both
@@ -44,14 +46,15 @@ internal sealed class RemoteObjectTable
 
     private int _next;
 
-    /// <summary>Creates the table for the target numbered <paramref name="targetSerial"/>.</summary>
-    /// <param name="targetSerial">
-    /// The target's position among the targets this process has made. It prefixes every identifier so that a
-    /// handle from one target is refused by another rather than resolving to a value of the wrong engine.
+    /// <summary>Creates the table for the runtime numbered <paramref name="runtimeSerial"/>.</summary>
+    /// <param name="runtimeSerial">
+    /// The runtime's position among the runtimes this process has built. It prefixes every identifier so that
+    /// a handle from another target — or from the document before last on this one — is refused rather than
+    /// resolving to a value of the wrong engine.
     /// </param>
-    internal RemoteObjectTable(int targetSerial)
+    internal RemoteObjectTable(int runtimeSerial)
     {
-        _prefix = targetSerial.ToString(CultureInfo.InvariantCulture) + ".";
+        _prefix = runtimeSerial.ToString(CultureInfo.InvariantCulture) + ".";
     }
 
     /// <summary>Gets how many handles are outstanding, which is what a leak test counts.</summary>
@@ -160,7 +163,7 @@ internal sealed class RemoteObjectTable
         Remove(entry => ReferenceEquals(entry.Owner, owner));
     }
 
-    /// <summary>Releases everything, which is what disposing the target means.</summary>
+    /// <summary>Releases everything, which is what replacing or closing the engine means.</summary>
     internal void Clear()
     {
         lock (_gate)

--- a/Jint.DevTools/Domains/RuntimeDomain.Events.cs
+++ b/Jint.DevTools/Domains/RuntimeDomain.Events.cs
@@ -65,7 +65,7 @@ internal sealed partial class RuntimeDomain
 
         EmitDetached(RuntimeEvents.ExceptionThrown(new ExceptionThrownEvent
         {
-            Timestamp = EngineTarget.UnixMilliseconds(),
+            Timestamp = DevToolsTarget.UnixMilliseconds(),
             ExceptionDetails = _objects.Exception(exception, NextExceptionId(), MainExecutionContextId),
         }));
     }
@@ -83,7 +83,7 @@ internal sealed partial class RuntimeDomain
 
         EmitDetached(RuntimeEvents.ExceptionThrown(new ExceptionThrownEvent
         {
-            Timestamp = EngineTarget.UnixMilliseconds(),
+            Timestamp = DevToolsTarget.UnixMilliseconds(),
             ExceptionDetails = _objects.Rejection(reason, exceptionId, MainExecutionContextId),
         }));
     }
@@ -103,6 +103,44 @@ internal sealed partial class RuntimeDomain
         }));
     }
 
+    /// <inheritdoc/>
+    /// <remarks>
+    /// <para>
+    /// The pair every client is written against: <c>executionContextsCleared</c> says every identifier it
+    /// holds has stopped meaning anything, and <c>executionContextCreated</c> gives it the one that now
+    /// does. Chrome sends them in that order on a cross-document navigation and so does this.
+    /// </para>
+    /// <para>
+    /// The handles are already gone -- the table belonged to the engine that has been replaced -- so a
+    /// client that comes back with one is told the object cannot be found, which is what Chrome tells it.
+    /// The rejections this domain was tracking go with them: they name promises of a realm that no longer
+    /// exists, and revoking one afterwards would be revoking against a document nobody is looking at.
+    /// </para>
+    /// </remarks>
+    void ITargetObserver.RuntimeReplaced(TargetRuntime runtime)
+    {
+        _rejections.Clear();
+
+        if (!IsEnabled)
+        {
+            return;
+        }
+
+        EmitDetached(RuntimeEvents.ExecutionContextsCleared());
+        EmitDetached(RuntimeEvents.ExecutionContextCreated(DefaultContext()));
+    }
+
+    /// <inheritdoc/>
+    void ITargetObserver.WorldCreated(TargetWorld world)
+    {
+        if (!IsEnabled)
+        {
+            return;
+        }
+
+        EmitDetached(RuntimeEvents.ExecutionContextCreated(WorldContext(world)));
+    }
+
     /// <summary>Replays the journal to a client that enabled the domain after the fact.</summary>
     /// <remarks>
     /// V8 does the same, and it is what makes a front end opened halfway through a run useful rather than
@@ -110,7 +148,7 @@ internal sealed partial class RuntimeDomain
     /// </remarks>
     private async ValueTask ReplayConsoleAsync(CommandContext context)
     {
-        foreach (var entry in _target.Console.Snapshot())
+        foreach (var entry in _target.Runtime.Console.Snapshot())
         {
             await EmitAsync(RuntimeEvents.ConsoleAPICalled(ConsoleCall(entry)), context.CancellationToken).ConfigureAwait(false);
         }
@@ -209,7 +247,7 @@ internal sealed partial class RuntimeDomain
             return null;
         }
 
-        var registry = _target.Scripts;
+        var registry = _target.Runtime.Scripts;
         var callFrames = new CallFrame[frames.Length];
         for (var i = 0; i < frames.Length; i++)
         {

--- a/Jint.DevTools/Domains/RuntimeDomain.Properties.cs
+++ b/Jint.DevTools/Domains/RuntimeDomain.Properties.cs
@@ -52,7 +52,7 @@ internal sealed partial class RuntimeDomain
     /// <inheritdoc/>
     protected override ValueTask<GetPropertiesResponse> GetPropertiesAsync(GetPropertiesRequest parameters, CommandContext context)
     {
-        var value = _target.RemoteObjects.Resolve(parameters.ObjectId, out var group);
+        var value = _target.Runtime.RemoteObjects.Resolve(parameters.ObjectId, out var group);
 
         var request = new RemoteObjectRequest
         {
@@ -383,7 +383,7 @@ internal sealed partial class RuntimeDomain
             properties.Add(new InternalPropertyDescriptor
             {
                 Name = "[[BoundArgs]]",
-                Value = _objects.Describe(new JsArray(_target.Engine, copy), request),
+                Value = _objects.Describe(new JsArray(_target.Runtime.Engine, copy), request),
             });
 
             return;
@@ -406,7 +406,7 @@ internal sealed partial class RuntimeDomain
     private RemoteObject Location(Node declaration)
     {
         var location = declaration.Location;
-        var script = _target.Scripts?.At(location.SourceFile, location.Start.Line, location.Start.Column);
+        var script = _target.Runtime.Scripts?.At(location.SourceFile, location.Start.Line, location.Start.Column);
 
         var buffer = new ArrayBufferWriter<byte>(96);
         using (var writer = new Utf8JsonWriter(buffer))

--- a/Jint.DevTools/Domains/RuntimeDomain.cs
+++ b/Jint.DevTools/Domains/RuntimeDomain.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+using System.Buffers;
 using System.Text.Json;
 using Jint.DevTools.Protocol;
 using Jint.DevTools.Protocol.Runtime;
@@ -31,22 +31,27 @@ namespace Jint.DevTools.Domains;
 /// </remarks>
 internal sealed partial class RuntimeDomain : RuntimeDomainBase, IBindingListener, ITargetObserver
 {
-    /// <summary>
-    /// The one execution context an engine target has. Chrome numbers page contexts from 1 and so does this;
-    /// there is no second realm to number, because a <c>ShadowRealm</c> is not something a client can address.
-    /// </summary>
-    private const int MainExecutionContextId = 1;
-
-    private readonly EngineTarget _target;
+    private readonly DevToolsTarget _target;
     private readonly RemoteObjectMapper _objects;
 
     private int _exceptionId;
 
-    internal RuntimeDomain(EngineTarget target)
+    internal RuntimeDomain(DevToolsTarget target)
     {
         _target = target;
         _objects = new RemoteObjectMapper(target, this);
     }
+
+    /// <summary>
+    /// Gets the identifier of the document's default execution context.
+    /// </summary>
+    /// <remarks>
+    /// Chrome numbers page contexts from 1 and so does this -- but the counter is the <i>target's</i>, so a
+    /// second document's default context is 2 and never 1 again. That is what makes a client sending back an
+    /// identifier from before a navigation distinguishable from one sending the current one, which is the
+    /// whole reason the number is not a constant.
+    /// </remarks>
+    private int MainExecutionContextId => _target.Runtime.ExecutionContextId;
 
     /// <summary>
     /// Releases everything this attachment holds of the engine: its handles, and its share of every binding.
@@ -86,29 +91,22 @@ internal sealed partial class RuntimeDomain : RuntimeDomainBase, IBindingListene
     /// </remarks>
     protected override async ValueTask OnEnabledAsync(CommandContext context)
     {
-        var created = new ExecutionContextCreatedEvent
+        await EmitAsync(RuntimeEvents.ExecutionContextCreated(DefaultContext()), context.CancellationToken).ConfigureAwait(false);
+
+        // Every alias minted over the document that is running, so a client that enabled after
+        // Page.createIsolatedWorld still knows the identifier it was handed is live.
+        foreach (var world in _target.Worlds)
         {
-            Context = new ExecutionContextDescription
-            {
-                Id = MainExecutionContextId,
+            await EmitAsync(RuntimeEvents.ExecutionContextCreated(WorldContext(world)), context.CancellationToken).ConfigureAwait(false);
+        }
 
-                // An engine target has no document, so it has no origin and no name to give. Chrome sends
-                // the empty string for both on a Node target and clients read them as opaque.
-                Origin = "",
-                Name = "",
-                UniqueId = _target.TargetId + "." + MainExecutionContextId.ToString(CultureInfo.InvariantCulture),
-                AuxData = AuxData,
-            },
-        };
-
-        await EmitAsync(RuntimeEvents.ExecutionContextCreated(created), context.CancellationToken).ConfigureAwait(false);
         await ReplayConsoleAsync(context).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
     protected override ValueTask<EmptyResult> RunIfWaitingForDebuggerAsync(EmptyParameters parameters, CommandContext context)
     {
-        _target.Dispatcher.ReleaseDebuggerWait();
+        _target.ReleaseDebuggerWait();
         return new ValueTask<EmptyResult>(EmptyResult.Instance);
     }
 
@@ -122,7 +120,7 @@ internal sealed partial class RuntimeDomain : RuntimeDomainBase, IBindingListene
     /// </remarks>
     protected override ValueTask<EmptyResult> DiscardConsoleEntriesAsync(EmptyParameters parameters, CommandContext context)
     {
-        _target.Console.Clear(_target.RemoteObjects);
+        _target.Runtime.Console.Clear(_target.Runtime.RemoteObjects);
         return new ValueTask<EmptyResult>(EmptyResult.Instance);
     }
 
@@ -166,7 +164,7 @@ internal sealed partial class RuntimeDomain : RuntimeDomainBase, IBindingListene
     /// <inheritdoc/>
     protected override ValueTask<EvaluateResponse> EvaluateAsync(EvaluateRequest parameters, CommandContext context)
     {
-        RequireMainContext(parameters.ContextId);
+        _target.RequireContext(parameters.ContextId);
         RefuseSideEffectFreeEvaluation(parameters.ThrowOnSideEffect);
 
         var request = RemoteObjectRequest.From(parameters.ReturnByValue, parameters.GeneratePreview, parameters.ObjectGroup);
@@ -195,10 +193,10 @@ internal sealed partial class RuntimeDomain : RuntimeDomainBase, IBindingListene
     /// <inheritdoc/>
     protected override ValueTask<CallFunctionOnResponse> CallFunctionOnAsync(CallFunctionOnRequest parameters, CommandContext context)
     {
-        RequireMainContext(parameters.ExecutionContextId);
+        _target.RequireContext(parameters.ExecutionContextId);
         RefuseSideEffectFreeEvaluation(parameters.ThrowOnSideEffect);
 
-        var engine = _target.Engine;
+        var engine = _target.Runtime.Engine;
 
         // The group a client asked for, or the one the receiver already belongs to. Inheriting it is what
         // makes releaseObjectGroup free the handles a client walked to rather than only the one it started
@@ -208,7 +206,7 @@ internal sealed partial class RuntimeDomain : RuntimeDomainBase, IBindingListene
 
         if (parameters.ObjectId is { } objectId)
         {
-            thisValue = _target.RemoteObjects.Resolve(objectId, out var owningGroup);
+            thisValue = _target.Runtime.RemoteObjects.Resolve(objectId, out var owningGroup);
             group ??= owningGroup;
         }
 
@@ -217,7 +215,7 @@ internal sealed partial class RuntimeDomain : RuntimeDomainBase, IBindingListene
         JsValue function;
         try
         {
-            function = Evaluate(_target.CompiledScripts.Declaration(parameters.FunctionDeclaration));
+            function = Evaluate(_target.Runtime.CompiledScripts.Declaration(parameters.FunctionDeclaration));
         }
         catch (ScriptPreparationException exception)
         {
@@ -257,7 +255,7 @@ internal sealed partial class RuntimeDomain : RuntimeDomainBase, IBindingListene
     /// <inheritdoc/>
     protected override ValueTask<AwaitPromiseResponse> AwaitPromiseAsync(AwaitPromiseRequest parameters, CommandContext context)
     {
-        var promise = _target.RemoteObjects.Resolve(parameters.PromiseObjectId, out var group);
+        var promise = _target.Runtime.RemoteObjects.Resolve(parameters.PromiseObjectId, out var group);
         if (!promise.IsPromise())
         {
             // Chrome's wording. A client sends this only for a handle it was told is a promise, so getting
@@ -281,7 +279,7 @@ internal sealed partial class RuntimeDomain : RuntimeDomainBase, IBindingListene
         GetExceptionDetailsRequest parameters,
         CommandContext context)
     {
-        var error = _target.RemoteObjects.Resolve(parameters.ErrorObjectId, out _);
+        var error = _target.Runtime.RemoteObjects.Resolve(parameters.ErrorObjectId, out _);
         if (!RemoteObjectMapper.IsError(error))
         {
             // Chrome's wording, verbatim: a client feature-detects nothing on it, but a host debugging a
@@ -289,7 +287,7 @@ internal sealed partial class RuntimeDomain : RuntimeDomainBase, IBindingListene
             Throw.ServerError("errorObjectId is not a JS error object");
         }
 
-        var details = _objects.ErrorDetails(error, NextExceptionId(), MainExecutionContextId, _target.Scripts);
+        var details = _objects.ErrorDetails(error, NextExceptionId(), MainExecutionContextId, _target.Runtime.Scripts);
         return new ValueTask<GetExceptionDetailsResponse>(new GetExceptionDetailsResponse { ExceptionDetails = details });
     }
 
@@ -298,7 +296,7 @@ internal sealed partial class RuntimeDomain : RuntimeDomainBase, IBindingListene
     {
         // A handle nothing knows about is not an error: a client releasing what it already released, or what
         // a detach took with it, is tidying up, and Chrome answers that with a success too.
-        _target.RemoteObjects.Release(parameters.ObjectId);
+        _target.Runtime.RemoteObjects.Release(parameters.ObjectId);
         return new ValueTask<EmptyResult>(EmptyResult.Instance);
     }
 
@@ -312,7 +310,7 @@ internal sealed partial class RuntimeDomain : RuntimeDomainBase, IBindingListene
     /// <inheritdoc/>
     protected override ValueTask<CompileScriptResponse> CompileScriptAsync(CompileScriptRequest parameters, CommandContext context)
     {
-        RequireMainContext(parameters.ExecutionContextId);
+        _target.RequireContext(parameters.ExecutionContextId);
 
         Prepared<Acornima.Ast.Script> prepared;
         try
@@ -346,16 +344,16 @@ internal sealed partial class RuntimeDomain : RuntimeDomainBase, IBindingListene
         {
             // Not persisting is a compile-only syntax check, which is what a client sends it for; Chrome
             // answers that with no identifier rather than with one that addresses nothing.
-            ScriptId = parameters.PersistScript ? _target.CompiledScripts.Persist(prepared) : null,
+            ScriptId = parameters.PersistScript ? _target.Runtime.CompiledScripts.Persist(prepared) : null,
         });
     }
 
     /// <inheritdoc/>
     protected override ValueTask<RunScriptResponse> RunScriptAsync(RunScriptRequest parameters, CommandContext context)
     {
-        RequireMainContext(parameters.ExecutionContextId);
+        _target.RequireContext(parameters.ExecutionContextId);
 
-        if (!_target.CompiledScripts.TryGetPersisted(parameters.ScriptId, out var prepared))
+        if (!_target.Runtime.CompiledScripts.TryGetPersisted(parameters.ScriptId, out var prepared))
         {
             // Chrome's wording for a script identifier that names nothing.
             Throw.ServerError("No script with given id");
@@ -366,7 +364,7 @@ internal sealed partial class RuntimeDomain : RuntimeDomainBase, IBindingListene
         JsValue value;
         try
         {
-            value = _target.Engine.Evaluate(prepared);
+            value = _target.Runtime.Engine.Evaluate(prepared);
         }
         catch (JavaScriptException exception)
         {
@@ -388,12 +386,12 @@ internal sealed partial class RuntimeDomain : RuntimeDomainBase, IBindingListene
     /// <inheritdoc/>
     protected override ValueTask<EmptyResult> AddBindingAsync(AddBindingRequest parameters, CommandContext context)
     {
-        RequireMainContext(parameters.ExecutionContextId);
+        _target.RequireContext(parameters.ExecutionContextId);
 
         // executionContextName is deliberately not checked against anything. It names an isolated world, and
         // an engine target has one context and no worlds; a client that asked for a named one gets the one
         // there is, because a binding it cannot call would fail silently in the page rather than loudly here.
-        _target.Bindings.Add(_target.Engine, parameters.Name, this);
+        _target.Bindings.Add(_target.Runtime.Engine, parameters.Name, this);
 
         return new ValueTask<EmptyResult>(EmptyResult.Instance);
     }
@@ -401,7 +399,7 @@ internal sealed partial class RuntimeDomain : RuntimeDomainBase, IBindingListene
     /// <inheritdoc/>
     protected override ValueTask<EmptyResult> RemoveBindingAsync(RemoveBindingRequest parameters, CommandContext context)
     {
-        _target.Bindings.Remove(_target.Engine, parameters.Name, this);
+        _target.Bindings.Remove(_target.Runtime.Engine, parameters.Name, this);
 
         return new ValueTask<EmptyResult>(EmptyResult.Instance);
     }
@@ -462,12 +460,12 @@ internal sealed partial class RuntimeDomain : RuntimeDomainBase, IBindingListene
     {
         if (!_target.IsPaused)
         {
-            return _target.Engine.Evaluate(expression);
+            return _target.Runtime.Engine.Evaluate(expression);
         }
 
         try
         {
-            return _target.Engine.Debugger.Evaluate(expression);
+            return _target.Runtime.Engine.Debugger.Evaluate(expression);
         }
         catch (DebugEvaluationException exception)
         {
@@ -480,12 +478,12 @@ internal sealed partial class RuntimeDomain : RuntimeDomainBase, IBindingListene
     {
         if (!_target.IsPaused)
         {
-            return _target.Engine.Evaluate(prepared);
+            return _target.Runtime.Engine.Evaluate(prepared);
         }
 
         try
         {
-            return _target.Engine.Debugger.Evaluate(prepared);
+            return _target.Runtime.Engine.Debugger.Evaluate(prepared);
         }
         catch (DebugEvaluationException exception)
         {
@@ -536,7 +534,7 @@ internal sealed partial class RuntimeDomain : RuntimeDomainBase, IBindingListene
             return new ValueTask<TResponse>(build(_objects.Describe(promise, request), null));
         }
 
-        var engine = _target.Engine;
+        var engine = _target.Runtime.Engine;
         var then = promise.Get("then");
         if (!then.IsCallable())
         {
@@ -615,25 +613,66 @@ internal sealed partial class RuntimeDomain : RuntimeDomainBase, IBindingListene
             : request;
     }
 
-    /// <summary>Refuses a context that is not the one context an engine target has.</summary>
-    private static void RequireMainContext(int? contextId)
-    {
-        if (contextId is { } id && id != MainExecutionContextId)
-        {
-            // Chrome's wording, which several clients match on to decide a context went away rather than
-            // that the call was wrong.
-            Throw.ServerError("Cannot find context with specified id");
-        }
-    }
-
     private int NextExceptionId() => ++_exceptionId;
 
-    private static JsonElement AuxData
+    /// <summary>The document's own context, as every client waits to be told about it.</summary>
+    /// <remarks>
+    /// <c>frameId</c> is the target's own identifier, which is what a page target's main frame is named by:
+    /// a client matches the frame it navigated against the context it evaluates in, and the two have to be
+    /// the same string. An engine target has no document, so it has no name to give -- Chrome sends the
+    /// empty string on a Node target and clients read it as opaque.
+    /// </remarks>
+    private ExecutionContextCreatedEvent DefaultContext() => new()
     {
-        get
+        Context = new ExecutionContextDescription
         {
-            using var document = JsonDocument.Parse("""{"isDefault":true,"type":"default"}""");
-            return document.RootElement.Clone();
+            Id = MainExecutionContextId,
+            Origin = _target.Url,
+            Name = "",
+            UniqueId = _target.Runtime.UniqueContextId,
+            AuxData = AuxData(isDefault: true, "default", _target.TargetId, name: null),
+        },
+    };
+
+    /// <summary>One isolated world, which is an alias for the document's own realm under a name.</summary>
+    private ExecutionContextCreatedEvent WorldContext(TargetWorld world) => new()
+    {
+        Context = new ExecutionContextDescription
+        {
+            Id = world.Id,
+            Origin = _target.Url,
+            Name = world.Name,
+            UniqueId = world.UniqueId,
+            AuxData = AuxData(isDefault: false, "isolated", _target.TargetId, world.Name),
+        },
+    };
+
+    /// <summary>
+    /// The <c>auxData</c> a client reads to tell a page's own context from a world it asked for.
+    /// </summary>
+    /// <remarks>
+    /// Written rather than serialized from a record because the protocol types it as <c>any</c>: it is a bag
+    /// whose shape is the embedder's, and Chrome's shape is the one every client parses.
+    /// </remarks>
+    private static JsonElement AuxData(bool isDefault, string type, string frameId, string? name)
+    {
+        var buffer = new ArrayBufferWriter<byte>(128);
+        using (var writer = new Utf8JsonWriter(buffer))
+        {
+            writer.WriteStartObject();
+            writer.WriteBoolean("isDefault", isDefault);
+            writer.WriteString("type", type);
+            writer.WriteString("frameId", frameId);
+
+            if (!string.IsNullOrEmpty(name))
+            {
+                writer.WriteString("name", name);
+            }
+
+            writer.WriteEndObject();
         }
+
+        using var document = JsonDocument.Parse(buffer.WrittenMemory);
+        return document.RootElement.Clone();
     }
 }

--- a/Jint.DevTools/Domains/ScriptRegistry.cs
+++ b/Jint.DevTools/Domains/ScriptRegistry.cs
@@ -17,10 +17,11 @@ namespace Jint.DevTools.Domains;
 /// registered answers the identifier the first one minted.
 /// </para>
 /// <para>
-/// <b>It is the target's, not a session's.</b> Scripts belong to the engine, so two attachments name the same
+/// <b>It is the engine's, not a session's.</b> Scripts belong to the engine, so two attachments name the same
 /// program by the same identifier and a client that attaches after a run is replayed everything already
 /// parsed — which is what the front end's Sources panel is built from and why the subscription is taken when
-/// the target is made rather than when a client enables the domain.
+/// the runtime is built rather than when a client enables the domain. A navigation starts a fresh one, and
+/// the identifiers of the document that is going stop resolving with it.
 /// </para>
 /// <para>
 /// <b>It is bounded, and that is a memory decision.</b> A registry that never forgets holds every abstract
@@ -47,11 +48,15 @@ internal sealed class ScriptRegistry
     private int _next;
     private int _subscribed;
 
-    /// <summary>Creates the registry of the target numbered <paramref name="targetSerial"/>.</summary>
-    internal ScriptRegistry(Engine engine, int targetSerial)
+    /// <summary>Creates the registry of the runtime numbered <paramref name="runtimeSerial"/>.</summary>
+    /// <remarks>
+    /// The serial prefixes every script identifier, so that one from the document before last fails to
+    /// resolve rather than naming a program of the engine that replaced it.
+    /// </remarks>
+    internal ScriptRegistry(Engine engine, int runtimeSerial)
     {
         _engine = engine;
-        _prefix = targetSerial.ToString(CultureInfo.InvariantCulture) + ".";
+        _prefix = runtimeSerial.ToString(CultureInfo.InvariantCulture) + ".";
         _beforeEvaluate = OnBeforeEvaluate;
     }
 
@@ -69,7 +74,7 @@ internal sealed class ScriptRegistry
         _engine.Debugger.BeforeEvaluate += _beforeEvaluate;
     }
 
-    /// <summary>Stops listening and forgets everything, which is what disposing the target means.</summary>
+    /// <summary>Stops listening and forgets everything, which is what replacing the engine means.</summary>
     internal void Stop()
     {
         if (Interlocked.Exchange(ref _subscribed, 0) == 0)

--- a/Jint.DevTools/Domains/TargetDomain.cs
+++ b/Jint.DevTools/Domains/TargetDomain.cs
@@ -5,7 +5,7 @@ using Jint.DevTools.Session;
 namespace Jint.DevTools.Domains;
 
 /// <summary>
-/// Answers the <c>Target</c> commands: what engines exist, and which of them a client is attached to.
+/// Answers the <c>Target</c> commands: what targets exist, and which of them a client is attached to.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -16,10 +16,12 @@ namespace Jint.DevTools.Domains;
 /// routing path kept alive forever for nobody.
 /// </para>
 /// <para>
-/// <b>A browser context is not something an engine target has.</b> <c>getBrowserContexts</c> answers an
-/// empty list, and <c>createBrowserContext</c> refuses with a reason rather than minting an identifier that
-/// partitions nothing: a client that was handed one would believe its next target was isolated. The page
-/// package, where a context really does own cookies and storage, is where they start meaning something.
+/// <b>Creating targets and contexts is the host's, when there is one.</b> A server with no
+/// <see cref="ITargetHost"/> has nothing to open and nothing to partition, so <c>createBrowserContext</c>
+/// refuses with a reason rather than minting an identifier that isolates nothing and
+/// <c>createTarget</c> falls back to <see cref="DevToolsServerOptions.EngineFactory"/>. A server that
+/// <i>has</i> one — <c>Jint.Browser</c>, which is AngleSharp plus Jint — routes all four commands through it,
+/// and everything else on this domain behaves identically either way.
 /// </para>
 /// <para>
 /// See <see href="https://chromedevtools.github.io/devtools-protocol/tot/Target/"/>.
@@ -40,7 +42,7 @@ internal sealed class TargetDomain : TargetDomainBase
     /// <param name="browser">The conversation whose attachments this domain mints.</param>
     /// <param name="nested">
     /// Whether this is the copy on an attached session rather than on the browser session, which decides
-    /// only what <c>setAutoAttach</c> does: an engine target has no children to attach to.
+    /// only what <c>setAutoAttach</c> does: a target here has no children to attach to.
     /// </param>
     internal TargetDomain(BrowserSession browser, bool nested)
     {
@@ -52,7 +54,7 @@ internal sealed class TargetDomain : TargetDomainBase
     protected override ValueTask<GetTargetsResponse> GetTargetsAsync(GetTargetsRequest parameters, CommandContext context)
     {
         var infos = new List<TargetInfo>();
-        foreach (var target in _browser.Server.Targets)
+        foreach (var target in _browser.Server.AllTargets)
         {
             if (Matches(parameters.Filter, target.Type))
             {
@@ -81,7 +83,7 @@ internal sealed class TargetDomain : TargetDomainBase
         {
             // Chrome replays targetCreated for everything that already exists, which is what makes discovery
             // usable by a client that connected after the targets did.
-            foreach (var target in _browser.Server.Targets)
+            foreach (var target in _browser.Server.AllTargets)
             {
                 if (Matches(_discoverFilter, target.Type))
                 {
@@ -103,9 +105,10 @@ internal sealed class TargetDomain : TargetDomainBase
 
         if (_nested)
         {
-            // An engine target has no children, so there is nothing to attach to and nothing to remember.
-            // Answered as the success it is: a client walks down the tree by sending this on every session
-            // it is given, and a refusal there reads to it as a broken target.
+            // A target here has no children — a worker is not a target in this server, and an engine has
+            // none at all — so there is nothing to attach to and nothing to remember. Answered as the
+            // success it is: a client walks down the tree by sending this on every session it is given, and
+            // a refusal there reads to it as a broken target.
             return EmptyResult.Instance;
         }
 
@@ -118,7 +121,7 @@ internal sealed class TargetDomain : TargetDomainBase
             return EmptyResult.Instance;
         }
 
-        foreach (var target in _browser.Server.Targets)
+        foreach (var target in _browser.Server.AllTargets)
         {
             if (Matches(_autoAttachFilter, target.Type))
             {
@@ -169,18 +172,38 @@ internal sealed class TargetDomain : TargetDomainBase
         return EmptyResult.Instance;
     }
 
-    /// <inheritdoc/>
-    protected override ValueTask<CreateTargetResponse> CreateTargetAsync(CreateTargetRequest parameters, CommandContext context)
+    /// <summary>
+    /// Creates one target, through the host when there is one and from the engine factory otherwise.
+    /// </summary>
+    /// <remarks>
+    /// <b>A target created while this session asked for <c>waitForDebuggerOnStart</c> is created waiting.</b>
+    /// The flag travels with the request rather than being applied afterwards, because a host that navigates
+    /// as it creates would otherwise have run the first document before anybody could hold it. What releases
+    /// it is <c>Runtime.runIfWaitingForDebugger</c> on the session the client is about to be attached on, and
+    /// <c>attachedToTarget.waitingForDebugger</c> is what tells the client it has to send one.
+    /// </remarks>
+    protected override async ValueTask<CreateTargetResponse> CreateTargetAsync(CreateTargetRequest parameters, CommandContext context)
     {
-        var target = _browser.Server.CreateTarget();
-        return new ValueTask<CreateTargetResponse>(new CreateTargetResponse { TargetId = target.TargetId });
+        var server = _browser.Server;
+
+        if (server.Host is not { } host)
+        {
+            var engineTarget = server.CreateTarget();
+            return new CreateTargetResponse { TargetId = engineTarget.TargetId };
+        }
+
+        var request = new TargetCreationRequest(parameters.Url, parameters.BrowserContextId, _autoAttach && _autoAttachWaitsForDebugger);
+        var target = await host.CreateTargetAsync(request, context.CancellationToken).ConfigureAwait(false);
+
+        server.AddTarget(target);
+        return new CreateTargetResponse { TargetId = target.TargetId };
     }
 
     /// <inheritdoc/>
     protected override async ValueTask<CloseTargetResponse> CloseTargetAsync(CloseTargetRequest parameters, CommandContext context)
     {
         var target = Find(parameters.TargetId);
-        await _browser.Server.CloseTargetAsync(target).ConfigureAwait(false);
+        await _browser.Server.CloseTargetAsync(target, context.CancellationToken).ConfigureAwait(false);
         return new CloseTargetResponse { Success = true };
     }
 
@@ -200,27 +223,47 @@ internal sealed class TargetDomain : TargetDomainBase
     /// <inheritdoc/>
     protected override ValueTask<GetBrowserContextsResponse> GetBrowserContextsAsync(EmptyParameters parameters, CommandContext context)
     {
-        return new ValueTask<GetBrowserContextsResponse>(new GetBrowserContextsResponse { BrowserContextIds = [] });
+        var host = _browser.Server.Host;
+        return new ValueTask<GetBrowserContextsResponse>(new GetBrowserContextsResponse
+        {
+            BrowserContextIds = host is null ? [] : [.. host.BrowserContextIds],
+        });
     }
 
     /// <inheritdoc/>
-    protected override ValueTask<CreateBrowserContextResponse> CreateBrowserContextAsync(CreateBrowserContextRequest parameters, CommandContext context)
+    /// <remarks>
+    /// With no host there is nothing to partition, and a client handed an identifier would believe its next
+    /// target was isolated when it is not — so it is refused with the reason rather than answered.
+    /// </remarks>
+    protected override async ValueTask<CreateBrowserContextResponse> CreateBrowserContextAsync(CreateBrowserContextRequest parameters, CommandContext context)
     {
-        return Throw.ServerError<ValueTask<CreateBrowserContextResponse>>(
-            "Browser contexts are not supported",
-            "an engine target has no cookies, storage or cache to partition, so a context identifier would isolate nothing");
+        if (_browser.Server.Host is not { } host)
+        {
+            return Throw.ServerError<CreateBrowserContextResponse>(
+                "Browser contexts are not supported",
+                "an engine target has no cookies, storage or cache to partition, so a context identifier would isolate nothing");
+        }
+
+        var browserContextId = await host.CreateBrowserContextAsync(context.CancellationToken).ConfigureAwait(false);
+        return new CreateBrowserContextResponse { BrowserContextId = browserContextId };
     }
 
-    /// <inheritdoc/>
-    protected override ValueTask<EmptyResult> DisposeBrowserContextAsync(DisposeBrowserContextRequest parameters, CommandContext context)
+    /// <inheritdoc cref="CreateBrowserContextAsync"/>
+    protected override async ValueTask<EmptyResult> DisposeBrowserContextAsync(DisposeBrowserContextRequest parameters, CommandContext context)
     {
-        return Throw.ServerError<ValueTask<EmptyResult>>(
-            "Browser contexts are not supported",
-            "an engine target has no cookies, storage or cache to partition, so there is no context to dispose");
+        if (_browser.Server.Host is not { } host)
+        {
+            return Throw.ServerError<EmptyResult>(
+                "Browser contexts are not supported",
+                "an engine target has no cookies, storage or cache to partition, so there is no context to dispose");
+        }
+
+        await host.DisposeBrowserContextAsync(parameters.BrowserContextId, context.CancellationToken).ConfigureAwait(false);
+        return EmptyResult.Instance;
     }
 
     /// <summary>Tells the client about a target that has just appeared, if it asked to be told.</summary>
-    internal async ValueTask TargetAddedAsync(EngineTarget target, CancellationToken cancellationToken)
+    internal async ValueTask TargetAddedAsync(DevToolsTarget target, CancellationToken cancellationToken)
     {
         if (_discover && Matches(_discoverFilter, target.Type))
         {
@@ -233,8 +276,25 @@ internal sealed class TargetDomain : TargetDomainBase
         }
     }
 
+    /// <summary>Tells the client that a target's title or location moved, if it asked to be told.</summary>
+    /// <remarks>
+    /// A page changes both on every navigation, which is what makes this event worth emitting at all: a
+    /// client keeps its own idea of where each target is, and Puppeteer's <c>page.url()</c> reads it.
+    /// </remarks>
+    internal async ValueTask TargetInfoChangedAsync(DevToolsTarget target, CancellationToken cancellationToken)
+    {
+        if (!_discover || !Matches(_discoverFilter, target.Type))
+        {
+            return;
+        }
+
+        await EmitAsync(
+            TargetEvents.TargetInfoChanged(new TargetInfoChangedEvent { TargetInfo = Describe(target) }),
+            cancellationToken).ConfigureAwait(false);
+    }
+
     /// <summary>Tells the client about a target that has gone, detaching first if it was attached.</summary>
-    internal async ValueTask TargetRemovedAsync(EngineTarget target, CancellationToken cancellationToken)
+    internal async ValueTask TargetRemovedAsync(DevToolsTarget target, CancellationToken cancellationToken)
     {
         if (_browser.SessionIdOf(target) is { } sessionId)
         {
@@ -250,7 +310,7 @@ internal sealed class TargetDomain : TargetDomainBase
         }
     }
 
-    private async ValueTask<string> AttachAsync(EngineTarget target, CancellationToken cancellationToken)
+    private async ValueTask<string> AttachAsync(DevToolsTarget target, CancellationToken cancellationToken)
     {
         var sessionId = _browser.Attach(target, out var created);
         if (!created)
@@ -275,7 +335,7 @@ internal sealed class TargetDomain : TargetDomainBase
         return sessionId;
     }
 
-    private EngineTarget Find(string? targetId)
+    private DevToolsTarget Find(string? targetId)
     {
         if (targetId is not null && _browser.Server.FindTarget(targetId) is { } target)
         {
@@ -284,21 +344,11 @@ internal sealed class TargetDomain : TargetDomainBase
 
         // Chrome's wording, which clients match on to tell a target that went away from a call that was
         // wrong.
-        return Throw.ServerError<EngineTarget>("No target with given id found");
+        return Throw.ServerError<DevToolsTarget>("No target with given id found");
     }
 
-    private TargetInfo Describe(EngineTarget target, bool attached = false)
-    {
-        return new TargetInfo
-        {
-            TargetId = target.TargetId,
-            Type = target.Type,
-            Title = target.Title,
-            Url = target.Url,
-            Attached = attached || _browser.SessionIdOf(target) is not null,
-            CanAccessOpener = false,
-        };
-    }
+    private TargetInfo Describe(DevToolsTarget target, bool attached = false)
+        => target.Describe(attached || _browser.SessionIdOf(target) is not null);
 
     [System.Diagnostics.CodeAnalysis.DoesNotReturn]
     private static void RefuseUnflattened()

--- a/Jint.DevTools/EngineTarget.cs
+++ b/Jint.DevTools/EngineTarget.cs
@@ -1,8 +1,4 @@
-using Jint.DevTools.Domains;
-using Jint.DevTools.Session;
-using Jint.Native.Promise;
 using Jint.Runtime;
-using Jint.WebApi;
 
 namespace Jint.DevTools;
 
@@ -21,11 +17,15 @@ namespace Jint.DevTools;
 /// JavaScript-only layout and never asks the target for a page. Page targets belong to the browser package.
 /// </para>
 /// <para>
+/// <b>One engine, for the target's whole life.</b> A page replaces its engine on every navigation; an engine
+/// target never does, which is why every identifier it hands out stays valid until it is disposed.
+/// </para>
+/// <para>
 /// <b>The target does not own the engine's lifetime.</b> Disposing it stops the thread it started, if it
 /// started one, and stops answering commands; the <see cref="Engine"/> is the host's, before and after.
 /// </para>
 /// </remarks>
-public sealed class EngineTarget : IAsyncDisposable
+public sealed class EngineTarget : DevToolsTarget, IAsyncDisposable
 {
     /// <summary>
     /// How long the library-owned loop parks before looking again. It is woken by every arrival, so this
@@ -36,21 +36,10 @@ public sealed class EngineTarget : IAsyncDisposable
     /// <summary>The longest a single wait may ask for, which is what the blocking primitives accept.</summary>
     private static readonly TimeSpan MaxWait = TimeSpan.FromMilliseconds(int.MaxValue);
 
-    /// <summary>
-    /// How many targets this process has made, which is what prefixes a target's remote-object identifiers
-    /// so that a handle from one target is refused by another rather than resolving in the wrong engine.
-    /// </summary>
-    private static int _serial;
-
-    private readonly EngineDispatcher _dispatcher;
     private readonly CancellationTokenSource? _stopping;
     private readonly Thread? _thread;
     private readonly ManualResetEventSlim? _debuggerWaitEnded;
-    private readonly DevToolsConsoleSink? _console;
-    private readonly object _observerLock = new();
 
-    private ITargetObserver[] _observers = [];
-    private DebuggerDomain? _debugger;
     private int _disposed;
 
     /// <summary>Creates a target over <paramref name="engine"/>.</summary>
@@ -58,59 +47,40 @@ public sealed class EngineTarget : IAsyncDisposable
     /// <param name="options">How the target presents itself and which thread runs it, or the defaults.</param>
     /// <exception cref="ArgumentNullException"><paramref name="engine"/> is <see langword="null"/>.</exception>
     public EngineTarget(Engine engine, EngineTargetOptions? options = null)
+        : this(options ?? new EngineTargetOptions(), engine)
+    {
+    }
+
+    /// <summary>Builds the target once the options are known to be there, so each is read exactly once.</summary>
+    /// <remarks>
+    /// The URL goes through the same mapping a script's own source name does, so a host that names its
+    /// target after the file it runs sees one URL in <c>/json/list</c> and in <c>Debugger.scriptParsed</c>
+    /// rather than two spellings of one location.
+    /// </remarks>
+    private EngineTarget(EngineTargetOptions options, Engine engine)
+        : base(
+            type: "node",
+            title: options.Title,
+            url: Domains.ScriptUrl.From(options.Url),
+            browserContextId: null,
+            openerId: null,
+            describer: options.RemoteObjectDescriber,
+            waitForDebuggerOnStart: options.WaitForDebuggerOnStart)
     {
         if (engine is null)
         {
             Throw.ArgumentNull(nameof(engine));
         }
 
-        options ??= new EngineTargetOptions();
-
-        var serial = Interlocked.Increment(ref _serial);
-
         Engine = engine;
-        Title = options.Title;
-
-        // Through the same mapping a script's own name goes through, so a host that names its target after
-        // the file it runs sees one URL in /json/list and in Debugger.scriptParsed rather than two.
-        Url = Domains.ScriptUrl.From(options.Url);
         ThreadMode = options.ThreadMode;
-        TargetId = Identifiers.New();
-        Describer = options.RemoteObjectDescriber;
-        RemoteObjects = new RemoteObjectTable(serial);
-
-        _dispatcher = new EngineDispatcher(engine, DevToolsServerOptions.DefaultCommandTimeout, options.WaitForDebuggerOnStart);
-
-        // Scripts are registered from the moment the target exists rather than from the moment a client asks,
-        // because Debugger.enable replays what has already been parsed and a front end's Sources panel is
-        // built from that replay. An engine the host did not build with the debugger has no BeforeEvaluate to
-        // subscribe to and no pause to serve, and the domain says so rather than answering something untrue.
-        if (engine.Options.Debugger.Enabled)
-        {
-            Scripts = new ScriptRegistry(engine, serial);
-            Scripts.Start();
-        }
-
-        // Console records reach a client only if the engine was built with UseDevTools, which is what
-        // installed the sink this binds to. An engine built without it is attachable and evaluable and says
-        // nothing about what its scripts logged, which is stated rather than silently half-true.
-        _console = engine.Options.WebApi.Console.Sink as DevToolsConsoleSink;
-        if (_console?.TryBind(this) == false)
-        {
-            // A second engine built from one Options instance. The first target speaks for that sink; this
-            // one keeps everything else and reports no console traffic.
-            _console = null;
-        }
-
-        // An unhandled rejection is an event rather than a command, so the subscription is the target's and
-        // outlives every attachment. It is taken before the loop thread starts, so nothing is missed.
-        engine.Tasks.PromiseRejectionTracker += OnPromiseRejection;
+        InstallRuntime(engine);
 
         if (options.WaitForDebuggerOnStart)
         {
             var released = new ManualResetEventSlim(initialState: false);
             _debuggerWaitEnded = released;
-            _dispatcher.DebuggerWaitEnded += released.Set;
+            DebuggerWaitEnded += released.Set;
         }
 
         if (ThreadMode != ThreadMode.LibraryOwned)
@@ -132,105 +102,33 @@ public sealed class EngineTarget : IAsyncDisposable
     public Engine Engine { get; }
 
     /// <summary>Gets the opaque identifier a client addresses this target by.</summary>
-    public string TargetId { get; }
+    /// <remarks>
+    /// Declared here as well as on the base so that the surface an embedder compiles against stays declared
+    /// on the type an embedder holds; the base class is internal, and its members are the package's own.
+    /// </remarks>
+    public new string TargetId => base.TargetId;
 
     /// <summary>Gets the target's protocol type, which is always <c>node</c> for an engine target.</summary>
-    public string Type { get; } = "node";
+    /// <inheritdoc cref="TargetId" path="/remarks"/>
+    public new string Type => base.Type;
 
     /// <summary>Gets the name a client lists the target under.</summary>
-    public string Title { get; }
+    /// <inheritdoc cref="TargetId" path="/remarks"/>
+    public new string Title => base.Title;
 
     /// <summary>Gets the location a client shows for the target.</summary>
-    public string Url { get; }
+    /// <inheritdoc cref="TargetId" path="/remarks"/>
+    public new string Url => base.Url;
 
     /// <summary>Gets which thread runs the engine and answers commands addressed to this target.</summary>
     public ThreadMode ThreadMode { get; }
 
     /// <summary>Gets whether work posted to the target is still held for a client that has not released it.</summary>
-    public bool IsWaitingForDebugger => _dispatcher.IsWaitingForDebugger;
+    /// <inheritdoc cref="TargetId" path="/remarks"/>
+    public new bool IsWaitingForDebugger => base.IsWaitingForDebugger;
 
-    /// <summary>Gets the mailbox every protocol command addressed to this target crosses.</summary>
-    internal EngineDispatcher Dispatcher => _dispatcher;
-
-    /// <summary>
-    /// Gets the scripts this engine has parsed, or <see langword="null"/> when it was not built with the
-    /// debugger enabled.
-    /// </summary>
-    internal ScriptRegistry? Scripts { get; }
-
-    /// <summary>
-    /// Gets or sets how long the engine may stay paused with no client saying what to do next.
-    /// </summary>
-    /// <remarks>
-    /// Settable for the same reason <see cref="EngineDispatcher.CommandTimeout"/> is: the bound belongs to
-    /// the server a target is published on, and a target may exist before that server does.
-    /// </remarks>
-    internal TimeSpan PauseTimeout { get; set; } = DevToolsServerOptions.DefaultPauseTimeout;
-
-    /// <summary>Gets the token that is cancelled when a library-owned target stops running.</summary>
-    /// <remarks>
-    /// What the pause loop watches so that disposing a target cannot leave its thread parked inside a pause
-    /// waiting for a client that has gone. A host-owned target has none: the thread inside the pause is the
-    /// host's own, and its lifetime is the host's business.
-    /// </remarks>
-    internal CancellationToken StoppingToken => _stopping?.Token ?? CancellationToken.None;
-
-    /// <summary>
-    /// Gets the handles this target has handed out, which live for as long as the client holding one does.
-    /// </summary>
-    /// <remarks>
-    /// On the target rather than on a session because the values in it belong to the engine: two sessions
-    /// attached to one engine address the same value by the same identifier, and each releases only what it
-    /// registered.
-    /// </remarks>
-    internal RemoteObjectTable RemoteObjects { get; }
-
-    /// <summary>Gets what names a value this package does not recognize, or <see langword="null"/>.</summary>
-    internal RemoteObjectDescriber? Describer { get; }
-
-    /// <summary>
-    /// Gets the scripts <c>Runtime.compileScript</c> persisted, by the identifier it answered with.
-    /// </summary>
-    /// <remarks>
-    /// On the target for the same reason the object table is: a compiled script belongs to the engine that
-    /// would run it, and the identifier a client is holding has to mean the same thing on every attachment.
-    /// </remarks>
-    internal CompiledScriptRegistry CompiledScripts { get; } = new();
-
-    /// <summary>Gets the global functions <c>Runtime.addBinding</c> installed, and who hears them.</summary>
-    internal BindingRegistry Bindings { get; } = new();
-
-    /// <summary>Gets the last few <c>console</c> calls, which a client enabling after the fact is replayed.</summary>
-    internal ConsoleJournal Console { get; } = new();
-
-    /// <summary>Gets the one attachment that has the <c>Debugger</c> domain enabled, if any.</summary>
-    /// <remarks>
-    /// <b>One at a time, which is a documented divergence from Chrome.</b> Breakpoints and the step mode live
-    /// on the engine's own <c>DebugHandler</c> rather than per session, so a second client enabling the domain
-    /// would silently share the first one's breakpoints and steal its pauses. It is refused instead.
-    /// </remarks>
-    internal DebuggerDomain? ActiveDebugger => Volatile.Read(ref _debugger);
-
-    /// <summary>Gets whether the engine is currently stopped inside the debugger.</summary>
-    /// <remarks>
-    /// Asked by the <c>Runtime</c> domain of <i>every</i> attachment, not only the debugging one: a paused
-    /// engine is paused for all of them, and an evaluation has to go through the paused frame's environment
-    /// rather than through a public engine entry whichever client asked for it.
-    /// </remarks>
-    internal bool IsPaused => Volatile.Read(ref _debugger)?.IsPaused == true;
-
-    /// <summary>Claims the debugger for <paramref name="domain"/>, answering whether it now has it.</summary>
-    internal bool TryClaimDebugger(DebuggerDomain domain)
-    {
-        var existing = Interlocked.CompareExchange(ref _debugger, domain, null);
-        return existing is null || ReferenceEquals(existing, domain);
-    }
-
-    /// <summary>Gives the debugger back, if <paramref name="domain"/> is what held it.</summary>
-    internal void ReleaseDebugger(DebuggerDomain domain)
-    {
-        Interlocked.CompareExchange(ref _debugger, null, domain);
-    }
+    /// <inheritdoc/>
+    internal override CancellationToken StoppingToken => _stopping?.Token ?? CancellationToken.None;
 
     /// <summary>
     /// Reports one exception that escaped the engine, so that every attached client hears about it.
@@ -255,50 +153,7 @@ public sealed class EngineTarget : IAsyncDisposable
     /// </para>
     /// </remarks>
     /// <exception cref="ArgumentNullException"><paramref name="exception"/> is <see langword="null"/>.</exception>
-    public void ReportUncaughtException(JavaScriptException exception)
-    {
-        if (exception is null)
-        {
-            Throw.ArgumentNull(nameof(exception));
-        }
-
-        foreach (var observer in Volatile.Read(ref _observers))
-        {
-            observer.ExceptionThrown(exception);
-        }
-    }
-
-    /// <summary>Registers what hears the engine's own events, from the attachment that owns them.</summary>
-    internal void Observe(ITargetObserver observer)
-    {
-        lock (_observerLock)
-        {
-            _observers = [.. _observers, observer];
-        }
-    }
-
-    /// <summary>Stops telling <paramref name="observer"/> anything, which is what detaching means.</summary>
-    internal void Unobserve(ITargetObserver observer)
-    {
-        lock (_observerLock)
-        {
-            _observers = [.. _observers.Where(candidate => !ReferenceEquals(candidate, observer))];
-        }
-    }
-
-    /// <summary>Journals one <c>console</c> call and tells everyone attached, on the engine thread.</summary>
-    internal void Record(in ConsoleRecord record)
-    {
-        var entry = Console.Add(in record, UnixMilliseconds(), RemoteObjects);
-
-        foreach (var observer in Volatile.Read(ref _observers))
-        {
-            observer.ConsoleRecorded(entry);
-        }
-    }
-
-    /// <summary>The protocol's timestamp: milliseconds since the Unix epoch, as a double.</summary>
-    internal static double UnixMilliseconds() => DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+    public new void ReportUncaughtException(JavaScriptException exception) => base.ReportUncaughtException(exception);
 
     /// <summary>
     /// Gives the engine one turn: answers the protocol commands waiting for it, then runs the event loop.
@@ -320,7 +175,7 @@ public sealed class EngineTarget : IAsyncDisposable
             Throw.InvalidOperation("A LibraryOwned target pumps itself; calling Pump on it from another thread is what the engine's single-drainer guard refuses.");
         }
 
-        _dispatcher.Drain();
+        Runtime.Dispatcher.Drain();
         Engine.Tasks.ProcessTasks();
     }
 
@@ -342,7 +197,7 @@ public sealed class EngineTarget : IAsyncDisposable
         }
 
         ThrowIfDisposed();
-        _dispatcher.Post(work);
+        Runtime.Dispatcher.Post(work);
     }
 
     /// <summary>Queues host work and answers when it has run.</summary>
@@ -384,7 +239,7 @@ public sealed class EngineTarget : IAsyncDisposable
         ThrowIfDisposed();
 
         var completion = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
-        _dispatcher.Post(engine =>
+        Runtime.Dispatcher.Post(engine =>
         {
             try
             {
@@ -463,15 +318,7 @@ public sealed class EngineTarget : IAsyncDisposable
         // The engine is the host's, before and after: a disposed target stops reaching into it first, so
         // that nothing arrives after the release below. A target that is disposed while its engine is paused
         // has to let go of the pause too, or the thread inside it waits for a client nothing will deliver.
-        Engine.Tasks.PromiseRejectionTracker -= OnPromiseRejection;
-        _console?.Unbind(this);
-        Volatile.Read(ref _debugger)?.Detach();
-
-        // A handle is a promise to keep a value alive until the client releases it, and there is no client
-        // left to release one. Dropping the references runs no engine code, so it is safe from here, and so
-        // is letting go of the journal that was holding the arguments of the last hundred console calls.
-        Console.Clear(RemoteObjects);
-        RemoteObjects.Clear();
+        ActiveDebugger?.Detach();
 
         if (_stopping is not null)
         {
@@ -483,12 +330,15 @@ public sealed class EngineTarget : IAsyncDisposable
             _thread.Join(TimeSpan.FromSeconds(5));
         }
 
-        Scripts?.Stop();
+        // The subscriptions, the handles and the journal, all of them the runtime's.
+        DisposeRuntime();
 
         _stopping?.Dispose();
         _debuggerWaitEnded?.Dispose();
-        _dispatcher.Dispose();
     }
+
+    /// <inheritdoc/>
+    internal override ValueTask CloseAsync() => DisposeAsync();
 
     private void RunLoop()
     {
@@ -498,7 +348,7 @@ public sealed class EngineTarget : IAsyncDisposable
         {
             try
             {
-                _dispatcher.Drain();
+                Runtime.Dispatcher.Drain();
                 Engine.Tasks.ProcessTasks();
                 Engine.Tasks.WaitForScheduledWork(IdleInterval, token);
             }
@@ -537,41 +387,8 @@ public sealed class EngineTarget : IAsyncDisposable
         }
     }
 
-    /// <summary>
-    /// The engine's own unhandled-rejection channel, which is where <c>Runtime.exceptionThrown</c> and
-    /// <c>Runtime.exceptionRevoked</c> come from.
-    /// </summary>
-    /// <remarks>
-    /// The engine raises <c>Reject</c> the moment a promise is rejected with nothing to handle it, and
-    /// <c>Handle</c> if something handles it afterwards. V8 waits for the end of the microtask checkpoint
-    /// before deciding, so a rejection handled on the very next line produces a throw and a revoke here
-    /// where Chrome produces neither — which is exactly the pair <c>exceptionRevoked</c> exists for, and is
-    /// why the identifier is remembered rather than the event delayed.
-    /// </remarks>
-    private void OnPromiseRejection(object? sender, PromiseRejectionTrackerEventArgs arguments)
-    {
-        var observers = Volatile.Read(ref _observers);
-        if (observers.Length == 0)
-        {
-            return;
-        }
-
-        foreach (var observer in observers)
-        {
-            if (arguments.Operation == PromiseRejectionOperation.Reject)
-            {
-                observer.RejectionThrown(arguments.Promise, arguments.Value ?? Native.JsValue.Undefined);
-            }
-            else
-            {
-                observer.RejectionHandled(arguments.Promise);
-            }
-        }
-    }
-
     private void ThrowIfDisposed()
     {
         ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
     }
-
 }

--- a/Jint.DevTools/ITargetHost.cs
+++ b/Jint.DevTools/ITargetHost.cs
@@ -1,0 +1,73 @@
+using System.Runtime.InteropServices;
+
+namespace Jint.DevTools;
+
+/// <summary>
+/// What mints a target when a client asks for one, and what partitions the targets it mints.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>Target.createTarget</c> and <c>Target.createBrowserContext</c> are the two commands every automation
+/// client sends before it can do anything at all, and an engine-level server has no honest answer to either:
+/// there is nothing to open and nothing to partition. A host that <i>does</i> — <c>Jint.Browser</c>, which is
+/// AngleSharp plus Jint — registers one of these, and the <c>Target</c> domain routes those commands through
+/// it instead of refusing them.
+/// </para>
+/// <para>
+/// <b>Registering a host changes what those commands mean and nothing else.</b> Targets a host added itself
+/// keep working exactly as before, discovery and attachment are unchanged, and a server with no host behaves
+/// as it always did — which is what keeps this seam from being a second server.
+/// </para>
+/// <para>
+/// Every member runs on a transport thread: a host that has to reach an engine posts to that engine's own
+/// mailbox, like everything else in this package.
+/// </para>
+/// </remarks>
+internal interface ITargetHost
+{
+    /// <summary>Gets the browser contexts that exist, which <c>Target.getBrowserContexts</c> answers.</summary>
+    /// <remarks>
+    /// The default context is deliberately absent, as it is in Chrome: a client reads this list to find the
+    /// contexts <i>it</i> created.
+    /// </remarks>
+    IReadOnlyList<string> BrowserContextIds { get; }
+
+    /// <summary>Creates one browser context and answers the identifier a client addresses it by.</summary>
+    /// <param name="cancellationToken">Cancels the creation.</param>
+    ValueTask<string> CreateBrowserContextAsync(CancellationToken cancellationToken);
+
+    /// <summary>Disposes one browser context and everything in it.</summary>
+    /// <param name="browserContextId">The context to dispose.</param>
+    /// <param name="cancellationToken">Cancels the disposal.</param>
+    /// <exception cref="Protocol.ProtocolException">There is no such context.</exception>
+    ValueTask DisposeBrowserContextAsync(string browserContextId, CancellationToken cancellationToken);
+
+    /// <summary>Creates one target and answers it, ready to be published.</summary>
+    /// <param name="request">What the client asked for.</param>
+    /// <param name="cancellationToken">Cancels the creation.</param>
+    /// <remarks>
+    /// The target must be returned <i>before</i> anything of its own runs when
+    /// <see cref="TargetCreationRequest.WaitForDebugger"/> holds, because a client that asked for
+    /// <c>waitForDebuggerOnStart</c> asked to be attached before the first line executes.
+    /// </remarks>
+    ValueTask<DevToolsTarget> CreateTargetAsync(TargetCreationRequest request, CancellationToken cancellationToken);
+
+    /// <summary>Closes one target the host made.</summary>
+    /// <param name="target">The target to close.</param>
+    /// <param name="cancellationToken">Cancels the close.</param>
+    ValueTask CloseTargetAsync(DevToolsTarget target, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// What <c>Target.createTarget</c> asked a host for.
+/// </summary>
+/// <param name="Url">Where the new target should go, or <see langword="null"/> for a blank one.</param>
+/// <param name="BrowserContextId">Which context to create it in, or <see langword="null"/> for the default.</param>
+/// <param name="WaitForDebugger">
+/// Whether the target runs nothing until a client sends <c>Runtime.runIfWaitingForDebugger</c>. It is the
+/// asking session's <c>Target.setAutoAttach(waitForDebuggerOnStart:)</c>, carried in the request rather than
+/// read back off the target afterwards: a host that navigates as it creates would otherwise have run the
+/// first document before anybody could hold it.
+/// </param>
+[StructLayout(LayoutKind.Auto)]
+internal readonly record struct TargetCreationRequest(string? Url, string? BrowserContextId, bool WaitForDebugger);

--- a/Jint.DevTools/Protocol/Generated/ProtocolManifest.g.cs
+++ b/Jint.DevTools/Protocol/Generated/ProtocolManifest.g.cs
@@ -132,10 +132,12 @@ namespace Jint.DevTools.Protocol
             "Runtime.exceptionRevoked",
             "Runtime.exceptionThrown",
             "Runtime.executionContextCreated",
+            "Runtime.executionContextsCleared",
             "Target.attachedToTarget",
             "Target.detachedFromTarget",
             "Target.targetCreated",
             "Target.targetDestroyed",
+            "Target.targetInfoChanged",
         ];
 
         /// <summary>What <c>Schema.getDomains</c> answers.</summary>

--- a/Jint.DevTools/Session/BrowserSession.cs
+++ b/Jint.DevTools/Session/BrowserSession.cs
@@ -46,7 +46,7 @@ internal sealed class BrowserSession
     /// <c>AddTarget</c> reaching auto-attach -- produce one attachment and one announcement rather than two.
     /// </param>
     /// <returns>The session identifier, new or existing.</returns>
-    internal string Attach(EngineTarget target, out bool created)
+    internal string Attach(DevToolsTarget target, out bool created)
     {
         lock (_attached)
         {
@@ -67,7 +67,7 @@ internal sealed class BrowserSession
     }
 
     /// <summary>Detaches one session, answering the target it was attached to.</summary>
-    internal EngineTarget? Detach(string sessionId)
+    internal DevToolsTarget? Detach(string sessionId)
     {
         TargetSession? attached;
         lock (_attached)
@@ -83,7 +83,7 @@ internal sealed class BrowserSession
     }
 
     /// <summary>Answers whether this session is attached to <paramref name="target"/>, and under which identifier.</summary>
-    internal string? SessionIdOf(EngineTarget target)
+    internal string? SessionIdOf(DevToolsTarget target)
     {
         lock (_attached)
         {
@@ -123,10 +123,14 @@ internal sealed class BrowserSession
     }
 
     /// <summary>Tells this session that a target appeared on the server.</summary>
-    internal ValueTask TargetAddedAsync(EngineTarget target, CancellationToken cancellationToken)
+    internal ValueTask TargetAddedAsync(DevToolsTarget target, CancellationToken cancellationToken)
         => _targets.TargetAddedAsync(target, cancellationToken);
 
+    /// <summary>Tells this session that a target's title or location moved.</summary>
+    internal ValueTask TargetInfoChangedAsync(DevToolsTarget target, CancellationToken cancellationToken)
+        => _targets.TargetInfoChangedAsync(target, cancellationToken);
+
     /// <summary>Tells this session that a target went away.</summary>
-    internal ValueTask TargetRemovedAsync(EngineTarget target, CancellationToken cancellationToken)
+    internal ValueTask TargetRemovedAsync(DevToolsTarget target, CancellationToken cancellationToken)
         => _targets.TargetRemovedAsync(target, cancellationToken);
 }

--- a/Jint.DevTools/Session/EngineDispatcher.cs
+++ b/Jint.DevTools/Session/EngineDispatcher.cs
@@ -43,39 +43,37 @@ namespace Jint.DevTools.Session;
 internal sealed class EngineDispatcher : ICommandGateway, IDisposable
 {
     private readonly Engine _engine;
+    private readonly DevToolsTarget _target;
     private readonly Action _drain;
     private readonly ConcurrentQueue<CommandItem> _commands = new();
     private readonly ConcurrentQueue<Action<Engine>> _hostWork = new();
     private readonly ManualResetEventSlim _arrivals = new(initialState: false);
 
-    private int _waitingForDebugger;
     private int _draining;
+    private int _abandoned;
 
-    internal EngineDispatcher(Engine engine, TimeSpan commandTimeout, bool waitForDebuggerOnStart)
+    internal EngineDispatcher(Engine engine, DevToolsTarget target)
     {
         _engine = engine;
+        _target = target;
         _drain = Drain;
-        CommandTimeout = commandTimeout;
-        _waitingForDebugger = waitForDebuggerOnStart ? 1 : 0;
     }
 
     /// <summary>
-    /// Gets or sets how long a client waits for one command before it is told the engine is not pumped.
+    /// Gets how long a client waits for one command before it is told the engine is not pumped.
     /// </summary>
     /// <remarks>
-    /// Settable because a target may exist before the server it is added to, and the bound is the server's
-    /// configuration rather than the target's.
+    /// The target's, not the mailbox's: the bound is the server's configuration, a target may exist before
+    /// the server it is added to, and the mailbox is replaced with the engine while the bound is not.
     /// </remarks>
-    internal TimeSpan CommandTimeout { get; set; }
+    internal TimeSpan CommandTimeout => _target.CommandTimeout;
 
     /// <summary>Gets whether host work is still held for a client that has not said to run it.</summary>
-    internal bool IsWaitingForDebugger => Volatile.Read(ref _waitingForDebugger) != 0;
-
-    /// <summary>
-    /// Raised on the engine thread the first time the wait for a debugger ends, so a host-owned target can
-    /// stop pumping for it.
-    /// </summary>
-    internal event Action? DebuggerWaitEnded;
+    /// <remarks>
+    /// The state is the target's, because it survives a navigation: a page held for a debugger is held
+    /// across the engine that runs its first document.
+    /// </remarks>
+    internal bool IsWaitingForDebugger => _target.IsWaitingForDebugger;
 
     /// <inheritdoc/>
     public async ValueTask<string> DispatchAsync(DevToolsSession session, ProtocolRequest request, CommandContext context)
@@ -87,6 +85,13 @@ internal sealed class EngineDispatcher : ICommandGateway, IDisposable
         var item = new CommandItem(session, request with { Parameters = request.Parameters?.Clone() }, context);
         _commands.Enqueue(item);
         ScheduleDrain();
+
+        if (Volatile.Read(ref _abandoned) != 0)
+        {
+            // The engine behind this mailbox was replaced between the gateway reading it and the enqueue.
+            // Answering here rather than leaving the item to the client's own timeout.
+            Abandon();
+        }
 
         try
         {
@@ -115,18 +120,36 @@ internal sealed class EngineDispatcher : ICommandGateway, IDisposable
     }
 
     /// <summary>
-    /// Ends the wait for a debugger, releasing whatever host work was held. Idempotent, and a no-op on a
-    /// target that was never waiting.
+    /// Answers everything still queued, because the engine behind this mailbox is going away.
     /// </summary>
-    internal void ReleaseDebuggerWait()
+    /// <remarks>
+    /// <para>
+    /// A navigation replaces the engine under its target, and a command queued for the engine that is going
+    /// would otherwise sit there until the client's own timeout — which reads to the client as a server that
+    /// stopped answering rather than as a context that was destroyed. Chrome's wording for exactly this, and
+    /// what several clients match on to decide a navigation raced their command.
+    /// </para>
+    /// <para>
+    /// Idempotent, and it drains on every call rather than only the first: the flag is what a command
+    /// arriving <i>after</i> the swap reads, and that command still has to be answered.
+    /// </para>
+    /// </remarks>
+    internal void Abandon()
     {
-        if (Interlocked.Exchange(ref _waitingForDebugger, 0) == 0)
+        Volatile.Write(ref _abandoned, 1);
+
+        while (_commands.TryDequeue(out var item))
         {
-            return;
+            item.Abandon();
         }
 
-        DebuggerWaitEnded?.Invoke();
-        ScheduleDrain();
+        while (_hostWork.TryDequeue(out _))
+        {
+            // Host work for an engine that will never run again. It is dropped rather than answered: the
+            // queue carries an Action<Engine> and nothing else, so there is no completion to fail -- a host
+            // awaiting one is in exactly the position it was in before, which is why PostAsync is documented
+            // as work for a running target.
+        }
     }
 
     /// <summary>
@@ -282,9 +305,24 @@ internal sealed class EngineDispatcher : ICommandGateway, IDisposable
     /// mailbox for a host that pumps through <see cref="Engine.TaskOperations.ProcessTasks"/> alone. Protocol
     /// traffic is human-scale; a concurrent enqueue per message is not worth that.
     /// </remarks>
-    private void ScheduleDrain()
+    internal void ScheduleDrain()
     {
-        _engine.Tasks.Post(_drain);
+        if (Volatile.Read(ref _abandoned) != 0)
+        {
+            // The engine is gone; posting to its loop would be reaching into something the host disposed.
+            Set();
+            return;
+        }
+
+        try
+        {
+            _engine.Tasks.Post(_drain);
+        }
+#pragma warning disable CA1031 // the engine may be disposed underneath us; the arrival flag still has to be set
+        catch (Exception)
+#pragma warning restore CA1031
+        {
+        }
 
         // The post above wakes whichever thread pumps the engine, and a paused engine has no such thread:
         // it is inside the debugger's handler, running a loop of its own. This is what that loop waits on.
@@ -320,6 +358,16 @@ internal sealed class EngineDispatcher : ICommandGateway, IDisposable
 
         /// <summary>Gets the qualified method the client asked for, which is what a paused drain filters on.</summary>
         internal string Method => _request.Method;
+
+        /// <summary>Answers a command whose engine is being replaced under it.</summary>
+        internal void Abandon()
+        {
+            Volatile.Write(ref _started, 1);
+            Completion.TrySetException(new ProtocolException(
+                ProtocolErrorCodes.ServerError,
+                "Execution context was destroyed.",
+                "the document this command was addressed to was replaced before the engine reached it"));
+        }
 
         /// <summary>Answers a command the engine may not run in the state it is in.</summary>
         internal void Refuse()

--- a/Jint.DevTools/Session/TargetSession.cs
+++ b/Jint.DevTools/Session/TargetSession.cs
@@ -25,23 +25,25 @@ internal sealed class TargetSession
 
     private int _detached;
 
-    private TargetSession(DevToolsSession session, EngineTarget target, BrowserSession? browser)
+    private TargetSession(DevToolsSession session, DevToolsTarget target, BrowserSession? browser)
     {
         Session = session;
         Target = target;
         _browser = browser;
 
         // Everything registered below holds engine state, so every command addressed here crosses to the
-        // engine thread first. That is the whole of the thread rule, in one line.
-        session.UseGateway(target.Dispatcher);
-        _domains = BuiltInDomains.RegisterTargetDomains(session, target, browser);
+        // engine thread first. That is the whole of the thread rule, in one line -- and the gateway is the
+        // target rather than one mailbox, because a page replaces its mailbox with its engine on every
+        // navigation and a session that captured one would queue for a document that has gone.
+        session.UseGateway(target);
+        _domains = target.RegisterDomains(session, browser);
     }
 
     /// <summary>Gets the session node this attachment answers on.</summary>
     internal DevToolsSession Session { get; }
 
     /// <summary>Gets the engine this session speaks to.</summary>
-    internal EngineTarget Target { get; }
+    internal DevToolsTarget Target { get; }
 
     /// <summary>
     /// Gets the identifier a client addresses this session by, or <see langword="null"/> for a direct
@@ -50,13 +52,13 @@ internal sealed class TargetSession
     internal string? SessionId => Session.SessionId;
 
     /// <summary>Attaches to <paramref name="target"/> under a new child of <paramref name="browser"/>.</summary>
-    internal static TargetSession Attach(BrowserSession browser, EngineTarget target, string sessionId)
+    internal static TargetSession Attach(BrowserSession browser, DevToolsTarget target, string sessionId)
     {
         return new TargetSession(browser.Session.CreateChild(sessionId), target, browser);
     }
 
     /// <summary>Builds the session a direct <c>/devtools/page/</c> connection speaks over.</summary>
-    internal static TargetSession Direct(DevToolsSession root, EngineTarget target)
+    internal static TargetSession Direct(DevToolsSession root, DevToolsTarget target)
     {
         return new TargetSession(root, target, browser: null);
     }

--- a/Jint.DevTools/TargetRuntime.cs
+++ b/Jint.DevTools/TargetRuntime.cs
@@ -1,0 +1,191 @@
+using System.Globalization;
+using Jint.DevTools.Domains;
+using Jint.DevTools.Session;
+using Jint.Native.Promise;
+
+namespace Jint.DevTools;
+
+/// <summary>
+/// One engine under a target, and everything that dies with it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A page is one target with one engine <i>per navigation</i>, so the state a client addresses splits in
+/// two: what survives a document — the target's identity, its bindings, whether it is waiting for a
+/// debugger — and what cannot, which is all of this. A handle names a value of <i>this</i> engine, a script
+/// identifier names a program <i>this</i> engine parsed, and a console journal is the history of what
+/// <i>this</i> document logged. Committing the next document replaces the lot through
+/// <see cref="DevToolsTarget.Replace"/>.
+/// </para>
+/// <para>
+/// <b>Every identifier it mints is unique for the life of the process</b>, not merely for the life of the
+/// runtime. A client holding an <c>objectId</c> from the document before last must be told the handle has
+/// gone rather than be answered about a value of the new engine that happens to sit at the same number, so
+/// the tables are seeded from a serial that only ever increases.
+/// </para>
+/// <para>
+/// Built and disposed on the engine's own thread, like everything else that touches an engine.
+/// </para>
+/// </remarks>
+internal sealed class TargetRuntime : IDisposable
+{
+    /// <summary>How many runtimes this process has built, which is what makes every identifier distinct.</summary>
+    private static int _serial;
+
+    private readonly DevToolsTarget _target;
+    private readonly DevToolsConsoleSink? _console;
+    private readonly EventHandler<PromiseRejectionTrackerEventArgs> _onRejection;
+
+    private int _disposed;
+
+    /// <summary>Builds the runtime of <paramref name="engine"/> under <paramref name="target"/>.</summary>
+    /// <param name="target">The target this engine is the current one of.</param>
+    /// <param name="engine">The engine a client evaluates in.</param>
+    /// <param name="executionContextId">
+    /// The identifier the protocol's default execution context carries. It comes from a counter on the
+    /// target, so the second document's context is <c>2</c> and never <c>1</c> again — which is what makes a
+    /// client sending back a stale one distinguishable from one sending the current one.
+    /// </param>
+    internal TargetRuntime(DevToolsTarget target, Engine engine, int executionContextId)
+    {
+        var serial = Interlocked.Increment(ref _serial);
+
+        _target = target;
+        _onRejection = OnPromiseRejection;
+
+        Engine = engine;
+        ExecutionContextId = executionContextId;
+        UniqueContextId = target.TargetId + "." + executionContextId.ToString(CultureInfo.InvariantCulture);
+        RemoteObjects = new RemoteObjectTable(serial);
+        Dispatcher = new EngineDispatcher(engine, target);
+
+        // Scripts are registered from the moment the runtime exists rather than from the moment a client
+        // asks, because Debugger.enable replays what has already been parsed and a front end's Sources panel
+        // is built from that replay. An engine the host did not build with the debugger has no
+        // BeforeEvaluate to subscribe to and no pause to serve, and the domain says so rather than answering
+        // something untrue.
+        if (engine.Options.Debugger.Enabled)
+        {
+            Scripts = new ScriptRegistry(engine, serial);
+            Scripts.Start();
+        }
+
+        // Console records reach a client only if the engine was built with UseDevTools, which is what
+        // installed the sink this binds to. An engine built without it is attachable and evaluable and says
+        // nothing about what its scripts logged, which is stated rather than silently half-true.
+        _console = engine.Options.WebApi.Console.Sink as DevToolsConsoleSink;
+        if (_console?.TryBind(target, engine) == false)
+        {
+            // A second engine built from one Options instance. The first runtime speaks for that sink; this
+            // one keeps everything else and reports no console traffic.
+            _console = null;
+        }
+
+        // An unhandled rejection is an event rather than a command, so the subscription is taken before any
+        // thread starts pumping and nothing is missed.
+        engine.Tasks.PromiseRejectionTracker += _onRejection;
+    }
+
+    /// <summary>Gets the engine a client attached to the target is evaluating in right now.</summary>
+    internal Engine Engine { get; }
+
+    /// <summary>Gets the mailbox every protocol command addressed to this engine crosses.</summary>
+    internal EngineDispatcher Dispatcher { get; }
+
+    /// <summary>Gets the handles minted against this engine, which die with it.</summary>
+    internal RemoteObjectTable RemoteObjects { get; }
+
+    /// <summary>Gets the programs this engine has parsed, or <see langword="null"/> without a debugger.</summary>
+    internal ScriptRegistry? Scripts { get; }
+
+    /// <summary>Gets the scripts <c>Runtime.compileScript</c> persisted against this engine.</summary>
+    internal CompiledScriptRegistry CompiledScripts { get; } = new();
+
+    /// <summary>Gets the last few <c>console</c> calls this document made.</summary>
+    internal ConsoleJournal Console { get; } = new();
+
+    /// <summary>Gets the identifier the protocol's default execution context carries.</summary>
+    internal int ExecutionContextId { get; }
+
+    /// <summary>Gets the opaque identifier a client tells two contexts apart by across a reload.</summary>
+    internal string UniqueContextId { get; }
+
+    /// <summary>Gets whether this runtime has been replaced or its target disposed.</summary>
+    internal bool IsDisposed => Volatile.Read(ref _disposed) != 0;
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Called on the engine thread, from <see cref="DevToolsTarget.Replace"/> or from the target going away.
+    /// Every unsubscription is guarded: the engine this runtime was built over may already have been
+    /// disposed by whoever owns it — a page disposes the old engine as it commits the next document — and a
+    /// failure to let go of something that is already gone must not stop the rest of the release.
+    /// </remarks>
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        Release(() => Engine.Tasks.PromiseRejectionTracker -= _onRejection);
+        Release(() => _console?.Unbind(_target));
+        Release(() => Scripts?.Stop());
+
+        // A handle is a promise to keep a value alive until the client releases it, and the engine those
+        // values belong to is going. Dropping the references runs no engine code, and so does letting go of
+        // the journal that was holding the arguments of this document's console calls.
+        Release(() => Console.Clear(RemoteObjects));
+        Release(RemoteObjects.Clear);
+
+        // Last: whatever a client had queued for an engine that will never run it again is answered rather
+        // than left to time out.
+        Release(Dispatcher.Abandon);
+        Release(Dispatcher.Dispose);
+    }
+
+    /// <summary>Runs one step of the release, so that a failure in it cannot skip the rest.</summary>
+    private static void Release(Action step)
+    {
+        try
+        {
+            step();
+        }
+#pragma warning disable CA1031 // the engine may already be gone; the rest of the release is still owed
+        catch (Exception)
+#pragma warning restore CA1031
+        {
+        }
+    }
+
+    /// <summary>
+    /// The engine's own unhandled-rejection channel, which is where <c>Runtime.exceptionThrown</c> and
+    /// <c>Runtime.exceptionRevoked</c> come from.
+    /// </summary>
+    /// <remarks>
+    /// The engine raises <c>Reject</c> the moment a promise is rejected with nothing to handle it, and
+    /// <c>Handle</c> if something handles it afterwards. V8 waits for the end of the microtask checkpoint
+    /// before deciding, so a rejection handled on the very next line produces a throw and a revoke here
+    /// where Chrome produces neither — which is exactly the pair <c>exceptionRevoked</c> exists for, and is
+    /// why the identifier is remembered rather than the event delayed.
+    /// </remarks>
+    private void OnPromiseRejection(object? sender, PromiseRejectionTrackerEventArgs arguments)
+    {
+        var observers = _target.Observers;
+        if (observers.Length == 0)
+        {
+            return;
+        }
+
+        foreach (var observer in observers)
+        {
+            if (arguments.Operation == PromiseRejectionOperation.Reject)
+            {
+                observer.RejectionThrown(arguments.Promise, arguments.Value ?? Native.JsValue.Undefined);
+            }
+            else
+            {
+                observer.RejectionHandled(arguments.Promise);
+            }
+        }
+    }
+}

--- a/Jint.DevTools/Transport/HttpDiscovery.cs
+++ b/Jint.DevTools/Transport/HttpDiscovery.cs
@@ -100,7 +100,7 @@ internal static class HttpDiscovery
         using (var writer = new Utf8JsonWriter(buffer))
         {
             writer.WriteStartArray();
-            foreach (var target in server.Targets)
+            foreach (var target in server.AllTargets)
             {
                 WriteTarget(writer, authority, target);
             }
@@ -215,16 +215,27 @@ internal static class HttpDiscovery
         return HttpDiscoveryResponse.NotFound;
     }
 
-    private static void WriteTarget(Utf8JsonWriter writer, string authority, EngineTarget target)
+    /// <summary>
+    /// Writes one target exactly as <c>Target.getTargets</c> describes it, plus the two addresses only the
+    /// discovery document carries.
+    /// </summary>
+    /// <remarks>
+    /// The description comes from <see cref="DevToolsTarget.Describe"/>, the same one the socket answers
+    /// with: a client that reads <c>/json/list</c> and then asks the same question over the socket must not
+    /// be told two different things about one target.
+    /// </remarks>
+    private static void WriteTarget(Utf8JsonWriter writer, string authority, DevToolsTarget target)
     {
+        var info = target.Describe(attached: false);
+
         writer.WriteStartObject();
         writer.WriteString("description", "");
-        writer.WriteString("devtoolsFrontendUrl", FrontendUrl(authority, target.TargetId));
-        writer.WriteString("id", target.TargetId);
-        writer.WriteString("title", target.Title);
-        writer.WriteString("type", target.Type);
-        writer.WriteString("url", target.Url);
-        writer.WriteString("webSocketDebuggerUrl", PageUrl(authority, target.TargetId));
+        writer.WriteString("devtoolsFrontendUrl", FrontendUrl(authority, info.TargetId, info.Type));
+        writer.WriteString("id", info.TargetId);
+        writer.WriteString("title", info.Title);
+        writer.WriteString("type", info.Type);
+        writer.WriteString("url", info.Url);
+        writer.WriteString("webSocketDebuggerUrl", PageUrl(authority, info.TargetId));
         writer.WriteEndObject();
     }
 
@@ -236,17 +247,23 @@ internal static class HttpDiscovery
     }
 
     /// <summary>
-    /// The address of the DevTools front end for one target, in Node's flavour.
+    /// The address of the DevTools front end for one target, in the flavour that target's type calls for.
     /// </summary>
     /// <remarks>
-    /// <c>v8only=true</c> is what makes the front end open its JavaScript-only layout — Sources, Console,
-    /// Memory — rather than asking the target for a page it does not have.
+    /// Two layouts, and picking the wrong one is what a client sees. <c>js_app.html?v8only=true</c> is Node's:
+    /// Sources, Console and Memory, and the front end never asks the target for a page. A <c>page</c> target
+    /// has one, so it gets <c>inspector.html</c> — Chrome's own page-flavoured address, with the Elements and
+    /// Network panels the layout above deliberately leaves out.
     /// </remarks>
-    private static string FrontendUrl(string authority, string targetId)
+    private static string FrontendUrl(string authority, string targetId, string type)
     {
-        return string.Create(
-            CultureInfo.InvariantCulture,
-            $"devtools://devtools/bundled/js_app.html?experiments=true&v8only=true&ws={authority}/devtools/page/{targetId}");
+        return string.Equals(type, "page", StringComparison.Ordinal)
+            ? string.Create(
+                CultureInfo.InvariantCulture,
+                $"devtools://devtools/bundled/inspector.html?experiments=true&ws={authority}/devtools/page/{targetId}")
+            : string.Create(
+                CultureInfo.InvariantCulture,
+                $"devtools://devtools/bundled/js_app.html?experiments=true&v8only=true&ws={authority}/devtools/page/{targetId}");
     }
 
     private static string PageUrl(string authority, string targetId)

--- a/Jint.DevTools/Transport/WebSocketServerTransport.cs
+++ b/Jint.DevTools/Transport/WebSocketServerTransport.cs
@@ -302,7 +302,7 @@ internal sealed class WebSocketServerTransport : IAsyncDisposable
         return () => _server.CloseBrowserSession(session);
     }
 
-    private static Action? OpenTarget(WebSocketConnection connection, EngineTarget target)
+    private static Action? OpenTarget(WebSocketConnection connection, DevToolsTarget target)
     {
         // There is no browser conversation to forget, but the session itself holds engine state — the
         // handles it minted, the bindings it installed, the debugger it may have paused — and a connection
@@ -321,7 +321,7 @@ internal sealed class WebSocketServerTransport : IAsyncDisposable
     /// for anything else — including a stale identifier, so a client holding one is told the browser or the
     /// target is gone rather than silently attached to a different one.
     /// </returns>
-    private (RouteKind Kind, EngineTarget? Target) Route(string path)
+    private (RouteKind Kind, DevToolsTarget? Target) Route(string path)
     {
         var query = path.IndexOf('?', StringComparison.Ordinal);
         if (query >= 0)

--- a/Jint.Tests.DevTools/Session/AttachedSession.cs
+++ b/Jint.Tests.DevTools/Session/AttachedSession.cs
@@ -156,24 +156,8 @@ internal sealed class AttachedSession : IAsyncDisposable
     /// test that can hang is a continuous-integration leg that can hang, and a pause that never arrives is
     /// exactly the defect these tests are looking for.
     /// </remarks>
-    internal async Task<JsonElement> EventAsync(string method, int index = 0, int timeoutSeconds = 120)
-    {
-        var deadline = Environment.TickCount64 + (timeoutSeconds * 1000L);
-
-        while (Environment.TickCount64 < deadline)
-        {
-            var events = EventsOf(method);
-            if (events.Count > index)
-            {
-                return events[index].GetProperty("params");
-            }
-
-            await Task.Delay(5).ConfigureAwait(false);
-        }
-
-        Assert.Fail($"'{method}' number {index} never arrived within {timeoutSeconds} seconds.");
-        return default;
-    }
+    internal Task<JsonElement> EventAsync(string method, int index = 0, int timeoutSeconds = 120)
+        => _session.EventAsync(method, index, timeoutSeconds);
 
     /// <summary>Enables the domains a debugging client enables, in the order a client sends them.</summary>
     internal async Task EnableDebuggerAsync()

--- a/Jint.Tests.DevTools/Session/ConsoleSessionTests.cs
+++ b/Jint.Tests.DevTools/Session/ConsoleSessionTests.cs
@@ -179,11 +179,11 @@ public class ConsoleSessionTests
         await session.ResultAsync("Runtime.enable");
         await session.EvaluateAsync("console.log({ a: 1 })");
 
-        session.Target.RemoteObjects.Count.Should().BeGreaterThan(0);
+        session.Target.Runtime.RemoteObjects.Count.Should().BeGreaterThan(0);
 
         await session.ResultAsync("Runtime.discardConsoleEntries");
 
-        session.Target.RemoteObjects.Count.Should().Be(0, "the handles the journal minted go with it");
+        session.Target.Runtime.RemoteObjects.Count.Should().Be(0, "the handles the journal minted go with it");
 
         // And a client enabling now is replayed nothing.
         await session.ResultAsync("Runtime.disable");
@@ -210,7 +210,7 @@ public class ConsoleSessionTests
 
         await session.EvaluateAsync("for (var i = 0; i < 200; i++) { console.log({ i: i }); }");
 
-        session.Target.RemoteObjects.Count.Should().BeLessThan(
+        session.Target.Runtime.RemoteObjects.Count.Should().BeLessThan(
             201,
             "a page that logs an object every turn must not keep every one of them alive for as long as a client stays attached");
 

--- a/Jint.Tests.DevTools/Session/NavigableTarget.cs
+++ b/Jint.Tests.DevTools/Session/NavigableTarget.cs
@@ -1,0 +1,159 @@
+using Jint.DevTools;
+
+namespace Jint.Tests.DevTools.Session;
+
+/// <summary>
+/// A target that replaces its engine, which is what a page does on every navigation.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The suite declares one rather than waiting for <c>Jint.Browser</c> to bring one, for the reason
+/// <c>DomainLifecycleTests</c> declares a domain: an extension point nothing exercises is a design nobody has
+/// tried. It is the smallest thing that is a real target — an identity, a loop thread that owns its engine,
+/// and <see cref="DevToolsTarget.Replace"/> called from that thread — and everything the built-in domains do
+/// about a swap is visible through it.
+/// </para>
+/// <para>
+/// The loop is the shape every host's is: drain the mailbox, run the event loop, park. It reads
+/// <see cref="DevToolsTarget.Runtime"/> afresh on every turn, because that is the whole point — a loop that
+/// captured the engine would go on pumping the document that was replaced.
+/// </para>
+/// </remarks>
+internal sealed class NavigableTarget : DevToolsTarget
+{
+    private readonly CancellationTokenSource _stopping = new();
+    private readonly Thread _thread;
+
+    private int _closed;
+
+    /// <summary>Creates a target over <paramref name="engine"/> and starts pumping it.</summary>
+    /// <param name="engine">The engine of the first document.</param>
+    /// <param name="url">Where the target says it is.</param>
+    /// <param name="browserContextId">Which context it belongs to, or <see langword="null"/>.</param>
+    /// <param name="waitForDebuggerOnStart">Whether it runs nothing until a client releases it.</param>
+    internal NavigableTarget(
+        Engine engine,
+        string url = "about:blank",
+        string? browserContextId = null,
+        bool waitForDebuggerOnStart = false)
+        : base(
+            type: "page",
+            title: "Test page",
+            url: url,
+            browserContextId: browserContextId,
+            openerId: null,
+            describer: null,
+            waitForDebuggerOnStart: waitForDebuggerOnStart)
+    {
+        InstallRuntime(engine);
+
+        _thread = new Thread(Run)
+        {
+            IsBackground = true,
+            Name = "Navigable target " + TargetId,
+        };
+
+        _thread.Start();
+    }
+
+    /// <summary>Commits the next document, which builds an engine and hands it to the target.</summary>
+    /// <param name="next">What builds the engine, run on the loop thread.</param>
+    /// <returns>A task that completes once the swap has been made and announced.</returns>
+    /// <remarks>
+    /// Posted rather than called, because replacing the engine is an engine-owning operation and the caller
+    /// is a test thread. That is the arrangement a page is in: the loop that runs the old document is the one
+    /// that builds the new.
+    /// </remarks>
+    internal Task NavigateAsync(Func<Engine> next)
+    {
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Runtime.Dispatcher.Post(_ =>
+        {
+            try
+            {
+                Replace(next());
+                completion.TrySetResult();
+            }
+            catch (Exception exception)
+            {
+                completion.TrySetException(exception);
+            }
+        });
+
+        return completion.Task;
+    }
+
+    /// <summary>Runs host work on the loop thread and answers what it returned.</summary>
+    internal Task<T> PostAsync<T>(Func<Engine, T> work)
+    {
+        var completion = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Runtime.Dispatcher.Post(engine =>
+        {
+            try
+            {
+                completion.TrySetResult(work(engine));
+            }
+            catch (Exception exception)
+            {
+                completion.TrySetException(exception);
+            }
+        });
+
+        return completion.Task;
+    }
+
+    /// <inheritdoc cref="PostAsync{T}"/>
+    internal Task PostAsync(Action<Engine> work) => PostAsync<object?>(engine =>
+    {
+        work(engine);
+        return null;
+    });
+
+    /// <inheritdoc/>
+    internal override async ValueTask CloseAsync()
+    {
+        if (Interlocked.Exchange(ref _closed, 1) != 0)
+        {
+            return;
+        }
+
+        ActiveDebugger?.Detach();
+        await _stopping.CancelAsync().ConfigureAwait(false);
+
+        if (_thread.IsAlive)
+        {
+            _thread.Join(TimeSpan.FromSeconds(5));
+        }
+
+        DisposeRuntime();
+        _stopping.Dispose();
+    }
+
+    private void Run()
+    {
+        var token = _stopping.Token;
+
+        while (!token.IsCancellationRequested)
+        {
+            try
+            {
+                // Read afresh: a navigation replaces all three of these under the loop.
+                var runtime = Runtime;
+                runtime.Dispatcher.Drain();
+                runtime.Engine.Tasks.ProcessTasks();
+                runtime.Engine.Tasks.WaitForScheduledWork(TimeSpan.FromMilliseconds(20), token);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+#pragma warning disable CA1031 // the loop is the last thing between one bad command and a dead target
+            catch (Exception)
+#pragma warning restore CA1031
+            {
+            }
+        }
+    }
+}

--- a/Jint.Tests.DevTools/Session/ProtocolSession.cs
+++ b/Jint.Tests.DevTools/Session/ProtocolSession.cs
@@ -76,7 +76,7 @@ internal sealed class ProtocolSession : IAsyncDisposable
     }
 
     /// <summary>Attaches to <paramref name="target"/> the way a client does, and hands back the session identifier.</summary>
-    internal async Task<string> AttachAsync(EngineTarget target)
+    internal async Task<string> AttachAsync(DevToolsTarget target)
     {
         var reply = await SendAsync(
             "Target.attachToTarget",
@@ -126,6 +126,49 @@ internal sealed class ProtocolSession : IAsyncDisposable
         return error;
     }
 
+    /// <summary>Sends one command on an attachment and hands back its <c>result</c>, asserting success.</summary>
+    internal async Task<JsonElement> ResultAsync(string method, string? parameters, string sessionId)
+    {
+        var reply = await SendAsync(method, parameters, sessionId).ConfigureAwait(false);
+        reply.TryGetProperty("error", out var error).Should().BeFalse("'{0}' was expected to succeed, and it answered {1}", method, error);
+        return reply.GetProperty("result");
+    }
+
+    /// <summary>Sends one command on an attachment and hands back its <c>error</c>, asserting failure.</summary>
+    internal async Task<JsonElement> ErrorAsync(string method, string? parameters, string sessionId)
+    {
+        var reply = await SendAsync(method, parameters, sessionId).ConfigureAwait(false);
+        reply.TryGetProperty("error", out var error).Should().BeTrue("'{0}' was expected to fail, and it answered {1}", method, reply);
+        return error;
+    }
+
+    /// <summary>
+    /// Waits for the event at <paramref name="index"/> of <paramref name="method"/>, failing rather than
+    /// hanging.
+    /// </summary>
+    /// <remarks>
+    /// <b>Every wait here is bounded.</b> A protocol test that can hang is a continuous-integration leg that
+    /// can hang, and an event that never arrives is exactly the defect these tests are looking for.
+    /// </remarks>
+    internal async Task<JsonElement> EventAsync(string method, int index = 0, int timeoutSeconds = 60)
+    {
+        var deadline = Environment.TickCount64 + (timeoutSeconds * 1000L);
+
+        while (Environment.TickCount64 < deadline)
+        {
+            var events = EventsOf(method);
+            if (events.Count > index)
+            {
+                return events[index].GetProperty("params");
+            }
+
+            await Task.Delay(5).ConfigureAwait(false);
+        }
+
+        Assert.Fail($"'{method}' number {index} never arrived within {timeoutSeconds} seconds.");
+        return default;
+    }
+
     /// <summary>Every event of <paramref name="method"/> the session has sent, oldest first.</summary>
     internal IReadOnlyList<JsonElement> EventsOf(string method)
     {
@@ -151,9 +194,9 @@ internal sealed class ProtocolSession : IAsyncDisposable
             return;
         }
 
-        foreach (var target in _server.Targets)
+        foreach (var target in _server.AllTargets)
         {
-            await target.DisposeAsync().ConfigureAwait(false);
+            await target.CloseAsync().ConfigureAwait(false);
         }
 
         await _server.DisposeAsync().ConfigureAwait(false);

--- a/Jint.Tests.DevTools/Session/RemoteObjectTests.cs
+++ b/Jint.Tests.DevTools/Session/RemoteObjectTests.cs
@@ -74,10 +74,10 @@ public class RemoteObjectTests
         await using var session = await AttachedSession.CreateAsync();
 
         var objectId = await session.HandleAsync("({ a: 1 })");
-        session.Target.RemoteObjects.Count.Should().Be(1);
+        session.Target.Runtime.RemoteObjects.Count.Should().Be(1);
 
         await session.ResultAsync("Runtime.releaseObject", $$"""{"objectId":"{{objectId}}"}""");
-        session.Target.RemoteObjects.Count.Should().Be(0);
+        session.Target.Runtime.RemoteObjects.Count.Should().Be(0);
 
         // A client tidying up releases what a detach may already have taken, and Chrome answers that with a
         // success rather than an error.
@@ -134,11 +134,11 @@ public class RemoteObjectTests
 
         await session.HandleAsync("({ a: 1 })");
         await session.HandleAsync("({ b: 2 })");
-        session.Target.RemoteObjects.Count.Should().Be(2);
+        session.Target.Runtime.RemoteObjects.Count.Should().Be(2);
 
         await session.Protocol.SendAsync("Target.detachFromTarget", $$"""{"sessionId":"{{session.SessionId}}"}""");
 
-        session.Target.RemoteObjects.Count.Should().Be(0);
+        session.Target.Runtime.RemoteObjects.Count.Should().Be(0);
     }
 
     [Test]
@@ -148,10 +148,10 @@ public class RemoteObjectTests
         try
         {
             await session.HandleAsync("({ a: 1 })");
-            session.Target.RemoteObjects.Count.Should().Be(1);
+            session.Target.Runtime.RemoteObjects.Count.Should().Be(1);
 
             await session.Target.DisposeAsync();
-            session.Target.RemoteObjects.Count.Should().Be(0);
+            session.Target.Runtime.RemoteObjects.Count.Should().Be(0);
         }
         finally
         {

--- a/Jint.Tests.DevTools/Session/TargetRuntimeTests.cs
+++ b/Jint.Tests.DevTools/Session/TargetRuntimeTests.cs
@@ -1,0 +1,369 @@
+using System.Text.Json;
+using Jint.DevTools;
+
+namespace Jint.Tests.DevTools.Session;
+
+/// <summary>
+/// A target outlives its engine: what a client is told when the engine under it is replaced, and what stops
+/// meaning anything when it is.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the half of the protocol layer a page needs and an engine target never exercises. Everything a
+/// client holds — a handle, a script identifier, an execution-context identifier — names one engine, and a
+/// navigation ends all of them at once; everything the client <i>asked for</i> — a binding, a breakpoint by
+/// URL — is owed to the next document as much as it was to this one. Each test below is one half of that.
+/// </para>
+/// <para>
+/// Every wait is bounded, and the engine is always pumped by a thread that is not the test's, which is the
+/// arrangement a real client is in.
+/// </para>
+/// </remarks>
+[NonParallelizable]
+public class TargetRuntimeTests
+{
+    [Test]
+    public async Task ReplacingTheEngineClearsTheContextsAndAnnouncesTheNextOne()
+    {
+        await using var session = ProtocolSession.Create();
+
+        var target = new NavigableTarget(NewEngine());
+        session.Server.AddTarget(target);
+        var attachment = await session.AttachAsync(target);
+
+        await session.ResultAsync("Runtime.enable", null, attachment);
+
+        var first = await session.EventAsync("Runtime.executionContextCreated");
+        first.GetProperty("context").GetProperty("id").GetInt32().Should().Be(1);
+        first.GetProperty("context").GetProperty("auxData").GetProperty("isDefault").GetBoolean().Should().BeTrue();
+        first.GetProperty("context").GetProperty("auxData").GetProperty("type").GetString().Should().Be("default");
+        first.GetProperty("context").GetProperty("auxData").GetProperty("frameId").GetString().Should().Be(target.TargetId);
+
+        await target.NavigateAsync(NewEngine);
+
+        await session.EventAsync("Runtime.executionContextsCleared");
+
+        var second = await session.EventAsync("Runtime.executionContextCreated", index: 1);
+        second.GetProperty("context").GetProperty("id").GetInt32().Should().Be(
+            2,
+            "the counter is the target's, so the second document's default context is never 1 again");
+        second.GetProperty("context").GetProperty("auxData").GetProperty("isDefault").GetBoolean().Should().BeTrue();
+
+        // The order is Chrome's: the client is told everything it holds has gone before it is told what it
+        // now has.
+        var order = session.EventsOf("Runtime.executionContextsCleared").Count;
+        order.Should().Be(1);
+        Ordinal(session, "Runtime.executionContextsCleared").Should()
+            .BeLessThan(Ordinal(session, "Runtime.executionContextCreated", 1), "cleared comes first");
+    }
+
+    [Test]
+    public async Task ReplacingTheEngineReleasesEveryHandleTheClientHeld()
+    {
+        await using var session = ProtocolSession.Create();
+
+        var target = new NavigableTarget(NewEngine());
+        session.Server.AddTarget(target);
+        var attachment = await session.AttachAsync(target);
+
+        await session.ResultAsync("Runtime.enable", null, attachment);
+
+        var evaluated = await session.ResultAsync(
+            "Runtime.evaluate",
+            """{"expression":"({ answer: 42 })"}""",
+            attachment);
+
+        var objectId = evaluated.GetProperty("result").GetProperty("objectId").GetString();
+        objectId.Should().NotBeNullOrEmpty();
+
+        await target.NavigateAsync(NewEngine);
+
+        var error = await session.ErrorAsync(
+            "Runtime.getProperties",
+            $$"""{"objectId":"{{objectId}}"}""",
+            attachment);
+
+        error.GetProperty("code").GetInt32().Should().Be(-32000);
+        error.GetProperty("message").GetString().Should().Be(
+            "Could not find object with given id",
+            "Chrome's wording, which a client matches on to decide a handle it holds has gone");
+    }
+
+    [Test]
+    public async Task AContextIdentifierFromBeforeTheNavigationIsRefusedInChromesWording()
+    {
+        await using var session = ProtocolSession.Create();
+
+        var target = new NavigableTarget(NewEngine());
+        session.Server.AddTarget(target);
+        var attachment = await session.AttachAsync(target);
+
+        await session.ResultAsync("Runtime.enable", null, attachment);
+
+        // The identifier the client read off the first executionContextCreated is good while it names the
+        // document that minted it.
+        await session.ResultAsync("Runtime.evaluate", """{"expression":"1","contextId":1}""", attachment);
+
+        await target.NavigateAsync(NewEngine);
+
+        var error = await session.ErrorAsync("Runtime.evaluate", """{"expression":"1","contextId":1}""", attachment);
+        error.GetProperty("code").GetInt32().Should().Be(-32000);
+        error.GetProperty("message").GetString().Should().Be("Cannot find context with specified id");
+
+        // The current one is answered, which is what tells the two failures apart.
+        await session.ResultAsync("Runtime.evaluate", """{"expression":"1","contextId":2}""", attachment);
+    }
+
+    [Test]
+    public async Task ABindingIsReinstalledIntoEveryNewEngine()
+    {
+        await using var session = ProtocolSession.Create();
+
+        var target = new NavigableTarget(NewEngine());
+        session.Server.AddTarget(target);
+        var attachment = await session.AttachAsync(target);
+
+        await session.ResultAsync("Runtime.enable", null, attachment);
+        await session.ResultAsync("Runtime.addBinding", """{"name":"report"}""", attachment);
+
+        await session.ResultAsync("Runtime.evaluate", """{"expression":"report('first')"}""", attachment);
+        (await session.EventAsync("Runtime.bindingCalled")).GetProperty("payload").GetString().Should().Be("first");
+
+        await target.NavigateAsync(NewEngine);
+
+        // The binding is a global function of an engine that no longer exists, and the client never asked
+        // for it again. It is owed to the document that is about to run.
+        await session.ResultAsync("Runtime.evaluate", """{"expression":"report('second')"}""", attachment);
+
+        var second = await session.EventAsync("Runtime.bindingCalled", index: 1);
+        second.GetProperty("payload").GetString().Should().Be("second");
+        second.GetProperty("executionContextId").GetInt32().Should().Be(2);
+    }
+
+    [Test]
+    public async Task ABreakpointSetByUrlIsResolvedAgainstTheNextDocument()
+    {
+        await using var session = ProtocolSession.Create();
+
+        var target = new NavigableTarget(NewEngine());
+        session.Server.AddTarget(target);
+        var attachment = await session.AttachAsync(target);
+
+        await session.ResultAsync("Runtime.enable", null, attachment);
+        await session.ResultAsync("Debugger.enable", null, attachment);
+
+        var set = await session.ResultAsync(
+            "Debugger.setBreakpointByUrl",
+            """{"url":"app.js","lineNumber":1,"columnNumber":0}""",
+            attachment);
+
+        var breakpointId = set.GetProperty("breakpointId").GetString();
+
+        _ = target.PostAsync(engine => engine.Execute(Source, "app.js"));
+
+        var resolved = await session.EventAsync("Debugger.breakpointResolved");
+        resolved.GetProperty("breakpointId").GetString().Should().Be(breakpointId);
+
+        await session.EventAsync("Debugger.paused");
+        await session.ResultAsync("Debugger.resume", null, attachment);
+
+        await target.NavigateAsync(NewEngine);
+
+        // A new engine, a new DebugHandler and an empty breakpoint collection: the request outlives all
+        // three, and the client is told where it landed this time.
+        _ = target.PostAsync(engine => engine.Execute(Source, "app.js"));
+
+        var again = await session.EventAsync("Debugger.breakpointResolved", index: 1);
+        again.GetProperty("breakpointId").GetString().Should().Be(breakpointId);
+
+        var pausedAgain = await session.EventAsync("Debugger.paused", index: 1);
+        pausedAgain.GetProperty("hitBreakpoints").EnumerateArray().Select(id => id.GetString()).Should().Equal(breakpointId);
+
+        await session.ResultAsync("Debugger.resume", null, attachment);
+    }
+
+    [Test]
+    public async Task AnIsolatedWorldIsAnAliasForTheDocumentsOwnRealm()
+    {
+        await using var session = ProtocolSession.Create();
+
+        var target = new NavigableTarget(NewEngine());
+        session.Server.AddTarget(target);
+        var attachment = await session.AttachAsync(target);
+
+        await session.ResultAsync("Runtime.enable", null, attachment);
+        await session.ResultAsync("Runtime.evaluate", """{"expression":"var marker = 7"}""", attachment);
+
+        var world = await target.PostAsync(_ => target.CreateWorldContext("utility"));
+
+        var announced = await session.EventAsync("Runtime.executionContextCreated", index: 1);
+        announced.GetProperty("context").GetProperty("id").GetInt32().Should().Be(world.Id);
+        announced.GetProperty("context").GetProperty("name").GetString().Should().Be("utility");
+        announced.GetProperty("context").GetProperty("auxData").GetProperty("isDefault").GetBoolean().Should().BeFalse();
+        announced.GetProperty("context").GetProperty("auxData").GetProperty("type").GetString().Should().Be("isolated");
+
+        // The documented divergence: there is one realm per document and a world is a name for it, so the
+        // page's own global is visible in it.
+        var evaluated = await session.ResultAsync(
+            "Runtime.evaluate",
+            $$"""{"expression":"marker","contextId":{{world.Id}},"returnByValue":true}""",
+            attachment);
+
+        evaluated.GetProperty("result").GetProperty("value").GetInt32().Should().Be(7);
+
+        // The alias lasts as long as the realm it names.
+        await target.NavigateAsync(NewEngine);
+
+        var error = await session.ErrorAsync(
+            "Runtime.evaluate",
+            $$"""{"expression":"1","contextId":{{world.Id}}}""",
+            attachment);
+
+        error.GetProperty("message").GetString().Should().Be("Cannot find context with specified id");
+    }
+
+    [Test]
+    public async Task AHostedTargetCreatedUnderWaitForDebuggerRunsNothingUntilItIsReleased()
+    {
+        await using var session = ProtocolSession.Create();
+
+        var host = new StubTargetHost();
+        session.Server.UseHost(host);
+
+        await session.ResultOfAsync("""{"id":1,"method":"Target.setDiscoverTargets","params":{"discover":true}}""");
+        await session.ResultOfAsync("""{"id":2,"method":"Target.setAutoAttach","params":{"autoAttach":true,"waitForDebuggerOnStart":true,"flatten":true}}""");
+
+        var contextId = (await session.ResultOfAsync("""{"id":3,"method":"Target.createBrowserContext","params":{}}"""))
+            .GetProperty("browserContextId").GetString();
+
+        contextId.Should().NotBeNullOrEmpty();
+        (await session.ResultOfAsync("""{"id":4,"method":"Target.getBrowserContexts"}"""))
+            .GetProperty("browserContextIds").EnumerateArray().Select(id => id.GetString()).Should().Equal(contextId);
+
+        await session.ResultOfAsync($$$"""{"id":5,"method":"Target.createTarget","params":{"url":"about:blank","browserContextId":"{{{contextId}}}"}}""");
+
+        var attached = await session.EventAsync("Target.attachedToTarget");
+        attached.GetProperty("waitingForDebugger").GetBoolean().Should().BeTrue();
+        attached.GetProperty("targetInfo").GetProperty("browserContextId").GetString().Should().Be(contextId);
+        attached.GetProperty("targetInfo").GetProperty("type").GetString().Should().Be("page");
+
+        var attachment = attached.GetProperty("sessionId").GetString()!;
+        var target = host.Created.Should().ContainSingle().Subject;
+
+        // Host work is held while the wait is on: this is what "runs nothing" means.
+        var ran = target.PostAsync(engine => engine.Evaluate("1 + 1").AsNumber());
+        (await Task.WhenAny(ran, Task.Delay(200))).Should().NotBeSameAs(ran, "the target is holding everything posted to it");
+
+        await session.ResultAsync("Runtime.runIfWaitingForDebugger", null, attachment);
+
+        (await ran.WaitAsync(TimeSpan.FromSeconds(10))).Should().Be(2);
+        target.IsWaitingForDebugger.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task ATargetThatMovesTellsEveryDiscoveringClient()
+    {
+        await using var session = ProtocolSession.Create();
+
+        var target = new NavigableTarget(NewEngine());
+        session.Server.AddTarget(target);
+
+        await session.ResultOfAsync("""{"id":1,"method":"Target.setDiscoverTargets","params":{"discover":true}}""");
+
+        await target.PostAsync(_ => target.UpdateInfo(title: "Second page", url: "https://example.test/two"));
+
+        var changed = await session.EventAsync("Target.targetInfoChanged");
+        changed.GetProperty("targetInfo").GetProperty("title").GetString().Should().Be("Second page");
+        changed.GetProperty("targetInfo").GetProperty("url").GetString().Should().Be("https://example.test/two");
+    }
+
+    /// <summary>Line 1 is the assignment the breakpoint lands on.</summary>
+    private const string Source = """
+        function work() {
+            var value = 1;
+            return value;
+        }
+        work();
+        """;
+
+    private static Engine NewEngine() => new(options => options.UseDevTools());
+
+    /// <summary>Where one event sits among everything the connection has sent, for an ordering assertion.</summary>
+    private static int Ordinal(ProtocolSession session, string method, int index = 0)
+    {
+        var seen = 0;
+        for (var i = 0; i < session.Sent.Count; i++)
+        {
+            using var document = JsonDocument.Parse(session.Sent[i]);
+            if (document.RootElement.TryGetProperty("method", out var name) && name.GetString() == method && seen++ == index)
+            {
+                return i;
+            }
+        }
+
+        return int.MaxValue;
+    }
+
+    /// <summary>
+    /// The smallest thing that is a host: it mints contexts and targets and remembers what it made.
+    /// </summary>
+    /// <remarks>
+    /// <c>Jint.Browser</c> is the real one — a context is a cookie jar and a storage partition, a target is a
+    /// page with a loop of its own. What this pins is the seam rather than the browser: that
+    /// <c>Target.createTarget</c> reaches the host at all, that the <c>waitForDebuggerOnStart</c> a session
+    /// asked for travels with the request, and that a hosted target is announced and attached like any other.
+    /// </remarks>
+    private sealed class StubTargetHost : ITargetHost
+    {
+        private readonly List<string> _contexts = [];
+
+        internal List<NavigableTarget> Created { get; } = [];
+
+        public IReadOnlyList<string> BrowserContextIds
+        {
+            get
+            {
+                lock (_contexts)
+                {
+                    return _contexts.ToArray();
+                }
+            }
+        }
+
+        public ValueTask<string> CreateBrowserContextAsync(CancellationToken cancellationToken)
+        {
+            var id = "context-" + Guid.NewGuid().ToString("N");
+            lock (_contexts)
+            {
+                _contexts.Add(id);
+            }
+
+            return new ValueTask<string>(id);
+        }
+
+        public ValueTask DisposeBrowserContextAsync(string browserContextId, CancellationToken cancellationToken)
+        {
+            lock (_contexts)
+            {
+                _contexts.Remove(browserContextId);
+            }
+
+            return default;
+        }
+
+        public ValueTask<DevToolsTarget> CreateTargetAsync(TargetCreationRequest request, CancellationToken cancellationToken)
+        {
+            var target = new NavigableTarget(
+                NewEngine(),
+                request.Url ?? "about:blank",
+                request.BrowserContextId,
+                request.WaitForDebugger);
+
+            Created.Add(target);
+            return new ValueTask<DevToolsTarget>(target);
+        }
+
+        public ValueTask CloseTargetAsync(DevToolsTarget target, CancellationToken cancellationToken)
+            => target.CloseAsync();
+    }
+}

--- a/Jint.Tests.DevTools/Verify/PublicApiTest.verified.txt
+++ b/Jint.Tests.DevTools/Verify/PublicApiTest.verified.txt
@@ -35,22 +35,23 @@ namespace Jint.DevTools
         public int Port { get; set; }
         public string? Product { get; set; }
     }
-    public sealed class EngineTarget : System.IAsyncDisposable
+    public abstract class DevToolsTarget { }
+    public sealed class EngineTarget : Jint.DevTools.DevToolsTarget, System.IAsyncDisposable
     {
         public EngineTarget(Jint.Engine engine, Jint.DevTools.EngineTargetOptions? options = null) { }
         public Jint.Engine Engine { get; }
-        public bool IsWaitingForDebugger { get; }
-        public string TargetId { get; }
+        public new bool IsWaitingForDebugger { get; }
+        public new string TargetId { get; }
         public Jint.DevTools.ThreadMode ThreadMode { get; }
-        public string Title { get; }
-        public string Type { get; }
-        public string Url { get; }
+        public new string Title { get; }
+        public new string Type { get; }
+        public new string Url { get; }
         public System.Threading.Tasks.ValueTask DisposeAsync() { }
         public void Post(System.Action<Jint.Engine> work) { }
         public System.Threading.Tasks.Task PostAsync(System.Action<Jint.Engine> work) { }
         public System.Threading.Tasks.Task<T> PostAsync<T>(System.Func<Jint.Engine, T> work) { }
         public void Pump() { }
-        public void ReportUncaughtException(Jint.Runtime.JavaScriptException exception) { }
+        public new void ReportUncaughtException(Jint.Runtime.JavaScriptException exception) { }
         public bool WaitForDebugger(System.TimeSpan timeout) { }
     }
     public sealed class EngineTargetOptions

--- a/tools/devtools-protocol/manifest.json
+++ b/tools/devtools-protocol/manifest.json
@@ -110,11 +110,10 @@
     "Target.setDiscoverTargets"
   ],
 
-  // The events Jint.DevTools emits. Target.targetInfoChanged is deliberately not among them: an engine
-  // target's title and location are fixed when the host makes it, so there is nothing that could change
-  // and claiming the event would be a claim nothing ever honours. Runtime.executionContextDestroyed and
-  // executionContextsCleared are absent for the same reason: an engine target's one context lives as long
-  // as the engine does. Debugger.scriptFailedToParse is absent because the engine raises
+  // The events Jint.DevTools emits. Runtime.executionContextDestroyed is deliberately not among them: a
+  // target that replaces its engine clears every context at once and says so with executionContextsCleared,
+  // which is what Chrome sends for a cross-document navigation, and there is no way to destroy one context
+  // of a target while others live. Debugger.scriptFailedToParse is absent because the engine raises
   // BeforeEvaluate only for a program it did parse; a parse failure never reaches this package.
   "implementedEvents": [
     "Console.messageAdded",
@@ -128,10 +127,12 @@
     "Runtime.exceptionRevoked",
     "Runtime.exceptionThrown",
     "Runtime.executionContextCreated",
+    "Runtime.executionContextsCleared",
     "Target.attachedToTarget",
     "Target.detachedFromTarget",
     "Target.targetCreated",
-    "Target.targetDestroyed"
+    "Target.targetDestroyed",
+    "Target.targetInfoChanged"
   ],
 
   // What Schema.getDomains answers. A domain reaches this list only once it has an implemented command,


### PR DESCRIPTION
## What

`Jint.DevTools` grows the half of the protocol layer a page needs and an engine target never exercises: a
target that outlives the engine behind it, and a host that mints targets and browser contexts when a client
asks for one. It is the first of three stacked pull requests for C1 of the headless-browser campaign
(sebastienros/jint#3575, plan row C1); nothing under `Jint/` changes, and `Jint.Browser` is untouched.

Everything hung off `EngineTarget`, which binds one engine forever. A page is one target with **one engine
per navigation**, so the class is split in two:

- **`DevToolsTarget`** — the identity a client keeps addressing: `TargetId`, `Type`, `Title`, `Url`,
  `BrowserContextId`, `OpenerId`, the observer list, the `Describer`, the `BindingRegistry`, the
  `WaitingForDebugger` state, the command and pause timeouts, and the execution-context counter.
- **`TargetRuntime`** — one engine and everything that dies with it: the `EngineDispatcher`, the
  `RemoteObjectTable`, the `ScriptRegistry`, the `CompiledScriptRegistry`, the `ConsoleJournal`, the
  console-sink binding, the promise-rejection subscription, and the default execution context's identifier.

`EngineTarget : DevToolsTarget` stays `public sealed`, keeps every member it published, and has one runtime
for its whole life. Every domain now holds the target and reads `target.Runtime` **per command**, so none of
them can go on answering about a document that has been replaced; `TargetSession` uses the target itself as
the command gateway, so a request is queued on the engine that is running now.

`DevToolsTarget.Replace(Engine)` is the swap. It disposes the previous runtime, installs the new one,
re-installs the bindings *before* any script of the new document runs, and tells every domain through
`ITargetObserver.RuntimeReplaced`:

| Domain | What a swap means to it |
| --- | --- |
| `Runtime` | `executionContextsCleared`, then `executionContextCreated` for the new default context (`auxData: { isDefault: true, type: "default", frameId }`). The handles are already gone with the table. |
| `Debugger` | Subscriptions move to the new `DebugHandler`; every request's *placed* positions are forgotten and every URL breakpoint is resolved again as the next document's scripts are parsed, with `breakpointResolved`. `setPauseOnExceptions`, `setSkipAllPauses` and `setAsyncCallStackDepth` carry over. |
| `Profiler` | A recording ends at the swap and is thrown away — a profile over two engines answers a question nobody asked. |
| `Console`, `Log` | Nothing: the journal is the runtime's and went with it. |

Two identifier rules make a stale reference *fail* rather than land somewhere wrong. The execution-context
counter is the **target's**, so the second document's default context is `2` and never `1` again, and a
`contextId` from before a navigation answers `-32000 Cannot find context with specified id` — Chrome's text,
which `handshakes/matrix.md` records PuppeteerSharp receiving and coping with. And every table is seeded from
a process-wide serial, so an `objectId` or a `scriptId` from the document before last fails to resolve rather
than naming a value of the engine that replaced it.

**Isolated worlds are aliases.** `CreateWorldContext(name)` mints an extra context identifier over the
*current* realm and announces it with `auxData: { isDefault: false, type: "isolated", frameId }`. There is one
realm per document here, so a world is a name for it: it buys a client its own identifier to address — which
is what Puppeteer and Playwright use `Page.createIsolatedWorld` for — and none of the isolation the name
promises. It lasts until the next navigation. Documented as a divergence in `Jint.DevTools/AGENTS.md`.

**A host that mints targets.** `ITargetHost` (internal) is `BrowserContextIds`, `CreateBrowserContextAsync`,
`DisposeBrowserContextAsync`, `CreateTargetAsync` and `CloseTargetAsync`; `DevToolsServer.UseHost` registers
one, and `Target.createTarget` / `closeTarget` / `createBrowserContext` / `disposeBrowserContext` /
`getBrowserContexts` route through it. **With no host registered every one of them behaves exactly as it did**
— `createBrowserContext` still refuses with its reason, `createTarget` still falls back to
`DevToolsServerOptions.EngineFactory`. A target created while the asking session had
`setAutoAttach(waitForDebuggerOnStart: true)` is created *waiting*, and `attachedToTarget.waitingForDebugger`
says so. `Target.targetInfoChanged` is new, fired when a target's title or location moves.
`DevToolsTarget.RegisterDomains` is virtual so a page target adds its own domains next to the built-in five,
and `/json/list` and `Target.getTargets` are written from one `TargetInfo` — with Chrome's page-flavoured
`inspector.html` front-end URL for a `type: "page"` target and Node's `js_app.html?v8only=true` for everything
else.

## Why

C2 cannot be written without it. A page replaces its engine on every commit, and until now a domain that
survived that would answer about handles, scripts and a context that had all gone; `Target.createTarget` had
nothing to create; and `createBrowserContext` refused, which is the first command every recorded automation
client sends after `connect`.

## Tests

`Jint.Tests.DevTools/Session/TargetRuntimeTests.cs`, eight cases over a `NavigableTarget` the suite declares —
the smallest thing that is a real target, with a loop thread of its own — for the reason `DomainLifecycleTests`
declares a domain: an extension point nothing exercises is a design nobody has tried.

1. A swap emits `executionContextsCleared` then `executionContextCreated` with id **2**, in that order.
2. A handle from before the swap answers `-32000 Could not find object with given id`.
3. A `contextId` from before the swap answers `-32000 Cannot find context with specified id`, and the current
   one is answered — which is what tells the two failures apart.
4. A `Runtime.addBinding` name is re-installed and callable in the next document, on context 2.
5. A breakpoint set by URL is resolved *and hit* again after a navigation.
6. An isolated world evaluates against the page's own global, and stops resolving at the next navigation.
7. A hosted `createTarget` under `waitForDebuggerOnStart` holds everything posted to it until
   `Runtime.runIfWaitingForDebugger`.
8. `Target.targetInfoChanged` reaches a discovering client when a target moves.

**These tests cannot be run against the code before the change**: `DevToolsTarget`, `Replace`,
`CreateWorldContext` and `ITargetHost` do not exist there, so they fail to compile rather than to assert. What
*is* checked against the old behaviour is everything else — all 387/389 existing `Jint.Tests.DevTools` cases
pass untouched, which is the property the split was supposed to keep.

Run in Release: `Jint.Tests.DevTools` 387 (net8.0) / 389 (net10.0), `Jint.Tests.Browser` 493/495,
`Jint.Tests.PublicInterface` 3573/3563/2850, `Jint.Tests` 12176 including `AgentInstructionFileTests`,
`ProtocolManifestTests`, `GeneratedProtocolIsCurrentTests`, `ProtocolCitationTests` and `PublicApiTest`, and
`Jint.Tests.Test262` 102573. The full solution passes.

## What was left out, and why

- **`Runtime.executionContextDestroyed`.** A target that replaces its engine clears every context at once and
  says so with `executionContextsCleared`, which is what Chrome sends for a cross-document navigation; there
  is no way to destroy one context of a target while others live. The manifest says so.
- **Auto-releasing a waiting target on `attachToTarget`.** A target is created waiting only when the asking
  session said `waitForDebuggerOnStart: true`, so a target attached without it was never held — the
  parenthetical case in the design is satisfied by construction rather than by a second release path, which
  would have changed what `EngineTargetOptions.WaitForDebuggerOnStart` means for existing hosts.
- **Making `Bindings` per-runtime.** They are the client's request and are owed to the next document; that is
  the whole reason `Reinstall` exists.
- **Anything page-level.** `Page`, `Emulation`, `Network`, `Fetch` and the rest are PR 2's.

## Where reality forced a change

- **`DevToolsTarget` had to be `public abstract`, not `internal abstract`.** C# refuses a public class with a
  less accessible base (CS0060), and `EngineTarget` is public. Every member of it is `internal` and the
  constructor is `private protected`, so nothing outside the assembly can construct one, derive from one or
  call anything on one; `ICommandGateway` is implemented explicitly for the same reason.
- **The public-API baseline therefore changes, and it is worth reading the diff.** Nothing an embedder could
  reach was removed: `EngineTarget` declares every member it declared before, `new` where the base carries an
  internal member of the same name, so the *reachable* surface is byte-for-byte what it was. What the snapshot
  gains is `public abstract class DevToolsTarget { }`, the base-type on `EngineTarget`'s declaration, and six
  `new` markers.
- **`DevToolsServer.Targets` still answers `IReadOnlyList<EngineTarget>`** and now filters: a page target is
  not an `EngineTarget` and the property is public, so it lists the engine targets and says so in its
  `<remarks>`. `AllTargets` is the internal whole list, and it is what discovery, `getTargets` and
  `/json/list` read.
- **`ITargetHost.CreateTargetAsync` takes a `TargetCreationRequest`, not three arguments.** The
  `waitForDebuggerOnStart` the asking session set has to travel *with* the request: a host that navigates as
  it creates would otherwise have run the first document before anybody could hold it.
- **A command queued on the engine being replaced is answered `-32000 "Execution context was destroyed."`**
  rather than left to the client's own `CommandTimeout`, which would read as a server that stopped answering.

## Divergences from Chrome

Two, both stated in `Jint.DevTools/AGENTS.md`:

- **An isolated world is an alias for the document's own realm**, not a realm of its own. One realm per
  document; a world is a name for it.
- **One `Debugger`-enabled session per target**, unchanged from before this pull request and unchanged by it.

## AngleSharp defects found

None — this pull request does not touch `Jint.Browser` or AngleSharp.

## Engine and package seams I wished I had

- **A way to observe an `Engine` being disposed.** `TargetRuntime.Dispose` unsubscribes from an engine whose
  owner may already have disposed it, so every release step is wrapped in a `try`. A `disposing` signal — or a
  documented "unsubscribing from a disposed engine is safe" — would let that be an assertion rather than a
  guard.
- **`Engine.Tasks.Post` on a disposed engine.** Same shape: `ScheduleDrain` swallows, because there is no way
  to ask whether posting is still meaningful.
- **A settled promise's value.** `[[PromiseResult]]` is still a description with no handle, for the reason
  `Domains/AGENTS.md` gives; a navigation makes it slightly more visible, because a client now has more
  reasons to re-read a promise it was told about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
