### PR TITLE
WPT scoreboard: upstream's own runner drives Jint.Browser over the DevTools Protocol nightly, through a wptrunner product

### DIFF
--- a/.github/workflows/wpt-scoreboard.yml
+++ b/.github/workflows/wpt-scoreboard.yml
@@ -1,0 +1,315 @@
+# The public web-platform-tests scoreboard: upstream's own runner, driving Jint.Browser over CDP.
+#
+# This is NOT a gate. A test that fails here fails the scoreboard, not the build; the only things that fail
+# this workflow are the runner failing to reach the browser at all and a run that produced no report worth
+# publishing. Everything that gates `Jint.Browser` is in `pr.yml` and runs in process.
+#
+# Nothing here is on the pull-request path, and nothing here writes to `main`: the page and the badge
+# document are committed to the orphan `wpt-scoreboard` branch, whose whole content is what this workflow
+# generates.
+#
+# The two numbers this repository publishes are deliberately different and neither replaces the other:
+#   * this one       -- upstream's runner, upstream's server, every case the manifest generates;
+#   * the census     -- Jint.Tests.Browser/Wpt/README.md, a vendored subset run in process, and a gate.
+name: WPT scoreboard
+
+on:
+  schedule:
+    # 04:17 UTC, off the hour so it does not queue behind everyone else's midnight cron.
+    - cron: '17 4 * * *'
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: 'Commit the result to the wpt-scoreboard branch'
+        type: boolean
+        default: true
+      suites:
+        description: 'Space-separated test paths to run (default: the ten the design names)'
+        type: string
+        default: ''
+
+permissions:
+  contents: write
+
+concurrency:
+  group: wpt-scoreboard
+  cancel-in-progress: false
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: 1
+  # Where `jint-browser serve` listens, and what the wptrunner product connects to.
+  JINT_BROWSER_URL: http://127.0.0.1:9222
+  # The suites §9 of docs/design/headless-browser.md names. `.any.js` files in them become several cases
+  # each; the wrappers for globals this engine has no lane for are run rather than filtered, and the
+  # scoreboard breaks them out so the totals cannot be mistaken for a verdict on the DOM.
+  DEFAULT_SUITES: >-
+    dom/
+    html/dom/
+    html/semantics/scripting-1/
+    html/webappapis/
+    html/browsers/history/
+    xhr/
+    url/
+    fetch/api/
+    FileAPI/
+    custom-elements/
+
+jobs:
+  scoreboard:
+
+    name: 'nightly wpt run'
+
+    runs-on: ubuntu-latest
+
+    # Generous, because it is a nightly and because a run that has to build the manifest from scratch pays
+    # for it once. A run that reaches this is killed and reports nothing, which is one of the two failures
+    # this workflow is allowed to have.
+    timeout-minutes: 300
+
+    steps:
+
+    - name: Checkout Jint
+      uses: actions/checkout@v7
+
+    - name: Setup NET
+      uses: actions/setup-dotnet@v6
+      with:
+        dotnet-version: 10.0
+
+    # One corpus, one pin: the commit is read out of the file that owns it, so the scoreboard and the
+    # in-process census can never be measured against different trees.
+    - name: Read the pinned web-platform-tests commit
+      id: pin
+      shell: bash
+      run: |
+        set -o pipefail
+        sha=$(grep -oE '\b[0-9a-f]{40}\b' Jint.Tests/Wpt/Vendor/README.md | head -1)
+        if [ -z "$sha" ]; then
+          echo 'Jint.Tests/Wpt/Vendor/README.md names no commit' >&2
+          exit 1
+        fi
+        echo "sha=$sha" >> "$GITHUB_OUTPUT"
+        echo "web-platform-tests pinned at $sha"
+
+    - name: Checkout web-platform-tests at the pin
+      uses: actions/checkout@v7
+      with:
+        repository: web-platform-tests/wpt
+        ref: ${{ steps.pin.outputs.sha }}
+        path: wpt
+        # The corpus is what is being run; its history is not.
+        fetch-depth: 1
+
+    # wptserve serves every subdomain wpt's substitution syntax names, and a page can only reach them if the
+    # machine resolves them. `wpt run` refuses to start without this for any product but its own handful,
+    # which is exactly right: without it a third of `fetch/api` and `xhr` would fail for the environment's
+    # reason and the number would be a lie.
+    - name: Map the wpt hosts onto loopback
+      shell: bash
+      working-directory: wpt
+      run: |
+        set -o pipefail
+        ./wpt make-hosts-file | sudo tee -a /etc/hosts > /dev/null
+        grep -c web-platform.test /etc/hosts
+
+    # Dropping the TLS servers. Jint.Browser cannot be told about an extra certificate authority, so a run
+    # over wpt's pregenerated certificates would fail every https case for the environment's reason; with
+    # --ssl-type=none wptrunner leaves https tests out of the run instead (include_https=ssl_enabled), which
+    # is the honest shape. The file itself only has to null three ports out, because ConfigBuilder._get_ports
+    # skips the bare `https` and `wss` schemes when SSL is off but not `https-local`, `https-public` or `h2`,
+    # and those three then try to start with no certificate and take the whole environment down with them.
+    - name: Configure the wpt servers
+      shell: bash
+      run: cp tools/wpt-scoreboard/wpt-config.json wpt/config.json
+
+    # Generating it takes minutes and it only depends on the pin, so it is cached on exactly that.
+    # --no-manifest-download in the run below is what keeps this the manifest that gets used: a downloaded
+    # one is built for whatever revision upstream last published, which is not necessarily this one.
+    - name: Restore the wpt manifest
+      id: manifest-cache
+      uses: actions/cache@v6
+      with:
+        path: wpt/MANIFEST.json
+        key: wpt-manifest-${{ steps.pin.outputs.sha }}
+
+    - name: Build the wpt manifest
+      if: steps.manifest-cache.outputs.cache-hit != 'true'
+      shell: bash
+      working-directory: wpt
+      run: ./wpt manifest --no-download
+
+    - name: Build jint-browser
+      run: dotnet build Jint.Browser.Tool/Jint.Browser.Tool.csproj --configuration Release --framework net10.0
+
+    # The virtualenv is ours rather than wpt's own `_venv3`, because the product has to be installed into it
+    # *before* `wpt run` looks for entry points. `wpt --venv` then reuses it and installs the runner's own
+    # requirements alongside. It is built with the runner's own `python3` -- the same interpreter `./wpt`
+    # runs under -- because `wpt` activates the virtualenv inside the process it is already in.
+    - name: Install the wptrunner product
+      shell: bash
+      run: |
+        set -o pipefail
+        python3 -m venv "$RUNNER_TEMP/wpt-venv"
+        "$RUNNER_TEMP/wpt-venv/bin/pip" install --quiet --upgrade pip
+        "$RUNNER_TEMP/wpt-venv/bin/pip" install --quiet pytest
+        "$RUNNER_TEMP/wpt-venv/bin/pip" install --quiet -e tools/wpt-scoreboard
+
+    # The unit tests of the plugin itself, and the one thing that tells "the scoreboard is zero because the
+    # engine fails everything" from "the scoreboard is zero because the runner never reached the page": one
+    # known-good document, served with upstream's own testharness.js and wptrunner's own report script, run
+    # through a `jint-browser serve` this step starts and stops on a port of its own. Three subtests must
+    # pass and one must fail; a bridge that reported nothing would time out here and a bridge that reported
+    # optimistically would not have the failure in it.
+    - name: Test the executor against a known-good document
+      shell: bash
+      env:
+        WPT_ROOT: ${{ github.workspace }}/wpt
+        JINT_BROWSER_COMMAND: dotnet ${{ github.workspace }}/artifacts/bin/Jint.Browser.Tool/release_net10.0/Jint.Browser.Tool.dll
+      run: |
+        set -o pipefail
+        "$RUNNER_TEMP/wpt-venv/bin/python" -m pytest tools/wpt-scoreboard/tests -q
+
+    # Deliberately NOT --untrusted, and the reason is worth having in the file that would otherwise grow it
+    # back. `BrowserOptions.ForUntrustedContent` applies `UntrustedCodeLimits.Default` to every page engine:
+    # one second per engine entry, 50 000 statements, 10 000-element arrays, recursion depth 64, a 250 ms
+    # regex budget. Those are the right numbers for a page nobody vouches for and the wrong ones for a
+    # conformance measurement -- a scoreboard taken under them would be a report on the hardened profile
+    # rather than on the engine, and the command line has no switch for any of the five. What the corpus is
+    # instead is vendored, pinned content served from loopback.
+    #
+    # --max-task-duration 0 for the same reason the in-process lane sets MaxTaskDuration to infinite: a
+    # legitimately slow file cut mid-script reads as an engine defect three layers from its cause. The bound
+    # on a page here is wptrunner's own per-test timeout, which is upstream's number.
+    - name: Start jint-browser serve
+      shell: bash
+      run: |
+        set -o pipefail
+        nohup dotnet artifacts/bin/Jint.Browser.Tool/release_net10.0/Jint.Browser.Tool.dll \
+          serve --port 9222 --max-task-duration 0 > "$RUNNER_TEMP/serve.log" 2>&1 &
+        echo $! > "$RUNNER_TEMP/serve.pid"
+
+        for _ in $(seq 1 60); do
+          if curl --silent --fail "$JINT_BROWSER_URL/json/version" > /dev/null; then
+            curl --silent "$JINT_BROWSER_URL/json/version"
+            echo
+            exit 0
+          fi
+          sleep 1
+        done
+
+        echo 'jint-browser serve never answered /json/version' >&2
+        cat "$RUNNER_TEMP/serve.log" >&2
+        exit 1
+
+    # --no-fail-on-unexpected is what makes this a scoreboard rather than a gate: a failing test is a number
+    # on the page, and the step's exit code is about the runner. The four .h2. files are named because the
+    # h2 server is off with TLS, and a test whose protocol has no port would be an internal error rather
+    # than a result.
+    - name: Run the suites
+      shell: bash
+      working-directory: wpt
+      # The total budget, and it sits on the step rather than on the job so that the two steps below still
+      # run when it is reached: a run that has to be killed leaves no wptreport, and the log is then the only
+      # evidence of why.
+      timeout-minutes: 240
+      env:
+        SUITES: ${{ inputs.suites || env.DEFAULT_SUITES }}
+      run: |
+        set -o pipefail
+        ./wpt --venv "$RUNNER_TEMP/wpt-venv" run jint-browser \
+          --jint-browser-url "$JINT_BROWSER_URL" \
+          --ssl-type none \
+          --no-manifest-download \
+          --processes 1 \
+          --test-types testharness \
+          --no-fail-on-unexpected \
+          --no-fail-on-unexpected-pass \
+          --timeout-multiplier 2 \
+          --log-wptreport "$RUNNER_TEMP/wptreport.json" \
+          --log-mach-level info \
+          --log-mach - \
+          --exclude fetch/api/basic/request-upload.h2.any.js \
+          --exclude fetch/api/basic/status.h2.any.js \
+          --exclude fetch/api/redirect/redirect-upload.h2.any.js \
+          --exclude xhr/status.h2.window.js \
+          $SUITES
+
+    - name: Stop jint-browser serve
+      if: always()
+      shell: bash
+      run: |
+        if [ -f "$RUNNER_TEMP/serve.pid" ]; then
+          kill "$(cat "$RUNNER_TEMP/serve.pid")" 2>/dev/null || true
+        fi
+        tail -40 "$RUNNER_TEMP/serve.log" || true
+
+    # The report is the artefact the page is derived from, so it is kept whether or not the page is
+    # published: everything on the page can be recomputed from it by anybody who downloads it.
+    - name: Upload wptreport.json
+      if: always()
+      uses: actions/upload-artifact@v5
+      with:
+        name: wptreport
+        path: ${{ runner.temp }}/wptreport.json
+        if-no-files-found: warn
+        retention-days: 30
+
+    # The other half of the "did the runner work" question, and it takes two thresholds because they catch
+    # different failures. --min-tests catches a run that produced almost no results. Its default sibling
+    # --min-subtests catches the one --min-tests cannot see: a browser that died has a result for every test
+    # -- every one an error -- so only the absence of any subtest anywhere tells that apart from a score.
+    # Publishing either would silently replace a real number with a wrong one.
+    - name: Generate the scoreboard
+      shell: bash
+      run: |
+        set -o pipefail
+        mkdir -p "$RUNNER_TEMP/out/docs"
+        "$RUNNER_TEMP/wpt-venv/bin/python" -m wpt_jint_browser.scoreboard \
+          "$RUNNER_TEMP/wptreport.json" \
+          --markdown "$RUNNER_TEMP/out/docs/wpt-scoreboard.md" \
+          --badge "$RUNNER_TEMP/out/badge.json" \
+          --jint-commit "$GITHUB_SHA" \
+          --wpt-commit "${{ steps.pin.outputs.sha }}" \
+          --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+          --min-tests 500
+        cat "$RUNNER_TEMP/out/docs/wpt-scoreboard.md" >> "$GITHUB_STEP_SUMMARY"
+
+    # A branch of its own, never main: the page changes every night and a commit on main every night would
+    # bury everything else in the history. The branch holds nothing but what this workflow generates, which
+    # is why it is orphaned and why every link on the page is absolute.
+    - name: Publish to the wpt-scoreboard branch
+      if: github.event_name == 'schedule' || inputs.publish
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -o pipefail
+        publish="$RUNNER_TEMP/publish"
+        rm -rf "$publish"
+        git init --quiet --initial-branch=wpt-scoreboard "$publish"
+        cd "$publish"
+        git config user.name 'github-actions[bot]'
+        git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+        git remote add origin "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git"
+        git config http.extraheader "AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 -w0)"
+
+        # Depth 1 so the branch does not accumulate a clone of the repository's history, and a fresh start
+        # when it does not exist yet.
+        if git fetch --quiet --depth 1 origin wpt-scoreboard 2>/dev/null; then
+          git reset --quiet --hard FETCH_HEAD
+        fi
+
+        mkdir -p docs
+        cp "$RUNNER_TEMP/out/docs/wpt-scoreboard.md" docs/wpt-scoreboard.md
+        cp "$RUNNER_TEMP/out/badge.json" badge.json
+
+        git add -A
+        if git diff --cached --quiet; then
+          echo 'the scoreboard is unchanged'
+          exit 0
+        fi
+
+        git commit --quiet -m "WPT scoreboard: $(date -u '+%Y-%m-%d') at ${GITHUB_SHA:0:12}"
+        git push --quiet origin wpt-scoreboard
+        echo "published $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/blob/wpt-scoreboard/docs/wpt-scoreboard.md"

--- a/.github/workflows/wpt-scoreboard.yml
+++ b/.github/workflows/wpt-scoreboard.yml
@@ -213,9 +213,9 @@ jobs:
     # comparison with. It is also the flag that decides how long this job takes, because the run's cost is
     # dominated by the cases that fail by *not reporting*: a `<meta name=timeout content=long>` file is 60
     # seconds each time, and `html/semantics/scripting-1/the-script-element/moving-between-documents/` alone
-    # is 52 of them, every one of which currently times out on one defect (a <script src> whose fetch fails
-    # fires neither load nor error, so the harness never completes). At 2 that one directory is an hour and
-    # three quarters of this job on its own.
+    # is 52 of them, every one of which waits for a message posted by script running inside an <iframe> --
+    # and iframes run no script in this version, by design, so the harness never completes. At 2 that one
+    # directory is an hour and three quarters of this job on its own.
     - name: Run the suites
       shell: bash
       working-directory: wpt

