### PR TITLE
Browser: the eleven defects the web-platform-tests browser lane found, fixed — the census falls from 238 to 61

### DIFF
--- a/Jint.Browser/AGENTS.md
+++ b/Jint.Browser/AGENTS.md
@@ -43,6 +43,7 @@ a swap to a source generator later is mechanical.
 | A `DomCollectionAccessor` per collection interface, from `[DomAccessor]` | `DomInterfaceObject`, `DomBindings`, `DomConvert`, `DomHostHooks` |
 | `DomTypeMap`'s candidate list, most derived first | `DomManualShapes` — the shapes the generator cannot express |
 | `DomEnums`, both directions, for the WebIDL string enumerations | `DomTypeMap.For` and its per-`Type` cache |
+| — | `DomManualInterfaces` and `DomConstructors` — the interface AngleSharp has no `[DomName]` for (`HTMLFrameSetElement`) and the one WebIDL really does give a constructor (`Document`) |
 
 **Never hand-edit a `.g.cs`.** `DomBindingsStalenessTests` runs the same emitter in memory and fails on any
 difference; `JINT_DOM_BINDINGS=update` writes the difference back, which is also the shortest regeneration
@@ -62,7 +63,8 @@ Every script-visible event is a Jint `Event` dispatched through the engine's tre
 algorithm points the package owns (design doc §5) — never AngleSharp's own bus, which holds nothing a script
 registered. What that costs the binding is the `skip` and `additions` rows above: `click`, `focus`, `blur`,
 `form.reset`, `document.activeElement` and `document.hasFocus` are all AngleSharp members that do nothing
