### PR TITLE
EventSource and WebSocket read their event handler attributes through EventHandlerAttributes, so there is one definition of what one is

### DIFF
--- a/Jint.Tests/Runtime/WebApi/EventSourceTests.cs
+++ b/Jint.Tests/Runtime/WebApi/EventSourceTests.cs
@@ -883,5 +883,51 @@ public class EventSourceTests
         engine.Evaluate("(() => { try { EventSource.prototype.close.call({}); } catch (e) { return e.constructor.name; } })()")
             .AsString().Should().Be("TypeError");
     }
+
+    /// <summary>
+    /// What an event handler IDL attribute is —
+    /// https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes — read on an
+    /// <c>EventSource</c>: the handler is <b>one entry of the object's own listener list</b> that keeps the
+    /// position it first took, a non-object clears it (<c>[LegacyTreatNonObjectAsNull]</c>), and an object
+    /// that is not callable is stored and read back but never invoked.
+    /// </summary>
+    [Test]
+    public void AHandlerAttributeKeepsItsPositionAndTakesANonObjectAsNull()
+    {
+        var stream = new PushStream();
+        var handler = new StubHandler { Responder = _ => Answer(stream) };
+        var (engine, _) = SseEngine(handler);
+
+        engine.Execute($"""
+            var es = new EventSource('{StreamUrl}');
+            es.onmessage = () => log.push('handler');
+            es.addEventListener('message', () => log.push('listener'));
+            es.onmessage = () => log.push('replaced');
+            """);
+
+        stream.Push("data: one\n\n");
+        PumpUntilLogHas(engine, 2, "both message handlers");
+
+        // Reassigning replaced the callback in place, so the handler still runs before a listener added after
+        // it — a remove-and-add would have put it last.
+        Log(engine, 2).Should().Be("replaced|listener");
+
+        engine.Execute("es.onmessage = 42;");
+        engine.Evaluate("es.onmessage").IsNull().Should().BeTrue();
+
+        stream.Push("data: two\n\n");
+        PumpUntilLogHas(engine, 3, "the listener alone");
+        Log(engine, 3).Should().Be("replaced|listener|listener");
+
+        // An object that is not callable is kept and read back, and the dispatch simply passes it over.
+        engine.Execute("var bag = {}; es.onmessage = bag;");
+        engine.Evaluate("es.onmessage === bag").AsBoolean().Should().BeTrue();
+
+        stream.Push("data: three\n\n");
+        PumpUntilLogHas(engine, 4, "the listener alone again");
+        Log(engine, 4).Should().Be("replaced|listener|listener|listener");
+
+        stream.Complete();
+    }
 }
 #endif

--- a/Jint.Tests/Runtime/WebApi/WebSocketTests.cs
+++ b/Jint.Tests/Runtime/WebApi/WebSocketTests.cs
@@ -1107,5 +1107,44 @@ public class WebSocketTests
         engine.Execute("ws.onopen = null;");
         engine.Evaluate("ws.onopen").IsNull().Should().BeTrue();
     }