--- a/.github/workflows/wpt-scoreboard.yml
+++ b/.github/workflows/wpt-scoreboard.yml
@@ -206,6 +206,16 @@ jobs:
     # on the page, and the step's exit code is about the runner. The four .h2. files are named because the
     # h2 server is off with TLS, and a test whose protocol has no port would be an internal error rather
     # than a result.
+    #
+    # There is deliberately no --timeout-multiplier, and it is worth knowing why before one is added back.
+    # Every per-test timeout in the corpus is the test author's, and wpt.fyi's own numbers are taken at the
+    # default of 1, so a scoreboard measured at 2 would be more generous than the figures it invites
+    # comparison with. It is also the flag that decides how long this job takes, because the run's cost is
+    # dominated by the cases that fail by *not reporting*: a `<meta name=timeout content=long>` file is 60
+    # seconds each time, and `html/semantics/scripting-1/the-script-element/moving-between-documents/` alone
+    # is 52 of them, every one of which currently times out on one defect (a <script src> whose fetch fails
+    # fires neither load nor error, so the harness never completes). At 2 that one directory is an hour and
+    # three quarters of this job on its own.
     - name: Run the suites
       shell: bash
       working-directory: wpt
@@ -225,7 +235,6 @@ jobs:
           --test-types testharness \
           --no-fail-on-unexpected \
           --no-fail-on-unexpected-pass \
-          --timeout-multiplier 2 \
           --log-wptreport "$RUNNER_TEMP/wptreport.json" \
           --log-mach-level info \
           --log-mach - \

--- a/Jint.Browser.Tool/AGENTS.md
+++ b/Jint.Browser.Tool/AGENTS.md
@@ -50,6 +50,16 @@ without opening it: **standard output is the protocol and nothing else** while `
 prints no banner and every diagnostic goes to standard error; and `mcp` **hardens the pages by default**,
 which is the opposite of every other command here and is why it takes `--trusted` rather than `--untrusted`.
 
+**`serve` has a second consumer now, and it is the one that would find a missing switch.**
+`.github/workflows/wpt-scoreboard.yml` runs upstream's own `wpt run` against `jint-browser serve` nightly
+(the plugin is [`tools/wpt-scoreboard/`](../tools/wpt-scoreboard/README.md)). It needed no new seam — but it
+did need two options to *not* be defaults, and the reasons are worth knowing before either is changed.
+`--max-task-duration 0` is passed because a five-second turn cuts a legitimately slow conformance file
+mid-script, and `--untrusted` is deliberately **not**, because `ForUntrustedContent` applies
+`UntrustedCodeLimits.Default` — one second per engine entry, 50 000 statements, 10 000-element arrays,
+recursion depth 64 — and no option here can move any of the five. A measurement taken under that profile
+would be a report on the profile.
+
 ### What is deliberately absent
 
 - **No command-line library.** A `dotnet tool` is restored by everyone who runs it, so every dependency is

--- a/Jint.Tests.Browser/Wpt/AGENTS.md
+++ b/Jint.Tests.Browser/Wpt/AGENTS.md
@@ -31,6 +31,16 @@ free of a browser.
 reason per row, what the corpus says about this browser, and the census. Read it for *what* is here; this file
 is *how* it works.
 
+**There is a second wpt number and it is not this one.** `.github/workflows/wpt-scoreboard.yml` runs
+*upstream's* `wpt run` nightly against `jint-browser serve` and publishes a page; the plugin that makes it
+possible is [`tools/wpt-scoreboard/`](../../tools/wpt-scoreboard/README.md). It runs the same corpus at the
+same pin — it reads the commit out of `Vendor/README.md` — but it is not a gate, it has no exclusion table,
+and it runs whole suites rather than a vendored subset. So: **a failure there is never an entry here.** A
+divergence the scoreboard finds in a suite this lane does not vendor is a candidate for vendoring, and one it
+finds in a suite this lane *does* vendor is a defect this table should already name — if it does not, the
+table is what is wrong. Nothing under `tools/wpt-scoreboard/` may become a second answer to "did this
+subtest pass": every judgement there is upstream's `testharness_result_converter`, on purpose.
+
 ### A suite is a directory, and a case is a path on the server
 
 `WptCorpus.BrowserSuites` names them and `WptCorpus.BrowserTestFiles` lists a directory's own documents without

--- a/Jint.Tests.Browser/Wpt/README.md
+++ b/Jint.Tests.Browser/Wpt/README.md
@@ -14,6 +14,13 @@ this project holds no copy of a vendored file. How the lane works — the result
 wrappers, the environment a document runs in, where a divergence goes — is
 [`AGENTS.md`](AGENTS.md) beside this file. What follows is what the lane *found*.
 
+**This is not the only web-platform-tests number, and the other one is not a rival.** The census below is
+*ours* — our driver, a vendored subset, an exclusion row per failure — and it is a **gate**. The
+[scoreboard](https://github.com/sebastienros/jint/blob/wpt-scoreboard/docs/wpt-scoreboard.md) is
+*upstream's*: a nightly `wpt run` over `wptserve`, across ten whole suites, and it gates nothing. It runs
+the same corpus at the same pin, so a suite it reports that this table does not have is a suite nobody has
+vendored here yet. Its plugin is [`tools/wpt-scoreboard/`](../../tools/wpt-scoreboard/README.md).
+
 ## The lane, suite by suite
 
 | Suite | Documents | Synthesized | Tests | Not passing |

--- a/README.md
+++ b/README.md
@@ -2725,6 +2725,16 @@ does not pass is named by the exclusion table with the cause it belongs to.
 
 ### Where to read further
 
+**And there is a second web-platform-tests number, measured by somebody else.**
+[The scoreboard](https://github.com/sebastienros/jint/blob/wpt-scoreboard/docs/wpt-scoreboard.md) — which the
+first nightly run publishes onto a branch of its own — is what
+*upstream's own runner* reports: a nightly `wpt run` over upstream's `wptserve`, driving `Jint.Browser`
+through the DevTools Protocol, across ten suites and every case the manifest generates for them. It is the
+figure that can be compared with what other engines publish, because wpt measured it rather than Jint. The
+census above is ours, is a subset, and is a gate; the scoreboard is upstream's, is the whole of those
+suites, and gates nothing. How it is run — and what it deliberately leaves out — is
+[`tools/wpt-scoreboard/README.md`](tools/wpt-scoreboard/README.md).
+
 The design, including what a v1 will and will not do, is
 [`docs/design/headless-browser.md`](docs/design/headless-browser.md), and the protocol half is
 [`docs/design/devtools-protocol.md`](docs/design/devtools-protocol.md); the tracking issue is

--- a/docs/design/headless-browser.md
+++ b/docs/design/headless-browser.md
@@ -354,8 +354,30 @@ upstream's other vendor slot, `testdriver-vendor.js`, so a document that drives 
 reaches the same `InputDispatcher` a protocol client does — one implementation, so the two cannot disagree.
 The suites arrive a PR at a
 time; the first are `dom/events` and `html/webappapis/scripting`'s events and processing-model halves, and the
-rest of the list above follows through the same lane. A nightly
-real `wpt run` over CDP produces a public scoreboard later; it is not a PR gate. Next to it, an obstacle course
+rest of the list above follows through the same lane.
+
+**The nightly `wpt run` over CDP is built**, and the two numbers it leaves the project with are not two
+measurements of the same thing — which is the sentence this paragraph used to leave implied. **The census**
+is *ours*: our driver, in our process, over the vendored subset, with an exclusion table that names every
+failure one at a time, and it **is a gate** — `Not passing` only ever goes down. **The scoreboard** is
+*upstream's*: `wpt run` over `wptserve`, across the whole of ten suites — `dom/`, `html/dom/`,
+`html/semantics/scripting-1/`, `html/webappapis/`, `html/browsers/history/`, `xhr/`, `url/`, `fetch/api/`,
+`FileAPI/` and `custom-elements/` — including every wrapper the manifest generates for a global this engine
+has no lane for, and it **gates nothing** — a failure there is a
+number on a page. The census is the one an engine change has to keep; the scoreboard is the one that can be
+compared with what another engine publishes, because wpt measured it. A suite in the scoreboard that the
+census does not have is a suite nobody has vendored yet, never a disagreement.
+
+`wpt run chrome` cannot produce it: that product requires a `--webdriver-binary`, launches that
+`chromedriver`, and speaks WebDriver classic — its CDP is tunnelled through `chromedriver`'s
+`goog/cdp/execute` extension command, and no `debuggerAddress` capability exists anywhere in the wpt tree.
+Lightpanda ships a WebDriver front end beside its CDP for exactly this reason. What is here instead is a
+**wptrunner product plugin**, [`tools/wpt-scoreboard/`](../../tools/wpt-scoreboard/README.md), registered
+through upstream's `wptrunner.products` entry-point group so that no fork of wpt is needed: its executor
+navigates a page over CDP and reads the results upstream's own `testharnessreport.js` posts, through a
+`Runtime.addBinding` binding, and every judgement about whether a subtest passed stays upstream's.
+`.github/workflows/wpt-scoreboard.yml` runs it nightly and commits the page to a `wpt-scoreboard` branch;
+it fails only when the runner could not reach the browser or produced no report. Next to it, an obstacle course
 of offline fixtures (React, Vue, Preact and Svelte TodoMVC, SSR hydration, jQuery 3 with `async: false`, htmx,
 Alpine, a `pushState` router, custom elements, modules with an import map, forms with redirects, a cookie login,
 `localStorage` persistence, `IntersectionObserver` and `MutationObserver` widgets, dialogs) each asserting a DOM

--- a/tools/wpt-scoreboard/.gitignore
+++ b/tools/wpt-scoreboard/.gitignore
@@ -1,0 +1,5 @@
+# `pip install -e .` and pytest both write into the source tree.
+__pycache__/
+*.py[cod]
+*.egg-info/
+.pytest_cache/

--- a/tools/wpt-scoreboard/README.md
+++ b/tools/wpt-scoreboard/README.md
@@ -120,9 +120,10 @@ cd wpt && ./wpt --venv ../.wpt-venv run jint-browser \
 
 The wall time is dominated by the cases that fail by **not reporting**: a document that never completes
 costs its whole timeout, and a `<meta name=timeout content=long>` file's timeout is 60 seconds.
-`html/semantics/scripting-1/the-script-element/moving-between-documents/` is 52 of those, and at the time of
-writing every one of them times out on the same defect — a `<script src>` whose fetch fails fires neither
-`load` nor `error`, so the harness never finishes — so that one directory is most of an hour.
+`html/semantics/scripting-1/the-script-element/moving-between-documents/` is 52 of those, and every one of
+them waits for a message posted by script running inside an `<iframe>` — and iframes run no script in this
+version, by design (`docs/design/headless-browser.md` keeps that for a later phase), so the harness never
+finishes — so that one directory is most of an hour, and will be until iframes run script.
 
 **There is therefore no `--timeout-multiplier`**, and the reason is not only cost. Every per-test timeout in
 the corpus is the test author's, and wpt.fyi's published figures are taken at the default of 1; a scoreboard

--- a/tools/wpt-scoreboard/README.md
+++ b/tools/wpt-scoreboard/README.md
@@ -1,0 +1,182 @@
+# `wpt run` against `Jint.Browser`
+
+A [wptrunner](https://web-platform-tests.org/tools/wptrunner/README.html) **product** called
+`jint_browser`, and the script that turns the run's `wptreport.json` into
+[the published scoreboard](https://github.com/sebastienros/jint/blob/wpt-scoreboard/docs/wpt-scoreboard.md)
+— a page that exists once the first nightly run has written the branch it lives on, and never before.
+
+This is the *other* web-platform-tests number in this repository, and the difference is the point:
+
+| | measured by | runs | is it a gate? |
+| --- | --- | --- | --- |
+| **The scoreboard** (here) | upstream's `wpt run`, over upstream's `wptserve` | every case the manifest generates for ten suites | **no** — `.github/workflows/wpt-scoreboard.yml` is nightly and publishes a page |
+| **The census** ([`Jint.Tests.Browser/Wpt/`](../../Jint.Tests.Browser/Wpt/README.md)) | our own driver, in process | a vendored subset, one exclusion row per failure | **yes** — the not-passing column only ever goes down |
+
+Neither replaces the other. The census is the one an engine change has to keep; the scoreboard is the one
+that can be compared with what other engines report, because upstream measured it.
+
+## The spike: why this is a product plugin and not `wpt run chrome`
+
+`wpt run chrome` cannot drive this browser, and the reason is structural rather than a missing flag.
+
+* `wptrunner/browsers/chrome.py` calls `require_arg(kwargs, "webdriver_binary")`, and its browser class is a
+  `WebDriverBrowser` that launches that `chromedriver` process and talks **WebDriver classic** to it.
+* Its executors (`ChromeDriverTestharnessExecutor` and friends) reach CDP only through
+  `chromedriver`'s `goog/cdp/execute` extension command — a WebDriver endpoint. There is no
+  `debuggerAddress` capability anywhere in the wpt tree, so there is no supported way to point that product
+  at a browser somebody else started.
+* `Jint.Browser` speaks CDP and nothing else. Lightpanda ships a WebDriver front end *as well as* CDP for
+  exactly this reason; this package is the other way of closing the same gap.
+
+So: a custom product. It needs no fork of wpt, because `wptrunner.products` loads external products from the
+`wptrunner.products` [entry-point group](https://web-platform-tests.org/tools/wptrunner/README.html) —
+`pip install` this package into the virtualenv `wpt run` uses and `wpt run jint-browser …` finds it.
+`wpt run` maps the hyphen to an underscore itself, and an unknown-but-loadable product gets
+`GenericBrowserSetup`, which requires no binary and installs no driver.
+
+**What is not re-implemented:** the harness, the report format, the result conversion, the server, the
+manifest, the timeouts, and the decision about whether a subtest passed. `wptrunner`'s own
+`testharnessreport.js` is what the server hands each page, and `CallbackHandler` +
+`testharness_result_converter` are what turn its output into results. What this package adds is a transport.
+
+## How a result gets out of a page
+
+1. `Page.addScriptToEvaluateOnNewDocument` installs [`bridge.js`](wpt_jint_browser/bridge.js) on every
+   document. `Jint.Browser`'s `PageTarget` commits a document by announcing the navigation, swapping the
+   engine, re-installing the `Runtime.addBinding` bindings and *then* running these scripts — all before the
+   document's first inline script — which is the only ordering in which any of this works.
+2. `bridge.js` **is** upstream's `message-queue.js`. That file opens by returning if the queue already
+   exists, because "another script already set up the testdriver infrastructure"; this is that script. So
+   `testharnessreport.js` still calls `add_completion_callback` and still pushes
+   `{type: "complete", tests, status}`, unchanged.
+3. Instead of handing the item to an asynchronous WebDriver script, the bridge hands it to a
+   `Runtime.addBinding` binding as one JSON string. It captures the binding function and deletes the global,
+   so a document that enumerates `window` does not find the runner's plumbing among its results.
+4. `Runtime.bindingCalled` arrives on the executor's CDP connection; `CallbackHandler` turns it into the
+   tuple `testharness_result_converter` wants, with the URL the executor navigated to rather than the one
+   the page reports — which is what upstream's `__wptrunner_url` dance exists to get right.
+
+The CDP client is [`cdp.py`](wpt_jint_browser/cdp.py) over [`websocket.py`](wpt_jint_browser/websocket.py),
+about 200 lines of RFC 6455 with no dependencies. That is deliberate: `wpt run` builds its own virtualenv,
+and every published CDP client for Python would add a dependency chain to it. The frame codec is unit-tested
+over a socket pair, because the two ways it can be wrong — an unmasked client frame and a mis-taken length
+branch — both look like the browser hanging up rather than like a bug.
+
+## What is deliberately left out
+
+* **Reftests.** `Jint.Browser` renders nothing. `JintBrowserRefTestExecutor` answers `PRECONDITION_FAILED`
+  with a sentence rather than failing the run or, worse, reporting a pass nothing measured. The workflow
+  passes `--test-types testharness` so one is never reached in practice.
+* **`testdriver.js` actions.** `supports_testdriver` is `False`, so wptrunner **skips** a test that needs
+  one and says why, rather than failing it. Turning an element into a point needs `getClientRects` inside
+  the page, which is real work; the in-process lane already maps `test_driver` onto the same
+  `InputDispatcher` the `Input` domain reaches, so this is a gap in the scoreboard rather than in the
+  engine. `send_message` is implemented anyway, so a document that reaches `test_driver` without the
+  manifest flag gets upstream's "not implemented" answer instead of hanging until its timeout.
+* **HTTPS.** `Jint.Browser` has no way to be told about an extra certificate authority, so a run over wpt's
+  pregenerated certificates would fail every `https` case for the environment's reason. The workflow passes
+  `--ssl-type=none`, and wptrunner then leaves https tests out of the run entirely
+  (`include_https=ssl_enabled`) rather than running them into a wall. Installing wpt's CA into the runner's
+  trust store would lift this; it is the obvious next step and is not in v1.
+* **`--untrusted`.** The nightly does not pass it. `BrowserOptions.ForUntrustedContent` applies
+  `UntrustedCodeLimits.Default` to every page engine — one second per engine entry, 50 000 statements,
+  10 000-element arrays, recursion depth 64, a 250 ms regex budget — and the command line has no switch for
+  any of the five. Those are the right numbers for a page nobody vouches for and the wrong ones for a
+  conformance measurement: a scoreboard taken under them would be a report on the hardened profile. What is
+  served is vendored, pinned content on loopback.
+
+## Running it yourself
+
+The nightly is `.github/workflows/wpt-scoreboard.yml` and it is the specification; this is the same thing
+by hand.
+
+```bash
+# 1. a wpt checkout at the pin Jint.Tests/Wpt/Vendor/README.md names
+git clone https://github.com/web-platform-tests/wpt.git
+git -C wpt checkout <pin>
+cp tools/wpt-scoreboard/wpt-config.json wpt/config.json
+(cd wpt && ./wpt make-hosts-file | sudo tee -a /etc/hosts)
+
+# 2. a virtualenv with this product in it, built with the python ./wpt will run under
+python3 -m venv .wpt-venv
+.wpt-venv/bin/pip install -e tools/wpt-scoreboard pytest
+
+# 3. the browser
+dotnet build Jint.Browser.Tool/Jint.Browser.Tool.csproj -c Release -f net10.0
+dotnet artifacts/bin/Jint.Browser.Tool/release_net10.0/Jint.Browser.Tool.dll serve --max-task-duration 0 &
+
+# 4. the run
+cd wpt && ./wpt --venv ../.wpt-venv run jint-browser \
+  --ssl-type none --no-manifest-download --processes 1 --test-types testharness \
+  --no-fail-on-unexpected --timeout-multiplier 2 \
+  --log-wptreport ../wptreport.json --log-mach - \
+  dom/
+
+# 5. the page
+.wpt-venv/bin/python -m wpt_jint_browser.scoreboard wptreport.json --markdown docs/wpt-scoreboard.md
+```
+
+### If the nightly gets too long
+
+The run restarts the test runner after almost every test, and that is not a defect: `restart_on_unexpected`
+defaults to on, this repository ships no wpt expectation metadata, so *every* failure is unexpected. It
+costs about a second per failing test — measured at roughly 15% of the wall time. `--no-restart-on-unexpected`
+removes it, and is safe here for a reason that is specific to this browser rather than general: a navigation
+already disposes the previous document's engine and cancels everything it had in flight, and a runner restart
+only mints a new page target rather than a new process, so the isolation the flag buys is isolation the next
+`Page.navigate` gives anyway. It is not passed today because upstream's default is what a reader expects.
+
+### `wpt-config.json`, and why it exists
+
+It is copied into the checkout as its `config.json`, which is the override
+`TestEnvironment.build_config` reads before it starts the servers. All it does is null three ports out:
+`ConfigBuilder._get_ports` skips the bare `https` and `wss` schemes when SSL is off, but **not**
+`https-local`, `https-public` or `h2`. Left in, those three try to start with no certificate and the whole
+environment dies with `Servers failed to start: https-local:8445, https-public:8446`. The four `.h2.` test
+files are excluded by name in the workflow for the same reason, so that they are absent rather than internal
+errors.
+
+### On a machine whose hosts file you cannot write
+
+`wpt run` refuses to start without the hosts entries, and that refusal is right — a third of `fetch/api` and
+`xhr` need a second origin. If you cannot have them, you can get a run out of the tree by pointing the
+*server* at a wildcard-loopback domain in the same `config.json`, and calling `wptrunner` directly rather
+than through `wpt run`:
+
+```json
+{
+  "browser_host": "web-platform.localtest.me",
+  "alternate_hosts": { "alt": "not-web-platform.localtest.me" },
+  "ports": { "https-local": [null], "https-public": [null], "h2": [null] }
+}
+```
+
+Every name under `localtest.me` resolves to `127.0.0.1` in public DNS. It is correct and it is *slow* —
+every subresource is a DNS round trip, which multiplies a page load by about ten — so it is a way to
+develop, never a way to measure.
+
+## The tests
+
+`tests/` runs under `pytest` and is what the workflow runs before anything else.
+
+* `test_websocket.py` — the frame codec over a socket pair. No browser, no server, no environment
+  variables; it always runs.
+* `test_scoreboard.py` — a report in, a page out. Likewise.
+* `test_executor_smoke.py` — the whole path against a real `jint-browser serve`, on one document with three
+  passing subtests and one that fails on purpose. It needs `WPT_ROOT` (a wpt checkout, for `testharness.js`
+  and `wptrunner`'s report script) and `JINT_BROWSER_COMMAND` (how to start the built tool), and **skips**
+  naming the missing one when it does not have them.
+
+```bash
+WPT_ROOT=$PWD/wpt \
+JINT_BROWSER_COMMAND="dotnet $PWD/artifacts/bin/Jint.Browser.Tool/release_net10.0/Jint.Browser.Tool.dll" \
+  .wpt-venv/bin/python -m pytest tools/wpt-scoreboard/tests -q
+```
+
+## What this is pinned against
+
+`wptrunner`'s external-product contract is young: `products.Product`, `get_all_products()` and the
+`wptrunner.products` entry-point group are what `product.py` builds against, and `Product` is constructed
+directly rather than through the older `__wptrunner__` dict so that a field it grows is a `TypeError` here
+rather than a silent default. The workflow always checks wpt out at the corpus pin, so an upstream change to
+that contract arrives with a deliberate pin bump and not on a random night.

--- a/tools/wpt-scoreboard/README.md
+++ b/tools/wpt-scoreboard/README.md
@@ -108,13 +108,26 @@ dotnet artifacts/bin/Jint.Browser.Tool/release_net10.0/Jint.Browser.Tool.dll ser
 # 4. the run
 cd wpt && ./wpt --venv ../.wpt-venv run jint-browser \
   --ssl-type none --no-manifest-download --processes 1 --test-types testharness \
-  --no-fail-on-unexpected --timeout-multiplier 2 \
+  --no-fail-on-unexpected \
   --log-wptreport ../wptreport.json --log-mach - \
   dom/
 
 # 5. the page
 .wpt-venv/bin/python -m wpt_jint_browser.scoreboard wptreport.json --markdown docs/wpt-scoreboard.md
 ```