-useful, so they are skipped and re-declared. The behaviour behind them — which algorithm point raises which
+useful, so they are skipped and re-declared — and `document.createEvent`, whose AngleSharp `Event` must never
+reach script, is re-declared against Jint's in `Events/LegacyEventCreation`. The behaviour behind them — which algorithm point raises which
 event, what activation means with no layout, and why the handler content attributes need no notification from
 AngleSharp — is [`Runtime/AGENTS.md`](Runtime/AGENTS.md#the-events-bridge).
 

--- a/Jint.Browser/Dom/AGENTS.md
+++ b/Jint.Browser/Dom/AGENTS.md
@@ -44,15 +44,32 @@ version of AngleSharp nobody references.
 | --- | --- |
 | `excludedInterfaces` | An interface the runtime owns instead. Today: `IWindow` (campaign item R1). |
 | `manual` | An interface whose shape is hand-written in `DomManualShapes`. Today: `IHtmlCollection<T>`, whose generic invariance keeps a member body from naming its receiver. A manual interface contributes no members to any closure — its children inherit them through the prototype chain. |
-| `skip` | A member whose AngleSharp implementation must not be projected: navigation (`location.assign`, `location.href`'s setter), the parser (`document.open`/`close`/`load`), `document.createEvent` whose AngleSharp `Event` must never reach script, and the six the events bridge re-declares because AngleSharp's own do nothing — see the divergence table. `half: "setter"` skips the write half only. |
-| `hooks` | A member routed through `DomHostHooks` so the parser driver can replace its body: the `innerHTML` and `outerHTML` setters, `insertAdjacentHTML`, `document.write`/`writeln`. The default implementations *are* the AngleSharp call, so the seam costs nothing until R3 uses it. The same class carries `WrapperCreated`, which is the other direction — a member the generator could not emit at all, added to one wrapper; it is also where the events bridge registers an element's handler content attributes. |
-| `additions` | A member the **standard** puts on a generated interface and AngleSharp's metadata cannot express: a callback parameter, a stringifier with no `[DomName]`, a Shadow DOM v0 spelling, a missing `[DomName]`, the whole of CSSOM View's box model (`getBoundingClientRect` and its `client*`/`scroll*`/`offset*` family, answered from the flat layout — [`../Runtime/AGENTS.md`](../Runtime/AGENTS.md)), and the operations whose body is an event rather than a DOM call (`click`/`focus`/`blur`, `form.submit`/`requestSubmit`/`reset`, `document.activeElement`/`hasFocus`). Two forms, and an entry uses exactly one: **reach for the member form**, which names one member and goes through the model like any projected member, so the generated file names it and a member AngleSharp later grows under that name is reported rather than shadowed; the `"extend"` form hands the builder to a method and exists only for a *family* whose member list is computed, which today is HTML's event handler IDL attributes. `Overrides.AdditionEntry` has the whole of why, including what the extend form gives up. Either way it adds rather than replaces, so the interface stays **one** shape — the only way to add a member to a class rather than to one object without costing the prototype its shape. |
+| `skip` | A member whose AngleSharp implementation must not be projected: navigation (`location.assign`, `location.href`'s setter), the parser (`document.open`/`close`/`load`), `document.createEvent` whose AngleSharp `Event` must never reach script, `DOMImplementation.createHTMLDocument` whose title AngleSharp makes required, and the six the events bridge re-declares because AngleSharp's own do nothing — see the divergence table. Every one of them is re-declared in `additions`, so a skip here is a *replacement* and not an absence. `half: "setter"` skips the write half only. |
+| `hooks` | A member routed through `DomHostHooks` so the package can replace its body: the `innerHTML` and `outerHTML` setters, `insertAdjacentHTML`, `document.write`/`writeln`, and `setAttribute`/`removeAttribute` — the one write of an attribute this package can see, and therefore where a handler content attribute takes its position in the element's listener list. The default implementations *are* the AngleSharp call, so the seam costs nothing until R3 uses it. The same class carries `WrapperCreated`, which is the other direction — a member the generator could not emit at all, added to one wrapper; it is also where the events bridge registers an element's handler content attributes. |
+| `additions` | A member the **standard** puts on a generated interface and AngleSharp's metadata cannot express: a callback parameter, a stringifier with no `[DomName]`, a Shadow DOM v0 spelling, a missing `[DomName]`, the whole of CSSOM View's box model (`getBoundingClientRect` and its `client*`/`scroll*`/`offset*` family, answered from the flat layout — [`../Runtime/AGENTS.md`](../Runtime/AGENTS.md)), the legacy event-creation surface (`document.createEvent`), and the operations whose body is an event rather than a DOM call (`click`/`focus`/`blur`, `form.submit`/`requestSubmit`/`reset`, `document.activeElement`/`hasFocus`). Two forms, and an entry uses exactly one: **reach for the member form**, which names one member and goes through the model like any projected member, so the generated file names it and a member AngleSharp later grows under that name is reported rather than shadowed; the `"extend"` form hands the builder to a method and exists only for a *family* whose member list is computed, which today is HTML's event handler IDL attributes. `Overrides.AdditionEntry` has the whole of why, including what the extend form gives up. Either way it adds rather than replaces, so the interface stays **one** shape — the only way to add a member to a class rather than to one object without costing the prototype its shape. |
 | `nullableStrings` | The members whose IDL type is `DOMString?` rather than `DOMString`. See the conversion table below. |
 | `stringEnums`, `constants` | The two enum decisions the heuristics above cannot make. |
 
 **A member the generator could not convert is not in this table.** It is skipped with the reason the generator
 worked out, and the reason is in the report the regeneration prints. That split is deliberate: this file is
 for decisions, the report is for consequences.
+
+### The two interfaces the generator cannot see
+
+`DomManualInterfaces` and `DomConstructors` are the whole of what the override table cannot express, and each
+holds exactly one entry today.
+
+- **`HTMLFrameSetElement` is declared by name and selected by local name.** AngleSharp models `<frameset>`
+  with the plain `IHtmlElement` — there is no `IHtmlFrameSetElement` and no `[DomName("HTMLFrameSetElement")]`
+  in the pinned assemblies — so `DomTypeMap`, which keys on the CLR type, cannot tell a frameset from a
+  `<div>`. Its shape is empty: HTML gives the interface no members beyond `WindowEventHandlers`, which this
+  package puts on `HTMLElement`. Its index continues `DomInterfaces`' own, which is what keeps `DomRealm`'s
+  per-engine arrays a dense array.
+- **`Document` is the one interface object a script may call `new` on.** AngleSharp puts `[DomConstructor]` on
+  no `[DomName]` interface at all, so the generator can never learn that an interface is constructible and
+  `DomInterfaceObject` refuses every `new` — which is also what a browser answers for `new HTMLDivElement()`.
+  The document it makes is DOM's: an XML document with no doctype, no document element and no browsing
+  context.
 
 ### The conversion table, and where it diverges from a browser
 

--- a/Jint.Browser/Dom/AGENTS.md
+++ b/Jint.Browser/Dom/AGENTS.md
@@ -114,7 +114,9 @@ here:
 | `el.click()` on a checkbox, radio, `<summary>` or `<a href>` | the element's activation behaviour runs | `DoClick` dispatches on AngleSharp's own bus and runs **no activation behaviour at all**, with or without a browsing context: nothing toggles, opens or navigates |
 | `document.activeElement` | the focused element, or the body | `null` for the life of every document — nothing in AngleSharp ever assigns it, `DoFocus()` included |
 | `el.tabIndex` when the attribute is absent | −1 for anything not inherently focusable | 0 for every element, including a bare `<div>`, so it cannot decide focusability |
-| `input.labels` | the `<label>`s whose `for` names the control | an empty collection, though `label.control` resolves correctly in the other direction |
+| `input.labels` | the `<label>`s whose `for` names the control | an empty collection |
+| `label.control` | the labeled control: the `for` target, or the first labelable **descendant** | `null` for a control the label contains, which is the commoner spelling; `Events/ActivationBehaviors` computes it instead so a click inside a wrapping label reaches its checkbox |
+| `script.src` | HTML reflects it *as a URL*, so it answers the resolved absolute URL | the raw attribute value, so `<script src="a.js">.src` is `"a.js"` where a browser answers `"http://…/a.js"` |
 | `select.selectedIndex` with no `selected` option | 0 — the selectedness-setting algorithm picks the first option of a non-`multiple`, display-size-1 select | −1 |
 | `input.value = …` | the cursor moves to the end and the selection is dropped | `SelectionStart`/`SelectionEnd` are left where they were, so they can point past the end of the new value |
 | `input.setSelectionRange` on a `type=checkbox` | `InvalidStateError` — the type does not support selection | answers, so the type test has to be the caller's |

--- a/Jint.Browser/Dom/DomBindings.cs
+++ b/Jint.Browser/Dom/DomBindings.cs
@@ -52,7 +52,7 @@ internal static class DomBindings
         // belong to the engine's own realm and to no other.
         var global = engine._mainRealm.GlobalObject;
 
-        foreach (var definition in DomInterfaces.All)
+        foreach (var definition in Interfaces())
         {
             if (!definition.HasInterfaceObject)
             {
@@ -68,6 +68,23 @@ internal static class DomBindings
             global.SetProperty(
                 definition.Name,
                 new LazyPropertyDescriptor<DomRealm>(realm, r => r.InterfaceObjectOf(captured), PropertyFlag.NonEnumerable));
+        }
+    }
+
+    /// <summary>
+    /// Every interface that gets a global: the generated ones, and the ones this package declares itself
+    /// because AngleSharp has no <c>[DomName]</c> interface for them. See <see cref="DomManualInterfaces"/>.
+    /// </summary>
+    private static IEnumerable<DomInterfaceDefinition> Interfaces()
+    {
+        foreach (var definition in DomInterfaces.All)
+        {
+            yield return definition;
+        }
+
+        foreach (var definition in DomManualInterfaces.All)
+        {
+            yield return definition;
         }
     }
 

--- a/Jint.Browser/Dom/DomConstructors.cs
+++ b/Jint.Browser/Dom/DomConstructors.cs
@@ -1,0 +1,56 @@
+using AngleSharp;
+using AngleSharp.Dom;
+using AngleSharp.Xml.Parser;
+using Jint.Native;
+using Jint.Native.Object;
+
+namespace Jint.Browser.Dom;
+
+/// <summary>
+/// The generated interfaces a script may really call <c>new</c> on.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>There is exactly one, and the emptiness of this table is the point.</b> AngleSharp puts
+/// <c>[DomConstructor]</c> on concrete classes and on no <c>[DomName]</c> interface, so the generator can
+/// never learn that an interface is constructible; <see cref="DomInterfaceObject"/> therefore refuses every
+/// <c>new</c>, which is also what a browser answers for <c>new HTMLDivElement()</c> and for all but a handful
+/// of DOM's interfaces. <c>Document</c> is the one this corpus reaches for —
+/// https://dom.spec.whatwg.org/#dom-document-document, "the Document() constructor" — and it is a decision
+/// rather than a projection, so it is written here by name.
+/// </para>
+/// <para>
+/// The document it makes is DOM's: an <b>XML</b> document with no doctype, no document element and no
+/// browsing context. Its parser gets the same configuration a <c>DOMParser</c> document gets — the CSS
+/// services and nothing else — so it reaches no network and runs no script, which is the whole of what "no
+/// browsing context" costs a page that then builds a tree in it.
+/// </para>
+/// </remarks>
+internal static class DomConstructors
+{
+    /// <summary>
+    /// Builds the instance for a <c>new</c> on <paramref name="definition"/>, or answers
+    /// <see langword="false"/> for an interface WebIDL gives no constructor.
+    /// </summary>
+    internal static bool TryConstruct(DomRealm realm, DomInterfaceDefinition definition, out ObjectInstance instance)
+    {
+        if (ReferenceEquals(definition, DomInterfaces.Document))
+        {
+            instance = (ObjectInstance) realm.WrapNode(NewXmlDocument());
+            return true;
+        }
+
+        instance = null!;
+        return false;
+    }
+
+    /// <summary>
+    /// An empty XML document. AngleSharp's <c>IImplementation</c> has no <c>createDocument</c> at all and its
+    /// <c>CreateHtmlDocument</c> answers an HTML one, so the empty parse is what is left — and it is exact,
+    /// because an XML document with no content has no document element, which is what the constructor
+    /// promises.
+    /// </summary>
+    private static IDocument NewXmlDocument()
+        => new XmlParser(new XmlParserOptions { IsSuppressingErrors = true }, BrowsingContext.New(Views.ViewInstaller.ParserConfiguration))
+            .ParseDocument(string.Empty);
+}

--- a/Jint.Browser/Dom/DomHostHooks.cs
+++ b/Jint.Browser/Dom/DomHostHooks.cs
@@ -67,6 +67,29 @@ internal class DomHostHooks
     /// <summary>https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-outerhtml</summary>
     internal virtual void SetOuterHtml(DomRealm realm, IElement element, string markup) => element.OuterHtml = markup;
 
+    /// <summary>
+    /// https://dom.spec.whatwg.org/#dom-element-setattribute, hooked so that a handler content attribute a
+    /// script writes activates its handler <i>then</i> — which is what fixes the handler's position in the
+    /// element's listener list. See <c>Events.EventHandlerContentAttributes.AttributeChanged</c>.
+    /// </summary>
+    internal virtual void SetAttribute(DomRealm realm, IElement element, JsValue[] arguments)
+    {
+        var name = DomConvert.RequiredText(arguments, 0, "Element.setAttribute");
+        element.SetAttribute(name, DomConvert.RequiredText(arguments, 1, "Element.setAttribute"));
+        Events.EventHandlerContentAttributes.AttributeChanged(realm, element, name);
+    }
+
+    /// <summary>
+    /// https://dom.spec.whatwg.org/#dom-element-removeattribute, the other half: removing the attribute
+    /// deactivates the handler, and the listener goes with it.
+    /// </summary>
+    internal virtual void RemoveAttribute(DomRealm realm, IElement element, JsValue[] arguments)
+    {
+        var name = DomConvert.RequiredText(arguments, 0, "Element.removeAttribute");
+        element.RemoveAttribute(name);
+        Events.EventHandlerContentAttributes.AttributeChanged(realm, element, name);
+    }
+
     /// <summary>https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-insertadjacenthtml</summary>
     internal virtual void InsertAdjacentHtml(DomRealm realm, IElement element, JsValue[] arguments)
     {

--- a/Jint.Browser/Dom/DomInterfaceObject.cs
+++ b/Jint.Browser/Dom/DomInterfaceObject.cs
@@ -11,10 +11,12 @@ namespace Jint.Browser.Dom;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Every one of them throws <c>TypeError: Illegal constructor</c>, and that is not a gap: AngleSharp puts
+/// All but one of them throw <c>TypeError: Illegal constructor</c>, and that is not a gap: AngleSharp puts
 /// <c>[DomConstructor]</c> on concrete classes (<c>Event</c>, <c>MouseEvent</c>, <c>MutationObserver</c>,
-/// <c>DOMRect</c>) and on no <c>[DomName]</c> interface at all, so not one generated interface here is
-/// constructible in WebIDL terms. It is also what a browser answers for <c>new HTMLDivElement()</c>.
+/// <c>DOMRect</c>) and on no <c>[DomName]</c> interface at all, so the generator can never learn that an
+/// interface is constructible. It is also what a browser answers for <c>new HTMLDivElement()</c>. The
+/// exception is <c>Document</c>, whose constructor WebIDL really does declare; <see cref="DomConstructors"/>
+/// is the table it is written in.
 /// </para>
 /// <para>
 /// It derives from <c>Constructor</c> rather than from a plain function so that <c>x instanceof Node</c>
@@ -24,11 +26,13 @@ namespace Jint.Browser.Dom;
 /// </remarks>
 internal sealed class DomInterfaceObject : Constructor
 {
+    private readonly DomRealm _domRealm;
     private readonly DomInterfaceDefinition _definition;
 
     internal DomInterfaceObject(DomRealm realm, DomInterfaceDefinition definition)
         : base(realm.Engine, realm.PrincipalRealm, new JsString(definition.Name))
     {
+        _domRealm = realm;
         _definition = definition;
         _prototype = realm.PrincipalRealm.Intrinsics.Function.PrototypeObject;
         _length = new PropertyDescriptor(JsNumber.PositiveZero, PropertyFlag.Configurable);
@@ -64,8 +68,17 @@ internal sealed class DomInterfaceObject : Constructor
     }
 
     /// <inheritdoc />
+    /// <remarks>
+    /// <see cref="DomConstructors"/> is the one exception, and it names a single interface: WebIDL gives
+    /// <c>Document</c> a constructor and the generator cannot learn that from AngleSharp's metadata.
+    /// </remarks>
     public override ObjectInstance Construct(JsValue[] arguments, JsValue newTarget)
     {
+        if (DomConstructors.TryConstruct(_domRealm, _definition, out var instance))
+        {
+            return instance;
+        }
+
         Throw.TypeError(_realm, "Illegal constructor");
         return null!;
     }

--- a/Jint.Browser/Dom/DomManualInterfaces.cs
+++ b/Jint.Browser/Dom/DomManualInterfaces.cs
@@ -1,0 +1,61 @@
+using AngleSharp.Dom;
+using AngleSharp.Html.Dom;
+using Jint.Native;
+
+namespace Jint.Browser.Dom;
+
+/// <summary>
+/// The interfaces this package declares itself, because AngleSharp has no <c>[DomName]</c> interface for them
+/// and the generator can therefore never see one.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>There is exactly one, and it is chosen by local name rather than by CLR type.</b> AngleSharp models
+/// <c>&lt;frameset&gt;</c> with the plain <c>IHtmlElement</c> — there is no <c>IHtmlFrameSetElement</c> and no
+/// <c>[DomName("HTMLFrameSetElement")]</c> anywhere in the pinned assemblies — so <c>DomTypeMap</c>, which
+/// keys on the CLR type, cannot tell a frameset from a <c>&lt;div&gt;</c>. The events bridge already makes the
+/// same test the same way (<c>EventHandlerContentAttributes.TargetFor</c>), because a frameset carries the
+/// window-forwarded handler attributes a <c>&lt;body&gt;</c> does.
+/// </para>
+/// <para>
+/// <b>The shape is empty on purpose.</b> HTML gives <c>HTMLFrameSetElement</c> no members of its own beyond
+/// <c>WindowEventHandlers</c>, which this package puts on <c>HTMLElement</c> along with
+/// <c>GlobalEventHandlers</c>; the interface exists so that <c>frameset instanceof HTMLFrameSetElement</c>
+/// holds, so that <c>HTMLFrameSetElement</c> is a name on the window, and so that
+/// <c>Object.prototype.toString</c> reports it. <c>dom/events/Body-FrameSet-Event-Handlers.html</c> is what
+/// asks for all three, and it asks first: it reaches for the name at file scope, so without it the whole
+/// document is a harness error rather than a run with two failures.
+/// </para>
+/// <para>
+/// The indices continue <c>DomInterfaces</c>' own, which is what keeps <see cref="DomRealm"/>'s per-engine
+/// arrays a dense array rather than a dictionary.
+/// </para>
+/// </remarks>
+internal static class DomManualInterfaces
+{
+    /// <summary>https://html.spec.whatwg.org/multipage/obsolete.html#htmlframesetelement.</summary>
+    internal static readonly DomInterfaceDefinition HTMLFrameSetElement = new(
+        "HTMLFrameSetElement",
+        typeof(IHtmlElement),
+        static () => new JsObjectShape.Builder()
+            .PerRealmSlot("constructor", enumerable: false)
+            .ToStringTag("HTMLFrameSetElement")
+            .Build(),
+        DomInterfaces.HTMLElement,
+        rootsAtEventTarget: true,
+        hasInterfaceObject: true,
+        DomWrapperKind.Node)
+    {
+        Index = DomInterfaces.All.Length,
+    };
+
+    /// <summary>Every manual interface, in index order.</summary>
+    internal static readonly DomInterfaceDefinition[] All = [HTMLFrameSetElement];
+
+    /// <summary>
+    /// The interface a node takes when its CLR type does not decide it, or <see langword="null"/> when
+    /// <c>DomTypeMap</c> is the answer — which it is for every node but a frameset.
+    /// </summary>
+    internal static DomInterfaceDefinition? For(INode node)
+        => node is IHtmlElement { LocalName: "frameset" } ? HTMLFrameSetElement : null;
+}

--- a/Jint.Browser/Dom/DomNodeObject.cs
+++ b/Jint.Browser/Dom/DomNodeObject.cs
@@ -53,6 +53,24 @@ internal class DomNodeObject : JsEventTarget, IDomWrapper
     internal override bool IsNode => true;
 
     /// <summary>
+    /// https://dom.spec.whatwg.org/#default-passive-value — the three node targets DOM names beside the
+    /// <c>Window</c>: the document, its document element and its body element.
+    /// </summary>
+    /// <remarks>
+    /// Read only for a <c>touchstart</c>, <c>touchmove</c>, <c>wheel</c> or <c>mousewheel</c> listener, which
+    /// the engine tests for first, so every other <c>addEventListener</c> on a node costs nothing. The
+    /// comparisons are against the node's <i>own</i> document rather than the page's, which is what makes a
+    /// document a <c>DOMParser</c> produced answer about itself.
+    /// </remarks>
+    internal override bool IsDefaultPassiveTarget => Node switch
+    {
+        IDocument => true,
+        IElement element => element.Owner is { } owner
+            && (ReferenceEquals(element, owner.DocumentElement) || ReferenceEquals(element, owner.Body)),
+        _ => false,
+    };
+
+    /// <summary>
     /// https://dom.spec.whatwg.org/#get-the-parent — the node tree parent, and for a shadow root the host.
     /// </summary>
     /// <remarks>

--- a/Jint.Browser/Dom/DomRealm.cs
+++ b/Jint.Browser/Dom/DomRealm.cs
@@ -51,8 +51,11 @@ internal sealed class DomRealm
     {
         Engine = engine;
         PrincipalRealm = engine._mainRealm;
-        _prototypes = new ObjectInstance?[DomInterfaces.All.Length];
-        _interfaceObjects = new DomInterfaceObject?[DomInterfaces.All.Length];
+        // The manual interfaces continue the generated ones' indices, so the two together stay one dense
+        // array; DomManualInterfaces says why there are any.
+        var interfaceCount = DomInterfaces.All.Length + DomManualInterfaces.All.Length;
+        _prototypes = new ObjectInstance?[interfaceCount];
+        _interfaceObjects = new DomInterfaceObject?[interfaceCount];
     }
 
     /// <summary>The engine every object in this realm belongs to.</summary>
@@ -210,7 +213,7 @@ internal sealed class DomRealm
             return (DomNodeObject) cached;
         }
 
-        var definition = DomTypeMap.For(node.GetType()) ?? DomInterfaces.Node;
+        var definition = DomManualInterfaces.For(node) ?? DomTypeMap.For(node.GetType()) ?? DomInterfaces.Node;
         return (DomNodeObject) Cache(node, new DomNodeObject(this, definition, node));
     }
 

--- a/Jint.Browser/Dom/Generated/DomShapes.Dom.g.cs
+++ b/Jint.Browser/Dom/Generated/DomShapes.Dom.g.cs
@@ -466,9 +466,9 @@ internal static partial class DomInterfaces
                 static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IImplementation>(thisObj, "DOMImplementation.createHTMLDocument");
-                    return self.Realm.WrapNodeValue(self.Target.CreateHtmlDocument(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "DOMImplementation.createHTMLDocument")));
+                    return self.Realm.WrapNodeValue(self.Target.CreateHtmlDocument(global::Jint.Browser.Dom.DomConvert.OptionalText(args, 0, "")!));
                 },
-                length: 1)
+                length: 0)
             .Method("hasFeature",
                 static (thisObj, args) =>
                 {
@@ -711,6 +711,13 @@ internal static partial class DomInterfaces
                     return self.Realm.WrapNodeValue(self.Target.CreateElement(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Document.createElementNS"), global::Jint.Browser.Dom.DomConvert.RequiredText(args, 1, "Document.createElementNS")));
                 },
                 length: 2)
+            .Method("createEvent",
+                static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.createEvent");
+                    return global::Jint.Browser.Events.LegacyEventCreation.CreateEvent(self.Realm, args);
+                },
+                length: 1)
             .Method("createNodeIterator",
                 static (thisObj, args) =>
                 {

--- a/Jint.Browser/Dom/Generated/DomShapes.Dom.g.cs
+++ b/Jint.Browser/Dom/Generated/DomShapes.Dom.g.cs
@@ -1539,7 +1539,7 @@ internal static partial class DomInterfaces
                 static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.removeAttribute");
-                    return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.RemoveAttribute(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Element.removeAttribute")));
+                    self.Realm.Hooks.RemoveAttribute(self.Realm, self.Target, args); return global::Jint.Native.JsValue.Undefined;
                 },
                 length: 1)
             .Method("removeAttributeNS",
@@ -1601,7 +1601,7 @@ internal static partial class DomInterfaces
                 static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.setAttribute");
-                    self.Target.SetAttribute(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Element.setAttribute"), global::Jint.Browser.Dom.DomConvert.RequiredText(args, 1, "Element.setAttribute")); return global::Jint.Native.JsValue.Undefined;
+                    self.Realm.Hooks.SetAttribute(self.Realm, self.Target, args); return global::Jint.Native.JsValue.Undefined;
                 },
                 length: 2)
             .Method("setAttributeNS",

--- a/Jint.Browser/Events/ActivationBehaviors.cs
+++ b/Jint.Browser/Events/ActivationBehaviors.cs
@@ -260,7 +260,7 @@ internal static class ActivationBehaviors
     /// </remarks>
     private static void RunLabel(DomNodeObject wrapper, IHtmlLabelElement label, JsEvent ev)
     {
-        if (label.Control is not { } control)
+        if (LabeledControl(label) is not { } control)
         {
             return;
         }
@@ -435,6 +435,46 @@ internal static class ActivationBehaviors
         "audio" or "video" => element.HasAttribute("controls"),
         "img" or "object" => element.HasAttribute("usemap"),
         _ => false,
+    };
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/forms.html#labeled-control — the control a <c>&lt;label&gt;</c>
+    /// labels: the element its <c>for</c> attribute names, and otherwise the first labelable descendant.
+    /// </summary>
+    /// <remarks>
+    /// Computed rather than read off AngleSharp, whose <c>IHtmlLabelElement.Control</c> answers
+    /// <see langword="null"/> for a control the label <i>contains</i> — which is the commoner of the two
+    /// spellings and the one <c>&lt;label&gt;&lt;input type=checkbox&gt;&lt;span&gt;text&lt;/span&gt;&lt;/label&gt;</c>
+    /// uses. It is recorded as an AngleSharp divergence in <c>Jint.Browser/Dom/AGENTS.md</c> beside
+    /// <c>input.labels</c>, which is the same gap seen from the other end.
+    /// </remarks>
+    private static IHtmlElement? LabeledControl(IHtmlLabelElement label)
+    {
+        if (label.GetAttribute("for") is { Length: > 0 } id)
+        {
+            return label.Owner?.GetElementById(id) is IHtmlElement named && IsLabelable(named) ? named : null;
+        }
+
+        foreach (var descendant in label.QuerySelectorAll("button, input, meter, output, progress, select, textarea"))
+        {
+            if (descendant is IHtmlElement candidate && IsLabelable(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/forms.html#category-label — the seven labelable element kinds.
+    /// A hidden input is the one exception the list carries with it.
+    /// </summary>
+    private static bool IsLabelable(IHtmlElement element) => element switch
+    {
+        IHtmlInputElement input => !IsType(input, "hidden"),
+        IHtmlButtonElement or IHtmlSelectElement or IHtmlTextAreaElement => true,
+        _ => element.LocalName is "meter" or "output" or "progress",
     };
 
     /// <summary>

--- a/Jint.Browser/Events/ActivationBehaviors.cs
+++ b/Jint.Browser/Events/ActivationBehaviors.cs
@@ -223,8 +223,18 @@ internal static class ActivationBehaviors
                 // The checkedness was already changed by the legacy pre-activation behaviour; the activation
                 // behaviour is only the two events. HTML fires `input` with bubbles and composed both true and
                 // `change` with bubbles true, in that order, and both are plain Events rather than InputEvents.
+                //
+                // Step 1 of the input activation behaviour is "if the element is not connected, then return",
+                // so a detached control toggles silently: the checkedness is the element's own state and the
+                // two events announce a change to a *document*. The snapshot is dropped either way — the
+                // toggle stands, so there is nothing left to roll back.
                 _snapshots.Remove(wrapper);
-                FireInputAndChange(wrapper);
+
+                if (IsConnected(input))
+                {
+                    FireInputAndChange(wrapper);
+                }
+
                 return;
 
             case "file":
@@ -426,6 +436,39 @@ internal static class ActivationBehaviors
         "img" or "object" => element.HasAttribute("usemap"),
         _ => false,
     };
+
+    /// <summary>
+    /// https://dom.spec.whatwg.org/#connected — whether the node's <i>shadow-including root</i> is a
+    /// document, which is what "connected" means and what the checkbox and radio activation behaviours ask
+    /// before they announce anything.
+    /// </summary>
+    /// <remarks>
+    /// The walk crosses a shadow boundary through the root's host, so a control inside an open or closed
+    /// shadow tree of a connected host is connected — the eight shadow cases of
+    /// <c>Event-dispatch-detached-input-and-change.html</c> are what say so. AngleSharp has no member that
+    /// answers this: <c>INode.Owner</c> is the node document whether or not the node is in it.
+    /// </remarks>
+    private static bool IsConnected(INode node)
+    {
+        var current = node;
+
+        while (true)
+        {
+            if (current.Parent is { } parent)
+            {
+                current = parent;
+                continue;
+            }
+
+            if (current is IShadowRoot { Host: { } host })
+            {
+                current = host;
+                continue;
+            }
+
+            return current is IDocument;
+        }
+    }
 
     private static T? Ancestor<T>(INode node) where T : class
     {

--- a/Jint.Browser/Events/BrowserEventInterfaces.cs
+++ b/Jint.Browser/Events/BrowserEventInterfaces.cs
@@ -33,7 +33,7 @@ internal static class BrowserEventInterfaces
         static (realm, args) =>
         {
             var init = EventInitReader.Dictionary(args);
-            var (view, detail, which) = EventInitReader.UiInit(init);
+            var (view, detail, which) = EventInitReader.UiInit(realm.Engine, init);
             return new JsUiEvent(realm.Engine, Type(realm, args, "UIEvent"), EventInit(realm, args, "UIEvent"), realm.TimeStamp, view, detail, which);
         });
 
@@ -45,7 +45,7 @@ internal static class BrowserEventInterfaces
         static (realm, args) =>
         {
             var init = EventInitReader.Dictionary(args);
-            var (view, detail, which) = EventInitReader.UiInit(init);
+            var (view, detail, which) = EventInitReader.UiInit(realm.Engine, init);
             return new JsMouseEvent(
                 realm.Engine,
                 Type(realm, args, "MouseEvent"),
@@ -65,7 +65,7 @@ internal static class BrowserEventInterfaces
         static (realm, args) =>
         {
             var init = EventInitReader.Dictionary(args);
-            var (view, detail, which) = EventInitReader.UiInit(init);
+            var (view, detail, which) = EventInitReader.UiInit(realm.Engine, init);
             return new JsPointerEvent(
                 realm.Engine,
                 Type(realm, args, "PointerEvent"),
@@ -96,7 +96,7 @@ internal static class BrowserEventInterfaces
         static (realm, args) =>
         {
             var init = EventInitReader.Dictionary(args);
-            var (view, detail, which) = EventInitReader.UiInit(init);
+            var (view, detail, which) = EventInitReader.UiInit(realm.Engine, init);
             return new JsWheelEvent(
                 realm.Engine,
                 Type(realm, args, "WheelEvent"),
@@ -121,7 +121,7 @@ internal static class BrowserEventInterfaces
         static (realm, args) =>
         {
             var init = EventInitReader.Dictionary(args);
-            var (view, detail, which) = EventInitReader.UiInit(init);
+            var (view, detail, which) = EventInitReader.UiInit(realm.Engine, init);
             return new JsKeyboardEvent(
                 realm.Engine,
                 Type(realm, args, "KeyboardEvent"),
@@ -156,7 +156,7 @@ internal static class BrowserEventInterfaces
         static (realm, args) =>
         {
             var init = EventInitReader.Dictionary(args);
-            var (view, detail, which) = EventInitReader.UiInit(init);
+            var (view, detail, which) = EventInitReader.UiInit(realm.Engine, init);
             return new JsInputEvent(
                 realm.Engine,
                 Type(realm, args, "InputEvent"),
@@ -178,7 +178,7 @@ internal static class BrowserEventInterfaces
         static (realm, args) =>
         {
             var init = EventInitReader.Dictionary(args);
-            var (view, detail, which) = EventInitReader.UiInit(init);
+            var (view, detail, which) = EventInitReader.UiInit(realm.Engine, init);
             return new JsCompositionEvent(
                 realm.Engine,
                 Type(realm, args, "CompositionEvent"),
@@ -198,7 +198,7 @@ internal static class BrowserEventInterfaces
         static (realm, args) =>
         {
             var init = EventInitReader.Dictionary(args);
-            var (view, detail, which) = EventInitReader.UiInit(init);
+            var (view, detail, which) = EventInitReader.UiInit(realm.Engine, init);
             return new JsFocusEvent(
                 realm.Engine,
                 Type(realm, args, "FocusEvent"),
@@ -370,12 +370,56 @@ internal static class BrowserEventInterfaces
         .Accessor("view", static (t, _) => Brand<JsUiEvent>(t, "UIEvent.view").View)
         .Accessor("detail", static (t, _) => JsNumber.Create(Brand<JsUiEvent>(t, "UIEvent.detail").Detail))
         .Accessor("which", static (t, _) => JsNumber.Create(Brand<JsUiEvent>(t, "UIEvent.which").Which))
+        .Method("initUIEvent", static (t, args) =>
+        {
+            var ev = Brand<JsUiEvent>(t, "UIEvent.initUIEvent");
+            if (Initializing(ev, args, "UIEvent.initUIEvent", out var type, out var bubbles, out var cancelable))
+            {
+                ev.Initialize(type, bubbles, cancelable, LegacyView(ev, args, 3), LegacyNumber(args, 4));
+            }
+
+            return JsValue.Undefined;
+        }, length: 3)
         .Build();
 
     private static JsObjectShape BuildMouseEvent()
     {
         var builder = Base("MouseEvent");
         AddMouseMembers(builder);
+        AddUiInitializer(builder, "MouseEvent");
+        builder.Method("initMouseEvent", static (t, args) =>
+        {
+            var ev = Brand<JsMouseEvent>(t, "MouseEvent.initMouseEvent");
+            if (!Initializing(ev, args, "MouseEvent.initMouseEvent", out var type, out var bubbles, out var cancelable))
+            {
+                return JsValue.Undefined;
+            }
+
+            var modifiers = EventModifiers.None;
+            if (LegacyBool(args, 9)) { modifiers |= EventModifiers.Control; }
+            if (LegacyBool(args, 10)) { modifiers |= EventModifiers.Alt; }
+            if (LegacyBool(args, 11)) { modifiers |= EventModifiers.Shift; }
+            if (LegacyBool(args, 12)) { modifiers |= EventModifiers.Meta; }
+
+            ev.Initialize(
+                type,
+                bubbles,
+                cancelable,
+                LegacyView(ev, args, 3),
+                LegacyNumber(args, 4),
+                new MouseEventState(
+                    LegacyNumber(args, 5),
+                    LegacyNumber(args, 6),
+                    LegacyNumber(args, 7),
+                    LegacyNumber(args, 8),
+                    (short) TypeConverter.ToUint16(args.At(13)),
+                    ev.Buttons,
+                    modifiers,
+                    EventInitReader.TargetOf(ev.Engine, args.At(14))));
+
+            return JsValue.Undefined;
+        }, length: 3);
+
         return builder.Build();
     }
 
@@ -412,6 +456,76 @@ internal static class BrowserEventInterfaces
         .Accessor("deltaMode", static (t, _) => JsNumber.Create(Brand<JsWheelEvent>(t, "WheelEvent.deltaMode").DeltaMode))
         .Build();
 
+    private static void AddUiInitializer(JsObjectShape.Builder builder, string owner)
+    {
+        var member = owner + ".initUIEvent";
+        builder.Method("initUIEvent", (t, args) =>
+        {
+            var ev = Brand<JsUiEvent>(t, member);
+            if (Initializing(ev, args, member, out var type, out var bubbles, out var cancelable))
+            {
+                ev.Initialize(type, bubbles, cancelable, LegacyView(ev, args, 3), LegacyNumber(args, 4));
+            }
+
+            return JsValue.Undefined;
+        }, length: 3);
+    }
+
+    /// <summary>
+    /// The three steps every legacy initializer shares: the required <c>type</c> argument, the dispatch-flag
+    /// short-circuit, and the two booleans.
+    /// </summary>
+    /// <remarks>
+    /// The arity check is before the short-circuit, because WebIDL converts the arguments whatever the
+    /// receiver is doing; <c>dom/events/Event-init-while-dispatching.html</c> is what pins the short-circuit
+    /// itself, one interface at a time.
+    /// </remarks>
+    private static bool Initializing(
+        JsEvent ev,
+        JsValue[] args,
+        string member,
+        out JsString type,
+        out bool bubbles,
+        out bool cancelable)
+    {
+        if (args.Length < 1)
+        {
+            Throw.TypeError(
+                ev.Engine.Realm,
+                "Failed to execute '" + member[(member.IndexOf('.') + 1)..] + "' on '" + member[..member.IndexOf('.')]
+                + "': 1 argument required, but only 0 present.");
+        }
+
+        type = TypeConverter.ToJsString(args.At(0));
+        bubbles = TypeConverter.ToBoolean(args.At(1));
+        cancelable = TypeConverter.ToBoolean(args.At(2));
+        return !ev.DispatchFlag;
+    }
+
+    private static double LegacyNumber(JsValue[] args, int index) => TypeConverter.ToInt32(args.At(index));
+
+    private static bool LegacyBool(JsValue[] args, int index) => TypeConverter.ToBoolean(args.At(index));
+
+    /// <summary>
+    /// The <c>view</c> argument of a legacy initializer, which is the same <c>Window?</c> the constructor's
+    /// dictionary member is.
+    /// </summary>
+    private static JsValue LegacyView(JsEvent ev, JsValue[] args, int index)
+    {
+        var view = args.At(index);
+        if (view.IsNull() || view.IsUndefined())
+        {
+            return JsValue.Null;
+        }
+
+        if (!ReferenceEquals(view, ev.Engine._mainRealm.GlobalObject))
+        {
+            Throw.TypeError(ev.Engine.Realm, "The view argument is not of type 'Window'.");
+        }
+
+        return view;
+    }
+
     private static JsObjectShape BuildKeyboardEvent() => Base("KeyboardEvent")
         .Constant("DOM_KEY_LOCATION_STANDARD", JsNumber.PositiveZero)
         .Constant("DOM_KEY_LOCATION_LEFT", JsNumber.PositiveOne)
@@ -434,6 +548,34 @@ internal static class BrowserEventInterfaces
                 Brand<JsKeyboardEvent>(t, "KeyboardEvent.getModifierState").Modifiers,
                 RequiredKeyArgument(t, args, "KeyboardEvent.getModifierState"))),
             length: 1)
+        .Method("initUIEvent", static (t, args) =>
+        {
+            var ev = Brand<JsUiEvent>(t, "KeyboardEvent.initUIEvent");
+            if (Initializing(ev, args, "KeyboardEvent.initUIEvent", out var type, out var bubbles, out var cancelable))
+            {
+                ev.Initialize(type, bubbles, cancelable, LegacyView(ev, args, 3), LegacyNumber(args, 4));
+            }
+
+            return JsValue.Undefined;
+        }, length: 3)
+        .Method("initKeyboardEvent", static (t, args) =>
+        {
+            var ev = Brand<JsKeyboardEvent>(t, "KeyboardEvent.initKeyboardEvent");
+            if (Initializing(ev, args, "KeyboardEvent.initKeyboardEvent", out var type, out var bubbles, out var cancelable))
+            {
+                ev.Initialize(
+                    type,
+                    bubbles,
+                    cancelable,
+                    LegacyView(ev, args, 3),
+                    TypeConverter.ToString(args.At(4)),
+                    LegacyNumber(args, 5),
+                    EventModifierNames.Parse(TypeConverter.ToString(args.At(6))),
+                    LegacyBool(args, 7));
+            }
+
+            return JsValue.Undefined;
+        }, length: 3)
         .Build();
 
     /// <remarks>
@@ -695,25 +837,46 @@ internal static class EventModifierNames
     /// </summary>
     internal static bool IsActive(EventModifiers modifiers, string key)
     {
-        var flag = key switch
-        {
-            "Alt" => EventModifiers.Alt,
-            "AltGraph" => EventModifiers.AltGraph,
-            "CapsLock" => EventModifiers.CapsLock,
-            "Control" => EventModifiers.Control,
-            "Fn" => EventModifiers.Fn,
-            "FnLock" => EventModifiers.FnLock,
-            "Hyper" => EventModifiers.Hyper,
-            "Meta" => EventModifiers.Meta,
-            "NumLock" => EventModifiers.NumLock,
-            "ScrollLock" => EventModifiers.ScrollLock,
-            "Shift" => EventModifiers.Shift,
-            "Super" => EventModifiers.Super,
-            "Symbol" => EventModifiers.Symbol,
-            "SymbolLock" => EventModifiers.SymbolLock,
-            _ => EventModifiers.None,
-        };
+        var flag = Flag(key);
 
         return flag != EventModifiers.None && (modifiers & flag) != EventModifiers.None;
     }
+
+    /// <summary>
+    /// https://w3c.github.io/uievents/#dom-keyboardevent-initkeyboardevent's <c>modifiersListArg</c>: an
+    /// unordered set of modifier key values separated by spaces, which is the legacy initializer's way of
+    /// saying what a dictionary says with a boolean each.
+    /// </summary>
+    /// <remarks>A name the specification does not define contributes nothing, as it does to
+    /// <see cref="IsActive"/>.</remarks>
+    internal static EventModifiers Parse(string modifiersList)
+    {
+        var modifiers = EventModifiers.None;
+
+        foreach (var name in modifiersList.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+        {
+            modifiers |= Flag(name);
+        }
+
+        return modifiers;
+    }
+
+    private static EventModifiers Flag(string key) => key switch
+    {
+        "Alt" => EventModifiers.Alt,
+        "AltGraph" => EventModifiers.AltGraph,
+        "CapsLock" => EventModifiers.CapsLock,
+        "Control" => EventModifiers.Control,
+        "Fn" => EventModifiers.Fn,
+        "FnLock" => EventModifiers.FnLock,
+        "Hyper" => EventModifiers.Hyper,
+        "Meta" => EventModifiers.Meta,
+        "NumLock" => EventModifiers.NumLock,
+        "ScrollLock" => EventModifiers.ScrollLock,
+        "Shift" => EventModifiers.Shift,
+        "Super" => EventModifiers.Super,
+        "Symbol" => EventModifiers.Symbol,
+        "SymbolLock" => EventModifiers.SymbolLock,
+        _ => EventModifiers.None,
+    };
 }

--- a/Jint.Browser/Events/EventHandlerContentAttributes.cs
+++ b/Jint.Browser/Events/EventHandlerContentAttributes.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using Acornima.Ast;
 using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
 using Jint.Browser.Dom;
@@ -6,6 +7,8 @@ using Jint.Native;
 using Jint.Native.Function;
 using Jint.Native.Object;
 using Jint.Runtime;
+using Jint.Runtime.Environments;
+using Jint.Runtime.Interpreter;
 using Jint.WebApi;
 using Jint.WebApi.Events;
 
@@ -114,6 +117,8 @@ internal static class EventHandlerContentAttributes
 
     private static readonly HashSet<string> _bodyHandlerLookup = new(BodyHandlersOwnedByTheWindow, StringComparer.Ordinal);
 
+    private static readonly HashSet<string> _elementHandlerLookup = BuildElementHandlerLookup();
+
     private static readonly HashSet<string> _handlerLookup = BuildHandlerLookup();
 
     /// <summary>
@@ -126,10 +131,27 @@ internal static class EventHandlerContentAttributes
     /// </remarks>
     internal static bool IsHandlerType(string type) => _handlerLookup.Contains(type);
 
-    private static HashSet<string> BuildHandlerLookup()
+    /// <summary>
+    /// The same question for an <b>element</b>, which is a smaller set: <c>onreadystatechange</c> and
+    /// <c>onvisibilitychange</c> are a <c>Document</c>'s IDL attributes and content attributes of nothing.
+    /// </summary>
+    /// <remarks>
+    /// <c>&lt;div onreadystatechange="…"&gt;</c> is an ordinary attribute, which
+    /// <c>event-handler-non-content-document-idl-attributes.html</c> checks by dispatching the event and
+    /// asserting nothing ran.
+    /// </remarks>
+    private static bool IsElementHandlerType(string type) => _elementHandlerLookup.Contains(type);
+
+    private static HashSet<string> BuildElementHandlerLookup()
     {
         var names = new HashSet<string>(ElementHandlers, StringComparer.Ordinal);
         names.UnionWith(BodyHandlersOwnedByTheWindow);
+        return names;
+    }
+
+    private static HashSet<string> BuildHandlerLookup()
+    {
+        var names = new HashSet<string>(_elementHandlerLookup, StringComparer.Ordinal);
         names.Add("readystatechange");
         names.Add("visibilitychange");
         return names;
@@ -151,7 +173,7 @@ internal static class EventHandlerContentAttributes
         foreach (var attribute in element.Attributes)
         {
             var name = attribute.Name;
-            if (name.Length > 2 && name[0] == 'o' && name[1] == 'n' && IsHandlerType(name.Substring(2)))
+            if (name.Length > 2 && name[0] == 'o' && name[1] == 'n' && IsElementHandlerType(name.Substring(2)))
             {
                 Reconcile(wrapper, name.Substring(2));
             }
@@ -193,8 +215,9 @@ internal static class EventHandlerContentAttributes
         }
 
         // A document carries no content attributes, so its handler slot has only the IDL half; the null here
-        // removes a handler the markup no longer declares, and for a document there never was one.
-        var attribute = element?.GetAttribute("on" + type);
+        // removes a handler the markup no longer declares, and for a document there never was one. An
+        // element's attribute is read only for a type an element can carry it for.
+        var attribute = element is not null && IsElementHandlerType(type) ? element.GetAttribute("on" + type) : null;
         var sources = _sources.GetOrCreateValue(target);
         var known = sources.TryGetLast(type, out var last);
 
@@ -217,20 +240,35 @@ internal static class EventHandlerContentAttributes
             return target;
         }
 
-        // https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-content-attributes — setting the
-        // attribute sets the handler to an internal raw uncompiled handler, and removing it sets the handler to
-        // null. Either way whatever was there, compiled or assigned by script, is replaced.
-        if (target.FindEventHandler(type) is { } existing)
-        {
-            target.RemoveListener(existing);
-        }
+        // https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-content-attributes — setting
+        // the attribute sets the handler to an internal raw uncompiled handler, and removing it sets the
+        // handler to null. Either way whatever was there, compiled or assigned by script, is replaced.
+        var existing = target.FindEventHandler(type);
 
         if (attribute is null)
         {
+            // "Deactivate an event handler": the handler is null, so the listener goes with it.
+            if (existing is not null)
+            {
+                target.RemoveListener(existing);
+            }
+
             return target;
         }
 
-        target.AddListener(new EventListenerRegistration(type, new UncompiledHandler(wrapper, target, type, attribute))
+        var handler = new UncompiledHandler(wrapper, target, type, attribute);
+
+        // **In place**, because an event handler's position in the listener list is fixed when the handler is
+        // first activated and a later value does not move it. Removing and re-adding would put every handler
+        // a page rewrites after the listeners registered since, which `inline-event-handler-ordering.html`
+        // measures by dispatching.
+        if (existing is not null)
+        {
+            existing.Callback = handler;
+            return target;
+        }
+
+        target.AddListener(new EventListenerRegistration(type, handler)
         {
             IsEventHandler = true,
         });
@@ -239,32 +277,83 @@ internal static class EventHandlerContentAttributes
     }
 
     /// <summary>
+    /// The one write of an attribute this package can see, and what makes a handler's <b>position</b> in the
+    /// listener list the one HTML gives it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// HTML activates an event handler when its content attribute is <i>set</i>, and the listener it creates
+    /// then keeps its place among the <c>addEventListener</c> listeners for ever. Reconciling only at a
+    /// dispatch or an IDL read would create it at the wrong moment — after every listener registered in
+    /// between — and no later reconciliation could recover the order.
+    /// </para>
+    /// <para>
+    /// It is reached from <c>DomHostHooks.SetAttribute</c> and <c>RemoveAttribute</c>, which is the seam the
+    /// override table already has for a member whose body this package owns. The two are the whole of what a
+    /// page uses; <c>setAttributeNS</c>, <c>toggleAttribute</c>, an <c>Attr</c>'s <c>value</c> and
+    /// <c>NamedNodeMap</c> write to the same attribute without passing here, and a handler written that way
+    /// is still reconciled at the next dispatch or IDL read — it merely takes its position then.
+    /// </para>
+    /// </remarks>
+    internal static void AttributeChanged(DomRealm realm, IElement element, string name)
+    {
+        if (name.Length <= 2 || (name[0] | 0x20) != 'o' || (name[1] | 0x20) != 'n')
+        {
+            return;
+        }
+
+        var type = name.Substring(2).ToLowerInvariant();
+        if (!IsElementHandlerType(type))
+        {
+            return;
+        }
+
+        if (realm.WrapNode(element) is DomNodeObject wrapper)
+        {
+            Reconcile(wrapper, type);
+        }
+    }
+
+    /// <summary>
     /// https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes — the getter, which
     /// compiles the content attribute if that is what the slot still holds.
     /// </summary>
     internal static JsValue Get(DomNodeObject wrapper, string type)
+        => CurrentValue(Reconcile(wrapper, type), type);
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/webappapis.html#getting-the-current-value-of-the-event-handler
+    /// over a target whose content attribute has already been reconciled — or that has none, which is the
+    /// <b>window</b>'s case.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Every read of an event handler IDL attribute goes through here, and that is the point: the compile-on-
+    /// read placeholder must never escape into script, and a <c>&lt;body onload&gt;</c> is read through
+    /// <c>window.onload</c> as often as through <c>body.onload</c>. Reading it as
+    /// <c>function onload() { [native code] }</c> is what <c>Body-FrameSet-Event-Handlers.html</c> caught.
+    /// </para>
+    /// <para>
+    /// A body that does not parse sets the handler to null and <b>leaves the registration where it is</b>:
+    /// HTML fixes an event handler's position in the listener list when the handler is first set, and a null
+    /// callback is skipped rather than removed. Removing it instead would move a later handler up, which
+    /// <c>inline-event-handler-ordering.html</c> measures by dispatching.
+    /// </para>
+    /// </remarks>
+    internal static JsValue CurrentValue(JsEventTarget? target, string type)
     {
-        var target = Reconcile(wrapper, type);
         if (target?.FindEventHandler(type) is not { } registration)
         {
             return JsValue.Null;
         }
 
-        if (registration.Callback is UncompiledHandler uncompiled)
+        if (registration.Callback is not UncompiledHandler uncompiled)
         {
-            // "Get the current value of the event handler" compiles on read, so el.onclick answers the
-            // function object rather than the placeholder — and answers null when the body would not parse.
-            var compiled = uncompiled.Compile();
-            if (compiled is null)
-            {
-                target.RemoveListener(registration);
-                return JsValue.Null;
-            }
-
-            registration.Callback = compiled;
-            return compiled;
+            return registration.Callback;
         }
 
+        var compiled = uncompiled.Compile();
+        registration.Callback = compiled is null ? JsValue.Null : compiled;
         return registration.Callback;
     }
 
@@ -366,20 +455,27 @@ internal static class EventHandlerContentAttributes
         /// </summary>
         /// <remarks>
         /// <para>
-        /// The scope is HTML's, emulated the way every implementation emulates it: the body runs inside
-        /// <c>with (document) { with (this) { … } }</c>, so an unqualified name resolves against the document
-        /// and then against the element before it reaches the global — which is what lets
-        /// <c>&lt;a onclick="return false"&gt;</c> and <c>&lt;input onchange="form.submit()"&gt;</c> work.
+        /// <b>The function is exactly the one HTML describes</b>: named for the attribute, taking one
+        /// parameter called <c>event</c> — five for a <c>Window</c>'s <c>error</c> handler — and with the
+        /// attribute's text as its body between two newlines. That is observable, because
+        /// <c>toString()</c> of it is, and the source text is parsed as such rather than assembled by
+        /// <c>Function</c>'s constructor.
         /// </para>
         /// <para>
-        /// <b>One level of HTML's scope is missing</b>: the form owner, which HTML puts between the document
-        /// and the element for a form-associated element. A handler naming a sibling control by its <c>name</c>
-        /// without going through <c>this.form</c> resolves here where a browser resolves it there.
+        /// <b>The scope chain is the function's, not its body's</b>, which is the half that cannot be
+        /// emulated with a <c>with</c> statement inside the source. HTML's chain is the realm's global
+        /// environment, then an object environment over the node document, then one over the form owner, then
+        /// one over the element — each with the <i>withEnvironment</i> flag, so <c>Symbol.unscopables</c>
+        /// applies to every one of them. Putting that inside the body instead would make the objects shadow
+        /// the function's own <b>parameters</b>: a <c>&lt;body onerror&gt;</c> whose first parameter is named
+        /// <c>event</c> would read <c>window.event</c> rather than the message, which is precisely what
+        /// <c>body-onerror-runtime-error.html</c> catches.
         /// </para>
         /// <para>
-        /// The function is built through <c>Function</c>'s own constructor rather than by evaluating source,
-        /// so the compilation is not a nested script execution and cannot re-arm the engine's per-entry
-        /// constraints. Its body is sloppy-mode, which is what makes <c>with</c> legal.
+        /// Nothing here executes a script. The parse goes through the engine's own parser, so the host's
+        /// parsing limits apply, and the function object is created directly — so the compilation is still
+        /// not a nested script execution and still cannot re-arm the engine's per-entry constraints. The body
+        /// is sloppy-mode, which is what lets an unqualified name reach the object environments at all.
         /// </para>
         /// </remarks>
         internal ObjectInstance? Compile()
@@ -392,31 +488,157 @@ internal static class EventHandlerContentAttributes
             var engine = _wrapper.Engine;
             var realm = _wrapper.DomRealm.PrincipalRealm;
 
+            // "If scripting is disabled for eventTarget, then return null." A document this package did not
+            // load — a `DOMParser` result, `createHTMLDocument`, `new Document()` — has a browsing context
+            // with no scripting service, so its handler attributes are text and nothing else. It is not a
+            // failure: nothing is reported and the slot is untouched, so the attribute compiles if the node
+            // is ever adopted into a document that does script.
+            if (!IsScriptingEnabled())
+            {
+                return null;
+            }
+
             try
             {
                 // HTML's special error event handling: a window `onerror` takes five parameters rather than
                 // the event. Everything else, including an element's own `onerror`, takes the event.
                 var parameters = _target.IsGlobalScope && string.Equals(_handlerType, "error", StringComparison.Ordinal)
-                    ? new JsValue[]
-                    {
-                        JsString.Create("event"), JsString.Create("source"), JsString.Create("lineno"),
-                        JsString.Create("colno"), JsString.Create("error"),
-                        JsString.Create("with (document) { with (this) { " + _body + "\n} }"),
-                    }
-                    : [JsString.Create("event"), JsString.Create("with (document) { with (this) { " + _body + "\n} }")];
+                    ? "event, source, lineno, colno, error"
+                    : "event";
 
-                return realm.Intrinsics.Function.Construct(parameters, realm.Intrinsics.Function);
+                var sourceText = "function on" + _handlerType + "(" + parameters + ") {\n" + _body + "\n}";
+
+                // Retained deliberately and per handler, whatever the engine's own setting: `toString()` of a
+                // handler is what HTML specifies, and the text is one attribute long.
+                var parser = engine.GetParserFor(ScriptParsingOptions.RetainingDefault);
+                var script = parser.ParseScriptGuarded(realm, sourceText, source: SourceName(), strict: false);
+
+                if (script.Body.Count != 1 || script.Body[0] is not FunctionDeclaration declaration)
+                {
+                    return Failed(engine, null);
+                }
+
+                var definition = new JintFunctionDefinition(declaration);
+                return realm.Intrinsics.Function.OrdinaryFunctionCreate(
+                    realm.Intrinsics.Function.PrototypeObject,
+                    definition,
+                    definition.ThisMode,
+                    ScopeChain(engine, realm),
+                    privateScope: null);
             }
             catch (JavaScriptException exception)
             {
-                // HTML: a body that does not parse reports the error and leaves the handler null. Reported
-                // through the same sink an uncaught listener error uses, so a page runtime sees it as a page
-                // error rather than losing it.
-                _failed = true;
+                return Failed(engine, exception);
+            }
+        }
+
+        /// <summary>
+        /// The document's URL, so that an exception escaping the handler is reported against the document the
+        /// attribute is in — which is what HTML's <c>filename</c> is for an inline handler.
+        /// </summary>
+        private string SourceName() => _wrapper.Node.Owner?.Url ?? "";
+
+        /// <summary>
+        /// https://html.spec.whatwg.org/multipage/webappapis.html#concept-n-noscript — whether scripting is
+        /// enabled for the node's document.
+        /// </summary>
+        /// <remarks>
+        /// The page's own document is the only one with a browsing context that scripts; every other document
+        /// an engine here can reach was parsed by <c>DOMParser</c>, built by <c>createHTMLDocument</c> or
+        /// constructed outright, and each of those gets a context with no scripting service on purpose. A
+        /// binding installed with no page runtime behind it has no such distinction to make — the host handed
+        /// the binding its document — so it answers true.
+        /// </remarks>
+        private bool IsScriptingEnabled()
+        {
+            if (Runtime.PageRuntime.Find(_wrapper.Engine) is not { } runtime)
+            {
+                return true;
+            }
+
+            var document = _wrapper.Node as IDocument ?? _wrapper.Node.Owner;
+            return ReferenceEquals(document, runtime.Document);
+        }
+
+        /// <summary>
+        /// https://html.spec.whatwg.org/multipage/webappapis.html#getting-the-current-value-of-the-event-handler
+        /// steps 10 and 11 — the environments an unqualified name in the body resolves through, outermost
+        /// first: the global environment, the node document, the form owner and the element.
+        /// </summary>
+        private Jint.Runtime.Environments.Environment ScopeChain(Engine engine, Realm realm)
+        {
+            Jint.Runtime.Environments.Environment scope = realm.GlobalEnv;
+            var dom = _wrapper.DomRealm;
+
+            if (_wrapper.Node is not IElement element)
+            {
+                // A document's own handler: the document is the target, so it is the only object environment.
+                return _wrapper.Node is IDocument document
+                    ? Wrap(engine, dom.WrapNode(document), scope)
+                    : scope;
+            }
+
+            if (element.Owner is { } owner)
+            {
+                scope = Wrap(engine, dom.WrapNode(owner), scope);
+            }
+
+            if (FormOwner(element) is { } form)
+            {
+                scope = Wrap(engine, dom.WrapNode(form), scope);
+            }
+
+            return Wrap(engine, _wrapper, scope);
+        }
+
+        private static ObjectEnvironment Wrap(Engine engine, ObjectInstance binding, Jint.Runtime.Environments.Environment outer)
+            => JintEnvironment.NewObjectEnvironment(engine, binding, outer, provideThis: true, withEnvironment: true);
+
+        /// <summary>
+        /// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#form-owner — the form the
+        /// <c>form</c> content attribute names when the element is connected, and otherwise the nearest
+        /// ancestor form.
+        /// </summary>
+        /// <remarks>
+        /// Computed rather than read off AngleSharp, whose <c>Form</c> property is declared separately on
+        /// each of the eight form-control interfaces and on no common one, so there is nothing to ask an
+        /// <c>IElement</c> for.
+        /// </remarks>
+        private static IHtmlFormElement? FormOwner(IElement element)
+        {
+            if (element.GetAttribute("form") is { Length: > 0 } id)
+            {
+                return element.Owner?.GetElementById(id) as IHtmlFormElement;
+            }
+
+            for (var current = element.ParentElement; current is not null; current = current.ParentElement)
+            {
+                if (current is IHtmlFormElement form)
+                {
+                    return form;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// HTML: a body that does not parse reports the error and leaves the handler null. Reporting is
+        /// <i>report an exception</i>, so it fires the global <c>error</c> event before it reaches the sink —
+        /// which is what lets <c>window.onerror</c> hear a syntax error in an <c>onclick</c> attribute.
+        /// </summary>
+        private ObjectInstance? Failed(Engine engine, JavaScriptException? exception)
+        {
+            _failed = true;
+
+            if (exception is not null)
+            {
+                engine._webApi?.FireGlobalErrorEvent(exception);
                 engine._webApi?.Diagnostics?.Report(
                     DiagnosticEvent.ForUncaughtCallbackError(exception, DiagnosticCallbackSource.EventListener));
-                return null;
             }
+
+            return null;
         }
     }
 }

--- a/Jint.Browser/Events/EventHandlerContentAttributes.cs
+++ b/Jint.Browser/Events/EventHandlerContentAttributes.cs
@@ -196,13 +196,26 @@ internal static class EventHandlerContentAttributes
         // removes a handler the markup no longer declares, and for a document there never was one.
         var attribute = element?.GetAttribute("on" + type);
         var sources = _sources.GetOrCreateValue(target);
+        var known = sources.TryGetLast(type, out var last);
 
-        if (!sources.HasChanged(type, attribute))
+        if (known && string.Equals(last, attribute, StringComparison.Ordinal))
         {
             return target;
         }
 
         sources.Record(type, attribute);
+
+        // **A slot nobody has looked at, for an attribute that is not there, is not a change.** HTML's "set
+        // the content attribute" step is what this reconciliation stands in for, and it observes an attribute
+        // appearing, changing or going away — never one that was absent all along. The distinction is only
+        // visible where the slot is *shared*: a body's `onerror`, `onload` and their kind are redirected to
+        // the window, so the first dispatch through a body of an event whose handler a script assigned to the
+        // window would otherwise arrive here, find no `onerror` attribute on the body, and remove it.
+        // `dom/events/event-global.html`'s ErrorEvent test is what found that.
+        if (!known && attribute is null)
+        {
+            return target;
+        }
 
         // https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-content-attributes — setting the
         // attribute sets the handler to an internal raw uncompiled handler, and removing it sets the handler to
@@ -293,8 +306,12 @@ internal static class EventHandlerContentAttributes
     {
         private readonly Dictionary<string, string?> _byType = new(StringComparer.Ordinal);
 
-        internal bool HasChanged(string type, string? attribute)
-            => !_byType.TryGetValue(type, out var last) || !string.Equals(last, attribute, StringComparison.Ordinal);
+        /// <summary>
+        /// Whether this slot has ever been reconciled, and against what. The caller needs the two answers
+        /// apart: "unchanged" and "never looked at, and still absent" both mean do nothing, but they are not
+        /// the same fact and only one of them may leave the recorded value alone.
+        /// </summary>
+        internal bool TryGetLast(string type, out string? attribute) => _byType.TryGetValue(type, out attribute);
 
         internal void Record(string type, string? attribute) => _byType[type] = attribute;
     }

--- a/Jint.Browser/Events/EventHandlerContentAttributes.cs
+++ b/Jint.Browser/Events/EventHandlerContentAttributes.cs
@@ -606,6 +606,21 @@ internal static class EventHandlerContentAttributes
         /// </remarks>
         private static IHtmlFormElement? FormOwner(IElement element)
         {
+            // https://html.spec.whatwg.org/multipage/forms.html#form-associated-element — only these have a
+            // form owner at all, which is why a `<div>` inside a `<form>` resolves an unqualified name against
+            // the document and the window and never against the form.
+            if (element is not (IHtmlButtonElement
+                or IHtmlFieldSetElement
+                or IHtmlInputElement
+                or IHtmlObjectElement
+                or IHtmlOutputElement
+                or IHtmlSelectElement
+                or IHtmlTextAreaElement
+                or IHtmlImageElement))
+            {
+                return null;
+            }
+
             if (element.GetAttribute("form") is { Length: > 0 } id)
             {
                 return element.Owner?.GetElementById(id) as IHtmlFormElement;

--- a/Jint.Browser/Events/EventInitReader.cs
+++ b/Jint.Browser/Events/EventInitReader.cs
@@ -145,8 +145,37 @@ internal static class EventInitReader
     /// dictionary said zero": the first lets each interface compute its own legacy value, the second is
     /// honoured as given.
     /// </remarks>
-    internal static (JsValue View, double Detail, double? Which) UiInit(ObjectInstance? init)
-        => (Any(init, _view, JsValue.Null), Long(init, _detail), OptionalUnsignedLong(init, _which));
+    internal static (JsValue View, double Detail, double? Which) UiInit(Engine engine, ObjectInstance? init)
+        => (View(engine, init), Long(init, _detail), OptionalUnsignedLong(init, _which));
+
+    /// <summary>
+    /// The <c>view</c> member on its own — https://w3c.github.io/uievents/#dom-uievent-view, whose IDL type is
+    /// <c>Window?</c> and therefore a WebIDL interface type: anything that is not a <c>Window</c> and not null
+    /// is a <c>TypeError</c> rather than a value quietly kept.
+    /// </summary>
+    /// <remarks>
+    /// This engine's <c>Window</c> is the global object itself (the page runtime's window installer says
+    /// why), so the check is an identity comparison against it — which is exactly as narrow as a browser's,
+    /// there being one window per page here.
+    /// </remarks>
+    internal static JsValue View(Engine engine, ObjectInstance? init)
+    {
+        var view = Any(init, _view, JsValue.Null);
+
+        if (view.IsNull() || view.IsUndefined())
+        {
+            return JsValue.Null;
+        }
+
+        if (!ReferenceEquals(view, engine._mainRealm.GlobalObject))
+        {
+            Throw.TypeError(
+                engine.Realm,
+                "Failed to construct 'UIEvent': member view is not of type 'Window'.");
+        }
+
+        return view;
+    }
 
     /// <summary>
     /// https://w3c.github.io/uievents/#dictdef-eventmodifierinit — the fourteen modifier members,

--- a/Jint.Browser/Events/LegacyEventCreation.cs
+++ b/Jint.Browser/Events/LegacyEventCreation.cs
@@ -1,0 +1,132 @@
+using Jint.Browser.Dom;
+using Jint.Native;
+using Jint.Runtime;
+using Jint.WebApi.DomException;
+using Jint.WebApi.Events;
+
+namespace Jint.Browser.Events;
+
+/// <summary>
+/// <c>document.createEvent(interface)</c> — DOM's legacy way of building an event, kept alive by the
+/// half of the web-platform corpus that predates the constructors.
+/// <para>
+/// https://dom.spec.whatwg.org/#dom-document-createevent
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>AngleSharp's own <c>createEvent</c> is skipped and this replaces it</b> (the override table says so):
+/// its result is an AngleSharp <c>Event</c>, and every script-visible event in this package is a Jint one
+/// dispatched through the engine's tree dispatcher. What the standard requires is only the alias table, so
+/// nothing here builds an event a constructor could not have built — the difference is entirely in the two
+/// steps after it.
+/// </para>
+/// <para>
+/// <b>Those two steps are the whole point of the method.</b> The event's <c>type</c> is the empty string and
+/// its <i>initialized flag</i> is unset, which makes it undispatchable until <c>initEvent()</c> has named it —
+/// <c>dispatchEvent</c> answers an <c>InvalidStateError</c> for one that has not been. The flag is the
+/// engine's (<c>JsEvent.InitializedFlag</c>), and <c>document.createEvent</c> is the only algorithm in the
+/// standard that unsets it, which is why the engine leaves the writer to a host.
+/// </para>
+/// <para>
+/// <b>An alias naming an interface this package does not have is a <c>NotSupportedError</c>, which is what the
+/// standard says for an alias it does not list at all.</b> Five of the table's rows name interfaces that do
+/// not exist here — <c>DragEvent</c> and <c>ClipboardEvent</c> need a <c>DataTransfer</c>,
+/// <c>StorageEvent</c> a storage area's change notification, <c>TouchEvent</c> a touch input, and the two
+/// device-orientation events a sensor — and answering with a plain <c>Event</c> under those names would be a
+/// lie a page cannot detect. A browser without the interface refuses in the same way.
+/// </para>
+/// </remarks>
+internal static class LegacyEventCreation
+{
+    /// <summary>
+    /// The alias table of https://dom.spec.whatwg.org/#dom-document-createevent, matched
+    /// ASCII-case-insensitively as the standard requires.
+    /// </summary>
+    /// <remarks>
+    /// The value is the package interface to build, or <see langword="null"/> for one of the three the engine
+    /// owns — which <see cref="EngineInterface"/> then names. The two spellings of each legacy plural
+    /// (<c>events</c>, <c>mouseevents</c>, <c>uievents</c>) are separate rows because that is how the table is
+    /// written.
+    /// </remarks>
+    private static readonly Dictionary<string, BrowserEventDefinition?> _aliases = new(StringComparer.Ordinal)
+    {
+        ["beforeunloadevent"] = BrowserEventInterfaces.BeforeUnloadEvent,
+        ["compositionevent"] = BrowserEventInterfaces.CompositionEvent,
+        ["customevent"] = null,
+        ["event"] = null,
+        ["events"] = null,
+        ["focusevent"] = BrowserEventInterfaces.FocusEvent,
+        ["hashchangeevent"] = BrowserEventInterfaces.HashChangeEvent,
+        ["htmlevents"] = null,
+        ["keyboardevent"] = BrowserEventInterfaces.KeyboardEvent,
+        ["messageevent"] = null,
+        ["mouseevent"] = BrowserEventInterfaces.MouseEvent,
+        ["mouseevents"] = BrowserEventInterfaces.MouseEvent,
+        ["svgevents"] = null,
+        ["textevent"] = BrowserEventInterfaces.CompositionEvent,
+        ["uievent"] = BrowserEventInterfaces.UIEvent,
+        ["uievents"] = BrowserEventInterfaces.UIEvent,
+    };
+
+    /// <summary>Which engine-owned interface an alias whose table entry is null names.</summary>
+    private static string EngineInterface(string alias) => alias switch
+    {
+        "customevent" => "CustomEvent",
+        "messageevent" => "MessageEvent",
+        _ => "Event",
+    };
+
+    /// <summary>
+    /// The member's body: one argument, the interface name, and an event of that interface with no type and
+    /// its initialized flag unset.
+    /// </summary>
+    internal static JsValue CreateEvent(DomRealm dom, JsValue[] arguments)
+    {
+        var realm = dom.PrincipalRealm;
+        var alias = DomConvert.RequiredText(arguments, 0, "Document.createEvent").ToLowerInvariant();
+
+        if (!_aliases.TryGetValue(alias, out var definition))
+        {
+            var notSupported = realm.Intrinsics.DomException.CreateException(
+                DomExceptionNames.NotSupported,
+                "Failed to execute 'createEvent' on 'Document': the provided event type ('" + alias + "') is invalid.");
+
+            var location = dom.Engine._lastSyntaxElement?.Location ?? default;
+            Throw.JavaScriptException(dom.Engine, notSupported, in location);
+        }
+
+        var events = BrowserEventRealm.Of(dom.Engine);
+
+        // Step 2's "create an event": the interface's own constructor with no dictionary, which gives the
+        // empty type and every member its default. The prototype is the caller's to assign, exactly as the
+        // interface object assigns it for `new`.
+        var created = definition is not null
+            ? Package(events, definition)
+            : Engine(realm, EngineInterface(alias));
+
+        // Steps 4 and 6. `isTrusted` is already false — nothing here creates a trusted event — and step 5's
+        // time stamp is the constructor's own.
+        created.InitializedFlag = false;
+        return created;
+    }
+
+    private static JsEvent Package(BrowserEventRealm events, BrowserEventDefinition definition)
+    {
+        var instance = definition.Construct(events, [JsString.Empty]);
+        instance._prototype = events.PrototypeOf(definition);
+        return instance;
+    }
+
+    private static JsEvent Engine(Realm realm, string name)
+    {
+        var constructor = name switch
+        {
+            "CustomEvent" => (Native.Constructor) realm.Intrinsics.CustomEvent,
+            "MessageEvent" => realm.Intrinsics.MessageEvent,
+            _ => realm.Intrinsics.Event,
+        };
+
+        return (JsEvent) constructor.Construct([JsString.Empty], constructor);
+    }
+}

--- a/Jint.Browser/Events/UiEventInstances.cs
+++ b/Jint.Browser/Events/UiEventInstances.cs
@@ -54,10 +54,26 @@ internal class JsUiEvent : JsEvent
     }
 
     /// <summary>https://w3c.github.io/uievents/#dom-uievent-view.</summary>
-    internal JsValue View { get; }
+    internal JsValue View { get; private set; }
 
     /// <summary>https://w3c.github.io/uievents/#dom-uievent-detail — a click count, a wheel tick count.</summary>
-    internal double Detail { get; }
+    internal double Detail { get; private set; }
+
+    /// <summary>
+    /// https://w3c.github.io/uievents/#dom-uievent-inituievent — the legacy initializer: <i>initialize an
+    /// event</i>, then this interface's own two members.
+    /// </summary>
+    /// <remarks>
+    /// Every one of these is a no-op while the event is being dispatched, which is
+    /// <c>JsEvent.InitializeEvent</c>'s own rule — the caller checks the dispatch flag once, before the
+    /// arguments are converted, and every derived initializer inherits it by calling up.
+    /// </remarks>
+    internal virtual void Initialize(JsString type, bool bubbles, bool cancelable, JsValue view, double detail)
+    {
+        InitializeEvent(type, bubbles, cancelable);
+        View = view;
+        Detail = detail;
+    }
 
     /// <summary>
     /// The <c>which</c> the init dictionary supplied, or <see langword="null"/> when it said nothing — which is
@@ -116,26 +132,51 @@ internal class JsMouseEvent : JsUiEvent
         RelatedTarget = state.RelatedTarget;
     }
 
+    /// <summary>
+    /// https://w3c.github.io/uievents/#dom-mouseevent-initmouseevent — the legacy initializer.
+    /// </summary>
+    /// <remarks>
+    /// <c>buttons</c> is not among its arguments and is deliberately left alone: the legacy signature
+    /// predates it, and inventing a value from <c>button</c> would be a guess a page cannot correct.
+    /// </remarks>
+    internal void Initialize(
+        JsString type,
+        bool bubbles,
+        bool cancelable,
+        JsValue view,
+        double detail,
+        in MouseEventState state)
+    {
+        Initialize(type, bubbles, cancelable, view, detail);
+        ScreenX = state.ScreenX;
+        ScreenY = state.ScreenY;
+        ClientX = state.ClientX;
+        ClientY = state.ClientY;
+        Button = state.Button;
+        Modifiers = state.Modifiers;
+        RelatedTarget = state.RelatedTarget;
+    }
+
     /// <summary>https://w3c.github.io/uievents/#dom-mouseevent-screenx.</summary>
-    internal double ScreenX { get; }
+    internal double ScreenX { get; private set; }
 
     /// <summary>https://w3c.github.io/uievents/#dom-mouseevent-screeny.</summary>
-    internal double ScreenY { get; }
+    internal double ScreenY { get; private set; }
 
     /// <summary>https://w3c.github.io/uievents/#dom-mouseevent-clientx.</summary>
-    internal double ClientX { get; }
+    internal double ClientX { get; private set; }
 
     /// <summary>https://w3c.github.io/uievents/#dom-mouseevent-clienty.</summary>
-    internal double ClientY { get; }
+    internal double ClientY { get; private set; }
 
     /// <summary>https://w3c.github.io/uievents/#dom-mouseevent-button — 0 primary, 1 auxiliary, 2 secondary.</summary>
-    internal double Button { get; }
+    internal double Button { get; private set; }
 
     /// <summary>https://w3c.github.io/uievents/#dom-mouseevent-buttons — the bit set of buttons held down.</summary>
     internal double Buttons { get; }
 
     /// <summary>The modifier keys, read by the four IDL attributes and by <c>getModifierState()</c>.</summary>
-    internal EventModifiers Modifiers { get; }
+    internal EventModifiers Modifiers { get; private set; }
 
     /// <summary>
     /// https://dom.spec.whatwg.org/#concept-event-dispatch step 6.4 — <c>true</c> exactly for a
@@ -328,29 +369,58 @@ internal sealed class JsKeyboardEvent : JsUiEvent
         KeyCode = state.KeyCode ?? LegacyKeyCodes.KeyCodeFor(TypeName, state.Key);
     }
 
+    /// <summary>
+    /// https://w3c.github.io/uievents/#dom-keyboardevent-initkeyboardevent — the legacy initializer, whose
+    /// signature is UI Events' own: no <c>code</c>, and the modifiers as a space-separated list of key values
+    /// rather than as booleans.
+    /// </summary>
+    /// <remarks>
+    /// The legacy signature has no <c>code</c>, no <c>isComposing</c> and no <c>charCode</c>/<c>keyCode</c>,
+    /// so those are left as they were and the two legacy codes are recomputed from the new key and type,
+    /// which is what the tables they come from are for.
+    /// </remarks>
+    internal void Initialize(
+        JsString type,
+        bool bubbles,
+        bool cancelable,
+        JsValue view,
+        string key,
+        double location,
+        EventModifiers modifiers,
+        bool repeat)
+    {
+        Initialize(type, bubbles, cancelable, view, detail: 0);
+        Key = key;
+        Location = location;
+        Modifiers = modifiers;
+        Repeat = repeat;
+        CharCode = LegacyKeyCodes.CharCodeFor(TypeName, key);
+        KeyCode = LegacyKeyCodes.KeyCodeFor(TypeName, key);
+    }
+
     /// <summary>https://w3c.github.io/uievents/#dom-keyboardevent-key.</summary>
-    internal string Key { get; }
+    internal string Key { get; private set; }
 
     /// <summary>https://w3c.github.io/uievents/#dom-keyboardevent-code.</summary>
     internal string Code { get; }
 
     /// <summary>https://w3c.github.io/uievents/#dom-keyboardevent-location.</summary>
-    internal double Location { get; }
+    internal double Location { get; private set; }
 
     /// <summary>https://w3c.github.io/uievents/#dom-keyboardevent-repeat.</summary>
-    internal bool Repeat { get; }
+    internal bool Repeat { get; private set; }
 
     /// <summary>https://w3c.github.io/uievents/#dom-keyboardevent-iscomposing.</summary>
     internal bool IsComposing { get; }
 
     /// <summary>The modifier keys.</summary>
-    internal EventModifiers Modifiers { get; }
+    internal EventModifiers Modifiers { get; private set; }
 
     /// <summary>https://w3c.github.io/uievents/#dom-keyboardevent-charcode.</summary>
-    internal double CharCode { get; }
+    internal double CharCode { get; private set; }
 
     /// <summary>https://w3c.github.io/uievents/#dom-keyboardevent-keycode.</summary>
-    internal double KeyCode { get; }
+    internal double KeyCode { get; private set; }
 
     /// <summary>
     /// https://w3c.github.io/uievents/#dom-uievent-which for a keyboard event: the character code when there is

--- a/Jint.Browser/Page.Navigation.cs
+++ b/Jint.Browser/Page.Navigation.cs
@@ -208,8 +208,14 @@ public sealed partial class Page
     /// awaited — the document that script is running in is the one being replaced — and a failure becomes a
     /// page error rather than an unobserved faulted task, because there is nobody to hand it to.
     /// </remarks>
-    internal void RequestNavigation(string url, bool replace, bool reload = false)
-        => Start(new NavigationRequest(
+    internal void RequestNavigation(string url, bool replace, bool reload = false, Engine? engine = null)
+    {
+        if (engine is not null && !reload && TryFragmentNavigation(engine, url, replace))
+        {
+            return;
+        }
+
+        Start(new NavigationRequest(
             url,
             NavigationOptions.Default,
             replace ? HistoryMode.Replace : HistoryMode.Push,
@@ -218,6 +224,50 @@ public sealed partial class Page
             ContentType: null,
             reload,
             Referrer: null));
+    }
+
+    /// <summary>
+    /// A same-document fragment navigation, done <b>on the loop</b> rather than through <see cref="Start"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// HTML's <i>navigate</i> queues a task and its fragment arm neither fetches, replaces the engine nor can
+    /// fail, so there is nothing for the off-loop half of a navigation to do — and going there anyway is
+    /// observable: a page that clicks an <c>&lt;a href="#x"&gt;</c> and then spins zero-delay timers waiting
+    /// for <c>hashchange</c> waits out the whole chain, because the thread hop and the navigation gate put
+    /// the commit behind every timer already due.
+    /// <c>dom/events/Event-dispatch-single-activation-behavior.html</c> is written exactly that way and gives
+    /// it two turns.
+    /// </para>
+    /// <para>
+    /// It declines while a navigation is in flight — the gate is what orders those, and a fragment move that
+    /// jumped it could be overwritten by a commit already on its way — so the slow path is still there for
+    /// the case it was protecting.
+    /// </para>
+    /// </remarks>
+    private bool TryFragmentNavigation(Engine engine, string url, bool replace)
+    {
+        if (_closed || _load is null || _navigationGate.CurrentCount == 0)
+        {
+            return false;
+        }
+
+        var target = PageUrl.Parse(url, _url);
+        if (target?.Fragment is null)
+        {
+            return false;
+        }
+
+        var href = target.Serialize();
+        if (!PageUrl.IsSameDocument(_url, href))
+        {
+            return false;
+        }
+
+        var history = replace ? HistoryMode.Replace : HistoryMode.Push;
+        engine.Tasks.Post(() => FragmentNavigate(engine, href, history));
+        return true;
+    }
 
     /// <summary>The same, for a form submission that ends in a <c>POST</c>.</summary>
     internal void RequestFormPost(string url, byte[] body, string contentType)

--- a/Jint.Browser/Runtime/AGENTS.md
+++ b/Jint.Browser/Runtime/AGENTS.md
@@ -104,11 +104,28 @@ no wrapper of its own, so nothing counts it — and by this second.
 ### The window: why the global stays `GlobalObject`, and the trap in it
 
 `Runtime/WindowInstaller` sets the global object's `[[Prototype]]` to
-`Window.prototype → EventTarget.prototype → Object.prototype` and installs the per-document singletons
-(`window`, `self`, `frames`, `top`, `parent`, `document`, `location`, `screen`) as own lazy globals through the
-public `Engine.AddLazyGlobal`. Substituting a host global would forfeit the global-identifier inline cache and
-mean re-installing every intrinsic; the prototype swap costs nothing, and
+`Window.prototype → WindowProperties → EventTarget.prototype → Object.prototype` and installs the
+per-document singletons (`window`, `self`, `frames`, `top`, `parent`, `document`, `location`, `screen`) as own
+lazy globals through the public `Engine.AddLazyGlobal`. Substituting a host global would forfeit the
+global-identifier inline cache and mean re-installing every intrinsic; the prototype swap costs nothing, and
 `GlobalEnvironment.HasBindingOnGlobalPrototype` already resolves a prototype member as a global.
+
+**`WindowProperties` is HTML's named access, and where it sits is the whole of why it is free.**
+`Runtime/WindowNamedProperties` makes `<div id=x>` and `<iframe name=x>` reach script as `x`, and WebIDL puts
+the *named properties object* below the interface prototype object rather than on the global — so a name the
+global owns and a member `Window.prototype` declares are both found before the document is consulted, and what
+reaches the lookup is a **miss**. Nothing about an ordinary global read changes, structurally rather than by
+hope: `JintIdentifierExpression.TryRememberGlobalBinding` admits only a descriptor the global object *owns*,
+because a prototype mutation bumps no global version, so a name answered there is never cached and never
+displaces one that is. Two divergences are stated on the class: a name several elements answer to gives the
+first rather than an `HTMLCollection`, and an `<iframe name=x>` gives the frame element rather than a nested
+`WindowProxy`, there being no engine in a child frame.
+
+**`window.event` is the one member that is an own property of the global** rather than an accessor on the
+shaped prototype, because WebIDL's `[Global]` puts an interface's members on the global object itself and
+`event` is the one a page can tell apart (`assert_own_property(window, "event")`). The slot it reads is the
+engine's — DOM's *current event*, maintained by the dispatch — and the engine maintains it only because the
+installer sets `GlobalEventTarget.IsWindow`, which is also what turns on DOM's default passive value.
 
 **The trap: a shape *method* on `Window.prototype` cannot find its page.** A page calls `alert(…)` and
 `requestAnimationFrame(…)` unqualified, and an unqualified call to a member of the global object passes
@@ -284,6 +301,12 @@ measures.
   them separate moments.
 - **One navigation at a time**, behind a `SemaphoreSlim`. A script's is `Task.Run` plus a page error on
   failure, because the document that script is in is the one being replaced and there is nobody to throw to.
+- **A same-document fragment move never leaves the loop.** It neither fetches, replaces the engine nor can
+  fail, so there is nothing for the off-loop half to do — and going there anyway is observable:
+  `Page.RequestNavigation` used to send an `<a href="#x">` round the thread pool and the gate, which put the
+  commit behind every timer already due, so a page that clicked a link and then spun zero-delay timers waiting
+  for `hashchange` waited out the whole chain (measured at turn 20 of 20; turn 1 now). It is a job on the
+  engine's own queue instead, and it declines while a navigation is in flight — the gate is what orders those.
 
 **Everything the network touches is the context's** — `Runtime/PageNetwork`, one per `BrowserContext`: the
 client, the composed `UrlFilter` (host filter and `BlockPrivateNetwork` combined once), the `CookieJar` and

--- a/Jint.Browser/Runtime/LocationInstaller.cs
+++ b/Jint.Browser/Runtime/LocationInstaller.cs
@@ -47,7 +47,7 @@ internal static class LocationInstaller
 
         Accessor(engine, wrapper, "href",
             static runtime => runtime.DocumentUrl,
-            static (runtime, value) => runtime.Page.RequestNavigation(value, replace: false));
+            static (runtime, value) => runtime.Page.RequestNavigation(value, replace: false, engine: runtime.Engine));
 
         Accessor(engine, wrapper, "protocol",
             static runtime => Read(runtime, static url => url.SerializeProtocol()),
@@ -80,8 +80,8 @@ internal static class LocationInstaller
         // Read-only: an origin is derived, and HTML declares no setter for it.
         Accessor(engine, wrapper, "origin", static runtime => Read(runtime, static url => url.SerializeOrigin()), setter: null);
 
-        Method(engine, wrapper, "assign", 1, static (runtime, value) => runtime.Page.RequestNavigation(value, replace: false));
-        Method(engine, wrapper, "replace", 1, static (runtime, value) => runtime.Page.RequestNavigation(value, replace: true));
+        Method(engine, wrapper, "assign", 1, static (runtime, value) => runtime.Page.RequestNavigation(value, replace: false, engine: runtime.Engine));
+        Method(engine, wrapper, "replace", 1, static (runtime, value) => runtime.Page.RequestNavigation(value, replace: true, engine: runtime.Engine));
 
         wrapper.DefineOwnPropertyUnchecked(
             "reload",
@@ -137,7 +137,7 @@ internal static class LocationInstaller
         }
 
         setter(url, value);
-        runtime.Page.RequestNavigation(url.Serialize(), replace: false);
+        runtime.Page.RequestNavigation(url.Serialize(), replace: false, engine: runtime.Engine);
     }
 
     private static void Accessor(

--- a/Jint.Browser/Runtime/PageActivationHost.cs
+++ b/Jint.Browser/Runtime/PageActivationHost.cs
@@ -57,7 +57,7 @@ internal sealed class PageActivationHost : BrowserActivationHost
                 source.LocalName));
         }
 
-        _runtime.Page.RequestNavigation(url, replace: false);
+        _runtime.Page.RequestNavigation(url, replace: false, engine: _runtime.Engine);
     }
 
     /// <summary>

--- a/Jint.Browser/Runtime/Parsing/ParserDriver.cs
+++ b/Jint.Browser/Runtime/Parsing/ParserDriver.cs
@@ -1,4 +1,5 @@
 using System.Net.Http;
+using Acornima;
 using AngleSharp;
 using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
@@ -404,17 +405,26 @@ internal sealed class ParserDriver : IDisposable
         }
 
         string text;
+        string source;
         string location;
+        var line = 1;
 
         if (external)
         {
             text = Read(response, element);
-            location = response.Address?.Href ?? element.Source!;
+            source = response.Address?.Href ?? element.Source!;
+            location = source;
         }
         else
         {
+            // https://html.spec.whatwg.org/multipage/webappapis.html#report-an-exception: an inline script's
+            // *filename* is the document's URL, so that is what the engine is given as the source name, and
+            // the line the script starts on is a parsing offset rather than part of the name. The page's own
+            // error recorder still gets the `url:line` string it always did, which is the one a host reads.
             text = element.Text ?? "";
-            location = _url + ":" + LineOf(element, text);
+            source = _url;
+            line = LineOf(element, text);
+            location = _url + ":" + line;
         }
 
         if (string.IsNullOrWhiteSpace(text))
@@ -425,6 +435,17 @@ internal sealed class ParserDriver : IDisposable
             }
 
             return;
+        }
+
+        // https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-content-attributes: a handler
+        // content attribute becomes the handler when the attribute is *set*, which for `<body onerror>` is
+        // when the body element is parsed — before this script and before any listener it could add. The
+        // body's handlers are the window's, so nothing else would build that wrapper; doing it here is what
+        // lets `<body onerror>` hear an exception from a script that follows it in the document. After the
+        // first script it is one lookup in the wrapper cache.
+        if (element.Owner is { } owner)
+        {
+            Events.EventHandlerContentAttributes.InstallBodyHandlers(_runtime.Dom, owner);
         }
 
         var previous = _runtime.CurrentScript;
@@ -441,13 +462,15 @@ internal sealed class ParserDriver : IDisposable
             // each script is bounded and a document is not failed for containing many. See PageBudget.
             using (_runtime.Budget.BeginTurn())
             {
-                _runtime.Engine.Execute(text, location);
+                _runtime.Engine.Execute(text, source, ParsingFrom(line));
             }
         }
         catch (JavaScriptException exception)
         {
-            // HTML's "report the exception" step: the script ends, the parse goes on, and the page is told.
-            Report(PageErrorKind.ScriptError, PageRecorder.Diagnostics.Describe(exception.Error, exception), location);
+            // HTML's "report the exception" step, both halves: the `error` event at the global scope, which
+            // is what `window.onerror` and `<body onerror>` hear, and then the page's own recorder. The
+            // script ends and the parse goes on either way.
+            ReportException(exception, location);
         }
         catch (Exception exception) when (PageBudget.IsBudgetFailure(exception))
         {
@@ -808,6 +831,75 @@ internal sealed class ParserDriver : IDisposable
         IHtmlLinkElement link => "a <link rel=\"" + (link.Relation ?? "") + "\"> is not fetched: only a stylesheet is",
         _ => source.LocalName + " resources are not fetched: there is no rendering to need them",
     };
+
+    /// <summary>
+    /// The parsing options an inline script gets: the engine's own, plus the position in the document its
+    /// text begins at, so a syntax error and a stack frame both name a line of the <i>document</i>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>window-onerror-parse-error.html</c> is what asks for this by name — it asserts line 34, which is
+    /// the line of the document its unparsable <c>&lt;script&gt;</c> sits on. The column is deliberately not
+    /// offset: AngleSharp exposes the parser's index just past the closing tag and not the index the text
+    /// began at, so the only honest column is the one within the script's own line.
+    /// </para>
+    /// <para>
+    /// A script on line 1 takes the engine's cached default parser instead, because an offset of nothing is
+    /// what <c>Execute(text, source)</c> already does and building a parser per script is not free.
+    /// </para>
+    /// </remarks>
+    private ScriptParsingOptions? ParsingFrom(int line)
+    {
+        if (line <= 1)
+        {
+            return null;
+        }
+
+        var defaults = _runtime.Engine.Options.RetainFunctionSourceText
+            ? ScriptParsingOptions.RetainingDefault
+            : ScriptParsingOptions.Default;
+
+        return defaults with { SourceOffset = Position.From(line, 0) };
+    }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/webappapis.html#report-an-exception, for an exception that
+    /// escaped a script this driver ran.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Step 5 before step 6.</b> The <c>error</c> event fires at the global scope first — that is what
+    /// reaches <c>window.onerror</c>, a global <c>error</c> listener and <c>&lt;body onerror&gt;</c>, and it
+    /// is a no-op on a page whose script registered none of them — and only then is the page's recorder told.
+    /// The order is observable: a handler that reads <c>page.Errors</c> through a host binding sees the entry
+    /// added after it ran, not before.
+    /// </para>
+    /// <para>
+    /// It runs a listener, so it takes a turn of its own for the reason each script does: a page whose
+    /// <c>onerror</c> loops is bounded by its own budget and not by what is left of the enclosing document's.
+    /// A budget it exhausts becomes a page error rather than ending the load, which is the same promise
+    /// <c>Execute</c> makes for the script that failed in the first place.
+    /// </para>
+    /// </remarks>
+    private void ReportException(JavaScriptException exception, string location)
+    {
+        try
+        {
+            using (_runtime.Budget.BeginTurn())
+            {
+                _runtime.Engine._webApi?.FireGlobalErrorEvent(exception);
+            }
+        }
+        catch (Exception nested) when (nested is not OperationCanceledException)
+        {
+            Report(
+                PageBudget.IsBudgetFailure(nested) ? PageErrorKind.BudgetExceeded : PageErrorKind.ScriptError,
+                nested.Message,
+                location);
+        }
+
+        Report(PageErrorKind.ScriptError, PageRecorder.Diagnostics.Describe(exception.Error, exception), location);
+    }
 
     private void Report(PageErrorKind kind, string message, string source)
         => _runtime.Recorder.Add(new PageError(kind, message, source));

--- a/Jint.Browser/Runtime/WindowInstaller.cs
+++ b/Jint.Browser/Runtime/WindowInstaller.cs
@@ -115,7 +115,16 @@ internal static class WindowInstaller
 
         // The window is the engine's global event target, and a document's event path ends at it. Publishing
         // it here rather than in the binding is what keeps the binding free of any notion of a window.
-        runtime.Dom.WindowTarget = engine._webApi?.GlobalEventTarget;
+        var windowTarget = engine._webApi?.GlobalEventTarget;
+        runtime.Dom.WindowTarget = windowTarget;
+
+        if (windowTarget is not null)
+        {
+            // This global scope is a `Window`, which is the fact DOM's default passive value turns on
+            // (https://dom.spec.whatwg.org/#default-passive-value) and which no engine without a document
+            // can claim.
+            windowTarget.IsWindow = true;
+        }
 
         foreach (var name in (string[]) ["window", "self", "frames", "top", "parent"])
         {

--- a/Jint.Browser/Runtime/WindowInstaller.cs
+++ b/Jint.Browser/Runtime/WindowInstaller.cs
@@ -579,8 +579,14 @@ internal static class WindowInstaller
             _type = type;
         }
 
+        /// <summary>
+        /// Read through the content-attribute path rather than <c>EventHandlerAttributes</c>, because the
+        /// window's handler slot may hold a <c>&lt;body onload&gt;</c> that has not been compiled yet: the
+        /// compile-on-read placeholder must never reach script, whichever of the two names it is read
+        /// through.
+        /// </summary>
         internal JsValue Get(JsValue thisObject, JsValue[] arguments)
-            => EventHandlerAttributes.Get(WindowTargetOf(thisObject, "on" + _type, "read"), _type);
+            => EventHandlerContentAttributes.CurrentValue(WindowTargetOf(thisObject, "on" + _type, "read"), _type);
 
         internal JsValue Set(JsValue thisObject, JsValue[] arguments)
             => EventHandlerAttributes.Set(WindowTargetOf(thisObject, "on" + _type, "set"), _type, arguments.At(0));

--- a/Jint.Browser/Runtime/WindowInstaller.cs
+++ b/Jint.Browser/Runtime/WindowInstaller.cs
@@ -120,10 +120,24 @@ internal static class WindowInstaller
 
         if (windowTarget is not null)
         {
-            // This global scope is a `Window`, which is the fact DOM's default passive value turns on
-            // (https://dom.spec.whatwg.org/#default-passive-value) and which no engine without a document
-            // can claim.
+            // This global scope is a `Window`, which is the fact two DOM rules turn on and which no engine
+            // without a document can claim: the default passive value
+            // (https://dom.spec.whatwg.org/#default-passive-value) and the current event
+            // (https://dom.spec.whatwg.org/#window-current-event) the accessor below reads.
             windowTarget.IsWindow = true;
+
+            // `window.event` is an *own* property of the global rather than an accessor on `Window.prototype`,
+            // which is where every other Window member here lives. WebIDL's [Global] puts an interface's
+            // members on the global object itself, and this is the one a page can tell apart:
+            // `dom/events/event-global.html` opens with `assert_own_property(window, "event")`. One property
+            // per engine, installed the way `PageStorage` installs its own.
+            var scope = windowTarget;
+            global.SetProperty(
+                "event",
+                new GetSetPropertyDescriptor(
+                    new ClrFunction(engine, "get event", (_, _) => scope.CurrentEvent),
+                    set: null,
+                    PropertyFlag.Configurable | PropertyFlag.Enumerable));
         }
 
         foreach (var name in (string[]) ["window", "self", "frames", "top", "parent"])
@@ -303,8 +317,9 @@ internal static class WindowInstaller
     /// own globals instead.
     /// </summary>
     /// <remarks>
-    /// <c>window.event</c> is HTML's "current event", a legacy attribute that is undefined outside a dispatch;
-    /// nothing sets it here, so a page reading it gets what a page with no dispatch in progress gets.
+    /// <c>event</c> is not here: DOM's <i>current event</i> is the one member a page can tell apart from an
+    /// accessor on <c>Window.prototype</c>, because WebIDL's <c>[Global]</c> makes it an own property of the
+    /// global object. <see cref="Install"/> installs it there.
     /// </remarks>
     private static JsObjectShape BuildWindowShape()
     {
@@ -333,7 +348,6 @@ internal static class WindowInstaller
                     return JsValue.Undefined;
                 })
             .Accessor("origin", static (t, _) => JsString.Create(PageRuntime.Of(t, "origin").Document?.Origin ?? "null"))
-            .Accessor("event", static (_, _) => JsValue.Undefined)
             .Method("stop", static (_, _) => JsValue.Undefined)
             .Method("focus", static (_, _) => JsValue.Undefined)
             .Method("blur", static (_, _) => JsValue.Undefined)

--- a/Jint.Browser/Runtime/WindowInstaller.cs
+++ b/Jint.Browser/Runtime/WindowInstaller.cs
@@ -90,7 +90,16 @@ internal static class WindowInstaller
         var realm = engine._mainRealm;
         var global = realm.GlobalObject;
 
-        var windowPrototype = _windowShape.Instantiate(engine, realm.Intrinsics.EventTarget.PrototypeObject);
+        // https://html.spec.whatwg.org/multipage/nav-history-apis.html#named-access-on-the-window-object —
+        // WebIDL's named properties object sits between the interface prototype object and its parent, which
+        // is what makes named access a *miss* path: `document`, `alert` and every other name the global owns
+        // or `Window.prototype` declares is found before it is asked. See WindowNamedProperties.
+        var namedProperties = new WindowNamedProperties(runtime)
+        {
+            Prototype = realm.Intrinsics.EventTarget.PrototypeObject,
+        };
+
+        var windowPrototype = _windowShape.Instantiate(engine, namedProperties);
         var windowInterface = new WindowInterfaceObject(engine, realm, windowPrototype);
 
         // The per-realm `constructor` slot, filled the way the DOM binding fills its own: the shape declared

--- a/Jint.Browser/Runtime/WindowNamedProperties.cs
+++ b/Jint.Browser/Runtime/WindowNamedProperties.cs
@@ -1,0 +1,145 @@
+using AngleSharp.Dom;
+using AngleSharp.Html.Dom;
+using Jint.Native;
+using Jint.Native.Object;
+
+namespace Jint.Browser.Runtime;
+
+/// <summary>
+/// HTML's <b>named access on the Window object</b>: the object that makes <c>&lt;div id=x&gt;</c> and
+/// <c>&lt;iframe name=x&gt;</c> reach script as <c>x</c>.
+/// <para>
+/// https://html.spec.whatwg.org/multipage/nav-history-apis.html#named-access-on-the-window-object
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>It is a link in the prototype chain, not a property of the global object</b> — which is both what WebIDL
+/// says (the <i>named properties object</i> is the interface prototype object's <c>[[Prototype]]</c>) and the
+/// only place it can go without costing anything. The chain here is
+/// <c>window → Window.prototype → WindowProperties → EventTarget.prototype → Object.prototype</c>, so a name
+/// the global object owns, and a member <c>Window.prototype</c> declares, are both found before this object is
+/// asked at all. What reaches it is a <b>miss</b>: an identifier that resolved nowhere else, which is exactly
+/// where HTML puts the lookup.
+/// </para>
+/// <para>
+/// <b>Nothing about an ordinary global read changes, and that is checked rather than assumed.</b> The
+/// global-identifier inline cache admits only a descriptor the global object owns —
+/// <c>JintIdentifierExpression.TryRememberGlobalBinding</c> re-probes the global's own storage and declines a
+/// name resolved from its prototype chain, because a prototype mutation bumps no global version — so a name
+/// answered here is never cached and never displaces one that is.
+/// </para>
+/// <para>
+/// <b>Two divergences, both about a name several elements answer to.</b> HTML collects every matching element
+/// in tree order and answers with an <c>HTMLCollection</c> when there is more than one; this answers the first
+/// it finds, preferring an <c>id</c> to a <c>name</c>. And where HTML answers a nested browsing context's
+/// <c>WindowProxy</c> for an <c>&lt;iframe name=x&gt;</c>, this answers the frame element: a page here parses
+/// child frames and gives none of them an engine (campaign item C6), so there is no window to hand back.
+/// </para>
+/// </remarks>
+internal sealed class WindowNamedProperties : NamedPropertyObject
+{
+    private readonly PageRuntime _runtime;
+
+    internal WindowNamedProperties(PageRuntime runtime) : base(runtime.Engine)
+    {
+        _runtime = runtime;
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Read only by an enumeration — <c>for..in</c> over the window, <c>Object.getOwnPropertyNames</c> of this
+    /// object — so it walks the document there and nowhere else. Every read goes through
+    /// <see cref="TryGetNamedValue"/>, which asks the document two direct questions instead.
+    /// </remarks>
+    public override int NameCount => Names().Count;
+
+    /// <inheritdoc />
+    public override string NameAt(int index) => Names()[index];
+
+    /// <inheritdoc />
+    public override bool TryGetNamedValue(string name, out JsValue value)
+    {
+        if (name.Length != 0 && _runtime.Document is { } document)
+        {
+            if (document.GetElementById(name) is { } byId)
+            {
+                value = _runtime.Dom.WrapNode(byId);
+                return true;
+            }
+
+            foreach (var element in document.GetElementsByName(name))
+            {
+                if (IsNamedAccessKind(element))
+                {
+                    value = _runtime.Dom.WrapNode(element);
+                    return true;
+                }
+            }
+        }
+
+        value = JsValue.Undefined;
+        return false;
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// <b>Writable, and the write is still refused</b> — which is WebIDL's named properties object exactly.
+    /// Its <c>[[GetOwnProperty]]</c> reports <c>writable: true</c> and its <c>[[DefineOwnProperty]]</c>
+    /// returns false, so a direct <c>Reflect.set</c> on it does nothing; what the flag is for is the write a
+    /// page really makes. <c>window.x = 1</c> walks the prototype chain, finds a writable data property here
+    /// and therefore creates an <b>own</b> property of the window that shadows it — which is what every page
+    /// that assigns to a global named after one of its own elements depends on.
+    /// </remarks>
+    protected override bool IsNameWritable(string name) => true;
+
+    /// <inheritdoc />
+    /// <remarks>The other half of the paragraph above: there is nowhere to write, and nothing may be.</remarks>
+    protected override bool TrySetNamedValue(string name, JsValue value) => false;
+
+    /// <summary>
+    /// The element kinds whose <c>name</c> content attribute is a supported property name. An <c>id</c> is one
+    /// for <b>every</b> element; a <c>name</c> is one only for these.
+    /// </summary>
+    private static bool IsNamedAccessKind(IElement element) => element is IHtmlAnchorElement
+        or IHtmlAreaElement
+        or IHtmlEmbedElement
+        or IHtmlFormElement
+        or IHtmlInlineFrameElement
+        or IHtmlImageElement
+        or IHtmlObjectElement
+        || element is IHtmlElement { LocalName: "frame" or "frameset" };
+
+    /// <summary>
+    /// Every supported property name, in tree order and without repeats — the two obligations
+    /// <see cref="NamedPropertyObject.NameAt"/> carries, and what host-contract verification checks.
+    /// </summary>
+    private List<string> Names()
+    {
+        var names = new List<string>();
+
+        if (_runtime.Document is not { } document)
+        {
+            return names;
+        }
+
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var element in document.All)
+        {
+            if (element.Id is { Length: > 0 } id && seen.Add(id))
+            {
+                names.Add(id);
+            }
+
+            if (IsNamedAccessKind(element)
+                && element.GetAttribute("name") is { Length: > 0 } name
+                && seen.Add(name))
+            {
+                names.Add(name);
+            }
+        }
+
+        return names;
+    }
+}

--- a/Jint.Tests.Browser/Events/ActivationBehaviorTests.cs
+++ b/Jint.Tests.Browser/Events/ActivationBehaviorTests.cs
@@ -510,4 +510,68 @@ public sealed class ActivationBehaviorTests
             "Navigation https://example.com/next",
             "FormSubmission /post (b)");
     }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/input.html#checkbox-state-(type=checkbox) — step 1 of the
+    /// checkbox and radio activation behaviours is "if the element is not connected, then return", so a
+    /// detached control toggles silently.
+    /// </summary>
+    /// <remarks>
+    /// <b>Connected is the shadow-including root being a document</b>, not the node having a parent, which is
+    /// the half a page cannot get wrong and an implementation can: a control inside a shadow tree of a
+    /// connected host is connected. AngleSharp has no member that answers the question — <c>INode.Owner</c>
+    /// is the node document whether or not the node is in it — so the walk is the package's own and this is
+    /// what holds it to the definition.
+    /// </remarks>
+    [Test]
+    public async Task OnlyAConnectedCheckboxAnnouncesItsToggle()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync("<div id='host'></div>");
+
+        (await page.EvaluateAsync<string>(
+            """
+            (() => {
+              const seen = [];
+
+              function watch(name, input) {
+                input.addEventListener('input', () => seen.push(name + ':input'));
+                input.addEventListener('change', () => seen.push(name + ':change'));
+                input.click();
+                seen.push(name + ':checked=' + input.checked);
+              }
+
+              const detached = document.createElement('input');
+              detached.type = 'checkbox';
+              watch('detached', detached);
+
+              // A detached *subtree* is still detached, however deep the control sits in it.
+              const orphanTree = document.createElement('div');
+              const inTree = document.createElement('input');
+              inTree.type = 'checkbox';
+              orphanTree.appendChild(inTree);
+              watch('inOrphanTree', inTree);
+
+              const connected = document.createElement('input');
+              connected.type = 'checkbox';
+              document.body.appendChild(connected);
+              watch('connected', connected);
+
+              // Inside a shadow tree of a connected host: the shadow-including root is the document.
+              const shadow = document.getElementById('host').attachShadow({ mode: 'closed' });
+              const inShadow = document.createElement('input');
+              inShadow.type = 'checkbox';
+              shadow.appendChild(inShadow);
+              watch('inShadow', inShadow);
+
+              return seen.join(',');
+            })()
+            """))
+            .Should().Be(
+                "detached:checked=true,"
+                + "inOrphanTree:checked=true,"
+                + "connected:input,connected:change,connected:checked=true,"
+                + "inShadow:input,inShadow:change,inShadow:checked=true");
+    }
 }

--- a/Jint.Tests.Browser/Events/ActivationBehaviorTests.cs
+++ b/Jint.Tests.Browser/Events/ActivationBehaviorTests.cs
@@ -512,6 +512,85 @@ public sealed class ActivationBehaviorTests
     }
 
     /// <summary>
+    /// https://html.spec.whatwg.org/multipage/forms.html#labeled-control — clicking inside a
+    /// <c>&lt;label&gt;</c> forwards the click to the control it labels, whether the label <i>contains</i> the
+    /// control or names it with <c>for</c>.
+    /// </summary>
+    /// <remarks>
+    /// The containing spelling is the one AngleSharp cannot answer — its <c>IHtmlLabelElement.Control</c> is
+    /// <see langword="null"/> for a control the label wraps — so the labeled control is computed here, and
+    /// this is what holds it to the two spellings and to the labelable-element list.
+    /// </remarks>
+    [Test]
+    public async Task ClickingInsideALabelForwardsToTheControlItLabels()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync(
+            "<label id='wrapping'><input id='inner' type='checkbox'><span id='text'>text</span></label>"
+            + "<label id='naming' for='outer'>text</label><input id='outer' type='checkbox'>"
+            + "<label id='hiddenOnly'><input type='hidden'><span id='hiddenText'>text</span></label>");
+
+        (await page.EvaluateAsync<string>(
+            """
+            (() => {
+              const seen = [];
+              for (const id of ['inner', 'outer']) {
+                document.getElementById(id).addEventListener('click', e => seen.push(id + ':' + e.isTrusted));
+              }
+
+              document.getElementById('text').click();
+              document.getElementById('naming').click();
+              document.getElementById('hiddenText').click();
+
+              return seen.join(',') + '|' + document.getElementById('inner').checked + document.getElementById('outer').checked;
+            })()
+            """))
+            // The forwarded click carries the original's trust, and a label whose only descendant control is
+            // a hidden input labels nothing at all.
+            .Should().Be("inner:false,outer:false|truetrue");
+    }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/links.html#following-hyperlinks-2 for a link to a fragment of
+    /// the page's own URL: it is a same-document navigation, and <c>hashchange</c> arrives on the <b>next</b>
+    /// turn rather than after whatever else the page has queued.
+    /// </summary>
+    /// <remarks>
+    /// The fragment arm of <i>navigate</i> neither fetches, replaces the engine nor can fail, so it is done on
+    /// the page loop; sending it round the navigation gate put the commit behind every timer already due, and
+    /// a page that clicks a link and then spins zero-delay timers waiting for <c>hashchange</c> waited out the
+    /// whole chain. Measured before the fix: turn 20 of 20.
+    /// </remarks>
+    [Test]
+    public async Task AFragmentLinkFiresHashChangeOnTheNextTurn()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync("<a id='go'>go</a><p id='target'>t</p>");
+
+        await page.EvaluateAsync(
+            """
+            window.turns = 0;
+            window.seen = null;
+            window.onhashchange = e => { window.seen = window.turns + ':' + e.newURL.endsWith('#target'); };
+            // The absolute form, because resolving a bare `#target` is AngleSharp's and it mangles an
+            // `about:blank` base; what is measured here is when the navigation lands, not how it resolved.
+            document.getElementById('go').setAttribute('href', location.href + '#target');
+            document.getElementById('go').click();
+            (function tick() {
+              window.turns++;
+              if (window.turns < 20 && window.seen === null) { setTimeout(tick, 0); }
+            })();
+            """);
+
+        await page.WaitForIdleAsync(TimeSpan.FromSeconds(5));
+
+        (await page.EvaluateAsync<string>("String(window.seen)")).Should().Be("1:true");
+        page.Errors.Should().BeEmpty();
+    }
+
+    /// <summary>
     /// https://html.spec.whatwg.org/multipage/input.html#checkbox-state-(type=checkbox) — step 1 of the
     /// checkbox and radio activation behaviours is "if the element is not connected, then return", so a
     /// detached control toggles silently.

--- a/Jint.Tests.Browser/Events/CurrentEventTests.cs
+++ b/Jint.Tests.Browser/Events/CurrentEventTests.cs
@@ -1,0 +1,95 @@
+namespace Jint.Tests.Browser.Events;
+
+using Browser = global::Jint.Browser.Browser;
+
+/// <summary>
+/// <c>window.event</c> — https://dom.spec.whatwg.org/#window-current-event, the legacy global that is the
+/// event whose listener is running.
+/// </summary>
+/// <remarks>
+/// The engine keeps the slot (it is <i>inner invoke</i> that sets and restores it) and the page installs the
+/// property that reads it. What is checked here is the page's half and the two properties the web-platform
+/// corpus does not pin from a page: that the property is an <b>own</b> property of the global, as WebIDL's
+/// <c>[Global]</c> requires, and that a listener dispatching an event of its own gets its own event back
+/// afterwards rather than the nested one.
+/// </remarks>
+public sealed class CurrentEventTests
+{
+    [Test]
+    public async Task TheCurrentEventIsAnOwnPropertyOfTheGlobalAndIsUndefinedOutsideADispatch()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync("<div id='d'></div>");
+
+        (await page.EvaluateAsync<string>(
+            """
+            [
+              Object.prototype.hasOwnProperty.call(window, 'event'),
+              window.event === undefined,
+              Object.getOwnPropertyDescriptor(Window.prototype, 'event') === undefined
+            ].join(',')
+            """))
+            .Should().Be("true,true,true");
+    }
+
+    /// <summary>
+    /// The slot is saved and restored per listener invocation, so a listener that dispatches an event of its
+    /// own — at another target, and re-entrantly at the same one — finds its own event again when that
+    /// returns.
+    /// </summary>
+    [Test]
+    public async Task ANestedDispatchRestoresTheOuterEventWhenItReturns()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync("<div id='outer'><span id='inner'></span></div>");
+
+        (await page.EvaluateAsync<string>(
+            """
+            (() => {
+              const outer = document.getElementById('outer');
+              const inner = document.getElementById('inner');
+              const seen = [];
+
+              const outerEvent = new Event('outer', { bubbles: true });
+              const innerEvent = new Event('inner');
+
+              inner.addEventListener('inner', () => seen.push('inner:' + (window.event === innerEvent)));
+              document.addEventListener('outer', () => {
+                seen.push('document:' + (window.event === outerEvent));
+                inner.dispatchEvent(innerEvent);
+                seen.push('after:' + (window.event === outerEvent));
+              });
+
+              outer.dispatchEvent(outerEvent);
+              seen.push('done:' + (window.event === undefined));
+              return seen.join(',');
+            })()
+            """))
+            .Should().Be("document:true,inner:true,after:true,done:true");
+    }
+
+    /// <summary>
+    /// A listener that throws still leaves the slot as it found it, which is what stops one failing handler
+    /// from making <c>window.event</c> lie for the rest of the turn.
+    /// </summary>
+    [Test]
+    public async Task AThrowingListenerRestoresTheSlot()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync("<div id='d'></div>");
+
+        (await page.EvaluateAsync<string>(
+            """
+            (() => {
+              const d = document.getElementById('d');
+              d.addEventListener('ping', () => { throw new Error('boom'); });
+              d.dispatchEvent(new Event('ping'));
+              return String(window.event === undefined);
+            })()
+            """))
+            .Should().Be("true");
+    }
+}

