### PR TITLE
Browser: a page error says when it happened and which document it came from

### DIFF
--- a/Jint.Browser/CustomElements/CustomElementRegistry.Reactions.cs
+++ b/Jint.Browser/CustomElements/CustomElementRegistry.Reactions.cs
@@ -364,10 +364,10 @@ internal sealed partial class CustomElementRegistry
             // A page whose own error handler throws is not a reason to lose the original report.
         }
 
-        _runtime.Recorder.Add(new PageError(
+        _runtime.Recorder.Add(
             PageErrorKind.UncaughtCallbackError,
             PageRecorder.Diagnostics.Describe(exception.Error, exception),
-            "custom element '" + name + "'"));
+            "custom element '" + name + "'");
     }
 
     /// <summary>Remembers the current value of every observed attribute, so the next change has an old one.</summary>

--- a/Jint.Browser/DevTools/PageTarget.cs
+++ b/Jint.Browser/DevTools/PageTarget.cs
@@ -407,17 +407,17 @@ internal sealed class NewDocumentScripts
             }
             catch (JavaScriptException exception)
             {
-                runtime.Recorder.Add(new PageError(
+                runtime.Recorder.Add(
                     PageErrorKind.ScriptError,
                     exception.Message,
-                    "Page.addScriptToEvaluateOnNewDocument#" + id));
+                    "Page.addScriptToEvaluateOnNewDocument#" + id);
             }
             catch (Exception exception) when (exception is not OutOfMemoryException and not StackOverflowException)
             {
-                runtime.Recorder.Add(new PageError(
+                runtime.Recorder.Add(
                     PageErrorKind.ScriptError,
                     exception.Message,
-                    "Page.addScriptToEvaluateOnNewDocument#" + id));
+                    "Page.addScriptToEvaluateOnNewDocument#" + id);
             }
         }
     }

--- a/Jint.Browser/Dom/DomHostHooks.cs
+++ b/Jint.Browser/Dom/DomHostHooks.cs
@@ -197,12 +197,12 @@ internal class DomHostHooks
             return false;
         }
 
-        runtime.Recorder.Add(new PageError(
+        runtime.Recorder.Add(
             PageErrorKind.ReportedError,
             "document." + member + "() after the document finished parsing implies document.open(), which "
             + "would replace the document; Jint.Browser does not implement it, so the call did nothing. "
             + "Build the markup with the DOM, or set the page's content again.",
-            document.Url));
+            document.Url);
 
         return true;
     }

--- a/Jint.Browser/Observers/JsIntersectionObserver.cs
+++ b/Jint.Browser/Observers/JsIntersectionObserver.cs
@@ -138,10 +138,10 @@ internal sealed class JsIntersectionObserver : ObjectInstance
         }
         catch (JavaScriptException exception)
         {
-            _runtime.Recorder.Add(new PageError(
+            _runtime.Recorder.Add(
                 PageErrorKind.UncaughtCallbackError,
                 PageRecorder.Diagnostics.Describe(exception.Error, exception),
-                "IntersectionObserver"));
+                "IntersectionObserver");
         }
     }
 

--- a/Jint.Browser/Observers/JsMutationObserver.cs
+++ b/Jint.Browser/Observers/JsMutationObserver.cs
@@ -182,10 +182,10 @@ internal sealed class JsMutationObserver : ObjectInstance
         {
             // WebIDL's "report the exception": the page survives a callback that threw, exactly as it
             // survives a timer callback that threw.
-            _runtime.Recorder.Add(new PageError(
+            _runtime.Recorder.Add(
                 PageErrorKind.UncaughtCallbackError,
                 PageRecorder.Diagnostics.Describe(exception.Error, exception),
-                "MutationObserver"));
+                "MutationObserver");
         }
     }
 

--- a/Jint.Browser/Observers/JsResizeObserver.cs
+++ b/Jint.Browser/Observers/JsResizeObserver.cs
@@ -118,10 +118,10 @@ internal sealed class JsResizeObserver : ObjectInstance
         }
         catch (JavaScriptException exception)
         {
-            _runtime.Recorder.Add(new PageError(
+            _runtime.Recorder.Add(
                 PageErrorKind.UncaughtCallbackError,
                 PageRecorder.Diagnostics.Describe(exception.Error, exception),
-                "ResizeObserver"));
+                "ResizeObserver");
         }
     }
 

