### PR TITLE
WebSocket: a relative URL resolves against the API base URL, as the constructor's step 2 says

### DIFF
--- a/Jint.Tests/Runtime/WebApi/WebSocketTests.cs
+++ b/Jint.Tests/Runtime/WebApi/WebSocketTests.cs
@@ -373,6 +373,46 @@ public class WebSocketTests
     }
 
     /// <summary>
+    /// Step 2 parses the URL against the API base URL, which for an embedded engine is
+    /// <c>Options.WebApi.Fetch.BaseUrl</c> — the same setting <c>fetch</c> and <c>new Request()</c> resolve
+    /// against, since it is one browsing position rather than one per interface.
+    /// </summary>
+    /// <remarks>
+    /// https://websockets.spec.whatwg.org/#dom-websocket-websocket step 2, and
+    /// https://url.spec.whatwg.org/#concept-basic-url-parser for what a base does. The scheme mapping of
+    /// steps 4 and 5 runs afterwards, so an <c>https</c> base makes a relative URL a <c>wss</c> socket.
+    /// </remarks>
+    [TestCase("/socket", "wss://example.org/socket")]
+    [TestCase("socket", "wss://example.org/app/socket")]
+    [TestCase("./socket?x=1", "wss://example.org/app/socket?x=1")]
+    [TestCase("//other.example/socket", "wss://other.example/socket")]
+    [TestCase("ws://elsewhere.example/s", "ws://elsewhere.example/s")]
+    public void ResolvesARelativeUrlAgainstTheApiBaseUrl(string input, string expected)
+    {
+        var (engine, sockets) = SocketEngine(fetch => fetch.BaseUrl = new Uri("https://example.org/app/page.html"));
+
+        engine.Execute($"var ws = new WebSocket('{input}');");
+
+        engine.Evaluate("ws.url").AsString().Should().Be(expected);
+        sockets.Last.Url.Should().Be(new Uri(expected));
+    }
+
+    /// <summary>
+    /// With no base URL a relative one still does not parse, which is the <c>SyntaxError</c> step 3 asks for
+    /// and what every engine did before there was a base URL to resolve against.
+    /// </summary>
+    [Test]
+    public void WithNoBaseUrlARelativeUrlIsStillASyntaxError()
+    {
+        var (engine, sockets) = SocketEngine();
+
+        var thrown = Assert.Throws<JavaScriptException>(() => engine.Execute("new WebSocket('/socket');"))!;
+
+        thrown.Error.Get("name").AsString().Should().Be("SyntaxError");
+        sockets.Created.Should().BeEmpty();
+    }
+
+    /// <summary>
     /// Steps 3, 6 and 7: an unparsable URL, a scheme that is not one of the four, and a fragment.
     /// </summary>
     [TestCase("not a url")]

--- a/Jint/Options.WebApi.cs
+++ b/Jint/Options.WebApi.cs
@@ -601,6 +601,9 @@ public sealed partial class Options
         /// <c>new Request("./x")</c> raise a <c>TypeError</c>, which is what an engine with no document has
         /// always done; with one they resolve exactly as https://url.spec.whatwg.org/#concept-basic-url-parser
         /// says, so <c>new URL(relative, base).href</c> is no longer the caller's job.
+        /// <c>XMLHttpRequest.open()</c> and <c>new WebSocket()</c> read it too — it is one browsing position,
+        /// not one per interface — and a <c>WebSocket</c> with no base still raises the <c>SyntaxError</c>
+        /// https://websockets.spec.whatwg.org/#dom-websocket-websocket step 3 asks for.
         /// </para>
         /// <para>
         /// Redirects are unaffected: a <c>Location</c> is resolved against the URL that answered it, which is

--- a/Jint/WebApi/WebSockets/WebSocketConstructor.cs
+++ b/Jint/WebApi/WebSockets/WebSocketConstructor.cs
@@ -60,10 +60,12 @@ internal sealed partial class WebSocketConstructor : Constructor
     /// </summary>
     /// <remarks>
     /// <para>
-    /// <b>There is no base URL.</b> The specification parses <c>url</c> against "the relevant settings
-    /// object's API base URL", which is a document's URL; an embedded engine has no document, so a relative
-    /// URL simply does not parse and is the <c>SyntaxError</c> step 3 asks for. Pass an absolute URL, or
-    /// resolve it yourself with <c>new URL(relative, base).href</c>.
+    /// <b>The base URL is <c>Options.WebApi.Fetch.BaseUrl</c>.</b> The specification parses <c>url</c>
+    /// against "the relevant settings object's API base URL", which is a document's URL, and an embedded
+    /// engine's stand-in for that is the one setting <c>fetch</c> and <c>new Request()</c> already resolve
+    /// against — a browsing position is one position, not one per interface. An engine whose host named none
+    /// has no document at all, and a relative URL then does not parse and is the <c>SyntaxError</c> step 3
+    /// asks for, exactly as before.
     /// </para>
     /// <para>
     /// Steps 4 and 5 — <c>http</c> becomes <c>ws</c> and <c>https</c> becomes <c>wss</c> — are the
@@ -80,8 +82,9 @@ internal sealed partial class WebSocketConstructor : Constructor
 
         var href = UrlValues.ToUsvString(arguments[0]);
 
