### PR TITLE
A page evaluates XPath, the obstacle course waits on an expression, and the handshake pin replays parameter shapes

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,11 +12,13 @@
          these assemblies' [DomName] surface. Bump both together, regenerate, and read the diff. -->
     <PackageVersion Include="AngleSharp" Version="1.7.2" />
     <PackageVersion Include="AngleSharp.Css" Version="1.0.2" />
-    <!-- AngleSharp.Xml is deliberately NOT in the binding generator's pin: the generator reads AngleSharp and
-         AngleSharp.Css and nothing else, and this package contributes no [DomName] interface to the binding.
-         It is referenced for one thing only — DOMParser's XML content types, which need an XML parser and
-         which this package's own principle says must not be written here. -->
+    <!-- Neither of these is in the binding generator's pin, and deliberately: the generator reads AngleSharp
+         and AngleSharp.Css and nothing else, and neither of these carries a [DomName] the binding could
+         project. Each is referenced for one thing the package's own principle says must not be written here —
+         DOMParser's XML content types, which need an XML parser, and DOM §7's XPath, which needs an
+         XPathNavigator over an AngleSharp tree. -->
     <PackageVersion Include="AngleSharp.Xml" Version="1.2.0" />
+    <PackageVersion Include="AngleSharp.XPath" Version="2.0.6" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="BenchmarkDotNet.TestAdapter" Version="0.15.8" />
     <PackageVersion Include="AwesomeAssertions" Version="9.6.0" />

--- a/Jint.Browser/DevTools/AGENTS.md
+++ b/Jint.Browser/DevTools/AGENTS.md
@@ -37,9 +37,13 @@ target/runtime split and the manifest are there and none of it is repeated here.
   reason a client that never called `getDocument` hears nothing. The records are AngleSharp's, delivered on
   the engine's queue at the same checkpoint a page's own `MutationObserver` fires. Every box is the flat
   model's ([`Runtime/AGENTS.md`](../Runtime/AGENTS.md)), and a node with no box is refused in Chrome's wording
-  rather than answered with zeros. `Input` is `dispatchMouseEvent`, `dispatchKeyEvent`, `insertText` and an
+  rather than answered with zeros. `performSearch` is Chrome's three arms in Chrome's order — a selector,
+  an XPath expression (the same evaluator `document.evaluate` answers from), then a text substring — and a
+  query that is none of them contributes nothing rather than failing, because a search box is typed into
+  one character at a time. `Input` is `dispatchMouseEvent`, `dispatchKeyEvent`, `insertText` and an
   `imeSetComposition` that is accepted and changes nothing; touch, drag and the synthesized gestures are
-  honestly `-32601`. The keyboard's own rules are
+  honestly `-32601`, and the public `Page.ClickAsync`/`TypeAsync`/`PressAsync` reach the same dispatcher
+  rather than a second one. The keyboard's own rules are
   [above](../AGENTS.md#the-keyboard-and-the-editor-under-it).
 - **A named isolated world is made again over every document.** Chrome does that, and Puppeteer and
   Playwright each create one utility world when they attach and then use it for the life of the page — so a
@@ -83,8 +87,11 @@ target/runtime split and the manifest are there and none of it is repeated here.
   draw on a surface that does not exist; `Security` has no certificate decision to report, the transport
   being the host's own `HttpClient`.
 
-`Jint.Tests.Browser/DevTools/` holds the handshake replay of every step four recorded clients walked but the
-two no domain here answers, `PageProtocolManifestTests` (the page half of the property `Jint.Tests.DevTools`
+`Jint.Tests.Browser/DevTools/` holds two handshake replays — every *method* four recorded clients sent, and
+every parameter **shape** they sent it with, the second built out of each call's own `paramsKeys` and typed
+from the vendored protocol, because the two Playwright defects C7 found were shapes (`Target.getTargetInfo`
+with no parameters, a default-context page naming no context) and a name-only pin cannot see one —
+`PageProtocolManifestTests` (the page half of the property `Jint.Tests.DevTools`
 holds for the engine half), a suite per domain — `DomDomainTests`, `NetworkDomainTests`, `FetchDomainTests`,
 `EmulationDomainTests`, `AccessibilityDomainTests`, `FrontEndDomainTests` — and the two client suites, the
 only tests here that can claim client compatibility, because they are the only ones that satisfy a library

--- a/Jint.Browser/DevTools/DomDomain.Events.cs
+++ b/Jint.Browser/DevTools/DomDomain.Events.cs
@@ -1,4 +1,6 @@
+using System.Xml.XPath;
 using AngleSharp.Dom;
+using AngleSharp.XPath;
 using Jint.Browser.Layout;
 using Jint.Browser.Runtime;
 using Jint.DevTools;
@@ -368,6 +370,49 @@ internal sealed partial class DomDomain
             return parent.QuerySelectorAll(selector);
         }
         catch (DomException)
+        {
+            return [];
+        }
+    }
+
+    /// <summary>
+    /// The nodes an XPath expression selects, or none when <paramref name="query"/> is not one.
+    /// </summary>
+    /// <remarks>
+    /// <c>System.Xml.XPath</c> over <c>AngleSharp.XPath</c>'s navigator, which is the same evaluator
+    /// <c>document.evaluate</c> answers from — so a front end's search and a page's own XPath agree. A query
+    /// that is not an expression raises, and raising is how this arm says "not mine": a search box is typed
+    /// into one character at a time, and every prefix of <c>//div</c> would otherwise be an error.
+    /// </remarks>
+    private static List<INode> XPathMatches(IDocument document, string query)
+    {
+        if (query.Length == 0 || document.DocumentElement is null)
+        {
+            return [];
+        }
+
+        try
+        {
+            var navigator = new HtmlDocumentNavigator(document, document, ignoreNamespaces: true);
+
+            if (navigator.Evaluate(query) is not XPathNodeIterator nodes)
+            {
+                return [];
+            }
+
+            var found = new List<INode>();
+
+            while (nodes.MoveNext())
+            {
+                if (nodes.Current is HtmlDocumentNavigator { CurrentNode: { } node })
+                {
+                    found.Add(node);
+                }
+            }
+
+            return found;
+        }
+        catch (Exception exception) when (exception is XPathException or ArgumentException)
         {
             return [];
         }

--- a/Jint.Browser/DevTools/DomDomain.cs
+++ b/Jint.Browser/DevTools/DomDomain.cs
@@ -414,13 +414,12 @@ internal sealed partial class DomDomain : DOMDomainBase, IDetachableDomain, ITar
     /// a text match.
     /// </summary>
     /// <remarks>
-    /// <b>Two of Chrome's three, and the missing one is XPath.</b> Chrome tries the query as a selector, as
-    /// plain text and as an XPath expression; AngleSharp's XPath support is a separate package this project
-    /// does not reference, and adding one for a command no recorded client sends would be a dependency
-    /// bought for a front-end search box. What is here is the selector — matched first, so
-    /// <c>performSearch("div")</c> finds elements rather than the word — and then a case-insensitive
-    /// substring of a text node's data or of an attribute's value, which is what the other two of Chrome's
-    /// three arms cover between them.
+    /// <b>Chrome's three arms, in Chrome's order.</b> The query is tried as a selector first, so
+    /// <c>performSearch("div")</c> finds elements rather than the word; then as an XPath expression, which is
+    /// what a front end's search box sends for anything beginning <c>//</c> or <c>(</c>; then as a
+    /// case-insensitive substring of a text node's data or of an attribute's value. A query that is not one
+    /// of the three simply contributes nothing rather than failing the command — a search box is allowed to
+    /// be typed into one character at a time.
     /// </remarks>
     protected override ValueTask<PerformSearchResponse> PerformSearchAsync(PerformSearchRequest parameters, CommandContext context)
     {
@@ -433,6 +432,14 @@ internal sealed partial class DomDomain : DOMDomainBase, IDetachableDomain, ITar
             if (seen.Add(element))
             {
                 found.Add(element);
+            }
+        }
+
+        foreach (var node in XPathMatches(document, parameters.Query))
+        {
+            if (seen.Add(node))
+            {
+                found.Add(node);
             }
         }
 

--- a/Jint.Browser/Dom/AGENTS.md
+++ b/Jint.Browser/Dom/AGENTS.md
@@ -67,11 +67,11 @@ for decisions, the report is for consequences.
   `<div>`. Its shape is empty: HTML gives the interface no members beyond `WindowEventHandlers`, which this
   package puts on `HTMLElement`. Its index continues `DomInterfaces`' own, which is what keeps `DomRealm`'s
   per-engine arrays a dense array.
-- **`Document` is the one interface object a script may call `new` on.** AngleSharp puts `[DomConstructor]` on
-  no `[DomName]` interface at all, so the generator can never learn that an interface is constructible and
-  `DomInterfaceObject` refuses every `new` — which is also what a browser answers for `new HTMLDivElement()`.
-  The document it makes is DOM's: an XML document with no doctype, no document element and no browsing
-  context.
+- **`Document` and `DocumentFragment` are the interface objects a script may call `new` on.** AngleSharp
+  puts `[DomConstructor]` on no `[DomName]` interface at all, so the generator can never learn that an
+  interface is constructible and `DomInterfaceObject` refuses every `new` — which is also what a browser
+  answers for `new HTMLDivElement()`. The document it makes is DOM's: an XML document with no doctype, no
+  document element and no browsing context; the fragment's node document is the page's.
 
 ### The conversion table, and where it diverges from a browser
 
@@ -147,6 +147,35 @@ here:
 The `dataset` one has a visible consequence inside the binding, and the one place a workaround is legitimate:
 the generated `SupportedNames` filters out a `null` value, because the projection's three hooks must agree at
 the same instant or host-contract verification fails. That is keeping *our* contract, not mending AngleSharp's.
+
+### DOM §7's XPath, and CSSOM's `CSS`
+
+Two surfaces neither pinned assembly declares, so neither could be generated: there is no
+`[DomName("evaluate")]` and no `[DomName("escape")]` anywhere in AngleSharp or AngleSharp.Css. Both are
+hand-written in `Dom/Views/` beside `DOMParser`, and the three `Document` members XPath adds are
+`overrides.json` `additions`. `Jint.Tests.Browser/Fixtures/htmx` is why: htmx 2 builds an `XPathEvaluator`
+expression and calls `CSS.escape` at the top level of its bundle.
+
+- **The XPath engine is `System.Xml.XPath` over `AngleSharp.XPath`'s `HtmlDocumentNavigator`** — the
+  AngleSharp project's own package, referenced for this and nothing else, and exactly the seam the BCL's
+  XPath 1.0 evaluator takes. Writing an evaluator here instead is the one thing this package is not for.
+- **Namespaces are ignored, and that is what makes `//div` match.** An HTML element is in the XHTML
+  namespace, so an unprefixed XPath 1.0 name test — which is what every page writes — would match nothing
+  if the navigator reported it; `AngleSharp.XPath`'s own default is the same choice. The consequence is
+  stated rather than hidden: a *prefixed* test (`svg:circle`) compiles, because a resolver the page
+  supplied is consulted while the expression is compiled, and then matches nothing.
+- **A node set is materialized at evaluation**, so `invalidIteratorState` is always `false` and an
+  iterator survives a mutation instead of raising `InvalidStateError`. DOM's iterator is live and needs a
+  mutation signal this has none of; the direction is the safe one, because what it removes is a page
+  throwing.
+- **`CSS` is a namespace object, not an interface** — no constructor, no prototype, `[object CSS]` — and
+  it carries both members rather than the one htmx needs, because `window.CSS && CSS.supports(…)` is how
+  the feature is detected and half of it is a trap. `escape` is CSSOM's serialize-an-identifier;
+  `supports` parses the condition as an `@supports` rule and asks AngleSharp.Css's own
+  `IConditionFunction.Check`, so what this claims to support is exactly what the cascade can act on.
+- **`DomConstructors` grew a second entry**: `new DocumentFragment()`, which DOM gives a constructor and
+  htmx builds for every swap whose response starts with `<html>` or `<body>`. The shortness of that table
+  is still the point.
 
 ### Wrapper identity, and the two classes that are not one hierarchy
 

--- a/Jint.Browser/Dom/DomConstructors.cs
+++ b/Jint.Browser/Dom/DomConstructors.cs
@@ -11,13 +11,14 @@ namespace Jint.Browser.Dom;
 /// </summary>
 /// <remarks>
 /// <para>
-/// <b>There is exactly one, and the emptiness of this table is the point.</b> AngleSharp puts
+/// <b>There are two, and the shortness of this table is the point.</b> AngleSharp puts
 /// <c>[DomConstructor]</c> on concrete classes and on no <c>[DomName]</c> interface, so the generator can
 /// never learn that an interface is constructible; <see cref="DomInterfaceObject"/> therefore refuses every
 /// <c>new</c>, which is also what a browser answers for <c>new HTMLDivElement()</c> and for all but a handful
-/// of DOM's interfaces. <c>Document</c> is the one this corpus reaches for —
-/// https://dom.spec.whatwg.org/#dom-document-document, "the Document() constructor" — and it is a decision
-/// rather than a projection, so it is written here by name.
+/// of DOM's interfaces. The two here are the ones this corpus reaches for and each is a decision rather than
+/// a projection: <c>Document</c> (https://dom.spec.whatwg.org/#dom-document-document) and
+/// <c>DocumentFragment</c> (https://dom.spec.whatwg.org/#dom-documentfragment-documentfragment), which htmx 2
+/// builds for every swap whose response starts with <c>&lt;html&gt;</c> or <c>&lt;body&gt;</c>.
 /// </para>
 /// <para>
 /// The document it makes is DOM's: an <b>XML</b> document with no doctype, no document element and no
@@ -37,6 +38,17 @@ internal static class DomConstructors
         if (ReferenceEquals(definition, DomInterfaces.Document))
         {
             instance = (ObjectInstance) realm.WrapNode(NewXmlDocument());
+            return true;
+        }
+
+        if (ReferenceEquals(definition, DomInterfaces.DocumentFragment))
+        {
+            // https://dom.spec.whatwg.org/#dom-documentfragment-documentfragment — the node document is the
+            // current global object's associated Document, which here is the page's. A binding installed on
+            // a bare engine has none, and an empty document of its own is the honest owner for a fragment
+            // nothing else can reach.
+            var document = Runtime.PageRuntime.Find(realm.Engine)?.Document ?? NewXmlDocument();
+            instance = (ObjectInstance) realm.WrapNode(document.CreateDocumentFragment());
             return true;
         }
 

--- a/Jint.Browser/Dom/Generated/DomShapes.Dom.g.cs
+++ b/Jint.Browser/Dom/Generated/DomShapes.Dom.g.cs
@@ -725,6 +725,20 @@ internal static partial class DomInterfaces
                     return global::Jint.Browser.Events.LegacyEventCreation.CreateEvent(self.Realm, args);
                 },
                 length: 1)