--- a/Jint.Browser/Page.Navigation.cs
+++ b/Jint.Browser/Page.Navigation.cs
@@ -380,7 +380,7 @@ public sealed partial class Page
             }
             catch (NavigationFailedException failure)
             {
-                _recorder.Add(new PageError(PageErrorKind.ReportedError, failure.Message, "Navigation"));
+                _recorder.Add(PageErrorKind.ReportedError, failure.Message, "Navigation");
             }
             catch (OperationCanceledException)
             {
@@ -391,7 +391,7 @@ public sealed partial class Page
             }
             catch (Exception exception)
             {
-                _recorder.Add(new PageError(PageErrorKind.ReportedError, exception.Message, "Navigation"));
+                _recorder.Add(PageErrorKind.ReportedError, exception.Message, "Navigation");
             }
         });
     }
@@ -529,7 +529,7 @@ public sealed partial class Page
                 {
                     if (task.Exception is { } exception)
                     {
-                        ((Page) state!)._recorder.Add(new PageError(PageErrorKind.ReportedError, exception.GetBaseException().Message, "Navigation"));
+                        ((Page) state!)._recorder.Add(PageErrorKind.ReportedError, exception.GetBaseException().Message, "Navigation");
                     }
                 },
                 this,

--- a/Jint.Browser/Page.cs
+++ b/Jint.Browser/Page.cs
@@ -97,18 +97,20 @@ public sealed partial class Page : IAsyncDisposable
             "Jint.Browser page loop",
             options.PumpIdle,
             () => BuildEngine("about:blank", ""),
-            exception => recorder.Add(PumpError(exception)));
+            exception => recorder.Add(PumpErrorKind(exception), exception.Message, "PageLoop"));
+
+        // The recorder is built before the page, so it is told here where to read the page's URL from — the
+        // same volatile field the network log reads, so an error and a request name one document.
+        recorder.DocumentUrl = () => _url;
     }
 
-    /// <summary>What a page records when something erupts from its pump rather than from a callback.</summary>
+    /// <summary>What a page calls something that erupts from its pump rather than from a callback.</summary>
     /// <remarks>
     /// A turn that ran out of its budget is not a callback that threw, and a host reading the log needs to
     /// tell "this page's script is in a loop" from "this page's script has a bug".
     /// </remarks>
-    private static PageError PumpError(Exception exception) => new(
-        PageBudget.IsBudgetFailure(exception) ? PageErrorKind.BudgetExceeded : PageErrorKind.UncaughtCallbackError,
-        exception.Message,
-        "PageLoop");
+    private static PageErrorKind PumpErrorKind(Exception exception)
+        => PageBudget.IsBudgetFailure(exception) ? PageErrorKind.BudgetExceeded : PageErrorKind.UncaughtCallbackError;
 
     /// <summary>The context this page belongs to.</summary>
     public BrowserContext Context { get; }
@@ -472,7 +474,7 @@ public sealed partial class Page : IAsyncDisposable
 
     /// <summary>Records what a worker's pump got wrong, from the worker's own thread.</summary>
     internal void RecordWorkerError(Exception exception, string name)
-        => _recorder.Add(new PageError(PageErrorKind.WorkerError, exception.Message, name.Length == 0 ? "Worker" : name));
+        => _recorder.Add(PageErrorKind.WorkerError, exception.Message, name.Length == 0 ? "Worker" : name);
 
     /// <summary>The engine one document runs in, built with that document's URL, origin and referrer.</summary>
     private Engine BuildEngine(string url, string referrer)
@@ -536,7 +538,7 @@ public sealed partial class Page : IAsyncDisposable
             {
                 // A job that ran out of budget ends; the wait does not, because the next drain gets a budget
                 // of its own and the caller's own ceiling is what bounds this loop.
-                _recorder.Add(new PageError(PageErrorKind.BudgetExceeded, exception.Message, "PageLoop"));
+                _recorder.Add(PageErrorKind.BudgetExceeded, exception.Message, "PageLoop");
             }
 
             if (engine.Tasks.TimeUntilNextScheduledWork is not { } next)