--- a/Jint.Tests.Browser/Runtime/WindowTests.cs
+++ b/Jint.Tests.Browser/Runtime/WindowTests.cs
@@ -34,7 +34,10 @@ public sealed class WindowTests
         (await page.EvaluateAsync<bool>("window instanceof Window")).Should().BeTrue();
         (await page.EvaluateAsync<bool>("window instanceof EventTarget")).Should().BeTrue();
         (await page.EvaluateAsync<bool>("Object.getPrototypeOf(window) === Window.prototype")).Should().BeTrue();
-        (await page.EvaluateAsync<bool>("Object.getPrototypeOf(Window.prototype) === EventTarget.prototype")).Should().BeTrue();
+        // https://webidl.spec.whatwg.org/#named-properties-object — the named properties object is the
+        // interface prototype object's [[Prototype]], so `EventTarget.prototype` is one hop further out than
+        // it used to be. See Runtime/WindowNamedProperties.
+        (await page.EvaluateAsync<bool>("Object.getPrototypeOf(Object.getPrototypeOf(Window.prototype)) === EventTarget.prototype")).Should().BeTrue();
         (await page.EvaluateAsync<bool>("Object.getPrototypeOf(Window) === EventTarget")).Should().BeTrue();
         (await page.EvaluateAsync<string>("Object.prototype.toString.call(window)")).Should().Be("[object Window]");
     }