+
+### What the run costs, and the flag that decides it
+
+The wall time is dominated by the cases that fail by **not reporting**: a document that never completes
+costs its whole timeout, and a `<meta name=timeout content=long>` file's timeout is 60 seconds.
+`html/semantics/scripting-1/the-script-element/moving-between-documents/` is 52 of those, and at the time of
+writing every one of them times out on the same defect — a `<script src>` whose fetch fails fires neither
+`load` nor `error`, so the harness never finishes — so that one directory is most of an hour.
+
+**There is therefore no `--timeout-multiplier`**, and the reason is not only cost. Every per-test timeout in
+the corpus is the test author's, and wpt.fyi's published figures are taken at the default of 1; a scoreboard
+measured at 2 would be systematically more generous than the numbers it invites comparison with. Raising it
+doubles exactly the cases that are already failing and changes nothing about the ones that pass.
 
 ### If the nightly gets too long
 

--- a/tools/wpt-scoreboard/pyproject.toml
+++ b/tools/wpt-scoreboard/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "wpt-jint-browser"
+version = "0.1.0"
+description = "A wptrunner product that drives Jint.Browser over the Chrome DevTools Protocol"
+readme = "README.md"
+requires-python = ">=3.9"
+license = { text = "BSD-2-Clause" }
+
+# Deliberately none. `wptrunner` is not declared because this is installed *into* the virtualenv that
+# already has it, and declaring it would make pip try to resolve a package that is not on PyPI under that
+# name. Everything else is the standard library, including the WebSocket client, so installing this adds
+# nothing to the environment `wpt run` builds for itself.
+dependencies = []
+
+[project.entry-points."wptrunner.products"]
+jint_browser = "wpt_jint_browser.product:load"
+
+[project.scripts]
+wpt-scoreboard = "wpt_jint_browser.scoreboard:main"
+
+[tool.setuptools]
+packages = ["wpt_jint_browser"]
+
+[tool.setuptools.package-data]
+wpt_jint_browser = ["bridge.js"]

--- a/tools/wpt-scoreboard/tests/conftest.py
+++ b/tools/wpt-scoreboard/tests/conftest.py
@@ -1,0 +1,112 @@
+"""Fixtures for the two tests that need something running: a wpt checkout, and a browser.
+
+Neither is downloaded or built here.  ``WPT_ROOT`` names a checkout — the workflow's, or a local clone at
+the pin — and ``JINT_BROWSER_COMMAND`` names how to start the server, which is a built ``dotnet`` command
+rather than a source tree so that a test run cannot silently measure a stale build.  A test that needs one
+of them and does not have it **skips**, and says which variable was missing.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shlex
+import subprocess
+import sys
+import threading
+from typing import Iterator, List, Optional
+
+import pytest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+PACKAGE_ROOT = os.path.dirname(HERE)
+
+if PACKAGE_ROOT not in sys.path:
+    sys.path.insert(0, PACKAGE_ROOT)
+
+
+def _wpt_root() -> Optional[str]:
+    root = os.environ.get("WPT_ROOT")
+    if root and os.path.isdir(os.path.join(root, "tools", "wptrunner")):
+        return os.path.abspath(root)
+    return None
+
+
+@pytest.fixture(scope="session")
+def wpt_root() -> str:
+    """A web-platform-tests checkout, with ``wptrunner`` and its vendored dependencies importable."""
+    root = _wpt_root()
+    if root is None:
+        pytest.skip("set WPT_ROOT to a web-platform-tests checkout to run this test")
+
+    tools = os.path.join(root, "tools")
+    if tools not in sys.path:
+        sys.path.insert(0, tools)
+    # `localpaths` is how every wpt entry point puts wptrunner and its vendored dependencies on the path;
+    # doing the same here means this test sees exactly what `wpt run` sees.
+    import localpaths  # noqa: F401
+
+    return root
+
+
+class ServerProcess:
+    """A running ``jint-browser serve``, with the endpoint it printed."""
+
+    def __init__(self, process: subprocess.Popen, url: str, output: List[str]) -> None:
+        self.process = process
+        self.url = url
+        self.output = output
+
+
+_BANNER = re.compile(r"listening on (http://\S+)")
+
+
+@pytest.fixture(scope="session")
+def jint_browser() -> Iterator[ServerProcess]:
+    """Starts one server for the session and reads its endpoint off the banner it prints."""
+    command = os.environ.get("JINT_BROWSER_COMMAND")
+    if not command:
+        pytest.skip("set JINT_BROWSER_COMMAND to the built `jint-browser` command to run this test")
+
+    argv = shlex.split(command, posix=os.name != "nt")
+    argv += ["serve", "--port", "0", "--allow-private-network"]
+
+    process = subprocess.Popen(  # noqa: S603
+        argv,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        bufsize=1,
+    )
+
+    lines: List[str] = []
+    found: List[str] = []
+    ready = threading.Event()
+
+    def pump() -> None:
+        assert process.stdout is not None
+        for line in process.stdout:
+            lines.append(line.rstrip("\n"))
+            match = _BANNER.search(line)
+            if match and not found:
+                found.append(match.group(1))
+                ready.set()
+        ready.set()
+
+    reader = threading.Thread(target=pump, name="jint-browser-output", daemon=True)
+    reader.start()
+
+    if not ready.wait(120) or not found:
+        process.kill()
+        raise AssertionError("jint-browser serve printed no endpoint:\n" + "\n".join(lines))
+
+    try:
+        yield ServerProcess(process, found[0], lines)
+    finally:
+        process.terminate()
+        try:
+            process.wait(timeout=30)
+        except subprocess.TimeoutExpired:
+            process.kill()

--- a/tools/wpt-scoreboard/tests/harness_fixture.py
+++ b/tools/wpt-scoreboard/tests/harness_fixture.py
@@ -1,0 +1,123 @@
+"""A one-document stand-in for the wpt server, so the CDP half can be tested without the whole runner.
+
+Everything a real ``wpt run`` serves at ``/resources/`` is served here from the same two sources it comes
+from: upstream's ``testharness.js`` (the copy this repository vendors, at the pin
+``Jint.Tests/Wpt/Vendor/README.md`` names) and ``wptrunner``'s own ``testharnessreport.js`` preceded by its
+``message-queue.js``, formatted with the same four properties ``TestEnvironment.get_routes`` formats them
+with.  Nothing in the results path is this file's own, which is the point: a fixture that shipped its own
+report script would prove the fixture works.
+"""
+
+from __future__ import annotations
+
+import http.server
+import os
+import threading
+from typing import Optional
+
+REPOSITORY_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+VENDORED_RESOURCES = os.path.join(REPOSITORY_ROOT, "Jint.Tests", "Wpt", "Vendor", "resources")
+
+#: The values ``TestEnvironment.get_routes`` substitutes when nothing on the command line moves them.
+REPORT_PROPERTIES = {"output": 0, "timeout_multiplier": 1, "explicit_timeout": "false", "debug": "false"}
+
+SMOKE_DOCUMENT = """<!doctype html>
+<meta charset="utf-8">
+<title>jint-browser scoreboard smoke test</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+test(function () {
+  assert_equals(document.title, "jint-browser scoreboard smoke test");
+}, "the document is the one that was navigated to");
+
+test(function () {
+  assert_equals(document.querySelector("#log").id, "log");
+}, "the harness has a DOM to render into");
+
+async_test(function (t) {
+  t.step_timeout(function () {
+    t.done();
+  }, 1);
+}, "a timer callback resumes the harness");
+
+test(function () {
+  assert_true(false, "this subtest fails on purpose");
+}, "a failing subtest is reported as a failure");
+</script>
+"""
+
+
+def report_script(wpt_root: str) -> bytes:
+    """``message-queue.js`` followed by ``wptrunner``'s ``testharnessreport.js``, exactly as wptrunner serves it."""
+    executors = os.path.join(wpt_root, "tools", "wptrunner", "wptrunner", "executors")
+    report = os.path.join(wpt_root, "tools", "wptrunner", "wptrunner", "testharnessreport.js")
+
+    with open(os.path.join(executors, "message-queue.js"), encoding="utf-8") as handle:
+        queue_source = handle.read()
+    with open(report, encoding="utf-8") as handle:
+        report_source = handle.read() % REPORT_PROPERTIES
+
+    return (queue_source + "\n" + report_source).encode("utf-8")
+
+
+class HarnessServer:
+    """Serves ``/resources/*`` and one document, on loopback, on a port the operating system picks."""
+
+    def __init__(self, wpt_root: str, document: str = SMOKE_DOCUMENT, path: str = "/smoke.html") -> None:
+        report = report_script(wpt_root)
+        body = document.encode("utf-8")
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            protocol_version = "HTTP/1.1"
+
+            def do_GET(self) -> None:  # noqa: N802 - the base class names it
+                if self.path == path:
+                    self._answer(body, "text/html; charset=utf-8")
+                elif self.path == "/resources/testharnessreport.js":
+                    self._answer(report, "text/javascript; charset=utf-8")
+                elif self.path.startswith("/resources/") and ".." not in self.path:
+                    name = self.path[len("/resources/"):]
+                    source = os.path.join(VENDORED_RESOURCES, name)
+                    if os.path.isfile(source):
+                        with open(source, "rb") as handle:
+                            self._answer(handle.read(), "text/javascript; charset=utf-8")
+                    else:
+                        self.send_error(404)
+                else:
+                    self.send_error(404)
+
+            def _answer(self, payload: bytes, content_type: str) -> None:
+                self.send_response(200)
+                self.send_header("Content-Type", content_type)
+                self.send_header("Content-Length", str(len(payload)))
+                self.end_headers()
+                self.wfile.write(payload)
+
+            def log_message(self, format: str, *args: object) -> None:
+                pass
+
+        self._server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self._thread: Optional[threading.Thread] = None
+        self.path = path
+
+    @property
+    def origin(self) -> str:
+        host, port = self._server.server_address[:2]
+        return f"http://{host}:{port}"
+
+    @property
+    def url(self) -> str:
+        return self.origin + self.path
+
+    def __enter__(self) -> "HarnessServer":
+        self._thread = threading.Thread(target=self._server.serve_forever, name="harness-fixture", daemon=True)
+        self._thread.start()
+        return self
+
+    def __exit__(self, *exception: object) -> None:
+        self._server.shutdown()
+        self._server.server_close()
+        if self._thread is not None:
+            self._thread.join(timeout=5.0)