+
+    /// <summary>
+    /// The rest of what an event handler IDL attribute is —
+    /// https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes — read on a
+    /// <c>WebSocket</c>: the handler is <b>one entry of the object's own listener list</b> that keeps the
+    /// position it first took, a non-object clears it (<c>[LegacyTreatNonObjectAsNull]</c>), and an object
+    /// that is not callable is stored and read back but never invoked.
+    /// </summary>
+    [Test]
+    public void AHandlerAttributeKeepsItsPositionAndTakesANonObjectAsNull()
+    {
+        var (engine, sockets) = OpenSocket("""
+            ws.onmessage = () => log.push('handler');
+            ws.addEventListener('message', () => log.push('listener'));
+            ws.onmessage = () => log.push('replaced');
+            """);
+
+        sockets.Last.Deliver(WebSocketReceipt.Message(isText: true, "a"u8.ToArray()));
+        PumpUntilLogged(engine, 3);
+
+        // Reassigning replaced the callback in place, so the handler still runs before a listener added after
+        // it — a remove-and-add would have put it last.
+        Log(engine).Should().Be("open:1:|replaced|listener");
+
+        engine.Execute("ws.onmessage = 42;");
+        engine.Evaluate("ws.onmessage").IsNull().Should().BeTrue();
+
+        sockets.Last.Deliver(WebSocketReceipt.Message(isText: true, "b"u8.ToArray()));
+        PumpUntilLogged(engine, 4);
+        Log(engine).Should().Be("open:1:|replaced|listener|listener");
+
+        // An object that is not callable is kept and read back, and the dispatch simply passes it over.
+        engine.Execute("var bag = {}; ws.onmessage = bag;");
+        engine.Evaluate("ws.onmessage === bag").AsBoolean().Should().BeTrue();
+
+        sockets.Last.Deliver(WebSocketReceipt.Message(isText: true, "c"u8.ToArray()));
+        PumpUntilLogged(engine, 5);
+        Log(engine).Should().Be("open:1:|replaced|listener|listener|listener");
+    }
 }
 #endif