@@ -317,5 +320,71 @@ public sealed class WindowTests
         (await navigated).Should().BeTrue();
 
         (await page.EvaluateAsync<string>("document.getElementById('moved').textContent")).Should().Be("moved");
+    }
+
+    // https://html.spec.whatwg.org/multipage/nav-history-apis.html#named-access-on-the-window-object
+
+    [Test]
+    public async Task AnElementReachesScriptByItsIdAndByItsName()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync(
+            "<div id='byId'></div><form name='byName'></form><iframe name='frame'></iframe><p name='notAKind'></p>");
+
+        (await page.EvaluateAsync<string>(
+            """
+            [
+              byId.tagName,
+              window.byId === document.getElementById('byId'),
+              byName.tagName,
+              frame.tagName,
+              typeof window.notAKind,
+              'byId' in window,
+              Object.getOwnPropertyNames(window).includes('byId')
+            ].join(',')
+            """))
+            // `name` is a supported property name only for the element kinds HTML lists, so a `<p name>` is
+            // not one; and the names live on the prototype chain, not on the window itself.
+            .Should().Be("DIV,true,FORM,IFRAME,undefined,true,false");
+    }
+
+    /// <summary>
+    /// What named access costs an ordinary global read: nothing. The names are on the <i>named properties
+    /// object</i>, which WebIDL puts below <c>Window.prototype</c>, so every name the global owns and every
+    /// member the prototype declares is found before the document is consulted — and an element cannot
+    /// shadow one.
+    /// </summary>
+    [Test]
+    public async Task NamedAccessIsAMissPathAndShadowsNothing()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync(
+            "<div id='document'></div><div id='alert'></div><div id='shadowMe'></div>");
+
+        (await page.EvaluateAsync<string>(
+            """
+            (() => {
+              var seen = [];
+
+              // An own global and a Window.prototype member both win over an element of the same name.
+              seen.push('document:' + (document.nodeType === 9));
+              seen.push('alert:' + (typeof alert));
+
+              // An assignment through the chain creates an own property of the window, which then wins too.
+              seen.push('before:' + (shadowMe.tagName === 'DIV'));
+              window.shadowMe = 'mine';
+              seen.push('after:' + shadowMe);
+              seen.push('own:' + Object.getOwnPropertyNames(window).includes('shadowMe'));
+
+              // A name nothing answers is still a ReferenceError rather than undefined.
+              try { nothingAnswersThis; seen.push('resolved'); }
+              catch (e) { seen.push('miss:' + (e instanceof ReferenceError)); }
+
+              return seen.join(',');
+            })()
+            """))
+            .Should().Be("document:true,alert:function,before:true,after:mine,own:true,miss:true");
     }
 }

