### PR TITLE
Fetch: every request an engine makes carries a User-Agent, and a page's is the one it reports

### DIFF
--- a/Jint.Browser.Tool/BrowserSettings.cs
+++ b/Jint.Browser.Tool/BrowserSettings.cs
@@ -103,8 +103,7 @@ internal sealed class BrowserSettings
         return options;
     }
 
-    /// <summary>A client that carries the user agent and <paramref name="headers"/> on every request.</summary>
-    /// <param name="userAgent">What the pages report themselves as, which is what they should also send.</param>
+    /// <summary>A client that carries <paramref name="headers"/> on every request.</summary>
     /// <param name="headers">The header lines <c>--header</c> gave, already split.</param>
     /// <returns>The client to hand the context, which the caller disposes.</returns>
     /// <remarks>
@@ -115,22 +114,27 @@ internal sealed class BrowserSettings
     /// that request, which is what "extra" has to mean.
     /// </para>
     /// <para>
-    /// <b>The user agent is one of them, and it has to be.</b> <c>BrowserOptions.UserAgent</c> is what a page
-    /// reports in script; the request header is set by the <c>Network</c> domain's override and therefore
-    /// only when a protocol client is attached, so a <c>fetch</c> from this tool would otherwise send no
-    /// <c>User-Agent</c> at all and a server that varies on it would answer the wrong thing. An explicit
-    /// <c>--header 'User-Agent: …'</c> replaces it rather than adding a second value.
+    /// <b>The user agent is not one of them any more.</b> The package puts the page's own user agent on
+    /// every request it makes ([#3720](https://github.com/sebastienros/jint/issues/3720)), which is a header
+    /// on the request itself and therefore beats any default this client could carry — so a
+    /// <c>--header 'User-Agent: …'</c> is turned into <see cref="UserAgent"/> by
+    /// <see cref="UserAgentFrom"/> and dropped here, and what the page reports and what it sends stay one
+    /// string.
     /// </para>
     /// </remarks>
-    internal static HttpClient CreateRequestClient(string userAgent, IReadOnlyList<(string Name, string Value)> headers)
+    internal static HttpClient CreateRequestClient(IReadOnlyList<(string Name, string Value)> headers)
     {
         // Redirects stay off and so do the handler's own cookies: the redirect loop and the jar are the
         // package's, so that every hop is re-checked against the URL filter and the Cookie header recomputed.
         var client = new HttpClient(new HttpClientHandler { AllowAutoRedirect = false, UseCookies = false });
-        client.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", userAgent);
 
         foreach (var (name, value) in headers)
         {
+            if (IsUserAgent(name))
+            {
+                continue;
+            }
+
             client.DefaultRequestHeaders.Remove(name);
 
             if (!client.DefaultRequestHeaders.TryAddWithoutValidation(name, value))
@@ -142,4 +146,28 @@ internal sealed class BrowserSettings
 
         return client;
     }
+
+    /// <summary>
+    /// The user agent a <c>--header 'User-Agent: …'</c> named, or <see langword="null"/> when none did.
+    /// </summary>
+    /// <remarks>
+    /// The last one wins, which is what the header loop above does with every other name.
+    /// </remarks>
+    internal static string? UserAgentFrom(IReadOnlyList<(string Name, string Value)> headers)
+    {
+        string? named = null;
+
+        foreach (var (name, value) in headers)
+        {
+            if (IsUserAgent(name))
+            {
+                named = value;
+            }
+        }
+
+        return named;
+    }
+
+    private static bool IsUserAgent(string name)
+        => string.Equals(name, "User-Agent", StringComparison.OrdinalIgnoreCase);
 }

--- a/Jint.Browser.Tool/PageRun.cs
+++ b/Jint.Browser.Tool/PageRun.cs
@@ -98,7 +98,16 @@ internal sealed class PageRun : IAsyncDisposable
     internal static async Task<PageRun> OpenAsync(BrowserSettings browser, LoadSettings load, PageSource source)
     {
         var options = browser.ToBrowserOptions();
-        var client = BrowserSettings.CreateRequestClient(options.UserAgent, load.Headers);
+
+        // A --header 'User-Agent: …' names the page's user agent rather than a client default, because the
+        // package puts the page's own on every request and a default header cannot replace one that is
+        // already on the request. It wins over --user-agent, being the more specific of the two.
+        if (BrowserSettings.UserAgentFrom(load.Headers) is { } named)
+        {
+            options.UserAgent = named;
+        }
+
+        var client = BrowserSettings.CreateRequestClient(load.Headers);
         var instance = new Browser(options);
 
         try

--- a/Jint.Browser/Page.Navigation.cs
+++ b/Jint.Browser/Page.Navigation.cs
@@ -566,7 +566,8 @@ public sealed partial class Page
             referrerUrl.Length == 0 ? null : UrlParser.Parse(referrerUrl),
             PageUrl.HasOrigin(currentUrl) ? UrlParser.Parse(currentUrl) : null,
             fetchOptions.MaxDocumentBytes,
-            fetchOptions.MaxRedirects);
+            fetchOptions.MaxRedirects,
+            Emulation.EffectiveUserAgent);
 
         // Resolved on the page's own thread, because that is where a host's client factory is documented to
         // be called and where the engine it is handed belongs. The engine it sees is the one the outgoing

--- a/Jint.Browser/Page.cs
+++ b/Jint.Browser/Page.cs
@@ -88,7 +88,7 @@ public sealed partial class Page : IAsyncDisposable
         Context = context;
         _options = options;
         _recorder = recorder;
-        Emulation = new EmulationState(options.Viewport);
+        Emulation = new EmulationState(options.Viewport, options.UserAgent);
         _requests = new PageNetworkRecorder(options.MaxRecordedEvents, options.MaxCapturedResponseBytes, () => _loaderId, () => _url);
         _network = context.Network;
         _workers = new ThreadPerWorkerProvider(this, _network, _requests, options);

--- a/Jint.Browser/Runtime/AGENTS.md
+++ b/Jint.Browser/Runtime/AGENTS.md
@@ -81,8 +81,8 @@ where one is configured, `BrowserOptions.MemoryLimit`. Four consequences are eas
 
 A worker's pump takes the same bracket over its own engine's constraints, which it has because
 `WorkerRequest.CreateDefaultOptions` replays the parent's constraint **factories**. What that replay does
-*not* carry is a web-API setting, so `MaxActiveTimers`, `MaxResponseBytes` and `FetchTimeout` are named again
-in `ThreadPerWorkerProvider`; a new page-sized limit needs the same second call or a worker keeps the engine
+*not* carry is a web-API setting, so `MaxActiveTimers`, `MaxResponseBytes`, `FetchTimeout` and the page's
+user agent are named again in `ThreadPerWorkerProvider`; a new page-sized limit needs the same second call or a worker keeps the engine
 default.
 
 `BrowserOptions.ForUntrustedContent` applies `Options.ForUntrustedCode` from inside the factory's own

--- a/Jint.Browser/Runtime/BrowserEngineFactory.cs
+++ b/Jint.Browser/Runtime/BrowserEngineFactory.cs
@@ -51,6 +51,7 @@ internal static class BrowserEngineFactory
         var modules = new Parsing.PageModuleScriptLoader(
             request.Network,
             request.Requests,
+            request.Emulation,
             request.Url,
             options.MaxSubresourceBytes);
 
@@ -175,6 +176,12 @@ internal static class BrowserEngineFactory
         fetch.UrlFilter = request.Network.UrlFilter;
         fetch.CookieJar = request.Network.CookieJar;
         fetch.Observer = request.Requests;