+            .Method("createExpression",
+                static (thisObj, args) =>
+                {
+                    _ = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.createExpression");
+                    return global::Jint.Browser.Dom.Views.XPathEvaluation.CreateExpression(global::Jint.Browser.Runtime.PageRuntime.Of(thisObj, "Document.createExpression"), args, "Document.createExpression");
+                },
+                length: 1)
+            .Method("createNSResolver",
+                static (thisObj, args) =>
+                {
+                    _ = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.createNSResolver");
+                    return global::Jint.Browser.Dom.Views.XPathEvaluation.CreateNSResolver(args, "Document.createNSResolver");
+                },
+                length: 1)
             .Method("createNodeIterator",
                 static (thisObj, args) =>
                 {
@@ -844,6 +858,13 @@ internal static partial class DomInterfaces
                     self.Target.EnableStyleSheetsForSet(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Document.enableStyleSheetsForSet")); return global::Jint.Native.JsValue.Undefined;
                 },
                 length: 1)
+            .Method("evaluate",
+                static (thisObj, args) =>
+                {
+                    _ = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.evaluate");
+                    return global::Jint.Browser.Dom.Views.XPathEvaluation.Evaluate(global::Jint.Browser.Runtime.PageRuntime.Of(thisObj, "Document.evaluate"), args, "Document.evaluate");
+                },
+                length: 2)
             .Method("execCommand",
                 static (thisObj, args) =>
                 {

--- a/Jint.Browser/Dom/HostInterfaceObject.cs
+++ b/Jint.Browser/Dom/HostInterfaceObject.cs
@@ -35,7 +35,8 @@ internal sealed class HostInterfaceObject : Constructor
         ObjectInstance prototype,
         int length,
         Func<JsValue[], ObjectInstance>? construct = null,
-        ObjectInstance? parent = null)
+        ObjectInstance? parent = null,
+        (string Name, int Value)[]? constants = null)
         : base(engine, realm, new JsString(name))
     {
         _name = name;
@@ -46,6 +47,20 @@ internal sealed class HostInterfaceObject : Constructor
         // https://webidl.spec.whatwg.org/#interface-object — { writable: false, enumerable: false,
         // configurable: false }.
         _prototypeDescriptor = new PropertyDescriptor(prototype, PropertyFlag.AllForbidden);
+
+        // https://webidl.spec.whatwg.org/#es-constants — a constant is an own property of BOTH the interface
+        // object and the interface prototype object, so `XPathResult.FIRST_ORDERED_NODE_TYPE` and
+        // `result.FIRST_ORDERED_NODE_TYPE` both answer. The prototype's copy comes from its shape; this is
+        // the other one, and DomInterfaceObject does exactly this for a generated interface.
+        if (constants is not null)
+        {
+            foreach (var (constantName, value) in constants)
+            {
+                DefineOwnPropertyUnchecked(
+                    constantName,
+                    new PropertyDescriptor(JsNumber.Create(value), PropertyFlag.OnlyEnumerable));
+            }
+        }
     }
 
     /// <summary>https://webidl.spec.whatwg.org/#es-interface-call — an interface object is never callable.</summary>

--- a/Jint.Browser/Dom/Views/JsCssNamespace.cs
+++ b/Jint.Browser/Dom/Views/JsCssNamespace.cs
@@ -1,0 +1,124 @@
+using System.Globalization;
+using System.Text;
+using AngleSharp.Css;
+using AngleSharp.Css.Dom;
+using AngleSharp.Css.Parser;
+using Jint.Native;
+using Jint.Runtime;
+
+namespace Jint.Browser.Dom.Views;
+
+/// <summary>
+/// CSSOM's <c>CSS</c> namespace: <c>escape</c> and <c>supports</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>It is a namespace object, not an interface</b> — <a href="https://drafts.csswg.org/cssom/#namespacedef-css">
+/// CSSOM</a> declares <c>namespace CSS</c>, so there is no constructor, no prototype and no instances, and
+/// <c>Object.prototype.toString.call(CSS)</c> is <c>[object CSS]</c>. <c>NodeFilter</c> is the same shape of
+/// thing here for the same reason.
+/// </para>
+/// <para>
+/// <b>Both members are here because half of one is a trap.</b> htmx 2 needs <c>CSS.escape</c> — it builds
+/// <c>'#' + CSS.escape(id)</c> for every out-of-band swap — and a page that tests
+/// <c>window.CSS &amp;&amp; CSS.supports(…)</c>, which is how the feature is detected, would find a truthy
+/// <c>CSS</c> whose <c>supports</c> is <see langword="undefined"/> and fail on the <i>second</i> half.
+/// </para>
+/// <para>
+/// <b><c>supports</c> is AngleSharp.Css's own condition evaluator</b>, reached the only way the library
+/// exposes it: the condition is parsed as an <c>@supports</c> rule and
+/// <c>IConditionFunction.Check</c> answers it. So the set of properties this claims to support is exactly the
+/// set that library implements, which is also the set the cascade can act on — one answer rather than two.
+/// </para>
+/// </remarks>
+internal static class JsCssNamespace
+{
+    private static readonly CssParser _parser = new();
+
+    /// <summary>
+    /// https://drafts.csswg.org/cssom/#the-css.escape()-method — CSS's "serialize an identifier".
+    /// </summary>
+    internal static JsValue Escape(JsValue[] arguments)
+    {
+        var identifier = TypeConverter.ToString(arguments.At(0));
+        var builder = new StringBuilder(identifier.Length);
+
+        for (var i = 0; i < identifier.Length; i++)
+        {
+            var character = identifier[i];
+
+            // https://drafts.csswg.org/cssom/#serialize-an-identifier, in its own order.
+            if (character == '\0')
+            {
+                builder.Append('\uFFFD');
+            }
+            else if (character <= '\u001F' || character == '\u007F'
+                || (i == 0 && IsDigit(character))
+                || (i == 1 && IsDigit(character) && identifier[0] == '-'))
+            {
+                builder.Append('\\')
+                    .Append(((int) character).ToString("x", CultureInfo.InvariantCulture))
+                    .Append(' ');
+            }
+            else if (i == 0 && character == '-' && identifier.Length == 1)
+            {
+                builder.Append("\\-");
+            }
+            else if (character >= '\u0080' || character == '-' || character == '_' || IsDigit(character)
+                || (character >= 'A' && character <= 'Z') || (character >= 'a' && character <= 'z'))
+            {
+                builder.Append(character);
+            }
+            else
+            {
+                builder.Append('\\').Append(character);
+            }
+        }
+
+        return JsString.Create(builder.ToString());
+    }
+
+    /// <summary>
+    /// https://drafts.csswg.org/css-conditional-3/#dom-css-supports — the one-argument and two-argument forms.
+    /// </summary>
+    /// <remarks>
+    /// The two-argument form is a declaration wrapped in parentheses, which is what the standard says it is;
+    /// a value carrying an unbalanced parenthesis therefore makes the whole condition unparseable and answers
+    /// <see langword="false"/>, where a browser reads the value with a proper value parser and answers the
+    /// same thing for a different reason.
+    /// </remarks>
+    internal static JsValue Supports(JsValue[] arguments)
+    {
+        var condition = arguments.Length >= 2
+            ? "(" + TypeConverter.ToString(arguments.At(0)) + ":" + TypeConverter.ToString(arguments.At(1)) + ")"
+            : TypeConverter.ToString(arguments.At(0));
+
+        return JsBoolean.Create(IsSupported(condition));
+    }
+
+    private static bool IsSupported(string condition)
+    {
+        try
+        {
+            var sheet = _parser.ParseStyleSheet("@supports " + condition + " { }");
+
+            foreach (var rule in sheet.Rules)
+            {
+                if (rule is ICssSupportsRule supports)
+                {
+                    return supports.Condition.Check(new DefaultRenderDevice());
+                }
+            }
+        }
+        catch (Exception exception) when (exception is not JavaScriptException)
+        {
+            // A condition the parser cannot read is one this does not support, which is what the standard's
+            // "return false" step amounts to. AngleSharp raises rather than answering for some of them.
+            return false;
+        }
+
+        return false;
+    }
+
+    private static bool IsDigit(char character) => character >= '0' && character <= '9';
+}

--- a/Jint.Browser/Dom/Views/JsXPath.cs
+++ b/Jint.Browser/Dom/Views/JsXPath.cs
@@ -1,0 +1,584 @@
+using System.Globalization;
+using System.Xml;
+using System.Xml.XPath;
+using AngleSharp.Dom;
+using AngleSharp.XPath;
+using Jint.Browser.Runtime;
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.WebApi.DomException;
+using CompiledExpression = System.Xml.XPath.XPathExpression;
+
+namespace Jint.Browser.Dom.Views;
+
+/// <summary>
+/// DOM §7's XPath: <c>XPathEvaluator</c>, <c>XPathExpression</c>, <c>XPathResult</c> and the three members
+/// <c>Document</c> gains from <c>XPathEvaluatorBase</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The engine is <c>System.Xml.XPath</c>, over <c>AngleSharp.XPath</c>'s navigator.</b> That package —
+/// the AngleSharp project's own, MIT, referenced for this and nothing else — is an
+/// <c>XPathNavigator</c> implementation over an AngleSharp tree, which is exactly the seam the BCL's XPath 1.0
+/// evaluator takes. Writing an XPath engine here instead would be the thing this package is not for.
+/// <b>It carries no <c>[DomName]</c> anywhere</b>, and neither does AngleSharp: there is no
+/// <c>IXPathEvaluator</c>, no <c>evaluate</c> on <c>IDocument</c>, nothing for the generator to project. So
+/// these three interfaces are hand-written host interfaces beside <c>DOMParser</c> and <c>Selection</c>, and
+/// the three <c>Document</c> members are <c>overrides.json</c> <c>additions</c>.
+/// </para>
+/// <para>
+/// <b>Namespaces are ignored, and that is what makes <c>//div</c> match.</b> An HTML element is in the XHTML
+/// namespace, so an XPath 1.0 name test with no prefix — which is what every page writes — would match
+/// nothing at all if the navigator reported it. <c>AngleSharp.XPath</c>'s own default is the same choice, and
+/// a browser reaches it from the other side (HTML documents get a name test that matches the HTML namespace).
+/// The consequence is stated rather than hidden: a <i>prefixed</i> name test (<c>svg:circle</c>) compiles,
+/// because a resolver the page supplied is consulted for the prefix, and then matches nothing, because the
+/// navigator answers no namespace for any node.
+/// </para>
+/// <para>
+/// <b>A node-set is materialized at evaluation.</b> DOM's iterator is live and becomes invalid when the
+/// document is mutated under it; this takes the snapshot immediately, so <c>invalidIteratorState</c> is
+/// always <see langword="false"/> and an iterator survives a mutation instead of raising
+/// <c>InvalidStateError</c>. That is the one divergence in the result object, and it is the safe direction:
+/// the failure mode it removes is a page throwing, and the one it introduces is a page seeing a node that has
+/// since moved.
+/// </para>
+/// </remarks>
+internal static class XPathEvaluation
+{
+    /// <summary>https://dom.spec.whatwg.org/#dom-xpathresult-any_type and the nine after it.</summary>
+    internal const int AnyType = 0;
+
+    internal const int NumberType = 1;
+    internal const int StringType = 2;
+    internal const int BooleanType = 3;
+    internal const int UnorderedNodeIteratorType = 4;
+    internal const int OrderedNodeIteratorType = 5;
+    internal const int UnorderedNodeSnapshotType = 6;
+    internal const int OrderedNodeSnapshotType = 7;
+    internal const int AnyUnorderedNodeType = 8;
+    internal const int FirstOrderedNodeType = 9;
+
+    /// <summary>
+    /// The ten result-type constants, by the names WebIDL gives them.
+    /// </summary>
+    /// <remarks>
+    /// <a href="https://webidl.spec.whatwg.org/#es-constants">WebIDL</a> puts a constant on <b>both</b> the
+    /// interface object and the interface prototype object, so <c>XPathResult.FIRST_ORDERED_NODE_TYPE</c> —
+    /// the spelling every page actually writes — and <c>result.FIRST_ORDERED_NODE_TYPE</c> both answer. The
+    /// prototype's copy comes from the shape; the list is here so that both copies are one table.
+    /// </remarks>
+    internal static (string Name, int Value)[] ResultConstants { get; } =
+    [
+        ("ANY_TYPE", AnyType),
+        ("NUMBER_TYPE", NumberType),
+        ("STRING_TYPE", StringType),
+        ("BOOLEAN_TYPE", BooleanType),
+        ("UNORDERED_NODE_ITERATOR_TYPE", UnorderedNodeIteratorType),
+        ("ORDERED_NODE_ITERATOR_TYPE", OrderedNodeIteratorType),
+        ("UNORDERED_NODE_SNAPSHOT_TYPE", UnorderedNodeSnapshotType),
+        ("ORDERED_NODE_SNAPSHOT_TYPE", OrderedNodeSnapshotType),
+        ("ANY_UNORDERED_NODE_TYPE", AnyUnorderedNodeType),
+        ("FIRST_ORDERED_NODE_TYPE", FirstOrderedNodeType),
+    ];
+
+    /// <summary>
+    /// https://dom.spec.whatwg.org/#dom-xpathevaluatorbase-createexpression — compiles, or raises the
+    /// <c>SyntaxError</c> the standard names.
+    /// </summary>
+    internal static JsValue CreateExpression(PageRuntime runtime, JsValue[] arguments, string member)
+    {
+        var source = DomConvert.RequiredText(arguments, 0, member);
+        var resolver = NamespaceResolver.From(runtime, arguments.At(1), member);
+
+        return new JsXPathExpression(runtime, runtime.Views.XPathExpressionPrototype, Compile(runtime, source, resolver, member));
+    }
+
+    /// <summary>
+    /// https://dom.spec.whatwg.org/#dom-xpathevaluatorbase-creatensresolver — legacy, and the whole of it is
+    /// "return the node".
+    /// </summary>
+    /// <remarks>
+    /// DOM keeps the member only because pages call it, and its steps are one line: the node itself is the
+    /// resolver, because a <c>Node</c> already has <c>lookupNamespaceURI</c>.
+    /// </remarks>
+    internal static JsValue CreateNSResolver(JsValue[] arguments, string member)
+    {
+        var node = DomBindings.Argument<INode>(arguments, 0, member);
+        _ = node;
+        return arguments.At(0);
+    }
+
+    /// <summary>
+    /// https://dom.spec.whatwg.org/#dom-xpathevaluatorbase-evaluate — compile and evaluate in one call.
+    /// </summary>
+    internal static JsValue Evaluate(PageRuntime runtime, JsValue[] arguments, string member)
+    {
+        var source = DomConvert.RequiredText(arguments, 0, member);
+        var context = DomBindings.Argument<INode>(arguments, 1, member);
+        var resolver = NamespaceResolver.From(runtime, arguments.At(2), member);
+        var type = DomConvert.OptionalInt32(arguments, 3, AnyType);
+
+        return Run(runtime, Compile(runtime, source, resolver, member), context, type, member);
+    }
+
+    /// <summary>
+    /// https://dom.spec.whatwg.org/#dom-xpathexpression-evaluate — the expression against one context node.
+    /// </summary>
+    internal static JsValue Run(PageRuntime runtime, CompiledExpression expression, INode context, int type, string member)
+    {
+        var document = context as IDocument ?? context.Owner;
+
+        if (document is null)
+        {
+            Throw.TypeError(runtime.Engine._mainRealm, "Failed to execute '" + member + "': the context node has no document.");
+            return JsValue.Undefined;
+        }
+
+        // The navigator is positioned at the context node, which is what makes a relative expression — htmx's
+        // `.//*[…]` — mean what the page meant by it.
+        var navigator = new HtmlDocumentNavigator(document, context, ignoreNamespaces: true);
+        object evaluated;
+
+        try
+        {
+            evaluated = navigator.Evaluate(expression.Clone());
+        }
+        catch (XPathException exception)
+        {
+            Throw.JavaScriptException(
+                runtime.Engine,
+                runtime.Engine._mainRealm.Intrinsics.DomException.CreateException(
+                    DomExceptionNames.Syntax,
+                    "Failed to execute '" + member + "': " + exception.Message),
+                runtime.Engine.GetLastSyntaxElement()?.Location ?? default);
+            return JsValue.Undefined;
+        }
+
+        return new JsXPathResult(runtime, runtime.Views.XPathResultPrototype, Coerce(runtime, evaluated, type, member));
+    }
+
+    /// <summary>Compiles one expression, turning a parse failure into the standard's <c>SyntaxError</c>.</summary>
+    private static CompiledExpression Compile(PageRuntime runtime, string source, IXmlNamespaceResolver? resolver, string member)
+    {
+        try
+        {
+            var expression = CompiledExpression.Compile(source);
+
+            if (resolver is not null)
+            {
+                expression.SetContext(resolver);
+            }
+
+            return expression;
+        }
+        catch (Exception exception) when (exception is XPathException or ArgumentException)
+        {
+            Throw.JavaScriptException(
+                runtime.Engine,
+                runtime.Engine._mainRealm.Intrinsics.DomException.CreateException(
+                    DomExceptionNames.Syntax,
+                    "Failed to execute '" + member + "': The string '" + source + "' is not a valid XPath expression."),
+                runtime.Engine.GetLastSyntaxElement()?.Location ?? default);
+            return null!;
+        }
+    }
+
+    /// <summary>
+    /// https://dom.spec.whatwg.org/#concept-evaluate — what the requested result type makes of what XPath
+    /// answered.
+    /// </summary>
+    private static XPathAnswer Coerce(PageRuntime runtime, object evaluated, int type, string member)
+    {
+        if (evaluated is XPathNodeIterator nodes)
+        {
+            return NodeSet(runtime, nodes, type, member);
+        }
+
+        // A non-node-set can still be asked for as a number, a string or a boolean, and XPath 1.0's own
+        // conversions are what the standard names.
+        return type switch
+        {
+            AnyType => evaluated switch
+            {
+                double number => XPathAnswer.Number(NumberType, number),
+                bool flag => XPathAnswer.Boolean(BooleanType, flag),
+                _ => XPathAnswer.String(StringType, Text(evaluated)),
+            },
+            NumberType => XPathAnswer.Number(NumberType, Number(evaluated)),
+            StringType => XPathAnswer.String(StringType, Text(evaluated)),
+            BooleanType => XPathAnswer.Boolean(BooleanType, Boolean(evaluated)),
+            _ => WrongType(runtime, member),
+        };
+    }
+
+    private static XPathAnswer NodeSet(PageRuntime runtime, XPathNodeIterator nodes, int type, string member)
+    {
+        // The whole set, now: DOM's live iterator needs a mutation signal this has none of, and the class
+        // summary states the divergence that follows.
+        var found = new List<INode>();
+
+        while (nodes.MoveNext())
+        {
+            if (nodes.Current is HtmlDocumentNavigator { CurrentNode: { } node })
+            {
+                found.Add(node);
+            }
+        }
+
+        return type switch
+        {
+            AnyType => XPathAnswer.NodeSet(UnorderedNodeIteratorType, found),
+            UnorderedNodeIteratorType or OrderedNodeIteratorType
+                or UnorderedNodeSnapshotType or OrderedNodeSnapshotType
+                or AnyUnorderedNodeType or FirstOrderedNodeType => XPathAnswer.NodeSet(type, found),
+
+            // XPath 1.0's node-set conversions: a set is true when it is not empty, and its string value is
+            // its first node's.
+            NumberType => XPathAnswer.Number(NumberType, StringToNumber(FirstText(found))),
+            StringType => XPathAnswer.String(StringType, FirstText(found)),
+            BooleanType => XPathAnswer.Boolean(BooleanType, found.Count > 0),
+            _ => WrongType(runtime, member),
+        };
+    }
+
+    private static XPathAnswer WrongType(PageRuntime runtime, string member)
+    {
+        Throw.TypeError(
+            runtime.Engine._mainRealm,
+            "Failed to execute '" + member + "': The result is not a node set, and therefore cannot be converted to the desired type.");
+        return default;
+    }
+
+    private static string FirstText(List<INode> nodes) => nodes.Count == 0 ? "" : nodes[0].TextContent ?? "";
+
+    private static string Text(object value) => value switch
+    {
+        string text => text,
+        double number => NumberToString(number),
+        bool flag => flag ? "true" : "false",
+        _ => value?.ToString() ?? "",
+    };
+
+    private static double Number(object value) => value switch
+    {
+        double number => number,
+        bool flag => flag ? 1 : 0,
+        string text => StringToNumber(text),
+        _ => double.NaN,
+    };
+
+    private static bool Boolean(object value) => value switch
+    {
+        bool flag => flag,
+        double number => number != 0 && !double.IsNaN(number),
+        string text => text.Length > 0,
+        _ => false,
+    };
+
+    /// <summary>XPath 1.0 §4.4's <c>number()</c>: a string that is not a number is <c>NaN</c>.</summary>
+    private static double StringToNumber(string text)
+        => double.TryParse(text.Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out var value) ? value : double.NaN;
+
+    /// <summary>XPath 1.0 §4.2's <c>string()</c> of a number, which is not .NET's round-trip form.</summary>
+    private static string NumberToString(double number)
+    {
+        if (double.IsNaN(number))
+        {
+            return "NaN";
+        }
+
+        if (double.IsPositiveInfinity(number))
+        {
+            return "Infinity";
+        }
+
+        if (double.IsNegativeInfinity(number))
+        {
+            return "-Infinity";
+        }
+
+        return number.ToString("R", CultureInfo.InvariantCulture);
+    }
+}
+
+/// <summary>One evaluation's answer, in the shape <c>XPathResult</c> publishes it.</summary>
+/// <param name="ResultType">The <c>XPathResult</c> constant this is.</param>
+/// <param name="NumberValue">The number, for <c>NUMBER_TYPE</c>.</param>
+/// <param name="StringValue">The string, for <c>STRING_TYPE</c>.</param>
+/// <param name="BooleanValue">The boolean, for <c>BOOLEAN_TYPE</c>.</param>
+/// <param name="Nodes">The node set, for the six node types.</param>
+[System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Auto)]
+internal readonly record struct XPathAnswer(
+    int ResultType,
+    double NumberValue,
+    string StringValue,
+    bool BooleanValue,
+    List<INode>? Nodes)
+{
+    internal static XPathAnswer Number(int type, double value) => new(type, value, "", false, null);
+
+    internal static XPathAnswer String(int type, string value) => new(type, double.NaN, value, false, null);
+
+    internal static XPathAnswer Boolean(int type, bool value) => new(type, double.NaN, "", value, null);
+
+    internal static XPathAnswer NodeSet(int type, List<INode> nodes) => new(type, double.NaN, "", false, nodes);
+}
+
+/// <summary>
+/// https://dom.spec.whatwg.org/#interface-xpathevaluator — the constructible half of DOM's XPath.
+/// </summary>
+internal sealed class JsXPathEvaluator : ObjectInstance
+{
+    private readonly PageRuntime _runtime;
+
+    internal JsXPathEvaluator(PageRuntime runtime, ObjectInstance prototype) : base(runtime.Engine)
+    {
+        _runtime = runtime;
+        Prototype = prototype;
+    }
+
+    /// <inheritdoc />
+    public override string ToString() => "[object XPathEvaluator]";
+
+    /// <summary>The receiver check every member starts with.</summary>
+    internal static JsXPathEvaluator Brand(JsValue thisObject, string member)
+        => thisObject as JsXPathEvaluator ?? Illegal<JsXPathEvaluator>(thisObject, "XPathEvaluator", member);
+
+    internal JsValue CreateExpression(JsValue[] arguments)
+        => XPathEvaluation.CreateExpression(_runtime, arguments, "XPathEvaluator.createExpression");
+
+    internal JsValue Evaluate(JsValue[] arguments)
+        => XPathEvaluation.Evaluate(_runtime, arguments, "XPathEvaluator.evaluate");
+
+    /// <summary>The <c>Illegal invocation</c> a host member answers a receiver it was not called on.</summary>
+    internal static T Illegal<T>(JsValue thisObject, string interfaceName, string member) where T : class
+    {
+        var message = "Failed to execute '" + member + "' on '" + interfaceName + "': Illegal invocation";
+
+        if (thisObject is ObjectInstance instance)
+        {
+            Throw.TypeError(instance.Engine.Realm, message);
+        }
+
+        Throw.TypeErrorNoEngine(message);
+        return null!;
+    }
+}
+
+/// <summary>https://dom.spec.whatwg.org/#interface-xpathexpression — one compiled expression.</summary>
+internal sealed class JsXPathExpression : ObjectInstance
+{
+    private readonly PageRuntime _runtime;
+    private readonly CompiledExpression _expression;
+
+    internal JsXPathExpression(PageRuntime runtime, ObjectInstance prototype, CompiledExpression expression) : base(runtime.Engine)
+    {
+        _runtime = runtime;
+        _expression = expression;
+        Prototype = prototype;
+    }
+
+    /// <inheritdoc />
+    public override string ToString() => "[object XPathExpression]";
+
+    /// <summary>The receiver check the one member starts with.</summary>
+    internal static JsXPathExpression Brand(JsValue thisObject, string member)
+        => thisObject as JsXPathExpression ?? JsXPathEvaluator.Illegal<JsXPathExpression>(thisObject, "XPathExpression", member);
+
+    /// <summary>https://dom.spec.whatwg.org/#dom-xpathexpression-evaluate.</summary>
+    internal JsValue Evaluate(JsValue[] arguments)
+    {
+        var context = DomBindings.Argument<INode>(arguments, 0, "XPathExpression.evaluate");
+        var type = DomConvert.OptionalInt32(arguments, 1, XPathEvaluation.AnyType);
+
+        return XPathEvaluation.Run(_runtime, _expression, context, type, "XPathExpression.evaluate");
+    }
+}
+
+/// <summary>https://dom.spec.whatwg.org/#interface-xpathresult — what one evaluation answered.</summary>
+internal sealed class JsXPathResult : ObjectInstance
+{
+    private readonly PageRuntime _runtime;
+    private readonly XPathAnswer _answer;
+
+    private int _next;
+
+    internal JsXPathResult(PageRuntime runtime, ObjectInstance prototype, XPathAnswer answer) : base(runtime.Engine)
+    {
+        _runtime = runtime;
+        _answer = answer;
+        Prototype = prototype;
+    }
+
+    /// <inheritdoc />
+    public override string ToString() => "[object XPathResult]";
+
+    /// <summary>The receiver check every member starts with.</summary>
+    internal static JsXPathResult Brand(JsValue thisObject, string member)
+        => thisObject as JsXPathResult ?? JsXPathEvaluator.Illegal<JsXPathResult>(thisObject, "XPathResult", member);
+
+    /// <summary>https://dom.spec.whatwg.org/#dom-xpathresult-resulttype.</summary>
+    internal JsValue ResultType => JsNumber.Create(_answer.ResultType);
+
+    /// <summary>
+    /// https://dom.spec.whatwg.org/#dom-xpathresult-invaliditeratorstate — always <see langword="false"/>.
+    /// </summary>
+    /// <remarks>
+    /// The node set was taken whole at evaluation, so nothing a page does to the document afterwards can put
+    /// this iterator into the invalid state DOM defines. <see cref="XPathEvaluation"/> argues the choice.
+    /// </remarks>
+    internal static JsValue InvalidIteratorState => JsBoolean.False;
+
+    /// <summary>https://dom.spec.whatwg.org/#dom-xpathresult-numbervalue.</summary>
+    internal JsValue NumberValue
+        => JsNumber.Create(Require(XPathEvaluation.NumberType, "numberValue") ? _answer.NumberValue : double.NaN);
+
+    /// <summary>https://dom.spec.whatwg.org/#dom-xpathresult-stringvalue.</summary>
+    internal JsValue StringValue
+        => JsString.Create(Require(XPathEvaluation.StringType, "stringValue") ? _answer.StringValue : "");
+
+    /// <summary>https://dom.spec.whatwg.org/#dom-xpathresult-booleanvalue.</summary>
+    internal JsValue BooleanValue
+        => JsBoolean.Create(Require(XPathEvaluation.BooleanType, "booleanValue") && _answer.BooleanValue);
+
+    /// <summary>https://dom.spec.whatwg.org/#dom-xpathresult-singlenodevalue.</summary>
+    internal JsValue SingleNodeValue
+    {
+        get
+        {
+            if (_answer.ResultType is not (XPathEvaluation.AnyUnorderedNodeType or XPathEvaluation.FirstOrderedNodeType))
+            {
+                WrongType("singleNodeValue");
+            }
+
+            var nodes = _answer.Nodes;
+            return nodes is { Count: > 0 } ? _runtime.Dom.WrapNode(nodes[0]) : JsValue.Null;
+        }
+    }
+
+    /// <summary>https://dom.spec.whatwg.org/#dom-xpathresult-snapshotlength.</summary>
+    internal JsValue SnapshotLength
+    {
+        get
+        {
+            if (!IsSnapshot)
+            {
+                WrongType("snapshotLength");
+            }
+
+            return JsNumber.Create(_answer.Nodes?.Count ?? 0);
+        }
+    }
+
+    /// <summary>https://dom.spec.whatwg.org/#dom-xpathresult-iteratenext.</summary>
+    internal JsValue IterateNext()
+    {
+        if (_answer.ResultType is not (XPathEvaluation.UnorderedNodeIteratorType or XPathEvaluation.OrderedNodeIteratorType))
+        {
+            WrongType("iterateNext");
+        }
+
+        var nodes = _answer.Nodes;
+        return nodes is not null && _next < nodes.Count ? _runtime.Dom.WrapNode(nodes[_next++]) : JsValue.Null;
+    }
+
+    /// <summary>https://dom.spec.whatwg.org/#dom-xpathresult-snapshotitem.</summary>
+    internal JsValue SnapshotItem(JsValue[] arguments)
+    {
+        if (!IsSnapshot)
+        {
+            WrongType("snapshotItem");
+        }
+
+        var index = DomConvert.RequiredUInt32(arguments, 0, "XPathResult.snapshotItem");
+        var nodes = _answer.Nodes;
+
+        return nodes is not null && index < (uint) nodes.Count ? _runtime.Dom.WrapNode(nodes[(int) index]) : JsValue.Null;
+    }
+
+    private bool IsSnapshot
+        => _answer.ResultType is XPathEvaluation.UnorderedNodeSnapshotType or XPathEvaluation.OrderedNodeSnapshotType;
+
+    private bool Require(int type, string member)
+    {
+        if (_answer.ResultType != type)
+        {
+            WrongType(member);
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// https://dom.spec.whatwg.org/#interface-xpathresult — reading a value the result is not is a
+    /// <c>TypeError</c>.
+    /// </summary>
+    private void WrongType(string member)
+        => Throw.TypeError(
+            _runtime.Engine._mainRealm,
+            "Failed to read the '" + member + "' property from 'XPathResult': The result type is not "
+            + _answer.ResultType.ToString(CultureInfo.InvariantCulture) + "'s.");
+}
+
+/// <summary>
+/// A page's <c>XPathNSResolver</c>, seen by <c>System.Xml</c> as an <see cref="IXmlNamespaceResolver"/>.
+/// </summary>
+/// <remarks>
+/// WebIDL's callback interface admits both spellings — a function, and an object with a
+/// <c>lookupNamespaceURI</c> method — and a `Node` handed back by <c>createNSResolver</c> is the second. The
+/// resolver is consulted while the expression is <i>compiled</i>, which is the only thing that stops a
+/// prefixed name test from being a <c>SyntaxError</c>; matching is a separate question the class summary of
+/// <see cref="XPathEvaluation"/> answers.
+/// </remarks>
+internal sealed class NamespaceResolver : IXmlNamespaceResolver
+{
+    private readonly Engine _engine;
+    private readonly JsValue _resolver;
+
+    private NamespaceResolver(Engine engine, JsValue resolver)
+    {
+        _engine = engine;
+        _resolver = resolver;
+    }
+
+    /// <summary>The resolver a page passed, or <see langword="null"/> when it passed none.</summary>
+    internal static IXmlNamespaceResolver? From(PageRuntime runtime, JsValue resolver, string member)
+    {
+        if (resolver.IsNullOrUndefined())
+        {
+            return null;
+        }
+
+        if (resolver is not ObjectInstance)
+        {
+            Throw.TypeError(
+                runtime.Engine._mainRealm,
+                "Failed to execute '" + member + "': parameter is not an XPathNSResolver.");
+        }
+
+        return new NamespaceResolver(runtime.Engine, resolver);
+    }
+
+    /// <inheritdoc />
+    public IDictionary<string, string> GetNamespacesInScope(XmlNamespaceScope scope)
+        => new Dictionary<string, string>(StringComparer.Ordinal);
+
+    /// <inheritdoc />
+    public string? LookupNamespace(string prefix)
+    {
+        var argument = string.IsNullOrEmpty(prefix) ? JsValue.Null : JsString.Create(prefix);
+
+        var answer = _resolver is ICallable callable
+            ? callable.Call(JsValue.Undefined, argument)
+            : _resolver.Get("lookupNamespaceURI") is ICallable method
+                ? method.Call(_resolver, argument)
+                : JsValue.Null;
+
+        return answer.IsNullOrUndefined() ? null : TypeConverter.ToString(answer);
+    }
+
+    /// <inheritdoc />
+    public string? LookupPrefix(string namespaceName) => null;
+}

--- a/Jint.Browser/Dom/Views/ViewInstaller.cs
+++ b/Jint.Browser/Dom/Views/ViewInstaller.cs
@@ -10,13 +10,15 @@ namespace Jint.Browser.Dom.Views;
 
 /// <summary>
 /// The interfaces the runtime owns rather than the generator: <c>DOMParser</c>, <c>XMLSerializer</c>,
-/// <c>NodeFilter</c>, <c>Selection</c> and <c>MediaQueryListEvent</c>.
+/// <c>NodeFilter</c>, <c>Selection</c>, <c>MediaQueryListEvent</c>, <c>Geolocation</c> and DOM's three XPath
+/// interfaces.
 /// </summary>
 /// <remarks>
 /// <para>
-/// None of the five exists in AngleSharp — three of them are host objects a browser supplies rather than DOM
-/// objects, <c>NodeFilter</c> is a callback interface with constants and no instances, and
-/// <c>MediaQueryListEvent</c> is CSSOM View's. Everything else in this folder is a <em>view</em> onto the DOM
+/// None of them exists in AngleSharp — several are host objects a browser supplies rather than DOM
+/// objects, <c>NodeFilter</c> is a callback interface with constants and no instances,
+/// <c>MediaQueryListEvent</c> is CSSOM View's, and DOM §7's XPath is projected from no assembly at all
+/// (<see cref="XPathEvaluation"/> says why). Everything else in this folder is a <em>view</em> onto the DOM
 /// that AngleSharp does have and that the generator already emits: <c>Range</c>, <c>TreeWalker</c> and
 /// <c>NodeIterator</c> are generated, and only the members whose signatures the conversion table could not
 /// cross arrive from <c>overrides.json</c>'s additions.
@@ -34,6 +36,10 @@ internal static class ViewInstaller
     private static readonly JsObjectShape _nodeFilter = BuildNodeFilterShape();
     private static readonly JsObjectShape _mediaQueryListEvent = BuildMediaQueryListEventShape();
     private static readonly JsObjectShape _geolocation = BuildGeolocationShape();
+    private static readonly JsObjectShape _xPathEvaluator = BuildXPathEvaluatorShape();
+    private static readonly JsObjectShape _xPathExpression = BuildXPathExpressionShape();
+    private static readonly JsObjectShape _xPathResult = BuildXPathResultShape();
+    private static readonly JsObjectShape _cssNamespace = BuildCssNamespaceShape();
 
     /// <summary>
     /// The configuration a <c>DOMParser</c> document is parsed with: the CSS services, so that
@@ -41,7 +47,7 @@ internal static class ViewInstaller
     /// </summary>
     internal static IConfiguration ParserConfiguration { get; } = Configuration.Default.WithCss();
 
-    /// <summary>Installs the five globals on <paramref name="runtime"/>'s engine. Called once, at construction.</summary>
+    /// <summary>Installs the globals on <paramref name="runtime"/>'s engine. Called once, at construction.</summary>
     internal static void Install(PageRuntime runtime)
     {
         var engine = runtime.Engine;
@@ -52,6 +58,10 @@ internal static class ViewInstaller
         Add(engine, "NodeFilter", static realm => realm.NodeFilter);
         Add(engine, "MediaQueryListEvent", static realm => realm.MediaQueryListEvent);
         Add(engine, "Geolocation", static realm => realm.GeolocationInterface);
+        Add(engine, "XPathEvaluator", static realm => realm.XPathEvaluator);
+        Add(engine, "XPathExpression", static realm => realm.XPathExpressionInterface);
+        Add(engine, "XPathResult", static realm => realm.XPathResultInterface);
+        Add(engine, "CSS", static realm => realm.CssNamespace);
     }
 
     private static void Add(Engine engine, string name, Func<ViewRealm, JsValue> factory)
@@ -72,6 +82,14 @@ internal static class ViewInstaller
     internal static JsObjectShape MediaQueryListEventShape => _mediaQueryListEvent;
 
     internal static JsObjectShape GeolocationShape => _geolocation;
+
+    internal static JsObjectShape XPathEvaluatorShape => _xPathEvaluator;
+
+    internal static JsObjectShape XPathExpressionShape => _xPathExpression;
+
+    internal static JsObjectShape XPathResultShape => _xPathResult;
+
+    internal static JsObjectShape CssNamespaceShape => _cssNamespace;
 
     /// <summary>
     /// https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#the-domparser-interface
@@ -143,6 +161,16 @@ internal static class ViewInstaller
         .Constant("SHOW_TEXT", JsNumber.Create(4))
         .Build();
 
+    /// <summary>
+    /// https://drafts.csswg.org/cssom/#namespacedef-css — a namespace object, so no constructor and no
+    /// prototype.
+    /// </summary>
+    private static JsObjectShape BuildCssNamespaceShape() => new JsObjectShape.Builder()
+        .ToStringTag("CSS")
+        .Method("escape", static (_, args) => JsCssNamespace.Escape(args), length: 1)
+        .Method("supports", static (_, args) => JsCssNamespace.Supports(args), length: 1)
+        .Build();
+
     /// <summary>https://w3c.github.io/geolocation/#geolocation_interface</summary>
     /// <remarks>
     /// The whole interface, and it is three operations: what a page has no way to observe is that the fix
@@ -155,6 +183,55 @@ internal static class ViewInstaller
         .Method("watchPosition", static (t, args) => JsGeolocation.Brand(t, "watchPosition").WatchPosition(args), length: 1)
         .Method("clearWatch", static (t, args) => JsGeolocation.Brand(t, "clearWatch").ClearWatch(args), length: 1)
         .Build();
+
+    /// <summary>https://dom.spec.whatwg.org/#interface-xpathevaluator — the three members of the mixin.</summary>
+    private static JsObjectShape BuildXPathEvaluatorShape() => new JsObjectShape.Builder()
+        .PerRealmSlot("constructor")
+        .ToStringTag("XPathEvaluator")
+        .Method("createExpression", static (t, args) => JsXPathEvaluator.Brand(t, "createExpression").CreateExpression(args), length: 1)
+        .Method("createNSResolver", static (t, args) =>
+        {
+            JsXPathEvaluator.Brand(t, "createNSResolver");
+            return XPathEvaluation.CreateNSResolver(args, "XPathEvaluator.createNSResolver");
+        }, length: 1)
+        .Method("evaluate", static (t, args) => JsXPathEvaluator.Brand(t, "evaluate").Evaluate(args), length: 2)
+        .Build();
+
+    /// <summary>https://dom.spec.whatwg.org/#interface-xpathexpression</summary>
+    private static JsObjectShape BuildXPathExpressionShape() => new JsObjectShape.Builder()
+        .PerRealmSlot("constructor")
+        .ToStringTag("XPathExpression")
+        .Method("evaluate", static (t, args) => JsXPathExpression.Brand(t, "evaluate").Evaluate(args), length: 1)
+        .Build();
+
+    /// <summary>https://dom.spec.whatwg.org/#interface-xpathresult</summary>
+    private static JsObjectShape BuildXPathResultShape()
+    {
+        var builder = new JsObjectShape.Builder()
+            .PerRealmSlot("constructor")
+            .ToStringTag("XPathResult");
+
+        foreach (var (name, value) in XPathEvaluation.ResultConstants)
+        {
+            builder = builder.Constant(name, JsNumber.Create(value));
+        }
+
+        return builder
+        .Accessor("resultType", static (t, _) => JsXPathResult.Brand(t, "resultType").ResultType)
+        .Accessor("numberValue", static (t, _) => JsXPathResult.Brand(t, "numberValue").NumberValue)
+        .Accessor("stringValue", static (t, _) => JsXPathResult.Brand(t, "stringValue").StringValue)
+        .Accessor("booleanValue", static (t, _) => JsXPathResult.Brand(t, "booleanValue").BooleanValue)
+        .Accessor("singleNodeValue", static (t, _) => JsXPathResult.Brand(t, "singleNodeValue").SingleNodeValue)
+        .Accessor("invalidIteratorState", static (t, _) =>
+        {
+            JsXPathResult.Brand(t, "invalidIteratorState");
+            return JsXPathResult.InvalidIteratorState;
+        })
+        .Accessor("snapshotLength", static (t, _) => JsXPathResult.Brand(t, "snapshotLength").SnapshotLength)
+        .Method("iterateNext", static (t, _) => JsXPathResult.Brand(t, "iterateNext").IterateNext())
+        .Method("snapshotItem", static (t, args) => JsXPathResult.Brand(t, "snapshotItem").SnapshotItem(args), length: 1)
+        .Build();
+    }
 
     /// <summary>https://drafts.csswg.org/cssom-view/#mediaquerylistevent</summary>
     private static JsObjectShape BuildMediaQueryListEventShape() => new JsObjectShape.Builder()
@@ -176,11 +253,12 @@ internal static class ViewInstaller
         Func<JsValue[], ObjectInstance>? construct,
         ObjectInstance? parentPrototype,
         ObjectInstance? parentInterface,
-        out HostInterfaceObject interfaceObject)
+        out HostInterfaceObject interfaceObject,
+        (string Name, int Value)[]? constants = null)
     {
         var realm = engine._mainRealm;
         var prototype = shape.Instantiate(engine, parentPrototype ?? realm.Intrinsics.Object.PrototypeObject);
-        interfaceObject = new HostInterfaceObject(engine, realm, name, prototype, length, construct, parentInterface);
+        interfaceObject = new HostInterfaceObject(engine, realm, name, prototype, length, construct, parentInterface, constants);
 
         prototype.DefineOwnPropertyUnchecked(
             "constructor",

--- a/Jint.Browser/Dom/Views/ViewRealm.cs
+++ b/Jint.Browser/Dom/Views/ViewRealm.cs
@@ -27,10 +27,17 @@ internal sealed class ViewRealm
     private ObjectInstance? _mediaQueryListEventPrototype;
     private HostInterfaceObject? _mediaQueryListEvent;
     private ObjectInstance? _nodeFilter;
+    private ObjectInstance? _cssNamespace;
     private ObjectInstance? _geolocationPrototype;
     private HostInterfaceObject? _geolocationInterface;
     private JsGeolocation? _geolocation;
     private JsSelection? _selection;
+    private ObjectInstance? _xPathEvaluatorPrototype;
+    private HostInterfaceObject? _xPathEvaluator;
+    private ObjectInstance? _xPathExpressionPrototype;
+    private HostInterfaceObject? _xPathExpressionInterface;
+    private ObjectInstance? _xPathResultPrototype;
+    private HostInterfaceObject? _xPathResultInterface;
 
     internal ViewRealm(PageRuntime runtime)
     {
@@ -144,6 +151,14 @@ internal sealed class ViewRealm
             _runtime.Engine,
             _runtime.Engine._mainRealm.Intrinsics.Object.PrototypeObject);
 
+    /// <summary>
+    /// The global <c>CSS</c>, which is CSSOM's namespace object and therefore a plain object too.
+    /// </summary>
+    internal ObjectInstance CssNamespace
+        => _cssNamespace ??= ViewInstaller.CssNamespaceShape.Instantiate(
+            _runtime.Engine,
+            _runtime.Engine._mainRealm.Intrinsics.Object.PrototypeObject);
+
     /// <summary>The global <c>Geolocation</c>, which is not constructible.</summary>
     internal HostInterfaceObject GeolocationInterface
     {
@@ -165,6 +180,99 @@ internal sealed class ViewRealm
             }
 
             return _geolocationInterface;
+        }
+    }
+
+    /// <summary>The global <c>XPathEvaluator</c>, which is the one of the three a page constructs.</summary>
+    internal HostInterfaceObject XPathEvaluator
+    {
+        get
+        {
+            if (_xPathEvaluator is null)
+            {
+                _xPathEvaluatorPrototype = ViewInstaller.Instantiate(
+                    _runtime.Engine,
+                    ViewInstaller.XPathEvaluatorShape,
+                    "XPathEvaluator",
+                    length: 0,
+                    _ => new JsXPathEvaluator(_runtime, _xPathEvaluatorPrototype!),
+                    parentPrototype: null,
+                    parentInterface: null,
+                    out var interfaceObject);
+
+                _xPathEvaluator = interfaceObject;
+            }
+
+            return _xPathEvaluator;
+        }
+    }
+
+    /// <summary>The global <c>XPathExpression</c>, which only <c>createExpression</c> makes.</summary>
+    internal HostInterfaceObject XPathExpressionInterface
+    {
+        get
+        {
+            if (_xPathExpressionInterface is null)
+            {
+                _xPathExpressionPrototype = ViewInstaller.Instantiate(
+                    _runtime.Engine,
+                    ViewInstaller.XPathExpressionShape,
+                    "XPathExpression",
+                    length: 0,
+                    construct: null,
+                    parentPrototype: null,
+                    parentInterface: null,
+                    out var interfaceObject);
+
+                _xPathExpressionInterface = interfaceObject;
+            }
+
+            return _xPathExpressionInterface;
+        }
+    }
+
+    /// <summary>The global <c>XPathResult</c>, which only an evaluation makes.</summary>
+    internal HostInterfaceObject XPathResultInterface
+    {
+        get
+        {
+            if (_xPathResultInterface is null)
+            {
+                _xPathResultPrototype = ViewInstaller.Instantiate(
+                    _runtime.Engine,
+                    ViewInstaller.XPathResultShape,
+                    "XPathResult",
+                    length: 0,
+                    construct: null,
+                    parentPrototype: null,
+                    parentInterface: null,
+                    out var interfaceObject,
+                    XPathEvaluation.ResultConstants);
+
+                _xPathResultInterface = interfaceObject;
+            }
+
+            return _xPathResultInterface;
+        }
+    }
+
+    /// <summary>The prototype every <c>XPathExpression</c> this engine makes is given.</summary>
+    internal ObjectInstance XPathExpressionPrototype
+    {
+        get
+        {
+            _ = XPathExpressionInterface;
+            return _xPathExpressionPrototype!;
+        }
+    }
+
+    /// <summary>The prototype every <c>XPathResult</c> this engine makes is given.</summary>
+    internal ObjectInstance XPathResultPrototype
+    {
+        get
+        {
+            _ = XPathResultInterface;
+            return _xPathResultPrototype!;
         }
     }
 