--- a/Jint.Browser/PageError.cs
+++ b/Jint.Browser/PageError.cs
@@ -17,11 +17,13 @@ namespace Jint.Browser;
 /// </remarks>
 public sealed class PageError
 {
-    internal PageError(PageErrorKind kind, string message, string? source)
+    internal PageError(PageErrorKind kind, string message, string? source, DateTimeOffset timestamp, string documentUrl)
     {
         Kind = kind;
         Message = message;
         Source = source;
+        Timestamp = timestamp;
+        DocumentUrl = documentUrl;
     }
 
     /// <summary>What produced the error.</summary>
@@ -32,6 +34,24 @@ public sealed class PageError
 
     /// <summary>Which callback the engine was running, when it was running one; otherwise <c>null</c>.</summary>
     public string? Source { get; }
+
+    /// <summary>When the page recorded it, on the wall clock in UTC.</summary>
+    /// <remarks>
+    /// <see cref="DateTimeOffset.UtcNow"/> rather than the engine's configured <c>TimeProvider</c>, for the
+    /// reason <c>PageRuntime.Now</c> gives about its own clock: a host that substituted a clock for its
+    /// timers did not thereby ask for its diagnostics to be stamped with a time that never happened.
+    /// </remarks>
+    public DateTimeOffset Timestamp { get; }
+
+    /// <summary>The URL of the document the page was showing when it was recorded.</summary>
+    /// <remarks>
+    /// <b>It is what a host cannot reconstruct afterwards.</b> <see cref="Page.Errors"/> is one list for the
+    /// life of the page while <see cref="Page.Url"/> answers where the page is <i>now</i>, so without this a
+    /// host that has driven several navigations cannot say which document an entry came from. It is
+    /// <c>about:blank</c> for a page that has loaded nothing, and the <i>outgoing</i> document's URL for an
+    /// error raised while a navigation is still in flight — the new one has not been committed yet.
+    /// </remarks>
+    public string DocumentUrl { get; }
 
     /// <inheritdoc />
     public override string ToString() => Source is null ? Message : Source + ": " + Message;

--- a/Jint.Browser/Runtime/AnimationFrameLane.cs
+++ b/Jint.Browser/Runtime/AnimationFrameLane.cs
@@ -150,10 +150,10 @@ internal sealed class AnimationFrameLane
                 }
                 catch (JavaScriptException exception)
                 {
-                    _runtime.Recorder.Add(new PageError(
+                    _runtime.Recorder.Add(
                         PageErrorKind.UncaughtCallbackError,
                         PageRecorder.Diagnostics.Describe(exception.Error, exception),
-                        "AnimationFrame"));
+                        "AnimationFrame");
                 }
             }
         }

--- a/Jint.Browser/Runtime/FormSubmitter.cs
+++ b/Jint.Browser/Runtime/FormSubmitter.cs
@@ -78,10 +78,10 @@ internal static class FormSubmitter
         var target = PageUrl.Parse(action!, runtime.DocumentUrl);
         if (target is null)
         {
-            runtime.Recorder.Add(new PageError(
+            runtime.Recorder.Add(
                 PageErrorKind.ReportedError,
                 "A form was submitted to '" + action + "', which is not a URL.",
-                "form"));
+                "form");
             return;
         }
 
@@ -90,10 +90,10 @@ internal static class FormSubmitter
 
         if (string.Equals(method, "dialog", StringComparison.Ordinal))
         {
-            runtime.Recorder.Add(new PageError(
+            runtime.Recorder.Add(
                 PageErrorKind.ReportedError,
                 "A form was submitted with method='dialog', and <dialog> is not implemented in this version.",
-                "form"));
+                "form");
             return;
         }
 
@@ -105,11 +105,11 @@ internal static class FormSubmitter
         if (!string.IsNullOrEmpty(frameTarget)
             && !string.Equals(frameTarget, "_self", StringComparison.OrdinalIgnoreCase))
         {
-            runtime.Recorder.Add(new PageError(
+            runtime.Recorder.Add(
                 PageErrorKind.ReportedError,
                 "A form targeting '" + frameTarget + "' was submitted into the same page: this version opens no "
                 + "second page, so _blank, a frame name and _top all load here.",
-                "form"));
+                "form");
         }
 
         if (string.Equals(method, "get", StringComparison.Ordinal))