+
+        // https://fetch.spec.whatwg.org/#default-user-agent-value: what this document's fetches, its
+        // XMLHttpRequests and — through the worker provider — its workers put on the wire is the same string
+        // navigator.userAgent answers. An override a client sets *after* the engine was built reaches the
+        // wire through PageNetworkState.Apply, which rewrites the header per hop.
+        fetch.UserAgent = request.Emulation.EffectiveUserAgent;
 
         if (request.Network.Client is { } client)
         {

--- a/Jint.Browser/Runtime/DocumentFetch.cs
+++ b/Jint.Browser/Runtime/DocumentFetch.cs
@@ -85,6 +85,7 @@ internal static class DocumentFetch
             Origin = request.Origin,
             SameOriginReference = request.Origin,
             CookieJar = network.CookieJar,
+            UserAgent = request.UserAgent,
         };
 
         try
@@ -333,6 +334,7 @@ internal static class DocumentFetch
 /// <param name="Origin">The origin the request reports, or <see langword="null"/> for an opaque one.</param>
 /// <param name="MaxResponseBytes">The ceiling on the document's size.</param>
 /// <param name="MaxRedirects">How many hops the chain may follow.</param>
+/// <param name="UserAgent">The user agent the page reports, which its own request carries too.</param>
 internal sealed record DocumentRequest(
     UrlRecord Url,
     string Method,
@@ -341,4 +343,5 @@ internal sealed record DocumentRequest(
     UrlRecord? Referrer,
     UrlRecord? Origin,
     long MaxResponseBytes,
-    int MaxRedirects);
+    int MaxRedirects,
+    string UserAgent);

--- a/Jint.Browser/Runtime/EmulationState.cs
+++ b/Jint.Browser/Runtime/EmulationState.cs
@@ -33,14 +33,18 @@ internal sealed class EmulationState
     private static readonly FrozenDictionary<string, string> _noFeatures =
         FrozenDictionary<string, string>.Empty;
 
-    internal EmulationState(Viewport defaultViewport)
+    internal EmulationState(Viewport defaultViewport, string defaultUserAgent)
     {
         DefaultViewport = defaultViewport;
+        DefaultUserAgent = defaultUserAgent;
         Viewport = defaultViewport;
     }
 
     /// <summary>The viewport the page opened with, which clearing an override restores.</summary>
     internal Viewport DefaultViewport { get; }
+
+    /// <summary><see cref="BrowserOptions.UserAgent"/>, which is what a page with no override reports.</summary>
+    internal string DefaultUserAgent { get; }
 
     /// <summary>What the page currently believes its window to be.</summary>
     /// <remarks>
@@ -82,6 +86,18 @@ internal sealed class EmulationState
     /// <c>navigator.userAgent</c> answers and what every request the page makes carries.
     /// </remarks>
     internal string? UserAgent { get; set; }
+
+    /// <summary>
+    /// The user agent this page reports and sends: the client's override, or the browser's own.
+    /// </summary>
+    /// <remarks>
+    /// <b>There is exactly one answer to that question and this is it.</b> <c>navigator.userAgent</c>, the
+    /// document's own request, every subresource, a script's <c>fetch</c> and <c>XMLHttpRequest</c> and a
+    /// worker's engine all read this one property — a second resolution of the same precedence somewhere
+    /// else is how a page came to report one string and send another
+    /// ([#3720](https://github.com/sebastienros/jint/issues/3720)).
+    /// </remarks>
+    internal string EffectiveUserAgent => UserAgent is { Length: > 0 } overridden ? overridden : DefaultUserAgent;
 
     /// <summary>What <c>navigator.language</c> answers when a user agent override named one.</summary>
     internal string? AcceptLanguage { get; set; }

--- a/Jint.Browser/Runtime/NavigatorInstaller.cs
+++ b/Jint.Browser/Runtime/NavigatorInstaller.cs
@@ -70,8 +70,7 @@ internal static class NavigatorInstaller
     }
 
     /// <summary>What <c>navigator.userAgent</c> answers and what every request the page makes carries.</summary>
-    internal static string UserAgentOf(PageRuntime runtime)
-        => runtime.Emulation.UserAgent is { Length: > 0 } overridden ? overridden : runtime.Options.UserAgent;
+    internal static string UserAgentOf(PageRuntime runtime) => runtime.Emulation.EffectiveUserAgent;
 
     /// <summary>
     /// What <c>navigator.language</c> answers: the first tag of the <c>Accept-Language</c> a user-agent