--- a/Jint.Browser/Jint.Browser.csproj
+++ b/Jint.Browser/Jint.Browser.csproj
@@ -54,9 +54,11 @@
     <!-- Pinned centrally in Directory.Packages.props, which is also the binding generator's pin. -->
     <PackageReference Include="AngleSharp" />
     <PackageReference Include="AngleSharp.Css" />
-    <!-- AngleSharp's XML parser, for DOMParser's four XML content types and nothing else. It is not a
-         generator input: no interface is projected from it, so the pin stays two assemblies. -->
+    <!-- AngleSharp's XML parser, for DOMParser's four XML content types, and its XPath navigator, for DOM
+         §7's XPath. Neither is a generator input: no interface is projected from either, so the pin stays
+         two assemblies. -->
     <PackageReference Include="AngleSharp.Xml" />
+    <PackageReference Include="AngleSharp.XPath" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jint.Browser/Page.Input.cs
+++ b/Jint.Browser/Page.Input.cs
@@ -2,6 +2,7 @@ using AngleSharp.Html.Dom;
 using Jint.Browser.Events;
 using Jint.Browser.Extraction;
 using Jint.Browser.Runtime;
+using Jint.Runtime;
 using Jint.WebApi.Events;
 
 namespace Jint.Browser;
@@ -360,6 +361,57 @@ public sealed partial class Page
             timeout);
     }
 
