### PR TITLE
Activation: a fragment link clicked while its own document is still parsing moves the document instead of queueing a navigation

### DIFF
--- a/Jint.Browser/Page.Navigation.cs
+++ b/Jint.Browser/Page.Navigation.cs
@@ -240,14 +240,25 @@ public sealed partial class Page
     /// it two turns.
     /// </para>
     /// <para>
-    /// It declines while a navigation is in flight — the gate is what orders those, and a fragment move that
-    /// jumped it could be overwritten by a commit already on its way — so the slow path is still there for
-    /// the case it was protecting.
+    /// <b>The one question asked is whose document is moving</b>, and it is answered by the engine: HTML's
+    /// <i>navigate to a fragment</i> is a task on the event loop of the document whose URL it is changing, so
+    /// the request is a same-document move exactly when it came from the document the page is showing.
+    /// Neither the page's own load having returned nor the navigation gate being free is that question —
+    /// <see cref="_load"/> is null for the whole of a document's parse and the gate is held by the very
+    /// navigation that produced it, so a script running during its own document's parse was refused the
+    /// fragment arm and had a whole navigation queued behind the gate instead. It landed after the parse, out
+    /// of order with everything queued after it, and the corpus file above never saw the <c>hashchange</c>.
+    /// </para>
+    /// <para>
+    /// A commit already on its way is ordered by the queue rather than by a refusal: a job posted here runs
+    /// before it if it was posted first, and dies with the engine it was posted to if the commit wins —
+    /// which is a document that went away, exactly as a browser drops a fragment move onto a replaced
+    /// document.
     /// </para>
     /// </remarks>
     private bool TryFragmentNavigation(Engine engine, string url, bool replace)
     {
-        if (_closed || _load is null || _navigationGate.CurrentCount == 0)
+        if (_closed || !ReferenceEquals(engine, _loop.CurrentEngine))
         {
             return false;
         }

--- a/Jint.Browser/Runtime/AGENTS.md
+++ b/Jint.Browser/Runtime/AGENTS.md
@@ -323,7 +323,15 @@ measures.
   `Page.RequestNavigation` used to send an `<a href="#x">` round the thread pool and the gate, which put the
   commit behind every timer already due, so a page that clicked a link and then spun zero-delay timers waiting
   for `hashchange` waited out the whole chain (measured at turn 20 of 20; turn 1 now). It is a job on the
-  engine's own queue instead, and it declines while a navigation is in flight — the gate is what orders those.
+  engine's own queue instead. **The one question it asks is whose document is moving**, and the engine
+  answers it: HTML's *navigate to a fragment* is a task on the event loop of the document whose URL changes,
+  so it is a same-document move exactly when the request came from the engine the page is showing. Neither
+  `_load` being set nor the gate being free is that question — `_load` is null for the whole of a document's
+  parse and the gate is held by the navigation that produced it, so gating on either refused the fragment arm
+  to every script that runs during its own parse and queued a whole navigation behind the gate instead
+  (#3693, and twenty-two rows of `dom/events/Event-dispatch-single-activation-behavior.html`). A commit
+  already on its way is ordered by the queue rather than by a refusal: a job posted first runs first, and one
+  the commit overtakes dies with the engine it was posted to.
 
 **Everything the network touches is the context's** — `Runtime/PageNetwork`, one per `BrowserContext`: the
 client, the composed `UrlFilter` (host filter and `BlockPrivateNetwork` combined once), the `CookieJar` and

--- a/Jint.Tests.Browser/Events/ActivationBehaviorTests.cs
+++ b/Jint.Tests.Browser/Events/ActivationBehaviorTests.cs
@@ -653,4 +653,129 @@ public sealed class ActivationBehaviorTests
                 + "connected:input,connected:change,connected:checked=true,"
                 + "inShadow:input,inShadow:change,inShadow:checked=true");
     }