--- a/Jint.Tests.Browser/Wpt/README.md
+++ b/Jint.Tests.Browser/Wpt/README.md
@@ -16,10 +16,10 @@ wrappers, the environment a document runs in, where a divergence goes — is
 
 | Suite | Documents | Synthesized | Tests | Not passing |
 | --- | --- | --- | --- | --- |
-| `dom/events/` | 50 | 9 | 490 | 181 |
-| `html/webappapis/scripting/events/` | 12 | 0 | 37 | 23 |
-| `html/webappapis/scripting/processing-model-2/` | 25 | 0 | 38 | 34 |
-| **total** | **87** | **9** | **565** | **238** |
+| `dom/events/` | 50 | 9 | 533 | 42 |
+| `html/webappapis/scripting/events/` | 12 | 0 | 37 | 5 |
+| `html/webappapis/scripting/processing-model-2/` | 25 | 0 | 44 | 14 |
+| **total** | **87** | **9** | **614** | **61** |
 
 *Measured on Windows.* **Documents** are `.html` files in this repository; **Synthesized** are the
 `<name>.any.html` wrappers `WptServerWrappers` manufactures for a suite's `.any.js` files, which are bytes
@@ -39,66 +39,46 @@ not-passing figure, for a corpus bump that genuinely arrives with new failures.
 
 ## What this corpus says about this browser
 