+    /// <summary>Waits until <paramref name="expression"/> answers something truthy in the page.</summary>
+    /// <param name="expression">A JavaScript expression, evaluated in the page between looks.</param>
+    /// <param name="timeout">The ceiling on the wait.</param>
+    /// <returns>
+    /// <see langword="true"/> when it became truthy, <see langword="false"/> when the timeout won or the
+    /// page closed first.
+    /// </returns>
+    /// <remarks>
+    /// <para>
+    /// The general form of the two waits above, for a condition neither an element nor a piece of text can
+    /// state — <c>location.pathname === '/next'</c>, a list that has reached a length, a flag a framework
+    /// set. It is the same wait: the page is looked at from off the loop, so it goes on running its timers,
+    /// its promises and its fetches while this lasts.
+    /// </para>
+    /// <para>
+    /// <b>An expression that throws is not yet true</b>, so
+    /// <c>document.querySelector('#x').textContent === 'y'</c> is a usable condition while <c>#x</c> is
+    /// still being rendered. If the timeout wins and the last evaluation threw, that failure is what comes
+    /// out rather than <see langword="false"/> — a typo in the expression is a failure with a reason, not a
+    /// silent wait.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ObjectDisposedException">The page has been closed.</exception>
+    public async Task<bool> WaitForAsync(string expression, TimeSpan timeout)
+    {
+        ArgumentNullException.ThrowIfNull(expression);
+        ObjectDisposedException.ThrowIf(_closed, this);
+
+        Exception? lastFailure = null;
+
+        var answered = await WaitForAsync(
+            engine =>
+            {
+                try
+                {
+                    var truthy = TypeConverter.ToBoolean(engine.Evaluate(expression));
+                    lastFailure = null;
+                    return truthy;
+                }
+                catch (JavaScriptException exception)
+                {
+                    // Not yet true: a condition written against an element a framework has not rendered
+                    // throws until it has. Kept so that a timeout can say why rather than only that.
+                    lastFailure = exception;
+                    return false;
+                }
+            },
+            timeout).ConfigureAwait(false);
+
+        return answered || lastFailure is null ? answered : throw lastFailure;
+    }
     /// <summary>Looks at the document until <paramref name="condition"/> holds, or until the time runs out.</summary>
     private async Task<bool> WaitForAsync(Func<Engine, bool> condition, TimeSpan timeout)
     {

--- a/Jint.Browser/Runtime/AGENTS.md
+++ b/Jint.Browser/Runtime/AGENTS.md
@@ -220,6 +220,19 @@ distinguishes it from `form.requestSubmit()` and from a submit button. Constrain
 readonly control and a control inside a disabled fieldset — without it every `<button type=button>` in the
 form would be examined.
 
+### The expression wait, and why it is not a pump
+
+`Page.WaitForAsync(expression, timeout)` is the general form of `Page.Input.cs`'s two other waits, and it
+is built the same way rather than the obvious way: the page is looked at from **off** the loop, every
+`WaitPoll`, through one mailbox request per look. Holding the loop and pumping inside a single request —
+which is what `WaitForIdleAsync` does — would be a wait for something the page could never do, because the
+loop it is holding is the one a navigation commits on and the one a mailbox request runs on. One wait
+mechanism, three public members over it.
+
+**An expression that throws is not yet true**, so a condition written against an element a framework has
+not rendered is usable; the last failure is kept, and a timeout rethrows it rather than answering
+`false`, so a typo in the expression is a failure with a reason.
+
 ### The flat box model, and the one number it is built from
 
 `Layout/FlatLayout` is the whole of what stands in for a layout engine, and its rule is one sentence: **every

--- a/Jint.Tests.Browser/DevTools/DomDomainTests.cs
+++ b/Jint.Tests.Browser/DevTools/DomDomainTests.cs
@@ -320,8 +320,9 @@ public class DomDomainTests
             .GetProperty("value").GetString().Should().Be("undefined");
     }
 
+    /// <summary>Chrome's three arms: a selector, an XPath expression, and a text substring.</summary>
     [Test]
-    public async Task PerformSearchFindsBySelectorAndByText()
+    public async Task PerformSearchFindsBySelectorByXPathAndByText()
     {
         await using var session = await PageSession.CreateAsync();
         var attachment = await session.OpenPageAsync();
@@ -338,6 +339,16 @@ public class DomDomainTests
             attachment);
 
         results.GetProperty("nodeIds").GetArrayLength().Should().Be(1);
+
+        // The arm this browser had none of until DOM XPath arrived: a front end's search box sends one of
+        // these for anything beginning `//`, and it is the same evaluator document.evaluate answers from.
+        var byXPath = await session.ResultAsync("DOM.performSearch", """{"query":"//div[@class='needle']"}""", attachment);
+        byXPath.GetProperty("resultCount").GetInt32().Should().Be(1);
+
+        // A query that is not an expression contributes nothing rather than failing the command: a search
+        // box is typed into one character at a time.
+        var nonsense = await session.ResultAsync("DOM.performSearch", """{"query":"//div["}""", attachment);
+        nonsense.GetProperty("resultCount").GetInt32().Should().Be(0);
 
         var byText = await session.ResultAsync("DOM.performSearch", """{"query":"haystack"}""", attachment);
         byText.GetProperty("resultCount").GetInt32().Should().Be(1);

--- a/Jint.Tests.Browser/DevTools/PageHandshakeReplayTests.cs
+++ b/Jint.Tests.Browser/DevTools/PageHandshakeReplayTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json;
+﻿using System.Globalization;
+using System.Text.Json;
 using Jint.Browser;
 using Jint.Tests.Browser.Navigation;
 
@@ -173,6 +174,511 @@ public class PageHandshakeReplayTests
 
         session.Ordinal("Target.attachedToTarget").Should().BeLessThan(session.Ordinal("Page.frameNavigated"));
         session.Ordinal("Page.frameNavigated").Should().BeLessThan(session.Ordinal("Page.loadEventFired"));