+
+    /// <summary>
+    /// https://dom.spec.whatwg.org/#concept-event-dispatch steps 6.5 and 6.9.5.1 — a dispatch chooses
+    /// <b>one</b> activation target, the nearest one at or above the click's target, so a nesting of
+    /// activatable elements runs exactly one behaviour.
+    /// </summary>
+    /// <remarks>
+    /// The nesting matrix <c>dom/events/Event-dispatch-single-activation-behavior.html</c> builds, reduced to
+    /// the four shapes whose two halves would each act on their own: a link inside a submit button, a button
+    /// inside a link, a label wrapping the control it labels, and a <c>&lt;summary&gt;</c> inside a link.
+    /// <b>Each shape is instrumented by the outer element's own default action</b> — a submission, a
+    /// navigation — rather than by a listener, because a listener cannot tell an activation behaviour from an
+    /// event that merely bubbled to it, which is exactly what the eight rows of that file this lane forgives
+    /// get wrong. The page is a real origin so that a link wrongly followed moves it and is seen.
+    /// </remarks>
+    [Test]
+    public async Task OnlyTheNearestActivationTargetsBehaviourRuns()
+    {
+        await using var fixture = await LoopbackPage.CreateAsync(server => server
+            .MapHtml(
+                "/start.html",
+                """
+                <title>start</title>
+                <form id='f' action='/submitted.html'>
+                  <button id='outerButton' type='submit'><a id='innerLink' href='/linked.html'>link</a></button>
+                </form>
+                <a id='outerLink' href='/linked.html'><button id='innerButton' type='button'>button</button></a>
+                <label id='label'><input id='labeled' type='checkbox'><span id='labelText'>text</span></label>
+                <a id='outerLinkAroundDetails' href='/linked.html'><details id='details'><summary id='summary'>s</summary></details></a>
+                """)
+            .MapHtml("/linked.html", "<title>linked</title>")
+            .MapHtml("/submitted.html", "<title>submitted</title>"));
+
+        await fixture.Page.NavigateAsync(fixture.Url("/start.html"));
+
+        (await fixture.Page.EvaluateAsync<string>(
+            """
+            (() => {
+              const seen = [];
+              const id = el => el === null ? 'none' : el.id;
+              document.getElementById('f').addEventListener('submit', e => { e.preventDefault(); seen.push('submit'); });
+
+              // The parser has to have built the nesting each case is about, or the case would assert nothing.
+              seen.push('nesting=' + [
+                id(document.getElementById('innerLink').closest('button')),
+                id(document.getElementById('innerButton').closest('a')),
+                id(document.getElementById('summary').closest('a')),
+              ].join('/'));
+
+              // A link inside a submit button: the link is the target and has an activation behaviour of its
+              // own, so the button's never runs and the form is not submitted. The link's own click is
+              // canceled, which is what keeps the rest of the cases on this document.
+              document.getElementById('innerLink').addEventListener('click', e => e.preventDefault(), { once: true });
+              document.getElementById('innerLink').click();
+              seen.push('submitted=' + seen.includes('submit'));
+
+              // A button inside a link: the button is the target, and a type=button button's activation
+              // behaviour is nothing at all — the link's must not run in its place.
+              document.getElementById('innerButton').click();
+
+              // A label wrapping its control: one toggle, from the forwarded click, not two.
+              document.getElementById('labelText').click();
+              seen.push('checked=' + document.getElementById('labeled').checked);
+
+              // A <summary> inside a link: the summary toggles its <details>, and the link is not followed.
+              document.getElementById('summary').click();
+              seen.push('open=' + document.getElementById('details').open);
+
+              return seen.join(',');
+            })()
+            """))
+            .Should().Be("nesting=outerButton/outerLink/outerLinkAroundDetails,submitted=false,checked=true,open=true");
+
+        // A navigation an activation behaviour started runs off the loop, so the page is given the chance to
+        // move before it is asserted not to have.
+        await fixture.Page.WaitForIdleAsync(TimeSpan.FromSeconds(5));
+
+        (await fixture.Page.TitleAsync()).Should().Be("start", "not one of the four outer behaviours ran");
+        fixture.Page.Url.Should().Be(fixture.Url("/start.html"));
+        fixture.Page.Errors.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate-fragid — a fragment navigation
+    /// is a same-document move on the document's own event loop, so it happens even while the navigation that
+    /// produced that document is still finishing.
+    /// </summary>
+    /// <remarks>
+    /// <b>This is the shape the corpus found.</b> A script that runs during its document's parse has a
+    /// document — it is the one showing — but the page's own load has not returned and the navigation gate is
+    /// still held by it, so a fragment move gated on either was refused and queued as a whole navigation
+    /// behind the gate instead. It then landed after the parse, in the wrong order, and after everything the
+    /// document had queued: <c>dom/events/Event-dispatch-single-activation-behavior.html</c> clicks such a
+    /// link from a test that gives it two zero-delay turns, and never saw the <c>hashchange</c> at all.
+    /// </remarks>
+    [Test]
+    public async Task AFragmentLinkClickedDuringTheParseFiresHashChangeOnTheNextTurn()
+    {
+        await using var fixture = await LoopbackPage.CreateAsync(server => server.MapHtml(
+            "/index.html",
+            """
+            <title>fragment</title>
+            <div id='wrapper'><a id='go' href='#frag'><span id='inner'>go</span></a></div>
+            <p id='frag'>target</p>
+            <script>
+              window.turns = 0;
+              window.seen = null;
+              window.onhashchange = e => { window.seen = window.turns + ':' + e.newURL; };
+              // The click is on a <span> inside the link, so the anchor is chosen as the activation target by
+              // the walk up the event path rather than by being the target.
+              document.getElementById('inner').click();
+              (function tick() { window.turns++; if (window.turns < 20 && window.seen === null) { setTimeout(tick, 0); } })();
+            </script>
+            """));
+
+        await fixture.Page.NavigateAsync(fixture.Url("/index.html"));
+        await fixture.Page.WaitForIdleAsync(TimeSpan.FromSeconds(5));
+
+        (await fixture.Page.EvaluateAsync<string>("String(window.seen)"))
+            .Should().Be("1:" + fixture.Url("/index.html") + "#frag", "the move is a job on the loop, not a navigation behind the gate");
+        (await fixture.Page.EvaluateAsync<string>("location.hash")).Should().Be("#frag");
+        (await fixture.Page.EvaluateAsync<double>("history.length")).Should().Be(2, "a fragment move pushes one entry");
+        fixture.Page.Url.Should().Be(fixture.Url("/index.html") + "#frag");
+        fixture.Page.Errors.Should().BeEmpty();
+    }
 }