--- a/Jint.Browser/Runtime/Parsing/PageModuleScriptLoader.cs
+++ b/Jint.Browser/Runtime/Parsing/PageModuleScriptLoader.cs
@@ -35,13 +35,20 @@ internal sealed class PageModuleScriptLoader : AsyncModuleLoader
 {
     private readonly PageNetwork _network;
     private readonly PageNetworkRecorder _requests;
+    private readonly EmulationState _emulation;
     private readonly Dictionary<string, string> _inline = new(StringComparer.Ordinal);
     private readonly long _maxBytes;
 
     private int _inlineCount;
 
-    internal PageModuleScriptLoader(PageNetwork network, PageNetworkRecorder requests, string documentUrl, long maxBytes)
+    internal PageModuleScriptLoader(
+        PageNetwork network,
+        PageNetworkRecorder requests,
+        EmulationState emulation,
+        string documentUrl,
+        long maxBytes)
     {
+        _emulation = emulation;
         _network = network;
         _requests = requests;
         _maxBytes = maxBytes;
@@ -135,7 +142,15 @@ internal sealed class PageModuleScriptLoader : AsyncModuleLoader
         var fetched = await SubresourceFetch.LoadAsync(
             _network,
             client,
-            new SubresourceRequest(url, referrer, referrer, _maxBytes, MaxRedirects, RequestInitiator.Subresource, PageRequestKind.Script),
+            new SubresourceRequest(
+                url,
+                referrer,
+                referrer,
+                _maxBytes,
+                MaxRedirects,
+                RequestInitiator.Subresource,
+                _emulation.EffectiveUserAgent,
+                PageRequestKind.Script),
             _requests,
             cancellationToken).ConfigureAwait(false);
 

--- a/Jint.Browser/Runtime/Parsing/ParserDriver.cs
+++ b/Jint.Browser/Runtime/Parsing/ParserDriver.cs
@@ -360,7 +360,15 @@ internal sealed class ParserDriver : IDisposable
         // derives the `Origin` header from it, never the path. `DocumentFetch` and `fetch()` pass the same
         // shape for the same reason.
         var documentUrl = UrlParser.Parse(_runtime.DocumentUrl);
-        var request = new SubresourceRequest(target, documentUrl, documentUrl, _maxBytes, _maxRedirects, RequestInitiator.Subresource, kind);
+        var request = new SubresourceRequest(
+            target,
+            documentUrl,
+            documentUrl,
+            _maxBytes,
+            _maxRedirects,
+            RequestInitiator.Subresource,
+            _runtime.Emulation.EffectiveUserAgent,
+            kind);
         using var timeout = CancellationTokenSource.CreateLinkedTokenSource(_cancellationToken);
         timeout.CancelAfter(_timeout);
 

--- a/Jint.Browser/Runtime/SubresourceFetch.cs
+++ b/Jint.Browser/Runtime/SubresourceFetch.cs
@@ -57,6 +57,7 @@ internal sealed record FetchedSubresource(byte[] Bytes, string? ContentType, str
 /// <param name="MaxResponseBytes">The ceiling on the body.</param>
 /// <param name="MaxRedirects">How many hops the chain may follow.</param>
 /// <param name="Initiator">What the page's network log should call this request.</param>
+/// <param name="UserAgent">The user agent the page reports, which every resource it asks for carries.</param>
 /// <param name="Kind">What the resource is for, which is what a protocol client filters requests on.</param>
 internal sealed record SubresourceRequest(
     UrlRecord Url,
@@ -65,6 +66,7 @@ internal sealed record SubresourceRequest(
     long MaxResponseBytes,
     int MaxRedirects,
     RequestInitiator Initiator,
+    string UserAgent,
     PageRequestKind Kind = PageRequestKind.Other);
 
 /// <summary>Raised when a subresource could not be obtained, with the sentence a page error should carry.</summary>
@@ -148,6 +150,7 @@ internal static class SubresourceFetch
             Origin = request.Origin,
             SameOriginReference = request.Origin,
             CookieJar = network.CookieJar,
+            UserAgent = request.UserAgent,
         };
 
         try

--- a/Jint.Browser/Workers/PageModuleLoader.cs
+++ b/Jint.Browser/Workers/PageModuleLoader.cs
@@ -37,6 +37,7 @@ internal sealed class PageModuleLoader : ModuleLoader
     private readonly Uri _baseUrl;
     private readonly long _maxBytes;
     private readonly TimeSpan _timeout;
+    private readonly string? _userAgent;
 
     internal PageModuleLoader(
         PageNetwork network,
@@ -44,8 +45,10 @@ internal sealed class PageModuleLoader : ModuleLoader
         HttpClient client,
         Uri baseUrl,
         long maxBytes,
-        TimeSpan timeout)
+        TimeSpan timeout,
+        string? userAgent)
     {
+        _userAgent = userAgent;
         _network = network;
         _requests = requests;
         _client = client;
@@ -121,6 +124,7 @@ internal sealed class PageModuleLoader : ModuleLoader
             Origin = origin,
             SameOriginReference = origin,
             CookieJar = _network.CookieJar,
+            UserAgent = _userAgent,
         };
 
         using var cancellation = new CancellationTokenSource(_timeout);

--- a/Jint.Browser/Workers/ThreadPerWorkerProvider.cs
+++ b/Jint.Browser/Workers/ThreadPerWorkerProvider.cs
@@ -100,6 +100,12 @@ internal sealed class ThreadPerWorkerProvider : WorkerProvider
         options.WebApi.Fetch.MaxResponseBytes = _options.MaxResponseBytes;
         options.WebApi.Fetch.Timeout = _options.FetchTimeout;
 
+        // A worker is the page making a request, so it says what the page says — the client's user agent
+        // override included, which is why this is read from the page's emulation state rather than from
+        // BrowserOptions. Read here, once per worker: a worker's engine options are frozen the moment it is
+        // built, exactly as its parent document's are.
+        options.WebApi.Fetch.UserAgent = _page.Emulation.EffectiveUserAgent;
+
         // On the parent's thread, inside the constructor, so the host's factory sees the engine that asked
         // for the worker — which is the engine whose HostDefined carries whatever varies per page.
         var client = _network.ClientFor(request.Parent);
@@ -126,7 +132,8 @@ internal sealed class ThreadPerWorkerProvider : WorkerProvider
                 client,
                 baseUrl,
                 options.WebApi.Fetch.MaxResponseBytes,
-                options.WebApi.Fetch.Timeout);
+                options.WebApi.Fetch.Timeout,
+                options.WebApi.Fetch.UserAgent);
         }
 
         return new Engine(options);

--- a/Jint.Tests.Browser/DevTools/EmulationDomainTests.cs
+++ b/Jint.Tests.Browser/DevTools/EmulationDomainTests.cs
@@ -318,6 +318,51 @@ public class EmulationDomainTests
         (await Text(session, attachment, "navigator.userAgent")).Should().Be("ViaEmulation/2.0");
     }
 
+    /// <summary>
+    /// A page a client attached to but never overrode still names itself: the document's own request and a
+    /// <c>fetch</c> the page makes both carry <see cref="BrowserOptions.UserAgent"/>, and an override set
+    /// afterwards moves the next request without a reload.
+    /// </summary>
+    /// <remarks>
+    /// The two halves are two mechanisms — <c>Options.WebApi.Fetch.UserAgent</c>, fixed when this document's
+    /// engine was built, and <c>PageNetworkPolicy.Apply</c> rewriting the header per hop — and before #3720
+    /// the first of them did not exist, so a page nobody had overridden sent no <c>User-Agent</c> at all.
+    /// </remarks>
+    [Test]
+    public async Task WithNoOverrideThePagesOwnUserAgentIsWhatEveryRequestCarries()
+    {
+        using var server = new LoopbackServer();
+        server.MapHtml("/page", "<html><body>ok</body></html>");
+        server.Map("/data.json", _ => LoopbackResponse.Json("{\"ok\":true}"));
+
+        await using var session = await PageSession.CreateAsync(new BrowserContextOptions { UrlFilter = server.Owns });
+        var page = await session.NewPageAsync();
+        var target = await session.TargetForAsync(page);
+        var attachment = await session.AttachAsync(target);
+        await session.EnablePageAsync(attachment);
+
+        await page.NavigateAsync(server.Url("/page"), new NavigationOptions { WaitUntil = WaitUntilState.Load });
+        await page.EvaluateAsync("window.first = false; fetch('/data.json').then(() => { window.first = true; });");
+        (await page.WaitForAsync("window.first === true", TimeSpan.FromSeconds(10))).Should().BeTrue();
+
+        var expected = await page.EvaluateAsync<string>("navigator.userAgent");
+        expected.Should().Contain("Jint.Browser");
+        server.Received.Single(received => received.Path == "/page").Header("User-Agent").Should().Be(expected);
+        server.Received.Single(received => received.Path == "/data.json").Header("User-Agent").Should().Be(expected);
+
+        // An override reaches the document that is already loaded, which is what makes it an override.
+        await session.ResultAsync(
+            "Emulation.setUserAgentOverride",
+            "{\"userAgent\":\"Late/3.0\"}",
+            attachment);
+
+        await page.EvaluateAsync("window.second = false; fetch('/data.json?again').then(() => { window.second = true; });");
+        (await page.WaitForAsync("window.second === true", TimeSpan.FromSeconds(10))).Should().BeTrue();
+
+        server.Received.Single(received => received.Query == "again").Header("User-Agent").Should().Be("Late/3.0");
+        (await Text(session, attachment, "navigator.userAgent")).Should().Be("Late/3.0");
+    }
+
     [Test]
     public async Task TheTimeZoneOverrideReachesTheNextDocument()
     {

--- a/Jint.Tests.Browser/Navigation/UserAgentTests.cs
+++ b/Jint.Tests.Browser/Navigation/UserAgentTests.cs
@@ -1,0 +1,91 @@
+using Jint.Browser;
+
+namespace Jint.Tests.Browser.Navigation;
+
+/// <summary>
+/// <see cref="BrowserOptions.UserAgent"/> is what <c>navigator.userAgent</c> answers <b>and</b> what every
+/// request the page makes carries, so the two can never disagree.
+/// </summary>
+/// <remarks>
+/// The lanes are the reason this is a suite rather than one case: a document, a subresource the markup
+/// referenced, a script's <c>fetch</c> and <c>XMLHttpRequest</c>, and a worker's own module load and fetch
+/// each compose their request in a different place, and the header was missing from every one of them until
+/// the policy the transport reads carried it (#3720).
+/// </remarks>
+public sealed class UserAgentTests
+{
+    private const string Agent = "TestAgent/9.9 (jint)";
+
+    [Test]
+    public async Task EveryLaneOfAPageCarriesTheConfiguredUserAgent()
+    {
+        await using var fixture = await LoopbackPage.CreateAsync(
+            server => server
+                .Map("/style.css", _ => LoopbackResponse.Css("body { color: red }"))
+                .Map("/app.js", _ => LoopbackResponse.Script("globalThis.__ran = true;"))
+                .Map("/data.json", _ => LoopbackResponse.Json("""{"ok":true}"""))
+                .Map("/rows.txt", _ => LoopbackResponse.Text("one"))
+                .Map("/api", _ => LoopbackResponse.Text("from the worker"))
+                .Map(
+                    "/worker.js",
+                    _ => LoopbackResponse.Bytes(
+                        """
+                        self.addEventListener('message', function () {
+                          fetch('/api')
+                            .then(function (r) { return r.text(); })
+                            .then(function (t) { self.postMessage(t); });
+                        });
+                        """,
+                        "text/javascript"))
+                .MapHtml(
+                    "/page",
+                    """
+                    <html><head>
+                      <link rel="stylesheet" href="/style.css">
+                      <script src="/app.js"></script>
+                    </head><body>
+                      <script>
+                        window.replies = [];
+                        fetch('/data.json');
+                        var request = new XMLHttpRequest();
+                        request.open('GET', '/rows.txt');
+                        request.send();
+                        var worker = new Worker('/worker.js', { type: 'module' });
+                        worker.addEventListener('message', function (e) { window.replies.push(e.data); });
+                        worker.postMessage('go');
+                      </script>
+                    </body></html>
+                    """),
+            configureBrowser: options => options.UserAgent = Agent);
+
+        await fixture.Page.NavigateAsync(fixture.Url("/page"), new NavigationOptions { WaitUntil = WaitUntilState.Load });
+        await WaitForAsync(fixture, "window.replies.length > 0");
+
+        string[] paths = ["/page", "/style.css", "/app.js", "/data.json", "/rows.txt", "/worker.js", "/api"];
+        foreach (var path in paths)
+        {
+            var request = fixture.Server.Received.SingleOrDefault(received => received.Path == path);
+            request.Should().NotBeNull(path + " should have been requested");
+            request!.Header("User-Agent").Should().Be(Agent, path + " should carry the page's user agent");
+        }
+    }
+
+    [Test]
+    public async Task ThePageDefaultNamesJintBrowserRatherThanNothingAtAll()
+    {
+        await using var fixture = await LoopbackPage.CreateAsync(
+            server => server.MapHtml("/page", "<html><body>ok</body></html>"));
+
+        await fixture.Page.NavigateAsync(fixture.Url("/page"));
+
+        var request = fixture.Server.Received.Single(received => received.Path == "/page");
+        request.Header("User-Agent").Should().Be(await fixture.Page.EvaluateAsync<string>("navigator.userAgent"));
+        request.Header("User-Agent").Should().Contain("Jint.Browser");
+    }
+
+    private static async Task WaitForAsync(LoopbackPage fixture, string expression)
+    {
+        (await fixture.Page.WaitForAsync(expression, TimeSpan.FromSeconds(10)))
+            .Should().BeTrue(expression + " should have become true");
+    }
+}

--- a/Jint.Tests.Browser/Tool/FetchCommandTests.cs
+++ b/Jint.Tests.Browser/Tool/FetchCommandTests.cs
@@ -239,6 +239,23 @@ public sealed class FetchCommandTests
         server.Received[0].Header("user-agent").Should().Be("Agent/1.0");
     }
 