+    }
+
+    /// <summary>
+    /// Every parameter <b>shape</b> a client was recorded sending, replayed against a real page.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>The name-only pin missed two defects, and this is the one that would not have.</b> The replay above
+    /// asks whether a method is <i>reachable</i>; a client sends a method with particular members, and two of
+    /// the four defects Playwright found were about exactly that — <c>Target.getTargetInfo</c> with
+    /// <b>no</b> parameters at all, and a page of the <i>default</i> browser context, which Playwright
+    /// refuses unless the target says which context it is in. Both are shapes rather than names, and both
+    /// passed a pin that only counted methods.
+    /// </para>
+    /// <para>
+    /// So this rebuilds each recorded call out of its own <c>paramsKeys</c> — the recorded
+    /// <c>paramsValues</c> where the recording kept one, the live identifier where the key names one, and a
+    /// value of the right JSON type otherwise — and asserts the answer is never <c>-32602</c>. A method this
+    /// server does not implement answers <c>-32601</c> before it looks at the parameters, which is Chrome's
+    /// own order and not a failure here; <see cref="Absent"/> is where a name is excused.
+    /// </para>
+    /// </remarks>
+    [TestCase("puppeteer-node")]
+    [TestCase("puppeteersharp-dotnet")]
+    [TestCase("playwright-node")]
+    [TestCase("playwright-dotnet")]
+    public async Task EveryParameterShapeAClientSendsIsUnderstood(string client)
+    {
+        var shapes = RecordedShapes(client);
+        shapes.Should().NotBeEmpty("the recording is the specification these tests are written against");
+
+        using var server = new LoopbackServer();
+        server.MapHtml("/page", "<html><head><title>Handshake</title></head><body><p>ready</p></body></html>");
+
+        await using var session = await PageSession.CreateAsync(new BrowserContextOptions { UrlFilter = server.Owns });
+
+        var contextId = (await session.ResultAsync("Target.createBrowserContext", "{}"))
+            .GetProperty("browserContextId").GetString()!;
+
+        await session.ResultAsync("Target.setAutoAttach", """{"autoAttach":true,"waitForDebuggerOnStart":true,"flatten":true}""");
+
+        var targetId = (await session.ResultAsync("Target.createTarget", $$"""{"url":"about:blank","browserContextId":"{{contextId}}"}"""))
+            .GetProperty("targetId").GetString()!;
+
+        var attached = await session.EventAsync("Target.attachedToTarget");
+        var attachment = attached.GetProperty("sessionId").GetString()!;
+
+        // What every client enables before it drives a page, and what makes the load event arrive: the
+        // replay needs a real document under it, because half of these shapes address a node in one.
+        await session.EnablePageAsync(attachment);
+
+        await session.ResultAsync("Page.navigate", $$"""{"url":"{{server.Url("/page")}}"}""", attachment);
+        await session.EventAsync("Page.loadEventFired", sessionId: attachment);
+
+        var node = await NodeHandleAsync(session, attachment);
+        var nodeId = await NodeIdAsync(session, attachment, node);
+        var handle = await HandleAsync(session, attachment);
+
+        var identifiers = new Identifiers(targetId, contextId, attachment, server.Url("/page"), handle, node, nodeId);
+        var misread = new List<string>();
+
+        foreach (var shape in shapes)
+        {
+            var parameters = Shape(shape, identifiers);
+            var reply = await BestAnswerAsync(session, shape.Method, attachment, parameters).ConfigureAwait(false);
+
+            if (!reply.TryGetProperty("error", out var error) || error.GetProperty("code").GetInt32() != -32602)
+            {
+                continue;
+            }
+
+            var detail = error.TryGetProperty("data", out var data) ? ": " + data.GetString() : "";
+            misread.Add($"{shape.Method}({string.Join(", ", shape.Keys)}) -> {error.GetProperty("message").GetString()}{detail}");
+        }
+
+        Assert.That(
+            misread.Count == 0,
+            $"""
+            {misread.Count} call(s) the '{client}' recording makes are answered -32602 — the parameters were
+            read and refused. Each is a member of the shape that client really sends, so each is either
+            accepted or a deliberate change to what this server takes:
+
+            {string.Join(Environment.NewLine, misread.Select(entry => "  " + entry))}
+            """);
+    }
+
+    /// <summary>
+    /// The two shapes the name-only pin let through, asserted by themselves so that a regression names itself.
+    /// </summary>
+    [Test]
+    public async Task TheTwoShapesTheNameOnlyPinMissedAreAnsweredExplicitly()
+    {
+        await using var session = await PageSession.CreateAsync();
+
+        await session.ResultAsync("Target.setAutoAttach", """{"autoAttach":true,"waitForDebuggerOnStart":true,"flatten":true}""");
+
+        // No browserContextId: the page belongs to the browser's default context, which is the case
+        // Playwright's connectOverCDP adopts and the one that used to name no context at all.
+        var targetId = (await session.ResultAsync("Target.createTarget", """{"url":"about:blank"}"""))
+            .GetProperty("targetId").GetString()!;
+
+        var attached = await session.EventAsync("Target.attachedToTarget");
+        var attachment = attached.GetProperty("sessionId").GetString()!;
+
+        attached.GetProperty("targetInfo").TryGetProperty("browserContextId", out var announced).Should().BeTrue(
+            "Playwright drops a page target that names no browser context, and a default-context page has one too");
+
+        announced.GetString().Should().NotBeNullOrEmpty();
+
+        // Target.getTargetInfo with no parameters at all: the target is the session's own, which is the only
+        // thing a client sending an empty object can mean.
+        var implied = await session.ResultAsync("Target.getTargetInfo", "{}", attachment);
+        implied.GetProperty("targetInfo").GetProperty("targetId").GetString().Should().Be(targetId);
+
+        // And with the identifier, which is the spelling the other three clients use.
+        var named = await session.ResultAsync("Target.getTargetInfo", $$"""{"targetId":"{{targetId}}"}""");
+        named.GetProperty("targetInfo").GetProperty("targetId").GetString().Should().Be(targetId);
+        named.GetProperty("targetInfo").GetProperty("browserContextId").GetString().Should().Be(
+            implied.GetProperty("targetInfo").GetProperty("browserContextId").GetString(),
+            "both spellings answer about one target");
+    }
+
+    /// <summary>The live identifiers a recorded parameter key is rewritten to.</summary>
+    /// <param name="TargetId">The page target this replay created.</param>
+    /// <param name="ContextId">The browser context it was created in.</param>
+    /// <param name="SessionId">The attachment every page-level command rides.</param>
+    /// <param name="Url">A URL on the loopback origin the page is allowed to reach.</param>
+    /// <param name="ObjectId">A remote object handle the server minted.</param>
+    /// <param name="NodeObjectId">A handle for an element of the page.</param>
+    /// <param name="NodeId">That element's node identifier.</param>
+    private readonly record struct Identifiers(
+        string TargetId,
+        string ContextId,
+        string SessionId,
+        string Url,
+        string ObjectId,
+        string NodeObjectId,
+        int NodeId);
+
+    /// <summary>One recorded call: the method, the members it carried, and any values kept with them.</summary>
+    private sealed record RecordedShape(string Method, IReadOnlyList<string> Keys, IReadOnlyDictionary<string, string> Values);
+
+    /// <summary>
+    /// The JSON one recorded call becomes: every key it carried, with a value of the right kind.
+    /// </summary>
+    private static string Shape(RecordedShape shape, in Identifiers ids)
+    {
+        var members = new List<string>(shape.Keys.Count);
+
+        foreach (var key in shape.Keys)
+        {
+            // A value the recording kept is the truest one there is, and it is what carries a client's own
+            // world name, its device metrics and its auto-attach flags.
+            var value = shape.Values.TryGetValue(key, out var recorded)
+                ? Recorded(shape.Method, key, recorded) ?? ValueFor(shape.Method, key, ids)
+                : ValueFor(shape.Method, key, ids);
+
+            members.Add(Quote(key) + ":" + value);
+        }
+
+        return "{" + string.Join(",", members) + "}";
+    }
+
+    /// <summary>
+    /// The value one parameter takes: the live identifier where the key names one, and otherwise a value of
+    /// the kind the <b>vendored protocol</b> declares for it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The type comes from <c>tools/devtools-protocol/</c> rather than from a table written here, which is
+    /// what keeps this a shape replay rather than a second guess at the protocol: a bump that changes a
+    /// member from a string to an enumeration changes what this sends, in the same pull request, without
+    /// anybody remembering to. A member the vendored files do not declare — a domain this server has never
+    /// heard of — is a flag, which is what most of them are.
+    /// </para>
+    /// <para>
+    /// The identifiers are the exception and have to be: a command addressed to a target, a frame, a node or
+    /// a handle that does not exist would be refused for the wrong reason, and the two Playwright shapes this
+    /// test exists for are both about identifiers.
+    /// </para>
+    /// </remarks>
+    private static string ValueFor(string method, string key, in Identifiers ids) => (method, key) switch
+    {
+        // A pattern that matches nothing, deliberately: a real interception here would leave the page's next
+        // request paused with nobody to release it.
+        ("Fetch.enable", "patterns") => """[{"urlPattern":"http://handshake.invalid/*"}]""",
+        (_, "requestId") => Quote("interception-job-0"),
+
+        (_, "targetId") => Quote(ids.TargetId),
+        (_, "browserContextId") => Quote(ids.ContextId),
+        (_, "sessionId") => Quote(ids.SessionId),
+        (_, "frameId") => Quote(ids.TargetId),
+        (_, "objectId") => Quote(method.StartsWith("DOM.", StringComparison.Ordinal) ? ids.NodeObjectId : ids.ObjectId),
+        (_, "nodeId") or (_, "backendNodeId") => ids.NodeId.ToString(CultureInfo.InvariantCulture),
+        (_, "url") => Quote(ids.Url),
+        (_, "expression") => Quote("document.title"),
+        (_, "functionDeclaration") => Quote("function () { return this.answer; }"),
+        (_, "selector") => Quote("p"),
+
+        _ => Declared(method, key),
+    };
+
+    /// <summary>A value of the kind the vendored protocol declares for one command's parameter.</summary>
+    private static string Declared(string method, string key)
+        => ProtocolParameters.TryGetValue(method + "." + key, out var value) ? value : "true";
+
+    /// <summary>
+    /// The recorded value for one parameter, or <see langword="null"/> when the recording kept a <i>set</i>
+    /// of them that this cannot take as it stands.
+    /// </summary>
+    /// <remarks>
+    /// <b>A recording keeps every distinct value a client sent for a member.</b> One value is stored as
+    /// itself; several become an array — <c>"returnByValue": [false, true]</c> is a client that sent both,
+    /// not a client that sent a list. So a recorded value is used where its JSON kind is the one the protocol
+    /// declares, and otherwise the first member of the set that is. An array-typed member seen twice becomes
+    /// an array of arrays, which is the one case the kinds cannot tell apart on their own.
+    /// </remarks>
+    private static string? Recorded(string method, string key, string raw)
+    {
+        if (!ProtocolKinds.TryGetValue(method + "." + key, out var kind))
+        {
+            return raw;
+        }
+
+        using var document = JsonDocument.Parse(raw);
+        var value = document.RootElement;
+
+        var isSet = value.ValueKind == JsonValueKind.Array
+            && (kind != "array" || (value.GetArrayLength() > 0 && value[0].ValueKind == JsonValueKind.Array));
+
+        if (!isSet)
+        {
+            return Matches(value, kind) ? raw : null;
+        }
+
+        foreach (var member in value.EnumerateArray())
+        {
+            if (Matches(member, kind))
+            {
+                return member.GetRawText();
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>Whether one JSON value is of the kind the protocol declares.</summary>
+    private static bool Matches(JsonElement value, string kind) => kind switch
+    {
+        "array" => value.ValueKind == JsonValueKind.Array,
+        "object" => value.ValueKind == JsonValueKind.Object,
+        "boolean" => value.ValueKind is JsonValueKind.True or JsonValueKind.False,
+        "integer" or "number" => value.ValueKind == JsonValueKind.Number,
+
+        // Everything else the protocol declares is a string: a plain one, an alias, or an enumeration.
+        _ => value.ValueKind == JsonValueKind.String,
+    };
+
+    /// <summary>
+    /// Every command parameter the vendored protocol declares, as a JSON value of its declared type.
+    /// </summary>
+    /// <remarks>
+    /// A <c>$ref</c> is resolved, and an object is built out of its own <i>required</i> members — which is
+    /// what a client sends and what a data transfer object with required members needs: an empty object for
+    /// <c>Emulation.setDeviceMetricsOverride</c>'s <c>screenOrientation</c> would be refused here for the
+    /// same reason Chrome refuses it, and that refusal would say nothing about this server. An enumeration
+    /// answers its first member, because a fixed set is the only string those commands accept.
+    /// </remarks>
+    /// <summary>The same parameters, as the JSON kind each takes rather than as a value.</summary>
+    /// <remarks>
+    /// Declared <i>before</i> the values it is filled alongside, because a static initializer runs in
+    /// source order and the one below writes into this.
+    /// </remarks>
+    private static Dictionary<string, string> ProtocolKinds { get; } = new(StringComparer.Ordinal);
+
+    private static Dictionary<string, string> ProtocolParameters { get; } = ReadProtocolParameters();
+
+    private static Dictionary<string, string> ReadProtocolParameters()
+    {
+        var declared = new Dictionary<string, string>(StringComparer.Ordinal);
+        var types = new Dictionary<string, JsonElement>(StringComparer.Ordinal);
+        var documents = new List<JsonDocument>();
+
+        foreach (var name in new[] { "browser_protocol.json", "js_protocol.json", "jint_protocol.json" })
+        {
+            var path = Path.Combine(RepositoryPaths.Root, "tools", "devtools-protocol", name);
+            File.Exists(path).Should().BeTrue("the protocol is vendored at {0}", path);
+            documents.Add(JsonDocument.Parse(File.ReadAllBytes(path)));
+        }
+
+        // The type declarations first, because a parameter's $ref may name one in another domain.
+        foreach (var domain in documents.SelectMany(Domains))
+        {
+            var domainName = domain.GetProperty("domain").GetString()!;
+
+            if (!domain.TryGetProperty("types", out var domainTypes))
+            {
+                continue;
+            }
+
+            foreach (var type in domainTypes.EnumerateArray())
+            {
+                types[domainName + "." + type.GetProperty("id").GetString()] = type;
+            }
+        }
+
+        foreach (var domain in documents.SelectMany(Domains))
+        {
+            var domainName = domain.GetProperty("domain").GetString()!;
+
+            if (!domain.TryGetProperty("commands", out var commands))
+            {
+                continue;
+            }
+
+            foreach (var command in commands.EnumerateArray())
+            {
+                if (!command.TryGetProperty("parameters", out var parameters))
+                {
+                    continue;
+                }
+
+                var method = domainName + "." + command.GetProperty("name").GetString();
+
+                foreach (var parameter in parameters.EnumerateArray())
+                {
+                    var name = method + "." + parameter.GetProperty("name").GetString();
+
+                    declared[name] = ValueOf(parameter, types, domainName, depth: 0);
+                    ProtocolKinds[name] = KindOf(parameter, types, domainName, depth: 0);
+                }
+            }
+        }
+
+        foreach (var document in documents)
+        {
+            document.Dispose();
+        }
+
+        return declared;
+    }
+
+    private static IEnumerable<JsonElement> Domains(JsonDocument document)
+        => document.RootElement.GetProperty("domains").EnumerateArray();
+
+    /// <summary>The JSON kind one declaration takes, resolving a <c>$ref</c> the way <see cref="ValueOf"/> does.</summary>
+    private static string KindOf(JsonElement declaration, Dictionary<string, JsonElement> types, string domain, int depth)
+    {
+        if (depth > 4)
+        {
+            return "object";
+        }
+
+        if (declaration.TryGetProperty("type", out var type))
+        {
+            return type.GetString()!;
+        }
+
+        if (!declaration.TryGetProperty("$ref", out var reference))
+        {
+            return "object";
+        }
+
+        var name = reference.GetString()!;
+        var qualified = name.Contains('.', StringComparison.Ordinal) ? name : domain + "." + name;
+
+        return types.TryGetValue(qualified, out var resolved)
+            ? KindOf(resolved, types, qualified[..qualified.IndexOf('.', StringComparison.Ordinal)], depth + 1)
+            : "object";
+    }
+
+    /// <summary>The JSON one declaration takes: its own type, its first enumeration member, or its <c>$ref</c>.</summary>
+    private static string ValueOf(JsonElement declaration, Dictionary<string, JsonElement> types, string domain, int depth)
+    {
+        if (depth > 4)
+        {
+            return "{}";
+        }
+
+        if (declaration.TryGetProperty("enum", out var members) && members.GetArrayLength() > 0)
+        {
+            return JsonSerializer.Serialize(members[0].GetString());
+        }
+
+        if (declaration.TryGetProperty("$ref", out var reference))
+        {
+            var name = reference.GetString()!;
+            var qualified = name.Contains('.', StringComparison.Ordinal) ? name : domain + "." + name;
+
+            return types.TryGetValue(qualified, out var resolved)
+                ? ValueOf(resolved, types, qualified[..qualified.IndexOf('.', StringComparison.Ordinal)], depth + 1)
+                : "{}";
+        }
+
+        return declaration.TryGetProperty("type", out var type) ? type.GetString() switch
+        {
+            "string" => JsonSerializer.Serialize("replay"),
+            "integer" or "number" => "1",
+            "boolean" => "true",
+            "array" => "[]",
+            "object" => Object(declaration, types, domain, depth),
+            _ => "true",
+        } : "{}";
+    }
+
+    /// <summary>An object built from the members its declaration does not call optional.</summary>
+    private static string Object(JsonElement declaration, Dictionary<string, JsonElement> types, string domain, int depth)
+    {
+        if (!declaration.TryGetProperty("properties", out var properties))
+        {
+            return "{}";
+        }
+
+        var members = new List<string>();
+
+        foreach (var property in properties.EnumerateArray())
+        {
+            if (property.TryGetProperty("optional", out var optional) && optional.GetBoolean())
+            {
+                continue;
+            }
+
+            members.Add(
+                JsonSerializer.Serialize(property.GetProperty("name").GetString())
+                + ":"
+                + ValueOf(property, types, domain, depth + 1));
+        }
+
+        return "{" + string.Join(",", members) + "}";
+    }
+
+    /// <summary>One recorded value as a JSON string.</summary>
+    private static string Quote(string value) => JsonSerializer.Serialize(value);
+
+    /// <summary>Sends one call where it belongs, keeping whichever session answered better.</summary>
+    private static async Task<JsonElement> BestAnswerAsync(PageSession session, string method, string attachment, string parameters)
+    {
+        var onAttachment = await session.SendAsync(method, parameters, attachment).ConfigureAwait(false);
+        if (!onAttachment.TryGetProperty("error", out _))
+        {
+            return onAttachment;
+        }
+
+        var onBrowser = await session.SendAsync(method, parameters).ConfigureAwait(false);
+        return onBrowser.TryGetProperty("error", out _) ? onAttachment : onBrowser;
+    }
+
+    /// <summary>Every distinct call shape one client was recorded making, across every step.</summary>
+    /// <remarks>
+    /// Every step rather than the fourteen the name replay covers: a shape is answered or refused whatever
+    /// the command does afterwards, and the two steps that replay leaves out — the screenshot and the PDF —
+    /// are refused with <c>-32000</c>, which this does not count.
+    /// </remarks>
+    private static IReadOnlyList<RecordedShape> RecordedShapes(string client)
+    {
+        var path = Path.Combine(RepositoryPaths.Root, "tools", "devtools-protocol", "handshakes", client + ".json");
+        File.Exists(path).Should().BeTrue("the recorded handshakes are checked in at {0}", path);
+
+        using var document = JsonDocument.Parse(File.ReadAllBytes(path));
+        var shapes = new List<RecordedShape>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var step in document.RootElement.GetProperty("scenarioSteps").EnumerateArray())
+        {
+            if (!step.TryGetProperty("methods", out var recorded))
+            {
+                continue;
+            }
+
+            foreach (var entry in recorded.EnumerateArray())
+            {
+                var method = entry.GetProperty("method").GetString()!;
+
+                // The four the replay itself already sent, and which would take the ground out from under it.
+                if (method is "Target.createTarget" or "Target.createBrowserContext" or "Target.closeTarget" or "Target.detachFromTarget")
+                {
+                    continue;
+                }
+
+                var keys = entry.TryGetProperty("paramsKeys", out var recordedKeys)
+                    ? recordedKeys.EnumerateArray().Select(key => key.GetString()!).ToArray()
+                    : [];
+
+                if (!seen.Add(method + "(" + string.Join(",", keys) + ")"))
+                {
+                    continue;
+                }
+
+                var values = new Dictionary<string, string>(StringComparer.Ordinal);
+
+                if (entry.TryGetProperty("paramsValues", out var recordedValues))
+                {
+                    foreach (var value in recordedValues.EnumerateObject())
+                    {
+                        // The raw text rather than the element: the document is disposed with this method,
+                        // and a JsonElement does not outlive the one it was read from.
+                        values[value.Name] = value.Value.GetRawText();
+                    }
+                }
+
+                shapes.Add(new RecordedShape(method, keys, values));
+            }
+        }
+
+        return shapes;
     }
 
     /// <summary>

--- a/Jint.Tests.Browser/Events/PageWaitForExpressionTests.cs
+++ b/Jint.Tests.Browser/Events/PageWaitForExpressionTests.cs
@@ -1,0 +1,94 @@
+namespace Jint.Tests.Browser.Events;
+
+using Browser = global::Jint.Browser.Browser;
+
+/// <summary>
+/// <c>Page.WaitForAsync(expression, timeout)</c>: the general form of the selector and text waits.
+/// </summary>
+/// <remarks>
+/// It exists for the conditions neither of those can state — a URL a router moved, a list that reached a
+/// length, a flag a framework set — and the obstacle course waits on exactly those. What these hold is the
+/// two things the other two waits have no equivalent of: that a chain of timers and microtasks is seen at
+/// all, and that an expression which throws is <i>not yet true</i> rather than a failure.
+/// </remarks>
+public sealed class PageWaitForExpressionTests
+{
+    private static readonly TimeSpan Patience = TimeSpan.FromSeconds(30);
+
+    [Test]
+    public async Task ItSeesAConditionAChainOfTimersMakesTrue()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync(
+            """
+            <p id="state">waiting</p>
+            <script>
+              // Two chained timers with a microtask between them, so nothing but a page that is really
+              // running gets there.
+              setTimeout(() => {
+                Promise.resolve().then(() => setTimeout(() => {
+                  document.getElementById('state').textContent = 'ready';
+                }, 30));
+              }, 30);
+            </script>
+            """);
+
+        (await page.WaitForAsync("document.getElementById('state').textContent === 'ready'", Patience))
+            .Should().BeTrue();
+
+        (await page.EvaluateAsync<string>("document.getElementById('state').textContent")).Should().Be("ready");
+    }
+
+    [Test]
+    public async Task AConditionThatNeverHoldsIsATimeoutRatherThanAHang()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync("<p id='state'>waiting</p>");
+
+        (await page.WaitForAsync("document.getElementById('state').textContent === 'ready'", TimeSpan.FromMilliseconds(200)))
+            .Should().BeFalse();
+    }
+
+    [Test]
+    public async Task AnExpressionThatThrowsIsNotYetTrueAndSaysSoAtTheCeiling()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync(
+            """
+            <div id="root"></div>
+            <script>
+              setTimeout(() => {
+                document.getElementById('root').innerHTML = '<span id="late">here</span>';
+              }, 30);
+            </script>
+            """);
+
+        // #late does not exist yet, so the condition throws until the timer has run.
+        (await page.WaitForAsync("document.getElementById('late').textContent === 'here'", Patience))
+            .Should().BeTrue();
+
+        var typo = async () => await page.WaitForAsync("thisIsNotDefined()", TimeSpan.FromMilliseconds(200));
+
+        await typo.Should().ThrowAsync<Exception>("a wait that never came true because of a typo says why");
+    }
+
+    [Test]
+    public async Task ItRefusesAClosedPage()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync("<p>done</p>");
+        await page.CloseAsync();
+
+        var wait = async () => await page.WaitForAsync("true", Patience);
+
+        await wait.Should().ThrowAsync<ObjectDisposedException>();
+    }
+}

