### PR TITLE
Events: the four page seams that have to live in the engine — the default passive value, the current event, the initialized flag and the legacy initializers' arity

### DIFF
--- a/Jint.Tests/Runtime/WebApi/EventTargetTests.cs
+++ b/Jint.Tests/Runtime/WebApi/EventTargetTests.cs
@@ -1,6 +1,7 @@
 #if NET8_0_OR_GREATER
 #nullable enable
 
+using Jint.Native;
 using Jint.Runtime;
 
 namespace Jint.Tests.Runtime.WebApi;
@@ -504,5 +505,69 @@ public class EventTargetTests
         engine.Evaluate("forcedResult").AsBoolean().Should().BeFalse();
     }
 
+    // https://dom.spec.whatwg.org/#window-current-event
+
+    /// <summary>
+    /// An engine whose global object is not a <c>Window</c> does not maintain DOM's <i>current event</i> at
+    /// all — the slot stays undefined right through a dispatch.
+    /// </summary>
+    /// <remarks>
+    /// The point of the negative test is the cost: the read is one field on a target that already exists, and
+    /// an engine that installs no document never writes it, so nothing about a dispatch changed for the
+    /// engines that ship.
+    /// </remarks>
+    [Test]
+    public void TheCurrentEventIsNotMaintainedForAGlobalThatIsNotAWindow()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Events | WebApiFeatures.GlobalEvents));
+        var scope = engine._webApi!.GlobalEventTarget;
+        engine.SetValue("readEvent", new Func<JsValue>(() => scope.CurrentEvent));
+
+        engine.Execute("""
+            var during = 'unset';
+            addEventListener('ping', function () { during = readEvent(); });
+            dispatchEvent(new Event('ping'));
+            """);
+
+        engine.Evaluate("during === undefined").AsBoolean().Should().BeTrue();
+        scope.CurrentEvent.Should().Be(JsValue.Undefined);
+    }
+
+    /// <summary>
+    /// Once a host says the global object is a <c>Window</c>, the current event is the event whose listener is
+    /// running and is restored when it returns — after a nested dispatch, and after a listener that threw.
+    /// </summary>
+    [Test]
+    public void TheCurrentEventOfAWindowIsSetPerInvocationAndAlwaysRestored()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Events | WebApiFeatures.GlobalEvents));
+        var scope = engine._webApi!.GlobalEventTarget;
+        scope.IsWindow = true;
+        engine.SetValue("readEvent", new Func<JsValue>(() => scope.CurrentEvent));
+
+        engine.Execute("""
+            var outer = new Event('outer');
+            var inner = new Event('inner');
+            var seen = [];
+            var nested = new EventTarget();
+
+            nested.addEventListener('inner', function () { seen.push('inner:' + (readEvent() === inner)); });
+            addEventListener('outer', function () {
+                seen.push('outer:' + (readEvent() === outer));
+                nested.dispatchEvent(inner);
+                seen.push('after:' + (readEvent() === outer));
+            });
+
+            dispatchEvent(outer);
+            seen.push('done:' + (readEvent() === undefined));
+            """);
+
+        engine.Evaluate("seen.join(',')").AsString().Should().Be("outer:true,inner:true,after:true,done:true");
+
+        // A listener that throws erupts on an engine with no diagnostics sink, and the slot is still restored.
+        engine.Execute("addEventListener('boom', function () { throw new Error('x'); });");
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("dispatchEvent(new Event('boom'))"));
+        scope.CurrentEvent.Should().Be(JsValue.Undefined);
+    }
 }
 #endif

--- a/Jint.Tests/Runtime/WebApi/EventTargetTests.cs
+++ b/Jint.Tests/Runtime/WebApi/EventTargetTests.cs
@@ -424,5 +424,85 @@ public class EventTargetTests
         Assert.Throws<JavaScriptException>(() => engine.Evaluate("EventTarget.prototype.dispatchEvent.call({}, new Event('x'))"))!
             .Message.Should().Contain("EventTarget");
     }