+    /// <summary>
+    /// A <c>--header 'User-Agent: …'</c> is the page's user agent, not a client default: the package puts
+    /// the page's own on every request, so a default could no longer replace it.
+    /// </summary>
+    [Test]
+    public async Task AUserAgentGivenAsAHeaderIsWhatThePageSendsAndReports()
+    {
+        using var server = new LoopbackServer();
+        server.MapHtml("/", "<!doctype html><html><body><script>document.body.textContent = navigator.userAgent;</script></body></html>");
+
+        var run = await ToolRun.RunAsync("fetch", server.Url("/"), "--header", "User-Agent: Header/2.0", "--dump", "text");
+
+        run.ExitCode.Should().Be(0);
+        run.Output.Should().Contain("Header/2.0");
+        server.Received[0].Header("user-agent").Should().Be("Header/2.0");
+    }
+
     [Test]
     public async Task NetworkIdleWaitsForWhatAScriptFetchedAfterLoad()
     {

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
@@ -328,6 +328,7 @@ namespace Jint
             public Jint.WebApi.Fetch.ReferrerPolicy ReferrerPolicy { get; set; }
             public System.TimeSpan Timeout { get; set; }
             public System.Func<System.Uri, bool> UrlFilter { get; set; }
+            public string? UserAgent { get; set; }
         }
         public sealed class HostOptions
         {

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
@@ -328,6 +328,7 @@ namespace Jint
             public Jint.WebApi.Fetch.ReferrerPolicy ReferrerPolicy { get; set; }
             public System.TimeSpan Timeout { get; set; }
             public System.Func<System.Uri, bool> UrlFilter { get; set; }
+            public string? UserAgent { get; set; }
         }
         public sealed class HostOptions
         {

--- a/Jint.Tests/Runtime/WebApi/WebSocketTests.cs
+++ b/Jint.Tests/Runtime/WebApi/WebSocketTests.cs
@@ -59,11 +59,12 @@ public class WebSocketTests
         private TaskCompletionSource<WebSocketReceipt>? _waiting;
         private bool _aborted;
 
-        internal FakeConnection(Uri url, IReadOnlyList<string> protocols, long maxMessageBytes)
+        internal FakeConnection(Uri url, IReadOnlyList<string> protocols, long maxMessageBytes, string? userAgent)
         {
             Url = url;
             Protocols = protocols;
             MaxMessageBytes = maxMessageBytes;
+            UserAgent = userAgent;
         }
 
         internal Uri Url { get; }
@@ -71,6 +72,9 @@ public class WebSocketTests
         internal IReadOnlyList<string> Protocols { get; }
 
         internal long MaxMessageBytes { get; }
+
+        /// <summary>The <c>User-Agent</c> the opening handshake was asked to carry.</summary>
+        internal string? UserAgent { get; }
 
         /// <summary>Completed by the test to finish the handshake, or faulted to fail it.</summary>
         internal TaskCompletionSource Handshake { get; } = new();
@@ -219,9 +223,9 @@ public class WebSocketTests
 
         internal FakeConnection Last => Created[^1];
 
-        public IWebSocketConnection Create(Uri url, IReadOnlyList<string> protocols, long maxMessageBytes)
+        public IWebSocketConnection Create(Uri url, IReadOnlyList<string> protocols, long maxMessageBytes, string? userAgent)
         {
-            var connection = new FakeConnection(url, protocols, maxMessageBytes);
+            var connection = new FakeConnection(url, protocols, maxMessageBytes, userAgent);
             Created.Add(connection);
             return connection;
         }
@@ -284,6 +288,31 @@ public class WebSocketTests
         PumpUntilLogged(engine, 1);
 
         return (engine, sockets);
+    }
+
+    /// <summary>
+    /// The opening handshake is an HTTP request, so it carries the same <c>User-Agent</c> a <c>fetch</c>
+    /// would — the engine's own token by default, and whatever the host named instead.
+    /// </summary>
+    /// <remarks>
+    /// https://fetch.spec.whatwg.org/#default-user-agent-value. What the transport does with the value is
+    /// two lines of <c>ClientWebSocketConnection</c>; what a host can get wrong is the wiring, which is what
+    /// this reads.
+    /// </remarks>
+    [Test]
+    public void TheHandshakeCarriesTheConfiguredUserAgent()
+    {
+        var (engine, sockets) = SocketEngine();
+        engine.Execute("new WebSocket('wss://example.org/socket');");
+        sockets.Last.UserAgent.Should().Be("Jint/" + typeof(Engine).Assembly.GetName().Version!.ToString(3));
+
+        var (named, namedSockets) = SocketEngine(fetch => fetch.UserAgent = "Named/1.0");
+        named.Execute("new WebSocket('wss://example.org/socket');");
+        namedSockets.Last.UserAgent.Should().Be("Named/1.0");
+
+        var (silent, silentSockets) = SocketEngine(fetch => fetch.UserAgent = null);
+        silent.Execute("new WebSocket('wss://example.org/socket');");
+        silentSockets.Last.UserAgent.Should().BeNull("a host that cleared the value sends no such header");
     }
 
     [Test]