--- a/Jint.Tests.Browser/Wpt/README.md
+++ b/Jint.Tests.Browser/Wpt/README.md
@@ -25,14 +25,14 @@ vendored here yet. Its plugin is [`tools/wpt-scoreboard/`](../../tools/wpt-score
 
 | Suite | Documents | Synthesized | Tests | Not passing |
 | --- | --- | --- | --- | --- |
-| `dom/events/` | 56 | 9 | 544 | 42 |
+| `dom/events/` | 56 | 9 | 544 | 20 |
 | `html/webappapis/scripting/events/` | 12 | 0 | 37 | 5 |
 | `html/webappapis/scripting/processing-model-2/` | 25 | 0 | 44 | 14 |
 | `custom-elements/` | 16 | 0 | 510 | 257 |
 | `custom-elements/parser/` | 8 | 0 | 20 | 11 |
 | `custom-elements/reactions/` | 14 | 0 | 255 | 219 |
 | `custom-elements/upgrading/` | 2 | 0 | 7 | 3 |
-| **total** | **133** | **9** | **1,417** | **551** |
+| **total** | **133** | **9** | **1,417** | **529** |
 
 *Measured on Windows.* **Documents** are `.html` files in this repository; **Synthesized** are the
 `<name>.any.html` wrappers `WptServerWrappers` manufactures for a suite's `.any.js` files, which are bytes
@@ -61,7 +61,7 @@ passive value, one activation behaviour per click, the detached control's silent
 the window — and the three seams two of them needed in the engine are
 [#3696](https://github.com/sebastienros/jint/pull/3696).
 
-What `NeedsTriage` holds now is five things, each bounded and each named by the exclusion table:
+What `NeedsTriage` holds now is four things, each bounded and each named by the exclusion table:
 
 1. **A `data:` URL is not fetched as a subresource.** A page navigates to one, so
    `<script src="data:text/javascript,…">` is the one shape of external script that never runs; three
@@ -81,11 +81,15 @@ What `NeedsTriage` holds now is five things, each bounded and each named by the 
    on an `<x-foo static formAssociated>` sees the *form's* lexical scope — which needs the element to be a
    form-associated element and take part in `form.elements`. This package records the flag and nothing
    consults it: there is no `ElementInternals`. The file's other three rows pass.
-5. **A fragment navigation does not land inside two turns.** Following an `<a href="#x">` of the page's own
-   URL now happens on the page loop and fires `hashchange` on the next turn — measured, and moved there from
-   after the whole timer chain — but `Event-dispatch-single-activation-behavior.html` gives it two zero-delay
-   turns and its twenty-two `<a>`/`<area>` shapes still do not see it. What is left is a question about the
-   page loop's scheduling rather than about activation behaviour.
+
+The twenty-two `<a>`/`<area>` shapes of `Event-dispatch-single-activation-behavior.html` were the fifth, and
+they pass now. What kept them red was not the page loop's scheduling but the fragment arm being gated on the
+page's own load having returned and on the navigation gate being free: this file's tests run *during* the
+parse, where neither is true, so every one of their fragment moves was queued as a whole navigation behind
+the gate and landed after the two turns the file allows. The move is a same-document one exactly when the
+request came from the document the page is showing, which is the question
+[`Jint.Browser/Runtime/AGENTS.md`](../../Jint.Browser/Runtime/AGENTS.md#navigation-is-a-fetch-and-a-new-engine)
+now says it asks.
 
 One further group left `NeedsTriage` for a category of its own. `document.createEvent`'s alias table names
 five interfaces this package deliberately does not build — `DragEvent` and `ClipboardEvent` need a

--- a/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
+++ b/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
@@ -404,12 +404,12 @@ internal static class WptBrowserExclusions
     /// test, or by a glob over a family the file generates.
     /// </para>
     /// <para>
-    /// <b><see cref="WptDivergence.NeedsTriage"/> is five distinct things, not eleven rows.</b> The eleven
+    /// <b><see cref="WptDivergence.NeedsTriage"/> is four distinct things, not eleven rows.</b> The eleven
     /// defects this lane first recorded were filed as
     /// https://github.com/sebastienros/jint/issues/3686 to 3695 and are fixed; what is left is named in
     /// <c>Wpt/README.md</c>, one section per cause, and every one of them is bounded — a scheme a subresource
     /// cannot fetch, a member AngleSharp reflects wrong, an <c>@@unscopables</c> object the binding does not
-    /// emit, a custom element, and a fragment navigation this lane's own timing does not wait for.
+    /// emit, and a custom element.
     /// </para>
     /// </remarks>
     internal static readonly WptExclusion[] All =
@@ -487,17 +487,6 @@ internal static class WptBrowserExclusions
         new("dom/events/Event-dispatch-single-activation-behavior.html", "When clicking child <FORM><INPUT type=reset></INPUT></FORM> of parent <FORM><BUTTON type=reset></BUTTON></FORM>, only child should be activated.", WptDivergence.AssertsWhatNothingRequires),
         new("dom/events/Event-dispatch-single-activation-behavior.html", "When clicking child <FORM><INPUT type=submit></INPUT></FORM> of parent <FORM><BUTTON type=submit></BUTTON></FORM>, only child should be activated.", WptDivergence.AssertsWhatNothingRequires),
         new("dom/events/Event-dispatch-single-activation-behavior.html", "When clicking child <FORM><INPUT type=submit></INPUT></FORM> of parent <FORM><INPUT type=image></INPUT></FORM>, only child should be activated.", WptDivergence.AssertsWhatNothingRequires),
-
-        // ---------------------------------------------------------------- 7. a fragment navigation the file does not wait for
-        // The same file's twenty-two `<a>`/`<area>` shapes click a link to a fragment of the page's own URL
-        // and give it two zero-delay turns to produce a `hashchange`. The navigation happens — a unit test
-        // measures it arriving on the *next* turn, and this change moved it there from after the whole timer
-        // chain by keeping a same-document fragment move on the page loop instead of sending it round the
-        // navigation gate — but in this document it still does not land inside the file's two turns. What is
-        // left is a scheduling question about the page loop rather than anything about activation behaviour,
-        // and it is the one row of #3693 this change does not retire.
-        new("dom/events/Event-dispatch-single-activation-behavior.html", "When clicking child <A></A> of parent *", WptDivergence.NeedsTriage),
-        new("dom/events/Event-dispatch-single-activation-behavior.html", "When clicking child <AREA></AREA> of parent *", WptDivergence.NeedsTriage),
 
         // ---------------------------------------------------------------- a frame that runs script
         // https://html.spec.whatwg.org/multipage/nav-history-apis.html#window: each of these needs a second


### PR DESCRIPTION
Fixes #3693.

### What was wrong

`dom/events/Event-dispatch-single-activation-behavior.html` builds 132 nesting shapes and asserts that exactly one activation behaviour runs. The activation-target half was fixed in #3699; twenty-two rows stayed red — every shape whose clicked child is an `<a>` or an `<area>` to a fragment — and were recorded as a scheduling question about the page loop. They are not.

HTML's [*navigate to a fragment*](https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate-fragid) is a task on the event loop of the document whose URL it changes, so a request is a same-document move exactly when it came from the document the page is showing. `Page.TryFragmentNavigation` asked two other questions instead — whether the page's own load had returned (`_load is not null`) and whether the navigation gate was free — and **neither is that question**: `_load` is null for the whole of a document's parse, and the gate is held by the very navigation that produced that document. So a script running during its own document's parse was refused the fragment arm and had a *whole navigation* queued behind the gate instead. It landed after the parse, out of order with everything queued after it, and long after anything the document was waiting for.

That is exactly the corpus file's shape: its tests all run during the parse, and each clicks a link to a fragment of the page's own URL and gives it two zero-delay turns to see a `hashchange`. Instrumented, every one of its 22 fragment moves was declined with `load=null gate=0` and re-queued as a navigation; the `hashchange` arrived after the whole timer chain, by which time the test had already asserted `got [] length 0`.

### What changed

One guard in `Jint.Browser/Page.Navigation.cs`: the fragment arm is taken when the page is open and the engine that asked is the one the page is showing. A commit already on its way is ordered by the queue rather than by a refusal — a job posted here runs before it if it was posted first, and dies with the engine it was posted to if the commit wins, which is a document that went away, exactly as a browser drops a fragment move onto a replaced document.

`Jint.Browser/Runtime/AGENTS.md` and the class remarks now say which question the arm asks and why the other two are not it.

### The tests that pin it

* `ActivationBehaviorTests.AFragmentLinkClickedDuringTheParseFiresHashChangeOnTheNextTurn` — a document whose inline script clicks a `<span>` inside an `<a href="#frag">` and then spins zero-delay timers. Against the unfixed code it reports `20:…#frag` (the whole chain waited out); with the fix, `1:…#frag`, `location.hash`, `history.length` and `Page.Url` all agree.
* `ActivationBehaviorTests.OnlyTheNearestActivationTargetsBehaviourRuns` — the nesting matrix as a unit test: a link inside a submit button, a button inside a link, a label wrapping its control, a `<summary>` inside a link. Each shape is instrumented by the **outer** element's own default action rather than by a listener, because a listener cannot tell an activation behaviour from an event that merely bubbled to it — which is what the eight `<form>` rows this lane forgives get wrong. It fails if the dispatcher stops choosing the nearest activation target (verified by mutating step 6.9.5).
* The lane itself: both `NeedsTriage` rows are retired, all 22 shapes pass, and the census falls from **551 to 529** (`dom/events/` 42 → 20), re-measured with `JINT_WPT_BROWSER_CENSUS=update`. `NeedsTriage` is now four causes, none about activation behaviour.

Nothing in `Jint/WebApi/Events` changed, so there is no migration-guide row: the dispatcher's activation-target selection was already the specification's.

Green: `Jint.Tests.Browser` on `net8.0` and `net10.0` (1163 / 1166), and `Jint.Tests` for `MigrationGuideTests`, `AgentInstructionFileTests`, `SpecCitationTests` and the engine's event suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
