### PR TITLE
Functions: a function value names the program it was parsed in, so [[FunctionLocation]] resolves its script by identity

### DIFF
--- a/Jint.DevTools/Domains/AGENTS.md
+++ b/Jint.DevTools/Domains/AGENTS.md
@@ -77,10 +77,12 @@ justifies making that a public commitment.
 a promise's `[[PromiseState]]`/`[[PromiseResult]]`, plus — for a function — `[[FunctionLocation]]`, and for a
 bound one `[[TargetFunction]]`, `[[BoundThis]]` and `[[BoundArgs]]`. `[[FunctionLocation]]` is the one that
 makes a function *clickable*: without it a front end names the function and opens nothing. It is the
-declaration node the function already carries — `Function.FunctionDeclaration`, published; the *program* that
-node was parsed in is not — so it is the one caller of `ScriptRegistry.At` that is not a rendered stack frame,
-and it inherits that lookup's caveat rather than resolving by identity. A function the engine has no
-declaration for carries no location at all, rather than one against the sentinel identifier `0`.
+declaration node the function already carries — `Function.FunctionDeclaration` — resolved to a script through
+`Function.Program` and `ScriptRegistry.For`, by identity, so two parses of one text are told apart. A
+function the engine has no declaration for carries no location at all, rather than one against the sentinel
+identifier `0`; a function whose *program* the registry does not know — `eval`, the `Function` constructor, a
+script evicted past `MaxScripts` — carries one against that sentinel, which is what Chrome sends for a
+location it cannot attribute.
 `[[BoundArgs]]` is a **copy** of the arguments array, because the engine's own is what every call through the
 bound function reads from. `[[Scopes]]` is absent for the same reason `[[Handler]]` and `[[Target]]` of a
 proxy are: the engine publishes neither the environment a closure captured nor a proxy's slots outside its own
@@ -169,11 +171,10 @@ bearing rather than incidental:
 - **`ScriptRegistry.At` is the fallback, and only a *rendered* stack frame may use it.** A frame of
   `Error.stack` and a `ConsoleStackFrame` are text — a source name, a line and a column, and no program —
   so `Runtime.consoleAPICalled`'s `stackTrace` and the frames parsed out of a thrown error's `stack` match by
-  name and range and cannot tell two sourceless scripts apart. `[[FunctionLocation]]` is the third caller and
-  the only one that is not rendered text: a function value publishes its declaration node
-  (`Function.FunctionDeclaration`) and not the program it was parsed in, so there is no identity to look up —
-  the seam #3632 opened for a frame, not yet extended to a function. Giving all three a program is a further
-  engine seam; until then, do not reach for `At` from anywhere that has one.
+  name and range and cannot tell two sourceless scripts apart. They are the only two callers left:
+  `[[FunctionLocation]]` was the third until `Function.Program`
+  ([#3666](https://github.com/sebastienros/jint/issues/3666)) extended the seam #3632 opened for a frame to a
+  function value, and it resolves through `For` now. Do not reach for `At` from anywhere that has a program.
 
 **A source name becomes a URL here, and nowhere else.** The engine's source names stay exactly what the host
 passed — a stack trace prints them, and `Options.Interop.BuildCallStackHandler` is handed them — so

--- a/Jint.DevTools/Domains/RuntimeDomain.Properties.cs
+++ b/Jint.DevTools/Domains/RuntimeDomain.Properties.cs
@@ -394,7 +394,7 @@ internal sealed partial class RuntimeDomain
             properties.Add(new InternalPropertyDescriptor
             {
                 Name = "[[FunctionLocation]]",
-                Value = Location(declaration),
+                Value = Location(function, declaration),
             });
         }
     }
@@ -403,10 +403,15 @@ internal sealed partial class RuntimeDomain
     /// One declaration position in the shape V8 sends it: a remote object with no handle, whose
     /// <c>value</c> is the location itself.
     /// </summary>