--- a/Jint/Options.WebApi.cs
+++ b/Jint/Options.WebApi.cs
@@ -420,9 +420,10 @@ public sealed partial class Options
     /// outright works too); <see cref="UrlFilter"/> is shown the <c>ws:</c> URL itself;
     /// <see cref="MaxResponseBytes"/> is the ceiling on one incoming message and on the bytes <c>send()</c>
     /// may have unwritten; <see cref="MaxConcurrentRequests"/> is how many sockets one engine may have open,
-    /// counted separately from the requests in flight; and <see cref="Timeout"/> bounds the opening and
-    /// closing handshakes rather than the connection, which is meant to be long-lived. The other three
-    /// members are about HTTP alone and a socket ignores them: <see cref="HttpClient"/>,
+    /// counted separately from the requests in flight; <see cref="Timeout"/> bounds the opening and
+    /// closing handshakes rather than the connection, which is meant to be long-lived; and
+    /// <see cref="UserAgent"/> is carried by the opening handshake, which is an HTTP request like any other.
+    /// The other three members are about HTTP alone and a socket ignores them: <see cref="HttpClient"/>,
     /// <see cref="HttpClientFactory"/> and <see cref="MaxRedirects"/> — the WebSocket handshake is not
     /// allowed to be redirected at all.
     /// </para>
@@ -564,6 +565,31 @@ public sealed partial class Options
         /// effectively unbounded; zero or less refuses every request.
         /// </remarks>
         public int MaxConcurrentRequests { get; set { ThrowIfReadOnly(); field = value; } } = 10;
+
+        /// <summary>
+        /// The <c>User-Agent</c> every request carries. Defaults to <c>Jint/&lt;version&gt;</c>, the same
+        /// string <c>navigator.userAgent</c> answers; <see langword="null"/> or the empty string sends no
+        /// such header at all.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This is the <i>default <c>User-Agent</c> value</i> of
+        /// https://fetch.spec.whatwg.org/#default-user-agent-value, appended by HTTP-network-or-cache fetch
+        /// (https://fetch.spec.whatwg.org/#concept-http-network-or-cache-fetch) only when the request's own
+        /// header list does not already contain one — so a script that sets <c>User-Agent</c> in a
+        /// <c>fetch</c> init or through <c>setRequestHeader</c> still decides for that request.
+        /// </para>
+        /// <para>
+        /// <b>Every lane reads it</b>, not only <c>fetch</c>: <c>XMLHttpRequest</c>, an <c>EventSource</c>
+        /// stream and a <c>WebSocket</c>'s opening handshake carry the same value, and a host embedding Jint
+        /// behind a browsing context sets it once so that what a page reports and what it sends cannot
+        /// disagree.
+        /// </para>
+        /// <para>
+        /// Read once, when the engine is built.
+        /// </para>
+        /// </remarks>
+        public string? UserAgent { get; set { ThrowIfReadOnly(); field = value; } } = ProductToken.UserAgent;
 
         /// <summary>
         /// The API base URL a relative URL is resolved against. Defaults to <see langword="null"/>, which