--- a/Jint.Tests.Browser/Fixtures/FixtureCourse.cs
+++ b/Jint.Tests.Browser/Fixtures/FixtureCourse.cs
@@ -18,10 +18,13 @@ using Browser = global::Jint.Browser.Browser;
 /// <i>something</i>, so the error sink is what tells a half-working page apart from a working one.
 /// </para>
 /// <para>
-/// <b>The driver is injected, never loaded.</b> <c>Fixtures/harness.js</c> is evaluated into the page after
-/// the load rather than referenced by the document, because the same fixtures are driven by PuppeteerSharp
-/// and by Playwright over the protocol with no help from it — a fixture that needed the harness would be a
-/// fixture only this suite could run.
+/// <b>Input is the public <c>Page</c> API; the harness is what is left.</b> A click, a fill and a key press
+/// go through <see cref="Page.ClickAsync"/>, <see cref="Page.FillAsync"/> and
+/// <see cref="Page.PressAsync"/>, which are the same paths a protocol client drives — so a case here and
+/// the same case in the PuppeteerSharp or Playwright suite exercise one input model rather than two.
+/// <c>Fixtures/harness.js</c> is evaluated into the page after the load, never referenced by the document,
+/// and it holds only the readers and the one click the public API has no member for: the <i>n</i>th match
+/// of a repeated selector.
 /// </para>
 /// </remarks>
 internal sealed class FixtureCourse : IAsyncDisposable
@@ -96,9 +99,16 @@ internal sealed class FixtureCourse : IAsyncDisposable
     internal Task SettleAsync() => Page.WaitForIdleAsync(TimeSpan.FromSeconds(2));
 
     /// <summary>Clicks the first match and lets whatever it started finish.</summary>
+    /// <remarks>
+    /// <see cref="Page.ClickAsync"/> rather than the harness: a real mouse sequence at the element's own
+    /// row, which is the same path <c>Input.dispatchMouseEvent</c> takes, so what this drives is what a
+    /// protocol client drives rather than a script calling <c>element.click()</c>.
+    /// </remarks>
     internal async Task ClickAsync(string selector)
     {
-        await Page.EvaluateAsync("__h.click(" + Literal(selector) + ")").ConfigureAwait(false);
+        (await Page.ClickAsync(selector).ConfigureAwait(false))
+            .Should().BeTrue("'" + selector + "' should have matched a clickable element");
+
         await SettleAsync().ConfigureAwait(false);
     }
 
@@ -109,10 +119,18 @@ internal sealed class FixtureCourse : IAsyncDisposable
         await SettleAsync().ConfigureAwait(false);
     }
 
-    /// <summary>Types into a field and lets whatever it started finish.</summary>
+    /// <summary>Puts a value in a field and lets whatever it started finish.</summary>
+    /// <remarks>
+    /// <see cref="Page.FillAsync"/>, which is what the harness member it replaced was: select everything,
+    /// then insert through the input model, so <c>beforeinput</c> and <c>input</c> fire and a controlled
+    /// field a framework owns is reached. It focuses the control, which is what lets
+    /// <see cref="PressAsync"/> follow it with no target of its own.
+    /// </remarks>
     internal async Task TypeAsync(string selector, string text)
     {
-        await Page.EvaluateAsync("__h.type(" + Literal(selector) + ", " + Literal(text) + ")").ConfigureAwait(false);
+        (await Page.FillAsync(selector, text).ConfigureAwait(false))
+            .Should().BeTrue("'" + selector + "' should have matched an editable element");
+
         await SettleAsync().ConfigureAwait(false);
     }
 
@@ -128,7 +146,7 @@ internal sealed class FixtureCourse : IAsyncDisposable
     internal async Task EnterAsync(string selector, string text)
     {
         await TypeAsync(selector, text).ConfigureAwait(false);
-        await PressAsync(selector, "Enter").ConfigureAwait(false);
+        await PressAsync("Enter").ConfigureAwait(false);
     }
 
     /// <summary>Clicks something that navigates, waits for the commit and re-injects the driver.</summary>
@@ -140,7 +158,8 @@ internal sealed class FixtureCourse : IAsyncDisposable
     internal async Task ClickAndNavigateAsync(string selector)
     {
         var navigated = Page.WaitForNavigationAsync(Bound);
-        await Page.EvaluateAsync("__h.click(" + Literal(selector) + ")").ConfigureAwait(false);
+        (await Page.ClickAsync(selector).ConfigureAwait(false))
+            .Should().BeTrue("'" + selector + "' should have matched a clickable element");
 
         (await navigated.ConfigureAwait(false)).Should().BeTrue("clicking '" + selector + "' should have navigated");
 
@@ -148,10 +167,14 @@ internal sealed class FixtureCourse : IAsyncDisposable
         await SettleAsync().ConfigureAwait(false);
     }
 
-    /// <summary>Presses a key at an element and lets whatever it started finish.</summary>
-    internal async Task PressAsync(string selector, string key)
+    /// <summary>Presses a key at whatever is focused and lets whatever it started finish.</summary>
+    /// <remarks>
+    /// <see cref="Page.PressAsync"/> takes no selector, because a key press has none: HTML sends it to the
+    /// currently focused area, which the fill or the click before it moved.
+    /// </remarks>
+    internal async Task PressAsync(string key)
     {
-        await Page.EvaluateAsync("__h.press(" + Literal(selector) + ", " + Literal(key) + ")").ConfigureAwait(false);
+        await Page.PressAsync(key).ConfigureAwait(false);
         await SettleAsync().ConfigureAwait(false);
     }
 
@@ -189,22 +212,14 @@ internal sealed class FixtureCourse : IAsyncDisposable
     /// </remarks>
     internal async Task UntilAsync(string expression, string expected)
     {
-        var deadline = Environment.TickCount64 + (long) Bound.TotalMilliseconds;
-        string? seen = null;
-
-        while (Environment.TickCount64 < deadline)
+        // One request that holds the page's thread and is woken by its own jobs, rather than a round trip
+        // per poll from here: Page.WaitForAsync is what a host has instead of this loop.
+        if (await Page.WaitForAsync("String(" + expression + ") === " + Literal(expected), Bound).ConfigureAwait(false))
         {
-            seen = await Page.EvaluateAsync<string>("String(" + expression + ")").ConfigureAwait(false);
-
-            if (string.Equals(seen, expected, StringComparison.Ordinal))
-            {
-                return;
-            }
-
-            await SettleAsync().ConfigureAwait(false);
-            await Task.Delay(25).ConfigureAwait(false);
+            return;
         }
 
+        var seen = await Page.EvaluateAsync<string>("String(" + expression + ")").ConfigureAwait(false);
         Assert.Fail($"'{expression}' was still '{seen}' rather than '{expected}' after {Bound}. Errors: {Errors()}");
     }
 

--- a/Jint.Tests.Browser/Fixtures/LibraryFixtureTests.cs
+++ b/Jint.Tests.Browser/Fixtures/LibraryFixtureTests.cs
@@ -73,16 +73,13 @@ public class LibraryFixtureTests
 
     /// <summary>htmx's three entry points: a load trigger, a click that swaps, and a boosted link.</summary>
     /// <remarks>
-    /// <b>The one fixture that does not pass, and it fails before htmx does anything.</b> htmx 2 evaluates
+    /// <b>This is the case DOM XPath bought.</b> htmx 2 evaluates
     /// <c>const … = (new XPathEvaluator).createExpression(…)</c> at the top level of its bundle, to find the
-    /// <c>hx-on:</c> attributes, so the whole library is a <c>ReferenceError</c> on a browser with no XPath —
-    /// and there is none here, because AngleSharp keeps XPath in a package of its own
-    /// (<c>AngleSharp.XPath</c>) that nothing references. Nothing about <c>hx-get</c>, <c>hx-swap</c>,
-    /// <c>hx-trigger</c> or <c>hx-boost</c> has been reached, let alone refuted. The row in
-    /// <c>Fixtures/README.md</c> is the record; remove this attribute when the XPath family exists.
+    /// <c>hx-on:</c> attributes, so the whole library was a <c>ReferenceError</c> before any <c>hx-</c>
+    /// attribute was read, and this was the corpus's <c>needs triage</c> row for a feature that did not
+    /// exist. Everything below was unreached rather than refuted.
     /// </remarks>
     [Test]