--- a/tools/wpt-scoreboard/tests/test_executor_smoke.py
+++ b/tools/wpt-scoreboard/tests/test_executor_smoke.py
@@ -1,0 +1,125 @@
+"""The executor against a real ``jint-browser serve``, on one known-good document.
+
+This is the test the nightly workflow runs before it runs anything else, and it is the only one that can
+tell "the scoreboard is zero because the engine fails everything" from "the scoreboard is zero because the
+runner never reached the page".  A document with three passing subtests and one deliberately failing one is
+enough for that: a bridge that reported nothing would time out, and a bridge that reported optimistically
+would not have the failure in it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from harness_fixture import HarnessServer
+from wpt_jint_browser.cdp import CdpConnection, browser_endpoint
+
+pytestmark = pytest.mark.usefixtures("wpt_root")
+
+
+@pytest.fixture
+def page(jint_browser):
+    """A page target with the bridge installed, driven the way the executor drives it."""
+    from wpt_jint_browser.executor import BINDING_NAME, BRIDGE_SOURCE
+
+    connection = CdpConnection(browser_endpoint(jint_browser.url))
+    try:
+        target = connection.send("Target.createTarget", {"url": "about:blank"})["targetId"]
+        session = connection.send("Target.attachToTarget", {"targetId": target, "flatten": True})["sessionId"]
+
+        connection.send("Page.enable", session_id=session)
+        connection.send("Runtime.enable", session_id=session)
+        connection.send("Runtime.addBinding", {"name": BINDING_NAME}, session_id=session)
+        connection.send("Page.addScriptToEvaluateOnNewDocument", {"source": BRIDGE_SOURCE}, session_id=session)
+
+        yield connection, session
+    finally:
+        connection.close()
+
+
+def _report(connection, session, url, timeout=60.0):
+    import json
+    import time
+
+    result = connection.send("Page.navigate", {"url": url}, session_id=session)
+    assert not result.get("errorText"), result.get("errorText")
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        event = connection.next_event(deadline - time.monotonic())
+        if event is None:
+            break
+        if event.get("method") == "Runtime.bindingCalled" and event["params"].get("name") == "__wptrunner_cdp_report":
+            return json.loads(event["params"]["payload"])
+
+    raise AssertionError(f"no report from {url} within {timeout:g}s")
+
+
+def test_the_harness_reports_through_the_binding(page, wpt_root):
+    connection, session = page
+
+    with HarnessServer(wpt_root) as server:
+        message_type, payload = _report(connection, session, server.url)
+
+    assert message_type == "complete"
+
+    status, message, _stack, subtests = payload
+    assert status == 0, f"the harness did not finish cleanly: {message}"
+
+    by_name = {name: (subtest_status, subtest_message) for name, subtest_status, subtest_message, _ in subtests}
+    assert len(by_name) == 4, by_name
+
+    assert by_name["the document is the one that was navigated to"][0] == 0
+    assert by_name["the harness has a DOM to render into"][0] == 0
+    assert by_name["a timer callback resumes the harness"][0] == 0
+
+    failing_status, failing_message = by_name["a failing subtest is reported as a failure"]
+    assert failing_status == 1, "a failing subtest must arrive as a failure, not be swallowed"
+    assert "on purpose" in (failing_message or "")
+
+
+def test_the_bridge_leaves_no_binding_on_the_global(page, wpt_root):
+    """The runner's plumbing must not show up in a document's own enumeration of ``window``."""
+    connection, session = page
+
+    with HarnessServer(wpt_root) as server:
+        _report(connection, session, server.url)
+
+        answer = connection.send(
+            "Runtime.evaluate",
+            {"expression": "typeof window.__wptrunner_cdp_report", "returnByValue": True},
+            session_id=session,
+        )
+
+    assert answer["result"]["value"] == "undefined"
+
+
+def test_the_payload_converts_the_way_wptrunner_expects(page, wpt_root):
+    """The seam between :mod:`bridge` and upstream's converter, which nothing else exercises."""
+    from wptrunner.executors.base import CallbackHandler, strip_server
+
+    connection, session = page
+
+    with HarnessServer(wpt_root) as server:
+        url = server.url
+        message_type, payload = _report(connection, session, url)
+
+    handler = CallbackHandler(_NullLogger(), None, None)
+    done, result = handler([url, message_type, payload])
+
+    assert done
+    result_url, status, _message, _stack, subtests = result
+    assert result_url == strip_server(url)
+    assert status == 0
+    assert sorted(subtest[1] for subtest in subtests) == [0, 0, 0, 1]
+
+
+class _NullLogger:
+    def debug(self, *args, **kwargs):
+        pass
+
+    def warning(self, *args, **kwargs):
+        pass
+
+    def info(self, *args, **kwargs):
+        pass