--- a/Jint/WebApi/Fetch/AGENTS.md
+++ b/Jint/WebApi/Fetch/AGENTS.md
@@ -13,6 +13,14 @@ byte-for-byte as it did before they existed: `BaseUrl` (the API base URL a relat
 are ordinary settings any embedder can use. Three things about them are decisions rather than
 implementations.
 
+**`UserAgent` is a sixth setting and is deliberately not one of the five**: it is on by default, because the
+standard's *default `User-Agent` value* is what a user agent appends when the request named none
+([#3720](https://github.com/sebastienros/jint/issues/3720)), and an engine that answered `Jint/<version>` to
+`navigator.userAgent` while sending nothing said two different things. Every lane reads it — `fetch`, XHR,
+`EventSource`, a `WebSocket` handshake — so it lives on `FetchPolicy` rather than being appended per lane,
+and a host driving its own pipeline through `FetchTransport` (`Jint.Browser`'s document and subresource
+fetches) puts its own there.
+
 **The referrer, the `Origin` header and the `Cookie` header are recomputed per redirect hop, not per fetch.**
 That is [main fetch](https://fetch.spec.whatwg.org/#concept-main-fetch) step 6 being re-run because a
 redirect re-enters main fetch, and it is what makes a chain that leaves the referrer's origin narrow the

--- a/Jint/WebApi/Fetch/FetchOperation.cs
+++ b/Jint/WebApi/Fetch/FetchOperation.cs
@@ -193,6 +193,7 @@ internal sealed class FetchOperation
             Origin = network.Origin,
             SameOriginReference = network.SameOriginReference,
             CookieJar = network.CookieJar,
+            UserAgent = options.UserAgent,
         };
 
         // The first hop's policy check runs here, on the engine thread, so a refused URL never reaches a

--- a/Jint/WebApi/Fetch/FetchTransport.cs
+++ b/Jint/WebApi/Fetch/FetchTransport.cs
@@ -122,6 +122,17 @@ internal sealed class FetchPolicy
     internal CookieJar? CookieJar { get; init; }
 
     /// <summary>
+    /// The <c>User-Agent</c> a hop carries when the request named none itself, or <see langword="null"/> to
+    /// send no such header — https://fetch.spec.whatwg.org/#default-user-agent-value.
+    /// </summary>
+    /// <remarks>
+    /// It is <c>Options.WebApi.Fetch.UserAgent</c> for every request an <i>engine</i> makes; a host driving
+    /// its own pipeline through this transport — a document fetch, a subresource — passes the one its
+    /// browsing context reports, so that a page's script and its requests cannot say different things.
+    /// </remarks>
+    internal string? UserAgent { get; init; }
+
+    /// <summary>
     /// The whole check one hop passes: the scheme list, the <see cref="Uri"/> grammar and the host's filter.
     /// Refusing is what stops a redirect to <c>http://169.254.169.254/</c> from reaching the socket.
     /// </summary>
@@ -575,6 +586,15 @@ internal static class FetchTransport
         if (origin is not null && !Contains(headers, "origin"))
         {
             headers.Add(new HeaderEntry("origin", origin));
+        }
+
+        // https://fetch.spec.whatwg.org/#concept-http-network-or-cache-fetch: "If httpRequest's header list
+        // does not contain `User-Agent`, then user agents should append (`User-Agent`, default `User-Agent`
+        // value) to httpRequest's header list." The condition is the standard's own, so unlike the three
+        // headers around it this one needs no divergence to honour what the script set.
+        if (policy.UserAgent is { Length: > 0 } userAgent && !Contains(headers, "user-agent"))
+        {
+            headers.Add(new HeaderEntry("user-agent", userAgent));
         }
 
         if (policy.CookieJar is { } jar && CredentialsAllow(request.Credentials, policy, url) && !Contains(headers, "cookie"))

--- a/Jint/WebApi/Navigator/NavigatorPrototype.cs
+++ b/Jint/WebApi/Navigator/NavigatorPrototype.cs
@@ -1,5 +1,4 @@
 #if NET8_0_OR_GREATER
-using System.Globalization;
 using Jint.Native;
 using Jint.Native.Object;
 using Jint.Runtime;
@@ -65,9 +64,11 @@ internal sealed partial class NavigatorPrototype : Prototype
 
     /// <summary>
     /// The user agent string, built once for the process: the assembly version cannot change while it is
-    /// loaded, so every engine and every realm hands out this one <see cref="JsString"/>.
+    /// loaded, so every engine and every realm hands out this one <see cref="JsString"/>. The token is
+    /// <see cref="ProductToken.UserAgent"/>, which is also the <c>User-Agent</c> a request carries when the
+    /// host named none of its own — what a script reads and what the wire carries are one string.
     /// </summary>
-    private static readonly JsString UserAgent = new("Jint/" + ProductVersion());
+    private static readonly JsString UserAgent = new(ProductToken.UserAgent);
 
     internal NavigatorPrototype(
         Engine engine,
@@ -99,25 +100,6 @@ internal sealed partial class NavigatorPrototype : Prototype
         }
 
         return UserAgent;
-    }
-
-    /// <summary>
-    /// The <c>product-version</c> half of the token: Jint's own assembly version, as
-    /// <c>major.minor.patch</c>. The fourth component is dropped because Jint never sets one, and the whole
-    /// thing degrades to <c>"0.0.0"</c> rather than throwing if the assembly somehow carries no version.
-    /// </summary>
-    private static string ProductVersion()
-    {
-        var version = typeof(Engine).Assembly.GetName().Version;
-        if (version is null)
-        {
-            return "0.0.0";
-        }
-
-        var build = version.Build < 0 ? 0 : version.Build;
-        return string.Create(
-            CultureInfo.InvariantCulture,
-            $"{version.Major}.{version.Minor}.{build}");
     }
 }
 #endif

--- a/Jint/WebApi/ProductToken.cs
+++ b/Jint/WebApi/ProductToken.cs
@@ -1,0 +1,45 @@
+#if NET8_0_OR_GREATER
+using System.Globalization;
+
+namespace Jint.WebApi;
+
+/// <summary>
+/// The engine's own product token, <c>Jint/&lt;major.minor.patch&gt;</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Two readers, one string, and that is the point.</b> It is what <c>navigator.userAgent</c> answers
+/// (https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator-useragent) and it is the
+/// <i>default <c>User-Agent</c> value</i> a request carries
+/// (https://fetch.spec.whatwg.org/#default-user-agent-value) — an engine that says one thing to script and
+/// another on the wire is the defect this exists to prevent.
+/// </para>
+/// <para>
+/// Built once for the process: the assembly version cannot change while it is loaded.
+/// </para>
+/// </remarks>
+internal static class ProductToken
+{
+    /// <summary>The token itself.</summary>
+    internal static string UserAgent { get; } = "Jint/" + ProductVersion();
+
+    /// <summary>
+    /// The <c>product-version</c> half of the token: Jint's own assembly version, as
+    /// <c>major.minor.patch</c>. The fourth component is dropped because Jint never sets one, and the whole
+    /// thing degrades to <c>"0.0.0"</c> rather than throwing if the assembly somehow carries no version.
+    /// </summary>
+    private static string ProductVersion()
+    {
+        var version = typeof(Engine).Assembly.GetName().Version;
+        if (version is null)
+        {
+            return "0.0.0";
+        }
+
+        var build = version.Build < 0 ? 0 : version.Build;
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"{version.Major}.{version.Minor}.{build}");
+    }
+}
+#endif

--- a/Jint/WebApi/ServerSentEvents/JsEventSource.cs
+++ b/Jint/WebApi/ServerSentEvents/JsEventSource.cs
@@ -125,6 +125,7 @@ internal sealed class JsEventSource : JsEventTarget
             UrlFilter = urlFilter,
             MaxResponseBytes = _options.MaxResponseBytes,
             MaxRedirects = _options.MaxRedirects,
+            UserAgent = _options.UserAgent,
         };
 
         // The first hop's check runs on the engine thread, so a refused URL never reaches a socket. Every

--- a/Jint/WebApi/WebSockets/ClientWebSocketConnection.cs
+++ b/Jint/WebApi/WebSockets/ClientWebSocketConnection.cs
@@ -37,7 +37,7 @@ internal sealed class ClientWebSocketConnection : IWebSocketConnection
     private readonly Uri _url;
     private readonly long _maxMessageBytes;
 
-    internal ClientWebSocketConnection(Uri url, IReadOnlyList<string> protocols, long maxMessageBytes)
+    internal ClientWebSocketConnection(Uri url, IReadOnlyList<string> protocols, long maxMessageBytes, string? userAgent)
     {
         _url = url;
         _maxMessageBytes = maxMessageBytes;
@@ -51,6 +51,14 @@ internal sealed class ClientWebSocketConnection : IWebSocketConnection
 
         _socket.Options.UseDefaultCredentials = false;
         _socket.Options.Cookies = null;
+
+        // The opening handshake is an HTTP request, so it carries the engine's own default `User-Agent`
+        // value (https://fetch.spec.whatwg.org/#default-user-agent-value) exactly as a fetch does. .NET
+        // sends none of its own, which is what made a socket the one lane that said nothing.
+        if (userAgent is { Length: > 0 })
+        {
+            _socket.Options.SetRequestHeader("User-Agent", userAgent);
+        }
     }
 
     public string SubProtocol => _socket.SubProtocol ?? string.Empty;
@@ -161,7 +169,7 @@ internal sealed class ClientWebSocketConnectionFactory : IWebSocketConnectionFac
     {
     }
 
-    public IWebSocketConnection Create(Uri url, IReadOnlyList<string> protocols, long maxMessageBytes)
-        => new ClientWebSocketConnection(url, protocols, maxMessageBytes);
+    public IWebSocketConnection Create(Uri url, IReadOnlyList<string> protocols, long maxMessageBytes, string? userAgent)
+        => new ClientWebSocketConnection(url, protocols, maxMessageBytes, userAgent);
 }
 #endif

--- a/Jint/WebApi/WebSockets/WebSocketConnection.cs
+++ b/Jint/WebApi/WebSockets/WebSocketConnection.cs
@@ -124,7 +124,12 @@ internal interface IWebSocketConnectionFactory
     /// The largest message the connection may reassemble before it raises
     /// <see cref="WebSocketMessageTooLargeException"/>, from <c>Options.WebApi.Fetch.MaxResponseBytes</c>.
     /// </param>
-    IWebSocketConnection Create(Uri url, IReadOnlyList<string> protocols, long maxMessageBytes);
+    /// <param name="userAgent">
+    /// The <c>User-Agent</c> the opening handshake carries, from <c>Options.WebApi.Fetch.UserAgent</c>, or
+    /// <see langword="null"/> for none. The handshake is an HTTP request like any other, so it says what the
+    /// rest of the engine says.
+    /// </param>
+    IWebSocketConnection Create(Uri url, IReadOnlyList<string> protocols, long maxMessageBytes, string? userAgent);
 }
 
 /// <summary>

