### PR TITLE
DevTools: an Input command that outlives the document it was sent for is dispatched to the one that replaced it

### DIFF
--- a/Jint.DevTools/Session/AGENTS.md
+++ b/Jint.DevTools/Session/AGENTS.md
@@ -97,7 +97,15 @@ Four consequences:
 - **The gateway is the target, not a mailbox.** `TargetSession` calls `UseGateway(target)` and the target
   forwards to the current runtime's dispatcher, so a command is queued on the engine that is running now. A
   command already queued on the engine being replaced is answered `-32000 "Execution context was
-  destroyed."` rather than left to the client's own timeout.
+  destroyed."` rather than left to the client's own timeout — **unless it never named a context**, which is
+  every `Input` command and only those (`EngineDispatcher.IsAddressedToTheTarget`). A mouse event, a key
+  event and an inserted string are delivered to the *page* and dispatched at whichever document is current
+  when they run; a client sends the two halves of one key press as two commands and a navigation is free to
+  happen between them, so `Abandon` hands such a command to the runtime that replaced this one instead of
+  refusing it (#3723, found as a `Keyboard.PressAsync` flake whose `keyDown` submitted a form). It reaches
+  the new document, or nothing at all when that document has not been parsed yet — never an error. Everything
+  else names a context however indirectly — a handle, a script identifier, a realm — so the refusal is the
+  truthful answer and stays.
 - **The context counter is the target's**, so the second document's default context is `2` and never `1`
   again. That is what makes a stale `contextId` distinguishable, and `DevToolsTarget.RequireContext` answers
   one with `-32000 "Cannot find context with specified id"` — Chrome's text, which the recordings show

--- a/Jint.DevTools/Session/EngineDispatcher.cs
+++ b/Jint.DevTools/Session/EngineDispatcher.cs
@@ -130,6 +130,14 @@ internal sealed class EngineDispatcher : ICommandGateway, IDisposable
     /// what several clients match on to decide a navigation raced their command.
     /// </para>
     /// <para>
+    /// <b>Except for a command that was never addressed to a context.</b> An <c>Input</c> command is
+    /// addressed to the <i>page</i>: Chrome dispatches a key or a mouse event to whatever document is
+    /// current when it runs, and a key-up that arrives while its document is being replaced is delivered to
+    /// the new one rather than refused. So such a command is handed to the runtime that replaced this one
+    /// and runs there — which is also where <see cref="IsAddressedToTheTarget"/> says the line is, since
+    /// <c>Runtime.callFunctionOn</c> and its kin really do name a context and must keep the refusal.
+    /// </para>
+    /// <para>
     /// Idempotent, and it drains on every call rather than only the first: the flag is what a command
     /// arriving <i>after</i> the swap reads, and that command still has to be answered.
     /// </para>
@@ -140,6 +148,12 @@ internal sealed class EngineDispatcher : ICommandGateway, IDisposable
 
         while (_commands.TryDequeue(out var item))
         {
+            if (IsAddressedToTheTarget(item.Method) && Successor() is { } successor)
+            {
+                successor.Hand(item);
+                continue;
+            }
+
             item.Abandon();
         }
 
@@ -268,6 +282,50 @@ internal sealed class EngineDispatcher : ICommandGateway, IDisposable
 
     /// <inheritdoc/>
     public void Dispose() => _arrivals.Dispose();
+
+    /// <summary>
+    /// Whether a command names the engine it is answered on, or only the target it was sent to.
+    /// </summary>
+    /// <remarks>
+    /// <b>One domain, and the list is Chrome's own addressing rather than a convenience.</b> Every
+    /// <c>Input</c> command — a mouse event, a key event, an inserted string — is delivered to the page's
+    /// widget and dispatched at whichever document is current when it runs; nothing in the request names an
+    /// execution context, and a client sends the two halves of one key press as two commands with a
+    /// navigation free to happen between them. Everything else a mailbox carries is addressed to a context,
+    /// however indirectly — a handle, a script identifier, a realm — so a swap under it really is a
+    /// destroyed context and the refusal is the truthful answer.
+    /// </remarks>
+    private static bool IsAddressedToTheTarget(string method)
+        => method.StartsWith("Input.", StringComparison.Ordinal);
+
+    /// <summary>
+    /// The mailbox that replaced this one, or <see langword="null"/> when nothing did.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="DevToolsTarget.Replace"/> installs the new runtime <i>before</i> disposing the previous
+    /// one, so by the time this runs the target already answers with the runtime a handed-over command
+    /// belongs to. A target that is going away rather than navigating answers with this same mailbox, and a
+    /// command for a page that has closed therefore keeps the refusal.
+    /// </remarks>
+    private EngineDispatcher? Successor()
+    {
+        var current = _target.Runtime;
+        return !current.IsDisposed && !ReferenceEquals(current.Dispatcher, this) ? current.Dispatcher : null;
+    }
+
+    /// <summary>Takes over a command the mailbox it was queued on could not answer.</summary>
+    private void Hand(CommandItem item)
+    {
+        _commands.Enqueue(item);
+        ScheduleDrain();
+
+        if (Volatile.Read(ref _abandoned) != 0)
+        {
+            // This mailbox was abandoned too — two navigations in the time the command spent queued — so the
+            // item moves on again, or is refused when there is nowhere left to move it to.
+            Abandon();
+        }
+    }
 
     /// <summary>
     /// Whether a command may be answered while the engine is paused.

--- a/Jint.Tests.Browser/DevTools/InputDuringNavigationTests.cs
+++ b/Jint.Tests.Browser/DevTools/InputDuringNavigationTests.cs
@@ -1,0 +1,250 @@
+using Jint.Browser;
+using Jint.Tests.Browser.Navigation;
+
+namespace Jint.Tests.Browser.DevTools;
+
+/// <summary>
+/// An <c>Input</c> command is addressed to the <b>page</b> rather than to an execution context, so a
+/// navigation replacing the document under it is never a reason to refuse it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The shape came out of a client suite.</b> <c>Keyboard.PressAsync("Enter")</c> is a <c>keyDown</c> and a
+/// <c>keyUp</c>; the <c>keyDown</c> runs HTML's implicit submission, which navigates; and the <c>keyUp</c>
+/// then arrives while the document it was sent for is being replaced. Chrome dispatches it to whatever
+/// document is current when it runs — or to none, silently — and never answers
+/// <c>Execution context was destroyed</c>, which is a sentence about a context a command named.
+/// </para>
+/// <para>
+/// <b>Every one of these is deterministic rather than timed.</b> The outgoing document blocks the page loop
+/// inside its own <c>pagehide</c> handler, so the commit is suspended at exactly the point the client's next
+/// command has to arrive at, and the test releases it. A test that raced the commit would be a
+/// continuous-integration leg that passes on a fast machine.
+/// </para>
+/// </remarks>
+[NonParallelizable]
+public class InputDuringNavigationTests
+{
+    /// <summary>How long the blocked page loop waits to be released before it gives up on the test.</summary>
+    private static readonly TimeSpan _bound = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// The flake's own shape: the key is queued for the engine that is going away, and is answered rather
+    /// than refused.
+    /// </summary>
+    [Test]
+    public async Task AKeyQueuedWhileTheDocumentIsReplacedIsAnsweredRatherThanRefused()
+    {
+        using var server = Origin();
+        var gate = new CommitGate();
+
+        await using var session = await PageSession.CreateAsync(Isolated(server), gate.Options());
+        var attachment = await session.OpenPageAsync();
+        await Watch(session, attachment);
+        await session.ResultAsync("Page.navigate", Navigate(server, "/start.html"), attachment);
+
+        var navigating = session.SendAsync("Page.navigate", Navigate(server, "/next.html"), attachment);
+        await gate.Unloading;
+
+        // The page loop is inside the commit now, held in the outgoing document's `pagehide` handler, so this
+        // key queues for an engine that is about to be replaced.
+        var key = session.SendAsync("Input.dispatchKeyEvent", KeyUp("Enter"), attachment);
+        await gate.LetTheCommandArriveAsync();
+        gate.Release();
+
+        var reply = await key;
+        await navigating;
+
+        reply.TryGetProperty("error", out var error).Should().BeFalse(
+            "an Input command is addressed to the page and it answered {0}", error);
+
+        // And the page is the new document, still driveable: a key sent now reaches it, which is what says
+        // the command ran against the target's current runtime rather than against a captured one.
+        await session.ResultAsync("Input.dispatchKeyEvent", KeyUp("a"), attachment);
+        (await Seen(session, attachment)).Should().Be("a");
+        (await Evaluate(session, attachment, "location.pathname")).Should().Be("/next.html");
+    }
+
+    /// <summary>
+    /// The other order: the key arrives while the document it was sent for is still the page's, so it is
+    /// delivered to that one — and lost with it, as it is in a browser.
+    /// </summary>
+    [Test]
+    public async Task AKeySentBeforeTheDocumentIsReplacedReachesTheOneThatIsStillThere()
+    {
+        using var server = Origin();
+        var gate = new CommitGate();
+
+        await using var session = await PageSession.CreateAsync(Isolated(server), gate.Options());
+        var attachment = await session.OpenPageAsync();
+        await Watch(session, attachment);
+        await session.ResultAsync("Page.navigate", Navigate(server, "/start.html"), attachment);
+
+        var key = session.SendAsync("Input.dispatchKeyEvent", KeyUp("Escape"), attachment);
+        (await key).TryGetProperty("error", out _).Should().BeFalse();
+        gate.SeenInTheOutgoingDocument.Should().Be("Escape");
+
+        var navigating = session.SendAsync("Page.navigate", Navigate(server, "/next.html"), attachment);
+        await gate.Unloading;
+        gate.Release();
+        await navigating;
+
+        (await Seen(session, attachment)).Should().BeEmpty("the new document was not there when the key was dispatched");
+    }
+
+    /// <summary>
+    /// The line this draws, from the other side: a command that really does name a context keeps Chrome's
+    /// refusal when the document it named is replaced.
+    /// </summary>
+    [Test]
+    public async Task AnEvaluationQueuedWhileTheDocumentIsReplacedIsStillRefused()
+    {
+        using var server = Origin();
+        var gate = new CommitGate();
+
+        await using var session = await PageSession.CreateAsync(Isolated(server), gate.Options());
+        var attachment = await session.OpenPageAsync();
+        await session.ResultAsync("Page.navigate", Navigate(server, "/start.html"), attachment);
+
+        var navigating = session.SendAsync("Page.navigate", Navigate(server, "/next.html"), attachment);
+        await gate.Unloading;
+
+        var evaluating = session.SendAsync(
+            "Runtime.evaluate",
+            """{"expression":"1 + 1","returnByValue":true}""",
+            attachment);
+
+        await gate.LetTheCommandArriveAsync();
+        gate.Release();
+
+        var reply = await evaluating;
+        await navigating;
+
+        reply.TryGetProperty("error", out var error).Should().BeTrue("an evaluation names the context it runs in");
+        error.GetProperty("code").GetInt32().Should().Be(-32000);
+        error.GetProperty("message").GetString().Should().Be("Execution context was destroyed.");
+    }
+
+    /// <summary>
+    /// A page that has <i>closed</i> keeps the refusal, which is the half of this that must not move: there
+    /// is no document to dispatch to and no runtime to hand the command on to.
+    /// </summary>
+    /// <remarks>
+    /// Closing unpublishes the target and detaches every session addressing it, so what the client is told is
+    /// that its session is gone rather than that a context was destroyed. Either way it is an error and not a
+    /// silent success — a client whose page has closed must not be told its key was delivered.
+    /// </remarks>
+    [Test]
+    public async Task AKeyForAPageThatHasClosedIsRefused()
+    {
+        using var server = Origin();
+        var gate = new CommitGate();
+
+        await using var session = await PageSession.CreateAsync(Isolated(server), gate.Options());
+        var page = await session.NewPageAsync();
+        var target = await session.TargetForAsync(page);
+        var attachment = await session.AttachAsync(target);
+
+        await session.ResultAsync("Page.navigate", Navigate(server, "/next.html"), attachment);
+        await page.CloseAsync();
+
+        var reply = await session.SendAsync("Input.dispatchKeyEvent", KeyUp("Enter"), attachment);
+
+        reply.TryGetProperty("error", out var error).Should().BeTrue("there is no page left to dispatch to");
+        error.GetProperty("code").GetInt32().Should().Be(-32001);
+        error.GetProperty("message").GetString().Should().Be("Session with given id not found.");
+    }
+
+    /// <summary>
+    /// The two documents: one that records what it is sent and blocks the loop while it unloads, and one that
+    /// only records.
+    /// </summary>
+    private static LoopbackServer Origin()
+    {
+        var server = new LoopbackServer();
+
+        server.MapHtml(
+            "/start.html",
+            """
+            <html><body><p>start</p><script>
+              window.addEventListener('keyup', e => __record(e.key));
+              window.addEventListener('pagehide', () => { __unloading(); __release(); });
+            </script></body></html>
+            """);
+
+        server.MapHtml("/next.html", "<html><body><p>next</p></body></html>");
+        return server;
+    }
+
+    private static BrowserContextOptions Isolated(LoopbackServer server) => new() { UrlFilter = server.Owns };
+
+    private static string Navigate(LoopbackServer server, string path) => $$"""{"url":"{{server.Url(path)}}"}""";
+
+    private static string KeyUp(string key) => $$"""{"type":"keyUp","key":"{{key}}","code":"Key"}""";
+
+    /// <summary>Installs the recorder every new document of the page gets, before its own scripts run.</summary>
+    private static Task Watch(PageSession session, string attachment) => session.ResultAsync(
+        "Page.addScriptToEvaluateOnNewDocument",
+        """{"source":"window.__seen = ''; window.addEventListener('keyup', e => { window.__seen += e.key; });"}""",
+        attachment);
+
+    private static Task<string> Seen(PageSession session, string attachment)
+        => Evaluate(session, attachment, "String(window.__seen || '')");
+
+    private static async Task<string> Evaluate(PageSession session, string attachment, string expression)
+    {
+        var result = await session.EvaluateAsync(expression, attachment);
+        return result.GetProperty("value").GetString() ?? "";
+    }
+
+    /// <summary>
+    /// The page loop, stopped inside the outgoing document's <c>pagehide</c> handler until the test lets it
+    /// go — which is what makes "a command that arrives while the document is being replaced" a moment a test
+    /// can address rather than a race it has to win.
+    /// </summary>
+    private sealed class CommitGate
+    {
+        private readonly TaskCompletionSource _unloading = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly ManualResetEventSlim _release = new(initialState: false);
+
+        private string _seen = "";
+
+        /// <summary>Completes when the page loop is held inside the outgoing document's unload.</summary>
+        internal Task Unloading => _unloading.Task;
+
+        /// <summary>What the outgoing document has been sent, readable from off the page's thread.</summary>
+        /// <remarks>
+        /// Recorded by the document into a field rather than read back with <c>Runtime.evaluate</c>, because
+        /// by the time the commit is released the document that saw it is gone.
+        /// </remarks>
+        internal string SeenInTheOutgoingDocument => Volatile.Read(ref _seen);
+
+        /// <summary>Options whose pages carry the three host functions the gate is built out of.</summary>
+        internal BrowserOptions Options()
+        {
+            // The bracket around a page turn is what would otherwise abandon the request the gate holds still.
+            var options = new BrowserOptions { MaxTaskDuration = Timeout.InfiniteTimeSpan };
+
+            options.ConfigureEngine(engineOptions => engineOptions.Configure(engine =>
+            {
+                engine.SetValue("__unloading", new Action(() => _unloading.TrySetResult()));
+                engine.SetValue("__release", new Action(() => _release.Wait(_bound)));
+                engine.SetValue("__record", new Action<string>(seen => Volatile.Write(ref _seen, seen)));
+            }));
+
+            return options;
+        }
+
+        /// <summary>Gives the command sent on the line above time to reach the mailbox it queues on.</summary>
+        /// <remarks>
+        /// The enqueue is synchronous on the sending thread and does no I/O, so this is slack rather than a
+        /// race; what it must not do is release the commit while the command is still on its way, which would
+        /// test nothing at all. The first test it guards fails against the unfixed code with exactly the
+        /// error the issue reported, which is what says the moment is really being hit.
+        /// </remarks>
+        internal Task LetTheCommandArriveAsync() => Task.Delay(TimeSpan.FromMilliseconds(250));
+
+        /// <summary>Lets the commit finish.</summary>
+        internal void Release() => _release.Set();
+    }
+}


### PR DESCRIPTION
Fixes #3723.

### What was wrong

An `Input` command is addressed to the **page**, not to an execution context. Chrome dispatches a mouse event, a key event or an inserted string to whichever document is current when the command runs, and a client sends the two halves of one key press as two commands with a navigation free to happen between them — `Keyboard.PressAsync("Enter")` on a form is exactly that shape, because the `keyDown` runs HTML's implicit submission and the `keyUp` then arrives while the document it was sent for is being replaced.

The mailbox belongs to one *engine*, so committing the next document abandoned everything queued on the outgoing one with `-32000 "Execution context was destroyed."`. For `Runtime.callFunctionOn` and its kin that is the truthful answer — they name a context, and the context is gone. For an `Input` command it is a refusal of something that named no context at all, and it reached a client as a protocol error out of an ordinary key press. #3718's first ARM run failed that way once.

### What changed

`EngineDispatcher.Abandon` hands such a command to the runtime that *replaced* this one instead of failing it, and `IsAddressedToTheTarget` is where the line is drawn: `Input.` and nothing else. The command then runs on the target's current runtime at the moment it is dequeued and reaches the document that is there — or dispatches nothing at all when that document has not been parsed yet, which is a success with no event rather than an error, exactly as the issue asks. A page that has **closed** has no successor and keeps the refusal.

`DevToolsTarget.Replace` installs the new runtime *before* disposing the previous one, so the successor is already in place by the time the hand-over runs; a mailbox that is itself abandoned in the meantime (two navigations while one command was queued) moves the item on again, or refuses it when there is nowhere left to move it to.

### The tests that pin it

`Jint.Tests.Browser/DevTools/InputDuringNavigationTests.cs`, four cases, each **deterministic rather than timed**: the outgoing document blocks the page loop inside its own `pagehide` handler, so "a command that arrives while the document is being replaced" is a moment a test addresses rather than a race it has to win.

* `AKeyQueuedWhileTheDocumentIsReplacedIsAnsweredRatherThanRefused` — the flake's own shape. Against the unfixed code it fails with exactly the reported error (`{"code":-32000,"message":"Execution context was destroyed.","data":"the document this command was addressed to was replaced before the engine reached it"}`); with the fix the command is answered, and the page is still driveable on the new document.
* `AKeySentBeforeTheDocumentIsReplacedReachesTheOneThatIsStillThere` — the other order: the key goes to the document it was sent for, and is lost with it, as it is in a browser.
* `AnEvaluationQueuedWhileTheDocumentIsReplacedIsStillRefused` — the control. A command that really does name a context keeps Chrome's wording.
* `AKeyForAPageThatHasClosedIsRefused` — the half that must not move.

`Jint.DevTools/Session/AGENTS.md`'s "a target outlives its engine" bullet now states the exception and why the rest of the mailbox keeps the refusal.

Green: `Jint.Tests.Browser` on `net8.0` and `net10.0` (1170 / 1173), `Jint.Tests.DevTools` on both, and both client suites with `JINT_BROWSER_CLIENTS=1` — PuppeteerSharp and Playwright, 17 cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