--- a/tools/wpt-scoreboard/tests/test_scoreboard.py
+++ b/tools/wpt-scoreboard/tests/test_scoreboard.py
@@ -1,0 +1,179 @@
+"""A report in, a page out.
+
+The generator has no browser and no runner behind it, so these are the tests that can say what the published
+page will actually claim.  The two that matter are the grouping rules — a case belongs to exactly one suite
+and exactly one kind — and the refusal to publish a run that produced almost nothing, which is the only
+thing standing between an infrastructure failure and a scoreboard that silently reads zero.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from wpt_jint_browser import scoreboard as sb
+
+
+def _report(*results, **extra):
+    document = {
+        "run_info": {"product": "jint_browser", "os": "linux"},
+        "time_start": 1_000_000,
+        "time_end": 1_060_000,
+        "results": list(results),
+    }
+    document.update(extra)
+    return document
+
+
+def _result(test, status="OK", subtests=()):
+    return {
+        "test": test,
+        "status": status,
+        "message": None,
+        "subtests": [{"name": name, "status": state, "message": None} for name, state in subtests],
+    }
+
+
+def _scoreboard(*results):
+    board = sb.Scoreboard()
+    board.add_report(_report(*results))
+    return board
+
+
+def test_a_case_belongs_to_the_longest_matching_suite():
+    assert sb.suite_of("/html/webappapis/timers/type-long-setinterval.any.html") == "html/webappapis"
+    assert sb.suite_of("/html/dom/aria-attribute-reflection.html") == "html/dom"
+    assert sb.suite_of("/dom/events/Event-constructors.any.html") == "dom"
+    assert sb.suite_of("/FileAPI/blob/Blob-constructor.any.html") == "FileAPI"
+
+
+def test_a_case_outside_the_named_suites_falls_back_to_its_first_segment():
+    assert sb.suite_of("/streams/readable-streams/general.any.html") == "streams"
+
+
+def test_generated_wrappers_are_told_from_documents():
+    assert sb.variant_of("/dom/events/Event-constructors.any.html") == "window (generated)"
+    assert sb.variant_of("/dom/events/Event-constructors.any.worker.html") == "dedicated worker"
+    assert sb.variant_of("/xhr/status.window.html") == "window (generated)"
+    assert sb.variant_of("/dom/events/Event-propagation.html") == "document"
+    assert sb.variant_of("/url/url-setters.any.html?include=file") == "window (generated)"
+
+
+def test_counts_are_totalled_over_suites_and_over_kinds():
+    board = _scoreboard(
+        _result("/dom/a.any.html", subtests=[("one", "PASS"), ("two", "FAIL")]),
+        _result("/dom/a.any.worker.html", status="ERROR"),
+        _result("/url/b.any.html", subtests=[("three", "PASS")]),
+    )
+
+    assert board.total.test_count == 3
+    assert board.total.subtest_count == 3
+    assert board.total.subtests.of("PASS") == 2
+    assert board.suites["dom"].test_count == 2
+    assert board.suites["url"].subtests.of("PASS") == 1
+    assert board.variants["dedicated worker"].tests.of("ERROR") == 1
+    assert board.variants["window (generated)"].subtest_count == 3
+
+
+def test_a_suite_whose_files_all_error_is_visible_rather_than_absent():
+    """Zero subtests and no pass rate, which is a different statement from "everything failed"."""
+    board = _scoreboard(_result("/xhr/a.any.html", status="ERROR"))
+
+    assert board.suites["xhr"].subtest_count == 0
+    assert board.suites["xhr"].subtest_pass_ratio is None
+    assert "—" in sb.render_markdown(board)
+
+
+def test_the_page_names_both_numbers_and_links_absolutely():
+    page = sb.render_markdown(_scoreboard(_result("/dom/a.any.html", subtests=[("one", "PASS")])))
+
+    assert "Jint.Tests.Browser/Wpt/README.md" in page
+    assert "](../" not in page, "the page lives on a branch of its own, so no link may be relative"
+    assert "## By suite" in page
+    assert "## By what the case is" in page
+
+
+def test_the_page_carries_the_run_it_came_from():
+    page = sb.render_markdown(
+        _scoreboard(_result("/dom/a.any.html", subtests=[("one", "PASS")])),
+        when="2026-09-03 04:21 UTC",
+        jint_commit="0123456789abcdef0123456789abcdef01234567",
+        wpt_commit="6c7127bdd9f2cc6a3668fd9791757843e09d5a9e",
+        run_url="https://github.com/sebastienros/jint/actions/runs/1",
+    )
+
+    assert "2026-09-03 04:21 UTC" in page
+    assert "0123456789ab" in page
+    assert "6c7127bdd9f2" in page
+    assert "actions/runs/1" in page
+
+
+def test_the_badge_reports_the_subtest_pass_rate():
+    board = _scoreboard(
+        _result("/dom/a.any.html", subtests=[("one", "PASS"), ("two", "PASS"), ("three", "FAIL")])
+    )
+    badge = json.loads(sb.render_badge(board))
+
+    assert badge["schemaVersion"] == 1
+    assert badge["message"].startswith("2 / 3")
+    assert badge["color"] == "yellow"
+
+
+def test_an_empty_run_is_refused_rather_than_published(tmp_path):
+    path = tmp_path / "wptreport.json"
+    path.write_text(json.dumps(_report()), encoding="utf-8")
+
+    assert sb.main([str(path), "--markdown", str(tmp_path / "out.md")]) == 1
+    assert not (tmp_path / "out.md").exists()
+
+
+def test_a_real_run_is_written_where_it_was_asked_for(tmp_path):
+    path = tmp_path / "wptreport.json"
+    path.write_text(
+        json.dumps(_report(_result("/dom/a.any.html", subtests=[("one", "PASS")]))),
+        encoding="utf-8",
+    )
+
+    markdown = tmp_path / "docs" / "wpt-scoreboard.md"
+    badge = tmp_path / "badge.json"
+
+    assert sb.main([str(path), "--markdown", str(markdown), "--badge", str(badge), "--min-tests", "1"]) == 0
+    assert "## By suite" in markdown.read_text(encoding="utf-8")
+    assert json.loads(badge.read_text(encoding="utf-8"))["label"] == "wpt subtests"
+
+
+def test_several_reports_total_together(tmp_path):
+    """A sharded run is several reports; the page is one."""
+    first, second = tmp_path / "one.json", tmp_path / "two.json"
+    first.write_text(json.dumps(_report(_result("/dom/a.any.html", subtests=[("x", "PASS")]))), encoding="utf-8")
+    second.write_text(json.dumps(_report(_result("/url/b.any.html", subtests=[("y", "FAIL")]))), encoding="utf-8")
+
+    board = sb.read_reports([str(first), str(second)])
+
+    assert board.total.test_count == 2
+    assert board.total.subtests.of("PASS") == 1
+    assert board.total.subtests.of("FAIL") == 1
+
+
+def test_a_run_where_every_document_errored_is_refused(tmp_path):
+    """A browser that died has a result per test and no subtest anywhere; that is not a score."""
+    path = tmp_path / "wptreport.json"
+    path.write_text(
+        json.dumps(_report(*[_result(f"/dom/{i}.any.html", status="ERROR") for i in range(50)])),
+        encoding="utf-8",
+    )
+
+    assert sb.main([str(path), "--markdown", str(tmp_path / "out.md"), "--min-tests", "10"]) == 1
+    assert not (tmp_path / "out.md").exists()
+
+
+@pytest.mark.parametrize(
+    ("passed", "failed", "colour"),
+    [(95, 5, "brightgreen"), (80, 20, "green"), (60, 40, "yellow"), (10, 90, "orange")],
+)
+def test_the_badge_colour_follows_the_rate(passed, failed, colour):
+    subtests = [(f"p{i}", "PASS") for i in range(passed)] + [(f"f{i}", "FAIL") for i in range(failed)]
+    board = _scoreboard(_result("/dom/a.any.html", subtests=subtests))
+
+    assert json.loads(sb.render_badge(board))["color"] == colour

--- a/tools/wpt-scoreboard/tests/test_websocket.py
+++ b/tools/wpt-scoreboard/tests/test_websocket.py
@@ -1,0 +1,129 @@
+"""The frame codec, over a socket pair, with no browser and no server.
+
+The three things that are silent when they are wrong: a client frame that is not masked (a conforming
+server fails the connection, which looks like the browser hanging up), a length that took the wrong branch
+of the 7/16/64-bit encoding, and a message split across continuation frames — which is exactly what a large
+``Runtime.getProperties`` answer arrives as.
+"""
+
+from __future__ import annotations
+
+import socket
+import struct
+import threading
+
+import pytest
+
+from wpt_jint_browser.websocket import WebSocket, WebSocketError
+
+
+def _detached(sock: socket.socket) -> WebSocket:
+    """A :class:`WebSocket` over an already-connected socket, skipping the HTTP upgrade."""
+    connection = object.__new__(WebSocket)
+    connection.url = "ws://socketpair/"
+    connection._socket = sock
+    connection._buffer = b""
+    connection._closed = False
+    return connection
+
+
+def _server_frame(opcode: int, payload: bytes, final: bool = True) -> bytes:
+    """One unmasked frame, which is what a server sends."""
+    header = bytearray([(0x80 if final else 0x00) | opcode])
+    if len(payload) < 126:
+        header.append(len(payload))
+    elif len(payload) < 0x10000:
+        header.append(126)
+        header += struct.pack("!H", len(payload))
+    else:
+        header.append(127)
+        header += struct.pack("!Q", len(payload))
+    return bytes(header) + payload
+
+
+@pytest.fixture
+def pair():
+    left, right = socket.socketpair()
+    try:
+        yield left, right
+    finally:
+        left.close()
+        right.close()
+
+
+def test_reads_a_short_text_frame(pair):
+    client, server = pair
+    server.sendall(_server_frame(0x1, b'{"id":1}'))
+    assert _detached(client).recv() == '{"id":1}'
+
+
+@pytest.mark.parametrize("size", [125, 126, 200, 0x10000, 0x10001])
+def test_reads_every_length_encoding(pair, size):
+    client, server = pair
+    payload = ("x" * size).encode("utf-8")
+
+    def send() -> None:
+        server.sendall(_server_frame(0x1, payload))
+
+    # A payload past the socket buffer would block the sender, so it goes on a thread of its own.
+    thread = threading.Thread(target=send, daemon=True)
+    thread.start()
+    assert _detached(client).recv() == payload.decode("utf-8")
+    thread.join(timeout=10)
+
+
+def test_reassembles_continuation_frames(pair):
+    client, server = pair
+    server.sendall(_server_frame(0x1, b'{"me', final=False))
+    server.sendall(_server_frame(0x0, b'thod', final=False))
+    server.sendall(_server_frame(0x0, b'":1}', final=True))
+    assert _detached(client).recv() == '{"method":1}'
+
+
+def test_answers_a_ping_before_the_message(pair):
+    client, server = pair
+    server.sendall(_server_frame(0x9, b"beat"))
+    server.sendall(_server_frame(0x1, b"after"))
+
+    connection = _detached(client)
+    assert connection.recv() == "after"
+
+    pong = server.recv(64)
+    assert pong[0] == 0x8A, "the answer to a ping is a pong"
+    assert pong[1] & 0x80, "a client masks every frame it sends, pongs included"
+
+
+def test_a_close_frame_ends_the_connection(pair):
+    client, server = pair
+    server.sendall(_server_frame(0x8, struct.pack("!H", 1001)))
+
+    with pytest.raises(WebSocketError, match="closed the connection"):
+        _detached(client).recv()
+
+
+def test_sent_frames_are_masked_and_decode_back(pair):
+    client, server = pair
+    _detached(client).send_text("hello")
+
+    frame = server.recv(64)
+    assert frame[0] == 0x81
+    assert frame[1] & 0x80, "an unmasked client frame is a protocol violation the server must fail on"
+
+    length = frame[1] & 0x7F
+    assert length == 5
+    mask, payload = frame[2:6], frame[6:6 + length]
+    assert bytes(byte ^ mask[index % 4] for index, byte in enumerate(payload)) == b"hello"
+
+
+def test_a_truncated_connection_is_an_error(pair):
+    client, server = pair
+    server.sendall(_server_frame(0x1, b"xxxxx")[:3])
+    server.close()
+
+    with pytest.raises(WebSocketError, match="closed by the browser"):
+        _detached(client).recv()
+
+
+def test_only_ws_urls_are_accepted():
+    with pytest.raises(WebSocketError, match="only ws://"):
+        WebSocket("wss://example.test/socket")

--- a/tools/wpt-scoreboard/wpt-config.json
+++ b/tools/wpt-scoreboard/wpt-config.json
@@ -1,0 +1,7 @@
+{
+  "ports": {
+    "https-local": [null],
+    "https-public": [null],
+    "h2": [null]
+  }
+}

--- a/tools/wpt-scoreboard/wpt_jint_browser/__init__.py
+++ b/tools/wpt-scoreboard/wpt_jint_browser/__init__.py
@@ -1,0 +1,12 @@
+"""Running upstream's own web-platform-tests runner against ``Jint.Browser`` over the DevTools Protocol.
+
+Two halves that do not depend on each other:
+
+* the ``wptrunner`` product ``jint_browser`` (:mod:`product`, :mod:`executor`, :mod:`cdp`,
+  :mod:`websocket`, ``bridge.js``), which needs ``wptrunner`` importable and is installed into the
+  virtualenv ``wpt run`` builds for itself;
+* :mod:`scoreboard`, which turns the ``wptreport.json`` that run produces into ``docs/wpt-scoreboard.md``
+  and a badge document, and imports nothing but the standard library so it can run anywhere.
+"""
+
+__version__ = "0.1.0"

--- a/tools/wpt-scoreboard/wpt_jint_browser/bridge.js
+++ b/tools/wpt-scoreboard/wpt_jint_browser/bridge.js
@@ -1,0 +1,88 @@
+// Installed with Page.addScriptToEvaluateOnNewDocument, so it runs after the protocol's bindings are
+// re-installed and before the document's first inline script — which is the order Jint.Browser's PageTarget
+// commits a document in, and the only order in which this can work at all.
+//
+// What it is: upstream's own `message-queue.js`, with the callback wired straight to a CDP binding instead
+// of to an async WebDriver script. `message-queue.js` opens by returning if the queue already exists,
+// because "another script already set up the testdriver infrastructure" — this is that script. Nothing here
+// re-implements the harness; `testharnessreport.js` still pushes `{type: "complete", tests, status}` and
+// `testdriver-extra.js` still pushes `{type: "action", ...}`, both unchanged and both upstream's.
+(function () {
+  "use strict";
+
+  if (window.__wptrunner_message_queue && window.__wptrunner_process_next_event) {
+    return;
+  }
+
+  // Captured and then removed from the global, so a document that enumerates `window` does not find the
+  // runner's plumbing among its results. Runtime.addBinding puts it back on the next document.
+  var report = window["%(binding)s"];
+  try {
+    delete window["%(binding)s"];
+  } catch (e) {
+  }
+
+  var queue = [];
+  var nextId = 0;
+
+  // testdriver-extra.js asks whether this window is the one actions are routed through; it is, because the
+  // runner navigates the top-level page to the test itself. testharnessreport.js sets this too.
+  window.__wptrunner_is_test_context = true;
+  window.__wptrunner_url = null;
+  window.__wptrunner_testdriver_callback = null;
+
+  window.__wptrunner_message_queue = {
+    push: function (item) {
+      var id = nextId++;
+      item.id = id;
+      queue.push(item);
+      window.__wptrunner_process_next_event();
+      return id;
+    },
+    shift: function () {
+      return queue.shift();
+    }
+  };
+
+  window.__wptrunner_process_next_event = function () {
+    var data = queue.shift();
+    if (!data) {
+      return;
+    }
+
+    var payload;
+
+    switch (data.type) {
+      case "complete":
+        var tests = data.tests;
+        var status = data.status;
+        if (tests && status) {
+          payload = [
+            status.status,
+            status.message,
+            status.stack,
+            tests.map(function (test) {
+              return [test.name, test.status, test.message, test.stack];
+            })
+          ];
+        } else {
+          // A non-testharness document, which this runner does not ask for.
+          payload = [];
+        }
+        break;
+      case "action":
+        payload = data;
+        break;
+      default:
+        return;
+    }
+
+    if (!report) {
+      return;
+    }
+
+    // One string, because that is the whole of what a binding can carry, and because a value crossing to
+    // the runner would be a value belonging to a thread the runner is not on.
+    report(JSON.stringify([data.type, payload]));
+  };
+})();

--- a/tools/wpt-scoreboard/wpt_jint_browser/cdp.py
+++ b/tools/wpt-scoreboard/wpt_jint_browser/cdp.py
@@ -1,0 +1,172 @@
+"""The Chrome DevTools Protocol, as much of it as a test runner needs.
+
+One socket to the browser endpoint and flattened sessions on top of it — which is not a preference, it is
+the only model ``Jint.Browser`` offers: ``Target.attachToTarget`` and ``Target.setAutoAttach`` both refuse
+``flatten: false``.  Every command therefore carries a ``sessionId``, and so does every event, which is what
+lets one reader thread hand an event to the right waiter.
+
+Reading happens on a thread of its own because the interesting events — ``Runtime.bindingCalled`` above all
+— arrive while no command is outstanding.  A caller waits on a :class:`queue.Queue` with a deadline, so a
+page that never reports is a timeout in the runner rather than a blocked reader.
+"""
+
+from __future__ import annotations
+
+import json
+import queue
+import threading
+import time
+import urllib.request
+from typing import Any, Dict, Optional
+
+from .websocket import WebSocket, WebSocketError
+
+__all__ = ["CdpError", "CdpConnection", "browser_endpoint"]
+
+
+class CdpError(Exception):
+    """A command the browser answered with an error, or a connection that ended under one."""
+
+
+def browser_endpoint(http_url: str, timeout: float = 30.0) -> str:
+    """Reads ``webSocketDebuggerUrl`` out of ``/json/version``, the way every recorded client does."""
+    base = http_url.rstrip("/")
+    with urllib.request.urlopen(base + "/json/version", timeout=timeout) as response:  # noqa: S310
+        document = json.loads(response.read().decode("utf-8"))
+
+    endpoint = document.get("webSocketDebuggerUrl")
+    if not endpoint:
+        raise CdpError(f"{base}/json/version named no webSocketDebuggerUrl")
+    return endpoint
+
+
+def wait_for_endpoint(http_url: str, deadline_seconds: float = 60.0) -> str:
+    """Polls ``/json/version`` until the server answers, so a start-up race is a wait and not a failure."""
+    deadline = time.monotonic() + deadline_seconds
+    last: Optional[Exception] = None
+
+    while time.monotonic() < deadline:
+        try:
+            return browser_endpoint(http_url, timeout=5.0)
+        except Exception as error:  # noqa: BLE001 - any failure here is "not up yet" until the deadline
+            last = error
+            time.sleep(0.25)
+
+    raise CdpError(f"no browser answered at {http_url} within {deadline_seconds:g}s: {last}")
+
+
+class CdpConnection:
+    """One connection to a browser endpoint, with a reader thread behind it."""
+
+    def __init__(self, endpoint: str, connect_timeout: float = 30.0) -> None:
+        self._socket = WebSocket(endpoint, connect_timeout=connect_timeout)
+        self._next_id = 0
+        self._lock = threading.Lock()
+        self._pending: Dict[int, "queue.Queue[Any]"] = {}
+        self._events: "queue.Queue[Dict[str, Any]]" = queue.Queue()
+        self._failure: Optional[BaseException] = None
+        self._stopping = False
+        self._reader = threading.Thread(target=self._read_loop, name="cdp-reader", daemon=True)
+        self._reader.start()
+
+    # -- the reader -----------------------------------------------------------------------------------
+
+    def _read_loop(self) -> None:
+        try:
+            while True:
+                message = json.loads(self._socket.recv())
+                identifier = message.get("id")
+
+                if identifier is None:
+                    self._events.put(message)
+                    continue
+
+                with self._lock:
+                    waiter = self._pending.pop(identifier, None)
+                if waiter is not None:
+                    waiter.put(message)
+        except BaseException as error:  # noqa: BLE001 - the thread's job is to record why it stopped
+            if not self._stopping:
+                self._failure = error
+            self._fail_everyone(error)
+
+    def _fail_everyone(self, error: BaseException) -> None:
+        with self._lock:
+            waiters = list(self._pending.values())
+            self._pending.clear()
+        for waiter in waiters:
+            waiter.put({"error": {"message": f"connection ended: {error}"}})
+        # Wake a caller blocked on the event queue rather than leaving it on its full deadline.
+        self._events.put({"method": "__jint.disconnected", "params": {"reason": str(error)}})
+
+    # -- commands -------------------------------------------------------------------------------------
+
+    def send(
+        self,
+        method: str,
+        params: Optional[Dict[str, Any]] = None,
+        session_id: Optional[str] = None,
+        timeout: float = 30.0,
+    ) -> Dict[str, Any]:
+        """Sends one command and returns its ``result``, raising :class:`CdpError` on a protocol error."""
+        with self._lock:
+            self._next_id += 1
+            identifier = self._next_id
+            waiter: "queue.Queue[Any]" = queue.Queue(maxsize=1)
+            self._pending[identifier] = waiter
+
+        message: Dict[str, Any] = {"id": identifier, "method": method, "params": params or {}}
+        if session_id is not None:
+            message["sessionId"] = session_id
+
+        try:
+            self._socket.send_text(json.dumps(message))
+        except WebSocketError as error:
+            with self._lock:
+                self._pending.pop(identifier, None)
+            raise CdpError(f"{method}: {error}") from error
+
+        try:
+            response = waiter.get(timeout=timeout)
+        except queue.Empty as error:
+            with self._lock:
+                self._pending.pop(identifier, None)
+            raise CdpError(f"{method}: no answer within {timeout:g}s") from error
+
+        if "error" in response:
+            detail = response["error"]
+            raise CdpError(f"{method}: {detail.get('code', '')} {detail.get('message', detail)}".strip())
+
+        return response.get("result", {})
+
+    # -- events ---------------------------------------------------------------------------------------
+
+    def next_event(self, timeout: float) -> Optional[Dict[str, Any]]:
+        """Returns the next event, or ``None`` once ``timeout`` seconds have passed with none."""
+        try:
+            return self._events.get(timeout=max(timeout, 0.0))
+        except queue.Empty:
+            return None
+
+    def drain_events(self) -> None:
+        """Throws away every event queued so far, which is what starting a new test wants."""
+        while True:
+            try:
+                self._events.get_nowait()
+            except queue.Empty:
+                return
+
+    @property
+    def failure(self) -> Optional[BaseException]:
+        """Why the reader stopped, or ``None`` while the connection is healthy."""
+        return self._failure
+
+    def is_alive(self) -> bool:
+        """Whether the reader thread is still reading."""
+        return self._failure is None and self._reader.is_alive()
+
+    def close(self) -> None:
+        """Closes the socket and lets the reader thread end."""
+        self._stopping = True
+        self._socket.close()
+        self._reader.join(timeout=5.0)

--- a/tools/wpt-scoreboard/wpt_jint_browser/executor.py
+++ b/tools/wpt-scoreboard/wpt_jint_browser/executor.py
@@ -1,0 +1,338 @@
+"""A wptrunner executor that drives ``Jint.Browser`` over the Chrome DevTools Protocol.
+
+``wpt run chrome`` cannot be pointed at this browser: its product module requires a ``--webdriver-binary``,
+its browser class launches that ``chromedriver`` process, and every one of its executors speaks WebDriver
+classic — the CDP it uses is tunnelled through ``chromedriver``'s ``goog/cdp/execute`` extension command.
+``Jint.Browser`` speaks CDP and nothing else, so there is no chromedriver to put in the middle.  This is the
+executor that closes that gap, and it is deliberately the smallest thing that can: it navigates a page and
+reads the results the harness posts, and everything else is upstream's.
+
+The result path is upstream's from end to end.  ``wptrunner``'s own ``testharnessreport.js`` (served at
+``/resources/testharnessreport.js`` by the test environment, together with ``message-queue.js``) calls
+``add_completion_callback`` and pushes ``{type: "complete", tests, status}`` onto ``__wptrunner_message_queue``;
+``bridge.js`` is that queue, and hands each item to a ``Runtime.addBinding`` binding as one JSON string;
+:class:`~wptrunner.executors.base.CallbackHandler` turns it into the tuple ``testharness_result_converter``
+wants.  Nothing here decides whether a subtest passed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from typing import Any, Dict, List, Optional
+
+from wptrunner.executors.base import (
+    CallbackHandler,
+    CrashtestExecutor,
+    RefTestExecutor,
+    TestharnessExecutor,
+)
+from wptrunner.executors.protocol import BaseProtocolPart, Protocol, TestDriverProtocolPart
+
+from .cdp import CdpConnection, CdpError, wait_for_endpoint
+
+__all__ = [
+    "JintBrowserProtocol",
+    "JintBrowserTestharnessExecutor",
+    "JintBrowserRefTestExecutor",
+    "JintBrowserCrashtestExecutor",
+]
+
+here = os.path.dirname(__file__)
+
+#: The global the bridge is handed and then deletes.  Anything a page could plausibly define itself would be
+#: a name the page could also shadow, so it carries the runner's prefix.
+BINDING_NAME = "__wptrunner_cdp_report"
+
+with open(os.path.join(here, "bridge.js"), encoding="utf-8") as _bridge:
+    BRIDGE_SOURCE = _bridge.read() % {"binding": BINDING_NAME}
+
+
+class JintBrowserBaseProtocolPart(BaseProtocolPart):
+    name = "base"
+
+    def setup(self) -> None:
+        self.connection = self.parent.connection
+        self.session_id = self.parent.session_id
+
+    def execute_script(self, script: str, asynchronous: bool = False) -> Any:
+        if asynchronous:
+            # Nothing in this executor asks for one: the results come back through the binding, not through
+            # a script that resolves. Saying so is better than a wrapper nothing exercises.
+            raise NotImplementedError("asynchronous execute_script is not part of this executor")
+
+        result = self.parent.command(
+            "Runtime.evaluate",
+            {"expression": f"(function() {{{script}}})()", "returnByValue": True, "awaitPromise": False},
+        )
+        return result.get("result", {}).get("value")
+
+    def set_timeout(self, timeout: float) -> None:
+        # There is no browser-side script timeout to set; the runner's own deadline is the only one.
+        pass
+
+    def wait(self) -> bool:
+        # Reached only under --pause-after-test, which has nothing to pause in a browser with no window.
+        return False
+
+    def create_window(self, type: str = "tab", **kwargs: Any) -> str:
+        raise NotImplementedError("this executor drives one top-level page")
+
+    @property
+    def current_window(self) -> Optional[str]:
+        return self.parent.target_id
+
+
+class JintBrowserTestDriverProtocolPart(TestDriverProtocolPart):
+    name = "testdriver"
+
+    def setup(self) -> None:
+        self.connection = self.parent.connection
+
+    def run(self, url: str, script_resume: str, test_window: Optional[str] = None) -> Any:
+        # The executor owns the navigate-and-wait loop, because the results arrive as events rather than as
+        # the return value of a script the runner is blocked in.
+        raise NotImplementedError("JintBrowserTestharnessExecutor.do_test drives the loop")
+
+    def get_next_message(self, url: str, script_resume: str, test_window: Optional[str]) -> Any:
+        raise NotImplementedError("JintBrowserTestharnessExecutor.do_test drives the loop")
+
+    def send_message(self, cmd_id: int, message_type: str, status: str, message: Optional[str] = None) -> None:
+        """Answers one ``test_driver`` action, the way ``testdriver-extra.js`` expects to be answered."""
+        payload: Dict[str, Any] = {
+            "cmd_id": cmd_id,
+            "type": f"testdriver-{message_type}",
+            "status": str(status),
+        }
+        if message:
+            payload["message"] = str(message)
+
+        self.parent.command(
+            "Runtime.evaluate",
+            {"expression": f"window.postMessage({json.dumps(payload)}, '*');", "returnByValue": True},
+        )
+
+
+class JintBrowserProtocol(Protocol):
+    """One CDP connection, one attached page target, and the bridge installed on every document of it."""
+
+    implements = [JintBrowserBaseProtocolPart, JintBrowserTestDriverProtocolPart]
+
+    def __init__(self, executor, browser, endpoint_url: str, startup_timeout: float = 60.0) -> None:
+        self.endpoint_url = endpoint_url
+        self.startup_timeout = startup_timeout
+        self.connection: Optional[CdpConnection] = None
+        self.session_id: Optional[str] = None
+        self.target_id: Optional[str] = None
+        super().__init__(executor, browser)
+
+    # -- lifecycle ------------------------------------------------------------------------------------
+
+    def connect(self) -> None:
+        endpoint = wait_for_endpoint(self.endpoint_url, self.startup_timeout)
+        self.logger.debug(f"Connecting to {endpoint}")
+        self.connection = CdpConnection(endpoint)
+
+        created = self.connection.send("Target.createTarget", {"url": "about:blank"})
+        self.target_id = created["targetId"]
+        attached = self.connection.send(
+            "Target.attachToTarget", {"targetId": self.target_id, "flatten": True}
+        )
+        self.session_id = attached["sessionId"]
+
+    def after_connect(self) -> None:
+        self.command("Page.enable")
+        self.command("Runtime.enable")
+        self.command("Runtime.addBinding", {"name": BINDING_NAME})
+        self.command("Page.addScriptToEvaluateOnNewDocument", {"source": BRIDGE_SOURCE})
+
+    def teardown(self) -> None:
+        super().teardown()
+        if self.connection is None:
+            return
+
+        try:
+            if self.target_id is not None:
+                self.connection.send("Target.closeTarget", {"targetId": self.target_id}, timeout=10.0)
+        except Exception:  # noqa: BLE001 - teardown must not turn a finished run into a failure
+            pass
+        finally:
+            self.connection.close()
+            self.connection = None
+
+    def is_alive(self) -> bool:
+        return self.connection is not None and self.connection.is_alive()
+
+    # -- the page -------------------------------------------------------------------------------------
+
+    def command(self, method: str, params: Optional[Dict[str, Any]] = None, timeout: float = 30.0) -> Dict[str, Any]:
+        """Sends one command on the page's session."""
+        if self.connection is None:
+            raise CdpError(f"{method}: not connected")
+        return self.connection.send(method, params, session_id=self.session_id, timeout=timeout)
+
+    def navigate(self, url: str, timeout: float = 30.0) -> None:
+        result = self.command("Page.navigate", {"url": url}, timeout=timeout)
+        if result.get("errorText"):
+            raise CdpError(f"navigation to {url} failed: {result['errorText']}")
+
+    def next_report(self, deadline: float) -> Optional[List[Any]]:
+        """Waits for the bridge's next message, or ``None`` when the deadline passes with none."""
+        assert self.connection is not None
+
+        while True:
+            # The disconnection marker is delivered once, so a connection that ended before this call would
+            # otherwise turn every remaining test into a full-length wait for a report nothing can send.
+            if not self.connection.is_alive():
+                raise CdpError(f"connection ended: {self.connection.failure}")
+
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return None
+
+            event = self.connection.next_event(remaining)
+            if event is None:
+                return None
+
+            method = event.get("method")
+            if method == "__jint.disconnected":
+                raise CdpError(f"connection ended: {event['params']['reason']}")
+            if method != "Runtime.bindingCalled":
+                continue
+
+            params = event.get("params", {})
+            if params.get("name") != BINDING_NAME:
+                continue
+            if event.get("sessionId") not in (None, self.session_id):
+                continue
+
+            return json.loads(params["payload"])
+
+
+class _JintBrowserExecutorMixin:
+    """The connection, and the reset between documents, which both testharness and crashtest need."""
+
+    protocol_cls = JintBrowserProtocol
+
+    def reset(self) -> None:
+        # --rerun starts the sequence again; a blank document is the cheapest way back to a known state.
+        if self.protocol.connection is not None:
+            self.protocol.navigate("about:blank")
+
+
+class JintBrowserTestharnessExecutor(_JintBrowserExecutorMixin, TestharnessExecutor):
+    # False, so wptrunner *skips* a test the manifest marks as needing `testdriver.js` and says why, rather
+    # than running it into an action this executor answers "not implemented". A capability the runner lacks
+    # is not a conformance failure of the engine, and the in-process lane already drives `test_driver`
+    # through the same `InputDispatcher` the `Input` domain reaches. `send_message` below is implemented
+    # anyway, for a document that reaches `test_driver` without carrying the flag: upstream's refusal is a
+    # readable failure, and a call with no answer at all is a wait until the deadline.
+    supports_testdriver = False
+
+    def __init__(
+        self,
+        logger,
+        browser,
+        server_config,
+        timeout_multiplier=1,
+        debug_info=None,
+        endpoint_url="http://127.0.0.1:9222",
+        startup_timeout=60.0,
+        **kwargs,
+    ) -> None:
+        TestharnessExecutor.__init__(
+            self, logger, browser, server_config, timeout_multiplier=timeout_multiplier, debug_info=debug_info, **kwargs
+        )
+        self.protocol = JintBrowserProtocol(self, browser, endpoint_url, startup_timeout)
+
+    def do_test(self, test):
+        url = self.test_url(test)
+        timeout = test.timeout * self.timeout_multiplier
+        deadline = time.monotonic() + timeout + self.extra_timeout
+
+        self.protocol.connection.drain_events()
+
+        try:
+            self.protocol.navigate(url, timeout=timeout + self.extra_timeout)
+        except CdpError as error:
+            return (test.make_result("ERROR", str(error)), [])
+
+        handler = CallbackHandler(self.logger, self.protocol, None)
+
+        while True:
+            message = self.protocol.next_report(deadline)
+
+            if message is None:
+                # Nothing more will come from this document; leaving it loaded would leave its timers
+                # running underneath the next one.
+                self._blank()
+                return (test.make_result("EXTERNAL-TIMEOUT", None), [])
+
+            message_type, payload = message
+            done, result = handler([url, message_type, payload])
+            if done:
+                return self.convert_result(test, result)
+
+    def _blank(self) -> None:
+        try:
+            self.protocol.navigate("about:blank", timeout=10.0)
+        except CdpError as error:
+            self.logger.warning(f"could not reset the page after a timeout: {error}")
+
+
+class JintBrowserCrashtestExecutor(_JintBrowserExecutorMixin, CrashtestExecutor):
+    """A crashtest passes if the browser is still answering afterwards, which is all this can check."""
+
+    def __init__(
+        self,
+        logger,
+        browser,
+        server_config,
+        timeout_multiplier=1,
+        debug_info=None,
+        endpoint_url="http://127.0.0.1:9222",
+        startup_timeout=60.0,
+        **kwargs,
+    ) -> None:
+        CrashtestExecutor.__init__(
+            self, logger, browser, server_config, timeout_multiplier=timeout_multiplier, debug_info=debug_info, **kwargs
+        )
+        self.protocol = JintBrowserProtocol(self, browser, endpoint_url, startup_timeout)
+
+    def do_test(self, test):
+        try:
+            self.protocol.navigate(self.test_url(test), timeout=test.timeout * self.timeout_multiplier)
+            self.protocol.command("Runtime.evaluate", {"expression": "1", "returnByValue": True})
+        except CdpError as error:
+            return (test.make_result("CRASH", str(error)), [])
+
+        return self.convert_result(test, {"status": "PASS", "message": None})
+
+
+class JintBrowserRefTestExecutor(RefTestExecutor):
+    """There are no reftests here, and there is no honest way to pretend otherwise.
+
+    ``Jint.Browser`` does not render, so there is nothing to screenshot and no comparison to make.  A
+    reftest reaches this only if one is selected by mistake; answering ``PRECONDITION_FAILED`` says that in
+    the report instead of failing the run or, worse, reporting a pass nothing measured.
+    """
+
+    def __init__(self, logger, browser, server_config, **kwargs) -> None:
+        RefTestExecutor.__init__(self, logger, browser, server_config, **kwargs)
+        self.protocol = None
+
+    def setup(self, runner, protocol=None) -> None:
+        self.runner = runner
+
+    def teardown(self) -> None:
+        pass
+
+    def do_test(self, test):
+        return (
+            test.make_result("PRECONDITION_FAILED", "Jint.Browser renders nothing, so it runs no reftests"),
+            [],
+        )
+
+    def wait(self) -> bool:
+        return False

