### PR TITLE
Temporal: the persian calendar extends into proleptic years on the 33-year cycle, so the ends of Temporal's range land in the right Persian year

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -212,24 +212,21 @@
     "intl402/Temporal/PlainDate/prototype/daysInMonth/basic-islamic-umalqura.js",
     "intl402/Temporal/PlainDate/prototype/daysInYear/basic-islamic-umalqura.js",
     "intl402/Temporal/PlainDate/prototype/inLeapYear/basic-islamic-umalqura.js",
-    "intl402/Temporal/PlainDate/prototype/withCalendar/extreme-dates.js",
+    // Still out, but on a range check rather than a calendar: one of its extremes raises
+    // "Date is outside valid range" from PlainDateTime.from. The persian rows it shares with the
+    // withCalendar files pass (https://github.com/sebastienros/jint/issues/3604).
     "intl402/Temporal/PlainDateTime/from/extreme-dates.js",
     "intl402/Temporal/PlainDateTime/prototype/daysInMonth/basic-islamic-umalqura.js",
     "intl402/Temporal/PlainDateTime/prototype/daysInYear/basic-islamic-umalqura.js",
     "intl402/Temporal/PlainDateTime/prototype/inLeapYear/basic-islamic-umalqura.js",
-    "intl402/Temporal/PlainDateTime/prototype/withCalendar/extreme-dates.js",
     "intl402/Temporal/PlainMonthDay/from/islamic-umalqura-month-codes.js",
     "intl402/Temporal/PlainYearMonth/from/extreme-unsupported-dates.js",
     "intl402/Temporal/PlainYearMonth/prototype/daysInMonth/basic-islamic-umalqura.js",
     "intl402/Temporal/PlainYearMonth/prototype/daysInYear/basic-islamic-umalqura.js",
     "intl402/Temporal/PlainYearMonth/prototype/inLeapYear/basic-islamic-umalqura.js",
-    "intl402/Temporal/ZonedDateTime/from/extreme-dates.js",
     "intl402/Temporal/ZonedDateTime/prototype/daysInMonth/basic-islamic-umalqura.js",
     "intl402/Temporal/ZonedDateTime/prototype/daysInYear/basic-islamic-umalqura.js",
-    "intl402/Temporal/ZonedDateTime/prototype/inLeapYear/basic-islamic-umalqura.js",
-    // Only the persian minimum date still fails here, on eraYear alone: -272443 for the -272442
-    // the file asserts, while its `year` of -272442 is already right.
-    "intl402/Temporal/ZonedDateTime/prototype/withCalendar/extreme-dates.js"
+    "intl402/Temporal/ZonedDateTime/prototype/inLeapYear/basic-islamic-umalqura.js"
 
   ],
   // Timing-sensitive suites: serialise the whole generated test method instead of

--- a/Jint.Tests/Runtime/HebrewMonthSteppingTests.cs
+++ b/Jint.Tests/Runtime/HebrewMonthSteppingTests.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 
 namespace Jint.Tests.Runtime;
 
@@ -25,6 +25,16 @@ namespace Jint.Tests.Runtime;
 /// a regression rather than a matter of taste
 /// (<see href="https://github.com/sebastienros/jint/issues/3520"/>).
 /// </para>
