### PR TITLE
WPT scoreboard: the product is installed as a copy, because a spawned test runner cannot see an editable install

### DIFF
--- a/.github/workflows/wpt-scoreboard.yml
+++ b/.github/workflows/wpt-scoreboard.yml
@@ -146,6 +146,13 @@ jobs:
     # *before* `wpt run` looks for entry points. `wpt --venv` then reuses it and installs the runner's own
     # requirements alongside. It is built with the runner's own `python3` -- the same interpreter `./wpt`
     # runs under -- because `wpt` activates the virtualenv inside the process it is already in.
+    #
+    # A plain install, never `pip install -e`. That activation is `site.addsitedir` on the virtualenv's
+    # site-packages in the *parent*: the `.pth` file an editable install leaves there registers its import
+    # finder on the parent's `sys.meta_path`, and a test-runner child -- `multiprocessing` spawns one per
+    # runner -- inherits `sys.path` but not `sys.meta_path` and never processes the `.pth`, so it dies on
+    # `ModuleNotFoundError: No module named 'wpt_jint_browser'` while the parent imports it fine. A copied
+    # package is on `sys.path` itself, which is the one thing a spawned child does get.
     - name: Install the wptrunner product
       shell: bash
       run: |
@@ -153,7 +160,7 @@ jobs:
         python3 -m venv "$RUNNER_TEMP/wpt-venv"
         "$RUNNER_TEMP/wpt-venv/bin/pip" install --quiet --upgrade pip
         "$RUNNER_TEMP/wpt-venv/bin/pip" install --quiet pytest
-        "$RUNNER_TEMP/wpt-venv/bin/pip" install --quiet -e tools/wpt-scoreboard
+        "$RUNNER_TEMP/wpt-venv/bin/pip" install --quiet tools/wpt-scoreboard
 
     # The unit tests of the plugin itself, and the one thing that tells "the scoreboard is zero because the
     # engine fails everything" from "the scoreboard is zero because the runner never reached the page": one

--- a/tools/wpt-scoreboard/README.md
+++ b/tools/wpt-scoreboard/README.md
@@ -97,9 +97,13 @@ git -C wpt checkout <pin>
 cp tools/wpt-scoreboard/wpt-config.json wpt/config.json
 (cd wpt && ./wpt make-hosts-file | sudo tee -a /etc/hosts)
 
-# 2. a virtualenv with this product in it, built with the python ./wpt will run under
+# 2. a virtualenv with this product in it, built with the python ./wpt will run under. A plain install,
+#    not `pip install -e`: `./wpt --venv` activates the virtualenv by adding its site-packages to the parent's
+#    path, and the test-runner children `multiprocessing` spawns inherit that path but not the import finder
+#    an editable install registers through its `.pth` file -- so they cannot import the product. Reinstall
+#    after editing the package.
 python3 -m venv .wpt-venv
-.wpt-venv/bin/pip install -e tools/wpt-scoreboard pytest
+.wpt-venv/bin/pip install tools/wpt-scoreboard pytest
 
 # 3. the browser
 dotnet build Jint.Browser.Tool/Jint.Browser.Tool.csproj -c Release -f net10.0


### PR DESCRIPTION
The second nightly run ([33770879348](https://github.com/sebastienros/jint/actions/runs/33770879348)) got past the argument parser, started the wpt servers and the first tests, then every test-runner child died on `ModuleNotFoundError: No module named 'wpt_jint_browser'` until the runner gave up (`Max restarts exceeded`).

`./wpt --venv` activates the virtualenv with `site.addsitedir` inside the parent process. That processes the `.pth` an editable install leaves in site-packages, which registers the package's import finder on the parent's `sys.meta_path`. A test-runner child (`multiprocessing` spawns one per runner) inherits `sys.path` but not `sys.meta_path`, and never processes the `.pth`, so the parent imports the product and the child cannot. A plain `pip install tools/wpt-scoreboard` copies the package onto `sys.path`, which the child does inherit.

Reproduced locally with a spawned child under both installs (editable: import fails; plain: import succeeds). The workflow and the README step say why. I will dispatch the workflow again once this is in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC