### PR TITLE
Docs: the browser and DevTools sections are written for a reader who did not follow the campaign, and the two packages get a README NuGet shows

### DIFF
--- a/Jint.Browser.Mcp/README.md
+++ b/Jint.Browser.Mcp/README.md
@@ -125,6 +125,6 @@ against the latter does not open.
 The engine underneath is an interpreter, so a page costs a fraction of Chromium's memory and CPU and some
 multiple of its wall-clock time. What the whole stack can and cannot do — and how much of it the
 web-platform-tests measure rather than claim — is in
-[Jint's README](https://github.com/sebastienros/jint#jintbrowser-opt-in-package-in-progress).
+[Jint's README](https://github.com/sebastienros/jint#headless-browser-opt-in-package).
 
 Licensed under BSD-2-Clause, like the rest of Jint.

--- a/Jint.Browser.Tool/README.md
+++ b/Jint.Browser.Tool/README.md
@@ -150,6 +150,6 @@ recorded in the request log with the reason instead.
 
 Full documentation of the package under it — what a page can and cannot do, and how much of it the
 web-platform-tests measure rather than claim — is in
-[Jint's README](https://github.com/sebastienros/jint#jintbrowser-opt-in-package-in-progress).
+[Jint's README](https://github.com/sebastienros/jint#headless-browser-opt-in-package).
 
 Licensed under BSD-2-Clause, like the rest of Jint.

--- a/Jint.Browser/Jint.Browser.csproj
+++ b/Jint.Browser/Jint.Browser.csproj
@@ -23,6 +23,7 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
 
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
 
     <!--
@@ -39,6 +40,11 @@
     -->
     <IsAotCompatible>false</IsAotCompatible>
   </PropertyGroup>
+
+  <ItemGroup>
+    <!-- The package README NuGet shows. -->
+    <None Include="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Jint\Jint.csproj" />

--- a/Jint.Browser/README.md
+++ b/Jint.Browser/README.md
@@ -1,0 +1,35 @@
+# Jint.Browser
+
+A headless browser in one .NET process, from [Jint](https://github.com/sebastienros/jint) and
+[AngleSharp](https://anglesharp.github.io/). AngleSharp is the HTML parser, the DOM and the CSSOM; Jint runs
+the document's scripts; this package is the binding layer between them and the page runtime on top of it. It
+navigates, runs a page's scripts against a real DOM, follows its network, keeps its cookies and storage, and
+answers what the page turned out to be. **It renders nothing** — no layout, no pixels, no screenshots — and
+there is no browser binary to download or launch.
+
+```c#
+await using var browser = new Browser();
+var page = await browser.NewPageAsync();
+
+await page.NavigateAsync("https://example.org/login");
+await page.SubmitFormAsync("#login");
+
+var user = await page.EvaluateAsync<string>("document.querySelector('#user').textContent");
+```
+
+A browser can also be published on a [`Jint.DevTools`](https://www.nuget.org/packages/Jint.DevTools) server
+with `server.AddBrowser(browser)`, which makes every page a Chrome DevTools Protocol `page` target that
+Puppeteer, PuppeteerSharp, Playwright and Playwright for .NET drive over `connect` — in the same process,
+with nothing to install. For the command line, see
+[`Jint.Browser.Tool`](https://www.nuget.org/packages/Jint.Browser.Tool); for an agent,
+[`Jint.Browser.Mcp`](https://www.nuget.org/packages/Jint.Browser.Mcp) serves the same page over the Model
+Context Protocol.
+
+Requires .NET 8 or later. Not trim- or AOT-compatible in this version, because AngleSharp is not
+trim-annotated.
+
+What a page can and cannot do, the per-page budgets, `ForUntrustedContent`, and how much of it is measured
+rather than claimed are in
+[Jint's README](https://github.com/sebastienros/jint#headless-browser-opt-in-package).
+
+Licensed under BSD-2-Clause, like the rest of Jint.

--- a/Jint.DevTools/Jint.DevTools.csproj
+++ b/Jint.DevTools/Jint.DevTools.csproj
@@ -23,6 +23,7 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
 
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
 
     <!--
@@ -41,6 +42,11 @@
     -->
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
   </PropertyGroup>
+
+  <ItemGroup>
+    <!-- The package README NuGet shows. -->
+    <None Include="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
   <ItemGroup>
     <!-- Jint's PUBLIC surface only. There is deliberately no InternalsVisibleTo grant from Jint to this

--- a/Jint.DevTools/README.md
+++ b/Jint.DevTools/README.md
@@ -1,0 +1,40 @@
+# Jint.DevTools
+
+A [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/) server for
+[Jint](https://github.com/sebastienros/jint), so a debugging client can attach to an engine your host is
+already running. It speaks CDP over a WebSocket, and a Jint engine appears to a client the way a Node process
+does — a target it can list, attach to and evaluate in — with no browser anywhere in the picture. `Runtime`,
+`Debugger`, `Profiler`, `Console`, `Log`, `Target`, `Browser` and `Schema` answer; everything else is
+honestly `-32601`, which is what a client feature-detects on.
+
+```c#
+using Jint.DevTools;
+
+var engine = new Engine(options => options.UseDevTools());
+
+await using var server = new DevToolsServer(new DevToolsServerOptions { Port = 9222 });
+server.AddTarget(new EngineTarget(engine));
+server.Start();
+
+// The host's own loop is what runs the engine AND answers the protocol.
+while (running)
+{
+    engine.Tasks.ProcessTasks();
+    engine.Tasks.WaitForScheduledWork(TimeSpan.FromMilliseconds(50));
+}
+```
+
+Point Chrome's `chrome://inspect` at `127.0.0.1:9222`, or connect PuppeteerSharp with
+`new ConnectOptions { BrowserURL = "http://127.0.0.1:9222" }`. **The endpoint is unauthenticated**, exactly as
+it is in Chrome: anything that can reach it can evaluate arbitrary script in your process, so `Host` defaults
+to `127.0.0.1` and should stay there.
+
+Requires .NET 8 or later, and is Native AOT compatible — everything the protocol serializes goes through a
+source-generated `System.Text.Json` context, and a published native binary is driven over a real socket in
+CI. [`Jint.Browser`](https://www.nuget.org/packages/Jint.Browser) adds the page domains (`Page`, `DOM`,
+`Network`, `Fetch`, `Input`, `Emulation`, `Storage`, `Accessibility`) on the same session core.
+
+Which thread answers a command, what each domain answers, and how to try it from the REPL are in
+[Jint's README](https://github.com/sebastienros/jint#chrome-devtools-protocol-opt-in-package).
+
+Licensed under BSD-2-Clause, like the rest of Jint.

--- a/README.md
+++ b/README.md
@@ -2250,17 +2250,16 @@ reverts global bindings, not host storage. A deployment running untrusted script
 itself: that is where a size limit, an eviction policy and a per-tenant partition belong. See
 [THREAT_MODEL.md](.github/THREAT_MODEL.md) TM-23 for the full analysis.
 
-
-
 ## Chrome DevTools Protocol (opt-in package)
 
 The `Jint.DevTools` package lets a debugging client attach to an engine your host is already running. It
 speaks the [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/) over a WebSocket,
 so a Jint engine appears to a client the way a Node process does — a target it can list, attach to and
-evaluate in — with no browser anywhere in the picture.
+evaluate in — with no browser anywhere in the picture. It is the engine half of the protocol;
+[the browser package](#headless-browser-opt-in-package) adds the page half on the same session core.
 
 ```csharp
-// dotnet add package Jint.DevTools   (net8.0 and later)
+// dotnet add package Jint.DevTools   (net8.0 and net10.0)
 using Jint.DevTools;
 
 var engine = new Engine(options => options.UseDevTools());
@@ -2277,9 +2276,10 @@ while (running)
 }
 ```
 
-Point a client at `http://127.0.0.1:9222` — `chrome://inspect` lists it, PuppeteerSharp's
+Point a client at `http://127.0.0.1:9222` — PuppeteerSharp's
 `Puppeteer.ConnectAsync(new ConnectOptions { BrowserURL = "http://127.0.0.1:9222" })` connects to it, and
-`server.BrowserWebSocketUrl` is the address for a client that wants the socket directly. Leave
+`server.BrowserWebSocketUrl` is the address for a client that wants the socket directly. Chrome's
+`chrome://inspect` lists the target once `127.0.0.1:9222` has been added to it under **Configure…**. Leave
 `DevToolsServerOptions.Port` at its default of `0` for an ephemeral port and read `server.BoundPort`.
 
 **Which thread answers a command is yours to choose.** `ThreadMode.HostOwned`, the default, means your own
@@ -2291,13 +2291,14 @@ so touching it from anywhere else still fails fast rather than corrupting anythi
 
 **The endpoint is unauthenticated**, exactly as it is in Chrome: anything that can reach it can evaluate
 arbitrary script in your process. `DevToolsServerOptions.Host` therefore defaults to `127.0.0.1`; do not
-bind it to a routable address.
+bind it to a routable address. The browser section below publishes its pages on this same server, so the
+warning covers that too.
 
 ### What answers today
 
-- **`Runtime`** — list targets, attach, hear about the execution context, and evaluate, including
-  `returnByValue`, object handles you can walk with `getProperties`, `callFunctionOn`, bindings and awaiting
-  a promise.
+- **`Runtime`** — evaluate, including `returnByValue`, object handles you can walk with `getProperties`,
+  `callFunctionOn`, bindings, and awaiting a promise; plus the execution context, console calls and uncaught
+  exceptions a client is told about without asking.
 - **`Debugger`** — breakpoints by URL or script, the three steps, `continueToLocation`, call frames, scopes
   (a getter-free snapshot, with a binding still in its temporal dead zone absent rather than `undefined`),
   `setVariableValue`, evaluation in any frame, and **pausing where a script throws**.
@@ -2305,10 +2306,17 @@ bind it to a routable address.
   which a function that never ran is reported with a zero count rather than being absent. Coverage is the
   one switch with a running cost, so it is opt-in: `options.UseDevTools(devTools => devTools.Coverage = true)`.
 - **`Console`, `Log`** — what a script logged, with its values still attached, and what it threw.
-- **`Target`, `Browser`, `Schema`** — the session core, flattened sessions only.
+- **`Target`, `Browser`, `Schema`** — the session core: listing targets, a flattened attach (`flatten: false`
+  is refused; no client sends it), and the domain list. These three are answered on the *browser* session, and
+  `Runtime`, `Debugger`, `Profiler`, `Console` and `Log` on a target's own — sending one down the other's
+  session identifier is a `-32601` like any other.
 
-Everything else answers `'Domain.method' wasn't found`, which is what a client feature-detects on, and the
-package's `AGENTS.md` says why for each. Page-level domains are not this package's business.
+Everything else answers `'Domain.method' wasn't found`, the `-32601` a client feature-detects on. The page
+domains (`Page`, `DOM`, `Network`, `Fetch`, `Input`, `Emulation`, `Storage`, `Accessibility`) belong to
+`Jint.Browser` and are absent on an engine target; for the rest, `Jint.Tests.DevTools`'s `Absent` table names
+a reason for every method the four recorded clients actually send, and the package's `AGENTS.md` argues the
+notable ones — async call stacks, source maps, blackboxing, `HeapProfiler` and per-session breakpoints among
+them.
 
 ### Trying it without writing a host
 
@@ -2318,11 +2326,11 @@ The REPL serves the protocol over `--inspect`:
 dotnet run --project Jint.Repl -c Release -- --inspect -f script.js -t 60
 ```
 
-It prints the WebSocket endpoint, the `devtools://` front-end address and what to type into
-`chrome://inspect`. `--inspect=[host:]port` chooses where to listen — `0` takes an ephemeral port and the
-banner names it — and `--inspect-brk` runs nothing until a client has attached and sent
-`Runtime.runIfWaitingForDebugger`. The engine stays attached after the script finishes, so a timer still
-fires and a client can still read it.
+It listens on `127.0.0.1:9229` — Node's port, not the `9222` used above — and prints the WebSocket endpoint,
+the `devtools://` front-end address and what to type into `chrome://inspect`. `--inspect=[host:]port` chooses
+where to listen; `0` takes an ephemeral port and the banner names it, and `--inspect-brk` runs nothing until a
+client has attached and sent `Runtime.runIfWaitingForDebugger`. The engine stays attached after the script
+finishes, so a timer still fires and a client can still read it.
 
 `Jint.DevTools/docs/manual-checklist.md` is what each panel should show, and
 `tools/devtools-frontend-smoke/` drives most of that walk against a real Chrome automatically.
@@ -2336,15 +2344,32 @@ if any trim or AOT analysis diagnostic is attributed to a file in `Jint.DevTools
 serializes goes through a source-generated `System.Text.Json` context, and the first reflective member would
 show up there and nowhere else.
 
-## Jint.Browser (opt-in package, in progress)
+## Headless browser (opt-in package)
 
-`Jint.Browser` is **AngleSharp + Jint**: AngleSharp is the HTML parser, the DOM and (with `AngleSharp.Css`)
-the CSSOM; Jint is the engine, and this package is the layer between them. It is the beginning of a headless
-browser — one that runs a page's scripts against a real DOM without rendering anything — and it is not
-finished. What ships today is a page runtime that navigates, submits forms, keeps cookies and storage and
-runs workers; what it still cannot do is listed below rather than left to be discovered.
+`Jint.Browser` is **AngleSharp + Jint**. AngleSharp is the HTML parser, the DOM and — with `AngleSharp.Css` —
+the CSSOM; Jint is the engine that runs the document's scripts; this package is the binding layer between
+them and the page runtime on top of it. It loads a URL, runs what the document loads, and answers what the
+page turned out to be.
+
+**It renders nothing.** There is no layout, no pixels, no screenshot and no PDF, and there is no browser
+binary to download or launch: this is one .NET process, on every platform .NET runs on. What that buys is a
+page you can drive from inside your own application; what it costs is everything that depends on knowing
+where a box really is.
+
+The principle the package is built to, and the one that decides its arguments, is the project founder's:
+
+> Jint should add value to AngleSharp without competing too much.
+
+So AngleSharp owns the parser, the DOM and the CSSOM, nothing here re-implements any of them, and an
+AngleSharp behaviour that disagrees with the standard is reported upstream and recorded rather than worked
+around in the binding.
+
+### Four ways in, and they are the same browser
+
+**The `Page` API**, in your own process — the whole package is reachable from it:
 
 ```c#
+// dotnet add package Jint.Browser   (net8.0 and net10.0)
 await using var browser = new Browser();
 var page = await browser.NewPageAsync();
 
@@ -2363,106 +2388,9 @@ neither an element nor a piece of text can state — a URL a router moved, a lis
 expression that throws is *not yet true*, so a condition written against an element a framework has not
 rendered is usable; a timeout reports that failure rather than a bare `false`.
 
-**What exists.** Generated bindings for every WebIDL interface AngleSharp describes: one prototype per
-interface built on Jint's own `JsObjectShape`, the interface objects (`Node`, `Element`, `HTMLDivElement`,
-`NodeList`, …) as globals so `instanceof` works, collections that index and iterate through the engine's
-array-like lane, and node wrappers that Jint's tree-aware event dispatcher can walk. On top of them, a page
-runtime: a `Browser` / `BrowserContext` / `Page` API, one engine and one thread per page, a `Window` whose
-prototype the global object inherits (so `window === globalThis`, `window instanceof EventTarget`, and
-`addEventListener` on the window is on a bubbling event's path), `document`, `location`, `screen`,
-`getComputedStyle` (read-only: the cascade, over a resolved value for the ten properties that decide whether
-an element can be interacted with), `matchMedia` (with `change`
-fired when the viewport moves), `requestAnimationFrame`, `postMessage`, dialogs as a host event, timers
-that fire because the page's thread pumps the engine, and console output and script errors recorded on the
-page. Content from `SetContentAsync`, `about:blank` and `data:text/html`, and a document's scripts run the
-way HTML says: inline and external classic scripts in document order as the parse reaches them, `defer` and
-`async` ones after it, then module scripts resolved through the document's import map, then
-`DOMContentLoaded`, `load` and `pageshow`, with `document.readyState` moving `loading` → `interactive` →
-`complete`. `document.write` during a parse writes at the insertion point, a script a script inserted runs
-and one `innerHTML` inserted does not, `import()` works from a classic script, and `<link rel=stylesheet>` is
-fetched so `getComputedStyle` answers from it.
-
-**And custom elements.** `window.customElements` is HTML's registry: `define` with `extends` and the
-reserved-name rules, `get`, `getName`, `whenDefined` and `upgrade`, with `connectedCallback`,
-`disconnectedCallback` and `attributeChangedCallback` running where a browser runs them — inside the DOM call
-that caused them, so `el.setAttribute('x', 1)` has already called back by the time it returns.
-`document.createElement`, `new MyElement()`, `innerHTML`, `cloneNode` and an element written in the markup
-all end in the same constructor, autonomous elements and customized built-ins (`extends: 'button'`,
-`<button is="my-button">`) alike, and a constructor or a callback that throws is reported to the page rather
-than crashing it. Two things differ from a browser and say so: an element the *parser* created is upgraded at
-the next script boundary rather than constructed as the tokenizer reaches it, and there is no
-`ElementInternals`, so `static formAssociated` is recorded and takes part in no form.
-
-**And the observers and views a page written this decade expects.** A `MutationObserver` whose records come
-from AngleSharp and are delivered at Jint's microtask checkpoint; `IntersectionObserver` and `ResizeObserver`
-as documented stubs that report every observed target once, since there is no layout for either to measure;
-`DOMParser` (HTML, and XML through `AngleSharp.Xml`) and `XMLSerializer`, `Range`, `TreeWalker`,
-`NodeIterator`, `getSelection()`, `<template>` content and `attachShadow`, with events crossing a shadow
-boundary the way the DOM says.
-
-**And XPath.** `document.evaluate`, `createExpression`, `createNSResolver`, `XPathEvaluator`,
-`XPathExpression` and `XPathResult` with its ten result types, evaluated by `System.Xml.XPath` over
-`AngleSharp.XPath`'s navigator — which is what htmx 2 needs before it reads a single `hx-` attribute.
-Namespaces are ignored, so an unprefixed `//div` matches an HTML element the way a page expects, and a
-node set is taken whole at evaluation rather than kept live. CSSOM's `CSS.escape` and `CSS.supports` are
-there too, the second answered by AngleSharp.Css's own condition evaluator.
-
-**And the network half.** `Page.NavigateAsync` loads an `http(s)` URL through Jint's own fetch pipeline and
-parses the result into a new engine — the document being left gets `beforeunload`, `pagehide` and `unload`,
-its pending requests are abandoned and its engine is disposed. Forms run HTML's submission algorithm
-(`submit` and `formdata` events, the entry list, `GET` query strings and `POST` in all three encodings);
-`history` and `location` travel a real session history with `popstate` and `hashchange`; `document.cookie`
-and every request share one jar per browser context; `localStorage` is partitioned by origin and
-`sessionStorage` by page, and a document with an opaque origin gets the `SecurityError` a browser gives;
-`Worker` runs on a thread the package starts, with its modules fetched over the page's own network. One
-`BrowserContextOptions.UrlFilter` bounds every load a page makes, on the first hop and on every redirect, and
-`Page.Requests` is the network log of what it made.
-
-**Events and input.** The UI Events family — `MouseEvent`, `PointerEvent`, `KeyboardEvent`, `InputEvent`,
-`FocusEvent`, `WheelEvent`, `CompositionEvent` — plus HTML's `SubmitEvent`, `FormDataEvent`,
-`HashChangeEvent`, `PopStateEvent`, `PageTransitionEvent` and `BeforeUnloadEvent`, each constructible from its
-init dictionary and each on the prototype chain below Jint's own `Event`. `onclick="…"` and its kind compile
-with HTML's own scope and share one slot with `el.onclick`, `<body onload>` included. The activation
-behaviours a click has a default action for are implemented against the standards rather than approximated: a
-link is followed, a submit button submits with itself as the `submitter`, a checkbox or radio toggles with the
-legacy pre-activation rollback a canceled click asks for, a `<label>` forwards to its control, a `<summary>`
-opens its `<details>`, an `<option>` selects. Focus is real — `document.activeElement`, `focus()`/`blur()`
-with the four events in HTML's order, `tabindex`-aware traversal, `autofocus` on load — and typing into an
-`<input>` or `<textarea>` edits the value at the selection with `beforeinput`, `input` and `change`,
-<kbd>Enter</kbd>'s implicit submission and <kbd>Tab</kbd>'s focus traversal. None of it needs a layout.
-
-**And a box for every element, without one.** Nothing is laid out, so every rendered element is given a
-deterministic box instead: one row of sixteen pixels per element in tree order, a container as tall as its
-whole subtree, the viewport wide. `getBoundingClientRect`, `getClientRects`, `offsetWidth`/`offsetTop` and
-their family, `clientWidth`, `scrollHeight`, `document.elementFromPoint`, `scrollIntoView` and the page's own
-`scrollY` all come from that one model — so a coordinate a script computes from a box is a coordinate that
-hits the element it came from, and `IntersectionObserver` and `ResizeObserver` entries report real numbers.
-The page scrolls virtually: `window.scrollTo`, `element.scrollIntoView` and
-`document.scrollingElement.scrollTop` move an offset every rectangle subtracts, and a `scroll` event fires at
-the document. An element that is `hidden`, `display: none` or `visibility: hidden` has no box, answers zeros,
-and is not hit. It is not a layout and does not pretend to be one: nothing wraps, nothing is measured, and two
-elements are never side by side.
-
-**And the budgets.** A page is a host-driven sequence of entries whose event loop is pumped, so neither of
-the engine's per-entry limits bounds one: `BrowserOptions.MaxTaskDuration` (five seconds) brackets every
-*turn* instead — one `Page` call, one drain of the event loop, one inline `<script>` — with the two
-constraints a per-entry reset never rewinds, and `BrowserOptions.MemoryLimit` is the allocation half of the
-same bracket. A `Page` call that runs out fails its own task with a `TimeoutException`; a runaway timer or a
-runaway `<script>` becomes a `PageError` and the page goes on answering. Workers are bracketed the same way.
-`MaxActiveTimers`, `MaxResponseBytes`, `FetchTimeout` and `MaxDomNodes` bound the rest, and
-`BrowserOptions.ForUntrustedContent()` is the one call that hardens a whole browser for content nobody
-vouches for: it applies `Options.ForUntrustedCode` to every page engine before any of your own configuration
-runs, derives the two budgets above from its limits, and turns `BlockPrivateNetwork` on for every context
-that did not choose for itself.
-
-```c#
-var options = new BrowserOptions { MaxTaskDuration = TimeSpan.FromSeconds(2) }.ForUntrustedContent();
-await using var browser = new Browser(options);
-```
-
-**And the automation protocol.** `AddBrowser` publishes every page of a browser on a
+**An automation client**, over the protocol. `AddBrowser` publishes every page of a browser on a
 `Jint.DevTools` server as a Chrome DevTools Protocol `page` target, so Puppeteer, PuppeteerSharp, Playwright
-and Playwright for .NET can drive it — in the same process, with no native binary and nothing to download:
+and Playwright for .NET drive it — in the same process, with no native binary and nothing to download:
 
 ```c#
 await using var browser = new Browser();
@@ -2471,13 +2399,151 @@ await using var server = new DevToolsServer(new DevToolsServerOptions { Port = 9
 await server.AddBrowser(browser);
 server.Start();
 
-// …and from anywhere that can reach the port:
 await using var client = await Puppeteer.ConnectAsync(
     new ConnectOptions { BrowserWSEndpoint = server.BrowserWebSocketUrl });
+```
 
-var page = await client.NewPageAsync();
-await page.GoToAsync("https://example.org/");
-var title = await page.EvaluateExpressionAsync<string>("document.title");
+**The command line.** `Jint.Browser.Tool` is a `dotnet tool` that serves that same protocol and dumps pages,
+and it drives the package through its published surface exactly as any other consumer would:
+
+```bash
+dotnet tool install -g Jint.Browser.Tool
+
+jint-browser fetch https://example.org/article --main-content --max-length 4000
+jint-browser serve --port 9222
+```
+
+`fetch --dump html|text|markdown|ax` writes the document to standard output and the page's own errors to
+standard error, `eval <url> <expression>` answers the page's own `JSON.stringify` of a result, and the exit
+codes separate a bad command line from a page that would not load, one that ran out of its budget, and an
+expression that threw. `--untrusted` hardens every page and blocks the private network. Its own README is
+[`Jint.Browser.Tool/README.md`](Jint.Browser.Tool/README.md).
+
+**An agent, over the Model Context Protocol.** `Jint.Browser.Mcp` is an
+[MCP](https://modelcontextprotocol.io/) server over the same `Page` API, and `jint-browser mcp` serves it on
+standard input and output — so a coding agent gets a real browser in one .NET process with nothing to
+download:
+
+```json
+{
+  "mcpServers": {
+    "jint-browser": { "command": "jint-browser", "args": ["mcp"] }
+  }
+}
+```
+
+Eighteen tools: `navigate`, `back`, `forward`, `reload`; `snapshot`, whose `ax` mode is the accessibility tree
+with a `ref=` on every element; `click`, `fill`, `type`, `press`, `select`, `hover` and `scroll`, each taking
+one of those references or a CSS selector; and `evaluate`, `wait_for`, `network_requests`, `cookies`,
+`set_cookie` and `close`. The page is a resource too — `jint://page/markdown` and `jint://page/requests`. The
+references are what make a snapshot actionable: an agent reading `- button "Save" [ref=42]` has a handle it
+can act on, where a selector is something it would have to invent. Every tool answers an error object rather
+than throwing through the transport, pages are hardened for untrusted content by default, and a host that
+already runs a server of its own composes the same tools with one call:
+
+```c#
+builder.Services.AddMcpServer().WithStdioServerTransport().AddJintBrowser();
+```
+
+Its README, including why stdio is the only transport the tool serves, is
+[`Jint.Browser.Mcp/README.md`](Jint.Browser.Mcp/README.md).
+
+### What a page does
+
+**It parses and it schedules like HTML says.** Inline and external classic scripts run in document order as
+the parse reaches them, `defer` and `async` ones after it, then module scripts resolved through the
+document's import map, then `DOMContentLoaded`, `load` and `pageshow`, with `document.readyState` moving
+`loading` → `interactive` → `complete`. `document.write` during a parse writes at the insertion point, a
+script that a script inserted runs and one that `innerHTML` inserted does not, `import()` works from a
+classic script, and `<link rel=stylesheet>` is fetched so `getComputedStyle` answers from it. Content also
+comes from `SetContentAsync`, `about:blank` and `data:text/html`.
+
+**The DOM is generated from AngleSharp's own WebIDL metadata.** One prototype per interface, built on Jint's
+`JsObjectShape`; the interface objects (`Node`, `Element`, `HTMLDivElement`, `NodeList`, …) as globals so
+`instanceof` works; collections that index and iterate through the engine's array-like lane; and node
+wrappers Jint's tree-aware event dispatcher can walk. A `Window` whose prototype the global object inherits
+sits over it, so `window === globalThis`, `window instanceof EventTarget`, and a listener on the window is on
+a bubbling event's path — with `document`, `location`, `screen`, `getComputedStyle` (the declared cascade,
+over a resolved value for the ten properties that decide whether an element can be interacted with),
+`matchMedia`, `requestAnimationFrame`, `postMessage`, dialogs raised as a host event, and timers that fire
+because the page's thread pumps the engine.
+
+**A host drives it too, not only a protocol client.** `Page.ClickAsync`, `HoverAsync`, `FillAsync`,
+`TypeAsync`, `PressAsync`, `SelectAsync` and `ScrollToAsync` take a CSS selector or an accessibility-snapshot
+reference and go through the same `InputDispatcher`, box model and activation paths the `Input` domain does,
+so a caller here and a client on the socket cannot make a page do two different things.
+`GoBackAsync`, `GoForwardAsync` and `ReloadAsync` travel the same session history, and
+`WaitForSelectorAsync`, `WaitForTextAsync` and `WaitForNetworkIdleAsync` are what a caller waits on.
+
+**Events, and input that does not need a layout.** The UI Events family — `MouseEvent`, `PointerEvent`,
+`KeyboardEvent`, `InputEvent`, `FocusEvent`, `WheelEvent`, `CompositionEvent` — plus HTML's `SubmitEvent`,
+`FormDataEvent`, `HashChangeEvent`, `PopStateEvent`, `PageTransitionEvent` and `BeforeUnloadEvent`, each
+constructible from its init dictionary and each below Jint's own `Event`. `onclick="…"` and its kind compile
+with HTML's own scope and share one slot with `el.onclick`, `<body onload>` included. The activation
+behaviours are implemented against the standards rather than approximated: a link is followed, a submit
+button submits with itself as the `submitter`, a checkbox or radio toggles with the legacy pre-activation
+rollback a canceled click asks for, a `<label>` forwards to its control, a `<summary>` opens its `<details>`,
+an `<option>` selects. Focus is real — `document.activeElement`, `focus()`/`blur()` with the four events in
+HTML's order, `tabindex`-aware traversal, `autofocus` on load — and typing into an `<input>` or `<textarea>`
+edits the value at the selection with `beforeinput`, `input` and `change`, <kbd>Enter</kbd>'s implicit
+submission and <kbd>Tab</kbd>'s focus traversal.
+
+**Custom elements are HTML's, not an approximation of them.** `window.customElements` has `define` with
+`extends` and the reserved-name rules, `get`, `getName`, `whenDefined` and `upgrade`, and
+`connectedCallback`, `disconnectedCallback` and `attributeChangedCallback` run where a browser runs them —
+inside the DOM call that caused them, so `el.setAttribute('x', 1)` has already called back by the time it
+returns. `document.createElement`, `new MyElement()`, `innerHTML`, `cloneNode` and an element written in the
+markup all end in the same constructor, autonomous elements and customized built-ins
+(`extends: 'button'`, `<button is="my-button">`) alike, and a constructor or a callback that throws is
+reported to the page rather than crashing it.
+
+**The observers and views a page written this decade expects.** A `MutationObserver` whose records come from
+AngleSharp and are delivered at Jint's microtask checkpoint; `IntersectionObserver` and `ResizeObserver`,
+whose entries carry real numbers from the box model below; `DOMParser` (HTML, and XML through
+`AngleSharp.Xml`) and `XMLSerializer`, `Range`, `TreeWalker`, `NodeIterator`, `getSelection()`, `<template>`
+content and `attachShadow`, with events crossing a shadow boundary the way the DOM says.
+
+**A network half, and a session.** `Page.NavigateAsync` loads an `http(s)` URL through Jint's own fetch
+pipeline and parses the result into a new engine — the document being left gets `beforeunload`, `pagehide`
+and `unload`, its pending requests are abandoned and its engine is disposed. Forms run HTML's submission
+algorithm (`submit` and `formdata` events, the entry list, `GET` query strings and `POST` in all three
+encodings); `history` and `location` travel a real session history with `popstate` and `hashchange`;
+`document.cookie` and every request share one jar per browser context; `localStorage` is partitioned by
+origin and `sessionStorage` by page, and a document with an opaque origin gets the `SecurityError` a browser
+gives; `Worker` runs on a thread the package starts, with its modules fetched over the page's own network.
+`BrowserContextOptions.UrlFilter` bounds every load a page makes, on the first hop and on every redirect, and
+`Page.Requests` is the log of what it made.
+
+**A box for every element, without a layout behind it.** Nothing is laid out, so every rendered element is
+given a deterministic box instead: sixteen pixels of height per element in tree order, a container as tall as
+its whole subtree, the viewport wide. `getBoundingClientRect`, `getClientRects`, `offsetWidth`/`offsetTop`
+and their family, `clientWidth`, `scrollHeight`, `document.elementFromPoint`, `scrollIntoView` and the page's
+own `scrollY` all come from that one model, so a coordinate a script computes from a box is a coordinate that
+hits the element it came from. The page scrolls virtually: `window.scrollTo`, `element.scrollIntoView` and
+`document.scrollingElement.scrollTop` move an offset every rectangle subtracts, and a `scroll` event fires at
+the document. An element that is `hidden`, `display: none` or `visibility: hidden` has no box, answers zeros,
+and is not hit. It is not a layout and does not pretend to be one: nothing wraps, nothing is measured, and
+two elements are never side by side.
+
+### What a client can do over the protocol
+
+A client's `newPage` opens a real page in a real browser context, `goto` navigates and answers a real
+response object, and `evaluate` runs in the page. Finding elements, clicking them and typing into them works
+too: the `DOM` domain answers about the document a client walks, `Input.dispatchMouseEvent` turns a
+coordinate into the pointer and mouse sequence a browser fires, and `Input.dispatchKeyEvent` and
+`Input.insertText` turn a key into `keydown`, `keypress` and `keyup` at whatever the page has focused, with
+the focus, the editing and the activation behaviour that go with them.
+
+```c#
+var button = await page.QuerySelectorAsync("#submit");
+var box = await button.BoundingBoxAsync();      // the flat model's box, the same one the page reads
+await button.ClickAsync();                       // a trusted click at its centre; a link here would navigate
+
+await page.TypeAsync("#search", "hello");        // one key press per character, editing the value as it goes
+await page.Keyboard.PressAsync("Enter");         // …and Enter is HTML's implicit submission
+
+await page.WaitForSelectorAsync("#result");
+var rows = await page.QuerySelectorAllAsync("tr.row");
 ```
 
 Playwright for .NET connects to the same server, over the HTTP discovery document rather than the socket —
@@ -2495,41 +2561,15 @@ await page.GotoAsync("https://example.org/");
 var title = await page.TitleAsync();
 ```
 
-Playwright's actionability check ends in `style.visibility !== "visible"`, so it needs `getComputedStyle` to
-answer a *resolved* value rather than only what the cascade declared. It does: `visibility`, `display`,
-`opacity`, `pointer-events`, `overflow` and its two longhands and `position` answer CSS's initial value where
-nothing declares them, and `width`/`height` answer the box model's numbers — so an unforced `ClickAsync`,
-`WaitForAsync` and `GetByRole` all work. Every other property is still the declared cascade, which has no
-layout behind it.
-
-A client's `newPage` opens a real page in a real browser context, `goto` navigates and answers a real
-response object, and `evaluate` runs in the page. **Finding elements, clicking them and typing into them works
-too** — the `DOM` domain answers about the document a client walks, `Input.dispatchMouseEvent` turns a
-coordinate into the pointer and mouse sequence a browser fires, and `Input.dispatchKeyEvent` and
-`Input.insertText` turn a key into `keydown`, `keypress` and `keyup` at whatever the page has focused, with
-the focus, the editing and the activation behaviour that go with them:
-
-```c#
-var button = await page.QuerySelectorAsync("#submit");
-var box = await button.BoundingBoxAsync();      // the flat model's box, the same one the page reads
-await button.ClickAsync();                       // a trusted click at its centre; a link here would navigate
-
-await page.TypeAsync("#search", "hello");        // one key press per character, editing the value as it goes
-await page.Keyboard.PressAsync("Enter");         // …and Enter is HTML's implicit submission
-
-await page.WaitForSelectorAsync("#result");
-var rows = await page.QuerySelectorAllAsync("tr.row");
-```
-
-**And the page a client asks it to pretend to be.** `Emulation` is effective rather than merely accepted. The
-viewport, the emulated media type and the Level 5 preference features move the document that is loaded — so
+**`Emulation` is effective rather than merely accepted.** The viewport, the emulated media type and the
+Media Queries Level 5 preference features move the document that is loaded — so
 `matchMedia('(prefers-color-scheme: dark)').matches` flips and every `MediaQueryList` whose answer moved
 hears `change` — while the time zone and the locale are read when the *next* document's engine is built,
 which is where every client sets them and what makes `new Date()` and `Intl` agree with each other. Touch
 emulation reaches `navigator.maxTouchPoints`, `'ontouchstart' in window` and `(pointer: coarse)`;
 `setGeolocationOverride` is what `navigator.geolocation` answers with; `setScriptExecutionDisabled` stops the
 next document's own scripts and leaves `evaluate` working. Whatever is not effective is an accepted no-op
-whose reason is stated in place — there is no renderer for auto dark mode or a CPU throttle to change:
+whose reason is stated in place — there is no renderer for auto dark mode and no CPU to throttle.
 
 ```c#
 await page.EmulateTimezoneAsync("Asia/Tokyo");                    // read when the next document loads
@@ -2541,59 +2581,36 @@ await page.EmulateMediaFeaturesAsync(
 var snapshot = await page.Accessibility.SnapshotAsync();          // roles and names, computed with no layout
 ```
 
-**And the accessibility tree over the protocol.** `Accessibility` answers the tree this package already
-computes — HTML-AAM's roles, accname's names, the CSS cascade's hidden verdict — in Chrome's own `AXNode`
-shape, with the `DOM` domain's `backendNodeId` on every node. That is what `page.accessibility.snapshot()`,
-an `aria/` selector and Playwright's `getByRole` read, and it means a node found by its role is a node the
-same client can then measure and click. `Security`, `Overlay` and `CSS` answer what a DevTools front end
-sends while attaching; `CSS.getComputedStyleForNode` is the same cascade `getComputedStyle` gives the page,
-and every command that would edit a style sheet is honestly absent.
-
-Three things a client may notice are decisions rather than
-gaps, and each is stated in the code that makes it: an isolated world is a second *name* for the document's
-own realm rather than a realm of its own; a dialog does not block the page, so `Page.handleJavaScriptDialog`
-sets the decision the next `alert`, `confirm` or `prompt` reads; and `Page.captureScreenshot` and
-`Page.printToPDF` answer an error saying this browser renders no pixels and naming what to ask for instead.
-The endpoint is unauthenticated by the protocol's own design, so it listens on loopback and should stay
-there.
-
-**And the network, seen and steered.** `Network.enable` reports every request the page makes — the
+**`Network` reports and `Fetch` steers.** `Network.enable` reports every request the page makes — the
 document, every script and style sheet the parse loads, every `fetch` and `XMLHttpRequest`, a worker's
 modules — with Chrome's own resource types, so `page.on('request')` and `page.on('response')` fire and a
 `goto` answers a response object with the status, the headers and the body. `Fetch.enable` is real
 interception: a request is paused before it goes on the wire, and the client continues it (rewriting the URL,
 the method, the headers or the body), fulfils it from its own bytes, or fails it. A paused request holds only
 its own connection — the page's timers go on firing, and the command that releases it is answered while it
-waits.
-
-```c#
-await page.SetRequestInterceptionAsync(true);
-
-page.Request += async (_, e) =>
-{
-    if (e.Request.Url.Contains("/analytics/", StringComparison.Ordinal))
-    {
-        await e.Request.AbortAsync();                       // never leaves the process
-    }
-    else if (e.Request.Url.EndsWith("/api/rows", StringComparison.Ordinal))
-    {
-        await e.Request.RespondAsync(new ResponseData { Status = HttpStatusCode.OK, Body = "[]" });
-    }
-    else
-    {
-        await e.Request.ContinueAsync();
-    }
-};
-```
-
-Around it: `Network.setExtraHTTPHeaders` and `setUserAgentOverride` reach every request the page makes,
-`setBlockedURLs` refuses a URL before a socket is opened, `emulateNetworkConditions(offline: true)` fails
-every request the way a browser with no network does, and the cookie commands — on `Network` and on
-`Storage`, which is where the clients actually send them — read and write the same jar `document.cookie`
-sees. `Network.getResponseBody` answers from a bounded per-page buffer
+waits. Around them, `Network.setExtraHTTPHeaders` and `setUserAgentOverride` reach every request the page
+makes, `setBlockedURLs` refuses a URL before a socket is opened,
+`emulateNetworkConditions(offline: true)` fails every request the way a browser with no network does, and the
+cookie commands — on `Network` and on `Storage`, which is where the clients actually send them — read and
+write the same jar `document.cookie` sees. `Network.getResponseBody` answers from a bounded per-page buffer
 (`BrowserOptions.MaxCapturedResponseBytes`) that is filled only while a client is watching.
 
-**And what to ask instead of a picture.** The refusal names a domain of Jint's own — described in
+**`Accessibility` answers the tree this package computes** — HTML-AAM's roles, accname's names, the CSS
+cascade's hidden verdict — in Chrome's own `AXNode` shape, with the `DOM` domain's `backendNodeId` on every
+node. That is what `page.accessibility.snapshot()`, an `aria/` selector and Playwright's `getByRole` read,
+and it means a node found by its role is a node the same client can then measure and click. `CSS`, `Security`
+and `Overlay` answer what a DevTools front end sends while attaching — `CSS.getComputedStyleForNode` is the
+same cascade `getComputedStyle` gives the page, and every command that would edit a style sheet is honestly
+absent — and `Performance.getMetrics` and `Audits.enable` are answered because refusing them fails an
+ordinary connection.
+
+Three things a client may notice are decisions rather than gaps, and each is stated in the code that makes
+it: an isolated world is a second *name* for the document's own realm rather than a realm of its own; a
+dialog does not block the page, so `Page.handleJavaScriptDialog` sets the decision the next `alert`,
+`confirm` or `prompt` reads; and `Page.captureScreenshot` and `Page.printToPDF` answer an error saying this
+browser renders no pixels and naming what to ask for instead.
+
+**What to ask instead of a picture.** That refusal names a domain of Jint's own — described in
 `tools/devtools-protocol/jint_protocol.json` beside the vendored Chrome ones, so a client reaches it with the
 raw `send` every library has:
 
@@ -2605,82 +2622,76 @@ var markdown = answer!.Value.GetProperty("markdown").GetString();
 
 `Jint.getMarkdown` renders the document as CommonMark, `Jint.getText` as `innerText` would, and
 `Jint.getAccessibilitySnapshot` as the indented accessibility outline an agent reads. All three are computed
-from the DOM — no layout, no rendering, and nothing that runs a line of the page's script — and each takes
-the options the extractor behind it already had. `Page.MarkdownAsync`, `Page.TextAsync` and
-`Page.AccessibilitySnapshotAsync` are the same three answers for a host in the same process, over the same
-code, so a caller here and a client on the socket cannot be told different things about one document.
+from the DOM — no layout, no rendering, and nothing that runs a line of the page's script.
+`Page.MarkdownAsync`, `Page.TextAsync` and `Page.AccessibilitySnapshotAsync` are the same three answers for a
+host in the same process, over the same extractors, so a caller here and a client on the socket cannot be
+told different things about one document.
 
-**And a command line.** `Jint.Browser.Tool` is a `dotnet tool` that serves the protocol and dumps pages, and
-it drives the package through its published surface exactly as any other consumer would:
+Playwright's actionability check ends in `style.visibility !== "visible"`, so it needs `getComputedStyle` to
+answer a *resolved* value rather than only what the cascade declared. It does: `visibility`, `display`,
+`opacity`, `pointer-events`, `overflow` and its two longhands and `position` answer CSS's initial value where
+nothing declares them, and `width`/`height` answer the box model's numbers, so an unforced `ClickAsync`,
+`WaitForAsync` and `GetByRole` all work. Every other property is still the declared cascade, which has no
+layout behind it.
 
-```bash
-dotnet tool install -g Jint.Browser.Tool
+### Budgets, and content nobody vouches for
 
-# A page as CommonMark, narrowed to its main content and capped — or as its accessibility tree
-jint-browser fetch https://example.org/article --main-content --max-length 4000
-jint-browser fetch https://example.org/ --dump ax --wait-until networkidle
+A page is a host-driven sequence of entries whose event loop is pumped, so neither of the engine's per-entry
+limits bounds one: `BrowserOptions.MaxTaskDuration` (five seconds) brackets every *turn* instead — one `Page`
+call, one drain of the event loop, one inline `<script>` — with the two constraints a per-entry reset never
+rewinds, and `BrowserOptions.MemoryLimit` is the allocation half of the same bracket. A `Page` call that runs
+out fails its own task with a `TimeoutException`; a runaway timer or a runaway `<script>` becomes a
+`PageError` and the page goes on answering. Workers are bracketed the same way. `MaxActiveTimers`,
+`MaxResponseBytes`, `FetchTimeout` and `MaxDomNodes` bound the rest.
 
-# …or a browser on 127.0.0.1:9222 that Puppeteer and Playwright connect to
-jint-browser serve --port 9222
-```
-
-`fetch --dump html|text|markdown|ax` writes the document to standard output and the page's own errors to
-standard error, `eval <url> <expression>` answers the page's own `JSON.stringify` of a result, and the exit
-code separates a bad command line from a page that would not load from one that ran out of its budget.
-`--untrusted` hardens every page and blocks the private network. Its README is
-[`Jint.Browser.Tool/README.md`](Jint.Browser.Tool/README.md).
-
-**And a browser an agent can drive.** `Jint.Browser.Mcp` is a [Model Context
-Protocol](https://modelcontextprotocol.io/) server over the same page API, and `jint-browser mcp` serves it
-on standard input and output — so a coding agent gets `navigate`, `snapshot`, `click`, `fill`, `type`,
-`press`, `select`, `hover`, `scroll`, `back`, `forward`, `reload`, `evaluate`, `wait_for`,
-`network_requests`, `cookies` and `set_cookie`, plus the page as a resource:
-
-```json
-{
-  "mcpServers": {
-    "jint-browser": { "command": "jint-browser", "args": ["mcp"] }
-  }
-}
-```
-
-`snapshot` is the one that matters: its `ax` mode is the accessibility tree with a `ref=` on every element,
-and `click`, `fill`, `type`, `select` and `hover` take one of those in place of a CSS selector — which is
-what an agent has, where a selector is something it would have to invent. Every tool answers an error object
-rather than throwing through the transport, the pages are hardened for untrusted content by default, and a
-host that already runs a server of its own composes the same tools with one call:
+`BrowserOptions.ForUntrustedContent()` is the one call that hardens a whole browser for content nobody
+vouches for: it applies `Options.ForUntrustedCode` to every page engine before any of your own configuration
+runs, derives the two budgets above from its limits, and turns `BlockPrivateNetwork` on for every context
+that did not choose for itself.
 
 ```c#
-builder.Services.AddMcpServer().WithStdioServerTransport().AddJintBrowser();
+var options = new BrowserOptions { MaxTaskDuration = TimeSpan.FromSeconds(2) }.ForUntrustedContent();
+await using var browser = new Browser(options);
 ```
 
-Its README, including why stdio is the only transport the tool serves, is
-[`Jint.Browser.Mcp/README.md`](Jint.Browser.Mcp/README.md).
+### What it cannot do
 
-**What does not exist yet.** No `ElementInternals` and no scoped custom element registries, no iframe
-scripting (frames are parsed and listed; `contentWindow` is absent),
-and no rendering — every box comes from the flat model above rather than from a layout, so nothing wraps and
-nothing is ever side by side. Over the protocol that means no touch or drag input and no screenshots; those are
-the later items of the same campaign. Three network lanes are absent with a reason rather than pending: `Fetch`'s
-**response** stage and with it the `IO` domain (an observer is told about a response and cannot answer it, so a
-response-stage pause could only ever continue unchanged), the **WebSocket and EventSource** events (the engine
-deliberately does not observe those two handshakes), and `Network`'s **timing** document (no phase of a request is
-measured, and a document of zeros would read as a page that loaded instantly). A page's `@media` rules are not
-re-evaluated against the emulated preferences either — the cascade is AngleSharp.Css's and it models none of them —
-so a themed page reads `matchMedia` rather than `getComputedStyle` to find out; and touch emulation changes what a
-page *detects* without a touch event ever being dispatched. Drag and drop and the clipboard are v1 non-goals, so
-`DragEvent` and `ClipboardEvent` are
-absent rather than stubbed. Deliberately absent for good: images and frame documents are never fetched — the
-reference is recorded in `Page.Requests` with the reason instead — `integrity` is accepted and not enforced,
-and `document.write` after a page has finished parsing is refused with a page error rather than implying
+**Absent by design.** There is no rendering, so no screenshots, no PDF, no `canvas`, no WebGL and no media —
+every box comes from the flat model above rather than from a layout, so nothing wraps and nothing is ever
+side by side, and over the protocol that means no touch or drag input and no screenshot commands. There is no
+iframe scripting: frames are parsed and listed, and an `<iframe>`'s `contentWindow` is absent and its `src`
+is not fetched. There is no `IndexedDB`, no `WebAssembly` (which the engine declines as well), no
+`SharedWorker` or `ServiceWorker`, and no CSP enforcement. Drag and drop and the clipboard are non-goals, so
+`DragEvent` and `ClipboardEvent` are absent rather than stubbed. Images are never fetched — the reference is
+recorded in `Page.Requests` with the reason instead — `integrity` is accepted and not enforced, and
+`document.write` after a page has finished parsing is refused with a page error rather than implying
 `document.open()`.
 
-**What works today, on real pages rather than on paper.**
-[`Jint.Tests.Browser/Fixtures/`](Jint.Tests.Browser/Fixtures/README.md) is an obstacle course of eighteen
+**Absent for now**, each with the issue that would close it:
+
+| What is missing | Tracked by |
+| --- | --- |
+| No XPath at all — no `XPathEvaluator`, no `document.evaluate`, and `DOM.performSearch` takes a selector or plain text and not an expression | [#3714](https://github.com/sebastienros/jint/issues/3714) |
+| `Fetch`'s **response** stage, and with it the `IO` domain: an observer is told about a response and cannot answer it, so a response-stage pause could only ever continue unchanged | [#3701](https://github.com/sebastienros/jint/issues/3701) |
+| `Network`'s WebSocket and EventSource events — the engine deliberately does not observe those two handshakes — and its **timing** document, since no phase of a request is measured and a document of zeros would read as a page that loaded instantly | [#3701](https://github.com/sebastienros/jint/issues/3701) |
+| `BrowserOptions.UserAgent` reaches script but not the wire unless a protocol client sets it | [#3720](https://github.com/sebastienros/jint/issues/3720) |
+| A page's `@media` rules are not re-evaluated against the emulated preferences — the cascade is AngleSharp.Css's and it models none of them — so a themed page reads `matchMedia` rather than `getComputedStyle` to find out | [#3721](https://github.com/sebastienros/jint/issues/3721) |
+| `ElementInternals`, so a `static formAssociated` custom element is recorded and takes part in no form; and no scoped custom element registries | [#3714](https://github.com/sebastienros/jint/issues/3714) |
+
+Two smaller ones are worth knowing before they surprise you. An element the *parser* created is upgraded at
+the next script boundary rather than constructed as the tokenizer reaches it — a page cannot see the
+difference, since a script only ever sees the document at those boundaries. And touch emulation changes what
+a page *detects* without a touch event ever being dispatched.
+
+### How much of this is measured rather than claimed
+
+Two suites answer that, and they answer different questions.
+
+[`Jint.Tests.Browser/Fixtures/`](Jint.Tests.Browser/Fixtures/README.md) is an obstacle course of **eighteen**
 offline pages built out of the libraries' own published bundles, served over a loopback socket and driven
 through the `Page` API — and three of them are driven again over the protocol by PuppeteerSharp and by
 Playwright for .NET. Each case asserts a DOM end state *and* that the page reported no errors at all, which
-is what tells a half-working page from a working one. All eighteen pass:
+is what tells a half-working page from a working one. **All eighteen pass:**
 
 | Works | Fixture |
 | --- | --- |
@@ -2705,15 +2716,24 @@ behaviour is a divergence: with no layout nothing can stop intersecting, so an o
 once and an infinite list loads every page at once — which is the readable outcome rather than the correct
 one, and is asserted as such.
 
-**How much of that is measured rather than claimed** is
-[`Jint.Tests.Browser/Wpt/README.md`](Jint.Tests.Browser/Wpt/README.md): the web-platform-tests browser lane
-loads the vendored `.html` corpus into a real page under upstream's own `testharness.js`, and its census
-counts, suite by suite, how many of those tests pass — a figure that is a ceiling and only ever goes down.
+[`Jint.Tests.Browser/Wpt/`](Jint.Tests.Browser/Wpt/README.md) is the other answer, and a harder one. The
+web-platform-tests browser lane loads the vendored `.html` corpus into a real page under upstream's own
+`testharness.js`, so the harness deciding what passed is upstream's and there is nothing of Jint's between
+the corpus and the verdict. It runs **133 documents and 1,417 of upstream's own tests, of which 866 pass** —
+`dom/events`, HTML's scripting events and processing model, and the whole of `custom-elements`. That figure
+is a ceiling, suite by suite: a rise fails as a regression and a fall fails as staleness, and every test that
+does not pass is named by the exclusion table with the cause it belongs to.
+
+### Where to read further
 
 The design, including what a v1 will and will not do, is
-[`docs/design/headless-browser.md`](docs/design/headless-browser.md); the tracking issue is
-[#3575](https://github.com/sebastienros/jint/issues/3575). The package targets `net8.0` and later and is
-**not** trim- or AOT-compatible in this version, because AngleSharp is not trim-annotated.
+[`docs/design/headless-browser.md`](docs/design/headless-browser.md), and the protocol half is
+[`docs/design/devtools-protocol.md`](docs/design/devtools-protocol.md); the tracking issue is
+[#3575](https://github.com/sebastienros/jint/issues/3575).
+[`docs/releases/headless-browser.md`](docs/releases/headless-browser.md) is what shipped package by package,
+the engine seams it rides, the AngleSharp contributions it produced, and what is knowingly left. The package
+targets `net8.0` and `net10.0` and is **not** trim- or AOT-compatible in this version, because AngleSharp is
+not trim-annotated.
 
 ## Performance
 

--- a/README.md
+++ b/README.md
@@ -2671,7 +2671,6 @@ recorded in `Page.Requests` with the reason instead — `integrity` is accepted 
 
 | What is missing | Tracked by |
 | --- | --- |
-| No XPath at all — no `XPathEvaluator`, no `document.evaluate`, and `DOM.performSearch` takes a selector or plain text and not an expression | [#3714](https://github.com/sebastienros/jint/issues/3714) |
 | `Fetch`'s **response** stage, and with it the `IO` domain: an observer is told about a response and cannot answer it, so a response-stage pause could only ever continue unchanged | [#3701](https://github.com/sebastienros/jint/issues/3701) |
 | `Network`'s WebSocket and EventSource events — the engine deliberately does not observe those two handshakes — and its **timing** document, since no phase of a request is measured and a document of zeros would read as a page that loaded instantly | [#3701](https://github.com/sebastienros/jint/issues/3701) |
 | `BrowserOptions.UserAgent` reaches script but not the wire unless a protocol client sets it | [#3720](https://github.com/sebastienros/jint/issues/3720) |

--- a/docs/design/devtools-protocol.md
+++ b/docs/design/devtools-protocol.md
@@ -4,6 +4,9 @@
 of [sebastienros/jint#3575](https://github.com/sebastienros/jint/issues/3575); where this
 document and that issue disagree, the issue wins and this file is brought back into line. What this file adds is
 the longer form: the engine mechanisms each decision rests on, named so that a reader can find them.
+[§9](#9-what-shipped-and-where-it-differs) is the index of what was built against this design and the one line
+in which each item differs from it. For what the package does rather than why, read
+[the README](../../README.md#chrome-devtools-protocol-opt-in-package) instead of this file.
 
 Everything normative here was read from the [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/)
 (the pinned `js_protocol.json` / `browser_protocol.json` under `tools/devtools-protocol/`), from V8's inspector
@@ -191,3 +194,31 @@ All of it is in place, and each layer claims something the one below it cannot:
   `IL2xxx`/`IL3xxx` diagnostic is attributed to a file in the package.
 - **The host-contract verification leg** with `JINT_HOST_CONTRACT_VERIFICATION=1`, which makes the thread rule
   exact rather than asserted: a `JsValue` touched from a transport thread fails loudly under it.
+
+## 9. What shipped, and where it differs
+
+The sections above are the design, kept as the design. This table is the index of what was built against it:
+one row per item, the pull request that built it, and the one line in which what shipped is not what was
+planned. A blank last column means the section above describes what exists.
+
+| § | What shipped | PR | Where it differs |
+| --- | --- | --- | --- |
+| 4 | The package itself: the pinned vendored protocol JSON, the manifest, the emitter and `Protocol/Generated/` | [#3586](https://github.com/sebastienros/jint/pull/3586) | — |
+| 4 | The handshakes four automation clients and the front end actually send, recorded rather than assumed | [#3599](https://github.com/sebastienros/jint/pull/3599) | — |
+| 2, 3 | `EngineDispatcher`, the two drains, `ThreadMode`, the transport and flattened sessions | [#3602](https://github.com/sebastienros/jint/pull/3602) | `flatten: false` is refused outright with `-32000` rather than supported, and breakpoints are the **target's** rather than the session's — V8 keeps them per session |
+| 3 | A target that outlives its engine: the `DevToolsTarget` / `TargetRuntime` split, and `ITargetHost` for a client's `Target.createTarget` | [#3678](https://github.com/sebastienros/jint/pull/3678) | `ITargetHost` is `internal`. `Jint.Browser` is its only implementer today, and it is promoted when there is a second — the seam a third party needs meanwhile is [#3684](https://github.com/sebastienros/jint/issues/3684) |
+| 5 | `Runtime`: handles, `getProperties`, `callFunctionOn`, `awaitPromise`, bindings | [#3605](https://github.com/sebastienros/jint/pull/3605), engine seam [#3597](https://github.com/sebastienros/jint/pull/3597) | — |
+| 5 | `Console` and `Log`: what a script logged and what it threw, values still attached | [#3606](https://github.com/sebastienros/jint/pull/3606) | — |
+| 5 | `Debugger`: breakpoints by URL or script, the three steps, `continueToLocation`, frames, scopes, `setVariableValue` | [#3620](https://github.com/sebastienros/jint/pull/3620), engine seams [#3587](https://github.com/sebastienros/jint/pull/3587) and [#3614](https://github.com/sebastienros/jint/pull/3614) | — |
+| 5 | Pausing where a script throws, and evaluating in any frame of the stack | [#3625](https://github.com/sebastienros/jint/pull/3625), engine seams [#3623](https://github.com/sebastienros/jint/pull/3623), [#3622](https://github.com/sebastienros/jint/pull/3622) and [#3662](https://github.com/sebastienros/jint/pull/3662) | — |
+| 5 | `Profiler`: a sampled CPU profile, and precise and best-effort coverage | [#3629](https://github.com/sebastienros/jint/pull/3629), engine seams [#3608](https://github.com/sebastienros/jint/pull/3608) and [#3654](https://github.com/sebastienros/jint/pull/3654) | — |
+| 5 | Describing a value: a function's declaration site, a console message's anchor, an error's details, a path published as a URL | [#3640](https://github.com/sebastienros/jint/pull/3640) | A function value does not publish the `Program` it was parsed in, so `[[FunctionLocation]]` still resolves its script by name ([#3666](https://github.com/sebastienros/jint/issues/3666)) |
+| 5 | A position resolves to its script by identity rather than by source name | [#3652](https://github.com/sebastienros/jint/pull/3652), engine seam [#3651](https://github.com/sebastienros/jint/pull/3651) | — |
+| 8 | The REPL's `--inspect`/`--inspect-brk`, the driven front end, and the native binary as a client | [#3633](https://github.com/sebastienros/jint/pull/3633) | Neither `tools/devtools-frontend-smoke/` nor `docs/manual-checklist.md` runs in CI — one downloads a browser and the other is a person — which is why the four layers below them exist |
+
+Two things a reader of §5 should know are decisions rather than omissions. The eight engine seams the table
+in that section names all merged, and every one is public and additive, so a third party can build the same
+server without an `InternalsVisibleTo` grant — `Jint.DevTools` consumes only Jint's published API, and that is
+what proves it. And the page domains (`Page`, `DOM`, `Network`, `Fetch`, `Input`, `Emulation`, `Storage`,
+`Accessibility`) are in the same manifest but are implemented in `Jint.Browser`; on an engine target every one
+of them is `-32601`.

--- a/docs/design/headless-browser.md
+++ b/docs/design/headless-browser.md
@@ -4,7 +4,10 @@
 of [sebastienros/jint#3575](https://github.com/sebastienros/jint/issues/3575); where this
 document and that issue disagree, the issue wins and this file is brought back into line. What this file adds is
 the longer form: the mechanisms each decision rests on, named so that a reader can find them. The protocol half
-is [`devtools-protocol.md`](devtools-protocol.md).
+is [`devtools-protocol.md`](devtools-protocol.md), and
+[§12](#12-what-shipped-and-where-it-differs) is the index of what was built against this design and the one
+line in which each item differs from it. For what the package does rather than why, read
+[the README](../../README.md#headless-browser-opt-in-package) instead of this file.
 
 Everything normative here was read from the [DOM](https://dom.spec.whatwg.org/), [HTML](https://html.spec.whatwg.org/multipage/),
 [Fetch](https://fetch.spec.whatwg.org/), [XMLHttpRequest](https://xhr.spec.whatwg.org/) and
@@ -398,3 +401,38 @@ seven defects between them, six of which were fixed in the pull request that add
 recorded rather than fixed and then fixed on its own: `getComputedStyle` resolved no initial values, so
 `visibility` was the empty string and Playwright's actionability check read every element of every page as
 hidden — `Jint.Browser/Dom/Views/ResolvedStyle` is the ten-property exception that closed it.
+
+## 12. What shipped, and where it differs
+
+The sections above are the design, kept as the design. This table is the index of what was built against it:
+one row per item, the pull request that built it, and the one line in which what shipped is not what was
+planned. A blank last column means the section above describes what exists.
+
+| § | What shipped | PR | Where it differs |
+| --- | --- | --- | --- |
+| 3 | One `PageLoop` thread per page, a new engine per navigation, and the global's `Window.prototype` chain | [#3648](https://github.com/sebastienros/jint/pull/3648) | — |
+| 3 | Frames, parsed and listed | [#3667](https://github.com/sebastienros/jint/pull/3667) | Nothing gives a child frame an engine, so `contentWindow` is absent and a document that needs a second global cannot run here at all — which is what puts thirty-seven `custom-elements/` files in the not-vendored table |
+| 4 | The generator over the two pinned AngleSharp assemblies, and the checked-in `Dom/Generated/` | [#3634](https://github.com/sebastienros/jint/pull/3634) | A DOM prototype carries no `@@unscopables`, because AngleSharp's metadata does not say which members are unscopable; and a nullable `DOMString` parameter converts `null` to the string `"null"` ([#3712](https://github.com/sebastienros/jint/issues/3712)) |
+| 4 | HTML §4.13: the registry, the construction stack, the element state and the reaction lane | [#3709](https://github.com/sebastienros/jint/pull/3709) | The element queue is drained as a reaction *arrives* rather than when the outermost `[CEReactions]` operation returns, and a parser-created element is upgraded at the driver's next script boundary rather than constructed by the tokenizer. There is no `ElementInternals`, so `static formAssociated` is recorded and consulted by nothing |
+| 5 | The UI event interfaces, HTML's handler content attributes and every activation behaviour a click has | [#3671](https://github.com/sebastienros/jint/pull/3671), engine seams [#3696](https://github.com/sebastienros/jint/pull/3696) | — |
+| 6 | The `ParserDriver` and the baton: classic, `defer` and `async` scripts, modules through the import map, `document.write`, `<link rel=stylesheet>` | [#3676](https://github.com/sebastienros/jint/pull/3676) | The refinement §6 already records: a subresource fetch finishes *before* AngleSharp's `IResourceLoader` returns, so the parse never suspends and stays on the thread it started on |
+| 6 | A navigation is a fetch and a new engine; forms, history, cookies, storage and workers | [#3667](https://github.com/sebastienros/jint/pull/3667) | Images and frame documents are recorded in `Page.Requests` as *not* fetched, there being nothing to render them with |
+| 5, 6 | The observers and the DOM views: `MutationObserver`, `IntersectionObserver`, `ResizeObserver`, `Range`, `TreeWalker`, `NodeIterator`, `DOMParser`, `XMLSerializer`, `getSelection` | [#3669](https://github.com/sebastienros/jint/pull/3669) | The two stubs the design named now carry real numbers from §8's model — but with no layout nothing can stop intersecting, so an observed target is reported once, fully intersecting, and a lazy list loads every page at once |
+| 7 | `PageBudget`: `MaxTaskDuration` and `MemoryLimit` over a turn, `ForUntrustedContent`, `MaxDomNodes` | [#3679](https://github.com/sebastienros/jint/pull/3679) | — |
+| 8 | `Layout/FlatLayout`, the hit test, the virtual scroll, `dispatchMouseEvent` and the activation behaviours | [#3697](https://github.com/sebastienros/jint/pull/3697) | Boxes are rows, so an excluded element takes its subtree with it — right for `display: none` and wrong for `visibility: hidden`, whose `visibility: visible` descendant CSS lets escape |
+| 8 | `dispatchKeyEvent`, `insertText`, the editor, and `testdriver.js` over the same dispatcher | [#3703](https://github.com/sebastienros/jint/pull/3703) | `imeSetComposition` is accepted and changes nothing; `contenteditable` splices one text node, so <kbd>Enter</kbd> there does nothing rather than something structural |
+| 8a | `PageTarget`, `AddBrowser`, `BrowserTargetHost` and the lifecycle events of a navigation | [#3680](https://github.com/sebastienros/jint/pull/3680), the target split [#3678](https://github.com/sebastienros/jint/pull/3678) | A **`tab` target** is published in front of every page, found by driving Puppeteer rather than by reading the protocol; and `frameNavigated` precedes the engine swap where Chrome interleaves it between the two context events |
+| 8a | A domain of Jint's own — `Jint.getMarkdown`, `getText`, `getAccessibilitySnapshot` — and the screenshot refusal that names it | [#3681](https://github.com/sebastienros/jint/pull/3681), the extractors [#3657](https://github.com/sebastienros/jint/pull/3657) | — |
+| 8a | `Network` reporting every request, and `Fetch` pausing one at the request stage | [#3700](https://github.com/sebastienros/jint/pull/3700) | The notifications and the interception run on the **transport thread**, not the page loop: moving them would deadlock the one fetch a page cannot pump through. The three absent lanes are [#3701](https://github.com/sebastienros/jint/issues/3701) |
+| 8a | `Emulation` effective rather than accepted, and `Accessibility` in Chrome's `AXNode` shape | [#3704](https://github.com/sebastienros/jint/pull/3704) | A page's `@media` rules are not re-evaluated against the emulated preferences, because the cascade models none of them, so a themed page reads `matchMedia` rather than `getComputedStyle` ([#3721](https://github.com/sebastienros/jint/issues/3721)) |
+| 9 | The web-platform-tests browser lane, and the eleven defects it first recorded | [#3685](https://github.com/sebastienros/jint/pull/3685), fixes [#3699](https://github.com/sebastienros/jint/pull/3699) | The four differences §9 already records — one corpus and one pin, strings through a host function rather than values through a binding, only the window wrapper synthesized, and an uncaught exception left to upstream's harness |
+| 9 | The obstacle course: eighteen offline fixtures through the `Page` API, three of them again over the protocol | [#3710](https://github.com/sebastienros/jint/pull/3710) | The Playwright suite is gated on `JINT_BROWSER_CLIENTS` because its driver is a Node process; PuppeteerSharp's runs on every leg. Two fixtures are `needs triage` rather than passing |
+| 10 | The `jint-browser` command line: `serve`, `fetch`, `eval`, `version` | [#3715](https://github.com/sebastienros/jint/pull/3715) | It takes no `InternalsVisibleTo` grant, so the three seams it needed were promoted onto the package rather than reached around |
+| 10 | `Jint.Browser.Mcp`, the Model Context Protocol server, and `jint-browser mcp` serving it on stdio | [#3717](https://github.com/sebastienros/jint/pull/3717) | **`--http` did not ship** — the protocol's 2026-07-28 revision removed the session header from streamable HTTP, and the two ways to hold per-session state either need an `[Experimental]` handler or put an ASP.NET Core framework reference in a `dotnet tool`; and a `ref=` is the accessibility tree's own identifier rather than a `backendNodeId`, which belongs to a protocol target an MCP session has none of |
+
+Two decisions in the v1/not-v1 table of §2 turned out differently and are worth naming here rather than
+leaving a reader to compare tables. `IntersectionObserver` and `ResizeObserver` are no longer stubs, since
+§8's model gives them numbers to report. And `getComputedStyle` answers a *resolved* value for the ten
+properties an automation client reads to decide whether an element can be interacted with
+([#3716](https://github.com/sebastienros/jint/pull/3716)) — the smallest exception to the standing decision
+against an initial-value table of our own, made because without it no supported client can drive a page.

--- a/docs/releases/headless-browser.md
+++ b/docs/releases/headless-browser.md
@@ -121,7 +121,6 @@ and this package works within — are the two tables at the end of
 
 | | |
 | --- | --- |
-| [#3714](https://github.com/sebastienros/jint/issues/3714) | No XPath — which is also why the htmx fixture does not pass |
 | [#3701](https://github.com/sebastienros/jint/issues/3701) | `Fetch`'s response stage and the `IO` domain, WebSocket and EventSource observation, and request timing |
 | [#3712](https://github.com/sebastienros/jint/issues/3712) | A nullable `DOMString` parameter in the binding generator, which is the single biggest cause in the custom-element corpus |
 | [#3720](https://github.com/sebastienros/jint/issues/3720) | `BrowserOptions.UserAgent` reaches script but not the wire |

--- a/docs/releases/headless-browser.md
+++ b/docs/releases/headless-browser.md
@@ -1,0 +1,134 @@
+# Release notes draft: the headless browser and the DevTools protocol
+
+**This is a draft for the maintainer to lift into the v5 release announcement**, not a published changelog —
+the repository keeps no changelog, and `.github/workflows/release.yml` produces packages from a `vX.Y.Z` tag
+and nothing else. It records what the campaign tracked by
+[#3575](https://github.com/sebastienros/jint/issues/3575) shipped: four new packages, the engine seams they
+were built on, the upstream contributions the work produced, and what is knowingly left.
+
+Reader-facing documentation is [`README.md`](../../README.md#chrome-devtools-protocol-opt-in-package) and
+[the browser section beside it](../../README.md#headless-browser-opt-in-package). The designs and the index of
+what was built against them are [`docs/design/devtools-protocol.md`](../design/devtools-protocol.md) §9 and
+[`docs/design/headless-browser.md`](../design/headless-browser.md) §12.
+
+## The new packages
+
+| Package | What it is | Targets |
+| --- | --- | --- |
+| `Jint.DevTools` | A Chrome DevTools Protocol server over a WebSocket, so a debugging client attaches to an engine the host is already running. `Runtime`, `Debugger`, `Profiler`, `Console`, `Log`, `Target`, `Browser`, `Schema`. Native AOT compatible, measured by a published binary a CI leg drives over a real socket. | `net8.0`, `net10.0` |
+| `Jint.Browser` | A headless browser: AngleSharp's parser, DOM and CSSOM under Jint, with a page runtime, HTML's script scheduling, custom elements, navigation, forms, cookies, storage, workers, a deterministic box model in place of a layout, and the page-level protocol domains that make a page drivable by Puppeteer, PuppeteerSharp, Playwright and Playwright for .NET. Not trim- or AOT-compatible in this version, because AngleSharp is not trim-annotated. | `net8.0`, `net10.0` |
+| `Jint.Browser.Tool` | The `jint-browser` dotnet tool: `serve` publishes the protocol, `fetch` dumps a page as HTML, text, CommonMark or its accessibility tree, `eval` answers an expression evaluated in the page, and `mcp` serves the MCP server on stdio. It consumes only the package's published surface. | `net8.0`, `net10.0` |
+| `Jint.Browser.Mcp` | A Model Context Protocol server over the same `Page` API: eighteen tools, an accessibility snapshot carrying a `ref=` on every element that the input tools take in place of a CSS selector, and the page as a resource. A host running a server of its own composes the same tools with `AddJintBrowser()`. | `net8.0`, `net10.0` |
+
+All five are packed by `release.yml` alongside `Jint` and carry a package README of their own.
+
+## The engine seams the campaign added
+
+Every one is additive, public, and usable without any of those packages — which is what lets a third party
+build the same thing. The migration guide's own rows are the reference; this is the index.
+
+| Seam | Migration row | PR |
+| --- | --- | --- |
+| `engine.Tasks.Post(Action)` — the one thread-safe door into a running engine — and `Engine.Advanced.TryGetSourceText(Program, out string)` | [5.8](../v5-migration.md#58-a-host-thread-can-hand-the-engine-work-and-read-back-the-source-a-program-was-parsed-from-3587) | [#3587](https://github.com/sebastienros/jint/pull/3587) |
+| `DebugHandler.GetStepLocations` / `FindStepLocation` — where the engine will stop, and snapping a breakpoint onto one | [5.9](../v5-migration.md#59-a-debugger-can-ask-where-the-engine-will-stop-3614) | [#3614](https://github.com/sebastienros/jint/pull/3614) |
+| `fetch` as a document's fetch: `BaseUrl`, `Referrer`, `ReferrerPolicy`, `Origin`, `CookieJar`, and the `FetchObserver` seam with interception | [5.10](../v5-migration.md#510-fetch-can-behave-as-a-documents-fetch-3617) | [#3617](https://github.com/sebastienros/jint/pull/3617) |
+| Evaluation in any call frame, not only the innermost | [5.11](../v5-migration.md#511-a-debugger-can-evaluate-in-any-call-frame-3622) | [#3622](https://github.com/sebastienros/jint/pull/3622) |
+| `PauseOnExceptions`, `ExceptionPauseMode`, `PauseType.Exception` — stopping at the throw, before the unwind | [5.12](../v5-migration.md#512-a-debugger-can-stop-where-an-exception-is-thrown-3623) | [#3623](https://github.com/sebastienros/jint/pull/3623) |
+| `XMLHttpRequest`, opt-in, synchronous requests included, and no network grant of its own | [5.13](../v5-migration.md#513-xmlhttprequest-opt-in-and-without-a-network-grant-of-its-own-3626) | [#3626](https://github.com/sebastienros/jint/pull/3626) |
+| `ConsoleSink.WantsStackTrace`, and a described function that carries its source | [5.14](../v5-migration.md#514-a-console-sink-can-ask-where-each-message-was-logged-from-3635), [5.15](../v5-migration.md#515-a-described-function-can-carry-its-source-instead-of-a-label-3635) | [#3635](https://github.com/sebastienros/jint/pull/3635) |
+| `CallFrame.Program`, `ScriptProfileFrame.Program`, `CoverageSource.Program` — a position matched to a script by identity rather than by name | [5.17](../v5-migration.md#517-a-frame-a-profile-frame-and-a-coverage-source-name-the-program-they-belong-to-3632) | [#3651](https://github.com/sebastienros/jint/pull/3651) |
+| `SampledProfile`'s sample, stack, frame and function tables, readable rather than only writable | [5.18](../v5-migration.md#518-a-sampled-profile-is-readable-not-only-writable-3630) | [#3654](https://github.com/sebastienros/jint/pull/3654) |
+| `ExceptionPauseMode.Caught` and `StepMode.Unchanged`, so declining a pause cannot cancel a step | [5.19](../v5-migration.md#519-a-debugger-can-stop-on-caught-exceptions-and-decline-a-pause-without-cancelling-a-step-3631) | [#3662](https://github.com/sebastienros/jint/pull/3662) |
+| `PerformanceObserver`, `FileReader` and blob URLs | [5.20](../v5-migration.md#520-a-script-can-watch-the-performance-timeline-as-it-fills-3660), [5.21](../v5-migration.md#521-a-blob-can-be-read-through-the-file-apis-reader-3660), [5.22](../v5-migration.md#522-a-blob-has-a-url-and-fetching-one-reaches-no-network-3660) | [#3660](https://github.com/sebastienros/jint/pull/3660) |
+| DOM's default passive value, the current event, and a real initialized flag — the four event seams a page needs and an engine has to own | [5.23](../v5-migration.md#523-addeventlistener-implements-doms-default-passive-value-3692), [5.24](../v5-migration.md#524-a-dispatch-maintains-doms-current-event-for-a-window-global-3687), [5.25](../v5-migration.md#525-an-events-initialized-flag-is-real-3686), [4.118](../v5-migration.md#4118-initevent-and-initcustomevent-require-a-type-3686) | [#3696](https://github.com/sebastienros/jint/pull/3696) |
+| A structured `ConsoleRecord` sink overload, and `ValueInspector.Describe` — a bounded, getter-free description of any value that runs no script | chapter 5's table | [#3597](https://github.com/sebastienros/jint/pull/3597) |
+| The sampling profiler: where script time goes, by sampling the engine's own call stack | chapter 5's table | [#3608](https://github.com/sebastienros/jint/pull/3608) |
+| Tree-aware event dispatch, so a host that supplies a node tree gets DOM's event path, retargeting and activation behaviour | none owed — the seam (`TreeParent`) is `internal`, and a target with no tree is untouched | [#3592](https://github.com/sebastienros/jint/pull/3592) |
+
+Eleven behaviour changes came out of the same work and are in chapter 4 rather than chapter 5:
+[4.108](../v5-migration.md#4108-a-frame-the-engine-was-entered-at-is-named-and-a-timer-callback-has-one-3635),
+[4.109](../v5-migration.md#4109-a-request-built-from-another-request-consumes-it-3618),
+[4.110](../v5-migration.md#4110-a-module-a-host-loader-supplied-honours-retainfunctionsourcetext-3588),
+[4.111](../v5-migration.md#4111-a-coverage-source-is-one-parse-not-one-name-3632),
+[4.112](../v5-migration.md#4112-exceptionthrown-fires-once-per-throw-not-once-per-frame-it-unwinds-through-3624) and
+[4.113](../v5-migration.md#4113-an-event-listener-has-a-call-stack-frame-of-its-own-3644),
+[4.114](../v5-migration.md#4114-bindfunction-is-a-function-3645),
+[4.115](../v5-migration.md#4115-performance-is-an-eventtarget-and-asking-for-it-brings-the-events-3660),
+[4.116](../v5-migration.md#4116-the-file-api-brings-the-event-interfaces-with-it-3660),
+[4.117](../v5-migration.md#4117-foruntrustedcode-keeps-the-cancellation-token-the-host-registered-3575) and
+[4.119](../v5-migration.md#4119-a-fetchobserver-is-told-which-requests-are-xmlhttprequests-and-sees-their-bodies-3575).
+
+## Upstream contributions
+
+Building the binding layer against AngleSharp found defects in AngleSharp itself, and the campaign's rule is
+that they are fixed there rather than worked around here. Eight pull requests and seven issues came out of it;
+six of the eight are merged, and the issues are the divergences whose fix has to be designed upstream rather
+than written from here.
+
+**AngleSharp** — merged:
+
+| | |
+| --- | --- |
+| [#1310](https://github.com/AngleSharp/AngleSharp/pull/1310) | `IStringMap.Remove` left the `data-*` attribute in place |
+| [#1311](https://github.com/AngleSharp/AngleSharp/pull/1311) | `AdjacentPosition` carries the `DomLiterals` annotation, so the enumeration is projectable |
+| [#1312](https://github.com/AngleSharp/AngleSharp/pull/1312) | `Document.CurrentScript` answered the deferred-script queue |
+| [#1313](https://github.com/AngleSharp/AngleSharp/pull/1313) | A reflected `DOMString` attribute returns the empty string when it is absent |
+
+**AngleSharp** — open:
+
+| | |
+| --- | --- |
+| [#1314](https://github.com/AngleSharp/AngleSharp/pull/1314) | A `DomSameObject` annotation for the `[SameObject]` IDL members |
+| [#1315](https://github.com/AngleSharp/AngleSharp/pull/1315) | The HTML parser tracks an exception escaping host code instead of throwing it or dropping it |
+| [#1309](https://github.com/AngleSharp/AngleSharp/issues/1309) | Host-owned navigation and parsing: a `location` setter navigates on the caller's thread, a sync-parse script exception is dropped, and `ReadyState` cannot be set by a host — the issue behind the parser driver's own `readyState` shadow |
+
+**AngleSharp.Css** — merged:
+
+| | |
+| --- | --- |
+| [#228](https://github.com/AngleSharp/AngleSharp.Css/pull/228) | `matchMedia`'s media query list is evaluated against the render device instead of answering `false` for every query |
+| [#229](https://github.com/AngleSharp/AngleSharp.Css/pull/229) | An opt-in switch for CSSOM-compliant colour serialization, for [#227](https://github.com/AngleSharp/AngleSharp.Css/issues/227) — an opaque colour serializes as `rgba(r, g, b, 1)` where CSSOM says `rgb(r, g, b)` |
+
+**AngleSharp.Css** — open issues, each one a divergence this work measured:
+
+| | |
+| --- | --- |
+| [#230](https://github.com/AngleSharp/AngleSharp.Css/issues/230) | A comma-separated media query list is evaluated as a conjunction |
+| [#231](https://github.com/AngleSharp/AngleSharp.Css/issues/231) | `not <known media type>` is always false |
+| [#232](https://github.com/AngleSharp/AngleSharp.Css/issues/232) | `Is()` never matches a `CssConstantValue`, so `orientation` and `scan` evaluate wrongly |
+| [#233](https://github.com/AngleSharp/AngleSharp.Css/issues/233) | The `scripting` media feature is registered with the `scan` validator |
+| [#234](https://github.com/AngleSharp/AngleSharp.Css/issues/234) | `IRenderDevice` has no Media Queries Level 5 user-preference features, which is why the browser answers them itself |
+
+The divergences that are *not* upstream contributions — because they are decisions AngleSharp is entitled to
+and this package works within — are the two tables at the end of
+[`Jint.Browser/AGENTS.md`](../../Jint.Browser/AGENTS.md) and
+[`Jint.Browser/Dom/AGENTS.md`](../../Jint.Browser/Dom/AGENTS.md).
+
+## What is measured
+
+- **The obstacle course**: eighteen offline pages built from the libraries' own published bundles — React 18,
+  Vue 3, Preact, Svelte 5, jQuery 3.7, Alpine 3, htmx 2, an import map, a `pushState` router, forms, cookies,
+  storage, both observers, dialogs — each asserting a DOM end state *and* an empty error sink. Sixteen pass;
+  three of them are driven again over the protocol by PuppeteerSharp and by Playwright for .NET.
+  [`Jint.Tests.Browser/Fixtures/README.md`](../../Jint.Tests.Browser/Fixtures/README.md).
+- **The web-platform-tests browser lane**: 133 vendored documents and 1,417 of upstream's own tests under
+  upstream's own `testharness.js`, of which 866 pass. The figure is a ceiling — a rise fails as a regression,
+  a fall fails as staleness. [`Jint.Tests.Browser/Wpt/README.md`](../../Jint.Tests.Browser/Wpt/README.md).
+- **Native AOT for `Jint.DevTools`**, published and run rather than claimed, with a CI step that fails if any
+  trim or AOT diagnostic is attributed to a file in the package.
+
+## What is knowingly left
+
+| | |
+| --- | --- |
+| [#3714](https://github.com/sebastienros/jint/issues/3714) | No XPath — which is also why the htmx fixture does not pass |
+| [#3701](https://github.com/sebastienros/jint/issues/3701) | `Fetch`'s response stage and the `IO` domain, WebSocket and EventSource observation, and request timing |
+| [#3712](https://github.com/sebastienros/jint/issues/3712) | A nullable `DOMString` parameter in the binding generator, which is the single biggest cause in the custom-element corpus |
+| [#3720](https://github.com/sebastienros/jint/issues/3720) | `BrowserOptions.UserAgent` reaches script but not the wire |
+| [#3721](https://github.com/sebastienros/jint/issues/3721) | A page's browsing context has no `IRenderDevice`, so `@media` and `matchMedia` disagree |
+| [#3711](https://github.com/sebastienros/jint/issues/3711) | An already-rejected promise fires `unhandledrejection` before a handler can attach |
+| [#3670](https://github.com/sebastienros/jint/issues/3670) | An AngleSharp `DomException` crosses into script as a raw CLR exception |
+| [#3698](https://github.com/sebastienros/jint/issues/3698), [#3706](https://github.com/sebastienros/jint/issues/3706), [#3707](https://github.com/sebastienros/jint/issues/3707), [#3684](https://github.com/sebastienros/jint/issues/3684), [#3683](https://github.com/sebastienros/jint/issues/3683) | The seams each area of the work wished it had, filed where the work stopped |
+
+Iframe scripting, `ElementInternals`, scoped custom element registries, real isolated worlds, screenshots and
+anything else that needs a rendering are v1 non-goals rather than debt; the design docs say which is which.

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -54,7 +54,7 @@ This table is filled by the pull request that removes the member. A member that 
 | `Realm()` (public parameterless constructor) | nothing. A `Realm` only makes sense as the one an `Engine` built; get it from `Engine.HostDefined` or `Host.InitializeShadowRealm`. It was `public` only inside `#if DEBUG`, plus the implicit constructor in Release, so the shipped package's surface differed from a source build's | [#3304](https://github.com/sebastienros/jint/pull/3304) |
 | `Engine.ModuleOperations(Engine, IModuleLoader)` → `internal` | nothing. `Engine.Modules`' setter is `internal`, so an instance a host constructed could never be installed | [#3304](https://github.com/sebastienros/jint/pull/3304) |
 | `JsMap(Engine, Realm)` → `internal` | nothing. It required a `Realm`, which a host has no supported way to obtain; `JsSet`'s equivalent was already `internal` | [#3304](https://github.com/sebastienros/jint/pull/3304) |
-| The `Options` extension methods that mirrored a property — `Strict`, `Culture`, `LocalTimeZone`, `DebugMode`, `AllowClrWrite`, `LimitRecursion`, `SetTypeResolver` and sixteen more | the property they set — the full table is in [3.3](#33-options-is-configured-through-its-properties) | [#3310](https://github.com/sebastienros/jint/pull/3310) |
+| The `Options` extension methods that mirrored a property — `Strict`, `Culture`, `LocalTimeZone`, `DebugMode`, `AllowClrWrite`, `LimitRecursion`, `SetTypeResolver` and sixteen more | the property they set — the full table is in [3.3](#33-options-is-configured-through-its-properties-3310) | [#3310](https://github.com/sebastienros/jint/pull/3310) |
 | `JsValueExtensions.AsInstance<TInstance>(JsValue)` | `value as TInstance` for the answer that may be absent, `(TInstance) value` for the one that must not be — see [2.4](#24-the-four-spellings-of-as-are-gone) | [#3319](https://github.com/sebastienros/jint/pull/3319) |
 | `JsValueExtensions.As<T>(JsValue)` (`where T : ObjectInstance`) | `value as T`. The `IsObject()` test it ran first is implied by the constraint, so the two are the same question | [#3319](https://github.com/sebastienros/jint/pull/3319) |
 | `JsValueExtensions.TryCast<T>(JsValue)` | `value as T` — the body was exactly that, and it is not the `Try` pattern: no `bool`, no `out` | [#3319](https://github.com/sebastienros/jint/pull/3319) |
@@ -73,7 +73,7 @@ This table is filled by the pull request that removes the member. A member that 
 | `JsonSerializer.Serialize(JsValue, JsValue, JsValue, ResultLimits)` | `new JsonSerializer(engine, limits).Serialize(value, replacer, space)` — see [2.6](#26-a-json-serializers-limits-are-its-own-not-an-argument-to-every-call) | [#3459](https://github.com/sebastienros/jint/pull/3459) |
 | `JsonSerializer.Serialize(JsValue, IBufferWriter<byte>, ResultLimits)` | `new JsonSerializer(engine, limits).Serialize(value, writer)` — see [2.6](#26-a-json-serializers-limits-are-its-own-not-an-argument-to-every-call) | [#3459](https://github.com/sebastienros/jint/pull/3459) |
 | `JsonSerializer.Serialize(JsValue, JsValue, JsValue, IBufferWriter<byte>, ResultLimits)` | `new JsonSerializer(engine, limits).Serialize(value, replacer, space, writer)` — see [2.6](#26-a-json-serializers-limits-are-its-own-not-an-argument-to-every-call) | [#3459](https://github.com/sebastienros/jint/pull/3459) |
-| `ObjectInstance.GetOwnProperties()` → **no longer `virtual`** | nothing to call instead — the method is still there, and still public. What is gone is the ability to *override* it: it is derived from `GetOwnPropertyKeys` + `GetOwnProperty` now. A host that overrode it declares the same properties by overriding `GetOwnPropertyKeys` (and `ProbeOwnProperty` beside it), which is what every script-visible enumeration already read — see [2.6](#27-getownproperties-is-derived-not-overridden) | [#3461](https://github.com/sebastienros/jint/pull/3461) |
+| `ObjectInstance.GetOwnProperties()` → **no longer `virtual`** | nothing to call instead — the method is still there, and still public. What is gone is the ability to *override* it: it is derived from `GetOwnPropertyKeys` + `GetOwnProperty` now. A host that overrode it declares the same properties by overriding `GetOwnPropertyKeys` (and `ProbeOwnProperty` beside it), which is what every script-visible enumeration already read — see [2.6](#27-getownproperties-is-derived-not-overridden-3461) | [#3461](https://github.com/sebastienros/jint/pull/3461) |
 | `ICldrProvider.GetSupportedCalendars` (and `DefaultCldrProvider`'s override) | `ICalendarProvider.GetSupportedCalendars`. ECMA-402 has one list of calendars, not two, and defines it as the calendars the implementation can format — which in Jint means the ones it can *convert*, because that is what formatting a non-ISO calendar goes through. A calendar with conversions and no names still formats numerically; one with names and no conversions cannot be formatted at all. Adding a calendar was already three overrides on `ICalendarProvider`, and it now reaches `Intl` as well as `Temporal` | [#3404](https://github.com/sebastienros/jint/issues/3404) |
 
 ### 2.1 Sealed types
@@ -123,6 +123,15 @@ members. Nothing in the type system said so. They now carry
 or, for a host that logs one on every request, `<NoWarn>$(NoWarn);JINT0001</NoWarn>` once in the project
 file. The identifier is stable: a member marked `JINT0001` keeps that identifier for as long as it is marked,
 so the suppression does not have to be revisited.
+
+**`JINT0002` is the second identifier, and it means something different.** A member marked with it is
+*preview*: the capability is settled and the shape of it is not, so its types may gain members, its enums may
+gain values and the text it produces may change in any release. `Diagnostics.ValueInspector` and the
+description types it answers with, the sampling profiler (`Engine.Diagnostics.StartSampling`,
+`SamplingOptions`, `SampledProfile`) and `Options.WebApi.Fetch.Observer` carry it today. It is acknowledged
+exactly as `JINT0001` is — a `#pragma warning disable` at the call site, or
+`<NoWarn>$(NoWarn);JINT0002</NoWarn>` once in the project file — and the two are separate identifiers on
+purpose, so suppressing the preview area does not also suppress the non-contract one.
 
 Two things this deliberately does *not* mark. `Engine.Tasks.ProcessTasks` is the canonical host loop —
 every host with timers, promises or workers must call it — so its stale "this API may break and change
@@ -300,7 +309,7 @@ indexed collection) derive the whole coherence matrix from two or three members 
 
 The in-box overrides are gone with it — `ArrayInstance`, `Function`, `JsRegExp`, `StringInstance`,
 `ObjectWrapper`, `ArrayLikeObject`, `NamedPropertyObject` and six others each declared their keys twice, and
-now declare them once. Two of those pairs did not agree; see [4.45](#445-getownproperties-reports-what-the-key-enumerations-report).
+now declare them once. Two of those pairs did not agree; see [4.45](#445-getownproperties-reports-what-the-key-enumerations-report-3461).
 
 ## 3. Renamed and reshaped API
 
@@ -562,7 +571,7 @@ is rejected with `InvalidOperationException` instead of racing the global object
 ### 3.8 The option registries are `OptionsList<T>` ([#3327](https://github.com/sebastienros/jint/pull/3327))
 
 Six registries changed type from `List<T>` to `OptionsList<T>`, so that they can refuse a change after an
-engine has read them — see [4.16](#416-options-is-configuration-until-an-engine-reads-it-and-frozen-afterwards),
+engine has read them — see [4.16](#416-options-is-configuration-until-an-engine-reads-it-and-frozen-afterwards-3327),
 which is the reason. `OptionsList<T>` is an `IList<T>` and an `IReadOnlyList<T>` with `AddRange`, `RemoveAll`
 and `ToArray`, so the calls a host already writes compile unchanged:
 
@@ -990,7 +999,7 @@ That is the shim, not the recommendation: a file that spells `Module` for the re
 
 ### 3.16 `UntrustedCodeLimits` and `ResultLimits` are named properties, and a preset is something you adjust ([#3459](https://github.com/sebastienros/jint/pull/3459))
 
-This is [3.3](#33-options-is-configured-through-its-properties)'s rule — optional configuration is a
+This is [3.3](#33-options-is-configured-through-its-properties-3310)'s rule — optional configuration is a
 property, never a positional argument — applied to the two limit bags that still ignored it.
 
 `UntrustedCodeLimits` took **fifteen constructor parameters, eight of them required and positional, four of
@@ -1339,7 +1348,7 @@ assigned rather than the normalized one — so `JINTSEC010` (recursion limit dis
 (recursion limit saturated) still tell the two mistakes apart.
 
 `LimitStatements` also lost the parameter default that made `MaxStatements()` mean "no limit"; see
-[3.4](#34-the-surviving-extension-methods-have-one-verb-per-intent).
+[3.4](#34-the-surviving-extension-methods-have-one-verb-per-intent-3310).
 
 ### 4.13 New limits, all defaulting to unlimited
 
@@ -1897,7 +1906,7 @@ A provider implementing `ICalendarProvider` from scratch is unaffected: both mem
 Second, a host calendar reaches construction, the field accessors, `with`, `toString` and the
 `PlainYearMonth`/`PlainMonthDay` conversions, but neither arithmetic nor `Intl.DateTimeFormat`; both refused
 it with a `RangeError` when this shipped.
-[§4.40](#440-one-list-of-calendars-and-icalendarprovider-owns-it-3404) gives it `Intl`, and
+[§4.40](#438-one-list-of-calendars-and-icalendarprovider-owns-it-3404) gives it `Intl`, and
 [§4.44](#444-calendar-arithmetic-is-answered-by-whoever-answers-for-the-calendar-3403) gives it arithmetic.
 
 ### 4.31 A module graph too deep to link raises an error instead of ending the process ([#3401](https://github.com/sebastienros/jint/issues/3401))
@@ -2374,7 +2383,7 @@ difference threw out of `Engine.Evaluate`.
 
 ### 4.45 `GetOwnProperties` reports what the key enumerations report ([#3461](https://github.com/sebastienros/jint/pull/3461))
 
-Deriving `GetOwnProperties` from `GetOwnPropertyKeys` ([2.6](#27-getownproperties-is-derived-not-overridden))
+Deriving `GetOwnProperties` from `GetOwnPropertyKeys` ([2.6](#27-getownproperties-is-derived-not-overridden-3461))
 makes it agree with every other enumeration, and for three object shapes the two used to differ. Nothing in
 script changes; what changes is what a host reading `GetOwnProperties`, converting an object with
 `ToObject()`, or inspecting a scope in the debugger sees.
@@ -2497,7 +2506,7 @@ answering `null`.
 **What could break:** `ar-SA` and its region-mates now report and format in `islamic-umalqura`. Every other
 locale reports exactly what it reported before, `.NET`'s answer and CLDR's having already agreed everywhere
 else. A host implementing `ICldrProvider` **from scratch** rather than deriving from `DefaultCldrProvider`
-has one more member to write; deriving costs nothing, and [5.2](#52-changing-one-locale-datum-is-one-override)
+has one more member to write; deriving costs nothing, and [5.2](#52-changing-one-locale-datum-is-one-override-3335)
 is why that is the shape the interface is documented for.
 ### 4.48 The blocking promise drain is bounded on the engine's clock, not on the wall clock ([#3406](https://github.com/sebastienros/jint/issues/3406))
 ### 4.49 `Duration.prototype.round` reckons in the calendar its `relativeTo` carries ([#3450](https://github.com/sebastienros/jint/issues/3450))
@@ -2621,7 +2630,7 @@ with a pattern that was quadratic on input holding no `]`.
 
 **What could break:** nothing an embedder configured. `Options.Constraints.RegexTimeout` never reached
 these patterns and still does not — it bounds script-supplied regular expressions, which is unchanged
-(see [§4.42](#442-a-regex-built-at-run-time-is-bounded-by-the-configured-regextimeout)). A host that
+(see [§4.42](#442-a-regex-built-at-run-time-is-bounded-by-the-configured-regextimeout-3431)). A host that
 caught `RegexMatchTimeoutException` around `Engine.Evaluate` to absorb this can drop that handler; a host
 that treated it as a signal the script was hostile was reading a scheduling artefact.
 ### 4.55 An index a wrapped collection does not have does not exist, in every lane ([#3423](https://github.com/sebastienros/jint/issues/3423))
@@ -2792,7 +2801,7 @@ consequences, none of which changes a signature:
 ### 4.58 A worker's time budgets are measured on the worker's own clock ([#3481](https://github.com/sebastienros/jint/issues/3481))
 
 `Options.Constraints.TimeProvider` governs two budgets — `LimitExecutionTime`'s constraint and
-`PromiseTimeout`'s blocking drain ([§4.48](#448-the-blocking-promise-drain-is-bounded-on-the-engines-clock-not-on-the-wall-clock)).
+`PromiseTimeout`'s blocking drain ([§4.48](#448-the-blocking-promise-drain-is-bounded-on-the-engines-clock-not-on-the-wall-clock-3406)).
 A worker inherited the second of those as a *value* and measured it on the system clock, while the first
 arrived as a replayed constraint factory that had closed over the **parent's** options and so read the
 parent's clock. One worker engine, two budgets, two clocks.
@@ -2942,7 +2951,7 @@ f.format(new Date(Date.UTC(2026, 7, 27)));  // "٢٧٫٠٨٫٢٠٢٦"  - U+066B 
 f.format(new Date(Date.UTC(2026, 7, 27)));  // "٢٧.٠٨.٢٠٢٦"
 ```
 
-This is [4.46](#446-intl-writes-the-numbering-systems-digits-in-the-parts-lane-and-only-in-the-number) one
+This is [4.46](#446-intl-writes-the-numbering-systems-digits-in-the-parts-lane-and-only-in-the-number-3455-3456) one
 constructor over: the same "a literal is pattern text and only a number is a number" split, applied to
 `Intl.DateTimeFormat`'s two lanes rather than `Intl.NumberFormat`'s.
 
@@ -3560,7 +3569,7 @@ async function* countdown(n) {
 Per [AsyncGeneratorYield](https://tc39.es/ecma262/#sec-asyncgeneratoryield) the generator is suspended *at* the
 yield, and [14.4.14](https://tc39.es/ecma262/#sec-generator-function-definitions-runtime-semantics-evaluation)
 resumes a `yield*` delegation with the completion its caller sent; neither re-evaluates the iteration statement
-the `yield*` sits inside. This is a second defect under the same shape as [§4.72](#472-a-yield-a-loop-comes-back-to-delegates-again),
+the `yield*` sits inside. This is a second defect under the same shape as [§4.72](#472-a-yield-a-loop-comes-back-to-delegates-again-3505),
 not the same one: that one was a stale memo of what a `yield` node had returned, this one is where the
 generator was standing when it stopped.
 
@@ -4866,6 +4875,7 @@ where it printed `[native code]`. Neither is new behaviour so much as the behavi
 promised, but a host that wants the old answer for loader-loaded modules can say so per loader — pass
 `new ModuleParsingOptions { RetainFunctionSourceText = false }` to
 `ModuleFactory.BuildSourceTextModule`.
+
 ### 4.111 A coverage source is one parse, not one name ([#3632](https://github.com/sebastienros/jint/issues/3632))
 
 `CoverageReport.Sources` used to hold one `CoverageSource` per source *name*, folding the counts of every
@@ -5045,7 +5055,7 @@ learn that their work has been abandoned. So an engine built from both was deaf 
 `engine.Constraints.Find<CancellationConstraint>()` answered `null` and every one of those operations ran on
 with `CancellationToken.None`.
 
-```c#
+```csharp
 var options = new Options();
 options.ObserveCancellation(token);
 options.ForUntrustedCode(UntrustedCodeLimits.Default);
@@ -5077,6 +5087,10 @@ error while it converts the arguments and knows nothing about what the receiver 
 even for an event a dispatch has in flight, where the call would otherwise have been a silent no-op.
 `dispatchEvent()` with no arguments now says "1 argument required" where it said "1 arguments required".
 
+**What could break:** a script that called `initEvent()` bare to reset an event now throws where it used to
+set the type to `"undefined"`. Pass the type it means — `initEvent('a')` — or, if the old value really was
+wanted, `initEvent(undefined)`, which still stringifies to `"undefined"`.
+
 ### 4.119 A `FetchObserver` is told which requests are `XMLHttpRequest`s, and sees their bodies ([#3575](https://github.com/sebastienros/jint/issues/3575))
 
 `XMLHttpRequest` reported itself to `Options.WebApi.Fetch.Observer` as `FetchInitiator.Script`, which is what
@@ -5084,9 +5098,17 @@ even for an event a dispatch has in flight, where the call would otherwise have 
 chunks the observer is promised were never handed over. Both are now what the surface says: the initiator is
 the new `FetchInitiator.XmlHttpRequest`, and every chunk reaches `OnData` as it comes off the wire.
 
-```c#
-// 5.0:  request.Initiator is FetchInitiator.Script for an XMLHttpRequest, and OnData is never called for one
-// 5.x:  request.Initiator is FetchInitiator.XmlHttpRequest, and OnData is called once per chunk
+```csharp
+public override ValueTask<FetchInterception?> OnRequestAsync(ObservedFetchRequest request, CancellationToken token)
+{
+    // 5.0: true for a fetch() AND for an XMLHttpRequest.
+    // 5.x: true for a fetch() only — an XMLHttpRequest is FetchInitiator.XmlHttpRequest.
+    var fromScript = request.Initiator == FetchInitiator.Script;
+    return new((FetchInterception?) null);
+}
+
+// 5.0: never called for an XMLHttpRequest.  5.x: called once per chunk, as it comes off the wire.
+public override void OnData(FetchRequestId id, ReadOnlySpan<byte> chunk) { }
 ```
 
 The enum's own documentation already said new members may appear and that a `switch` over it wants a default
@@ -5112,7 +5134,7 @@ none of it changes an engine that does not.
 | Statement-level code coverage | `options.Coverage.Enabled = true` | [Code coverage (opt-in)](../README.md#code-coverage-opt-in) |
 | `NamedPropertyObject` — one base class for a host object projecting *named* properties, the string-keyed sibling of `ArrayLikeObject` | derive from it instead of overriding `GetOwnProperty` / `ProbeOwnProperty` / `GetOwnPropertyKeys` / `TryGetOwnPropertyValue` / `GetOwnProperties` by hand | [Projecting host data](../README.md#embedding-performance) |
 | Source-generated CLR interop for annotated types | `[JsAccessible]` on the type, plus one `JsAccessibleRegistration.RegisterAll()` call | [§5.1](#51-source-generated-clr-interop) |
-| The three shipped locale-data providers are extensible — one datum is one override | derive from `DefaultCldrProvider` / `DefaultTimeZoneProvider` / `DefaultCalendarProvider` and assign the instance to the matching `Options` property | [5.2](#52-changing-one-locale-datum-is-one-override) |
+| The three shipped locale-data providers are extensible — one datum is one override | derive from `DefaultCldrProvider` / `DefaultTimeZoneProvider` / `DefaultCalendarProvider` and assign the instance to the matching `Options` property | [5.2](#52-changing-one-locale-datum-is-one-override-3335) |
 | Writable named projections, and named members on an `ArrayLikeObject` | `IsNameWritable` / `TrySetNamedValue` / `TryDeleteName`, and the same `NameCount` / `NameAt` / `TryGetNamedValue` triple on both classes | [§5.3](#53-host-objects-one-hook-set-for-named-properties-3338) |
 | `HostFunction` — one base class for a host-defined callable, the function sibling of `ArrayLikeObject` and `NamedPropertyObject` | derive from it and override `Invoke` | [§5.5](#55-a-host-function-is-a-class-you-can-derive-3345) |
 | Host-contract verification catches a value built for an engine another thread is using | `AppContext.SetSwitch("Jint.EnableHostContractVerification", true)` | [§5.6](#56-host-contract-verification-also-checks-thread-affinity-3332) |
@@ -5123,6 +5145,9 @@ none of it changes an engine that does not.
 | A `Referer` header under a referrer policy, and an `Origin` header | `options.WebApi.Fetch.Referrer`, `.ReferrerPolicy`, `.Origin` | [§5.10](#510-fetch-can-behave-as-a-documents-fetch-3617) |
 | Cookies, in a jar the host owns, consulted per redirect hop under the request's `credentials` mode | `options.WebApi.Fetch.CookieJar = new CookieContainerCookieJar()` | [§5.10](#510-fetch-can-behave-as-a-documents-fetch-3617) |
 | Watching and intercepting every request, response and body chunk | `options.WebApi.Fetch.Observer = …`, plus `<NoWarn>$(NoWarn);JINT0002</NoWarn>` | [§5.10](#510-fetch-can-behave-as-a-documents-fetch-3617) |
+| The Chrome DevTools Protocol over a WebSocket, so a debugging client can attach to an engine your host is already running | `dotnet add package Jint.DevTools`, then `options.UseDevTools()` | [Chrome DevTools Protocol (opt-in package)](../README.md#chrome-devtools-protocol-opt-in-package) |
+| A headless browser — AngleSharp's DOM under Jint, drivable by Puppeteer and Playwright, plus a `jint-browser` command line | `dotnet add package Jint.Browser`, or `dotnet tool install -g Jint.Browser.Tool` | [Headless browser (opt-in package)](../README.md#headless-browser-opt-in-package) |
+| A Model Context Protocol server over that browser, so an agent reads a page as its accessibility tree and clicks its way through it | `jint-browser mcp`, or `AddMcpServer().AddJintBrowser()` in a host of your own | [Headless browser (opt-in package)](../README.md#headless-browser-opt-in-package) |
 | `LazyJsString` — one base class for a host string whose text is expensive to produce | `class Field : LazyJsString { public Field(int len) : base(len) {} protected override string Materialize() => … }` | [Lazy strings](../README.md#embedding-performance) |
 
 The last row is the only one that replaces an existing spelling rather than adding a capability, so it is
@@ -5249,12 +5274,12 @@ var engine = new Engine(options => options.Intl.CldrProvider = new MyCldr());
 ```
 
 `ICldrProvider` is now nineteen members and every one of them has a caller, so whatever a derived class
-answers is what `Intl` shows — see [4.22](#422-intl-reads-the-cldr-provider-for-currency-symbols-and-week-info)
-and [4.29](#429-intl-reads-the-cldr-provider-for-date-names-and-numbering-system-digits) for the two changes
+answers is what `Intl` shows — see [4.22](#422-intl-reads-the-cldr-provider-for-currency-symbols-and-week-info-3336)
+and [4.29](#429-intl-reads-the-cldr-provider-for-date-names-and-numbering-system-digits-3354) for the two changes
 that closed the gap, and section [2](#2-removed-api) for the two members that went instead of being wired.
 On the calendar side, *correcting* a calendar Jint already knows is one override, while *adding* one it does
 not know is three — `GetSupportedCalendars` and both conversions — per
-[4.30](#430-a-calendar-icalendarprovider-claims-is-a-calendar-temporal-accepts).
+[4.30](#430-a-calendar-icalendarprovider-claims-is-a-calendar-temporal-accepts-3355).
 
 ### 5.3 Host objects: one hook set for named properties ([#3338](https://github.com/sebastienros/jint/pull/3338))
 
@@ -5606,7 +5631,7 @@ take notes: by the time a handler could act the engine was already unwinding. `D
 stops it at the throw instead:
 
 ```csharp
-engine.Debugger.PauseOnExceptions = ExceptionPauseMode.Uncaught; // or All; None is the default
+engine.Debugger.PauseOnExceptions = ExceptionPauseMode.Uncaught; // or Caught or All; None is the default
 
 engine.Debugger.Break += (sender, info) =>
 {
@@ -5633,12 +5658,14 @@ function body**, whose throw becomes a rejection of its own promise. So `async f
 called inside `try { f(); } catch {}` is reported uncaught, which is what a user asking to stop on uncaught
 exceptions means by it. A rejection with no throw behind it — `Promise.reject(x)` — never stops the engine.
 
-`ExceptionThrown` is unchanged and still fires for every throw whatever the mode is, including once per frame
-an unwind passes through. `ExceptionPauseMode.None`, the default, leaves the engine byte-identical to before.
+`ExceptionThrown` is unchanged: it still fires for every throw whatever the mode is, once per throw (see
+[4.112](#4112-exceptionthrown-fires-once-per-throw-not-once-per-frame-it-unwinds-through-3624)).
+`ExceptionPauseMode.None`, the default, leaves the engine byte-identical to before.
+
 ### 5.13 `XMLHttpRequest`, opt-in and without a network grant of its own ([#3626](https://github.com/sebastienros/jint/pull/3626))
 
-A new feature flag, a new extension method and one new options group. An engine that names none of
-them is unchanged.
+`XMLHttpRequest` is behind a feature flag of its own, so an engine that does not name it is unchanged, and
+it is not a network grant — turn one on beside it:
 
 ```csharp
 var engine = new Engine(options => options
@@ -5661,7 +5688,7 @@ Everything else it answers to is `Options.WebApi.Fetch`: `AllowedSchemes`, `UrlF
 fetches in flight), `BaseUrl` for a relative `open()`, and `CookieJar`, which `withCredentials = true`
 is what selects.
 
-**`open(url, method, false)` is supported and blocks the calling thread.** The wait is on the HTTP
+**`open(method, url, false)` is supported and blocks the calling thread.** The wait is on the HTTP
 transport, which never touches the engine, so it needs no `ProcessTasks` and cannot deadlock with a
 host loop; it holds the thread for as long as `Options.WebApi.Fetch.Timeout` and the request's own
 `timeout` allow, both enforced CLR-side.
@@ -5728,12 +5755,13 @@ new EngineTargetOptions { Url = Path.GetFullPath("app.js") }   // /json/list say
 `Options.Interop.BuildCallStackHandler` is handed, and they stay exactly what the host passed;
 `Debugger.setBreakpointByUrl` accepts either form. A `Url` that is not a path — `jint://repl`,
 `https://…`, the empty string — is unchanged.
+
 ### 5.17 A frame, a profile frame and a coverage source name the program they belong to ([#3632](https://github.com/sebastienros/jint/issues/3632))
 
-A `SourceLocation` carries a source *name*, and every `Execute` given no source is named `<anonymous>`, so a
-host mapping a position back to the script it announced through `DebugHandler.BeforeEvaluate` had to guess.
-Three types now carry the program itself — the same reference `BeforeEvaluate` hands over and
-`Engine.Advanced.TryGetSourceText` is keyed by:
+A `SourceLocation` carries a source *name*, which cannot tell two parses apart
+([4.111](#4111-a-coverage-source-is-one-parse-not-one-name-3632) is the same problem seen from the coverage
+side). Three types now carry the program itself — the same reference `DebugHandler.BeforeEvaluate` hands over
+and `Engine.Advanced.TryGetSourceText` is keyed by:
 
 ```csharp
 CallFrame frame = information.CallStack[0];
@@ -5744,8 +5772,8 @@ Program? covered = report.Sources[0].Program;           // which parse a coverag
 
 All three are `null` for code the engine reached another way — `eval` and the `Function` constructor are
 programs no execution context names, and a built-in or host callable has no source at all — rather than
-being attributed to whichever script was running. `ScriptProfileFrame`'s primary constructor gained the
-optional parameter that carries it, so a profile a host keeps now retains the abstract syntax trees it names.
+being attributed to whichever script was running. A profile a host keeps now retains the abstract syntax
+trees it names, which is worth knowing if it keeps many of them.
 
 ### 5.18 A sampled profile is readable, not only writable ([#3630](https://github.com/sebastienros/jint/issues/3630))
 
@@ -5792,7 +5820,7 @@ every other member sets the mode, and this one keeps it. As an engine's initial 
 Both are new members of existing enums, so nothing that compiled stops compiling — but a `switch` *expression*
 over either that listed every member and had no discard arm will now warn that it is not exhaustive.
 
-### 5.20 `PerformanceObserver` ([#3660](https://github.com/sebastienros/jint/pull/3660))
+### 5.20 A script can watch the performance timeline as it fills ([#3660](https://github.com/sebastienros/jint/pull/3660))
 
 `WebApiFeatures.Performance` now installs `PerformanceObserver` and `PerformanceObserverEntryList` beside
 `performance` and the entry interfaces. No new flag, and nothing changes for an engine that does not enable
@@ -5824,7 +5852,7 @@ binding.
 `Options.WebApi.Diagnostics.Sink` and the observers behind it are still delivered to, which is the
 `"report"` exception behaviour the algorithm invokes it with.
 
-### 5.21 `FileReader` ([#3660](https://github.com/sebastienros/jint/pull/3660))
+### 5.21 A `Blob` can be read through the File API's reader ([#3660](https://github.com/sebastienros/jint/pull/3660))
 
 `WebApiFeatures.Files` now installs `FileReader` beside `Blob`, `File` and `FormData`. No new flag.
 
@@ -5852,7 +5880,7 @@ piece of pending work has across a restore.
 not block on; here it would be a second spelling of `blob.text()` and `blob.arrayBuffer()` whose only
 distinguishing feature is being unavailable on the main thread.
 
-### 5.22 Blob URLs ([#3660](https://github.com/sebastienros/jint/pull/3660))
+### 5.22 A blob has a URL, and fetching one reaches no network ([#3660](https://github.com/sebastienros/jint/pull/3660))
 
 An engine with both `WebApiFeatures.Url` and `WebApiFeatures.Files` — which `WebApiFeatures.Default` has —
 now carries `URL.createObjectURL` and `URL.revokeObjectURL`, and a blob URL store behind them. They are
@@ -5866,7 +5894,7 @@ URL.revokeObjectURL(url);
 ```
 
 The URL reads `blob:null/<uuid>`, because an engine with no document has an opaque origin and `"null"` is
-what one serializes to; `Jint.Browser` is what will put a real origin there.
+what one serializes to; a page in `Jint.Browser` has a real origin and puts it there.
 
 **Fetching one reaches no network.** [Scheme fetch](https://fetch.spec.whatwg.org/#scheme-fetch) dispatches
 on the URL's scheme, and the `blob` arm is answered from the engine's own store before `AllowedSchemes`, the
@@ -5917,6 +5945,31 @@ has none.
 **Nothing changes for an engine without a DOM.** Every event a constructor makes has the flag set, so the
 guard can only fire for an event a host's own `createEvent` produced — `Jint.Browser`'s — and a re-entrant
 dispatch still reports the message it always did.
+
+### 5.26 Four packages of their own, outside the engine's contract ([#3575](https://github.com/sebastienros/jint/issues/3575))
+
+Four new packages ship beside `Jint`, and nothing about them reaches an engine that does not reference one.
+`Jint.DevTools` serves the Chrome DevTools Protocol for an engine your host is already running;
+`Jint.Browser` adds AngleSharp's DOM, a page runtime and the page-level protocol domains on top of it;
+`Jint.Browser.Mcp` is a Model Context Protocol server over that, for an agent rather than a client; and
+`Jint.Browser.Tool` is the `jint-browser` command line over both, installed rather than referenced. All four
+are `net8.0` and later.
+
+**There is nothing to migrate.** They are additive, they are separate packages, and they are outside the
+engine's compatibility contract in the ordinary way — a package a project does not reference cannot break it.
+Where they touch this document is the other direction: the engine seams they were built on are
+[5.8](#58-a-host-thread-can-hand-the-engine-work-and-read-back-the-source-a-program-was-parsed-from-3587)
+through [5.19](#519-a-debugger-can-stop-on-caught-exceptions-and-decline-a-pause-without-cancelling-a-step-3631),
+and every one of them is public and usable without either package — which is the point of them being seams
+rather than internals. The one member of theirs this document records is
+[5.16](#516-enginetargetoptionsurl-accepts-a-path-and-publishes-a-url-3640), which is here because it changed
+after the package's first release rather than because the package is in scope.
+
+The reference material is `README.md`, per this document's own rule: what they do, what a page can and
+cannot do, the per-page budgets and how much of it is measured rather than claimed are in
+[Chrome DevTools Protocol (opt-in package)](../README.md#chrome-devtools-protocol-opt-in-package) and
+[Headless browser (opt-in package)](../README.md#headless-browser-opt-in-package), and
+[`docs/releases/headless-browser.md`](releases/headless-browser.md) is the same thing package by package.
 
 ## 6. AOT and trimming
 
@@ -6005,7 +6058,7 @@ own call site rather than as a wrong answer at run time. Each message names what
 | `Options.AllowClr()` and `AllowClr(params Assembly[])` | script names CLR types and namespaces as strings; nothing statically references what they expose | root the assemblies you allow, or drop `AllowClr` and hand each type to script explicitly |
 | `Options.AddExtensionMethods(params Type[])` | the types are reflected over, and a `Type[]` parameter cannot carry `[DynamicallyAccessedMembers]` - only a `Type` or a `string` can | root the declaring types; a trimmed-away extension method fails as `not a function`, with no diagnostic |
 | `Engine.SetValue(string, object?)` | no type at the call site to annotate | prefer `SetValue<T>(string, T)`, or pass a `JsValue` |
-| `ShadowRealm.SetValue(string, object?)` | the same overload on the same API, pointed at a shadow realm's global object; it carried no annotation at all until v5, while the harmless `Delegate` overload beside it carried one ([§3.7](#37-shadowrealmsetvalue-is-enginesetvalue-mirrored)) | the same: prefer `SetValue<T>(string, T)`, or pass a `JsValue` |
+| `ShadowRealm.SetValue(string, object?)` | the same overload on the same API, pointed at a shadow realm's global object; it carried no annotation at all until v5, while the harmless `Delegate` overload beside it carried one ([§3.7](#37-shadowrealmsetvalue-is-enginesetvalue-mirrored-3321)) | the same: prefer `SetValue<T>(string, T)`, or pass a `JsValue` |
 | `ObjectWrapper.Create(Engine, object, Type?)` | same - and it is what a custom `WrapObjectHandler` calls | root the type, or project through `SetValue<T>` |
 
 (`ClrHelper.Unwrap` and `ClrHelper.Wrap`, reachable only from script through `clrHelper`, carry it too.)


### PR DESCRIPTION
Row X5 of the headless-browser campaign ([#3575](https://github.com/sebastienros/jint/issues/3575)): the
reader-facing documentation for what the campaign shipped, written from the code as it is on `main` rather
than from the plan. Docs and package metadata only — no code changes.

## What changed

**`README.md`.** The `Jint.DevTools` and `Jint.Browser` sections grew by accretion across twenty pull
requests and read like a changelog — twelve paragraphs each opening with "And …", the unauthenticated-endpoint
warning stated twice, the entry points scattered through the prose. Both are rewritten top-down for a reader
who has not followed the campaign:

- **Chrome DevTools Protocol** — what it is and that it is the engine half of the protocol, the
  install-and-run, which thread answers a command, one statement of the unauthenticated-endpoint warning, what
  answers today (with the browser/target session split), and the REPL.
- **Headless browser** (renamed from "Jint.Browser (opt-in package, in progress)") — AngleSharp + Jint and the
  founder's principle stated once; the three ways in, three lines each (`Page` API, `AddBrowser` +
  PuppeteerSharp, `dotnet tool install`); what a page does; what a client can do over the protocol; the
  budgets and `ForUntrustedContent`; what is absent **by design** and what is absent **for now**, the latter a
  table with the issue that would close each row; and the two numbers, from the obstacle course and the
  web-platform-tests browser lane, with links to both. No benchmark numbers — that is X4.

`Jint.Browser.Tool/README.md`'s deep link into the renamed section is repointed.

**Package READMEs.** `Jint.Browser` and `Jint.DevTools` were `IsPackable` with no `PackageReadmeFile` at all,
so nuget.org would have shown nothing for either. Both now have one — a paragraph, an example, the link to the
repository section — wired through `PackageReadmeFile` plus a `<None Include="README.md" Pack="true" …>` the
way `Jint` and `Jint.Browser.Tool` already do. Verified with `dotnet pack` on both.

**Design docs.** Kept as design; each gains a final "What shipped, and where it differs" table — one row per
item, the pull request that built it, and the one line in which what shipped is not what was planned (the flat
layout's rows, the `[CEReactions]` approximation, the transport-thread network listener, the `tab` target,
worlds as aliases, `frameNavigated` before the engine swap, `ITargetHost` staying internal, …).

**Migration guide.** Every row this campaign added, audited against the guide's own rules; prose only, nothing
renumbered. A new `5.26` says the three packages are additive and outside the engine's contract and points at
the README, which is where the guide's own rule puts reference material, plus three rows in chapter 5's table.

**`docs/releases/headless-browser.md`.** A draft for the maintainer to lift into the v5 announcement: the new
packages, the engine seams with their migration-row numbers, the upstream AngleSharp contributions the work
produced, what is measured, and what is knowingly left. The repository keeps no changelog and `release.yml`
generates no notes, so this is a `docs/` page rather than an entry in something.

**Docs site: there is none.** No mkdocs, docfx, Jekyll or Pages configuration anywhere in the tree, and `docs/`
has no index or nav — the pages are reachable only because prose links to them. So there was no navigation to
add these to, and the new pages are linked from the README and the migration guide instead.

## What was found false and corrected

Against `README.md`:

1. `Target.getTargets` and `Target.attachToTarget` were attributed to the **`Runtime`** bullet. They are
   `TargetDomain`, and they are registered on the browser session.
2. "`chrome://inspect` lists it" from pointing a client at `http://127.0.0.1:9222` — both the REPL's own banner
   and `manual-checklist.md` say `127.0.0.1:9222` has to be added under **Configure…** first.
3. `Target`, `Browser` and `Schema` were not said to be **browser-session only**, so `Browser.getVersion` down
   an attached target session reads as supported when it is `-32601`.
4. The page-domain list omitted **`Performance`** and **`Audits`**, both of which are registered and answer.
5. "the same three answers … each takes the options the extractor behind it already had" — the extractors are
   shared, the **option sets are not**: `Page.TextAsync(mainContentOnly, maxLength)` against
   `Jint.getText(useComputedStyle)`, and so on. The parity claim that survives is that they cannot disagree
   about a document, which is what the section now says.
6. "**custom elements** are a later item of the same campaign" — the registry shipped in #3709. The fixture is
   still `[Explicit]`, so "sixteen of eighteen" is right, but the reason was not.
7. "targets `net8.0` and later" → `net8.0` and `net10.0`, which is what the two csproj files list.

Against `docs/v5-migration.md`:

8. `5.12` closed with "`ExceptionThrown` … fires … once per frame an unwind passes through", which `4.112`
   (#3624, merged after it) had already changed to once per throw. The two sections contradicted each other.
9. `5.13` documented `open(url, method, false)`; the argument order is `open(method, url, async)`.
10. `5.12`'s example comment enumerated `ExceptionPauseMode` as "or All; None is the default" — `5.19` added
    `Caught` after it was written.
11. `5.22` said "`Jint.Browser` is what **will** put a real origin there"; it has shipped.
12. `4.118` had no `What could break` paragraph — the only campaign row in chapter 4 without one, and it turns
    a silent coercion into a hard `TypeError`.
13. `4.119`'s before/after "example" was a fenced block containing two comment lines and no code, and named
    `FetchObserver` members that do not exist; it is now the real signatures.
14. `JINT0002` was cited four times and defined nowhere — `2.2` defined only `JINT0001`. It is now defined
    beside it.
15. Three headings (`5.20`, `5.21`, `5.22`) were bare nouns where every other row's heading is a sentence
    stating the outcome; three (`4.111`, `5.13`, `5.17`) had no blank line before them; `4.117` was the one
    campaign block still fenced as `c#` where the rest use `csharp`; `5.17` re-argued `4.111`'s rationale
    rather than linking it, and `5.13` and `5.18` opened in release-note voice.
16. **Nineteen cross-references pointed at anchors that do not exist.** Eighteen lost their pull-request
    suffix when the target heading gained one (`#33-options-is-configured-through-its-properties` for a
    heading that ends `-3310`), and one named `#440-…` for a section that is now `4.38`. All are repointed and
    the whole set is verified.

## What is left

- **`README.md`** links `[npm-style packages](#npm-style-packages-opt-in)` and there is no such section
  anywhere in the file — `NodeStyleModuleLoader` is named twice and documented nowhere. Left alone rather than
  repointed at a guess; it predates this campaign and is unrelated to it.
- **`Jint/JintDiagnosticIds.cs`**'s `<remarks>` still says `Options.WebApi.Fetch.Observer`'s "first real
  consumer is a protocol layer that has not been written yet". `Jint.Browser`'s `PageNetworkRecorder` is that
  consumer. Not touched, because this pull request is documentation only and that is a source file.
- The `custom-elements` fixture is still `[Explicit]` with a reason that says the registry "is not on this
  branch". Turning it back on is a code change and belongs with whoever verifies it passes; `Fixtures/README.md`
  carries the same stale diagnosis and is left consistent with the attribute the test asserts against.
- `#3608` (the sampling profiler) and `#3597` (the console record and `ValueInspector`) reach the migration
  guide only as chapter-5 table rows with no pull-request citation. Left as they are — the table's other rows
  cite nothing either.
- **#3716 merged while this was being written and is folded in**: `getComputedStyle` answering a resolved
  value for the ten actionability properties is described as shipped, the row it closed is gone from the
  "absent for now" table, and both design-doc paragraphs about it are main's. **#3717 and #3718 are still
  open.** When they merge, two things here need one edit each: "three ways in" becomes four with the MCP
  server's `mcpServers` snippet, and the XPath row and the htmx fixture's line change.

## Verification

- `dotnet test -c Release --filter "FullyQualifiedName~AgentInstructionFileTests"` — 5/5 on all three target
  frameworks.
- `dotnet test -c Release --filter "FullyQualifiedName~MigrationGuideTests"` — 3/3 on all three.
- `dotnet pack -c Release` on `Jint.DevTools` and `Jint.Browser` — both produce a package with the new README
  (a missing `PackageReadmeFile` is `NU5039`, so a successful pack is the check).
- Every markdown link and heading anchor in the touched files was resolved mechanically; the two remaining
  misses are the pre-existing one above and an illustrative `[§x.y](#xy-...)` inside inline code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