--- a/Jint.Browser/Runtime/PageActivationHost.cs
+++ b/Jint.Browser/Runtime/PageActivationHost.cs
@@ -50,11 +50,11 @@ internal sealed class PageActivationHost : BrowserActivationHost
 
         if (target.Length != 0 && !string.Equals(target, "_self", StringComparison.OrdinalIgnoreCase))
         {
-            _runtime.Recorder.Add(new PageError(
+            _runtime.Recorder.Add(
                 PageErrorKind.ReportedError,
                 "A link targeting '" + target + "' was followed in the same page: this version opens no second "
                 + "page, so _blank, a frame name and _top all load here.",
-                source.LocalName));
+                source.LocalName);
         }
 
         _runtime.Page.RequestNavigation(url, replace: false, engine: _runtime.Engine);
@@ -74,9 +74,9 @@ internal sealed class PageActivationHost : BrowserActivationHost
     /// replaces the body without moving the seam.
     /// </summary>
     internal override void OpenFileChooser(BrowserEventRealm realm, IHtmlInputElement input)
-        => _runtime.Recorder.Add(new PageError(
+        => _runtime.Recorder.Add(
             PageErrorKind.ReportedError,
             "A file chooser was opened by clicking an <input type=file>, and this version has no file chooser "
             + "to open; the file list is unchanged.",
-            input.Id is { Length: > 0 } id ? id : input.Name ?? "input"));
+            input.Id is { Length: > 0 } id ? id : input.Name ?? "input");
 }

--- a/Jint.Browser/Runtime/PageEvents.cs
+++ b/Jint.Browser/Runtime/PageEvents.cs
@@ -54,10 +54,10 @@ internal static class PageEvents
         }
         catch (JavaScriptException exception)
         {
-            runtime.Recorder.Add(new PageError(
+            runtime.Recorder.Add(
                 PageErrorKind.UncaughtCallbackError,
                 PageRecorder.Diagnostics.Describe(exception.Error, exception),
-                ev.TypeName));
+                ev.TypeName);
             return true;
         }
     }

--- a/Jint.Browser/Runtime/PageRecorder.cs
+++ b/Jint.Browser/Runtime/PageRecorder.cs
@@ -32,6 +32,16 @@ internal sealed class PageRecorder
         _max = max;
     }
 
+    /// <summary>
+    /// The URL of the document the page is showing, read as each entry is taken.
+    /// </summary>
+    /// <remarks>
+    /// <b>Assigned by the page, because the recorder is built before the page it belongs to.</b> It is the
+    /// same volatile field <c>PageNetworkRecorder</c> reads and for the same reason: an entry has to name the
+    /// document it came from, and by the time a host looks at the list the page may be showing its third.
+    /// </remarks>
+    internal Func<string>? DocumentUrl { get; set; }
+
     /// <summary>A snapshot of the errors recorded so far, oldest first.</summary>
     internal IReadOnlyList<PageError> Errors
     {
@@ -56,8 +66,19 @@ internal sealed class PageRecorder
         }
     }
 
-    internal void Add(PageError error)
+    /// <summary>
+    /// Records one error, stamped with the moment and the document it belongs to.
+    /// </summary>
+    /// <remarks>
+    /// <b>The one place a <see cref="PageError"/> is built.</b> Twenty-odd call sites report one, and a
+    /// constructor they each reach is a constructor one of them forgets to stamp; here the stamp cannot be
+    /// left off. Callable from any thread — a worker's failure and the pump's own eruption both arrive here
+    /// — which is why it takes the same lock the reads do.
+    /// </remarks>
+    internal void Add(PageErrorKind kind, string message, string? source)
     {
+        var error = new PageError(kind, message, source, DateTimeOffset.UtcNow, DocumentUrl?.Invoke() ?? "");
+
         lock (_gate)
         {
             _errors.Enqueue(error);
@@ -100,7 +121,7 @@ internal sealed class PageRecorder
                 _ => PageErrorKind.ReportedError,
             };
 
-            _recorder.Add(new PageError(kind, Describe(report.Value, report.Exception), report.CallbackSource?.ToString()));
+            _recorder.Add(kind, Describe(report.Value, report.Exception), report.CallbackSource?.ToString());
         }
 
         /// <summary>

--- a/Jint.Browser/Runtime/Parsing/ParserDriver.cs
+++ b/Jint.Browser/Runtime/Parsing/ParserDriver.cs
@@ -945,7 +945,7 @@ internal sealed class ParserDriver : IDisposable
     }
 
     private void Report(PageErrorKind kind, string message, string source)