+
+    // https://dom.spec.whatwg.org/#default-passive-value
+
+    /// <summary>
+    /// The engine's answer to DOM's <i>default passive value</i> is false for every type and every target it
+    /// ships, because the rule names a <c>Window</c>, a document, a document element and a body element and
+    /// an engine with no DOM has none of them.
+    /// </summary>
+    /// <remarks>
+    /// Both spellings of "the member is absent" are checked, because WebIDL treats an explicit
+    /// <c>undefined</c> as absent and it would be easy to make one of the two take a different path.
+    /// </remarks>
+    [TestCase("touchstart")]
+    [TestCase("touchmove")]
+    [TestCase("wheel")]
+    [TestCase("mousewheel")]
+    [TestCase("touchend")]
+    public void TheDefaultPassiveValueIsFalseWithoutADocument(string type)
+    {
+        var engine = WebEngine();
+        engine.SetValue("type", type);
+
+        foreach (var options in new[] { "", ", undefined", ", {}", ", { passive: undefined }", ", { capture: false }" })
+        {
+            engine.Execute($$"""
+                var e = new Event(type, { cancelable: true });
+                var handler = function (ev) { ev.preventDefault(); };
+                target.addEventListener(type, handler{{options}});
+                var result = target.dispatchEvent(e);
+                target.removeEventListener(type, handler);
+                """);
+
+            engine.Evaluate("e.defaultPrevented").AsBoolean().Should().BeTrue($"a listener added with \"{options}\" is not passive");
+            engine.Evaluate("result").AsBoolean().Should().BeFalse();
+        }
+    }
+
+    /// <summary>
+    /// A host that installs a document says which targets DOM's rule names, and the engine then answers true
+    /// for the four types and false for every other. The global scope's half of that is
+    /// <c>GlobalEventTarget.IsWindow</c>.
+    /// </summary>
+    /// <remarks>
+    /// A test rather than a page, because the point is that the engine holds the type list and the host holds
+    /// nothing but the classification: <c>Jint.Browser</c>'s window installer is the only caller that sets
+    /// this, and its own half is pinned by the browser package's tests and by the web-platform-tests document
+    /// <c>dom/events/passive-by-default.html</c>.
+    /// </remarks>
+    [TestCase("touchstart", true)]
+    [TestCase("touchmove", true)]
+    [TestCase("wheel", true)]
+    [TestCase("mousewheel", true)]
+    [TestCase("touchend", false)]
+    [TestCase("click", false)]
+    public void AGlobalScopeAHostCallsAWindowTakesTheDefaultPassiveValue(string type, bool passive)
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Events | WebApiFeatures.GlobalEvents));
+        engine._webApi!.GlobalEventTarget.IsWindow = true;
+        engine.SetValue("type", type);
+
+        engine.Execute("""
+            var e = new Event(type, { cancelable: true });
+            addEventListener(type, function (ev) { ev.preventDefault(); });
+            var result = dispatchEvent(e);
+            """);
+
+        engine.Evaluate("e.defaultPrevented").AsBoolean().Should().Be(!passive);
+        engine.Evaluate("result").AsBoolean().Should().Be(passive);
+
+        // The explicit spellings are unaffected by the rule, which is what makes it a *default*.
+        engine.Execute("""
+            var forced = new Event(type, { cancelable: true });
+            addEventListener(type, function (ev) { ev.preventDefault(); }, { passive: false });
+            var forcedResult = dispatchEvent(forced);
+            """);
+
+        engine.Evaluate("forced.defaultPrevented").AsBoolean().Should().BeTrue();
+        engine.Evaluate("forcedResult").AsBoolean().Should().BeFalse();
+    }
+
 }
 #endif

--- a/Jint.Tests/Runtime/WebApi/EventTargetTests.cs
+++ b/Jint.Tests/Runtime/WebApi/EventTargetTests.cs
@@ -3,6 +3,7 @@
 
 using Jint.Native;
 using Jint.Runtime;
+using Jint.WebApi.Events;
 
 namespace Jint.Tests.Runtime.WebApi;
 
@@ -503,6 +504,40 @@ public class EventTargetTests
 
         engine.Evaluate("forced.defaultPrevented").AsBoolean().Should().BeTrue();
         engine.Evaluate("forcedResult").AsBoolean().Should().BeFalse();
+    }
+
+    // https://dom.spec.whatwg.org/#initialized-flag
+
+    /// <summary>
+    /// An event whose initialized flag is unset cannot be dispatched, and <c>initEvent()</c> is what makes it
+    /// dispatchable — DOM's <c>dispatchEvent</c> step 1.
+    /// </summary>
+    /// <remarks>
+    /// The only algorithm that unsets the flag is <c>document.createEvent()</c>, which a host with a document
+    /// supplies, so the test stands in for that host. Every event the engine constructs has the flag set,
+    /// which the first assertion is there to keep true.
+    /// </remarks>
+    [Test]
+    public void AnEventWhoseInitializedFlagIsUnsetCannotBeDispatched()
+    {
+        var engine = WebEngine();
+        var ev = (JsEvent) engine.Evaluate("var e = new Event(''); e");
+
+        ev.InitializedFlag.Should().BeTrue("a constructed event is initialized");
+
+        ev.InitializedFlag = false;
+        var caught = Assert.Throws<JavaScriptException>(() => engine.Evaluate("target.dispatchEvent(e)"))!;
+        caught.Error.Get("name").AsString().Should().Be("InvalidStateError");
+
+        // initEvent is the whole of "initialize an event", step 1 included.
+        engine.Execute("""
+            target.addEventListener('ping', function () { log.push('ran'); });
+            e.initEvent('ping', false, false);
+            """);
+
+        ev.InitializedFlag.Should().BeTrue();
+        engine.Evaluate("target.dispatchEvent(e)").AsBoolean().Should().BeTrue();
+        Log(engine).Should().Be("ran");
     }
 
     // https://dom.spec.whatwg.org/#window-current-event

--- a/Jint.Tests/Runtime/WebApi/EventTests.cs
+++ b/Jint.Tests/Runtime/WebApi/EventTests.cs
@@ -446,6 +446,43 @@ public class EventTests
     }
 
     /// <summary>