-    private RemoteObject Location(Node declaration)
+    private RemoteObject Location(Function function, Node declaration)
     {
         var location = declaration.Location;
-        var script = _target.Runtime.Scripts?.At(location.SourceFile, location.Start.Line, location.Start.Column);
+
+        // By identity, never by name: two scripts parsed under one name are two scripts, and every
+        // sourceless Execute shares the name <anonymous>. A function whose program the registry does not
+        // know - eval, the Function constructor, a script evicted past MaxScripts - is reported against
+        // Chrome's own sentinel identifier rather than against whichever script shares its name.
+        var script = _target.Runtime.Scripts?.For(function.Program);
 
         var buffer = new ArrayBufferWriter<byte>(96);
         using (var writer = new Utf8JsonWriter(buffer))

--- a/Jint.DevTools/Domains/ScriptRegistry.cs
+++ b/Jint.DevTools/Domains/ScriptRegistry.cs
@@ -114,9 +114,10 @@ internal sealed class ScriptRegistry
     /// Answers which script a program is, or <see langword="null"/> when none is known.
     /// </summary>
     /// <remarks>
-    /// The engine hands the program itself to a call frame, a profile frame and a coverage source, so the
-    /// answer is a lookup by reference rather than a guess from a source name — which is what keeps two
-    /// scripts parsed under one name (every sourceless <c>Execute</c> is <c>&lt;anonymous&gt;</c>) apart.
+    /// The engine hands the program itself to a call frame, a profile frame, a coverage source and a
+    /// function value, so the answer is a lookup by reference rather than a guess from a source name — which
+    /// is what keeps two scripts parsed under one name (every sourceless <c>Execute</c> is
+    /// <c>&lt;anonymous&gt;</c>) apart.
     /// Null for a program the engine reached another way — <c>eval</c>, the <c>Function</c> constructor —
     /// and for one this registry has forgotten.
     /// </remarks>
@@ -137,8 +138,8 @@ internal sealed class ScriptRegistry
     /// Answers which script a rendered stack frame belongs to, or <see langword="null"/> when none is known.
     /// </summary>
     /// <remarks>
-    /// <b>The name-and-range fallback, and the only place left that needs one.</b> A frame of a rendered
-    /// stack trace — a <c>ConsoleStackFrame</c>, a line of <c>Error.stack</c> — is text, so all it carries
+    /// <b>The name-and-range fallback, and rendered text is the only thing left that needs one.</b> A frame
+    /// of a rendered stack trace — a <c>ConsoleStackFrame</c>, a line of <c>Error.stack</c> — is text, so all it carries
     /// is a source name and a position: among the scripts registered under that name, the one whose own
     /// range contains the position, and failing that the most recently parsed. Several programs parsed under
     /// one name therefore share one answer. Anything that has the program itself resolves through

--- a/Jint.Tests.DevTools/Session/DebuggerScriptIdentityTests.cs
+++ b/Jint.Tests.DevTools/Session/DebuggerScriptIdentityTests.cs
@@ -139,6 +139,48 @@ public class DebuggerScriptIdentityTests
             script.Functions.Single(function => function.FunctionName == "used").Ranges[0].Count.Should().Be(1));
     }
 
+    /// <summary>
+    /// A function value names the script it was declared in, which two parses of one text is the case no
+    /// source name can answer: both are <c>&lt;anonymous&gt;</c>, and both ranges hold the other's positions.
+    /// </summary>
+    [Test]
+    public async Task TwoFunctionsFromTwoParsesOfOneTextCarryTheirOwnFunctionLocation()
+    {
+        // Every sourceless Execute is parsed under one name, and these two parses are character for
+        // character the same text - so the declaration's own position is inside both ranges and a match on
+        // name and range can only ever answer the newest.
+        const string Declaration = "globalThis.fns = globalThis.fns || []; fns.push(function work() { return 1; });";
+
+        await using var session = await AttachedSession.CreateAsync();
+        await session.EnableDebuggerAsync();
+
+        await session.Target.PostAsync(engine =>
+        {
+            engine.Execute(Declaration);
+            engine.Execute(Declaration);
+        });
+
+        var announced = session.EventsOf("Debugger.scriptParsed")
+            .Select(sent => sent.GetProperty("params").GetProperty("scriptId").GetString())
+            .ToList();
+
+        announced.Should().HaveCount(2, "two parses are two scripts, whatever they were named");
+
+        (await FunctionLocationScriptIdAsync(session, "fns[0]")).Should().Be(
+            announced[0], "the first function was declared in the first parse");
+        (await FunctionLocationScriptIdAsync(session, "fns[1]")).Should().Be(
+            announced[1], "the second function was declared in the second parse");
+    }
+
+    private static async Task<string?> FunctionLocationScriptIdAsync(AttachedSession session, string expression)
+    {
+        var handle = await session.HandleAsync(expression);
+        var properties = await session.PropertiesAsync(handle, ownProperties: true);
+
+        return properties.Internal("[[FunctionLocation]]")
+            .GetProperty("value").GetProperty("value").GetProperty("scriptId").GetString();
+    }
+
     private static string? ScriptIdOf(JsonElement frame)
         => frame.GetProperty("location").GetProperty("scriptId").GetString();
 

