### PR TITLE
DOM bindings: an AngleSharp refusal crosses into script as a DOMException with the standard's name and legacy code

### DIFF
--- a/Jint.Browser/AGENTS.md
+++ b/Jint.Browser/AGENTS.md
@@ -40,7 +40,7 @@ a swap to a source generator later is mechanical.
 | --- | --- |
 | One `JsObjectShape` per interface — operations, attributes, constants, the `constructor` slot, `@@toStringTag` | The wrapper classes (`DomObject`, `DomNodeObject`, `Collections/`) |
 | The registry (`DomInterfaces`): every interface, its parent, whether it roots at `EventTarget`, its wrapper kind | `DomRealm` (per-engine prototypes, interface objects, the wrapper cache) |
-| A `DomCollectionAccessor` per collection interface, from `[DomAccessor]` | `DomInterfaceObject`, `DomBindings`, `DomConvert`, `DomHostHooks` |
+| A `DomCollectionAccessor` per collection interface, from `[DomAccessor]` | `DomInterfaceObject`, `DomBindings`, `DomConvert`, `DomHostHooks`, `DomFailures` — the invoker every generated body is wrapped in, so an AngleSharp refusal is a `DOMException` and no `catch` is ever generated |
 | `DomTypeMap`'s candidate list, most derived first | `DomManualShapes` — the shapes the generator cannot express |
 | `DomEnums`, both directions, for the WebIDL string enumerations | `DomTypeMap.For` and its per-`Type` cache |
 | — | `DomManualInterfaces` and `DomConstructors` — the interface AngleSharp has no `[DomName]` for (`HTMLFrameSetElement`) and the one WebIDL really does give a constructor (`Document`) |

--- a/Jint.Browser/Dom/AGENTS.md
+++ b/Jint.Browser/Dom/AGENTS.md
@@ -103,6 +103,22 @@ Divergences from a browser that are **ours** and deliberate:
   is a `JsEventTarget` rather than an `ArrayLikeObject`, so it carries no property projection.
   `form.elements[0]` and `form.elements.namedItem('username')` are the same values.
 
+### Every member body goes through one invoker, and that is where a refusal is converted
+
+`DomFailures.Guard` wraps every emitted body — an operation, both halves of an attribute — and the emitter
+wraps it in exactly one place (`Emitter.AppendGuardedBody`); `Views/ViewInstaller`'s `Selection` shape is the
+one hand-written shape that takes it too, because its members reach AngleSharp's range algorithms.
+**Nothing generated carries a `catch`**, because
+two thousand copies of one decision is two thousand chances to disagree with it. What crosses is
+AngleSharp's `DomException` as the `DOMException` its `DomError` names, an `ArgumentException` as a
+`TypeError` (WebIDL's answer for an argument no conversion accepts), and a `NotSupportedException` /
+`NotImplementedException` as `NotSupportedError`; **everything else keeps the engine's own interop
+behaviour**, which [`Jint/Runtime/Interop/AGENTS.md`](../../Jint/Runtime/Interop/AGENTS.md) says is frozen —
+so a `JavaScriptException` a body raised itself, and every constraint and cancellation signal, are outside
+the filter. A member the standard gives a *different* name to is written by hand and calls
+`DomFailures.Refuse`, which is the same door `DomSelectorMembers` uses; the divergence table below is what
+says which those are.
+
 Divergences that are **AngleSharp's**, found by this work and to be reported upstream rather than patched
 here:
 
@@ -143,6 +159,12 @@ here:
 | `select.selectedIndex` with no `selected` option | 0 — the selectedness-setting algorithm picks the first option of a non-`multiple`, display-size-1 select | −1 |
 | `input.value = …` | the cursor moves to the end and the selection is dropped | `SelectionStart`/`SelectionEnd` are left where they were, so they can point past the end of the new value |
 | `input.setSelectionRange` on a `type=checkbox` | `InvalidStateError` — the type does not support selection | answers, so the type test has to be the caller's |
+| `DomException.Name` | DOM's error name — `HierarchyRequestError` | the **enum field name**, `HierarchyRequest`, so the string can never be handed to a page; `DomFailures.NameOf` is the table that maps a `DomError` to the standard's name, and `DomExceptionTests` pins every row of it |
+| `DomError.Validation` | WebIDL's legacy code for `ValidationError` is 16 | 15 — the value of `DomError.InvalidAccess` — so the two are one number and no `ValidationError` can be told from an `InvalidAccessError` |
+| a `DomException`'s message | a browser names the operation and what it refused | AngleSharp's own sentence, which is what `DomFailures` puts after the `Failed to execute '<interface>.<member>': ` prefix. DOM specifies a `name` and nothing about wording, and a page branches on the name |
+| `insertAdjacentHTML('beforebegin')` on an element with no parent element | HTML step 2: a `NoModificationAllowedError` | the one `DomException` in the assembly built from a *string*, so it carries no `DomError` at all and its `Name` is the sentence "The element has no parent."; `DomHostHooks.InsertAdjacentHtml` makes that refusal itself |
+| `createElementNS(null, 'a:b')`, `setAttributeNS(null, 'a:b', …)` | DOM's validate-and-extract is a `NamespaceError` for a prefixed name with no namespace | no refusal at all, so an element or attribute is created with a prefix nothing declares. The `xmlns` half of the same algorithm *is* checked |
+| `el.classList.add('')` / `add('a b')` | DOM §7.1: a `SyntaxError` for the empty token, an `InvalidCharacterError` for one containing ASCII whitespace | neither is validated, so the token list takes both |
 
 The `dataset` one has a visible consequence inside the binding, and the one place a workaround is legitimate:
 the generated `SupportedNames` filters out a `null` value, because the projection's three hooks must agree at

--- a/Jint.Browser/Dom/DomFailures.cs
+++ b/Jint.Browser/Dom/DomFailures.cs
@@ -1,0 +1,189 @@
+using System.Diagnostics.CodeAnalysis;
+using AngleSharp.Dom;
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.WebApi.DomException;
+
+namespace Jint.Browser.Dom;
+
+/// <summary>
+/// The one place a CLR exception from AngleSharp becomes the throw the standard prescribes: every generated
+/// member body is wrapped by <see cref="Guard"/>, so a DOM operation that refuses is a JavaScript
+/// <c>DOMException</c> with the right <c>name</c> and legacy <c>code</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why one wrapper rather than a <c>catch</c> per body.</b> A page's whole vocabulary for a refused DOM
+/// operation is <c>e.name</c> — <c>try { … } catch (e) { if (e.name === 'HierarchyRequestError') … }</c> —
+/// and AngleSharp raises an <c>AngleSharp.Dom.DomException</c>, which is a CLR exception: it walks straight
+/// through a script's <c>try</c>/<c>catch</c>, out of the page loop and into the host. The conversion is one
+/// function because the two thousand generated members must not each carry a copy of it, and because the
+/// mapping table is one table. <c>Dom/AGENTS.md</c> has the divergences it is written against.
+/// </para>
+/// <para>
+/// <b>What is translated, and what is deliberately left alone.</b> An <c>AngleSharp.Dom.DomException</c>
+/// becomes the <c>DOMException</c> its <see cref="DomError"/> names; an <see cref="ArgumentException"/> — a
+/// WebIDL conversion the CLR signature refused — becomes a <c>TypeError</c>; a
+/// <see cref="NotSupportedException"/> or <see cref="NotImplementedException"/> becomes
+/// <c>NotSupportedError</c>. <b>Everything else keeps the engine's own interop behaviour</b>, which is a
+/// frozen contract for embedders (<c>Jint/Runtime/Interop/AGENTS.md</c>): in particular a
+/// <see cref="JavaScriptException"/> the body raised itself, and every constraint and cancellation signal,
+/// are outside the filter and never touched.
+/// </para>
+/// <para>
+/// <b>The message after the colon is AngleSharp's sentence, not the standard's.</b> DOM specifies a name and
+/// nothing about wording, no page branches on the text, and AngleSharp's sentence at least says what went
+/// wrong; the <c>Failed to execute '&lt;interface&gt;.&lt;member&gt;': </c> prefix is the one
+/// <see cref="DomBindings"/> already puts in front of an illegal invocation and a bad argument.
+/// </para>
+/// </remarks>
+internal static class DomFailures
+{
+    /// <summary>
+    /// Wraps a generated member body so that the four CLR exceptions above cross into script as the throw
+    /// the standard prescribes. The wrapping happens once per member, when the interface's shape is built.
+    /// </summary>
+    /// <param name="member">
+    /// The qualified member name — <c>Node.appendChild</c> — the same label the body's brand check carries.
+    /// </param>
+    /// <param name="implementation">The member body.</param>
+    /// <remarks>
+    /// It costs one closure and one delegate per member, allocated when the shape is built and therefore once
+    /// per process per interface a page actually reaches, and one delegate hop per member call — the
+    /// <c>try</c> itself costs nothing until it fires. The alternative, a <c>try</c> inside every emitted
+    /// body, saves the hop and buys two thousand copies of one decision.
+    /// </remarks>
+    internal static Func<JsValue, JsValue[], JsValue> Guard(
+        string member,
+        Func<JsValue, JsValue[], JsValue> implementation)
+        => (thisObject, arguments) =>
+        {
+            try
+            {
+                return implementation(thisObject, arguments);
+            }
+            catch (Exception exception) when (Translates(thisObject, exception))
+            {
+                return Translate((ObjectInstance) thisObject, member, exception);
+            }
+        };
+
+    /// <summary>
+    /// The <a href="https://webidl.spec.whatwg.org/#idl-DOMException-error-names">error name</a> AngleSharp's
+    /// <see cref="DomError"/> stands for.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// AngleSharp's own <c>DomException.Name</c> is the <i>enum field name</i> —
+    /// <c>HierarchyRequest</c>, not <c>HierarchyRequestError</c> — so it cannot be handed to a page, and this
+    /// is the table that can. Its numeric values happen to be WebIDL's legacy codes, which is why the switch
+    /// reads as one; <see cref="DomExceptionNames.CodeFor"/> is still what computes the code, from the name.
+    /// </para>
+    /// <para>
+    /// <c>DomError.Validation</c> is absent because AngleSharp gives it 15, the value of
+    /// <c>DomError.InvalidAccess</c>, so the two are one case and no <c>ValidationError</c> can be
+    /// distinguished. It is recorded in <c>Dom/AGENTS.md</c>'s divergence table.
+    /// </para>
+    /// </remarks>
+    internal static string NameOf(DomException exception) => (DomError) exception.Code switch
+    {
+        DomError.IndexSizeError => DomExceptionNames.IndexSize,
+
+        // The two legacy-only names, spelled here rather than in DomExceptionNames because no web API in the
+        // engine raises either and AngleSharp is the only thing that does.
+        DomError.DomStringSize => "DOMStringSizeError",
+        DomError.NoDataAllowed => "NoDataAllowedError",
+
+        DomError.HierarchyRequest => DomExceptionNames.HierarchyRequest,
+        DomError.WrongDocument => DomExceptionNames.WrongDocument,
+        DomError.InvalidCharacter => DomExceptionNames.InvalidCharacter,
+        DomError.NoModificationAllowed => DomExceptionNames.NoModificationAllowed,
+        DomError.NotFound => DomExceptionNames.NotFound,
+        DomError.NotSupported => DomExceptionNames.NotSupported,
+        DomError.InUse => DomExceptionNames.InUseAttribute,
+        DomError.InvalidState => DomExceptionNames.InvalidState,
+        DomError.Syntax => DomExceptionNames.Syntax,
+        DomError.InvalidModification => DomExceptionNames.InvalidModification,
+        DomError.Namespace => DomExceptionNames.Namespace,
+        DomError.InvalidAccess => DomExceptionNames.InvalidAccess,
+        DomError.TypeMismatch => DomExceptionNames.TypeMismatch,
+        DomError.Security => DomExceptionNames.Security,
+        DomError.Network => DomExceptionNames.Network,
+        DomError.Abort => DomExceptionNames.Abort,
+        DomError.UrlMismatch => DomExceptionNames.UrlMismatch,
+        DomError.QuotaExceeded => DomExceptionNames.QuotaExceeded,
+        DomError.Timeout => DomExceptionNames.Timeout,
+        DomError.InvalidNodeType => DomExceptionNames.InvalidNodeType,
+        DomError.DataClone => DomExceptionNames.DataClone,
+
+        // AngleSharp's other constructor leaves the code 0 and puts its argument in `Name`, and its one use
+        // in the pinned assembly puts a *sentence* there ("The element has no parent."), so the name cannot
+        // be forwarded. DOM's general-purpose refusal is what such an exception becomes instead, with the
+        // sentence as the message. That one site is answered by hand — see DomHostHooks.InsertAdjacentHtml —
+        // so nothing in the pinned AngleSharp reaches this arm; it is here for the next version that does.
+        _ => DomExceptionNames.InvalidState,
+    };
+
+    /// <summary>
+    /// Whether an exception is one of the four this file converts, on a receiver there is an engine to build
+    /// the error in.
+    /// </summary>
+    /// <remarks>
+    /// A primitive receiver cannot be reached with any AngleSharp work already done — the body's brand check
+    /// refuses it first — so the receiver test is a guarantee that <see cref="Translate"/> has a realm, not a
+    /// case that happens.
+    /// </remarks>
+    private static bool Translates(JsValue thisObject, Exception exception)
+        => thisObject is ObjectInstance
+           && exception is DomException or ArgumentException or NotSupportedException or NotImplementedException;
+
+    /// <summary>
+    /// Raises the <c>DOMException</c> a member refuses with, in the message shape every refusal in this
+    /// binding wears. This is the door for a member whose refusal has to be written by hand, because the
+    /// standard names an error AngleSharp raises differently or not at all.
+    /// </summary>
+    /// <param name="engine">The engine the error is built in.</param>
+    /// <param name="member">The qualified member name — <c>Element.insertAdjacentHTML</c>.</param>
+    /// <param name="name">The error name; <see cref="DomExceptionNames"/> holds the ones with a legacy code.</param>
+    /// <param name="detail">What went wrong, as one sentence.</param>
+    [DoesNotReturn]
+    internal static JsValue Refuse(Engine engine, string member, string name, string detail)
+    {
+        // The PRINCIPAL realm, deliberately, for the reason DomRealm gives: a wrapper's prototypes come from
+        // the engine's own realm whatever realm happens to be executing, so the DOMException a DOM member
+        // raises has to come from there too or `e instanceof DOMException` in the page would answer false.
+        var intrinsics = engine._mainRealm.Intrinsics;
+        var message = "Failed to execute '" + member + "': " + detail;
+
+        // https://webidl.spec.whatwg.org/#quotaexceedederror is an interface of its own rather than a name a
+        // DOMException wears, and `e.constructor === QuotaExceededError` is how a page tells them apart.
+        var error = string.Equals(name, DomExceptionNames.QuotaExceeded, StringComparison.Ordinal)
+            ? intrinsics.QuotaExceededError.CreateException(message)
+            : intrinsics.DomException.CreateException(name, message);
+
+        Throw.JavaScriptException(engine, error, engine.GetLastSyntaxElement()?.Location ?? default);
+        return JsValue.Undefined;
+    }
+
+    [DoesNotReturn]
+    private static JsValue Translate(ObjectInstance receiver, string member, Exception exception)
+    {
+        var engine = receiver.Engine;
+
+        if (exception is ArgumentException)
+        {
+            // WebIDL's answer for an argument no conversion accepts —
+            // https://webidl.spec.whatwg.org/#es-type-mapping. A CLR signature that refused its argument is
+            // that and nothing more specific; where the standard names a DOMException instead, the member is
+            // written by hand and says so.
+            Throw.TypeError(engine._mainRealm, "Failed to execute '" + member + "': " + exception.Message);
+        }
+
+        // A DomException built from a string carries no message of its own — Exception.Message is then the
+        // CLR's "Exception of type … was thrown." — and the string it was given is in Name instead.
+        return exception is DomException dom
+            ? Refuse(engine, member, NameOf(dom), dom.Code == 0 ? dom.Name : dom.Message)
+            : Refuse(engine, member, DomExceptionNames.NotSupported, exception.Message);
+    }
+}

--- a/Jint.Browser/Dom/DomHostHooks.cs
+++ b/Jint.Browser/Dom/DomHostHooks.cs
@@ -2,6 +2,7 @@ using AngleSharp.Dom;
 using Jint.Native;
 using Jint.Native.Object;
 using Jint.Runtime;
+using Jint.WebApi.DomException;
 
 namespace Jint.Browser.Dom;
 
@@ -114,12 +115,33 @@ internal class DomHostHooks
 
     /// <summary>https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-insertadjacenthtml</summary>
     /// <remarks>
+    /// <para>
     /// Two of the four positions insert into the element's parent, so that is what is walked when there
     /// is one; see <see cref="SetInnerHtml"/> for why the walk is here at all.
+    /// </para>
+    /// <para>
+    /// Step 2's refusal is made here rather than left to AngleSharp, which is the one place in the pinned
+    /// assembly that raises a <c>DomException</c> carrying a sentence instead of a
+    /// <c>DomError</c> — so <see cref="DomFailures.NameOf"/> could only ever guess at its name, and the
+    /// standard's is <c>NoModificationAllowedError</c>. Recorded in <c>AGENTS.md</c>'s divergence table.
+    /// </para>
     /// </remarks>
     internal virtual void InsertAdjacentHtml(DomRealm realm, IElement element, JsValue[] arguments)
     {
         var position = DomEnums.ToAdjacentPosition(DomConvert.At(arguments, 0), "Element.insertAdjacentHTML");
+
+        // "If position is 'beforebegin' or 'afterend' … If context is null or a Document, throw a
+        // NoModificationAllowedError DOMException." A parent that is the document is not an IElement, so the
+        // one test covers both halves — and it is the very test AngleSharp's own `Parent as Element` makes.
+        if (position is AdjacentPosition.BeforeBegin or AdjacentPosition.AfterEnd && element.Parent is not IElement)
+        {
+            DomFailures.Refuse(
+                realm.Engine,
+                "Element.insertAdjacentHTML",
+                DomExceptionNames.NoModificationAllowed,
+                "the element has no parent element to insert " + (position == AdjacentPosition.BeforeBegin ? "before" : "after") + ".");
+        }
+
         element.Insert(position, DomConvert.RequiredText(arguments, 1, "Element.insertAdjacentHTML"));
         CustomElements.CustomElementRegistry.SubtreeCreated(realm, element.Parent ?? element);
     }

--- a/Jint.Browser/Dom/DomSelectorMembers.cs
+++ b/Jint.Browser/Dom/DomSelectorMembers.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using AngleSharp.Dom;
 using Jint.Native;
-using Jint.Runtime;
 using Jint.WebApi.DomException;
 
 namespace Jint.Browser.Dom;
@@ -103,12 +102,9 @@ internal static class DomSelectorMembers
     /// <summary>The <c>SyntaxError</c> DOM prescribes, in the wording a browser uses.</summary>
     [DoesNotReturn]
     private static JsValue Refuse(DomRealm realm, string member, string selectors)
-    {
-        var error = realm.Engine._mainRealm.Intrinsics.DomException.CreateException(
+        => DomFailures.Refuse(
+            realm.Engine,
+            member,
             DomExceptionNames.Syntax,
-            "Failed to execute '" + member + "': '" + selectors + "' is not a valid selector.");
-
-        Throw.JavaScriptException(realm.Engine, error, realm.Engine.GetLastSyntaxElement()?.Location ?? default);
-        return JsValue.Undefined;
-    }
+            "'" + selectors + "' is not a valid selector.");
 }

--- a/Jint.Browser/Dom/Generated/DomShapes.Browser.g.cs
+++ b/Jint.Browser/Dom/Generated/DomShapes.Browser.g.cs
@@ -26,31 +26,31 @@ internal static partial class DomInterfaces
             .Constant("UNCACHED", global::Jint.Native.JsNumber.Create(0))
             .Constant("UPDATEREADY", global::Jint.Native.JsNumber.Create(4))
             .Method("abort",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("ApplicationCache.abort", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Browser.Dom.IApplicationCache>(thisObj, "ApplicationCache.abort");
                     self.Target.Abort(); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Accessor("status",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("ApplicationCache.status", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Browser.Dom.IApplicationCache>(thisObj, "ApplicationCache.status");
                     return global::Jint.Browser.Dom.DomConvert.Number((int) (self.Target.Status));
-                })
+                }))
             .Method("swapCache",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("ApplicationCache.swapCache", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Browser.Dom.IApplicationCache>(thisObj, "ApplicationCache.swapCache");
                     self.Target.Swap(); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Method("update",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("ApplicationCache.update", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Browser.Dom.IApplicationCache>(thisObj, "ApplicationCache.update");
                     self.Target.Update(); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Build();
 
@@ -60,52 +60,52 @@ internal static partial class DomInterfaces
             .ToStringTag("History")
             .PerRealmSlot("constructor", enumerable: false)
             .Method("back",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("History.back", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Browser.Dom.IHistory>(thisObj, "History.back");
                     self.Target.Back(); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Method("forward",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("History.forward", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Browser.Dom.IHistory>(thisObj, "History.forward");
                     self.Target.Forward(); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Method("go",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("History.go", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Browser.Dom.IHistory>(thisObj, "History.go");
                     self.Target.Go(global::Jint.Browser.Dom.DomConvert.OptionalInt32(args, 0, 0)); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Accessor("length",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("History.length", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Browser.Dom.IHistory>(thisObj, "History.length");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Length);
-                })
+                }))
             .Method("pushState",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("History.pushState", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Browser.Dom.IHistory>(thisObj, "History.pushState");
                     self.Target.PushState(global::Jint.Browser.Dom.DomConvert.At(args, 0), global::Jint.Browser.Dom.DomConvert.RequiredText(args, 1, "History.pushState"), global::Jint.Browser.Dom.DomConvert.OptionalText(args, 2, null)!); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 2)
             .Method("replaceState",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("History.replaceState", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Browser.Dom.IHistory>(thisObj, "History.replaceState");
                     self.Target.ReplaceState(global::Jint.Browser.Dom.DomConvert.At(args, 0), global::Jint.Browser.Dom.DomConvert.RequiredText(args, 1, "History.replaceState"), global::Jint.Browser.Dom.DomConvert.OptionalText(args, 2, null)!); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 2)
             .Accessor("state",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("History.state", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Browser.Dom.IHistory>(thisObj, "History.state");
                     return global::Jint.Browser.Dom.DomConvert.Any(self.Realm, self.Target.State);
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>Navigator</c>.</summary>
@@ -114,83 +114,83 @@ internal static partial class DomInterfaces
             .ToStringTag("Navigator")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("appName",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Navigator.appName", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Browser.Dom.INavigator>(thisObj, "Navigator.appName");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Name);
-                })
+                }))
             .Accessor("appVersion",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Navigator.appVersion", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Browser.Dom.INavigator>(thisObj, "Navigator.appVersion");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Version);
-                })
+                }))
             .Method("isContentHandlerRegistered",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Navigator.isContentHandlerRegistered", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Browser.Dom.INavigator>(thisObj, "Navigator.isContentHandlerRegistered");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsContentHandlerRegistered(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Navigator.isContentHandlerRegistered"), global::Jint.Browser.Dom.DomConvert.RequiredText(args, 1, "Navigator.isContentHandlerRegistered")));
-                },
+                }),
                 length: 2)
             .Method("isProtocolHandlerRegistered",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Navigator.isProtocolHandlerRegistered", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Browser.Dom.INavigator>(thisObj, "Navigator.isProtocolHandlerRegistered");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsProtocolHandlerRegistered(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Navigator.isProtocolHandlerRegistered"), global::Jint.Browser.Dom.DomConvert.RequiredText(args, 1, "Navigator.isProtocolHandlerRegistered")));
-                },
+                }),
                 length: 2)
             .Accessor("onLine",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Navigator.onLine", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Browser.Dom.INavigator>(thisObj, "Navigator.onLine");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsOnline);
-                })
+                }))
             .Accessor("platform",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Navigator.platform", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Browser.Dom.INavigator>(thisObj, "Navigator.platform");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Platform);
-                })
+                }))
             .Method("registerContentHandler",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Navigator.registerContentHandler", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Browser.Dom.INavigator>(thisObj, "Navigator.registerContentHandler");
                     self.Target.RegisterContentHandler(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Navigator.registerContentHandler"), global::Jint.Browser.Dom.DomConvert.RequiredText(args, 1, "Navigator.registerContentHandler"), global::Jint.Browser.Dom.DomConvert.RequiredText(args, 2, "Navigator.registerContentHandler")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 3)
             .Method("registerProtocolHandler",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Navigator.registerProtocolHandler", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Browser.Dom.INavigator>(thisObj, "Navigator.registerProtocolHandler");
                     self.Target.RegisterProtocolHandler(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Navigator.registerProtocolHandler"), global::Jint.Browser.Dom.DomConvert.RequiredText(args, 1, "Navigator.registerProtocolHandler"), global::Jint.Browser.Dom.DomConvert.RequiredText(args, 2, "Navigator.registerProtocolHandler")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 3)
             .Method("unregisterContentHandler",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Navigator.unregisterContentHandler", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Browser.Dom.INavigator>(thisObj, "Navigator.unregisterContentHandler");
                     self.Target.UnregisterContentHandler(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Navigator.unregisterContentHandler"), global::Jint.Browser.Dom.DomConvert.RequiredText(args, 1, "Navigator.unregisterContentHandler")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 2)
             .Method("unregisterProtocolHandler",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Navigator.unregisterProtocolHandler", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Browser.Dom.INavigator>(thisObj, "Navigator.unregisterProtocolHandler");
                     self.Target.UnregisterProtocolHandler(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Navigator.unregisterProtocolHandler"), global::Jint.Browser.Dom.DomConvert.RequiredText(args, 1, "Navigator.unregisterProtocolHandler")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 2)
             .Accessor("userAgent",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Navigator.userAgent", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Browser.Dom.INavigator>(thisObj, "Navigator.userAgent");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.UserAgent);
-                })
+                }))
             .Method("yieldForStorageUpdates",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Navigator.yieldForStorageUpdates", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Browser.Dom.INavigator>(thisObj, "Navigator.yieldForStorageUpdates");
                     self.Target.WaitForStorageUpdates(); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Build();
 }

--- a/Jint.Browser/Dom/Generated/DomShapes.Css.g.cs
+++ b/Jint.Browser/Dom/Generated/DomShapes.Css.g.cs
@@ -45,34 +45,34 @@ internal static partial class DomInterfaces
             .Constant("VIEWPORT_RULE", global::Jint.Native.JsNumber.Create(15))
             .Constant("VIEW_TRANSITION_RULE", global::Jint.Native.JsNumber.Create(22))
             .Accessor("cssText",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSRule.cssText", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssRule>(thisObj, "CSSRule.cssText");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.CssText);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSRule.cssText", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssRule>(thisObj, "CSSRule.cssText");
                     self.Target.CssText = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSRule.cssText"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("parentRule",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSRule.parentRule", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssRule>(thisObj, "CSSRule.parentRule");
                     return self.Realm.Wrap(self.Target.Parent);
-                })
+                }))
             .Accessor("parentStyleSheet",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSRule.parentStyleSheet", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssRule>(thisObj, "CSSRule.parentStyleSheet");
                     return self.Realm.Wrap(self.Target.Owner);
-                })
+                }))
             .Accessor("type",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSRule.type", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssRule>(thisObj, "CSSRule.type");
                     return global::Jint.Browser.Dom.DomConvert.Number((int) (self.Target.Type));
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>CSSCharsetRule</c>.</summary>
@@ -81,16 +81,16 @@ internal static partial class DomInterfaces
             .ToStringTag("CSSCharsetRule")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("encoding",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSCharsetRule.encoding", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssCharsetRule>(thisObj, "CSSCharsetRule.encoding");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.CharacterSet);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSCharsetRule.encoding", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssCharsetRule>(thisObj, "CSSCharsetRule.encoding");
                     self.Target.CharacterSet = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSCharsetRule.encoding"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>CSSColorProfileRule</c>.</summary>
@@ -99,44 +99,44 @@ internal static partial class DomInterfaces
             .ToStringTag("CSSColorProfileRule")
             .PerRealmSlot("constructor", enumerable: false)
             .Method("getPropertyPriority",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSColorProfileRule.getPropertyPriority", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssColorProfileRule>(thisObj, "CSSColorProfileRule.getPropertyPriority");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetPropertyPriority(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSColorProfileRule.getPropertyPriority")));
-                },
+                }),
                 length: 1)
             .Method("getPropertyValue",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSColorProfileRule.getPropertyValue", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssColorProfileRule>(thisObj, "CSSColorProfileRule.getPropertyValue");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetPropertyValue(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSColorProfileRule.getPropertyValue")));
-                },
+                }),
                 length: 1)
             .Accessor("length",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSColorProfileRule.length", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssColorProfileRule>(thisObj, "CSSColorProfileRule.length");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Length);
-                })
+                }))
             .Accessor("name",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSColorProfileRule.name", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssColorProfileRule>(thisObj, "CSSColorProfileRule.name");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Name);
-                })
+                }))
             .Method("removeProperty",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSColorProfileRule.removeProperty", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssColorProfileRule>(thisObj, "CSSColorProfileRule.removeProperty");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.RemoveProperty(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSColorProfileRule.removeProperty")));
-                },
+                }),
                 length: 1)
             .Method("setProperty",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSColorProfileRule.setProperty", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssColorProfileRule>(thisObj, "CSSColorProfileRule.setProperty");
                     self.Target.SetProperty(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSColorProfileRule.setProperty"), global::Jint.Browser.Dom.DomConvert.RequiredText(args, 1, "CSSColorProfileRule.setProperty"), global::Jint.Browser.Dom.DomConvert.OptionalText(args, 2, null)!); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 2)
             .Build();
 
@@ -146,31 +146,31 @@ internal static partial class DomInterfaces
             .ToStringTag("CSSGroupingRule")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("cssRules",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSGroupingRule.cssRules", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssGroupingRule>(thisObj, "CSSGroupingRule.cssRules");
                     return self.Realm.Wrap(self.Target.Rules);
-                })
+                }))
             .Method("deleteRule",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSGroupingRule.deleteRule", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssGroupingRule>(thisObj, "CSSGroupingRule.deleteRule");
                     self.Target.RemoveAt(global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "CSSGroupingRule.deleteRule")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 1)
             .Method("insertRule",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSGroupingRule.insertRule", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssGroupingRule>(thisObj, "CSSGroupingRule.insertRule");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Insert(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSGroupingRule.insertRule"), global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 1, "CSSGroupingRule.insertRule")));
-                },
+                }),
                 length: 2)
             .Accessor("rules",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSGroupingRule.rules", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssGroupingRule>(thisObj, "CSSGroupingRule.rules");
                     return self.Realm.Wrap(self.Target.Rules);
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>CSSConditionRule</c>.</summary>
@@ -179,16 +179,16 @@ internal static partial class DomInterfaces
             .ToStringTag("CSSConditionRule")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("conditionText",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSConditionRule.conditionText", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssConditionRule>(thisObj, "CSSConditionRule.conditionText");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.ConditionText);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSConditionRule.conditionText", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssConditionRule>(thisObj, "CSSConditionRule.conditionText");
                     self.Target.ConditionText = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSConditionRule.conditionText"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>CSSContainerRule</c>.</summary>
@@ -197,17 +197,17 @@ internal static partial class DomInterfaces
             .ToStringTag("CSSContainerRule")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("containerName",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSContainerRule.containerName", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssContainerRule>(thisObj, "CSSContainerRule.containerName");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.ContainerName);
-                })
+                }))
             .Accessor("containerQuery",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSContainerRule.containerQuery", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssContainerRule>(thisObj, "CSSContainerRule.containerQuery");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.ContainerQuery);
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>CSSCounterStyleRule</c>.</summary>
@@ -216,126 +216,126 @@ internal static partial class DomInterfaces
             .ToStringTag("CSSCounterStyleRule")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("additiveSymbols",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSCounterStyleRule.additiveSymbols", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssCounterStyleRule>(thisObj, "CSSCounterStyleRule.additiveSymbols");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.AdditiveSymbols);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSCounterStyleRule.additiveSymbols", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssCounterStyleRule>(thisObj, "CSSCounterStyleRule.additiveSymbols");
                     self.Target.AdditiveSymbols = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSCounterStyleRule.additiveSymbols"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("fallback",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSCounterStyleRule.fallback", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssCounterStyleRule>(thisObj, "CSSCounterStyleRule.fallback");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Fallback);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSCounterStyleRule.fallback", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssCounterStyleRule>(thisObj, "CSSCounterStyleRule.fallback");
                     self.Target.Fallback = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSCounterStyleRule.fallback"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("name",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSCounterStyleRule.name", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssCounterStyleRule>(thisObj, "CSSCounterStyleRule.name");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Name);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSCounterStyleRule.name", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssCounterStyleRule>(thisObj, "CSSCounterStyleRule.name");
                     self.Target.Name = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSCounterStyleRule.name"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("negative",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSCounterStyleRule.negative", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssCounterStyleRule>(thisObj, "CSSCounterStyleRule.negative");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Negative);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSCounterStyleRule.negative", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssCounterStyleRule>(thisObj, "CSSCounterStyleRule.negative");
                     self.Target.Negative = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSCounterStyleRule.negative"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("pad",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSCounterStyleRule.pad", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssCounterStyleRule>(thisObj, "CSSCounterStyleRule.pad");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Pad);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSCounterStyleRule.pad", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssCounterStyleRule>(thisObj, "CSSCounterStyleRule.pad");
                     self.Target.Pad = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSCounterStyleRule.pad"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("prefix",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSCounterStyleRule.prefix", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssCounterStyleRule>(thisObj, "CSSCounterStyleRule.prefix");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Prefix);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSCounterStyleRule.prefix", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssCounterStyleRule>(thisObj, "CSSCounterStyleRule.prefix");
                     self.Target.Prefix = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSCounterStyleRule.prefix"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("range",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSCounterStyleRule.range", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssCounterStyleRule>(thisObj, "CSSCounterStyleRule.range");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Range);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSCounterStyleRule.range", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssCounterStyleRule>(thisObj, "CSSCounterStyleRule.range");
                     self.Target.Range = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSCounterStyleRule.range"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("speakAs",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSCounterStyleRule.speakAs", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssCounterStyleRule>(thisObj, "CSSCounterStyleRule.speakAs");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.SpeakAs);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSCounterStyleRule.speakAs", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssCounterStyleRule>(thisObj, "CSSCounterStyleRule.speakAs");
                     self.Target.SpeakAs = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSCounterStyleRule.speakAs"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("suffix",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSCounterStyleRule.suffix", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssCounterStyleRule>(thisObj, "CSSCounterStyleRule.suffix");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Suffix);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSCounterStyleRule.suffix", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssCounterStyleRule>(thisObj, "CSSCounterStyleRule.suffix");
                     self.Target.Suffix = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSCounterStyleRule.suffix"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("symbols",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSCounterStyleRule.symbols", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssCounterStyleRule>(thisObj, "CSSCounterStyleRule.symbols");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Symbols);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSCounterStyleRule.symbols", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssCounterStyleRule>(thisObj, "CSSCounterStyleRule.symbols");
                     self.Target.Symbols = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSCounterStyleRule.symbols"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("system",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSCounterStyleRule.system", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssCounterStyleRule>(thisObj, "CSSCounterStyleRule.system");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.System);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSCounterStyleRule.system", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssCounterStyleRule>(thisObj, "CSSCounterStyleRule.system");
                     self.Target.System = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSCounterStyleRule.system"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>CSSDocumentRule</c>.</summary>
@@ -351,127 +351,127 @@ internal static partial class DomInterfaces
             .ToStringTag("CSSFontFaceRule")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("family",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSFontFaceRule.family", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssFontFaceRule>(thisObj, "CSSFontFaceRule.family");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Family);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSFontFaceRule.family", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssFontFaceRule>(thisObj, "CSSFontFaceRule.family");
                     self.Target.Family = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSFontFaceRule.family"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("featureSettings",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSFontFaceRule.featureSettings", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssFontFaceRule>(thisObj, "CSSFontFaceRule.featureSettings");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Features);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSFontFaceRule.featureSettings", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssFontFaceRule>(thisObj, "CSSFontFaceRule.featureSettings");
                     self.Target.Features = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSFontFaceRule.featureSettings"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Method("getPropertyPriority",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSFontFaceRule.getPropertyPriority", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssFontFaceRule>(thisObj, "CSSFontFaceRule.getPropertyPriority");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetPropertyPriority(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSFontFaceRule.getPropertyPriority")));
-                },
+                }),
                 length: 1)
             .Method("getPropertyValue",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSFontFaceRule.getPropertyValue", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssFontFaceRule>(thisObj, "CSSFontFaceRule.getPropertyValue");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetPropertyValue(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSFontFaceRule.getPropertyValue")));
-                },
+                }),
                 length: 1)
             .Accessor("length",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSFontFaceRule.length", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssFontFaceRule>(thisObj, "CSSFontFaceRule.length");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Length);
-                })
+                }))
             .Method("removeProperty",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSFontFaceRule.removeProperty", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssFontFaceRule>(thisObj, "CSSFontFaceRule.removeProperty");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.RemoveProperty(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSFontFaceRule.removeProperty")));
-                },
+                }),
                 length: 1)
             .Method("setProperty",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSFontFaceRule.setProperty", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssFontFaceRule>(thisObj, "CSSFontFaceRule.setProperty");
                     self.Target.SetProperty(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSFontFaceRule.setProperty"), global::Jint.Browser.Dom.DomConvert.RequiredText(args, 1, "CSSFontFaceRule.setProperty"), global::Jint.Browser.Dom.DomConvert.OptionalText(args, 2, null)!); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 2)
             .Accessor("src",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSFontFaceRule.src", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssFontFaceRule>(thisObj, "CSSFontFaceRule.src");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Source);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSFontFaceRule.src", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssFontFaceRule>(thisObj, "CSSFontFaceRule.src");
                     self.Target.Source = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSFontFaceRule.src"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("stretch",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSFontFaceRule.stretch", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssFontFaceRule>(thisObj, "CSSFontFaceRule.stretch");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Stretch);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSFontFaceRule.stretch", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssFontFaceRule>(thisObj, "CSSFontFaceRule.stretch");
                     self.Target.Stretch = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSFontFaceRule.stretch"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("style",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSFontFaceRule.style", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssFontFaceRule>(thisObj, "CSSFontFaceRule.style");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Style);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSFontFaceRule.style", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssFontFaceRule>(thisObj, "CSSFontFaceRule.style");
                     self.Target.Style = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSFontFaceRule.style"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("unicodeRange",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSFontFaceRule.unicodeRange", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssFontFaceRule>(thisObj, "CSSFontFaceRule.unicodeRange");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Range);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSFontFaceRule.unicodeRange", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssFontFaceRule>(thisObj, "CSSFontFaceRule.unicodeRange");
                     self.Target.Range = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSFontFaceRule.unicodeRange"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("variant",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSFontFaceRule.variant", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssFontFaceRule>(thisObj, "CSSFontFaceRule.variant");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Variant);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSFontFaceRule.variant", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssFontFaceRule>(thisObj, "CSSFontFaceRule.variant");
                     self.Target.Variant = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSFontFaceRule.variant"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("weight",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSFontFaceRule.weight", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssFontFaceRule>(thisObj, "CSSFontFaceRule.weight");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Weight);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSFontFaceRule.weight", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssFontFaceRule>(thisObj, "CSSFontFaceRule.weight");
                     self.Target.Weight = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSFontFaceRule.weight"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>CSSFontFeatureValuesRule</c>.</summary>
@@ -480,16 +480,16 @@ internal static partial class DomInterfaces
             .ToStringTag("CSSFontFeatureValuesRule")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("fontFamily",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSFontFeatureValuesRule.fontFamily", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssFontFeatureValuesRule>(thisObj, "CSSFontFeatureValuesRule.fontFamily");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Family);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSFontFeatureValuesRule.fontFamily", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssFontFeatureValuesRule>(thisObj, "CSSFontFeatureValuesRule.fontFamily");
                     self.Target.Family = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSFontFeatureValuesRule.fontFamily"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>CSSFontPaletteValuesRule</c>.</summary>
@@ -498,44 +498,44 @@ internal static partial class DomInterfaces
             .ToStringTag("CSSFontPaletteValuesRule")
             .PerRealmSlot("constructor", enumerable: false)
             .Method("getPropertyPriority",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSFontPaletteValuesRule.getPropertyPriority", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssFontPaletteValuesRule>(thisObj, "CSSFontPaletteValuesRule.getPropertyPriority");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetPropertyPriority(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSFontPaletteValuesRule.getPropertyPriority")));
-                },
+                }),
                 length: 1)
             .Method("getPropertyValue",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSFontPaletteValuesRule.getPropertyValue", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssFontPaletteValuesRule>(thisObj, "CSSFontPaletteValuesRule.getPropertyValue");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetPropertyValue(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSFontPaletteValuesRule.getPropertyValue")));
-                },
+                }),
                 length: 1)
             .Accessor("length",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSFontPaletteValuesRule.length", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssFontPaletteValuesRule>(thisObj, "CSSFontPaletteValuesRule.length");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Length);
-                })
+                }))
             .Accessor("name",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSFontPaletteValuesRule.name", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssFontPaletteValuesRule>(thisObj, "CSSFontPaletteValuesRule.name");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Name);
-                })
+                }))
             .Method("removeProperty",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSFontPaletteValuesRule.removeProperty", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssFontPaletteValuesRule>(thisObj, "CSSFontPaletteValuesRule.removeProperty");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.RemoveProperty(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSFontPaletteValuesRule.removeProperty")));
-                },
+                }),
                 length: 1)
             .Method("setProperty",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSFontPaletteValuesRule.setProperty", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssFontPaletteValuesRule>(thisObj, "CSSFontPaletteValuesRule.setProperty");
                     self.Target.SetProperty(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSFontPaletteValuesRule.setProperty"), global::Jint.Browser.Dom.DomConvert.RequiredText(args, 1, "CSSFontPaletteValuesRule.setProperty"), global::Jint.Browser.Dom.DomConvert.OptionalText(args, 2, null)!); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 2)
             .Build();
 
@@ -545,28 +545,28 @@ internal static partial class DomInterfaces
             .ToStringTag("CSSImportRule")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("href",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSImportRule.href", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssImportRule>(thisObj, "CSSImportRule.href");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Href);
-                })
+                }))
             .Accessor("media",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSImportRule.media", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssImportRule>(thisObj, "CSSImportRule.media");
                     return self.Realm.Wrap(self.Target.Media);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSImportRule.media", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssImportRule>(thisObj, "CSSImportRule.media");
                     var forwardTarget = self.Target.Media; if (forwardTarget is not null) { forwardTarget.MediaText = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSImportRule.media"); } return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("styleSheet",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSImportRule.styleSheet", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssImportRule>(thisObj, "CSSImportRule.styleSheet");
                     return self.Realm.Wrap(self.Target.Sheet);
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>CSSKeyframeRule</c>.</summary>
@@ -575,22 +575,22 @@ internal static partial class DomInterfaces
             .ToStringTag("CSSKeyframeRule")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("keyText",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSKeyframeRule.keyText", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssKeyframeRule>(thisObj, "CSSKeyframeRule.keyText");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.KeyText);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSKeyframeRule.keyText", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssKeyframeRule>(thisObj, "CSSKeyframeRule.keyText");
                     self.Target.KeyText = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSKeyframeRule.keyText"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("style",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSKeyframeRule.style", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssKeyframeRule>(thisObj, "CSSKeyframeRule.style");
                     return self.Realm.Wrap(self.Target.Style);
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>CSSKeyframesRule</c>.</summary>
@@ -599,49 +599,49 @@ internal static partial class DomInterfaces
             .ToStringTag("CSSKeyframesRule")
             .PerRealmSlot("constructor", enumerable: false)
             .Method("appendRule",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSKeyframesRule.appendRule", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssKeyframesRule>(thisObj, "CSSKeyframesRule.appendRule");
                     self.Target.Add(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSKeyframesRule.appendRule")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 1)
             .Accessor("cssRules",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSKeyframesRule.cssRules", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssKeyframesRule>(thisObj, "CSSKeyframesRule.cssRules");
                     return self.Realm.Wrap(self.Target.Rules);
-                })
+                }))
             .Method("deleteRule",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSKeyframesRule.deleteRule", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssKeyframesRule>(thisObj, "CSSKeyframesRule.deleteRule");
                     self.Target.Remove(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSKeyframesRule.deleteRule")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 1)
             .Method("findRule",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSKeyframesRule.findRule", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssKeyframesRule>(thisObj, "CSSKeyframesRule.findRule");
                     return self.Realm.Wrap(self.Target.Find(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSKeyframesRule.findRule")));
-                },
+                }),
                 length: 1)
             .Accessor("name",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSKeyframesRule.name", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssKeyframesRule>(thisObj, "CSSKeyframesRule.name");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Name);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSKeyframesRule.name", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssKeyframesRule>(thisObj, "CSSKeyframesRule.name");
                     self.Target.Name = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSKeyframesRule.name"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("rules",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSKeyframesRule.rules", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssKeyframesRule>(thisObj, "CSSKeyframesRule.rules");
                     return self.Realm.Wrap(self.Target.Rules);
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>CSSLayerRule</c>.</summary>
@@ -650,17 +650,17 @@ internal static partial class DomInterfaces
             .ToStringTag("CSSLayerRule")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("name",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSLayerRule.name", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssLayerRule>(thisObj, "CSSLayerRule.name");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Name);
-                })
+                }))
             .Accessor("statement",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSLayerRule.statement", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssLayerRule>(thisObj, "CSSLayerRule.statement");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsStatement);
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>CSSMarginRule</c>.</summary>
@@ -669,22 +669,22 @@ internal static partial class DomInterfaces
             .ToStringTag("CSSMarginRule")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("name",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSMarginRule.name", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssMarginRule>(thisObj, "CSSMarginRule.name");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Name);
-                })
+                }))
             .Accessor("style",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSMarginRule.style", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssMarginRule>(thisObj, "CSSMarginRule.style");
                     return self.Realm.Wrap(self.Target.Style);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSMarginRule.style", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssMarginRule>(thisObj, "CSSMarginRule.style");
                     var forwardTarget = self.Target.Style; if (forwardTarget is not null) { forwardTarget.CssText = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSMarginRule.style"); } return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>CSSMediaRule</c>.</summary>
@@ -693,16 +693,16 @@ internal static partial class DomInterfaces
             .ToStringTag("CSSMediaRule")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("media",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSMediaRule.media", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssMediaRule>(thisObj, "CSSMediaRule.media");
                     return self.Realm.Wrap(self.Target.Media);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSMediaRule.media", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssMediaRule>(thisObj, "CSSMediaRule.media");
                     var forwardTarget = self.Target.Media; if (forwardTarget is not null) { forwardTarget.MediaText = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSMediaRule.media"); } return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>CSSNamespaceRule</c>.</summary>
@@ -711,27 +711,27 @@ internal static partial class DomInterfaces
             .ToStringTag("CSSNamespaceRule")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("namespaceURI",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSNamespaceRule.namespaceURI", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssNamespaceRule>(thisObj, "CSSNamespaceRule.namespaceURI");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.NamespaceUri);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSNamespaceRule.namespaceURI", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssNamespaceRule>(thisObj, "CSSNamespaceRule.namespaceURI");
                     self.Target.NamespaceUri = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSNamespaceRule.namespaceURI"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("prefix",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSNamespaceRule.prefix", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssNamespaceRule>(thisObj, "CSSNamespaceRule.prefix");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Prefix);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSNamespaceRule.prefix", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssNamespaceRule>(thisObj, "CSSNamespaceRule.prefix");
                     self.Target.Prefix = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSNamespaceRule.prefix"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>CSSPageRule</c>.</summary>
@@ -740,27 +740,27 @@ internal static partial class DomInterfaces
             .ToStringTag("CSSPageRule")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("selectorText",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSPageRule.selectorText", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssPageRule>(thisObj, "CSSPageRule.selectorText");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.SelectorText);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSPageRule.selectorText", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssPageRule>(thisObj, "CSSPageRule.selectorText");
                     self.Target.SelectorText = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSPageRule.selectorText"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("style",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSPageRule.style", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssPageRule>(thisObj, "CSSPageRule.style");
                     return self.Realm.Wrap(self.Target.Style);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSPageRule.style", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssPageRule>(thisObj, "CSSPageRule.style");
                     var forwardTarget = self.Target.Style; if (forwardTarget is not null) { forwardTarget.CssText = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSPageRule.style"); } return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>CSSPositionTryRule</c>.</summary>
@@ -769,17 +769,17 @@ internal static partial class DomInterfaces
             .ToStringTag("CSSPositionTryRule")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("name",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSPositionTryRule.name", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssPositionTryRule>(thisObj, "CSSPositionTryRule.name");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Name);
-                })
+                }))
             .Accessor("style",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSPositionTryRule.style", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssPositionTryRule>(thisObj, "CSSPositionTryRule.style");
                     return self.Realm.Wrap(self.Target.Style);
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>CSSProperty</c>.</summary>
@@ -788,33 +788,33 @@ internal static partial class DomInterfaces
             .ToStringTag("CSSProperty")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("important",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSProperty.important", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssProperty>(thisObj, "CSSProperty.important");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsImportant);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSProperty.important", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssProperty>(thisObj, "CSSProperty.important");
                     self.Target.IsImportant = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("name",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSProperty.name", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssProperty>(thisObj, "CSSProperty.name");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Name);
-                })
+                }))
             .Accessor("value",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSProperty.value", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssProperty>(thisObj, "CSSProperty.value");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Value);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSProperty.value", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssProperty>(thisObj, "CSSProperty.value");
                     self.Target.Value = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSProperty.value"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>CSSPropertyRule</c>.</summary>
@@ -823,44 +823,44 @@ internal static partial class DomInterfaces
             .ToStringTag("CSSPropertyRule")
             .PerRealmSlot("constructor", enumerable: false)
             .Method("getPropertyPriority",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSPropertyRule.getPropertyPriority", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssPropertyRule>(thisObj, "CSSPropertyRule.getPropertyPriority");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetPropertyPriority(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSPropertyRule.getPropertyPriority")));
-                },
+                }),
                 length: 1)
             .Method("getPropertyValue",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSPropertyRule.getPropertyValue", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssPropertyRule>(thisObj, "CSSPropertyRule.getPropertyValue");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetPropertyValue(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSPropertyRule.getPropertyValue")));
-                },
+                }),
                 length: 1)
             .Accessor("length",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSPropertyRule.length", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssPropertyRule>(thisObj, "CSSPropertyRule.length");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Length);
-                })
+                }))
             .Accessor("name",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSPropertyRule.name", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssPropertyRule>(thisObj, "CSSPropertyRule.name");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Name);
-                })
+                }))
             .Method("removeProperty",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSPropertyRule.removeProperty", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssPropertyRule>(thisObj, "CSSPropertyRule.removeProperty");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.RemoveProperty(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSPropertyRule.removeProperty")));
-                },
+                }),
                 length: 1)
             .Method("setProperty",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSPropertyRule.setProperty", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssPropertyRule>(thisObj, "CSSPropertyRule.setProperty");
                     self.Target.SetProperty(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSPropertyRule.setProperty"), global::Jint.Browser.Dom.DomConvert.RequiredText(args, 1, "CSSPropertyRule.setProperty"), global::Jint.Browser.Dom.DomConvert.OptionalText(args, 2, null)!); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 2)
             .Build();
 
@@ -870,17 +870,17 @@ internal static partial class DomInterfaces
             .ToStringTag("CSSPseudoElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("style",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSPseudoElement.style", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssPseudoElement>(thisObj, "CSSPseudoElement.style");
                     return self.Realm.Wrap(self.Target.Style);
-                })
+                }))
             .Accessor("type",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSPseudoElement.type", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssPseudoElement>(thisObj, "CSSPseudoElement.type");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Type);
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>CSSPseudoElementList</c>.</summary>
@@ -889,18 +889,18 @@ internal static partial class DomInterfaces
             .ToStringTag("CSSPseudoElementList")
             .PerRealmSlot("constructor", enumerable: false)
             .Method("getByType",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSPseudoElementList.getByType", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssPseudoElementList>(thisObj, "CSSPseudoElementList.getByType");
                     return self.Realm.Wrap(self.Target[global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSPseudoElementList.getByType")]);
-                },
+                }),
                 length: 1)
             .Method("item",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSPseudoElementList.item", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssPseudoElementList>(thisObj, "CSSPseudoElementList.item");
                     return self.Realm.Wrap(self.Target[global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "CSSPseudoElementList.item")]);
-                },
+                }),
                 length: 1)
             .Build();
 
@@ -910,11 +910,11 @@ internal static partial class DomInterfaces
             .ToStringTag("CSSRuleList")
             .PerRealmSlot("constructor", enumerable: false)
             .Method("item",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSRuleList.item", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssRuleList>(thisObj, "CSSRuleList.item");
                     return self.Realm.Wrap(self.Target[global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "CSSRuleList.item")]);
-                },
+                }),
                 length: 1)
             .Build();
 
@@ -924,16 +924,16 @@ internal static partial class DomInterfaces
             .ToStringTag("CSSScopeRule")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("scopeText",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSScopeRule.scopeText", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssScopeRule>(thisObj, "CSSScopeRule.scopeText");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.ScopeText);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSScopeRule.scopeText", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssScopeRule>(thisObj, "CSSScopeRule.scopeText");
                     self.Target.ScopeText = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSScopeRule.scopeText"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>CSSStartingStyleRule</c>.</summary>
@@ -949,2554 +949,2554 @@ internal static partial class DomInterfaces
             .ToStringTag("CSSStyleDeclaration")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("accelerator",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.accelerator", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.accelerator");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetAccelerator());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.accelerator", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.accelerator");
                     self.Target.SetAccelerator(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.accelerator")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("alignContent",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.alignContent", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.alignContent");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetAlignContent());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.alignContent", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.alignContent");
                     self.Target.SetAlignContent(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.alignContent")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("alignItems",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.alignItems", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.alignItems");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetAlignItems());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.alignItems", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.alignItems");
                     self.Target.SetAlignItems(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.alignItems")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("alignSelf",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.alignSelf", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.alignSelf");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetAlignSelf());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.alignSelf", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.alignSelf");
                     self.Target.SetAlignSelf(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.alignSelf")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("alignmentBaseline",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.alignmentBaseline", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.alignmentBaseline");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetAlignmentBaseline());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.alignmentBaseline", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.alignmentBaseline");
                     self.Target.SetAlignmentBaseline(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.alignmentBaseline")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("animation",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.animation", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.animation");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetAnimation());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.animation", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.animation");
                     self.Target.SetAnimation(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.animation")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("animationDelay",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.animationDelay", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.animationDelay");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetAnimationDelay());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.animationDelay", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.animationDelay");
                     self.Target.SetAnimationDelay(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.animationDelay")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("animationDirection",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.animationDirection", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.animationDirection");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetAnimationDirection());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.animationDirection", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.animationDirection");
                     self.Target.SetAnimationDirection(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.animationDirection")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("animationDuration",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.animationDuration", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.animationDuration");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetAnimationDuration());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.animationDuration", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.animationDuration");
                     self.Target.SetAnimationDuration(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.animationDuration")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("animationFillMode",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.animationFillMode", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.animationFillMode");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetAnimationFillMode());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.animationFillMode", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.animationFillMode");
                     self.Target.SetAnimationFillMode(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.animationFillMode")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("animationIterationCount",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.animationIterationCount", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.animationIterationCount");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetAnimationIterationCount());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.animationIterationCount", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.animationIterationCount");
                     self.Target.SetAnimationIterationCount(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.animationIterationCount")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("animationName",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.animationName", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.animationName");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetAnimationName());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.animationName", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.animationName");
                     self.Target.SetAnimationName(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.animationName")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("animationPlayState",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.animationPlayState", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.animationPlayState");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetAnimationPlayState());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.animationPlayState", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.animationPlayState");
                     self.Target.SetAnimationPlayState(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.animationPlayState")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("animationTimingFunction",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.animationTimingFunction", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.animationTimingFunction");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetAnimationTimingFunction());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.animationTimingFunction", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.animationTimingFunction");
                     self.Target.SetAnimationTimingFunction(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.animationTimingFunction")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("backfaceVisibility",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.backfaceVisibility", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.backfaceVisibility");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBackfaceVisibility());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.backfaceVisibility", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.backfaceVisibility");
                     self.Target.SetBackfaceVisibility(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.backfaceVisibility")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("background",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.background", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.background");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBackground());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.background", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.background");
                     self.Target.SetBackground(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.background")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("backgroundAttachment",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.backgroundAttachment", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.backgroundAttachment");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBackgroundAttachment());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.backgroundAttachment", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.backgroundAttachment");
                     self.Target.SetBackgroundAttachment(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.backgroundAttachment")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("backgroundClip",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.backgroundClip", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.backgroundClip");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBackgroundClip());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.backgroundClip", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.backgroundClip");
                     self.Target.SetBackgroundClip(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.backgroundClip")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("backgroundColor",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.backgroundColor", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.backgroundColor");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBackgroundColor());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.backgroundColor", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.backgroundColor");
                     self.Target.SetBackgroundColor(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.backgroundColor")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("backgroundImage",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.backgroundImage", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.backgroundImage");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBackgroundImage());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.backgroundImage", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.backgroundImage");
                     self.Target.SetBackgroundImage(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.backgroundImage")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("backgroundOrigin",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.backgroundOrigin", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.backgroundOrigin");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBackgroundOrigin());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.backgroundOrigin", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.backgroundOrigin");
                     self.Target.SetBackgroundOrigin(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.backgroundOrigin")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("backgroundPosition",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.backgroundPosition", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.backgroundPosition");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBackgroundPosition());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.backgroundPosition", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.backgroundPosition");
                     self.Target.SetBackgroundPosition(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.backgroundPosition")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("backgroundPositionX",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.backgroundPositionX", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.backgroundPositionX");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBackgroundPositionX());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.backgroundPositionX", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.backgroundPositionX");
                     self.Target.SetBackgroundPositionX(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.backgroundPositionX")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("backgroundPositionY",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.backgroundPositionY", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.backgroundPositionY");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBackgroundPositionY());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.backgroundPositionY", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.backgroundPositionY");
                     self.Target.SetBackgroundPositionY(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.backgroundPositionY")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("backgroundRepeat",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.backgroundRepeat", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.backgroundRepeat");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBackgroundRepeat());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.backgroundRepeat", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.backgroundRepeat");
                     self.Target.SetBackgroundRepeat(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.backgroundRepeat")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("backgroundSize",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.backgroundSize", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.backgroundSize");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBackgroundSize());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.backgroundSize", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.backgroundSize");
                     self.Target.SetBackgroundSize(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.backgroundSize")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("baselineShift",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.baselineShift", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.baselineShift");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBaselineShift());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.baselineShift", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.baselineShift");
                     self.Target.SetBaselineShift(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.baselineShift")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("behavior",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.behavior", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.behavior");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBehavior());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.behavior", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.behavior");
                     self.Target.SetBehavior(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.behavior")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("border",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.border", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.border");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBorder());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.border", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.border");
                     self.Target.SetBorder(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.border")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("borderBottom",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderBottom", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderBottom");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBorderBottom());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderBottom", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderBottom");
                     self.Target.SetBorderBottom(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.borderBottom")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("borderBottomColor",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderBottomColor", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderBottomColor");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBorderBottomColor());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderBottomColor", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderBottomColor");
                     self.Target.SetBorderBottomColor(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.borderBottomColor")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("borderBottomLeftRadius",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderBottomLeftRadius", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderBottomLeftRadius");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBorderBottomLeftRadius());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderBottomLeftRadius", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderBottomLeftRadius");
                     self.Target.SetBorderBottomLeftRadius(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.borderBottomLeftRadius")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("borderBottomRightRadius",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderBottomRightRadius", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderBottomRightRadius");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBorderBottomRightRadius());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderBottomRightRadius", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderBottomRightRadius");
                     self.Target.SetBorderBottomRightRadius(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.borderBottomRightRadius")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("borderBottomStyle",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderBottomStyle", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderBottomStyle");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBorderBottomStyle());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderBottomStyle", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderBottomStyle");
                     self.Target.SetBorderBottomStyle(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.borderBottomStyle")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("borderBottomWidth",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderBottomWidth", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderBottomWidth");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBorderBottomWidth());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderBottomWidth", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderBottomWidth");
                     self.Target.SetBorderBottomWidth(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.borderBottomWidth")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("borderCollapse",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderCollapse", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderCollapse");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBorderCollapse());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderCollapse", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderCollapse");
                     self.Target.SetBorderCollapse(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.borderCollapse")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("borderColor",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderColor", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderColor");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBorderColor());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderColor", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderColor");
                     self.Target.SetBorderColor(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.borderColor")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("borderImage",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderImage", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderImage");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBorderImage());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderImage", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderImage");
                     self.Target.SetBorderImage(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.borderImage")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("borderImageOutset",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderImageOutset", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderImageOutset");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBorderImageOutset());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderImageOutset", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderImageOutset");
                     self.Target.SetBorderImageOutset(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.borderImageOutset")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("borderImageRepeat",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderImageRepeat", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderImageRepeat");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBorderImageRepeat());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderImageRepeat", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderImageRepeat");
                     self.Target.SetBorderImageRepeat(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.borderImageRepeat")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("borderImageSlice",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderImageSlice", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderImageSlice");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBorderImageSlice());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderImageSlice", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderImageSlice");
                     self.Target.SetBorderImageSlice(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.borderImageSlice")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("borderImageSource",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderImageSource", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderImageSource");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBorderImageSource());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderImageSource", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderImageSource");
                     self.Target.SetBorderImageSource(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.borderImageSource")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("borderImageWidth",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderImageWidth", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderImageWidth");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBorderImageWidth());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderImageWidth", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderImageWidth");
                     self.Target.SetBorderImageWidth(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.borderImageWidth")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("borderLeft",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderLeft", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderLeft");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBorderLeft());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderLeft", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderLeft");
                     self.Target.SetBorderLeft(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.borderLeft")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("borderLeftColor",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderLeftColor", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderLeftColor");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBorderLeftColor());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderLeftColor", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderLeftColor");
                     self.Target.SetBorderLeftColor(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.borderLeftColor")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("borderLeftStyle",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderLeftStyle", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderLeftStyle");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBorderLeftStyle());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderLeftStyle", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderLeftStyle");
                     self.Target.SetBorderLeftStyle(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.borderLeftStyle")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("borderLeftWidth",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderLeftWidth", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderLeftWidth");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBorderLeftWidth());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderLeftWidth", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderLeftWidth");
                     self.Target.SetBorderLeftWidth(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.borderLeftWidth")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("borderRadius",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderRadius", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderRadius");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBorderRadius());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderRadius", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderRadius");
                     self.Target.SetBorderRadius(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.borderRadius")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("borderRight",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderRight", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderRight");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBorderRight());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderRight", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderRight");
                     self.Target.SetBorderRight(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.borderRight")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("borderRightColor",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderRightColor", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderRightColor");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBorderRightColor());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderRightColor", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderRightColor");
                     self.Target.SetBorderRightColor(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.borderRightColor")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("borderRightStyle",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderRightStyle", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderRightStyle");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBorderRightStyle());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderRightStyle", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderRightStyle");
                     self.Target.SetBorderRightStyle(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.borderRightStyle")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("borderRightWidth",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderRightWidth", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderRightWidth");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBorderRightWidth());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderRightWidth", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderRightWidth");
                     self.Target.SetBorderRightWidth(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.borderRightWidth")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("borderSpacing",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderSpacing", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderSpacing");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBorderSpacing());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderSpacing", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderSpacing");
                     self.Target.SetBorderSpacing(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.borderSpacing")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("borderStyle",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderStyle", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderStyle");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBorderStyle());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderStyle", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderStyle");
                     self.Target.SetBorderStyle(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.borderStyle")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("borderTop",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderTop", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderTop");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBorderTop());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderTop", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderTop");
                     self.Target.SetBorderTop(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.borderTop")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("borderTopColor",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderTopColor", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderTopColor");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBorderTopColor());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderTopColor", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderTopColor");
                     self.Target.SetBorderTopColor(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.borderTopColor")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("borderTopLeftRadius",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderTopLeftRadius", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderTopLeftRadius");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBorderTopLeftRadius());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderTopLeftRadius", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderTopLeftRadius");
                     self.Target.SetBorderTopLeftRadius(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.borderTopLeftRadius")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("borderTopRightRadius",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderTopRightRadius", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderTopRightRadius");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBorderTopRightRadius());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderTopRightRadius", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderTopRightRadius");
                     self.Target.SetBorderTopRightRadius(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.borderTopRightRadius")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("borderTopStyle",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderTopStyle", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderTopStyle");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBorderTopStyle());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderTopStyle", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderTopStyle");
                     self.Target.SetBorderTopStyle(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.borderTopStyle")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("borderTopWidth",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderTopWidth", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderTopWidth");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBorderTopWidth());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderTopWidth", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderTopWidth");
                     self.Target.SetBorderTopWidth(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.borderTopWidth")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("borderWidth",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderWidth", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderWidth");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBorderWidth());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.borderWidth", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.borderWidth");
                     self.Target.SetBorderWidth(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.borderWidth")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("bottom",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.bottom", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.bottom");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBottom());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.bottom", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.bottom");
                     self.Target.SetBottom(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.bottom")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("boxShadow",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.boxShadow", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.boxShadow");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBoxShadow());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.boxShadow", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.boxShadow");
                     self.Target.SetBoxShadow(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.boxShadow")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("boxSizing",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.boxSizing", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.boxSizing");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBoxSizing());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.boxSizing", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.boxSizing");
                     self.Target.SetBoxSizing(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.boxSizing")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("breakAfter",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.breakAfter", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.breakAfter");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBreakAfter());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.breakAfter", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.breakAfter");
                     self.Target.SetBreakAfter(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.breakAfter")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("breakBefore",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.breakBefore", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.breakBefore");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBreakBefore());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.breakBefore", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.breakBefore");
                     self.Target.SetBreakBefore(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.breakBefore")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("breakInside",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.breakInside", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.breakInside");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetBreakInside());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.breakInside", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.breakInside");
                     self.Target.SetBreakInside(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.breakInside")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("captionSide",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.captionSide", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.captionSide");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetCaptionSide());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.captionSide", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.captionSide");
                     self.Target.SetCaptionSide(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.captionSide")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("clear",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.clear", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.clear");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetClear());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.clear", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.clear");
                     self.Target.SetClear(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.clear")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("clip",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.clip", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.clip");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetClip());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.clip", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.clip");
                     self.Target.SetClip(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.clip")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("clipBottom",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.clipBottom", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.clipBottom");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetClipBottom());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.clipBottom", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.clipBottom");
                     self.Target.SetClipBottom(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.clipBottom")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("clipLeft",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.clipLeft", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.clipLeft");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetClipLeft());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.clipLeft", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.clipLeft");
                     self.Target.SetClipLeft(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.clipLeft")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("clipPath",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.clipPath", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.clipPath");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetClipPath());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.clipPath", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.clipPath");
                     self.Target.SetClipPath(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.clipPath")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("clipRight",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.clipRight", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.clipRight");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetClipRight());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.clipRight", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.clipRight");
                     self.Target.SetClipRight(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.clipRight")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("clipRule",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.clipRule", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.clipRule");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetClipRule());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.clipRule", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.clipRule");
                     self.Target.SetClipRule(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.clipRule")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("clipTop",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.clipTop", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.clipTop");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetClipTop());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.clipTop", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.clipTop");
                     self.Target.SetClipTop(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.clipTop")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("color",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.color", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.color");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetColor());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.color", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.color");
                     self.Target.SetColor(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.color")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("colorInterpolationFilters",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.colorInterpolationFilters", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.colorInterpolationFilters");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetColorInterpolationFilters());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.colorInterpolationFilters", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.colorInterpolationFilters");
                     self.Target.SetColorInterpolationFilters(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.colorInterpolationFilters")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("columnCount",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.columnCount", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.columnCount");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetColumnCount());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.columnCount", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.columnCount");
                     self.Target.SetColumnCount(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.columnCount")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("columnFill",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.columnFill", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.columnFill");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetColumnFill());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.columnFill", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.columnFill");
                     self.Target.SetColumnFill(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.columnFill")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("columnGap",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.columnGap", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.columnGap");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetColumnGap());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.columnGap", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.columnGap");
                     self.Target.SetColumnGap(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.columnGap")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("columnRule",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.columnRule", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.columnRule");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetColumnRule());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.columnRule", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.columnRule");
                     self.Target.SetColumnRule(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.columnRule")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("columnRuleColor",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.columnRuleColor", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.columnRuleColor");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetColumnRuleColor());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.columnRuleColor", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.columnRuleColor");
                     self.Target.SetColumnRuleColor(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.columnRuleColor")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("columnRuleStyle",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.columnRuleStyle", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.columnRuleStyle");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetColumnRuleStyle());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.columnRuleStyle", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.columnRuleStyle");
                     self.Target.SetColumnRuleStyle(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.columnRuleStyle")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("columnRuleWidth",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.columnRuleWidth", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.columnRuleWidth");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetColumnRuleWidth());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.columnRuleWidth", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.columnRuleWidth");
                     self.Target.SetColumnRuleWidth(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.columnRuleWidth")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("columnSpan",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.columnSpan", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.columnSpan");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetColumnSpan());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.columnSpan", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.columnSpan");
                     self.Target.SetColumnSpan(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.columnSpan")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("columnWidth",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.columnWidth", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.columnWidth");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetColumnWidth());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.columnWidth", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.columnWidth");
                     self.Target.SetColumnWidth(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.columnWidth")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("columns",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.columns", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.columns");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetColumns());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.columns", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.columns");
                     self.Target.SetColumns(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.columns")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("content",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.content", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.content");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetContent());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.content", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.content");
                     self.Target.SetContent(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.content")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("counterIncrement",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.counterIncrement", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.counterIncrement");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetCounterIncrement());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.counterIncrement", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.counterIncrement");
                     self.Target.SetCounterIncrement(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.counterIncrement")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("counterReset",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.counterReset", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.counterReset");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetCounterReset());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.counterReset", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.counterReset");
                     self.Target.SetCounterReset(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.counterReset")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("cssFloat",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.cssFloat", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.cssFloat");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetFloat());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.cssFloat", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.cssFloat");
                     self.Target.SetFloat(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.cssFloat")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("cssText",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.cssText", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.cssText");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.CssText);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.cssText", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.cssText");
                     self.Target.CssText = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.cssText"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("cursor",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.cursor", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.cursor");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetCursor());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.cursor", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.cursor");
                     self.Target.SetCursor(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.cursor")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("direction",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.direction", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.direction");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetDirection());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.direction", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.direction");
                     self.Target.SetDirection(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.direction")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("display",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.display", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.display");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetDisplay());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.display", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.display");
                     self.Target.SetDisplay(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.display")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("dominantBaseline",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.dominantBaseline", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.dominantBaseline");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetDominantBaseline());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.dominantBaseline", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.dominantBaseline");
                     self.Target.SetDominantBaseline(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.dominantBaseline")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("emptyCells",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.emptyCells", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.emptyCells");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetEmptyCells());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.emptyCells", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.emptyCells");
                     self.Target.SetEmptyCells(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.emptyCells")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("enableBackground",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.enableBackground", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.enableBackground");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetEnableBackground());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.enableBackground", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.enableBackground");
                     self.Target.SetEnableBackground(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.enableBackground")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("fill",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.fill", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.fill");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetFill());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.fill", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.fill");
                     self.Target.SetFill(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.fill")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("fillOpacity",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.fillOpacity", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.fillOpacity");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetFillOpacity());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.fillOpacity", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.fillOpacity");
                     self.Target.SetFillOpacity(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.fillOpacity")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("fillRule",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.fillRule", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.fillRule");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetFillRule());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.fillRule", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.fillRule");
                     self.Target.SetFillRule(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.fillRule")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("filter",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.filter", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.filter");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetFilter());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.filter", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.filter");
                     self.Target.SetFilter(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.filter")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("flex",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.flex", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.flex");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetFlex());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.flex", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.flex");
                     self.Target.SetFlex(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.flex")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("flexBasis",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.flexBasis", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.flexBasis");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetFlexBasis());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.flexBasis", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.flexBasis");
                     self.Target.SetFlexBasis(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.flexBasis")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("flexDirection",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.flexDirection", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.flexDirection");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetFlexDirection());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.flexDirection", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.flexDirection");
                     self.Target.SetFlexDirection(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.flexDirection")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("flexFlow",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.flexFlow", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.flexFlow");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetFlexFlow());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.flexFlow", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.flexFlow");
                     self.Target.SetFlexFlow(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.flexFlow")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("flexGrow",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.flexGrow", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.flexGrow");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetFlexGrow());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.flexGrow", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.flexGrow");
                     self.Target.SetFlexGrow(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.flexGrow")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("flexShrink",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.flexShrink", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.flexShrink");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetFlexShrink());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.flexShrink", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.flexShrink");
                     self.Target.SetFlexShrink(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.flexShrink")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("flexWrap",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.flexWrap", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.flexWrap");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetFlexWrap());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.flexWrap", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.flexWrap");
                     self.Target.SetFlexWrap(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.flexWrap")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("font",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.font", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.font");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetFont());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.font", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.font");
                     self.Target.SetFont(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.font")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("fontFamily",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.fontFamily", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.fontFamily");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetFontFamily());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.fontFamily", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.fontFamily");
                     self.Target.SetFontFamily(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.fontFamily")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("fontFeatureSettings",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.fontFeatureSettings", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.fontFeatureSettings");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetFontFeatureSettings());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.fontFeatureSettings", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.fontFeatureSettings");
                     self.Target.SetFontFeatureSettings(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.fontFeatureSettings")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("fontSize",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.fontSize", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.fontSize");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetFontSize());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.fontSize", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.fontSize");
                     self.Target.SetFontSize(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.fontSize")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("fontSizeAdjust",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.fontSizeAdjust", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.fontSizeAdjust");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetFontSizeAdjust());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.fontSizeAdjust", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.fontSizeAdjust");
                     self.Target.SetFontSizeAdjust(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.fontSizeAdjust")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("fontStretch",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.fontStretch", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.fontStretch");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetFontStretch());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.fontStretch", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.fontStretch");
                     self.Target.SetFontStretch(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.fontStretch")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("fontStyle",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.fontStyle", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.fontStyle");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetFontStyle());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.fontStyle", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.fontStyle");
                     self.Target.SetFontStyle(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.fontStyle")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("fontVariant",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.fontVariant", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.fontVariant");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetFontVariant());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.fontVariant", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.fontVariant");
                     self.Target.SetFontVariant(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.fontVariant")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("fontWeight",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.fontWeight", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.fontWeight");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetFontWeight());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.fontWeight", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.fontWeight");
                     self.Target.SetFontWeight(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.fontWeight")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Method("getPropertyPriority",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.getPropertyPriority", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.getPropertyPriority");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetPropertyPriority(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.getPropertyPriority")));
-                },
+                }),
                 length: 1)
             .Method("getPropertyValue",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.getPropertyValue", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.getPropertyValue");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetPropertyValue(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.getPropertyValue")));
-                },
+                }),
                 length: 1)
             .Accessor("glyphOrientationHorizontal",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.glyphOrientationHorizontal", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.glyphOrientationHorizontal");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetGlyphOrientationHorizontal());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.glyphOrientationHorizontal", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.glyphOrientationHorizontal");
                     self.Target.SetGlyphOrientationHorizontal(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.glyphOrientationHorizontal")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("glyphOrientationVertical",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.glyphOrientationVertical", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.glyphOrientationVertical");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetGlyphOrientationVertical());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.glyphOrientationVertical", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.glyphOrientationVertical");
                     self.Target.SetGlyphOrientationVertical(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.glyphOrientationVertical")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("height",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.height", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.height");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetHeight());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.height", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.height");
                     self.Target.SetHeight(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.height")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("imeMode",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.imeMode", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.imeMode");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetImeMode());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.imeMode", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.imeMode");
                     self.Target.SetImeMode(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.imeMode")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Method("item",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.item", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.item");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target[global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "CSSStyleDeclaration.item")]);
-                },
+                }),
                 length: 1)
             .Accessor("justifyContent",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.justifyContent", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.justifyContent");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetJustifyContent());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.justifyContent", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.justifyContent");
                     self.Target.SetJustifyContent(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.justifyContent")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("layoutGrid",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.layoutGrid", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.layoutGrid");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetLayoutGrid());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.layoutGrid", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.layoutGrid");
                     self.Target.SetLayoutGrid(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.layoutGrid")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("layoutGridChar",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.layoutGridChar", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.layoutGridChar");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetLayoutGridChar());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.layoutGridChar", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.layoutGridChar");
                     self.Target.SetLayoutGridChar(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.layoutGridChar")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("layoutGridLine",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.layoutGridLine", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.layoutGridLine");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetLayoutGridLine());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.layoutGridLine", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.layoutGridLine");
                     self.Target.SetLayoutGridLine(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.layoutGridLine")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("layoutGridMode",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.layoutGridMode", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.layoutGridMode");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetLayoutGridMode());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.layoutGridMode", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.layoutGridMode");
                     self.Target.SetLayoutGridMode(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.layoutGridMode")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("layoutGridType",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.layoutGridType", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.layoutGridType");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetLayoutGridType());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.layoutGridType", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.layoutGridType");
                     self.Target.SetLayoutGridType(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.layoutGridType")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("left",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.left", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.left");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetLeft());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.left", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.left");
                     self.Target.SetLeft(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.left")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("letterSpacing",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.letterSpacing", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.letterSpacing");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetLetterSpacing());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.letterSpacing", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.letterSpacing");
                     self.Target.SetLetterSpacing(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.letterSpacing")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("lineHeight",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.lineHeight", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.lineHeight");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetLineHeight());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.lineHeight", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.lineHeight");
                     self.Target.SetLineHeight(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.lineHeight")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("listStyle",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.listStyle", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.listStyle");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetListStyle());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.listStyle", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.listStyle");
                     self.Target.SetListStyle(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.listStyle")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("listStyleImage",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.listStyleImage", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.listStyleImage");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetListStyleImage());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.listStyleImage", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.listStyleImage");
                     self.Target.SetListStyleImage(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.listStyleImage")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("listStylePosition",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.listStylePosition", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.listStylePosition");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetListStylePosition());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.listStylePosition", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.listStylePosition");
                     self.Target.SetListStylePosition(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.listStylePosition")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("listStyleType",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.listStyleType", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.listStyleType");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetListStyleType());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.listStyleType", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.listStyleType");
                     self.Target.SetListStyleType(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.listStyleType")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("margin",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.margin", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.margin");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetMargin());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.margin", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.margin");
                     self.Target.SetMargin(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.margin")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("marginBottom",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.marginBottom", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.marginBottom");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetMarginBottom());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.marginBottom", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.marginBottom");
                     self.Target.SetMarginBottom(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.marginBottom")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("marginLeft",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.marginLeft", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.marginLeft");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetMarginLeft());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.marginLeft", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.marginLeft");
                     self.Target.SetMarginLeft(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.marginLeft")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("marginRight",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.marginRight", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.marginRight");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetMarginRight());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.marginRight", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.marginRight");
                     self.Target.SetMarginRight(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.marginRight")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("marginTop",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.marginTop", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.marginTop");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetMarginTop());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.marginTop", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.marginTop");
                     self.Target.SetMarginTop(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.marginTop")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("marker",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.marker", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.marker");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetMarker());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.marker", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.marker");
                     self.Target.SetMarker(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.marker")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("markerEnd",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.markerEnd", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.markerEnd");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetMarkerEnd());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.markerEnd", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.markerEnd");
                     self.Target.SetMarkerEnd(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.markerEnd")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("markerMid",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.markerMid", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.markerMid");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetMarkerMid());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.markerMid", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.markerMid");
                     self.Target.SetMarkerMid(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.markerMid")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("markerStart",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.markerStart", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.markerStart");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetMarkerStart());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.markerStart", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.markerStart");
                     self.Target.SetMarkerStart(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.markerStart")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("mask",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.mask", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.mask");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetMask());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.mask", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.mask");
                     self.Target.SetMask(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.mask")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("maxHeight",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.maxHeight", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.maxHeight");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetMaxHeight());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.maxHeight", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.maxHeight");
                     self.Target.SetMaxHeight(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.maxHeight")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("minHeight",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.minHeight", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.minHeight");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetMinHeight());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.minHeight", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.minHeight");
                     self.Target.SetMinHeight(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.minHeight")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("minWidth",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.minWidth", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.minWidth");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetMinWidth());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.minWidth", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.minWidth");
                     self.Target.SetMinWidth(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.minWidth")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("opacity",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.opacity", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.opacity");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetOpacity());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.opacity", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.opacity");
                     self.Target.SetOpacity(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.opacity")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("order",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.order", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.order");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetOrder());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.order", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.order");
                     self.Target.SetOrder(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.order")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("orphans",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.orphans", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.orphans");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetOrphans());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.orphans", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.orphans");
                     self.Target.SetOrphans(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.orphans")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("outline",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.outline", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.outline");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetOutline());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.outline", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.outline");
                     self.Target.SetOutline(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.outline")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("outlineColor",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.outlineColor", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.outlineColor");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetOutlineColor());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.outlineColor", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.outlineColor");
                     self.Target.SetOutlineColor(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.outlineColor")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("outlineStyle",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.outlineStyle", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.outlineStyle");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetOutlineStyle());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.outlineStyle", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.outlineStyle");
                     self.Target.SetOutlineStyle(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.outlineStyle")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("outlineWidth",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.outlineWidth", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.outlineWidth");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetOutlineWidth());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.outlineWidth", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.outlineWidth");
                     self.Target.SetOutlineWidth(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.outlineWidth")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("overflow",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.overflow", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.overflow");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetOverflow());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.overflow", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.overflow");
                     self.Target.SetOverflow(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.overflow")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("overflowWrap",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.overflowWrap", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.overflowWrap");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetOverflowWrap());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.overflowWrap", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.overflowWrap");
                     self.Target.SetOverflowWrap(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.overflowWrap")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("overflowX",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.overflowX", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.overflowX");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetOverflowX());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.overflowX", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.overflowX");
                     self.Target.SetOverflowX(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.overflowX")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("overflowY",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.overflowY", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.overflowY");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetOverflowY());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.overflowY", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.overflowY");
                     self.Target.SetOverflowY(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.overflowY")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("padding",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.padding", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.padding");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetPadding());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.padding", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.padding");
                     self.Target.SetPadding(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.padding")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("paddingBottom",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.paddingBottom", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.paddingBottom");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetPaddingBottom());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.paddingBottom", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.paddingBottom");
                     self.Target.SetPaddingBottom(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.paddingBottom")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("paddingLeft",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.paddingLeft", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.paddingLeft");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetPaddingLeft());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.paddingLeft", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.paddingLeft");
                     self.Target.SetPaddingLeft(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.paddingLeft")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("paddingRight",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.paddingRight", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.paddingRight");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetPaddingRight());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.paddingRight", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.paddingRight");
                     self.Target.SetPaddingRight(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.paddingRight")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("paddingTop",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.paddingTop", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.paddingTop");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetPaddingTop());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.paddingTop", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.paddingTop");
                     self.Target.SetPaddingTop(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.paddingTop")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("pageBreakAfter",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.pageBreakAfter", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.pageBreakAfter");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetPageBreakAfter());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.pageBreakAfter", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.pageBreakAfter");
                     self.Target.SetPageBreakAfter(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.pageBreakAfter")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("pageBreakBefore",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.pageBreakBefore", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.pageBreakBefore");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetPageBreakBefore());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.pageBreakBefore", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.pageBreakBefore");
                     self.Target.SetPageBreakBefore(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.pageBreakBefore")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("pageBreakInside",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.pageBreakInside", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.pageBreakInside");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetPageBreakInside());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.pageBreakInside", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.pageBreakInside");
                     self.Target.SetPageBreakInside(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.pageBreakInside")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("parentRule",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.parentRule", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.parentRule");
                     return self.Realm.Wrap(self.Target.Parent);
-                })
+                }))
             .Accessor("perspective",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.perspective", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.perspective");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetPerspective());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.perspective", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.perspective");
                     self.Target.SetPerspective(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.perspective")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("perspectiveOrigin",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.perspectiveOrigin", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.perspectiveOrigin");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetPerspectiveOrigin());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.perspectiveOrigin", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.perspectiveOrigin");
                     self.Target.SetPerspectiveOrigin(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.perspectiveOrigin")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("pointerEvents",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.pointerEvents", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.pointerEvents");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetPointerEvents());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.pointerEvents", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.pointerEvents");
                     self.Target.SetPointerEvents(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.pointerEvents")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("position",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.position", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.position");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetPosition());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.position", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.position");
                     self.Target.SetPosition(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.position")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("quotes",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.quotes", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.quotes");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetQuotes());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.quotes", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.quotes");
                     self.Target.SetQuotes(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.quotes")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Method("removeProperty",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.removeProperty", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.removeProperty");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.RemoveProperty(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.removeProperty")));
-                },
+                }),
                 length: 1)
             .Accessor("right",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.right", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.right");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetRight());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.right", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.right");
                     self.Target.SetRight(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.right")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("rubyAlign",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.rubyAlign", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.rubyAlign");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetRubyAlign());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.rubyAlign", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.rubyAlign");
                     self.Target.SetRubyAlign(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.rubyAlign")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("rubyOverhang",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.rubyOverhang", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.rubyOverhang");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetRubyOverhang());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.rubyOverhang", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.rubyOverhang");
                     self.Target.SetRubyOverhang(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.rubyOverhang")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("rubyPosition",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.rubyPosition", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.rubyPosition");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetRubyPosition());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.rubyPosition", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.rubyPosition");
                     self.Target.SetRubyPosition(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.rubyPosition")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("scrollbar3dLightColor",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.scrollbar3dLightColor", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.scrollbar3dLightColor");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetScrollbar3dLightColor());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.scrollbar3dLightColor", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.scrollbar3dLightColor");
                     self.Target.SetScrollbar3dLightColor(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.scrollbar3dLightColor")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("scrollbarArrowColor",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.scrollbarArrowColor", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.scrollbarArrowColor");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetScrollbarArrowColor());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.scrollbarArrowColor", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.scrollbarArrowColor");
                     self.Target.SetScrollbarArrowColor(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.scrollbarArrowColor")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("scrollbarDarkShadowColor",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.scrollbarDarkShadowColor", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.scrollbarDarkShadowColor");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetScrollbarDarkShadowColor());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.scrollbarDarkShadowColor", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.scrollbarDarkShadowColor");
                     self.Target.SetScrollbarDarkShadowColor(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.scrollbarDarkShadowColor")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("scrollbarFaceColor",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.scrollbarFaceColor", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.scrollbarFaceColor");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetScrollbarFaceColor());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.scrollbarFaceColor", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.scrollbarFaceColor");
                     self.Target.SetScrollbarFaceColor(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.scrollbarFaceColor")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("scrollbarHighlightColor",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.scrollbarHighlightColor", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.scrollbarHighlightColor");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetScrollbarHighlightColor());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.scrollbarHighlightColor", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.scrollbarHighlightColor");
                     self.Target.SetScrollbarHighlightColor(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.scrollbarHighlightColor")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("scrollbarShadowColor",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.scrollbarShadowColor", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.scrollbarShadowColor");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetScrollbarShadowColor());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.scrollbarShadowColor", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.scrollbarShadowColor");
                     self.Target.SetScrollbarShadowColor(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.scrollbarShadowColor")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("scrollbarTrackColor",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.scrollbarTrackColor", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.scrollbarTrackColor");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetScrollbarTrackColor());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.scrollbarTrackColor", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.scrollbarTrackColor");
                     self.Target.SetScrollbarTrackColor(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.scrollbarTrackColor")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Method("setProperty",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.setProperty", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.setProperty");
                     self.Target.SetProperty(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.setProperty"), global::Jint.Browser.Dom.DomConvert.RequiredText(args, 1, "CSSStyleDeclaration.setProperty"), global::Jint.Browser.Dom.DomConvert.OptionalText(args, 2, null)!); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 2)
             .Accessor("stroke",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.stroke", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.stroke");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetStroke());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.stroke", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.stroke");
                     self.Target.SetStroke(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.stroke")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("strokeDasharray",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.strokeDasharray", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.strokeDasharray");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetStrokeDashArray());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.strokeDasharray", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.strokeDasharray");
                     self.Target.SetStrokeDashArray(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.strokeDasharray")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("strokeDashoffset",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.strokeDashoffset", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.strokeDashoffset");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetStrokeDashOffset());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.strokeDashoffset", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.strokeDashoffset");
                     self.Target.SetStrokeDashOffset(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.strokeDashoffset")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("strokeLinecap",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.strokeLinecap", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.strokeLinecap");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetStrokeLineCap());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.strokeLinecap", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.strokeLinecap");
                     self.Target.SetStrokeLineCap(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.strokeLinecap")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("strokeLinejoin",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.strokeLinejoin", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.strokeLinejoin");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetStrokeLineJoin());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.strokeLinejoin", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.strokeLinejoin");
                     self.Target.SetStrokeLineJoin(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.strokeLinejoin")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("strokeMiterlimit",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.strokeMiterlimit", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.strokeMiterlimit");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetStrokeMiterLimit());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.strokeMiterlimit", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.strokeMiterlimit");
                     self.Target.SetStrokeMiterLimit(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.strokeMiterlimit")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("strokeOpacity",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.strokeOpacity", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.strokeOpacity");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetStrokeOpacity());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.strokeOpacity", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.strokeOpacity");
                     self.Target.SetStrokeOpacity(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.strokeOpacity")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("strokeWidth",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.strokeWidth", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.strokeWidth");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetStrokeWidth());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.strokeWidth", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.strokeWidth");
                     self.Target.SetStrokeWidth(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.strokeWidth")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("tableLayout",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.tableLayout", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.tableLayout");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetTableLayout());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.tableLayout", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.tableLayout");
                     self.Target.SetTableLayout(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.tableLayout")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("textAlign",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.textAlign", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.textAlign");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetTextAlign());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.textAlign", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.textAlign");
                     self.Target.SetTextAlign(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.textAlign")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("textAlignLast",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.textAlignLast", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.textAlignLast");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetTextAlignLast());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.textAlignLast", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.textAlignLast");
                     self.Target.SetTextAlignLast(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.textAlignLast")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("textAnchor",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.textAnchor", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.textAnchor");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetTextAnchor());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.textAnchor", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.textAnchor");
                     self.Target.SetTextAnchor(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.textAnchor")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("textAutospace",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.textAutospace", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.textAutospace");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetTextAutospace());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.textAutospace", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.textAutospace");
                     self.Target.SetTextAutospace(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.textAutospace")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("textDecoration",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.textDecoration", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.textDecoration");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetTextDecoration());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.textDecoration", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.textDecoration");
                     self.Target.SetTextDecoration(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.textDecoration")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("textDecorationColor",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.textDecorationColor", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.textDecorationColor");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetTextDecorationColor());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.textDecorationColor", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.textDecorationColor");
                     self.Target.SetTextDecorationColor(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.textDecorationColor")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("textDecorationLine",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.textDecorationLine", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.textDecorationLine");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetTextDecorationLine());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.textDecorationLine", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.textDecorationLine");
                     self.Target.SetTextDecorationLine(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.textDecorationLine")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("textDecorationStyle",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.textDecorationStyle", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.textDecorationStyle");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetTextDecorationStyle());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.textDecorationStyle", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.textDecorationStyle");
                     self.Target.SetTextDecorationStyle(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.textDecorationStyle")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("textIndent",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.textIndent", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.textIndent");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetTextIndent());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.textIndent", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.textIndent");
                     self.Target.SetTextIndent(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.textIndent")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("textJustify",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.textJustify", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.textJustify");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetTextJustify());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.textJustify", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.textJustify");
                     self.Target.SetTextJustify(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.textJustify")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("textOverflow",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.textOverflow", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.textOverflow");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetTextOverflow());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.textOverflow", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.textOverflow");
                     self.Target.SetTextOverflow(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.textOverflow")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("textShadow",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.textShadow", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.textShadow");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetTextShadow());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.textShadow", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.textShadow");
                     self.Target.SetTextShadow(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.textShadow")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("textTransform",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.textTransform", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.textTransform");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetTextTransform());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.textTransform", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.textTransform");
                     self.Target.SetTextTransform(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.textTransform")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("textUnderlinePosition",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.textUnderlinePosition", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.textUnderlinePosition");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetTextUnderlinePosition());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.textUnderlinePosition", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.textUnderlinePosition");
                     self.Target.SetTextUnderlinePosition(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.textUnderlinePosition")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("top",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.top", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.top");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetTop());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.top", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.top");
                     self.Target.SetTop(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.top")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("transform",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.transform", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.transform");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetTransform());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.transform", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.transform");
                     self.Target.SetTransform(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.transform")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("transformOrigin",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.transformOrigin", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.transformOrigin");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetTransformOrigin());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.transformOrigin", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.transformOrigin");
                     self.Target.SetTransformOrigin(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.transformOrigin")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("transformStyle",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.transformStyle", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.transformStyle");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetTransformStyle());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.transformStyle", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.transformStyle");
                     self.Target.SetTransformStyle(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.transformStyle")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("transition",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.transition", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.transition");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetTransition());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.transition", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.transition");
                     self.Target.SetTransition(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.transition")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("transitionDelay",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.transitionDelay", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.transitionDelay");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetTransitionDelay());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.transitionDelay", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.transitionDelay");
                     self.Target.SetTransitionDelay(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.transitionDelay")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("transitionDuration",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.transitionDuration", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.transitionDuration");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetTransitionDuration());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.transitionDuration", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.transitionDuration");
                     self.Target.SetTransitionDuration(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.transitionDuration")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("transitionProperty",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.transitionProperty", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.transitionProperty");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetTransitionProperty());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.transitionProperty", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.transitionProperty");
                     self.Target.SetTransitionProperty(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.transitionProperty")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("transitionTimingFunction",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.transitionTimingFunction", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.transitionTimingFunction");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetTransitionTimingFunction());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.transitionTimingFunction", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.transitionTimingFunction");
                     self.Target.SetTransitionTimingFunction(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.transitionTimingFunction")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("unicodeBidi",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.unicodeBidi", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.unicodeBidi");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetUnicodeBidi());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.unicodeBidi", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.unicodeBidi");
                     self.Target.SetUnicodeBidi(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.unicodeBidi")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("verticalAlign",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.verticalAlign", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.verticalAlign");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetVerticalAlign());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.verticalAlign", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.verticalAlign");
                     self.Target.SetVerticalAlign(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.verticalAlign")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("visibility",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.visibility", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.visibility");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetVisibility());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.visibility", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.visibility");
                     self.Target.SetVisibility(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.visibility")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("whiteSpace",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.whiteSpace", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.whiteSpace");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetWhiteSpace());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.whiteSpace", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.whiteSpace");
                     self.Target.SetWhiteSpace(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.whiteSpace")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("widows",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.widows", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.widows");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetWidows());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.widows", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.widows");
                     self.Target.SetWidows(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.widows")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("width",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.width", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.width");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetWidth());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.width", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.width");
                     self.Target.SetWidth(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.width")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("wordBreak",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.wordBreak", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.wordBreak");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetWordBreak());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.wordBreak", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.wordBreak");
                     self.Target.SetWordBreak(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.wordBreak")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("wordSpacing",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.wordSpacing", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.wordSpacing");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetWordSpacing());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.wordSpacing", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.wordSpacing");
                     self.Target.SetWordSpacing(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.wordSpacing")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("wordWrap",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.wordWrap", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.wordWrap");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetWordWrap());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.wordWrap", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.wordWrap");
                     self.Target.SetWordWrap(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.wordWrap")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("writingMode",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.writingMode", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.writingMode");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetWritingMode());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.writingMode", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.writingMode");
                     self.Target.SetWritingMode(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.writingMode")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("zIndex",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.zIndex", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.zIndex");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetZIndex());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.zIndex", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.zIndex");
                     self.Target.SetZIndex(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.zIndex")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("zoom",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.zoom", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.zoom");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetZoom());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.zoom", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleDeclaration>(thisObj, "CSSStyleDeclaration.zoom");
                     self.Target.SetZoom(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleDeclaration.zoom")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>CSSStyleRule</c>.</summary>
@@ -3505,39 +3505,39 @@ internal static partial class DomInterfaces
             .ToStringTag("CSSStyleRule")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("cssRules",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleRule.cssRules", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleRule>(thisObj, "CSSStyleRule.cssRules");
                     return self.Realm.Wrap(self.Target.Rules);
-                })
+                }))
             .Accessor("rules",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleRule.rules", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleRule>(thisObj, "CSSStyleRule.rules");
                     return self.Realm.Wrap(self.Target.Rules);
-                })
+                }))
             .Accessor("selectorText",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleRule.selectorText", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleRule>(thisObj, "CSSStyleRule.selectorText");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.SelectorText);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleRule.selectorText", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleRule>(thisObj, "CSSStyleRule.selectorText");
                     self.Target.SelectorText = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleRule.selectorText"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("style",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleRule.style", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleRule>(thisObj, "CSSStyleRule.style");
                     return self.Realm.Wrap(self.Target.Style);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleRule.style", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleRule>(thisObj, "CSSStyleRule.style");
                     var forwardTarget = self.Target.Style; if (forwardTarget is not null) { forwardTarget.CssText = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleRule.style"); } return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>CSSStyleSheet</c>.</summary>
@@ -3546,43 +3546,43 @@ internal static partial class DomInterfaces
             .ToStringTag("CSSStyleSheet")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("cssRules",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleSheet.cssRules", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleSheet>(thisObj, "CSSStyleSheet.cssRules");
                     return self.Realm.Wrap(self.Target.Rules);
-                })
+                }))
             .Method("deleteRule",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleSheet.deleteRule", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleSheet>(thisObj, "CSSStyleSheet.deleteRule");
                     self.Target.RemoveAt(global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "CSSStyleSheet.deleteRule")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 1)
             .Method("insertRule",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleSheet.insertRule", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleSheet>(thisObj, "CSSStyleSheet.insertRule");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Insert(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSStyleSheet.insertRule"), global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 1, "CSSStyleSheet.insertRule")));
-                },
+                }),
                 length: 2)
             .Accessor("ownerRule",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleSheet.ownerRule", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleSheet>(thisObj, "CSSStyleSheet.ownerRule");
                     return self.Realm.Wrap(self.Target.OwnerRule);
-                })
+                }))
             .Accessor("parentStyleSheet",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleSheet.parentStyleSheet", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleSheet>(thisObj, "CSSStyleSheet.parentStyleSheet");
                     return self.Realm.Wrap(self.Target.Parent);
-                })
+                }))
             .Accessor("rules",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleSheet.rules", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssStyleSheet>(thisObj, "CSSStyleSheet.rules");
                     return self.Realm.Wrap(self.Target.Rules);
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>CSSSupportsRule</c>.</summary>
@@ -3598,38 +3598,38 @@ internal static partial class DomInterfaces
             .ToStringTag("CSSViewTransitionRule")
             .PerRealmSlot("constructor", enumerable: false)
             .Method("getPropertyPriority",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSViewTransitionRule.getPropertyPriority", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssViewTransitionRule>(thisObj, "CSSViewTransitionRule.getPropertyPriority");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetPropertyPriority(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSViewTransitionRule.getPropertyPriority")));
-                },
+                }),
                 length: 1)
             .Method("getPropertyValue",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSViewTransitionRule.getPropertyValue", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssViewTransitionRule>(thisObj, "CSSViewTransitionRule.getPropertyValue");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetPropertyValue(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSViewTransitionRule.getPropertyValue")));
-                },
+                }),
                 length: 1)
             .Accessor("length",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSViewTransitionRule.length", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssViewTransitionRule>(thisObj, "CSSViewTransitionRule.length");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Length);
-                })
+                }))
             .Method("removeProperty",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSViewTransitionRule.removeProperty", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssViewTransitionRule>(thisObj, "CSSViewTransitionRule.removeProperty");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.RemoveProperty(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSViewTransitionRule.removeProperty")));
-                },
+                }),
                 length: 1)
             .Method("setProperty",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CSSViewTransitionRule.setProperty", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICssViewTransitionRule>(thisObj, "CSSViewTransitionRule.setProperty");
                     self.Target.SetProperty(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CSSViewTransitionRule.setProperty"), global::Jint.Browser.Dom.DomConvert.RequiredText(args, 1, "CSSViewTransitionRule.setProperty"), global::Jint.Browser.Dom.DomConvert.OptionalText(args, 2, null)!); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 2)
             .Build();
 
@@ -3639,17 +3639,17 @@ internal static partial class DomInterfaces
             .ToStringTag("CaretPosition")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("offset",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CaretPosition.offset", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICaretPosition>(thisObj, "CaretPosition.offset");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Offset);
-                })
+                }))
             .Accessor("offsetNode",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CaretPosition.offsetNode", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.ICaretPosition>(thisObj, "CaretPosition.offsetNode");
                     return self.Realm.WrapNodeValue(self.Target.Node);
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>MediaList</c>.</summary>
@@ -3658,36 +3658,36 @@ internal static partial class DomInterfaces
             .ToStringTag("MediaList")
             .PerRealmSlot("constructor", enumerable: false)
             .Method("appendMedium",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("MediaList.appendMedium", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.IMediaList>(thisObj, "MediaList.appendMedium");
                     self.Target.Add(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "MediaList.appendMedium")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 1)
             .Method("item",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("MediaList.item", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.IMediaList>(thisObj, "MediaList.item");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target[global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "MediaList.item")]);
-                },
+                }),
                 length: 1)
             .Accessor("mediaText",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("MediaList.mediaText", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.IMediaList>(thisObj, "MediaList.mediaText");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.MediaText);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("MediaList.mediaText", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.IMediaList>(thisObj, "MediaList.mediaText");
                     self.Target.MediaText = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "MediaList.mediaText"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Method("removeMedium",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("MediaList.removeMedium", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.IMediaList>(thisObj, "MediaList.removeMedium");
                     self.Target.Remove(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "MediaList.removeMedium")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 1)
             .Build();
 
@@ -3697,16 +3697,16 @@ internal static partial class DomInterfaces
             .ToStringTag("MediaQueryList")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("matches",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("MediaQueryList.matches", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.IMediaQueryList>(thisObj, "MediaQueryList.matches");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsMatched);
-                })
+                }))
             .Accessor("media",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("MediaQueryList.media", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Css.Dom.IMediaQueryList>(thisObj, "MediaQueryList.media");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.MediaText);
-                })
+                }))
             .Build();
 }

--- a/Jint.Browser/Dom/Generated/DomShapes.Dom.g.cs
+++ b/Jint.Browser/Dom/Generated/DomShapes.Dom.g.cs
@@ -38,197 +38,197 @@ internal static partial class DomInterfaces
             .Constant("PROCESSING_INSTRUCTION_NODE", global::Jint.Native.JsNumber.Create(7))
             .Constant("TEXT_NODE", global::Jint.Native.JsNumber.Create(3))
             .Method("appendChild",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Node.appendChild", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INode>(thisObj, "Node.appendChild");
                     return self.Realm.WrapNodeValue(self.Target.AppendChild(global::Jint.Browser.Dom.DomBindings.Argument<global::AngleSharp.Dom.INode>(args, 0, "Node.appendChild")));
-                },
+                }),
                 length: 1)
             .Accessor("baseURI",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Node.baseURI", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INode>(thisObj, "Node.baseURI");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.BaseUri);
-                })
+                }))
             .Accessor("childNodes",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Node.childNodes", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INode>(thisObj, "Node.childNodes");
                     return self.Realm.Wrap(self.Target.ChildNodes);
-                })
+                }))
             .Method("cloneNode",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Node.cloneNode", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INode>(thisObj, "Node.cloneNode");
                     return global::Jint.Browser.CustomElements.CustomElementCreation.CloneNode(self.Realm, self.Target, args);
-                },
+                }),
                 length: 0)
             .Method("compareDocumentPosition",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Node.compareDocumentPosition", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INode>(thisObj, "Node.compareDocumentPosition");
                     return global::Jint.Browser.Dom.DomConvert.Number((int) (self.Target.CompareDocumentPosition(global::Jint.Browser.Dom.DomBindings.Argument<global::AngleSharp.Dom.INode>(args, 0, "Node.compareDocumentPosition"))));
-                },
+                }),
                 length: 1)
             .Method("contains",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Node.contains", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INode>(thisObj, "Node.contains");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.Contains(global::Jint.Browser.Dom.DomBindings.Argument<global::AngleSharp.Dom.INode>(args, 0, "Node.contains")));
-                },
+                }),
                 length: 1)
             .Accessor("firstChild",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Node.firstChild", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INode>(thisObj, "Node.firstChild");
                     return self.Realm.WrapNodeValue(self.Target.FirstChild);
-                })
+                }))
             .Method("getRootNode",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Node.getRootNode", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INode>(thisObj, "Node.getRootNode");
                     return global::Jint.Browser.Dom.DomNodeMembers.GetRootNode(self.Realm, self.Target, args);
-                },
+                }),
                 length: 0)
             .Method("hasChildNodes",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Node.hasChildNodes", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INode>(thisObj, "Node.hasChildNodes");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.HasChildNodes);
-                },
+                }),
                 length: 0)
             .Method("insertBefore",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Node.insertBefore", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INode>(thisObj, "Node.insertBefore");
                     return self.Realm.WrapNodeValue(self.Target.InsertBefore(global::Jint.Browser.Dom.DomBindings.Argument<global::AngleSharp.Dom.INode>(args, 0, "Node.insertBefore"), global::Jint.Browser.Dom.DomBindings.NullableArgument<global::AngleSharp.Dom.INode>(args, 1, "Node.insertBefore")));
-                },
+                }),
                 length: 2)
             .Accessor("isConnected",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Node.isConnected", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INode>(thisObj, "Node.isConnected");
                     return global::Jint.Browser.Dom.Views.DomViewMembers.IsConnected(self.Target);
-                })
+                }))
             .Method("isDefaultNamespace",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Node.isDefaultNamespace", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INode>(thisObj, "Node.isDefaultNamespace");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsDefaultNamespace(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Node.isDefaultNamespace")));
-                },
+                }),
                 length: 1)
             .Method("isEqualNode",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Node.isEqualNode", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INode>(thisObj, "Node.isEqualNode");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.Equals(global::Jint.Browser.Dom.DomBindings.Argument<global::AngleSharp.Dom.INode>(args, 0, "Node.isEqualNode")));
-                },
+                }),
                 length: 1)
             .Accessor("lastChild",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Node.lastChild", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INode>(thisObj, "Node.lastChild");
                     return self.Realm.WrapNodeValue(self.Target.LastChild);
-                })
+                }))
             .Method("lookupNamespaceURI",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Node.lookupNamespaceURI", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INode>(thisObj, "Node.lookupNamespaceURI");
                     return global::Jint.Browser.Dom.DomConvert.NullableText(self.Target.LookupNamespaceUri(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Node.lookupNamespaceURI")));
-                },
+                }),
                 length: 1)
             .Method("lookupPrefix",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Node.lookupPrefix", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INode>(thisObj, "Node.lookupPrefix");
                     return global::Jint.Browser.Dom.DomConvert.NullableText(self.Target.LookupPrefix(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Node.lookupPrefix")));
-                },
+                }),
                 length: 1)
             .Accessor("nextSibling",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Node.nextSibling", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INode>(thisObj, "Node.nextSibling");
                     return self.Realm.WrapNodeValue(self.Target.NextSibling);
-                })
+                }))
             .Accessor("nodeName",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Node.nodeName", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INode>(thisObj, "Node.nodeName");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.NodeName);
-                })
+                }))
             .Accessor("nodeType",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Node.nodeType", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INode>(thisObj, "Node.nodeType");
                     return global::Jint.Browser.Dom.DomConvert.Number((int) (self.Target.NodeType));
-                })
+                }))
             .Accessor("nodeValue",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Node.nodeValue", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INode>(thisObj, "Node.nodeValue");
                     return global::Jint.Browser.Dom.DomConvert.NullableText(self.Target.NodeValue);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("Node.nodeValue", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INode>(thisObj, "Node.nodeValue");
                     self.Target.NodeValue = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Node.nodeValue"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Method("normalize",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Node.normalize", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INode>(thisObj, "Node.normalize");
                     self.Target.Normalize(); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Accessor("ownerDocument",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Node.ownerDocument", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INode>(thisObj, "Node.ownerDocument");
                     return self.Realm.WrapNodeValue(self.Target.Owner);
-                })
+                }))
             .Accessor("parentElement",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Node.parentElement", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INode>(thisObj, "Node.parentElement");
                     return self.Realm.WrapNodeValue(self.Target.ParentElement);
-                })
+                }))
             .Accessor("parentNode",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Node.parentNode", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INode>(thisObj, "Node.parentNode");
                     return self.Realm.WrapNodeValue(self.Target.Parent);
-                })
+                }))
             .Accessor("previousSibling",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Node.previousSibling", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INode>(thisObj, "Node.previousSibling");
                     return self.Realm.WrapNodeValue(self.Target.PreviousSibling);
-                })
+                }))
             .Method("removeChild",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Node.removeChild", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INode>(thisObj, "Node.removeChild");
                     return self.Realm.WrapNodeValue(self.Target.RemoveChild(global::Jint.Browser.Dom.DomBindings.Argument<global::AngleSharp.Dom.INode>(args, 0, "Node.removeChild")));
-                },
+                }),
                 length: 1)
             .Method("replaceChild",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Node.replaceChild", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INode>(thisObj, "Node.replaceChild");
                     return self.Realm.WrapNodeValue(self.Target.ReplaceChild(global::Jint.Browser.Dom.DomBindings.Argument<global::AngleSharp.Dom.INode>(args, 0, "Node.replaceChild"), global::Jint.Browser.Dom.DomBindings.Argument<global::AngleSharp.Dom.INode>(args, 1, "Node.replaceChild")));
-                },
+                }),
                 length: 2)
             .Accessor("textContent",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Node.textContent", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INode>(thisObj, "Node.textContent");
                     return global::Jint.Browser.Dom.DomConvert.NullableText(self.Target.TextContent);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("Node.textContent", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INode>(thisObj, "Node.textContent");
                     self.Target.TextContent = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Node.textContent"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>Attr</c>.</summary>
@@ -237,52 +237,52 @@ internal static partial class DomInterfaces
             .ToStringTag("Attr")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("localName",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Attr.localName", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IAttr>(thisObj, "Attr.localName");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.LocalName);
-                })
+                }))
             .Accessor("name",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Attr.name", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IAttr>(thisObj, "Attr.name");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Name);
-                })
+                }))
             .Accessor("namespaceURI",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Attr.namespaceURI", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IAttr>(thisObj, "Attr.namespaceURI");
                     return global::Jint.Browser.Dom.DomConvert.NullableText(self.Target.NamespaceUri);
-                })
+                }))
             .Accessor("ownerElement",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Attr.ownerElement", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IAttr>(thisObj, "Attr.ownerElement");
                     return self.Realm.WrapNodeValue(self.Target.OwnerElement);
-                })
+                }))
             .Accessor("prefix",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Attr.prefix", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IAttr>(thisObj, "Attr.prefix");
                     return global::Jint.Browser.Dom.DomConvert.NullableText(self.Target.Prefix);
-                })
+                }))
             .Accessor("specified",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Attr.specified", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IAttr>(thisObj, "Attr.specified");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsSpecified);
-                })
+                }))
             .Accessor("value",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Attr.value", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IAttr>(thisObj, "Attr.value");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Value);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("Attr.value", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IAttr>(thisObj, "Attr.value");
                     self.Target.Value = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Attr.value"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>StyleSheet</c>.</summary>
@@ -291,51 +291,51 @@ internal static partial class DomInterfaces
             .ToStringTag("StyleSheet")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("disabled",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("StyleSheet.disabled", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IStyleSheet>(thisObj, "StyleSheet.disabled");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsDisabled);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("StyleSheet.disabled", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IStyleSheet>(thisObj, "StyleSheet.disabled");
                     self.Target.IsDisabled = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("href",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("StyleSheet.href", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IStyleSheet>(thisObj, "StyleSheet.href");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Href);
-                })
+                }))
             .Accessor("media",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("StyleSheet.media", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IStyleSheet>(thisObj, "StyleSheet.media");
                     return self.Realm.Wrap(self.Target.Media);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("StyleSheet.media", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IStyleSheet>(thisObj, "StyleSheet.media");
                     var forwardTarget = self.Target.Media; if (forwardTarget is not null) { forwardTarget.MediaText = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "StyleSheet.media"); } return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("ownerNode",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("StyleSheet.ownerNode", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IStyleSheet>(thisObj, "StyleSheet.ownerNode");
                     return self.Realm.WrapNodeValue(self.Target.OwnerNode);
-                })
+                }))
             .Accessor("title",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("StyleSheet.title", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IStyleSheet>(thisObj, "StyleSheet.title");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Title);
-                })
+                }))
             .Accessor("type",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("StyleSheet.type", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IStyleSheet>(thisObj, "StyleSheet.type");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Type);
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>CharacterData</c>.</summary>
@@ -344,96 +344,96 @@ internal static partial class DomInterfaces
             .ToStringTag("CharacterData")
             .PerRealmSlot("constructor", enumerable: false)
             .Method("after",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CharacterData.after", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ICharacterData>(thisObj, "CharacterData.after");
                     self.Target.After(global::Jint.Browser.Dom.DomConvert.ObjectRest<global::AngleSharp.Dom.INode>(args, 0, "CharacterData.after")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Method("appendData",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CharacterData.appendData", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ICharacterData>(thisObj, "CharacterData.appendData");
                     self.Target.Append(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CharacterData.appendData")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 1)
             .Method("before",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CharacterData.before", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ICharacterData>(thisObj, "CharacterData.before");
                     self.Target.Before(global::Jint.Browser.Dom.DomConvert.ObjectRest<global::AngleSharp.Dom.INode>(args, 0, "CharacterData.before")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Accessor("data",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CharacterData.data", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ICharacterData>(thisObj, "CharacterData.data");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Data);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CharacterData.data", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ICharacterData>(thisObj, "CharacterData.data");
                     self.Target.Data = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "CharacterData.data"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Method("deleteData",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CharacterData.deleteData", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ICharacterData>(thisObj, "CharacterData.deleteData");
                     self.Target.Delete(global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "CharacterData.deleteData"), global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 1, "CharacterData.deleteData")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 2)
             .Method("insertData",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CharacterData.insertData", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ICharacterData>(thisObj, "CharacterData.insertData");
                     self.Target.Insert(global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "CharacterData.insertData"), global::Jint.Browser.Dom.DomConvert.RequiredText(args, 1, "CharacterData.insertData")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 2)
             .Accessor("length",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CharacterData.length", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ICharacterData>(thisObj, "CharacterData.length");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Length);
-                })
+                }))
             .Accessor("nextElementSibling",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CharacterData.nextElementSibling", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ICharacterData>(thisObj, "CharacterData.nextElementSibling");
                     return self.Realm.WrapNodeValue(self.Target.NextElementSibling);
-                })
+                }))
             .Accessor("previousElementSibling",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CharacterData.previousElementSibling", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ICharacterData>(thisObj, "CharacterData.previousElementSibling");
                     return self.Realm.WrapNodeValue(self.Target.PreviousElementSibling);
-                })
+                }))
             .Method("remove",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CharacterData.remove", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ICharacterData>(thisObj, "CharacterData.remove");
                     self.Target.Remove(); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Method("replace",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CharacterData.replace", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ICharacterData>(thisObj, "CharacterData.replace");
                     self.Target.Replace(global::Jint.Browser.Dom.DomConvert.ObjectRest<global::AngleSharp.Dom.INode>(args, 0, "CharacterData.replace")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Method("replaceData",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CharacterData.replaceData", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ICharacterData>(thisObj, "CharacterData.replaceData");
                     self.Target.Replace(global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "CharacterData.replaceData"), global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 1, "CharacterData.replaceData"), global::Jint.Browser.Dom.DomConvert.RequiredText(args, 2, "CharacterData.replaceData")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 3)
             .Method("substringData",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CharacterData.substringData", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ICharacterData>(thisObj, "CharacterData.substringData");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Substring(global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "CharacterData.substringData"), global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 1, "CharacterData.substringData")));
-                },
+                }),
                 length: 2)
             .Build();
 
@@ -450,11 +450,11 @@ internal static partial class DomInterfaces
             .ToStringTag("DOMException")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("code",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("DOMException.code", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDomException>(thisObj, "DOMException.code");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Code);
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>DOMImplementation</c>.</summary>
@@ -463,25 +463,25 @@ internal static partial class DomInterfaces
             .ToStringTag("DOMImplementation")
             .PerRealmSlot("constructor", enumerable: false)
             .Method("createDocumentType",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("DOMImplementation.createDocumentType", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IImplementation>(thisObj, "DOMImplementation.createDocumentType");
                     return self.Realm.WrapNodeValue(self.Target.CreateDocumentType(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "DOMImplementation.createDocumentType"), global::Jint.Browser.Dom.DomConvert.RequiredText(args, 1, "DOMImplementation.createDocumentType"), global::Jint.Browser.Dom.DomConvert.RequiredText(args, 2, "DOMImplementation.createDocumentType")));
-                },
+                }),
                 length: 3)
             .Method("createHTMLDocument",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("DOMImplementation.createHTMLDocument", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IImplementation>(thisObj, "DOMImplementation.createHTMLDocument");
                     return self.Realm.WrapNodeValue(self.Target.CreateHtmlDocument(global::Jint.Browser.Dom.DomConvert.OptionalText(args, 0, "")!));
-                },
+                }),
                 length: 0)
             .Method("hasFeature",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("DOMImplementation.hasFeature", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IImplementation>(thisObj, "DOMImplementation.hasFeature");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.HasFeature(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "DOMImplementation.hasFeature"), global::Jint.Browser.Dom.DomConvert.OptionalText(args, 1, null)!));
-                },
+                }),
                 length: 1)
             .Build();
 
@@ -491,39 +491,39 @@ internal static partial class DomInterfaces
             .ToStringTag("DOMTokenList")
             .PerRealmSlot("constructor", enumerable: false)
             .Method("add",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("DOMTokenList.add", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ITokenList>(thisObj, "DOMTokenList.add");
                     self.Target.Add(global::Jint.Browser.Dom.DomConvert.TextRest(args, 0)); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Method("contains",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("DOMTokenList.contains", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ITokenList>(thisObj, "DOMTokenList.contains");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.Contains(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "DOMTokenList.contains")));
-                },
+                }),
                 length: 1)
             .Method("item",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("DOMTokenList.item", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ITokenList>(thisObj, "DOMTokenList.item");
                     return global::Jint.Browser.Dom.DomConvert.Text(((global::System.Collections.Generic.IReadOnlyList<global::System.String>) self.Target)[global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "DOMTokenList.item")]);
-                },
+                }),
                 length: 1)
             .Method("remove",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("DOMTokenList.remove", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ITokenList>(thisObj, "DOMTokenList.remove");
                     self.Target.Remove(global::Jint.Browser.Dom.DomConvert.TextRest(args, 0)); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Method("toggle",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("DOMTokenList.toggle", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ITokenList>(thisObj, "DOMTokenList.toggle");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.Toggle(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "DOMTokenList.toggle"), global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 1, false)));
-                },
+                }),
                 length: 1)
             .Build();
 
@@ -533,16 +533,16 @@ internal static partial class DomInterfaces
             .ToStringTag("DOMSettableTokenList")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("value",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("DOMSettableTokenList.value", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ISettableTokenList>(thisObj, "DOMSettableTokenList.value");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Value);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("DOMSettableTokenList.value", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ISettableTokenList>(thisObj, "DOMSettableTokenList.value");
                     self.Target.Value = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "DOMSettableTokenList.value"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>DOMStringList</c>.</summary>
@@ -551,18 +551,18 @@ internal static partial class DomInterfaces
             .ToStringTag("DOMStringList")
             .PerRealmSlot("constructor", enumerable: false)
             .Method("contains",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("DOMStringList.contains", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IStringList>(thisObj, "DOMStringList.contains");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.Contains(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "DOMStringList.contains")));
-                },
+                }),
                 length: 1)
             .Method("item",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("DOMStringList.item", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IStringList>(thisObj, "DOMStringList.item");
                     return global::Jint.Browser.Dom.DomConvert.Text(((global::System.Collections.Generic.IReadOnlyList<global::System.String>) self.Target)[global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "DOMStringList.item")]);
-                },
+                }),
                 length: 1)
             .Build();
 
@@ -580,501 +580,501 @@ internal static partial class DomInterfaces
             .ToStringTag("Document")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("URL",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.URL", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.URL");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Url);
-                })
+                }))
             .Accessor("activeElement",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.activeElement", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.activeElement");
                     var element = global::Jint.Browser.Events.FocusController.ActiveElement(global::Jint.Browser.Events.BrowserEventRealm.Of(self.Realm.Engine), self.Target);
                     return element is null ? global::Jint.Native.JsValue.Null : self.Realm.WrapNode(element);
-                })
+                }))
             .Method("adoptNode",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.adoptNode", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.adoptNode");
                     return self.Realm.WrapNodeValue(self.Target.Adopt(global::Jint.Browser.Dom.DomBindings.Argument<global::AngleSharp.Dom.INode>(args, 0, "Document.adoptNode")));
-                },
+                }),
                 length: 1)
             .Accessor("all",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.all", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.all");
                     return self.Realm.WrapCollection<global::AngleSharp.Dom.IElement>(self.Target.All);
-                })
+                }))
             .Accessor("anchors",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.anchors", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.anchors");
                     return self.Realm.WrapCollection<global::AngleSharp.Html.Dom.IHtmlAnchorElement>(self.Target.Anchors);
-                })
+                }))
             .Method("append",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.append", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.append");
                     self.Target.Append(global::Jint.Browser.Dom.DomConvert.ObjectRest<global::AngleSharp.Dom.INode>(args, 0, "Document.append")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Accessor("body",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.body", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.body");
                     return self.Realm.WrapNodeValue(self.Target.Body);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.body", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.body");
                     self.Target.Body = global::Jint.Browser.Dom.DomBindings.Argument<global::AngleSharp.Html.Dom.IHtmlElement>(args, 0, "Document.body"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("characterSet",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.characterSet", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.characterSet");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.CharacterSet);
-                })
+                }))
             .Accessor("childElementCount",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.childElementCount", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.childElementCount");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.ChildElementCount);
-                })
+                }))
             .Accessor("children",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.children", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.children");
                     return self.Realm.WrapCollection<global::AngleSharp.Dom.IElement>(self.Target.Children);
-                })
+                }))
             .Accessor("commands",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.commands", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.commands");
                     return self.Realm.WrapCollection<global::AngleSharp.Dom.IElement>(self.Target.Commands);
-                })
+                }))
             .Accessor("compatMode",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.compatMode", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.compatMode");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.CompatMode);
-                })
+                }))
             .Accessor("contentType",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.contentType", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.contentType");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.ContentType);
-                })
+                }))
             .Accessor("cookie",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.cookie", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.cookie");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Cookie);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.cookie", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.cookie");
                     self.Target.Cookie = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Document.cookie"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Method("createAttribute",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.createAttribute", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.createAttribute");
                     return self.Realm.WrapNodeValue(self.Target.CreateAttribute(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Document.createAttribute")));
-                },
+                }),
                 length: 1)
             .Method("createAttributeNS",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.createAttributeNS", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.createAttributeNS");
                     return self.Realm.WrapNodeValue(self.Target.CreateAttribute(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Document.createAttributeNS"), global::Jint.Browser.Dom.DomConvert.RequiredText(args, 1, "Document.createAttributeNS")));
-                },
+                }),
                 length: 2)
             .Method("createComment",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.createComment", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.createComment");
                     return self.Realm.WrapNodeValue(self.Target.CreateComment(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Document.createComment")));
-                },
+                }),
                 length: 1)
             .Method("createDocumentFragment",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.createDocumentFragment", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.createDocumentFragment");
                     return self.Realm.WrapNodeValue(self.Target.CreateDocumentFragment());
-                },
+                }),
                 length: 0)
             .Method("createElement",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.createElement", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.createElement");
                     return global::Jint.Browser.CustomElements.CustomElementCreation.CreateElement(self.Realm, self.Target, args);
-                },
+                }),
                 length: 1)
             .Method("createElementNS",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.createElementNS", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.createElementNS");
                     return global::Jint.Browser.CustomElements.CustomElementCreation.CreateElementNS(self.Realm, self.Target, args);
-                },
+                }),
                 length: 2)
             .Method("createEvent",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.createEvent", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.createEvent");
                     return global::Jint.Browser.Events.LegacyEventCreation.CreateEvent(self.Realm, args);
-                },
+                }),
                 length: 1)
             .Method("createExpression",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.createExpression", static (thisObj, args) =>
                 {
                     _ = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.createExpression");
                     return global::Jint.Browser.Dom.Views.XPathEvaluation.CreateExpression(global::Jint.Browser.Runtime.PageRuntime.Of(thisObj, "Document.createExpression"), args, "Document.createExpression");
-                },
+                }),
                 length: 1)
             .Method("createNSResolver",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.createNSResolver", static (thisObj, args) =>
                 {
                     _ = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.createNSResolver");
                     return global::Jint.Browser.Dom.Views.XPathEvaluation.CreateNSResolver(args, "Document.createNSResolver");
-                },
+                }),
                 length: 1)
             .Method("createNodeIterator",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.createNodeIterator", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.createNodeIterator");
                     return global::Jint.Browser.Dom.Views.DomViewMembers.CreateNodeIterator(self.Realm, self.Target, args);
-                },
+                }),
                 length: 1)
             .Method("createProcessingInstruction",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.createProcessingInstruction", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.createProcessingInstruction");
                     return self.Realm.WrapNodeValue(self.Target.CreateProcessingInstruction(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Document.createProcessingInstruction"), global::Jint.Browser.Dom.DomConvert.RequiredText(args, 1, "Document.createProcessingInstruction")));
-                },
+                }),
                 length: 2)
             .Method("createRange",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.createRange", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.createRange");
                     return self.Realm.Wrap(self.Target.CreateRange());
-                },
+                }),
                 length: 0)
             .Method("createTextNode",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.createTextNode", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.createTextNode");
                     return self.Realm.WrapNodeValue(self.Target.CreateTextNode(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Document.createTextNode")));
-                },
+                }),
                 length: 1)
             .Method("createTreeWalker",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.createTreeWalker", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.createTreeWalker");
                     return global::Jint.Browser.Dom.Views.DomViewMembers.CreateTreeWalker(self.Realm, self.Target, args);
-                },
+                }),
                 length: 1)
             .Accessor("currentScript",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.currentScript", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.currentScript");
                     return self.Realm.WrapNodeValue(self.Target.CurrentScript);
-                })
+                }))
             .Accessor("designMode",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.designMode", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.designMode");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.DesignMode);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.designMode", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.designMode");
                     self.Target.DesignMode = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Document.designMode"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("dir",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.dir", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.dir");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Direction);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.dir", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.dir");
                     self.Target.Direction = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Document.dir"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("doctype",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.doctype", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.doctype");
                     return self.Realm.WrapNodeValue(self.Target.Doctype);
-                })
+                }))
             .Accessor("documentElement",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.documentElement", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.documentElement");
                     return self.Realm.WrapNodeValue(self.Target.DocumentElement);
-                })
+                }))
             .Accessor("documentURI",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.documentURI", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.documentURI");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.DocumentUri);
-                })
+                }))
             .Accessor("domain",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.domain", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.domain");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Domain);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.domain", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.domain");
                     self.Target.Domain = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Document.domain"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Method("elementFromPoint",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.elementFromPoint", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.elementFromPoint");
                     return global::Jint.Browser.Layout.LayoutMembers.ElementFromPoint(self.Realm, args);
-                },
+                }),
                 length: 2)
             .Method("elementsFromPoint",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.elementsFromPoint", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.elementsFromPoint");
                     return global::Jint.Browser.Layout.LayoutMembers.ElementsFromPoint(self.Realm, args);
-                },
+                }),
                 length: 2)
             .Accessor("embeds",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.embeds", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.embeds");
                     return self.Realm.WrapCollection<global::AngleSharp.Html.Dom.IHtmlEmbedElement>(self.Target.Plugins);
-                })
+                }))
             .Method("enableStyleSheetsForSet",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.enableStyleSheetsForSet", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.enableStyleSheetsForSet");
                     self.Target.EnableStyleSheetsForSet(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Document.enableStyleSheetsForSet")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 1)
             .Method("evaluate",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.evaluate", static (thisObj, args) =>
                 {
                     _ = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.evaluate");
                     return global::Jint.Browser.Dom.Views.XPathEvaluation.Evaluate(global::Jint.Browser.Runtime.PageRuntime.Of(thisObj, "Document.evaluate"), args, "Document.evaluate");
-                },
+                }),
                 length: 2)
             .Method("execCommand",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.execCommand", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.execCommand");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.ExecuteCommand(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Document.execCommand"), global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 1, false), global::Jint.Browser.Dom.DomConvert.OptionalText(args, 2, "")!));
-                },
+                }),
                 length: 1)
             .Accessor("firstElementChild",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.firstElementChild", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.firstElementChild");
                     return self.Realm.WrapNodeValue(self.Target.FirstElementChild);
-                })
+                }))
             .Accessor("forms",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.forms", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.forms");
                     return self.Realm.WrapCollection<global::AngleSharp.Html.Dom.IHtmlFormElement>(self.Target.Forms);
-                })
+                }))
             .Method("getElementById",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.getElementById", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.getElementById");
                     return self.Realm.WrapNodeValue(self.Target.GetElementById(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Document.getElementById")));
-                },
+                }),
                 length: 1)
             .Method("getElementsByClassName",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.getElementsByClassName", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.getElementsByClassName");
                     return self.Realm.WrapCollection<global::AngleSharp.Dom.IElement>(self.Target.GetElementsByClassName(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Document.getElementsByClassName")));
-                },
+                }),
                 length: 1)
             .Method("getElementsByName",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.getElementsByName", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.getElementsByName");
                     return self.Realm.WrapCollection<global::AngleSharp.Dom.IElement>(self.Target.GetElementsByName(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Document.getElementsByName")));
-                },
+                }),
                 length: 1)
             .Method("getElementsByTagName",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.getElementsByTagName", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.getElementsByTagName");
                     return self.Realm.WrapCollection<global::AngleSharp.Dom.IElement>(self.Target.GetElementsByTagName(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Document.getElementsByTagName")));
-                },
+                }),
                 length: 1)
             .Method("getElementsByTagNameNS",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.getElementsByTagNameNS", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.getElementsByTagNameNS");
                     return self.Realm.WrapCollection<global::AngleSharp.Dom.IElement>(self.Target.GetElementsByTagName(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Document.getElementsByTagNameNS"), global::Jint.Browser.Dom.DomConvert.RequiredText(args, 1, "Document.getElementsByTagNameNS")));
-                },
+                }),
                 length: 2)
             .Method("getSelection",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.getSelection", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.getSelection");
                     return global::Jint.Browser.Dom.Views.DomViewMembers.GetSelection(self.Realm);
-                },
+                }),
                 length: 0)
             .Method("hasFocus",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.hasFocus", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.hasFocus");
                     return global::Jint.Native.JsBoolean.Create(global::Jint.Browser.Events.BrowserEventRealm.Of(self.Realm.Engine).DocumentHasFocus);
-                },
+                }),
                 length: 0)
             .Accessor("head",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.head", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.head");
                     return self.Realm.WrapNodeValue(self.Target.Head);
-                })
+                }))
             .Accessor("hidden",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.hidden", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.hidden");
                     return global::Jint.Native.JsBoolean.Create(global::Jint.Browser.Runtime.PageRuntime.Find(self.Realm.Engine) is { } page && page.VisibilityState != "visible");
-                })
+                }))
             .Accessor("images",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.images", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.images");
                     return self.Realm.WrapCollection<global::AngleSharp.Html.Dom.IHtmlImageElement>(self.Target.Images);
-                })
+                }))
             .Accessor("implementation",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.implementation", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.implementation");
                     return self.Realm.Wrap(self.Target.Implementation);
-                })
+                }))
             .Method("importNode",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.importNode", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.importNode");
                     return self.Realm.WrapNodeValue(self.Target.Import(global::Jint.Browser.Dom.DomBindings.Argument<global::AngleSharp.Dom.INode>(args, 0, "Document.importNode"), global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 1, true)));
-                },
+                }),
                 length: 1)
             .Accessor("lastElementChild",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.lastElementChild", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.lastElementChild");
                     return self.Realm.WrapNodeValue(self.Target.LastElementChild);
-                })
+                }))
             .Accessor("lastModified",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.lastModified", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.lastModified");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.LastModified);
-                })
+                }))
             .Accessor("lastStyleSheetSet",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.lastStyleSheetSet", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.lastStyleSheetSet");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.LastStyleSheetSet);
-                })
+                }))
             .Accessor("links",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.links", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.links");
                     return self.Realm.WrapCollection<global::AngleSharp.Dom.IElement>(self.Target.Links);
-                })
+                }))
             .Accessor("location",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.location", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.location");
                     return self.Realm.Wrap(self.Target.Location);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.location", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.location");
                     var forwardTarget = self.Target.Location; if (forwardTarget is not null) { forwardTarget.Href = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Document.location"); } return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("origin",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.origin", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.origin");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Origin);
-                })
+                }))
             .Accessor("plugins",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.plugins", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.plugins");
                     return self.Realm.WrapCollection<global::AngleSharp.Html.Dom.IHtmlEmbedElement>(self.Target.Plugins);
-                })
+                }))
             .Accessor("preferredStyleSheetSet",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.preferredStyleSheetSet", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.preferredStyleSheetSet");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.PreferredStyleSheetSet);
-                })
+                }))
             .Method("prepend",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.prepend", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.prepend");
                     self.Target.Prepend(global::Jint.Browser.Dom.DomConvert.ObjectRest<global::AngleSharp.Dom.INode>(args, 0, "Document.prepend")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Method("queryCommandEnabled",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.queryCommandEnabled", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.queryCommandEnabled");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsCommandEnabled(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Document.queryCommandEnabled")));
-                },
+                }),
                 length: 1)
             .Method("queryCommandIndeterm",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.queryCommandIndeterm", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.queryCommandIndeterm");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsCommandIndeterminate(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Document.queryCommandIndeterm")));
-                },
+                }),
                 length: 1)
             .Method("queryCommandState",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.queryCommandState", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.queryCommandState");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsCommandExecuted(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Document.queryCommandState")));
-                },
+                }),
                 length: 1)
             .Method("queryCommandSupported",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.queryCommandSupported", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.queryCommandSupported");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsCommandSupported(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Document.queryCommandSupported")));
-                },
+                }),
                 length: 1)
             .Method("queryCommandValue",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.queryCommandValue", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.queryCommandValue");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetCommandValue(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Document.queryCommandValue")));
-                },
+                }),
                 length: 1)
             .Method("querySelector",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.querySelector", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.querySelector");
                     return global::Jint.Browser.Dom.DomSelectorMembers.QuerySelector(self.Realm, self.Target, args, "Document.querySelector");
-                },
+                }),
                 length: 1)
             .Method("querySelectorAll",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.querySelectorAll", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.querySelectorAll");
                     return global::Jint.Browser.Dom.DomSelectorMembers.QuerySelectorAll(self.Realm, self.Target, args, "Document.querySelectorAll");
-                },
+                }),
                 length: 1)
             .Accessor("readyState",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.readyState", static (thisObj, args) =>
                 {
                     if (!global::Jint.Browser.Dom.DomBindings.TryBind<global::AngleSharp.Dom.IDocument>(thisObj, out var self))
                     {
@@ -1082,78 +1082,78 @@ internal static partial class DomInterfaces
                     }
 
                     return global::Jint.Browser.Dom.DomEnums.FromDocumentReadyState(self.Target.ReadyState);
-                })
+                }))
             .Accessor("referrer",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.referrer", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.referrer");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Referrer);
-                })
+                }))
             .Accessor("scripts",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.scripts", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.scripts");
                     return self.Realm.WrapCollection<global::AngleSharp.Html.Dom.IHtmlScriptElement>(self.Target.Scripts);
-                })
+                }))
             .Accessor("scrollingElement",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.scrollingElement", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.scrollingElement");
                     return global::Jint.Browser.Layout.LayoutMembers.ScrollingElement(self.Realm, self.Target);
-                })
+                }))
             .Accessor("selectedStyleSheetSet",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.selectedStyleSheetSet", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.selectedStyleSheetSet");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.SelectedStyleSheetSet);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.selectedStyleSheetSet", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.selectedStyleSheetSet");
                     self.Target.SelectedStyleSheetSet = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Document.selectedStyleSheetSet"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("styleSheetSets",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.styleSheetSets", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.styleSheetSets");
                     return self.Realm.Wrap(self.Target.StyleSheetSets);
-                })
+                }))
             .Accessor("styleSheets",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.styleSheets", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.styleSheets");
                     return self.Realm.Wrap(self.Target.StyleSheets);
-                })
+                }))
             .Accessor("title",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.title", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.title");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Title);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.title", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.title");
                     self.Target.Title = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Document.title"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("visibilityState",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.visibilityState", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.visibilityState");
                     return global::Jint.Native.JsString.Create(global::Jint.Browser.Runtime.PageRuntime.Find(self.Realm.Engine)?.VisibilityState ?? "visible");
-                })
+                }))
             .Method("write",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.write", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.write");
                     self.Realm.Hooks.Write(self.Realm, self.Target, args); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 1)
             .Method("writeln",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.writeln", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.writeln");
                     self.Realm.Hooks.WriteLine(self.Realm, self.Target, args); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 1);
 
         global::Jint.Browser.Events.DomShapeAdditions.DocumentHandlers(builder);
@@ -1166,63 +1166,63 @@ internal static partial class DomInterfaces
             .ToStringTag("DocumentFragment")
             .PerRealmSlot("constructor", enumerable: false)
             .Method("append",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("DocumentFragment.append", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocumentFragment>(thisObj, "DocumentFragment.append");
                     self.Target.Append(global::Jint.Browser.Dom.DomConvert.ObjectRest<global::AngleSharp.Dom.INode>(args, 0, "DocumentFragment.append")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Accessor("childElementCount",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("DocumentFragment.childElementCount", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocumentFragment>(thisObj, "DocumentFragment.childElementCount");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.ChildElementCount);
-                })
+                }))
             .Accessor("children",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("DocumentFragment.children", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocumentFragment>(thisObj, "DocumentFragment.children");
                     return self.Realm.WrapCollection<global::AngleSharp.Dom.IElement>(self.Target.Children);
-                })
+                }))
             .Accessor("firstElementChild",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("DocumentFragment.firstElementChild", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocumentFragment>(thisObj, "DocumentFragment.firstElementChild");
                     return self.Realm.WrapNodeValue(self.Target.FirstElementChild);
-                })
+                }))
             .Method("getElementById",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("DocumentFragment.getElementById", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocumentFragment>(thisObj, "DocumentFragment.getElementById");
                     return self.Realm.WrapNodeValue(self.Target.GetElementById(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "DocumentFragment.getElementById")));
-                },
+                }),
                 length: 1)
             .Accessor("lastElementChild",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("DocumentFragment.lastElementChild", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocumentFragment>(thisObj, "DocumentFragment.lastElementChild");
                     return self.Realm.WrapNodeValue(self.Target.LastElementChild);
-                })
+                }))
             .Method("prepend",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("DocumentFragment.prepend", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocumentFragment>(thisObj, "DocumentFragment.prepend");
                     self.Target.Prepend(global::Jint.Browser.Dom.DomConvert.ObjectRest<global::AngleSharp.Dom.INode>(args, 0, "DocumentFragment.prepend")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Method("querySelector",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("DocumentFragment.querySelector", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocumentFragment>(thisObj, "DocumentFragment.querySelector");
                     return global::Jint.Browser.Dom.DomSelectorMembers.QuerySelector(self.Realm, self.Target, args, "DocumentFragment.querySelector");
-                },
+                }),
                 length: 1)
             .Method("querySelectorAll",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("DocumentFragment.querySelectorAll", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocumentFragment>(thisObj, "DocumentFragment.querySelectorAll");
                     return global::Jint.Browser.Dom.DomSelectorMembers.QuerySelectorAll(self.Realm, self.Target, args, "DocumentFragment.querySelectorAll");
-                },
+                }),
                 length: 1)
             .Build();
 
@@ -1232,51 +1232,51 @@ internal static partial class DomInterfaces
             .ToStringTag("DocumentType")
             .PerRealmSlot("constructor", enumerable: false)
             .Method("after",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("DocumentType.after", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocumentType>(thisObj, "DocumentType.after");
                     self.Target.After(global::Jint.Browser.Dom.DomConvert.ObjectRest<global::AngleSharp.Dom.INode>(args, 0, "DocumentType.after")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Method("before",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("DocumentType.before", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocumentType>(thisObj, "DocumentType.before");
                     self.Target.Before(global::Jint.Browser.Dom.DomConvert.ObjectRest<global::AngleSharp.Dom.INode>(args, 0, "DocumentType.before")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Accessor("name",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("DocumentType.name", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocumentType>(thisObj, "DocumentType.name");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Name);
-                })
+                }))
             .Accessor("publicId",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("DocumentType.publicId", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocumentType>(thisObj, "DocumentType.publicId");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.PublicIdentifier);
-                })
+                }))
             .Method("remove",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("DocumentType.remove", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocumentType>(thisObj, "DocumentType.remove");
                     self.Target.Remove(); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Method("replace",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("DocumentType.replace", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocumentType>(thisObj, "DocumentType.replace");
                     self.Target.Replace(global::Jint.Browser.Dom.DomConvert.ObjectRest<global::AngleSharp.Dom.INode>(args, 0, "DocumentType.replace")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Accessor("systemId",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("DocumentType.systemId", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocumentType>(thisObj, "DocumentType.systemId");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.SystemIdentifier);
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>Element</c>.</summary>
@@ -1285,406 +1285,406 @@ internal static partial class DomInterfaces
             .ToStringTag("Element")
             .PerRealmSlot("constructor", enumerable: false)
             .Method("after",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.after", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.after");
                     self.Target.After(global::Jint.Browser.Dom.DomConvert.ObjectRest<global::AngleSharp.Dom.INode>(args, 0, "Element.after")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Method("append",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.append", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.append");
                     self.Target.Append(global::Jint.Browser.Dom.DomConvert.ObjectRest<global::AngleSharp.Dom.INode>(args, 0, "Element.append")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Accessor("assignedSlot",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.assignedSlot", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.assignedSlot");
                     return self.Realm.WrapNodeValue(self.Target.AssignedSlot);
-                })
+                }))
             .Method("attachShadow",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.attachShadow", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.attachShadow");
                     return self.Realm.WrapNodeValue(self.Target.AttachShadow(global::Jint.Browser.Dom.DomEnums.ToShadowRootMode(global::Jint.Browser.Dom.DomConvert.DictionaryMember(args, 0, "mode"), "Element.attachShadow")));
-                },
+                }),
                 length: 0)
             .Accessor("attributes",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.attributes", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.attributes");
                     return self.Realm.Wrap(self.Target.Attributes);
-                })
+                }))
             .Method("before",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.before", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.before");
                     self.Target.Before(global::Jint.Browser.Dom.DomConvert.ObjectRest<global::AngleSharp.Dom.INode>(args, 0, "Element.before")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Accessor("childElementCount",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.childElementCount", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.childElementCount");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.ChildElementCount);
-                })
+                }))
             .Accessor("children",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.children", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.children");
                     return self.Realm.WrapCollection<global::AngleSharp.Dom.IElement>(self.Target.Children);
-                })
+                }))
             .Accessor("classList",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.classList", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.classList");
                     return self.Realm.Wrap(self.Target.ClassList);
-                })
+                }))
             .Accessor("className",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.className", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.className");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.ClassName);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.className", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.className");
                     self.Target.ClassName = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Element.className"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("clientHeight",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.clientHeight", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.clientHeight");
                     return global::Jint.Browser.Layout.LayoutMembers.ClientHeight(self.Realm, self.Target);
-                })
+                }))
             .Accessor("clientLeft",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.clientLeft", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.clientLeft");
                     return global::Jint.Browser.Layout.LayoutMembers.ClientEdge(self.Realm, self.Target);
-                })
+                }))
             .Accessor("clientTop",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.clientTop", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.clientTop");
                     return global::Jint.Browser.Layout.LayoutMembers.ClientEdge(self.Realm, self.Target);
-                })
+                }))
             .Accessor("clientWidth",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.clientWidth", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.clientWidth");
                     return global::Jint.Browser.Layout.LayoutMembers.ClientWidth(self.Realm, self.Target);
-                })
+                }))
             .Method("closest",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.closest", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.closest");
                     return global::Jint.Browser.Dom.DomSelectorMembers.Closest(self.Realm, self.Target, args);
-                },
+                }),
                 length: 1)
             .Accessor("firstElementChild",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.firstElementChild", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.firstElementChild");
                     return self.Realm.WrapNodeValue(self.Target.FirstElementChild);
-                })
+                }))
             .Method("getAttribute",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.getAttribute", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.getAttribute");
                     return global::Jint.Browser.Dom.DomConvert.NullableText(self.Target.GetAttribute(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Element.getAttribute")));
-                },
+                }),
                 length: 1)
             .Method("getAttributeNS",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.getAttributeNS", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.getAttributeNS");
                     return global::Jint.Browser.Dom.DomConvert.NullableText(self.Target.GetAttribute(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Element.getAttributeNS"), global::Jint.Browser.Dom.DomConvert.RequiredText(args, 1, "Element.getAttributeNS")));
-                },
+                }),
                 length: 2)
             .Method("getBoundingClientRect",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.getBoundingClientRect", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.getBoundingClientRect");
                     return global::Jint.Browser.Layout.LayoutMembers.BoundingClientRect(self.Realm, self.Target);
-                },
+                }),
                 length: 0)
             .Method("getClientRects",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.getClientRects", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.getClientRects");
                     return global::Jint.Browser.Layout.LayoutMembers.ClientRects(self.Realm, self.Target);
-                },
+                }),
                 length: 0)
             .Method("getElementsByClassName",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.getElementsByClassName", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.getElementsByClassName");
                     return self.Realm.WrapCollection<global::AngleSharp.Dom.IElement>(self.Target.GetElementsByClassName(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Element.getElementsByClassName")));
-                },
+                }),
                 length: 1)
             .Method("getElementsByTagName",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.getElementsByTagName", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.getElementsByTagName");
                     return self.Realm.WrapCollection<global::AngleSharp.Dom.IElement>(self.Target.GetElementsByTagName(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Element.getElementsByTagName")));
-                },
+                }),
                 length: 1)
             .Method("getElementsByTagNameNS",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.getElementsByTagNameNS", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.getElementsByTagNameNS");
                     return self.Realm.WrapCollection<global::AngleSharp.Dom.IElement>(self.Target.GetElementsByTagNameNS(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Element.getElementsByTagNameNS"), global::Jint.Browser.Dom.DomConvert.RequiredText(args, 1, "Element.getElementsByTagNameNS")));
-                },
+                }),
                 length: 2)
             .Method("hasAttribute",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.hasAttribute", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.hasAttribute");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.HasAttribute(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Element.hasAttribute")));
-                },
+                }),
                 length: 1)
             .Method("hasAttributeNS",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.hasAttributeNS", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.hasAttributeNS");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.HasAttribute(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Element.hasAttributeNS"), global::Jint.Browser.Dom.DomConvert.RequiredText(args, 1, "Element.hasAttributeNS")));
-                },
+                }),
                 length: 2)
             .Accessor("id",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.id", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.id");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Id);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.id", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.id");
                     self.Target.Id = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Element.id"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("innerHTML",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.innerHTML", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.innerHTML");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.InnerHtml);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.innerHTML", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.innerHTML");
                     self.Realm.Hooks.SetInnerHtml(self.Realm, self.Target, global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Element.innerHTML")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("innerText",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.innerText", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.innerText");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.GetInnerText());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.innerText", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.innerText");
                     self.Target.SetInnerText(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Element.innerText")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Method("insertAdjacentHTML",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.insertAdjacentHTML", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.insertAdjacentHTML");
                     self.Realm.Hooks.InsertAdjacentHtml(self.Realm, self.Target, args); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 2)
             .Accessor("lastElementChild",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.lastElementChild", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.lastElementChild");
                     return self.Realm.WrapNodeValue(self.Target.LastElementChild);
-                })
+                }))
             .Accessor("localName",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.localName", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.localName");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.LocalName);
-                })
+                }))
             .Method("matches",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.matches", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.matches");
                     return global::Jint.Browser.Dom.DomSelectorMembers.Matches(self.Realm, self.Target, args, "Element.matches");
-                },
+                }),
                 length: 1)
             .Accessor("namespaceURI",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.namespaceURI", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.namespaceURI");
                     return global::Jint.Browser.Dom.DomConvert.NullableText(self.Target.NamespaceUri);
-                })
+                }))
             .Accessor("nextElementSibling",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.nextElementSibling", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.nextElementSibling");
                     return self.Realm.WrapNodeValue(self.Target.NextElementSibling);
-                })
+                }))
             .Accessor("outerHTML",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.outerHTML", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.outerHTML");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.OuterHtml);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.outerHTML", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.outerHTML");
                     self.Realm.Hooks.SetOuterHtml(self.Realm, self.Target, global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Element.outerHTML")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("prefix",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.prefix", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.prefix");
                     return global::Jint.Browser.Dom.DomConvert.NullableText(self.Target.Prefix);
-                })
+                }))
             .Method("prepend",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.prepend", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.prepend");
                     self.Target.Prepend(global::Jint.Browser.Dom.DomConvert.ObjectRest<global::AngleSharp.Dom.INode>(args, 0, "Element.prepend")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Accessor("previousElementSibling",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.previousElementSibling", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.previousElementSibling");
                     return self.Realm.WrapNodeValue(self.Target.PreviousElementSibling);
-                })
+                }))
             .Method("querySelector",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.querySelector", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.querySelector");
                     return global::Jint.Browser.Dom.DomSelectorMembers.QuerySelector(self.Realm, self.Target, args, "Element.querySelector");
-                },
+                }),
                 length: 1)
             .Method("querySelectorAll",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.querySelectorAll", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.querySelectorAll");
                     return global::Jint.Browser.Dom.DomSelectorMembers.QuerySelectorAll(self.Realm, self.Target, args, "Element.querySelectorAll");
-                },
+                }),
                 length: 1)
             .Method("remove",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.remove", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.remove");
                     self.Target.Remove(); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Method("removeAttribute",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.removeAttribute", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.removeAttribute");
                     self.Realm.Hooks.RemoveAttribute(self.Realm, self.Target, args); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 1)
             .Method("removeAttributeNS",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.removeAttributeNS", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.removeAttributeNS");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.RemoveAttribute(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Element.removeAttributeNS"), global::Jint.Browser.Dom.DomConvert.RequiredText(args, 1, "Element.removeAttributeNS")));
-                },
+                }),
                 length: 2)
             .Method("replace",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.replace", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.replace");
                     self.Target.Replace(global::Jint.Browser.Dom.DomConvert.ObjectRest<global::AngleSharp.Dom.INode>(args, 0, "Element.replace")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Accessor("scrollHeight",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.scrollHeight", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.scrollHeight");
                     return global::Jint.Browser.Layout.LayoutMembers.ScrollHeight(self.Realm, self.Target);
-                })
+                }))
             .Method("scrollIntoView",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.scrollIntoView", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.scrollIntoView");
                     return global::Jint.Browser.Layout.LayoutMembers.ScrollIntoView(self.Realm, self.Target, args);
-                },
+                }),
                 length: 0)
             .Accessor("scrollLeft",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.scrollLeft", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.scrollLeft");
                     return global::Jint.Browser.Layout.LayoutMembers.ScrollLeft(self.Realm, self.Target);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.scrollLeft", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.scrollLeft");
                     return global::Jint.Browser.Layout.LayoutMembers.SetScrollLeft(self.Realm, self.Target, args);
-                })
+                }))
             .Accessor("scrollTop",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.scrollTop", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.scrollTop");
                     return global::Jint.Browser.Layout.LayoutMembers.ScrollTop(self.Realm, self.Target);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.scrollTop", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.scrollTop");
                     return global::Jint.Browser.Layout.LayoutMembers.SetScrollTop(self.Realm, self.Target, args);
-                })
+                }))
             .Accessor("scrollWidth",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.scrollWidth", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.scrollWidth");
                     return global::Jint.Browser.Layout.LayoutMembers.ScrollWidth(self.Realm, self.Target);
-                })
+                }))
             .Method("setAttribute",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.setAttribute", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.setAttribute");
                     self.Realm.Hooks.SetAttribute(self.Realm, self.Target, args); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 2)
             .Method("setAttributeNS",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.setAttributeNS", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.setAttributeNS");
                     self.Target.SetAttribute(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Element.setAttributeNS"), global::Jint.Browser.Dom.DomConvert.RequiredText(args, 1, "Element.setAttributeNS"), global::Jint.Browser.Dom.DomConvert.RequiredText(args, 2, "Element.setAttributeNS")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 3)
             .Accessor("shadowRoot",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.shadowRoot", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.shadowRoot");
                     return self.Realm.WrapNodeValue(self.Target.ShadowRoot);
-                })
+                }))
             .Accessor("slot",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.slot", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.slot");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Slot);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.slot", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.slot");
                     self.Target.Slot = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Element.slot"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("style",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.style", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.style");
                     return self.Realm.Wrap(self.Target.GetStyle());
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.style", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.style");
                     self.Target.SetStyle(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Element.style")); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("tagName",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Element.tagName", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.tagName");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.TagName);
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLAllCollection</c>.</summary>
@@ -1700,116 +1700,116 @@ internal static partial class DomInterfaces
             .ToStringTag("Location")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("hash",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Location.hash", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ILocation>(thisObj, "Location.hash");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Hash);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("Location.hash", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ILocation>(thisObj, "Location.hash");
                     self.Target.Hash = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Location.hash"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("host",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Location.host", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ILocation>(thisObj, "Location.host");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Host);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("Location.host", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ILocation>(thisObj, "Location.host");
                     self.Target.Host = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Location.host"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("hostname",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Location.hostname", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ILocation>(thisObj, "Location.hostname");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.HostName);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("Location.hostname", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ILocation>(thisObj, "Location.hostname");
                     self.Target.HostName = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Location.hostname"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("href",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Location.href", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ILocation>(thisObj, "Location.href");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Href);
-                })
+                }))
             .Accessor("origin",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Location.origin", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ILocation>(thisObj, "Location.origin");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Origin);
-                })
+                }))
             .Accessor("password",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Location.password", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ILocation>(thisObj, "Location.password");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Password);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("Location.password", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ILocation>(thisObj, "Location.password");
                     self.Target.Password = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Location.password"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("pathname",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Location.pathname", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ILocation>(thisObj, "Location.pathname");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.PathName);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("Location.pathname", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ILocation>(thisObj, "Location.pathname");
                     self.Target.PathName = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Location.pathname"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("port",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Location.port", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ILocation>(thisObj, "Location.port");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Port);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("Location.port", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ILocation>(thisObj, "Location.port");
                     self.Target.Port = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Location.port"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("protocol",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Location.protocol", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ILocation>(thisObj, "Location.protocol");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Protocol);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("Location.protocol", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ILocation>(thisObj, "Location.protocol");
                     self.Target.Protocol = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Location.protocol"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("search",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Location.search", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ILocation>(thisObj, "Location.search");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Search);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("Location.search", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ILocation>(thisObj, "Location.search");
                     self.Target.Search = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Location.search"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("username",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Location.username", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ILocation>(thisObj, "Location.username");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.UserName);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("Location.username", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ILocation>(thisObj, "Location.username");
                     self.Target.UserName = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Location.username"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>MessagePort</c>.</summary>
@@ -1818,25 +1818,25 @@ internal static partial class DomInterfaces
             .ToStringTag("MessagePort")
             .PerRealmSlot("constructor", enumerable: false)
             .Method("close",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("MessagePort.close", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.Events.IMessagePort>(thisObj, "MessagePort.close");
                     self.Target.Close(); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Method("postMessage",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("MessagePort.postMessage", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.Events.IMessagePort>(thisObj, "MessagePort.postMessage");
                     self.Target.Send(global::Jint.Browser.Dom.DomConvert.At(args, 0)); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 1)
             .Method("start",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("MessagePort.start", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.Events.IMessagePort>(thisObj, "MessagePort.start");
                     self.Target.Open(); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Build();
 
@@ -1846,59 +1846,59 @@ internal static partial class DomInterfaces
             .ToStringTag("MutationRecord")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("addedNodes",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("MutationRecord.addedNodes", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IMutationRecord>(thisObj, "MutationRecord.addedNodes");
                     return self.Realm.Wrap(self.Target.Added);
-                })
+                }))
             .Accessor("attributeName",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("MutationRecord.attributeName", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IMutationRecord>(thisObj, "MutationRecord.attributeName");
                     return global::Jint.Browser.Dom.DomConvert.NullableText(self.Target.AttributeName);
-                })
+                }))
             .Accessor("attributeNamespace",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("MutationRecord.attributeNamespace", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IMutationRecord>(thisObj, "MutationRecord.attributeNamespace");
                     return global::Jint.Browser.Dom.DomConvert.NullableText(self.Target.AttributeNamespace);
-                })
+                }))
             .Accessor("nextSibling",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("MutationRecord.nextSibling", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IMutationRecord>(thisObj, "MutationRecord.nextSibling");
                     return self.Realm.WrapNodeValue(self.Target.NextSibling);
-                })
+                }))
             .Accessor("oldValue",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("MutationRecord.oldValue", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IMutationRecord>(thisObj, "MutationRecord.oldValue");
                     return global::Jint.Browser.Dom.DomConvert.NullableText(self.Target.PreviousValue);
-                })
+                }))
             .Accessor("previousSibling",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("MutationRecord.previousSibling", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IMutationRecord>(thisObj, "MutationRecord.previousSibling");
                     return self.Realm.WrapNodeValue(self.Target.PreviousSibling);
-                })
+                }))
             .Accessor("removedNodes",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("MutationRecord.removedNodes", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IMutationRecord>(thisObj, "MutationRecord.removedNodes");
                     return self.Realm.Wrap(self.Target.Removed);
-                })
+                }))
             .Accessor("target",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("MutationRecord.target", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IMutationRecord>(thisObj, "MutationRecord.target");
                     return self.Realm.WrapNodeValue(self.Target.Target);
-                })
+                }))
             .Accessor("type",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("MutationRecord.type", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IMutationRecord>(thisObj, "MutationRecord.type");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Type);
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>NamedNodeMap</c>.</summary>
@@ -1907,53 +1907,53 @@ internal static partial class DomInterfaces
             .ToStringTag("NamedNodeMap")
             .PerRealmSlot("constructor", enumerable: false)
             .Method("getNamedItem",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("NamedNodeMap.getNamedItem", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INamedNodeMap>(thisObj, "NamedNodeMap.getNamedItem");
                     return self.Realm.WrapNodeValue(self.Target.GetNamedItem(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "NamedNodeMap.getNamedItem")));
-                },
+                }),
                 length: 1)
             .Method("getNamedItemNS",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("NamedNodeMap.getNamedItemNS", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INamedNodeMap>(thisObj, "NamedNodeMap.getNamedItemNS");
                     return self.Realm.WrapNodeValue(self.Target.GetNamedItem(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "NamedNodeMap.getNamedItemNS"), global::Jint.Browser.Dom.DomConvert.RequiredText(args, 1, "NamedNodeMap.getNamedItemNS")));
-                },
+                }),
                 length: 2)
             .Method("item",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("NamedNodeMap.item", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INamedNodeMap>(thisObj, "NamedNodeMap.item");
                     return self.Realm.WrapNodeValue(self.Target[global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "NamedNodeMap.item")]);
-                },
+                }),
                 length: 1)
             .Method("removeNamedItem",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("NamedNodeMap.removeNamedItem", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INamedNodeMap>(thisObj, "NamedNodeMap.removeNamedItem");
                     return self.Realm.WrapNodeValue(self.Target.RemoveNamedItem(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "NamedNodeMap.removeNamedItem")));
-                },
+                }),
                 length: 1)
             .Method("removeNamedItemNS",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("NamedNodeMap.removeNamedItemNS", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INamedNodeMap>(thisObj, "NamedNodeMap.removeNamedItemNS");
                     return self.Realm.WrapNodeValue(self.Target.RemoveNamedItem(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "NamedNodeMap.removeNamedItemNS"), global::Jint.Browser.Dom.DomConvert.RequiredText(args, 1, "NamedNodeMap.removeNamedItemNS")));
-                },
+                }),
                 length: 2)
             .Method("setNamedItem",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("NamedNodeMap.setNamedItem", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INamedNodeMap>(thisObj, "NamedNodeMap.setNamedItem");
                     return self.Realm.WrapNodeValue(self.Target.SetNamedItem(global::Jint.Browser.Dom.DomBindings.Argument<global::AngleSharp.Dom.IAttr>(args, 0, "NamedNodeMap.setNamedItem")));
-                },
+                }),
                 length: 1)
             .Method("setNamedItemNS",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("NamedNodeMap.setNamedItemNS", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INamedNodeMap>(thisObj, "NamedNodeMap.setNamedItemNS");
                     return self.Realm.WrapNodeValue(self.Target.SetNamedItemWithNamespaceUri(global::Jint.Browser.Dom.DomBindings.Argument<global::AngleSharp.Dom.IAttr>(args, 0, "NamedNodeMap.setNamedItemNS")));
-                },
+                }),
                 length: 1)
             .Build();
 
@@ -1976,49 +1976,49 @@ internal static partial class DomInterfaces
             .Constant("SHOW_PROCESSING_INSTRUCTION", global::Jint.Native.JsNumber.Create(64))
             .Constant("SHOW_TEXT", global::Jint.Native.JsNumber.Create(4))
             .Accessor("filter",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("NodeIterator.filter", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INodeIterator>(thisObj, "NodeIterator.filter");
                     return global::Jint.Browser.Dom.Views.DomViewMembers.Filter(self.Target);
-                })
+                }))
             .Method("nextNode",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("NodeIterator.nextNode", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INodeIterator>(thisObj, "NodeIterator.nextNode");
                     return self.Realm.WrapNodeValue(self.Target.Next());
-                },
+                }),
                 length: 0)
             .Accessor("pointerBeforeReferenceNode",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("NodeIterator.pointerBeforeReferenceNode", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INodeIterator>(thisObj, "NodeIterator.pointerBeforeReferenceNode");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsBeforeReference);
-                })
+                }))
             .Method("previousNode",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("NodeIterator.previousNode", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INodeIterator>(thisObj, "NodeIterator.previousNode");
                     return self.Realm.WrapNodeValue(self.Target.Previous());
-                },
+                }),
                 length: 0)
             .Accessor("referenceNode",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("NodeIterator.referenceNode", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INodeIterator>(thisObj, "NodeIterator.referenceNode");
                     return self.Realm.WrapNodeValue(self.Target.Reference);
-                })
+                }))
             .Accessor("root",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("NodeIterator.root", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INodeIterator>(thisObj, "NodeIterator.root");
                     return self.Realm.WrapNodeValue(self.Target.Root);
-                })
+                }))
             .Accessor("whatToShow",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("NodeIterator.whatToShow", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INodeIterator>(thisObj, "NodeIterator.whatToShow");
                     return global::Jint.Browser.Dom.DomConvert.Number((long) (self.Target.Settings));
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>NodeList</c>.</summary>
@@ -2027,11 +2027,11 @@ internal static partial class DomInterfaces
             .ToStringTag("NodeList")
             .PerRealmSlot("constructor", enumerable: false)
             .Method("item",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("NodeList.item", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.INodeList>(thisObj, "NodeList.item");
                     return self.Realm.WrapNodeValue(self.Target[global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "NodeList.item")]);
-                },
+                }),
                 length: 1)
             .Build();
 
@@ -2041,11 +2041,11 @@ internal static partial class DomInterfaces
             .ToStringTag("ProcessingInstruction")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("target",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("ProcessingInstruction.target", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IProcessingInstruction>(thisObj, "ProcessingInstruction.target");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Target);
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>PseudoElement</c>.</summary>
@@ -2054,23 +2054,23 @@ internal static partial class DomInterfaces
             .ToStringTag("PseudoElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("cascadedStyle",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("PseudoElement.cascadedStyle", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IPseudoElement>(thisObj, "PseudoElement.cascadedStyle");
                     return self.Realm.Wrap(self.Target.GetCascadedStyle());
-                })
+                }))
             .Accessor("defaultStyle",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("PseudoElement.defaultStyle", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IPseudoElement>(thisObj, "PseudoElement.defaultStyle");
                     return self.Realm.Wrap(self.Target.GetDefaultStyle());
-                })
+                }))
             .Accessor("rawComputedStyle",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("PseudoElement.rawComputedStyle", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IPseudoElement>(thisObj, "PseudoElement.rawComputedStyle");
                     return self.Realm.Wrap(self.Target.GetRawComputedStyle());
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>Range</c>.</summary>
@@ -2083,201 +2083,201 @@ internal static partial class DomInterfaces
             .Constant("START_TO_END", global::Jint.Native.JsNumber.Create(1))
             .Constant("START_TO_START", global::Jint.Native.JsNumber.Create(0))
             .Method("cloneContents",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Range.cloneContents", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IRange>(thisObj, "Range.cloneContents");
                     return self.Realm.WrapNodeValue(self.Target.CopyContent());
-                },
+                }),
                 length: 0)
             .Method("cloneRange",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Range.cloneRange", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IRange>(thisObj, "Range.cloneRange");
                     return self.Realm.Wrap(self.Target.Clone());
-                },
+                }),
                 length: 0)
             .Method("collapse",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Range.collapse", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IRange>(thisObj, "Range.collapse");
                     self.Target.Collapse(global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false)); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 1)
             .Accessor("collapsed",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Range.collapsed", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IRange>(thisObj, "Range.collapsed");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsCollapsed);
-                })
+                }))
             .Accessor("commonAncestorContainer",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Range.commonAncestorContainer", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IRange>(thisObj, "Range.commonAncestorContainer");
                     return self.Realm.WrapNodeValue(self.Target.CommonAncestor);
-                })
+                }))
             .Method("compareBoundaryPoints",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Range.compareBoundaryPoints", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IRange>(thisObj, "Range.compareBoundaryPoints");
                     return global::Jint.Browser.Dom.DomConvert.Number((int) (self.Target.CompareBoundaryTo((global::AngleSharp.Dom.RangeType) global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "Range.compareBoundaryPoints"), global::Jint.Browser.Dom.DomBindings.Argument<global::AngleSharp.Dom.IRange>(args, 1, "Range.compareBoundaryPoints"))));
-                },
+                }),
                 length: 2)
             .Method("comparePoint",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Range.comparePoint", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IRange>(thisObj, "Range.comparePoint");
                     return global::Jint.Browser.Dom.DomConvert.Number((int) (self.Target.CompareTo(global::Jint.Browser.Dom.DomBindings.Argument<global::AngleSharp.Dom.INode>(args, 0, "Range.comparePoint"), global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 1, "Range.comparePoint"))));
-                },
+                }),
                 length: 2)
             .Method("deleteContents",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Range.deleteContents", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IRange>(thisObj, "Range.deleteContents");
                     self.Target.ClearContent(); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Method("detach",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Range.detach", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IRange>(thisObj, "Range.detach");
                     self.Target.Detach(); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Accessor("endContainer",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Range.endContainer", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IRange>(thisObj, "Range.endContainer");
                     return self.Realm.WrapNodeValue(self.Target.Tail);
-                })
+                }))
             .Accessor("endOffset",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Range.endOffset", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IRange>(thisObj, "Range.endOffset");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.End);
-                })
+                }))
             .Method("extractContents",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Range.extractContents", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IRange>(thisObj, "Range.extractContents");
                     return self.Realm.WrapNodeValue(self.Target.ExtractContent());
-                },
+                }),
                 length: 0)
             .Method("getBoundingClientRect",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Range.getBoundingClientRect", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IRange>(thisObj, "Range.getBoundingClientRect");
                     return global::Jint.Browser.Dom.Views.DomViewMembers.RangeRect(self.Realm);
-                },
+                }),
                 length: 0)
             .Method("getClientRects",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Range.getClientRects", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IRange>(thisObj, "Range.getClientRects");
                     return global::Jint.Browser.Dom.Views.DomViewMembers.RangeRects(self.Realm);
-                },
+                }),
                 length: 0)
             .Method("insertNode",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Range.insertNode", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IRange>(thisObj, "Range.insertNode");
                     self.Target.Insert(global::Jint.Browser.Dom.DomBindings.Argument<global::AngleSharp.Dom.INode>(args, 0, "Range.insertNode")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 1)
             .Method("intersectsNode",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Range.intersectsNode", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IRange>(thisObj, "Range.intersectsNode");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.Intersects(global::Jint.Browser.Dom.DomBindings.Argument<global::AngleSharp.Dom.INode>(args, 0, "Range.intersectsNode")));
-                },
+                }),
                 length: 1)
             .Method("isPointInRange",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Range.isPointInRange", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IRange>(thisObj, "Range.isPointInRange");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.Contains(global::Jint.Browser.Dom.DomBindings.Argument<global::AngleSharp.Dom.INode>(args, 0, "Range.isPointInRange"), global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 1, "Range.isPointInRange")));
-                },
+                }),
                 length: 2)
             .Method("selectNode",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Range.selectNode", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IRange>(thisObj, "Range.selectNode");
                     self.Target.Select(global::Jint.Browser.Dom.DomBindings.Argument<global::AngleSharp.Dom.INode>(args, 0, "Range.selectNode")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 1)
             .Method("selectNodeContents",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Range.selectNodeContents", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IRange>(thisObj, "Range.selectNodeContents");
                     self.Target.SelectContent(global::Jint.Browser.Dom.DomBindings.Argument<global::AngleSharp.Dom.INode>(args, 0, "Range.selectNodeContents")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 1)
             .Method("setEnd",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Range.setEnd", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IRange>(thisObj, "Range.setEnd");
                     self.Target.EndWith(global::Jint.Browser.Dom.DomBindings.Argument<global::AngleSharp.Dom.INode>(args, 0, "Range.setEnd"), global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 1, "Range.setEnd")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 2)
             .Method("setEndAfter",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Range.setEndAfter", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IRange>(thisObj, "Range.setEndAfter");
                     self.Target.EndAfter(global::Jint.Browser.Dom.DomBindings.Argument<global::AngleSharp.Dom.INode>(args, 0, "Range.setEndAfter")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 1)
             .Method("setEndBefore",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Range.setEndBefore", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IRange>(thisObj, "Range.setEndBefore");
                     self.Target.EndBefore(global::Jint.Browser.Dom.DomBindings.Argument<global::AngleSharp.Dom.INode>(args, 0, "Range.setEndBefore")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 1)
             .Method("setStart",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Range.setStart", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IRange>(thisObj, "Range.setStart");
                     self.Target.StartWith(global::Jint.Browser.Dom.DomBindings.Argument<global::AngleSharp.Dom.INode>(args, 0, "Range.setStart"), global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 1, "Range.setStart")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 2)
             .Method("setStartAfter",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Range.setStartAfter", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IRange>(thisObj, "Range.setStartAfter");
                     self.Target.StartAfter(global::Jint.Browser.Dom.DomBindings.Argument<global::AngleSharp.Dom.INode>(args, 0, "Range.setStartAfter")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 1)
             .Method("setStartBefore",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Range.setStartBefore", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IRange>(thisObj, "Range.setStartBefore");
                     self.Target.StartBefore(global::Jint.Browser.Dom.DomBindings.Argument<global::AngleSharp.Dom.INode>(args, 0, "Range.setStartBefore")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 1)
             .Accessor("startContainer",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Range.startContainer", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IRange>(thisObj, "Range.startContainer");
                     return self.Realm.WrapNodeValue(self.Target.Head);
-                })
+                }))
             .Accessor("startOffset",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Range.startOffset", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IRange>(thisObj, "Range.startOffset");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Start);
-                })
+                }))
             .Method("surroundContents",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Range.surroundContents", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IRange>(thisObj, "Range.surroundContents");
                     self.Target.Surround(global::Jint.Browser.Dom.DomBindings.Argument<global::AngleSharp.Dom.INode>(args, 0, "Range.surroundContents")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 1)
             .Method("toString",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Range.toString", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IRange>(thisObj, "Range.toString");
                     return global::Jint.Browser.Dom.Views.DomViewMembers.RangeToString(self.Target);
-                },
+                }),
                 length: 0)
             .Build();
 
@@ -2287,40 +2287,40 @@ internal static partial class DomInterfaces
             .ToStringTag("ShadowRoot")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("activeElement",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("ShadowRoot.activeElement", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IShadowRoot>(thisObj, "ShadowRoot.activeElement");
                     return self.Realm.WrapNodeValue(self.Target.ActiveElement);
-                })
+                }))
             .Accessor("host",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("ShadowRoot.host", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IShadowRoot>(thisObj, "ShadowRoot.host");
                     return self.Realm.WrapNodeValue(self.Target.Host);
-                })
+                }))
             .Accessor("innerHTML",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("ShadowRoot.innerHTML", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IShadowRoot>(thisObj, "ShadowRoot.innerHTML");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.InnerHtml);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("ShadowRoot.innerHTML", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IShadowRoot>(thisObj, "ShadowRoot.innerHTML");
                     self.Target.InnerHtml = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "ShadowRoot.innerHTML"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("mode",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("ShadowRoot.mode", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IShadowRoot>(thisObj, "ShadowRoot.mode");
                     return global::Jint.Browser.Dom.DomEnums.FromShadowRootMode(self.Target.Mode);
-                })
+                }))
             .Accessor("styleSheets",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("ShadowRoot.styleSheets", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IShadowRoot>(thisObj, "ShadowRoot.styleSheets");
                     return self.Realm.Wrap(self.Target.StyleSheets);
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>StyleSheetList</c>.</summary>
@@ -2329,11 +2329,11 @@ internal static partial class DomInterfaces
             .ToStringTag("StyleSheetList")
             .PerRealmSlot("constructor", enumerable: false)
             .Method("item",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("StyleSheetList.item", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IStyleSheetList>(thisObj, "StyleSheetList.item");
                     return self.Realm.Wrap(self.Target[global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "StyleSheetList.item")]);
-                },
+                }),
                 length: 1)
             .Build();
 
@@ -2343,24 +2343,24 @@ internal static partial class DomInterfaces
             .ToStringTag("Text")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("assignedSlot",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Text.assignedSlot", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IText>(thisObj, "Text.assignedSlot");
                     return self.Realm.WrapNodeValue(self.Target.AssignedSlot);
-                })
+                }))
             .Method("splitText",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Text.splitText", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IText>(thisObj, "Text.splitText");
                     return self.Realm.WrapNodeValue(self.Target.Split(global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "Text.splitText")));
-                },
+                }),
                 length: 1)
             .Accessor("wholeText",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Text.wholeText", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IText>(thisObj, "Text.wholeText");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Text);
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>TreeWalker</c>.</summary>
@@ -2382,82 +2382,82 @@ internal static partial class DomInterfaces
             .Constant("SHOW_PROCESSING_INSTRUCTION", global::Jint.Native.JsNumber.Create(64))
             .Constant("SHOW_TEXT", global::Jint.Native.JsNumber.Create(4))
             .Accessor("currentNode",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("TreeWalker.currentNode", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ITreeWalker>(thisObj, "TreeWalker.currentNode");
                     return self.Realm.WrapNodeValue(self.Target.Current);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("TreeWalker.currentNode", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ITreeWalker>(thisObj, "TreeWalker.currentNode");
                     self.Target.Current = global::Jint.Browser.Dom.DomBindings.Argument<global::AngleSharp.Dom.INode>(args, 0, "TreeWalker.currentNode"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("filter",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("TreeWalker.filter", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ITreeWalker>(thisObj, "TreeWalker.filter");
                     return global::Jint.Browser.Dom.Views.DomViewMembers.Filter(self.Target);
-                })
+                }))
             .Method("firstChild",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("TreeWalker.firstChild", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ITreeWalker>(thisObj, "TreeWalker.firstChild");
                     return self.Realm.WrapNodeValue(self.Target.ToFirst());
-                },
+                }),
                 length: 0)
             .Method("lastChild",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("TreeWalker.lastChild", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ITreeWalker>(thisObj, "TreeWalker.lastChild");
                     return self.Realm.WrapNodeValue(self.Target.ToLast());
-                },
+                }),
                 length: 0)
             .Method("nextNode",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("TreeWalker.nextNode", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ITreeWalker>(thisObj, "TreeWalker.nextNode");
                     return self.Realm.WrapNodeValue(self.Target.ToNext());
-                },
+                }),
                 length: 0)
             .Method("nextSibling",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("TreeWalker.nextSibling", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ITreeWalker>(thisObj, "TreeWalker.nextSibling");
                     return self.Realm.WrapNodeValue(self.Target.ToNextSibling());
-                },
+                }),
                 length: 0)
             .Method("parentNode",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("TreeWalker.parentNode", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ITreeWalker>(thisObj, "TreeWalker.parentNode");
                     return self.Realm.WrapNodeValue(self.Target.ToParent());
-                },
+                }),
                 length: 0)
             .Method("previousNode",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("TreeWalker.previousNode", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ITreeWalker>(thisObj, "TreeWalker.previousNode");
                     return self.Realm.WrapNodeValue(self.Target.ToPrevious());
-                },
+                }),
                 length: 0)
             .Method("previousSibling",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("TreeWalker.previousSibling", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ITreeWalker>(thisObj, "TreeWalker.previousSibling");
                     return self.Realm.WrapNodeValue(self.Target.ToPreviousSibling());
-                },
+                }),
                 length: 0)
             .Accessor("root",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("TreeWalker.root", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ITreeWalker>(thisObj, "TreeWalker.root");
                     return self.Realm.WrapNodeValue(self.Target.Root);
-                })
+                }))
             .Accessor("whatToShow",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("TreeWalker.whatToShow", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ITreeWalker>(thisObj, "TreeWalker.whatToShow");
                     return global::Jint.Browser.Dom.DomConvert.Number((long) (self.Target.Settings));
-                })
+                }))
             .Build();
 }

--- a/Jint.Browser/Dom/Generated/DomShapes.Html.g.cs
+++ b/Jint.Browser/Dom/Generated/DomShapes.Html.g.cs
@@ -21,216 +21,216 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("accessKey",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLElement.accessKey", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlElement>(thisObj, "HTMLElement.accessKey");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.AccessKey);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLElement.accessKey", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlElement>(thisObj, "HTMLElement.accessKey");
                     self.Target.AccessKey = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLElement.accessKey"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("accessKeyLabel",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLElement.accessKeyLabel", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlElement>(thisObj, "HTMLElement.accessKeyLabel");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.AccessKeyLabel);
-                })
+                }))
             .Method("blur",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLElement.blur", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlElement>(thisObj, "HTMLElement.blur");
                     global::Jint.Browser.Events.FocusController.Blur(self.Realm, self.Target);
                     return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Method("click",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLElement.click", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlElement>(thisObj, "HTMLElement.click");
                     global::Jint.Browser.Events.InputDispatcher.FireSyntheticClick((global::Jint.Browser.Dom.DomNodeObject) thisObj, trusted: false);
                     return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Accessor("contentEditable",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLElement.contentEditable", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlElement>(thisObj, "HTMLElement.contentEditable");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.ContentEditable);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLElement.contentEditable", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlElement>(thisObj, "HTMLElement.contentEditable");
                     self.Target.ContentEditable = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLElement.contentEditable"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("contextMenu",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLElement.contextMenu", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlElement>(thisObj, "HTMLElement.contextMenu");
                     return self.Realm.WrapNodeValue(self.Target.ContextMenu);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLElement.contextMenu", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlElement>(thisObj, "HTMLElement.contextMenu");
                     self.Target.ContextMenu = global::Jint.Browser.Dom.DomBindings.Argument<global::AngleSharp.Html.Dom.IHtmlMenuElement>(args, 0, "HTMLElement.contextMenu"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("dataset",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLElement.dataset", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlElement>(thisObj, "HTMLElement.dataset");
                     return self.Realm.Wrap(self.Target.Dataset);
-                })
+                }))
             .Accessor("dir",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLElement.dir", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlElement>(thisObj, "HTMLElement.dir");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Direction);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLElement.dir", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlElement>(thisObj, "HTMLElement.dir");
                     self.Target.Direction = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLElement.dir"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("draggable",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLElement.draggable", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlElement>(thisObj, "HTMLElement.draggable");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsDraggable);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLElement.draggable", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlElement>(thisObj, "HTMLElement.draggable");
                     self.Target.IsDraggable = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("dropzone",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLElement.dropzone", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlElement>(thisObj, "HTMLElement.dropzone");
                     return self.Realm.Wrap(self.Target.DropZone);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLElement.dropzone", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlElement>(thisObj, "HTMLElement.dropzone");
                     var forwardTarget = self.Target.DropZone; if (forwardTarget is not null) { forwardTarget.Value = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLElement.dropzone"); } return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Method("focus",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLElement.focus", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlElement>(thisObj, "HTMLElement.focus");
                     global::Jint.Browser.Events.FocusController.Focus(self.Realm, self.Target);
                     return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Method("forceSpellCheck",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLElement.forceSpellCheck", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlElement>(thisObj, "HTMLElement.forceSpellCheck");
                     self.Target.DoSpellCheck(); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Accessor("hidden",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLElement.hidden", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlElement>(thisObj, "HTMLElement.hidden");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsHidden);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLElement.hidden", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlElement>(thisObj, "HTMLElement.hidden");
                     self.Target.IsHidden = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("isContentEditable",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLElement.isContentEditable", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlElement>(thisObj, "HTMLElement.isContentEditable");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsContentEditable);
-                })
+                }))
             .Accessor("lang",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLElement.lang", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlElement>(thisObj, "HTMLElement.lang");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Language);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLElement.lang", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlElement>(thisObj, "HTMLElement.lang");
                     self.Target.Language = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLElement.lang"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("offsetHeight",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLElement.offsetHeight", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlElement>(thisObj, "HTMLElement.offsetHeight");
                     return global::Jint.Browser.Layout.LayoutMembers.OffsetHeight(self.Realm, self.Target);
-                })
+                }))
             .Accessor("offsetLeft",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLElement.offsetLeft", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlElement>(thisObj, "HTMLElement.offsetLeft");
                     return global::Jint.Browser.Layout.LayoutMembers.OffsetLeft(self.Realm, self.Target);
-                })
+                }))
             .Accessor("offsetParent",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLElement.offsetParent", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlElement>(thisObj, "HTMLElement.offsetParent");
                     return global::Jint.Browser.Layout.LayoutMembers.OffsetParent(self.Realm, self.Target);
-                })
+                }))
             .Accessor("offsetTop",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLElement.offsetTop", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlElement>(thisObj, "HTMLElement.offsetTop");
                     return global::Jint.Browser.Layout.LayoutMembers.OffsetTop(self.Realm, self.Target);
-                })
+                }))
             .Accessor("offsetWidth",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLElement.offsetWidth", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlElement>(thisObj, "HTMLElement.offsetWidth");
                     return global::Jint.Browser.Layout.LayoutMembers.OffsetWidth(self.Realm, self.Target);
-                })
+                }))
             .Accessor("spellcheck",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLElement.spellcheck", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlElement>(thisObj, "HTMLElement.spellcheck");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsSpellChecked);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLElement.spellcheck", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlElement>(thisObj, "HTMLElement.spellcheck");
                     self.Target.IsSpellChecked = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("tabIndex",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLElement.tabIndex", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlElement>(thisObj, "HTMLElement.tabIndex");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.TabIndex);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLElement.tabIndex", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlElement>(thisObj, "HTMLElement.tabIndex");
                     self.Target.TabIndex = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLElement.tabIndex"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("title",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLElement.title", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlElement>(thisObj, "HTMLElement.title");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Title);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLElement.title", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlElement>(thisObj, "HTMLElement.title");
                     self.Target.Title = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLElement.title"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("translate",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLElement.translate", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlElement>(thisObj, "HTMLElement.translate");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsTranslated);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLElement.translate", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlElement>(thisObj, "HTMLElement.translate");
                     self.Target.IsTranslated = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                });
+                }));
 
         global::Jint.Browser.Events.DomShapeAdditions.HtmlElementHandlers(builder);
         return builder.Build();
@@ -242,189 +242,189 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLAnchorElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("download",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAnchorElement.download", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAnchorElement>(thisObj, "HTMLAnchorElement.download");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Download);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAnchorElement.download", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAnchorElement>(thisObj, "HTMLAnchorElement.download");
                     self.Target.Download = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLAnchorElement.download"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("hash",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAnchorElement.hash", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAnchorElement>(thisObj, "HTMLAnchorElement.hash");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Hash);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAnchorElement.hash", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAnchorElement>(thisObj, "HTMLAnchorElement.hash");
                     self.Target.Hash = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLAnchorElement.hash"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("host",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAnchorElement.host", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAnchorElement>(thisObj, "HTMLAnchorElement.host");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Host);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAnchorElement.host", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAnchorElement>(thisObj, "HTMLAnchorElement.host");
                     self.Target.Host = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLAnchorElement.host"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("hostname",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAnchorElement.hostname", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAnchorElement>(thisObj, "HTMLAnchorElement.hostname");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.HostName);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAnchorElement.hostname", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAnchorElement>(thisObj, "HTMLAnchorElement.hostname");
                     self.Target.HostName = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLAnchorElement.hostname"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("href",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAnchorElement.href", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAnchorElement>(thisObj, "HTMLAnchorElement.href");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Href);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAnchorElement.href", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAnchorElement>(thisObj, "HTMLAnchorElement.href");
                     self.Target.Href = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLAnchorElement.href"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("hreflang",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAnchorElement.hreflang", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAnchorElement>(thisObj, "HTMLAnchorElement.hreflang");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.TargetLanguage);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAnchorElement.hreflang", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAnchorElement>(thisObj, "HTMLAnchorElement.hreflang");
                     self.Target.TargetLanguage = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLAnchorElement.hreflang"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("origin",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAnchorElement.origin", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAnchorElement>(thisObj, "HTMLAnchorElement.origin");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Origin);
-                })
+                }))
             .Accessor("password",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAnchorElement.password", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAnchorElement>(thisObj, "HTMLAnchorElement.password");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Password);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAnchorElement.password", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAnchorElement>(thisObj, "HTMLAnchorElement.password");
                     self.Target.Password = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLAnchorElement.password"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("pathname",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAnchorElement.pathname", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAnchorElement>(thisObj, "HTMLAnchorElement.pathname");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.PathName);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAnchorElement.pathname", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAnchorElement>(thisObj, "HTMLAnchorElement.pathname");
                     self.Target.PathName = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLAnchorElement.pathname"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("ping",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAnchorElement.ping", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAnchorElement>(thisObj, "HTMLAnchorElement.ping");
                     return self.Realm.Wrap(self.Target.Ping);
-                })
+                }))
             .Accessor("port",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAnchorElement.port", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAnchorElement>(thisObj, "HTMLAnchorElement.port");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Port);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAnchorElement.port", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAnchorElement>(thisObj, "HTMLAnchorElement.port");
                     self.Target.Port = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLAnchorElement.port"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("protocol",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAnchorElement.protocol", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAnchorElement>(thisObj, "HTMLAnchorElement.protocol");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Protocol);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAnchorElement.protocol", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAnchorElement>(thisObj, "HTMLAnchorElement.protocol");
                     self.Target.Protocol = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLAnchorElement.protocol"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("rel",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAnchorElement.rel", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAnchorElement>(thisObj, "HTMLAnchorElement.rel");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Relation);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAnchorElement.rel", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAnchorElement>(thisObj, "HTMLAnchorElement.rel");
                     self.Target.Relation = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLAnchorElement.rel"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("relList",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAnchorElement.relList", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAnchorElement>(thisObj, "HTMLAnchorElement.relList");
                     return self.Realm.Wrap(self.Target.RelationList);
-                })
+                }))
             .Accessor("search",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAnchorElement.search", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAnchorElement>(thisObj, "HTMLAnchorElement.search");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Search);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAnchorElement.search", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAnchorElement>(thisObj, "HTMLAnchorElement.search");
                     self.Target.Search = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLAnchorElement.search"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("target",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAnchorElement.target", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAnchorElement>(thisObj, "HTMLAnchorElement.target");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Target);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAnchorElement.target", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAnchorElement>(thisObj, "HTMLAnchorElement.target");
                     self.Target.Target = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLAnchorElement.target"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("text",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAnchorElement.text", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAnchorElement>(thisObj, "HTMLAnchorElement.text");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Text);
-                })
+                }))
             .Accessor("type",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAnchorElement.type", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAnchorElement>(thisObj, "HTMLAnchorElement.type");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Type);
-                })
+                }))
             .Accessor("username",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAnchorElement.username", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAnchorElement>(thisObj, "HTMLAnchorElement.username");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.UserName);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAnchorElement.username", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAnchorElement>(thisObj, "HTMLAnchorElement.username");
                     self.Target.UserName = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLAnchorElement.username"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLAreaElement</c>.</summary>
@@ -433,221 +433,221 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLAreaElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("alt",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.alt", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAreaElement>(thisObj, "HTMLAreaElement.alt");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.AlternativeText);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.alt", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAreaElement>(thisObj, "HTMLAreaElement.alt");
                     self.Target.AlternativeText = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLAreaElement.alt"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("coords",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.coords", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAreaElement>(thisObj, "HTMLAreaElement.coords");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Coordinates);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.coords", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAreaElement>(thisObj, "HTMLAreaElement.coords");
                     self.Target.Coordinates = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLAreaElement.coords"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("download",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.download", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAreaElement>(thisObj, "HTMLAreaElement.download");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Download);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.download", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAreaElement>(thisObj, "HTMLAreaElement.download");
                     self.Target.Download = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLAreaElement.download"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("hash",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.hash", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAreaElement>(thisObj, "HTMLAreaElement.hash");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Hash);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.hash", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAreaElement>(thisObj, "HTMLAreaElement.hash");
                     self.Target.Hash = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLAreaElement.hash"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("host",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.host", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAreaElement>(thisObj, "HTMLAreaElement.host");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Host);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.host", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAreaElement>(thisObj, "HTMLAreaElement.host");
                     self.Target.Host = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLAreaElement.host"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("hostname",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.hostname", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAreaElement>(thisObj, "HTMLAreaElement.hostname");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.HostName);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.hostname", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAreaElement>(thisObj, "HTMLAreaElement.hostname");
                     self.Target.HostName = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLAreaElement.hostname"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("href",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.href", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAreaElement>(thisObj, "HTMLAreaElement.href");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Href);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.href", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAreaElement>(thisObj, "HTMLAreaElement.href");
                     self.Target.Href = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLAreaElement.href"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("hreflang",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.hreflang", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAreaElement>(thisObj, "HTMLAreaElement.hreflang");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.TargetLanguage);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.hreflang", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAreaElement>(thisObj, "HTMLAreaElement.hreflang");
                     self.Target.TargetLanguage = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLAreaElement.hreflang"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("origin",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.origin", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAreaElement>(thisObj, "HTMLAreaElement.origin");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Origin);
-                })
+                }))
             .Accessor("password",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.password", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAreaElement>(thisObj, "HTMLAreaElement.password");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Password);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.password", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAreaElement>(thisObj, "HTMLAreaElement.password");
                     self.Target.Password = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLAreaElement.password"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("pathname",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.pathname", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAreaElement>(thisObj, "HTMLAreaElement.pathname");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.PathName);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.pathname", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAreaElement>(thisObj, "HTMLAreaElement.pathname");
                     self.Target.PathName = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLAreaElement.pathname"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("ping",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.ping", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAreaElement>(thisObj, "HTMLAreaElement.ping");
                     return self.Realm.Wrap(self.Target.Ping);
-                })
+                }))
             .Accessor("port",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.port", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAreaElement>(thisObj, "HTMLAreaElement.port");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Port);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.port", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAreaElement>(thisObj, "HTMLAreaElement.port");
                     self.Target.Port = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLAreaElement.port"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("protocol",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.protocol", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAreaElement>(thisObj, "HTMLAreaElement.protocol");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Protocol);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.protocol", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAreaElement>(thisObj, "HTMLAreaElement.protocol");
                     self.Target.Protocol = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLAreaElement.protocol"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("rel",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.rel", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAreaElement>(thisObj, "HTMLAreaElement.rel");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Relation);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.rel", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAreaElement>(thisObj, "HTMLAreaElement.rel");
                     self.Target.Relation = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLAreaElement.rel"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("relList",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.relList", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAreaElement>(thisObj, "HTMLAreaElement.relList");
                     return self.Realm.Wrap(self.Target.RelationList);
-                })
+                }))
             .Accessor("search",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.search", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAreaElement>(thisObj, "HTMLAreaElement.search");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Search);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.search", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAreaElement>(thisObj, "HTMLAreaElement.search");
                     self.Target.Search = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLAreaElement.search"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("shape",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.shape", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAreaElement>(thisObj, "HTMLAreaElement.shape");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Shape);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.shape", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAreaElement>(thisObj, "HTMLAreaElement.shape");
                     self.Target.Shape = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLAreaElement.shape"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("target",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.target", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAreaElement>(thisObj, "HTMLAreaElement.target");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Target);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.target", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAreaElement>(thisObj, "HTMLAreaElement.target");
                     self.Target.Target = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLAreaElement.target"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("type",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.type", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAreaElement>(thisObj, "HTMLAreaElement.type");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Type);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.type", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAreaElement>(thisObj, "HTMLAreaElement.type");
                     self.Target.Type = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLAreaElement.type"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("username",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.username", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAreaElement>(thisObj, "HTMLAreaElement.username");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.UserName);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.username", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAreaElement>(thisObj, "HTMLAreaElement.username");
                     self.Target.UserName = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLAreaElement.username"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLMediaElement</c>.</summary>
@@ -665,285 +665,285 @@ internal static partial class DomInterfaces
             .Constant("NETWORK_LOADING", global::Jint.Native.JsNumber.Create(2))
             .Constant("NETWORK_NO_SOURCE", global::Jint.Native.JsNumber.Create(3))
             .Method("addTextTrack",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.addTextTrack", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.addTextTrack");
                     return self.Realm.Wrap(self.Target.AddTextTrack(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLMediaElement.addTextTrack"), global::Jint.Browser.Dom.DomConvert.OptionalText(args, 1, null)!, global::Jint.Browser.Dom.DomConvert.OptionalText(args, 2, null)!));
-                },
+                }),
                 length: 1)
             .Accessor("audioTracks",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.audioTracks", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.audioTracks");
                     return self.Realm.Wrap(self.Target.AudioTracks);
-                })
+                }))
             .Accessor("autoplay",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.autoplay", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.autoplay");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsAutoplay);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.autoplay", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.autoplay");
                     self.Target.IsAutoplay = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("buffered",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.buffered", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.buffered");
                     return self.Realm.Wrap(self.Target.BufferedTime);
-                })
+                }))
             .Method("canPlayType",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.canPlayType", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.canPlayType");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.CanPlayType(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLMediaElement.canPlayType")));
-                },
+                }),
                 length: 1)
             .Accessor("controller",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.controller", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.controller");
                     return self.Realm.Wrap(self.Target.Controller);
-                })
+                }))
             .Accessor("controls",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.controls", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.controls");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsShowingControls);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.controls", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.controls");
                     self.Target.IsShowingControls = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("crossOrigin",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.crossOrigin", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.crossOrigin");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.CrossOrigin);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.crossOrigin", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.crossOrigin");
                     self.Target.CrossOrigin = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLMediaElement.crossOrigin"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("currentSrc",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.currentSrc", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.currentSrc");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.CurrentSource);
-                })
+                }))
             .Accessor("currentTime",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.currentTime", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.currentTime");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.CurrentTime);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.currentTime", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.currentTime");
                     self.Target.CurrentTime = global::Jint.Browser.Dom.DomConvert.RequiredDouble(args, 0, "HTMLMediaElement.currentTime"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("defaultMuted",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.defaultMuted", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.defaultMuted");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsDefaultMuted);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.defaultMuted", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.defaultMuted");
                     self.Target.IsDefaultMuted = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("defaultPlaybackRate",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.defaultPlaybackRate", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.defaultPlaybackRate");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.DefaultPlaybackRate);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.defaultPlaybackRate", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.defaultPlaybackRate");
                     self.Target.DefaultPlaybackRate = global::Jint.Browser.Dom.DomConvert.RequiredDouble(args, 0, "HTMLMediaElement.defaultPlaybackRate"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("duration",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.duration", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.duration");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Duration);
-                })
+                }))
             .Accessor("ended",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.ended", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.ended");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsEnded);
-                })
+                }))
             .Accessor("error",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.error", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.error");
                     return self.Realm.Wrap(self.Target.MediaError);
-                })
+                }))
             .Method("load",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.load", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.load");
                     self.Target.Load(); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Accessor("loop",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.loop", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.loop");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsLoop);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.loop", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.loop");
                     self.Target.IsLoop = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("mediaGroup",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.mediaGroup", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.mediaGroup");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.MediaGroup);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.mediaGroup", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.mediaGroup");
                     self.Target.MediaGroup = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLMediaElement.mediaGroup"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("muted",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.muted", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.muted");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsMuted);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.muted", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.muted");
                     self.Target.IsMuted = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("networkState",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.networkState", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.networkState");
                     return global::Jint.Browser.Dom.DomConvert.Number((int) (self.Target.NetworkState));
-                })
+                }))
             .Method("pause",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.pause", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.pause");
                     self.Target.Pause(); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Accessor("paused",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.paused", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.paused");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsPaused);
-                })
+                }))
             .Method("play",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.play", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.play");
                     self.Target.Play(); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Accessor("playbackRate",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.playbackRate", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.playbackRate");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.PlaybackRate);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.playbackRate", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.playbackRate");
                     self.Target.PlaybackRate = global::Jint.Browser.Dom.DomConvert.RequiredDouble(args, 0, "HTMLMediaElement.playbackRate"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("playbackState",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.playbackState", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.playbackState");
                     return global::Jint.Browser.Dom.DomEnums.FromMediaControllerPlaybackState(self.Target.PlaybackState);
-                })
+                }))
             .Accessor("played",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.played", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.played");
                     return self.Realm.Wrap(self.Target.PlayedTime);
-                })
+                }))
             .Accessor("preload",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.preload", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.preload");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Preload);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.preload", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.preload");
                     self.Target.Preload = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLMediaElement.preload"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("readyState",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.readyState", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.readyState");
                     return global::Jint.Browser.Dom.DomConvert.Number((int) (self.Target.ReadyState));
-                })
+                }))
             .Accessor("seekable",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.seekable", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.seekable");
                     return self.Realm.Wrap(self.Target.SeekableTime);
-                })
+                }))
             .Accessor("seeking",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.seeking", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.seeking");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsSeeking);
-                })
+                }))
             .Accessor("src",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.src", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.src");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Source);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.src", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.src");
                     self.Target.Source = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLMediaElement.src"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("startDate",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.startDate", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.startDate");
                     return global::Jint.Browser.Dom.DomConvert.Timestamp(self.Target.StartDate);
-                })
+                }))
             .Accessor("textTracks",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.textTracks", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.textTracks");
                     return self.Realm.Wrap(self.Target.TextTracks);
-                })
+                }))
             .Accessor("videoTracks",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.videoTracks", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.videoTracks");
                     return self.Realm.Wrap(self.Target.VideoTracks);
-                })
+                }))
             .Accessor("volume",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.volume", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.volume");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Volume);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.volume", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.volume");
                     self.Target.Volume = global::Jint.Browser.Dom.DomConvert.RequiredDouble(args, 0, "HTMLMediaElement.volume"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLAudioElement</c>.</summary>
@@ -966,27 +966,27 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLBaseElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("href",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLBaseElement.href", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlBaseElement>(thisObj, "HTMLBaseElement.href");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Href);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLBaseElement.href", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlBaseElement>(thisObj, "HTMLBaseElement.href");
                     self.Target.Href = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLBaseElement.href"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("target",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLBaseElement.target", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlBaseElement>(thisObj, "HTMLBaseElement.target");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Target);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLBaseElement.target", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlBaseElement>(thisObj, "HTMLBaseElement.target");
                     self.Target.Target = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLBaseElement.target"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLBodyElement</c>.</summary>
@@ -1002,159 +1002,159 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLButtonElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("autofocus",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLButtonElement.autofocus", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlButtonElement>(thisObj, "HTMLButtonElement.autofocus");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.Autofocus);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLButtonElement.autofocus", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlButtonElement>(thisObj, "HTMLButtonElement.autofocus");
                     self.Target.Autofocus = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Method("checkValidity",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLButtonElement.checkValidity", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlButtonElement>(thisObj, "HTMLButtonElement.checkValidity");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.CheckValidity());
-                },
+                }),
                 length: 0)
             .Accessor("disabled",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLButtonElement.disabled", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlButtonElement>(thisObj, "HTMLButtonElement.disabled");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsDisabled);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLButtonElement.disabled", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlButtonElement>(thisObj, "HTMLButtonElement.disabled");
                     self.Target.IsDisabled = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("form",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLButtonElement.form", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlButtonElement>(thisObj, "HTMLButtonElement.form");
                     return self.Realm.WrapNodeValue(self.Target.Form);
-                })
+                }))
             .Accessor("formAction",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLButtonElement.formAction", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlButtonElement>(thisObj, "HTMLButtonElement.formAction");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.FormAction);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLButtonElement.formAction", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlButtonElement>(thisObj, "HTMLButtonElement.formAction");
                     self.Target.FormAction = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLButtonElement.formAction"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("formEncType",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLButtonElement.formEncType", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlButtonElement>(thisObj, "HTMLButtonElement.formEncType");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.FormEncType);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLButtonElement.formEncType", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlButtonElement>(thisObj, "HTMLButtonElement.formEncType");
                     self.Target.FormEncType = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLButtonElement.formEncType"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("formMethod",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLButtonElement.formMethod", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlButtonElement>(thisObj, "HTMLButtonElement.formMethod");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.FormMethod);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLButtonElement.formMethod", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlButtonElement>(thisObj, "HTMLButtonElement.formMethod");
                     self.Target.FormMethod = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLButtonElement.formMethod"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("formNoValidate",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLButtonElement.formNoValidate", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlButtonElement>(thisObj, "HTMLButtonElement.formNoValidate");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.FormNoValidate);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLButtonElement.formNoValidate", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlButtonElement>(thisObj, "HTMLButtonElement.formNoValidate");
                     self.Target.FormNoValidate = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("formTarget",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLButtonElement.formTarget", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlButtonElement>(thisObj, "HTMLButtonElement.formTarget");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.FormTarget);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLButtonElement.formTarget", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlButtonElement>(thisObj, "HTMLButtonElement.formTarget");
                     self.Target.FormTarget = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLButtonElement.formTarget"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("labels",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLButtonElement.labels", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlButtonElement>(thisObj, "HTMLButtonElement.labels");
                     return self.Realm.Wrap(self.Target.Labels);
-                })
+                }))
             .Accessor("name",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLButtonElement.name", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlButtonElement>(thisObj, "HTMLButtonElement.name");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Name);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLButtonElement.name", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlButtonElement>(thisObj, "HTMLButtonElement.name");
                     self.Target.Name = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLButtonElement.name"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Method("setCustomValidity",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLButtonElement.setCustomValidity", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlButtonElement>(thisObj, "HTMLButtonElement.setCustomValidity");
                     self.Target.SetCustomValidity(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLButtonElement.setCustomValidity")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 1)
             .Accessor("type",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLButtonElement.type", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlButtonElement>(thisObj, "HTMLButtonElement.type");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Type);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLButtonElement.type", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlButtonElement>(thisObj, "HTMLButtonElement.type");
                     self.Target.Type = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLButtonElement.type"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("validationMessage",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLButtonElement.validationMessage", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlButtonElement>(thisObj, "HTMLButtonElement.validationMessage");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.ValidationMessage);
-                })
+                }))
             .Accessor("validity",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLButtonElement.validity", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlButtonElement>(thisObj, "HTMLButtonElement.validity");
                     return self.Realm.Wrap(self.Target.Validity);
-                })
+                }))
             .Accessor("value",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLButtonElement.value", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlButtonElement>(thisObj, "HTMLButtonElement.value");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Value);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLButtonElement.value", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlButtonElement>(thisObj, "HTMLButtonElement.value");
                     self.Target.Value = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLButtonElement.value"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("willValidate",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLButtonElement.willValidate", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlButtonElement>(thisObj, "HTMLButtonElement.willValidate");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.WillValidate);
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLCanvasElement</c>.</summary>
@@ -1163,55 +1163,55 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLCanvasElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Method("getContext",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLCanvasElement.getContext", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlCanvasElement>(thisObj, "HTMLCanvasElement.getContext");
                     return self.Realm.Wrap(self.Target.GetContext(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLCanvasElement.getContext")));
-                },
+                }),
                 length: 1)
             .Accessor("height",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLCanvasElement.height", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlCanvasElement>(thisObj, "HTMLCanvasElement.height");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Height);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLCanvasElement.height", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlCanvasElement>(thisObj, "HTMLCanvasElement.height");
                     self.Target.Height = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLCanvasElement.height"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Method("probablySupportsContext",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLCanvasElement.probablySupportsContext", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlCanvasElement>(thisObj, "HTMLCanvasElement.probablySupportsContext");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsSupportingContext(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLCanvasElement.probablySupportsContext")));
-                },
+                }),
                 length: 1)
             .Method("setContext",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLCanvasElement.setContext", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlCanvasElement>(thisObj, "HTMLCanvasElement.setContext");
                     self.Target.SetContext(global::Jint.Browser.Dom.DomBindings.Argument<global::AngleSharp.Media.Dom.IRenderingContext>(args, 0, "HTMLCanvasElement.setContext")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 1)
             .Method("toDataURL",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLCanvasElement.toDataURL", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlCanvasElement>(thisObj, "HTMLCanvasElement.toDataURL");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.ToDataUrl(global::Jint.Browser.Dom.DomConvert.OptionalText(args, 0, null)!));
-                },
+                }),
                 length: 0)
             .Accessor("width",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLCanvasElement.width", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlCanvasElement>(thisObj, "HTMLCanvasElement.width");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Width);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLCanvasElement.width", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlCanvasElement>(thisObj, "HTMLCanvasElement.width");
                     self.Target.Width = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLCanvasElement.width"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLCommandElement</c>.</summary>
@@ -1220,77 +1220,77 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLCommandElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("checked",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLCommandElement.checked", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlCommandElement>(thisObj, "HTMLCommandElement.checked");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsChecked);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLCommandElement.checked", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlCommandElement>(thisObj, "HTMLCommandElement.checked");
                     self.Target.IsChecked = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("command",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLCommandElement.command", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlCommandElement>(thisObj, "HTMLCommandElement.command");
                     return self.Realm.WrapNodeValue(self.Target.Command);
-                })
+                }))
             .Accessor("disabled",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLCommandElement.disabled", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlCommandElement>(thisObj, "HTMLCommandElement.disabled");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsDisabled);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLCommandElement.disabled", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlCommandElement>(thisObj, "HTMLCommandElement.disabled");
                     self.Target.IsDisabled = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("icon",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLCommandElement.icon", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlCommandElement>(thisObj, "HTMLCommandElement.icon");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Icon);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLCommandElement.icon", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlCommandElement>(thisObj, "HTMLCommandElement.icon");
                     self.Target.Icon = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLCommandElement.icon"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("label",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLCommandElement.label", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlCommandElement>(thisObj, "HTMLCommandElement.label");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Label);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLCommandElement.label", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlCommandElement>(thisObj, "HTMLCommandElement.label");
                     self.Target.Label = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLCommandElement.label"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("radiogroup",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLCommandElement.radiogroup", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlCommandElement>(thisObj, "HTMLCommandElement.radiogroup");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.RadioGroup);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLCommandElement.radiogroup", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlCommandElement>(thisObj, "HTMLCommandElement.radiogroup");
                     self.Target.RadioGroup = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLCommandElement.radiogroup"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("type",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLCommandElement.type", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlCommandElement>(thisObj, "HTMLCommandElement.type");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Type);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLCommandElement.type", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlCommandElement>(thisObj, "HTMLCommandElement.type");
                     self.Target.Type = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLCommandElement.type"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLDataElement</c>.</summary>
@@ -1299,16 +1299,16 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLDataElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("value",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLDataElement.value", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlDataElement>(thisObj, "HTMLDataElement.value");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Value);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLDataElement.value", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlDataElement>(thisObj, "HTMLDataElement.value");
                     self.Target.Value = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLDataElement.value"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLDataListElement</c>.</summary>
@@ -1317,11 +1317,11 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLDataListElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("options",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLDataListElement.options", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlDataListElement>(thisObj, "HTMLDataListElement.options");
                     return self.Realm.WrapCollection<global::AngleSharp.Html.Dom.IHtmlOptionElement>(self.Target.Options);
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLDetailsElement</c>.</summary>
@@ -1330,16 +1330,16 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLDetailsElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("open",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLDetailsElement.open", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlDetailsElement>(thisObj, "HTMLDetailsElement.open");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsOpen);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLDetailsElement.open", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlDetailsElement>(thisObj, "HTMLDetailsElement.open");
                     self.Target.IsOpen = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLDialogElement</c>.</summary>
@@ -1348,47 +1348,47 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLDialogElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Method("close",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLDialogElement.close", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlDialogElement>(thisObj, "HTMLDialogElement.close");
                     self.Target.Close(global::Jint.Browser.Dom.DomConvert.OptionalText(args, 0, null)!); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Accessor("open",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLDialogElement.open", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlDialogElement>(thisObj, "HTMLDialogElement.open");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.Open);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLDialogElement.open", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlDialogElement>(thisObj, "HTMLDialogElement.open");
                     self.Target.Open = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("returnValue",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLDialogElement.returnValue", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlDialogElement>(thisObj, "HTMLDialogElement.returnValue");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.ReturnValue);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLDialogElement.returnValue", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlDialogElement>(thisObj, "HTMLDialogElement.returnValue");
                     self.Target.ReturnValue = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLDialogElement.returnValue"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Method("show",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLDialogElement.show", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlDialogElement>(thisObj, "HTMLDialogElement.show");
                     self.Target.Show(global::Jint.Browser.Dom.DomBindings.NullableArgument<global::AngleSharp.Dom.IElement>(args, 0, "HTMLDialogElement.show")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Method("showModal",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLDialogElement.showModal", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlDialogElement>(thisObj, "HTMLDialogElement.showModal");
                     self.Target.ShowModal(global::Jint.Browser.Dom.DomBindings.NullableArgument<global::AngleSharp.Dom.IElement>(args, 0, "HTMLDialogElement.showModal")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Build();
 
@@ -1412,49 +1412,49 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLEmbedElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("height",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLEmbedElement.height", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlEmbedElement>(thisObj, "HTMLEmbedElement.height");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.DisplayHeight);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLEmbedElement.height", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlEmbedElement>(thisObj, "HTMLEmbedElement.height");
                     self.Target.DisplayHeight = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLEmbedElement.height"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("src",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLEmbedElement.src", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlEmbedElement>(thisObj, "HTMLEmbedElement.src");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Source);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLEmbedElement.src", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlEmbedElement>(thisObj, "HTMLEmbedElement.src");
                     self.Target.Source = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLEmbedElement.src"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("type",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLEmbedElement.type", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlEmbedElement>(thisObj, "HTMLEmbedElement.type");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Type);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLEmbedElement.type", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlEmbedElement>(thisObj, "HTMLEmbedElement.type");
                     self.Target.Type = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLEmbedElement.type"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("width",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLEmbedElement.width", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlEmbedElement>(thisObj, "HTMLEmbedElement.width");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.DisplayWidth);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLEmbedElement.width", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlEmbedElement>(thisObj, "HTMLEmbedElement.width");
                     self.Target.DisplayWidth = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLEmbedElement.width"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLFieldSetElement</c>.</summary>
@@ -1463,77 +1463,77 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLFieldSetElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Method("checkValidity",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLFieldSetElement.checkValidity", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlFieldSetElement>(thisObj, "HTMLFieldSetElement.checkValidity");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.CheckValidity());
-                },
+                }),
                 length: 0)
             .Accessor("disabled",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLFieldSetElement.disabled", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlFieldSetElement>(thisObj, "HTMLFieldSetElement.disabled");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsDisabled);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLFieldSetElement.disabled", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlFieldSetElement>(thisObj, "HTMLFieldSetElement.disabled");
                     self.Target.IsDisabled = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("elements",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLFieldSetElement.elements", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlFieldSetElement>(thisObj, "HTMLFieldSetElement.elements");
                     return self.Realm.WrapCollection<global::AngleSharp.Html.Dom.IHtmlElement>(self.Target.Elements);
-                })
+                }))
             .Accessor("form",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLFieldSetElement.form", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlFieldSetElement>(thisObj, "HTMLFieldSetElement.form");
                     return self.Realm.WrapNodeValue(self.Target.Form);
-                })
+                }))
             .Accessor("name",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLFieldSetElement.name", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlFieldSetElement>(thisObj, "HTMLFieldSetElement.name");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Name);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLFieldSetElement.name", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlFieldSetElement>(thisObj, "HTMLFieldSetElement.name");
                     self.Target.Name = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLFieldSetElement.name"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Method("setCustomValidity",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLFieldSetElement.setCustomValidity", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlFieldSetElement>(thisObj, "HTMLFieldSetElement.setCustomValidity");
                     self.Target.SetCustomValidity(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLFieldSetElement.setCustomValidity")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 1)
             .Accessor("type",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLFieldSetElement.type", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlFieldSetElement>(thisObj, "HTMLFieldSetElement.type");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Type);
-                })
+                }))
             .Accessor("validationMessage",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLFieldSetElement.validationMessage", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlFieldSetElement>(thisObj, "HTMLFieldSetElement.validationMessage");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.ValidationMessage);
-                })
+                }))
             .Accessor("validity",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLFieldSetElement.validity", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlFieldSetElement>(thisObj, "HTMLFieldSetElement.validity");
                     return self.Realm.Wrap(self.Target.Validity);
-                })
+                }))
             .Accessor("willValidate",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLFieldSetElement.willValidate", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlFieldSetElement>(thisObj, "HTMLFieldSetElement.willValidate");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.WillValidate);
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLFormControlsCollection</c>.</summary>
@@ -1549,161 +1549,161 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLFormElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("acceptCharset",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLFormElement.acceptCharset", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlFormElement>(thisObj, "HTMLFormElement.acceptCharset");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.AcceptCharset);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLFormElement.acceptCharset", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlFormElement>(thisObj, "HTMLFormElement.acceptCharset");
                     self.Target.AcceptCharset = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLFormElement.acceptCharset"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("action",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLFormElement.action", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlFormElement>(thisObj, "HTMLFormElement.action");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Action);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLFormElement.action", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlFormElement>(thisObj, "HTMLFormElement.action");
                     self.Target.Action = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLFormElement.action"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("autocomplete",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLFormElement.autocomplete", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlFormElement>(thisObj, "HTMLFormElement.autocomplete");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Autocomplete);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLFormElement.autocomplete", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlFormElement>(thisObj, "HTMLFormElement.autocomplete");
                     self.Target.Autocomplete = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLFormElement.autocomplete"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Method("checkValidity",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLFormElement.checkValidity", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlFormElement>(thisObj, "HTMLFormElement.checkValidity");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.CheckValidity());
-                },
+                }),
                 length: 0)
             .Accessor("elements",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLFormElement.elements", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlFormElement>(thisObj, "HTMLFormElement.elements");
                     return self.Realm.WrapCollection<global::AngleSharp.Html.Dom.IHtmlElement>(self.Target.Elements);
-                })
+                }))
             .Accessor("encoding",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLFormElement.encoding", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlFormElement>(thisObj, "HTMLFormElement.encoding");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Encoding);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLFormElement.encoding", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlFormElement>(thisObj, "HTMLFormElement.encoding");
                     self.Target.Encoding = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLFormElement.encoding"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("enctype",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLFormElement.enctype", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlFormElement>(thisObj, "HTMLFormElement.enctype");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Enctype);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLFormElement.enctype", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlFormElement>(thisObj, "HTMLFormElement.enctype");
                     self.Target.Enctype = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLFormElement.enctype"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("length",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLFormElement.length", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlFormElement>(thisObj, "HTMLFormElement.length");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Length);
-                })
+                }))
             .Accessor("method",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLFormElement.method", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlFormElement>(thisObj, "HTMLFormElement.method");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Method);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLFormElement.method", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlFormElement>(thisObj, "HTMLFormElement.method");
                     self.Target.Method = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLFormElement.method"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("name",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLFormElement.name", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlFormElement>(thisObj, "HTMLFormElement.name");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Name);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLFormElement.name", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlFormElement>(thisObj, "HTMLFormElement.name");
                     self.Target.Name = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLFormElement.name"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("noValidate",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLFormElement.noValidate", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlFormElement>(thisObj, "HTMLFormElement.noValidate");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.NoValidate);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLFormElement.noValidate", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlFormElement>(thisObj, "HTMLFormElement.noValidate");
                     self.Target.NoValidate = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Method("reportValidity",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLFormElement.reportValidity", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlFormElement>(thisObj, "HTMLFormElement.reportValidity");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.ReportValidity());
-                },
+                }),
                 length: 0)
             .Method("requestAutocomplete",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLFormElement.requestAutocomplete", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlFormElement>(thisObj, "HTMLFormElement.requestAutocomplete");
                     self.Target.RequestAutocomplete(); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Method("requestSubmit",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLFormElement.requestSubmit", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlFormElement>(thisObj, "HTMLFormElement.requestSubmit");
                     global::Jint.Browser.Events.FormSubmission.RequestSubmit(self.Realm, self.Target, args.Length > 0 ? args[0] : global::Jint.Native.JsValue.Undefined);
                     return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Method("reset",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLFormElement.reset", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlFormElement>(thisObj, "HTMLFormElement.reset");
                     global::Jint.Browser.Events.FormSubmission.Reset(self.Realm, self.Target);
                     return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Method("submit",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLFormElement.submit", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlFormElement>(thisObj, "HTMLFormElement.submit");
                     global::Jint.Browser.Events.FormSubmission.SubmitWithoutEvent(self.Realm, self.Target, submitter: null);
                     return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Accessor("target",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLFormElement.target", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlFormElement>(thisObj, "HTMLFormElement.target");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Target);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLFormElement.target", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlFormElement>(thisObj, "HTMLFormElement.target");
                     self.Target.Target = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLFormElement.target"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLHRElement</c>.</summary>
@@ -1733,16 +1733,16 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLHtmlElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("manifest",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLHtmlElement.manifest", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlHtmlElement>(thisObj, "HTMLHtmlElement.manifest");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Manifest);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLHtmlElement.manifest", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlHtmlElement>(thisObj, "HTMLHtmlElement.manifest");
                     self.Target.Manifest = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLHtmlElement.manifest"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLIFrameElement</c>.</summary>
@@ -1751,116 +1751,116 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLIFrameElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("allowFullscreen",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLIFrameElement.allowFullscreen", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInlineFrameElement>(thisObj, "HTMLIFrameElement.allowFullscreen");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsFullscreenAllowed);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLIFrameElement.allowFullscreen", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInlineFrameElement>(thisObj, "HTMLIFrameElement.allowFullscreen");
                     self.Target.IsFullscreenAllowed = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("allowPaymentRequest",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLIFrameElement.allowPaymentRequest", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInlineFrameElement>(thisObj, "HTMLIFrameElement.allowPaymentRequest");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsPaymentRequestAllowed);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLIFrameElement.allowPaymentRequest", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInlineFrameElement>(thisObj, "HTMLIFrameElement.allowPaymentRequest");
                     self.Target.IsPaymentRequestAllowed = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("contentDocument",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLIFrameElement.contentDocument", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInlineFrameElement>(thisObj, "HTMLIFrameElement.contentDocument");
                     return self.Realm.WrapNodeValue(self.Target.ContentDocument);
-                })
+                }))
             .Accessor("height",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLIFrameElement.height", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInlineFrameElement>(thisObj, "HTMLIFrameElement.height");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.DisplayHeight);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLIFrameElement.height", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInlineFrameElement>(thisObj, "HTMLIFrameElement.height");
                     self.Target.DisplayHeight = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLIFrameElement.height"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("name",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLIFrameElement.name", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInlineFrameElement>(thisObj, "HTMLIFrameElement.name");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Name);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLIFrameElement.name", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInlineFrameElement>(thisObj, "HTMLIFrameElement.name");
                     self.Target.Name = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLIFrameElement.name"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("referrerPolicy",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLIFrameElement.referrerPolicy", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInlineFrameElement>(thisObj, "HTMLIFrameElement.referrerPolicy");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.ReferrerPolicy);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLIFrameElement.referrerPolicy", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInlineFrameElement>(thisObj, "HTMLIFrameElement.referrerPolicy");
                     self.Target.ReferrerPolicy = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLIFrameElement.referrerPolicy"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("sandbox",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLIFrameElement.sandbox", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInlineFrameElement>(thisObj, "HTMLIFrameElement.sandbox");
                     return self.Realm.Wrap(self.Target.Sandbox);
-                })
+                }))
             .Accessor("seamless",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLIFrameElement.seamless", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInlineFrameElement>(thisObj, "HTMLIFrameElement.seamless");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsSeamless);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLIFrameElement.seamless", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInlineFrameElement>(thisObj, "HTMLIFrameElement.seamless");
                     self.Target.IsSeamless = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("src",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLIFrameElement.src", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInlineFrameElement>(thisObj, "HTMLIFrameElement.src");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Source);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLIFrameElement.src", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInlineFrameElement>(thisObj, "HTMLIFrameElement.src");
                     self.Target.Source = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLIFrameElement.src"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("srcdoc",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLIFrameElement.srcdoc", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInlineFrameElement>(thisObj, "HTMLIFrameElement.srcdoc");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.ContentHtml);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLIFrameElement.srcdoc", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInlineFrameElement>(thisObj, "HTMLIFrameElement.srcdoc");
                     self.Target.ContentHtml = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLIFrameElement.srcdoc"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("width",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLIFrameElement.width", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInlineFrameElement>(thisObj, "HTMLIFrameElement.width");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.DisplayWidth);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLIFrameElement.width", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInlineFrameElement>(thisObj, "HTMLIFrameElement.width");
                     self.Target.DisplayWidth = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLIFrameElement.width"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLImageElement</c>.</summary>
@@ -1869,128 +1869,128 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLImageElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("alt",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.alt", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.alt");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.AlternativeText);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.alt", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.alt");
                     self.Target.AlternativeText = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLImageElement.alt"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("complete",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.complete", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.complete");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsCompleted);
-                })
+                }))
             .Accessor("crossOrigin",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.crossOrigin", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.crossOrigin");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.CrossOrigin);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.crossOrigin", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.crossOrigin");
                     self.Target.CrossOrigin = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLImageElement.crossOrigin"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("currentSrc",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.currentSrc", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.currentSrc");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.ActualSource);
-                })
+                }))
             .Accessor("height",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.height", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.height");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.DisplayHeight);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.height", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.height");
                     self.Target.DisplayHeight = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLImageElement.height"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("isMap",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.isMap", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.isMap");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsMap);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.isMap", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.isMap");
                     self.Target.IsMap = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("naturalHeight",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.naturalHeight", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.naturalHeight");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.OriginalHeight);
-                })
+                }))
             .Accessor("naturalWidth",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.naturalWidth", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.naturalWidth");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.OriginalWidth);
-                })
+                }))
             .Accessor("sizes",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.sizes", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.sizes");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Sizes);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.sizes", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.sizes");
                     self.Target.Sizes = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLImageElement.sizes"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("src",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.src", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.src");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Source);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.src", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.src");
                     self.Target.Source = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLImageElement.src"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("srcset",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.srcset", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.srcset");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.SourceSet);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.srcset", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.srcset");
                     self.Target.SourceSet = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLImageElement.srcset"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("useMap",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.useMap", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.useMap");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.UseMap);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.useMap", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.useMap");
                     self.Target.UseMap = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLImageElement.useMap"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("width",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.width", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.width");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.DisplayWidth);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.width", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.width");
                     self.Target.DisplayWidth = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLImageElement.width"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLInputElement</c>.</summary>
@@ -1999,491 +1999,491 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLInputElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("accept",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.accept", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.accept");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Accept);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.accept", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.accept");
                     self.Target.Accept = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLInputElement.accept"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("alt",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.alt", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.alt");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.AlternativeText);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.alt", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.alt");
                     self.Target.AlternativeText = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLInputElement.alt"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("autocomplete",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.autocomplete", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.autocomplete");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Autocomplete);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.autocomplete", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.autocomplete");
                     self.Target.Autocomplete = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLInputElement.autocomplete"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("autofocus",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.autofocus", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.autofocus");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.Autofocus);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.autofocus", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.autofocus");
                     self.Target.Autofocus = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Method("checkValidity",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.checkValidity", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.checkValidity");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.CheckValidity());
-                },
+                }),
                 length: 0)
             .Accessor("checked",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.checked", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.checked");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsChecked);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.checked", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.checked");
                     self.Target.IsChecked = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("defaultChecked",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.defaultChecked", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.defaultChecked");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsDefaultChecked);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.defaultChecked", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.defaultChecked");
                     self.Target.IsDefaultChecked = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("defaultValue",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.defaultValue", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.defaultValue");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.DefaultValue);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.defaultValue", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.defaultValue");
                     self.Target.DefaultValue = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLInputElement.defaultValue"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("dirName",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.dirName", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.dirName");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.DirectionName);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.dirName", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.dirName");
                     self.Target.DirectionName = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLInputElement.dirName"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("disabled",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.disabled", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.disabled");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsDisabled);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.disabled", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.disabled");
                     self.Target.IsDisabled = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("files",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.files", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.files");
                     return self.Realm.Wrap(self.Target.Files);
-                })
+                }))
             .Accessor("form",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.form", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.form");
                     return self.Realm.WrapNodeValue(self.Target.Form);
-                })
+                }))
             .Accessor("formAction",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.formAction", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.formAction");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.FormAction);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.formAction", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.formAction");
                     self.Target.FormAction = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLInputElement.formAction"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("formEncType",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.formEncType", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.formEncType");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.FormEncType);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.formEncType", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.formEncType");
                     self.Target.FormEncType = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLInputElement.formEncType"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("formMethod",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.formMethod", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.formMethod");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.FormMethod);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.formMethod", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.formMethod");
                     self.Target.FormMethod = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLInputElement.formMethod"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("formNoValidate",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.formNoValidate", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.formNoValidate");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.FormNoValidate);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.formNoValidate", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.formNoValidate");
                     self.Target.FormNoValidate = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("formTarget",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.formTarget", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.formTarget");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.FormTarget);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.formTarget", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.formTarget");
                     self.Target.FormTarget = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLInputElement.formTarget"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("height",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.height", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.height");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.DisplayHeight);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.height", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.height");
                     self.Target.DisplayHeight = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLInputElement.height"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("indeterminate",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.indeterminate", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.indeterminate");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsIndeterminate);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.indeterminate", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.indeterminate");
                     self.Target.IsIndeterminate = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("labels",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.labels", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.labels");
                     return self.Realm.Wrap(self.Target.Labels);
-                })
+                }))
             .Accessor("list",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.list", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.list");
                     return self.Realm.WrapNodeValue(self.Target.List);
-                })
+                }))
             .Accessor("max",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.max", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.max");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Maximum);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.max", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.max");
                     self.Target.Maximum = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLInputElement.max"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("maxLength",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.maxLength", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.maxLength");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.MaxLength);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.maxLength", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.maxLength");
                     self.Target.MaxLength = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLInputElement.maxLength"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("min",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.min", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.min");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Minimum);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.min", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.min");
                     self.Target.Minimum = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLInputElement.min"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("minLength",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.minLength", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.minLength");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.MinLength);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.minLength", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.minLength");
                     self.Target.MinLength = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLInputElement.minLength"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("multiple",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.multiple", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.multiple");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsMultiple);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.multiple", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.multiple");
                     self.Target.IsMultiple = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("name",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.name", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.name");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Name);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.name", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.name");
                     self.Target.Name = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLInputElement.name"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("pattern",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.pattern", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.pattern");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Pattern);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.pattern", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.pattern");
                     self.Target.Pattern = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLInputElement.pattern"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("placeholder",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.placeholder", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.placeholder");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Placeholder);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.placeholder", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.placeholder");
                     self.Target.Placeholder = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLInputElement.placeholder"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("readOnly",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.readOnly", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.readOnly");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsReadOnly);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.readOnly", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.readOnly");
                     self.Target.IsReadOnly = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("required",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.required", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.required");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsRequired);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.required", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.required");
                     self.Target.IsRequired = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Method("select",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.select", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.select");
                     self.Target.SelectAll(); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Accessor("selectionDirection",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.selectionDirection", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.selectionDirection");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.SelectionDirection);
-                })
+                }))
             .Accessor("selectionEnd",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.selectionEnd", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.selectionEnd");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.SelectionEnd);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.selectionEnd", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.selectionEnd");
                     self.Target.SelectionEnd = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLInputElement.selectionEnd"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("selectionStart",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.selectionStart", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.selectionStart");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.SelectionStart);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.selectionStart", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.selectionStart");
                     self.Target.SelectionStart = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLInputElement.selectionStart"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Method("setCustomValidity",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.setCustomValidity", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.setCustomValidity");
                     self.Target.SetCustomValidity(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLInputElement.setCustomValidity")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 1)
             .Method("setSelectionRange",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.setSelectionRange", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.setSelectionRange");
                     self.Target.Select(global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLInputElement.setSelectionRange"), global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 1, "HTMLInputElement.setSelectionRange"), global::Jint.Browser.Dom.DomConvert.OptionalText(args, 2, null)!); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 2)
             .Accessor("size",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.size", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.size");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Size);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.size", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.size");
                     self.Target.Size = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLInputElement.size"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("src",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.src", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.src");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Source);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.src", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.src");
                     self.Target.Source = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLInputElement.src"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("step",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.step", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.step");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Step);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.step", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.step");
                     self.Target.Step = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLInputElement.step"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Method("stepDown",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.stepDown", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.stepDown");
                     self.Target.StepDown(global::Jint.Browser.Dom.DomConvert.OptionalInt32(args, 0, 1)); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Method("stepUp",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.stepUp", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.stepUp");
                     self.Target.StepUp(global::Jint.Browser.Dom.DomConvert.OptionalInt32(args, 0, 1)); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Accessor("type",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.type", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.type");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Type);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.type", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.type");
                     self.Target.Type = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLInputElement.type"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("validationMessage",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.validationMessage", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.validationMessage");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.ValidationMessage);
-                })
+                }))
             .Accessor("validity",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.validity", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.validity");
                     return self.Realm.Wrap(self.Target.Validity);
-                })
+                }))
             .Accessor("value",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.value", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.value");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Value);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.value", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.value");
                     self.Target.Value = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLInputElement.value"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("valueAsDate",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.valueAsDate", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.valueAsDate");
                     return global::Jint.Browser.Dom.DomConvert.Timestamp(self.Target.ValueAsDate);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.valueAsDate", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.valueAsDate");
                     self.Target.ValueAsDate = global::Jint.Browser.Dom.DomConvert.NullableTimestamp(args, 0); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("valueAsNumber",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.valueAsNumber", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.valueAsNumber");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.ValueAsNumber);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.valueAsNumber", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.valueAsNumber");
                     self.Target.ValueAsNumber = global::Jint.Browser.Dom.DomConvert.RequiredDouble(args, 0, "HTMLInputElement.valueAsNumber"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("width",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.width", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.width");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.DisplayWidth);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.width", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.width");
                     self.Target.DisplayWidth = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLInputElement.width"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("willValidate",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.willValidate", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.willValidate");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.WillValidate);
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLKeygenElement</c>.</summary>
@@ -2492,110 +2492,110 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLKeygenElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("autofocus",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLKeygenElement.autofocus", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlKeygenElement>(thisObj, "HTMLKeygenElement.autofocus");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.Autofocus);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLKeygenElement.autofocus", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlKeygenElement>(thisObj, "HTMLKeygenElement.autofocus");
                     self.Target.Autofocus = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("challenge",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLKeygenElement.challenge", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlKeygenElement>(thisObj, "HTMLKeygenElement.challenge");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Challenge);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLKeygenElement.challenge", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlKeygenElement>(thisObj, "HTMLKeygenElement.challenge");
                     self.Target.Challenge = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLKeygenElement.challenge"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Method("checkValidity",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLKeygenElement.checkValidity", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlKeygenElement>(thisObj, "HTMLKeygenElement.checkValidity");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.CheckValidity());
-                },
+                }),
                 length: 0)
             .Accessor("disabled",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLKeygenElement.disabled", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlKeygenElement>(thisObj, "HTMLKeygenElement.disabled");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsDisabled);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLKeygenElement.disabled", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlKeygenElement>(thisObj, "HTMLKeygenElement.disabled");
                     self.Target.IsDisabled = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("form",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLKeygenElement.form", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlKeygenElement>(thisObj, "HTMLKeygenElement.form");
                     return self.Realm.WrapNodeValue(self.Target.Form);
-                })
+                }))
             .Accessor("keytype",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLKeygenElement.keytype", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlKeygenElement>(thisObj, "HTMLKeygenElement.keytype");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.KeyEncryption);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLKeygenElement.keytype", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlKeygenElement>(thisObj, "HTMLKeygenElement.keytype");
                     self.Target.KeyEncryption = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLKeygenElement.keytype"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("labels",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLKeygenElement.labels", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlKeygenElement>(thisObj, "HTMLKeygenElement.labels");
                     return self.Realm.Wrap(self.Target.Labels);
-                })
+                }))
             .Accessor("name",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLKeygenElement.name", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlKeygenElement>(thisObj, "HTMLKeygenElement.name");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Name);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLKeygenElement.name", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlKeygenElement>(thisObj, "HTMLKeygenElement.name");
                     self.Target.Name = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLKeygenElement.name"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Method("setCustomValidity",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLKeygenElement.setCustomValidity", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlKeygenElement>(thisObj, "HTMLKeygenElement.setCustomValidity");
                     self.Target.SetCustomValidity(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLKeygenElement.setCustomValidity")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 1)
             .Accessor("type",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLKeygenElement.type", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlKeygenElement>(thisObj, "HTMLKeygenElement.type");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Type);
-                })
+                }))
             .Accessor("validationMessage",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLKeygenElement.validationMessage", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlKeygenElement>(thisObj, "HTMLKeygenElement.validationMessage");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.ValidationMessage);
-                })
+                }))
             .Accessor("validity",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLKeygenElement.validity", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlKeygenElement>(thisObj, "HTMLKeygenElement.validity");
                     return self.Realm.Wrap(self.Target.Validity);
-                })
+                }))
             .Accessor("willValidate",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLKeygenElement.willValidate", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlKeygenElement>(thisObj, "HTMLKeygenElement.willValidate");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.WillValidate);
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLLIElement</c>.</summary>
@@ -2604,16 +2604,16 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLLIElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("value",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLLIElement.value", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlListItemElement>(thisObj, "HTMLLIElement.value");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Value);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLLIElement.value", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlListItemElement>(thisObj, "HTMLLIElement.value");
                     self.Target.Value = global::Jint.Browser.Dom.DomConvert.NullableInt32(args, 0); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLLabelElement</c>.</summary>
@@ -2622,28 +2622,28 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLLabelElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("control",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLLabelElement.control", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlLabelElement>(thisObj, "HTMLLabelElement.control");
                     return self.Realm.WrapNodeValue(self.Target.Control);
-                })
+                }))
             .Accessor("form",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLLabelElement.form", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlLabelElement>(thisObj, "HTMLLabelElement.form");
                     return self.Realm.WrapNodeValue(self.Target.Form);
-                })
+                }))
             .Accessor("htmlFor",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLLabelElement.htmlFor", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlLabelElement>(thisObj, "HTMLLabelElement.htmlFor");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.HtmlFor);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLLabelElement.htmlFor", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlLabelElement>(thisObj, "HTMLLabelElement.htmlFor");
                     self.Target.HtmlFor = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLLabelElement.htmlFor"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLLegendElement</c>.</summary>
@@ -2652,11 +2652,11 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLLegendElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("form",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLLegendElement.form", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlLegendElement>(thisObj, "HTMLLegendElement.form");
                     return self.Realm.WrapNodeValue(self.Target.Form);
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLLinkElement</c>.</summary>
@@ -2665,139 +2665,139 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLLinkElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("crossOrigin",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLLinkElement.crossOrigin", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlLinkElement>(thisObj, "HTMLLinkElement.crossOrigin");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.CrossOrigin);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLLinkElement.crossOrigin", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlLinkElement>(thisObj, "HTMLLinkElement.crossOrigin");
                     self.Target.CrossOrigin = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLLinkElement.crossOrigin"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("disabled",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLLinkElement.disabled", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlLinkElement>(thisObj, "HTMLLinkElement.disabled");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsDisabled);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLLinkElement.disabled", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlLinkElement>(thisObj, "HTMLLinkElement.disabled");
                     self.Target.IsDisabled = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("href",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLLinkElement.href", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlLinkElement>(thisObj, "HTMLLinkElement.href");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Href);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLLinkElement.href", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlLinkElement>(thisObj, "HTMLLinkElement.href");
                     self.Target.Href = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLLinkElement.href"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("hreflang",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLLinkElement.hreflang", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlLinkElement>(thisObj, "HTMLLinkElement.hreflang");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.TargetLanguage);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLLinkElement.hreflang", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlLinkElement>(thisObj, "HTMLLinkElement.hreflang");
                     self.Target.TargetLanguage = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLLinkElement.hreflang"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("import",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLLinkElement.import", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlLinkElement>(thisObj, "HTMLLinkElement.import");
                     return self.Realm.WrapNodeValue(self.Target.Import);
-                })
+                }))
             .Accessor("integrity",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLLinkElement.integrity", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlLinkElement>(thisObj, "HTMLLinkElement.integrity");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Integrity);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLLinkElement.integrity", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlLinkElement>(thisObj, "HTMLLinkElement.integrity");
                     self.Target.Integrity = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLLinkElement.integrity"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("media",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLLinkElement.media", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlLinkElement>(thisObj, "HTMLLinkElement.media");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Media);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLLinkElement.media", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlLinkElement>(thisObj, "HTMLLinkElement.media");
                     self.Target.Media = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLLinkElement.media"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("nonce",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLLinkElement.nonce", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlLinkElement>(thisObj, "HTMLLinkElement.nonce");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.NumberUsedOnce);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLLinkElement.nonce", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlLinkElement>(thisObj, "HTMLLinkElement.nonce");
                     self.Target.NumberUsedOnce = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLLinkElement.nonce"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("rel",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLLinkElement.rel", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlLinkElement>(thisObj, "HTMLLinkElement.rel");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Relation);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLLinkElement.rel", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlLinkElement>(thisObj, "HTMLLinkElement.rel");
                     self.Target.Relation = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLLinkElement.rel"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("relList",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLLinkElement.relList", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlLinkElement>(thisObj, "HTMLLinkElement.relList");
                     return self.Realm.Wrap(self.Target.RelationList);
-                })
+                }))
             .Accessor("rev",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLLinkElement.rev", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlLinkElement>(thisObj, "HTMLLinkElement.rev");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.ReverseRelation);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLLinkElement.rev", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlLinkElement>(thisObj, "HTMLLinkElement.rev");
                     self.Target.ReverseRelation = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLLinkElement.rev"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("sheet",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLLinkElement.sheet", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlLinkElement>(thisObj, "HTMLLinkElement.sheet");
                     return self.Realm.Wrap(self.Target.Sheet);
-                })
+                }))
             .Accessor("sizes",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLLinkElement.sizes", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlLinkElement>(thisObj, "HTMLLinkElement.sizes");
                     return self.Realm.Wrap(self.Target.Sizes);
-                })
+                }))
             .Accessor("type",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLLinkElement.type", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlLinkElement>(thisObj, "HTMLLinkElement.type");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Type);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLLinkElement.type", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlLinkElement>(thisObj, "HTMLLinkElement.type");
                     self.Target.Type = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLLinkElement.type"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLMapElement</c>.</summary>
@@ -2806,28 +2806,28 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLMapElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("areas",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMapElement.areas", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMapElement>(thisObj, "HTMLMapElement.areas");
                     return self.Realm.WrapCollection<global::AngleSharp.Html.Dom.IHtmlAreaElement>(self.Target.Areas);
-                })
+                }))
             .Accessor("images",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMapElement.images", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMapElement>(thisObj, "HTMLMapElement.images");
                     return self.Realm.WrapCollection<global::AngleSharp.Html.Dom.IHtmlImageElement>(self.Target.Images);
-                })
+                }))
             .Accessor("name",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMapElement.name", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMapElement>(thisObj, "HTMLMapElement.name");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Name);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMapElement.name", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMapElement>(thisObj, "HTMLMapElement.name");
                     self.Target.Name = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLMapElement.name"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLMarqueeElement</c>.</summary>
@@ -2836,38 +2836,38 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLMarqueeElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("loop",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMarqueeElement.loop", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMarqueeElement>(thisObj, "HTMLMarqueeElement.loop");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Loop);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMarqueeElement.loop", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMarqueeElement>(thisObj, "HTMLMarqueeElement.loop");
                     self.Target.Loop = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLMarqueeElement.loop"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("scrollamount",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMarqueeElement.scrollamount", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMarqueeElement>(thisObj, "HTMLMarqueeElement.scrollamount");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.ScrollAmount);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMarqueeElement.scrollamount", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMarqueeElement>(thisObj, "HTMLMarqueeElement.scrollamount");
                     self.Target.ScrollAmount = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLMarqueeElement.scrollamount"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("scrolldelay",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMarqueeElement.scrolldelay", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMarqueeElement>(thisObj, "HTMLMarqueeElement.scrolldelay");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.ScrollDelay);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMarqueeElement.scrolldelay", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMarqueeElement>(thisObj, "HTMLMarqueeElement.scrolldelay");
                     self.Target.ScrollDelay = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLMarqueeElement.scrolldelay"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLMenuElement</c>.</summary>
@@ -2876,27 +2876,27 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLMenuElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("label",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMenuElement.label", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMenuElement>(thisObj, "HTMLMenuElement.label");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Label);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMenuElement.label", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMenuElement>(thisObj, "HTMLMenuElement.label");
                     self.Target.Label = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLMenuElement.label"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("type",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMenuElement.type", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMenuElement>(thisObj, "HTMLMenuElement.type");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Type);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMenuElement.type", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMenuElement>(thisObj, "HTMLMenuElement.type");
                     self.Target.Type = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLMenuElement.type"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLMenuItemElement</c>.</summary>
@@ -2905,88 +2905,88 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLMenuItemElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("checked",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMenuItemElement.checked", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMenuItemElement>(thisObj, "HTMLMenuItemElement.checked");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsChecked);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMenuItemElement.checked", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMenuItemElement>(thisObj, "HTMLMenuItemElement.checked");
                     self.Target.IsChecked = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("command",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMenuItemElement.command", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMenuItemElement>(thisObj, "HTMLMenuItemElement.command");
                     return self.Realm.WrapNodeValue(self.Target.Command);
-                })
+                }))
             .Accessor("default",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMenuItemElement.default", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMenuItemElement>(thisObj, "HTMLMenuItemElement.default");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsDefault);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMenuItemElement.default", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMenuItemElement>(thisObj, "HTMLMenuItemElement.default");
                     self.Target.IsDefault = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("disabled",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMenuItemElement.disabled", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMenuItemElement>(thisObj, "HTMLMenuItemElement.disabled");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsDisabled);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMenuItemElement.disabled", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMenuItemElement>(thisObj, "HTMLMenuItemElement.disabled");
                     self.Target.IsDisabled = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("icon",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMenuItemElement.icon", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMenuItemElement>(thisObj, "HTMLMenuItemElement.icon");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Icon);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMenuItemElement.icon", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMenuItemElement>(thisObj, "HTMLMenuItemElement.icon");
                     self.Target.Icon = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLMenuItemElement.icon"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("label",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMenuItemElement.label", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMenuItemElement>(thisObj, "HTMLMenuItemElement.label");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Label);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMenuItemElement.label", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMenuItemElement>(thisObj, "HTMLMenuItemElement.label");
                     self.Target.Label = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLMenuItemElement.label"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("radiogroup",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMenuItemElement.radiogroup", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMenuItemElement>(thisObj, "HTMLMenuItemElement.radiogroup");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.RadioGroup);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMenuItemElement.radiogroup", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMenuItemElement>(thisObj, "HTMLMenuItemElement.radiogroup");
                     self.Target.RadioGroup = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLMenuItemElement.radiogroup"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("type",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMenuItemElement.type", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMenuItemElement>(thisObj, "HTMLMenuItemElement.type");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Type);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMenuItemElement.type", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMenuItemElement>(thisObj, "HTMLMenuItemElement.type");
                     self.Target.Type = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLMenuItemElement.type"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLMetaElement</c>.</summary>
@@ -2995,38 +2995,38 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLMetaElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("content",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMetaElement.content", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMetaElement>(thisObj, "HTMLMetaElement.content");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Content);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMetaElement.content", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMetaElement>(thisObj, "HTMLMetaElement.content");
                     self.Target.Content = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLMetaElement.content"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("httpEquiv",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMetaElement.httpEquiv", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMetaElement>(thisObj, "HTMLMetaElement.httpEquiv");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.HttpEquivalent);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMetaElement.httpEquiv", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMetaElement>(thisObj, "HTMLMetaElement.httpEquiv");
                     self.Target.HttpEquivalent = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLMetaElement.httpEquiv"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("name",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMetaElement.name", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMetaElement>(thisObj, "HTMLMetaElement.name");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Name);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMetaElement.name", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMetaElement>(thisObj, "HTMLMetaElement.name");
                     self.Target.Name = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLMetaElement.name"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLMeterElement</c>.</summary>
@@ -3035,77 +3035,77 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLMeterElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("high",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMeterElement.high", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMeterElement>(thisObj, "HTMLMeterElement.high");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.High);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMeterElement.high", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMeterElement>(thisObj, "HTMLMeterElement.high");
                     self.Target.High = global::Jint.Browser.Dom.DomConvert.RequiredDouble(args, 0, "HTMLMeterElement.high"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("labels",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMeterElement.labels", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMeterElement>(thisObj, "HTMLMeterElement.labels");
                     return self.Realm.Wrap(self.Target.Labels);
-                })
+                }))
             .Accessor("low",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMeterElement.low", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMeterElement>(thisObj, "HTMLMeterElement.low");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Low);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMeterElement.low", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMeterElement>(thisObj, "HTMLMeterElement.low");
                     self.Target.Low = global::Jint.Browser.Dom.DomConvert.RequiredDouble(args, 0, "HTMLMeterElement.low"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("max",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMeterElement.max", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMeterElement>(thisObj, "HTMLMeterElement.max");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Maximum);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMeterElement.max", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMeterElement>(thisObj, "HTMLMeterElement.max");
                     self.Target.Maximum = global::Jint.Browser.Dom.DomConvert.RequiredDouble(args, 0, "HTMLMeterElement.max"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("min",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMeterElement.min", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMeterElement>(thisObj, "HTMLMeterElement.min");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Minimum);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMeterElement.min", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMeterElement>(thisObj, "HTMLMeterElement.min");
                     self.Target.Minimum = global::Jint.Browser.Dom.DomConvert.RequiredDouble(args, 0, "HTMLMeterElement.min"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("optimum",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMeterElement.optimum", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMeterElement>(thisObj, "HTMLMeterElement.optimum");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Optimum);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMeterElement.optimum", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMeterElement>(thisObj, "HTMLMeterElement.optimum");
                     self.Target.Optimum = global::Jint.Browser.Dom.DomConvert.RequiredDouble(args, 0, "HTMLMeterElement.optimum"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("value",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMeterElement.value", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMeterElement>(thisObj, "HTMLMeterElement.value");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Value);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMeterElement.value", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMeterElement>(thisObj, "HTMLMeterElement.value");
                     self.Target.Value = global::Jint.Browser.Dom.DomConvert.RequiredDouble(args, 0, "HTMLMeterElement.value"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLModElement</c>.</summary>
@@ -3114,27 +3114,27 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLModElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("cite",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLModElement.cite", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlModElement>(thisObj, "HTMLModElement.cite");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Citation);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLModElement.cite", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlModElement>(thisObj, "HTMLModElement.cite");
                     self.Target.Citation = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLModElement.cite"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("datetime",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLModElement.datetime", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlModElement>(thisObj, "HTMLModElement.datetime");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.DateTime);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLModElement.datetime", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlModElement>(thisObj, "HTMLModElement.datetime");
                     self.Target.DateTime = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLModElement.datetime"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLOListElement</c>.</summary>
@@ -3143,38 +3143,38 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLOListElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("reversed",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLOListElement.reversed", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOrderedListElement>(thisObj, "HTMLOListElement.reversed");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsReversed);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLOListElement.reversed", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOrderedListElement>(thisObj, "HTMLOListElement.reversed");
                     self.Target.IsReversed = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("start",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLOListElement.start", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOrderedListElement>(thisObj, "HTMLOListElement.start");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Start);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLOListElement.start", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOrderedListElement>(thisObj, "HTMLOListElement.start");
                     self.Target.Start = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLOListElement.start"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("type",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLOListElement.type", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOrderedListElement>(thisObj, "HTMLOListElement.type");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Type);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLOListElement.type", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOrderedListElement>(thisObj, "HTMLOListElement.type");
                     self.Target.Type = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLOListElement.type"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLObjectElement</c>.</summary>
@@ -3183,126 +3183,126 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLObjectElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Method("checkValidity",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.checkValidity", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.checkValidity");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.CheckValidity());
-                },
+                }),
                 length: 0)
             .Accessor("contentDocument",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.contentDocument", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.contentDocument");
                     return self.Realm.WrapNodeValue(self.Target.ContentDocument);
-                })
+                }))
             .Accessor("data",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.data", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.data");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Source);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.data", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.data");
                     self.Target.Source = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLObjectElement.data"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("form",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.form", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.form");
                     return self.Realm.WrapNodeValue(self.Target.Form);
-                })
+                }))
             .Accessor("height",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.height", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.height");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.DisplayHeight);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.height", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.height");
                     self.Target.DisplayHeight = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLObjectElement.height"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("name",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.name", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.name");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Name);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.name", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.name");
                     self.Target.Name = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLObjectElement.name"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Method("setCustomValidity",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.setCustomValidity", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.setCustomValidity");
                     self.Target.SetCustomValidity(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLObjectElement.setCustomValidity")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 1)
             .Accessor("type",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.type", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.type");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Type);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.type", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.type");
                     self.Target.Type = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLObjectElement.type"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("typeMustMatch",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.typeMustMatch", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.typeMustMatch");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.TypeMustMatch);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.typeMustMatch", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.typeMustMatch");
                     self.Target.TypeMustMatch = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("useMap",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.useMap", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.useMap");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.UseMap);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.useMap", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.useMap");
                     self.Target.UseMap = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLObjectElement.useMap"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("validationMessage",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.validationMessage", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.validationMessage");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.ValidationMessage);
-                })
+                }))
             .Accessor("validity",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.validity", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.validity");
                     return self.Realm.Wrap(self.Target.Validity);
-                })
+                }))
             .Accessor("width",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.width", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.width");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.DisplayWidth);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.width", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.width");
                     self.Target.DisplayWidth = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLObjectElement.width"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("willValidate",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.willValidate", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.willValidate");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.WillValidate);
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLOptGroupElement</c>.</summary>
@@ -3311,27 +3311,27 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLOptGroupElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("disabled",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLOptGroupElement.disabled", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOptionsGroupElement>(thisObj, "HTMLOptGroupElement.disabled");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsDisabled);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLOptGroupElement.disabled", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOptionsGroupElement>(thisObj, "HTMLOptGroupElement.disabled");
                     self.Target.IsDisabled = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("label",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLOptGroupElement.label", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOptionsGroupElement>(thisObj, "HTMLOptGroupElement.label");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Label);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLOptGroupElement.label", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOptionsGroupElement>(thisObj, "HTMLOptGroupElement.label");
                     self.Target.Label = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLOptGroupElement.label"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLOptionElement</c>.</summary>
@@ -3340,83 +3340,83 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLOptionElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("defaultSelected",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLOptionElement.defaultSelected", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOptionElement>(thisObj, "HTMLOptionElement.defaultSelected");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsDefaultSelected);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLOptionElement.defaultSelected", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOptionElement>(thisObj, "HTMLOptionElement.defaultSelected");
                     self.Target.IsDefaultSelected = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("disabled",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLOptionElement.disabled", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOptionElement>(thisObj, "HTMLOptionElement.disabled");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsDisabled);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLOptionElement.disabled", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOptionElement>(thisObj, "HTMLOptionElement.disabled");
                     self.Target.IsDisabled = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("form",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLOptionElement.form", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOptionElement>(thisObj, "HTMLOptionElement.form");
                     return self.Realm.WrapNodeValue(self.Target.Form);
-                })
+                }))
             .Accessor("index",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLOptionElement.index", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOptionElement>(thisObj, "HTMLOptionElement.index");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Index);
-                })
+                }))
             .Accessor("label",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLOptionElement.label", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOptionElement>(thisObj, "HTMLOptionElement.label");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Label);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLOptionElement.label", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOptionElement>(thisObj, "HTMLOptionElement.label");
                     self.Target.Label = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLOptionElement.label"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("selected",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLOptionElement.selected", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOptionElement>(thisObj, "HTMLOptionElement.selected");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsSelected);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLOptionElement.selected", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOptionElement>(thisObj, "HTMLOptionElement.selected");
                     self.Target.IsSelected = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("text",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLOptionElement.text", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOptionElement>(thisObj, "HTMLOptionElement.text");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Text);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLOptionElement.text", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOptionElement>(thisObj, "HTMLOptionElement.text");
                     self.Target.Text = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLOptionElement.text"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("value",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLOptionElement.value", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOptionElement>(thisObj, "HTMLOptionElement.value");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Value);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLOptionElement.value", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOptionElement>(thisObj, "HTMLOptionElement.value");
                     self.Target.Value = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLOptionElement.value"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLOptionsCollection</c>.</summary>
@@ -3425,30 +3425,30 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLOptionsCollection")
             .PerRealmSlot("constructor", enumerable: false)
             .Method("add",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLOptionsCollection.add", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOptionsCollection>(thisObj, "HTMLOptionsCollection.add");
                     self.Target.Add(global::Jint.Browser.Dom.DomBindings.Argument<global::AngleSharp.Html.Dom.IHtmlOptionElement>(args, 0, "HTMLOptionsCollection.add"), global::Jint.Browser.Dom.DomBindings.NullableArgument<global::AngleSharp.Html.Dom.IHtmlElement>(args, 1, "HTMLOptionsCollection.add")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 1)
             .Method("remove",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLOptionsCollection.remove", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOptionsCollection>(thisObj, "HTMLOptionsCollection.remove");
                     self.Target.Remove(global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLOptionsCollection.remove")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 1)
             .Accessor("selectedIndex",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLOptionsCollection.selectedIndex", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOptionsCollection>(thisObj, "HTMLOptionsCollection.selectedIndex");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.SelectedIndex);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLOptionsCollection.selectedIndex", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOptionsCollection>(thisObj, "HTMLOptionsCollection.selectedIndex");
                     self.Target.SelectedIndex = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLOptionsCollection.selectedIndex"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLOutputElement</c>.</summary>
@@ -3457,94 +3457,94 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLOutputElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Method("checkValidity",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLOutputElement.checkValidity", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOutputElement>(thisObj, "HTMLOutputElement.checkValidity");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.CheckValidity());
-                },
+                }),
                 length: 0)
             .Accessor("defaultValue",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLOutputElement.defaultValue", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOutputElement>(thisObj, "HTMLOutputElement.defaultValue");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.DefaultValue);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLOutputElement.defaultValue", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOutputElement>(thisObj, "HTMLOutputElement.defaultValue");
                     self.Target.DefaultValue = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLOutputElement.defaultValue"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("form",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLOutputElement.form", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOutputElement>(thisObj, "HTMLOutputElement.form");
                     return self.Realm.WrapNodeValue(self.Target.Form);
-                })
+                }))
             .Accessor("htmlFor",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLOutputElement.htmlFor", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOutputElement>(thisObj, "HTMLOutputElement.htmlFor");
                     return self.Realm.Wrap(self.Target.HtmlFor);
-                })
+                }))
             .Accessor("labels",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLOutputElement.labels", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOutputElement>(thisObj, "HTMLOutputElement.labels");
                     return self.Realm.Wrap(self.Target.Labels);
-                })
+                }))
             .Accessor("name",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLOutputElement.name", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOutputElement>(thisObj, "HTMLOutputElement.name");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Name);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLOutputElement.name", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOutputElement>(thisObj, "HTMLOutputElement.name");
                     self.Target.Name = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLOutputElement.name"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Method("setCustomValidity",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLOutputElement.setCustomValidity", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOutputElement>(thisObj, "HTMLOutputElement.setCustomValidity");
                     self.Target.SetCustomValidity(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLOutputElement.setCustomValidity")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 1)
             .Accessor("type",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLOutputElement.type", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOutputElement>(thisObj, "HTMLOutputElement.type");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Type);
-                })
+                }))
             .Accessor("validationMessage",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLOutputElement.validationMessage", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOutputElement>(thisObj, "HTMLOutputElement.validationMessage");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.ValidationMessage);
-                })
+                }))
             .Accessor("validity",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLOutputElement.validity", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOutputElement>(thisObj, "HTMLOutputElement.validity");
                     return self.Realm.Wrap(self.Target.Validity);
-                })
+                }))
             .Accessor("value",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLOutputElement.value", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOutputElement>(thisObj, "HTMLOutputElement.value");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Value);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLOutputElement.value", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOutputElement>(thisObj, "HTMLOutputElement.value");
                     self.Target.Value = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLOutputElement.value"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("willValidate",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLOutputElement.willValidate", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOutputElement>(thisObj, "HTMLOutputElement.willValidate");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.WillValidate);
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLParagraphElement</c>.</summary>
@@ -3560,27 +3560,27 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLParamElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("name",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLParamElement.name", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlParamElement>(thisObj, "HTMLParamElement.name");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Name);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLParamElement.name", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlParamElement>(thisObj, "HTMLParamElement.name");
                     self.Target.Name = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLParamElement.name"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("value",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLParamElement.value", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlParamElement>(thisObj, "HTMLParamElement.value");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Value);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLParamElement.value", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlParamElement>(thisObj, "HTMLParamElement.value");
                     self.Target.Value = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLParamElement.value"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLPictureElement</c>.</summary>
@@ -3603,39 +3603,39 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLProgressElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("labels",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLProgressElement.labels", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlProgressElement>(thisObj, "HTMLProgressElement.labels");
                     return self.Realm.Wrap(self.Target.Labels);
-                })
+                }))
             .Accessor("max",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLProgressElement.max", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlProgressElement>(thisObj, "HTMLProgressElement.max");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Maximum);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLProgressElement.max", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlProgressElement>(thisObj, "HTMLProgressElement.max");
                     self.Target.Maximum = global::Jint.Browser.Dom.DomConvert.RequiredDouble(args, 0, "HTMLProgressElement.max"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("position",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLProgressElement.position", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlProgressElement>(thisObj, "HTMLProgressElement.position");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Position);
-                })
+                }))
             .Accessor("value",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLProgressElement.value", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlProgressElement>(thisObj, "HTMLProgressElement.value");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Value);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLProgressElement.value", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlProgressElement>(thisObj, "HTMLProgressElement.value");
                     self.Target.Value = global::Jint.Browser.Dom.DomConvert.RequiredDouble(args, 0, "HTMLProgressElement.value"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLQuoteElement</c>.</summary>
@@ -3644,16 +3644,16 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLQuoteElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("cite",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLQuoteElement.cite", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlQuoteElement>(thisObj, "HTMLQuoteElement.cite");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Citation);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLQuoteElement.cite", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlQuoteElement>(thisObj, "HTMLQuoteElement.cite");
                     self.Target.Citation = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLQuoteElement.cite"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLScriptElement</c>.</summary>
@@ -3662,93 +3662,93 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLScriptElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("async",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLScriptElement.async", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlScriptElement>(thisObj, "HTMLScriptElement.async");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsAsync);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLScriptElement.async", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlScriptElement>(thisObj, "HTMLScriptElement.async");
                     self.Target.IsAsync = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("charset",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLScriptElement.charset", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlScriptElement>(thisObj, "HTMLScriptElement.charset");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.CharacterSet);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLScriptElement.charset", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlScriptElement>(thisObj, "HTMLScriptElement.charset");
                     self.Target.CharacterSet = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLScriptElement.charset"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("crossOrigin",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLScriptElement.crossOrigin", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlScriptElement>(thisObj, "HTMLScriptElement.crossOrigin");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.CrossOrigin);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLScriptElement.crossOrigin", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlScriptElement>(thisObj, "HTMLScriptElement.crossOrigin");
                     self.Target.CrossOrigin = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLScriptElement.crossOrigin"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("defer",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLScriptElement.defer", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlScriptElement>(thisObj, "HTMLScriptElement.defer");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsDeferred);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLScriptElement.defer", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlScriptElement>(thisObj, "HTMLScriptElement.defer");
                     self.Target.IsDeferred = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("integrity",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLScriptElement.integrity", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlScriptElement>(thisObj, "HTMLScriptElement.integrity");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Integrity);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLScriptElement.integrity", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlScriptElement>(thisObj, "HTMLScriptElement.integrity");
                     self.Target.Integrity = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLScriptElement.integrity"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("src",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLScriptElement.src", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlScriptElement>(thisObj, "HTMLScriptElement.src");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Source);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLScriptElement.src", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlScriptElement>(thisObj, "HTMLScriptElement.src");
                     self.Target.Source = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLScriptElement.src"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("text",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLScriptElement.text", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlScriptElement>(thisObj, "HTMLScriptElement.text");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Text);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLScriptElement.text", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlScriptElement>(thisObj, "HTMLScriptElement.text");
                     self.Target.Text = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLScriptElement.text"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("type",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLScriptElement.type", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlScriptElement>(thisObj, "HTMLScriptElement.type");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Type);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLScriptElement.type", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlScriptElement>(thisObj, "HTMLScriptElement.type");
                     self.Target.Type = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLScriptElement.type"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLSelectElement</c>.</summary>
@@ -3757,170 +3757,170 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLSelectElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Method("add",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLSelectElement.add", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSelectElement>(thisObj, "HTMLSelectElement.add");
                     self.Target.AddOption(global::Jint.Browser.Dom.DomBindings.Argument<global::AngleSharp.Html.Dom.IHtmlOptionElement>(args, 0, "HTMLSelectElement.add"), global::Jint.Browser.Dom.DomBindings.NullableArgument<global::AngleSharp.Html.Dom.IHtmlElement>(args, 1, "HTMLSelectElement.add")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 1)
             .Accessor("autofocus",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLSelectElement.autofocus", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSelectElement>(thisObj, "HTMLSelectElement.autofocus");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.Autofocus);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLSelectElement.autofocus", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSelectElement>(thisObj, "HTMLSelectElement.autofocus");
                     self.Target.Autofocus = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Method("checkValidity",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLSelectElement.checkValidity", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSelectElement>(thisObj, "HTMLSelectElement.checkValidity");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.CheckValidity());
-                },
+                }),
                 length: 0)
             .Accessor("disabled",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLSelectElement.disabled", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSelectElement>(thisObj, "HTMLSelectElement.disabled");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsDisabled);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLSelectElement.disabled", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSelectElement>(thisObj, "HTMLSelectElement.disabled");
                     self.Target.IsDisabled = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("form",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLSelectElement.form", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSelectElement>(thisObj, "HTMLSelectElement.form");
                     return self.Realm.WrapNodeValue(self.Target.Form);
-                })
+                }))
             .Accessor("labels",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLSelectElement.labels", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSelectElement>(thisObj, "HTMLSelectElement.labels");
                     return self.Realm.Wrap(self.Target.Labels);
-                })
+                }))
             .Accessor("length",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLSelectElement.length", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSelectElement>(thisObj, "HTMLSelectElement.length");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Length);
-                })
+                }))
             .Accessor("multiple",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLSelectElement.multiple", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSelectElement>(thisObj, "HTMLSelectElement.multiple");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsMultiple);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLSelectElement.multiple", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSelectElement>(thisObj, "HTMLSelectElement.multiple");
                     self.Target.IsMultiple = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("name",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLSelectElement.name", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSelectElement>(thisObj, "HTMLSelectElement.name");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Name);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLSelectElement.name", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSelectElement>(thisObj, "HTMLSelectElement.name");
                     self.Target.Name = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLSelectElement.name"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("options",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLSelectElement.options", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSelectElement>(thisObj, "HTMLSelectElement.options");
                     return self.Realm.WrapCollection<global::AngleSharp.Html.Dom.IHtmlOptionElement>(self.Target.Options);
-                })
+                }))
             .Method("remove",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLSelectElement.remove", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSelectElement>(thisObj, "HTMLSelectElement.remove");
                     self.Target.RemoveOptionAt(global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLSelectElement.remove")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 1)
             .Accessor("required",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLSelectElement.required", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSelectElement>(thisObj, "HTMLSelectElement.required");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsRequired);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLSelectElement.required", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSelectElement>(thisObj, "HTMLSelectElement.required");
                     self.Target.IsRequired = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("selectedIndex",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLSelectElement.selectedIndex", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSelectElement>(thisObj, "HTMLSelectElement.selectedIndex");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.SelectedIndex);
-                })
+                }))
             .Accessor("selectedOptions",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLSelectElement.selectedOptions", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSelectElement>(thisObj, "HTMLSelectElement.selectedOptions");
                     return self.Realm.WrapCollection<global::AngleSharp.Html.Dom.IHtmlOptionElement>(self.Target.SelectedOptions);
-                })
+                }))
             .Method("setCustomValidity",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLSelectElement.setCustomValidity", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSelectElement>(thisObj, "HTMLSelectElement.setCustomValidity");
                     self.Target.SetCustomValidity(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLSelectElement.setCustomValidity")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 1)
             .Accessor("size",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLSelectElement.size", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSelectElement>(thisObj, "HTMLSelectElement.size");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Size);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLSelectElement.size", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSelectElement>(thisObj, "HTMLSelectElement.size");
                     self.Target.Size = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLSelectElement.size"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("type",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLSelectElement.type", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSelectElement>(thisObj, "HTMLSelectElement.type");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Type);
-                })
+                }))
             .Accessor("validationMessage",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLSelectElement.validationMessage", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSelectElement>(thisObj, "HTMLSelectElement.validationMessage");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.ValidationMessage);
-                })
+                }))
             .Accessor("validity",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLSelectElement.validity", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSelectElement>(thisObj, "HTMLSelectElement.validity");
                     return self.Realm.Wrap(self.Target.Validity);
-                })
+                }))
             .Accessor("value",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLSelectElement.value", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSelectElement>(thisObj, "HTMLSelectElement.value");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Value);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLSelectElement.value", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSelectElement>(thisObj, "HTMLSelectElement.value");
                     self.Target.Value = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLSelectElement.value"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("willValidate",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLSelectElement.willValidate", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSelectElement>(thisObj, "HTMLSelectElement.willValidate");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.WillValidate);
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLSlotElement</c>.</summary>
@@ -3929,37 +3929,37 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLSlotElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Method("assignedElements",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLSlotElement.assignedElements", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSlotElement>(thisObj, "HTMLSlotElement.assignedElements");
                     return global::Jint.Browser.Dom.Views.DomViewMembers.AssignedElements(self.Realm, self.Target);
-                },
+                }),
                 length: 0)
             .Method("assignedNodes",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLSlotElement.assignedNodes", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSlotElement>(thisObj, "HTMLSlotElement.assignedNodes");
                     return global::Jint.Browser.Dom.Views.DomViewMembers.AssignedNodes(self.Realm, self.Target);
-                },
+                }),
                 length: 0)
             .Method("getDistributedNodes",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLSlotElement.getDistributedNodes", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSlotElement>(thisObj, "HTMLSlotElement.getDistributedNodes");
                     return global::Jint.Browser.Dom.DomConvert.NodeSequence(self.Realm, self.Target.GetDistributedNodes());
-                },
+                }),
                 length: 0)
             .Accessor("name",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLSlotElement.name", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSlotElement>(thisObj, "HTMLSlotElement.name");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Name);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLSlotElement.name", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSlotElement>(thisObj, "HTMLSlotElement.name");
                     self.Target.Name = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLSlotElement.name"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLSourceElement</c>.</summary>
@@ -3968,60 +3968,60 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLSourceElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("media",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLSourceElement.media", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSourceElement>(thisObj, "HTMLSourceElement.media");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Media);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLSourceElement.media", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSourceElement>(thisObj, "HTMLSourceElement.media");
                     self.Target.Media = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLSourceElement.media"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("sizes",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLSourceElement.sizes", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSourceElement>(thisObj, "HTMLSourceElement.sizes");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Sizes);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLSourceElement.sizes", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSourceElement>(thisObj, "HTMLSourceElement.sizes");
                     self.Target.Sizes = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLSourceElement.sizes"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("src",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLSourceElement.src", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSourceElement>(thisObj, "HTMLSourceElement.src");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Source);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLSourceElement.src", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSourceElement>(thisObj, "HTMLSourceElement.src");
                     self.Target.Source = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLSourceElement.src"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("srcset",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLSourceElement.srcset", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSourceElement>(thisObj, "HTMLSourceElement.srcset");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.SourceSet);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLSourceElement.srcset", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSourceElement>(thisObj, "HTMLSourceElement.srcset");
                     self.Target.SourceSet = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLSourceElement.srcset"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("type",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLSourceElement.type", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSourceElement>(thisObj, "HTMLSourceElement.type");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Type);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLSourceElement.type", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSourceElement>(thisObj, "HTMLSourceElement.type");
                     self.Target.Type = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLSourceElement.type"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLSpanElement</c>.</summary>
@@ -4037,55 +4037,55 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLStyleElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("disabled",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLStyleElement.disabled", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlStyleElement>(thisObj, "HTMLStyleElement.disabled");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsDisabled);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLStyleElement.disabled", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlStyleElement>(thisObj, "HTMLStyleElement.disabled");
                     self.Target.IsDisabled = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("media",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLStyleElement.media", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlStyleElement>(thisObj, "HTMLStyleElement.media");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Media);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLStyleElement.media", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlStyleElement>(thisObj, "HTMLStyleElement.media");
                     self.Target.Media = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLStyleElement.media"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("scoped",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLStyleElement.scoped", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlStyleElement>(thisObj, "HTMLStyleElement.scoped");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsScoped);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLStyleElement.scoped", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlStyleElement>(thisObj, "HTMLStyleElement.scoped");
                     self.Target.IsScoped = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("sheet",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLStyleElement.sheet", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlStyleElement>(thisObj, "HTMLStyleElement.sheet");
                     return self.Realm.Wrap(self.Target.Sheet);
-                })
+                }))
             .Accessor("type",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLStyleElement.type", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlStyleElement>(thisObj, "HTMLStyleElement.type");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Type);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLStyleElement.type", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlStyleElement>(thisObj, "HTMLStyleElement.type");
                     self.Target.Type = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLStyleElement.type"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLTableCaptionElement</c>.</summary>
@@ -4101,39 +4101,39 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLTableCellElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("cellIndex",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTableCellElement.cellIndex", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTableCellElement>(thisObj, "HTMLTableCellElement.cellIndex");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Index);
-                })
+                }))
             .Accessor("colSpan",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTableCellElement.colSpan", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTableCellElement>(thisObj, "HTMLTableCellElement.colSpan");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.ColumnSpan);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTableCellElement.colSpan", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTableCellElement>(thisObj, "HTMLTableCellElement.colSpan");
                     self.Target.ColumnSpan = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLTableCellElement.colSpan"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("headers",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTableCellElement.headers", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTableCellElement>(thisObj, "HTMLTableCellElement.headers");
                     return self.Realm.Wrap(self.Target.Headers);
-                })
+                }))
             .Accessor("rowSpan",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTableCellElement.rowSpan", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTableCellElement>(thisObj, "HTMLTableCellElement.rowSpan");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.RowSpan);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTableCellElement.rowSpan", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTableCellElement>(thisObj, "HTMLTableCellElement.rowSpan");
                     self.Target.RowSpan = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLTableCellElement.rowSpan"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLTableColElement</c>.</summary>
@@ -4142,16 +4142,16 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLTableColElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("span",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTableColElement.span", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTableColumnElement>(thisObj, "HTMLTableColElement.span");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Span);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTableColElement.span", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTableColumnElement>(thisObj, "HTMLTableColElement.span");
                     self.Target.Span = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLTableColElement.span"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLTableDataCellElement</c>.</summary>
@@ -4167,124 +4167,124 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLTableElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("border",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTableElement.border", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTableElement>(thisObj, "HTMLTableElement.border");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Border);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTableElement.border", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTableElement>(thisObj, "HTMLTableElement.border");
                     self.Target.Border = global::Jint.Browser.Dom.DomConvert.RequiredUInt32(args, 0, "HTMLTableElement.border"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("caption",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTableElement.caption", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTableElement>(thisObj, "HTMLTableElement.caption");
                     return self.Realm.WrapNodeValue(self.Target.Caption);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTableElement.caption", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTableElement>(thisObj, "HTMLTableElement.caption");
                     self.Target.Caption = global::Jint.Browser.Dom.DomBindings.Argument<global::AngleSharp.Html.Dom.IHtmlTableCaptionElement>(args, 0, "HTMLTableElement.caption"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Method("createCaption",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTableElement.createCaption", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTableElement>(thisObj, "HTMLTableElement.createCaption");
                     return self.Realm.WrapNodeValue(self.Target.CreateCaption());
-                },
+                }),
                 length: 0)
             .Method("createTBody",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTableElement.createTBody", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTableElement>(thisObj, "HTMLTableElement.createTBody");
                     return self.Realm.WrapNodeValue(self.Target.CreateBody());
-                },
+                }),
                 length: 0)
             .Method("createTFoot",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTableElement.createTFoot", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTableElement>(thisObj, "HTMLTableElement.createTFoot");
                     return self.Realm.WrapNodeValue(self.Target.CreateFoot());
-                },
+                }),
                 length: 0)
             .Method("createTHead",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTableElement.createTHead", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTableElement>(thisObj, "HTMLTableElement.createTHead");
                     return self.Realm.WrapNodeValue(self.Target.CreateHead());
-                },
+                }),
                 length: 0)
             .Method("deleteCaption",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTableElement.deleteCaption", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTableElement>(thisObj, "HTMLTableElement.deleteCaption");
                     self.Target.DeleteCaption(); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Method("deleteRow",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTableElement.deleteRow", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTableElement>(thisObj, "HTMLTableElement.deleteRow");
                     self.Target.RemoveRowAt(global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLTableElement.deleteRow")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 1)
             .Method("deleteTFoot",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTableElement.deleteTFoot", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTableElement>(thisObj, "HTMLTableElement.deleteTFoot");
                     self.Target.DeleteFoot(); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Method("deleteTHead",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTableElement.deleteTHead", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTableElement>(thisObj, "HTMLTableElement.deleteTHead");
                     self.Target.DeleteHead(); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Method("insertRow",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTableElement.insertRow", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTableElement>(thisObj, "HTMLTableElement.insertRow");
                     return self.Realm.WrapNodeValue(self.Target.InsertRowAt(global::Jint.Browser.Dom.DomConvert.OptionalInt32(args, 0, -1)));
-                },
+                }),
                 length: 0)
             .Accessor("rows",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTableElement.rows", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTableElement>(thisObj, "HTMLTableElement.rows");
                     return self.Realm.WrapCollection<global::AngleSharp.Html.Dom.IHtmlTableRowElement>(self.Target.Rows);
-                })
+                }))
             .Accessor("tBodies",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTableElement.tBodies", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTableElement>(thisObj, "HTMLTableElement.tBodies");
                     return self.Realm.WrapCollection<global::AngleSharp.Html.Dom.IHtmlTableSectionElement>(self.Target.Bodies);
-                })
+                }))
             .Accessor("tFoot",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTableElement.tFoot", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTableElement>(thisObj, "HTMLTableElement.tFoot");
                     return self.Realm.WrapNodeValue(self.Target.Foot);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTableElement.tFoot", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTableElement>(thisObj, "HTMLTableElement.tFoot");
                     self.Target.Foot = global::Jint.Browser.Dom.DomBindings.Argument<global::AngleSharp.Html.Dom.IHtmlTableSectionElement>(args, 0, "HTMLTableElement.tFoot"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("tHead",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTableElement.tHead", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTableElement>(thisObj, "HTMLTableElement.tHead");
                     return self.Realm.WrapNodeValue(self.Target.Head);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTableElement.tHead", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTableElement>(thisObj, "HTMLTableElement.tHead");
                     self.Target.Head = global::Jint.Browser.Dom.DomBindings.Argument<global::AngleSharp.Html.Dom.IHtmlTableSectionElement>(args, 0, "HTMLTableElement.tHead"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLTableHeaderCellElement</c>.</summary>
@@ -4293,16 +4293,16 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLTableHeaderCellElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("scope",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTableHeaderCellElement.scope", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTableHeaderCellElement>(thisObj, "HTMLTableHeaderCellElement.scope");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Scope);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTableHeaderCellElement.scope", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTableHeaderCellElement>(thisObj, "HTMLTableHeaderCellElement.scope");
                     self.Target.Scope = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLTableHeaderCellElement.scope"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLTableRowElement</c>.</summary>
@@ -4311,37 +4311,37 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLTableRowElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("cells",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTableRowElement.cells", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTableRowElement>(thisObj, "HTMLTableRowElement.cells");
                     return self.Realm.WrapCollection<global::AngleSharp.Html.Dom.IHtmlTableCellElement>(self.Target.Cells);
-                })
+                }))
             .Method("deleteCell",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTableRowElement.deleteCell", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTableRowElement>(thisObj, "HTMLTableRowElement.deleteCell");
                     self.Target.RemoveCellAt(global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLTableRowElement.deleteCell")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 1)
             .Method("insertCell",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTableRowElement.insertCell", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTableRowElement>(thisObj, "HTMLTableRowElement.insertCell");
                     return self.Realm.WrapNodeValue(self.Target.InsertCellAt(global::Jint.Browser.Dom.DomConvert.OptionalInt32(args, 0, -1), (global::AngleSharp.Html.Dom.TableCellKind) global::Jint.Browser.Dom.DomConvert.OptionalInt32(args, 1, 0)));
-                },
+                }),
                 length: 0)
             .Accessor("rowIndex",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTableRowElement.rowIndex", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTableRowElement>(thisObj, "HTMLTableRowElement.rowIndex");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Index);
-                })
+                }))
             .Accessor("sectionRowIndex",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTableRowElement.sectionRowIndex", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTableRowElement>(thisObj, "HTMLTableRowElement.sectionRowIndex");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.IndexInSection);
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLTableSectionElement</c>.</summary>
@@ -4350,25 +4350,25 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLTableSectionElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Method("deleteRow",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTableSectionElement.deleteRow", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTableSectionElement>(thisObj, "HTMLTableSectionElement.deleteRow");
                     self.Target.RemoveRowAt(global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLTableSectionElement.deleteRow")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 1)
             .Method("insertRow",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTableSectionElement.insertRow", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTableSectionElement>(thisObj, "HTMLTableSectionElement.insertRow");
                     return self.Realm.WrapNodeValue(self.Target.InsertRowAt(global::Jint.Browser.Dom.DomConvert.OptionalInt32(args, 0, -1)));
-                },
+                }),
                 length: 0)
             .Accessor("rows",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTableSectionElement.rows", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTableSectionElement>(thisObj, "HTMLTableSectionElement.rows");
                     return self.Realm.WrapCollection<global::AngleSharp.Html.Dom.IHtmlTableRowElement>(self.Target.Rows);
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLTemplateElement</c>.</summary>
@@ -4377,11 +4377,11 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLTemplateElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("content",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTemplateElement.content", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTemplateElement>(thisObj, "HTMLTemplateElement.content");
                     return self.Realm.WrapNodeValue(self.Target.Content);
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLTextAreaElement</c>.</summary>
@@ -4390,246 +4390,246 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLTextAreaElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("autofocus",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTextAreaElement.autofocus", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTextAreaElement>(thisObj, "HTMLTextAreaElement.autofocus");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.Autofocus);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTextAreaElement.autofocus", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTextAreaElement>(thisObj, "HTMLTextAreaElement.autofocus");
                     self.Target.Autofocus = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Method("checkValidity",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTextAreaElement.checkValidity", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTextAreaElement>(thisObj, "HTMLTextAreaElement.checkValidity");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.CheckValidity());
-                },
+                }),
                 length: 0)
             .Accessor("cols",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTextAreaElement.cols", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTextAreaElement>(thisObj, "HTMLTextAreaElement.cols");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Columns);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTextAreaElement.cols", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTextAreaElement>(thisObj, "HTMLTextAreaElement.cols");
                     self.Target.Columns = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLTextAreaElement.cols"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("defaultValue",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTextAreaElement.defaultValue", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTextAreaElement>(thisObj, "HTMLTextAreaElement.defaultValue");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.DefaultValue);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTextAreaElement.defaultValue", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTextAreaElement>(thisObj, "HTMLTextAreaElement.defaultValue");
                     self.Target.DefaultValue = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLTextAreaElement.defaultValue"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("dirName",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTextAreaElement.dirName", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTextAreaElement>(thisObj, "HTMLTextAreaElement.dirName");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.DirectionName);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTextAreaElement.dirName", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTextAreaElement>(thisObj, "HTMLTextAreaElement.dirName");
                     self.Target.DirectionName = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLTextAreaElement.dirName"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("disabled",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTextAreaElement.disabled", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTextAreaElement>(thisObj, "HTMLTextAreaElement.disabled");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsDisabled);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTextAreaElement.disabled", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTextAreaElement>(thisObj, "HTMLTextAreaElement.disabled");
                     self.Target.IsDisabled = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("form",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTextAreaElement.form", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTextAreaElement>(thisObj, "HTMLTextAreaElement.form");
                     return self.Realm.WrapNodeValue(self.Target.Form);
-                })
+                }))
             .Accessor("labels",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTextAreaElement.labels", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTextAreaElement>(thisObj, "HTMLTextAreaElement.labels");
                     return self.Realm.Wrap(self.Target.Labels);
-                })
+                }))
             .Accessor("maxLength",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTextAreaElement.maxLength", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTextAreaElement>(thisObj, "HTMLTextAreaElement.maxLength");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.MaxLength);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTextAreaElement.maxLength", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTextAreaElement>(thisObj, "HTMLTextAreaElement.maxLength");
                     self.Target.MaxLength = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLTextAreaElement.maxLength"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("name",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTextAreaElement.name", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTextAreaElement>(thisObj, "HTMLTextAreaElement.name");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Name);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTextAreaElement.name", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTextAreaElement>(thisObj, "HTMLTextAreaElement.name");
                     self.Target.Name = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLTextAreaElement.name"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("placeholder",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTextAreaElement.placeholder", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTextAreaElement>(thisObj, "HTMLTextAreaElement.placeholder");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Placeholder);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTextAreaElement.placeholder", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTextAreaElement>(thisObj, "HTMLTextAreaElement.placeholder");
                     self.Target.Placeholder = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLTextAreaElement.placeholder"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("readOnly",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTextAreaElement.readOnly", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTextAreaElement>(thisObj, "HTMLTextAreaElement.readOnly");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsReadOnly);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTextAreaElement.readOnly", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTextAreaElement>(thisObj, "HTMLTextAreaElement.readOnly");
                     self.Target.IsReadOnly = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("required",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTextAreaElement.required", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTextAreaElement>(thisObj, "HTMLTextAreaElement.required");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsRequired);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTextAreaElement.required", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTextAreaElement>(thisObj, "HTMLTextAreaElement.required");
                     self.Target.IsRequired = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("rows",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTextAreaElement.rows", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTextAreaElement>(thisObj, "HTMLTextAreaElement.rows");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Rows);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTextAreaElement.rows", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTextAreaElement>(thisObj, "HTMLTextAreaElement.rows");
                     self.Target.Rows = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLTextAreaElement.rows"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Method("select",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTextAreaElement.select", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTextAreaElement>(thisObj, "HTMLTextAreaElement.select");
                     self.Target.SelectAll(); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Accessor("selectionDirection",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTextAreaElement.selectionDirection", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTextAreaElement>(thisObj, "HTMLTextAreaElement.selectionDirection");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.SelectionDirection);
-                })
+                }))
             .Accessor("selectionEnd",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTextAreaElement.selectionEnd", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTextAreaElement>(thisObj, "HTMLTextAreaElement.selectionEnd");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.SelectionEnd);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTextAreaElement.selectionEnd", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTextAreaElement>(thisObj, "HTMLTextAreaElement.selectionEnd");
                     self.Target.SelectionEnd = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLTextAreaElement.selectionEnd"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("selectionStart",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTextAreaElement.selectionStart", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTextAreaElement>(thisObj, "HTMLTextAreaElement.selectionStart");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.SelectionStart);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTextAreaElement.selectionStart", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTextAreaElement>(thisObj, "HTMLTextAreaElement.selectionStart");
                     self.Target.SelectionStart = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLTextAreaElement.selectionStart"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Method("setCustomValidity",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTextAreaElement.setCustomValidity", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTextAreaElement>(thisObj, "HTMLTextAreaElement.setCustomValidity");
                     self.Target.SetCustomValidity(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLTextAreaElement.setCustomValidity")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 1)
             .Method("setSelectionRange",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTextAreaElement.setSelectionRange", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTextAreaElement>(thisObj, "HTMLTextAreaElement.setSelectionRange");
                     self.Target.Select(global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLTextAreaElement.setSelectionRange"), global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 1, "HTMLTextAreaElement.setSelectionRange"), global::Jint.Browser.Dom.DomConvert.OptionalText(args, 2, null)!); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 2)
             .Accessor("textLength",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTextAreaElement.textLength", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTextAreaElement>(thisObj, "HTMLTextAreaElement.textLength");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.TextLength);
-                })
+                }))
             .Accessor("type",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTextAreaElement.type", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTextAreaElement>(thisObj, "HTMLTextAreaElement.type");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Type);
-                })
+                }))
             .Accessor("validationMessage",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTextAreaElement.validationMessage", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTextAreaElement>(thisObj, "HTMLTextAreaElement.validationMessage");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.ValidationMessage);
-                })
+                }))
             .Accessor("validity",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTextAreaElement.validity", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTextAreaElement>(thisObj, "HTMLTextAreaElement.validity");
                     return self.Realm.Wrap(self.Target.Validity);
-                })
+                }))
             .Accessor("value",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTextAreaElement.value", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTextAreaElement>(thisObj, "HTMLTextAreaElement.value");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Value);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTextAreaElement.value", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTextAreaElement>(thisObj, "HTMLTextAreaElement.value");
                     self.Target.Value = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLTextAreaElement.value"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("willValidate",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTextAreaElement.willValidate", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTextAreaElement>(thisObj, "HTMLTextAreaElement.willValidate");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.WillValidate);
-                })
+                }))
             .Accessor("wrap",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTextAreaElement.wrap", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTextAreaElement>(thisObj, "HTMLTextAreaElement.wrap");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Wrap);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTextAreaElement.wrap", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTextAreaElement>(thisObj, "HTMLTextAreaElement.wrap");
                     self.Target.Wrap = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLTextAreaElement.wrap"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLTimeElement</c>.</summary>
@@ -4638,16 +4638,16 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLTimeElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("datetime",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTimeElement.datetime", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTimeElement>(thisObj, "HTMLTimeElement.datetime");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.DateTime);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTimeElement.datetime", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTimeElement>(thisObj, "HTMLTimeElement.datetime");
                     self.Target.DateTime = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLTimeElement.datetime"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLTitleElement</c>.</summary>
@@ -4656,16 +4656,16 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLTitleElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("text",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTitleElement.text", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTitleElement>(thisObj, "HTMLTitleElement.text");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Text);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTitleElement.text", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTitleElement>(thisObj, "HTMLTitleElement.text");
                     self.Target.Text = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLTitleElement.text"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLTrackElement</c>.</summary>
@@ -4678,72 +4678,72 @@ internal static partial class DomInterfaces
             .Constant("LOADING", global::Jint.Native.JsNumber.Create(1))
             .Constant("NONE", global::Jint.Native.JsNumber.Create(0))
             .Accessor("default",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTrackElement.default", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTrackElement>(thisObj, "HTMLTrackElement.default");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsDefault);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTrackElement.default", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTrackElement>(thisObj, "HTMLTrackElement.default");
                     self.Target.IsDefault = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("kind",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTrackElement.kind", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTrackElement>(thisObj, "HTMLTrackElement.kind");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Kind);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTrackElement.kind", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTrackElement>(thisObj, "HTMLTrackElement.kind");
                     self.Target.Kind = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLTrackElement.kind"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("label",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTrackElement.label", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTrackElement>(thisObj, "HTMLTrackElement.label");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Label);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTrackElement.label", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTrackElement>(thisObj, "HTMLTrackElement.label");
                     self.Target.Label = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLTrackElement.label"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("readyState",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTrackElement.readyState", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTrackElement>(thisObj, "HTMLTrackElement.readyState");
                     return global::Jint.Browser.Dom.DomConvert.Number((int) (self.Target.ReadyState));
-                })
+                }))
             .Accessor("src",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTrackElement.src", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTrackElement>(thisObj, "HTMLTrackElement.src");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Source);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTrackElement.src", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTrackElement>(thisObj, "HTMLTrackElement.src");
                     self.Target.Source = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLTrackElement.src"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("srclang",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTrackElement.srclang", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTrackElement>(thisObj, "HTMLTrackElement.srclang");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.SourceLanguage);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTrackElement.srclang", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTrackElement>(thisObj, "HTMLTrackElement.srclang");
                     self.Target.SourceLanguage = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLTrackElement.srclang"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("track",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLTrackElement.track", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTrackElement>(thisObj, "HTMLTrackElement.track");
                     return self.Realm.Wrap(self.Target.Track);
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLUListElement</c>.</summary>
@@ -4766,50 +4766,50 @@ internal static partial class DomInterfaces
             .ToStringTag("HTMLVideoElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("height",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLVideoElement.height", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlVideoElement>(thisObj, "HTMLVideoElement.height");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.DisplayHeight);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLVideoElement.height", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlVideoElement>(thisObj, "HTMLVideoElement.height");
                     self.Target.DisplayHeight = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLVideoElement.height"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("poster",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLVideoElement.poster", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlVideoElement>(thisObj, "HTMLVideoElement.poster");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Poster);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLVideoElement.poster", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlVideoElement>(thisObj, "HTMLVideoElement.poster");
                     self.Target.Poster = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLVideoElement.poster"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("videoHeight",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLVideoElement.videoHeight", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlVideoElement>(thisObj, "HTMLVideoElement.videoHeight");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.OriginalHeight);
-                })
+                }))
             .Accessor("videoWidth",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLVideoElement.videoWidth", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlVideoElement>(thisObj, "HTMLVideoElement.videoWidth");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.OriginalWidth);
-                })
+                }))
             .Accessor("width",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLVideoElement.width", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlVideoElement>(thisObj, "HTMLVideoElement.width");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.DisplayWidth);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLVideoElement.width", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlVideoElement>(thisObj, "HTMLVideoElement.width");
                     self.Target.DisplayWidth = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLVideoElement.width"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>Touch</c>.</summary>
@@ -4818,47 +4818,47 @@ internal static partial class DomInterfaces
             .ToStringTag("Touch")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("clientX",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Touch.clientX", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.Events.ITouchPoint>(thisObj, "Touch.clientX");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.ClientX);
-                })
+                }))
             .Accessor("clientY",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Touch.clientY", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.Events.ITouchPoint>(thisObj, "Touch.clientY");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.ClientY);
-                })
+                }))
             .Accessor("identifier",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Touch.identifier", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.Events.ITouchPoint>(thisObj, "Touch.identifier");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Id);
-                })
+                }))
             .Accessor("pageX",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Touch.pageX", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.Events.ITouchPoint>(thisObj, "Touch.pageX");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.PageX);
-                })
+                }))
             .Accessor("pageY",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Touch.pageY", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.Events.ITouchPoint>(thisObj, "Touch.pageY");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.PageY);
-                })
+                }))
             .Accessor("screenX",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Touch.screenX", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.Events.ITouchPoint>(thisObj, "Touch.screenX");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.ScreenX);
-                })
+                }))
             .Accessor("screenY",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Touch.screenY", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.Events.ITouchPoint>(thisObj, "Touch.screenY");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.ScreenY);
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>TouchList</c>.</summary>
@@ -4867,11 +4867,11 @@ internal static partial class DomInterfaces
             .ToStringTag("TouchList")
             .PerRealmSlot("constructor", enumerable: false)
             .Method("item",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("TouchList.item", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.Events.ITouchList>(thisObj, "TouchList.item");
                     return self.Realm.Wrap(self.Target[global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "TouchList.item")]);
-                },
+                }),
                 length: 1)
             .Build();
 
@@ -4881,70 +4881,70 @@ internal static partial class DomInterfaces
             .ToStringTag("ValidityState")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("badInput",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("ValidityState.badInput", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IValidityState>(thisObj, "ValidityState.badInput");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsBadInput);
-                })
+                }))
             .Accessor("customError",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("ValidityState.customError", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IValidityState>(thisObj, "ValidityState.customError");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsCustomError);
-                })
+                }))
             .Accessor("patternMismatch",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("ValidityState.patternMismatch", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IValidityState>(thisObj, "ValidityState.patternMismatch");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsPatternMismatch);
-                })
+                }))
             .Accessor("rangeOverflow",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("ValidityState.rangeOverflow", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IValidityState>(thisObj, "ValidityState.rangeOverflow");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsRangeOverflow);
-                })
+                }))
             .Accessor("rangeUnderflow",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("ValidityState.rangeUnderflow", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IValidityState>(thisObj, "ValidityState.rangeUnderflow");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsRangeUnderflow);
-                })
+                }))
             .Accessor("stepMismatch",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("ValidityState.stepMismatch", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IValidityState>(thisObj, "ValidityState.stepMismatch");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsStepMismatch);
-                })
+                }))
             .Accessor("tooLong",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("ValidityState.tooLong", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IValidityState>(thisObj, "ValidityState.tooLong");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsTooLong);
-                })
+                }))
             .Accessor("tooShort",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("ValidityState.tooShort", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IValidityState>(thisObj, "ValidityState.tooShort");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsTooShort);
-                })
+                }))
             .Accessor("typeMismatch",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("ValidityState.typeMismatch", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IValidityState>(thisObj, "ValidityState.typeMismatch");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsTypeMismatch);
-                })
+                }))
             .Accessor("valid",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("ValidityState.valid", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IValidityState>(thisObj, "ValidityState.valid");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsValid);
-                })
+                }))
             .Accessor("valueMissing",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("ValidityState.valueMissing", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IValidityState>(thisObj, "ValidityState.valueMissing");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsValueMissing);
-                })
+                }))
             .Build();
 }

--- a/Jint.Browser/Dom/Generated/DomShapes.Io.g.cs
+++ b/Jint.Browser/Dom/Generated/DomShapes.Io.g.cs
@@ -20,37 +20,37 @@ internal static partial class DomInterfaces
             .ToStringTag("Blob")
             .PerRealmSlot("constructor", enumerable: false)
             .Method("close",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Blob.close", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Io.Dom.IBlob>(thisObj, "Blob.close");
                     self.Target.Close(); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Accessor("isClosed",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Blob.isClosed", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Io.Dom.IBlob>(thisObj, "Blob.isClosed");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsClosed);
-                })
+                }))
             .Accessor("size",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Blob.size", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Io.Dom.IBlob>(thisObj, "Blob.size");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Length);
-                })
+                }))
             .Method("slice",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Blob.slice", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Io.Dom.IBlob>(thisObj, "Blob.slice");
                     return self.Realm.Wrap(self.Target.Slice(global::Jint.Browser.Dom.DomConvert.OptionalInt32(args, 0, 0), global::Jint.Browser.Dom.DomConvert.OptionalInt32(args, 1, 2147483647), global::Jint.Browser.Dom.DomConvert.OptionalText(args, 2, null)!));
-                },
+                }),
                 length: 0)
             .Accessor("type",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("Blob.type", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Io.Dom.IBlob>(thisObj, "Blob.type");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Type);
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>File</c>.</summary>
@@ -59,17 +59,17 @@ internal static partial class DomInterfaces
             .ToStringTag("File")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("lastModified",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("File.lastModified", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Io.Dom.IFile>(thisObj, "File.lastModified");
                     return global::Jint.Browser.Dom.DomConvert.Timestamp(self.Target.LastModified);
-                })
+                }))
             .Accessor("name",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("File.name", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Io.Dom.IFile>(thisObj, "File.name");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Name);
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>FileList</c>.</summary>
@@ -78,11 +78,11 @@ internal static partial class DomInterfaces
             .ToStringTag("FileList")
             .PerRealmSlot("constructor", enumerable: false)
             .Method("item",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("FileList.item", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Io.Dom.IFileList>(thisObj, "FileList.item");
                     return self.Realm.Wrap(self.Target[global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "FileList.item")]);
-                },
+                }),
                 length: 1)
             .Build();
 }

--- a/Jint.Browser/Dom/Generated/DomShapes.Media.g.cs
+++ b/Jint.Browser/Dom/Generated/DomShapes.Media.g.cs
@@ -20,40 +20,40 @@ internal static partial class DomInterfaces
             .ToStringTag("AudioTrack")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("enabled",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("AudioTrack.enabled", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.IAudioTrack>(thisObj, "AudioTrack.enabled");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsEnabled);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("AudioTrack.enabled", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.IAudioTrack>(thisObj, "AudioTrack.enabled");
                     self.Target.IsEnabled = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("id",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("AudioTrack.id", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.IAudioTrack>(thisObj, "AudioTrack.id");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Id);
-                })
+                }))
             .Accessor("kind",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("AudioTrack.kind", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.IAudioTrack>(thisObj, "AudioTrack.kind");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Kind);
-                })
+                }))
             .Accessor("label",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("AudioTrack.label", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.IAudioTrack>(thisObj, "AudioTrack.label");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Label);
-                })
+                }))
             .Accessor("language",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("AudioTrack.language", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.IAudioTrack>(thisObj, "AudioTrack.language");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Language);
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>AudioTrackList</c>.</summary>
@@ -62,11 +62,11 @@ internal static partial class DomInterfaces
             .ToStringTag("AudioTrackList")
             .PerRealmSlot("constructor", enumerable: false)
             .Method("getTrackById",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("AudioTrackList.getTrackById", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.IAudioTrackList>(thisObj, "AudioTrackList.getTrackById");
                     return self.Realm.Wrap(self.Target.GetTrackById(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "AudioTrackList.getTrackById")));
-                },
+                }),
                 length: 1)
             .Build();
 
@@ -83,47 +83,47 @@ internal static partial class DomInterfaces
             .ToStringTag("CanvasRenderingContext2D")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("canvas",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CanvasRenderingContext2D.canvas", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.ICanvasRenderingContext2D>(thisObj, "CanvasRenderingContext2D.canvas");
                     return self.Realm.WrapNodeValue(self.Target.Canvas);
-                })
+                }))
             .Accessor("height",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CanvasRenderingContext2D.height", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.ICanvasRenderingContext2D>(thisObj, "CanvasRenderingContext2D.height");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Height);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CanvasRenderingContext2D.height", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.ICanvasRenderingContext2D>(thisObj, "CanvasRenderingContext2D.height");
                     self.Target.Height = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "CanvasRenderingContext2D.height"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Method("restore",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CanvasRenderingContext2D.restore", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.ICanvasRenderingContext2D>(thisObj, "CanvasRenderingContext2D.restore");
                     self.Target.RestoreState(); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Method("save",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CanvasRenderingContext2D.save", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.ICanvasRenderingContext2D>(thisObj, "CanvasRenderingContext2D.save");
                     self.Target.SaveState(); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Accessor("width",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("CanvasRenderingContext2D.width", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.ICanvasRenderingContext2D>(thisObj, "CanvasRenderingContext2D.width");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Width);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("CanvasRenderingContext2D.width", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.ICanvasRenderingContext2D>(thisObj, "CanvasRenderingContext2D.width");
                     self.Target.Width = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "CanvasRenderingContext2D.width"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>MediaController</c>.</summary>
@@ -137,116 +137,116 @@ internal static partial class DomInterfaces
             .Constant("HAVE_METADATA", global::Jint.Native.JsNumber.Create(1))
             .Constant("HAVE_NOTHING", global::Jint.Native.JsNumber.Create(0))
             .Accessor("buffered",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("MediaController.buffered", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.IMediaController>(thisObj, "MediaController.buffered");
                     return self.Realm.Wrap(self.Target.BufferedTime);
-                })
+                }))
             .Accessor("currentTime",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("MediaController.currentTime", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.IMediaController>(thisObj, "MediaController.currentTime");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.CurrentTime);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("MediaController.currentTime", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.IMediaController>(thisObj, "MediaController.currentTime");
                     self.Target.CurrentTime = global::Jint.Browser.Dom.DomConvert.RequiredDouble(args, 0, "MediaController.currentTime"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("defaultPlaybackRate",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("MediaController.defaultPlaybackRate", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.IMediaController>(thisObj, "MediaController.defaultPlaybackRate");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.DefaultPlaybackRate);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("MediaController.defaultPlaybackRate", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.IMediaController>(thisObj, "MediaController.defaultPlaybackRate");
                     self.Target.DefaultPlaybackRate = global::Jint.Browser.Dom.DomConvert.RequiredDouble(args, 0, "MediaController.defaultPlaybackRate"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("duration",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("MediaController.duration", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.IMediaController>(thisObj, "MediaController.duration");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Duration);
-                })
+                }))
             .Accessor("muted",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("MediaController.muted", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.IMediaController>(thisObj, "MediaController.muted");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsMuted);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("MediaController.muted", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.IMediaController>(thisObj, "MediaController.muted");
                     self.Target.IsMuted = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Method("pause",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("MediaController.pause", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.IMediaController>(thisObj, "MediaController.pause");
                     self.Target.Pause(); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Accessor("paused",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("MediaController.paused", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.IMediaController>(thisObj, "MediaController.paused");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsPaused);
-                })
+                }))
             .Method("play",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("MediaController.play", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.IMediaController>(thisObj, "MediaController.play");
                     self.Target.Play(); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 0)
             .Accessor("playbackRate",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("MediaController.playbackRate", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.IMediaController>(thisObj, "MediaController.playbackRate");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.PlaybackRate);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("MediaController.playbackRate", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.IMediaController>(thisObj, "MediaController.playbackRate");
                     self.Target.PlaybackRate = global::Jint.Browser.Dom.DomConvert.RequiredDouble(args, 0, "MediaController.playbackRate"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("playbackState",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("MediaController.playbackState", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.IMediaController>(thisObj, "MediaController.playbackState");
                     return global::Jint.Browser.Dom.DomEnums.FromMediaControllerPlaybackState(self.Target.PlaybackState);
-                })
+                }))
             .Accessor("played",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("MediaController.played", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.IMediaController>(thisObj, "MediaController.played");
                     return self.Realm.Wrap(self.Target.PlayedTime);
-                })
+                }))
             .Accessor("readyState",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("MediaController.readyState", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.IMediaController>(thisObj, "MediaController.readyState");
                     return global::Jint.Browser.Dom.DomConvert.Number((int) (self.Target.ReadyState));
-                })
+                }))
             .Accessor("seekable",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("MediaController.seekable", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.IMediaController>(thisObj, "MediaController.seekable");
                     return self.Realm.Wrap(self.Target.SeekableTime);
-                })
+                }))
             .Accessor("volume",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("MediaController.volume", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.IMediaController>(thisObj, "MediaController.volume");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Volume);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("MediaController.volume", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.IMediaController>(thisObj, "MediaController.volume");
                     self.Target.Volume = global::Jint.Browser.Dom.DomConvert.RequiredDouble(args, 0, "MediaController.volume"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>MediaError</c>.</summary>
@@ -259,11 +259,11 @@ internal static partial class DomInterfaces
             .Constant("MEDIA_ERR_NETWORK", global::Jint.Native.JsNumber.Create(2))
             .Constant("MEDIA_ERR_SRC_NOT_SUPPORTED", global::Jint.Native.JsNumber.Create(4))
             .Accessor("code",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("MediaError.code", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.IMediaError>(thisObj, "MediaError.code");
                     return global::Jint.Browser.Dom.DomConvert.Number((int) (self.Target.Code));
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>TextTrack</c>.</summary>
@@ -272,59 +272,59 @@ internal static partial class DomInterfaces
             .ToStringTag("TextTrack")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("activeCues",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("TextTrack.activeCues", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.ITextTrack>(thisObj, "TextTrack.activeCues");
                     return self.Realm.Wrap(self.Target.ActiveCues);
-                })
+                }))
             .Method("addCue",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("TextTrack.addCue", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.ITextTrack>(thisObj, "TextTrack.addCue");
                     self.Target.Add(global::Jint.Browser.Dom.DomBindings.Argument<global::AngleSharp.Media.Dom.ITextTrackCue>(args, 0, "TextTrack.addCue")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 1)
             .Accessor("cues",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("TextTrack.cues", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.ITextTrack>(thisObj, "TextTrack.cues");
                     return self.Realm.Wrap(self.Target.Cues);
-                })
+                }))
             .Accessor("kind",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("TextTrack.kind", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.ITextTrack>(thisObj, "TextTrack.kind");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Kind);
-                })
+                }))
             .Accessor("label",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("TextTrack.label", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.ITextTrack>(thisObj, "TextTrack.label");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Label);
-                })
+                }))
             .Accessor("language",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("TextTrack.language", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.ITextTrack>(thisObj, "TextTrack.language");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Language);
-                })
+                }))
             .Accessor("mode",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("TextTrack.mode", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.ITextTrack>(thisObj, "TextTrack.mode");
                     return global::Jint.Browser.Dom.DomEnums.FromTextTrackMode(self.Target.Mode);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("TextTrack.mode", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.ITextTrack>(thisObj, "TextTrack.mode");
                     self.Target.Mode = global::Jint.Browser.Dom.DomEnums.ToTextTrackMode(global::Jint.Browser.Dom.DomConvert.At(args, 0), "TextTrack.mode"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Method("removeCue",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("TextTrack.removeCue", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.ITextTrack>(thisObj, "TextTrack.removeCue");
                     self.Target.Remove(global::Jint.Browser.Dom.DomBindings.Argument<global::AngleSharp.Media.Dom.ITextTrackCue>(args, 0, "TextTrack.removeCue")); return global::Jint.Native.JsValue.Undefined;
-                },
+                }),
                 length: 1)
             .Build();
 
@@ -334,139 +334,139 @@ internal static partial class DomInterfaces
             .ToStringTag("TextTrackCue")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("align",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("TextTrackCue.align", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.ITextTrackCue>(thisObj, "TextTrackCue.align");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Alignment);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("TextTrackCue.align", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.ITextTrackCue>(thisObj, "TextTrackCue.align");
                     self.Target.Alignment = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "TextTrackCue.align"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("endTime",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("TextTrackCue.endTime", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.ITextTrackCue>(thisObj, "TextTrackCue.endTime");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.EndTime);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("TextTrackCue.endTime", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.ITextTrackCue>(thisObj, "TextTrackCue.endTime");
                     self.Target.EndTime = global::Jint.Browser.Dom.DomConvert.RequiredDouble(args, 0, "TextTrackCue.endTime"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Method("getCueAsHTML",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("TextTrackCue.getCueAsHTML", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.ITextTrackCue>(thisObj, "TextTrackCue.getCueAsHTML");
                     return self.Realm.WrapNodeValue(self.Target.AsHtml());
-                },
+                }),
                 length: 0)
             .Accessor("id",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("TextTrackCue.id", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.ITextTrackCue>(thisObj, "TextTrackCue.id");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Id);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("TextTrackCue.id", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.ITextTrackCue>(thisObj, "TextTrackCue.id");
                     self.Target.Id = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "TextTrackCue.id"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("line",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("TextTrackCue.line", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.ITextTrackCue>(thisObj, "TextTrackCue.line");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Line);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("TextTrackCue.line", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.ITextTrackCue>(thisObj, "TextTrackCue.line");
                     self.Target.Line = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "TextTrackCue.line"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("pauseOnExit",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("TextTrackCue.pauseOnExit", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.ITextTrackCue>(thisObj, "TextTrackCue.pauseOnExit");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsPausedOnExit);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("TextTrackCue.pauseOnExit", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.ITextTrackCue>(thisObj, "TextTrackCue.pauseOnExit");
                     self.Target.IsPausedOnExit = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("position",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("TextTrackCue.position", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.ITextTrackCue>(thisObj, "TextTrackCue.position");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Position);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("TextTrackCue.position", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.ITextTrackCue>(thisObj, "TextTrackCue.position");
                     self.Target.Position = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "TextTrackCue.position"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("size",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("TextTrackCue.size", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.ITextTrackCue>(thisObj, "TextTrackCue.size");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Size);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("TextTrackCue.size", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.ITextTrackCue>(thisObj, "TextTrackCue.size");
                     self.Target.Size = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "TextTrackCue.size"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("snapToLines",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("TextTrackCue.snapToLines", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.ITextTrackCue>(thisObj, "TextTrackCue.snapToLines");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsSnappedToLines);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("TextTrackCue.snapToLines", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.ITextTrackCue>(thisObj, "TextTrackCue.snapToLines");
                     self.Target.IsSnappedToLines = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("startTime",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("TextTrackCue.startTime", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.ITextTrackCue>(thisObj, "TextTrackCue.startTime");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.StartTime);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("TextTrackCue.startTime", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.ITextTrackCue>(thisObj, "TextTrackCue.startTime");
                     self.Target.StartTime = global::Jint.Browser.Dom.DomConvert.RequiredDouble(args, 0, "TextTrackCue.startTime"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("text",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("TextTrackCue.text", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.ITextTrackCue>(thisObj, "TextTrackCue.text");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Text);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("TextTrackCue.text", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.ITextTrackCue>(thisObj, "TextTrackCue.text");
                     self.Target.Text = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "TextTrackCue.text"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("track",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("TextTrackCue.track", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.ITextTrackCue>(thisObj, "TextTrackCue.track");
                     return self.Realm.Wrap(self.Target.Track);
-                })
+                }))
             .Accessor("vertical",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("TextTrackCue.vertical", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.ITextTrackCue>(thisObj, "TextTrackCue.vertical");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Vertical);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("TextTrackCue.vertical", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.ITextTrackCue>(thisObj, "TextTrackCue.vertical");
                     self.Target.Vertical = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "TextTrackCue.vertical"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>TextTrackCueList</c>.</summary>
@@ -475,18 +475,18 @@ internal static partial class DomInterfaces
             .ToStringTag("TextTrackCueList")
             .PerRealmSlot("constructor", enumerable: false)
             .Method("getCueById",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("TextTrackCueList.getCueById", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.ITextTrackCueList>(thisObj, "TextTrackCueList.getCueById");
                     return self.Realm.Wrap(self.Target.GetCueById(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "TextTrackCueList.getCueById")));
-                },
+                }),
                 length: 1)
             .Accessor("length",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("TextTrackCueList.length", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.ITextTrackCueList>(thisObj, "TextTrackCueList.length");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Length);
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>TextTrackList</c>.</summary>
@@ -502,24 +502,24 @@ internal static partial class DomInterfaces
             .ToStringTag("TimeRanges")
             .PerRealmSlot("constructor", enumerable: false)
             .Method("end",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("TimeRanges.end", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.ITimeRanges>(thisObj, "TimeRanges.end");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.End(global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "TimeRanges.end")));
-                },
+                }),
                 length: 1)
             .Accessor("length",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("TimeRanges.length", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.ITimeRanges>(thisObj, "TimeRanges.length");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Length);
-                })
+                }))
             .Method("start",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("TimeRanges.start", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.ITimeRanges>(thisObj, "TimeRanges.start");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Start(global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "TimeRanges.start")));
-                },
+                }),
                 length: 1)
             .Build();
 
@@ -529,40 +529,40 @@ internal static partial class DomInterfaces
             .ToStringTag("VideoTrack")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("id",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("VideoTrack.id", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.IVideoTrack>(thisObj, "VideoTrack.id");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Id);
-                })
+                }))
             .Accessor("kind",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("VideoTrack.kind", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.IVideoTrack>(thisObj, "VideoTrack.kind");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Kind);
-                })
+                }))
             .Accessor("label",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("VideoTrack.label", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.IVideoTrack>(thisObj, "VideoTrack.label");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Label);
-                })
+                }))
             .Accessor("language",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("VideoTrack.language", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.IVideoTrack>(thisObj, "VideoTrack.language");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Language);
-                })
+                }))
             .Accessor("selected",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("VideoTrack.selected", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.IVideoTrack>(thisObj, "VideoTrack.selected");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsSelected);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("VideoTrack.selected", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.IVideoTrack>(thisObj, "VideoTrack.selected");
                     self.Target.IsSelected = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>VideoTrackList</c>.</summary>
@@ -571,17 +571,17 @@ internal static partial class DomInterfaces
             .ToStringTag("VideoTrackList")
             .PerRealmSlot("constructor", enumerable: false)
             .Method("getTrackById",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("VideoTrackList.getTrackById", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.IVideoTrackList>(thisObj, "VideoTrackList.getTrackById");
                     return self.Realm.Wrap(self.Target.GetTrackById(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "VideoTrackList.getTrackById")));
-                },
+                }),
                 length: 1)
             .Accessor("selectedIndex",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("VideoTrackList.selectedIndex", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Media.Dom.IVideoTrackList>(thisObj, "VideoTrackList.selectedIndex");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.SelectedIndex);
-                })
+                }))
             .Build();
 }

--- a/Jint.Browser/Dom/Generated/DomShapes.Svg.g.cs
+++ b/Jint.Browser/Dom/Generated/DomShapes.Svg.g.cs
@@ -55,44 +55,44 @@ internal static partial class DomInterfaces
             .ToStringTag("SVGStyleElement")
             .PerRealmSlot("constructor", enumerable: false)
             .Accessor("disabled",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("SVGStyleElement.disabled", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Svg.Dom.ISvgStyleElement>(thisObj, "SVGStyleElement.disabled");
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.IsDisabled);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("SVGStyleElement.disabled", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Svg.Dom.ISvgStyleElement>(thisObj, "SVGStyleElement.disabled");
                     self.Target.IsDisabled = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("media",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("SVGStyleElement.media", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Svg.Dom.ISvgStyleElement>(thisObj, "SVGStyleElement.media");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Media);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("SVGStyleElement.media", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Svg.Dom.ISvgStyleElement>(thisObj, "SVGStyleElement.media");
                     self.Target.Media = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "SVGStyleElement.media"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Accessor("sheet",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("SVGStyleElement.sheet", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Svg.Dom.ISvgStyleElement>(thisObj, "SVGStyleElement.sheet");
                     return self.Realm.Wrap(self.Target.Sheet);
-                })
+                }))
             .Accessor("type",
-                static (thisObj, args) =>
+                global::Jint.Browser.Dom.DomFailures.Guard("SVGStyleElement.type", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Svg.Dom.ISvgStyleElement>(thisObj, "SVGStyleElement.type");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Type);
-                },
-                static (thisObj, args) =>
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("SVGStyleElement.type", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Svg.Dom.ISvgStyleElement>(thisObj, "SVGStyleElement.type");
                     self.Target.Type = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "SVGStyleElement.type"); return global::Jint.Native.JsValue.Undefined;
-                })
+                }))
             .Build();
 
     /// <summary>The members of <c>SVGTitleElement</c>.</summary>

--- a/Jint.Browser/Dom/Views/ViewInstaller.cs
+++ b/Jint.Browser/Dom/Views/ViewInstaller.cs
@@ -112,30 +112,42 @@ internal static class ViewInstaller
         .Build();
 
     /// <summary>https://w3c.github.io/selection-api/#selection-interface</summary>
+    /// <remarks>
+    /// The one hand-written shape whose members reach AngleSharp's own range algorithms — a collapse to an
+    /// offset past the end of a node is an <c>IndexSizeError</c>, selecting the contents of a doctype an
+    /// <c>InvalidNodeTypeError</c> — so every one goes through <see cref="DomFailures.Guard"/>, exactly as a
+    /// generated body does. <see cref="Selection"/> is only there to keep the qualified name in one place.
+    /// </remarks>
     private static JsObjectShape BuildSelectionShape() => new JsObjectShape.Builder()
         .PerRealmSlot("constructor")
         .ToStringTag("Selection")
-        .Accessor("anchorNode", static (t, _) => JsSelection.Brand(t, "anchorNode").AnchorNode)
-        .Accessor("anchorOffset", static (t, _) => JsNumber.Create(JsSelection.Brand(t, "anchorOffset").AnchorOffset))
-        .Accessor("focusNode", static (t, _) => JsSelection.Brand(t, "focusNode").FocusNode)
-        .Accessor("focusOffset", static (t, _) => JsNumber.Create(JsSelection.Brand(t, "focusOffset").FocusOffset))
-        .Accessor("isCollapsed", static (t, _) => JsSelection.Brand(t, "isCollapsed").IsCollapsed ? JsBoolean.True : JsBoolean.False)
-        .Accessor("rangeCount", static (t, _) => JsNumber.Create(JsSelection.Brand(t, "rangeCount").RangeCount))
-        .Accessor("type", static (t, _) => JsString.Create(JsSelection.Brand(t, "type").SelectionType))
-        .Method("getRangeAt", static (t, args) => JsSelection.Brand(t, "getRangeAt").GetRangeAt(args), length: 1)
-        .Method("addRange", static (t, args) => JsSelection.Brand(t, "addRange").AddRange(args), length: 1)
-        .Method("removeRange", static (t, args) => JsSelection.Brand(t, "removeRange").RemoveRange(args), length: 1)
-        .Method("removeAllRanges", static (t, _) => JsSelection.Brand(t, "removeAllRanges").RemoveAllRanges())
-        .Method("empty", static (t, _) => JsSelection.Brand(t, "empty").RemoveAllRanges())
-        .Method("collapse", static (t, args) => JsSelection.Brand(t, "collapse").Collapse(args), length: 1)
-        .Method("setPosition", static (t, args) => JsSelection.Brand(t, "setPosition").Collapse(args), length: 1)
-        .Method("collapseToStart", static (t, _) => JsSelection.Brand(t, "collapseToStart").CollapseTo(true, "collapseToStart"))
-        .Method("collapseToEnd", static (t, _) => JsSelection.Brand(t, "collapseToEnd").CollapseTo(false, "collapseToEnd"))
-        .Method("selectAllChildren", static (t, args) => JsSelection.Brand(t, "selectAllChildren").SelectAllChildren(args), length: 1)
-        .Method("containsNode", static (t, args) => JsSelection.Brand(t, "containsNode").ContainsNode(args), length: 1)
-        .Method("deleteFromDocument", static (t, _) => JsSelection.Brand(t, "deleteFromDocument").DeleteFromDocument())
-        .Method("toString", static (t, _) => JsString.Create(JsSelection.Brand(t, "toString").ToString()))
+        .Accessor("anchorNode", Selection("anchorNode", static (t, _) => JsSelection.Brand(t, "anchorNode").AnchorNode))
+        .Accessor("anchorOffset", Selection("anchorOffset", static (t, _) => JsNumber.Create(JsSelection.Brand(t, "anchorOffset").AnchorOffset)))
+        .Accessor("focusNode", Selection("focusNode", static (t, _) => JsSelection.Brand(t, "focusNode").FocusNode))
+        .Accessor("focusOffset", Selection("focusOffset", static (t, _) => JsNumber.Create(JsSelection.Brand(t, "focusOffset").FocusOffset)))
+        .Accessor("isCollapsed", Selection("isCollapsed", static (t, _) => JsSelection.Brand(t, "isCollapsed").IsCollapsed ? JsBoolean.True : JsBoolean.False))
+        .Accessor("rangeCount", Selection("rangeCount", static (t, _) => JsNumber.Create(JsSelection.Brand(t, "rangeCount").RangeCount)))
+        .Accessor("type", Selection("type", static (t, _) => JsString.Create(JsSelection.Brand(t, "type").SelectionType)))
+        .Method("getRangeAt", Selection("getRangeAt", static (t, args) => JsSelection.Brand(t, "getRangeAt").GetRangeAt(args)), length: 1)
+        .Method("addRange", Selection("addRange", static (t, args) => JsSelection.Brand(t, "addRange").AddRange(args)), length: 1)
+        .Method("removeRange", Selection("removeRange", static (t, args) => JsSelection.Brand(t, "removeRange").RemoveRange(args)), length: 1)
+        .Method("removeAllRanges", Selection("removeAllRanges", static (t, _) => JsSelection.Brand(t, "removeAllRanges").RemoveAllRanges()))
+        .Method("empty", Selection("empty", static (t, _) => JsSelection.Brand(t, "empty").RemoveAllRanges()))
+        .Method("collapse", Selection("collapse", static (t, args) => JsSelection.Brand(t, "collapse").Collapse(args)), length: 1)
+        .Method("setPosition", Selection("setPosition", static (t, args) => JsSelection.Brand(t, "setPosition").Collapse(args)), length: 1)
+        .Method("collapseToStart", Selection("collapseToStart", static (t, _) => JsSelection.Brand(t, "collapseToStart").CollapseTo(true, "collapseToStart")))
+        .Method("collapseToEnd", Selection("collapseToEnd", static (t, _) => JsSelection.Brand(t, "collapseToEnd").CollapseTo(false, "collapseToEnd")))
+        .Method("selectAllChildren", Selection("selectAllChildren", static (t, args) => JsSelection.Brand(t, "selectAllChildren").SelectAllChildren(args)), length: 1)
+        .Method("containsNode", Selection("containsNode", static (t, args) => JsSelection.Brand(t, "containsNode").ContainsNode(args)), length: 1)
+        .Method("deleteFromDocument", Selection("deleteFromDocument", static (t, _) => JsSelection.Brand(t, "deleteFromDocument").DeleteFromDocument()))
+        .Method("toString", Selection("toString", static (t, _) => JsString.Create(JsSelection.Brand(t, "toString").ToString())))
         .Build();
+
+    /// <summary>One <c>Selection</c> member body, wrapped so an AngleSharp refusal is a <c>DOMException</c>.</summary>
+    private static Func<JsValue, JsValue[], JsValue> Selection(
+        string member,
+        Func<JsValue, JsValue[], JsValue> implementation)
+        => DomFailures.Guard("Selection." + member, implementation);
 
     /// <summary>
     /// https://dom.spec.whatwg.org/#interface-nodefilter — a callback interface, so its interface object is

--- a/Jint.Tests.Browser/DomExceptionTests.cs
+++ b/Jint.Tests.Browser/DomExceptionTests.cs
@@ -1,0 +1,229 @@
+using AngleSharp.Dom;
+using Jint.Browser.Dom;
+
+namespace Jint.Tests.Browser;
+
+/// <summary>
+/// What a page sees when a DOM operation refuses: a JavaScript <c>DOMException</c> with the name and the
+/// legacy code the standard prescribes, never AngleSharp's CLR exception.
+/// </summary>
+/// <remarks>
+/// Before <see href="https://github.com/sebastienros/jint/issues/3670">#3670</see> every one of these walked
+/// through the script's own <c>try</c>/<c>catch</c> and out of the page loop as an
+/// <c>AngleSharp.Dom.DomException</c>, so a page could neither read <c>e.name</c> nor catch it at all.
+/// </remarks>
+public sealed class DomExceptionTests
+{
+    private const string Page = """
+        <!doctype html>
+        <html><body><div id="a">hello <b>world</b></div><p id="b">other</p></body></html>
+        """;
+
+    /// <summary>
+    /// One refusal per row: the script that provokes it, and the
+    /// <a href="https://webidl.spec.whatwg.org/#idl-DOMException-error-names">error name</a> plus legacy code
+    /// it has to arrive as.
+    /// </summary>
+    /// <remarks>
+    /// <c>querySelector</c> is here although <c>DomSelectorMembers</c> already answered it by hand, because
+    /// the wrapping must not change what a member that refuses on its own says.
+    /// </remarks>
+    [TestCase("document.createElement('1bad')", "InvalidCharacterError", 5, TestName = "createElement with an invalid name is an InvalidCharacterError")]
+    [TestCase("document.createAttribute('1bad')", "InvalidCharacterError", 5, TestName = "createAttribute with an invalid name is an InvalidCharacterError")]
+    [TestCase("document.getElementById('a').setAttribute('=bad', 'v')", "InvalidCharacterError", 5, TestName = "setAttribute with an invalid name is an InvalidCharacterError")]
+    [TestCase("var d = document.getElementById('a'); d.appendChild(d)", "HierarchyRequestError", 3, TestName = "appendChild of an ancestor is a HierarchyRequestError")]
+    [TestCase("document.getElementById('a').appendChild(document.body)", "HierarchyRequestError", 3, TestName = "appendChild of the body is a HierarchyRequestError")]
+    [TestCase("document.getElementById('a').removeChild(document.getElementById('b'))", "NotFoundError", 8, TestName = "removeChild of an unrelated node is a NotFoundError")]
+    [TestCase("document.getElementById('a').insertBefore(document.createElement('i'), document.getElementById('b'))", "NotFoundError", 8, TestName = "insertBefore with an unrelated reference is a NotFoundError")]
+    [TestCase("document.createRange().setStart(document.getElementById('a'), 99)", "IndexSizeError", 1, TestName = "setStart past the end is an IndexSizeError")]
+    [TestCase("document.getElementById('a').firstChild.splitText(99)", "IndexSizeError", 1, TestName = "splitText past the end is an IndexSizeError")]
+    [TestCase("document.getElementById('a').firstChild.substringData(99, 1)", "IndexSizeError", 1, TestName = "substringData past the end is an IndexSizeError")]
+    [TestCase("document.querySelector('!!')", "SyntaxError", 12, TestName = "an unparseable selector is a SyntaxError")]
+    [TestCase("document.importNode(document, true)", "NotSupportedError", 9, TestName = "importing a document is a NotSupportedError")]
+    [TestCase("document.createRange().selectNode(document)", "InvalidNodeTypeError", 24, TestName = "selecting the document node is an InvalidNodeTypeError")]
+    [TestCase("document.getElementById('a').attributes.removeNamedItem('nope')", "NotFoundError", 8, TestName = "removeNamedItem of an absent attribute is a NotFoundError")]
+    [TestCase("document.createElementNS('http://x/', 'xmlns:b')", "NamespaceError", 14, TestName = "an xmlns prefix is a NamespaceError")]
+    [TestCase("document.documentElement.insertAdjacentHTML('beforebegin', '<i>x</i>')", "NoModificationAllowedError", 7, TestName = "insertAdjacentHTML with no parent element is a NoModificationAllowedError")]
+    public void ARefusedOperationIsADomException(string source, string name, int code)
+    {
+        using var fixture = DomTestFixture.Create(Page);
+
+        fixture.Text($$"""
+            (function () {
+              try { {{source}}; return 'no throw'; }
+              catch (e) { return [e.name, e.code].join('/'); }
+            })()
+            """).Should().Be(name + "/" + code);
+    }
+
+    /// <summary>
+    /// The whole <see cref="DomError"/> table, so a pin bump that adds, renames or renumbers a value fails
+    /// here rather than in one page's <c>catch</c> block.
+    /// </summary>
+    /// <remarks>
+    /// <c>Validation</c> reads <c>InvalidAccessError</c> because AngleSharp numbers it 15, the value of
+    /// <c>InvalidAccess</c>, where WebIDL's legacy code for <c>ValidationError</c> is 16. That is the
+    /// divergence, asserted rather than described.
+    /// </remarks>
+    [Test]
+    public void EveryDomErrorNamesTheStandardsErrorName()
+    {
+        var table = string.Join(
+            "\n",
+            Enum.GetNames<DomError>()
+                .Select(field => Enum.Parse<DomError>(field))
+                .Select(error => (int) error + " " + Enum.GetName(error) + " -> " + DomFailures.NameOf(new DomException(error))));
+
+        table.Should().Be(
+            """
+            1 IndexSizeError -> IndexSizeError
+            2 DomStringSize -> DOMStringSizeError
+            3 HierarchyRequest -> HierarchyRequestError
+            4 WrongDocument -> WrongDocumentError
+            5 InvalidCharacter -> InvalidCharacterError
+            6 NoDataAllowed -> NoDataAllowedError
+            7 NoModificationAllowed -> NoModificationAllowedError
+            8 NotFound -> NotFoundError
+            9 NotSupported -> NotSupportedError
+            10 InUse -> InUseAttributeError
+            11 InvalidState -> InvalidStateError
+            12 Syntax -> SyntaxError
+            13 InvalidModification -> InvalidModificationError
+            14 Namespace -> NamespaceError
+            15 InvalidAccess -> InvalidAccessError
+            15 InvalidAccess -> InvalidAccessError
+            17 TypeMismatch -> TypeMismatchError
+            18 Security -> SecurityError
+            19 Network -> NetworkError
+            20 Abort -> AbortError
+            21 UrlMismatch -> URLMismatchError
+            22 QuotaExceeded -> QuotaExceededError
+            23 Timeout -> TimeoutError
+            24 InvalidNodeType -> InvalidNodeTypeError
+            25 DataClone -> DataCloneError
+            """);
+    }
+
+    /// <summary>
+    /// A <c>DomException</c> carrying no <see cref="DomError"/> is DOM's general refusal, because the string
+    /// AngleSharp puts in its <c>Name</c> in that case is a sentence rather than an error name.
+    /// </summary>
+    [Test]
+    public void ADomExceptionWithNoCodeIsAnInvalidStateError()
+        => DomFailures.NameOf(new DomException("The element has no parent.")).Should().Be("InvalidStateError");
+
+    /// <summary>
+    /// <c>QuotaExceededError</c> is an interface of its own rather than a name a <c>DOMException</c> wears,
+    /// so a refusal for want of room has to arrive as one.
+    /// </summary>
+    /// <remarks>
+    /// Nothing in AngleSharp raises <c>DomError.QuotaExceeded</c> today, so the interface rather than the
+    /// projection is what is asserted: <c>DomFailures</c> routes the name to
+    /// <c>QuotaExceededErrorConstructor</c> and this is what makes that reachable at all.
+    /// </remarks>
+    [Test]
+    public void TheQuotaNameIsItsOwnInterface()
+    {
+        using var fixture = DomTestFixture.Create(Page);
+
+        fixture.Text("""
+            (function () {
+              var e = new DOMException('x', 'QuotaExceededError');
+              return [e.code, QuotaExceededError.prototype instanceof DOMException].join('/');
+            })()
+            """).Should().Be("22/true");
+    }
+
+    /// <summary>
+    /// The exception is the page's own <c>DOMException</c> — its prototype, its interface object, its brand —
+    /// and an <c>Error</c> as WebIDL says a <c>DOMException</c> is.
+    /// </summary>
+    [Test]
+    public void TheExceptionIsThePagesOwnDomException()
+    {
+        using var fixture = DomTestFixture.Create(Page);
+
+        fixture.Text("""
+            (function () {
+              var d = document.getElementById('a');
+              try { d.appendChild(d); return 'no throw'; }
+              catch (e) {
+                return [
+                  e instanceof DOMException,
+                  e instanceof Error,
+                  e.constructor === DOMException,
+                  Object.prototype.toString.call(e),
+                  typeof e.stack
+                ].join('|');
+              }
+            })()
+            """).Should().Be("true|true|true|[object DOMException]|string");
+    }
+
+    /// <summary>
+    /// The message names the member that refused, in the wording <c>DomBindings</c> already uses for an
+    /// illegal invocation, and carries AngleSharp's own sentence after it.
+    /// </summary>
+    [Test]
+    public void TheMessageNamesTheMemberThatRefused()
+    {
+        using var fixture = DomTestFixture.Create(Page);
+
+        fixture.Text("""
+            (function () {
+              var d = document.getElementById('a');
+              try { d.appendChild(d); return 'no throw'; }
+              catch (e) { return e.message; }
+            })()
+            """).Should().Be("Failed to execute 'Node.appendChild': The operation would yield an incorrect node tree.");
+
+        fixture.Text("""
+            (function () {
+              try { document.createElement('1bad'); return 'no throw'; }
+              catch (e) { return e.message; }
+            })()
+            """).Should().Be("Failed to execute 'Document.createElement': Invalid character detected.");
+    }
+
+    /// <summary>
+    /// A refusal is catchable, so a page can go on. The proof a browser-shaped one is worth having: the
+    /// operation after the <c>catch</c> runs.
+    /// </summary>
+    [Test]
+    public void APageGoesOnAfterCatchingOne()
+    {
+        using var fixture = DomTestFixture.Create(Page);
+
+        fixture.Text("""
+            var seen = 'none';
+            var d = document.getElementById('a');
+            try { d.appendChild(d); } catch (e) { seen = e.name; }
+            d.appendChild(document.createElement('i'));
+            seen + '/' + d.lastChild.tagName;
+            """).Should().Be("HierarchyRequestError/I");
+    }
+
+    /// <summary>
+    /// What the wrapping must <i>not</i> change: an error the member body raised itself. A bad WebIDL
+    /// enumeration value and a wrong receiver are both <c>TypeError</c>s, and they stay that.
+    /// </summary>
+    [Test]
+    public void AnErrorTheBodyRaisedItselfIsUntouched()
+    {
+        using var fixture = DomTestFixture.Create(Page);
+
+        fixture.Text("""
+            (function () {
+              try { document.getElementById('a').insertAdjacentHTML('nope', '<i>x</i>'); return 'no throw'; }
+              catch (e) { return e.name + '/' + (e instanceof DOMException); }
+            })()
+            """).Should().Be("TypeError/false");
+
+        fixture.Text("""
+            (function () {
+              try { Element.prototype.getAttribute.call({}, 'id'); return 'no throw'; }
+              catch (e) { return e.name + ': ' + e.message; }
+            })()
+            """).Should().Be("TypeError: Failed to execute 'Element.getAttribute': Illegal invocation");
+    }
+}

--- a/Jint.Tests.Browser/DomExceptionTests.cs
+++ b/Jint.Tests.Browser/DomExceptionTests.cs
@@ -74,7 +74,8 @@ public sealed class DomExceptionTests
                 .Select(field => Enum.Parse<DomError>(field))
                 .Select(error => (int) error + " " + Enum.GetName(error) + " -> " + DomFailures.NameOf(new DomException(error))));
 
-        table.Should().Be(
+        // The literal takes the source file's line endings, so both sides are normalized before they meet.
+        table.ReplaceLineEndings("\n").Should().Be(
             """
             1 IndexSizeError -> IndexSizeError
             2 DomStringSize -> DOMStringSizeError
@@ -101,7 +102,7 @@ public sealed class DomExceptionTests
             23 Timeout -> TimeoutError
             24 InvalidNodeType -> InvalidNodeTypeError
             25 DataClone -> DataCloneError
-            """);
+            """.ReplaceLineEndings("\n"));
     }
 
     /// <summary>

--- a/Jint.Tests.Browser/Views/SelectionTests.cs
+++ b/Jint.Tests.Browser/Views/SelectionTests.cs
@@ -169,4 +169,33 @@ public sealed class SelectionTests
 
         (await page.EvaluateAsync<string>("window.left")).Should().BeEmpty();
     }
+
+    /// <summary>
+    /// A member that reaches AngleSharp's own range algorithms refuses as a <c>DOMException</c>, not as the
+    /// CLR exception AngleSharp raises — <see href="https://github.com/sebastienros/jint/issues/3670">#3670</see>.
+    /// </summary>
+    [Test]
+    public async Task ARefusedRangeOperationIsADomException()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        // The doctype is written out because the second case needs a node no range may select the contents
+        // of, and SetContentAsync's fragment form leaves document.doctype null.
+        await page.SetContentAsync("<!doctype html><html><body><div id=\"host\">hello</div></body></html>");
+
+        (await page.EvaluateAsync<string>("""
+            (() => {
+              try { getSelection().collapse(document.getElementById('host'), 99); return 'no throw' }
+              catch (e) { return [e instanceof DOMException, e.name, e.code].join('/') }
+            })()
+            """)).Should().Be("true/IndexSizeError/1");
+
+        (await page.EvaluateAsync<string>("""
+            (() => {
+              try { getSelection().selectAllChildren(document.doctype); return 'no throw' }
+              catch (e) { return [e instanceof DOMException, e.name, e.code].join('/') }
+            })()
+            """)).Should().Be("true/InvalidNodeTypeError/24");
+    }
 }

--- a/docs/releases/headless-browser.md
+++ b/docs/releases/headless-browser.md
@@ -126,7 +126,6 @@ and this package works within — are the two tables at the end of
 | [#3720](https://github.com/sebastienros/jint/issues/3720) | `BrowserOptions.UserAgent` reaches script but not the wire |
 | [#3721](https://github.com/sebastienros/jint/issues/3721) | A page's browsing context has no `IRenderDevice`, so `@media` and `matchMedia` disagree |
 | [#3711](https://github.com/sebastienros/jint/issues/3711) | An already-rejected promise fires `unhandledrejection` before a handler can attach |
-| [#3670](https://github.com/sebastienros/jint/issues/3670) | An AngleSharp `DomException` crosses into script as a raw CLR exception |
 | [#3698](https://github.com/sebastienros/jint/issues/3698), [#3706](https://github.com/sebastienros/jint/issues/3706), [#3707](https://github.com/sebastienros/jint/issues/3707), [#3684](https://github.com/sebastienros/jint/issues/3684), [#3683](https://github.com/sebastienros/jint/issues/3683) | The seams each area of the work wished it had, filed where the work stopped |
 
 Iframe scripting, `ElementInternals`, scoped custom element registries, real isolated worlds, screenshots and

--- a/tools/dom-bindings/Jint.Browser.BindingGenerator/Emitter.cs
+++ b/tools/dom-bindings/Jint.Browser.BindingGenerator/Emitter.cs
@@ -169,15 +169,16 @@ internal sealed class Emitter
 
             foreach (var member in model.Members)
             {
+                var label = model.DomName + "." + member.DomName;
+
                 if (member.Kind == MemberKind.Operation)
                 {
                     // https://webidl.spec.whatwg.org/#es-operations — { writable: true, enumerable: true,
                     // configurable: true }, which is JsObjectShape.Method's default and the opposite of
                     // ECMAScript's rule for a built-in.
                     builder.Append("            .Method(").Append(CSharpNames.Literal(member.DomName)).Append(",\n");
-                    builder.Append("                static (thisObj, args) =>\n                {\n");
-                    AppendBody(builder, member.Body, "                    ");
-                    builder.Append("                },\n");
+                    AppendGuardedBody(builder, label, member.Body);
+                    builder.Append(",\n");
                     builder.Append("                length: ").Append(member.Length).Append(")\n");
                 }
                 else
@@ -185,15 +186,12 @@ internal sealed class Emitter
                     // https://webidl.spec.whatwg.org/#es-attributes — { enumerable: true, configurable: true },
                     // JsObjectShape.Accessor's default.
                     builder.Append("            .Accessor(").Append(CSharpNames.Literal(member.DomName)).Append(",\n");
-                    builder.Append("                static (thisObj, args) =>\n                {\n");
-                    AppendBody(builder, member.Body, "                    ");
-                    builder.Append("                }");
+                    AppendGuardedBody(builder, label, member.Body);
 
                     if (member.SetterBody is { } setter)
                     {
-                        builder.Append(",\n                static (thisObj, args) =>\n                {\n");
-                        AppendBody(builder, setter, "                    ");
-                        builder.Append("                }");
+                        builder.Append(",\n");
+                        AppendGuardedBody(builder, label, setter);
                     }
 
                     builder.Append(")\n");
@@ -218,6 +216,22 @@ internal sealed class Emitter
 
         builder.Append("}\n");
         return builder.ToString();
+    }
+
+    /// <summary>
+    /// One member body, wrapped in the invoker that turns an <c>AngleSharp.Dom.DomException</c> into the
+    /// <c>DOMException</c> the standard prescribes. Every member goes through it — an operation, both halves
+    /// of an attribute — because which of them can refuse is AngleSharp's business rather than the metadata's,
+    /// and a page's only vocabulary for a refusal is <c>e.name</c>. <c>Jint.Browser/Dom/DomFailures</c> is the
+    /// whole of the conversion; here there is deliberately no <c>catch</c> to get out of step with it.
+    /// </summary>
+    private static void AppendGuardedBody(StringBuilder builder, string label, string body)
+    {
+        builder.Append("                global::Jint.Browser.Dom.DomFailures.Guard(")
+            .Append(CSharpNames.Literal(label))
+            .Append(", static (thisObj, args) =>\n                {\n");
+        AppendBody(builder, body, "                    ");
+        builder.Append("                })");
     }
 
     private static void AppendBody(StringBuilder builder, string body, string indent)


### PR DESCRIPTION
## What script saw before

Every AngleSharp refusal was an `AngleSharp.Dom.DomException`, which is a CLR exception: it walked straight
through the script's own `try`/`catch`, out of the page loop and into the host. Measured on `main`, with a
`try { … } catch (e) { … }` around each:

| Script | What script saw |
| --- | --- |
| `document.createElement('1bad')` | escaped the `catch` — `AngleSharp.Dom.DomException: Invalid character detected.` |
| `d.appendChild(d)` | escaped — `AngleSharp.Dom.DomException: The operation would yield an incorrect node tree.` |
| `a.removeChild(b)` | escaped — `AngleSharp.Dom.DomException: The object can not be found here.` |
| `el.setAttribute('=bad', 'v')` | escaped — `AngleSharp.Dom.DomException: Invalid character detected.` |
| `range.setStart(node, 99)` | escaped — `AngleSharp.Dom.DomException: The index is not in the allowed range.` |
| `text.splitText(99)`, `substringData(99, 1)` | escaped, same exception |
| `document.querySelector('!!')` | `SyntaxError`, code 12 — the five selector members were already answered by hand (`DomSelectorMembers`) |

## What it sees now

`DOMException`, from the page's own realm, with the name and legacy code the standard prescribes:

```
e instanceof DOMException === true
e instanceof Error        === true
e.constructor             === DOMException
Object.prototype.toString.call(e) === '[object DOMException]'
typeof e.stack            === 'string'
e.name                    === 'HierarchyRequestError'
e.code                    === 3
e.message                 === "Failed to execute 'Node.appendChild': The operation would yield an incorrect node tree."
```

The message prefix is the one `DomBindings` already puts in front of an illegal invocation and a bad
argument; the sentence after it is AngleSharp's, because DOM specifies a `name` and nothing about wording.

## Where the conversion lives

**One function, and the emitter emits calls to it from exactly one place.** `DomFailures.Guard(member, body)`
wraps every emitted member body — an operation, both halves of an attribute — and `Emitter.AppendGuardedBody`
is the only place that writes it, so **nothing generated carries a `catch`** that could get out of step with
the table. It costs one closure and one delegate per member, allocated when an interface's shape is built and
therefore once per process per interface a page reaches, plus one delegate hop per member call; the `try`
itself costs nothing until it fires. A `try` inside every emitted body would save the hop and buy two
thousand copies of one decision.

`Views/ViewInstaller`'s hand-written `Selection` shape takes the same guard, because its members reach
AngleSharp's range algorithms directly — `getSelection().collapse(el, 99)` and
`selectAllChildren(document.doctype)` were escaping the same way.

## The mapping

`DomFailures.NameOf` is the table, and `DomExceptionTests.EveryDomErrorNamesTheStandardsErrorName` pins every
row of it so a pin bump that adds or renumbers a value fails there rather than in a page's `catch`. Nothing
under `Jint/` changed: the engine's `DOMException` intrinsic, its `name`-to-`code` table and its tests are
untouched, and `DomExceptionNames.CodeFor` is still what computes the code from the name.

| `AngleSharp.Dom.DomError` | `e.name` | `e.code` |
| --- | --- | --- |
| `IndexSizeError` | `IndexSizeError` | 1 |
| `DomStringSize` | `DOMStringSizeError` | 2 |
| `HierarchyRequest` | `HierarchyRequestError` | 3 |
| `WrongDocument` | `WrongDocumentError` | 4 |
| `InvalidCharacter` | `InvalidCharacterError` | 5 |
| `NoDataAllowed` | `NoDataAllowedError` | 6 |
| `NoModificationAllowed` | `NoModificationAllowedError` | 7 |
| `NotFound` | `NotFoundError` | 8 |
| `NotSupported` | `NotSupportedError` | 9 |
| `InUse` | `InUseAttributeError` | 10 |
| `InvalidState` | `InvalidStateError` | 11 |
| `Syntax` | `SyntaxError` | 12 |
| `InvalidModification` | `InvalidModificationError` | 13 |
| `Namespace` | `NamespaceError` | 14 |
| `InvalidAccess`, `Validation` | `InvalidAccessError` | 15 |
| `TypeMismatch` | `TypeMismatchError` | 17 |
| `Security` | `SecurityError` | 18 |
| `Network` | `NetworkError` | 19 |
| `Abort` | `AbortError` | 20 |
| `UrlMismatch` | `URLMismatchError` | 21 |
| `QuotaExceeded` | `QuotaExceededError` — the **interface**, through `QuotaExceededErrorConstructor`, not a name a `DOMException` wears | 22 |
| `Timeout` | `TimeoutError` | 23 |
| `InvalidNodeType` | `InvalidNodeTypeError` | 24 |
| `DataClone` | `DataCloneError` | 25 |
| no `DomError` (the string constructor) | `InvalidStateError` | 11 |

And what the other CLR exceptions become, which is the decision this PR asks to be reviewed:

| CLR exception | Becomes | Why |
| --- | --- | --- |
| `ArgumentException`, `ArgumentNullException`, `ArgumentOutOfRangeException` | `TypeError` | WebIDL's answer for an argument no conversion accepts. A CLR signature that refused its argument is that and nothing more specific; where the standard names a `DOMException` instead, the member is written by hand and says so |
| `NotSupportedException`, `NotImplementedException` | `NotSupportedError` `DOMException` | the standard's name for an operation this environment does not perform |
| **everything else** | **unchanged** | the engine's own interop behaviour is a frozen contract for embedders (`Jint/Runtime/Interop/AGENTS.md`). A `JavaScriptException` a body raised itself, and every constraint, memory, recursion and cancellation signal, are outside the exception filter and are never caught, so their stacks are untouched |

## AngleSharp divergences found

Recorded in `Jint.Browser/Dom/AGENTS.md`'s divergence table, per the campaign's rule, and **no issue has been
opened upstream** — that is the maintainer's call.

| What | The standard | AngleSharp |
| --- | --- | --- |
| `DomException.Name` | the error name, `HierarchyRequestError` | the **enum field name**, `HierarchyRequest`, so the string can never be handed to a page — which is why `NameOf` exists at all |
| `DomError.Validation` | WebIDL's legacy code for `ValidationError` is 16 | 15, the value of `DomError.InvalidAccess`, so the two are one number and no `ValidationError` can be told from an `InvalidAccessError` |
| a `DomException`'s message | a browser names the operation and what it refused | AngleSharp's own sentence, which is what goes after the `Failed to execute '…': ` prefix |
| `insertAdjacentHTML('beforebegin')` with no parent element | HTML step 2: `NoModificationAllowedError` | the one `DomException` in the assembly built from a *string*: no `DomError` at all, and its `Name` is the sentence "The element has no parent.". `DomHostHooks.InsertAdjacentHtml` makes the refusal itself |
| `createElementNS(null, 'a:b')`, `setAttributeNS(null, 'a:b', …)` | validate-and-extract is a `NamespaceError` for a prefixed name with no namespace | no refusal at all. The `xmlns` half of the same algorithm *is* checked (`createElementNS('http://x/', 'xmlns:b')` is a `NamespaceError`) |
| `el.classList.add('')` / `add('a b')` | DOM §7.1: a `SyntaxError` for the empty token, an `InvalidCharacterError` for one containing ASCII whitespace | neither is validated, so the token list takes both |

## Tests

- `Jint.Tests.Browser/DomExceptionTests.cs` — 17 refusals as `[TestCase]` rows (name + code), the brand and
  prototype (`instanceof DOMException`, `instanceof Error`, `constructor`, the `toStringTag`, `stack`), the
  message, that a page goes on after catching one, the whole `DomError` table, the no-code fallback, and —
  the other half — that an error a member body raised itself (a bad WebIDL enumeration value, an illegal
  invocation) is still exactly the `TypeError` it was.
- `Jint.Tests.Browser/Views/SelectionTests.cs` — the two `Selection` members that were escaping.
- **Run against unfixed code first**: with `DomFailures.Guard` reduced to `=> implementation`, 13 of the 15
  cases that existed at that point failed; the two that passed were the selector case (already answered by
  hand) and the "an error the body raised itself is untouched" case.
- `dotnet test Jint.Tests.Browser -c Release` — 1189 passed on `net10.0`, 1186 on `net8.0`, 0 failed
  (4 Playwright cases skipped, as they are without `JINT_BROWSER_CLIENTS`).
- `dotnet test Jint.Tests -c Release -f net10.0 --filter "…WebApi|…MigrationGuideTests|…AgentInstructionFileTests|…SpecCitationTests"`
  — 2851 passed, 0 failed. `dotnet test Jint.Tests.DevTools -c Release` — 392/390 passed, 0 failed.

## web-platform-tests: before and after, unchanged

`JINT_WPT_BROWSER_CENSUS=1` before the change and after it: **551 not passing out of 1,417, both times**, and
the census check passes in both directions (a fall would fail as staleness), so no exclusion row became
passing and none was retired. The reason is that the browser lane vendors `dom/events`,
`html/webappapis/scripting/*` and `custom-elements/*` — **not `dom/nodes`**, which is the suite that asserts
DOMException names everywhere; `Jint.Tests/Wpt/Vendor/dom/nodes/` holds one helper file and no cases.
Vendoring `dom/nodes` is now worth doing and is a change of its own, following that lane's
"Adding a suite" procedure.

## What was left out

- **No `dom/nodes` vendoring.** See above — a suite is vendored at the pin, byte-verified, with its own
  `[TestCaseSource]`, three tables written from what it reported and a re-census. That is a separate PR.
- **No `docs/v5-migration.md` row.** Nothing under `Jint/` changed, the public API baseline
  (`PublicApiTest.verified.txt`) is byte-identical, and `Jint.Browser` is new in v5 — there is no 4.16
  behaviour to migrate from. `docs/releases/headless-browser.md` loses its "knowingly left" row for this
  issue instead.
- **The message wording is AngleSharp's**, not the per-operation sentence a browser writes
  ("The new child element contains the parent."). Reproducing those would be a table of prose keyed on
  operation and cause, which nothing branches on; the `name` and `code` are what a page reads.
- **The six AngleSharp divergences above are recorded, not patched**, and no upstream issue was filed.
- **`removeAttributeNode` / `getAttributeNode` / `setAttributeNode` are still absent** from the binding (a
  generator skip, reported by the regeneration), so `InUseAttributeError` has no path to reach a page yet.
  Unrelated to this change and left as it was.

Fixes #3670

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