+/// <para>
+/// <b>The four Persian values past ISO 9999 moved once.</b> Not because a step is taken differently — the
+/// two spellings still agree on every one of those cases — but because the reckoning underneath them
+/// became the 33-year cycle rather than the 2820-year one, which is what every other Temporal
+/// implementation answers a proleptic <c>persian</c> date with
+/// (<see href="https://github.com/sebastienros/jint/issues/3604"/>). Those years lie outside
+/// <c>PersianCalendar</c>'s window, so nothing but integer arithmetic on a fixed epoch decides them; where
+/// that window ends, and that it is Jint's to state rather than the runner's, is
+/// <see cref="PersianCalendarBoundaryTests"/>.
+/// </para>
 /// </remarks>
 public class HebrewMonthSteppingTests
 {
@@ -40,7 +50,7 @@ public class HebrewMonthSteppingTests
     [TestCase("hebrew", 100_000, "+010085-03-13")]
     [TestCase("hebrew", 300_000, "+026255-08-10")]
     [TestCase("hebrew", 3_000_000, "+244556-01-22")]
-    [TestCase("persian", 3_000_000, "+251999-10-18")]
+    [TestCase("persian", 3_000_000, "+251999-12-13")]
     public void ABulkMonthAdditionDoesNotWalkYearByYear(string calendar, int months, string expected)
     {
         var engine = new Engine(options => options.LimitStatements(2));
@@ -141,7 +151,7 @@ public class HebrewMonthSteppingTests
     /// the whole span reaches.
     /// </summary>
     [TestCase("hebrew", "+042426-02-07")]
-    [TestCase("persian", "+043666-09-25")]
+    [TestCase("persian", "+043666-10-04")]
     public void AMonthSpanSplitInTwoReachesWhereTheWholeSpanReaches(string calendar, string expected)
     {
         var engine = new Engine();
@@ -195,8 +205,8 @@ public class HebrewMonthSteppingTests
     [TestCase("hebrew", "+100000-01-01", -1, "+099999-12-02")]
     [TestCase("hebrew", "+100000-01-01", 13, "+100001-01-20")]
     [TestCase("persian", "9999-12-31", -1, "9999-12-01")]
-    [TestCase("persian", "9999-12-31", 1, "+010000-01-31")]
-    [TestCase("persian", "9999-12-31", 13, "+010001-01-30")]
+    [TestCase("persian", "9999-12-31", 1, "+010000-02-02")]
+    [TestCase("persian", "9999-12-31", 13, "+010001-02-01")]
     public void AStepAcrossTheEndOfTheTableLandsWhereItAlwaysDid(string calendar, string start, int months, string expected)
     {
         var engine = new Engine();

--- a/Jint.Tests/Runtime/NonIsoCalendarTests.cs
+++ b/Jint.Tests/Runtime/NonIsoCalendarTests.cs
@@ -72,4 +72,56 @@ public class NonIsoCalendarTests
         combinations.Should().Be(Calendars.Length * Years.Length * MonthCodes.Length * 15 * Days.Length);
         failures.ToString().Should().BeEmpty();
     }
+
+    /// <summary>
+    /// The Persian calendar at both ends of Temporal's own range, where the arithmetic rule is the only
+    /// thing that can answer: <c>PersianCalendar</c>'s table stops at ISO 622-03-22 and 9999-12-31, and
+    /// these two dates are a quarter of a million years outside it in either direction.
+    /// </summary>
+    /// <remarks>
+    /// The expected values are test262's own — the three
+    /// <c>intl402/Temporal/*/prototype/withCalendar/extreme-dates.js</c> files assert exactly these, and
+    /// <c>ZonedDateTime/from/extreme-dates.js</c> asserts the way back — which is to say they are ICU's
+    /// 33-year cycle. The 2820-year cycle Jint used to extend the calendar with put both ends about two
+    /// months out, and therefore in the wrong Persian year
+    /// (<see href="https://github.com/sebastienros/jint/issues/3604"/>). <c>eraYear</c> is the same number
+    /// as <c>year</c> because <c>ap</c> is the calendar's only era, which is why the off-by-one was first
+    /// read as an era defect.
+    /// </remarks>
+    [TestCase("-271821-04-20", -272442, 1, "M01", 10)]
+    [TestCase("+275760-09-13", 275139, 7, "M07", 12)]
+    public void ThePersianCalendarPlacesTheEndsOfTemporalsRangeWhereTheStandardLibrariesDo(
+        string iso, int year, int month, string monthCode, int day)
+    {
+        var engine = new Engine();
+        var date = $"Temporal.PlainDate.from('{iso}').withCalendar('persian')";
+
+        engine.Evaluate($"{date}.year").AsNumber().Should().Be(year);
+        engine.Evaluate($"{date}.month").AsNumber().Should().Be(month);
+        engine.Evaluate($"{date}.monthCode").AsString().Should().Be(monthCode);
+        engine.Evaluate($"{date}.day").AsNumber().Should().Be(day);
+        engine.Evaluate($"{date}.era").AsString().Should().Be("ap");
+        engine.Evaluate($"{date}.eraYear").AsNumber().Should().Be(year);
+
+        // And the way back, which is what ZonedDateTime/from/extreme-dates.js failed on: the fields are
+        // an answer only if they name the day they came from.
+        engine.Evaluate($"Temporal.PlainDate.from({{ calendar: 'persian', year: {year}, month: {month}, day: {day} }}).toString()")
+            .AsString().Should().Be($"{iso}[u-ca=persian]");
+    }
+
+    /// <summary>
+    /// The years <c>PersianCalendar</c> does cover are still its own to place, which the arithmetic rule
+    /// never reaches: Nowruz 1403 fell on ISO 2024-03-20, and the revolution of 22 Bahman 1357 on
+    /// 1979-02-11.
+    /// </summary>
+    [TestCase("2024-03-20", 1403, 1, 1)]
+    [TestCase("1979-02-11", 1357, 11, 22)]
+    public void ThePersianCalendarStillPlacesTheYearsItsTableCovers(string iso, int year, int month, int day)
+    {
+        var engine = new Engine();
+        var date = $"Temporal.PlainDate.from('{iso}').withCalendar('persian')";
+
+        engine.Evaluate($"[{date}.year, {date}.month, {date}.day].join('-')")
+            .AsString().Should().Be($"{year}-{month}-{day}");
+    }
 }

--- a/Jint.Tests/Runtime/PersianCalendarBoundaryTests.cs
+++ b/Jint.Tests/Runtime/PersianCalendarBoundaryTests.cs
@@ -1,0 +1,386 @@
+#nullable enable
+
+using System.Globalization;
+using System.Text;
+using Jint.Native.Temporal;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Where the <c>persian</c> calendar stops delegating to <see cref="PersianCalendar"/> and starts
+/// reckoning on the 33-year cycle, and that each side of that seam is answered by one rule alone.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The seam used to be wherever the runner's own calendar data put it — <c>MinSupportedDateTime</c>,
+/// <c>MaxSupportedDateTime</c>, and the refusal <c>ToDateTime</c> raises outside them — so "outside the
+/// table" was a different set of dates on a runtime whose data differed, and every proleptic answer moved
+/// with it. It is now an ISO window Jint states for itself, 622-03-22 through 9999-12-31
+/// (<see href="https://github.com/sebastienros/jint/issues/3604"/>).
+/// </para>
+/// <para>
+/// So there are two kinds of assertion here, and neither is a date written down because a run once
+/// produced it. <see cref="ThePlatformsPersianTableCoversExactlyTheWindowJintStates"/> asserts the
+/// constants against the platform, so a runtime that ever moves its window fails there, naming the
+/// reason, rather than moving a date a quarter of a million years away on one CI leg. Everything else
+/// asserts Jint against the 33-year cycle, which this file writes out for itself — a test that asked the
+/// engine what the engine's arithmetic ought to be would say nothing — and that cycle is integer
+/// arithmetic on a fixed epoch, so its answers are the same on every runner by construction.
+/// </para>
+/// <para>
+/// Both rules are needed, which is why the delegation is still there. Over the 9,377 whole years the two
+/// share they disagree about 4,144 year-starts, and about which Persian month 1,514,413 of the window's
+/// 3,425,164 days fall in: the table derives a year from the true vernal equinox at Tehran and is what
+/// makes a date anybody keeps right, while the cycle is what every other Temporal implementation answers
+/// a proleptic date with.
+/// </para>
+/// </remarks>
+public class PersianCalendarBoundaryTests
+{
+    // The window Jint states, restated here so that moving it has to be a decision taken twice.
+    private static readonly DateTime FirstIsoDay = new(622, 3, 22);
+    private static readonly DateTime LastIsoDay = new(9999, 12, 31);
+    private const int LastTableYear = 9378;
+    private const int LastTableMonth = 10;
+    private const int LastTableDay = 13;
+
+    // The 33-year cycle, written out rather than reached for. The epoch is the Julian Day Number of ISO
+    // 622-03-21, which is where the cycle starts Persian year 1 — a day before the table does.
+    private const long PersianEpochJdn = 1948320L;
+    private const long JdnOfEpochDay = 2440588L; // ISO 1970-01-01, the day count Temporal reckons in
+
+    private static long FloorDiv(long a, long b)
+    {
+        var q = a / b;
+        if ((a ^ b) < 0L && q * b != a)
+        {
+            q--;
+        }
+
+        return q;
+    }
+
+    private static long FloorMod(long a, long b)
+    {
+        var r = a % b;
+        if (r != 0L && (r ^ b) < 0L)
+        {
+            r += b;
+        }
+
+        return r;
+    }
+
+    private static bool CycleIsLeapYear(long year) => FloorMod(25L * year + 11L, 33L) < 8L;
+
+    private static long CycleYearStartJdn(long year)
+        => PersianEpochJdn + 365L * (year - 1L) + FloorDiv(8L * year + 21L, 33L);
+
+    private static int CycleDaysInMonth(long year, int month)
+    {
+        if (month <= 6)
+        {
+            return 31;
+        }
+
+        if (month <= 11)
+        {
+            return 30;
+        }
+
+        return CycleIsLeapYear(year) ? 30 : 29;
+    }
+
+    /// <summary>The Persian date the cycle puts on a Julian Day Number.</summary>
+    private static (long Year, int Month, int Day) CyclePlace(long jdn)
+    {
+        var year = FloorDiv(jdn - PersianEpochJdn, 365L) + 1L;
+        while (CycleYearStartJdn(year + 1L) <= jdn)
+        {
+            year++;
+        }
+
+        while (CycleYearStartJdn(year) > jdn)
+        {
+            year--;
+        }
+
+        var dayOfYear = jdn - CycleYearStartJdn(year) + 1L;
+
+        if (dayOfYear <= 186L)
+        {
+            var early = (int) ((dayOfYear - 1L) / 31L) + 1;
+            return (year, early, (int) (dayOfYear - (early - 1) * 31L));
+        }
+
+        var remaining = dayOfYear - 186L;
+        var late = (int) ((remaining - 1L) / 30L) + 7;
+        return (year, late, (int) (remaining - (late - 7) * 30L));
+    }
+
+    private static long JdnOfIsoDay(DateTime day)
+        => TemporalHelpers.IsoDateToDays(day.Year, day.Month, day.Day) + JdnOfEpochDay;
+
+    private static (long Year, int Month, int Day) PlacedByJint(long jdn)
+    {
+        var iso = TemporalHelpers.DaysToIsoDate(jdn - JdnOfEpochDay);
+        var placed = NonIsoCalendars.IsoToCalendarDate("persian", in iso);
+        return (placed.Year, placed.Month, placed.Day);
+    }
+
+    /// <summary>
+    /// The platform's table still covers exactly the window Jint says it does, in ISO days and in Persian
+    /// fields both. This is the one assertion here that can fail for a reason which is not Jint's, and it
+    /// exists so that reason gets named: every proleptic Persian date in the engine is decided by these
+    /// numbers agreeing with the runtime underneath.
+    /// </summary>
+    [Test]
+    public void ThePlatformsPersianTableCoversExactlyTheWindowJintStates()
+    {
+        var cal = new PersianCalendar();
+
+        cal.MinSupportedDateTime.Date.Should().Be(FirstIsoDay);
+        cal.MaxSupportedDateTime.Date.Should().Be(LastIsoDay);
+
+        cal.GetYear(FirstIsoDay).Should().Be(1);
+        cal.GetMonth(FirstIsoDay).Should().Be(1);
+        cal.GetDayOfMonth(FirstIsoDay).Should().Be(1);
+
+        cal.GetYear(LastIsoDay).Should().Be(LastTableYear);
+        cal.GetMonth(LastIsoDay).Should().Be(LastTableMonth);
+        cal.GetDayOfMonth(LastIsoDay).Should().Be(LastTableDay);
+
+        cal.ToDateTime(1, 1, 1, 0, 0, 0, 0).Should().Be(FirstIsoDay);
+        cal.ToDateTime(LastTableYear, LastTableMonth, LastTableDay, 0, 0, 0, 0).Should().Be(LastIsoDay);
+
+        // And nothing past either end, which is the question PersianTableHolds now answers by comparison
+        // rather than by catching this.
+        Action pastTheLastDay = () => cal.ToDateTime(LastTableYear, LastTableMonth, LastTableDay + 1, 0, 0, 0, 0);
+        Action pastTheLastMonth = () => cal.ToDateTime(LastTableYear, LastTableMonth + 1, 1, 0, 0, 0, 0);
+        Action pastTheLastYear = () => cal.ToDateTime(LastTableYear + 1, 1, 1, 0, 0, 0, 0);
+        Action beforeTheFirstYear = () => cal.ToDateTime(0, 12, 29, 0, 0, 0, 0);
+
+        pastTheLastDay.Should().Throw<ArgumentOutOfRangeException>();
+        pastTheLastMonth.Should().Throw<ArgumentOutOfRangeException>();
+        pastTheLastYear.Should().Throw<ArgumentOutOfRangeException>();
+        beforeTheFirstYear.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    /// <summary>
+    /// The year the window stops inside is still reported whole. <c>DateTime</c> ends part-way through
+    /// Persian 9378, so the table answers for that year with ten months, 289 days and a tenth month
+    /// thirteen days long; its lengths come from the reckoning instead, while the day the table placed
+    /// keeps its place (<see href="https://github.com/sebastienros/jint/issues/3523"/>).
+    /// </summary>
+    [Test]
+    public void TheYearTheWindowStopsInsideIsStillAWholeYear()
+    {
+        var lastDay = new IsoDate(LastIsoDay.Year, LastIsoDay.Month, LastIsoDay.Day);
+        var placed = NonIsoCalendars.IsoToCalendarDate("persian", in lastDay);
+
+        placed.Year.Should().Be(LastTableYear);
+        placed.Month.Should().Be(LastTableMonth);
+        placed.Day.Should().Be(LastTableDay);
+
+        placed.MonthsInYear.Should().Be(12);
+        placed.DaysInMonth.Should().Be(CycleDaysInMonth(LastTableYear, LastTableMonth));
+        placed.DaysInYear.Should().Be(CycleIsLeapYear(LastTableYear) ? 366 : 365);
+        placed.InLeapYear.Should().Be(CycleIsLeapYear(LastTableYear));
+    }
+
+    /// <summary>
+    /// Every day for four hundred either side of each edge of the window: inside it the answer is the
+    /// table's, outside it the cycle's, and the change happens on the day the constants name and on no
+    /// other. The sweep is dense rather than sampled because the seam is one day wide.
+    /// </summary>
+    [Test]
+    public void TheHandOffHappensOnTheDayTheWindowNamesAndOnNoOther()
+    {
+        var cal = new PersianCalendar();
+        var firstJdn = JdnOfIsoDay(FirstIsoDay);
+        var lastJdn = JdnOfIsoDay(LastIsoDay);
+
+        var failures = new StringBuilder();
+        var days = 0;
+
+        foreach (var edge in new[] { firstJdn, lastJdn })
+        {
+            for (var jdn = edge - 400L; jdn <= edge + 400L; jdn++)
+            {
+                days++;
+                var iso = TemporalHelpers.DaysToIsoDate(jdn - JdnOfEpochDay);
+
+                (long Year, int Month, int Day) expected;
+                string by;
+
+                if (jdn >= firstJdn && jdn <= lastJdn)
+                {
+                    var dt = new DateTime(iso.Year, iso.Month, iso.Day);
+                    expected = (cal.GetYear(dt), cal.GetMonth(dt), cal.GetDayOfMonth(dt));
+                    by = "the table";
+                }
+                else
+                {
+                    expected = CyclePlace(jdn);
+                    by = "the cycle";
+                }
+
+                var actual = PlacedByJint(jdn);
+                if (actual != expected)
+                {
+                    failures.AppendLine(
+                        $"ISO {iso.Year:D4}-{iso.Month:D2}-{iso.Day:D2}: {actual.Year}-{actual.Month}-{actual.Day}, "
+                        + $"but {by} says {expected.Year}-{expected.Month}-{expected.Day}");
+                }
+            }
+        }
+
+        days.Should().Be(2 * 801);
+        failures.ToString().Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// The seam is a seam: the two rules answer differently on the very day the window ends, so the sweep
+    /// above is asserting a choice rather than a coincidence.
+    /// </summary>
+    /// <remarks>
+    /// At the bottom the cycle begins Persian year 1 a day before the table does, so ISO 622-03-21 and
+    /// 622-03-22 both read as 1-01-01. At the top the table is thirteen days into Persian 9378's tenth
+    /// month where the cycle is ten, so the answer steps two days backwards at ISO 10000-01-01. Each is
+    /// one day of the year the two rules change over in, and neither is reachable from a date anything
+    /// keeps.
+    /// </remarks>
+    [Test]
+    public void TheTwoRulesDisagreeAtBothEdgesOfTheWindow()
+    {
+        var firstJdn = JdnOfIsoDay(FirstIsoDay);
+        var lastJdn = JdnOfIsoDay(LastIsoDay);
+
+        CyclePlace(firstJdn).Should().NotBe(PlacedByJint(firstJdn));
+        CyclePlace(lastJdn).Should().NotBe(PlacedByJint(lastJdn));
+
+        PlacedByJint(firstJdn - 1L).Should().Be((1L, 1, 1));
+        PlacedByJint(firstJdn).Should().Be((1L, 1, 1));
+        PlacedByJint(lastJdn).Should().Be((9378L, 10, 13));
+        PlacedByJint(lastJdn + 1L).Should().Be((9378L, 10, 11));
+    }
+
+    /// <summary>
+    /// A proleptic Persian year is as long as the cycle's leap rule says it is, and the next one starts
+    /// exactly that many days later — which is the whole of what a calendar past the end of its table is.
+    /// </summary>
+    /// <remarks>
+    /// Read through the engine in both directions, so the year-start formula, the leap predicate and the
+    /// month lengths have to agree with each other as well as with the cycle. Nothing here touches the
+    /// platform: every year sampled lies outside the window.
+    /// </remarks>
+    [TestCase(-272442, 200)]
+    [TestCase(-100000, 100)]
+    [TestCase(-200, 190)]
+    [TestCase(9379, 400)]
+    [TestCase(43666, 100)]
+    [TestCase(275000, 100)]
+    public void AProlepticYearIsAsLongAsTheCyclesLeapRuleSaysAndTheNextStartsThere(int firstYear, int years)
+    {
+        var failures = new StringBuilder();
+
+        for (var year = firstYear; year < firstYear + years; year++)
+        {
+            var start = NonIsoCalendars.CalendarDateToIso("persian", year, "M01", 1, 1, "reject");
+            var next = NonIsoCalendars.CalendarDateToIso("persian", year + 1, "M01", 1, 1, "reject");
+
+            if (start is null || next is null)
+            {
+                failures.AppendLine($"{year}: the calendar declined to place its own first day");
+                continue;
+            }
+
+            var startIso = start.Value;
+            var startDay = TemporalHelpers.IsoDateToDays(startIso.Year, startIso.Month, startIso.Day);
+            var nextDay = TemporalHelpers.IsoDateToDays(next.Value.Year, next.Value.Month, next.Value.Day);
+            var expectedLength = CycleIsLeapYear(year) ? 366 : 365;
+
+            var offBy = startDay + JdnOfEpochDay - CycleYearStartJdn(year);
+            if (offBy != 0L)
+            {
+                failures.AppendLine(
+                    $"{year}-01-01 is ISO {startIso.Year:D4}-{startIso.Month:D2}-{startIso.Day:D2}, "
+                    + $"{offBy} days off the cycle's");
+            }
+
+            if (nextDay - startDay != expectedLength)
+            {
+                failures.AppendLine($"{year} is {nextDay - startDay} days long, not {expectedLength}");
+            }
+
+            var placed = NonIsoCalendars.IsoToCalendarDate("persian", in startIso);
+            if (placed.Year != year || placed.Month != 1 || placed.Day != 1)
+            {
+                failures.AppendLine($"{year}-01-01 read back as {placed.Year}-{placed.Month}-{placed.Day}");
+            }
+
+            if (placed.DaysInYear != expectedLength || placed.InLeapYear != CycleIsLeapYear(year))
+            {
+                failures.AppendLine(
+                    $"{year} reports {placed.DaysInYear} days and inLeapYear={placed.InLeapYear}, "
+                    + $"not {expectedLength} and {CycleIsLeapYear(year)}");
+            }
+        }
+
+        failures.ToString().Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Every day of every month of a proleptic year, placed and read back: six months of 31 days, five of
+    /// 30, and a twelfth of 30 or 29 as the leap rule says, laid end to end with no day left over.
+    /// </summary>
+    [TestCase(-272442)]
+    [TestCase(9379)]
+    [TestCase(9380)]
+    [TestCase(43666)]
+    [TestCase(275139)]
+    public void EveryMonthOfAProlepticYearIsWhereTheCyclePutsIt(int year)
+    {
+        var failures = new StringBuilder();
+        var jdn = CycleYearStartJdn(year);
+
+        for (var month = 1; month <= 12; month++)
+        {
+            var length = CycleDaysInMonth(year, month);
+
+            for (var day = 1; day <= length; day++, jdn++)
+            {
+                var iso = NonIsoCalendars.CalendarDateToIso("persian", year, $"M{month:D2}", month, day, "reject");
+                if (iso is null)
+                {
+                    failures.AppendLine($"{year}-{month:D2}-{day:D2} was declined");
+                    continue;
+                }
+
+                var isoDate = iso.Value;
+                var placedJdn = TemporalHelpers.IsoDateToDays(isoDate.Year, isoDate.Month, isoDate.Day) + JdnOfEpochDay;
+                if (placedJdn != jdn)
+                {
+                    failures.AppendLine($"{year}-{month:D2}-{day:D2} is {placedJdn - jdn} days off the cycle's day");
+                }
+
+                var placed = NonIsoCalendars.IsoToCalendarDate("persian", in isoDate);
+                if (placed.Year != year || placed.Month != month || placed.Day != day || placed.DaysInMonth != length)
+                {
+                    failures.AppendLine(
+                        $"{year}-{month:D2}-{day:D2} read back as {placed.Year}-{placed.Month}-{placed.Day} "
+                        + $"in a month of {placed.DaysInMonth} days, not {length}");
+                }
+            }
+
+            var pastTheMonth = NonIsoCalendars.CalendarDateToIso("persian", year, $"M{month:D2}", month, length + 1, "reject");
+            if (pastTheMonth is not null)
+            {
+                failures.AppendLine($"{year}-{month:D2} accepted a day {length + 1}");
+            }
+        }
+
+        (jdn - CycleYearStartJdn(year)).Should().Be(CycleIsLeapYear(year) ? 366 : 365);
+        failures.ToString().Should().BeEmpty();
+    }
+}

--- a/Jint/Native/Temporal/NonIsoCalendars.cs
+++ b/Jint/Native/Temporal/NonIsoCalendars.cs
@@ -2452,27 +2452,83 @@ internal static class NonIsoCalendars
 
     #region Persian Calendar
 
-    // The Persian (Solar Hijri) arithmetic calendar on its 33-year cycle, which is the rule the
-    // platform's `persian` calendar is: ICU's own PersianCalendar places a year's first day
-    // 365 × (year − 1) + floor((8 × year + 21) / 33) days after the epoch and calls a year a leap year
-    // when floorMod(25 × year + 11, 33) < 8, so eight years in every thirty-three are 366 days long and
-    // the mean year is 365 + 8/33 = 365.2424 days.
+    // The Persian (Solar Hijri) arithmetic calendar on its 33-year cycle, which is the rule ICU's own
+    // PersianCalendar is and therefore the one every other Temporal implementation answers a proleptic
+    // `persian` date with: a year's first day is 365 × (year − 1) + floor((8 × year + 21) / 33) days after
+    // the epoch, and a year is a leap year when floorMod(25 × year + 11, 33) < 8, so eight years in every
+    // thirty-three are 366 days long and the mean year is 365 + 8/33 = 365.2424 days. *Which* arithmetic
+    // rule this is was what https://github.com/sebastienros/jint/issues/3604 was about: the 2820-year
+    // cycle it used to be (Reingold–Dershowitz / Birashk) drifts from ICU's by two months over Temporal's
+    // own range, so both ends of that range came back in the wrong Persian year.
     //
-    // Used as a proleptic fallback for the years PersianCalendar cannot answer for — it spans
-    // ISO 622-03-22 to 9999-12-31, which is Persian 1 to 9378, and derives those astronomically (the
-    // true vernal equinox at Tehran) rather than arithmetically. Far outside that range only an
-    // arithmetic rule can answer at all: no ephemeris covers a quarter of a million years. *Which*
-    // arithmetic rule is what https://github.com/sebastienros/jint/issues/3604 was about — the
-    // 2820-year cycle this used to carry (Reingold–Dershowitz / Birashk) drifts from ICU's by two
-    // months over Temporal's own range, so its extremes came back in the wrong Persian year.
+    // It answers outside the window below, and only outside it. Inside, PersianCalendar places the date,
+    // because inside it that calendar is not arithmetic at all — it derives a year from the true vernal
+    // equinox at Tehran — and the two answers really are different. Over the 9,377 whole years they share,
+    // 4,144 year-starts differ, by −1 to +3 days, and 1,514,413 of the window's 3,425,164 days fall in a
+    // different Persian month; the disagreement is 19 years per thousand around the present, none of them
+    // between 1300 and 1500 AP, and grows past 4,000 AP as the mean year drifts from the equinox. So the
+    // delegation earns its keep at both ends: the table is what makes a date anybody keeps right, and the
+    // cycle is what makes a proleptic one agree with the rest of the world. Far outside the window only an
+    // arithmetic rule can answer at all — no ephemeris covers a quarter of a million years.
+    //
+    // *Where the hand-off happens is stated here rather than asked of the platform.* It used to be
+    // PersianCalendar's own MinSupportedDateTime, MaxSupportedDateTime and the ArgumentOutOfRangeException
+    // ToDateTime raises outside them, which is to say it was whatever calendar data the runner shipped: a
+    // runtime that moved its window by a day would have moved every proleptic answer with it, and the only
+    // symptom would have been a date a quarter of a million years away landing somewhere else on one CI
+    // leg. The window is the same on net472 and on .NET 10 today, and PersianCalendarBoundaryTests is what
+    // says so on every runner — it asserts these constants against the platform, so a platform that ever
+    // disagrees fails there, naming the reason, rather than silently moving the proleptic years.
     //
     // Two rules meeting leaves the junctions imperfect, as they already were: at the top the answer
     // steps two days backwards at ISO 10000-01-01, because the table stops part-way through Persian
     // 9378 (https://github.com/sebastienros/jint/issues/3523), and at the bottom ISO 622-03-21 and
-    // 622-03-22 both read as Persian 1-01-01, because ICU begins Persian year 1 a day before the
+    // 622-03-22 both read as Persian 1-01-01, because the cycle begins Persian year 1 a day before the
     // table does. Each is one day of the year the two rules change over in, and neither is reachable
     // from a date anything actually keeps.
     private const long PersianEpochJdn = 1948320L;
+
+    /// <summary>
+    /// The ISO window <see cref="PersianCal"/> places a date in — 622-03-22 to 9999-12-31 inclusive — as
+    /// the pair of Julian Day Numbers the placement is decided by. Everything outside it is the 33-year
+    /// cycle's.
+    /// </summary>
+    private static readonly long PersianTableFirstJdn = IsoToJulianDay(622, 3, 22);
+
+    /// <inheritdoc cref="PersianTableFirstJdn"/>
+    private static readonly long PersianTableLastJdn = IsoToJulianDay(9999, 12, 31);
+
+    /// <summary>
+    /// The same window read in Persian fields, which is the direction <see cref="PersianDateToIso"/> asks
+    /// it in: 1-01-01 through 9378-10-13. The last year is a part of one — DateTime's end falls inside
+    /// Persian 9378 — so the top edge needs the month and the day as well as the year.
+    /// </summary>
+    private const int PersianTableLastYear = 9378;
+
+    /// <inheritdoc cref="PersianTableLastYear"/>
+    private const int PersianTableLastMonth = 10;
+
+    /// <inheritdoc cref="PersianTableLastYear"/>
+    private const int PersianTableLastDay = 13;
+
+    /// <summary>
+    /// Whether <see cref="PersianCal"/>'s window holds these Persian fields, which is the question the
+    /// <c>try</c> around <c>ToDateTime</c> used to ask by catching the refusal.
+    /// </summary>
+    private static bool PersianTableHolds(int year, int month, int day)
+    {
+        if (year < 1 || year > PersianTableLastYear)
+        {
+            return false;
+        }
+
+        if (year < PersianTableLastYear)
+        {
+            return true;
+        }
+
+        return month < PersianTableLastMonth || (month == PersianTableLastMonth && day <= PersianTableLastDay);
+    }
 
     private static bool IsPersianLeapYearAlgorithmic(int year)
         => FloorMod(25L * year + 11L, 33L) < 8L;
@@ -2495,10 +2551,8 @@ internal static class NonIsoCalendars
         return IsPersianLeapYearAlgorithmic(year) ? 30 : 29;
     }
 
-    private static CalendarDate PersianAlgorithmicFromIso(in IsoDate isoDate)
+    private static CalendarDate PersianAlgorithmicFromIso(long jdn)
     {
-        long jdn = IsoToJulianDay(isoDate.Year, isoDate.Month, isoDate.Day);
-
         // Estimate Persian year then walk to exact.
         long days = jdn - PersianEpochJdn;
         int yearEst = (int) (days / 365L) + 1;
@@ -2539,19 +2593,16 @@ internal static class NonIsoCalendars
 
     private static CalendarDate PersianToCalendarDate(in IsoDate isoDate)
     {
+        var jdn = IsoToJulianDay(isoDate.Year, isoDate.Month, isoDate.Day);
+
+        if (jdn < PersianTableFirstJdn || jdn > PersianTableLastJdn)
+        {
+            return PersianAlgorithmicFromIso(jdn);
+        }
+
+        // Inside the window the ISO year is 622 to 9999, which is DateTime's own range.
         var cal = PersianCal;
-
-        if (isoDate.Year < 1 || isoDate.Year > 9999)
-        {
-            return PersianAlgorithmicFromIso(in isoDate);
-        }
-
         var dt = new DateTime(isoDate.Year, isoDate.Month, isoDate.Day);
-
-        if (dt < cal.MinSupportedDateTime || dt > cal.MaxSupportedDateTime)
-        {
-            return PersianAlgorithmicFromIso(in isoDate);
-        }
 
         var year = cal.GetYear(dt);
         var ordinalMonth = cal.GetMonth(dt);
@@ -2620,8 +2671,8 @@ internal static class NonIsoCalendars
 
         // Constrain day. The algorithmic computation answers for every year past the last whole one the
         // table holds, which includes the partial year at the end of it: there the table's month lengths
-        // are DateTime's end rather than the calendar's. The placement below still tries the table
-        // first, so a day it can still put somewhere keeps the table's answer.
+        // are DateTime's end rather than the calendar's. The placement below still asks the window first,
+        // so a day it still holds keeps the table's answer.
         var maxDay = SupportsYear(cal, year) && TryGetDaysInMonth(cal, year, ordinalMonth, out var tableDay)
             ? tableDay
             : PersianAlgorithmicDaysInMonth(year, ordinalMonth);
@@ -2635,16 +2686,13 @@ internal static class NonIsoCalendars
             return null;
         }
 
-        try
+        if (!PersianTableHolds(year, ordinalMonth, day))
         {
-            var dt = cal.ToDateTime(year, ordinalMonth, day, 0, 0, 0, 0);
-            return new IsoDate(dt.Year, dt.Month, dt.Day);
-        }
-        catch
-        {
-            // Year is outside .NET PersianCalendar range — use algorithmic conversion.
             return PersianAlgorithmicToIso(year, ordinalMonth, day);
         }
+
+        var dt = cal.ToDateTime(year, ordinalMonth, day, 0, 0, 0, 0);
+        return new IsoDate(dt.Year, dt.Month, dt.Day);
     }
 
     #endregion

--- a/Jint/Native/Temporal/NonIsoCalendars.cs
+++ b/Jint/Native/Temporal/NonIsoCalendars.cs
@@ -2452,28 +2452,33 @@ internal static class NonIsoCalendars
 
     #region Persian Calendar
 
-    // Persian arithmetic calendar (2820-year cycle, Reingold–Dershowitz / Birashk).
-    // Used as a proleptic fallback for years outside the .NET PersianCalendar range
-    // (which only supports years 1–9999, ≈ ISO 622–10620). The 2820-year cycle has
-    // 683 leap years; year 1 starts at JDN 1948321 = ISO 622-03-22 (proleptic Gregorian).
-    private const long PersianEpochJdn = 1948321L;
+    // The Persian (Solar Hijri) arithmetic calendar on its 33-year cycle, which is the rule the
+    // platform's `persian` calendar is: ICU's own PersianCalendar places a year's first day
+    // 365 × (year − 1) + floor((8 × year + 21) / 33) days after the epoch and calls a year a leap year
+    // when floorMod(25 × year + 11, 33) < 8, so eight years in every thirty-three are 366 days long and
+    // the mean year is 365 + 8/33 = 365.2424 days.
+    //
+    // Used as a proleptic fallback for the years PersianCalendar cannot answer for — it spans
+    // ISO 622-03-22 to 9999-12-31, which is Persian 1 to 9378, and derives those astronomically (the
+    // true vernal equinox at Tehran) rather than arithmetically. Far outside that range only an
+    // arithmetic rule can answer at all: no ephemeris covers a quarter of a million years. *Which*
+    // arithmetic rule is what https://github.com/sebastienros/jint/issues/3604 was about — the
+    // 2820-year cycle this used to carry (Reingold–Dershowitz / Birashk) drifts from ICU's by two
+    // months over Temporal's own range, so its extremes came back in the wrong Persian year.
+    //
+    // Two rules meeting leaves the junctions imperfect, as they already were: at the top the answer
+    // steps two days backwards at ISO 10000-01-01, because the table stops part-way through Persian
+    // 9378 (https://github.com/sebastienros/jint/issues/3523), and at the bottom ISO 622-03-21 and
+    // 622-03-22 both read as Persian 1-01-01, because ICU begins Persian year 1 a day before the
+    // table does. Each is one day of the year the two rules change over in, and neither is reachable
+    // from a date anything actually keeps.
+    private const long PersianEpochJdn = 1948320L;
 
     private static bool IsPersianLeapYearAlgorithmic(int year)
-    {
-        long yp = (long) year - 474L;
-        long mod = ((yp % 2820L) + 2820L) % 2820L;
-        long yc = mod + 474L;
-        return ((yc + 38L) * 682L) % 2816L < 682L;
-    }
+        => FloorMod(25L * year + 11L, 33L) < 8L;
 
     private static long PersianYearStartJdn(int year)
-    {
-        long yp = (long) year - 474L;
-        long mod = ((yp % 2820L) + 2820L) % 2820L;
-        long cycle = (yp - mod) / 2820L;
-        long yc = mod + 474L;
-        return PersianEpochJdn + cycle * 1029983L + 365L * (yc - 1L) + (yc * 682L - 110L) / 2816L;
-    }
+        => PersianEpochJdn + 365L * ((long) year - 1L) + FloorDiv(8L * year + 21L, 33L);
 
     /// <summary>
     /// Days in a Persian month, computed algorithmically for the years PersianCalendar cannot answer for.


### PR DESCRIPTION
Fixes #3604

## What was wrong — and it is not the era

`System.Globalization.PersianCalendar` spans ISO 622-03-22 to 9999-12-31 (Persian 1 to 9378) and derives those years astronomically. Everything outside them is answered by an arithmetic rule, because no ephemeris covers a quarter of a million years — and the rule Jint carried was the **2820-year cycle** (Reingold–Dershowitz / Birashk), which is not the one the platform's `persian` calendar is. ICU's `PersianCalendar` uses the **33-year cycle**: a year's first day is `365 × (year − 1) + floor((8 × year + 21) / 33)` days after the epoch, and a year is a leap year when `floorMod(25 × year + 11, 33) < 8`.

Over Temporal's own range the two drift about two months apart, so both ends came back in the wrong Persian year:

| ISO | Jint, before | test262 / ICU |
| --- | --- | --- |
| `-271821-04-20` | `-272443-M11-08` | `-272442-M01-10` |
| `+275760-09-13` | `275139-M09-14` | `275139-M07-12` |

**The issue's reading of the symptom was wrong, and worth recording.** It reported that only `eraYear` failed and that `year` already passed. `TemporalHelpers.assertPlainDateTime` asserts `era`, then `eraYear`, then `year` — so the run stopped at `eraYear` and never reached `year`. `persian` has a single era, `ap`, so `eraYear` **is** `year` (`NonIsoCalendars.CalendarEraYear`), and both were off by the same one. The era arithmetic was never involved.

Against unfixed code, all six cases of the three files fail identically on `eraYear`, expecting `-272442` and getting `-272443`; the fourth file, which asserts the way back, fails by 61 days.

## What changed since this was parked

The parked draft failed four `Jint.Tests` cases on every CI leg — `linux`, `linux - ARM`, `macos` and `windows` alike, with byte-identical actual values — while the local run passed. The comment on the draft read that as the platform's calendar data differing per runner. It is not: the four are `HebrewMonthSteppingTests` cases whose expected persian values were recorded under the 2820-year cycle and lie outside `PersianCalendar`'s window, so changing the rule legitimately moved them. The local run passed because the filter that was run (`~Temporal|~Intl|~Calendar|…`) does not match `HebrewMonthSteppingTests`. Five platforms agreeing to the day is what says so.

The remedy asked for stands anyway, and is the substance of the second commit: **the hand-off is now Jint's to place rather than the platform's.**

- `PersianToCalendarDate` compared against `PersianCalendar.MinSupportedDateTime` / `MaxSupportedDateTime`, and `PersianDateToIso` asked the same question by catching the `ArgumentOutOfRangeException` `ToDateTime` raises outside them. So "outside the table" was whatever calendar data the runner shipped, and a runtime that moved its window by a day would have moved every proleptic answer with it — with the only symptom a date a quarter of a million years away landing somewhere else on one leg.
- It is now an ISO window this repository states: **622-03-22 through 9999-12-31**, which is Persian 1-01-01 through 9378-10-13, held as `PersianTableFirstJdn` / `PersianTableLastJdn` and, for the direction that asks in Persian fields, `PersianTableHolds`. The `try`/`catch` goes with it.
- The four persian expectations past ISO 9999 in `HebrewMonthSteppingTests` move with the reckoning underneath them. A step is still taken the same way and the two spellings of it still agree on every case; the answer they agree on is now the cycle's. The class remarks say so and point at the boundary tests.

## The delegation stays, and here is the measurement

The honest question was whether delegating still earns its keep — if the cycle agreed with `PersianCalendar` throughout the window, using the cycle everywhere would be simpler than a hand-off. It does not agree. Measured over the 9,377 whole years the two share, identically on `net472` and on .NET 10:

| | |
| --- | --- |
| year-starts that differ | **4,144 of 9,377**, by −1 to +3 days |
| days placed in a different Persian month | **1,514,413 of 3,425,164** |
| disagreeing years per millennium AP | 66 · **19** · 69 · 128 · 241 · 446 · 798 · 1000 · 1000 |
| years 1300–1500 AP | **none** — no date anybody keeps moves |

The table derives a year from the true vernal equinox at Tehran and is what makes a real Persian date right; the cycle is what every other Temporal implementation answers a proleptic date with. Both are needed, so both stay, and the region comment now records where and why they differ.

Making `persian` ICU's calendar *throughout*, rather than only outside the window, is a much larger change with a much larger blast radius and is still not this fix.

## Tests

`Jint.Tests/Runtime/PersianCalendarBoundaryTests.cs` (15 cases) is what makes the window hold, and nothing in it is a date written down because a run once produced it:

- `ThePlatformsPersianTableCoversExactlyTheWindowJintStates` asserts the four numbers against the platform — the ISO window, the Persian fields at each end, and that `ToDateTime` accepts up to 9378-10-13 and refuses past it — so a runtime that ever disagrees fails **there**, naming the reason, instead of silently moving the proleptic years.
- `TheHandOffHappensOnTheDayTheWindowNamesAndOnNoOther` sweeps every day for four hundred either side of each edge: inside, the answer must be the table's; outside, the cycle's. Moving either constant by one day fails it and two of its neighbours — checked by doing exactly that.
- `TheTwoRulesDisagreeAtBothEdgesOfTheWindow` pins that the seam is a seam, so the sweep is asserting a choice and not a coincidence.
- `AProlepticYearIsAsLongAsTheCyclesLeapRuleSaysAndTheNextStartsThere` and `EveryMonthOfAProlepticYearIsWhereTheCyclePutsIt` assert Jint against the 33-year cycle **written out in the test file** — a test that asked the engine what the engine's arithmetic ought to be would say nothing — over 1,090 proleptic years and every day of five of them, in both directions. That cycle is integer arithmetic on a fixed epoch, so its answers are the same on every runner by construction.
- `TheYearTheWindowStopsInsideIsStillAWholeYear` keeps #3523's answer pinned where the two rules meet.

`NonIsoCalendarTests.ThePersianCalendarPlacesTheEndsOfTemporalsRangeWhereTheStandardLibrariesDo` pins both extremes of Temporal's range with test262's own numbers; against unfixed code it fails with `Expected value to be -272442.0, but found -272443.0`. `ThePersianCalendarStillPlacesTheYearsItsTableCovers` pins Nowruz 1403 (2024-03-20) and 22 Bahman 1357 (1979-02-11), and passes on both sides of the change, which is what says the table-backed range is untouched.

## Exclusions removed

Four files, eight cases:

- `intl402/Temporal/PlainDate/prototype/withCalendar/extreme-dates.js`
- `intl402/Temporal/PlainDateTime/prototype/withCalendar/extreme-dates.js`
- `intl402/Temporal/ZonedDateTime/prototype/withCalendar/extreme-dates.js`
- `intl402/Temporal/ZonedDateTime/from/extreme-dates.js` — the issue expected three; this one was excluded in the same block, fails on the same date before the change and passes after, so it goes too

`intl402/Temporal/PlainDateTime/from/extreme-dates.js` stays, and now carries the reason it actually fails for: one of its extremes raises `Date is outside valid range` from `PlainDateTime.from`, which is a range check rather than a calendar. `PlainYearMonth/from/extreme-unsupported-dates.js` stays as it was.

## Runs

- **Test262: 102,581 passed, 0 failed, 107 skipped** — the whole suite, after the rebase onto `main`.
- `Jint.Tests` `net10.0`, whole project: **12,282 passed, 0 failed**, 5 skipped.
- `Jint.Tests` `net472`, the calendar and stepping classes: 160 passed — the second target the window was measured on.
- `Jint.Tests.PublicInterface` `net10.0`: 3,590 passed.
- Solution build in Release: clean.

No migration-guide row: nothing public moved, and the dates that changed are outside the range any `PersianCalendar`-backed answer ever covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