-        // Steps 2 and 3.
-        var url = UrlParser.Parse(href);
+        // Steps 2 and 3. The base is read off the engine's parsed network context rather than from Options,
+        // so a relative URL costs no re-parse of the base and reaches the same record fetch resolves against.
+        var url = UrlParser.Parse(href, _engine._webApi?.FetchNetwork.BaseUrl);
         if (url is null)
         {
             ThrowSyntaxError($"Failed to construct 'WebSocket': The URL '{href}' is invalid.");

--- a/README.md
+++ b/README.md
@@ -1258,7 +1258,8 @@ var jar = new CookieContainerCookieJar();
 
 var engine = new Engine(options => options.UseFetch(fetch =>
 {
-    fetch.BaseUrl = new Uri("https://example.org/app/page.html");   // resolves fetch('/api') and new Request('x')
+    fetch.BaseUrl = new Uri("https://example.org/app/page.html");   // resolves fetch('/api'), new Request('x'),
+                                                                    // xhr.open() and new WebSocket('/feed')
     fetch.Referrer = new Uri("https://example.org/app/page.html");  // what a Referer header is computed from
     fetch.ReferrerPolicy = ReferrerPolicy.StrictOriginWhenCrossOrigin;
     fetch.Origin = "https://example.org";                           // an Origin header, on POST/PUT/…
@@ -1704,8 +1705,11 @@ died. Every event dispatches from the engine's job queue on the engine's thread,
 and `https` admits `wss` — so a policy written for fetch carries over — and naming `ws` or `wss` outright
 works too, for a host that wants sockets and not fetches. The `UrlFilter` is shown the `ws:` URL the script
 asked for, which fails safe: a filter that tests `uri.Scheme == "https"` refuses every socket rather than
-admitting one it was never shown. There is no per-hop re-check because there are no hops — the WHATWG
-handshake forbids redirects outright. Three settings shift meaning the same way they do for an event stream:
+admitting one it was never shown. `BaseUrl` is what a relative URL in the constructor resolves against, the
+same setting `fetch` and `new Request()` use, and an `https` base makes `new WebSocket('/feed')` a `wss`
+socket; without one a relative URL is the `SyntaxError` the standard's step 3 raises. There is no per-hop
+re-check because there are no hops — the WHATWG handshake forbids redirects outright. Three settings shift
+meaning the same way they do for an event stream:
 
 - **`Timeout` bounds the opening handshake only.** The peer has to answer it; a socket that then idles for an
   hour is a socket doing its job.


### PR DESCRIPTION
Part of #3621 — its item 1.

## What was wrong

[The `WebSocket` constructor's step 2](https://websockets.spec.whatwg.org/#dom-websocket-websocket) parses its URL *against the relevant settings object's API base URL*. Jint parsed it against nothing, and said so in the class remarks — "There is no base URL" — but by then there was one: `Options.WebApi.Fetch.BaseUrl` is what `fetch`, `new Request()` and `XMLHttpRequest.open()` already resolve against. So an engine given a browsing position had it for three interfaces and not for the fourth.

```
Jint.Runtime.JavaScriptException : Failed to construct 'WebSocket': The URL '/socket' is invalid.
Error: SyntaxError: Failed to construct 'WebSocket': The URL '/socket' is invalid.
```

— the new `ResolvesARelativeUrlAgainstTheApiBaseUrl("/socket", …)` on an engine whose `fetch.BaseUrl` is `https://example.org/app/page.html`, against unfixed code.

## What changed

One argument: `UrlParser.Parse(href, _engine._webApi?.FetchNetwork.BaseUrl)`. It reads the base off the engine's own parsed `FetchNetworkContext` rather than out of `Options`, so a relative URL costs no re-parse of the base and reaches the very record `fetch` resolves against.

Steps 4 and 5 still run afterwards, so an `https` base makes `new WebSocket('/feed')` a `wss` socket — which is the whole point of ordering the scheme mapping after the parse.

An engine whose host named no base URL is unchanged: a relative URL still does not parse and is still the `SyntaxError` step 3 asks for.

## The tests that pin it

- `WebSocketTests.ResolvesARelativeUrlAgainstTheApiBaseUrl` — five cases: an absolute path, a relative path, a dot-relative one with a query, a scheme-relative `//other.example`, and an absolute `ws:` URL that a base must not disturb.
- `WebSocketTests.WithNoBaseUrlARelativeUrlIsStillASyntaxError` — the negative, so the old behaviour stays pinned where it is still the behaviour.

`Jint.Tests` (`WebApi|Wpt|MigrationGuideTests|AgentInstructionFileTests|SpecCitationTests`, net10.0) 3549 passed, `Jint.Tests.PublicInterface` (net10.0) 3582 passed, `Jint.Tests.Browser` 1200 / 1203 passed on both frameworks. **No web-platform-tests change in either direction**: no exclusion row was retired and none added — the vendored corpus has no `websockets/` suite (there is no server in the `.any.js` lane that speaks the handshake), which is why the pin is a unit test.

No `docs/v5-migration.md` row: `WebSocket` and `Options.WebApi.Fetch` are both new in v5 — §5's own row — so there is no 4.16 behaviour for this to break.

## What was left out

Nothing of item 1. Items 2 (observing `EventSource` and `WebSocket`) and 3 (the `credentials` WPT handlers) of #3621 are separate pull requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