-    [Explicit("htmx: htmx 2 constructs an XPathEvaluator at load, and this browser has no XPath, so the bundle is a ReferenceError before any hx- attribute is read.")]
     public async Task HtmxSwapsFragmentsAndBoostsALink()
     {
         await using var course = await FixtureCourse.OpenAsync("htmx");
@@ -133,13 +130,12 @@ public class LibraryFixtureTests
     /// A custom element upgraded by the parser, moved through the tree, and told its attribute changed.
     /// </summary>
     /// <remarks>
-    /// <b>Explicit, and the fixture is checked in anyway.</b> <c>customElements</c> does not exist on this
-    /// branch — campaign item C6 is the one that adds the registry, the upgrade and the four reactions — so
-    /// this case is a fixture waiting for it rather than a stub of it. Remove the attribute when C6 lands;
-    /// the fixture needs no change, which is the point of writing it now.
+    /// <b>The fixture was checked in before the feature was.</b> It was written against a branch with no
+    /// <c>customElements</c> at all, marked <c>[Explicit]</c> with a <c>needs triage</c> row beside it, and
+    /// turned on by deleting one attribute once the registry, the upgrade and the four reactions landed —
+    /// which is the shape a triage row is supposed to have.
     /// </remarks>
     [Test]
-    [Explicit("custom-elements: customElements is campaign item C6 and is not on this branch; the fixture is here so that C6 has something to turn on.")]
     public async Task ACustomElementIsUpgradedAndHearsItsReactions()
     {
         await using var course = await FixtureCourse.OpenAsync("custom-elements");

--- a/Jint.Tests.Browser/Fixtures/README.md
+++ b/Jint.Tests.Browser/Fixtures/README.md
@@ -22,20 +22,23 @@ To add one:
    `/vendor/<library>-<version>/<file>` — the server answers the corpus at the paths it is stored at.
 2. Add a row to the inventory below. `FixtureInventoryTests` fails if a directory has no row or a row has no
    directory, so the table cannot drift from the corpus.
-3. Add one NUnit case, through `FixtureCourse`. Drive it with `harness.js`'s members rather than raw script:
-   they are what a real client's input would do, and the fixture must work without them.
+3. Add one NUnit case, through `FixtureCourse`. Drive it with the public `Page` input members — the same
+   ones a protocol client's input goes through — rather than with raw script, and read the end state with
+   `harness.js`'s. The fixture must work without any of it.
 4. If it does not pass, **do not delete it and do not quietly ignore it.** Mark the case
    `[Explicit("<fixture>: <one-line diagnosis>")]` — the reason has to start with the fixture's directory name,
    which is what `FixtureInventoryTests` matches against the `needs triage` rows here — and set the row's
    status below. A `needs triage` row is somebody's debt, the way a `NeedsTriage` row in the web-platform-tests
    lane is.
 
-`harness.js` is injected by the in-process suite and never loaded by a fixture. Two of its members exist
-because of something real: `type` writes through the prototype's `value` setter, because React installs an own
-`value` property that swallows a change whose value it already knows; and `FixtureCourse.EnterAsync` types and
-presses Enter as **two** turns, because a browser runs a microtask checkpoint between two user events and a
-library that re-renders on a microtask (Preact does, React does not) would otherwise read a draft it had
-already cleared.
+`harness.js` is injected by the in-process suite and never loaded by a fixture, and it is now the readers
+plus one click: `clickAt`, for the *n*th match of a repeated selector, which the public API has no member
+for. Everything else a case does to a page — a click, a fill, a key, a wait — is `Page.ClickAsync`,
+`FillAsync`, `PressAsync` and `WaitForAsync`, so a case here and the same case in the PuppeteerSharp or
+Playwright suite exercise one input model rather than two. One thing about the driver is still real rather
+than tidy: `FixtureCourse.EnterAsync` fills and presses Enter as **two** turns, because a browser runs a
+microtask checkpoint between two user events and a library that re-renders on a microtask (Preact does,
+React does not) would otherwise read a draft it had already cleared.
 
 ## The fixtures
 
@@ -47,10 +50,10 @@ already cleared.
 | `todomvc-svelte` | Svelte 5 compiled ahead of time: no framework runtime is loaded, only the component's own output | passes |
 | `ssr-hydration` | React `hydrateRoot` over server-rendered markup — the nodes are adopted, not replaced, and `onRecoverableError` stays empty | passes |
 | `jquery` | jQuery 3.7: `$.ajax({ async: false })` (a *synchronous* XMLHttpRequest), `$(fn)` readiness, delegated events on rows added later | passes |
-| `htmx` | htmx 2: `hx-trigger="load"`, `hx-get` + `hx-swap`, `hx-boost` | **needs triage** |
+| `htmx` | htmx 2: `hx-trigger="load"`, `hx-get` + `hx-swap`, `hx-boost` | passes |
 | `alpine` | Alpine 3: `x-data`, `x-model`, `x-text`, `x-show` — attributes found by walking the document, kept live by a `MutationObserver` | passes |
 | `spa-router` | An intercepted click, `history.pushState`, `popstate`, `back()`/`forward()`, and a link the router does not claim | passes |
-| `custom-elements` | `customElements.define`, the upgrade of an element the parser already made, and all four reactions | **needs triage** |
+| `custom-elements` | `customElements.define`, the upgrade of an element the parser already made, and all four reactions | passes |
 | `modules-importmap` | `<script type="importmap">`, a bare specifier, a mapped directory prefix, and a dynamic `import()` | passes |
 | `fetch-json` | `fetch` of JSON rendered into a list, a request header the script set, and the page's own request log | passes |
 | `form-redirect` | A form's entry list, a urlencoded `POST`, a `303`, and the `GET` that shows what the server read | passes |
@@ -60,12 +63,16 @@ already cleared.
 | `mutation-observer` | A widget kept in step with its subtree: `childList`, `attributeFilter` with old values, `characterData`, one batch per turn | passes |
 | `dialogs` | `alert`/`confirm`/`prompt` answered through `Page.DialogOpened`, and the default dismiss with no handler | passes |
 
-### The two that need triage
+### The triage table is empty, and what it took to empty it
 
-| Fixture | The failing assertion | Diagnosis |
+No fixture is `needs triage` today, so `FixtureInventoryTests` holds the corpus to *no* `[Explicit]` case
+at all. Both rows that stood were features rather than defects, and each was retired by the pull request
+that added the feature — which is what a triage row is for:
+
+| Fixture | What it was owed | Paid by |
 | --- | --- | --- |
-| `htmx` | `#on-load` is still `pending`; the page reports `ReferenceError: XPathEvaluator is not defined` from `htmx.min.js` | htmx 2 builds an `XPathEvaluator` expression at the **top level** of its bundle to find `hx-on:` attributes, so the library is a `ReferenceError` before any `hx-` attribute is read. This browser has no XPath at all: AngleSharp keeps it in `AngleSharp.XPath`, which nothing references, and there is no `XPathEvaluator`/`XPathExpression`/`XPathResult`/`document.evaluate`. Nothing about `hx-get`, `hx-swap`, `hx-trigger` or `hx-boost` has been reached, let alone refuted. |
-| `custom-elements` | `customElements` is not defined | The registry, the upgrade and the four reactions are campaign item **C6**, which had not merged when this landed. The fixture is checked in unchanged so that C6 can turn the case on by deleting one attribute. |
+| `htmx` | htmx 2 builds an `XPathEvaluator` expression at the **top level** of its bundle, so the library was a `ReferenceError` before any `hx-` attribute was read | DOM §7's XPath over `AngleSharp.XPath` (`Jint.Browser/Dom/Views/JsXPath`), plus `CSS.escape` and `new DocumentFragment`, which are the next two things it reaches for |
+| `custom-elements` | `customElements` did not exist | campaign item C6: the registry, the upgrade and the four reactions |
 
 ### The one whose *passing* behaviour is a divergence
 

--- a/Jint.Tests.Browser/Fixtures/harness.js
+++ b/Jint.Tests.Browser/Fixtures/harness.js
@@ -1,7 +1,11 @@
-// The obstacle course's driver, injected into a fixture by the in-process suite rather than loaded by the
+// The obstacle course's readers, injected into a fixture by the in-process suite rather than loaded by the
 // fixture itself. A fixture must run under a real automation client too -- PuppeteerSharp and Playwright
-// drive three of them over the protocol, with trusted input and no help from this file -- so nothing here
-// may be something a fixture depends on.
+// drive three of them over the protocol with no help from this file -- so nothing here may be something a
+// fixture depends on.
+//
+// Input is NOT here. Clicking, filling and pressing a key are Page.ClickAsync, Page.FillAsync and
+// Page.PressAsync, which go through the same input model a protocol client drives; `clickAt` is the one
+// that stayed, because the public API answers about the first match and a list case wants the nth.
 //
 // Every member answers a string, a number or a boolean. Nothing that belongs to the engine crosses back to
 // the caller, which is the page runtime's thread rule restated at the only place a test could break it.
@@ -16,25 +20,7 @@
     return element;
   };
 
-  // React installs an own `value` property on every controlled input, which records the last value it saw
-  // and makes it ignore a change whose value already equals it -- so `element.value = 'x'` types into a
-  // React input and nothing happens. The prototype's setter is the real one, underneath React's.
-  const setValue = (element, value) => {
-    const descriptor = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(element), 'value');
-    if (descriptor && typeof descriptor.set === 'function') {
-      descriptor.set.call(element, value);
-    } else {
-      element.value = value;
-    }
-  };
-
   globalThis.__h = {
-    /** Clicks the first match, through the element's own activation behaviour. */
-    click(selector) {
-      one(selector).click();
-      return true;
-    },
-
     /** Clicks the match at an index, for a list whose rows are all the same selector. */
     clickAt(selector, index) {
       const matches = document.querySelectorAll(selector);
@@ -42,24 +28,6 @@
         throw new Error(selector + ' has ' + matches.length + ' matches, so there is no [' + index + ']');
       }
       matches[index].click();
-      return true;
-    },
-
-    /** Puts text in a field the way a keystroke would: the real setter, then a bubbling `input`. */
-    type(selector, text) {
-      const element = one(selector);
-      element.focus();
-      setValue(element, text);
-      element.dispatchEvent(new Event('input', { bubbles: true }));
-      return true;
-    },
-
-    /** A key press at the element, as a `keydown`/`keyup` pair a framework's handler sees. */
-    press(selector, key) {
-      const element = one(selector);
-      const init = { key: key, code: key, bubbles: true, cancelable: true };
-      element.dispatchEvent(new KeyboardEvent('keydown', init));
-      element.dispatchEvent(new KeyboardEvent('keyup', init));
       return true;
     },
 

--- a/Jint.Tests.Browser/Verify/PublicApiTest.verified.txt
+++ b/Jint.Tests.Browser/Verify/PublicApiTest.verified.txt
@@ -140,6 +140,7 @@ namespace Jint.Browser
         public System.Threading.Tasks.Task<string> TextAsync(bool mainContentOnly = false, int maxLength = 0) { }
         public System.Threading.Tasks.Task<string> TitleAsync() { }
         public System.Threading.Tasks.Task<bool> TypeAsync(string target, string text) { }
+        public System.Threading.Tasks.Task<bool> WaitForAsync(string expression, System.TimeSpan timeout) { }
         public System.Threading.Tasks.Task<bool> WaitForIdleAsync(System.TimeSpan timeout) { }
         public System.Threading.Tasks.Task<bool> WaitForNavigationAsync(System.TimeSpan timeout) { }
         public System.Threading.Tasks.Task<bool> WaitForNetworkIdleAsync(System.TimeSpan timeout) { }

--- a/Jint.Tests.Browser/Views/HostInterfaceDisciplineTests.cs
+++ b/Jint.Tests.Browser/Views/HostInterfaceDisciplineTests.cs
@@ -1,3 +1,4 @@
+using Jint.Browser.Dom.Views;
 using Jint.Native;
 using Jint.Native.Object;
 using Jint.Native.Symbol;
@@ -34,7 +35,21 @@ public sealed class HostInterfaceDisciplineTests
         "Geolocation",
         "Window",
         "CustomElementRegistry",
+        "XPathEvaluator",
+        "XPathExpression",
+        "XPathResult",
     ];
+
+    /// <summary>The constants each of these interfaces declares, by the names WebIDL gives them.</summary>
+    /// <remarks>
+    /// A generated interface publishes its own list through <c>DomInterfaceDefinition.Constants</c>, which is
+    /// what <c>WebIdlPropertyAttributeTests</c> reads; a hand-written one has no such list, so this names the
+    /// table the shape was built from rather than guessing from the spelling of a key.
+    /// </remarks>
+    private static readonly Dictionary<string, string[]> _constants = new(StringComparer.Ordinal)
+    {
+        ["XPathResult"] = [.. XPathEvaluation.ResultConstants.Select(constant => constant.Name)],
+    };
 
     [Test]
     public async Task EveryRuntimeOwnedPrototypeKeepsItsSharedShape()
@@ -98,6 +113,16 @@ public sealed class HostInterfaceDisciplineTests
                     if (descriptor.Get is not null || descriptor.Set is not null)
                     {
                         Check(found, member, null, descriptor.Enumerable, descriptor.Configurable, null, true, true);
+                        continue;
+                    }
+
+                    // https://webidl.spec.whatwg.org/#es-constants — enumerable and nothing else, which is
+                    // the one kind whose attributes differ from an operation's. Membership in the
+                    // interface's own constant list rather than a naming heuristic, the way
+                    // WebIdlPropertyAttributeTests reads a generated interface's.
+                    if (_constants.TryGetValue(name, out var constants) && constants.Contains(key.AsString(), StringComparer.Ordinal))
+                    {
+                        Check(found, member, descriptor.Writable, descriptor.Enumerable, descriptor.Configurable, false, true, false);
                         continue;
                     }
 

--- a/Jint.Tests.Browser/Views/XPathTests.cs
+++ b/Jint.Tests.Browser/Views/XPathTests.cs
@@ -1,0 +1,221 @@
+namespace Jint.Tests.Browser.Views;
+
+// The test namespace sits under Jint.Tests.Browser, so the bare name Browser binds to that namespace rather
+// than to the type. The alias belongs inside the namespace declaration, where it wins that lookup.
+using Browser = global::Jint.Browser.Browser;
+
+/// <summary>
+/// DOM §7's XPath: <c>XPathEvaluator</c>, <c>XPathExpression</c>, <c>XPathResult</c> and
+/// <c>document.evaluate</c>.
+/// </summary>
+/// <remarks>
+/// The engine is <c>System.Xml.XPath</c> over <c>AngleSharp.XPath</c>'s navigator, so what these assert is
+/// the <i>binding</i>: the interfaces exist, a page can construct the one it is meant to, the ten result
+/// types are answered and coerced the way the standard says, and the two documented divergences (namespaces
+/// are ignored, and a node set is materialized) hold. <c>Jint.Browser/Dom/Views/JsXPath</c> argues both.
+/// </remarks>
+public sealed class XPathTests
+{
+    private const string Page =
+        """
+        <div id="root">
+          <p class="note">first</p>
+          <p class="note" data-tag="x">second</p>
+          <span id="only">alone</span>
+        </div>
+        """;
+
+    private static async Task<global::Jint.Browser.Page> OpenAsync(Browser browser)
+    {
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync(Page);
+        return page;
+    }
+
+    [Test]
+    public async Task TheThreeInterfacesAreGlobalsAndOnlyTheEvaluatorIsConstructible()
+    {
+        await using var browser = new Browser();
+        var page = await OpenAsync(browser);
+
+        (await page.EvaluateAsync<string>("typeof XPathEvaluator")).Should().Be("function");
+        (await page.EvaluateAsync<string>("typeof XPathExpression")).Should().Be("function");
+        (await page.EvaluateAsync<string>("typeof XPathResult")).Should().Be("function");
+
+        (await page.EvaluateAsync<bool>("new XPathEvaluator() instanceof XPathEvaluator")).Should().BeTrue();
+        (await page.EvaluateAsync<string>("Object.prototype.toString.call(new XPathEvaluator())"))
+            .Should().Be("[object XPathEvaluator]");
+
+        (await page.EvaluateAsync<string>(
+            "(() => { try { new XPathResult(); return 'no throw' } catch (e) { return e.message } })()"))
+            .Should().Be("Illegal constructor", "only XPathEvaluator has a constructor in DOM");
+    }
+
+    /// <summary>The two spellings of a constant WebIDL requires, and the ten values.</summary>
+    [Test]
+    public async Task TheResultTypeConstantsAreOnTheInterfaceObjectAndOnThePrototype()
+    {
+        await using var browser = new Browser();
+        var page = await OpenAsync(browser);
+
+        (await page.EvaluateAsync<int>("XPathResult.FIRST_ORDERED_NODE_TYPE")).Should().Be(9);
+        (await page.EvaluateAsync<int>("XPathResult.prototype.FIRST_ORDERED_NODE_TYPE")).Should().Be(9);
+
+        (await page.EvaluateAsync<string>(
+            """
+            [
+              'ANY_TYPE', 'NUMBER_TYPE', 'STRING_TYPE', 'BOOLEAN_TYPE',
+              'UNORDERED_NODE_ITERATOR_TYPE', 'ORDERED_NODE_ITERATOR_TYPE',
+              'UNORDERED_NODE_SNAPSHOT_TYPE', 'ORDERED_NODE_SNAPSHOT_TYPE',
+              'ANY_UNORDERED_NODE_TYPE', 'FIRST_ORDERED_NODE_TYPE'
+            ].map(name => XPathResult[name]).join(',')
+            """))
+            .Should().Be("0,1,2,3,4,5,6,7,8,9");
+    }
+
+    /// <summary>The shape htmx uses: compile once at the top level, evaluate against a node, iterate.</summary>
+    [Test]
+    public async Task ACompiledExpressionIteratesTheNodesItMatched()
+    {
+        await using var browser = new Browser();
+        var page = await OpenAsync(browser);
+
+        (await page.EvaluateAsync<string>(
+            """
+            (() => {
+              const expression = (new XPathEvaluator).createExpression('.//p[@class="note"]');
+              const result = expression.evaluate(document.getElementById('root'));
+              const seen = [];
+              let node = null;
+              while (node = result.iterateNext()) { seen.push(node.textContent) }
+              return seen.join('|');
+            })()
+            """))
+            .Should().Be("first|second");
+
+        (await page.EvaluateAsync<bool>(
+            "(new XPathEvaluator).createExpression('//p') instanceof XPathExpression")).Should().BeTrue();
+    }
+
+    /// <summary>An unprefixed name test matches an HTML element, which is the whole point of the choice.</summary>
+    [Test]
+    public async Task AnUnprefixedNameTestMatchesAnHtmlElement()
+    {
+        await using var browser = new Browser();
+        var page = await OpenAsync(browser);
+
+        (await page.EvaluateAsync<string>(
+            """
+            document.evaluate('//span[@id="only"]', document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null)
+              .singleNodeValue.textContent
+            """))
+            .Should().Be("alone");
+
+        // And the node that comes back is the page's own wrapper, not a copy.
+        (await page.EvaluateAsync<bool>(
+            """
+            document.evaluate('//span[@id="only"]', document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null)
+              .singleNodeValue === document.getElementById('only')
+            """))
+            .Should().BeTrue("wrapper identity is the cache's, so an XPath result is the same object querySelector gives");
+    }
+
+    /// <summary>The result types other than a node set, and the coercions between them.</summary>
+    [Test]
+    public async Task ANumberAStringAndABooleanAreAnsweredAndCoerced()
+    {
+        await using var browser = new Browser();
+        var page = await OpenAsync(browser);
+
+        var evaluate = "((expression, type) => document.evaluate(expression, document, null, type, null))";
+
+        (await page.EvaluateAsync<double>(evaluate + "('count(//p)', XPathResult.NUMBER_TYPE).numberValue"))
+            .Should().Be(2);
+
+        (await page.EvaluateAsync<string>(evaluate + "('string(//span)', XPathResult.STRING_TYPE).stringValue"))
+            .Should().Be("alone");
+
+        (await page.EvaluateAsync<bool>(evaluate + "('//p', XPathResult.BOOLEAN_TYPE).booleanValue"))
+            .Should().BeTrue("a non-empty node set is true");
+
+        (await page.EvaluateAsync<bool>(evaluate + "('//table', XPathResult.BOOLEAN_TYPE).booleanValue"))
+            .Should().BeFalse("an empty one is false");
+
+        // ANY_TYPE infers, which is what a page that passes nothing gets.
+        (await page.EvaluateAsync<int>(evaluate + "('count(//p)', XPathResult.ANY_TYPE).resultType"))
+            .Should().Be(1);
+        (await page.EvaluateAsync<int>(evaluate + "('//p', XPathResult.ANY_TYPE).resultType"))
+            .Should().Be(4, "a node set with no type asked for is an unordered iterator");
+    }
+
+    /// <summary>A snapshot is indexed, and reading the wrong member off a result is a TypeError.</summary>
+    [Test]
+    public async Task ASnapshotIsIndexedAndTheWrongAccessorIsATypeError()
+    {
+        await using var browser = new Browser();
+        var page = await OpenAsync(browser);
+
+        var snapshot = "document.evaluate('//p', document, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null)";
+
+        (await page.EvaluateAsync<int>(snapshot + ".snapshotLength")).Should().Be(2);
+        (await page.EvaluateAsync<string>(snapshot + ".snapshotItem(1).textContent")).Should().Be("second");
+        (await page.EvaluateAsync<string>("String(" + snapshot + ".snapshotItem(9))")).Should().Be("null");
+
+        (await page.EvaluateAsync<string>(
+            "(() => { try { return String(" + snapshot + ".numberValue) } catch (e) { return e.constructor.name } })()"))
+            .Should().Be("TypeError", "a snapshot has no number value");
+    }
+
+    /// <summary>An expression the parser refuses is the standard's <c>SyntaxError</c>, not a CLR exception.</summary>
+    [Test]
+    public async Task AnUnparseableExpressionIsASyntaxError()
+    {
+        await using var browser = new Browser();
+        var page = await OpenAsync(browser);
+
+        (await page.EvaluateAsync<string>(
+            """
+            (() => {
+              try { document.evaluate('//p[', document, null, 0, null); return 'no throw' }
+              catch (e) { return e.name }
+            })()
+            """))
+            .Should().Be("SyntaxError");
+
+        page.Errors.Should().BeEmpty();
+    }
+
+    /// <summary><c>createNSResolver</c> is legacy, and its whole definition is "return the node".</summary>
+    [Test]
+    public async Task CreateNsResolverAnswersTheNodeItWasGiven()
+    {
+        await using var browser = new Browser();
+        var page = await OpenAsync(browser);
+
+        (await page.EvaluateAsync<bool>("document.createNSResolver(document) === document")).Should().BeTrue();
+        (await page.EvaluateAsync<bool>("(new XPathEvaluator).createNSResolver(document) === document")).Should().BeTrue();
+    }
+
+    /// <summary>
+    /// The documented divergence: the node set is taken whole, so a mutation cannot invalidate an iterator.
+    /// </summary>
+    [Test]
+    public async Task AnIteratorSurvivesAMutationRatherThanBecomingInvalid()
+    {
+        await using var browser = new Browser();
+        var page = await OpenAsync(browser);
+
+        (await page.EvaluateAsync<string>(
+            """
+            (() => {
+              const result = document.evaluate('//p', document, null, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null);
+              const first = result.iterateNext();
+              document.getElementById('root').appendChild(document.createElement('p'));
+              const second = result.iterateNext();
+              return [result.invalidIteratorState, first.textContent, second.textContent].join('|');
+            })()
+            """))
+            .Should().Be("false|first|second",
+                "the set is materialized at evaluation, so a browser's InvalidStateError cannot arise here");
+    }
+}