--- a/tools/wpt-scoreboard/wpt_jint_browser/product.py
+++ b/tools/wpt-scoreboard/wpt_jint_browser/product.py
@@ -1,0 +1,99 @@
+"""The ``jint_browser`` wptrunner product.
+
+``wptrunner`` loads external products from the ``wptrunner.products`` entry-point group, so nothing under
+the ``wpt`` checkout is patched to make this work: ``pip install`` this package into the virtualenv
+``wpt run`` uses and ``wpt run jint-browser …`` finds it (``wpt run`` maps the hyphen to an underscore
+itself).  That mechanism is the reason this is a package beside the repository rather than a fork of wpt.
+
+The browser class is :class:`~wptrunner.browsers.base.NullBrowser`, because this product **connects** to a
+server somebody else started rather than launching one.  ``jint-browser serve`` is a .NET process with a
+long start-up compared with a page load, and a run that restarted it per test group would spend most of its
+budget in the runtime; the workflow starts it once, and the executor waits for the endpoint to answer.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from typing import Any, Mapping
+
+from wptrunner.browsers.base import NullBrowser, get_timeout_multiplier
+from wptrunner.executors import executor_kwargs as base_executor_kwargs
+from wptrunner.products import Product
+
+from .executor import (
+    JintBrowserCrashtestExecutor,
+    JintBrowserRefTestExecutor,
+    JintBrowserTestharnessExecutor,
+)
+
+__all__ = ["load"]
+
+#: Where ``jint-browser serve`` is expected to be listening.  The environment variable is what the workflow
+#: sets, so the command line stays the same whichever port the server ended up on.
+DEFAULT_ENDPOINT = os.environ.get("JINT_BROWSER_URL", "http://127.0.0.1:9222")
+
+
+def add_arguments(parser: argparse.ArgumentParser) -> None:
+    """Adds this product's options.  Called for every registered product, so the names are prefixed."""
+    group = parser.add_argument_group("jint-browser")
+    group.add_argument(
+        "--jint-browser-url",
+        default=DEFAULT_ENDPOINT,
+        help="HTTP endpoint of a running `jint-browser serve` (default: %(default)s)",
+    )
+    group.add_argument(
+        "--jint-browser-startup-timeout",
+        type=float,
+        default=60.0,
+        help="How long to wait for that endpoint to answer, in seconds (default: %(default)s)",
+    )
+
+
+def check_args(**kwargs: Any) -> None:
+    """Nothing to require: there is no binary to find and no driver to install."""
+
+
+def browser_kwargs(logger, test_type, run_info_data, config, **kwargs: Any) -> Mapping[str, Any]:
+    return {}
+
+
+def executor_kwargs(logger, test_type, test_environment, run_info_data, subsuite=None, **kwargs: Any):
+    executor_kwargs = dict(base_executor_kwargs(test_type, test_environment, run_info_data, subsuite, **kwargs))
+    executor_kwargs["endpoint_url"] = kwargs.get("jint_browser_url") or DEFAULT_ENDPOINT
+    executor_kwargs["startup_timeout"] = kwargs.get("jint_browser_startup_timeout") or 60.0
+    return executor_kwargs
+
+
+def env_options() -> Mapping[str, Any]:
+    """The defaults: ``web-platform.test`` on loopback, which is what ``wpt make-hosts-file`` writes.
+
+    Nothing is overridden here on purpose.  A machine that cannot write its hosts file changes the *server's*
+    configuration instead — ``config.json`` in the checkout, which ``TestEnvironment.build_config`` reads —
+    and the README says how; a product that quietly moved the host would move it for the nightly run too.
+    """
+    return {}
+
+
+def env_extras(**kwargs: Any):
+    return []
+
+
+def load() -> Product:
+    """The entry point ``wptrunner.products`` calls; it must return a :class:`Product` named as registered."""
+    return Product(
+        name="jint_browser",
+        browser_classes={None: NullBrowser},
+        check_args=check_args,
+        get_browser_kwargs=browser_kwargs,
+        get_executor_kwargs=executor_kwargs,
+        env_options=env_options(),
+        get_env_extras=env_extras,
+        get_timeout_multiplier=get_timeout_multiplier,
+        executor_classes={
+            "testharness": JintBrowserTestharnessExecutor,
+            "crashtest": JintBrowserCrashtestExecutor,
+            "reftest": JintBrowserRefTestExecutor,
+        },
+        add_arguments=add_arguments,
+    )