+    /// <c>type</c> is a required argument of both legacy initializers, so calling one with none is WebIDL's
+    /// arity <c>TypeError</c> — and an explicit <c>undefined</c> is not the same call, because the argument
+    /// is there and a <c>DOMString</c> stringifies it.
+    /// </summary>
+    /// <remarks>
+    /// The check is before the dispatch flag: WebIDL raises the arity error while it converts the arguments,
+    /// which happens whatever the receiver is doing, so <c>initEvent()</c> throws even for an event whose
+    /// dispatch would have made the call a no-op.
+    /// </remarks>
+    [Test]
+    public void TheLegacyInitializersRequireAType()
+    {
+        var engine = WebEngine();
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new Event('a').initEvent()"))!
+            .Message.Should().Contain("1 argument required");
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new CustomEvent('a').initCustomEvent()"))!
+            .Message.Should().Contain("1 argument required");
+
+        engine.Evaluate("new Event('a').initEvent(undefined) === undefined").AsBoolean().Should().BeTrue();
+        engine.Execute("var arity = new Event('a'); arity.initEvent(undefined);");
+        engine.Evaluate("arity.type").AsString().Should().Be("undefined");
+
+        // Even while a dispatch is in flight, where the call itself would otherwise be a silent no-op.
+        engine.Execute("""
+            var target = new EventTarget();
+            var caught = null;
+            var dispatched = new Event('a');
+            target.addEventListener('a', function (e) { try { e.initEvent(); } catch (err) { caught = err; } });
+            target.dispatchEvent(dispatched);
+            """);
+
+        engine.Evaluate("caught instanceof TypeError").AsBoolean().Should().BeTrue();
+    }
+
+    /// <summary>
     /// "Initialize event's target to null" and "Set event's isTrusted attribute to false" — the two steps of
     /// <i>initialize an event</i> that are not about the type or the flags.
     /// </summary>

--- a/Jint/WebApi/Events/CustomEventPrototype.cs
+++ b/Jint/WebApi/Events/CustomEventPrototype.cs
@@ -57,19 +57,22 @@ internal sealed partial class CustomEventPrototype : Prototype
     /// <c>initEvent</c>'s is: only <c>type</c> is required.
     /// </remarks>
     [JsFunction(Name = "initCustomEvent", Length = 1, Flags = PropertyFlag.ConfigurableEnumerableWritable)]
-    private JsValue InitCustomEvent(JsValue thisObject, JsValue type, JsValue bubbles, JsValue cancelable, JsValue detail)
+    private JsValue InitCustomEvent(JsValue thisObject, JsCallArguments arguments)
     {
         var ev = Brand(thisObject);
+        EventTargetArguments.RequireArguments(_realm, arguments, 1, "initCustomEvent", "CustomEvent");
+
         if (ev.DispatchFlag)
         {
             return Undefined;
         }
 
         ev.InitializeEvent(
-            TypeConverter.ToJsString(type),
-            TypeConverter.ToBoolean(bubbles),
-            TypeConverter.ToBoolean(cancelable));
+            TypeConverter.ToJsString(arguments.At(0)),
+            TypeConverter.ToBoolean(arguments.At(1)),
+            TypeConverter.ToBoolean(arguments.At(2)));
 
+        var detail = arguments.At(3);
         ev.Detail = detail.IsUndefined() ? Null : detail;
         return Undefined;
     }

--- a/Jint/WebApi/Events/EventDispatch.cs
+++ b/Jint/WebApi/Events/EventDispatch.cs
@@ -373,8 +373,10 @@ internal static class EventDispatch
         // Step 6.
         ev.CurrentTarget = item.InvocationTarget.EventTargetValue;
 
-        // Steps 7 to 9.
-        item.InvocationTarget.InvokeListeners(ev, capturePass);
+        // Steps 7 to 9. The struct's invocation-target-in-shadow-tree flag travels with them, because inner
+        // invoke reads it: a listener whose invocation target is inside a shadow tree runs without the
+        // Window's `event` being set to the event it is handling.
+        item.InvocationTarget.InvokeListeners(ev, capturePass, item.InvocationTargetInShadowTree);
     }
 
     /// <summary>

--- a/Jint/WebApi/Events/EventPrototype.cs
+++ b/Jint/WebApi/Events/EventPrototype.cs
@@ -319,20 +319,28 @@ internal sealed partial class EventPrototype : Prototype
     /// Step 1 is what stops a listener re-initializing the very event it is being handed: the dispatch flag is
     /// set for the whole of <c>dispatchEvent</c>, so the call is a silent no-op there rather than an error.
     /// </para>
+    /// <para>
+    /// The required argument is checked <b>before</b> the dispatch flag, because WebIDL's arity error is
+    /// raised while the arguments are being converted and knows nothing about what the receiver is doing:
+    /// <c>initEvent()</c> is a <c>TypeError</c> even for an event a dispatch has in flight. Passing an
+    /// explicit <c>undefined</c> is not the same call — the member exists, so it stringifies.
+    /// </para>
     /// </remarks>
     [JsFunction(Name = "initEvent", Length = 1, Flags = PropertyFlag.ConfigurableEnumerableWritable)]
-    private JsValue InitEvent(JsValue thisObject, JsValue type, JsValue bubbles, JsValue cancelable)
+    private JsValue InitEvent(JsValue thisObject, JsCallArguments arguments)
     {
         var ev = Brand(thisObject);
+        EventTargetArguments.RequireArguments(_realm, arguments, 1, "initEvent", "Event");
+
         if (ev.DispatchFlag)
         {
             return Undefined;
         }
 
         ev.InitializeEvent(
-            TypeConverter.ToJsString(type),
-            TypeConverter.ToBoolean(bubbles),
-            TypeConverter.ToBoolean(cancelable));
+            TypeConverter.ToJsString(arguments.At(0)),
+            TypeConverter.ToBoolean(arguments.At(1)),
+            TypeConverter.ToBoolean(arguments.At(2)));
 
         return Undefined;
     }

--- a/Jint/WebApi/Events/EventTargetPrototype.cs
+++ b/Jint/WebApi/Events/EventTargetPrototype.cs
@@ -301,13 +301,19 @@ internal static class EventTargetArguments
     /// WebIDL's arity check: an operation whose required arguments were not all supplied raises a
     /// <c>TypeError</c> before anything else is converted.
     /// </summary>