--- a/Jint.Tests.PublicInterface/HostFrameProgramTests.cs
+++ b/Jint.Tests.PublicInterface/HostFrameProgramTests.cs
@@ -157,6 +157,86 @@ public class HostFrameProgramTests
     }
 
     /// <summary>
+    /// A function <em>value</em> answers the same question, which is what makes <c>[[FunctionLocation]]</c>
+    /// resolvable by identity: two parses of one text declare two functions under one source name.
+    /// </summary>
+    [Test]
+    public void TwoFunctionsFromTwoParsesOfOneTextNameTheirOwnProgram()
+    {
+        const string Declaration = "globalThis.fns = globalThis.fns || []; fns.push(function work() { return 1; });";
+
+        var engine = CreateDebuggerEngine();
+
+        var parsed = new List<Program>();
+        engine.Debugger.BeforeEvaluate += (sender, ast) => parsed.Add(ast);
+
+        engine.Execute(Declaration);
+        engine.Execute(Declaration);
+
+        parsed.Should().HaveCount(2);
+        FunctionOf(engine, "fns[0]").Program.Should().BeSameAs(parsed[0]);
+        FunctionOf(engine, "fns[1]").Program.Should().BeSameAs(parsed[1]);
+    }
+
+    /// <summary>
+    /// The contract <c>TryGetSourceText</c> keeps: one <c>Prepared&lt;Script&gt;</c> shared by several
+    /// engines answers the same program on every one of them.
+    /// </summary>
+    [Test]
+    public void AFunctionBuiltOnEitherOfTwoEnginesNamesTheOnePreparedProgram()
+    {
+        var prepared = Engine.PrepareScript("function work() { return 1; }", "shared.js");
+
+        var first = new Engine();
+        var second = new Engine();
+        first.Execute(prepared);
+        second.Execute(prepared);
+
+        FunctionOf(first, "work").Program.Should().BeSameAs(prepared.Program);
+        FunctionOf(second, "work").Program.Should().BeSameAs(prepared.Program);
+    }
+
+    /// <summary>
+    /// A built-in, a host callable and a bound function have no declaration at all, so they name no program
+    /// rather than the script that happened to be running when they were created.
+    /// </summary>
+    [Test]
+    public void AFunctionValueWithNoDeclarationNamesNoProgram()
+    {
+        var engine = new Engine();
+        engine.SetValue("host", new System.Func<int>(() => 1));
+        engine.Execute("function work() { return 1; } globalThis.bound = work.bind(null);", "host.js");
+
+        FunctionOf(engine, "Math.max").Program.Should().BeNull();
+        FunctionOf(engine, "host").Program.Should().BeNull();
+        FunctionOf(engine, "bound").Program.Should().BeNull();
+    }
+
+    /// <summary>
+    /// A body the engine reached another way is a program no execution context names, so it is declined
+    /// rather than attributed to the script that ran it.
+    /// </summary>
+    [Test]
+    public void AFunctionDeclaredInsideEvalOrTheFunctionConstructorNamesNoProgram()
+    {
+        var engine = new Engine();
+        engine.Execute(
+            """
+            globalThis.evaluated = eval('(function fromEval() { return 1; })');
+            globalThis.constructed = new Function('return 2;');
+            function declared() { return 3; }
+            """,
+            "host.js");
+
+        FunctionOf(engine, "evaluated").Program.Should().BeNull();
+        FunctionOf(engine, "constructed").Program.Should().BeNull();
+        FunctionOf(engine, "declared").Program.Should().NotBeNull();
+    }
+
+    private static Jint.Native.Function.Function FunctionOf(Engine engine, string expression)
+        => (Jint.Native.Function.Function) engine.Evaluate(expression);
+
+    /// <summary>
     /// A built-in and a host callable have no source, so they name no program either — the answer is
     /// <see langword="null"/> rather than the script that happened to be running when they were created.
     /// </summary>

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
@@ -1406,6 +1406,7 @@ namespace Jint.Native.Function
         protected Jint.Runtime.Descriptors.PropertyDescriptor? _length;
         protected Jint.Runtime.Descriptors.PropertyDescriptor? _prototypeDescriptor;
         public Acornima.Ast.IFunction? FunctionDeclaration { get; }