--- a/tools/wpt-scoreboard/wpt_jint_browser/scoreboard.py
+++ b/tools/wpt-scoreboard/wpt_jint_browser/scoreboard.py
@@ -286,6 +286,7 @@ def render_markdown(
 
     variant_header = ("Case", *_HEADER[1:])
     variant_rows = [_group_row(scoreboard.variants[name], name) for name in sorted(scoreboard.variants)]
+    variant_rows.append(_group_row(total, "**total**"))
     lines.extend(_table(variant_header, _ALIGN, variant_rows))
     lines.append("")
 

--- a/tools/wpt-scoreboard/wpt_jint_browser/scoreboard.py
+++ b/tools/wpt-scoreboard/wpt_jint_browser/scoreboard.py
@@ -1,0 +1,391 @@
+"""Turns a ``wptreport.json`` into the published scoreboard.
+
+Standard library only, and no ``wptrunner`` import: the report is a finished artefact, so reading it must
+work on a checkout that has never built the runner's virtualenv — which is what makes the page reproducible
+from a downloaded artefact rather than only from inside the workflow that made it.
+
+Two numbers come out of one run and they are not interchangeable.  A **test** is a document, and its status
+is the harness's verdict on the whole file (``OK`` means the file ran to completion, which is not the same
+as everything in it passing).  A **subtest** is one ``test()`` call inside it, and that is the number that
+moves when the engine changes.  The page reports both, per suite, because a suite whose files all ``ERROR``
+has a subtest count of zero and would otherwise look like a suite with nothing to fix.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import os
+import sys
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence
+
+__all__ = ["Scoreboard", "read_reports", "render_markdown", "render_badge", "main"]
+
+#: The suites the design names, longest first so `html/webappapis/` wins over `html/`.
+SUITES: Sequence[str] = (
+    "/custom-elements/",
+    "/dom/",
+    "/fetch/api/",
+    "/FileAPI/",
+    "/html/browsers/history/",
+    "/html/dom/",
+    "/html/semantics/scripting-1/",
+    "/html/webappapis/",
+    "/url/",
+    "/xhr/",
+)
+
+#: The harness verdicts, in the order the table shows them.
+TEST_STATUSES: Sequence[str] = ("OK", "ERROR", "TIMEOUT", "EXTERNAL-TIMEOUT", "CRASH", "PRECONDITION_FAILED", "SKIP")
+
+#: The subtest verdicts, likewise.
+SUBTEST_STATUSES: Sequence[str] = ("PASS", "FAIL", "TIMEOUT", "NOTRUN", "PRECONDITION_FAILED")
+
+#: The page lives on a branch of its own, so every link in it is absolute.
+_MAIN = "https://github.com/sebastienros/jint/blob/main/"
+
+#: How a generated variant is told from a document somebody wrote.
+VARIANTS: Sequence[tuple] = (
+    (".any.worker.html", "dedicated worker"),
+    (".any.sharedworker.html", "shared worker"),
+    (".any.serviceworker.html", "service worker"),
+    (".any.shadowrealm-in-window.html", "shadow realm"),
+    (".any.html", "window (generated)"),
+    (".window.html", "window (generated)"),
+)
+
+
+class Counter(dict):
+    """A dict of counts that answers zero for anything it has not seen."""
+
+    def add(self, key: str, amount: int = 1) -> None:
+        self[key] = self.get(key, 0) + amount
+
+    def of(self, key: str) -> int:
+        return self.get(key, 0)
+
+    def total(self) -> int:
+        return sum(self.values())
+
+    def merge(self, other: "Counter") -> None:
+        for key, value in other.items():
+            self.add(key, value)
+
+
+class Group:
+    """One row: a suite, or a variant kind, or the whole run."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.tests = Counter()
+        self.subtests = Counter()
+
+    @property
+    def test_count(self) -> int:
+        return self.tests.total()
+
+    @property
+    def subtest_count(self) -> int:
+        return self.subtests.total()
+
+    @property
+    def subtest_pass_ratio(self) -> Optional[float]:
+        total = self.subtest_count
+        return self.subtests.of("PASS") / total if total else None
+
+    def merge(self, other: "Group") -> None:
+        self.tests.merge(other.tests)
+        self.subtests.merge(other.subtests)
+
+
+def suite_of(test: str) -> str:
+    """The suite a test URL belongs to: a configured prefix, else its first path segment."""
+    for suite in sorted(SUITES, key=len, reverse=True):
+        if test.startswith(suite):
+            return suite.strip("/")
+
+    head = test.lstrip("/").split("/", 1)[0]
+    return head or "(root)"
+
+
+def variant_of(test: str) -> str:
+    """Whether a case is a document in the tree or a wrapper the server generates for a ``.js`` file."""
+    path = test.split("?", 1)[0]
+    for suffix, name in VARIANTS:
+        if path.endswith(suffix):
+            return name
+    return "document"
+
+
+class Scoreboard:
+    """Every count a run produced, grouped the two ways the page shows them."""
+
+    def __init__(self) -> None:
+        self.suites: Dict[str, Group] = {}
+        self.variants: Dict[str, Group] = {}
+        self.total = Group("total")
+        self.run_info: Dict[str, Any] = {}
+        self.duration_seconds: Optional[float] = None
+
+    def add_report(self, report: Mapping[str, Any]) -> None:
+        if not self.run_info:
+            self.run_info = dict(report.get("run_info") or {})
+
+        start, end = report.get("time_start"), report.get("time_end")
+        if isinstance(start, (int, float)) and isinstance(end, (int, float)):
+            seconds = (end - start) / 1000.0
+            self.duration_seconds = (self.duration_seconds or 0.0) + seconds
+
+        for result in report.get("results") or []:
+            self.add_result(result)
+
+    def add_result(self, result: Mapping[str, Any]) -> None:
+        test = result.get("test") or ""
+        status = result.get("status") or "MISSING"
+
+        for group in (
+            self.suites.setdefault(suite_of(test), Group(suite_of(test))),
+            self.variants.setdefault(variant_of(test), Group(variant_of(test))),
+            self.total,
+        ):
+            group.tests.add(status)
+            for subtest in result.get("subtests") or []:
+                group.subtests.add(subtest.get("status") or "MISSING")
+
+
+def read_reports(paths: Iterable[str]) -> Scoreboard:
+    """Reads one or more ``wptreport.json`` files into a single scoreboard."""
+    scoreboard = Scoreboard()
+    for path in paths:
+        with open(path, encoding="utf-8") as handle:
+            scoreboard.add_report(json.load(handle))
+    return scoreboard
+
+
+# -- rendering -----------------------------------------------------------------------------------------
+
+
+def _percent(ratio: Optional[float]) -> str:
+    return "—" if ratio is None else f"{ratio * 100:.1f}%"
+
+
+def _row(cells: Sequence[str]) -> str:
+    return "| " + " | ".join(cells) + " |"
+
+
+def _table(header: Sequence[str], alignment: Sequence[str], rows: Iterable[Sequence[str]]) -> List[str]:
+    lines = [_row(header), _row(alignment)]
+    lines.extend(_row(row) for row in rows)
+    return lines
+
+
+def _group_row(group: Group, label: str) -> List[str]:
+    return [
+        label,
+        str(group.test_count),
+        str(group.tests.of("OK")),
+        str(group.tests.of("ERROR")),
+        str(group.tests.of("TIMEOUT") + group.tests.of("EXTERNAL-TIMEOUT")),
+        str(group.tests.of("SKIP")),
+        str(group.subtest_count),
+        str(group.subtests.of("PASS")),
+        str(group.subtests.of("FAIL")),
+        str(group.subtest_count - group.subtests.of("PASS") - group.subtests.of("FAIL")),
+        _percent(group.subtest_pass_ratio),
+    ]
+
+
+_HEADER = ("Suite", "Files", "OK", "Error", "Timeout", "Skip", "Subtests", "Pass", "Fail", "Other", "Pass rate")
+_ALIGN = ("---", "---:", "---:", "---:", "---:", "---:", "---:", "---:", "---:", "---:", "---:")
+
+
+def render_markdown(
+    scoreboard: Scoreboard,
+    *,
+    when: Optional[str] = None,
+    jint_commit: Optional[str] = None,
+    wpt_commit: Optional[str] = None,
+    run_url: Optional[str] = None,
+) -> str:
+    """Renders the whole page, which is generated in full every night and never edited by hand."""
+    when = when or datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+    lines: List[str] = [
+        "# The web-platform-tests scoreboard",
+        "",
+        "**Generated — do not edit.** `.github/workflows/wpt-scoreboard.yml` writes this file nightly from",
+        "the `wptreport.json` of a run of *upstream's own* `wpt run`, driving `Jint.Browser` over the Chrome",
+        "DevTools Protocol through the `jint_browser` product in",
+        "[`tools/wpt-scoreboard/`](" + _MAIN + "tools/wpt-scoreboard/README.md).",
+        "",
+        "This branch holds nothing else: every file on it is generated by that workflow, which is why every",
+        "link here points at `main` rather than at a sibling path.",
+        "",
+        "There are two web-platform-tests numbers in this repository and they measure different things.",
+        "",
+        "* **This one** is measured by upstream's runner, over upstream's server, on the whole of the suites",
+        "  below — every file the manifest generates, including the wrappers a `.any.js` file produces for",
+        "  globals this engine has no lane for. It is a scoreboard, not a gate: nothing here fails a build.",
+        "* **The census** in [`Jint.Tests.Browser/Wpt/README.md`](" + _MAIN + "Jint.Tests.Browser/Wpt/README.md)",
+        "  is ours. It runs a vendored subset in process, its exclusion table names every failure one at a",
+        "  time, and it *is* a gate — the not-passing column only ever goes down.",
+        "",
+        "A number here that the census does not have is a suite nobody has vendored yet, not a disagreement.",
+        "",
+        "## The run",
+        "",
+    ]
+
+    facts = [("Taken", when)]
+    if jint_commit:
+        facts.append(("Jint", f"[`{jint_commit[:12]}`](https://github.com/sebastienros/jint/commit/{jint_commit})"))
+    if wpt_commit:
+        facts.append(
+            ("web-platform-tests", f"[`{wpt_commit[:12]}`](https://github.com/web-platform-tests/wpt/commit/{wpt_commit})")
+        )
+    if scoreboard.duration_seconds:
+        facts.append(("Wall time", f"{scoreboard.duration_seconds / 60:.0f} min"))
+    if run_url:
+        facts.append(("Workflow run", f"[log and `wptreport.json`]({run_url})"))
+    product = scoreboard.run_info.get("product")
+    if product:
+        facts.append(("Product", f"`{product}`"))
+
+    # A list rather than a table: a two-column table with no headings renders as an empty header row.
+    lines.extend(f"* **{name}** — {value}" for name, value in facts)
+    lines.append("")
+
+    total = scoreboard.total
+    lines.extend(
+        [
+            f"**{total.subtests.of('PASS')} of {total.subtest_count} subtests pass** "
+            f"({_percent(total.subtest_pass_ratio)}), over {total.test_count} files.",
+            "",
+            "## By suite",
+            "",
+        ]
+    )
+
+    rows = [_group_row(scoreboard.suites[name], name) for name in sorted(scoreboard.suites)]
+    rows.append(_group_row(total, "**total**"))
+    lines.extend(_table(_HEADER, _ALIGN, rows))
+
+    lines.extend(
+        [
+            "",
+            "## By what the case is",
+            "",
+            "A `.any.js` file becomes several cases: the document in the tree, and one wrapper per global its",
+            "`// META: global=` names. `Jint.Browser` runs no classic dedicated worker, no shared worker and",
+            "no service worker, so those wrapper rows are a floor rather than a finding — they are here so",
+            "that the totals above cannot be read as a verdict on the engine's DOM.",
+            "",
+        ]
+    )
+
+    variant_header = ("Case", *_HEADER[1:])
+    variant_rows = [_group_row(scoreboard.variants[name], name) for name in sorted(scoreboard.variants)]
+    lines.extend(_table(variant_header, _ALIGN, variant_rows))
+    lines.append("")
+
+    return "\n".join(lines) + "\n"
+
+
+def render_badge(scoreboard: Scoreboard) -> str:
+    """A [shields.io endpoint](https://shields.io/badges/endpoint-badge) document for the README's badge."""
+    total = scoreboard.total
+    ratio = total.subtest_pass_ratio or 0.0
+
+    if ratio >= 0.9:
+        colour = "brightgreen"
+    elif ratio >= 0.75:
+        colour = "green"
+    elif ratio >= 0.5:
+        colour = "yellow"
+    else:
+        colour = "orange"
+
+    document = {
+        "schemaVersion": 1,
+        "label": "wpt subtests",
+        "message": f"{total.subtests.of('PASS')} / {total.subtest_count} ({ratio * 100:.1f}%)",
+        "color": colour,
+    }
+    return json.dumps(document, indent=2, sort_keys=True) + "\n"
+
+
+# -- the command line ----------------------------------------------------------------------------------
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Turn a wptreport.json into the published scoreboard.")
+    parser.add_argument("report", nargs="+", help="wptreport.json files to total together")
+    parser.add_argument("--markdown", help="where to write the page")
+    parser.add_argument("--badge", help="where to write the shields.io endpoint document")
+    parser.add_argument("--date", help="what to print as the run's date (default: now, in UTC)")
+    parser.add_argument("--jint-commit", help="the Jint commit the browser was built from")
+    parser.add_argument("--wpt-commit", help="the web-platform-tests commit the corpus was read at")
+    parser.add_argument("--run-url", help="a link to the workflow run that produced the report")
+    parser.add_argument(
+        "--min-tests",
+        type=int,
+        default=1,
+        help="fail if the report has fewer results than this, which is how an empty run is caught",
+    )
+    parser.add_argument(
+        "--min-subtests",
+        type=int,
+        default=1,
+        help=(
+            "fail if the report has fewer subtests than this. A browser that died mid-run still has a "
+            "result per test -- every one an error -- so the count of results alone cannot tell that apart "
+            "from a run; a report in which nothing anywhere reported a subtest is not a scoreboard"
+        ),
+    )
+    options = parser.parse_args(argv)
+
+    scoreboard = read_reports(options.report)
+
+    if scoreboard.total.test_count < options.min_tests:
+        print(
+            f"{scoreboard.total.test_count} results in the report, expected at least {options.min_tests}; "
+            "the runner produced nothing worth publishing",
+            file=sys.stderr,
+        )
+        return 1
+
+    if scoreboard.total.subtest_count < options.min_subtests:
+        print(
+            f"{scoreboard.total.subtest_count} subtests in the report, expected at least "
+            f"{options.min_subtests}; every document failed before it could register one, which is a broken "
+            "run rather than a score",
+            file=sys.stderr,
+        )
+        return 1
+
+    page = render_markdown(
+        scoreboard,
+        when=options.date,
+        jint_commit=options.jint_commit,
+        wpt_commit=options.wpt_commit,
+        run_url=options.run_url,
+    )
+
+    if options.markdown:
+        os.makedirs(os.path.dirname(os.path.abspath(options.markdown)), exist_ok=True)
+        with open(options.markdown, "w", encoding="utf-8", newline="\n") as handle:
+            handle.write(page)
+    else:
+        sys.stdout.write(page)
+
+    if options.badge:
+        os.makedirs(os.path.dirname(os.path.abspath(options.badge)), exist_ok=True)
+        with open(options.badge, "w", encoding="utf-8", newline="\n") as handle:
+            handle.write(render_badge(scoreboard))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/wpt-scoreboard/wpt_jint_browser/websocket.py
+++ b/tools/wpt-scoreboard/wpt_jint_browser/websocket.py
@@ -1,0 +1,224 @@
+"""A WebSocket client just big enough for the Chrome DevTools Protocol.
+
+The Chrome DevTools Protocol is JSON over one ``ws://`` connection, and every published Python client for
+it carries a dependency chain (``websockets``, ``websocket-client``, ``aiohttp``) that ``wpt run`` would
+have to install into the virtualenv it builds for itself.  This is the whole of RFC 6455 that a loopback
+CDP connection uses: the opening handshake, text frames, continuations, ping/pong and close.  There is no
+TLS, no permessage-deflate and no server role, because none of the three would ever run.
+
+The one rule that is easy to get wrong and impossible to see when it is: **a client masks every frame it
+sends**.  A server is required to fail the connection on an unmasked frame, so an unmasked send does not
+look like a protocol mistake, it looks like the browser hung up.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import os
+import socket
+import struct
+from urllib.parse import urlsplit
+
+__all__ = ["WebSocket", "WebSocketError"]
+
+#: RFC 6455 §4.2.2's constant, appended to the client's key before hashing.
+_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+
+_OP_CONTINUATION = 0x0
+_OP_TEXT = 0x1
+_OP_BINARY = 0x2
+_OP_CLOSE = 0x8
+_OP_PING = 0x9
+_OP_PONG = 0xA
+
+
+class WebSocketError(Exception):
+    """Raised when the connection cannot be made, or ends before the caller is done with it."""
+
+
+class WebSocket:
+    """One client connection.  Not thread safe for sending; :meth:`recv` is meant for a single reader."""
+
+    def __init__(self, url: str, connect_timeout: float = 30.0) -> None:
+        parts = urlsplit(url)
+        if parts.scheme != "ws":
+            raise WebSocketError(f"only ws:// is supported, got {url!r}")
+
+        host = parts.hostname or "127.0.0.1"
+        port = parts.port or 80
+        path = parts.path or "/"
+        if parts.query:
+            path += "?" + parts.query
+
+        self.url = url
+        self._closed = False
+        self._buffer = b""
+
+        try:
+            self._socket = socket.create_connection((host, port), timeout=connect_timeout)
+        except OSError as error:
+            raise WebSocketError(f"cannot connect to {host}:{port}: {error}") from error
+
+        self._socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        self._handshake(host, port, path, connect_timeout)
+        # The reader blocks indefinitely from here on; callers bound a wait with their own deadline and
+        # close the socket to unblock it, which is what makes a hung page a timeout rather than a hang.
+        self._socket.settimeout(None)
+
+    # -- the opening handshake ------------------------------------------------------------------------
+
+    def _handshake(self, host: str, port: int, path: str, timeout: float) -> None:
+        key = base64.b64encode(os.urandom(16)).decode("ascii")
+        request = (
+            f"GET {path} HTTP/1.1\r\n"
+            f"Host: {host}:{port}\r\n"
+            "Upgrade: websocket\r\n"
+            "Connection: Upgrade\r\n"
+            f"Sec-WebSocket-Key: {key}\r\n"
+            "Sec-WebSocket-Version: 13\r\n"
+            "\r\n"
+        )
+        self._socket.settimeout(timeout)
+        self._socket.sendall(request.encode("ascii"))
+
+        head = self._read_until(b"\r\n\r\n")
+        status_line, _, header_block = head.partition(b"\r\n")
+        if b" 101 " not in status_line:
+            raise WebSocketError(f"upgrade refused: {status_line.decode('latin-1', 'replace')}")
+
+        headers = {}
+        for line in header_block.split(b"\r\n"):
+            name, _, value = line.partition(b":")
+            if name:
+                headers[name.strip().lower().decode("latin-1")] = value.strip().decode("latin-1")
+
+        expected = base64.b64encode(hashlib.sha1((key + _GUID).encode("ascii")).digest()).decode("ascii")
+        if headers.get("sec-websocket-accept") != expected:
+            raise WebSocketError("server did not echo the key; this is not a WebSocket endpoint")
+
+    def _read_until(self, terminator: bytes) -> bytes:
+        while terminator not in self._buffer:
+            chunk = self._socket.recv(4096)
+            if not chunk:
+                raise WebSocketError("connection closed during the opening handshake")
+            self._buffer += chunk
+
+        head, _, rest = self._buffer.partition(terminator)
+        self._buffer = rest
+        return head
+
+    # -- frames ---------------------------------------------------------------------------------------
+
+    def _read_exactly(self, count: int) -> bytes:
+        while len(self._buffer) < count:
+            chunk = self._socket.recv(max(4096, count - len(self._buffer)))
+            if not chunk:
+                raise WebSocketError("connection closed by the browser")
+            self._buffer += chunk
+
+        head, self._buffer = self._buffer[:count], self._buffer[count:]
+        return head
+
+    def _read_frame(self):
+        header = self._read_exactly(2)
+        final = bool(header[0] & 0x80)
+        opcode = header[0] & 0x0F
+        masked = bool(header[1] & 0x80)
+        length = header[1] & 0x7F
+
+        if length == 126:
+            (length,) = struct.unpack("!H", self._read_exactly(2))
+        elif length == 127:
+            (length,) = struct.unpack("!Q", self._read_exactly(8))
+
+        mask = self._read_exactly(4) if masked else b""
+        payload = self._read_exactly(length) if length else b""
+
+        if masked:
+            payload = bytes(byte ^ mask[index % 4] for index, byte in enumerate(payload))
+
+        return final, opcode, payload
+
+    def _send_frame(self, opcode: int, payload: bytes) -> None:
+        if self._closed:
+            raise WebSocketError("send on a closed connection")
+
+        length = len(payload)
+        header = bytearray()
+        header.append(0x80 | opcode)
+
+        if length < 126:
+            header.append(0x80 | length)
+        elif length < 0x10000:
+            header.append(0x80 | 126)
+            header += struct.pack("!H", length)
+        else:
+            header.append(0x80 | 127)
+            header += struct.pack("!Q", length)
+
+        mask = os.urandom(4)
+        header += mask
+        masked = bytes(byte ^ mask[index % 4] for index, byte in enumerate(payload))
+
+        try:
+            self._socket.sendall(bytes(header) + masked)
+        except OSError as error:
+            raise WebSocketError(f"send failed: {error}") from error
+
+    # -- the caller's view ----------------------------------------------------------------------------
+
+    def send_text(self, text: str) -> None:
+        """Sends one text message."""
+        self._send_frame(_OP_TEXT, text.encode("utf-8"))
+
+    def recv(self) -> str:
+        """Blocks until one whole text message arrives, answering pings and refusing binary ones."""
+        while True:
+            final, opcode, payload = self._read_frame()
+
+            if opcode == _OP_PING:
+                self._send_frame(_OP_PONG, payload)
+                continue
+            if opcode == _OP_PONG:
+                continue
+            if opcode == _OP_CLOSE:
+                self._closed = True
+                raise WebSocketError("the browser closed the connection")
+            if opcode == _OP_BINARY:
+                raise WebSocketError("binary frame on a JSON protocol")
+            if opcode not in (_OP_TEXT, _OP_CONTINUATION):
+                raise WebSocketError(f"unknown opcode {opcode}")
+
+            message = payload
+            while not final:
+                final, opcode, payload = self._read_frame()
+                if opcode not in (_OP_CONTINUATION, _OP_PING, _OP_PONG):
+                    raise WebSocketError(f"opcode {opcode} interleaved with a fragmented message")
+                if opcode == _OP_PING:
+                    self._send_frame(_OP_PONG, payload)
+                    final = False
+                    continue
+                if opcode == _OP_PONG:
+                    final = False
+                    continue
+                message += payload
+
+            return message.decode("utf-8")
+
+    def close(self) -> None:
+        """Sends a close frame if it still can, then drops the socket either way."""
+        if self._closed:
+            return
+
+        try:
+            self._send_frame(_OP_CLOSE, struct.pack("!H", 1000))
+        except (WebSocketError, OSError):
+            pass
+        finally:
+            self._closed = True
+            try:
+                self._socket.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+            self._socket.close()


### PR DESCRIPTION
Phase 4, row X3 of #3575: a nightly scoreboard measured by **upstream's own `wpt run`**, driving `Jint.Browser` over the Chrome DevTools Protocol, published to an orphan `wpt-scoreboard` branch. It gates nothing.

## What

- **A wptrunner product plugin**, `tools/wpt-scoreboard/wpt_jint_browser/`, registered through upstream's `wptrunner.products` entry-point group, so the wpt checkout stays unforked. `wpt run chrome` cannot be pointed at this browser: that product requires a `chromedriver`, speaks WebDriver classic, and tunnels its CDP through `goog/cdp/execute`; no `debuggerAddress` capability exists in the wpt tree.
- **The result path is upstream's end to end.** `Page.addScriptToEvaluateOnNewDocument` installs a bridge that *is* upstream's `message-queue.js` (that file returns early if the queue already exists; this is the script it exists for), so `testharnessreport.js` pushes `{type: "complete", tests, status}` unchanged; the bridge hands each item to a `Runtime.addBinding` binding as one JSON string and `CallbackHandler` plus `testharness_result_converter` decide the rest. Nothing here judges whether a subtest passed.
- **The workflow** (`.github/workflows/wpt-scoreboard.yml`, Linux, nightly and on demand) builds `jint-browser`, serves the protocol, runs `wpt run jint_browser` with `--no-fail-on-unexpected`, renders `wptreport.json` into a page plus a badge with `scoreboard.py`, and commits both to the orphan branch. It fails only when the runner could not reach the browser or produced no report worth publishing.
- **No `--timeout-multiplier`**: the corpus's per-test timeouts are the authors' own and wpt.fyi's figures are taken at the default, so a scoreboard measured at 2 would be more generous than the numbers it invites comparison with. It is also the flag that decides the job's length, because the cost is dominated by tests that fail by *not reporting*. Two local runs of `dom/` in halves gave identical outcomes at 1 and at 2.
- Design doc section 9 now says what the two web-platform-tests numbers are: the census (`Jint.Tests.Browser/Wpt/`) is ours, a subset, and a gate; the scoreboard is upstream's, whole suites, and gates nothing. Pointers in `README.md`, `Jint.Tests.Browser/Wpt/AGENTS.md`, `Jint.Tests.Browser/Wpt/README.md`, `Jint.Browser.Tool/AGENTS.md`.

## What a local run produced

The workflow's exact flags, run on Windows in four chunks (`FileAPI`, `custom-elements`, `url`, `xhr`, and `dom/nodes` in two halves), rendered with the tool:

| Suite | Files | Subtests | Pass | Pass rate |
| --- | ---: | ---: | ---: | ---: |
| FileAPI | 110 | 830 | 701 | 84.5% |
| custom-elements | 187 | 3726 | 2284 | 61.3% |
| dom | 331 | 3263 | 1016 | 31.1% |
| url | 77 | 8691 | 6802 | 78.3% |
| xhr | 427 | 1382 | 893 | 64.6% |
| **total** | 1132 | 17892 | 11696 | 65.4% |

The per-case table separates the `.any.js` wrapper rows for globals this engine has no lane for (dedicated, shared and service workers: 149 files, all error or skip) from the document and generated-window rows, so the totals cannot be read as a verdict on the DOM. The `dom` rate is low because `dom/nodes` carries 1,405 subtests in the "other" bucket: a document that never completes reports none of its subtests. The single most expensive directory, `html/semantics/scripting-1/the-script-element/moving-between-documents/`, is 52 long-timeout files that each wait for a message posted by script inside an `<iframe>`, which this version does not run by design (the design doc keeps iframe scripting for a later phase), so each costs its full minute until it does. A failed `<script src>` fetch itself fires `error` correctly in both the static and the dynamic form; an earlier draft of the workflow comment blamed that, and the branch's last commit corrects it.

## Deliberately left out

- **Reftests**: nothing to render.
- **`testdriver.js` actions**: skipped rather than failed; a capability the runner lacks is not a conformance failure of the engine.
- **https**: this browser cannot be told about an extra certificate authority, so `--ssl-type none` leaves those tests out rather than failing them for the environment's reason. The four `.h2.` files are excluded by name for the same reason.
- **`--untrusted`**: `UntrustedCodeLimits.Default` would make the number a report on the hardened profile rather than on the engine.
- **A Windows or macOS leg**: the scoreboard is a Linux nightly; the census remains the four-leg gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