-        => _runtime.Recorder.Add(new PageError(kind, message, source));
+        => _runtime.Recorder.Add(kind, message, source);
 
     /// <summary>
     /// What erupted out of the baton's pump — a job the diagnostics sink does not cover, or a constraint

--- a/Jint.Tests.Browser/Navigation/LoopbackServer.cs
+++ b/Jint.Tests.Browser/Navigation/LoopbackServer.cs
@@ -35,6 +35,8 @@ internal sealed class LoopbackServer : IDisposable
     private readonly ConcurrentDictionary<string, Func<LoopbackRequest, LoopbackResponse>> _routes = new(StringComparer.Ordinal);
     private readonly ConcurrentQueue<LoopbackRequest> _received = new();
 
+    private volatile bool _disposed;
+
     internal LoopbackServer()
     {
         _listener = new TcpListener(IPAddress.Loopback, 0);
@@ -80,8 +82,20 @@ internal sealed class LoopbackServer : IDisposable
     internal LoopbackServer MapHtml(string path, string html)
         => Map(path, _ => LoopbackResponse.Html(html));
 
+    /// <summary>Stops the listener and ends every connection. Calling it twice does nothing the second time.</summary>
+    /// <remarks>
+    /// A suite that hands its server to a <c>LoopbackPage</c> and also writes <c>using var server = …</c>
+    /// disposes it twice, and cancelling an already-disposed source throws — which fails whichever test
+    /// happens to be shaped that way rather than the one that owns the mistake.
+    /// </remarks>
     public void Dispose()
     {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
         _stopping.Cancel();
         _listener.Stop();
         _stopping.Dispose();

--- a/Jint.Tests.Browser/Navigation/LoopbackServerTests.cs
+++ b/Jint.Tests.Browser/Navigation/LoopbackServerTests.cs
@@ -1,0 +1,28 @@
+namespace Jint.Tests.Browser.Navigation;
+
+/// <summary>
+/// The fixture server itself, where its own contract is what a test depends on.
+/// </summary>
+public sealed class LoopbackServerTests
+{
+    /// <summary>
+    /// Disposing twice does nothing the second time, which is what <see cref="IDisposable"/> asks for.
+    /// </summary>
+    /// <remarks>
+    /// A suite that hands its server to a <c>LoopbackPage</c> and also writes <c>using var server = …</c>
+    /// disposes it twice, and the second call used to <c>Cancel()</c> an already-disposed
+    /// <see cref="System.Threading.CancellationTokenSource"/> — an <see cref="ObjectDisposedException"/> out
+    /// of a <c>using</c> block, which fails whichever test happened to be shaped that way rather than the
+    /// one that owns the mistake ([#3720](https://github.com/sebastienros/jint/issues/3720)).
+    /// </remarks>
+    [Test]
+    public void DisposingTwiceIsNotAnError()
+    {
+        var server = new LoopbackServer();
+        server.Dispose();
+
+        var again = server.Dispose;
+
+        again.Should().NotThrow();
+    }
+}

--- a/Jint.Tests.Browser/Runtime/PageTests.cs
+++ b/Jint.Tests.Browser/Runtime/PageTests.cs
@@ -166,6 +166,39 @@ public sealed class PageTests
         (await page.EvaluateAsync<bool?>("undefined")).Should().BeNull();
     }
 
+    /// <summary>
+    /// An error says <b>when</b> it happened and <b>which document</b> was showing, so a host that has driven
+    /// a page through several navigations can attribute one.
+    /// </summary>
+    /// <remarks>
+    /// The URL is the page's at the instant the recorder took the entry, which is the one thing a host cannot
+    /// reconstruct afterwards: <c>Page.Url</c> answers where the page is <i>now</i>, and the errors of three
+    /// documents are one list.
+    /// </remarks>
+    [Test]
+    public async Task AnErrorSaysWhenItHappenedAndWhichDocumentItCameFrom()
+    {
+        await using var fixture = await Navigation.LoopbackPage.CreateAsync(s => s
+            .MapHtml("/first", "<script>reportError(new Error('from the first'))</script>")
+            .MapHtml("/second", "<script>reportError(new Error('from the second'))</script>"));
+
+        var before = DateTimeOffset.UtcNow;
+        await fixture.Page.NavigateAsync(fixture.Url("/first"), new NavigationOptions { WaitUntil = WaitUntilState.Load });
+        await fixture.Page.NavigateAsync(fixture.Url("/second"), new NavigationOptions { WaitUntil = WaitUntilState.Load });
+        var after = DateTimeOffset.UtcNow;
+
+        fixture.Page.Errors.Should().HaveCount(2);
+
+        var first = fixture.Page.Errors.Single(error => error.Message.Contains("from the first", StringComparison.Ordinal));
+        var second = fixture.Page.Errors.Single(error => error.Message.Contains("from the second", StringComparison.Ordinal));
+
+        first.DocumentUrl.Should().Be(fixture.Url("/first"));
+        second.DocumentUrl.Should().Be(fixture.Url("/second"));
+
+        first.Timestamp.Should().BeOnOrAfter(before).And.BeOnOrBefore(after);
+        first.Timestamp.Should().BeOnOrBefore(second.Timestamp);
+    }
+
     [Test]
     public async Task AMalformedDataUrlAssignedFromScriptIsAPageErrorAndNotAFault()
     {

--- a/Jint.Tests.Browser/Verify/PublicApiTest.verified.txt
+++ b/Jint.Tests.Browser/Verify/PublicApiTest.verified.txt
@@ -149,9 +149,11 @@ namespace Jint.Browser
     }
     public sealed class PageError
     {
+        public string DocumentUrl { get; }
         public Jint.Browser.PageErrorKind Kind { get; }
         public string Message { get; }
         public string? Source { get; }
+        public System.DateTimeOffset Timestamp { get; }
         public override string ToString() { }
     }
     public enum PageErrorKind


### PR DESCRIPTION
Fixes #3720 — the two smaller items in it. The user-agent half is #3747, which this does not depend on.

## What was wrong

**A `PageError` could not be attributed.** `Page.Errors` is one list for the life of a page, and `Page.Url` answers where the page is *now*, so a host that has driven a page through three navigations cannot tell which document an entry came from — and cannot order two entries against anything else it recorded, there being no time on them either.

**`LoopbackServer.Dispose` was not idempotent.** The second call cancelled an already-disposed `CancellationTokenSource`:

```
Did not expect any exception, but found System.ObjectDisposedException: The CancellationTokenSource has been disposed.
```

— the new `LoopbackServerTests.DisposingTwiceIsNotAnError`, against unfixed code. A suite that hands its server to a `LoopbackPage` and also writes `using var server = …` disposes it twice, so the throw failed whichever test happened to be shaped that way rather than the one that owned the mistake.

## What changed

`PageError` carries two more members:

- `Timestamp` — when the page recorded it, `DateTimeOffset.UtcNow` rather than the engine's configured `TimeProvider`, for the reason `PageRuntime.Now` already gives about its own clock: a host that substituted a clock for its timers did not thereby ask for its diagnostics to be stamped with a time that never happened.
- `DocumentUrl` — the page's URL at that instant, read through the same volatile field `PageNetworkRecorder` reads, so an error and a request name one document. `about:blank` for a page that has loaded nothing, and the *outgoing* document for an error raised while a navigation is still in flight, which is what "the document that was showing" means.

**`PageRecorder.Add(kind, message, source)` is now the only way to make one**, and that is the point of the change rather than a detail of it: twenty-one call sites reported an error through a constructor each of them reached, and a stamp one of them forgets is a stamp that is wrong exactly where a host would rely on it. The rewrite of those call sites is mechanical — `Recorder.Add(new PageError(k, m, s))` → `Recorder.Add(k, m, s)` — and `Page.PumpError` becomes `PumpErrorKind`, since the pump now names the kind rather than building the entry.

`LoopbackServer.Dispose` returns on a second call.

## The tests that pin it

- `PageTests.AnErrorSaysWhenItHappenedAndWhichDocumentItCameFrom` — two documents on the loopback server, one `reportError` each, and each entry naming its own URL and a timestamp inside the window the test brackets, in order.
- `LoopbackServerTests.DisposingTwiceIsNotAnError` — the throw quoted above.

`Jint.Tests.Browser` is green on both frameworks (1202 / 1205 passed), and `Verify/PublicApiTest.verified.txt` carries the two new members.

## What was left out

No `docs/v5-migration.md` row: `Jint.Browser` is new in v5 — it has its own row in §5 — so there is no 4.16 embedder for two added properties to break. The protocol side is untouched: `Runtime.exceptionThrown` and `Log.entryAdded` already carry their own timestamps from the events that raise them, and nothing there reads `Page.Errors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