--- a/Jint/WebApi/WebSockets/WebSocketConstructor.cs
+++ b/Jint/WebApi/WebSockets/WebSocketConstructor.cs
@@ -170,7 +170,7 @@ internal sealed partial class WebSocketConstructor : Constructor
         if (WebSocketPolicy.Allows(options, url, out var uri))
         {
             var factory = state.WebSocketConnections ?? ClientWebSocketConnectionFactory.Instance;
-            connection = factory.Create(uri, protocols, options.MaxResponseBytes);
+            connection = factory.Create(uri, protocols, options.MaxResponseBytes, options.UserAgent);
         }
 
         var operation = new WebSocketOperation(_engine, _realm, socket, connection, options.Timeout);

--- a/Jint/WebApi/Xhr/XhrOperation.cs
+++ b/Jint/WebApi/Xhr/XhrOperation.cs
@@ -379,6 +379,7 @@ internal sealed class XhrOperation : IDisposable
             Origin = network.Origin,
             SameOriginReference = network.SameOriginReference,
             CookieJar = network.CookieJar,
+            UserAgent = options.UserAgent,
         };
 
         // The first hop's policy check runs here, on the engine thread, so a refused URL never reaches a

--- a/README.md
+++ b/README.md
@@ -510,7 +510,9 @@ carries all four, with `onerror` in HTML's legacy five-argument shape.
 
 §7 asks that `navigator.userAgent` be a single opaque RFC 7231 product token identifying the runtime; Jint
 answers `Jint/<version>`, which `Options.WebApi` does not let you change — a script that branches on the
-runtime should get the truth.
+runtime should get the truth. `Options.WebApi.Fetch.UserAgent` names what a *request* carries and leaves that
+answer alone; a host that wants the two to move together — a browsing context, say — shadows the member the
+way `Jint.Browser` does.
 
 ### Enabling web APIs on an engine that already exists
 