+        public Acornima.Ast.Program? Program { get; }
         public bool Strict { get; }
         protected abstract Jint.Native.JsValue Call(Jint.Native.JsValue thisObject, Jint.Native.JsValue[] arguments);
         public override Jint.Runtime.Descriptors.PropertyDescriptor GetOwnProperty(Jint.Native.JsValue property) { }

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net472.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net472.verified.txt
@@ -1229,6 +1229,7 @@ namespace Jint.Native.Function
         protected Jint.Runtime.Descriptors.PropertyDescriptor? _length;
         protected Jint.Runtime.Descriptors.PropertyDescriptor? _prototypeDescriptor;
         public Acornima.Ast.IFunction? FunctionDeclaration { get; }
+        public Acornima.Ast.Program? Program { get; }
         public bool Strict { get; }
         protected abstract Jint.Native.JsValue Call(Jint.Native.JsValue thisObject, Jint.Native.JsValue[] arguments);
         public override Jint.Runtime.Descriptors.PropertyDescriptor GetOwnProperty(Jint.Native.JsValue property) { }

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
@@ -1406,6 +1406,7 @@ namespace Jint.Native.Function
         protected Jint.Runtime.Descriptors.PropertyDescriptor? _length;
         protected Jint.Runtime.Descriptors.PropertyDescriptor? _prototypeDescriptor;
         public Acornima.Ast.IFunction? FunctionDeclaration { get; }
+        public Acornima.Ast.Program? Program { get; }
         public bool Strict { get; }
         protected abstract Jint.Native.JsValue Call(Jint.Native.JsValue thisObject, Jint.Native.JsValue[] arguments);
         public override Jint.Runtime.Descriptors.PropertyDescriptor GetOwnProperty(Jint.Native.JsValue property) { }

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.0.verified.txt
@@ -1229,6 +1229,7 @@ namespace Jint.Native.Function
         protected Jint.Runtime.Descriptors.PropertyDescriptor? _length;
         protected Jint.Runtime.Descriptors.PropertyDescriptor? _prototypeDescriptor;
         public Acornima.Ast.IFunction? FunctionDeclaration { get; }
+        public Acornima.Ast.Program? Program { get; }
         public bool Strict { get; }
         protected abstract Jint.Native.JsValue Call(Jint.Native.JsValue thisObject, Jint.Native.JsValue[] arguments);
         public override Jint.Runtime.Descriptors.PropertyDescriptor GetOwnProperty(Jint.Native.JsValue property) { }

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.1.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.1.verified.txt
@@ -1229,6 +1229,7 @@ namespace Jint.Native.Function
         protected Jint.Runtime.Descriptors.PropertyDescriptor? _length;
         protected Jint.Runtime.Descriptors.PropertyDescriptor? _prototypeDescriptor;
         public Acornima.Ast.IFunction? FunctionDeclaration { get; }
+        public Acornima.Ast.Program? Program { get; }
         public bool Strict { get; }
         protected abstract Jint.Native.JsValue Call(Jint.Native.JsValue thisObject, Jint.Native.JsValue[] arguments);
         public override Jint.Runtime.Descriptors.PropertyDescriptor GetOwnProperty(Jint.Native.JsValue property) { }

--- a/Jint/Native/Function/Function.cs
+++ b/Jint/Native/Function/Function.cs
@@ -136,6 +136,41 @@ public abstract partial class Function : ObjectInstance, ICallable
     public IFunction? FunctionDeclaration => _functionDefinition?.Function;
 
     /// <summary>