--- a/Jint/WebApi/ServerSentEvents/EventSourcePrototype.cs
+++ b/Jint/WebApi/ServerSentEvents/EventSourcePrototype.cs
@@ -74,19 +74,19 @@ internal sealed partial class EventSourcePrototype : Prototype
     /// https://html.spec.whatwg.org/multipage/server-sent-events.html#handler-eventsource-onopen
     /// </summary>
     [JsAccessor("onopen", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
-    private JsValue OnOpenGet(JsValue thisObject) => HandlerGet(thisObject, JsEventSource.OpenEventType);
+    private JsValue OnOpenGet(JsValue thisObject) => EventHandlerAttributes.Get(Brand(thisObject), JsEventSource.OpenEventType);
 
     /// <summary>
     /// https://html.spec.whatwg.org/multipage/server-sent-events.html#handler-eventsource-onopen, setter half.
     /// </summary>
     [JsAccessor("onopen", AccessorKind.Set, Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
-    private JsValue OnOpenSet(JsValue thisObject, JsValue value) => HandlerSet(thisObject, JsEventSource.OpenEventType, value);
+    private JsValue OnOpenSet(JsValue thisObject, JsValue value) => EventHandlerAttributes.Set(Brand(thisObject), JsEventSource.OpenEventType, value);
 
     /// <summary>
     /// https://html.spec.whatwg.org/multipage/server-sent-events.html#handler-eventsource-onmessage
     /// </summary>
     [JsAccessor("onmessage", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
-    private JsValue OnMessageGet(JsValue thisObject) => HandlerGet(thisObject, EventStreamParser.DefaultEventType);
+    private JsValue OnMessageGet(JsValue thisObject) => EventHandlerAttributes.Get(Brand(thisObject), EventStreamParser.DefaultEventType);
 
     /// <summary>
     /// https://html.spec.whatwg.org/multipage/server-sent-events.html#handler-eventsource-onmessage, setter
@@ -95,13 +95,13 @@ internal sealed partial class EventSourcePrototype : Prototype
     /// custom event types worth sending.
     /// </summary>
     [JsAccessor("onmessage", AccessorKind.Set, Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
-    private JsValue OnMessageSet(JsValue thisObject, JsValue value) => HandlerSet(thisObject, EventStreamParser.DefaultEventType, value);
+    private JsValue OnMessageSet(JsValue thisObject, JsValue value) => EventHandlerAttributes.Set(Brand(thisObject), EventStreamParser.DefaultEventType, value);
 
     /// <summary>
     /// https://html.spec.whatwg.org/multipage/server-sent-events.html#handler-eventsource-onerror
     /// </summary>
     [JsAccessor("onerror", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
-    private JsValue OnErrorGet(JsValue thisObject) => HandlerGet(thisObject, JsEventSource.ErrorEventType);
+    private JsValue OnErrorGet(JsValue thisObject) => EventHandlerAttributes.Get(Brand(thisObject), JsEventSource.ErrorEventType);
 
     /// <summary>
     /// https://html.spec.whatwg.org/multipage/server-sent-events.html#handler-eventsource-onerror, setter
@@ -110,7 +110,7 @@ internal sealed partial class EventSourcePrototype : Prototype
     /// whether this one is retrying (<c>CONNECTING</c>) or over (<c>CLOSED</c>).
     /// </summary>
     [JsAccessor("onerror", AccessorKind.Set, Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
-    private JsValue OnErrorSet(JsValue thisObject, JsValue value) => HandlerSet(thisObject, JsEventSource.ErrorEventType, value);
+    private JsValue OnErrorSet(JsValue thisObject, JsValue value) => EventHandlerAttributes.Set(Brand(thisObject), JsEventSource.ErrorEventType, value);
 
     /// <summary>
     /// https://html.spec.whatwg.org/multipage/server-sent-events.html#dom-eventsource-close — "must abort any
@@ -121,50 +121,6 @@ internal sealed partial class EventSourcePrototype : Prototype
     private JsValue Close(JsValue thisObject)
     {
         Brand(thisObject).Close();
-        return Undefined;
-    }
-
-    /// <summary>
-    /// The getter half of an event handler IDL attribute,
-    /// https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes.
-    /// </summary>
-    private JsValue HandlerGet(JsValue thisObject, string type)
-        => Brand(thisObject).FindEventHandler(type)?.Callback ?? Null;
-
-    /// <summary>
-    /// The setter half. <c>EventHandler</c> is a nullable callback function annotated
-    /// <c>[LegacyTreatNonObjectAsNull]</c>, so assigning anything that is not an object clears the handler
-    /// rather than raising a <c>TypeError</c>; an object that is not callable is stored and read back but
-    /// never invoked.
-    /// </summary>
-    /// <remarks>
-    /// The handler is one entry of the object's own event listener list, so it takes its turn in registration
-    /// order among the <c>addEventListener</c> listeners rather than running before or after all of them.
-    /// Reassigning replaces the value in place — the entry keeps the position it was first given — and
-    /// assigning a non-object removes the entry outright.
-    /// </remarks>
-    private JsValue HandlerSet(JsValue thisObject, string type, JsValue value)
-    {
-        var source = Brand(thisObject);
-        var existing = source.FindEventHandler(type);
-
-        if (value is not ObjectInstance)
-        {
-            if (existing is not null)
-            {
-                source.RemoveListener(existing);
-            }
-
-            return Undefined;
-        }
-
-        if (existing is not null)
-        {
-            existing.Callback = value;
-            return Undefined;
-        }
-
-        source.AddListener(new EventListenerRegistration(type, value) { IsEventHandler = true });
         return Undefined;
     }
 

--- a/Jint/WebApi/WebSockets/WebSocketPrototype.cs
+++ b/Jint/WebApi/WebSockets/WebSocketPrototype.cs
@@ -261,88 +261,49 @@ internal sealed partial class WebSocketPrototype : Prototype
     /// https://websockets.spec.whatwg.org/#handler-websocket-onopen
     /// </summary>
     [JsAccessor("onopen", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
-    private JsValue OnOpenGet(JsValue thisObject) => HandlerGet(thisObject, JsWebSocket.OpenEventType);
+    private JsValue OnOpenGet(JsValue thisObject) => EventHandlerAttributes.Get(Brand(thisObject), JsWebSocket.OpenEventType);
 
     /// <summary>
     /// https://websockets.spec.whatwg.org/#handler-websocket-onopen, setter half.
     /// </summary>
     [JsAccessor("onopen", AccessorKind.Set, Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
-    private JsValue OnOpenSet(JsValue thisObject, JsValue value) => HandlerSet(thisObject, value, JsWebSocket.OpenEventType);
+    private JsValue OnOpenSet(JsValue thisObject, JsValue value) => EventHandlerAttributes.Set(Brand(thisObject), JsWebSocket.OpenEventType, value);
 
     /// <summary>
     /// https://websockets.spec.whatwg.org/#handler-websocket-onmessage
     /// </summary>
     [JsAccessor("onmessage", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
-    private JsValue OnMessageGet(JsValue thisObject) => HandlerGet(thisObject, JsWebSocket.MessageEventType);
+    private JsValue OnMessageGet(JsValue thisObject) => EventHandlerAttributes.Get(Brand(thisObject), JsWebSocket.MessageEventType);
 
     /// <summary>
     /// https://websockets.spec.whatwg.org/#handler-websocket-onmessage, setter half.
     /// </summary>
     [JsAccessor("onmessage", AccessorKind.Set, Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
-    private JsValue OnMessageSet(JsValue thisObject, JsValue value) => HandlerSet(thisObject, value, JsWebSocket.MessageEventType);
+    private JsValue OnMessageSet(JsValue thisObject, JsValue value) => EventHandlerAttributes.Set(Brand(thisObject), JsWebSocket.MessageEventType, value);
 
     /// <summary>
     /// https://websockets.spec.whatwg.org/#handler-websocket-onerror
     /// </summary>
     [JsAccessor("onerror", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
-    private JsValue OnErrorGet(JsValue thisObject) => HandlerGet(thisObject, JsWebSocket.ErrorEventType);
+    private JsValue OnErrorGet(JsValue thisObject) => EventHandlerAttributes.Get(Brand(thisObject), JsWebSocket.ErrorEventType);
 
     /// <summary>
     /// https://websockets.spec.whatwg.org/#handler-websocket-onerror, setter half.
     /// </summary>
     [JsAccessor("onerror", AccessorKind.Set, Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
-    private JsValue OnErrorSet(JsValue thisObject, JsValue value) => HandlerSet(thisObject, value, JsWebSocket.ErrorEventType);
+    private JsValue OnErrorSet(JsValue thisObject, JsValue value) => EventHandlerAttributes.Set(Brand(thisObject), JsWebSocket.ErrorEventType, value);
 
     /// <summary>
     /// https://websockets.spec.whatwg.org/#handler-websocket-onclose
     /// </summary>
     [JsAccessor("onclose", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
-    private JsValue OnCloseGet(JsValue thisObject) => HandlerGet(thisObject, JsWebSocket.CloseEventType);
+    private JsValue OnCloseGet(JsValue thisObject) => EventHandlerAttributes.Get(Brand(thisObject), JsWebSocket.CloseEventType);
 
     /// <summary>
     /// https://websockets.spec.whatwg.org/#handler-websocket-onclose, setter half.
     /// </summary>
     [JsAccessor("onclose", AccessorKind.Set, Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
-    private JsValue OnCloseSet(JsValue thisObject, JsValue value) => HandlerSet(thisObject, value, JsWebSocket.CloseEventType);
-
-    /// <summary>
-    /// An event handler IDL attribute's getter,
-    /// https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes: whatever was
-    /// assigned, or null.
-    /// </summary>
-    private JsValue HandlerGet(JsValue thisObject, string type)
-        => Brand(thisObject).FindEventHandler(type)?.Callback ?? Null;
-
-    /// <summary>
-    /// An event handler IDL attribute's setter. <c>EventHandler</c> is <c>[LegacyTreatNonObjectAsNull]</c>, so
-    /// assigning anything that is not an object clears the handler instead of raising; an object that is not
-    /// callable is stored and read back but never invoked. Reassigning replaces the value in place, so the
-    /// handler keeps the position it first took among the <c>addEventListener</c> listeners.
-    /// </summary>
-    private JsValue HandlerSet(JsValue thisObject, JsValue value, string type)
-    {
-        var socket = Brand(thisObject);
-        var existing = socket.FindEventHandler(type);
-
-        if (value is not ObjectInstance)
-        {
-            if (existing is not null)
-            {
-                socket.RemoveListener(existing);
-            }
-
-            return Undefined;
-        }
-
-        if (existing is not null)
-        {
-            existing.Callback = value;
-            return Undefined;
-        }
-
-        socket.AddListener(new EventListenerRegistration(type, value) { IsEventHandler = true });
-        return Undefined;
-    }
+    private JsValue OnCloseSet(JsValue thisObject, JsValue value) => EventHandlerAttributes.Set(Brand(thisObject), JsWebSocket.CloseEventType, value);
 
     /// <summary>
     /// The bytes to put on the wire, and whether they are a text frame — the


### PR DESCRIPTION
Fixes #3628

## What was wrong

[#3626](https://github.com/sebastienros/jint/pull/3626) introduced `Jint/WebApi/Events/EventHandlerAttributes` as the shared helper for `on*` [event handler IDL attributes](https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes). `EventSourcePrototype` and `WebSocketPrototype` predate it and carried their own `HandlerGet`/`HandlerSet` — the same three rules written out a second and a third time:

```csharp
// EventSourcePrototype, before                    // WebSocketPrototype, before
var source = Brand(thisObject);                    var socket = Brand(thisObject);
var existing = source.FindEventHandler(type);      var existing = socket.FindEventHandler(type);
if (value is not ObjectInstance) { … Remove … }    if (value is not ObjectInstance) { … Remove … }
if (existing is not null) { existing.Callback …}   if (existing is not null) { existing.Callback …}
source.AddListener(new EventListenerRegistration(type, value) { IsEventHandler = true });
```

The two even disagreed about parameter order (`HandlerSet(thisObject, type, value)` against `HandlerSet(thisObject, value, type)`), which is the sort of thing three copies of one algorithm produce.

## What changed

Ten accessors — `EventSource`'s `onopen`/`onmessage`/`onerror` and `WebSocket`'s `onopen`/`onmessage`/`onerror`/`onclose` — now call `EventHandlerAttributes.Get(Brand(thisObject), type)` and `EventHandlerAttributes.Set(Brand(thisObject), type, value)`, the way `XMLHttpRequestEventTarget` and `FileReader` already do, and the two private pairs are deleted. Each accessor keeps its own doc comment and its own spec link; what goes is the shared body, whose reasoning is already on the helper. The branding is untouched, so a foreign receiver still gets its `TypeError` from the same place.

No behaviour changes: the helper's body **is** what both copies said, in the same order, with the same `IsEventHandler = true` registration.

## Tests

Two new tests, one per interface, pin the three rules the helper defines rather than the delivery the existing tests already cover:

- `EventSourceTests.AHandlerAttributeKeepsItsPositionAndTakesANonObjectAsNull`
- `WebSocketTests.AHandlerAttributeKeepsItsPositionAndTakesANonObjectAsNull`

Each assigns a handler, adds an `addEventListener` listener after it, reassigns the handler, and asserts the handler still runs **first** — a remove-and-add would have put it last. Then `onmessage = 42` reads back `null` and stops running, and a non-callable object is read back by identity and simply passed over by the dispatch.

**Both pass against the private copies as well**, which is what makes them a check on this change rather than a description of it: they were run with the two prototype files reverted to `main` and are green there too. `Jint.Tests` for `WebApi|Wpt|Temporal|Intl|MigrationGuideTests|AgentInstructionFileTests|SpecCitationTests`: 4,123 passed, 0 failed. `Jint.Tests.PublicInterface`: 3,582 passed, 0 failed — the baseline is untouched, since every member involved is `private` on an `internal sealed` type. Solution build in Release is clean.

There is no `eventsource/` or `websockets/` corpus in the vendored wpt tree, so nothing there moves; the whole wpt driver is green regardless.

## Left out

Five more private copies of the same algorithm exist, and this pull request leaves them where the issue left them: `AbortSignalPrototype.OnAbortSet`, `TaskSignalPrototype.OnPriorityChangeSet`, `BroadcastChannelPrototype.SetEventHandler`, `MessagePortPrototype.SetEventHandler` and `WorkerErrors.SetEventHandler`. The last two are the ones to look at before folding them in — `MessagePort`'s `onmessage` setter additionally starts the port, and `WorkerErrors` documents *not* doing so — so they are a decision rather than a substitution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
