### PR TITLE
WPT scoreboard: the product and the test paths go after every option, which is the only order wpt run parses

### DIFF
--- a/.github/workflows/wpt-scoreboard.yml
+++ b/.github/workflows/wpt-scoreboard.yml
@@ -207,6 +207,10 @@ jobs:
     # h2 server is off with TLS, and a test whose protocol has no port would be an internal error rather
     # than a result.
     #
+    # The product and the test paths come *last*, after every option, and not by taste: `wpt run`'s parser
+    # takes `product [test_list ...]` as one block of positionals, so a path that follows an option after
+    # the product is "unrecognized arguments" -- which is exactly how the first run of this workflow died.
+    #
     # There is deliberately no --timeout-multiplier, and it is worth knowing why before one is added back.
     # Every per-test timeout in the corpus is the test author's, and wpt.fyi's own numbers are taken at the
     # default of 1, so a scoreboard measured at 2 would be more generous than the figures it invites
@@ -227,7 +231,7 @@ jobs:
         SUITES: ${{ inputs.suites || env.DEFAULT_SUITES }}
       run: |
         set -o pipefail
-        ./wpt --venv "$RUNNER_TEMP/wpt-venv" run jint-browser \
+        ./wpt --venv "$RUNNER_TEMP/wpt-venv" run \
           --jint-browser-url "$JINT_BROWSER_URL" \
           --ssl-type none \
           --no-manifest-download \
@@ -242,7 +246,7 @@ jobs:
           --exclude fetch/api/basic/status.h2.any.js \
           --exclude fetch/api/redirect/redirect-upload.h2.any.js \
           --exclude xhr/status.h2.window.js \
-          $SUITES
+          jint-browser $SUITES
 
     - name: Stop jint-browser serve
       if: always()

--- a/tools/wpt-scoreboard/README.md
+++ b/tools/wpt-scoreboard/README.md
@@ -106,11 +106,13 @@ dotnet build Jint.Browser.Tool/Jint.Browser.Tool.csproj -c Release -f net10.0
 dotnet artifacts/bin/Jint.Browser.Tool/release_net10.0/Jint.Browser.Tool.dll serve --max-task-duration 0 &
 
 # 4. the run
-cd wpt && ./wpt --venv ../.wpt-venv run jint-browser \
+cd wpt && ./wpt --venv ../.wpt-venv run \
   --ssl-type none --no-manifest-download --processes 1 --test-types testharness \
   --no-fail-on-unexpected \
   --log-wptreport ../wptreport.json --log-mach - \
-  dom/
+  jint-browser dom/
+# the product and the paths go last, after every option: `wpt run` parses `product [test_list ...]` as
+# one block, and a path that follows an option after the product is "unrecognized arguments"
 
 # 5. the page
 .wpt-venv/bin/python -m wpt_jint_browser.scoreboard wptreport.json --markdown docs/wpt-scoreboard.md


### PR DESCRIPTION
The first run of the nightly ([33767390971](https://github.com/sebastienros/jint/actions/runs/33767390971)) reached the browser and passed the executor smoke test, then died in `wpt run`'s argument parser: `product [test_list ...]` is one block of positionals, so the suite paths that followed the `--exclude` options after `jint-browser` were `unrecognized arguments`. The agent's local runs had invoked wptrunner directly with `--product`, so the `wpt run` entry point was never exercised.

The workflow and the README example now put `jint-browser <paths>` last, after every option. Both shapes were checked against the pinned checkout with `--list-tests`: the old one fails the same way, the new one parses. A comment in each says why the order matters.

I will dispatch the workflow again once this is in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC