### PR TITLE
Tests: the sampling profiler's self-time floor is 0.8, which is what "the loop dominates" needs

### DIFF
--- a/Jint.Tests/Runtime/SamplingProfilerTests.cs
+++ b/Jint.Tests/Runtime/SamplingProfilerTests.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 
 using System;
 using System.Collections.Generic;
@@ -110,7 +110,10 @@ public class SamplingProfilerTests
         var total = self.Values.Sum();
 
         self.Should().ContainKey("innermost");
-        (self["innermost"] / total).Should().BeGreaterThan(0.9, "the loop is the only work the script does");
+        // A wall-clock sampler over-attributes to whichever frame is on top when a descheduled thread is
+        // sampled, so on a loaded CI runner this share has read 0.881, 0.842 and 0.895 with no profiler change
+        // in the pull request; 0.8 still says the loop dominates, which is what the test is about.
+        (self["innermost"] / total).Should().BeGreaterThan(0.8, "the loop is the only work the script does");
 
         // middle and outermost do nothing but delegate, so they own almost no self time and almost all of
         // the inclusive time - which is the shape a call tree has to show for a profile to be worth reading.


### PR DESCRIPTION
`TheHotFunctionDominatesSelfTime` has failed the Linux leg three times in two days on pull requests that touch no profiler code, reading 0.881, 0.842 and 0.895 against a 0.9 floor. A wall-clock sampler over-attributes to whichever frame is on top when a descheduled thread is sampled, so on a loaded runner the share drifts down. The assertion is about the loop dominating, not a speed figure; 0.8 keeps the property and stops the re-runs. One line plus the comment that says why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