+    /// Gets the program this function's declaration was parsed in, or <see langword="null"/> when the engine
+    /// knows of none.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The same reference <see cref="Runtime.Debugger.DebugHandler.BeforeEvaluate"/> hands over,
+    /// <see cref="Runtime.Debugger.CallFrame.Program"/> carries and
+    /// <see cref="Engine.AdvancedOperations.TryGetSourceText"/> is keyed by, so a host maps a function to a
+    /// script it announced by reference rather than by matching <see cref="FunctionDeclaration"/>'s source
+    /// name — which every sourceless <c>Execute</c> shares.
+    /// </para>
+    /// <para>
+    /// The answer does not depend on the engine: two engines sharing one <c>Prepared&lt;Script&gt;</c>
+    /// answer the same program for the functions each of them built from it.
+    /// </para>
+    /// <para>
+    /// Null for a function with no declaration — a built-in, a host callable, a bound function — and for one
+    /// declared in a program no execution context names: an <c>eval</c> body and a <c>Function</c>
+    /// constructor body are programs of their own, and are declined rather than attributed to the script
+    /// that ran them.
+    /// </para>
+    /// </remarks>
+    public Program? Program
+    {
+        get
+        {
+            // The function's [[ScriptOrModule]] is the script that was active when it was created, which is
+            // the program its declaration belongs to for everything but eval and the Function constructor -
+            // and those two are what OwningProgramOf declines rather than mis-attributing. Same reading as
+            // ScriptProfileFrame's, so a profile frame and a function value can never name two programs.
+            return _functionDefinition?.Function is Node node ? _scriptOrModule.OwningProgramOf(node) : null;
+        }
+    }
+
+    /// <summary>
     /// True when the function already carries a non-empty own name, materialized or pending
     /// (a pending descriptor stands for the definition's own name, which is never empty).
     /// </summary>

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -5214,6 +5214,7 @@ none of it changes an engine that does not.
 | A headless browser — AngleSharp's DOM under Jint, drivable by Puppeteer and Playwright, plus a `jint-browser` command line | `dotnet add package Jint.Browser`, or `dotnet tool install -g Jint.Browser.Tool` | [Headless browser (opt-in package)](../README.md#headless-browser-opt-in-package) |
 | A Model Context Protocol server over that browser, so an agent reads a page as its accessibility tree and clicks its way through it | `jint-browser mcp`, or `AddMcpServer().AddJintBrowser()` in a host of your own | [Headless browser (opt-in package)](../README.md#headless-browser-opt-in-package) |
 | The names of the global `let`/`const`/`class` declarations, which `globalThis` does not carry | `engine.Advanced.GetGlobalLexicalNames()` | [§5.27](#527-a-host-can-list-the-global-lexical-bindings-3610) |
+| The program a function value was parsed in, so a tooling protocol resolves its script by identity | `function.Program`, beside `FunctionDeclaration` | [§5.28](#528-a-function-value-names-the-program-it-was-parsed-in-3666) |
 | `LazyJsString` — one base class for a host string whose text is expensive to produce | `class Field : LazyJsString { public Field(int len) : base(len) {} protected override string Materialize() => … }` | [Lazy strings](../README.md#embedding-performance) |
 
 The last row is the only one that replaces an existing spelling rather than adding a capability, so it is
@@ -6059,6 +6060,33 @@ Names only — read a value with `engine.Evaluate(name)` — and a fresh list pe
 afterwards does not change one already handed out. A binding still in its temporal dead zone is named too.
 `Jint.DevTools` answers `Runtime.globalLexicalScopeNames` over it, which is the console completion list in
 Chrome's front end; that command was `-32601` before.
+
+### 5.28 A function value names the program it was parsed in ([#3666](https://github.com/sebastienros/jint/issues/3666))
+
+[5.17](#517-a-frame-a-profile-frame-and-a-coverage-source-name-the-program-they-belong-to-3632) gave a call
+frame, a profile frame and a coverage source the program they belong to. A function *value* published only
+its declaration node — `Function.FunctionDeclaration` — so anything resolving "which script is this function
+in?" had to match the declaration's source *name*, and every sourceless `Execute` is `<anonymous>`.
+`Jint.Native.Function.Function.Program` closes it:
+
+```csharp
+const string declaration = "globalThis.fns = globalThis.fns || []; fns.push(function work() { return 1; });";
+engine.Execute(declaration);
+engine.Execute(declaration);   // two parses of one text, under one name
+
+var first = (Function) engine.Evaluate("fns[0]");
+var second = (Function) engine.Evaluate("fns[1]");
+first.Program.Should().NotBeSameAs(second.Program);   // each names its own parse
+```
+
+Same reference `DebugHandler.BeforeEvaluate` hands over and `engine.Advanced.TryGetSourceText` is keyed by,
+and the same contract: two engines sharing one `Prepared<Script>` answer the same program for the functions
+each built from it. `null` for a function with no declaration — a built-in, a host callable, a bound function
+— and for one declared in a program no execution context names, since an `eval` body and a `Function`
+constructor body are declined rather than attributed to the script that ran them.
+
+`Jint.DevTools` resolves `[[FunctionLocation]]`'s `scriptId` through it, which was the last thing in that
+package still matching a script by name.
 
 ## 6. AOT and trimming
 


### PR DESCRIPTION
Fixes #3666.

**Stacked on #3742**, which is stacked on #3738. Only the last of the three commits below belongs to this PR; review `Functions: a function value names the program it was parsed in…`.

### What was wrong

#3651 put the owning `Program` on `CallFrame`, `ScriptProfileFrame` and `CoverageSource`, and #3652 made `Jint.DevTools` resolve scripts by identity — leaving `ScriptRegistry.At`, the source-name-and-range heuristic, for *rendered* text only (a `ConsoleStackFrame`, a line of `Error.stack`). A function **value** was the one exception: it published its declaration node through `Function.FunctionDeclaration` and not the program that node was parsed in, so `Runtime.getProperties`' `[[FunctionLocation]]` had no identity to look up.

Every sourceless `Execute` is `<anonymous>`, and two parses of one text have the same range too, so `At` could only ever answer the newest. Against the unfixed code, two functions from two parses of one declaration:

```
Expected FunctionLocationScriptIdAsync(...) to be "1.1" because the first function was
declared in the first parse, but "1.2" differs near "2" (index 2).
```

Both functions were reported against the second script — a front end opening the wrong one.

### What changed, and why

`Jint.Native.Function.Function.Program`, beside `FunctionDeclaration`. It publishes what the function **already holds** rather than adding a field per function: the `[[ScriptOrModule]]` captured at construction, run through the existing internal `OwningProgramOf(node)` guard so that a body no execution context names — `eval`, the `Function` constructor — is declined rather than attributed to the script that ran it. That is the same reading `ProfileFrames.Describe` already takes for a `ScriptProfileFrame`, so a profile frame and a function value can never name two programs.

Nothing engine-affine is added, so the interpreter's `UserData` rule is untouched and no function pins an engine it did not already: the answer *is* the `Prepared<T>`'s own `Program`, which is why two engines sharing one preparation answer the same reference — the contract `TryGetSourceText` states.

It is public rather than internal-plus-`InternalsVisibleTo` because `Jint.DevTools/AGENTS.md` forbids the alternative: *"There is deliberately no `InternalsVisibleTo` grant from `Jint` to this package… every seam it turns out to need is a seam the engine should expose."*

`RuntimeDomain.Location` then takes the `Function` and resolves through `ScriptRegistry.For`. A function whose program the registry does not know (`eval`, the `Function` constructor, a script evicted past `MaxScripts`) is reported against `scriptId: "0"` — Chrome's own sentinel for a location it cannot attribute — instead of against whichever script happens to share its name. Rendered stack frames are now the only callers of `At`, which `Jint.DevTools/Domains/AGENTS.md` and `ScriptRegistry`'s own remarks now say.

### Tests

- `Jint.Tests.DevTools/Session/DebuggerScriptIdentityTests.TwoFunctionsFromTwoParsesOfOneTextCarryTheirOwnFunctionLocation` — the issue's case end to end over the protocol: two parses of one text, `Runtime.getProperties` on a function from each, each `[[FunctionLocation]].scriptId` its own `Debugger.scriptParsed`.
- `Jint.Tests.PublicInterface/HostFrameProgramTests` gains four, from outside the assembly: the two-parses case on the engine seam; one `Prepared<Script>` answering the same program on two engines; a built-in, a host callable and a bound function naming none; and `eval` / `new Function` declined while an ordinary declaration is not.
- Green: `Jint.Tests.DevTools` on both TFMs (396 + 394), `Jint.Tests.PublicInterface` on `net10.0` (3594), the `Debugger`/`MigrationGuideTests`/`AgentInstructionFileTests`/`SpecCitationTests` filter on `Jint.Tests`, and a full `dotnet build -c Release` of the solution.

The five public-API baselines gain exactly `public Acornima.Ast.Program? Program { get; }`, and `docs/v5-migration.md` gains §5.28 plus a chapter-5 table row.

### Left out

Not taken: `engine.Advanced.GetProgram(JsValue)`, the issue's other spelling — the answer depends on the function and not on the engine, so a property on the function is the narrower seam and the one that matches `CallFrame.Program` from #3651. `ScriptRegistry.At` stays for the two rendered-text callers that genuinely have no program. Nothing changes for a host that reads `FunctionDeclaration`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