-Eleven distinct defects, each recorded rather than fixed, because the change that first runs a suite must not
-also be the change that moves the engine — otherwise nobody can tell which of the two a number came from.
-Every one of them is a `NeedsTriage` row in `WptBrowserExclusions.All`, and **a non-zero count there is a list
-somebody owes a fix for**.
+**The eleven defects this lane first recorded are fixed.** They were filed as
+[#3686](https://github.com/sebastienros/jint/issues/3686) to
+[#3695](https://github.com/sebastienros/jint/issues/3695) — `document.createEvent` and the document
+constructors, `window.event`, the report of a script's exception, the compiled handler's shape and scope, the
+body's window-forwarded handlers and `HTMLFrameSetElement`, the legacy UI-event initializers, the default
+passive value, one activation behaviour per click, the detached control's silent toggle, and named access on
+the window — and the three seams two of them needed in the engine are
+[#3696](https://github.com/sebastienros/jint/pull/3696).
 
-1. **`document.createEvent` does not exist**, and it is the largest single cause in the lane: seventeen
-   documents fail entirely on it and seven more in part.
-   [DOM still requires it](https://dom.spec.whatwg.org/#dom-document-createevent) — deprecated, not removed —
-   and half of `dom/events/` is written against it because the file predates the constructors. `new Document()`
-   and `document.implementation.createHTMLDocument()` are the same gap seen from two more angles, and four
-   further documents cannot report at all because they reach for one before a test could register —
-   `Event-constants.html`, `Event-propagation.html` and `keypress-dispatch-crash.html` at file scope, and
-   `Event-dispatch-detached-click.html` inside its only test.
-2. **`window.event` does not exist.** [The legacy global](https://dom.spec.whatwg.org/#dom-window-event) is set
-   for the duration of a dispatch and restored afterwards, and an inline handler that reads a bare `event`
-   reads it. `event-global.html` fails all eight of its tests on it, and
-   `Event-stopPropagation-cancel-bubbling.html` cannot report at all.
-3. **An exception escaping a classic `<script>` is not reported at the global scope.**
-   [Report an exception](https://html.spec.whatwg.org/multipage/webappapis.html#report-an-exception) fires an
-   `error` event that reaches `window.onerror` and `<body onerror>`; here a script's parse error or runtime
-   error becomes a `PageErrorKind.ScriptError` on the page's recorder and nothing else. Seventeen documents of
-   `processing-model-2/` say so, every one on `assert_true: ran expected true got false`. The engine *does*
-   fire that event for a timer callback, a listener and a microtask
-   (`Jint/WebApi/GlobalEvents/GlobalEventTarget.cs`), so what is missing is the parser driver's own report and
-   not the mechanism.
-4. **The `error` event carries no column number.**
-   [`ErrorEventInit.colno`](https://html.spec.whatwg.org/multipage/webappapis.html#erroreventinit) reaches the
-   five-argument `onerror` as `undefined`. Only two rows can say so — every other document that would asks for
-   it after the report of defect 3 that never arrives.
-5. **A compiled handler is not the function HTML describes.** The function a handler content attribute
-   [compiles to](https://html.spec.whatwg.org/multipage/webappapis.html#getting-the-current-value-of-the-event-handler)
-   must be named for the attribute with the attribute's text as its body — `function onclick(event) {\nfoo\n}`
-   — and is `function anonymous(event\n) {\nwith (document) …`, which is the scope chain leaking into the
-   source text. Seven documents in `scripting/events/` assert around it: the text itself, what the chain
-   resolves, which IDL members are handlers at all, that an invalid handler keeps its position, that a form
-   owner is in the chain, and that a scripting-disabled document compiles none of them.
-6. **`<body>`'s window-forwarded handlers reflect as an object**, not a function, and
-   **`HTMLFrameSetElement` is not an interface object** — the other half of the same table.
-7. **The legacy UI-event init methods are absent**: `initUIEvent`, `initMouseEvent`, `initKeyboardEvent`.
-   Beside them, `new UIEvent(type, {view: notAWindow})` must throw a `TypeError` and does not.
-8. **Passive is not the default for `touchstart`, `touchmove`, `wheel` and `mousewheel`** on the Window, the
-   Document, the document element and the body
-   ([DOM's default passive value](https://dom.spec.whatwg.org/#default-passive-value)), so their
-   `preventDefault()` still cancels. Thirty-two rows of `passive-by-default.html`; the explicit
-   `{passive: true}` and `{passive: false}` spellings pass, so the rule is what is missing and not the
-   mechanism.
-9. **One click runs more than one activation behaviour.**
-   [A dispatch runs the behaviour of one element](https://dom.spec.whatwg.org/#eventtarget-activation-behavior),
-   the nearest ancestor in the path that has one. A `<form>` nested in a `<form>` submits **both** here; and a
-   nested `<a>` or `<area>` records nothing at all, because following a hyperlink to a fragment of the page's
-   own URL is not something this activation host does. 108 of that file's 132 shapes are right, which is what
-   makes the two wrong ones worth naming.
-10. **A detached checkbox or radio fires `input` and `change` on `click()`**, where the pre-click activation
-    steps fire them only for a connected control. The eight connected cases of the same file pass.
-11. **`window` has no named properties.**
-    [Named access on the Window object](https://html.spec.whatwg.org/multipage/nav-history-apis.html#named-access-on-the-window-object)
-    is what makes `<iframe name=x>` and `<div id=x>` reach script as `x`, and a surprising number of wpt
-    documents are written that way. It is not a category of its own because every document that meets it needs
-    something else as well — a scripted frame, or a rendering — so it is recorded here and named in the
-    `NeedsIframeScripting` comment of the exclusion table.
+What `NeedsTriage` holds now is five things, each bounded and each named by the exclusion table:
+
+1. **A `data:` URL is not fetched as a subresource.** A page navigates to one, so
+   `<script src="data:text/javascript,…">` is the one shape of external script that never runs; three
+   `processing-model-2/` documents are about exactly that script. The report site those documents test works,
+   which their `<script src>` and inline siblings say.
+2. **`script.src` does not reflect a URL.** HTML reflects it *as a URL*, so it answers the resolved absolute
+   one; AngleSharp's `IHtmlScriptElement.Source` answers the raw attribute value, so four rows compare a
+   correct absolute filename against the unresolved string the document wrote. It is AngleSharp's divergence
+   and is recorded in [`Jint.Browser/Dom/AGENTS.md`](../../Jint.Browser/Dom/AGENTS.md).
+3. **A DOM prototype carries no `@@unscopables`.** WebIDL puts one on the interface prototype object of every
+   interface with an `[Unscopable]` member — `Element`'s and `Document`'s `append`, `prepend` and
+   `replaceChildren` among them — and the generator emits none, because AngleSharp's metadata does not say
+   which members are unscopable. `compile-event-handler-symbol-unscopables.html` never reaches its subject:
+   it *writes* to `document[Symbol.unscopables]`.
+4. **`window.customElements` is absent**, which one row of
+   `compile-event-handler-lexical-scopes-form-owner.html` needs to define a form-associated custom element.
+   The file's other three rows pass.
+5. **A fragment navigation does not land inside two turns.** Following an `<a href="#x">` of the page's own
+   URL now happens on the page loop and fires `hashchange` on the next turn — measured, and moved there from
+   after the whole timer chain — but `Event-dispatch-single-activation-behavior.html` gives it two zero-delay
+   turns and its twenty-two `<a>`/`<area>` shapes still do not see it. What is left is a question about the
+   page loop's scheduling rather than about activation behaviour.
+
+One further group left `NeedsTriage` for a category of its own. `document.createEvent`'s alias table names
+five interfaces this package deliberately does not build — `DragEvent` and `ClipboardEvent` need a
+`DataTransfer`, `StorageEvent` a storage area's change notification, `TouchEvent` a touch input, and the two
+device events a sensor — so four rows of `EventTarget-dispatchEvent.html` are `NeedsMoreEventInterfaces`,
+which names what would move them. And eight rows of `Event-dispatch-single-activation-behavior.html` moved to
+`AssertsWhatNothingRequires`: the file's instrumentation is a `<form onsubmit>` handler and cannot tell an
+activation behaviour from an ordinary bubble, and `submit` and `reset` both bubble.
 
 Two more things the corpus found are **not** defects and are recorded where they belong instead.
 `Element.insertAdjacentText` is missing, which upstream's own result renderer calls — the overlay turns the
@@ -121,8 +101,8 @@ into thirteen groups; the counts are rows rather than files, since several are g
 | a sub-directory that is not a suite | 2 | `dom/events/scrolling/` and `non-cancelable-when-passive/`, both layout |
 | not a document, or a directory this PR does not vendor | 7 | `.window.js`, `.worker.js`, and four directories of the scripting tree |
 | upstream's own markers | 5 | `.tentative.`, `-manual.`, and `.sub.html`, which needs a second origin to substitute into |
-| `document.createEvent` and its kin | 4 | defect 1 above, met before a test could report |
-| a name this browser does not have | 3 | `window.event`, `customElements`, a `javascript:` URL |
+| a cause that has gone | 4 | they met `document.createEvent` before a test could report; it exists now, and vendoring them moves the census's Documents and Tests columns, so it is a change of its own |
+| a name this browser does not have | 3 | `customElements`, a `javascript:` URL, and one that read `window.event` before it existed |
 | a rendering | 4 | a CSS animation or transition event, and the coarse-clock assertion |
 | a focus event that does not arrive | 1 | the one row that is a finding rather than an environment; see its reason |
 | `testdriver.js` | 7 | campaign item C4 maps it onto the same dispatcher `Input.dispatchMouseEvent` reaches |

--- a/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
+++ b/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
@@ -313,14 +313,6 @@ internal static class WptBrowserExclusions
         new("html/webappapis/scripting/processing-model-2/compile-error-in-attribute.html", "window.onerror - compile error in attribute", WptDivergence.NeedsTriage),
         new("html/webappapis/scripting/processing-model-2/runtime-error-in-attribute.html", "window.onerror - runtime error in attribute", WptDivergence.NeedsTriage),
 
-        // ---------------------------------------------------------------- 2. window.event
-        // https://dom.spec.whatwg.org/#dom-window-event: the global `event`, set for the duration of a
-        // dispatch and restored afterwards. It is absent, which is what `assert_own_property: expected
-        // property "event" missing` says, and it is why an inline handler that reads a bare `event` reads
-        // nothing. Two more documents cannot even report because of it and are in NotVendored above.
-        new("dom/events/event-global.html", "*", WptDivergence.NeedsTriage),
-        new("dom/events/window-event-restored-after-throwing-onerror.html", "*", WptDivergence.NeedsTriage),
-
         // ---------------------------------------------------------------- 3. a script's exception is not reported
         // https://html.spec.whatwg.org/multipage/webappapis.html#report-an-exception. An exception escaping a
         // classic `<script>` — a parse error, a runtime error, an external script's either — must be reported

--- a/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
+++ b/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
@@ -334,25 +334,38 @@ internal static class WptBrowserExclusions
         // group below by cause, and is here only because the file is in another suite.
         new("html/webappapis/scripting/events/eventhandler-cancellation.html", "*", WptDivergence.NeedsIframeScripting),
 
-        // ---------------------------------------------------------------- 9. one click, one activation behaviour
-        // https://dom.spec.whatwg.org/#eventtarget-activation-behavior: a dispatch runs the activation
-        // behaviour of *one* element — the nearest ancestor in the event path that has one — and these rows
-        // are the two ways that goes wrong here. A nested `<a>` or `<area>` records nothing at all, because
-        // following a hyperlink to a fragment of the page's own URL is not what this activation host does;
-        // and a `<form>` nested in a `<form>` submits **both**, because the walk does not stop at the first
-        // behaviour it finds. 108 of the file's 132 shapes are right, which is what makes the two wrong ones
-        // worth naming.
+        // ---------------------------------------------------------------- 6. a bubbling `submit` the file counts as an activation
+        // `Event-dispatch-single-activation-behavior.html` builds 132 nesting shapes and asserts that exactly
+        // one activation behaviour runs. Its instrumentation is the *handler* — `<form onsubmit="activated(this)">`
+        // — and for eight of the shapes that cannot tell an activation behaviour from an ordinary bubble:
+        // the child form is a descendant of the parent form (the file appends it into the parent's `<input>`),
+        // and https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-form-submit
+        // fires `submit` "with the bubbles and cancelable attributes initialized to true", as
+        // https://html.spec.whatwg.org/multipage/forms.html#dom-form-reset does `reset`. So the parent's
+        // handler runs because the child's event reached it, and no implementation may stop it.
+        //
+        // The shape of the eight says the same thing from the other side: they are exactly the pairs whose
+        // two forms listen for the *same* event. A submitting child inside a resetting parent passes, because
+        // the parent has no `onsubmit` for the bubble to find.
+        new("dom/events/Event-dispatch-single-activation-behavior.html", "When clicking child <FORM><BUTTON type=reset></BUTTON></FORM> of parent <FORM><INPUT type=reset></INPUT></FORM>, only child should be activated.", WptDivergence.AssertsWhatNothingRequires),
+        new("dom/events/Event-dispatch-single-activation-behavior.html", "When clicking child <FORM><BUTTON type=submit></BUTTON></FORM> of parent <FORM><INPUT type=image></INPUT></FORM>, only child should be activated.", WptDivergence.AssertsWhatNothingRequires),
+        new("dom/events/Event-dispatch-single-activation-behavior.html", "When clicking child <FORM><BUTTON type=submit></BUTTON></FORM> of parent <FORM><INPUT type=submit></INPUT></FORM>, only child should be activated.", WptDivergence.AssertsWhatNothingRequires),
+        new("dom/events/Event-dispatch-single-activation-behavior.html", "When clicking child <FORM><INPUT type=image></INPUT></FORM> of parent <FORM><BUTTON type=submit></BUTTON></FORM>, only child should be activated.", WptDivergence.AssertsWhatNothingRequires),
+        new("dom/events/Event-dispatch-single-activation-behavior.html", "When clicking child <FORM><INPUT type=image></INPUT></FORM> of parent <FORM><INPUT type=submit></INPUT></FORM>, only child should be activated.", WptDivergence.AssertsWhatNothingRequires),
+        new("dom/events/Event-dispatch-single-activation-behavior.html", "When clicking child <FORM><INPUT type=reset></INPUT></FORM> of parent <FORM><BUTTON type=reset></BUTTON></FORM>, only child should be activated.", WptDivergence.AssertsWhatNothingRequires),
+        new("dom/events/Event-dispatch-single-activation-behavior.html", "When clicking child <FORM><INPUT type=submit></INPUT></FORM> of parent <FORM><BUTTON type=submit></BUTTON></FORM>, only child should be activated.", WptDivergence.AssertsWhatNothingRequires),
+        new("dom/events/Event-dispatch-single-activation-behavior.html", "When clicking child <FORM><INPUT type=submit></INPUT></FORM> of parent <FORM><INPUT type=image></INPUT></FORM>, only child should be activated.", WptDivergence.AssertsWhatNothingRequires),
+
+        // ---------------------------------------------------------------- 7. a fragment navigation the file does not wait for
+        // The same file's twenty-two `<a>`/`<area>` shapes click a link to a fragment of the page's own URL
+        // and give it two zero-delay turns to produce a `hashchange`. The navigation happens — a unit test
+        // measures it arriving on the *next* turn, and this change moved it there from after the whole timer
+        // chain by keeping a same-document fragment move on the page loop instead of sending it round the
+        // navigation gate — but in this document it still does not land inside the file's two turns. What is
+        // left is a scheduling question about the page loop rather than anything about activation behaviour,
+        // and it is the one row of #3693 this change does not retire.
         new("dom/events/Event-dispatch-single-activation-behavior.html", "When clicking child <A></A> of parent *", WptDivergence.NeedsTriage),
         new("dom/events/Event-dispatch-single-activation-behavior.html", "When clicking child <AREA></AREA> of parent *", WptDivergence.NeedsTriage),
-        new("dom/events/Event-dispatch-single-activation-behavior.html", "When clicking child <LABEL><INPUT type=checkbox></INPUT><SPAN></SPAN></LABEL> of parent *", WptDivergence.NeedsTriage),
-        new("dom/events/Event-dispatch-single-activation-behavior.html", "When clicking child <FORM><BUTTON type=reset></BUTTON></FORM> of parent <FORM><INPUT type=reset></INPUT></FORM>, only child should be activated.", WptDivergence.NeedsTriage),
-        new("dom/events/Event-dispatch-single-activation-behavior.html", "When clicking child <FORM><BUTTON type=submit></BUTTON></FORM> of parent <FORM><INPUT type=image></INPUT></FORM>, only child should be activated.", WptDivergence.NeedsTriage),
-        new("dom/events/Event-dispatch-single-activation-behavior.html", "When clicking child <FORM><BUTTON type=submit></BUTTON></FORM> of parent <FORM><INPUT type=submit></INPUT></FORM>, only child should be activated.", WptDivergence.NeedsTriage),
-        new("dom/events/Event-dispatch-single-activation-behavior.html", "When clicking child <FORM><INPUT type=image></INPUT></FORM> of parent <FORM><BUTTON type=submit></BUTTON></FORM>, only child should be activated.", WptDivergence.NeedsTriage),
-        new("dom/events/Event-dispatch-single-activation-behavior.html", "When clicking child <FORM><INPUT type=image></INPUT></FORM> of parent <FORM><INPUT type=submit></INPUT></FORM>, only child should be activated.", WptDivergence.NeedsTriage),
-        new("dom/events/Event-dispatch-single-activation-behavior.html", "When clicking child <FORM><INPUT type=reset></INPUT></FORM> of parent <FORM><BUTTON type=reset></BUTTON></FORM>, only child should be activated.", WptDivergence.NeedsTriage),
-        new("dom/events/Event-dispatch-single-activation-behavior.html", "When clicking child <FORM><INPUT type=submit></INPUT></FORM> of parent <FORM><BUTTON type=submit></BUTTON></FORM>, only child should be activated.", WptDivergence.NeedsTriage),
-        new("dom/events/Event-dispatch-single-activation-behavior.html", "When clicking child <FORM><INPUT type=submit></INPUT></FORM> of parent <FORM><INPUT type=image></INPUT></FORM>, only child should be activated.", WptDivergence.NeedsTriage),
 
         // ---------------------------------------------------------------- a frame that runs script
         // https://html.spec.whatwg.org/multipage/nav-history-apis.html#window: each of these needs a second

--- a/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
+++ b/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
@@ -390,16 +390,6 @@ internal static class WptBrowserExclusions
         new("dom/events/Event-init-while-dispatching.html", "Calling initUIEvent while dispatching.", WptDivergence.NeedsTriage),
         new("dom/events/Event-subclasses-constructors.html", "UIEvent constructor (view argument with wrong type)", WptDivergence.NeedsTriage),
 
-        // ---------------------------------------------------------------- 8. passive by default
-        // https://dom.spec.whatwg.org/#default-passive-value: a `touchstart`, `touchmove`, `wheel` or
-        // `mousewheel` listener added to the Window, the Document, the document element or the body with no
-        // `passive` member is passive, so its `preventDefault()` does nothing. Here it is active, and the
-        // thirty-two rows are those four types over those four targets in the two spellings that leave the
-        // member out. The `{passive:true}` and `{passive:false}` spellings pass, so the rule is what is
-        // missing rather than the mechanism.
-        new("dom/events/passive-by-default.html", "* listener is passive by default for *", WptDivergence.NeedsTriage),
-        new("dom/events/passive-by-default.html", "* listener is passive with {passive:undefined} for *", WptDivergence.NeedsTriage),
-
         // ---------------------------------------------------------------- 9. one click, one activation behaviour
         // https://dom.spec.whatwg.org/#eventtarget-activation-behavior: a dispatch runs the activation
         // behaviour of *one* element — the nearest ancestor in the event path that has one — and these rows

--- a/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
+++ b/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
@@ -274,10 +274,12 @@ internal static class WptBrowserExclusions
     /// test, or by a glob over a family the file generates.
     /// </para>
     /// <para>
-    /// <b><see cref="WptDivergence.NeedsTriage"/> is eleven distinct defects, not eighty rows.</b>
-    /// <c>Wpt/README.md</c> has one section per defect with what it is and which rows it earns; they are what
-    /// this PR owes the engine and the package, recorded rather than fixed so that the change which first ran
-    /// these suites is not also the change that moved them.
+    /// <b><see cref="WptDivergence.NeedsTriage"/> is five distinct things, not eleven rows.</b> The eleven
+    /// defects this lane first recorded were filed as
+    /// https://github.com/sebastienros/jint/issues/3686 to 3695 and are fixed; what is left is named in
+    /// <c>Wpt/README.md</c>, one section per cause, and every one of them is bounded — a scheme a subresource
+    /// cannot fetch, a member AngleSharp reflects wrong, an <c>@@unscopables</c> object the binding does not
+    /// emit, a custom element, and a fragment navigation this lane's own timing does not wait for.
     /// </para>
     /// </remarks>
     internal static readonly WptExclusion[] All =
@@ -373,10 +375,8 @@ internal static class WptBrowserExclusions
         // frame's realm, an exception reported in the realm of the listener that threw. A page here parses
         // child frames and gives none of them an engine.
         //
-        // The eleventh defect this lane found is visible in every one of them and is *not* what puts them
-        // here: `window` has no named properties, so `<iframe name=x>` and `<div id=x>` do not reach script
-        // as `x`. That is https://html.spec.whatwg.org/multipage/nav-history-apis.html#named-access-on-the-window-object,
-        // and it is what these files meet first — but a fix for it would leave them needing the frame.
+        // Named access on the window is what these files used to meet first, and it is implemented now
+        // (Runtime/WindowNamedProperties); the frame is what is left, and no fix short of one moves them.
         new("dom/events/EventListener-handleEvent-cross-realm.html", "*", WptDivergence.NeedsIframeScripting),
         new("dom/events/event-global-is-still-set-when-coercing-beforeunload-result.html", "*", WptDivergence.NeedsIframeScripting),
         new("dom/events/event-global-is-still-set-when-reporting-exception-onerror.html", "*", WptDivergence.NeedsIframeScripting),
@@ -388,8 +388,8 @@ internal static class WptBrowserExclusions
 
         // ---------------------------------------------------------------- a rendering
         // `MouseEvent.offsetX` against a `body { margin: 8px }`, which is a used value and not a computed
-        // one. It reaches the assertion by way of named access, so today it fails on that instead — but no
-        // fix short of campaign item C4's flat renderer moves the row.
+        // one. Named access now carries it as far as the assertion, which is where no fix short of campaign
+        // item C4's flat renderer moves it.
         new("dom/events/mouse-event-retarget.html", "*", WptDivergence.NeedsLayout),
     ];
 }

--- a/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
+++ b/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
@@ -322,12 +322,11 @@ internal static class WptBrowserExclusions
         // `document[Symbol.unscopables]`, which is undefined here.
         new("html/webappapis/scripting/events/compile-event-handler-symbol-unscopables.html", "*", WptDivergence.NeedsTriage),
 
-        // ---------------------------------------------------------------- 4b. named access on the window
-        // `compile-event-handler-lexical-scopes-form-owner.html` reaches its own `<form id=form>` as the bare
-        // identifier `form`, which is HTML's named access on the Window object — the eleventh defect this
-        // corpus found. Its subject, the form owner in a handler's scope chain, is implemented; the file
-        // cannot say so until the name resolves. Its fourth row needs custom elements as well.
-        new("html/webappapis/scripting/events/compile-event-handler-lexical-scopes-form-owner.html", "*", WptDivergence.NeedsTriage),
+        // ---------------------------------------------------------------- 4b. a custom element
+        // The file's other three rows pass. This one defines a form-associated custom element, and
+        // `window.customElements` is a name this browser does not have — the same reason
+        // `EventTarget-add-listener-platform-object.html` is not vendored.
+        new("html/webappapis/scripting/events/compile-event-handler-lexical-scopes-form-owner.html", "form-associated <x-foo> has a form owner", WptDivergence.NeedsTriage),
 
         // ---------------------------------------------------------------- 5. a frame that runs script
         // `eventhandler-cancellation.html` fires its events at `frames[0]`, which is an iframe's window; a

--- a/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
+++ b/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
@@ -168,7 +168,7 @@ internal static class WptBrowserExclusions
         ["dom/events/AddEventListenerOptions-once.any.html"] = 4,
         ["dom/events/AddEventListenerOptions-passive.any.html"] = 5,
         ["dom/events/AddEventListenerOptions-signal.any.html"] = 11,
-        ["dom/events/Body-FrameSet-Event-Handlers.html"] = 5,
+        ["dom/events/Body-FrameSet-Event-Handlers.html"] = 48,
         ["dom/events/CustomEvent.html"] = 3,
         ["dom/events/Event-cancelBubble.html"] = 8,
         ["dom/events/Event-constructors.any.html"] = 14,
@@ -293,66 +293,47 @@ internal static class WptBrowserExclusions
         new("dom/events/EventTarget-dispatchEvent.html", "If the event's initialized flag is not set, an InvalidStateError must be thrown (DragEvent).", WptDivergence.NeedsMoreEventInterfaces),
         new("dom/events/EventTarget-dispatchEvent.html", "If the event's initialized flag is not set, an InvalidStateError must be thrown (StorageEvent).", WptDivergence.NeedsMoreEventInterfaces),
 
-        // ---------------------------------------------------------------- 3. a script's exception is not reported
-        // https://html.spec.whatwg.org/multipage/webappapis.html#report-an-exception. An exception escaping a
-        // classic `<script>` — a parse error, a runtime error, an external script's either — must be reported
-        // at the global scope, which fires `error` and reaches `window.onerror` and `<body onerror>`. Here it
-        // becomes a PageErrorKind.ScriptError on the page's recorder and nothing else: every one of these
-        // documents fails on `assert_true: ran expected true got false`. The engine fires that event for a
-        // timer callback, a listener and a microtask (GlobalEventTarget), so what is missing is the parser
-        // driver's own report and not the mechanism.
-        new("html/webappapis/scripting/processing-model-2/addEventListener.html", "*", WptDivergence.NeedsTriage),
-        new("html/webappapis/scripting/processing-model-2/compile-error.html", "*", WptDivergence.NeedsTriage),
+        // ---------------------------------------------------------------- 2. a `data:` URL subresource
+        // A page navigates to a `data:` URL and cannot fetch one as a subresource, so a
+        // `<script src="data:text/javascript,…">` is never run — which is what "ran expected true got false"
+        // says here. The report site these documents are about works; what is missing is the scheme, and
+        // adding it is `Runtime/SubresourceFetch`'s change rather than this one.
         new("html/webappapis/scripting/processing-model-2/compile-error-data-url.html", "*", WptDivergence.NeedsTriage),
-        new("html/webappapis/scripting/processing-model-2/compile-error-same-origin.html", "*", WptDivergence.NeedsTriage),
-        new("html/webappapis/scripting/processing-model-2/compile-error-same-origin-with-hash.html", "*", WptDivergence.NeedsTriage),
-        new("html/webappapis/scripting/processing-model-2/runtime-error.html", "*", WptDivergence.NeedsTriage),
         new("html/webappapis/scripting/processing-model-2/runtime-error-data-url.html", "*", WptDivergence.NeedsTriage),
-        new("html/webappapis/scripting/processing-model-2/runtime-error-same-origin.html", "*", WptDivergence.NeedsTriage),
-        new("html/webappapis/scripting/processing-model-2/runtime-error-same-origin-with-hash.html", "*", WptDivergence.NeedsTriage),
-        new("html/webappapis/scripting/processing-model-2/runtime-error-in-body-onerror.html", "*", WptDivergence.NeedsTriage),
-        new("html/webappapis/scripting/processing-model-2/runtime-error-in-window-onerror.html", "*", WptDivergence.NeedsTriage),
-        new("html/webappapis/scripting/processing-model-2/window-onerror-parse-error.html", "*", WptDivergence.NeedsTriage),
-        new("html/webappapis/scripting/processing-model-2/window-onerror-runtime-error.html", "*", WptDivergence.NeedsTriage),
-        new("html/webappapis/scripting/processing-model-2/window-onerror-runtime-error-throw.html", "*", WptDivergence.NeedsTriage),
-        new("html/webappapis/scripting/processing-model-2/body-onerror-compile-error.html", "<body onerror> - compile error in <script>", WptDivergence.NeedsTriage),
         new("html/webappapis/scripting/processing-model-2/body-onerror-compile-error-data-url.html", "<body onerror> - compile error in <script src=data:...>", WptDivergence.NeedsTriage),
-        new("html/webappapis/scripting/processing-model-2/body-onerror-runtime-error.html", "<body onerror> - runtime error in <script>", WptDivergence.NeedsTriage),
 
-        // The same defect met through a handler *content attribute* rather than a <script>. The runtime half
-        // of it is reported — an exception escaping a compiled handler is an exception escaping a listener,
-        // which the engine already reports — so what these two rows say is narrower: the compile error is
-        // not reported at all, and the report the runtime error does make names no file, because the handler
-        // is compiled through `Function` and a dynamic function has no source URL.
-        new("html/webappapis/scripting/processing-model-2/compile-error-in-attribute.html", "window.onerror - compile error in attribute", WptDivergence.NeedsTriage),
-        new("html/webappapis/scripting/processing-model-2/compile-error-in-attribute.html", "window.onerror - compile error in attribute (column)", WptDivergence.NeedsTriage),
-        new("html/webappapis/scripting/processing-model-2/runtime-error-in-attribute.html", "window.onerror - runtime error in attribute", WptDivergence.NeedsTriage),
+        // ---------------------------------------------------------------- 3. `script.src` does not reflect a URL
+        // HTML: the `src` IDL attribute of a `<script>` reflects the content attribute **as a URL**, so it
+        // answers the resolved absolute URL. AngleSharp's `IHtmlScriptElement.Source` answers the raw
+        // attribute value, so the four rows below compare the report's filename — which is correct, and
+        // absolute — against the unresolved string the document wrote. It is AngleSharp's divergence and it
+        // is recorded in `Jint.Browser/Dom/AGENTS.md`; working around it in the binding is the thing that
+        // file says not to do.
+        new("html/webappapis/scripting/processing-model-2/compile-error-same-origin.html", "window.onerror - compile error in <script src=...>", WptDivergence.NeedsTriage),
+        new("html/webappapis/scripting/processing-model-2/compile-error-same-origin-with-hash.html", "window.onerror - compile error in <script src=...> with hash", WptDivergence.NeedsTriage),
+        new("html/webappapis/scripting/processing-model-2/runtime-error-same-origin.html", "window.onerror - runtime error in <script src=...>", WptDivergence.NeedsTriage),
+        new("html/webappapis/scripting/processing-model-2/runtime-error-same-origin-with-hash.html", "window.onerror - runtime error in <script src=...> with hash", WptDivergence.NeedsTriage),
 
-        // ---------------------------------------------------------------- 5. the compiled handler is not HTML's
-        // https://html.spec.whatwg.org/multipage/webappapis.html#getting-the-current-value-of-the-event-handler.
-        // The function a handler content attribute compiles to must be named for the attribute and have the
-        // attribute's text as its body: `function onclick(event) {\nfoo\n}`. It is
-        // `function anonymous(event\n) {\nwith (document) …`, which is the scope chain leaking into the
-        // source text. `event-handler-sourcetext` asserts the text; the unscopables and cancellation
-        // documents assert what the chain does; `-non-content-document-idl-attributes` asserts which members
-        // are handlers at all; `inline-event-handler-ordering` asserts that an invalid one keeps its slot;
-        // `-lexical-scopes-form-owner` asserts the form owner is in the chain (and needs custom elements for
-        // its fourth test); and `uncompiled_event_handler_with_scripting_disabled` asserts that a document
-        // with scripting disabled compiles none of them.
-        new("html/webappapis/scripting/events/event-handler-sourcetext.html", "*", WptDivergence.NeedsTriage),
-        new("html/webappapis/scripting/events/event-handler-non-content-document-idl-attributes.html", "*", WptDivergence.NeedsTriage),
-        new("html/webappapis/scripting/events/inline-event-handler-ordering.html", "*", WptDivergence.NeedsTriage),
+        // ---------------------------------------------------------------- 4. a DOM prototype has no @@unscopables
+        // WebIDL puts an `@@unscopables` object on the interface prototype object of every interface with an
+        // `[Unscopable]` member — `Element`'s and `Document`'s `append`, `prepend` and `replaceChildren`
+        // among them — and this binding emits none, because AngleSharp's metadata does not say which members
+        // are unscopable. The three rows below never reach their subject: they *write* to
+        // `document[Symbol.unscopables]`, which is undefined here.
         new("html/webappapis/scripting/events/compile-event-handler-symbol-unscopables.html", "*", WptDivergence.NeedsTriage),
-        new("html/webappapis/scripting/events/eventhandler-cancellation.html", "*", WptDivergence.NeedsTriage),
-        new("html/webappapis/scripting/events/uncompiled_event_handler_with_scripting_disabled.html", "*", WptDivergence.NeedsTriage),
+
+        // ---------------------------------------------------------------- 4b. named access on the window
+        // `compile-event-handler-lexical-scopes-form-owner.html` reaches its own `<form id=form>` as the bare
+        // identifier `form`, which is HTML's named access on the Window object — the eleventh defect this
+        // corpus found. Its subject, the form owner in a handler's scope chain, is implemented; the file
+        // cannot say so until the name resolves. Its fourth row needs custom elements as well.
         new("html/webappapis/scripting/events/compile-event-handler-lexical-scopes-form-owner.html", "*", WptDivergence.NeedsTriage),
 
-        // ---------------------------------------------------------------- 6. two names HTML gives a body and a frameset
-        // `<body>`'s handler attributes that HTML redirects to the Window are reflected as an object rather
-        // than a function, and `HTMLFrameSetElement` — which owns the other half of that table — is not an
-        // interface object at all.
-        new("dom/events/Body-FrameSet-Event-Handlers.html", "Forward HTMLBodyElement.onblur to Window", WptDivergence.NeedsTriage),
-        new("dom/events/Body-FrameSet-Event-Handlers.html", "Set HTMLFrameSetElement.onblur", WptDivergence.NeedsTriage),
+        // ---------------------------------------------------------------- 5. a frame that runs script
+        // `eventhandler-cancellation.html` fires its events at `frames[0]`, which is an iframe's window; a
+        // page here parses child frames and gives none of them an engine. It is the NeedsIframeScripting
+        // group below by cause, and is here only because the file is in another suite.
+        new("html/webappapis/scripting/events/eventhandler-cancellation.html", "*", WptDivergence.NeedsIframeScripting),
 
         // ---------------------------------------------------------------- 7. the legacy init methods of the UI events
         // `initUIEvent`, `initMouseEvent` and `initKeyboardEvent`: deprecated, still in the UI Events

--- a/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
+++ b/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
@@ -72,17 +72,20 @@ internal static class WptBrowserExclusions
         // says the same about `fetch/api/*/*.sub.any.js`, and Vendor/README.md's serving section argues it.
         ("dom/events/*.sub.html", "wptserve substitution into a *second* origin, which this server does not have"),
 
-        // ------------------------------------------------------------ needs `document.createEvent` at file scope
-        // The same defect the NeedsTriage rows below record, met before a test could be registered — so there
-        // is no per-test result for it here and the file is a harness error. `Event-cancelBubble.html` and its
-        // sixteen siblings name the defect from the other side, which is why nothing is lost by these rows.
-        ("dom/events/Event-constants.html", "calls document.createEvent at file scope, which the bindings do not have"),
-        ("dom/events/Event-propagation.html", "calls document.createEvent at file scope, which the bindings do not have"),
-        ("dom/events/Event-dispatch-detached-click.html", "calls document.createEvent inside its one test, which never completes"),
-        ("dom/events/keypress-dispatch-crash.html", "calls document.implementation.createDocument at file scope"),
+        // ------------------------------------------------------------ not vendored, and the cause has gone
+        // These four were harness errors because `document.createEvent` did not exist and each of them reaches
+        // for it before a test could report. It exists now, so the reason these are not vendored is spent and
+        // vendoring them is a change of its own: it moves the census's Documents and Tests columns, which the
+        // change that fixes an engine deliberately does not. `keypress-dispatch-crash.html` needs one more
+        // thing — `document.implementation.createDocument`, which AngleSharp's IImplementation does not have
+        // at all (`createHTMLDocument` and `new Document()` are the two this package answers).
+        ("dom/events/Event-constants.html", "not vendored: it called document.createEvent at file scope, which now exists"),
+        ("dom/events/Event-propagation.html", "not vendored: it called document.createEvent at file scope, which now exists"),
+        ("dom/events/Event-dispatch-detached-click.html", "not vendored: it called document.createEvent inside its one test, which now exists"),
+        ("dom/events/keypress-dispatch-crash.html", "calls document.implementation.createDocument at file scope, which AngleSharp's IImplementation does not have"),
 
         // ------------------------------------------------------------ needs a name this browser does not have
-        ("dom/events/Event-stopPropagation-cancel-bubbling.html", "reads the legacy global `window.event`, which is a NeedsTriage row of event-global.html"),
+        ("dom/events/Event-stopPropagation-cancel-bubbling.html", "not vendored: it read the legacy global `window.event`, which now exists"),
         ("dom/events/EventTarget-add-listener-platform-object.html", "defines a custom element: window.customElements is absent"),
         ("dom/events/Event-dispatch-click.html", "follows a `javascript:` URL 87 times; a page here loads http, https, about: and data:"),
 
@@ -279,39 +282,16 @@ internal static class WptBrowserExclusions
     /// </remarks>
     internal static readonly WptExclusion[] All =
     [
-        // ---------------------------------------------------------------- 1. document.createEvent
-        // https://dom.spec.whatwg.org/#dom-document-createevent, the legacy creation surface DOM still
-        // requires: `document.createEvent(alias)` then `initEvent`. Nothing in the bindings has it, and half
-        // this corpus is written against it because it predates the constructors. `new Document()` and
-        // `document.implementation.createHTMLDocument()` are the same section of the same gap — the two
-        // documents that reach for one are Event-dispatch-bubbles-{true,false}.
-        new("dom/events/CustomEvent.html", "*", WptDivergence.NeedsTriage),
-        new("dom/events/Event-cancelBubble.html", "*", WptDivergence.NeedsTriage),
-        new("dom/events/Event-defaultPrevented-after-dispatch.html", "*", WptDivergence.NeedsTriage),
-        new("dom/events/Event-defaultPrevented.html", "*", WptDivergence.NeedsTriage),
-        new("dom/events/Event-dispatch-bubble-canceled.html", "*", WptDivergence.NeedsTriage),
-        new("dom/events/Event-dispatch-bubbles-false.html", "*", WptDivergence.NeedsTriage),
-        new("dom/events/Event-dispatch-bubbles-true.html", "*", WptDivergence.NeedsTriage),
-        new("dom/events/Event-dispatch-handlers-changed.html", "*", WptDivergence.NeedsTriage),
-        new("dom/events/Event-dispatch-multiple-cancelBubble.html", "*", WptDivergence.NeedsTriage),
-        new("dom/events/Event-dispatch-multiple-stopPropagation.html", "*", WptDivergence.NeedsTriage),
-        new("dom/events/Event-dispatch-omitted-capture.html", "*", WptDivergence.NeedsTriage),
-        new("dom/events/Event-dispatch-propagation-stopped.html", "*", WptDivergence.NeedsTriage),
-        new("dom/events/Event-dispatch-reenter.html", "*", WptDivergence.NeedsTriage),
-        new("dom/events/Event-dispatch-target-moved.html", "*", WptDivergence.NeedsTriage),
-        new("dom/events/Event-dispatch-target-removed.html", "*", WptDivergence.NeedsTriage),
-        new("dom/events/Event-initEvent.html", "*", WptDivergence.NeedsTriage),
-        new("dom/events/EventTarget-dispatchEvent-returnvalue.html", "*", WptDivergence.NeedsTriage),
-        new("dom/events/EventTarget-dispatchEvent.html", "If the event's initialized flag is not set, an InvalidStateError must be thrown (*", WptDivergence.NeedsTriage),
-        new("dom/events/EventTarget-dispatchEvent.html", "If the event's dispatch flag is set, an InvalidStateError must be thrown.", WptDivergence.NeedsTriage),
-        new("dom/events/EventTarget-dispatchEvent.html", "Exceptions from event listeners must not be propagated.", WptDivergence.NeedsTriage),
-        new("dom/events/Event-returnValue.html", "initEvent should unset returnValue.", WptDivergence.NeedsTriage),
-        new("dom/events/Event-type-empty.html", "initEvent", WptDivergence.NeedsTriage),
-        new("dom/events/Event-type.html", "Event.type should initially be the empty string", WptDivergence.NeedsTriage),
-        new("dom/events/Event-type.html", "Event.type should be initialized by initEvent", WptDivergence.NeedsTriage),
-        new("dom/events/KeyEvent-initKeyEvent.html", "KeyboardEvent.initKeyEvent shouldn't be defined (created by createEvent(\"KeyboardEvent\")", WptDivergence.NeedsTriage),
-        new("html/webappapis/scripting/processing-model-2/compile-error-in-attribute.html", "window.onerror - compile error in attribute", WptDivergence.NeedsTriage),
-        new("html/webappapis/scripting/processing-model-2/runtime-error-in-attribute.html", "window.onerror - runtime error in attribute", WptDivergence.NeedsTriage),
+        // ---------------------------------------------------------------- 1. an event interface this browser has not built
+        // https://dom.spec.whatwg.org/#dom-document-createevent's alias table names five interfaces
+        // Jint.Browser deliberately does not build, and this file is the only place a page meets them all at
+        // once: it asks each of them for an uninitialized event and dispatches it. `createEvent` refuses the
+        // alias with the NotSupportedError the standard gives one it does not list, which is what these four
+        // rows say. See WptDivergence.NeedsMoreEventInterfaces.
+        new("dom/events/EventTarget-dispatchEvent.html", "If the event's initialized flag is not set, an InvalidStateError must be thrown (DeviceMotionEvent).", WptDivergence.NeedsMoreEventInterfaces),
+        new("dom/events/EventTarget-dispatchEvent.html", "If the event's initialized flag is not set, an InvalidStateError must be thrown (DeviceOrientationEvent).", WptDivergence.NeedsMoreEventInterfaces),
+        new("dom/events/EventTarget-dispatchEvent.html", "If the event's initialized flag is not set, an InvalidStateError must be thrown (DragEvent).", WptDivergence.NeedsMoreEventInterfaces),
+        new("dom/events/EventTarget-dispatchEvent.html", "If the event's initialized flag is not set, an InvalidStateError must be thrown (StorageEvent).", WptDivergence.NeedsMoreEventInterfaces),
 
         // ---------------------------------------------------------------- 3. a script's exception is not reported
         // https://html.spec.whatwg.org/multipage/webappapis.html#report-an-exception. An exception escaping a
@@ -339,13 +319,14 @@ internal static class WptBrowserExclusions
         new("html/webappapis/scripting/processing-model-2/body-onerror-compile-error-data-url.html", "<body onerror> - compile error in <script src=data:...>", WptDivergence.NeedsTriage),
         new("html/webappapis/scripting/processing-model-2/body-onerror-runtime-error.html", "<body onerror> - runtime error in <script>", WptDivergence.NeedsTriage),
 
-        // ---------------------------------------------------------------- 4. the error event carries no column
-        // https://html.spec.whatwg.org/multipage/webappapis.html#erroreventinit: `colno`. The five-argument
-        // `onerror` receives `undefined` where a number is owed. These two rows are the only ones that can
-        // say so, because every other document that would asks it after the report of defect 3 that never
-        // arrives.
+        // The same defect met through a handler *content attribute* rather than a <script>. The runtime half
+        // of it is reported — an exception escaping a compiled handler is an exception escaping a listener,
+        // which the engine already reports — so what these two rows say is narrower: the compile error is
+        // not reported at all, and the report the runtime error does make names no file, because the handler
+        // is compiled through `Function` and a dynamic function has no source URL.
+        new("html/webappapis/scripting/processing-model-2/compile-error-in-attribute.html", "window.onerror - compile error in attribute", WptDivergence.NeedsTriage),
         new("html/webappapis/scripting/processing-model-2/compile-error-in-attribute.html", "window.onerror - compile error in attribute (column)", WptDivergence.NeedsTriage),
-        new("html/webappapis/scripting/processing-model-2/runtime-error-in-attribute.html", "window.onerror - runtime error in attribute (column)", WptDivergence.NeedsTriage),
+        new("html/webappapis/scripting/processing-model-2/runtime-error-in-attribute.html", "window.onerror - runtime error in attribute", WptDivergence.NeedsTriage),
 
         // ---------------------------------------------------------------- 5. the compiled handler is not HTML's
         // https://html.spec.whatwg.org/multipage/webappapis.html#getting-the-current-value-of-the-event-handler.

--- a/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
+++ b/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
@@ -335,15 +335,6 @@ internal static class WptBrowserExclusions
         // group below by cause, and is here only because the file is in another suite.
         new("html/webappapis/scripting/events/eventhandler-cancellation.html", "*", WptDivergence.NeedsIframeScripting),
 
-        // ---------------------------------------------------------------- 7. the legacy init methods of the UI events
-        // `initUIEvent`, `initMouseEvent` and `initKeyboardEvent`: deprecated, still in the UI Events
-        // specification, and absent here. Beside them, `new UIEvent(type, {view: notAWindow})` must throw a
-        // TypeError and does not.
-        new("dom/events/Event-init-while-dispatching.html", "Calling initKeyboardEvent while dispatching.", WptDivergence.NeedsTriage),
-        new("dom/events/Event-init-while-dispatching.html", "Calling initMouseEvent while dispatching.", WptDivergence.NeedsTriage),
-        new("dom/events/Event-init-while-dispatching.html", "Calling initUIEvent while dispatching.", WptDivergence.NeedsTriage),
-        new("dom/events/Event-subclasses-constructors.html", "UIEvent constructor (view argument with wrong type)", WptDivergence.NeedsTriage),
-
         // ---------------------------------------------------------------- 9. one click, one activation behaviour
         // https://dom.spec.whatwg.org/#eventtarget-activation-behavior: a dispatch runs the activation
         // behaviour of *one* element — the nearest ancestor in the event path that has one — and these rows

--- a/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
+++ b/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
@@ -420,16 +420,6 @@ internal static class WptBrowserExclusions
         new("dom/events/Event-dispatch-single-activation-behavior.html", "When clicking child <FORM><INPUT type=submit></INPUT></FORM> of parent <FORM><BUTTON type=submit></BUTTON></FORM>, only child should be activated.", WptDivergence.NeedsTriage),
         new("dom/events/Event-dispatch-single-activation-behavior.html", "When clicking child <FORM><INPUT type=submit></INPUT></FORM> of parent <FORM><INPUT type=image></INPUT></FORM>, only child should be activated.", WptDivergence.NeedsTriage),
 
-        // ---------------------------------------------------------------- 10. a detached control still fires input
-        // https://html.spec.whatwg.org/multipage/input.html#checkbox-state-(type=checkbox): the pre-click
-        // activation steps fire `input` and `change` only for a control that is *connected*. A detached
-        // checkbox or radio fires them here, on `click()` and on a dispatched `MouseEvent` alike. The eight
-        // connected cases of the same file pass.
-        new("dom/events/Event-dispatch-detached-input-and-change.html", "detached checkbox should not emit input or change events on click().", WptDivergence.NeedsTriage),
-        new("dom/events/Event-dispatch-detached-input-and-change.html", "detached checkbox should not emit input or change events on dispatchEvent(new MouseEvent('click')).", WptDivergence.NeedsTriage),
-        new("dom/events/Event-dispatch-detached-input-and-change.html", "detached radio should not emit input or change events on click().", WptDivergence.NeedsTriage),
-        new("dom/events/Event-dispatch-detached-input-and-change.html", "detached radio should not emit input or change events on dispatchEvent(new MouseEvent('click')).", WptDivergence.NeedsTriage),
-
         // ---------------------------------------------------------------- a frame that runs script
         // https://html.spec.whatwg.org/multipage/nav-history-apis.html#window: each of these needs a second
         // global with a document in it — a cross-realm listener, a `beforeunload` result coerced in the

--- a/Jint.Tests/Wpt/WptExclusions.cs
+++ b/Jint.Tests/Wpt/WptExclusions.cs
@@ -594,6 +594,26 @@ internal enum WptDivergence
 
     /// <summary>
     /// <para>
+    /// The test names an <b>event interface this browser does not build</b>. <c>document.createEvent</c>'s
+    /// alias table (https://dom.spec.whatwg.org/#dom-document-createevent) is the only place a page meets
+    /// them all at once, and five of its rows name interfaces <c>Jint.Browser</c> deliberately has not:
+    /// <c>DragEvent</c> and <c>ClipboardEvent</c> need a <c>DataTransfer</c>, <c>StorageEvent</c> a storage
+    /// area's change notification, <c>TouchEvent</c> a touch input, and <c>DeviceMotionEvent</c> and
+    /// <c>DeviceOrientationEvent</c> a sensor. <c>Jint.Browser/Events/BrowserEventInterfaces.cs</c> is the
+    /// list of the fourteen it does build, and the absence of the rest is stated there.
+    /// </para>
+    /// <para>
+    /// It is <see cref="NeedsTriage"/>'s opposite in the way that matters: the interface is named, the reason
+    /// it is absent is a scope decision somebody made rather than a defect somebody owes, and the rows move
+    /// the day one of them is built. Answering a plain <c>Event</c> under those names instead would be a lie
+    /// a page cannot detect, which is why <c>createEvent</c> refuses them with the <c>NotSupportedError</c>
+    /// the standard gives an alias it does not list.
+    /// </para>
+    /// </summary>
+    NeedsMoreEventInterfaces,
+
+    /// <summary>
+    /// <para>
     /// The test asserts behaviour <b>nothing requires of anybody</b> — not of Jint, and not of any
     /// implementation. This is the corpus's analogue of test262's <c>=== PERMANENT EXCLUSIONS ===</c> banner
     /// and it is earned the same way: only when the standard the test claims to be about does not ask for

--- a/tools/dom-bindings/overrides.json
+++ b/tools/dom-bindings/overrides.json
@@ -32,6 +32,11 @@
       "reason": "Returns an AngleSharp Event. Every script-visible event in this design is a Jint Event dispatched through the engine's own tree dispatcher (design doc §5), and letting AngleSharp's event objects reach script would create a second event bus with a second brand."
     },
     {
+      "interface": "DOMImplementation",
+      "member": "createHTMLDocument",
+      "reason": "AngleSharp's parameter is non-optional, so the projection would make DOM's `optional DOMString title` required and `document.implementation.createHTMLDocument()` a TypeError. Re-declared in `additions` over the same AngleSharp call with the argument optional."
+    },
+    {
       "interface": "Document",
       "member": "open",
       "reason": "document.open() re-enters the parser and replaces the document; the parser driver owns that (campaign item R3)."
@@ -100,6 +105,28 @@
   ],
 
   "additions": [
+    {
+      "interface": "DOMImplementation",
+      "member": "createHTMLDocument",
+      "kind": "operation",
+      "length": 0,
+      "body": [
+        "var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IImplementation>(thisObj, \"DOMImplementation.createHTMLDocument\");",
+        "return self.Realm.WrapNodeValue(self.Target.CreateHtmlDocument(global::Jint.Browser.Dom.DomConvert.OptionalText(args, 0, \"\")!));"
+      ],
+      "reason": "DOM §4.5.1: the title is optional. The one divergence left is AngleSharp's: an omitted title still produces an empty <title> element, where the standard creates none at all."
+    },
+    {
+      "interface": "Document",
+      "member": "createEvent",
+      "kind": "operation",
+      "length": 1,
+      "body": [
+        "var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, \"Document.createEvent\");",
+        "return global::Jint.Browser.Events.LegacyEventCreation.CreateEvent(self.Realm, args);"
+      ],
+      "reason": "DOM §4.5's legacy creation surface, which the standard still requires and half the events corpus is written against. AngleSharp's own is skipped because it answers an AngleSharp Event; this builds the Jint event the alias names, with the empty type and the initialized flag unset that make it undispatchable until initEvent() has named it."
+    },
     {
       "interface": "Document",
       "member": "createTreeWalker",

--- a/tools/dom-bindings/overrides.json
+++ b/tools/dom-bindings/overrides.json
@@ -567,6 +567,20 @@
     },
     {
       "interface": "Element",
+      "member": "setAttribute",
+      "half": "operation",
+      "hook": "SetAttribute",
+      "reason": "HTML activates an event handler when its content attribute is set, and the listener it creates keeps its position among the addEventListener listeners for ever. This is the one write of an attribute the package can see, so it is where `onclick=\"\u2026\"` takes its place in the list; the hook's body is the AngleSharp call it replaced, plus that reconciliation."
+    },
+    {
+      "interface": "Element",
+      "member": "removeAttribute",
+      "half": "operation",
+      "hook": "RemoveAttribute",
+      "reason": "The other half of setAttribute: removing a handler content attribute deactivates the handler, and the listener goes with it."
+    },
+    {
+      "interface": "Element",
       "member": "insertAdjacentHTML",
       "half": "operation",
       "hook": "InsertAdjacentHtml",


### PR DESCRIPTION
Stacked on #3696, which carries the four seams these fixes need from the engine; review that first and this
against it. Both are rebased onto `main` after #3697, whose flat layout and `Input` domain this leaves
untouched.

The web-platform-tests browser lane ([#3685](https://github.com/sebastienros/jint/pull/3685)) ran `dom/events/`
and `html/webappapis/scripting/` against `Jint.Browser` and recorded eleven defects as `NeedsTriage` rows,
filed as #3686–#3695. **This fixes all eleven.**

| | before | after |
| --- | --- | --- |
| `dom/events/` | 181 | **42** |
| `html/webappapis/scripting/events/` | 23 | **5** |
| `html/webappapis/scripting/processing-model-2/` | 34 | **14** |
| **total not passing** | **238** | **61** |

The `Tests` column rises with it — 565 → 614 — because documents that could not register their cases now do;
that column is an equality read off the run rather than a ceiling. The census falls in every suite and rises
nowhere.

### What each issue took

**#3686 — `document.createEvent`, and the documents.** Half of `dom/events/` predates the constructors, so
this was the largest single cause in the lane: seventeen documents failed entirely on it. AngleSharp's own
`createEvent` stays skipped for the reason it always was — its result is an AngleSharp `Event` — and this
re-declares it through `additions` against Jint's, which is the shape `click`, `focus` and `blur` already
have. Only the last two steps are new work: the empty type and the unset initialized flag that make the event
undispatchable until `initEvent()` has named it. Two documents reach for a *document* instead:
`createHTMLDocument()`'s title becomes optional, as DOM has it, and `new Document()` is the one interface
object WebIDL really does give a constructor and the generator can never learn about, since AngleSharp puts
`[DomConstructor]` on no `[DomName]` interface at all.

**#3687 — `window.event`.** The engine keeps DOM's current event (#3696); this is the property that reads it,
an **own** property of the global object rather than an accessor on `Window.prototype`, because WebIDL's
`[Global]` puts an interface's members on the global itself and `event` is the one a page can tell apart.
Its last row found a second defect worth reading twice: a body's `onerror` and its kind are redirected to the
window, so the window is the target whose handler slot the body's content attribute reconciles against — and
an `error` event travelling up through the body found no `onerror` attribute there, treated "never looked at,
and absent" as a change, and **removed the handler a script had assigned to `window.onerror`**.

**#3688 — reporting a script's exception.** `ParserDriver.Execute` did step 6 of *run a classic script* and
not step 5, so a parse error or a runtime error in a document's own script reached neither `window.onerror`
nor `<body onerror>`. It now fires the `error` event first and records second. Two things the report needs are
the script's rather than the engine's: an inline script's filename is the document's URL, and its line is a
`ScriptParsingOptions.SourceOffset`, so a syntax error names a line of the *document* —
`window-onerror-parse-error.html` asserts line 34 and gets it. `<body onerror>` needed one more thing: its
handler belongs to the window, so nothing else would ever build the body's wrapper, and it was built when the
parse ended — after the script that failed.

**#3689 — the compiled handler.** HTML compiles `onclick="foo"` to `function onclick(event) {\nfoo\n}` and
`toString()` of it is observable. The source text is now parsed as that function, through the engine's own
parser so the host's parsing limits apply, and **the scope chain is the function's rather than its body's**:
the global environment, then object environments over the node document, the form owner and the element. That
last is not a refinement — a `with` inside the body makes those objects shadow the function's own
*parameters*, so a `<body onerror>` whose first parameter is `event` read `window.event` instead of the
message the moment `window.event` began to exist. Three smaller rules came with it: an element's handler
content attributes are not a document's, a handler keeps its **position** in the listener list whether its
body failed to parse or a page rewrote it (which is why `setAttribute`/`removeAttribute` are now
`DomHostHooks` members — HTML activates a handler when the attribute is *set*), and a document with scripting
disabled compiles none of them.

**#3690 — `HTMLFrameSetElement`.** AngleSharp models `<frameset>` with the plain `IHtmlElement`, so the
generator can never see the interface; `DomManualInterfaces` declares it by name and selects it by local name,
with an empty shape over `HTMLElement.prototype` because HTML gives it no members of its own. Without it
`Body-FrameSet-Event-Handlers.html` threw at file scope, and once a script's exception is reported that made
the whole document a harness error. All forty-eight of its tests pass now.

**#3691 — the legacy UI-event initializers**, each *initialize an event* followed by the interface's own
members and each short-circuiting while the event is being dispatched; and `UIEventInit`'s `view` is a
`Window?`, so anything else is a `TypeError`.

**#3692 — the default passive value**: `DomNodeObject` reports the three node targets DOM names, and the
window installer declares the global scope a `Window`. All thirty-two rows of `passive-by-default.html` pass
and the sixty-eight that already did still do.

**#3693 — one activation behaviour per click.** Two real defects of the eleven that failed: a `<label>` did
not forward its click to a control it *contains*, because AngleSharp's `label.control` answers null for that
spelling; and a fragment link went round the navigation gate and a thread, so `hashchange` arrived after every
timer already due (measured: turn 20 of 20; turn 1 now). See "what is left" below for the rest of this one.

**#3694 — a detached checkbox** toggles without announcing it, connected being DOM's *shadow-including root
is a document* rather than "has a parent".

**#3695 — named access on the window.** A link in the prototype chain, not a property of the global object —
which is both what WebIDL says and the only place it can go without costing anything: the chain is
`window → Window.prototype → WindowProperties → EventTarget.prototype → Object.prototype`, so what reaches
the lookup is a *miss*. Nothing about an ordinary global read changes, structurally: the global-identifier
inline cache admits only a descriptor the global object owns, so a name answered here is never cached and
never displaces one that is.

### What is left, and why

`NeedsTriage` is not empty, and what is in it is five bounded things rather than eleven defects.
`Jint.Tests.Browser/Wpt/README.md` has the list; in short:

1. **A `data:` URL is not fetched as a subresource**, so `<script src="data:text/javascript,…">` never runs —
   three `processing-model-2/` documents are about exactly that script, and the report site they test works,
   which their inline and `<script src>` siblings say. It is `Runtime/SubresourceFetch`'s change.
2. **`script.src` does not reflect a URL.** AngleSharp answers the raw attribute where HTML reflects the
   resolved absolute one, so four rows compare a correct filename against the string the document wrote.
   **An AngleSharp defect**, recorded in `Jint.Browser/Dom/AGENTS.md` rather than worked around; I have opened
   no issue upstream — see below.
3. **No DOM prototype carries an `@@unscopables` object**, which WebIDL puts on every interface with an
   `[Unscopable]` member. `compile-event-handler-symbol-unscopables.html` never reaches its subject: it
   *writes* to `document[Symbol.unscopables]`.
4. **`window.customElements` is absent**, which one row of the form-owner file needs. Its other three pass.
5. **A fragment navigation does not land inside two turns.**
   `Event-dispatch-single-activation-behavior.html` gives it two zero-delay turns and its twenty-two
   `<a>`/`<area>` shapes still do not see it, although a unit test measures it arriving on the next turn. What
   is left is a question about the page loop's scheduling rather than about activation behaviour, and it is
   the one part of #3693 this does not close.

Two groups left `NeedsTriage` for categories that name what would move them. `WptDivergence` gains
**`NeedsMoreEventInterfaces`** for the five interfaces `createEvent`'s alias table names and this package
deliberately does not build (`DragEvent` and `ClipboardEvent` need a `DataTransfer`, `StorageEvent` a storage
area's change notification, `TouchEvent` a touch input, the two device events a sensor) — `createEvent`
answers the `NotSupportedError` the standard gives an alias it does not list rather than a plain `Event` under
a name a page cannot check. And eight rows of `Event-dispatch-single-activation-behavior.html` move to
**`AssertsWhatNothingRequires`**: the file's instrumentation is a `<form onsubmit>` handler and cannot tell an
activation behaviour from an ordinary bubble — the child form is a descendant of the parent form, and `submit`
and `reset` both fire with `bubbles` true, so the parent's handler runs because the child's event reached it.
The shape of the eight says so from the other side: they are exactly the pairs whose forms listen for the
*same* event, and a submitting child inside a resetting parent passes.

### An AngleSharp defect to report

`IHtmlScriptElement.Source` answers the raw `src` attribute where HTML reflects it as a URL, and
`IHtmlLabelElement.Control` answers null for a control the label contains. Both are in the divergence table in
`Jint.Browser/Dom/AGENTS.md`; the second is worked around (the labeled control is computed here) because a
click inside a label reaching nothing is a page-visible failure, and the first is not. **No issue has been
opened on AngleSharp** — that is not mine to do without asking.

### New public API

None. Everything added is `internal`; `Jint.Tests.Browser/Verify/PublicApiTest.verified.txt` is unchanged.

### Verified

Release throughout, `dotnet test -c Release` over the whole solution. Every new test was run against the code
before its fix and fails there. The lane itself is the main witness: the exclusion table is held to matching
at least one failing test and no passing one, so every row this retires had to be measured rather than
asserted, and `JINT_WPT_BROWSER_CENSUS=update` was run last.

Fixes #3686. Fixes #3687. Fixes #3688. Fixes #3689. Fixes #3690. Fixes #3691. Fixes #3692. Fixes #3694.
Fixes #3695.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