-    private static void RequireArguments(Realm realm, JsCallArguments arguments, int required, string operationName)
+    internal static void RequireArguments(
+        Realm realm,
+        JsCallArguments arguments,
+        int required,
+        string operationName,
+        string interfaceName = "EventTarget")
     {
         if (arguments.Length < required)
         {
+            var plural = required == 1 ? "argument" : "arguments";
             Throw.TypeError(
                 realm,
-                $"Failed to execute '{operationName}' on 'EventTarget': {required} arguments required, but only {arguments.Length} present.");
+                $"Failed to execute '{operationName}' on '{interfaceName}': {required} {plural} required, but only {arguments.Length} present.");
         }
     }
 

--- a/Jint/WebApi/Events/EventTargetPrototype.cs
+++ b/Jint/WebApi/Events/EventTargetPrototype.cs
@@ -140,7 +140,7 @@ internal static class EventTargetArguments
 
         var type = TypeConverter.ToString(arguments.At(0));
         var callback = ReadCallback(realm, arguments.At(1), "addEventListener");
-        var options = FlattenMoreOptions(realm, arguments.At(2));
+        var options = FlattenMoreOptions(realm, target, type, arguments.At(2));
 
         target.AddListener(new EventListenerRegistration(type, callback)
         {
@@ -216,20 +216,27 @@ internal static class EventTargetArguments
     /// inherited dictionary's members in: <c>capture</c> first, then <c>once</c>, <c>passive</c>,
     /// <c>signal</c>.
     /// </summary>
-    private static ListenerOptions FlattenMoreOptions(Realm realm, JsValue options)
+    private static ListenerOptions FlattenMoreOptions(Realm realm, JsEventTarget target, string type, JsValue options)
     {
         var capture = FlattenOptions(options);
 
         if (options is not ObjectInstance dictionary)
         {
-            return new ListenerOptions(capture, Passive: false, Once: false, Signal: null);
+            // No dictionary at all is the commonest way for the `passive` member to be absent, so this arm
+            // owes the default passive value exactly as the one below does.
+            return new ListenerOptions(capture, DefaultPassiveValue(target, type), Once: false, Signal: null);
         }
 
         var once = TypeConverter.ToBoolean(dictionary.Get(CommonEventProperties.Once));
 
-        // "If options["passive"] exists" — an absent member leaves passive null, and the default passive
-        // value is false for every type an engine without a document can see.
-        var passive = TypeConverter.ToBoolean(dictionary.Get(CommonEventProperties.Passive));
+        // "If options["passive"] exists, then set passive to options["passive"]; otherwise set passive to the
+        // default passive value given type and eventTarget." A WebIDL dictionary member whose value is
+        // `undefined` does not exist, so `{passive: undefined}` takes the default and `{passive: null}` — a
+        // value that does exist — converts to false.
+        var passiveValue = dictionary.Get(CommonEventProperties.Passive);
+        var passive = passiveValue.IsUndefined()
+            ? DefaultPassiveValue(target, type)
+            : TypeConverter.ToBoolean(passiveValue);
 
         // `AbortSignal signal` is a non-nullable interface type with no default: an absent member means no
         // signal, and anything present that is not an AbortSignal — null included — is a TypeError.
@@ -246,6 +253,24 @@ internal static class EventTargetArguments
 
         return new ListenerOptions(capture, passive, once, signal);
     }
+
+    /// <summary>
+    /// https://dom.spec.whatwg.org/#default-passive-value — a <c>touchstart</c>, <c>touchmove</c>,
+    /// <c>wheel</c> or <c>mousewheel</c> listener added to a <c>Window</c>, a document, a document element or
+    /// a body element with no <c>passive</c> member is passive.
+    /// </summary>
+    /// <remarks>
+    /// The type is tested first because it is the cheap half and the one that is nearly always false: every
+    /// other listener a page adds costs one switch over four names and never reaches the virtual. The target
+    /// half is <see cref="JsEventTarget.IsDefaultPassiveTarget"/>, which is false for every target this engine
+    /// ships — an engine with no document has no <c>Window</c> and no body — so nothing changes for an engine
+    /// that installs no DOM.
+    /// </remarks>
+    private static bool DefaultPassiveValue(JsEventTarget target, string type) => type switch
+    {
+        "touchstart" or "touchmove" or "wheel" or "mousewheel" => target.IsDefaultPassiveTarget,
+        _ => false,
+    };
 
     /// <summary>
     /// The <c>EventListener?</c> callback interface conversion,

--- a/Jint/WebApi/Events/EventTargetPrototype.cs
+++ b/Jint/WebApi/Events/EventTargetPrototype.cs
@@ -177,13 +177,17 @@ internal static class EventTargetArguments
             return false;
         }
 
-        // Step 1. Every event this engine can produce has its initialized flag set from construction, so the
-        // only way here is a re-entrant dispatch of an event that is already being dispatched.
-        if (ev.DispatchFlag)
+        // Step 1, both halves. Every event this engine constructs has its initialized flag set, so on an
+        // engine with no document the second is a re-entrant dispatch of an event already being dispatched
+        // and nothing else; a host with `document.createEvent()` is what can produce the first, and an event
+        // it made is undispatchable until `initEvent()` has named it.
+        if (ev.DispatchFlag || !ev.InitializedFlag)
         {
             var invalidState = realm.Intrinsics.DomException.CreateException(
                 DomExceptionNames.InvalidState,
-                "Failed to execute 'dispatchEvent' on 'EventTarget': the event is already being dispatched.");
+                ev.DispatchFlag
+                    ? "Failed to execute 'dispatchEvent' on 'EventTarget': the event is already being dispatched."
+                    : "Failed to execute 'dispatchEvent' on 'EventTarget': the event has not been initialized.");
 
             var location = engine._lastSyntaxElement?.Location ?? default;
             Throw.JavaScriptException(engine, invalidState, in location);

--- a/Jint/WebApi/Events/JsEvent.cs
+++ b/Jint/WebApi/Events/JsEvent.cs
@@ -126,6 +126,19 @@ internal class JsEvent : ObjectInstance
     internal bool InPassiveListenerFlag { get; set; }
 
     /// <summary>
+    /// https://dom.spec.whatwg.org/#initialized-flag. Set for every event this engine constructs, because a
+    /// constructor sets it and there is only one algorithm in the whole standard that unsets it —
+    /// <c>document.createEvent()</c>, which a host with a document supplies.
+    /// </summary>
+    /// <remarks>
+    /// Read by exactly one algorithm too: <c>dispatchEvent</c>'s <c>InvalidStateError</c> guard, which is what
+    /// makes <c>document.createEvent("Event")</c> undispatchable until <c>initEvent()</c> has named it. Its
+    /// only writer outside <see cref="InitializeEvent"/> is that host <c>createEvent</c>, so no engine the box
+    /// ships can produce an event whose flag is unset and nothing about a dispatch changed for one.
+    /// </remarks>
+    internal bool InitializedFlag { get; set; } = true;
+
+    /// <summary>
     /// https://dom.spec.whatwg.org/#dispatch-flag. Set for the duration of one <c>dispatchEvent</c>, which is
     /// what makes a re-entrant dispatch of the same event an <c>InvalidStateError</c> and what
     /// <c>composedPath()</c> answers from.
@@ -191,10 +204,10 @@ internal class JsEvent : ObjectInstance
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Step 1, "set event's initialized flag", has nothing to set. The flag is unset by exactly one algorithm
-    /// in the standard, <c>document.createEvent()</c>, and read by exactly one, <c>dispatchEvent</c>'s
-    /// <c>InvalidStateError</c> guard. There is no <c>document</c> here, so every event Jint can build has the
-    /// flag set from birth and no observation can tell a stored flag from an assumed one.
+    /// Step 1, "set event's initialized flag", is what makes an event a host's <c>document.createEvent()</c>
+    /// built dispatchable: that algorithm is the only one in the standard that unsets the flag, and this is
+    /// the only one that sets it again. Every event the engine constructs has it set from birth, so for an
+    /// engine with no document the assignment is a store nothing can observe.
     /// </para>
     /// <para>
     /// What it deliberately does <b>not</b> touch is the composed flag, which is why the specification notes
@@ -203,6 +216,9 @@ internal class JsEvent : ObjectInstance
     /// </remarks>
     internal void InitializeEvent(JsString type, bool bubbles, bool cancelable)
     {
+        // Step 1.
+        InitializedFlag = true;
+
         // Step 2.
         StopPropagationFlag = false;
         StopImmediatePropagationFlag = false;

--- a/Jint/WebApi/Events/JsEventTarget.cs
+++ b/Jint/WebApi/Events/JsEventTarget.cs
@@ -461,13 +461,26 @@ internal class JsEventTarget : ObjectInstance
     /// exists only to drive the second pass over the four <c>webkit</c>-prefixed animation and transition
     /// event types, and no algorithm in this engine can produce one.
     /// </remarks>
-    internal void InvokeListeners(JsEvent ev, bool capturePass)
+    /// <param name="ev">The event being dispatched.</param>
+    /// <param name="capturePass">Which of the two passes this is, which decides which listeners run in it.</param>
+    /// <param name="invocationTargetInShadowTree">
+    /// The path item's <i>invocation-target-in-shadow-tree</i>, which is what stops a listener inside a
+    /// shadow tree from being told the event through the Window's <c>event</c>. Always false for the flat
+    /// dispatch, where the target is not a node and has no root.
+    /// </param>
+    internal void InvokeListeners(JsEvent ev, bool capturePass, bool invocationTargetInShadowTree = false)
     {
         var listeners = _listeners;
         if (listeners is null || !HasListenerFor(listeners, ev.TypeName, capturePass))
         {
             return;
         }
+
+        // Inner invoke steps 2.6 to 2.8 and 2.12: while a listener runs, a `Window` global's `event` is the
+        // event being dispatched, and afterwards it is whatever it was — a throw included. Null for every
+        // engine whose global object is not a `Window`, which is every engine that installs no document, so
+        // the slot is not merely unread there but not maintained at all.
+        var window = _engine._webApi?.GlobalEventTargetIfCreated is { IsWindow: true } windowScope ? windowScope : null;
 
         // Invoke step 7: "Let listeners be a clone of ... event listener list. This avoids event listeners
         // added after this point from being run." The scan above keeps that clone off the common paths — a
@@ -501,6 +514,14 @@ internal class JsEventTarget : ObjectInstance
                 ev.InPassiveListenerFlag = true;
             }
 
+            // Steps 2.7 and 2.8: the previous value is kept per invocation rather than per pass, because a
+            // listener may dispatch an event of its own and must find its own event again when that returns.
+            var previousEvent = window?.CurrentEvent;
+            if (window is not null && !invocationTargetInShadowTree)
+            {
+                window.CurrentEvent = ev;
+            }
+
             try
             {
                 InvokeCallback(listener, ev);
@@ -523,10 +544,18 @@ internal class JsEventTarget : ObjectInstance
             }
             finally
             {
+                // Step 2.12, after step 2.10's report and before the next listener: a listener that threw
+                // must not leave the Window's `event` pointing at an event whose dispatch is over.
+                if (previousEvent is not null)
+                {
+                    window!.CurrentEvent = previousEvent;
+                }
+
+                // Step 2.11.
                 ev.InPassiveListenerFlag = false;
             }
 
-            // Step 2.11.
+            // Step 2.13.
             if (ev.StopImmediatePropagationFlag)
             {
                 break;

--- a/Jint/WebApi/Events/JsEventTarget.cs
+++ b/Jint/WebApi/Events/JsEventTarget.cs
@@ -140,6 +140,26 @@ internal class JsEventTarget : ObjectInstance
     internal virtual bool IsNode => false;
 
     /// <summary>
+    /// The target half of https://dom.spec.whatwg.org/#default-passive-value: whether this target is a
+    /// <c>Window</c>, a document, a document element or a body element.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// DOM's rule is a conjunction of two conditions, and this is the one only a host can answer. The other —
+    /// the type being <c>touchstart</c>, <c>touchmove</c>, <c>wheel</c> or <c>mousewheel</c> — is the
+    /// engine's, and <c>EventTargetArguments</c> tests it <i>first</i>, so a listener of any other type never
+    /// reaches this virtual at all.
+    /// </para>
+    /// <para>
+    /// <b>False for every target this engine ships</b>, including the synthetic global one: DOM says
+    /// "<c>Window</c> object", and an engine with no document has none. A host that installs a document says
+    /// so — <c>Jint.Browser</c>'s node wrappers override this, and its window installer sets
+    /// <c>GlobalEventTarget.IsWindow</c>.
+    /// </para>
+    /// </remarks>
+    internal virtual bool IsDefaultPassiveTarget => false;
+
+    /// <summary>
     /// https://dom.spec.whatwg.org/#get-the-parent — the target the event travels to next, or
     /// <see langword="null"/> to end the path.
     /// </summary>

--- a/Jint/WebApi/GlobalEvents/GlobalEventTarget.cs
+++ b/Jint/WebApi/GlobalEvents/GlobalEventTarget.cs
@@ -74,6 +74,18 @@ internal sealed class GlobalEventTarget : JsEventTarget
     internal override bool IsDefaultPassiveTarget => IsWindow;
 
     /// <summary>
+    /// https://dom.spec.whatwg.org/#window-current-event — what <c>window.event</c> answers: the event whose
+    /// listener is running right now, and <see cref="JsValue.Undefined"/> the rest of the time.
+    /// </summary>
+    /// <remarks>
+    /// Maintained by <c>JsEventTarget.InvokeListeners</c> and only while <see cref="IsWindow"/> is true, so
+    /// an engine with no document neither writes nor reads it. A host installs the <c>event</c> accessor
+    /// itself: the slot is DOM's, the global property is HTML's, and an engine whose global is not a
+    /// <c>Window</c> must not grow one.
+    /// </remarks>
+    internal JsValue CurrentEvent { get; set; } = Undefined;
+
+    /// <summary>
     /// Whether a report is being dispatched at this target right now — HTML's <i>in error reporting mode</i>,
     /// and the reason <see cref="FireReport"/> declines a second one.
     /// </summary>

--- a/Jint/WebApi/GlobalEvents/GlobalEventTarget.cs
+++ b/Jint/WebApi/GlobalEvents/GlobalEventTarget.cs
@@ -57,6 +57,23 @@ internal sealed class GlobalEventTarget : JsEventTarget
     internal override bool IsGlobalScope => true;
 
     /// <summary>
+    /// Whether this global scope is a <c>Window</c> — a global object with a document behind it — rather than
+    /// the bare global of an engine that has none.
+    /// </summary>
+    /// <remarks>
+    /// False for every engine the box ships, and set by a host that installs a document on the global
+    /// (<c>Jint.Browser</c>'s window installer). DOM's <i>default passive value</i> is the one rule that turns
+    /// on it, which is why the property says what it is rather than what it is for: HTML's other
+    /// <c>Window</c>-only rules — <i>special error event handling</i> and dispatch's "parent is a
+    /// <c>Window</c> object" branch — already hold for a worker's global too and read
+    /// <see cref="JsEventTarget.IsGlobalScope"/> instead.
+    /// </remarks>
+    internal bool IsWindow { get; set; }
+
+    /// <inheritdoc />
+    internal override bool IsDefaultPassiveTarget => IsWindow;
+
+    /// <summary>
     /// Whether a report is being dispatched at this target right now — HTML's <i>in error reporting mode</i>,
     /// and the reason <see cref="FireReport"/> declines a second one.
     /// </summary>

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -5869,6 +5869,18 @@ declared to be a `Window`, which no engine the box ships is, so a dispatch on a 
 and writes none. There is no `window.event` global either way: the slot is DOM's, the property is HTML's, and
 `Jint.Browser` is what puts the two together.
 
+### 5.25 An event's initialized flag is real ([#3686](https://github.com/sebastienros/jint/issues/3686))
+
+[DOM's *initialized flag*](https://dom.spec.whatwg.org/#initialized-flag) is what makes
+`document.createEvent("Event")` undispatchable until `initEvent()` has named it: `dispatchEvent` throws an
+`InvalidStateError` for an event whose flag is unset, and `initEvent` sets it. The flag used to be assumed
+rather than stored, because the only algorithm that unsets it is `createEvent` and an engine with no document
+has none.
+
+**Nothing changes for an engine without a DOM.** Every event a constructor makes has the flag set, so the
+guard can only fire for an event a host's own `createEvent` produced — `Jint.Browser`'s — and a re-entrant
+dispatch still reports the message it always did.
+
 ## 6. AOT and trimming
 
 Jint 4.16 asserted Native AOT compatibility with the `IsAotCompatible` property and nothing else. In

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -5061,6 +5061,22 @@ built, not when it is declared, so a token registered after it was already lost 
 a cancellation the host had requested. Withdrawing the token still withdraws it (`ObserveCancellation(default)`
 before the profile leaves the engine unobserved), and the profile still clears every other constraint.
 
+### 4.118 `initEvent()` and `initCustomEvent()` require a type ([#3686](https://github.com/sebastienros/jint/issues/3686))
+
+`type` is a required argument of both legacy initializers, so calling one with no arguments is WebIDL's arity
+`TypeError`. It used to re-initialize the event with the type `"undefined"`.
+
+```js
+new Event('a').initEvent();            // 5.0: type becomes "undefined";  5.x: TypeError
+new Event('a').initEvent(undefined);   // both: type becomes "undefined" — the argument is there, and a
+                                       // DOMString stringifies it
+```
+
+The check runs before the "if this's dispatch flag is set, then return" step, because WebIDL raises an arity
+error while it converts the arguments and knows nothing about what the receiver is doing: `initEvent()` throws
+even for an event a dispatch has in flight, where the call would otherwise have been a silent no-op.
+`dispatchEvent()` with no arguments now says "1 argument required" where it said "1 arguments required".
+
 ## 5. New in v5
 
 Everything in the table below is opt-in: nothing in it is installed unless the host asks for it, so

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -5843,6 +5843,20 @@ never revokes grows the store, and no execution constraint describes that memory
 `RestoreGlobalSnapshot` **empties the store**, the way it empties the timer queue: the URLs were minted by
 the cycle that has ended and their strings are unreachable once its globals are gone.
 
+### 5.23 `addEventListener` implements DOM's default passive value ([#3692](https://github.com/sebastienros/jint/issues/3692))
+
+[DOM's *default passive value*](https://dom.spec.whatwg.org/#default-passive-value) makes a `touchstart`,
+`touchmove`, `wheel` or `mousewheel` listener passive when the target is a `Window`, a document, a document
+element or a body element and the `passive` member was left out — so its `preventDefault()` does nothing.
+`addEventListener` now applies that rule instead of defaulting `passive` to false unconditionally, and it
+reads `{ passive: undefined }` as WebIDL does: the member does not exist, so the default applies rather than
+`false`.
+
+**Nothing changes for an engine without a DOM.** The rule is a conjunction, and the half that names the four
+targets is answered by the host: an engine with no document has no `Window` and no body element, so every
+target Jint ships answers false and every listener stays active exactly as before. `Jint.Browser` is what
+answers otherwise, for its window, its `document`, its `documentElement` and its `body`.
+
 ## 6. AOT and trimming
 
 Jint 4.16 asserted Native AOT compatibility with the `IsAotCompatible` property and nothing else. In

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -5857,6 +5857,18 @@ targets is answered by the host: an engine with no document has no `Window` and 
 target Jint ships answers false and every listener stays active exactly as before. `Jint.Browser` is what
 answers otherwise, for its window, its `document`, its `documentElement` and its `body`.
 
+### 5.24 A dispatch maintains DOM's current event for a `Window` global ([#3687](https://github.com/sebastienros/jint/issues/3687))
+
+[DOM's *current event*](https://dom.spec.whatwg.org/#window-current-event) is what `window.event` answers: the
+event a listener is running for, set before each invocation and restored after it — after a nested dispatch,
+and after a listener that threw. It cannot be kept anywhere but in the dispatch, so the engine keeps it, and a
+host with a document is what installs the `event` property that reads it.
+
+**Nothing changes for an engine without a DOM.** The slot is maintained only for a global object a host has
+declared to be a `Window`, which no engine the box ships is, so a dispatch on a stock engine reads one field
+and writes none. There is no `window.event` global either way: the slot is DOM's, the property is HTML's, and
+`Jint.Browser` is what puts the two together.
+
 ## 6. AOT and trimming
 
 Jint 4.16 asserted Native AOT compatibility with the `IsAotCompatible` property and nothing else. In


### PR DESCRIPTION
The web-platform-tests browser lane ([#3685](https://github.com/sebastienros/jint/pull/3685)) recorded eleven
defects as `NeedsTriage` rows, filed as #3686–#3695. Four things they need cannot be done in `Jint.Browser` at
all, because the thing that has to change is in the engine: DOM puts the rule inside `addEventListener` or
inside the dispatch, and a package has nowhere to stand. This is those four, one commit each, and nothing
else — the package half of every one of them is the pull request stacked on this.

**Each is a seam whose engine-side default is unchanged**, which is the property to check when reviewing: an
engine that installs no document must behave exactly as it did, and each commit says how that is kept true.

### 1. The default passive value ([#3692](https://github.com/sebastienros/jint/issues/3692))

[DOM's *default passive value*](https://dom.spec.whatwg.org/#default-passive-value) makes a `touchstart`,
`touchmove`, `wheel` or `mousewheel` listener passive — so its `preventDefault()` does nothing — when the
target is a `Window`, a document, a document element or a body element and the `passive` member was left out.
`addEventListener` applied no such rule, and the comment in `EventTargetPrototype` said the default was false
for every type an engine without a document can see: true when it was written, wrong now that there is a
document.

The rule is a conjunction and its two halves belong in different places. The type — one of four names — is
DOM's and stays in the engine, tested first, so every other listener a page adds costs one switch and never
reaches a virtual call. The target is the half only a host can answer, so it is a seam:
`JsEventTarget.IsDefaultPassiveTarget`, false for every target the engine ships. `{ passive: undefined }` now
takes the default too, which is what WebIDL means by a dictionary member that does not exist.

### 2. The current event ([#3687](https://github.com/sebastienros/jint/issues/3687))

[DOM's *current event*](https://dom.spec.whatwg.org/#window-current-event) is what `window.event` answers, and
*inner invoke* is the only place it can be kept: set before each listener runs, restored after it, so a
listener that dispatches an event of its own finds its own event again when that returns and a listener that
throws does not leave the window pointing at an event whose dispatch is over. The package could not have done
it — its `event` accessor answered `undefined` because nothing in the dispatch had anywhere to write.

`GlobalEventTarget.CurrentEvent` is that slot, maintained only while `IsWindow` is true. The shadow-tree
exception came free: the path item already carries *invocation-target-in-shadow-tree*, so `InvokeListeners`
takes it and declines to set the slot for a listener inside a shadow tree. The inner-invoke step numbers in
the file are corrected while the steps around them are being written.

### 3. The initialized flag ([#3686](https://github.com/sebastienros/jint/issues/3686))

[DOM's *initialized flag*](https://dom.spec.whatwg.org/#initialized-flag) is unset by exactly one algorithm —
`document.createEvent()` — and read by exactly one, `dispatchEvent`'s `InvalidStateError` guard. It was
assumed rather than stored, on the stated ground that an engine with no document can never produce an event
whose flag is unset. There is a document now, so it can, and `createEvent("Event")` has to hand back an event
that refuses to be dispatched until `initEvent()` has named it.

### 4. `initEvent()` and `initCustomEvent()` require a type ([#3686](https://github.com/sebastienros/jint/issues/3686))

Both legacy initializers declare `type` as a required argument, so calling one with none is WebIDL's arity
`TypeError`; they re-initialized the event with the type `"undefined"` instead.
`dom/events/Event-initEvent.html` and `dom/events/CustomEvent.html` each have a row that says so, and both
became reachable the moment `document.createEvent` existed to build the event they call it on. The check is
before the dispatch-flag step, because WebIDL raises an arity error while it converts the arguments whatever
the receiver is doing. This is the one commit here with an observable behaviour change for an embedder, and
it has the `docs/v5-migration.md` row that goes with one.

### What was left out, and why

**The column of the `error` event — the half of [#3688](https://github.com/sebastienros/jint/issues/3688) the
issue puts in the engine — is already there, and the issue's premise is wrong.** `ErrorEventDetails` has
carried `Colno` since [#3170](https://github.com/sebastienros/jint/pull/3170), `ReadLocation` converts
Acornima's zero-based column to HTML's one-based one, `ErrorEventPrototype.colno` publishes it, and
`GlobalErrorEventTests` asserts `seen.colno > 0`. Measured on this branch's parent for the two shapes the wpt
rows actually meet — a runtime error and a *parse* error handed to `FireGlobalErrorEvent` — both report a
filename, a line and a column, and `typeof colno` is `"number"`. The two rows that say otherwise
(`compile-error-in-attribute.html` and `runtime-error-in-attribute.html`, "(column)") fail because the `error`
event is never fired for an exception escaping a classic script or a handler content attribute, which is the
*report site*, and that is `ParserDriver` — package, and the next pull request.

**No `docs/v5-migration.md` row claims an API change**, because there is none: all three seams are `internal`
on `internal` types. The three rows say what changed for an embedder, which is the behaviour, and each one
states the "nothing changes without a DOM" half explicitly.

### Verified

`dotnet test -c Release` over the solution, Release throughout: `Jint.Tests`, `Jint.Tests.Browser` (the wpt
browser lane included, so the existing `Events` results in `Jint.Tests/Wpt` and the whole browser lane are
unchanged), `Jint.Tests.PublicInterface`, `Jint.Tests.Test262`, `Jint.Tests.DevTools`,
`Jint.Tests.CommonScripts` and `Jint.Tests.SourceGenerators`, all green.

**The census does not move**: this branch changes nothing in `Jint.Browser`, so `dom/events/` stays 181,
`html/webappapis/scripting/events/` 23 and `processing-model-2/` 34, total 238. Every `NeedsTriage` row is
still a `NeedsTriage` row; the next pull request is what retires them.

Each new test was run against the code before its fix and fails there — the two positive ones by behaviour
(`AGlobalScopeAHostCallsAWindowTakesTheDefaultPassiveValue` and
`TheCurrentEventOfAWindowIsSetPerInvocationAndAlwaysRestored` were checked with the new rule stubbed out) and
`AnEventWhoseInitializedFlagIsUnsetCannotBeDispatched` because the flag it sets did not exist. The two
negative ones — the default stays false without a document, and the current event is not maintained for a
global that is not a `Window` — are pins of the unchanged default and pass on both sides by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