@@ -1218,6 +1220,13 @@ var body = engine.Evaluate("fetch('https://api.example.org/x').then(r => r.json(
 Enabling it also brings `Events`, `Url`, `Files` and `Streams`, because fetch's own surface is built out of
 them: a `Request` always has an `AbortSignal`, its URL is a WHATWG URL, `response.blob()` answers with a
 `Blob`, and `response.body` is a `ReadableStream`.
+
+**Every request names the engine.** `fetch.UserAgent` is the `User-Agent` a `fetch`, an `XMLHttpRequest`, an
+`EventSource` stream and a `WebSocket`'s opening handshake carry. It defaults to `Jint/<version>` — the token
+`navigator.userAgent` answers — and `null` sends no such header at all; a request that sets `User-Agent`
+itself still decides for itself, which is the [standard's own
+condition](https://fetch.spec.whatwg.org/#concept-http-network-or-cache-fetch). It changes what the wire sees
+and not what a script reads, for the reason the WinterTC note above gives.
 
 `Headers`, `Request` and `Response` are the standard's own classes — the full `Headers` (sorted, combined
 iteration, `getSetCookie`), method normalization, `redirect` modes, `clone()`, `Response.error()`,
@@ -2675,7 +2684,6 @@ recorded in `Page.Requests` with the reason instead — `integrity` is accepted 
 | --- | --- |
 | `Fetch`'s **response** stage, and with it the `IO` domain: an observer is told about a response and cannot answer it, so a response-stage pause could only ever continue unchanged | [#3701](https://github.com/sebastienros/jint/issues/3701) |
 | `Network`'s WebSocket and EventSource events — the engine deliberately does not observe those two handshakes — and its **timing** document, since no phase of a request is measured and a document of zeros would read as a page that loaded instantly | [#3701](https://github.com/sebastienros/jint/issues/3701) |
-| `BrowserOptions.UserAgent` reaches script but not the wire unless a protocol client sets it | [#3720](https://github.com/sebastienros/jint/issues/3720) |
 | A page's `@media` rules are evaluated against the page's viewport and emulated media type, but not against the emulated **preferences** — AngleSharp.Css's render device models none of them — so a themed page reads `matchMedia` rather than `getComputedStyle` to find out whether the scheme is dark | [#3707](https://github.com/sebastienros/jint/issues/3707) |
 | `ElementInternals`, so a `static formAssociated` custom element is recorded and takes part in no form; and no scoped custom element registries | [#3714](https://github.com/sebastienros/jint/issues/3714) |
 

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -1,4 +1,4 @@
-﻿# Migrating from Jint 4.16 to Jint 5
+# Migrating from Jint 4.16 to Jint 5
 
 Jint 5 is under development on `main`. This document is the running record of every change a
 4.16.x embedder has to react to; it is written for someone upgrading, so it says what broke and
@@ -5223,6 +5223,29 @@ effect beyond cancelling the event: it is HTML's *notHandled*, so a handler atta
 There is no option that restores the old timing. A host that wants the report where the rejection happened
 can subscribe to `PromiseRejectionTracker` and read `Operation`, which still names the two
 `HostPromiseRejectionTracker` operations — what changed is *when* the event is raised, not what it carries.
+### 4.124 Every request the engine makes carries a `User-Agent` ([#3720](https://github.com/sebastienros/jint/issues/3720))
+
+`fetch`, `XMLHttpRequest`, an `EventSource` stream and a `WebSocket`'s opening handshake sent no
+`User-Agent` header at all, while `navigator.userAgent` answered `Jint/<version>` — so an engine said one
+thing to script and nothing on the wire. They now send that same token, which is what
+[HTTP-network-or-cache fetch](https://fetch.spec.whatwg.org/#concept-http-network-or-cache-fetch) asks a
+user agent to append when the request's own header list does not contain one.
+
+```csharp
+var engine = new Engine(options => options.UseFetch(fetch =>
+{
+    // 5.0: no User-Agent header was sent.
+    // 5.x: "Jint/<version>", the string navigator.userAgent answers.
+    fetch.UserAgent = "MyApp/2.1";   // or null / "" to send none at all
+}));
+```
+
+`navigator.userAgent` is unchanged and still not configurable: this names what a *request* carries. A
+request that sets `User-Agent` itself still wins, because the standard's own condition is "does not contain".
+
+**What could break:** a server or a test double that asserts on the exact set of request headers, and a
+host that deliberately made anonymous requests. `fetch.UserAgent = null` restores the 4.16 behaviour for
+every lane at once.
 
 ### 4.123 An error is rendered without running its `name` or `message` accessor ([#3598](https://github.com/sebastienros/jint/issues/3598))
 

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -5223,30 +5223,6 @@ effect beyond cancelling the event: it is HTML's *notHandled*, so a handler atta
 There is no option that restores the old timing. A host that wants the report where the rejection happened
 can subscribe to `PromiseRejectionTracker` and read `Operation`, which still names the two
 `HostPromiseRejectionTracker` operations — what changed is *when* the event is raised, not what it carries.
-### 4.124 Every request the engine makes carries a `User-Agent` ([#3720](https://github.com/sebastienros/jint/issues/3720))
-
-`fetch`, `XMLHttpRequest`, an `EventSource` stream and a `WebSocket`'s opening handshake sent no
-`User-Agent` header at all, while `navigator.userAgent` answered `Jint/<version>` — so an engine said one
-thing to script and nothing on the wire. They now send that same token, which is what
-[HTTP-network-or-cache fetch](https://fetch.spec.whatwg.org/#concept-http-network-or-cache-fetch) asks a
-user agent to append when the request's own header list does not contain one.
-
-```csharp
-var engine = new Engine(options => options.UseFetch(fetch =>
-{
-    // 5.0: no User-Agent header was sent.
-    // 5.x: "Jint/<version>", the string navigator.userAgent answers.
-    fetch.UserAgent = "MyApp/2.1";   // or null / "" to send none at all
-}));
-```
-
-`navigator.userAgent` is unchanged and still not configurable: this names what a *request* carries. A
-request that sets `User-Agent` itself still wins, because the standard's own condition is "does not contain".
-
-**What could break:** a server or a test double that asserts on the exact set of request headers, and a
-host that deliberately made anonymous requests. `fetch.UserAgent = null` restores the 4.16 behaviour for
-every lane at once.
-
 ### 4.123 An error is rendered without running its `name` or `message` accessor ([#3598](https://github.com/sebastienros/jint/issues/3598))
 
 `console.log(err)` and `console.error(err)` rendered an error through `Error.prototype.toString`, which is
@@ -5348,6 +5324,30 @@ in the message. The argument and candidate types are, once the host asks:
 ```csharp
 var engine = new Engine(options => options.Interop.ExposeDetailedResolutionErrors = true);
 ```
+
+### 4.125 Every request the engine makes carries a `User-Agent` ([#3720](https://github.com/sebastienros/jint/issues/3720))
+
+`fetch`, `XMLHttpRequest`, an `EventSource` stream and a `WebSocket`'s opening handshake sent no
+`User-Agent` header at all, while `navigator.userAgent` answered `Jint/<version>` — so an engine said one
+thing to script and nothing on the wire. They now send that same token, which is what
+[HTTP-network-or-cache fetch](https://fetch.spec.whatwg.org/#concept-http-network-or-cache-fetch) asks a
+user agent to append when the request's own header list does not contain one.
+
+```csharp
+var engine = new Engine(options => options.UseFetch(fetch =>
+{
+    // 5.0: no User-Agent header was sent.
+    // 5.x: "Jint/<version>", the string navigator.userAgent answers.
+    fetch.UserAgent = "MyApp/2.1";   // or null / "" to send none at all
+}));
+```
+
+`navigator.userAgent` is unchanged and still not configurable: this names what a *request* carries. A
+request that sets `User-Agent` itself still wins, because the standard's own condition is "does not contain".
+
+**What could break:** a server or a test double that asserts on the exact set of request headers, and a
+host that deliberately made anonymous requests. `fetch.UserAgent = null` restores the 4.16 behaviour for
+every lane at once.
 
 ## 5. New in v5
 


### PR DESCRIPTION
Part of #3720 — the user-agent half. (The issue's two smaller items, `LoopbackServer.Dispose` and what a `PageError` carries, are a second pull request.)

## What was wrong

`BrowserOptions.UserAgent` is documented as what a page reports "in script and on the wire", and only the script half held. `navigator.userAgent` answered it; the document's own request, every subresource, a `fetch`, an `XMLHttpRequest` and a worker's loads sent **no `User-Agent` header at all** unless a protocol client had called `Emulation.setUserAgentOverride` — because `PageNetworkPolicy.Apply`, which runs only while a client is attached, was the one writer of that header. An embedder driving pages through the `Page` API sent anonymous requests, and `jint-browser` worked around it with a default header on its own `HttpClient`.

The engine had the same split one level down: `navigator.userAgent` answers `Jint/<version>` while `fetch`, `XMLHttpRequest`, `EventSource` and a `WebSocket` handshake named nobody.

```
Expected request.Header("User-Agent") to be "Mozilla/5.0 (compatible; Jint.Browser/5.0.0; +https://github.com/sebastienros/jint)", but found <null>.
```

— the new `UserAgentTests.ThePageDefaultNamesJintBrowserRatherThanNothingAtAll`, against unfixed code.

## What changed

**The engine grew the seam, because there was none.** `Options.WebApi.Fetch.UserAgent` is the [default `User-Agent` value](https://fetch.spec.whatwg.org/#default-user-agent-value), read once when the engine is built and carried on `FetchPolicy`, and `FetchTransport.Append` appends it under the standard's own condition — [HTTP-network-or-cache fetch](https://fetch.spec.whatwg.org/#concept-http-network-or-cache-fetch): "If httpRequest's header list does not contain `User-Agent`, then user agents should append (`User-Agent`, default `User-Agent` value)". Unlike the `Referer`, `Origin` and `Cookie` beside it, that needs no divergence to honour a header the script set: the condition is in the standard. One place serves `fetch`, XHR, `EventSource` and a host pipeline rather than four appends that could drift; a `WebSocket`'s opening handshake takes it through the connection factory, being an HTTP request like any other.

It defaults to `Jint/<version>` — the same token `navigator.userAgent` answers, now one string in `ProductToken` rather than two spellings — and `null` or `""` sends no header. That default is the behaviour change, and it has a migration row (§4.121). `navigator.userAgent` stays unconfigurable, for the reason the README's WinterTC note gives.

**The page then has one answer to "what is this page's user agent".** `EmulationState.EffectiveUserAgent` — the client's override, or `BrowserOptions.UserAgent` — is read by `NavigatorInstaller` (as before), by `BrowserEngineFactory` for the document's engine, by `Page.Navigation` for the document fetch, by `ParserDriver` and both module loaders for subresources and modules, and by `ThreadPerWorkerProvider` for a worker's engine. A client's override still wins for the page it was set on, and for the document *already loaded*: it is a page-level field, so the recorder rewrites the header per hop exactly as it did.

**The tool stops working around it.** A header on the request beats an `HttpClient` default, so `jint-browser`'s default `User-Agent` could no longer take effect — a `--header 'User-Agent: …'` now names the page's user agent instead, which is what keeps it working.

## The tests that pin it

- `Jint.Tests.Browser/Navigation/UserAgentTests` — seven lanes of one page against the loopback server (document, style sheet, `<script src>`, `fetch`, `XMLHttpRequest`, a worker's module and the worker's own `fetch`), and the default naming `Jint.Browser` rather than nothing.
- `EmulationDomainTests.WithNoOverrideThePagesOwnUserAgentIsWhatEveryRequestCarries` — a client attached and nothing overridden: the document and a `fetch` carry the page's own; then `Emulation.setUserAgentOverride` moves the next request with no reload. Its sibling `EitherUserAgentCommandMovesBothTheNavigatorAndTheHeader` is unchanged and still green.
- `WebSocketTests.TheHandshakeCarriesTheConfiguredUserAgent` — the default token, a host's string, and `null` for none.
- `FetchCommandTests.AUserAgentGivenAsAHeaderIsWhatThePageSendsAndReports` — the tool's `--header 'User-Agent: …'`, which nothing covered before and which the mechanism change would otherwise have broken silently.

`Jint.Tests` (`WebApi|Wpt|MigrationGuideTests|AgentInstructionFileTests|SpecCitationTests`, net10.0) 3544 passed, `Jint.Tests.Browser` 1198/1201 passed on both frameworks, `Jint.Tests.PublicInterface` (net10.0) 3582 passed, solution builds clean in Release.

**web-platform-tests: no change in either direction.** No exclusion row was retired and none was added — the fetch corpus's own suites do not assert on the request headers a user agent adds (`fetch/api/basic/request-headers.any.js`, which does, is a `_notVendored` row for exactly that reason), so a corpus that was green before is green with the header on the wire. The census is unmoved.

## What was left out

`navigator.userAgent` is still fixed at `Jint/<version>` for a bare engine: WinterTC §7 asks for a token that identifies the runtime truthfully, and a host that wants script and wire to move together shadows the member the way `Jint.Browser` does. `Emulation.setUserAgentOverride`'s `userAgentMetadata` (client hints) is still accepted and ignored; nothing sends `Sec-CH-UA`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