--- a/README.md
+++ b/README.md
@@ -2349,10 +2349,19 @@ await using var browser = new Browser();
 var page = await browser.NewPageAsync();
 
 var response = await page.NavigateAsync("https://example.org/login");
-await page.SubmitFormAsync("#login");
 
+await page.FillAsync("#email", "ada@example.org");
+await page.FillAsync("#password", "correct horse");
+await page.ClickAsync("#sign-in");
+
+await page.WaitForAsync("document.querySelector('#user') !== null", TimeSpan.FromSeconds(10));
 var user = await page.EvaluateAsync<string>("document.querySelector('#user').textContent");
 ```
+
+`WaitForAsync` is the general form of `WaitForSelectorAsync` and `WaitForTextAsync`, for a condition
+neither an element nor a piece of text can state — a URL a router moved, a list that reached a length. An
+expression that throws is *not yet true*, so a condition written against an element a framework has not
+rendered is usable; a timeout reports that failure rather than a bare `false`.
 
 **What exists.** Generated bindings for every WebIDL interface AngleSharp describes: one prototype per
 interface built on Jint's own `JsObjectShape`, the interface objects (`Node`, `Element`, `HTMLDivElement`,
@@ -2390,6 +2399,13 @@ as documented stubs that report every observed target once, since there is no la
 `DOMParser` (HTML, and XML through `AngleSharp.Xml`) and `XMLSerializer`, `Range`, `TreeWalker`,
 `NodeIterator`, `getSelection()`, `<template>` content and `attachShadow`, with events crossing a shadow
 boundary the way the DOM says.
+
+**And XPath.** `document.evaluate`, `createExpression`, `createNSResolver`, `XPathEvaluator`,
+`XPathExpression` and `XPathResult` with its ten result types, evaluated by `System.Xml.XPath` over
+`AngleSharp.XPath`'s navigator — which is what htmx 2 needs before it reads a single `hx-` attribute.
+Namespaces are ignored, so an unprefixed `//div` matches an HTML element the way a page expects, and a
+node set is taken whole at evaluation rather than kept live. CSSOM's `CSS.escape` and `CSS.supports` are
+there too, the second answered by AngleSharp.Css's own condition evaluator.
 
 **And the network half.** `Page.NavigateAsync` loads an `http(s)` URL through Jint's own fetch pipeline and
 parses the result into a new engine — the document being left gets `beforeunload`, `pagehide` and `unload`,
@@ -2664,7 +2680,7 @@ and `document.write` after a page has finished parsing is refused with a page er
 offline pages built out of the libraries' own published bundles, served over a loopback socket and driven
 through the `Page` API — and three of them are driven again over the protocol by PuppeteerSharp and by
 Playwright for .NET. Each case asserts a DOM end state *and* that the page reported no errors at all, which
-is what tells a half-working page from a working one. Sixteen of the eighteen pass:
+is what tells a half-working page from a working one. All eighteen pass:
 
 | Works | Fixture |
 | --- | --- |
@@ -2681,9 +2697,10 @@ is what tells a half-working page from a working one. Sixteen of the eighteen pa
 | **Both observers** — a `MutationObserver` widget batching a turn's mutations into one callback, and an `IntersectionObserver` lazy list | `mutation-observer`, `intersection-observer` |
 | **Dialogs** — `alert`, `confirm` and `prompt` answered through `Page.DialogOpened`, and dismissed by default | `dialogs` |
 
-Two do not, and both say why in the inventory rather than being quietly dropped: **htmx 2** builds an
-`XPathEvaluator` expression at the top level of its bundle and this browser has no XPath at all, and
-**custom elements** are a later item of the same campaign. The lazy list is the one whose *passing*
+**htmx 2** — `hx-trigger="load"`, `hx-get` with a swap, and a boosted link — and **custom elements** pass
+too, and both are worth a sentence because neither did when the course was written: each was a
+`needs triage` row in the inventory naming the feature it was owed, and each was retired by the pull
+request that added it rather than by being quietly dropped. The lazy list is the one whose *passing*
 behaviour is a divergence: with no layout nothing can stop intersecting, so an observed target is reported
 once and an infinite list loads every page at once — which is the readable outcome rather than the correct
 one, and is asserted as such.

--- a/docs/design/headless-browser.md
+++ b/docs/design/headless-browser.md
@@ -387,7 +387,9 @@ about them differ from the paragraph above. The course runs on all four legs, as
 because it costs nothing. A fixture that does not pass is a **`needs triage` row** in
 [`Fixtures/README.md`](../../Jint.Tests.Browser/Fixtures/README.md) with the failing assertion and a
 one-line diagnosis, and `FixtureInventoryTests` fails unless that set is exactly the set of cases marked
-`[Explicit]` — the discipline the web-platform-tests exclusion table is under, for the same reason. And the
+`[Explicit]` — the discipline the web-platform-tests exclusion table is under, for the same reason. Both
+rows that were ever written have since been retired by the pull request that paid them: `htmx` was owed
+DOM XPath and `custom-elements` was owed the registry. And the
 course is a **gate on the engine as much as on the package**: the eighteen fixtures and the two clients found
 seven defects between them, six of which were fixed in the pull request that added them — an
 `insertBefore(node, null)` that was a `TypeError`, a selector refusal a page could not catch, a

--- a/tools/dom-bindings/overrides.json
+++ b/tools/dom-bindings/overrides.json
@@ -746,6 +746,39 @@
       "reason": "The one element whose scrollTop moves the window, which is how a client finds the page's own scroll offset. Standards mode always: it is the document element."
     },
     {
+      "interface": "Document",
+      "member": "evaluate",
+      "kind": "operation",
+      "length": 2,
+      "body": [
+        "_ = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, \"Document.evaluate\");",
+        "return global::Jint.Browser.Dom.Views.XPathEvaluation.Evaluate(global::Jint.Browser.Runtime.PageRuntime.Of(thisObj, \"Document.evaluate\"), args, \"Document.evaluate\");"
+      ],
+      "reason": "DOM 7's XPath, which neither pinned assembly declares: there is no [DomName(\"evaluate\")] anywhere in AngleSharp, so nothing could generate it. The evaluator is System.Xml.XPath over AngleSharp.XPath's navigator - see Dom/Views/JsXPath. htmx 2 builds an XPathEvaluator at the top level of its bundle, so a page that loads it is a ReferenceError without this."
+    },
+    {
+      "interface": "Document",
+      "member": "createExpression",
+      "kind": "operation",
+      "length": 1,
+      "body": [
+        "_ = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, \"Document.createExpression\");",
+        "return global::Jint.Browser.Dom.Views.XPathEvaluation.CreateExpression(global::Jint.Browser.Runtime.PageRuntime.Of(thisObj, \"Document.createExpression\"), args, \"Document.createExpression\");"
+      ],
+      "reason": "The compiling half of XPathEvaluatorBase, which a page reuses across evaluations the way htmx does."
+    },
+    {
+      "interface": "Document",
+      "member": "createNSResolver",
+      "kind": "operation",
+      "length": 1,
+      "body": [
+        "_ = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, \"Document.createNSResolver\");",
+        "return global::Jint.Browser.Dom.Views.XPathEvaluation.CreateNSResolver(args, \"Document.createNSResolver\");"
+      ],
+      "reason": "Legacy, and DOM keeps it only because pages call it: its whole definition is now 'return the node'."
+    },
+    {
       "interface": "HTMLElement",
       "extend": "Jint.Browser.Events.DomShapeAdditions.HtmlElementHandlers",
       "reason": "HTML's GlobalEventHandlers and DocumentAndElementEventHandlers mixins - eighty-odd on* IDL attributes with an identically shaped accessor pair each. AngleSharp declares the handlers as CLR events, which the member closure never yields, and as member entries they would be a hundred and seventy near-identical rows; the extend form exists for exactly this."


### PR DESCRIPTION
> **Stacked on two branches.** Its base is `headless/browser-mcp` (#3717, the MCP/tool work) with #3716
> (`headless/browser-resolved-style`) on top, so the diff shown here carries all three. **The last commit is
> this PR's**; once #3715/#3717 and #3716 have merged it becomes a one-commit diff and I will rebase.
>
> The public page input API — `ClickAsync`, `HoverAsync`, `FillAsync`, `TypeAsync`, `PressAsync`,
> `SelectAsync`, `ScrollToAsync`, `WaitForSelectorAsync`, `WaitForTextAsync` — is **#3717's**, not this one's.
> This adds one member to it and uses the rest.

## XPath

htmx 2 evaluates `(new XPathEvaluator).createExpression(…)` at the **top level** of its bundle, to find
`hx-on:` attributes — so the whole library was a `ReferenceError` before a single `hx-` attribute was read,
and the `htmx` fixture was a `needs triage` row for a feature that did not exist. `Jint.Browser` now
references `AngleSharp.XPath` and binds `XPathEvaluator`, `XPathExpression`, `XPathResult` with its ten
result-type constants (on the interface object *and* the prototype, as WebIDL requires), and
`document.evaluate` / `createExpression` / `createNSResolver`.

**The issue's suggested shape does not work, and that is worth recording.** It expected the generator to
project these from `[DomName]`-annotated attributes. Neither `AngleSharp.XPath` nor AngleSharp carries a
`[DomName]` for any of it — there is no `IXPathEvaluator`, no `evaluate` on `IDocument`, nothing to project
(`AngleSharp.XPath` is four public types: extension methods, a navigator and an attribute selector). So the
three interfaces are hand-written host interfaces beside `DOMParser` and `Selection`, the three `Document`
members are `overrides.json` `additions`, and the evaluator is `System.Xml.XPath` over `AngleSharp.XPath`'s
`HtmlDocumentNavigator` — which is exactly the seam the BCL's XPath 1.0 evaluator takes, so nothing here is
an XPath engine.

Two decisions are stated rather than hidden, both in `Dom/Views/JsXPath`:

- **Namespaces are ignored**, which is what makes an unprefixed `//div` match an HTML element — that element
  is in the XHTML namespace, so an XPath 1.0 name test would match nothing if the navigator reported it, and
  `AngleSharp.XPath`'s own default is the same choice. A *prefixed* test compiles (a resolver the page
  supplied is consulted) and then matches nothing.
- **A node set is materialized at evaluation**, so `invalidIteratorState` is always `false` and an iterator
  survives a mutation instead of raising `InvalidStateError`. DOM's iterator is live and needs a mutation
  signal this has none of; the direction is the safe one, because what it removes is a page throwing.

`DOM.performSearch` gained Chrome's third arm from the same evaluator, in Chrome's order — selector, XPath,
text — and a query that is none of the three contributes nothing rather than failing the command, because a
search box is typed into one character at a time.

**Two more things htmx needed**, both found by driving the fixture rather than by reading it:

- **CSSOM's `CSS`** — `escape` (the serialize-an-identifier algorithm; htmx builds `'#' + CSS.escape(id)` for
  every out-of-band swap) and `supports`, because `window.CSS && CSS.supports(…)` is how the feature is
  detected and a `CSS` with only half of it is a trap. `supports` parses the condition as an `@supports` rule
  and asks AngleSharp.Css's own `IConditionFunction.Check`, so what it claims to support is exactly what the
  cascade can act on.
- **`new DocumentFragment()`**, which DOM gives a constructor and `DomConstructors` did not. htmx builds one
  for every swap whose response starts with `<html>` or `<body>`.

## One wait, not a second input model

The one thing the obstacle course needed that #3717's input API has no member for is a wait on an arbitrary
**expression** — `location.pathname === '/next'`, a list that reached a length, a flag a framework set.
`Page.WaitForAsync(expression, timeout)` joins `WaitForSelectorAsync` and `WaitForTextAsync` over the *same*
private helper, so there is one wait mechanism and three public members over it: the page is looked at from
off the loop, and it goes on running its timers, promises and fetches while the wait lasts.

**An expression that throws is not yet true**, so a condition written against an element a framework has not
rendered is usable; the last failure is kept, and a timeout rethrows it rather than answering `false`, so a
typo in the expression is a failure with a reason. One line on `PublicApiTest.verified.txt`.

**The course's JS harness is down to the readers.** Every click, fill, key press and wait in `FixtureCourse`
goes through the public API now; `harness.js` keeps only the readers and `clickAt`, which is the one input
member the public API has none of (a host wants the first match; a list case wants the *n*th).

## The handshake pin replays parameter shapes

The name-only replay asks whether a method is *reachable*. Two of the four defects Playwright found were
about what a call **carries** — `Target.getTargetInfo` with no parameters at all, and a default-context page
whose target named no `browserContextId` — and a pin that counts method names cannot see either. So each
recorded call is rebuilt from its own `paramsKeys`: the recorded value where the recording kept one, the live
identifier where the key names one, and a value typed from the **vendored protocol** otherwise (so a bump
that turns a member into an enumeration changes what this sends, in the same pull request). The answer must
never be `-32602`. The two shapes are asserted on their own as well, so a regression names itself.

One thing the recordings needed reading twice: `paramsValues` keeps every *distinct* value a client sent, so
`"returnByValue": [false, true]` is a client that sent both rather than a client that sent a list. A recorded
value is used where its JSON kind is the declared one, and otherwise the first member of the set that is.

## The triage table is empty

`custom-elements` was the corpus's other `needs triage` row and C6 (#3709) has landed, so its `[Explicit]`
comes off here too. `FixtureInventoryTests` now holds the course to **no** skipped case at all — both rows
were owed a feature rather than a fix, and each was retired by the pull request that paid it.

## One instruction-file cut

`Jint.Browser/AGENTS.md` crosses its 32 KiB cap once #3717's paragraph and #3716's two divergence rows are
both under it — 176 bytes over, which is a silent mid-file truncation for every agent that reads it. Two rows
**this stack itself added** are shortened to the trap plus a pointer at the remedy (the remedy is already in
`Runtime/WindowInstaller.Cascade`'s and `Dom/Views/ResolvedStyle`'s own documentation), which is the split
the root `AGENTS.md` prescribes. That leaves 220 bytes; the file wants a proper rebalance, and nothing here
adds to it.

## What was left out, and why

- **No input members of my own.** An earlier revision of this branch added `ClickAsync`/`TypeAsync`/
  `FillAsync`/`PressAsync`; #3717 got there first with a better surface (a `ref=` target, an awaited
  navigation, hover and select), so they are gone and the course drives through those.
- **A namespace prefix resolves but does not match.** The resolver a page passes is consulted while the
  expression is compiled — which is what stops `svg:circle` from being a `SyntaxError` — and the navigator
  reports no namespace for any node, so the test matches nothing. Recorded in `Dom/AGENTS.md`.
- **`CSS.supports`'s two-argument form is a declaration in parentheses**, so a value carrying an unbalanced
  parenthesis makes the whole condition unparseable and answers `false`, where a browser reaches the same
  answer through a proper value parser.
- **`XPathResult` keeps DOM's members and no more**: no `length`, no iteration protocol, nothing invented.

## Verified

Against the rebased stack (`headless/browser-mcp` + #3716 + this): `Jint.Tests.Browser` **1168 / 1165**
passed (`net10.0` / `net8.0`, `JINT_BROWSER_CLIENTS=1`, so both client suites ran), with **zero**
`[Explicit]` fixtures where there were two. `Jint.Tests.DevTools` 392 / 390, `Jint.Tests` 12,198 ×2 plus
8,447 on `net472`, `Jint.Tests.PublicInterface`, `Jint.Tests.CommonScripts` and
`Jint.Tests.SourceGenerators` green. `Jint.Tests.Test262` was 102,571 passed with 2 pre-existing `intl402`
locale failures that reproduce unchanged on the base; nothing here touches `Jint/`.

The bindings were regenerated with `JINT_DOM_BINDINGS=update` and `DomBindingsStalenessTests` passes; the
`.g.cs` diff is 21 lines, the three `Document` members. New tests were run against the code before the
change and fail there — `XPathTests` because the page reported `ReferenceError: XPathEvaluator is not
defined`, the `htmx` case for the same reason, and `PerformSearchFindsBySelectorByXPathAndByText` with
`resultCount` 0 instead of 1. The parameter-shape replay is a **pin** rather than a fix: the two shapes it
names were fixed by #3710, and it exists so that the next one cannot pass unnoticed.

Fixes #3714

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
